### PR TITLE
fix(gateway): prevent clarify session split on session key mismatch

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6614,7 +6614,12 @@ class GatewayRunner:
             # this, the clarify is not found → message falls through
             # → a new Session is created → two Sessions run in parallel
             # in the same Thread (Session split).
-            if _pending_clarify is None:
+            # Guard: only in Thread contexts where session key mismatch
+            # can actually occur — non-Thread paths (DM, channel root)
+            # always have _quick_key == canonical key, so calling
+            # get_or_create_session here breaks Telegram topic mode lobby
+            # (which asserts it's never called).
+            if _pending_clarify is None and source.thread_id:
                 try:
                     _canonical_entry = self.session_store.get_or_create_session(source)
                     _canonical_key = _canonical_entry.session_key

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6608,6 +6608,20 @@ class GatewayRunner:
         try:
             from tools import clarify_gateway as _clarify_mod
             _pending_clarify = _clarify_mod.get_pending_for_session(_quick_key)
+            # P46 fix: when _quick_key doesn't match (e.g. due to
+            # thread_sessions_per_user config mismatch), fall back to the
+            # canonical session key from get_or_create_session.  Without
+            # this, the clarify is not found → message falls through
+            # → a new Session is created → two Sessions run in parallel
+            # in the same Thread (Session split).
+            if _pending_clarify is None:
+                try:
+                    _canonical_entry = self.session_store.get_or_create_session(source)
+                    _canonical_key = _canonical_entry.session_key
+                    if _canonical_key != _quick_key:
+                        _pending_clarify = _clarify_mod.get_pending_for_session(_canonical_key)
+                except Exception:
+                    pass
         except Exception:
             _pending_clarify = None
         if _pending_clarify is not None:
@@ -7849,6 +7863,28 @@ class GatewayRunner:
 
         session_entry = self.session_store.get_or_create_session(source)
         session_key = session_entry.session_key
+        # P46 concurrency guard: belt-and-suspenders clarify check using
+        # the canonical session key.  The earlier check in _handle_message
+        # uses _quick_key which may differ from session_key when
+        # thread_sessions_per_user configs diverge.  When keys differ and
+        # no agent is found in _running_agents under _quick_key, a new
+        # Session is spawned before the clarify-blocked agent can respond.
+        if session_key != _quick_key:
+            try:
+                from tools import clarify_gateway as _clarify_mod2
+                _pc = _clarify_mod2.get_pending_for_session(session_key)
+                if _pc is not None:
+                    _raw = (event.text or '').strip()
+                    if _raw and not _raw.startswith('/'):
+                        _clarify_mod2.resolve_gateway_clarify(_pc.clarify_id, _raw)
+                        logger.info(
+                            'Gateway intercepted clarify at session guard '
+                            '(session=%s, clarify_id=%s)',
+                            session_key, _pc.clarify_id,
+                        )
+                        return None  # consumed by clarify — no new turn
+            except Exception:
+                pass
         self._cache_session_source(session_key, source)
         if self._is_telegram_topic_lane(source):
             try:


### PR DESCRIPTION
## Problem

When the `clarify` tool blocks waiting for a user response, the gateway can create a **new Session** for the same Thread, running in parallel with the clarify-blocked Session. The user sees the agent respond with `history=0` (total amnesia), then later the original session's clarify eventually resolves — two conversations interleave.

Root cause: `_handle_message` checks for pending clarifies using `_quick_key` from `_session_key_for_source`, which may **differ** from the canonical session key used when the clarify was registered (from `get_or_create_session`). When `thread_sessions_per_user` configs diverge, keys don't match → `get_pending_for_session` returns `None` → the message falls through → if no agent is in `_running_agents` under `_quick_key`, a new Session spawns.

## Fix: Two-Layer Defense

### Layer 1: Clarify intercept fallback (`_handle_message`, ~line 6608)

When `_quick_key` doesn't find a pending clarify, additionally try the canonical session key — **only in Thread contexts** (guarded by `source.thread_id`). Non-Thread paths (DM, channel root) never have session key divergence, and calling `get_or_create_session` there breaks Telegram topic mode lobby (which asserts it's never called).

```python
if _pending_clarify is None and source.thread_id:
    try:
        _canonical_entry = self.session_store.get_or_create_session(source)
        _canonical_key = _canonical_entry.session_key
        if _canonical_key != _quick_key:
            _pending_clarify = _clarify_mod.get_pending_for_session(_canonical_key)
    except Exception:
        pass
```

### Layer 2: Session guard intercept (`_handle_message_with_agent`, ~line 7863)

Belt-and-suspenders. After `get_or_create_session` returns the canonical `session_key`, check again **before** proceeding with agent initialization.

```python
if session_key != _quick_key:
    try:
        from tools import clarify_gateway as _clarify_mod2
        _pc = _clarify_mod2.get_pending_for_session(session_key)
        if _pc is not None:
            _raw = (event.text or "").strip()
            if _raw and not _raw.startswith("/"):
                _clarify_mod2.resolve_gateway_clarify(_pc.clarify_id, _raw)
                return None
    except Exception:
        pass
```

## Testing

- [x] Verified on local Hermes + Mattermost deployment (self-hosted Docker)
- [x] Clarify interception works with both matching and mismatched session keys
- [x] No regression on normal (non-clarify) message flow
- [x] Belt-and-suspenders guard prevents session creation at the last possible moment
- [x] `source.thread_id` guard prevents side effects in Telegram topic mode lobby