### PR TITLE
fix(kanban): explicit board= arg outranks HERMES_KANBAN_DB env override

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -314,20 +314,25 @@ def kanban_db_path(board: Optional[str] = None) -> Path:
 
     Resolution (highest precedence first):
 
-    1. ``HERMES_KANBAN_DB`` env var — pins the path directly. Honoured for
-       back-compat and for the dispatcher→worker handoff (defense in
-       depth: dispatcher injects this into worker env so workers are
+    1. Explicit ``board`` arg → resolves to that board's DB, ignoring
+       ``HERMES_KANBAN_DB``.  When the caller asks for a specific board
+       it must be honoured — the env override is only a fallback for
+       contexts that don't specify a board.
+    2. ``HERMES_KANBAN_DB`` env var — pins the path directly. Honoured
+       for back-compat and for the dispatcher→worker handoff (defense
+       in depth: dispatcher injects this into worker env so workers are
        immune to any path-resolution disagreement).
-    2. When ``board`` arg is None, the active board from
+    3. When ``board`` arg is None, the active board from
        :func:`get_current_board` is used.
-    3. Board ``default`` → ``<root>/kanban.db`` (back-compat path).
+    4. Board ``default`` → ``<root>/kanban.db`` (back-compat path).
        Other boards → ``<root>/kanban/boards/<slug>/kanban.db``.
     """
-    override = os.environ.get("HERMES_KANBAN_DB", "").strip()
-    if override:
-        return Path(override).expanduser()
     slug = _normalize_board_slug(board)
     if slug is None:
+        # No explicit board — env override takes precedence.
+        override = os.environ.get("HERMES_KANBAN_DB", "").strip()
+        if override:
+            return Path(override).expanduser()
         slug = get_current_board()
     if slug == DEFAULT_BOARD:
         return kanban_home() / "kanban.db"
@@ -338,18 +343,20 @@ def workspaces_root(board: Optional[str] = None) -> Path:
     """Return the directory under which ``scratch`` workspaces are created.
 
     Anchored per-board so workspaces don't leak between projects.
-    ``HERMES_KANBAN_WORKSPACES_ROOT`` pins the path directly (highest
-    precedence) — the dispatcher injects this into worker env.
+
+    ``HERMES_KANBAN_WORKSPACES_ROOT`` pins the path directly (second-highest
+    precedence after an explicit ``board`` arg) — the dispatcher injects
+    this into worker env.
 
     ``default`` keeps the legacy path ``<root>/kanban/workspaces/`` so
     that existing scratch workspaces from before the boards feature are
     preserved. Other boards use ``<root>/kanban/boards/<slug>/workspaces/``.
     """
-    override = os.environ.get("HERMES_KANBAN_WORKSPACES_ROOT", "").strip()
-    if override:
-        return Path(override).expanduser()
     slug = _normalize_board_slug(board)
     if slug is None:
+        override = os.environ.get("HERMES_KANBAN_WORKSPACES_ROOT", "").strip()
+        if override:
+            return Path(override).expanduser()
         slug = get_current_board()
     if slug == DEFAULT_BOARD:
         return kanban_home() / "kanban" / "workspaces"

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -127,16 +127,31 @@ class TestPathResolution:
         )
 
     def test_env_var_db_override_still_wins(self, fresh_home, tmp_path, monkeypatch):
-        """``HERMES_KANBAN_DB`` pins the file regardless of board= arg."""
+        """``HERMES_KANBAN_DB`` pins the file when no board= arg is given."""
         forced = tmp_path / "custom.db"
         monkeypatch.setenv("HERMES_KANBAN_DB", str(forced))
         assert kb.kanban_db_path() == forced
-        assert kb.kanban_db_path(board="ignored") == forced
+
+    def test_explicit_board_overrides_env_var_db(self, fresh_home, tmp_path, monkeypatch):
+        """Explicit ``board=`` arg wins over ``HERMES_KANBAN_DB``."""
+        forced = tmp_path / "custom.db"
+        monkeypatch.setenv("HERMES_KANBAN_DB", str(forced))
+        # Explicit board should resolve normally, ignoring the env override.
+        expected = fresh_home / "kanban" / "boards" / "myboard" / "kanban.db"
+        assert kb.kanban_db_path(board="myboard") == expected
 
     def test_env_var_workspaces_override(self, fresh_home, tmp_path, monkeypatch):
         forced = tmp_path / "ws"
         monkeypatch.setenv("HERMES_KANBAN_WORKSPACES_ROOT", str(forced))
-        assert kb.workspaces_root(board="any") == forced
+        # No explicit board → env override applies.
+        assert kb.workspaces_root() == forced
+
+    def test_explicit_board_overrides_env_var_workspaces(self, fresh_home, tmp_path, monkeypatch):
+        """Explicit ``board=`` arg wins over ``HERMES_KANBAN_WORKSPACES_ROOT``."""
+        forced = tmp_path / "ws"
+        monkeypatch.setenv("HERMES_KANBAN_WORKSPACES_ROOT", str(forced))
+        expected = fresh_home / "kanban" / "boards" / "other" / "workspaces"
+        assert kb.workspaces_root(board="other") == expected
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`kanban_db_path()` and `workspaces_root()` unconditionally returned the `HERMES_KANBAN_DB` / `HERMES_KANBAN_WORKSPACES_ROOT` env-var override even when the caller passed an explicit `board=` argument.

In dispatched worker contexts where these env vars are pinned, tool calls like `kanban_show(board="other")` and CLI invocations like `hermes kanban --board other show <id>` silently resolved to the worker's own DB instead of the requested board.

## Root cause

Both functions checked the env-var override **before** inspecting the `board` argument:

```python
override = os.environ.get("HERMES_KANBAN_DB", "").strip()
if override:
    return Path(override).expanduser()  # always wins, even with board="other"
slug = _normalize_board_slug(board)
```

## Fix

Move the env-var check inside the `slug is None` branch so it only fires when no explicit board was provided. Explicit `board=` now outranks the env override — which matches the documented intent that callers requesting a specific board get that board.

## Tests

- Updated `test_env_var_db_override_still_wins` — now only asserts the no-board case
- Added `test_explicit_board_overrides_env_var_db` — asserts `board=` wins over `HERMES_KANBAN_DB`
- Updated `test_env_var_workspaces_override` — now only asserts the no-board case
- Added `test_explicit_board_overrides_env_var_workspaces` — asserts `board=` wins over `HERMES_KANBAN_WORKSPACES_ROOT`

All 58 board tests + 81 kanban tool tests pass.

Fixes #30678