### PR TITLE
gateway: add EXPECTED_BOT_ID identity guard for Discord and Telegram

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1458,6 +1458,71 @@ class BasePlatformAdapter(ABC):
         self._fatal_error_retryable = retryable
         self._write_runtime_status_safe("fatal", platform_state="fatal", error_code=code, error_message=message)
 
+    def _check_expected_bot_id(
+        self,
+        *,
+        env_var: str,
+        actual_id: Optional[int],
+        actual_label: str,
+        logger_: Any,
+    ) -> bool:
+        """Identity guard: verify the connected bot matches the expected ID.
+
+        Reads ``env_var`` from the environment. Returns True if the guard
+        passes (or is disabled because the env var is unset). Returns False
+        and sets a fatal error if the guard fails or the env var is malformed.
+
+        Opt-in: only enforced when the env var is set. When unset, a WARNING
+        is logged so operators see the protection is available. Codes set
+        when failing:
+          - ``<platform>_expected_bot_id_invalid`` — env var not an int (non-retryable)
+          - ``<platform>_bot_id_mismatch`` — id mismatch (non-retryable)
+
+        ``actual_label`` is included verbatim in the failure log line so the
+        platform-specific identity (e.g. ``Bot#1234`` or ``@username``) is
+        visible alongside the numeric id.
+
+        Primary use: prevent double-bot presence when the same identity is
+        running both natively and in a container with mismatched tokens.
+        """
+        expected_id_raw = os.getenv(env_var, "").strip()
+        platform_key = self.platform.value if hasattr(self.platform, "value") else str(self.platform)
+        if not expected_id_raw:
+            logger_.warning(
+                "[%s] %s not set — identity guard is disabled. Set it in .env "
+                "to prevent token-swap double-bot incidents.",
+                self.name, env_var,
+            )
+            return True
+        try:
+            expected_id = int(expected_id_raw)
+        except ValueError:
+            message = (
+                f"{env_var} is set but not a valid integer: "
+                f"{expected_id_raw!r}. Refusing to start."
+            )
+            logger_.error("[%s] %s", self.name, message)
+            self._set_fatal_error(
+                f"{platform_key}_expected_bot_id_invalid", message, retryable=False,
+            )
+            return False
+        if actual_id != expected_id:
+            message = (
+                f"{platform_key.capitalize()} identity mismatch: token "
+                f"resolves to bot id={actual_id} ({actual_label}) but "
+                f"{env_var}={expected_id}. Refusing to start to prevent "
+                f"double-bot presence."
+            )
+            logger_.error("[%s] %s", self.name, message)
+            self._set_fatal_error(
+                f"{platform_key}_bot_id_mismatch", message, retryable=False,
+            )
+            return False
+        logger_.info(
+            "[%s] %s guard passed (id=%s)", self.name, env_var, actual_id,
+        )
+        return True
+
     def _write_runtime_status_safe(self, context: str, **kwargs) -> None:
         """Write runtime status; log first failure per context at warning, rest at debug.
 

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -706,6 +706,22 @@ class DiscordAdapter(BasePlatformAdapter):
             async def on_ready():
                 logger.info("[%s] Connected as %s", adapter_self.name, adapter_self._client.user)
 
+                # EXPECTED_BOT_ID guard — fail closed if the token resolves to
+                # a different bot than configured. Protects against double-bot
+                # presence races (e.g. native + containerized Telos with the
+                # wrong tokens swapped). Opt-in: only enforced when
+                # DISCORD_EXPECTED_BOT_ID is set in the environment.
+                actual_user = adapter_self._client.user
+                actual_id = getattr(actual_user, "id", None)
+                if not adapter_self._check_expected_bot_id(
+                    env_var="DISCORD_EXPECTED_BOT_ID",
+                    actual_id=actual_id,
+                    actual_label=str(actual_user),
+                    logger_=logger,
+                ):
+                    await adapter_self._client.close()
+                    return
+
                 # Resolve any usernames in the allowed list to numeric IDs
                 await adapter_self._resolve_allowed_usernames()
                 adapter_self._ready_event.set()

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1471,6 +1471,40 @@ class TelegramAdapter(BasePlatformAdapter):
                         raise
             await self._app.start()
 
+            # EXPECTED_BOT_ID guard — fail closed if the token resolves to a
+            # different bot than configured. Protects against double-bot
+            # presence races (e.g. native + containerized Telos with the wrong
+            # tokens swapped). Opt-in: only enforced when
+            # TELEGRAM_EXPECTED_BOT_ID is set in the environment.
+            if os.getenv("TELEGRAM_EXPECTED_BOT_ID", "").strip():
+                try:
+                    me = await self._app.bot.get_me()
+                except Exception as get_me_err:
+                    message = (
+                        f"TELEGRAM_EXPECTED_BOT_ID guard could not call "
+                        f"get_me() to verify identity: {get_me_err}. Refusing "
+                        f"to start."
+                    )
+                    logger.error("[%s] %s", self.name, message, exc_info=True)
+                    self._set_fatal_error(
+                        "telegram_get_me_failed", message, retryable=True,
+                    )
+                    self._release_platform_lock()
+                    return False
+                actual_id = getattr(me, "id", None)
+                actual_label = f"@{getattr(me, 'username', '?')}"
+            else:
+                actual_id = None
+                actual_label = ""
+            if not self._check_expected_bot_id(
+                env_var="TELEGRAM_EXPECTED_BOT_ID",
+                actual_id=actual_id,
+                actual_label=actual_label,
+                logger_=logger,
+            ):
+                self._release_platform_lock()
+                return False
+
             # Decide between webhook and polling mode
             webhook_url = os.getenv("TELEGRAM_WEBHOOK_URL", "").strip()
 

--- a/tests/gateway/test_expected_bot_id_guard.py
+++ b/tests/gateway/test_expected_bot_id_guard.py
@@ -1,0 +1,175 @@
+"""Unit tests for BasePlatformAdapter._check_expected_bot_id.
+
+Identity guard for the EXPECTED_BOT_ID env-var protection. Prevents
+double-bot presence when the same logical identity is running both
+natively and in a container with mismatched tokens.
+
+Tests exercise the helper directly on a lightweight subclass of
+BasePlatformAdapter so they're free of discord/telegram library
+dependencies. End-to-end wiring in the adapters is tested elsewhere.
+"""
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter
+
+
+class _StubAdapter(BasePlatformAdapter):
+    """Minimal concrete subclass so we can instantiate the base class."""
+
+    # All abstract methods are no-ops — we only exercise the guard helper.
+    async def connect(self) -> bool:  # pragma: no cover - not exercised
+        return True
+
+    async def disconnect(self) -> None:  # pragma: no cover - not exercised
+        return None
+
+    async def send(self, *args, **kwargs):  # pragma: no cover - not exercised
+        return None
+
+    async def get_chat_info(self, *args, **kwargs):  # pragma: no cover
+        return None
+
+
+@pytest.fixture
+def adapter(monkeypatch):
+    """Build a stub adapter with the runtime-status writer stubbed out.
+
+    ``_write_runtime_status_safe`` touches the gateway's runtime status
+    file; we don't want test runs writing real files. Stubbing it leaves
+    fatal-error state-setting intact so we can assert on it.
+    """
+    a = _StubAdapter(
+        config=PlatformConfig(enabled=True, token="test"),
+        platform=Platform.DISCORD,
+    )
+    monkeypatch.setattr(a, "_write_runtime_status_safe", lambda *a, **k: None)
+    return a
+
+
+@pytest.fixture
+def logger_():
+    return logging.getLogger("test_expected_bot_id_guard")
+
+
+class TestExpectedBotIdGuard:
+    def test_guard_disabled_when_env_var_unset(self, adapter, logger_, monkeypatch):
+        """Unset env var → guard returns True (disabled) and no fatal error."""
+        monkeypatch.delenv("DISCORD_EXPECTED_BOT_ID", raising=False)
+        result = adapter._check_expected_bot_id(
+            env_var="DISCORD_EXPECTED_BOT_ID",
+            actual_id=12345,
+            actual_label="Bot#0001",
+            logger_=logger_,
+        )
+        assert result is True
+        assert not adapter.has_fatal_error
+
+    def test_guard_disabled_when_env_var_blank(self, adapter, logger_, monkeypatch):
+        """Whitespace-only env var → treated as unset."""
+        monkeypatch.setenv("DISCORD_EXPECTED_BOT_ID", "   ")
+        result = adapter._check_expected_bot_id(
+            env_var="DISCORD_EXPECTED_BOT_ID",
+            actual_id=12345,
+            actual_label="Bot#0001",
+            logger_=logger_,
+        )
+        assert result is True
+        assert not adapter.has_fatal_error
+
+    def test_guard_passes_when_ids_match(self, adapter, logger_, monkeypatch):
+        """Matching ID → guard passes, no fatal error."""
+        monkeypatch.setenv("DISCORD_EXPECTED_BOT_ID", "12345")
+        result = adapter._check_expected_bot_id(
+            env_var="DISCORD_EXPECTED_BOT_ID",
+            actual_id=12345,
+            actual_label="Bot#0001",
+            logger_=logger_,
+        )
+        assert result is True
+        assert not adapter.has_fatal_error
+
+    def test_guard_passes_with_surrounding_whitespace(self, adapter, logger_, monkeypatch):
+        """Env var with surrounding whitespace still parses + matches."""
+        monkeypatch.setenv("DISCORD_EXPECTED_BOT_ID", "  12345  ")
+        result = adapter._check_expected_bot_id(
+            env_var="DISCORD_EXPECTED_BOT_ID",
+            actual_id=12345,
+            actual_label="Bot#0001",
+            logger_=logger_,
+        )
+        assert result is True
+        assert not adapter.has_fatal_error
+
+    def test_guard_fails_on_id_mismatch(self, adapter, logger_, monkeypatch):
+        """Mismatched ID → guard fails, fatal error set non-retryable."""
+        monkeypatch.setenv("DISCORD_EXPECTED_BOT_ID", "12345")
+        result = adapter._check_expected_bot_id(
+            env_var="DISCORD_EXPECTED_BOT_ID",
+            actual_id=99999,
+            actual_label="Bot#9999",
+            logger_=logger_,
+        )
+        assert result is False
+        assert adapter.has_fatal_error
+        assert adapter.fatal_error_code == "discord_bot_id_mismatch"
+        assert adapter.fatal_error_retryable is False
+        assert "99999" in adapter.fatal_error_message
+        assert "12345" in adapter.fatal_error_message
+
+    def test_guard_fails_on_none_actual_id(self, adapter, logger_, monkeypatch):
+        """actual_id=None → treated as mismatch (no identity available)."""
+        monkeypatch.setenv("DISCORD_EXPECTED_BOT_ID", "12345")
+        result = adapter._check_expected_bot_id(
+            env_var="DISCORD_EXPECTED_BOT_ID",
+            actual_id=None,
+            actual_label="unknown",
+            logger_=logger_,
+        )
+        assert result is False
+        assert adapter.fatal_error_code == "discord_bot_id_mismatch"
+
+    def test_guard_fails_on_non_integer_env(self, adapter, logger_, monkeypatch):
+        """Non-integer env var → guard fails with invalid-format code."""
+        monkeypatch.setenv("DISCORD_EXPECTED_BOT_ID", "not-an-int")
+        result = adapter._check_expected_bot_id(
+            env_var="DISCORD_EXPECTED_BOT_ID",
+            actual_id=12345,
+            actual_label="Bot#0001",
+            logger_=logger_,
+        )
+        assert result is False
+        assert adapter.has_fatal_error
+        assert adapter.fatal_error_code == "discord_expected_bot_id_invalid"
+        assert adapter.fatal_error_retryable is False
+
+    def test_failure_label_included_in_message(self, adapter, logger_, monkeypatch):
+        """actual_label appears verbatim in the failure message for diag."""
+        monkeypatch.setenv("DISCORD_EXPECTED_BOT_ID", "12345")
+        adapter._check_expected_bot_id(
+            env_var="DISCORD_EXPECTED_BOT_ID",
+            actual_id=99999,
+            actual_label="@some_other_bot",
+            logger_=logger_,
+        )
+        assert "@some_other_bot" in adapter.fatal_error_message
+
+    def test_platform_prefix_uses_platform_value(self, monkeypatch, logger_):
+        """Fatal error codes are prefixed with the platform's value attr."""
+        a = _StubAdapter(
+            config=PlatformConfig(enabled=True, token="test"),
+            platform=Platform.TELEGRAM,
+        )
+        monkeypatch.setattr(a, "_write_runtime_status_safe", lambda *a, **k: None)
+        monkeypatch.setenv("TELEGRAM_EXPECTED_BOT_ID", "12345")
+        a._check_expected_bot_id(
+            env_var="TELEGRAM_EXPECTED_BOT_ID",
+            actual_id=99999,
+            actual_label="@other",
+            logger_=logger_,
+        )
+        assert a.fatal_error_code == "telegram_bot_id_mismatch"

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -243,6 +243,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | Variable | Description |
 |----------|-------------|
 | `TELEGRAM_BOT_TOKEN` | Telegram bot token (from @BotFather) |
