### PR TITLE
fix(acp): model switch via set_session_model discards ACP-injected MCP toolsets

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -756,6 +756,12 @@ class HermesACPAgent(acp.Agent):
         if not mcp_servers:
             return
 
+        # Stash on the session so model-switch (which rebuilds state.agent
+        # from scratch via _make_agent) can re-register MCP servers against
+        # the new agent. Without this, ACP-injected MCP tools silently
+        # vanish on every /model change.
+        state.mcp_servers = list(mcp_servers)
+
         try:
             from tools.mcp_tool import register_mcp_servers
 
@@ -1898,6 +1904,14 @@ class HermesACPAgent(acp.Agent):
                 base_url=current_base_url,
                 api_mode=current_api_mode,
             )
+            # Re-register ACP-injected MCP servers against the freshly-rebuilt
+            # agent — _make_agent() returns a new AIAgent with default toolsets
+            # (["hermes-acp"]) and no MCP expansion, so ACP-provided MCP tools
+            # (Paseo, etc.) would otherwise silently disappear on every model
+            # switch.
+            if state.mcp_servers:
+                await self._register_session_mcp_servers(state, state.mcp_servers)
+
             self.session_manager.save_session(session_id)
             logger.info(
                 "Session %s: model switched to %s via provider %s",

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -181,6 +181,7 @@ class SessionState:
     runtime_lock: Any = field(default_factory=Lock)
     current_prompt_text: str = ""
     interrupted_prompt_text: str = ""
+    mcp_servers: List[Any] = field(default_factory=list)
 
 
 class SessionManager:

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -987,6 +987,174 @@ class TestSessionConfiguration:
         assert state.agent.base_url == "https://anthropic.example/v1"
         assert runtime_calls[-1] == "anthropic"
 
+    @pytest.mark.asyncio
+    async def test_set_session_model_replays_acp_injected_mcp_servers(
+        self, tmp_path, monkeypatch
+    ):
+        """Model switch must re-register ACP-injected MCP servers on the new agent.
+
+        Regression: before the fix, ``set_session_model`` called ``_make_agent`` and
+        replaced ``state.agent`` wholesale. The fresh AIAgent's ``enabled_toolsets``
+        defaulted to ``["hermes-acp"]`` with no MCP expansion, so ACP-client-injected
+        MCP tools (Paseo, Zed-with-mcp, Continue, …) silently vanished on every
+        ``/model`` switch. This test asserts both that ``state.mcp_servers`` is
+        preserved and that the new ``state.agent`` carries the MCP tool surface.
+        """
+        from acp.schema import McpServerStdio, EnvVariable
+
+        def fake_resolve_runtime_provider(requested=None, **kwargs):
+            provider = requested or "openrouter"
+            return {
+                "provider": provider,
+                "api_mode": "chat_completions",
+                "base_url": f"https://{provider}.example/v1",
+                "api_key": f"{provider}-key",
+                "command": None,
+                "args": [],
+            }
+
+        def fake_agent(**kwargs):
+            # Mirror the shape of a fresh AIAgent: default toolset, empty tools.
+            # Each call returns a new SimpleNamespace, so the model switch
+            # genuinely replaces ``state.agent`` with a different object.
+            return SimpleNamespace(
+                model=kwargs.get("model"),
+                provider=kwargs.get("provider"),
+                base_url=kwargs.get("base_url"),
+                api_mode=kwargs.get("api_mode"),
+                enabled_toolsets=list(kwargs.get("enabled_toolsets") or ["hermes-acp"]),
+                disabled_toolsets=None,
+                tools=[],
+                valid_tool_names=set(),
+                _invalidate_system_prompt=MagicMock(),
+            )
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"model": {"provider": "openrouter", "default": "openrouter/gpt-5"}},
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve_runtime_provider,
+        )
+        manager = SessionManager(db=SessionDB(tmp_path / "state.db"))
+
+        server = McpServerStdio(
+            name="paseo",
+            command="/usr/bin/paseo",
+            args=["--mcp"],
+            env=[EnvVariable(name="TOKEN", value="x")],
+        )
+        mcp_tools = [
+            {"function": {"name": "mcp_paseo_search"}},
+            {"function": {"name": "mcp_paseo_open_url"}},
+        ]
+
+        with patch("run_agent.AIAgent", side_effect=fake_agent), \
+             patch("tools.mcp_tool.register_mcp_servers", return_value=["mcp_paseo_search"]), \
+             patch("model_tools.get_tool_definitions", return_value=mcp_tools):
+            acp_agent = HermesACPAgent(session_manager=manager)
+            state = manager.create_session(cwd="/tmp")
+
+            # Initial ACP injection — populates state.mcp_servers and expands
+            # the tool surface on state.agent.
+            await acp_agent._register_session_mcp_servers(state, [server])
+            assert state.mcp_servers == [server]
+            assert "mcp-paseo" in state.agent.enabled_toolsets
+            assert {t["function"]["name"] for t in state.agent.tools} == {
+                "mcp_paseo_search",
+                "mcp_paseo_open_url",
+            }
+            original_agent_id = id(state.agent)
+
+            # Model switch — replaces state.agent wholesale and must replay
+            # the stashed MCP servers against the new agent.
+            result = await acp_agent.set_session_model(
+                model_id="anthropic:claude-sonnet-4-6",
+                session_id=state.session_id,
+            )
+
+        assert isinstance(result, SetSessionModelResponse)
+        # _make_agent really did produce a fresh agent.
+        assert id(state.agent) != original_agent_id
+        # The MCP server stash survives the switch.
+        assert state.mcp_servers == [server]
+        # Most importantly: MCP toolset is replayed onto the new agent.
+        assert "mcp-paseo" in state.agent.enabled_toolsets
+        tool_names = {t["function"]["name"] for t in state.agent.tools or []}
+        assert {"mcp_paseo_search", "mcp_paseo_open_url"} <= tool_names
+
+    @pytest.mark.asyncio
+    async def test_repeated_model_switches_preserve_mcp_servers(
+        self, tmp_path, monkeypatch
+    ):
+        """Stash must survive multiple consecutive model switches (A→B→A→B)."""
+        from acp.schema import McpServerStdio, EnvVariable
+
+        def fake_resolve_runtime_provider(requested=None, **kwargs):
+            provider = requested or "openrouter"
+            return {
+                "provider": provider,
+                "api_mode": "chat_completions",
+                "base_url": f"https://{provider}.example/v1",
+                "api_key": f"{provider}-key",
+                "command": None,
+                "args": [],
+            }
+
+        def fake_agent(**kwargs):
+            return SimpleNamespace(
+                model=kwargs.get("model"),
+                provider=kwargs.get("provider"),
+                base_url=kwargs.get("base_url"),
+                api_mode=kwargs.get("api_mode"),
+                enabled_toolsets=list(kwargs.get("enabled_toolsets") or ["hermes-acp"]),
+                disabled_toolsets=None,
+                tools=[],
+                valid_tool_names=set(),
+                _invalidate_system_prompt=MagicMock(),
+            )
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"model": {"provider": "openrouter", "default": "openrouter/gpt-5"}},
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve_runtime_provider,
+        )
+        manager = SessionManager(db=SessionDB(tmp_path / "state.db"))
+
+        server = McpServerStdio(
+            name="paseo",
+            command="/usr/bin/paseo",
+            args=[],
+            env=[EnvVariable(name="TOKEN", value="x")],
+        )
+        mcp_tools = [{"function": {"name": "mcp_paseo_search"}}]
+
+        with patch("run_agent.AIAgent", side_effect=fake_agent), \
+             patch("tools.mcp_tool.register_mcp_servers", return_value=["mcp_paseo_search"]), \
+             patch("model_tools.get_tool_definitions", return_value=mcp_tools):
+            acp_agent = HermesACPAgent(session_manager=manager)
+            state = manager.create_session(cwd="/tmp")
+            await acp_agent._register_session_mcp_servers(state, [server])
+
+            for model_id in [
+                "anthropic:claude-sonnet-4-6",
+                "openrouter:openai/gpt-5",
+                "anthropic:claude-sonnet-4-6",
+                "openrouter:openai/gpt-5",
+            ]:
+                await acp_agent.set_session_model(
+                    model_id=model_id, session_id=state.session_id
+                )
+                assert state.mcp_servers == [server]
+                assert "mcp-paseo" in state.agent.enabled_toolsets
+                assert "mcp_paseo_search" in {
+                    t["function"]["name"] for t in state.agent.tools or []
+                }
+
 
 # ---------------------------------------------------------------------------
 # prompt


