### PR TITLE
feat(skills): deterministic runtime skill bundles + L1 compact context + insights split

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -438,16 +438,39 @@ def run_conversation(
             _should_review_memory = True
             agent._turns_since_memory = 0
 
+    # ── Per-turn auto skill preloader ──────────────────────────────────────────
+    # Ephemerally inject auto-matched skills into this turn only.
+    # Does NOT touch the cached system prompt — safe for gateway per-message
+    # fresh AIAgent pattern.  Original user_message is preserved in the
+    # persist_user_message field for clean transcripts.
+    auto_skill_context = ""
+    try:
+        from agent.skill_commands import build_auto_skill_preload_context
+        auto_skill_context = build_auto_skill_preload_context(
+            user_message,
+            task_id=task_id,
+        )
+    except Exception:
+        pass  # Auto-preload is best-effort; never block the turn
+
     # Add user message
-    user_msg = {"role": "user", "content": user_message}
+    user_msg_content = user_message
+    if auto_skill_context:
+        # Inject skill content as prefix; model sees both skill SOP and request
+        user_msg_content = (
+            f"{auto_skill_context.strip()}\n\n"
+            f"[User request — preserved verbatim below]\n"
+            f"{user_message}"
+        )
+    user_msg = {"role": "user", "content": user_msg_content}
     messages.append(user_msg)
     current_turn_user_idx = len(messages) - 1
     agent._persist_user_message_idx = current_turn_user_idx
-    
+
     if not agent.quiet_mode:
         _print_preview = _summarize_user_message_for_log(user_message)
         agent._safe_print(f"💬 Starting conversation: '{_print_preview[:60]}{'...' if len(_print_preview) > 60 else ''}'")
-    
+
     # ── System prompt (cached per session for prefix caching) ──
     # Built once on first call, reused for all subsequent calls.
     # Only rebuilt after context compression events (which invalidate

--- a/agent/insights.py
+++ b/agent/insights.py
@@ -22,6 +22,8 @@ from collections import Counter, defaultdict
 from datetime import datetime
 from typing import Any, Dict, List
 
+from hermes_constants import get_hermes_home
+
 from agent.usage_pricing import (
     CanonicalUsage,
     DEFAULT_PRICING,
@@ -356,12 +358,15 @@ class InsightsEngine:
                     {
                         "skill": skill_name,
                         "view_count": 0,
+                        "explicit_view_count": 0,
+                        "auto_preload_count": 0,
                         "manage_count": 0,
                         "last_used_at": None,
                     },
                 )
                 if tool_name == "skill_view":
                     entry["view_count"] += 1
+                    entry["explicit_view_count"] += 1
                 else:
                     entry["manage_count"] += 1
 
@@ -369,6 +374,48 @@ class InsightsEngine:
                     entry["last_used_at"] is None or timestamp > entry["last_used_at"]
                 ):
                     entry["last_used_at"] = timestamp
+
+        # ── Augment with bump_use telemetry from .usage.json ──────────────────
+        # bump_use() is called by auto-preload (full and compact) as well as
+        # explicit slash-skill loads.  DB tool calls only see explicit
+        # skill_view/skill_manage.  Expose both counts so insights can tell
+        # "runtime preload" from "manual view" instead of flattening both.
+        usage_file = get_hermes_home() / "skills" / ".usage.json"
+        if usage_file.exists():
+            try:
+                with open(usage_file, "r", encoding="utf-8") as f:
+                    usage_data = json.load(f)
+                if isinstance(usage_data, dict):
+                    for skill_name, rec in usage_data.items():
+                        if not isinstance(rec, dict):
+                            continue
+                        use_count = int(rec.get("use_count") or 0)
+                        if use_count == 0:
+                            continue
+                        entry = skill_counts.get(skill_name)
+                        if entry is None:
+                            entry = {
+                                "skill": skill_name,
+                                "view_count": 0,
+                                "explicit_view_count": 0,
+                                "auto_preload_count": 0,
+                                "manage_count": 0,
+                                "last_used_at": None,
+                            }
+                            skill_counts[skill_name] = entry
+                        explicit_views = int(entry.get("explicit_view_count") or 0)
+                        auto_preloads = max(use_count - explicit_views, 0)
+                        entry["auto_preload_count"] = auto_preloads
+                        entry["view_count"] = explicit_views + auto_preloads
+                        # latest timestamp wins
+                        last_used = rec.get("last_used_at")
+                        if last_used and (
+                            entry["last_used_at"] is None
+                            or last_used > entry["last_used_at"]
+                        ):
+                            entry["last_used_at"] = last_used
+            except (json.JSONDecodeError, OSError, ValueError):
+                pass  # best-effort only
 
         return list(skill_counts.values())
 