+| `TELEGRAM_EXPECTED_BOT_ID` | Optional. When set, the Telegram adapter calls `get_me()` at startup and refuses to start if the bot ID returned by Telegram doesn't match this value. Prevents double-bot presence when the same logical identity is run in two places with mismatched tokens (e.g. parallel native + containerized deployments). Opt-in: when unset, a WARNING is logged but startup proceeds. |
 | `TELEGRAM_ALLOWED_USERS` | Comma-separated user IDs allowed to use the bot (applies to DMs, groups, and forums) |
 | `TELEGRAM_GROUP_ALLOWED_USERS` | Comma-separated sender user IDs authorized in groups/forums only (does NOT grant DM access). Chat-ID-shaped values (starting with `-`) are still honored as chat IDs for backward compat with pre-#17686 configs, with a deprecation warning. |
 | `TELEGRAM_GROUP_ALLOWED_CHATS` | Comma-separated group/forum chat IDs; any member is authorized |
@@ -260,6 +261,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `TELEGRAM_IGNORED_THREADS` | Comma-separated Telegram forum topic/thread IDs where the bot never responds |
 | `TELEGRAM_PROXY` | Proxy URL for Telegram connections — overrides `HTTPS_PROXY`. Supports `http://`, `https://`, `socks5://` |
 | `DISCORD_BOT_TOKEN` | Discord bot token |