### PR DESCRIPTION
## Summary

`set_session_model` rebuilds `state.agent` from scratch via `_make_agent(...)`, returning a fresh `AIAgent` whose `enabled_toolsets` defaults to `["hermes-acp"]` with no MCP expansion. ACP-client-injected MCP servers (registered against the old `state.agent` from `new_session` / `load_session` / `resume_session`) silently vanish from the new agent's tool surface on every `/model` switch.

This is distinct from #14986 (which covered the static-config-MCP path and has been fixed); the bug here affects **ACP-client-injected** MCP servers only — Paseo, Zed with MCP config, Continue, any ACP client that injects MCP servers via the lifecycle methods.

## Reproduction

Connect any ACP client that injects MCP servers and triggers a model switch.

1. Start a session with an ACP client that ships MCP servers in `new_session`.
2. Run `/tools` — MCP tools (e.g. `mcp_paseo_*`) appear.
3. Run `/model <other>` to switch models.
4. Run `/tools` again — the MCP tools are gone, silently.

Log evidence from a Paseo session:

```
22:05:50.359  Paseo registers 32 tools
22:05:50.362  refresh shows 74 tools (MCP expansion applied)
22:05:51.050  /model switch fires
22:05:51.???  next /tools  →  42 tools  (MCP tools vanished)
```

