### PR TITLE
feat(agent): add provider fallback telemetry helper

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -64,6 +64,16 @@ from utils import base_url_host_matches, base_url_hostname
 logger = logging.getLogger(__name__)
 
 
+def _append_provider_telemetry(event: dict) -> None:
+    """Best-effort provider telemetry bridge for hot fallback paths."""
+    try:
+        from agent.provider_telemetry import append_provider_event
+
+        append_provider_event(event)
+    except Exception:
+        logger.debug("provider telemetry bridge failed", exc_info=True)
+
+
 def _ra():
     """Lazy ``run_agent`` reference.
 
@@ -771,6 +781,19 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             logging.warning(
                 "Fallback to %s failed: provider not configured",
                 fb_provider)
+            _append_provider_telemetry({
+                "event": "fallback_activation_failed",
+                "status": "failed",
+                "resolution": "fail",
+                "failure_kind": "provider_error",
+                "platform": getattr(agent, "platform", None) or "unknown",
+                "session_id": getattr(agent, "session_id", None),
+                "provider": current_provider or "unknown",
+                "model": current_model or "unknown",
+                "fallback": {"provider": fb_provider, "model": fb_model},
+                "retry_count": max(agent._fallback_index - 1, 0),
+                "notes": "fallback provider not configured",
+            })
             return agent._try_activate_fallback()  # try next in chain
         try:
             from hermes_cli.model_normalize import normalize_model_for_provider
@@ -808,6 +831,8 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             fb_api_mode = "bedrock_converse"
 
         old_model = agent.model
+        old_provider = getattr(agent, "provider", "") or ""
+        old_base_url = getattr(agent, "base_url", "") or ""
 
         # Clear the per-config context_length override so the fallback
         # model's actual context window is resolved instead of inheriting
@@ -915,9 +940,43 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             "Fallback activated: %s → %s (%s)",
             old_model, fb_model, fb_provider,
         )
+        _append_provider_telemetry({
+            "event": "fallback_activated",
+            "status": "fallback_activated",
+            "resolution": "fallback",
+            "failure_kind": (getattr(reason, "value", None) or str(reason or "provider_error")),
+            "platform": getattr(agent, "platform", None) or "unknown",
+            "session_id": getattr(agent, "session_id", None),
+            "provider": old_provider or "unknown",
+            "model": old_model or "unknown",
+            "engine": "hermes-runtime",
+            "fallback": {
+                "provider": fb_provider,
+                "model": fb_model,
+                "base_url": fb_base_url,
+                "previous_provider": old_provider,
+                "previous_model": old_model,
+                "previous_base_url": old_base_url,
+            },
+            "retry_count": max(agent._fallback_index - 1, 0),
+            "notes": "provider fallback activated",
+        })
         return True
     except Exception as e:
         logging.error("Failed to activate fallback %s: %s", fb_model, e)
+        _append_provider_telemetry({
+            "event": "fallback_activation_failed",
+            "status": "failed",
+            "resolution": "fail",
+            "failure_kind": "provider_error",
+            "platform": getattr(agent, "platform", None) or "unknown",
+            "session_id": getattr(agent, "session_id", None),
+            "provider": current_provider or getattr(agent, "provider", None) or "unknown",
+            "model": current_model or getattr(agent, "model", None) or "unknown",
+            "fallback": {"provider": fb_provider, "model": fb_model},
+            "retry_count": max(getattr(agent, "_fallback_index", 1) - 1, 0),
+            "notes": repr(e),
+        })
         return agent._try_activate_fallback()  # try next in chain
 
 

--- a/agent/provider_telemetry.py
+++ b/agent/provider_telemetry.py
@@ -1,0 +1,211 @@
+"""Append redacted provider/fallback/safety telemetry events.
+
+The runtime calls this module from hot error/fallback paths, so every public
+function is deliberately best-effort: telemetry must never break an agent turn.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_LOG_NAME = "provider-failover.log"
+CANONICAL_SCHEMA = "hermes.provider-failover.v2"
+MAX_STRING_LENGTH = 500
+
+REQUIRED_FIELDS = (
+    "schema",
+    "ts",
+    "event",
+    "session_id",
+    "platform",
+    "role",
+    "domain",
+    "task",
+    "provider",
+    "model",
+    "engine",
+    "status",
+    "resolution",
+    "failure_kind",
+    "fallback",
+    "latency_ms",
+    "retry_count",
+    "input_tokens",
+    "output_tokens",
+    "estimated_cost_usd",
+    "safety_rail_tripped",
+    "manual_rescue",
+    "notes",
+)
+
+_ALLOWED_FAILURE_KINDS = {
+    "none",
+    "rate_limit",
+    "billing",
+    "auth",
+    "overloaded",
+    "context_overflow",
+    "provider_error",
+    "safety",
+    "timeout",
+    "payload_too_large",
+    "model_not_found",
+    "unknown",
+}
+_ALLOWED_STATUSES = {
+    "started",
+    "completed",
+    "failed",
+    "blocked",
+    "fallback_activated",
+}
+_ALLOWED_RESOLUTIONS = {
+    "pass",
+    "fail",
+    "blocked",
+    "fallback",
+    "manual_rescue",
+    "required",
+    "unknown",
+}
+
+_SECRET_PATTERNS = (
+    re.compile(r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]+"),
+    re.compile(r"(?i)(api[_-]?key\s*[=:]\s*)[^\s&,'\"]+"),
+    re.compile(r"(?i)(token\s*[=:]\s*)[^\s&,'\"]+"),
+    re.compile(r"(?i)(password\s*[=:]\s*)[^\s&,'\"]+"),
+    re.compile(r"(?i)(secret\s*[=:]\s*)[^\s&,'\"]+"),
+)
+
+
+def _now_utc() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _default_log_path() -> Path:
+    # Keep this import lazy: telemetry must remain importable in embedded/test
+    # contexts where runtime constants are stubbed or partially initialized.
+    from hermes_constants import get_hermes_home
+
+    return Path(get_hermes_home()) / "logs" / DEFAULT_LOG_NAME
+
+
+def redact_value(value: Any) -> Any:
+    """Return *value* with obvious secrets removed and large strings bounded."""
+    if isinstance(value, str):
+        redacted = value
+        for pattern in _SECRET_PATTERNS:
+            redacted = pattern.sub(r"\1[REDACTED]", redacted)
+        # Catch very long high-entropy-ish fragments that are commonly bearer
+        # tokens but avoid mangling normal prose.
+        redacted = re.sub(r"\b[A-Za-z0-9_-]{80,}\b", "[REDACTED_LONG_TOKEN]", redacted)
+        if len(redacted) > MAX_STRING_LENGTH:
+            return redacted[:MAX_STRING_LENGTH] + "…[truncated]"
+        return redacted
+    if isinstance(value, Mapping):
+        return {str(redact_value(k)): redact_value(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [redact_value(v) for v in value]
+    return value
+
+
+def _coerce_int(value: Any, default: int = 0) -> int:
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+    return bool(value)
+
+
+def _coerce_failure_kind(value: Any) -> str:
+    failure_kind = str(value or "none").strip().lower()
+    if failure_kind == "quota":
+        failure_kind = "rate_limit"
+    elif failure_kind == "safety_block":
+        failure_kind = "safety"
+    elif failure_kind == "fallback":
+        failure_kind = "provider_error"
+    elif failure_kind == "tool_error":
+        failure_kind = "unknown"
+    return failure_kind if failure_kind in _ALLOWED_FAILURE_KINDS else "unknown"
+
+
+def sanitize_event(event: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Normalize an event to the provider telemetry v2 JSONL schema."""
+    raw = redact_value(dict(event or {}))
+    status = str(raw.get("status") or "completed").strip().lower()
+    if status not in _ALLOWED_STATUSES:
+        status = "failed" if status in {"error", "errored"} else "completed"
+    resolution = str(raw.get("resolution") or "pass").strip().lower()
+    if resolution not in _ALLOWED_RESOLUTIONS:
+        resolution = "unknown"
+
+    sanitized = {
+        "schema": str(raw.get("schema") or CANONICAL_SCHEMA),
+        "ts": str(raw.get("ts") or _now_utc()),
+        "event": str(raw.get("event") or "provider_request_end"),
+        "session_id": raw.get("session_id"),
+        "platform": str(raw.get("platform") or "unknown"),
+        "role": str(raw.get("role") or "executor"),
+        "domain": str(raw.get("domain") or "unknown"),
+        "task": raw.get("task"),
+        "provider": str(raw.get("provider") or "unknown"),
+        "model": str(raw.get("model") or "unknown"),
+        "engine": str(raw.get("engine") or "hermes-runtime"),
+        "status": status,
+        "resolution": resolution,
+        "failure_kind": _coerce_failure_kind(raw.get("failure_kind")),
+        "fallback": raw.get("fallback"),
+        "latency_ms": _coerce_int(raw.get("latency_ms")),
+        "retry_count": _coerce_int(raw.get("retry_count")),
+        "input_tokens": _coerce_int(raw.get("input_tokens")),
+        "output_tokens": _coerce_int(raw.get("output_tokens")),
+        "estimated_cost_usd": raw.get("estimated_cost_usd"),
+        "safety_rail_tripped": _coerce_bool(raw.get("safety_rail_tripped")),
+        "manual_rescue": _coerce_bool(raw.get("manual_rescue")),
+        "notes": str(raw.get("notes") or ""),
+    }
+
+    # Preserve explicitly supplied non-secret diagnostic fields after the
+    # canonical fields. This lets tests and operators carry status_code/reason
+    # without expanding the required schema every time.
+    for key, value in raw.items():
+        if key not in sanitized:
+            sanitized[str(key)] = value
+    return sanitized
+
+
+def append_provider_event(event: Mapping[str, Any] | None, path: str | Path | None = None) -> None:
+    """Append a sanitized JSONL event, swallowing all telemetry failures."""
+    try:
+        sanitized = sanitize_event(event)
+        log_path = Path(path).expanduser() if path is not None else _default_log_path()
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(sanitized, sort_keys=True, separators=(",", ":")) + "\n")
+    except Exception as exc:  # pragma: no cover - exact OS errors vary
+        logger.warning("provider telemetry append failed: %s", exc, exc_info=logger.isEnabledFor(logging.DEBUG))
+
+
+__all__ = [
+    "CANONICAL_SCHEMA",
+    "REQUIRED_FIELDS",
+    "append_provider_event",
+    "redact_value",
+    "sanitize_event",
+]

--- a/tests/test_provider_fallback_telemetry.py
+++ b/tests/test_provider_fallback_telemetry.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from agent.error_classifier import FailoverReason
+from agent import chat_completion_helpers as helpers
+from agent.provider_telemetry import sanitize_event
+
+
+class DummyAgent:
+    def __init__(self) -> None:
+        self._fallback_index = 0
+        self._fallback_chain = [{"provider": "custom", "model": "fallback-model", "base_url": "https://fallback.example/v1"}]
+        self._fallback_activated = False
+        self._primary_runtime = {"provider": "primary-provider"}
+        self.provider = "primary-provider"
+        self.model = "primary-model"
+        self.base_url = "https://primary.example/v1"
+        self.platform = "cli"
+        self.session_id = "session-1"
+        self._config_context_length = None
+        self.client = None
+        self.api_key = ""
+        self._client_kwargs = {}
+
+    def _try_activate_fallback(self, reason=None):  # pragma: no cover - recursion guard
+        return helpers.try_activate_fallback(self, reason)
+
+    def _is_azure_openai_url(self, base_url: str) -> bool:
+        return False
+
+    def _is_direct_openai_url(self, base_url: str) -> bool:
+        return False
+
+    def _provider_model_requires_responses_api(self, model: str, provider: str | None = None) -> bool:
+        return False
+
+    def _anthropic_prompt_cache_policy(self, **kwargs):
+        return False, False
+
+    def _ensure_lmstudio_runtime_loaded(self) -> None:
+        return None
+
+    def _emit_status(self, message: str) -> None:
+        self.last_status = message
+
+
+def _patch_common(monkeypatch, events):
+    monkeypatch.setattr(helpers, "_append_provider_telemetry", lambda event: events.append(sanitize_event(event)))
+    monkeypatch.setattr(helpers, "get_provider_request_timeout", lambda provider, model: None)
+
+
+def test_try_activate_fallback_emits_provider_telemetry(monkeypatch) -> None:
+    events = []
+    agent = DummyAgent()
+    _patch_common(monkeypatch, events)
+
+    import agent.auxiliary_client as auxiliary_client
+
+    monkeypatch.setattr(
+        auxiliary_client,
+        "resolve_provider_client",
+        lambda *args, **kwargs: (SimpleNamespace(base_url="https://fallback.example/v1", api_key="key"), "fallback-model"),
+    )
+
+    assert helpers.try_activate_fallback(agent, FailoverReason.rate_limit) is True
+
+    assert agent.provider == "custom"
+    assert agent.model == "fallback-model"
+    assert len(events) == 1
+    event = events[0]
+    assert event["event"] == "fallback_activated"
+    assert event["status"] == "fallback_activated"
+    assert event["failure_kind"] == "rate_limit"
+    assert event["provider"] == "primary-provider"
+    assert event["model"] == "primary-model"
+    assert event["fallback"]["provider"] == "custom"
+    assert event["fallback"]["model"] == "fallback-model"
+
+
+def test_try_activate_fallback_emits_failed_event_when_provider_unconfigured(monkeypatch) -> None:
+    events = []
+    agent = DummyAgent()
+    _patch_common(monkeypatch, events)
+
+    import agent.auxiliary_client as auxiliary_client
+
+    monkeypatch.setattr(auxiliary_client, "resolve_provider_client", lambda *args, **kwargs: (None, None))
+
+    assert helpers.try_activate_fallback(agent, FailoverReason.billing) is False
+    assert len(events) == 1
+    event = events[0]
+    assert event["event"] == "fallback_activation_failed"
+    assert event["status"] == "failed"
+    assert event["failure_kind"] == "provider_error"
+    assert event["fallback"] == {"provider": "custom", "model": "fallback-model"}
+
+
+def test_try_activate_fallback_emits_failed_event_when_activation_raises(monkeypatch) -> None:
+    events = []
+    agent = DummyAgent()
+    _patch_common(monkeypatch, events)
+
+    import agent.auxiliary_client as auxiliary_client
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("token=fake-token-value provider exploded")
+
+    monkeypatch.setattr(auxiliary_client, "resolve_provider_client", boom)
+
+    assert helpers.try_activate_fallback(agent, FailoverReason.rate_limit) is False
+    assert len(events) == 1
+    event = events[0]
+    assert event["event"] == "fallback_activation_failed"
+    assert event["status"] == "failed"
+    assert event["fallback"] == {"provider": "custom", "model": "fallback-model"}
+    assert event["notes"]
+    assert "RuntimeError" in event["notes"]
+    assert "[REDACTED]" in event["notes"]
+    assert "fake-token-value" not in event["notes"]

--- a/tests/test_provider_telemetry.py
+++ b/tests/test_provider_telemetry.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agent import provider_telemetry as telemetry
+from agent.provider_telemetry import (
+    CANONICAL_SCHEMA,
+    REQUIRED_FIELDS,
+    append_provider_event,
+    redact_value,
+    sanitize_event,
+)
+
+
+def test_redact_value_masks_common_secret_shapes() -> None:
+    raw = {
+        "headers": "Authorization: Bearer tokenabc123 Authorization: Bearer sk-test-placeholder api_key=abc123 password=hunter2 token=tok_456",
+        "nested": ["secret=keep-out", "x" * 120],
+    }
+
+    redacted = redact_value(raw)
+    joined = json.dumps(redacted)
+
+    assert "tokenabc123" not in joined
+    assert "sk-test-placeholder" not in joined
+    assert "abc123" not in joined
+    assert "hunter2" not in joined
+    assert "tok_456" not in joined
+    assert "[REDACTED]" in joined
+    assert "[REDACTED_LONG_TOKEN]" in joined
+
+
+def test_sanitize_event_populates_canonical_schema_and_compat_failure_kind() -> None:
+    event = sanitize_event(
+        {
+            "event": "fallback_activated",
+            "platform": "cli",
+            "provider": "openai-codex",
+            "model": "gpt-5.5",
+            "failure_kind": "quota",
+            "fallback": {"provider": "opencode-go", "model": "kimi-k2.6"},
+            "input_tokens": "10",
+            "output_tokens": "20",
+            "notes": "bearer secret-token-here",
+            "status_code": 429,
+        }
+    )
+
+    assert all(field in event for field in REQUIRED_FIELDS)
+    assert event["schema"] == CANONICAL_SCHEMA
+    assert event["status"] == "completed"
+    assert event["resolution"] == "pass"
+    assert event["failure_kind"] == "rate_limit"
+    assert event["input_tokens"] == 10
+    assert event["output_tokens"] == 20
+    assert event["status_code"] == 429
+    assert "secret-token-here" not in event["notes"]
+
+
+def test_sanitize_event_preserves_fallback_status_and_redacts_nested_fallback() -> None:
+    event = sanitize_event(
+        {
+            "event": "fallback_activated",
+            "status": "fallback_activated",
+            "resolution": "fallback",
+            "failure_kind": "billing",
+            "fallback": {
+                "provider": "custom",
+                "model": "fallback-model",
+                "base_url": "https://example.test/v1?api_key=fake-key-123",
+            },
+        }
+    )
+
+    assert event["status"] == "fallback_activated"
+    assert event["resolution"] == "fallback"
+    assert event["failure_kind"] == "billing"
+    assert "fake-key-123" not in json.dumps(event["fallback"])
+
+
+def test_default_log_path_uses_hermes_home(monkeypatch, tmp_path) -> None:
+    import hermes_constants
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: str(tmp_path))
+
+    assert telemetry._default_log_path() == Path(tmp_path) / "logs" / "provider-failover.log"
+
+
+def test_append_provider_event_writes_jsonl(tmp_path) -> None:
+    log_path = tmp_path / "provider-failover.log"
+
+    append_provider_event(
+        {
+            "event": "provider_request_end",
+            "provider": "fixture",
+            "model": "unit-test",
+            "latency_ms": 12,
+        },
+        path=log_path,
+    )
+
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    event = json.loads(lines[0])
+    assert event["schema"] == CANONICAL_SCHEMA
+    assert event["provider"] == "fixture"
+    assert event["latency_ms"] == 12
+
+
+def test_append_provider_event_never_raises_for_unwritable_path(tmp_path) -> None:
+    directory = tmp_path / "is-a-directory"
+    directory.mkdir()
+
+    append_provider_event({"event": "provider_request_error"}, path=directory)


### PR DESCRIPTION
## Summary
- Add a best-effort provider telemetry helper that writes redacted JSONL events to `~/.hermes/logs/provider-failover.log`.
- Emit telemetry when chat-completions provider fallback activates or fails to activate.
- Cover redaction, schema normalization, fallback activation, and fallback failure paths with focused tests.

## Verification
- `/Users/colecarden/.hermes/hermes-agent/.venv/bin/python -m pytest tests/run_agent/test_provider_fallback.py tests/test_empty_model_fallback.py tests/run_agent/test_switch_model_fallback_prune.py tests/test_provider_telemetry.py tests/test_provider_fallback_telemetry.py -q` — 47 passed
- `git diff --check origin/main..HEAD`
- `/Users/colecarden/.hermes/hermes-agent/.venv/bin/python -m py_compile agent/provider_telemetry.py agent/chat_completion_helpers.py`

## Notes
- Clean PR branch rebuilt from current `origin/main`; excludes unrelated local commits from the working checkout.
- Pre-push scan found only fake/redaction-test secret-shaped strings, not live credentials.
