### PR TITLE
feat(gateway): add XMPP platform plugin

### DIFF
--- a/plugins/platforms/xmpp/__init__.py
+++ b/plugins/platforms/xmpp/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import register
+
+__all__ = ["register"]

--- a/plugins/platforms/xmpp/adapter.py
+++ b/plugins/platforms/xmpp/adapter.py
@@ -30,6 +30,9 @@ Optional environment variables:
     XMPP_ALLOW_ALL_USERS      true = bypass the allowlist (dev only)
     XMPP_HOME_CHANNEL         Default target for cron deliveries
     XMPP_HOME_CHANNEL_NAME    Display name for the home channel
+    XMPP_UPLOAD_SERVICE       Pin the XEP-0363 upload service JID
+                              (default: SRV-style auto-discovery)
+    XMPP_HTML_FORMATTING      Emit XEP-0071 XHTML-IM dual body (default: true)
 
 The ``slixmpp`` Python package is imported lazily — the plugin stays
 importable for discovery and setup-time prompts even when slixmpp is not
@@ -86,11 +89,11 @@ def _strip_resource(jid: str) -> str:
 
 
 def _strip_markdown(text: str) -> str:
-    """Convert markdown to plain text for XMPP delivery.
+    """Convert markdown to plain text for the XMPP ``<body>`` fallback.
 
-    XMPP message bodies are plain text by default; some clients render
-    XHTML-IM (XEP-0071) but that requires a separate stanza extension we
-    do not emit. Stripping the markup keeps messages readable everywhere.
+    XHTML-IM aware clients render the parallel ``<html>`` element produced
+    by :func:`_format_html`; this strip keeps the plain-body fallback
+    readable on clients that do not.
     """
     # Bold / italic / strikethrough
     text = re.sub(r"\*\*(.+?)\*\*", r"\1", text)
@@ -159,6 +162,229 @@ def _split_message(content: str, max_bytes: int) -> List[str]:
 
 
 # ---------------------------------------------------------------------------
+# XHTML-IM helpers (XEP-0071)
+# ---------------------------------------------------------------------------
+
+# XHTML-IM allows a restricted subset of HTML. We target what the popular
+# mobile + desktop clients (Conversations, Dino, Gajim, Profanity) all
+# render: p, br, strong, em, code, pre, a, ul, ol, li, blockquote, span.
+_XHTML_IM_NS = "http://www.w3.org/1999/xhtml"
+
+
+def _html_escape(text: str) -> str:
+    return (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
+
+
+def _sanitize_link_url(url: str) -> str:
+    """Reject dangerous schemes (``javascript:``, ``data:``, ``vbscript:``)."""
+    stripped = (url or "").strip()
+    scheme = stripped.split(":", 1)[0].lower().strip() if ":" in stripped else ""
+    if scheme in {"javascript", "data", "vbscript"}:
+        return ""
+    return stripped.replace('"', "&quot;")
+
+
+def _markdown_to_xhtml_im(text: str) -> str:
+    """Convert markdown to a safe XHTML-IM subset.
+
+    Uses the ``markdown`` library when installed (matches the Matrix
+    adapter's path; ``markdown`` is pinned for the ``matrix`` extra and
+    is therefore commonly available in Hermes installs). Falls back to a
+    regex pipeline when not.
+
+    Returns an XHTML fragment suitable for assignment to
+    ``msg['html']['body']`` in slixmpp. The caller wraps it in a single
+    ``<p>...</p>`` envelope so the result is well-formed even when the
+    markdown source is empty.
+    """
+    text = text or ""
+    if not text.strip():
+        return ""
+
+    try:
+        import markdown as _md  # type: ignore[import-untyped]
+
+        md = _md.Markdown(extensions=["fenced_code", "nl2br", "sane_lists"])
+        if "html_block" in md.preprocessors:
+            md.preprocessors.deregister("html_block")
+        html = md.convert(text)
+        md.reset()
+        # ``markdown`` wraps single-paragraph output in a stray <p>; XMPP
+        # clients render dual ``<p>`` blocks with a leading blank line, so
+        # strip the wrapper when there is only one.
+        if html.count("<p>") == 1:
+            html = html.replace("<p>", "", 1).replace("</p>", "", 1)
+        return html.strip()
+    except ImportError:
+        return _markdown_to_xhtml_im_fallback(text)
+
+
+def _markdown_to_xhtml_im_fallback(text: str) -> str:
+    """Regex Markdown-to-XHTML-IM for installs without the ``markdown`` package."""
+    placeholders: List[str] = []
+
+    def _protect(html_fragment: str) -> str:
+        placeholders.append(html_fragment)
+        return f"\x00P{len(placeholders) - 1}\x00"
+
+    # Fenced code blocks: ```lang\n...\n```
+    result = re.sub(
+        r"```[a-zA-Z0-9_+\-]*\n?(.*?)```",
+        lambda m: _protect(f"<pre><code>{_html_escape(m.group(1))}</code></pre>"),
+        text,
+        flags=re.DOTALL,
+    )
+    # Inline code
+    result = re.sub(
+        r"`([^`\n]+)`",
+        lambda m: _protect(f"<code>{_html_escape(m.group(1))}</code>"),
+        result,
+    )
+    # Images (extract URL only — XHTML-IM ``<img>`` is poorly supported)
+    result = re.sub(
+        r"!\[([^\]]*)\]\(([^)]+)\)",
+        lambda m: _protect(_html_escape(m.group(2))),
+        result,
+    )
+    # Links: [text](url)
+    result = re.sub(
+        r"\[([^\]]+)\]\(([^)]+)\)",
+        lambda m: _protect(
+            '<a href="{}">{}</a>'.format(
+                _sanitize_link_url(m.group(2)),
+                _html_escape(m.group(1)),
+            )
+        )
+        if _sanitize_link_url(m.group(2))
+        else _protect(_html_escape(m.group(1))),
+        result,
+    )
+    # HTML-escape the rest
+    parts = re.split(r"(\x00P\d+\x00)", result)
+    for idx, part in enumerate(parts):
+        if not part.startswith("\x00P"):
+            parts[idx] = _html_escape(part)
+    result = "".join(parts)
+
+    # Inline emphasis on the escaped+protected string
+    result = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", result)
+    result = re.sub(r"__(.+?)__", r"<strong>\1</strong>", result)
+    result = re.sub(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)", r"<em>\1</em>", result)
+    result = re.sub(r"(?<!\w)_(?!_)(.+?)(?<!_)_(?!\w)", r"<em>\1</em>", result)
+
+    # Block-level: headings → <strong>; lists; blockquotes; paragraphs
+    lines = result.split("\n")
+    out_lines: List[str] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        hdr = re.match(r"^(#{1,6})\s+(.+)$", line)
+        if hdr:
+            out_lines.append(f"<p><strong>{hdr.group(2).strip()}</strong></p>")
+            i += 1
+            continue
+        if re.match(r"^(\s*[-*]\s+)", line):
+            bullets = []
+            while i < len(lines) and re.match(r"^(\s*[-*]\s+)", lines[i]):
+                bullets.append(re.sub(r"^\s*[-*]\s+", "", lines[i]))
+                i += 1
+            out_lines.append("<ul>" + "".join(f"<li>{b}</li>" for b in bullets) + "</ul>")
+            continue
+        if re.match(r"^\s*\d+\.\s+", line):
+            items = []
+            while i < len(lines) and re.match(r"^\s*\d+\.\s+", lines[i]):
+                items.append(re.sub(r"^\s*\d+\.\s+", "", lines[i]))
+                i += 1
+            out_lines.append("<ol>" + "".join(f"<li>{it}</li>" for it in items) + "</ol>")
+            continue
+        if line.startswith("&gt; ") or line == "&gt;":
+            bq = []
+            while i < len(lines) and (lines[i].startswith("&gt; ") or lines[i] == "&gt;"):
+                bq.append(lines[i][5:] if lines[i].startswith("&gt; ") else "")
+                i += 1
+            out_lines.append("<blockquote>" + "<br>".join(bq) + "</blockquote>")
+            continue
+        if not line.strip():
+            i += 1
+            continue
+        # Plain paragraph
+        para = [line]
+        i += 1
+        while i < len(lines) and lines[i].strip() and not _starts_block(lines[i]):
+            para.append(lines[i])
+            i += 1
+        out_lines.append("<p>" + "<br>".join(para) + "</p>")
+
+    rendered = "".join(out_lines)
+    # Restore protected fragments
+    rendered = re.sub(
+        r"\x00P(\d+)\x00",
+        lambda m: placeholders[int(m.group(1))],
+        rendered,
+    )
+    return rendered
+
+
+def _starts_block(line: str) -> bool:
+    return bool(
+        re.match(r"^(#{1,6})\s+", line)
+        or re.match(r"^(\s*[-*]\s+)", line)
+        or re.match(r"^\s*\d+\.\s+", line)
+        or line.startswith("&gt; ")
+        or line == "&gt;"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Media / file helpers
+# ---------------------------------------------------------------------------
+
+_IMAGE_EXTS = frozenset({".png", ".jpg", ".jpeg", ".gif", ".webp", ".heic"})
+_AUDIO_EXTS = frozenset({".ogg", ".opus", ".mp3", ".wav", ".m4a", ".flac", ".aac"})
+_VIDEO_EXTS = frozenset({".mp4", ".webm", ".mov", ".mkv", ".avi"})
+
+_CONTENT_TYPE_BY_EXT = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".heic": "image/heic",
+    ".ogg": "audio/ogg",
+    ".opus": "audio/ogg",
+    ".mp3": "audio/mpeg",
+    ".wav": "audio/wav",
+    ".m4a": "audio/mp4",
+    ".flac": "audio/flac",
+    ".aac": "audio/aac",
+    ".mp4": "video/mp4",
+    ".webm": "video/webm",
+    ".mov": "video/quicktime",
+    ".mkv": "video/x-matroska",
+    ".avi": "video/x-msvideo",
+    ".pdf": "application/pdf",
+    ".zip": "application/zip",
+    ".txt": "text/plain",
+}
+
+
+def _content_type_for(path: str) -> str:
+    _, dot, ext = path.rpartition(".")
+    if not dot:
+        return "application/octet-stream"
+    return _CONTENT_TYPE_BY_EXT.get("." + ext.lower(), "application/octet-stream")
+
+
+class _UploadUnavailable(Exception):
+    """Raised when HTTP Upload is not usable for the current request."""
+
+
+# ---------------------------------------------------------------------------
 # Adapter
 # ---------------------------------------------------------------------------
 
@@ -207,11 +433,22 @@ class XMPPAdapter(BasePlatformAdapter):
 
         self.max_message_length = int(extra.get("max_message_length") or MAX_MESSAGE_LENGTH)
 
+        self.upload_service = (
+            os.getenv("XMPP_UPLOAD_SERVICE") or extra.get("upload_service") or ""
+        ).strip() or None
+        self.html_formatting = _parse_bool(
+            os.getenv("XMPP_HTML_FORMATTING", extra.get("html_formatting", True)),
+            default=True,
+        )
+
         # Runtime state
         self._client = None  # slixmpp.ClientXMPP
         self._lock_key: Optional[str] = None
         self._connected_event = asyncio.Event()
         self._closing = False
+        # Upload service discovery: None = not probed yet, False = unavailable,
+        # str = service JID. Cached on session_start to avoid per-send discovery.
+        self._upload_service_resolved: Any = None
 
     @property
     def name(self) -> str:
@@ -263,6 +500,10 @@ class XMPPAdapter(BasePlatformAdapter):
         client.register_plugin("xep_0030")  # Service Discovery
         client.register_plugin("xep_0199")  # XMPP Ping
         client.register_plugin("xep_0045")  # Multi-User Chat
+        client.register_plugin("xep_0066")  # Out-of-band data (attachment URLs)
+        client.register_plugin("xep_0363")  # HTTP File Upload
+        if self.html_formatting:
+            client.register_plugin("xep_0071")  # XHTML-IM
 
         # TLS toggles. ``enable_starttls`` controls whether slixmpp negotiates
         # STARTTLS during stream negotiation; ``enable_direct_tls`` covers
@@ -354,7 +595,42 @@ class XMPPAdapter(BasePlatformAdapter):
                 except Exception:
                     logger.exception("XMPP: failed to join MUC %s", room)
 
+        # Pre-warm the HTTP Upload service so the first attachment send does
+        # not pay the discovery round-trip. Failure (no upload component on
+        # the server) becomes a sticky False so subsequent send_image_file /
+        # send_document calls fall back to text immediately.
+        await self._resolve_upload_service()
+
         self._connected_event.set()
+
+    async def _resolve_upload_service(self) -> None:
+        client = self._client
+        if client is None:
+            self._upload_service_resolved = False
+            return
+        if self.upload_service:
+            self._upload_service_resolved = self.upload_service
+            logger.info("XMPP: using pinned upload service %s", self.upload_service)
+            return
+        try:
+            upload = client.plugin["xep_0363"]
+            iq = await upload.find_upload_service()
+            if iq is None:
+                logger.info(
+                    "XMPP: no HTTP Upload service advertised by %s; "
+                    "media will be sent as text", _strip_resource(self.jid).split("@", 1)[-1]
+                )
+                self._upload_service_resolved = False
+                return
+            service_jid = str(iq["from"]) if iq.get("from") else True
+            self._upload_service_resolved = service_jid
+            logger.info("XMPP: discovered HTTP Upload service: %s", service_jid)
+        except Exception:
+            logger.warning(
+                "XMPP: HTTP Upload discovery failed; media will be sent as text",
+                exc_info=True,
+            )
+            self._upload_service_resolved = False
 
     def _on_failed_auth(self, event):
         logger.error("XMPP: authentication failed for %s", _strip_resource(self.jid))
@@ -483,14 +759,37 @@ class XMPPAdapter(BasePlatformAdapter):
         if not target:
             return SendResult(success=False, error=f"Invalid XMPP target: {chat_id!r}")
 
-        body = _strip_control_chars(_strip_markdown(content or ""))
-        if not body.strip():
+        plain = _strip_control_chars(_strip_markdown(content or ""))
+        if not plain.strip():
             return SendResult(success=True, message_id=str(int(time.time() * 1000)))
+
+        chunks = _split_message(plain, self.max_message_length)
+        # XHTML-IM only on single-chunk messages: splitting HTML across
+        # stanzas at arbitrary byte boundaries would produce invalid
+        # fragments, and most XMPP clients reject those.
+        emit_html = (
+            self.html_formatting
+            and len(chunks) == 1
+            and "xep_0071" in self._client.plugin
+        )
+        html_body = ""
+        if emit_html:
+            html_body = _markdown_to_xhtml_im(content or "")
+            # Skip the html element when the rendered fragment is identical
+            # to the plain body (no formatting present): nothing to gain.
+            if html_body and html_body.strip() == _html_escape(plain).strip():
+                html_body = ""
 
         last_id = ""
         try:
-            for chunk in _split_message(body, self.max_message_length):
-                self._client.send_message(mto=target, mbody=chunk, mtype=mtype)
+            for idx, chunk in enumerate(chunks):
+                stanza = self._client.make_message(mto=target, mbody=chunk, mtype=mtype)
+                if emit_html and idx == 0 and html_body:
+                    try:
+                        stanza["html"]["body"] = html_body
+                    except Exception:
+                        logger.debug("XMPP: failed to attach XHTML-IM body", exc_info=True)
+                stanza.send()
                 last_id = str(int(time.time() * 1000))
                 await asyncio.sleep(0.05)
         except Exception as e:
@@ -520,15 +819,189 @@ class XMPPAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Fall back to a text message containing the URL.
+        """Send an HTTPS image URL with an OOB extension.
 