+| `DISCORD_EXPECTED_BOT_ID` | Optional. When set, the Discord adapter checks `client.user.id` in `on_ready` and refuses to start if it doesn't match this value. Prevents double-bot presence when the same logical identity is run in two places with mismatched tokens (e.g. parallel native + containerized deployments). Opt-in: when unset, a WARNING is logged but startup proceeds. |
 | `DISCORD_ALLOWED_USERS` | Comma-separated Discord user IDs allowed to use the bot |
 | `DISCORD_ALLOWED_ROLES` | Comma-separated Discord role IDs allowed to use the bot (OR with `DISCORD_ALLOWED_USERS`). Auto-enables the Members intent. Useful when moderation teams churn — role grants propagate automatically. |
 | `DISCORD_ALLOWED_CHANNELS` | Comma-separated Discord channel IDs. When set, the bot only responds in these channels (plus DMs if allowed). Overrides `config.yaml` `discord.allowed_channels`. |


### PR DESCRIPTION
What,
Adds an opt-in identity guard for Discord and Telegram gateway adapters. When DISCORD_EXPECTED_BOT_ID or TELEGRAM_EXPECTED_BOT_ID is set, the corresponding adapter verifies the connected bot's ID at startup and refuses to start (fail-closed) if it doesn't match.

Why,
Bot tokens are bearer credentials. The platform happily accepts two simultaneous connections from the same identity using the same token, or a swapped token from a different identity. Neither side flags the mismatch — but downstream the user sees double responses, fights over message handling, or wrong-bot behavior.

