### PR TITLE
fix(kanban): stop archived parents promoting children

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2094,7 +2094,7 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
 
 
 def recompute_ready(conn: sqlite3.Connection) -> int:
-    """Promote ``todo`` tasks to ``ready`` when all parents are ``done`` or ``archived``.
+    """Promote ``todo`` tasks to ``ready`` when all parents are ``done``.
 
     Returns the number of tasks promoted.  Safe to call inside or outside
     an existing transaction; it opens its own IMMEDIATE txn.
@@ -2128,7 +2128,7 @@ def recompute_ready(conn: sqlite3.Connection) -> int:
                 "WHERE l.child_id = ?",
                 (task_id,),
             ).fetchall()
-            if all(p["status"] in ("done", "archived") for p in parents):
+            if all(p["status"] == "done" for p in parents):
                 # Blocked tasks also get their failure counters reset —
                 # this is effectively an auto-unblock (circuit-breaker
                 # recovery; worker-initiated blocks are skipped above).
@@ -2180,7 +2180,7 @@ def claim_task(
         undone = conn.execute(
             "SELECT 1 FROM task_links l "
             "JOIN tasks p ON p.id = l.parent_id "
-            "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived') LIMIT 1",
+            "WHERE l.child_id = ? AND p.status != 'done' LIMIT 1",
             (task_id,),
         ).fetchone()
         if undone:
@@ -3450,9 +3450,9 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
             summary="task archived with run still active",
         )
         _append_event(conn, task_id, "archived", None, run_id=run_id)
-    # ``archived`` parents no longer block children, same as ``done``.
-    # Promote newly-unblocked dependents immediately instead of waiting
-    # for a later dispatcher tick.
+    # Archiving cancels/retires a task; it does not satisfy dependencies.
+    # Still run the normal promotion pass so unrelated dependents whose
+    # remaining parents are done do not wait for a later dispatcher tick.
     recompute_ready(conn)
     return True
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -744,6 +744,31 @@ def test_claim_rejects_when_parents_not_done(kanban_home):
     assert "claimed" not in kinds
 
 
+
+def test_claim_rejects_when_parent_archived(kanban_home):
+    """claim_task must reject a ready child whose parent was archived."""
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="a")
+        assert kb.archive_task(conn, parent) is True
+        child = kb.create_task(
+            conn, title="child", assignee="a", parents=[parent],
+        )
+        assert kb.get_task(conn, child).status == "todo"
+
+        # Simulate stale data from older versions or direct DB writes where
+        # archived parents counted as satisfied dependencies.
+        conn.execute(
+            "UPDATE tasks SET status='ready' WHERE id=?", (child,),
+        )
+        conn.commit()
+        assert kb.get_task(conn, child).status == "ready"
+
+        result = kb.claim_task(conn, child, claimer="host:1")
+
+    assert result is None
+    with kb.connect() as conn:
+        assert kb.get_task(conn, child).status == "todo"
+
 def test_claim_succeeds_once_parents_done(kanban_home):
     """After parents complete, recompute_ready -> claim_task must succeed."""
     with kb.connect() as conn:
@@ -2046,14 +2071,8 @@ def test_unlink_tasks_triggers_recompute_ready(kanban_home):
         )
 
 
-def test_archive_task_triggers_recompute_ready_for_dependents(kanban_home):
-    """Archiving a parent must immediately unblock its children.
-
-    ``recompute_ready()`` already treats ``archived`` parents as satisfied
-    dependencies, just like ``done``. Regression: ``archive_task()`` updated
-    the parent row but never ran the ready-promotion pass, so children stayed
-    stuck in ``todo`` until a later dispatcher tick.
-    """
+def test_archive_task_does_not_promote_dependents(kanban_home):
+    """Archiving cancels a parent; it must not satisfy child dependencies."""
     with kb.connect() as conn:
         parent = kb.create_task(conn, title="obsolete parent")
         child = kb.create_task(conn, title="child", parents=[parent])
@@ -2061,10 +2080,12 @@ def test_archive_task_triggers_recompute_ready_for_dependents(kanban_home):
         assert kb.get_task(conn, child).status == "todo"
         assert kb.archive_task(conn, parent) is True
 
-        assert kb.get_task(conn, child).status == "ready", (
-            "child should promote to ready immediately after its last blocking "
-            "parent is archived"
+        assert kb.get_task(conn, child).status == "todo", (
+            "child must stay todo because archived parents are not "
+            "successful completions"
         )
+        assert kb.recompute_ready(conn) == 0
+        assert kb.get_task(conn, child).status == "todo"
 
 # ---------------------------------------------------------------------------
 # _add_column_if_missing / _migrate_add_optional_columns idempotency (#21708)


### PR DESCRIPTION
## Summary
- stop treating `archived` parents as satisfied dependencies in `recompute_ready`
- align the `claim_task` parent gate so stale `ready` children with archived parents are demoted back to `todo`
- update regression coverage for archiving a parent and for the defensive claim gate

Addresses Bug 3 from #30417. This intentionally does not claim to fix the other dispatcher resilience bugs in that issue.

## Tests
- `HERMES_HOME=/tmp/hermes-agent-test-home ./.venv/bin/python -m pytest tests/hermes_cli/test_kanban_db.py -q`
- `HERMES_HOME=/tmp/hermes-agent-test-home ./.venv/bin/python -m pytest tests/hermes_cli/test_kanban_db.py -q -k "archive_task_does_not_promote or claim_rejects_when_parent_archived or claim_rejects_when_parents_not_done or create_with_parents_stays_todo_until_parents_done"`
- `HERMES_HOME=/tmp/hermes-agent-test-home ./.venv/bin/python - <<'PY' ... parent_in_different_status_states scenario ... PY`
- `./.venv/bin/ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py`