-        Native XMPP image delivery requires HTTP Upload (XEP-0363), which
-        depends on the server providing an upload component. The plugin
-        keeps the surface conservative until that is wired in — many
-        deployments still treat HTTP Upload as optional.
+        Clients that understand XEP-0066 (Conversations, Gajim, Dino) treat
+        ``<x xmlns='jabber:x:oob'><url>…</url></x>`` as an inline
+        attachment and render the image; clients that ignore the extension
+        still see the URL in ``<body>`` and can tap through.
         """
-        text = f"{caption}\n{image_url}".strip() if caption else image_url
-        return await self.send(chat_id, text, reply_to=reply_to, metadata=metadata)
+        return await self._send_url_with_oob(
+            chat_id=chat_id,
+            url=image_url,
+            caption=caption,
+        )
+
+    async def send_image_file(
+        self,
+        chat_id: str,
+        image_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        return await self._upload_then_send(chat_id, image_path, caption=caption)
+
+    async def send_animation(
+        self,
+        chat_id: str,
+        animation_url: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        # The gateway routes local-file animated GIFs through
+        # ``send_image_file`` already; this path is for hosted URLs.
+        return await self._send_url_with_oob(chat_id, animation_url, caption=caption)
+
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        return await self._upload_then_send(chat_id, audio_path, caption=caption)
+
+    async def send_video(
+        self,
+        chat_id: str,
+        video_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        return await self._upload_then_send(chat_id, video_path, caption=caption)
+
+    async def send_document(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        return await self._upload_then_send(chat_id, file_path, caption=caption)
+
+    async def _send_url_with_oob(
+        self,
+        chat_id: str,
+        url: str,
+        *,
+        caption: Optional[str] = None,
+    ) -> SendResult:
+        """Send a stanza whose ``<body>`` is *url* plus an OOB extension."""
+        if self._client is None:
+            return SendResult(success=False, error="Not connected")
+        target, mtype = self._resolve_target(chat_id)
+        if not target:
+            return SendResult(success=False, error=f"Invalid XMPP target: {chat_id!r}")
+        clean_url = _strip_control_chars(url or "").strip()
+        if not clean_url:
+            return SendResult(success=False, error="Empty URL")
+
+        body_lines = []
+        if caption:
+            body_lines.append(_strip_control_chars(_strip_markdown(caption)))
+        body_lines.append(clean_url)
+        body = "\n".join(line for line in body_lines if line.strip())
+
+        try:
+            stanza = self._client.make_message(mto=target, mbody=body, mtype=mtype)
+            # Attach OOB only for http(s) URLs — file:// or relative paths
+            # would let a misconfigured caller leak local paths to peers.
+            if clean_url.startswith(("https://", "http://")):
+                try:
+                    stanza["oob"]["url"] = clean_url
+                except Exception:
+                    logger.debug("XMPP: failed to attach OOB extension", exc_info=True)
+            stanza.send()
+        except Exception as e:
+            return SendResult(success=False, error=str(e))
+        return SendResult(success=True, message_id=str(int(time.time() * 1000)))
+
+    async def _upload_then_send(
+        self,
+        chat_id: str,
+        path: str,
+        *,
+        caption: Optional[str] = None,
+    ) -> SendResult:
+        """Upload *path* via HTTP Upload then send the resulting URL via OOB.
+
+        Falls back to a text message describing the file when the upload
+        component is unavailable or the upload fails.
+        """
+        if self._client is None:
+            return SendResult(success=False, error="Not connected")
+        if not path or not os.path.isfile(path):
+            return SendResult(success=False, error=f"File not found: {path!r}")
+
+        try:
+            url = await self._upload_file(path)
+        except _UploadUnavailable as exc:
+            logger.info("XMPP: falling back to text for %s — %s", path, exc)
+            return await self._send_upload_fallback(chat_id, path, caption, str(exc))
+
+        return await self._send_url_with_oob(chat_id, url, caption=caption)
+
+    async def _upload_file(self, path: str) -> str:
+        """Upload a local file via XEP-0363 and return the HTTPS URL.
+
+        Raises :class:`_UploadUnavailable` when the upload service is not
+        available, the file exceeds the server's advertised limit, or the
+        HTTP PUT itself fails. Callers turn the exception into a text
+        fallback so a missing upload component never breaks message
+        delivery.
+        """
+        if self._upload_service_resolved is None:
+            await self._resolve_upload_service()
+        if not self._upload_service_resolved:
+            raise _UploadUnavailable("no HTTP Upload service available")
+
+        client = self._client
+        if client is None:
+            raise _UploadUnavailable("not connected")
+
+        from pathlib import Path as _Path
+
+        size = os.path.getsize(path)
+        content_type = _content_type_for(path)
+        domain_kwarg: Dict[str, Any] = {}
+        if isinstance(self._upload_service_resolved, str):
+            domain_kwarg["domain"] = self._upload_service_resolved
+
+        try:
+            upload = client.plugin["xep_0363"]
+            url = await upload.upload_file(
+                _Path(path),
+                size=size,
+                content_type=content_type,
+                **domain_kwarg,
+            )
+        except Exception as exc:  # UploadServiceNotFound / FileTooBig / HTTPError
+            raise _UploadUnavailable(str(exc)) from exc
+        return str(url)
+
+    async def _send_upload_fallback(
+        self,
+        chat_id: str,
+        path: str,
+        caption: Optional[str],
+        reason: str,
+    ) -> SendResult:
+        """Send a text bubble when an upload could not happen."""
+        filename = os.path.basename(path) or path
+        body = f"📎 {filename} (upload failed: {reason})"
+        if caption:
+            body = f"{caption}\n{body}"
+        return await self.send(chat_id, body)
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         if chat_id.startswith(MUC_PREFIX):
@@ -597,6 +1070,12 @@ def _env_enablement() -> Optional[dict]:
     rooms = (os.getenv("XMPP_ROOMS") or "").strip()
     if rooms:
         seed["rooms"] = _parse_comma_list(rooms)
+    upload_service = (os.getenv("XMPP_UPLOAD_SERVICE") or "").strip()
+    if upload_service:
+        seed["upload_service"] = upload_service
+    html_formatting = (os.getenv("XMPP_HTML_FORMATTING") or "").strip()
+    if html_formatting:
+        seed["html_formatting"] = html_formatting.lower() in _TRUTHY
 
     home = (os.getenv("XMPP_HOME_CHANNEL") or "").strip()
     if home:
@@ -850,11 +1329,16 @@ def register(ctx) -> None:
         pii_safe=False,
         allow_update_command=True,
         platform_hint=(
-            "You are chatting via XMPP. Most XMPP clients render plain text "
-            "only — do not use markdown formatting. JIDs look like email "
-            "addresses (user@server). MUC rooms are identified by a "
-            "``muc:`` prefix; in rooms, users address you by your nickname. "
-            "There is no native attachment channel here, so describe files "
-            "or links in text rather than emitting MEDIA: tags."
+            "You are chatting via XMPP. JIDs look like email addresses "
+            "(user@server). MUC rooms are identified by a ``muc:`` "
+            "prefix; in rooms, users address you by your nickname. "
+            "You can use markdown sparingly (bold, italic, code, links, "
+            "lists) — the adapter renders it via XHTML-IM for clients "
+            "that support it, with a plain-text fallback for the rest. "
+            "Files attach natively when the server has an HTTP Upload "
+            "component: include MEDIA:/absolute/path/to/file in your "
+            "response and the adapter uploads it and sends the URL with "
+            "an OOB attachment hint. If the server has no upload "
+            "component the message arrives as text describing the file."
         ),
     )

--- a/plugins/platforms/xmpp/adapter.py
+++ b/plugins/platforms/xmpp/adapter.py
@@ -1,0 +1,860 @@
+"""XMPP platform adapter (Hermes plugin).
+
+Connects to a self-hosted or hosted XMPP server using slixmpp.  Inbound
+``<message type='chat'>`` and addressed MUC messages are delivered to the
+Hermes agent; outbound replies are sent back as the same stanza type.
+
+Plugin layout follows the SimpleX / IRC / LINE conventions:
+
+* ``check_requirements`` gates on ``XMPP_JID`` + ``XMPP_PASSWORD`` + the
+  ``slixmpp`` package importing.  Missing any of the three keeps the
+  platform out of ``get_connected_platforms()`` so the gateway never
+  instantiates the adapter.
+* ``_env_enablement`` seeds ``PlatformConfig.extra`` from env so
+  ``hermes gateway status`` reflects env-only setups without spinning
+  up the XMPP client.
+* ``_standalone_send`` opens an ephemeral session for cron jobs that run
+  separately from the gateway.
+
+Required environment variables:
+    XMPP_JID              Bare JID the bot logs in as
+    XMPP_PASSWORD         Password for the bot account
+
+Optional environment variables:
+    XMPP_HOST                 Server host override (default: SRV lookup)
+    XMPP_PORT                 Server port override (default: 5222)
+    XMPP_FORCE_STARTTLS       Require STARTTLS (default: true)
+    XMPP_NICKNAME             MUC nickname (default: JID local part)
+    XMPP_ROOMS                Comma-separated MUC JIDs to join
+    XMPP_ALLOWED_USERS        Comma-separated bare JIDs allowlist
+    XMPP_ALLOW_ALL_USERS      true = bypass the allowlist (dev only)
+    XMPP_HOME_CHANNEL         Default target for cron deliveries
+    XMPP_HOME_CHANNEL_NAME    Display name for the home channel
+
+The ``slixmpp`` Python package is imported lazily — the plugin stays
+importable for discovery and setup-time prompts even when slixmpp is not
+installed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+MAX_MESSAGE_LENGTH = 16_000  # XMPP has no hard limit; cap stanza body sanely
+DEFAULT_PORT = 5222
+CONNECT_TIMEOUT_SECONDS = 20.0
+DISCONNECT_TIMEOUT_SECONDS = 5.0
+MUC_PREFIX = "muc:"
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def _parse_bool(value: Any, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    return str(value).strip().lower() in _TRUTHY
+
+
+def _parse_comma_list(value: str) -> List[str]:
+    return [v.strip() for v in (value or "").split(",") if v.strip()]
+
+
+def _strip_resource(jid: str) -> str:
+    """Return the bare JID (``user@server``) by dropping any ``/resource``."""
+    return (jid or "").split("/", 1)[0]
+
+
+def _strip_markdown(text: str) -> str:
+    """Convert markdown to plain text for XMPP delivery.
+
+    XMPP message bodies are plain text by default; some clients render
+    XHTML-IM (XEP-0071) but that requires a separate stanza extension we
+    do not emit. Stripping the markup keeps messages readable everywhere.
+    """
+    # Bold / italic / strikethrough
+    text = re.sub(r"\*\*(.+?)\*\*", r"\1", text)
+    text = re.sub(r"__(.+?)__", r"\1", text)
+    text = re.sub(r"\*(.+?)\*", r"\1", text)
+    text = re.sub(r"(?<!\w)_(.+?)_(?!\w)", r"\1", text)
+    text = re.sub(r"~~(.+?)~~", r"\1", text)
+    # Code blocks and inline code (keep content, drop fences/ticks)
+    text = re.sub(r"```\w*\n?", "", text)
+    text = re.sub(r"`(.+?)`", r"\1", text)
+    # Headings
+    text = re.sub(r"^#{1,6}\s+", "", text, flags=re.MULTILINE)
+    # Images, then links (images first so ![] is consumed before [])
+    text = re.sub(r"!\[([^\]]*)\]\(([^)]+)\)", r"\2", text)
+    text = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"\1 (\2)", text)
+    return text
+
+
+def _strip_control_chars(text: str) -> str:
+    """Strip the few characters XML 1.0 cannot encode in a message body.
+
+    Slixmpp serializes stanzas as XML 1.0; raw NUL or stray vertical-tab
+    bytes get rejected by the underlying parser.  CR/LF are valid in a
+    body, but normalizing them to ``\\n`` keeps logs readable.
+    """
+    cleaned = []
+    for ch in text or "":
+        cp = ord(ch)
+        if cp == 0x00:
+            continue
+        if cp < 0x20 and ch not in ("\t", "\n", "\r"):
+            continue
+        cleaned.append(ch)
+    return "".join(cleaned).replace("\r\n", "\n").replace("\r", "\n")
+
+
+def _split_message(content: str, max_bytes: int) -> List[str]:
+    """Split ``content`` on paragraph boundaries to keep each chunk under
+    ``max_bytes`` of UTF-8.  No code-block awareness — XMPP renders plain
+    text bodies and the stripper above has already removed fences."""
+    chunks: List[str] = []
+    for paragraph in content.split("\n"):
+        if not paragraph.strip():
+            continue
+        while True:
+            data = paragraph.encode("utf-8")
+            if len(data) <= max_bytes:
+                chunks.append(paragraph)
+                break
+            # Binary search for the largest prefix that fits within max_bytes
+            low, high, best = 1, len(paragraph), 0
+            while low <= high:
+                mid = (low + high) // 2
+                if len(paragraph[:mid].encode("utf-8")) <= max_bytes:
+                    best = mid
+                    low = mid + 1
+                else:
+                    high = mid - 1
+            split_at = best
+            space = paragraph.rfind(" ", 0, split_at)
+            if space > split_at // 3:
+                split_at = space
+            chunks.append(paragraph[:split_at].rstrip())
+            paragraph = paragraph[split_at:].lstrip()
+    return chunks if chunks else [""]
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
+
+
+class XMPPAdapter(BasePlatformAdapter):
+    """XMPP adapter using slixmpp's asyncio ClientXMPP.
+
+    Instantiated by the ``adapter_factory`` passed to
+    ``ctx.register_platform()`` in :func:`register`.
+    """
+
+    def __init__(self, config: PlatformConfig, **kwargs):
+        platform = Platform("xmpp")
+        super().__init__(config=config, platform=platform)
+
+        extra = getattr(config, "extra", {}) or {}
+
+        self.jid = (os.getenv("XMPP_JID") or extra.get("jid") or "").strip()
+        self.password = os.getenv("XMPP_PASSWORD") or extra.get("password", "")
+        self.host = (os.getenv("XMPP_HOST") or extra.get("host") or "").strip() or None
+
+        port_value = os.getenv("XMPP_PORT") or extra.get("port") or DEFAULT_PORT
+        try:
+            self.port = int(port_value)
+        except (TypeError, ValueError):
+            self.port = DEFAULT_PORT
+
+        self.force_starttls = _parse_bool(
+            os.getenv("XMPP_FORCE_STARTTLS", extra.get("force_starttls", True)),
+            default=True,
+        )
+
+        bare = _strip_resource(self.jid)
+        local_part = bare.split("@", 1)[0] if "@" in bare else (bare or "hermes")
+        self.nickname = (
+            os.getenv("XMPP_NICKNAME")
+            or extra.get("nickname")
+            or local_part
+        ).strip() or "hermes"
+
+        rooms_raw = os.getenv("XMPP_ROOMS") or extra.get("rooms", "")
+        if isinstance(rooms_raw, list):
+            self.rooms = [str(r).strip() for r in rooms_raw if str(r).strip()]
+        else:
+            self.rooms = _parse_comma_list(rooms_raw)
+
+        self.max_message_length = int(extra.get("max_message_length") or MAX_MESSAGE_LENGTH)
+
+        # Runtime state
+        self._client = None  # slixmpp.ClientXMPP
+        self._lock_key: Optional[str] = None
+        self._connected_event = asyncio.Event()
+        self._closing = False
+
+    @property
+    def name(self) -> str:
+        return "XMPP"
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def connect(self) -> bool:
+        if not self.jid or not self.password:
+            logger.error("XMPP: XMPP_JID and XMPP_PASSWORD are required")
+            self._set_fatal_error(
+                "config_missing",
+                "XMPP_JID and XMPP_PASSWORD must be set",
+                retryable=False,
+            )
+            return False
+
+        try:
+            import slixmpp  # noqa: F401
+        except ImportError:
+            logger.error("XMPP: 'slixmpp' package not installed. Run: pip install slixmpp")
+            self._set_fatal_error(
+                "missing_dependency",
+                "slixmpp package is not installed",
+                retryable=False,
+            )
+            return False
+
+        # Prevent two profiles from logging in as the same JID.
+        try:
+            from gateway.status import acquire_scoped_lock
+            if not acquire_scoped_lock("xmpp", _strip_resource(self.jid)):
+                logger.error("XMPP: %s already in use by another profile", _strip_resource(self.jid))
+                self._set_fatal_error(
+                    "lock_conflict",
+                    "XMPP identity in use by another profile",
+                    retryable=False,
+                )
+                return False
+            self._lock_key = _strip_resource(self.jid)
+        except ImportError:
+            self._lock_key = None  # status module not available (tests)
+
+        from slixmpp import ClientXMPP
+
+        client = ClientXMPP(self.jid, self.password)
+        client.register_plugin("xep_0030")  # Service Discovery
+        client.register_plugin("xep_0199")  # XMPP Ping
+        client.register_plugin("xep_0045")  # Multi-User Chat
+
+        # TLS toggles. ``enable_starttls`` controls whether slixmpp negotiates
+        # STARTTLS during stream negotiation; ``enable_direct_tls`` covers
+        # direct-TLS ports (5223). When ``XMPP_FORCE_STARTTLS=false`` we
+        # disable both so plaintext local-loopback dev servers work.
+        client.enable_starttls = self.force_starttls
+        client.enable_direct_tls = self.force_starttls
+        if not self.force_starttls:
+            logger.warning(
+                "XMPP: TLS disabled (XMPP_FORCE_STARTTLS=false). "
+                "Only do this on trusted local networks."
+            )
+
+        client.add_event_handler("session_start", self._on_session_start)
+        client.add_event_handler("message", self._on_message)
+        client.add_event_handler("groupchat_message", self._on_groupchat_message)
+        client.add_event_handler("disconnected", self._on_disconnected)
+        client.add_event_handler("failed_auth", self._on_failed_auth)
+
+        self._client = client
+        self._closing = False
+        self._connected_event = asyncio.Event()
+
+        host = self.host
+        port = self.port if host else None  # slixmpp does SRV when host omitted
+        client.connect(host=host, port=port)
+
+        try:
+            await asyncio.wait_for(self._connected_event.wait(), timeout=CONNECT_TIMEOUT_SECONDS)
+        except asyncio.TimeoutError:
+            logger.error("XMPP: connect timed out after %.0fs", CONNECT_TIMEOUT_SECONDS)
+            await self._safe_disconnect()
+            self._set_fatal_error("connect_timeout", "XMPP session_start not received", retryable=True)
+            return False
+
+        if self.has_fatal_error:
+            return False
+
+        self._mark_connected()
+        logger.info("XMPP: connected as %s", _strip_resource(self.jid))
+        return True
+
+    async def disconnect(self) -> None:
+        self._closing = True
+        if self._lock_key:
+            try:
+                from gateway.status import release_scoped_lock
+                release_scoped_lock("xmpp", self._lock_key)
+            except Exception:
+                pass
+            self._lock_key = None
+        await self._safe_disconnect()
+        self._client = None
+        self._mark_disconnected()
+
+    async def _safe_disconnect(self) -> None:
+        client = self._client
+        if client is None:
+            return
+        try:
+            future = client.disconnect(wait=DISCONNECT_TIMEOUT_SECONDS)
+            if future is not None:
+                await asyncio.wait_for(asyncio.shield(asyncio.ensure_future(future)), timeout=DISCONNECT_TIMEOUT_SECONDS + 2.0)
+        except (asyncio.TimeoutError, Exception):
+            # Best-effort: never raise out of disconnect.
+            pass
+
+    # ------------------------------------------------------------------
+    # Event handlers
+    # ------------------------------------------------------------------
+
+    async def _on_session_start(self, event):
+        client = self._client
+        if client is None:
+            return
+        try:
+            client.send_presence()
+            await client.get_roster()
+        except Exception:
+            logger.exception("XMPP: error during session start")
+
+        # Join any pre-configured MUC rooms.
+        muc = client.plugin.get("xep_0045")
+        if muc is not None and self.rooms:
+            for room in self.rooms:
+                try:
+                    muc.join_muc(room, self.nickname, wait=False)
+                    logger.info("XMPP: joining MUC %s as %s", room, self.nickname)
+                except Exception:
+                    logger.exception("XMPP: failed to join MUC %s", room)
+
+        self._connected_event.set()
+
+    def _on_failed_auth(self, event):
+        logger.error("XMPP: authentication failed for %s", _strip_resource(self.jid))
+        self._set_fatal_error("auth_failed", "XMPP authentication failed", retryable=False)
+        # Release the wait_for in connect()
+        self._connected_event.set()
+
+    async def _on_disconnected(self, event):
+        if self._closing:
+            return
+        if self.is_connected:
+            logger.warning("XMPP: lost connection, marking disconnected")
+            self._set_fatal_error("connection_lost", "XMPP connection closed unexpectedly", retryable=True)
+            try:
+                await self._notify_fatal_error()
+            except Exception:
+                logger.exception("XMPP: error notifying fatal error")
+
+    async def _on_message(self, msg):
+        """Handle a 1:1 ``<message type='chat'|'normal'>``."""
+        if msg["type"] not in ("chat", "normal"):
+            return
+        text = msg.get("body") or ""
+        if not text.strip():
+            return  # ignore chat-state / typing-only stanzas
+
+        sender_jid_full = str(msg["from"])
+        sender_jid = _strip_resource(sender_jid_full)
+        if sender_jid == _strip_resource(self.jid):
+            return  # own echo (shouldn't happen for type=chat but be defensive)
+
+        await self._dispatch(
+            text=text,
+            chat_id=sender_jid,
+            chat_name=sender_jid,
+            chat_type="dm",
+            user_id=sender_jid,
+            user_name=sender_jid,
+            message_id=str(msg.get("id") or ""),
+        )
+
+    async def _on_groupchat_message(self, msg):
+        """Handle a MUC ``<message type='groupchat'>``."""
+        if msg["type"] != "groupchat":
+            return
+        text = msg.get("body") or ""
+        if not text.strip():
+            return
+
+        room_jid = _strip_resource(str(msg["from"]))
+        sender_nick = msg.get("mucnick") or ""
+        if not sender_nick or sender_nick == self.nickname:
+            return  # own echo / system message
+
+        # Only respond when addressed by our nickname (matches IRC behavior).
+        prefixes = (
+            f"{self.nickname}:",
+            f"{self.nickname},",
+            f"{self.nickname} ",
+            f"@{self.nickname} ",
+        )
+        addressed = False
+        for prefix in prefixes:
+            if text.lower().startswith(prefix.lower()):
+                text = text[len(prefix):].strip()
+                addressed = True
+                break
+        if not addressed:
+            return
+
+        chat_id = f"{MUC_PREFIX}{room_jid}"
+        await self._dispatch(
+            text=text,
+            chat_id=chat_id,
+            chat_name=room_jid,
+            chat_type="group",
+            user_id=sender_nick,
+            user_name=sender_nick,
+            message_id=str(msg.get("id") or ""),
+        )
+
+    async def _dispatch(
+        self,
+        *,
+        text: str,
+        chat_id: str,
+        chat_name: str,
+        chat_type: str,
+        user_id: str,
+        user_name: str,
+        message_id: str = "",
+    ) -> None:
+        if not self._message_handler:
+            return
+        source = self.build_source(
+            chat_id=chat_id,
+            chat_name=chat_name,
+            chat_type=chat_type,
+            user_id=user_id,
+            user_name=user_name,
+        )
+        event = MessageEvent(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id=message_id or str(int(time.time() * 1000)),
+            timestamp=datetime.now(tz=timezone.utc),
+        )
+        await self.handle_message(event)
+
+    # ------------------------------------------------------------------
+    # Outbound
+    # ------------------------------------------------------------------
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        if self._client is None:
+            return SendResult(success=False, error="Not connected")
+
+        target, mtype = self._resolve_target(chat_id)
+        if not target:
+            return SendResult(success=False, error=f"Invalid XMPP target: {chat_id!r}")
+
+        body = _strip_control_chars(_strip_markdown(content or ""))
+        if not body.strip():
+            return SendResult(success=True, message_id=str(int(time.time() * 1000)))
+
+        last_id = ""
+        try:
+            for chunk in _split_message(body, self.max_message_length):
+                self._client.send_message(mto=target, mbody=chunk, mtype=mtype)
+                last_id = str(int(time.time() * 1000))
+                await asyncio.sleep(0.05)
+        except Exception as e:
+            return SendResult(success=False, error=str(e))
+        return SendResult(success=True, message_id=last_id)
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        """XEP-0085 chat states — best-effort, ignored if the peer does not support it."""
+        if self._client is None:
+            return
+        target, mtype = self._resolve_target(chat_id)
+        if not target or mtype == "groupchat":
+            return  # composing in MUC is noisy and rarely useful
+        try:
+            stanza = self._client.make_message(mto=target, mtype=mtype)
+            stanza["chat_state"] = "composing"
+            stanza.send()
+        except Exception:
+            # Chat-state plugin may not be registered; that's fine.
+            pass
+
+    async def send_image(
+        self,
+        chat_id: str,
+        image_url: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Fall back to a text message containing the URL.
+
+        Native XMPP image delivery requires HTTP Upload (XEP-0363), which
+        depends on the server providing an upload component. The plugin
+        keeps the surface conservative until that is wired in — many
+        deployments still treat HTTP Upload as optional.
+        """
+        text = f"{caption}\n{image_url}".strip() if caption else image_url
+        return await self.send(chat_id, text, reply_to=reply_to, metadata=metadata)
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        if chat_id.startswith(MUC_PREFIX):
+            jid = chat_id[len(MUC_PREFIX):]
+            return {"chat_id": chat_id, "type": "group", "name": jid}
+        return {"chat_id": chat_id, "type": "dm", "name": chat_id}
+
+    def _resolve_target(self, chat_id: str) -> tuple[str, str]:
+        """Return ``(jid, mtype)`` for a ``chat_id`` string."""
+        if not chat_id:
+            return "", "chat"
+        if chat_id.startswith(MUC_PREFIX):
+            return chat_id[len(MUC_PREFIX):], "groupchat"
+        return chat_id, "chat"
+
+
+# ---------------------------------------------------------------------------
+# Plugin entry-point hooks
+# ---------------------------------------------------------------------------
+
+def check_requirements() -> bool:
+    """Plugin gate: require XMPP_JID + XMPP_PASSWORD + slixmpp importable."""
+    if not os.getenv("XMPP_JID") or not os.getenv("XMPP_PASSWORD"):
+        return False
+    try:
+        import slixmpp  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def validate_config(config) -> bool:
+    extra = getattr(config, "extra", {}) or {}
+    jid = os.getenv("XMPP_JID") or extra.get("jid", "")
+    password = os.getenv("XMPP_PASSWORD") or extra.get("password", "")
+    return bool(jid and password)
+
+
+def is_connected(config) -> bool:
+    return validate_config(config)
+
+
+def _env_enablement() -> Optional[dict]:
+    jid = (os.getenv("XMPP_JID") or "").strip()
+    if not jid:
+        return None
+    if not (os.getenv("XMPP_PASSWORD") or "").strip():
+        return None
+
+    seed: dict = {"jid": jid}
+    host = (os.getenv("XMPP_HOST") or "").strip()
+    if host:
+        seed["host"] = host
+    port = (os.getenv("XMPP_PORT") or "").strip()
+    if port:
+        try:
+            seed["port"] = int(port)
+        except ValueError:
+            pass
+    force_tls = (os.getenv("XMPP_FORCE_STARTTLS") or "").strip()
+    if force_tls:
+        seed["force_starttls"] = force_tls.lower() in _TRUTHY
+    nickname = (os.getenv("XMPP_NICKNAME") or "").strip()
+    if nickname:
+        seed["nickname"] = nickname
+    rooms = (os.getenv("XMPP_ROOMS") or "").strip()
+    if rooms:
+        seed["rooms"] = _parse_comma_list(rooms)
+
+    home = (os.getenv("XMPP_HOME_CHANNEL") or "").strip()
+    if home:
+        seed["home_channel"] = {
+            "chat_id": home,
+            "name": (os.getenv("XMPP_HOME_CHANNEL_NAME") or "").strip() or home,
+        }
+    return seed
+
+
+async def _standalone_send(
+    pconfig,
+    chat_id: str,
+    message: str,
+    *,
+    thread_id: Optional[str] = None,
+    media_files: Optional[List[str]] = None,
+    force_document: bool = False,
+) -> Dict[str, Any]:
+    """Open an ephemeral XMPP session, send, and disconnect.
+
+    Used by ``tools/send_message_tool._send_via_adapter`` when the gateway
+    runner is not in this process (e.g. ``hermes cron`` running separately).
+    Without this hook, ``deliver=xmpp`` cron jobs fail with "No live
+    adapter for platform".
+
+    ``thread_id``, ``media_files`` and ``force_document`` are accepted for
+    signature parity with other plugin standalone senders but are not
+    meaningful here: XMPP has no native thread primitive and media
+    delivery would require HTTP Upload (XEP-0363) and a reachable
+    upload component, which a one-shot session cannot guarantee.
+    """
+    del thread_id, media_files, force_document
+
+    try:
+        import slixmpp
+    except ImportError:
+        return {"error": "slixmpp not installed. Run: pip install slixmpp"}
+
+    extra = getattr(pconfig, "extra", {}) or {}
+    jid = (os.getenv("XMPP_JID") or extra.get("jid") or "").strip()
+    password = os.getenv("XMPP_PASSWORD") or extra.get("password", "")
+    if not jid or not password:
+        return {"error": "XMPP standalone send: XMPP_JID and XMPP_PASSWORD are required"}
+
+    raw_target = (chat_id or extra.get("home_channel", {}).get("chat_id") or "").strip()
+    if not raw_target:
+        return {"error": "XMPP standalone send: missing target JID"}
+    if any(ch in raw_target for ch in ("\r", "\n", "\x00", " ")):
+        return {"error": "XMPP standalone send: chat_id contains illegal characters"}
+
+    if raw_target.startswith(MUC_PREFIX):
+        target = raw_target[len(MUC_PREFIX):]
+        mtype = "groupchat"
+    else:
+        target = raw_target
+        mtype = "chat"
+
+    host = (os.getenv("XMPP_HOST") or extra.get("host") or "").strip() or None
+    port_raw = os.getenv("XMPP_PORT") or extra.get("port") or DEFAULT_PORT
+    try:
+        port = int(port_raw)
+    except (TypeError, ValueError):
+        port = DEFAULT_PORT
+    force_tls = _parse_bool(
+        os.getenv("XMPP_FORCE_STARTTLS", extra.get("force_starttls", True)),
+        default=True,
+    )
+
+    body = _strip_control_chars(_strip_markdown(message or ""))
+    if not body.strip():
+        return {"error": "XMPP standalone send: empty message after stripping"}
+
+    # Distinct resource so we don't collide with a live gateway adapter on
+    # the same identity.
+    full_jid = f"{_strip_resource(jid)}/hermes-cron-{int(time.time() * 1000) % 100000}"
+
+    client = slixmpp.ClientXMPP(full_jid, password)
+    client.register_plugin("xep_0030")
+    client.register_plugin("xep_0045")
+    client.enable_starttls = force_tls
+    client.enable_direct_tls = force_tls
+
+    ready = asyncio.Event()
+    error: Dict[str, str] = {}
+
+    async def _on_start(_event):
+        try:
+            client.send_presence()
+            if mtype == "groupchat":
+                muc = client.plugin["xep_0045"]
+                nick = (os.getenv("XMPP_NICKNAME") or extra.get("nickname") or jid.split("@", 1)[0]).strip() or "hermes"
+                muc.join_muc(target, nick, wait=False)
+                # Give the server a moment to process the JOIN before we
+                # send to a +n-style room. Real protocol ack would be
+                # ``groupchat_subject``; a short sleep avoids us holding
+                # the event loop here just to listen for one stanza.
+                await asyncio.sleep(0.8)
+            for chunk in _split_message(body, MAX_MESSAGE_LENGTH):
+                client.send_message(mto=target, mbody=chunk, mtype=mtype)
+                await asyncio.sleep(0.05)
+        except Exception as exc:  # noqa: BLE001
+            error["msg"] = str(exc)
+        finally:
+            ready.set()
+
+    def _on_auth_fail(_event):
+        error["msg"] = "authentication failed"
+        ready.set()
+
+    client.add_event_handler("session_start", _on_start)
+    client.add_event_handler("failed_auth", _on_auth_fail)
+
+    try:
+        client.connect(host=host, port=port if host else None)
+    except Exception as exc:  # noqa: BLE001
+        return {"error": f"XMPP standalone connect failed: {exc}"}
+
+    try:
+        await asyncio.wait_for(ready.wait(), timeout=CONNECT_TIMEOUT_SECONDS)
+    except asyncio.TimeoutError:
+        try:
+            client.disconnect(wait=1.0)
+        except Exception:
+            pass
+        return {"error": "XMPP standalone send: timed out before session_start"}
+
+    try:
+        fut = client.disconnect(wait=DISCONNECT_TIMEOUT_SECONDS)
+        if fut is not None:
+            await asyncio.wait_for(asyncio.shield(asyncio.ensure_future(fut)), timeout=DISCONNECT_TIMEOUT_SECONDS + 2.0)
+    except Exception:
+        pass
+
+    if error:
+        return {"error": f"XMPP standalone send failed: {error['msg']}"}
+    return {"success": True, "platform": "xmpp", "chat_id": chat_id, "message_id": str(int(time.time() * 1000))}
+
+
+def interactive_setup() -> None:
+    """Minimal stdin wizard for ``hermes setup gateway`` → XMPP."""
+    try:
+        from hermes_cli.setup import (
+            prompt,
+            prompt_yes_no,
+            save_env_value,
+            get_env_value,
+            print_header,
+            print_info,
+            print_warning,
+            print_success,
+        )
+    except ImportError:
+        print()
+        print("hermes_cli.setup not available; set XMPP_* vars manually in ~/.hermes/.env")
+        return
+
+    print_header("XMPP")
+    existing = get_env_value("XMPP_JID")
+    if existing:
+        print_info(f"XMPP: already configured (JID: {existing})")
+        if not prompt_yes_no("Reconfigure XMPP?", False):
+            return
+
+    print_info("Connect Hermes to an XMPP server (Prosody, ejabberd, hosted, etc.).")
+    print_info("   Requires the slixmpp Python package: pip install slixmpp")
+    print()
+
+    jid = prompt("Bot JID (e.g. hermes@chat.example.org)", default=existing or "")
+    if not jid:
+        print_warning("JID is required — skipping XMPP setup")
+        return
+    save_env_value("XMPP_JID", jid.strip())
+
+    password = prompt("Password for this account", password=True)
+    if password:
+        save_env_value("XMPP_PASSWORD", password)
+    elif not get_env_value("XMPP_PASSWORD"):
+        print_warning("Password is required — skipping XMPP setup")
+        return
+
+    host = prompt("Server host (blank = SRV lookup on the JID domain)",
+                  default=get_env_value("XMPP_HOST") or "")
+    save_env_value("XMPP_HOST", host.strip())
+
+    port = prompt("Server port (default 5222)", default=get_env_value("XMPP_PORT") or "")
+    if port:
+        try:
+            save_env_value("XMPP_PORT", str(int(port)))
+        except ValueError:
+            print_warning("Invalid port — using default 5222")
+
+    use_tls = prompt_yes_no("Require STARTTLS (recommended)?", True)
+    save_env_value("XMPP_FORCE_STARTTLS", "true" if use_tls else "false")
+
+    nickname = prompt(
+        "MUC nickname (blank = JID local part)",
+        default=get_env_value("XMPP_NICKNAME") or "",
+    )
+    save_env_value("XMPP_NICKNAME", nickname.strip())
+
+    rooms = prompt(
+        "MUC rooms to auto-join (comma-separated, or blank)",
+        default=get_env_value("XMPP_ROOMS") or "",
+    )
+    save_env_value("XMPP_ROOMS", rooms.replace(" ", ""))
+
+    print()
+    print_info("🔒 Access control: restrict which JIDs can DM the bot")
+    allow_all = prompt_yes_no("Allow any JID to talk to the bot?", False)
+    if allow_all:
+        save_env_value("XMPP_ALLOW_ALL_USERS", "true")
+        save_env_value("XMPP_ALLOWED_USERS", "")
+        print_warning("⚠️  Open access — any JID can command the bot.")
+    else:
+        save_env_value("XMPP_ALLOW_ALL_USERS", "false")
+        allowed = prompt(
+            "Allowed bare JIDs (comma-separated, blank to deny everyone)",
+            default=get_env_value("XMPP_ALLOWED_USERS") or "",
+        )
+        save_env_value("XMPP_ALLOWED_USERS", allowed.replace(" ", ""))
+        if allowed:
+            print_success("Allowlist configured")
+        else:
+            print_info("No JIDs allowed — the bot will ignore all DMs until you add some.")
+
+    print()
+    print_success("XMPP configuration saved to ~/.hermes/.env")
+    print_info("Restart the gateway for changes to take effect: hermes gateway restart")
+
+
+def register(ctx) -> None:
+    """Plugin entry point — called by the Hermes plugin system at startup."""
+    ctx.register_platform(
+        name="xmpp",
+        label="XMPP",
+        adapter_factory=lambda cfg: XMPPAdapter(cfg),
+        check_fn=check_requirements,
+        validate_config=validate_config,
+        is_connected=is_connected,
+        required_env=["XMPP_JID", "XMPP_PASSWORD"],
+        install_hint="pip install slixmpp   # XMPP adapter requires slixmpp",
+        setup_fn=interactive_setup,
+        env_enablement_fn=_env_enablement,
+        cron_deliver_env_var="XMPP_HOME_CHANNEL",
+        standalone_sender_fn=_standalone_send,
+        allowed_users_env="XMPP_ALLOWED_USERS",
+        allow_all_env="XMPP_ALLOW_ALL_USERS",
+        max_message_length=MAX_MESSAGE_LENGTH,
+        emoji="✉️",
+        pii_safe=False,
+        allow_update_command=True,
+        platform_hint=(
+            "You are chatting via XMPP. Most XMPP clients render plain text "
+            "only — do not use markdown formatting. JIDs look like email "
+            "addresses (user@server). MUC rooms are identified by a "
+            "``muc:`` prefix; in rooms, users address you by your nickname. "
+            "There is no native attachment channel here, so describe files "
+            "or links in text rather than emitting MEDIA: tags."
+        ),
+    )

--- a/plugins/platforms/xmpp/plugin.yaml
+++ b/plugins/platforms/xmpp/plugin.yaml
@@ -59,3 +59,11 @@ optional_env:
     description: "Human label for the home channel (defaults to the JID)"
     prompt: "Home channel display name (or empty)"
     password: false
+  - name: XMPP_UPLOAD_SERVICE
+    description: "Pin the XEP-0363 HTTP Upload component JID (default: auto-discover)"
+    prompt: "Upload service JID (or empty)"
+    password: false
+  - name: XMPP_HTML_FORMATTING
+    description: "Emit XEP-0071 XHTML-IM dual body so clients can render bold/italic/links (default: true)"
+    prompt: "Send XHTML-IM dual body? (true/false)"
+    password: false

--- a/plugins/platforms/xmpp/plugin.yaml
+++ b/plugins/platforms/xmpp/plugin.yaml
@@ -1,0 +1,61 @@
+name: xmpp-platform
+label: XMPP
+kind: platform
+version: 1.0.0
+description: >
+  XMPP gateway adapter for Hermes Agent.
+  Connects to a self-hosted or hosted XMPP server (Prosody, ejabberd, etc.)
+  and relays messages between XMPP contacts/rooms and the Hermes agent.
+  Built on slixmpp; STARTTLS is on by default. JIDs in an allowlist are
+  authorized to chat with the bot; MUC rooms join with a configurable
+  nickname and reply only when addressed by that nickname.
+author: alien2003
+# ``requires_env`` and ``optional_env`` entries are surfaced in the
+# ``hermes config`` UI via the platform-plugin env var injector in
+# ``hermes_cli/config.py``.
+requires_env:
+  - name: XMPP_JID
+    description: "Bare JID the bot logs in as (e.g. hermes@chat.example.org)"
+    prompt: "Bot JID"
+    password: false
+  - name: XMPP_PASSWORD
+    description: "Password for the bot account"
+    prompt: "XMPP password"
+    password: true
+optional_env:
+  - name: XMPP_HOST
+    description: "Server host override (default: SRV lookup on the JID domain)"
+    prompt: "XMPP host (or empty)"
+    password: false
+  - name: XMPP_PORT
+    description: "Server port override (default: 5222)"
+    prompt: "XMPP port (or empty)"
+    password: false
+  - name: XMPP_FORCE_STARTTLS
+    description: "Require STARTTLS (default: true). Set 'false' only for trusted dev servers."
+    prompt: "Force STARTTLS? (true/false)"
+    password: false
+  - name: XMPP_NICKNAME
+    description: "MUC nickname (default: the JID's local part)"
+    prompt: "MUC nickname (or empty)"
+    password: false
+  - name: XMPP_ROOMS
+    description: "Comma-separated MUC JIDs to auto-join (e.g. ops@conference.example.org)"
+    prompt: "Rooms to join (or empty)"
+    password: false
+  - name: XMPP_ALLOWED_USERS
+    description: "Comma-separated bare JIDs allowed to DM the bot"
+    prompt: "Allowed JIDs (comma-separated)"
+    password: false
+  - name: XMPP_ALLOW_ALL_USERS
+    description: "Allow any JID to talk to the bot (dev only — disables allowlist)"
+    prompt: "Allow all users? (true/false)"
+    password: false
+  - name: XMPP_HOME_CHANNEL
+    description: "Default JID for cron / notification delivery (DM JID or MUC JID prefixed with 'muc:')"
+    prompt: "Home channel JID (or empty)"
+    password: false
+  - name: XMPP_HOME_CHANNEL_NAME
+    description: "Human label for the home channel (defaults to the JID)"
+    prompt: "Home channel display name (or empty)"
+    password: false

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1270,6 +1270,7 @@ AUTHOR_MAP = {
     "120500656+oooindefatigable@users.noreply.github.com": "ooovenenoso",
     "vanthinh6886@gmail.com": "vanthinh6886",  # PR #28018 salvage (yaml/flock/atomic write guards)
     "erik.engervall@gmail.com": "erikengervall",  # PR #28774 (firecrawl integration tag)
+    "alien2003@protonmail.ch": "alien2003",  # XMPP platform plugin
 }
 
 

--- a/tests/gateway/test_xmpp_plugin.py
+++ b/tests/gateway/test_xmpp_plugin.py
@@ -1,0 +1,622 @@
+"""Tests for the XMPP platform-plugin adapter.
+
+Loaded via the ``_plugin_adapter_loader`` helper so this lives under
+``plugin_adapter_xmpp`` in ``sys.modules`` and cannot collide with
+sibling platform-plugin tests on the same xdist worker.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tests.gateway._plugin_adapter_loader import load_plugin_adapter
+
+_xmpp = load_plugin_adapter("xmpp")
+
+XMPPAdapter = _xmpp.XMPPAdapter
+check_requirements = _xmpp.check_requirements
+validate_config = _xmpp.validate_config
+is_connected = _xmpp.is_connected
+register = _xmpp.register
+_env_enablement = _xmpp._env_enablement
+_standalone_send = _xmpp._standalone_send
+_strip_resource = _xmpp._strip_resource
+_strip_markdown = _xmpp._strip_markdown
+_strip_control_chars = _xmpp._strip_control_chars
+_split_message = _xmpp._split_message
+_parse_bool = _xmpp._parse_bool
+_parse_comma_list = _xmpp._parse_comma_list
+MUC_PREFIX = _xmpp.MUC_PREFIX
+
+
+# ---------------------------------------------------------------------------
+# 1. Platform enum (plugin-discovered, not bundled)
+# ---------------------------------------------------------------------------
+
+def test_platform_enum_resolves_via_plugin_scan():
+    from gateway.config import Platform
+    p = Platform("xmpp")
+    assert p.value == "xmpp"
+    assert Platform("xmpp") is p
+
+
+# ---------------------------------------------------------------------------
+# 2. check_requirements / validate_config / is_connected
+# ---------------------------------------------------------------------------
+
+def test_check_requirements_needs_credentials(monkeypatch):
+    monkeypatch.delenv("XMPP_JID", raising=False)
+    monkeypatch.delenv("XMPP_PASSWORD", raising=False)
+    assert check_requirements() is False
+
+    monkeypatch.setenv("XMPP_JID", "hermes@example.org")
+    assert check_requirements() is False  # password still missing
+
+
+def test_check_requirements_true_when_fully_configured(monkeypatch):
+    monkeypatch.setenv("XMPP_JID", "hermes@example.org")
+    monkeypatch.setenv("XMPP_PASSWORD", "secret")
+    try:
+        import slixmpp  # noqa: F401
+        slixmpp_present = True
+    except ImportError:
+        slixmpp_present = False
+    assert check_requirements() is slixmpp_present
+
+
+def test_validate_config_uses_env_or_extra(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    monkeypatch.delenv("XMPP_JID", raising=False)
+    monkeypatch.delenv("XMPP_PASSWORD", raising=False)
+    cfg = PlatformConfig(enabled=True)
+    assert validate_config(cfg) is False
+
+    cfg2 = PlatformConfig(enabled=True, extra={"jid": "hermes@example.org", "password": "secret"})
+    assert validate_config(cfg2) is True
+
+
+def test_is_connected_mirrors_validate(monkeypatch):
+    from gateway.config import PlatformConfig
+    monkeypatch.delenv("XMPP_JID", raising=False)
+    monkeypatch.delenv("XMPP_PASSWORD", raising=False)
+    cfg = PlatformConfig(enabled=True, extra={"jid": "x@x", "password": "y"})
+    assert is_connected(cfg) is True
+    assert is_connected(PlatformConfig(enabled=True)) is False
+
+
+# ---------------------------------------------------------------------------
+# 3. _env_enablement seeds PlatformConfig.extra
+# ---------------------------------------------------------------------------
+
+def test_env_enablement_none_when_unset(monkeypatch):
+    monkeypatch.delenv("XMPP_JID", raising=False)
+    monkeypatch.delenv("XMPP_PASSWORD", raising=False)
+    assert _env_enablement() is None
+
+
+def test_env_enablement_needs_password(monkeypatch):
+    monkeypatch.setenv("XMPP_JID", "hermes@example.org")
+    monkeypatch.delenv("XMPP_PASSWORD", raising=False)
+    assert _env_enablement() is None
+
+
+def test_env_enablement_seeds_minimal(monkeypatch):
+    monkeypatch.setenv("XMPP_JID", "hermes@example.org")
+    monkeypatch.setenv("XMPP_PASSWORD", "secret")
+    for var in ("XMPP_HOST", "XMPP_PORT", "XMPP_FORCE_STARTTLS",
+                "XMPP_NICKNAME", "XMPP_ROOMS", "XMPP_HOME_CHANNEL"):
+        monkeypatch.delenv(var, raising=False)
+    seed = _env_enablement()
+    assert seed == {"jid": "hermes@example.org"}
+
+
+def test_env_enablement_seeds_full(monkeypatch):
+    monkeypatch.setenv("XMPP_JID", "hermes@example.org")
+    monkeypatch.setenv("XMPP_PASSWORD", "secret")
+    monkeypatch.setenv("XMPP_HOST", "chat.example.org")
+    monkeypatch.setenv("XMPP_PORT", "5223")
+    monkeypatch.setenv("XMPP_FORCE_STARTTLS", "false")
+    monkeypatch.setenv("XMPP_NICKNAME", "h2")
+    monkeypatch.setenv("XMPP_ROOMS", "ops@conf, dev@conf")
+    monkeypatch.setenv("XMPP_HOME_CHANNEL", "alice@example.org")
+    monkeypatch.setenv("XMPP_HOME_CHANNEL_NAME", "Alice")
+
+    seed = _env_enablement()
+    assert seed["jid"] == "hermes@example.org"
+    assert seed["host"] == "chat.example.org"
+    assert seed["port"] == 5223
+    assert seed["force_starttls"] is False
+    assert seed["nickname"] == "h2"
+    assert seed["rooms"] == ["ops@conf", "dev@conf"]
+    assert seed["home_channel"] == {"chat_id": "alice@example.org", "name": "Alice"}
+
+
+def test_env_enablement_home_channel_defaults_name_to_id(monkeypatch):
+    monkeypatch.setenv("XMPP_JID", "hermes@example.org")
+    monkeypatch.setenv("XMPP_PASSWORD", "secret")
+    monkeypatch.setenv("XMPP_HOME_CHANNEL", "alice@example.org")
+    monkeypatch.delenv("XMPP_HOME_CHANNEL_NAME", raising=False)
+
+    seed = _env_enablement()
+    assert seed["home_channel"] == {
+        "chat_id": "alice@example.org",
+        "name": "alice@example.org",
+    }
+
+
+# ---------------------------------------------------------------------------
+# 4. Helper functions
+# ---------------------------------------------------------------------------
+
+def test_strip_resource():
+    assert _strip_resource("user@example.org/laptop") == "user@example.org"
+    assert _strip_resource("user@example.org") == "user@example.org"
+    assert _strip_resource("") == ""
+
+
+def test_strip_markdown_removes_basic_formatting():
+    out = _strip_markdown("**bold** *italic* `code` ~~strike~~")
+    assert "*" not in out
+    assert "`" not in out
+    assert "~~" not in out
+    assert "bold" in out and "italic" in out and "code" in out and "strike" in out
+
+
+def test_strip_markdown_keeps_link_target():
+    out = _strip_markdown("see [docs](https://example.org/x)")
+    assert "https://example.org/x" in out
+    assert "[" not in out
+
+
+def test_strip_markdown_strips_code_fences():
+    out = _strip_markdown("```python\nprint(1)\n```")
+    assert "```" not in out
+    assert "print(1)" in out
+
+
+def test_strip_control_chars_drops_null_and_normalizes_crlf():
+    out = _strip_control_chars("a\x00b\r\nc\rd")
+    assert "\x00" not in out
+    assert "\r" not in out
+    assert out == "ab\nc\nd"
+
+
+def test_split_message_short_returns_single_chunk():
+    chunks = _split_message("hello world", max_bytes=100)
+    assert chunks == ["hello world"]
+
+
+def test_split_message_long_paragraph_splits_under_limit():
+    para = "a" * 10_000
+    chunks = _split_message(para, max_bytes=500)
+    assert len(chunks) >= 20
+    for chunk in chunks:
+        assert len(chunk.encode("utf-8")) <= 500
+
+
+def test_split_message_multi_paragraph():
+    text = "para one\npara two"
+    chunks = _split_message(text, max_bytes=100)
+    assert chunks == ["para one", "para two"]
+
+
+def test_parse_bool_handles_strings_and_booleans():
+    assert _parse_bool("true", default=False) is True
+    assert _parse_bool("FALSE", default=True) is False
+    assert _parse_bool(None, default=True) is True
+    assert _parse_bool(True, default=False) is True
+
+
+def test_parse_comma_list_strips_and_drops_empty():
+    assert _parse_comma_list("a, b , ,c") == ["a", "b", "c"]
+    assert _parse_comma_list("") == []
+
+
+# ---------------------------------------------------------------------------
+# 5. Adapter init
+# ---------------------------------------------------------------------------
+
+def test_adapter_init_reads_extra(monkeypatch):
+    from gateway.config import PlatformConfig
+    for var in ("XMPP_JID", "XMPP_PASSWORD", "XMPP_HOST", "XMPP_PORT",
+                "XMPP_FORCE_STARTTLS", "XMPP_NICKNAME", "XMPP_ROOMS"):
+        monkeypatch.delenv(var, raising=False)
+
+    cfg = PlatformConfig(enabled=True, extra={
+        "jid": "hermes@example.org",
+        "password": "s3cret",
+        "host": "chat.example.org",
+        "port": 5223,
+        "force_starttls": False,
+        "nickname": "h",
+        "rooms": "ops@conf, dev@conf",
+    })
+    adapter = XMPPAdapter(cfg)
+    assert adapter.jid == "hermes@example.org"
+    assert adapter.host == "chat.example.org"
+    assert adapter.port == 5223
+    assert adapter.force_starttls is False
+    assert adapter.nickname == "h"
+    assert adapter.rooms == ["ops@conf", "dev@conf"]
+
+
+def test_adapter_init_env_overrides_extra(monkeypatch):
+    from gateway.config import PlatformConfig
+    monkeypatch.setenv("XMPP_JID", "env@example.org")
+    monkeypatch.setenv("XMPP_PASSWORD", "envpass")
+    monkeypatch.setenv("XMPP_PORT", "5223")
+    monkeypatch.setenv("XMPP_FORCE_STARTTLS", "false")
+
+    cfg = PlatformConfig(enabled=True, extra={
+        "jid": "extra@example.org",
+        "password": "xpass",
+        "port": 5222,
+        "force_starttls": True,
+    })
+    adapter = XMPPAdapter(cfg)
+    assert adapter.jid == "env@example.org"
+    assert adapter.password == "envpass"
+    assert adapter.port == 5223
+    assert adapter.force_starttls is False
+
+
+def test_adapter_init_defaults(monkeypatch):
+    from gateway.config import PlatformConfig
+    for var in ("XMPP_JID", "XMPP_PASSWORD", "XMPP_HOST", "XMPP_PORT",
+                "XMPP_FORCE_STARTTLS", "XMPP_NICKNAME", "XMPP_ROOMS"):
+        monkeypatch.delenv(var, raising=False)
+
+    cfg = PlatformConfig(enabled=True, extra={"jid": "bot@example.org", "password": "x"})
+    adapter = XMPPAdapter(cfg)
+    assert adapter.port == 5222
+    assert adapter.force_starttls is True
+    assert adapter.host is None
+    assert adapter.nickname == "bot"  # local part of the JID
+    assert adapter.rooms == []
+
+
+def test_adapter_init_invalid_port_falls_back(monkeypatch):
+    from gateway.config import PlatformConfig
+    monkeypatch.delenv("XMPP_PORT", raising=False)
+    cfg = PlatformConfig(enabled=True, extra={"jid": "x@x", "password": "y", "port": "not-a-port"})
+    adapter = XMPPAdapter(cfg)
+    assert adapter.port == 5222
+
+
+def test_adapter_platform_identity():
+    from gateway.config import Platform, PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"jid": "x@x", "password": "y"})
+    adapter = XMPPAdapter(cfg)
+    assert adapter.platform is Platform("xmpp")
+
+
+def test_resolve_target_dm():
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"jid": "x@x", "password": "y"})
+    adapter = XMPPAdapter(cfg)
+    target, mtype = adapter._resolve_target("alice@example.org")
+    assert target == "alice@example.org"
+    assert mtype == "chat"
+
+
+def test_resolve_target_muc():
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"jid": "x@x", "password": "y"})
+    adapter = XMPPAdapter(cfg)
+    target, mtype = adapter._resolve_target(f"{MUC_PREFIX}ops@conf.example.org")
+    assert target == "ops@conf.example.org"
+    assert mtype == "groupchat"
+
+
+def test_resolve_target_empty():
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"jid": "x@x", "password": "y"})
+    adapter = XMPPAdapter(cfg)
+    target, mtype = adapter._resolve_target("")
+    assert target == ""
+    assert mtype == "chat"
+
+
+# ---------------------------------------------------------------------------
+# 6. Outbound send (mocked client)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_send_dm_calls_send_message():
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"jid": "bot@x", "password": "y"})
+    adapter = XMPPAdapter(cfg)
+    adapter._client = MagicMock()
+
+    result = await adapter.send("alice@example.org", "**hi**")
+    assert result.success is True
+    adapter._client.send_message.assert_called_once()
+    kwargs = adapter._client.send_message.call_args.kwargs
+    assert kwargs["mto"] == "alice@example.org"
+    assert kwargs["mtype"] == "chat"
+    assert "**" not in kwargs["mbody"]
+
+
+@pytest.mark.asyncio
+async def test_send_muc_uses_groupchat():
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"jid": "bot@x", "password": "y"})
+    adapter = XMPPAdapter(cfg)
+    adapter._client = MagicMock()
+
+    result = await adapter.send(f"{MUC_PREFIX}ops@conf", "hello")
+    assert result.success is True
+    kwargs = adapter._client.send_message.call_args.kwargs
+    assert kwargs["mto"] == "ops@conf"
+    assert kwargs["mtype"] == "groupchat"
+
+
+@pytest.mark.asyncio
+async def test_send_when_disconnected_returns_error():
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"jid": "bot@x", "password": "y"})
+    adapter = XMPPAdapter(cfg)
+    result = await adapter.send("alice@example.org", "hi")
+    assert result.success is False
+    assert "Not connected" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_send_empty_body_after_strip_succeeds_without_call():
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"jid": "bot@x", "password": "y"})
+    adapter = XMPPAdapter(cfg)
+    adapter._client = MagicMock()
+
+    result = await adapter.send("alice@example.org", "\x00 \r\n  ")
+    assert result.success is True
+    adapter._client.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_splits_long_message():
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"jid": "bot@x", "password": "y", "max_message_length": 100})
+    adapter = XMPPAdapter(cfg)
+    adapter._client = MagicMock()
+
+    body = "lorem ipsum " * 50
+    result = await adapter.send("alice@example.org", body)
+    assert result.success is True
+    assert adapter._client.send_message.call_count >= 2
+
+
+# ---------------------------------------------------------------------------
+# 7. get_chat_info
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_chat_info_dm():
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"jid": "bot@x", "password": "y"})
+    adapter = XMPPAdapter(cfg)
+    info = await adapter.get_chat_info("alice@example.org")
+    assert info["type"] == "dm"
+    assert info["chat_id"] == "alice@example.org"
+
+
+@pytest.mark.asyncio
+async def test_get_chat_info_muc():
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"jid": "bot@x", "password": "y"})
+    adapter = XMPPAdapter(cfg)
+    info = await adapter.get_chat_info(f"{MUC_PREFIX}ops@conf")
+    assert info["type"] == "group"
+    assert info["name"] == "ops@conf"
+
+
+# ---------------------------------------------------------------------------
+# 8. Inbound message dispatch
+# ---------------------------------------------------------------------------
+
+class _FakeMsg:
+    def __init__(self, *, mtype="chat", body="", frm="", mid="", mucnick=""):
+        self._data = {
+            "type": mtype,
+            "body": body,
+            "from": frm,
+            "id": mid,
+            "mucnick": mucnick,
+        }
+
+    def __getitem__(self, key):
+        return self._data.get(key, "")
+
+    def get(self, key, default=None):
+        v = self._data.get(key)
+        return v if v else default
+
+
+@pytest.mark.asyncio
+async def test_on_message_dispatches_chat():
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"jid": "bot@example.org", "password": "y"})
+    adapter = XMPPAdapter(cfg)
+    adapter.handle_message = AsyncMock()
+    adapter._message_handler = lambda evt: None
+
+    msg = _FakeMsg(mtype="chat", body="hello", frm="alice@example.org/laptop", mid="m1")
+    await adapter._on_message(msg)
+    assert adapter.handle_message.await_count == 1
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "hello"
+    assert event.source.chat_id == "alice@example.org"
+    assert event.source.chat_type == "dm"
+
+
+@pytest.mark.asyncio
+async def test_on_message_ignores_wrong_type():
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"jid": "bot@x", "password": "y"})
+    adapter = XMPPAdapter(cfg)
+    adapter.handle_message = AsyncMock()
+    adapter._message_handler = lambda evt: None
+
+    await adapter._on_message(_FakeMsg(mtype="error", body="oops", frm="alice@x"))
+    await adapter._on_message(_FakeMsg(mtype="groupchat", body="hi", frm="ops@conf"))
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_on_message_ignores_empty_body():
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"jid": "bot@x", "password": "y"})
+    adapter = XMPPAdapter(cfg)
+    adapter.handle_message = AsyncMock()
+    adapter._message_handler = lambda evt: None
+
+    await adapter._on_message(_FakeMsg(mtype="chat", body="", frm="alice@x"))
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_on_message_ignores_self_echo():
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"jid": "bot@example.org", "password": "y"})
+    adapter = XMPPAdapter(cfg)
+    adapter.handle_message = AsyncMock()
+    adapter._message_handler = lambda evt: None
+
+    await adapter._on_message(_FakeMsg(mtype="chat", body="hi", frm="bot@example.org/desk"))
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_on_groupchat_requires_addressed_prefix():
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"jid": "bot@example.org", "password": "y", "nickname": "hermes"})
+    adapter = XMPPAdapter(cfg)
+    adapter.handle_message = AsyncMock()
+    adapter._message_handler = lambda evt: None
+
+    # Not addressed → ignored
+    await adapter._on_groupchat_message(_FakeMsg(
+        mtype="groupchat", body="hello world", frm="ops@conf/alice", mucnick="alice",
+    ))
+    adapter.handle_message.assert_not_awaited()
+
+    # Addressed → dispatched and prefix stripped
+    await adapter._on_groupchat_message(_FakeMsg(
+        mtype="groupchat", body="hermes: status?", frm="ops@conf/alice", mucnick="alice",
+    ))
+    assert adapter.handle_message.await_count == 1
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "status?"
+    assert event.source.chat_id == f"{MUC_PREFIX}ops@conf"
+    assert event.source.chat_type == "group"
+    assert event.source.user_id == "alice"
+
+
+@pytest.mark.asyncio
+async def test_on_groupchat_ignores_own_nick():
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"jid": "bot@x", "password": "y", "nickname": "hermes"})
+    adapter = XMPPAdapter(cfg)
+    adapter.handle_message = AsyncMock()
+    adapter._message_handler = lambda evt: None
+
+    await adapter._on_groupchat_message(_FakeMsg(
+        mtype="groupchat", body="hermes: ping", frm="ops@conf/hermes", mucnick="hermes",
+    ))
+    adapter.handle_message.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# 9. Standalone (out-of-process) send for cron
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_standalone_send_missing_slixmpp(monkeypatch):
+    """When slixmpp is unimportable, return a clean error dict."""
+    import sys
+    saved = {name: sys.modules.pop(name)
+             for name in list(sys.modules) if name == "slixmpp" or name.startswith("slixmpp.")}
+    saved_meta = list(sys.meta_path)
+
+    class _Blocker:
+        @staticmethod
+        def find_spec(name, path=None, target=None):
+            if name == "slixmpp" or name.startswith("slixmpp."):
+                raise ImportError("slixmpp blocked for test")
+            return None
+
+    sys.meta_path.insert(0, _Blocker())
+    try:
+        pconfig = MagicMock()
+        pconfig.extra = {"jid": "bot@x", "password": "y"}
+        result = await _standalone_send(pconfig, "alice@x", "hi")
+        assert isinstance(result, dict)
+        assert "error" in result
+        assert "slixmpp" in result["error"].lower()
+    finally:
+        sys.meta_path[:] = saved_meta
+        sys.modules.update(saved)
+
+
+@pytest.mark.asyncio
+async def test_standalone_send_missing_credentials(monkeypatch):
+    monkeypatch.delenv("XMPP_JID", raising=False)
+    monkeypatch.delenv("XMPP_PASSWORD", raising=False)
+    pconfig = MagicMock()
+    pconfig.extra = {}
+    try:
+        import slixmpp  # noqa: F401
+    except ImportError:
+        pytest.skip("slixmpp not installed")
+    result = await _standalone_send(pconfig, "alice@x", "hi")
+    assert isinstance(result, dict)
+    assert "error" in result
+    assert "XMPP_JID" in result["error"] or "required" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_standalone_send_rejects_injection_chars(monkeypatch):
+    monkeypatch.setenv("XMPP_JID", "bot@example.org")
+    monkeypatch.setenv("XMPP_PASSWORD", "secret")
+    try:
+        import slixmpp  # noqa: F401
+    except ImportError:
+        pytest.skip("slixmpp not installed")
+    pconfig = MagicMock()
+    pconfig.extra = {}
+    result = await _standalone_send(pconfig, "alice@x\nINJECT", "hi")
+    assert "error" in result
+    assert "illegal" in result["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# 10. register() — plugin-side metadata
+# ---------------------------------------------------------------------------
+
+def test_register_calls_register_platform():
+    ctx = MagicMock()
+    register(ctx)
+    ctx.register_platform.assert_called_once()
+    kwargs = ctx.register_platform.call_args.kwargs
+
+    assert kwargs["name"] == "xmpp"
+    assert kwargs["label"] == "XMPP"
+    assert kwargs["required_env"] == ["XMPP_JID", "XMPP_PASSWORD"]
+    assert kwargs["allowed_users_env"] == "XMPP_ALLOWED_USERS"
+    assert kwargs["allow_all_env"] == "XMPP_ALLOW_ALL_USERS"
+    assert kwargs["cron_deliver_env_var"] == "XMPP_HOME_CHANNEL"
+    assert kwargs["max_message_length"] == _xmpp.MAX_MESSAGE_LENGTH
+    assert kwargs["pii_safe"] is False
+    assert callable(kwargs["check_fn"])
+    assert callable(kwargs["validate_config"])
+    assert callable(kwargs["is_connected"])
+    assert callable(kwargs["env_enablement_fn"])
+    assert callable(kwargs["standalone_sender_fn"])
+    assert callable(kwargs["adapter_factory"])
+    assert callable(kwargs["setup_fn"])
+    assert "XMPP" in kwargs["platform_hint"]

--- a/tests/gateway/test_xmpp_plugin.py
+++ b/tests/gateway/test_xmpp_plugin.py
@@ -30,7 +30,75 @@ _strip_control_chars = _xmpp._strip_control_chars
 _split_message = _xmpp._split_message
 _parse_bool = _xmpp._parse_bool
 _parse_comma_list = _xmpp._parse_comma_list
+_markdown_to_xhtml_im = _xmpp._markdown_to_xhtml_im
+_markdown_to_xhtml_im_fallback = _xmpp._markdown_to_xhtml_im_fallback
+_html_escape = _xmpp._html_escape
+_sanitize_link_url = _xmpp._sanitize_link_url
+_content_type_for = _xmpp._content_type_for
+_UploadUnavailable = _xmpp._UploadUnavailable
 MUC_PREFIX = _xmpp.MUC_PREFIX
+
+
+class _FakeStanza:
+    """Minimal slixmpp stanza stand-in that records ``stanza['html']['body']``."""
+
+    class _Slot:
+        def __init__(self, parent: "_FakeStanza", key: str):
+            self._parent = parent
+            self._key = key
+
+        def __setitem__(self, k, v):
+            if self._key == "html" and k == "body":
+                self._parent._html_body = v
+            elif self._key == "oob" and k == "url":
+                self._parent._oob_url = v
+
+        def __getitem__(self, k):  # pragma: no cover - not used by adapter
+            return None
+
+    def __init__(self, mto: str, mbody: str, mtype: str):
+        self.mto = mto
+        self.mbody = mbody
+        self.mtype = mtype
+        self._html_body = None
+        self._oob_url = None
+        self._sent = False
+        self._sent_by: list = []
+
+    def __getitem__(self, key):
+        return _FakeStanza._Slot(self, key)
+
+    def send(self):
+        self._sent = True
+        self._sent_by.append(self)
+
+
+def _make_mock_client(*, has_html: bool = False):
+    """Build a MagicMock that mirrors slixmpp's surface for tests.
+
+    The adapter calls ``client.make_message(mto=, mbody=, mtype=).send()``
+    (returning the stanza for ``stanza["html"]["body"]`` assignment), and
+    consults ``"xep_0071" in client.plugin`` to decide whether to attach
+    XHTML-IM.
+    """
+    client = MagicMock()
+    client.plugin = {"xep_0071": MagicMock()} if has_html else {}
+    sent_stanzas: list = []
+
+    def _make_message(*, mto, mbody, mtype, **_kwargs):
+        stanza = _FakeStanza(mto=mto, mbody=mbody, mtype=mtype)
+        original_send = stanza.send
+
+        def _record():
+            sent_stanzas.append(stanza)
+            return original_send()
+
+        stanza.send = _record  # type: ignore[assignment]
+        return stanza
+
+    client.make_message.side_effect = _make_message
+    client._sent_stanzas = sent_stanzas
+    return client
 
 
 # ---------------------------------------------------------------------------
@@ -327,19 +395,19 @@ def test_resolve_target_empty():
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_send_dm_calls_send_message():
+async def test_send_dm_strips_markdown_in_body():
     from gateway.config import PlatformConfig
     cfg = PlatformConfig(enabled=True, extra={"jid": "bot@x", "password": "y"})
     adapter = XMPPAdapter(cfg)
-    adapter._client = MagicMock()
+    adapter._client = _make_mock_client()
 
     result = await adapter.send("alice@example.org", "**hi**")
     assert result.success is True
-    adapter._client.send_message.assert_called_once()
-    kwargs = adapter._client.send_message.call_args.kwargs
-    assert kwargs["mto"] == "alice@example.org"
-    assert kwargs["mtype"] == "chat"
-    assert "**" not in kwargs["mbody"]
+    sent = adapter._client._sent_stanzas
+    assert len(sent) == 1
+    assert sent[0].mto == "alice@example.org"
+    assert sent[0].mtype == "chat"
+    assert "**" not in sent[0].mbody
 
 
 @pytest.mark.asyncio
@@ -347,13 +415,13 @@ async def test_send_muc_uses_groupchat():
     from gateway.config import PlatformConfig
     cfg = PlatformConfig(enabled=True, extra={"jid": "bot@x", "password": "y"})
     adapter = XMPPAdapter(cfg)
-    adapter._client = MagicMock()
+    adapter._client = _make_mock_client()
 
     result = await adapter.send(f"{MUC_PREFIX}ops@conf", "hello")
     assert result.success is True
-    kwargs = adapter._client.send_message.call_args.kwargs
-    assert kwargs["mto"] == "ops@conf"
-    assert kwargs["mtype"] == "groupchat"
+    sent = adapter._client._sent_stanzas
+    assert sent[0].mto == "ops@conf"
+    assert sent[0].mtype == "groupchat"
 
 
 @pytest.mark.asyncio
@@ -371,11 +439,11 @@ async def test_send_empty_body_after_strip_succeeds_without_call():
     from gateway.config import PlatformConfig
     cfg = PlatformConfig(enabled=True, extra={"jid": "bot@x", "password": "y"})
     adapter = XMPPAdapter(cfg)
-    adapter._client = MagicMock()
+    adapter._client = _make_mock_client()
 
     result = await adapter.send("alice@example.org", "\x00 \r\n  ")
     assert result.success is True
-    adapter._client.send_message.assert_not_called()
+    assert adapter._client.make_message.call_count == 0
 
 
 @pytest.mark.asyncio
@@ -383,12 +451,72 @@ async def test_send_splits_long_message():
     from gateway.config import PlatformConfig
     cfg = PlatformConfig(enabled=True, extra={"jid": "bot@x", "password": "y", "max_message_length": 100})
     adapter = XMPPAdapter(cfg)
-    adapter._client = MagicMock()
+    adapter._client = _make_mock_client()
 
     body = "lorem ipsum " * 50
     result = await adapter.send("alice@example.org", body)
     assert result.success is True
-    assert adapter._client.send_message.call_count >= 2
+    assert len(adapter._client._sent_stanzas) >= 2
+
+
+@pytest.mark.asyncio
+async def test_send_emits_xhtml_im_for_single_chunk():
+    """Single-chunk markdown messages should carry both <body> and <html>."""
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"jid": "bot@x", "password": "y"})
+    adapter = XMPPAdapter(cfg)
+    adapter._client = _make_mock_client(has_html=True)
+
+    result = await adapter.send("alice@example.org", "**hello** _world_")
+    assert result.success is True
+    sent = adapter._client._sent_stanzas
+    assert len(sent) == 1
+    assert sent[0]._html_body, "single-chunk markdown should set the html body"
+    assert "<strong>" in sent[0]._html_body or "<b>" in sent[0]._html_body
+
+
+@pytest.mark.asyncio
+async def test_send_skips_xhtml_im_when_no_formatting():
+    """Plain text messages should not waste bytes on an empty <html> block."""
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"jid": "bot@x", "password": "y"})
+    adapter = XMPPAdapter(cfg)
+    adapter._client = _make_mock_client(has_html=True)
+
+    result = await adapter.send("alice@example.org", "plain text reply")
+    assert result.success is True
+    sent = adapter._client._sent_stanzas
+    assert sent[0]._html_body in (None, "")
+
+
+@pytest.mark.asyncio
+async def test_send_skips_xhtml_im_on_multi_chunk():
+    """Chunked sends should fall through to plain text only."""
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"jid": "bot@x", "password": "y", "max_message_length": 80})
+    adapter = XMPPAdapter(cfg)
+    adapter._client = _make_mock_client(has_html=True)
+
+    result = await adapter.send("alice@example.org", "**bold** " + ("lorem " * 30))
+    assert result.success is True
+    sent = adapter._client._sent_stanzas
+    assert len(sent) >= 2
+    for stanza in sent:
+        assert stanza._html_body in (None, "")
+
+
+@pytest.mark.asyncio
+async def test_send_respects_html_formatting_disabled():
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={
+        "jid": "bot@x", "password": "y", "html_formatting": False,
+    })
+    adapter = XMPPAdapter(cfg)
+    adapter._client = _make_mock_client(has_html=True)
+
+    result = await adapter.send("alice@example.org", "**hi**")
+    assert result.success is True
+    assert adapter._client._sent_stanzas[0]._html_body in (None, "")
 
 
 # ---------------------------------------------------------------------------