Concrete incident this resolves (from a downstream deployment):
Running a native install of a bot.,
Spun up a containerized copy of the same bot to dry-run a migration.,
The containerized copy booted with the production token (.env carried over).,
For ~80 seconds, both processes were online as the same Discord identity, both received every message, both replied.,

Muzzling tokens in the dry-run config (blanking DISCORD_BOT_TOKEN) is a workaround — it prevents the second process from connecting at all. But that doesn't catch token-swap scenarios (right token in wrong deployment), and it doesn't help anyone who legitimately wants to run two bots side-by-side with different identities.

The durable fix is identity verification: tell each deployment which bot ID it should be, and refuse to connect if the platform says it's something else.

How,
 (edited)Friday, May 22, 2026 7:59 PM
:heart:
Click to react
:white_check_mark:
Click to react
:100:
Click to react
Add Reaction
Reply
Forward
More

@Operator
empty

Steve
APP
 — 7:59 PMFriday, May 22, 2026 7:59 PM
BasePlatformAdapter._check_expected_bot_id(env_var, actual_id, actual_label, logger_) — single source of truth. Reads the env var, parses to int, compares against actual_id. Returns True on match or when unset; returns False and calls _set_fatal_error(retryable=False) on mismatch / malformed value. Logs a WARNING when the env var is unset (so operators see the protection is available but disabled).,
Discord adapter — calls the helper inside on_ready. client.user.id is available at that point. On fail: closes the discord client and returns from on_ready without registering further handlers.,
Telegram adapter — calls the helper after _app.start() and before polling/webhook setup. Uses bot.get_me() to obtain the identity. On fail: releases the platform lock and returns False from connect().,

