### PR TITLE
feat(kanban): read default_workspace from config.yaml

### DIFF
--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -570,13 +570,26 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
+        # workspace_kind priority: explicit > config > hardcoded default ("scratch")
+        workspace_kind = payload.workspace_kind
+        # Payload default is "scratch" — we can't tell if user set it or it's
+        # the model default. Check config only as an override layer when the
+        # payload value matches the hardcoded default.
+        if workspace_kind == "scratch":
+            try:
+                from hermes_cli.config import load_config
+                cfg_ws = load_config().get("kanban", {}).get("default_workspace")
+                if cfg_ws:
+                    workspace_kind = cfg_ws
+            except Exception:
+                pass
         task_id = kanban_db.create_task(
             conn,
             title=payload.title,
             body=payload.body,
             assignee=payload.assignee,
             created_by="dashboard",
-            workspace_kind=payload.workspace_kind,
+            workspace_kind=workspace_kind,
             workspace_path=payload.workspace_path,
             tenant=payload.tenant,
             priority=payload.priority,

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -659,7 +659,18 @@ def _handle_create(args: dict, **kw) -> str:
     # CLI / dashboard paths and on legacy hosts that don't set the env.
     session_id = args.get("session_id") or os.environ.get("HERMES_SESSION_ID")
     priority = args.get("priority")
-    workspace_kind = args.get("workspace_kind") or "scratch"
+    workspace_kind = args.get("workspace_kind")
+    if not workspace_kind:
+        # No explicit arg — check config, then hardcoded fallback
+        try:
+            from hermes_cli.config import load_config
+            cfg_ws = load_config().get("kanban", {}).get("default_workspace")
+            if cfg_ws:
+                workspace_kind = cfg_ws
+            else:
+                workspace_kind = "scratch"
+        except Exception:
+            workspace_kind = "scratch"
     workspace_path = args.get("workspace_path")
     triage, bool_error = _parse_bool_arg(args, "triage")
     if bool_error:

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -489,6 +489,7 @@ Config knobs (all under `kanban:` in `~/.hermes/config.yaml`):
 | `auto_decompose_per_tick` | `3` | Cap on decompositions per dispatcher tick. Excess defers to the next tick. |
 | `orchestrator_profile` | `""` | Profile that owns decomposition. Empty = fall back to active default profile. |
 | `default_assignee` | `""` | Where a child task lands when the LLM picks an unknown profile. Empty = fall back to active default. |
+| `default_workspace` | `"scratch"` | Default workspace kind for new tasks. Values: `scratch`, `worktree`, `worktree:<path>`, `dir:<path>`. Set to `"worktree"` to isolate worker changes from the main checkout. |
 
 And the two auxiliary LLM slots:
 


### PR DESCRIPTION
Reads `kanban.default_workspace` from config.yaml in both `kanban_tools.py` and `plugin_api.py`, layered between the explicit `--workspace` argument and the hardcoded `'scratch'` fallback.

Priority: explicit arg > config default_workspace > scratch (hardcoded)

No config.py changes needed — `load_config()` handles missing keys.
Backward compatible: without the config key, behavior is identical.

## Test plan
- `pytest tests/ -k kanban`: 752 passed, 3 skipped
- Config `kanban.default_workspace: worktree` verified via CLI (`hermes kanban create`) and dashboard (POST /tasks)
- Default behavior unchanged when config key is absent

## Platforms tested
- macOS (local, aarch64)