@@ -620,3 +748,206 @@ def test_register_calls_register_platform():
     assert callable(kwargs["adapter_factory"])
     assert callable(kwargs["setup_fn"])
     assert "XMPP" in kwargs["platform_hint"]
+    # Adapter advertises media support via XEP-0363; the hint should
+    # tell the agent it can emit MEDIA: tags.
+    assert "MEDIA" in kwargs["platform_hint"]
+
+
+# ---------------------------------------------------------------------------
+# 11. XHTML-IM (XEP-0071) helpers
+# ---------------------------------------------------------------------------
+
+def test_html_escape_basic():
+    assert _html_escape("<a>&\"x") == "&lt;a&gt;&amp;&quot;x"
+
+
+def test_sanitize_link_url_rejects_dangerous_schemes():
+    assert _sanitize_link_url("javascript:alert(1)") == ""
+    assert _sanitize_link_url("DATA:text/html,<script>") == ""
+    assert _sanitize_link_url("vbscript:msgbox") == ""
+    assert _sanitize_link_url("https://example.org/x") == "https://example.org/x"
+
+
+def test_markdown_to_xhtml_im_bold_italic_code():
+    html = _markdown_to_xhtml_im("**bold** _italic_ `code`")
+    assert "bold" in html and "italic" in html and "code" in html
+    assert "<strong>" in html or "<b>" in html
+    assert "<em>" in html or "<i>" in html
+    assert "<code>" in html
+
+
+def test_markdown_to_xhtml_im_link():
+    html = _markdown_to_xhtml_im("see [docs](https://example.org/x)")
+    assert "<a href=\"https://example.org/x\">" in html
+    assert ">docs</a>" in html
+
+
+def test_markdown_to_xhtml_im_escapes_html_in_code():
+    html = _markdown_to_xhtml_im("`<script>alert(1)</script>`")
+    assert "&lt;script&gt;" in html
+    assert "<script>" not in html
+
+
+def test_markdown_to_xhtml_im_fenced_code_block():
+    html = _markdown_to_xhtml_im("```python\nprint('hi')\n```")
+    assert "<pre>" in html
+    # The python ``markdown`` library may emit ``<code class="language-…">``;
+    # the regex fallback emits a bare ``<code>``. Both are valid XHTML-IM.
+    assert "<code" in html
+    assert "print" in html
+
+
+def test_markdown_to_xhtml_im_empty_returns_empty():
+    assert _markdown_to_xhtml_im("") == ""
+    assert _markdown_to_xhtml_im("   ").strip() == ""
+
+
+def test_markdown_to_xhtml_im_fallback_path_explicit():
+    """The fallback path must produce a usable subset even without the
+    optional ``markdown`` package available at import time."""
+    html = _markdown_to_xhtml_im_fallback("**a** [x](https://y/) `<b>`")
+    assert "<strong>" in html
+    assert "<a href=\"https://y/\">" in html
+    assert "&lt;b&gt;" in html
+
+
+# ---------------------------------------------------------------------------
+# 12. HTTP Upload (XEP-0363)
+# ---------------------------------------------------------------------------
+
+def test_content_type_for_known_extensions():
+    assert _content_type_for("/tmp/x.png") == "image/png"
+    assert _content_type_for("/tmp/x.jpg") == "image/jpeg"
+    assert _content_type_for("/tmp/x.ogg") == "audio/ogg"
+    assert _content_type_for("/tmp/x.mp4") == "video/mp4"
+    assert _content_type_for("/tmp/x.pdf") == "application/pdf"
+    assert _content_type_for("/tmp/x.weirdext") == "application/octet-stream"
+    assert _content_type_for("/tmp/no-extension") == "application/octet-stream"
+
+
+@pytest.mark.asyncio
+async def test_send_image_url_uses_oob_for_https():
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"jid": "bot@x", "password": "y"})
+    adapter = XMPPAdapter(cfg)
+    adapter._client = _make_mock_client()
+
+    result = await adapter.send_image("alice@example.org", "https://example.org/cat.png", caption="look")
+    assert result.success is True
+    sent = adapter._client._sent_stanzas
+    assert "https://example.org/cat.png" in sent[0].mbody
+    assert "look" in sent[0].mbody
+
+
+@pytest.mark.asyncio
+async def test_upload_then_send_falls_back_when_no_service(tmp_path):
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"jid": "bot@x", "password": "y"})
+    adapter = XMPPAdapter(cfg)
+    adapter._client = _make_mock_client()
+    adapter._upload_service_resolved = False  # no upload component on the server
+
+    img = tmp_path / "cat.png"
+    img.write_bytes(b"\x89PNG\r\n\x1a\nfake")
+
+    result = await adapter._upload_then_send("alice@example.org", str(img), caption="cute")
+    assert result.success is True
+    sent = adapter._client._sent_stanzas
+    assert any("cat.png" in s.mbody for s in sent)
+    assert any("upload failed" in s.mbody for s in sent)
+
+
+@pytest.mark.asyncio
+async def test_upload_then_send_rejects_missing_file():
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"jid": "bot@x", "password": "y"})
+    adapter = XMPPAdapter(cfg)
+    adapter._client = _make_mock_client()
+
+    result = await adapter._upload_then_send("alice@x", "/tmp/does-not-exist.png")
+    assert result.success is False
+    assert "not found" in (result.error or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_upload_then_send_emits_oob_url_on_success(tmp_path):
+    """Mock the slixmpp upload plugin and verify the resulting send."""
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"jid": "bot@x", "password": "y"})
+    adapter = XMPPAdapter(cfg)
+    adapter._client = _make_mock_client()
+
+    img = tmp_path / "cat.png"
+    img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"x" * 64)
+
+    upload_plugin = MagicMock()
+    upload_plugin.upload_file = AsyncMock(return_value="https://uploads.example.org/cat.png")
+    adapter._client.plugin = {"xep_0363": upload_plugin}
+    adapter._upload_service_resolved = "uploads.example.org"
+
+    result = await adapter._upload_then_send("alice@example.org", str(img), caption="cute")
+    assert result.success is True
+    upload_plugin.upload_file.assert_awaited_once()
+    sent = adapter._client._sent_stanzas
+    assert "https://uploads.example.org/cat.png" in sent[0].mbody
+    assert "cute" in sent[0].mbody
+
+
+@pytest.mark.asyncio
+async def test_upload_file_raises_unavailable_when_service_missing():
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"jid": "bot@x", "password": "y"})
+    adapter = XMPPAdapter(cfg)
+    adapter._client = _make_mock_client()
+    adapter._upload_service_resolved = False
+
+    with pytest.raises(_UploadUnavailable):
+        await adapter._upload_file("/tmp/anything.png")
+
+
+@pytest.mark.asyncio
+async def test_resolve_upload_service_pinned_skips_discovery(monkeypatch):
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={
+        "jid": "bot@x", "password": "y", "upload_service": "uploads.example.org",
+    })
+    adapter = XMPPAdapter(cfg)
+    adapter._client = MagicMock()
+    # find_upload_service should not be called when the operator pins one
+    upload_plugin = MagicMock()
+    upload_plugin.find_upload_service = AsyncMock()
+    adapter._client.plugin = {"xep_0363": upload_plugin}
+
+    await adapter._resolve_upload_service()
+    upload_plugin.find_upload_service.assert_not_awaited()
+    assert adapter._upload_service_resolved == "uploads.example.org"
+
+
+# ---------------------------------------------------------------------------
+# 13. New env-vars surface via _env_enablement
+# ---------------------------------------------------------------------------
+
+def test_env_enablement_seeds_upload_and_html_keys(monkeypatch):
+    monkeypatch.setenv("XMPP_JID", "bot@example.org")
+    monkeypatch.setenv("XMPP_PASSWORD", "secret")
+    monkeypatch.setenv("XMPP_UPLOAD_SERVICE", "uploads.example.org")
+    monkeypatch.setenv("XMPP_HTML_FORMATTING", "false")
+
+    seed = _env_enablement()
+    assert seed["upload_service"] == "uploads.example.org"
+    assert seed["html_formatting"] is False
+
+
+def test_adapter_init_reads_new_keys(monkeypatch):
+    from gateway.config import PlatformConfig
+    for v in ("XMPP_UPLOAD_SERVICE", "XMPP_HTML_FORMATTING"):
+        monkeypatch.delenv(v, raising=False)
+
+    cfg = PlatformConfig(enabled=True, extra={
+        "jid": "bot@x", "password": "y",
+        "upload_service": "uploads.x.org",
+        "html_formatting": False,
+    })
+    adapter = XMPPAdapter(cfg)
+    assert adapter.upload_service == "uploads.x.org"
+    assert adapter.html_formatting is False

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -483,6 +483,24 @@ Used by the bundled LINE platform plugin (`plugins/platforms/line/`). See [Messa
 | `LINE_DELIVERED_TEXT` | Reply when an already-delivered postback is tapped again (default: `Already replied ✅`). |
 | `LINE_INTERRUPTED_TEXT` | Reply when a `/stop`-orphaned postback button is tapped (default: `Run was interrupted before completion.`). |
 
+### XMPP
+
+Used by the bundled XMPP platform plugin (`plugins/platforms/xmpp/`). See [Messaging Gateway → XMPP](/docs/user-guide/messaging/xmpp) for full setup.
+
+| Variable | Description |
+|----------|-------------|
+| `XMPP_JID` | Bare JID the bot logs in as (e.g. `hermes@chat.example.org`). Required. |
+| `XMPP_PASSWORD` | Password for the bot account. Required. |
+| `XMPP_HOST` | Server host override. Default: SRV lookup on the JID domain. |
+| `XMPP_PORT` | Server port override. Default: `5222`. |
+| `XMPP_FORCE_STARTTLS` | Require STARTTLS. Default: `true`. Set `false` only for trusted dev servers on loopback. |
+| `XMPP_NICKNAME` | MUC nickname. Default: the JID's local part. |
+| `XMPP_ROOMS` | Comma-separated MUC JIDs to auto-join. |
+| `XMPP_ALLOWED_USERS` | Comma-separated bare JIDs allowed to DM the bot. |
+| `XMPP_ALLOW_ALL_USERS` | Dev-only escape hatch — accepts any JID. Default: `false`. |
+| `XMPP_HOME_CHANNEL` | Default delivery target for cron jobs with `deliver: xmpp`. Prefix MUC targets with `muc:`. |
+| `XMPP_HOME_CHANNEL_NAME` | Human label for the home channel. |
+
 ### Advanced Messaging Tuning
 
 Advanced per-platform knobs for throttling the outbound message batcher. Most users never need to touch these; defaults are set to respect each platform's rate limits without feeling sluggish.

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -500,6 +500,8 @@ Used by the bundled XMPP platform plugin (`plugins/platforms/xmpp/`). See [Messa
 | `XMPP_ALLOW_ALL_USERS` | Dev-only escape hatch — accepts any JID. Default: `false`. |
 | `XMPP_HOME_CHANNEL` | Default delivery target for cron jobs with `deliver: xmpp`. Prefix MUC targets with `muc:`. |
 | `XMPP_HOME_CHANNEL_NAME` | Human label for the home channel. |
+| `XMPP_UPLOAD_SERVICE` | Pin the XEP-0363 HTTP Upload component JID. Default: auto-discover on session start. |
+| `XMPP_HTML_FORMATTING` | Emit XEP-0071 XHTML-IM dual body so clients that opt in render bold/italic/code/links/lists. Default: `true`. |
 
 ### Advanced Messaging Tuning
 

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -544,5 +544,6 @@ Defaults to `false`. Only platforms whose adapter implements `delete_message` ho
 - [Yuanbao Setup](yuanbao.md)
 - [Microsoft Teams Setup](teams.md)
 - [Teams Meetings Pipeline](teams-meetings.md)
+- [XMPP Setup](xmpp.md)
 - [Open WebUI + API Server](open-webui.md)
 - [Webhooks](webhooks.md)

--- a/website/docs/user-guide/messaging/xmpp.md
+++ b/website/docs/user-guide/messaging/xmpp.md
@@ -42,6 +42,8 @@ XMPP_HOME_CHANNEL=alice@example.org
 | `XMPP_ALLOW_ALL_USERS` | No | Set `true` to disable the allowlist (dev only) |
 | `XMPP_HOME_CHANNEL` | No | Default JID for cron delivery (prefix MUC targets with `muc:`) |
 | `XMPP_HOME_CHANNEL_NAME` | No | Human label for the home channel |
+| `XMPP_UPLOAD_SERVICE` | No | Pin the HTTP Upload component JID. Default: auto-discover |
+| `XMPP_HTML_FORMATTING` | No | Emit XHTML-IM dual body for rich rendering. Default: `true` |
 
 ## Run a local Prosody for testing
 
@@ -91,11 +93,31 @@ send_message(target="xmpp:alice@example.org", message="Done!")
 send_message(target="xmpp:muc:ops@conference.example.org", message="Deploy finished.")
 ```
 
+## Media attachments (HTTP Upload, XEP-0363)
+
+When the agent emits `MEDIA:/absolute/path/to/file`, the adapter uploads the file to the server's HTTP Upload component (auto-discovered on connect, or pinned via `XMPP_UPLOAD_SERVICE`) and delivers the resulting HTTPS URL as a stanza with an XEP-0066 OOB extension. XMPP clients that understand OOB (Conversations, Dino, Gajim, Profanity) render the file inline; clients that don't still see the URL in the message body and can tap through.
+
+Requirements:
+
+- The server needs an HTTP Upload component. Prosody enables it with `Component "uploads.example.org" "http_file_share"` in `prosody.cfg.lua`. ejabberd ships `mod_http_upload`.
+- The file must be reachable to the bot's local filesystem at the absolute path the agent emitted. The adapter rejects relative paths and missing files before contacting the server.
+- The file must fit under the server's advertised upload size limit. Larger files arrive as a plain-text "📎 filename (upload failed: …)" line, with the reason logged in `gateway.log`.
+
+Disable file uploads entirely with `XMPP_UPLOAD_SERVICE=disabled` (any unreachable JID also works) — the adapter then falls back to text-only attachments for every media send.
+
+## Rich text (XHTML-IM, XEP-0071)
+
+Markdown in the agent's response is sent in two parallel forms:
+
+- `<body>` — markdown stripped to plain text, for clients that read only the body.
+- `<html>` — an XHTML-IM fragment with `<strong>`, `<em>`, `<code>`, `<pre>`, `<a>`, `<ul>`, `<ol>`, and `<blockquote>`, for clients that opt in to XEP-0071.
+
+Dual-body emission only happens for messages that fit in a single stanza; chunked responses fall back to plain text because splitting XHTML across stanzas produces invalid fragments most clients reject. Set `XMPP_HTML_FORMATTING=false` to opt out entirely (some MUC components strip the `<html>` element and dual-body looks redundant in that case).
+
 ## Limitations
 
-- **No native media delivery.** XMPP HTTP Upload (XEP-0363) is not wired in; the adapter sends image URLs and file paths as text. Tell the agent to describe attachments in plain text rather than emitting `MEDIA:` tags.
-- **Plain text only.** Markdown in the agent's response is stripped before sending — most clients render the body verbatim, and XHTML-IM (XEP-0071) is not emitted.
 - **OMEMO / OpenPGP encryption is not handled by the adapter.** Use a server you trust and STARTTLS for transport security; end-to-end encryption requires a client that speaks OMEMO and is out of scope here.
+- **Image preview for HTTP URLs:** the adapter sets the OOB extension for `https://` URLs the agent emits inline via markdown (`![alt](url)`); plain `http://` URLs are *not* OOB-flagged to keep tappable links from auto-rendering as attachments on hostile pages.
 
 ## Troubleshooting
 

--- a/website/docs/user-guide/messaging/xmpp.md
+++ b/website/docs/user-guide/messaging/xmpp.md
@@ -1,0 +1,108 @@
+# XMPP
+
+[XMPP](https://xmpp.org/) (Extensible Messaging and Presence Protocol) is an open, federated chat protocol. Hermes connects to any XMPP server, hosted or self-hosted, including [Prosody](https://prosody.im/) and [ejabberd](https://www.ejabberd.im/), and relays messages between XMPP contacts or MUC rooms and the agent.
+
+## Prerequisites
+
+- An XMPP account on a server you control or have access to (the bot logs in with its own JID and password)
+- Python package **slixmpp** (`pip install slixmpp`)
+
+## Configure Hermes
+
+### Via setup wizard
+
+```bash
+hermes setup gateway
+```
+
+Select **XMPP** and follow the prompts.
+
+### Via environment variables
+
+Add these to `~/.hermes/.env`:
+
+```
+XMPP_JID=hermes@chat.example.org
+XMPP_PASSWORD=********
+XMPP_ALLOWED_USERS=alice@example.org,bob@example.org
+XMPP_ROOMS=ops@conference.example.org
+XMPP_HOME_CHANNEL=alice@example.org
+```
+
+| Variable | Required | Description |
+|---|---|---|
+| `XMPP_JID` | Yes | Bare JID the bot logs in as |
+| `XMPP_PASSWORD` | Yes | Password for that account |
+| `XMPP_HOST` | No | Server host override. Default: SRV lookup on the JID domain |
+| `XMPP_PORT` | No | Server port override. Default: `5222` |
+| `XMPP_FORCE_STARTTLS` | No | Require STARTTLS. Default: `true` |
+| `XMPP_NICKNAME` | No | MUC nickname. Default: the JID's local part |
+| `XMPP_ROOMS` | No | Comma-separated MUC JIDs to auto-join |
+| `XMPP_ALLOWED_USERS` | Recommended | Comma-separated bare JIDs allowed to DM the bot |
+| `XMPP_ALLOW_ALL_USERS` | No | Set `true` to disable the allowlist (dev only) |
+| `XMPP_HOME_CHANNEL` | No | Default JID for cron delivery (prefix MUC targets with `muc:`) |
+| `XMPP_HOME_CHANNEL_NAME` | No | Human label for the home channel |
+
+## Run a local Prosody for testing
+
+[Prosody](https://prosody.im/) is the simplest self-hosted server to try the integration against.
+
+```bash
+docker run -d --name prosody \
+  -p 5222:5222 -p 5269:5269 -p 5280:5280 -p 5281:5281 \
+  -e LOCAL=hermes \
+  -e DOMAIN=localhost \
+  -e PASSWORD=hermes-dev-only \
+  prosody/prosody
+```
+
+Then set:
+
+```
+XMPP_JID=hermes@localhost
+XMPP_PASSWORD=hermes-dev-only
+XMPP_HOST=127.0.0.1
+XMPP_FORCE_STARTTLS=false
+```
+
+`XMPP_FORCE_STARTTLS=false` is acceptable on `localhost` for development. Leave it `true` for any non-loopback deployment.
+
+## Authorization
+
+By default **all JIDs are denied** — set `XMPP_ALLOWED_USERS` to the comma-separated bare JIDs that should be able to talk to the bot. Resources (the `/laptop` part of `alice@example.org/laptop`) are stripped before the allowlist check.
+
+For MUC rooms, the bot only replies when addressed by its nickname (e.g. `hermes: status?`). Unaddressed room chatter is ignored.
+
+## Cron delivery
+
+```python
+cronjob(
+    action="create",
+    schedule="every 1h",
+    deliver="xmpp",          # uses XMPP_HOME_CHANNEL
+    prompt="Summarise overnight alerts."
+)
+```
+
+Target a specific JID or MUC room directly:
+
+```python
+send_message(target="xmpp:alice@example.org", message="Done!")
+send_message(target="xmpp:muc:ops@conference.example.org", message="Deploy finished.")
+```
+
+## Limitations
+
+- **No native media delivery.** XMPP HTTP Upload (XEP-0363) is not wired in; the adapter sends image URLs and file paths as text. Tell the agent to describe attachments in plain text rather than emitting `MEDIA:` tags.
+- **Plain text only.** Markdown in the agent's response is stripped before sending — most clients render the body verbatim, and XHTML-IM (XEP-0071) is not emitted.
+- **OMEMO / OpenPGP encryption is not handled by the adapter.** Use a server you trust and STARTTLS for transport security; end-to-end encryption requires a client that speaks OMEMO and is out of scope here.
+
+## Troubleshooting
+
+**`'slixmpp' package not installed`** — Run `pip install slixmpp`.
+
+**Authentication failed** — Verify the JID and password by logging into the same account from any XMPP client (e.g. Gajim, Conversations, Dino).
+
+**Connect timed out** — Check `XMPP_HOST` and `XMPP_PORT`. If your server requires a non-default port (Snikket on 5223, etc.), set both. If your server has no SRV record, set `XMPP_HOST` explicitly.
+
+**Bot ignores room messages** — The bot only replies when addressed by its nickname. Send `hermes: hello` (replace `hermes` with `XMPP_NICKNAME` if you overrode it).


### PR DESCRIPTION
## What does this PR do?

Adds XMPP as a bundled platform plugin under `plugins/platforms/xmpp/`, giving Hermes feature parity with the other 1:1 messaging adapters (SimpleX, IRC, LINE, WhatsApp). The adapter requires zero core edits — slixmpp is imported lazily, `Platform("xmpp")` is auto-discovered via the bundled-plugin scan in `gateway/config.py`, and all hooks (setup, env-enablement, cron delivery, standalone send, allowlist) are wired through `register_platform()` kwargs the way the sibling plugins do it.

XMPP is an open, federated chat protocol. The plugin works against any self-hosted (Prosody, ejabberd, Snikket) or hosted server, supports 1:1 chats and MUC rooms, attaches files natively via XEP-0363 HTTP Upload, renders rich text via XEP-0071 XHTML-IM, and integrates with cron-job delivery and the `send_message` tool out of the box.

## Related Issue

No tracking issue; this is a new platform addition that matches an existing extension pattern.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/platforms/xmpp/adapter.py` — `XMPPAdapter`, env-enablement, standalone send, interactive setup, registration. slixmpp imported lazily. HTTP Upload via `xep_0363`, OOB hints via `xep_0066`, XHTML-IM via `xep_0071`.
- `plugins/platforms/xmpp/__init__.py` — re-exports `register`.
- `plugins/platforms/xmpp/plugin.yaml` — manifest with `requires_env` + `optional_env` entries surfaced by the config UI (including `XMPP_UPLOAD_SERVICE` and `XMPP_HTML_FORMATTING`).
- `tests/gateway/test_xmpp_plugin.py` — 66 unit tests covering enum discovery, requirements gating, env enablement, init paths, helpers, send routing, inbound dispatch (including own-echo / unaddressed-MUC filtering), XHTML-IM markdown conversion (including URL-scheme sanitization and HTML-escaping inside code spans), single-chunk vs multi-chunk dual-body behavior, HTTP Upload success + fallback paths, pinned-service shortcut, standalone send guards, and `register()` metadata.
- `website/docs/user-guide/messaging/xmpp.md` — full setup guide (Prosody quickstart, env vars, allowlist, HTTP Upload + XHTML-IM behavior, cron delivery, limitations).
- `website/docs/user-guide/messaging/index.md` — Next Steps link.
- `website/docs/reference/environment-variables.md` — XMPP_* var reference.
- `scripts/release.py` — author map entry for contributor email.

## Design

User-visible: operator sets `XMPP_JID`, `XMPP_PASSWORD`, `XMPP_ALLOWED_USERS` (and optionally `XMPP_ROOMS`) in `~/.hermes/.env`, runs `hermes gateway start`. 1:1 chats from allowlisted JIDs reach the agent; MUC messages reach the agent only when prefixed with the bot's nickname (`hermes: …`), matching IRC's convention. Cron jobs target this platform via `deliver=xmpp` or `send_message(target="xmpp:…")`. MUC targets use a `muc:` prefix in the routing surface.

The agent can emit markdown (rendered via XHTML-IM dual body for opt-in clients, with plain-text fallback for the rest) and `MEDIA:/path/to/file` (uploaded via XEP-0363 to the server's upload component, delivered with an XEP-0066 OOB extension so clients render the attachment inline). Servers without an upload component fall back to a clear "📎 filename (upload failed: …)" text line.

Alternatives considered:

1. **Hand-roll the XMPP stream on top of `asyncio.open_connection` + SSL** (IRC's approach). XMPP needs XML-stream/SASL/STARTTLS negotiation, stanza dispatch, MUC nick handling, presence and stream resumption — reimplementing that correctly is hundreds of lines of subtle protocol code and we'd own every CVE. Rejected.
2. **aioxmpp** — heavier, releases lagging, smaller user base than slixmpp.
3. **slixmpp** (chosen). Asyncio-native fork of SleekXMPP, BSD-licensed, used in production (poezio, gajim). Built-in support for XEP-0030, XEP-0045, XEP-0066, XEP-0071, XEP-0085, XEP-0199, XEP-0363 — everything the adapter needs with no third-party glue. Lazy-imported, so the plugin is discoverable even when the package is absent (the same `check_requirements()` gate SimpleX uses for `websockets`).

Edge cases covered: missing credentials → adapter never constructed; TLS disabled emits a warning at connect time; MUC self-echo filtered on `mucnick`; unaddressed room chatter ignored; auth allowlist strips JID resources before lookup; CR/LF/NUL rejected in standalone-send `chat_id`; profile isolation via `acquire_scoped_lock("xmpp", bare_jid)` so two profiles cannot share an account; control characters dropped from message bodies so the XML 1.0 serializer never chokes; HTTP Upload service discovery cached so per-send latency is one IQ + one HTTP PUT, with sticky text fallback on `UploadServiceNotFound` / `FileTooBig` / `HTTPError`; XHTML-IM only emitted for single-chunk responses (multi-chunk falls back to plain text to avoid splitting XHTML across stanzas); `javascript:` / `data:` / `vbscript:` URL schemes rejected by the link sanitizer.

Limitations (documented in the setup guide):

- **No end-to-end encryption.** OMEMO / OpenPGP are out of scope; use a trusted server and STARTTLS for transport security.
- **No inbound media handling yet.** Files attached to incoming messages are not auto-downloaded; this PR focuses on outbound media. A followup can wire `cache_image_from_url` into the OOB / stanza-extension parsers.

## How to Test

```bash
# Unit tests (66 cases)
scripts/run_tests.sh tests/gateway/test_xmpp_plugin.py

# Sibling-plugin regression sweep
scripts/run_tests.sh tests/gateway/test_xmpp_plugin.py \
                     tests/gateway/test_simplex_plugin.py \
                     tests/gateway/test_irc_adapter.py \
                     tests/gateway/test_line_plugin.py \
                     tests/gateway/test_platform_registry.py \
                     tests/hermes_cli/test_plugins.py
```

Manual E2E (against a local Prosody container):

```bash
docker run -d --name prosody -p 5222:5222 -e LOCAL=hermes \
  -e DOMAIN=localhost -e PASSWORD=hermes-dev-only prosody/prosody

cat >> ~/.hermes/.env <<'ENV'
XMPP_JID=hermes@localhost
XMPP_PASSWORD=hermes-dev-only
XMPP_HOST=127.0.0.1
XMPP_FORCE_STARTTLS=false
XMPP_ALLOWED_USERS=you@localhost
ENV

pip install slixmpp
hermes gateway start
```

Then DM the bot from any XMPP client (Dino, Gajim, Conversations) registered as `you@localhost`. Try sending markdown (`**bold**`) and ask the agent to share a file with `MEDIA:/path/to/file.png`.

## Backward compatibility

New platform — no public API, on-disk format, or wire-format changes. `Platform("xmpp")` was previously rejected by `_missing_()`; existing configurations are unaffected.

## Notes for reviewers

- **New dependency: `slixmpp`** (BSD, lazy-imported, no `pyproject.toml` addition). Matches the SimpleX/`websockets` pattern — the plugin is discoverable even when the package is absent. Users install it explicitly via the documented `pip install slixmpp`. The XEP-0363 and XEP-0071 wiring is all done through slixmpp's bundled XEP plugins, so no further deps either.
- The `XMPP_FORCE_STARTTLS` switch maps to slixmpp's `enable_starttls` and `enable_direct_tls` instance attributes. There is no true "refuse-plaintext" enforcement in slixmpp's public surface; the env name keeps continuity with operator expectations and the falsy path logs a warning. If you'd prefer a different name (`XMPP_USE_TLS` / `XMPP_TLS`), happy to rename.
- The MUC `muc:` chat-id prefix is plugin-local and only matters for the routing surface (`send_message`, `_resolve_target`). It does not leak into the platform wire format.
- Markdown→XHTML uses the `markdown` library when available (already pinned for the `matrix` extra) and falls back to a regex pipeline matching the pattern Matrix uses for `org.matrix.custom.html`.