Fatal error codes (all non-retryable):
<platform>_bot_id_mismatch — token resolved to wrong identity,
<platform>_expected_bot_id_invalid — env var present but not a valid int,
telegram_get_me_failed — get_me() itself threw (this one is retryable; could be a transient network blip),

Behavior matrix,
| *_EXPECTED_BOT_ID | Connected ID | Behavior |
|---|---|---|
| unset | any | WARNING logged, startup proceeds (backward compatible) |
| 12345 | 12345 | INFO logged, startup proceeds |
| 12345 | 99999 | ERROR logged, fatal error set, startup refused |
| 12345 | None | ERROR logged, fatal error set, startup refused |
| not-an-int | any | ERROR logged, fatal error set, startup refused |

Tests,
tests/gateway/test_expected_bot_id_guard.py — 9 cases covering:
env unset → guard disabled,
env blank-whitespace → guard disabled,
env matches → guard passes,
env mismatches → fatal, non-retryable, correct error code,
env non-integer → fatal, correct error code,
actual_id=None → treated as mismatch,
 (edited)Friday, May 22, 2026 7:59 PM
:heart:
Click to react
:white_check_mark:
Click to react
:100:
Click to react
Add Reaction
Reply
Forward
More
NEW

@Operator
empty

Steve
APP
 — 7:59 PMFriday, May 22, 2026 7:59 PM
whitespace-padded env value parses correctly,
failure message includes the platform-specific actual_label for diagnostics,
error codes are platform-prefixed (discord_* vs telegram_*),

Full tests/gateway/ + tests/e2e/ runs identically against this branch and origin/main — same 11 pre-existing flakes in both (Markdown-V2 escaping + Discord mention parsing tests; they pass in isolation, fail under suite-wide ordering). No regressions introduced.

Documentation,
website/docs/reference/environment-variables.md — rows added under both TELEGRAM_BOT_TOKEN and DISCORD_BOT_TOKEN describing the opt-in guard.

Compatibility,
Strictly additive. Existing deployments (env var unset) see one extra WARNING line at startup and otherwise behave identically.