## Root cause

`acp_adapter/server.py::set_session_model` calls `self.session_manager._make_agent(...)`, which returns a brand-new `AIAgent`. The new agent's `enabled_toolsets` is the constructor default (`["hermes-acp"]`), and `_register_session_mcp_servers` was never called against it, so the MCP toolsets never get expanded into its tool surface.

## Fix

Stash the resolved MCP server list on `SessionState.mcp_servers` at registration time, then replay `_register_session_mcp_servers` after the model switch so the new agent inherits the same toolset, tool surface, and `valid_tool_names`. `_register_session_mcp_servers` already calls `_invalidate_system_prompt` on tool-surface refresh, so the system prompt is rebuilt on the new agent too — no extra wiring needed.

A few small details worth flagging:

- The stash uses `list(mcp_servers)` rather than holding the original reference, so callers can't mutate it through the original list.
- The replay is a no-op when no ACP MCP servers were ever registered (the early `if not mcp_servers: return` inside `_register_session_mcp_servers` handles the empty-stash case).
- This only touches the ACP-injected path; the existing static-config-MCP flow from `_make_agent` is unchanged.

## Tests

Two new regression tests in `tests/acp/test_server.py::TestSessionConfiguration`:

- `test_set_session_model_replays_acp_injected_mcp_servers` — single model switch; asserts both `state.mcp_servers` survives and the new `state.agent` exposes MCP tools.
- `test_repeated_model_switches_preserve_mcp_servers` — exercises A→B→A→B switches to make sure the stash isn't cleared on some other code path.

Both tests fail on `main` and pass with the fix applied. Full `tests/acp/` + `tests/acp_adapter/` suites (295 tests) pass locally.

## Test plan

- [x] New tests fail without the fix (`AttributeError: 'SessionState' object has no attribute 'mcp_servers'` once stash removed; assertion failure on new-agent tools when only the replay is removed).
- [x] New tests pass with the fix.
- [x] `tests/acp/` + `tests/acp_adapter/` green (295 passed).
- [ ] Maintainer to verify on at least one ACP client (Paseo / Zed-with-mcp / Continue) end-to-end.