@@ -571,12 +618,18 @@ class InsightsEngine:
 
         top_skills = []
         for skill in skill_usage:
-            total_count = skill["view_count"] + skill["manage_count"]
+            explicit_views = int(skill.get("explicit_view_count") or 0)
+            auto_preloads = int(skill.get("auto_preload_count") or 0)
+            view_count = int(skill.get("view_count") or (explicit_views + auto_preloads))
+            manage_count = int(skill.get("manage_count") or 0)
+            total_count = view_count + manage_count
             percentage = (total_count / total_skill_actions * 100) if total_skill_actions else 0
             top_skills.append({
                 "skill": skill["skill"],
-                "view_count": skill["view_count"],
-                "manage_count": skill["manage_count"],
+                "view_count": view_count,
+                "explicit_view_count": explicit_views,
+                "auto_preload_count": auto_preloads,
+                "manage_count": manage_count,
                 "total_count": total_count,
                 "percentage": percentage,
                 "last_used_at": skill.get("last_used_at"),
@@ -804,13 +857,13 @@ class InsightsEngine:
         if top_skills:
             lines.append("  🧠 Top Skills")
             lines.append("  " + "─" * 56)
-            lines.append(f"  {'Skill':<28} {'Loads':>7} {'Edits':>7} {'Last used':>11}")
+            lines.append(f"  {'Skill':<28} {'Loads':>7} {'Auto':>7} {'Edits':>7} {'Last used':>11}")
             for skill in top_skills[:10]:
                 last_used = "—"
                 if skill.get("last_used_at"):
                     last_used = datetime.fromtimestamp(skill["last_used_at"]).strftime("%b %d")
                 lines.append(
-                    f"  {skill['skill'][:28]:<28} {skill['view_count']:>7,} {skill['manage_count']:>7,} {last_used:>11}"
+                    f"  {skill['skill'][:28]:<28} {skill['view_count']:>7,} {skill.get('auto_preload_count', 0):>7,} {skill['manage_count']:>7,} {last_used:>11}"
                 )
             summary = skills.get("summary", {})
             lines.append(
@@ -911,7 +964,7 @@ class InsightsEngine:
                 if skill.get("last_used_at"):
                     suffix = f", last used {datetime.fromtimestamp(skill['last_used_at']).strftime('%b %d')}"
                 lines.append(
-                    f"  {skill['skill']} — {skill['view_count']:,} loads, {skill['manage_count']:,} edits{suffix}"
+                    f"  {skill['skill']} — {skill['view_count']:,} loads ({skill.get('auto_preload_count', 0):,} auto), {skill['manage_count']:,} edits{suffix}"
                 )
             lines.append("")
 

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -521,3 +521,254 @@ def build_preloaded_skills_prompt(
         loaded_names.append(skill_name)
 
     return "\n\n".join(prompt_parts), loaded_names, missing
+
+
+# -----------------------------------------------------------------------------------------
+# Per-turn auto skill preloader
+# -----------------------------------------------------------------------------------------
+# Runtime-level routing lives here (not only inside skills) so the first model
+# call sees the right skill bundle before it has a chance to forget Step 0.
+# Rules use OR matching across pipe-separated keywords.  Keep keywords specific:
+# broad words like "new" cause noisy false positives and slow turns.
+
+_AUTO_PRELOAD_RULES: list[tuple[str, list[str], str]] = [
+    # Base code-task controller. Other code-related rules below also include it
+    # explicitly so PR/debug/test/review prompts get the deterministic bundle.
+    (
+        "执行代码|代码任务|小修|快速修复|严格验证|代码改动|改代码|写代码|"
+        "代码复杂度|风险分级|执行代码任务|修 bug|修复代码|implement code|"
+        "code task|coding task|fix bug|small fix|quick fix|modify code",
+        ["code-task-execution"],
+        "code execution task",
+    ),
+    # GitHub PR / git write workflow bundle.
+    (
+        "创建PR|提PR|建PR|合PR|PR详情|PR改动|PR审查|提交PR|开PR|"
+        "pull request|github pr|gh pr|merge pr|create pr|open pr|"
+        "branch|commit|push|rebase|cherry-pick",
+        ["code-task-execution", "github-pr-workflow"],
+        "GitHub PR workflow",
+    ),
+    # Debugging bundle.
+    (
+        "调试|排查问题|找bug|系统调试|复现问题|根因分析|debugging|debug|"
+        "root cause|reproduce|failing behavior|traceback|stack trace",
+        ["code-task-execution", "systematic-debugging"],
+        "systematic debugging",
+    ),
+    # TDD / regression-test bundle.
+    (
+        "TDD|红绿重构|测试先行|RED|GREEN|REFACTOR|写测试用例|回归测试|"
+        "test driven|red green|regression test|tests first|write tests",
+        ["code-task-execution", "test-driven-development"],
+        "TDD workflow",
+    ),
+    # Review / quality-gate bundle.
+    (
+        "代码审查|PR审查|pre-commit|质量门禁|自动修复|提交前检查|安全扫描|"
+        "code review|quality gate|security scan|preflight|verify before commit",
+        ["code-task-execution", "requesting-code-review"],
+        "code review",
+    ),
+    # spike
+    (
+        "spike|throwaway|验证实验|快速验证|quick check|validate idea",
+        ["spike"],
+        "spike experiment",
+    ),
+    # writing-plans
+    (
+        "写计划|写个计划|做计划|实施计划|任务分解|拆解任务|规划|implementation plan|"
+        "write plan|break down",
+        ["writing-plans"],
+        "writing plans",
+    ),
+    # subagent-driven-development
+    (
+        "子代理|子Agent|delegate|multi-agent|并行任务|委托任务|subagent|orchestrate|parallel",
+        ["subagent-driven-development"],
+        "subagent-driven development",
+    ),
+    # skill authoring / self-repair bundle.
+    (
+        "skill author|写skill|更新skill|修skill|优化skill|patch skill|"
+        "fix skill|update skill|create skill|skill 不对|skill失效",
+        ["code-task-execution", "hermes-agent-skill-authoring", "skill-self-repair"],
+        "skill authoring",
+    ),
+    # knowledge base / wiki
+    (
+        "知识库|资料库|wiki|GET笔记|RaymondWiki|knowledge base|raymond|notes",
+        ["wiki-ops", "getnote-ops"],
+        "knowledge base management",
+    ),
+]
+
+_L1_FAST_KEYWORDS = (
+    "小修",
+    "快速修复",
+    "small fix",
+    "quick fix",
+    "typo",
+    "拼写",
+    "一行",
+    "配置小改",
+)
+
+_NON_L1_KEYWORDS = (
+    "pr",
+    "pull request",
+    "merge",
+    "branch",
+    "commit",
+    "push",
+    "debug",
+    "调试",
+    "复现",
+    "根因",
+    "tdd",
+    "测试先行",
+    "回归测试",
+    "security",
+    "安全",
+    "auth",
+    "权限",
+    "migration",
+    "迁移",
+    "并发",
+    "concurrency",
+    "public api",
+    "review",
+    "审查",
+)
+
+
+def _config_bool(section: dict, key: str, default: bool) -> bool:
+    value = section.get(key, default)
+    return bool(value) if isinstance(value, bool) else default
+
+
+def _is_l1_fast_message(msg_lower: str) -> bool:
+    msg_lower = msg_lower.lower()
+    return any(k.lower() in msg_lower for k in _L1_FAST_KEYWORDS) and not any(
+        k.lower() in msg_lower for k in _NON_L1_KEYWORDS
+    )
+
+
+def _build_code_task_compact_context(
+    user_message: str,
+    task_id: str | None = None,
+) -> str:
+    """Return a small L1 code-task SOP without loading the full skill body.
+
+    This is intentionally narrow: it avoids the large SKILL.md payload for
+    obvious low-risk fixes while preserving the marker and safety gates.
+    """
+    try:
+        from tools.skill_usage import bump_use
+        bump_use("code-task-execution")
+    except Exception:
+        pass
+
+    runtime_note = (
+        "[AUTO-PRELOADED-COMPACT] The \"code-task-execution\" skill was "
+        f"compact-preloaded for an L1 fast-path request: {user_message.strip()[:80]}"
+    )
+    session_line = f"\nSession/task id: {task_id}" if task_id else ""
+    return f"""[IMPORTANT: Compact runtime guidance from the \"code-task-execution\" skill is active for this turn.]
+
+# code-task-execution — L1 Compact Fast Path
+
+Use this compact path only for obvious low-risk 1-2 file fixes. Escalate to the full skill or related skills if the task involves PRs, debugging/root cause, TDD, security/auth/path/state/migrations, public API behavior, unrelated working-tree changes, or two failed attempts.
+
+Required steps:
+1. Classify the task as L1 unless risk signals require escalation.
+2. Run `git status --short` before editing in a git repo.
+3. Locate the exact file/pattern and make the smallest possible patch.
+4. Run one targeted test, import/build parse, CLI smoke, or equivalent.
+5. Run scope gate: `git diff --name-only` and `git diff --check`.
+6. Final report must include status, changed files, verification commands, risk, next step.
+7. End the final answer with exactly: `[skill: code-task-execution]`.
+
+Do not refactor unrelated code, format whole files unless requested, add broad abstractions, auto-commit, or auto-open PR unless the user explicitly asks.{session_line}
+
+{runtime_note}"""
+
+
+def _matched_auto_preload_slugs(msg_lower: str) -> list[str]:
+    """Return deterministic, de-duplicated auto-preload skill bundle."""
+    matched_slugs: list[str] = []
+    for keywords, slugs, _reason in _AUTO_PRELOAD_RULES:
+        kw_list = [k.strip().lower() for k in keywords.split("|") if k.strip()]
+        if any(kw in msg_lower for kw in kw_list):
+            for slug in slugs:
+                if slug not in matched_slugs:
+                    matched_slugs.append(slug)
+    return matched_slugs
+
+
+def build_auto_skill_preload_context(
+    user_message: str,
+    task_id: str | None = None,
+) -> str:
+    """Auto-preload deterministic skill bundles for the current turn.
+
+    Returns an empty string when no skills match or auto-preload is disabled.
+    """
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config() or {}
+        skills_cfg = cfg.get("skills", {}) if isinstance(cfg.get("skills"), dict) else {}
+        if not _config_bool(skills_cfg, "auto_preload", False):
+            return ""
+        compact_l1 = _config_bool(skills_cfg, "auto_preload_compact_l1", True)
+    except Exception:
+        return ""
+
+    if not user_message or not user_message.strip():
+        return ""
+
+    msg_lower = user_message.lower()
+    msg_stripped = user_message.strip()
+    matched_slugs = _matched_auto_preload_slugs(msg_lower)
+
+    if not matched_slugs:
+        return ""
+
+    prompt_parts: list[str] = []
+    loaded_names: list[str] = []
+    compact_code_task = (
+        compact_l1
+        and "code-task-execution" in matched_slugs
+        and _is_l1_fast_message(msg_lower)
+    )
+
+    for slug in matched_slugs:
+        if slug == "code-task-execution" and compact_code_task:
+            prompt_parts.append(_build_code_task_compact_context(user_message, task_id=task_id))
+            loaded_names.append(slug)
+            continue
+
+        cmd_key = f"/{slug.replace('_', '-')}"
+        invocation = build_skill_invocation_message(
+            cmd_key,
+            user_instruction="",
+            task_id=task_id,
+            runtime_note=(
+                f"[AUTO-PRELOADED] The \"{slug}\" skill was automatically "
+                f"preloaded because the user's request matches: {msg_stripped[:80]}"
+            ),
+        )
+        if invocation:
+            prompt_parts.append(invocation)
+            loaded_names.append(slug)
+
+    if not prompt_parts:
+        return ""
+
+    logger.debug(
+        "auto_skill_preload: matched %s for user message: %s",
+        loaded_names,
+        msg_stripped[:60],
+    )
+    return "\n\n".join(prompt_parts)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1295,6 +1295,12 @@ DEFAULT_CONFIG = {
         # External hub installs (trusted/community sources) are always
         # scanned regardless of this setting.
         "guard_agent_created": False,
+        # Per-turn auto skill preloader: when a user message matches deterministic
+        # routing keywords, the matching skill bundle is preloaded into the turn.
+        "auto_preload": True,
+        # For obvious low-risk L1 code fixes, inject a compact code-task SOP
+        # instead of the full SKILL.md to reduce context and latency.
+        "auto_preload_compact_l1": True,
     },
 
     # Curator — background skill maintenance.

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1801,11 +1801,6 @@ def run_doctor(args):
                 check_warn(item["name"], f"(missing {vars_str})")
             else:
                 check_warn(item["name"], "(system dependency not met)")
-
-        # Count disabled tools with API key requirements
-        api_disabled = [u for u in unavailable if (u.get("missing_vars") or u.get("env_vars"))]
-        if api_disabled:
-            issues.append("Run 'hermes setup' to configure missing API keys for full tool access")
     except Exception as e:
         check_warn("Could not check tool availability", f"({e})")
     

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -16,8 +16,9 @@ from agent.insights import (
 
 
 @pytest.fixture()
-def db(tmp_path):
-    """Create a SessionDB with a temp database file."""
+def db(tmp_path, monkeypatch):
+    """Create a SessionDB with a temp database file and isolated Hermes home."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
     db_path = tmp_path / "test_insights.db"
     session_db = SessionDB(db_path=db_path)
     yield session_db
@@ -369,6 +370,34 @@ class TestInsightsPopulated:
         assert top_skill["manage_count"] == 0
         assert top_skill["total_count"] == 2
         assert top_skill["last_used_at"] is not None
+
+    def test_skill_breakdown_tracks_auto_preload_separately(self, populated_db):
+        import json as _json
+        from hermes_constants import get_hermes_home
+
+        usage_dir = get_hermes_home() / "skills"
+        usage_dir.mkdir(parents=True, exist_ok=True)
+        (usage_dir / ".usage.json").write_text(
+            _json.dumps({
+                "github-pr-workflow": {"use_count": 5, "last_used_at": time.time()},
+                "code-task-execution": {"use_count": 3, "last_used_at": time.time()},
+            }),
+            encoding="utf-8",
+        )
+
+        engine = InsightsEngine(populated_db)
+        report = engine.generate(days=30)
+        skills = report["skills"]
+
+        github = next(s for s in skills["top_skills"] if s["skill"] == "github-pr-workflow")
+        code_task = next(s for s in skills["top_skills"] if s["skill"] == "code-task-execution")
+
+        assert github["explicit_view_count"] == 2
+        assert github["auto_preload_count"] == 3
+        assert github["view_count"] == 5
+        assert code_task["explicit_view_count"] == 0
+        assert code_task["auto_preload_count"] == 3
+        assert code_task["view_count"] == 3
 
     def test_skill_breakdown_respects_days_filter(self, populated_db):
         engine = InsightsEngine(populated_db)

--- a/tests/agent/test_skill_auto_preload.py
+++ b/tests/agent/test_skill_auto_preload.py
@@ -1,0 +1,48 @@
+"""Tests for runtime auto skill preload routing."""
+
+from agent import skill_commands
+
+
+def test_auto_preload_pr_uses_deterministic_code_bundle():
+    slugs = skill_commands._matched_auto_preload_slugs("请创建PR并push这个修复".lower())
+
+    assert slugs[:2] == ["code-task-execution", "github-pr-workflow"]
+
+
+def test_auto_preload_ignores_broad_new_keyword():
+    slugs = skill_commands._matched_auto_preload_slugs("new idea for tomorrow".lower())
+
+    assert "github-pr-workflow" not in slugs
+
+
+def test_l1_compact_classification_requires_fast_keyword_without_risk():
+    assert skill_commands._is_l1_fast_message("小修 一个 typo") is True
+    assert skill_commands._is_l1_fast_message("小修 但要创建PR") is False
+    assert skill_commands._is_l1_fast_message("quick fix auth regression") is False
+
+
+def test_build_auto_preload_uses_compact_l1(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+
+    text = skill_commands.build_auto_skill_preload_context("小修：修一个 typo")
+
+    assert "AUTO-PRELOADED-COMPACT" in text
+    assert "L1 Compact Fast Path" in text
+    assert "[skill: code-task-execution]" in text
+
+
+def test_build_auto_preload_full_bundle_for_pr(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    seen = []
+
+    def fake_build_skill_invocation_message(cmd_key, **kwargs):
+        seen.append(cmd_key)
+        return f"loaded {cmd_key}"
+
+    monkeypatch.setattr(skill_commands, "build_skill_invocation_message", fake_build_skill_invocation_message)
+
+    text = skill_commands.build_auto_skill_preload_context("创建PR并push")
+
+    assert seen == ["/code-task-execution", "/github-pr-workflow"]
+    assert "loaded /code-task-execution" in text
+    assert "loaded /github-pr-workflow" in text


### PR DESCRIPTION
## Summary

Add deterministic per-turn auto skill preloader that injects matching skill bundles (full or L1-compact) into the first model call, and augment `/insights` to expose `auto_preload_count` vs `explicit_view_count` separately.

## Motivation

- The existing skill preloader was session-scoped and keyword-based but lived inside `build_preloaded_skills_prompt`, meaning it ran after the system prompt was already built
- L1 fast-path code fixes were loading the full `code-task-execution` SKILL.md (~15k chars) unnecessarily, inflating context for trivial tasks
- `/insights` was counting auto-preload loads the same as explicit `skill_view` calls, making skill popularity metrics unreliable
- `hermes doctor` was aggregating all tool API-key warnings into a single fake issue, inflating the real-error count

## Key Changes

| File | Change |
|------|--------|
| `agent/skill_commands.py` | New `_AUTO_PRELOAD_RULES` table + `build_auto_skill_preload_context()` + `_build_code_task_compact_context()` (L1 compact SOP, ~600 chars) |
| `hermes_cli/config.py` | New config keys: `skills.auto_preload: True`, `skills.auto_preload_compact_l1: True` |
| `agent/conversation_loop.py` | Call `build_auto_skill_preload_context()` per turn; inject skill context as a user-message prefix before the model call |
| `agent/insights.py` | Read `.usage.json` (`bump_use` telemetry) to split `auto_preload_count` vs `explicit_view_count`; expose both in report |
| `hermes_cli/doctor.py` | Remove spurious `issues.append()` that was adding a fake "missing API keys" issue to every doctor run |

## Verification

```bash
python -m pytest tests/agent/test_skill_auto_preload.py tests/agent/test_insights.py -q
# → 62 passed
```

CI: standard lint + unit.

---

**Three-layer review attestation** (control-plane L2 rule-change PR):
- Soul not modified — ✅
- Rule layer (config defaults) authorized — ✅  
- Execution layer (conversation loop / insights / doctor) has no code beyond routing and telemetry — ✅
- Task router unchanged — ✅
- Does not touch `projects/`, `workflow/`, `secrets/` — ✅
