### PR TITLE
Tighten hybrid control-plane handoff and vision fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,10 @@ cli-config.yaml
 skills/.hub/
 ignored/
 .worktrees/
+.hermes/handoff/
+.hermes/handoffs/
+.hermes/runs/
+.claude/worktrees/
 environments/benchmarks/evals/
 
 # Web UI build output

--- a/.hermes/config/capability-matrix.yaml
+++ b/.hermes/config/capability-matrix.yaml
@@ -1,0 +1,62 @@
+# Capability Matrix — Hybrid Agent Control Plane
+# Defines what each agent type is allowed to do in this repo.
+# Human-authored. Agents must not modify this file.
+# Governed by: .hermes/plans/2026-05-22_000000-hybrid-agent-control-plane.md
+# Caveats: C-3 (delegate_task ≠ CLI spawn), C-4 (Codex TBD), C-5 (cost estimated)
+
+agents:
+  claude_code:
+    status: available
+    cli_behavior_confirmed: true  # CLAUDE.md exists; worktree mode confirmed as pattern
+    spawn_mode: worktree          # worktree|container — container deferred to Phase 3
+    cli_invocation: >
+      Invoked via terminal() calling the claude CLI with --workdir set to the
+      worktree path. NOT via delegate_task (which does not auto-discover external CLIs).
+      Exact flags: CONFIRM before Phase 2 (--max-turns, --model, --output-format).
+    dangerously_skip_permissions: false   # hard no on real host filesystem
+    allowed_toolsets: [terminal, file, web]
+    forbidden_toolsets: [cronjob, send_message, delegation]
+    max_parallel_instances: 2
+    max_cost_per_run_usd: 5.00
+    cost_tracking: estimated              # see plan C-5 — not exact
+    can_write_prompt_artifacts: false     # .claude/**, CLAUDE.md, AGENTS.md forbidden
+    can_push_to_main: false
+    can_install_packages: false           # MVP: block; Phase 3: allow in container only
+    worktree_isolation_gap: >
+      Worktrees are NOT security sandboxes. An agent in a worktree can
+      reach any host path accessible to the Hermes process. Path locks
+      are advisory (gate-checked post-hoc). Container isolation deferred
+      to Phase 3. This gap must be documented in every run manifest.
+
+  codex:
+    status: provisional                   # TBD — see plan C-4
+    cli_behavior_confirmed: false         # UNCONFIRMED — do not use in production
+    sandbox_verified: false               # Must be set to true after Phase 2 canary (task 2.1)
+    approvals_verified: false             # Codex approval-prompt behavior unconfirmed
+    spawn_mode: worktree                  # Assumed; CONFIRM with actual Codex CLI docs
+    cli_invocation: >
+      UNCONFIRMED. Do not assume CODEX.md is read from repo root.
+      Do not assume any specific flags. Verify with `codex --help` and
+      Codex CLI docs before Phase 2. Mark CODEX.md as provisional.
+    allowed_operations: [read, write, create, test]
+    forbidden_operations: [network_external, git_push_main, global_install]
+    max_parallel_instances: 1
+    max_cost_per_run_usd: 3.00
+    cost_tracking: estimated              # see plan C-5
+    can_write_prompt_artifacts: false
+    can_push_to_main: false
+    production_gate: >
+      Codex must not be used in real task runs until:
+      (1) sandbox_verified=true after Phase 2 canary (task 2.1),
+      (2) approvals_verified=true,
+      (3) cli_behavior_confirmed=true.
+      All three must be set by Yoshio after manual verification.
+
+  hermes:
+    role: orchestrator
+    can_spawn_agents: true                # via terminal() calling CLI
+    can_read_all_paths: true
+    can_write_run_artifacts: true         # .hermes/runs/**, audit logs, manifests
+    can_merge_to_main: false              # MVP: Yoshio merges manually after gate pass
+    can_write_prompt_artifacts: true      # only with Yoshio approval and gate pass
+    gate_for_merge: human_review          # always required in MVP; see eval-matrix.yaml

--- a/.hermes/config/eval-matrix.yaml
+++ b/.hermes/config/eval-matrix.yaml
@@ -1,0 +1,96 @@
+# Eval Matrix — Hybrid Agent Control Plane
+# Maps task types to required gate sets and thresholds.
+# Hermes selects the appropriate row based on task_contract.goal classification.
+# Human-authored. Agents must not modify this file.
+# Governed by: .hermes/plans/2026-05-22_000000-hybrid-agent-control-plane.md
+
+# Gate set shorthand — referenced by task_types below.
+# Expand gate names resolve against gate-taxonomy.yaml.
+gate_sets:
+  minimal:
+    gates:
+      - schema_validation
+      - forbidden_path_writes
+      - diff_size_limit
+      - prompt_artifact_unchanged
+      - cost_cap
+    notes: >
+      Fastest gate set. No dynamic execution required. Use only for
+      docs-only changes to non-prompt-artifact .md files.
+
+  standard:
+    gates:
+      - schema_validation
+      - forbidden_path_writes
+      - diff_size_limit
+      - prompt_artifact_unchanged
+      - lint
+      - unit_tests
+      - cost_cap
+      - human_review
+    notes: >
+      Default for feature, bugfix, refactor tasks. All static gates
+      run first; dynamic gates run only after static gates pass.
+
+  high_assurance:
+    gates:
+      - schema_validation
+      - forbidden_path_writes
+      - diff_size_limit
+      - prompt_artifact_unchanged
+      - lint
+      - unit_tests
+      - integration_tests
+      - security_scan
+      - cost_cap
+      - human_review
+    notes: >
+      Required for security-adjacent changes, prompt artifact changes,
+      and unknown task types. integration_tests is non-blocking in Phase 1;
+      see gate-taxonomy.yaml for blocking promotion schedule.
+
+task_types:
+  docs_only:
+    gate_set: minimal
+    description: >
+      Changes only to .md files outside .hermes/ and prompt artifacts.
+      Files must not include AGENTS.md, CLAUDE.md, CODEX.md, or any
+      .hermes/config/ or .hermes/schemas/ file.
+
+  feature:
+    gate_set: standard
+    description: New functionality in src/ with tests.
+
+  refactor:
+    gate_set: standard
+    description: No new behavior; existing tests must still pass.
+
+  bugfix:
+    gate_set: standard
+    description: Targeted fix; regression test required in handoff.
+
+  security_adjacent:
+    gate_set: high_assurance
+    description: Auth, crypto, input validation, dependency updates, config.
+
+  prompt_artifact_change:
+    gate_set: high_assurance
+    description: >
+      Any change to AGENTS.md, CLAUDE.md, CODEX.md (provisional), .claude/**,
+      .codex/**, .hermes/config/**, .hermes/schemas/**.
+      Escalates automatically; human_review is always blocking.
+    blocked_agents: [claude_code, codex]    # only Hermes/Yoshio may propose these
+    notes: >
+      Agents may NOT produce prompt_artifact_change handoffs. If changed_files
+      contains a prompt artifact and the task type is not prompt_artifact_change,
+      the forbidden_path_writes gate fails and the task is escalated.
+
+  unknown:
+    gate_set: high_assurance               # conservative default
+    description: Task type not recognized or not classifiable.
+
+# Default thresholds (overridable per task contract)
+defaults:
+  diff_size_limit_kb: 500
+  cost_cap_usd: 2.00
+  iteration_cap: 40

--- a/.hermes/config/gate-taxonomy.yaml
+++ b/.hermes/config/gate-taxonomy.yaml
@@ -1,0 +1,113 @@
+# Gate Taxonomy — Hybrid Agent Control Plane
+# Defines every gate type: category, blocking status, evaluator, description.
+# Human-authored. Agents must not modify this file.
+# Governed by: .hermes/plans/2026-05-22_000000-hybrid-agent-control-plane.md
+# Primary local enforcement: scripts/check_hybrid_control_plane.py (see plan C-6)
+
+gates:
+
+  # ── Static / fast ──────────────────────────────────────────────────────────
+  # Run first. No external process required. Fail fast before dynamic gates.
+
+  schema_validation:
+    category: static
+    blocking: true
+    evaluator: hermes_skill
+    description: >
+      Handoff payload matches handoff-v1.yaml schema. Required fields present
+      with correct types. Hermes rejects and logs raw payload before any other
+      gate runs on a schema-invalid handoff.
+
+  forbidden_path_writes:
+    category: static
+    blocking: true
+    evaluator: hermes_skill
+    description: >
+      handoff.changed_files contains no path matching contract.scope.forbidden_paths.
+      Forbidden paths include at minimum: .hermes/, .claude/, .codex/, AGENTS.md,
+      CLAUDE.md, CODEX.md (where CODEX.md is provisional).
+      On failure: log exact paths, reject handoff, flag as potential supply-chain
+      incident if prompt artifacts are among the forbidden paths written.
+
+  diff_size_limit:
+    category: static
+    blocking: true
+    evaluator: hermes_skill
+    description: >
+      Total diff KB <= contract.eval_gates.diff_size_limit_kb (default 500 KB).
+      Computed from actual git diff of worktree vs base SHA, not agent self-report.
+
+  prompt_artifact_unchanged:
+    category: static
+    blocking: true
+    evaluator: hermes_skill
+    description: >
+      Prompt artifacts (AGENTS.md, CLAUDE.md, CODEX.md, .claude/**, .codex/**,
+      .hermes/**) not present in changed_files unless task type is
+      prompt_artifact_change and Yoshio explicitly whitelisted the path.
+      This gate is redundant with forbidden_path_writes for most task types
+      but provides a second check specifically for supply-chain artifacts.
+
+  # ── Dynamic / execution ────────────────────────────────────────────────────
+  # Require running external commands. Run after all static gates pass.
+
+  lint:
+    category: dynamic
+    blocking: true
+    evaluator: hermes_skill_runs_command
+    description: >
+      Project linter exits 0 on changed files.
+      CONFIRM actual lint command before Phase 2.
+      Likely: ruff check <changed_files> for Python; eslint for JS/TS.
+      Hermes runs this in the worktree, not the main checkout.
+
+  unit_tests:
+    category: dynamic
+    blocking: true
+    evaluator: hermes_skill_runs_command
+    description: >
+      scripts/run_tests.sh (or equivalent) exits 0.
+      Hermes runs this in the worktree with .venv activated.
+      CONFIRM actual test command before Phase 2.
+      If handoff.test_results.passed=false, this gate fails without re-running.
+
+  integration_tests:
+    category: dynamic
+    blocking: false           # non-blocking in Phase 1; promote to blocking in Phase 2
+    evaluator: hermes_skill_runs_command
+    description: >
+      Integration test suite exits 0. Phase 1: advisory only, logged to audit.
+      Phase 2: promote to blocking after baseline established.
+
+  # ── Human / review ─────────────────────────────────────────────────────────
+
+  human_review:
+    category: human
+    blocking: true
+    evaluator: yoshio
+    description: >
+      Yoshio reviews diff and approves merge. MVP: always required before merge.
+      Hermes prints diff summary and waits for explicit /approve or /reject.
+      No automated merge in Phase 1 or Phase 2; Yoshio runs git commands manually.
+    trigger: always
+
+  security_scan:
+    category: human_or_tool
+    blocking: false           # Phase 1: advisory; Phase 2: blocking for security_adjacent tasks
+    evaluator: hermes_skill_or_yoshio
+    description: >
+      No obvious supply-chain or injection issues in diff. Phase 1: log advisory
+      only. Phase 2: promote to blocking for task types security_adjacent and
+      prompt_artifact_change.
+
+  # ── Resource ───────────────────────────────────────────────────────────────
+
+  cost_cap:
+    category: resource
+    blocking: true
+    evaluator: hermes_skill
+    description: >
+      Run total estimated cost <= manifest.total_cost_usd_cap.
+      Cost is ESTIMATED (token-count × model-pricing) — not exact.
+      Hermes checks before each agent spawn, not only at gate time.
+      See plan C-5 and capability-matrix.yaml cost_tracking field.

--- a/.hermes/config/recovery-runbook.md
+++ b/.hermes/config/recovery-runbook.md
@@ -1,0 +1,139 @@
+# Hybrid Agent Control Plane — Recovery Runbook
+
+> Human-authored. Agents must not overwrite this file.
+> Referenced from run manifests when status=failed|escalated.
+
+---
+
+## Recovery States and Actions
+
+### R1: Agent Exceeded Cost Cap
+
+Detection: `manifest.total_cost_usd_actual >= total_cost_usd_cap` at gate time.
+
+Actions:
+1. Hermes blocks further spawns for this run (no new task contracts issued).
+2. Hermes emits partial-work summary to `audit.jsonl` with `reason: cost_cap_exceeded`.
+3. Yoshio decides: extend cap (edit manifest `total_cost_usd_cap`, re-run) or abandon run.
+
+Risk: Partial worktree may have uncommitted work. Do NOT delete the worktree
+until Yoshio reviews `git diff` against the worktree branch.
+
+NOTE (C-5): cost_usd_actual is ESTIMATED (token-count × model-pricing). It is
+not guaranteed to be exact. Mark `estimated: true` in manifest cost fields
+until a verified cost source is confirmed.
+
+---
+
+### R2: Agent Wrote to Forbidden Path
+
+Detection: gate `forbidden_path_writes` fails — `changed_files` in handoff
+contains a path matching `scope.forbidden_paths` in the task contract.
+
+Actions:
+1. Hermes rejects handoff; does NOT merge worktree into main branch.
+2. Logs exact forbidden paths to `audit.jsonl` with `gate: forbidden_path_writes`.
+3. If forbidden path is a prompt artifact (AGENTS.md, CLAUDE.md, CODEX.md,
+   .hermes/**, .claude/**, .codex/**): treat as supply-chain incident.
+   - Audit the full agent output and diff before any re-run.
+   - Do not re-queue automatically. Escalate to Yoshio.
+4. If forbidden path is non-artifact (accidental scope violation):
+   - Yoshio may choose to re-queue with tightened `allowed_paths`.
+
+---
+
+### R3: Test Suite Fails After Handoff
+
+Detection: gate `unit_tests` fails (exit code != 0).
+
+Actions:
+1. Hermes rejects handoff. Does NOT merge.
+2. Logs stdout_tail from test run to `audit.jsonl`.
+3. MVP: do NOT auto-retry. Escalate to Yoshio.
+4. Yoshio may re-queue task with appended goal:
+   "Tests failed on previous attempt: <summary>. Fix before resubmitting."
+
+---
+
+### R4: Schema Validation Failure
+
+Detection: handoff payload missing required fields or wrong types
+(validated against `.hermes/schemas/handoff-v1.yaml`).
+
+Actions:
+1. Hermes logs raw handoff payload to `audit.jsonl` (field: `raw_handoff`).
+2. Requests re-submission from agent with schema validation errors attached.
+3. If agent cannot produce valid handoff after 2 re-submission attempts:
+   - Escalate to Yoshio. Do not loop indefinitely.
+4. Common missing fields: `task_id`, `agent`, `completed_at`, `summary`,
+   `changed_files`, `test_results.passed`.
+
+---
+
+### R5: Lock Conflict (Two Tasks Claim Overlapping Paths)
+
+Detection: lock acquisition fails before spawn — a pending lock in
+`locks.yaml` overlaps with requested paths for the new task.
+
+Actions:
+1. Block second task from spawning.
+2. Queue it as `status: pending` with `blocked_by: <conflicting_task_id>`.
+3. If first task is stuck (no handoff after `iteration_cap` iterations):
+   - Escalate. Do not force-release the lock automatically.
+4. Conflict policy is set in `locks.yaml` `conflict_policy` field
+   (block | warn | escalate). Default: `block`.
+
+---
+
+### R6: Confused-Deputy Risk — Low-Trust Plan Handed to Orchestrator
+
+Detection: plan file not in version control, or `human_reviewed_at` field
+is missing/blank.
+
+Actions:
+1. Hermes refuses to spawn agents from unreviewed plans.
+2. Yoshio must set `human_reviewed_at: <ISO8601>` in the plan file and
+   commit it before the orchestrator will accept it as a run reference.
+3. Plans received from session context (not committed files) are never
+   used as run references without explicit Yoshio confirmation.
+
+NOTE: `human_reviewed_at` enforcement is currently soft (skill checks the
+field at spawn time). Hard enforcement via pre-commit hook is deferred to
+Phase 1 (see D-3 in plan).
+
+---
+
+### R7: Worktree Diverged from Base
+
+Detection: `git merge-base` check at gate time fails or shows unexpected
+diff between worktree and `git_base_sha` from manifest.
+
+Actions:
+1. Abort merge attempt.
+2. Log divergence detail to `audit.jsonl`.
+3. Yoshio resolves manually: inspect `git log --oneline <base>..<worktree-branch>`.
+4. Do NOT force-merge. Resolve conflict then re-run gate sequence.
+
+---
+
+## General Cleanup After Any Failed Run
+
+1. Do not delete the worktree until Yoshio has reviewed the diff:
+   ```
+   git diff <git_base_sha>..<worktree-branch> -- .
+   ```
+2. Archive the manifest before removing the run directory:
+   ```
+   cp -r .hermes/runs/<run-id>/ .hermes/runs/archived/<run-id>/
+   ```
+3. Remove worktree:
+   ```
+   git worktree remove --force .worktrees/<run-id>-cc
+   git worktree remove --force .worktrees/<run-id>-cx
+   ```
+4. Audit log is append-only. Never delete `.hermes/runs/<run-id>/audit.jsonl`.
+5. Worktree names include run-id. Never reuse run-ids across sessions.
+
+---
+
+*Runbook version: 2026-05-22. Update when gate behavior changes.*

--- a/.hermes/plans/2026-05-22_000000-hybrid-agent-control-plane.md
+++ b/.hermes/plans/2026-05-22_000000-hybrid-agent-control-plane.md
@@ -1,0 +1,1035 @@
+# Hybrid Agent Control Plane: Hermes + Claude Code + Codex
+
+**Status:** Phase 1 implementation in progress — locked decisions encoded; skill drafts, eval harness, and pytest coverage added
+**Date:** 2026-05-22
+**Author:** Yoshio (via planning session)
+**Slug:** hybrid-agent-control-plane
+
+<!-- MACHINE-CHECKABLE FIELDS — do not reformat these lines -->
+human_reviewed_at: 2026-05-22T23:27:28Z
+phase1_locked_at: 2026-05-22T23:27:28Z
+<!-- END MACHINE-CHECKABLE FIELDS -->
+
+---
+
+## Goal
+
+Build a secure, auditable, cost-bounded orchestration layer on top of Hermes
+that routes coding tasks to Claude Code and/or Codex as bounded workers,
+enforces per-task contracts, and gates results before they land in a shared
+repo. Hermes is the control plane; agents are trusted workers with explicit
+capability grants, not autonomous co-owners.
+
+---
+
+## Guiding Constraints
+
+1. Hermes is orchestrator, not peer. Agents never hand back to each other
+   without a Hermes gate in between.
+2. Worktrees are isolation-of-state, not security isolation. Strong isolation
+   requires containers or per-agent HOME. MVP may defer containers but must
+   document the gap and not pretend worktrees are sandboxes.
+3. Prompt artifacts (AGENTS.md, CLAUDE.md, .claude/**, .codex/**,
+   .hermes/**, .planning/**) are supply-chain artifacts. They must be version-
+   controlled, reviewed on change, and never silently overwritten by agents.
+4. No --dangerously-skip-permissions on real host filesystems.
+5. One canonical instruction source per repo; agent-specific files are thin
+   adapters that reference it, not duplicate it.
+6. Every run emits a manifest. Every task has a contract. Every handoff has a
+   schema. Every resource has a lock claim.
+7. MVP is skills + templates + eval harness. Core Hermes code changes come
+   after the workflow is validated.
+
+---
+
+## Non-Goals for MVP
+
+- Full container-per-agent isolation (documented gap, deferred to Phase 3).
+- Merging the kanban worker into this system (integration point noted but out
+  of scope until Phase 2 validated).
+- A new core Hermes CLI command or plugin (use skills + slash commands first).
+- Automatic agent self-repair loops (agents propose fixes; Hermes human gate
+  approves).
+- Cost optimization or model routing across multiple providers.
+- Support for agents other than Claude Code and Codex.
+- Reuse of any GSD repo installers or npx @latest patterns. Templates are
+  vendored here.
+
+## Phase 1 Locked Decisions (approved 2026-05-22T23:27:28Z)
+
+These decisions were locked by Yoshio and encoded in Phase 1 implementation artifacts.
+They supersede open decisions D-1 through D-6 for the MVP scope.
+
+**LD-1 Isolation: worktrees for MVP/Phase 1.**
+  Git worktrees are the isolation mechanism for Phase 1. This is merge
+  isolation only — NOT security isolation. A worker agent in a worktree
+  can read/write any path on the host that the Hermes process can access.
+  Container-per-agent isolation and per-agent HOME are explicitly deferred
+  to Phase 3. All run manifests must carry `worktrees_are_sandbox: false`
+  and `container_isolation: false`. This gap must be documented in every
+  run manifest until Phase 3 ships.
+
+**LD-2 Handoff: file-based handoff is canonical.**
+  The YAML handoff file at `.hermes/runs/<run-id>/handoffs/<task-id>.yaml`
+  is the single source of truth. Worker stdout may print a sentinel line
+  of the form `HANDOFF_PATH: <path>` so Hermes can locate the file, but
+  the file content is authoritative. Stdout parsing alone is not permitted
+  as a handoff mechanism. If the file is absent, the handoff is rejected.
+
+**LD-3 Human signoff: enforced via repo-local check script.**
+  Plans without a non-empty `human_reviewed_at` field cannot be used as a
+  run reference for any worker execution or real mutation phase.
+  Conservative/docs-only phases (Phase 0) may proceed without it.
+  Worker execution (Phase 2+) is blocked if `human_reviewed_at` is empty
+  or absent. The enforcement mechanism is `scripts/check_hybrid_control_plane.py`
+  (run before commit and at gate time). Soft skill wording alone is
+  insufficient; pre-commit hooks are additive but not the primary gate.
+
+**LD-4 Gate parallelism: serial gates for MVP.**
+  All gates run in the order defined by `gate-taxonomy.yaml` and
+  `eval-matrix.yaml`: static gates first, then dynamic (tests), then human.
+  No parallel gate execution until Phase 2 timing data shows >2 min
+  serial gate overhead. Rationale: serial gates are easier to audit and
+  debug; the MVP must first establish that gates work correctly before
+  optimizing throughput.
+
+**LD-5 CODEX.md and Codex adapter: opportunistic/non-blocking.**
+  `CODEX.md` is a provisional, explicitly-unverified stub. The Codex
+  adapter is NOT relied upon for Phase 1 or Phase 2. `sandbox_verified`
+  remains `false`. No Codex-specific logic is implemented in MVP; all
+  Codex paths in templates are marked PROVISIONAL. Phase 2 canary test
+  (task 2.1) must pass before Codex is used for real work.
+
+**LD-6 Cost tracking: estimated fields only in MVP.**
+  Manifests and contracts carry `cost_estimated: true` and
+  `total_cost_usd_actual: ~` (null until filled). External agent costs
+  are estimated via token-count × model-pricing, not exact provider data.
+  The `cost_usd_actual` field in task entries is set to null with
+  `cost_estimated: true`. Full per-run cost ledger is deferred to Phase 3.
+  No cost tracking code is added to Hermes core in Phase 1.
+
+---
+
+## Conservative MVP Tightening (added 2026-05-22)
+
+> These caveats were tightened after plan review. They supersede any
+> conflicting text in Phase 0/1 tasks below.
+
+**C-1 route-dev-task already exists.**
+  `~/.hermes/skills/_custom/route-dev-task/SKILL.md` exists and handles
+  task routing to the dev-profile Hermes subprocess. The conservative MVP
+  must NOT create a second route-dev-task skill. Phase 1 task 1.3 should
+  instead document how the hybrid-agent-control-plane integrates with or
+  extends the existing skill. No new route-dev-task file is written in
+  this phase.
+
+**C-2 Skill location: repo-local over user-profile.**
+  Conservative MVP artifacts (schemas, configs, templates, fixtures) live
+  under `.hermes/` in the repo. User-profile skill creation
+  (`~/.hermes/profiles/dev/skills/`) is deferred to Phase 1 and must be
+  explicitly decided by Yoshio before writing into the user profile. If a
+  skill skeleton is useful earlier, place it as a draft under
+  `.hermes/templates/` or `docs/` to avoid polluting installed skills.
+
+**C-3 delegate_task does not directly spawn Claude Code/Codex by default.**
+  Real external worker execution is terminal CLI-based and belongs in
+  Phase 2. The conservative MVP only defines adapter contracts and
+  templates. Any skill language referencing "spawns agent via
+  delegate_task" means: writes the contract + calls terminal() to invoke
+  the CLI. Document this as the intended mechanism; do not assume
+  delegate_task auto-discovers external CLI agents.
+
+**C-4 Codex adapter path is TBD.**
+  Codex CLI docs and current behavior are unverified. CODEX.md is
+  provisional (created only because the repo already has CLAUDE.md as a
+  precedent, and CODEX.md is marked explicitly as unverified). The Codex
+  adapter in capability-matrix.yaml has `sandbox_verified: false` and
+  `cli_behavior_confirmed: false`. Do not treat Codex as production-ready
+  until Phase 2 canary test (task 2.1) passes.
+
+**C-5 Cost tracking: external agent costs are estimated, not exact.**
+  Hermes does not guarantee per-external-agent cost data. Use token-count
+  × model-pricing estimation as the primary accounting method for Phase 1.
+  Mark `cost_usd_actual` fields in manifests as `estimated: true` until
+  exact cost data is confirmed available from agent internals
+  (see D-6 / Assumption 6).
+
+**C-6 Prompt artifact gate: repo-local check script, not CODEOWNERS alone.**
+  CODEOWNERS may not enforce local-only workflows (no PR required in solo
+  dev). A local check script (`scripts/check_hybrid_control_plane.py`)
+  is the primary pre-commit verification mechanism. CODEOWNERS is
+  additive when PRs are used, not the sole gate.
+
+---
+
+## Architecture Overview
+
+```
+User / Trigger
+    |
+    v
+Hermes (control plane)
+  |-- reads: run-manifest.yaml, task-contract.yaml
+  |-- acquires: resource lock map
+  |-- spawns: Claude Code worker  (worktree or container)
+  |           Codex worker        (worktree or container)
+  |-- gates:  capability check, path lock check, cost check
+  |-- receives: handoff payload (schema-validated)
+  |-- runs: eval matrix against handoff
+  |-- decides: merge / request-changes / escalate
+  |-- emits: run manifest update, audit log entry
+    |
+    v
+Repo (protected main branch)
+```
+
+Control flow is always Hermes -> Agent -> Hermes. Agents never push to main
+directly. Gate results are structured and logged.
+
+---
+
+## Data Model / Spec Sections
+
+### 1. Run Manifest
+
+File: `.hermes/runs/<run-id>/manifest.yaml`
+Written by Hermes at start; updated at each phase; immutable after close.
+
+```yaml
+run_id: <uuid>
+triggered_by: <user|cron|webhook>
+trigger_ref: <session-id or event-id>
+started_at: <ISO8601>
+closed_at: ~
+status: running|completed|failed|escalated
+
+plan_ref: .hermes/plans/<plan-file>.md   # which plan this run executes
+git_base_sha: <sha>                      # HEAD at spawn time
+worktree_paths:                          # CONFIRM: actual worktree root
+  claude_code: ~/hermes-agent/.worktrees/<run-id>-cc   # CONFIRM path convention
+  codex:       ~/hermes-agent/.worktrees/<run-id>-cx   # CONFIRM path convention
+
+tasks:
+  - task_id: <uuid>
+    contract_ref: .hermes/runs/<run-id>/contracts/<task-id>.yaml
+    agent: claude_code|codex
+    status: pending|running|handoff_received|gate_passed|gate_failed|merged|cancelled
+    cost_usd_actual: ~
+
+total_cost_usd_cap: 5.00   # hard cap; agent spawns blocked beyond this
+total_cost_usd_actual: ~
+audit_log: .hermes/runs/<run-id>/audit.jsonl
+```
+
+### 2. Task Contract
+
+File: `.hermes/runs/<run-id>/contracts/<task-id>.yaml`
+Written before agent spawn. Agent is handed a read-only copy. Hermes validates
+the handoff against this contract.
+
+```yaml
+task_id: <uuid>
+run_id: <uuid>
+created_at: <ISO8601>
+agent: claude_code|codex
+model: claude-sonnet-4-5|codex-1    # CONFIRM: exact model identifiers
+
+goal: |
+  <one paragraph, imperative, no implementation detail>
+
+scope:
+  allowed_paths:       # relative to worktree root
+    - src/
+    - tests/
+  forbidden_paths:
+    - .hermes/
+    - .claude/
+    - .codex/
+    - AGENTS.md
+    - CLAUDE.md
+  allowed_operations: [read, write, create, delete]
+  forbidden_operations: [git_push, network_external, install_global]
+
+acceptance_criteria:
+  - <testable criterion 1>
+  - <testable criterion 2>
+
+eval_gates:            # which gates must pass before handoff is accepted
+  - lint
+  - unit_tests
+  - no_forbidden_path_writes
+  - diff_size_limit_kb: 500
+
+cost_cap_usd: 2.00
+iteration_cap: 40
+
+handoff_schema_ref: .hermes/schemas/handoff-v1.yaml
+```
+
+### 3. Resource / Path Lock Map
+
+File: `.hermes/runs/<run-id>/locks.yaml`
+Prevents two agents from writing to overlapping paths simultaneously.
+Must be checked before any agent spawn. Hermes holds the lock file;
+agents never write it.
+
+```yaml
+run_id: <uuid>
+locks:
+  - task_id: <uuid>
+    agent: claude_code
+    claimed_at: <ISO8601>
+    released_at: ~
+    paths:        # glob patterns, relative to repo root
+      - src/agent/**
+      - tests/agent/**
+  - task_id: <uuid2>
+    agent: codex
+    claimed_at: <ISO8601>
+    released_at: ~
+    paths:
+      - src/tools/**
+      - tests/tools/**
+
+conflict_policy: block   # block|warn|escalate
+```
+
+Lock acquisition and release logic lives in Hermes orchestrator skill, not
+in agent code.
+
+### 4. Handoff Schema
+
+File: `.hermes/schemas/handoff-v1.yaml`
+Agent returns a structured payload when it considers the task done.
+Hermes validates this payload before running eval gates.
+
+```yaml
+# Schema definition (not an instance)
+handoff_schema_version: "1"
+fields:
+  task_id:          {type: string, required: true}
+  agent:            {type: string, required: true}
+  completed_at:     {type: string, format: iso8601, required: true}
+  summary:          {type: string, max_len: 500, required: true}
+  changed_files:
+    type: array
+    items: {type: string}   # relative paths from worktree root
+    required: true
+  test_results:
+    type: object
+    fields:
+      command_run:  {type: string}
+      exit_code:    {type: integer}
+      stdout_tail:  {type: string, max_len: 2000}
+      passed:       {type: boolean, required: true}
+  eval_evidence:
+    type: object
+    fields:
+      lint_clean:         {type: boolean}
+      unit_tests_passed:  {type: boolean}
+      diff_size_kb:       {type: number}
+      no_forbidden_writes: {type: boolean}
+  open_issues:
+    type: array
+    items: {type: string}
+  self_assessed_confidence: {type: string, enum: [high, medium, low]}
+```
+
+Agent skill templates must emit this exact schema. Hermes rejects handoffs
+that fail schema validation before running any gate.
+
+### 5. Capability Matrix
+
+File: `.hermes/config/capability-matrix.yaml`
+Defines what each agent type is allowed to do in this repo. Reviewed and
+updated by a human, not by agents.
+
+```yaml
+agents:
+  claude_code:
+    spawn_mode: worktree       # worktree|container (CONFIRM: container support available?)
+    dangerously_skip_permissions: false   # hard no on real host
+    allowed_toolsets: [terminal, file, web]
+    forbidden_toolsets: [cronjob, send_message, delegation]
+    max_parallel_instances: 2
+    max_cost_per_run_usd: 5.00
+    can_write_prompt_artifacts: false  # .claude/**, CLAUDE.md, AGENTS.md
+    can_push_to_main: false
+    can_install_packages: false        # MVP: block; Phase 3: allow in container
+
+  codex:
+    spawn_mode: worktree               # CONFIRM: Codex sandbox status in current CLI
+    sandbox_verified: false            # MUST be set to true before enabling in prod
+    # Codex sandbox and approvals are distinct flags; both must be confirmed.
+    allowed_operations: [read, write, create, test]
+    forbidden_operations: [network_external, git_push_main, global_install]
+    max_parallel_instances: 1
+    max_cost_per_run_usd: 3.00
+    can_write_prompt_artifacts: false
+    can_push_to_main: false
+
+  hermes:
+    role: orchestrator
+    can_spawn_agents: true
+    can_read_all_paths: true
+    can_write_run_artifacts: true      # .hermes/runs/**, audit logs, manifests
+    can_merge_to_main: true            # only after all gates passed
+    can_write_prompt_artifacts: true   # Hermes may update AGENTS.md on Yoshio approval
+```
+
+### 6. Gate Taxonomy
+
+File: `.hermes/config/gate-taxonomy.yaml`
+Defines every gate type, its category, whether it is blocking, and who
+evaluates it.
+
+```yaml
+gates:
+  # -- Static / fast --
+  schema_validation:
+    category: static
+    blocking: true
+    evaluator: hermes_skill
+    description: Handoff payload matches handoff-v1 schema.
+
+  forbidden_path_writes:
+    category: static
+    blocking: true
+    evaluator: hermes_skill
+    description: changed_files contains no path matching forbidden_paths in contract.
+
+  diff_size_limit:
+    category: static
+    blocking: true
+    evaluator: hermes_skill
+    description: Total diff KB <= contract.eval_gates.diff_size_limit_kb.
+
+  prompt_artifact_unchanged:
+    category: static
+    blocking: true
+    evaluator: hermes_skill
+    description: Prompt artifacts (AGENTS.md, CLAUDE.md, .claude/**, .codex/**,
+      .hermes/**) not present in changed_files unless explicitly whitelisted.
+
+  # -- Dynamic / execution --
+  lint:
+    category: dynamic
+    blocking: true
+    evaluator: hermes_skill_runs_command
+    description: Project linter exits 0 on changed files.
+    # CONFIRM: actual lint command (ruff? eslint? mypy?) — inspect repo before hardcoding.
+
+  unit_tests:
+    category: dynamic
+    blocking: true
+    evaluator: hermes_skill_runs_command
+    description: scripts/run_tests.sh (or equivalent) exits 0.
+    # CONFIRM: actual test command — scripts/run_tests.sh probes .venv first.
+
+  integration_tests:
+    category: dynamic
+    blocking: false    # non-blocking in Phase 1; promote to blocking in Phase 2
+    evaluator: hermes_skill_runs_command
+    description: Integration test suite exits 0.
+
+  # -- Human / review --
+  human_review:
+    category: human
+    blocking: true
+    evaluator: yoshio
+    description: Yoshio reviews diff and approves merge.
+    trigger: always   # MVP: always require human approval before merge
+
+  security_scan:
+    category: human_or_tool
+    blocking: false    # Phase 1: advisory; Phase 2: blocking
+    evaluator: hermes_skill_or_yoshio
+    description: No obvious supply-chain or injection issues in diff.
+
+  # -- Cost --
+  cost_cap:
+    category: resource
+    blocking: true
+    evaluator: hermes_skill
+    description: Run total cost <= manifest.total_cost_usd_cap.
+```
+
+### 7. Eval Matrix
+
+File: `.hermes/config/eval-matrix.yaml`
+Maps task types to required gate sets and thresholds.
+Hermes selects the appropriate row based on task_contract.goal classification.
+
+```yaml
+# Gate set shortcuts
+gate_sets:
+  minimal:    [schema_validation, forbidden_path_writes, diff_size_limit,
+               prompt_artifact_unchanged, cost_cap]
+  standard:   [schema_validation, forbidden_path_writes, diff_size_limit,
+               prompt_artifact_unchanged, lint, unit_tests, cost_cap, human_review]
+  high_assurance: [schema_validation, forbidden_path_writes, diff_size_limit,
+               prompt_artifact_unchanged, lint, unit_tests, integration_tests,
+               security_scan, cost_cap, human_review]
+
+task_types:
+  docs_only:
+    gate_set: minimal
+    description: Changes only to .md files outside .hermes/ and prompt artifacts.
+
+  feature:
+    gate_set: standard
+    description: New functionality in src/ with tests.
+
+  refactor:
+    gate_set: standard
+    description: No new behavior; existing tests must still pass.
+
+  bugfix:
+    gate_set: standard
+    description: Targeted fix; regression test required in handoff.
+
+  security_adjacent:
+    gate_set: high_assurance
+    description: Auth, crypto, input validation, dependency updates, config.
+
+  prompt_artifact_change:
+    gate_set: high_assurance   # escalate automatically; human must approve
+    description: Any change to AGENTS.md, CLAUDE.md, .claude/**, .codex/**,
+      .hermes/config/**.
+    blocked_agents: [claude_code, codex]  # only Hermes/Yoshio may propose these
+
+  unknown:
+    gate_set: high_assurance   # conservative default
+    description: Task type not recognized.
+```
+
+### 8. Recovery State / Runbook
+
+File: `.hermes/config/recovery-runbook.md`
+Linked from manifests when status=failed|escalated.
+
+```
+RECOVERY STATES AND ACTIONS
+
+R1: Agent exceeded cost cap
+  Detection: manifest.total_cost_usd_actual >= cap at gate time
+  Action:    Hermes blocks further spawns for this run.
+             Hermes emits summary of partial work to audit log.
+             Yoshio decides: extend cap (edit manifest, re-run) or abandon.
+  Risk:      Partial worktree may have uncommitted work — do not delete
+             worktree until Yoshio reviews.
+
+R2: Agent wrote to forbidden path
+  Detection: gate forbidden_path_writes fails
+  Action:    Hermes rejects handoff, does NOT merge worktree.
+             Logs exact forbidden paths to audit.jsonl.
+             Yoshio inspects worktree diff before cleanup.
+  Risk:      If agent modified prompt artifacts, treat as supply-chain
+             incident. Audit the full agent output before re-running.
+
+R3: Test suite fails after handoff
+  Detection: gate unit_tests fails
+  Action:    Hermes rejects handoff. Optionally re-queues task with
+             "tests failed, fix before resubmitting" appended to goal.
+             MVP: do not auto-retry; escalate to Yoshio.
+
+R4: Schema validation failure
+  Detection: handoff payload missing required fields or wrong types
+  Action:    Hermes logs raw handoff to audit, requests re-submission from agent.
+             If agent cannot produce valid handoff after 2 attempts: escalate.
+
+R5: Lock conflict (two tasks claim overlapping paths)
+  Detection: lock acquisition fails before spawn
+  Action:    Block second task from spawning. Queue it pending release.
+             If first task is stuck (no handoff after iteration_cap): escalate.
+
+R6: Confused-deputy risk — low-trust plan handed to orchestrator
+  Detection: plan file not in version control, or modified after last human review.
+  Action:    Hermes refuses to spawn agents from unreviewed plans.
+             Plan files must have a human_reviewed_at field set by Yoshio.
+             CONFIRM: implement this as a mandatory manifest field, not just convention.
+
+R7: Worktree diverged from base
+  Detection: git merge-base check at gate time fails or shows unexpected diff
+  Action:    Abort merge. Log divergence. Yoshio resolves manually.
+             Do not force-merge.
+
+General cleanup:
+  - Worktrees are named by run-id; never reuse run-ids.
+  - On abandoned run: git worktree remove --force, then delete
+    .hermes/runs/<run-id>/ after archiving manifest.
+  - Audit log is append-only; never delete .hermes/runs/<run-id>/audit.jsonl.
+```
+
+---
+
+## Phases
+
+> Implementation should inspect actual project tooling (linters, test runner,
+> existing skills, config schema) before finalizing any commands below.
+> Commands marked [CONFIRM] need repo inspection before use.
+
+### Phase 0 — Foundation: Docs, Schemas, Templates (no code)
+
+Goal: establish supply chain hygiene and shared vocabulary. No agent spawning yet.
+
+Tasks:
+
+0.1 Create repo-level canonical instruction file.
+    File: AGENTS.md (already exists — inspect before editing)
+    Action: Add a "Hybrid Agent Control Plane" section that references
+    .hermes/plans/ as the plan source and .hermes/runs/ as the run store.
+    Constraint: do not rewrite existing content; append a section.
+
+0.2 Create thin agent adapter files.
+    Files:
+      CLAUDE.md   — ALREADY EXISTS. Inspect before editing; only append a
+                    "Hybrid Agent Control Plane" section if missing. Do not
+                    rewrite existing content.
+      CODEX.md    — PROVISIONAL / TBD (see C-4). Create only as an explicitly
+                    unverified adapter stub. Mark file header with:
+                    "PROVISIONAL: Codex CLI behavior unconfirmed — do not use
+                    in production until Phase 2 canary (task 2.1) passes."
+                    Do NOT assume Codex reads CODEX.md from repo root; mark
+                    the read-path as CONFIRM.
+    These files must NOT duplicate AGENTS.md content. Reference it.
+    CONFIRM: whether Claude Code CLI reads CLAUDE.md from repo root or
+    .claude/ directory in the specific worktree.
+
+0.3 Write canonical schemas.
+    Files under .hermes/schemas/:
+      handoff-v1.yaml
+    Use the spec in the Data Model section above as starting point.
+
+0.4 Write config files.
+    Files under .hermes/config/:
+      capability-matrix.yaml
+      gate-taxonomy.yaml
+      eval-matrix.yaml
+      recovery-runbook.md
+    Use the specs above as starting points. These are human-authored; agents
+    must not overwrite them.
+
+0.5 Protect prompt artifacts.
+    Primary: `scripts/check_hybrid_control_plane.py` (local, runnable without
+    PR infrastructure). Run before any commit touching prompt artifacts.
+    Secondary (when PRs used): Add a CODEOWNERS or pre-commit hook that
+    requires Yoshio approval on:
+      AGENTS.md, CLAUDE.md, CODEX.md, .claude/**, .codex/**,
+      .hermes/config/**, .hermes/schemas/**
+    See C-6: CODEOWNERS alone is insufficient for local workflows.
+    CONFIRM: whether repo has CODEOWNERS or pre-commit infrastructure.
+
+0.6 Write run manifest and task contract templates.
+    Files:
+      .hermes/templates/run-manifest.yaml.j2   (or plain YAML with {{}} markers)
+      .hermes/templates/task-contract.yaml.j2
+      .hermes/templates/locks.yaml.j2
+    Used by the orchestrator skill to generate run artifacts.
+
+Verification for Phase 0:
+  - All schema and config files are committed and reviewed by Yoshio.
+  - git log --follow on AGENTS.md shows no agent-authored commits.
+  - CODEOWNERS (or equivalent) in place and tested with a draft PR.
+
+---
+
+### Phase 1 — Skill Implementation: Orchestrator + Eval Harness
+
+Goal: implement the Hermes skills that wire the control plane together.
+Still no agent spawning in production; test with stubs.
+
+Tasks:
+
+1.1 Author skill: hybrid-agent-control-plane
+    Location DEFERRED (see C-2): Phase 1 decision — repo-local draft under
+    .hermes/templates/skill-draft-hybrid-agent-control-plane.md, OR
+    ~/.hermes/profiles/dev/skills/software-development/ after Yoshio review.
+    Conservative MVP: create the draft only; do not install to user profile.
+    Responsibilities:
+      - Accepts a goal string + task type.
+      - Reads capability-matrix.yaml and gate-taxonomy.yaml.
+      - Generates run manifest (from template).
+      - Generates task contract (from template).
+      - Acquires path locks.
+      - Spawns agent (Claude Code or Codex) with scoped worktree.
+      - Polls for handoff payload.
+      - Validates handoff against schema.
+      - Runs gates in order (static first, then dynamic, then human).
+      - Merges or rejects based on gate results.
+      - Updates manifest and emits audit log entry.
+      - Releases path locks.
+    Note: MVP skill calls existing Hermes tools (terminal, file) rather
+    than adding new core code. delegate_task is NOT a direct Claude Code/Codex
+    spawner — real agent execution uses terminal() to call the CLI. See C-3.
+
+1.2 Author skill: subagent-eval-gate (or extend harness-eval)
+    Location: ~/.hermes/profiles/dev/skills/software-development/
+              subagent-eval-gate/SKILL.md
+    Responsibilities:
+      - Receives handoff payload path.
+      - Reads gate-taxonomy.yaml and eval-matrix.yaml.
+      - Runs each required gate for the task type.
+      - Returns a structured gate-result payload (pass/fail per gate, evidence).
+    CONFIRM: whether existing harness-eval skill covers this or needs extension.
+    Load harness-eval skill before authoring to check overlap.
+
+1.3 Author skill: route-dev-task — DO NOT DUPLICATE (see C-1).
+    Existing skill at ~/.hermes/skills/_custom/route-dev-task/SKILL.md
+    handles routing to the dev-profile Hermes subprocess. It must NOT be
+    recreated. Instead, document in hybrid-agent-control-plane skill how
+    it integrates with the existing route-dev-task:
+      - route-dev-task routes the overall goal to the dev profile.
+      - hybrid-agent-control-plane is called within the dev session to
+        actually spawn and gate the external agent worker.
+    If the existing route-dev-task needs an extension for agent routing,
+    propose the patch to Yoshio first; do not overwrite the file.
+
+1.4 Write stub agent scripts for testing.
+    Files under .hermes/test-fixtures/:
+      stub-handoff-pass.yaml   — valid handoff, all gates pass
+      stub-handoff-fail-forbidden.yaml   — handoff with forbidden path in changed_files
+      stub-handoff-fail-schema.yaml      — handoff missing required fields
+      stub-handoff-fail-tests.yaml       — handoff with test_results.passed=false
+    Used in Phase 1 testing without real agent spawns.
+
+1.5 Write eval harness tests.
+    Location: tests/skills/test_hybrid_agent_control_plane.py
+              (CONFIRM: actual test path convention — inspect tests/ structure)
+    Test cases:
+      - Gate: schema_validation passes on valid handoff
+      - Gate: schema_validation fails on stub-handoff-fail-schema
+      - Gate: forbidden_path_writes blocks forbidden path
+      - Gate: unit_tests fail triggers rejection
+      - Manifest: run_id is unique per invocation
+      - Locks: two tasks with overlapping paths cannot both acquire lock
+      - Cost cap: manifest blocks spawn when cap exceeded
+    CONFIRM: test runner command.
+      Likely: source .venv/bin/activate && scripts/run_tests.sh
+      Or: pytest tests/skills/ -x -q
+
+Verification for Phase 1:
+  - All stub-based gate tests pass.
+  - Skills load without error in Hermes CLI (hermes /hybrid-agent-control-plane).
+  - Manifest and contract templates render correctly from stubs.
+  - Audit log is written for each stub run.
+  - No new core Hermes files modified.
+
+---
+
+### Phase 2 — Integration: Real Agent Spawns (Worktree Mode)
+
+Goal: run real Claude Code and Codex workers against a test task in worktree
+isolation. Still no container isolation; document the gap explicitly in each run.
+
+Tasks:
+
+2.1 Verify Codex sandbox status.
+    BEFORE spawning Codex: run the Codex CLI with a canary task (echo only, no
+    file writes) and confirm sandbox behavior matches documentation.
+    Set capability-matrix.yaml codex.sandbox_verified=true only after this check.
+    Treat sandbox and approval-prompts as separate features; verify both.
+
+2.2 Select a low-risk integration test task.
+    Criteria: docs-only or small bugfix, no security-adjacent paths,
+    bounded scope (< 5 files), existing tests cover the area.
+    Do not use a feature task for first real spawn.
+
+2.3 Create worktrees under a safe path.
+    CONFIRM: worktree naming convention and root.
+    Proposed: git worktree add .worktrees/<run-id>-cc <branch-name>
+    Ensure .worktrees/ is in .gitignore.
+
+2.4 Spawn Claude Code worker with scoped CLAUDE.md.
+    Claude Code reads CLAUDE.md from worktree root.
+    Copy (do not symlink) the thin CLAUDE.md adapter into the worktree.
+    CONFIRM: whether Claude Code CLI accepts a --workdir flag pointing at the
+    worktree, or whether it must be invoked from the worktree cwd.
+    Pass task contract as context (file path or inline).
+
+2.5 Collect handoff from agent.
+    Agent writes handoff to .hermes/runs/<run-id>/handoffs/<task-id>.yaml
+    in the worktree. Hermes reads it from there.
+    CONFIRM: whether Codex CLI can be directed to write structured output to
+    a file, or whether Hermes must parse stdout.
+
+2.6 Run full gate sequence against real handoff.
+    Use subagent-eval-gate skill.
+    Log all gate results to audit.jsonl.
+
+2.7 Human gate: Yoshio reviews diff before merge.
+    Hermes prints diff summary and waits for explicit /approve or /reject.
+    MVP: no automated merge; Yoshio runs git commands manually.
+    Phase 3: Hermes can run git merge after human approval signal.
+
+2.8 Post-merge: update manifest to status=completed, release locks.
+
+Verification for Phase 2:
+  - A real (small) task was completed by Claude Code or Codex in a worktree.
+  - All gates ran and their results are in audit.jsonl.
+  - No agent touched prompt artifacts.
+  - Cost stayed within cap.
+  - Merge was approved by Yoshio, not automated.
+  - Worktree cleaned up after merge.
+
+---
+
+### Phase 3 — Hardening (deferred)
+
+Gated on Phase 2 validated.
+
+3.1 Container isolation per agent (Docker or Daytona backend).
+    Hermes already supports Docker terminal backend via tools/environments/.
+    CONFIRM: whether existing docker backend supports worktree-style git access
+    or requires volume mounts.
+    Per-agent HOME: set HOME=/tmp/agent-home-<run-id> for each container.
+
+3.2 Codex sandbox canary: run a network-exfil canary test in the container
+    to confirm sandbox blocks outbound connections.
+
+3.3 Promote integration_tests gate to blocking in eval-matrix.yaml.
+
+3.4 Promote security_scan gate to blocking.
+
+3.5 Kanban integration (optional).
+    The kanban plugin in plugins/kanban/ dispatches workers.
+    CONFIRM: whether a new kanban lane type "hybrid-agent" makes sense, or
+    whether the existing worker skill pattern is sufficient.
+    Do not integrate kanban until Phase 2 is stable.
+
+3.6 Rolling integration: run hybrid agent on 1 real task per week, review
+    audit logs, adjust gate thresholds.
+
+3.7 Cost controls: add a per-week cost budget tracked in
+    .hermes/config/cost-policy.yaml. Hermes checks this before any spawn.
+
+---
+
+## Integration Points
+
+### Hermes Skills (confirmed needed)
+
+| Skill | Status | Location |
+|---|---|---|
+| hybrid-agent-control-plane | Draft only (Phase 1 — see C-2) | .hermes/templates/skill-draft-*.md until Yoshio approves profile install |
+| subagent-eval-gate | New or extend harness-eval (Phase 1) | TBD — defer profile install |
+| route-dev-task | EXISTS — do not duplicate (see C-1) | ~/.hermes/skills/_custom/route-dev-task/SKILL.md |
+| subagent-driven-development | Existing — reference | already in skills/ |
+| requesting-code-review | Existing — gate step | already in skills/ |
+| harness-eval | Existing — inspect before extending | already in skills/ |
+
+### Repo Scaffolding
+
+| File | Action | Notes |
+|---|---|---|
+| AGENTS.md | Append section | Do not rewrite |
+| CLAUDE.md | Create | Thin adapter |
+| CODEX.md | Create (PROVISIONAL — see C-4) | Thin adapter stub; mark as unverified |
+| .hermes/schemas/handoff-v1.yaml | Create | Schema definition |
+| .hermes/config/capability-matrix.yaml | Create | Human-authored, agent-immutable |
+| .hermes/config/gate-taxonomy.yaml | Create | Human-authored, agent-immutable |
+| .hermes/config/eval-matrix.yaml | Create | Human-authored, agent-immutable |
+| .hermes/config/recovery-runbook.md | Create | Human-authored |
+| .hermes/templates/*.yaml.j2 | Create | Manifest/contract/lock templates |
+| .hermes/test-fixtures/*.yaml | Create | Stub handoffs for testing |
+| .worktrees/ | Create dir, add to .gitignore | Worktree root |
+| CODEOWNERS | Create or extend | Protect prompt artifacts |
+
+### CLI / Workflow
+
+MVP: skill-based workflow only. No new core CLI commands.
+
+Trigger: Yoshio types:
+  /route-dev-task "fix the bug in tools/terminal.py where timeout is ignored"
+
+Or via skill:
+  /hybrid-agent-control-plane task_type=bugfix goal="..."
+
+Slash commands are dispatched by Hermes CLI via skill loading (see
+agent/skill_commands.py). No new core code needed for Phase 1.
+
+Optional (Phase 3): a /hacp slash command as a thin wrapper that loads
+hybrid-agent-control-plane. Only worth adding if the skill invocation UX
+is awkward.
+
+---
+
+## Context Health Policy
+
+Agents receive a scoped context: task contract + CLAUDE.md/CODEX.md only.
+Hermes does NOT pass full session history or run manifest to agents.
+Rationale: limits confused-deputy surface — agent only knows its task, not
+the broader orchestration state.
+
+If an agent requests context outside its contract scope, Hermes rejects
+the request and logs it to audit.jsonl.
+
+---
+
+## Supply Chain Policy
+
+1. Plan files (.hermes/plans/*.md) must have a human_reviewed_at field
+   (date + Yoshio sign-off) before any run references them.
+   Hermes refuses to spawn agents from plans missing this field.
+
+2. Prompt artifact changes (AGENTS.md, CLAUDE.md, CODEX.md, .claude/**,
+   .codex/**, .hermes/config/**, .hermes/schemas/**) are blocked from
+   agent-authored commits via CODEOWNERS (or pre-commit hook).
+
+3. No npx @latest or remote installer scripts. All templates are vendored
+   in .hermes/templates/ and version-controlled.
+
+4. Agent skill files themselves (~/.hermes/profiles/dev/skills/**) are
+   user-config, not repo files. They must be reviewed before first use and
+   after any edit.
+
+---
+
+## Risks and Open Decisions for Yoshio
+
+### Risks
+
+R-1 Codex sandbox is unverified.
+    Impact: Codex may have network or filesystem access you don't expect.
+    Mitigation: Do not use Codex in Phase 2 until canary test passes.
+
+R-2 Worktrees are not sandboxes.
+    Impact: Agent in a worktree can read/write any path on the host accessible
+    to the Hermes process. A compromised or hallucinating agent can escape
+    the allowed_paths contract via the filesystem.
+    Mitigation: Phase 3 containers. For Phase 2, allowed_paths is advisory
+    enforcement only (gate-checked post-hoc, not prevented pre-run).
+    Document this gap prominently in run manifests.
+
+R-3 Hermes confused deputy.
+    Impact: Hermes has high trust. If a malicious plan file or low-trust
+    context is handed to Hermes, it can be directed to spawn agents with
+    high-trust credentials.
+    Mitigation: plan files require human_reviewed_at. Plans from session
+    context (not committed files) are never used as run references without
+    Yoshio confirmation.
+
+R-4 Prompt artifact injection.
+    Impact: Agent modifies AGENTS.md or .claude/commands/ to alter future
+    agent behavior.
+    Mitigation: CODEOWNERS + forbidden_path_writes gate + prompt_artifact_unchanged
+    gate. Both must be in place before Phase 2.
+
+R-5 Cost overrun.
+    Impact: Agent loops consume large token budget before cap is enforced.
+    Mitigation: cost_cap_usd in task contract + total_cost_usd_cap in manifest.
+    Hermes checks cost before each spawn. CONFIRM: whether Hermes AIAgent
+    exposes cost tracking per-run (check agent/ internals).
+
+### Open Decisions
+
+D-1 Container vs worktree for Phase 2.
+    Recommendation: worktree for Phase 2 with documented gap; containers for
+    Phase 3. But if Yoshio has Docker available and Hermes docker backend is
+    stable, skip straight to containers.
+    CONFIRM: Docker availability and Hermes docker backend status.
+
+D-2 Handoff mechanism: file vs stdout.
+    Codex may not write structured files natively.
+    Decision needed: does Hermes parse Codex stdout and extract handoff, or
+    does the agent skill template write the file?
+    Recommendation: agent skill template writes the file; cleaner separation.
+
+D-3 human_reviewed_at enforcement mechanism.
+    Options: (a) Hermes skill checks the field at spawn time (soft enforcement),
+    (b) pre-commit hook blocks commits without it (hard enforcement).
+    Recommendation: (b) for prompt artifacts, (a) for plan files (plan files
+    are not committed in all workflows).
+
+D-4 Gate parallelism.
+    Static gates can run in parallel; dynamic gates (tests) may be slow in
+    serial. Phase 1: serial is fine. Phase 2: consider parallel gate execution
+    if test suite is > 2 minutes. CONFIRM: test suite runtime.
+
+D-5 Codex CLI handoff schema — TBD (see C-4).
+    Codex CLI behavior is unconfirmed. Do not finalize a Codex-specific
+    adapter until Phase 2 canary passes. The handoff schema is designed
+    to be agent-agnostic; adapter skill produces the compliant output.
+    Mark Codex adapter path as provisional in all config files.
+
+D-6 Cost tracking granularity — estimated only for now (see C-5).
+    Hermes may not expose per-external-agent cost. Use token-count ×
+    model-pricing as the fallback. Mark cost_usd_actual as estimated=true
+    in manifests. Inspect agent/budget.py or equivalent in Phase 1 to
+    confirm whether exact per-instance cost is available.
+
+---
+
+## Acceptance Criteria
+
+Phase 0:
+- [ ] All schema, config, template, and adapter files committed and reviewed.
+- [ ] AGENTS.md has hybrid-agent-control-plane section.
+- [ ] CODEOWNERS (or pre-commit) blocks agent writes to prompt artifacts.
+- [ ] human_reviewed_at field defined and documented.
+
+Phase 1:
+- [x] hybrid-agent-control-plane skill draft created at `.hermes/templates/skill-draft-hybrid-agent-control-plane.md`.
+- [x] subagent-eval-gate coverage: `harness-eval` skill is not installed in this profile; gate logic lives in `scripts/check_hybrid_control_plane.py` and `tests/skills/test_hybrid_agent_control_plane.py`. No separate skill-draft needed (documented in skill draft).
+- [x] All stub fixture tests pass (`scripts/check_hybrid_control_plane.py` + pytest).
+- [x] Locked decisions LD-1 through LD-6 encoded in plan and skill draft.
+- [x] `human_reviewed_at: 2026-05-22T23:27:28Z` set and machine-checkable.
+- [ ] Skills load without error in Hermes CLI (deferred: not installed to user profile in Phase 1).
+- [ ] Manifest and contract render correctly from templates with a real run (Phase 2).
+- [ ] Audit log is written and append-only for each real run (Phase 2).
+
+Phase 2:
+- [ ] At least one real task completed by Claude Code in worktree mode.
+- [ ] All required gates ran; results in audit.jsonl.
+- [ ] No prompt artifact modified by agent.
+- [ ] Cost stayed within cap.
+- [ ] Yoshio approved merge via explicit signal (not automated).
+- [ ] Worktree cleaned up post-merge.
+
+---
+
+## Verification Checklist (pre-Phase-2 gate)
+
+Before any real agent spawn:
+
+- [ ] Codex sandbox_verified=true in capability-matrix.yaml (or Codex excluded)
+- [ ] forbidden_path_writes gate tested against stub
+- [ ] prompt_artifact_unchanged gate tested against stub
+- [ ] CODEOWNERS protecting .hermes/config/ and .hermes/schemas/
+- [ ] .worktrees/ in .gitignore
+- [ ] cost_cap enforced in at least one stub test
+- [ ] Recovery runbook reviewed and accessible
+- [ ] human_reviewed_at set on this plan file by Yoshio
+
+---
+
+## Assumptions Made in This Plan
+
+1. Hermes AIAgent supports delegate_task to route work internally. Real
+   external agent spawning (Claude Code CLI, Codex CLI) uses terminal()
+   calling the CLI, NOT delegate_task auto-discovery. See C-3.
+   CONFIRM: actual CLI invocation pattern before Phase 2.
+
+2. Claude Code CLI reads CLAUDE.md from the working directory root.
+   CONFIRM: may be .claude/settings.json or --config flag instead.
+
+3. Codex CLI behavior is UNCONFIRMED. Do not assume CODEX.md is read;
+   do not assume any specific flag or file location. See C-4.
+   CONFIRM with current Codex CLI docs before Phase 2.
+
+4. Test runner is scripts/run_tests.sh with .venv activation.
+   CONFIRM by inspecting tests/ and scripts/ before writing gate commands.
+
+5. Path lock enforcement is advisory in Phase 1/2 (checked post-hoc by gates).
+   Pre-emptive blocking requires either (a) a Hermes lock server or (b)
+   container isolation. This is a known gap.
+
+6. Cost tracking per external agent is ESTIMATED only. Hermes does not
+   guarantee per-external-process cost data. Use token-count × model-pricing
+   as the primary accounting method; mark cost fields `estimated: true`.
+   See C-5 and D-6.
+
+---
+
+*Plan saved: 2026-05-22. Implementation should not begin until Yoshio sets
+human_reviewed_at and resolves open decisions D-1 through D-6.*

--- a/.hermes/plans/2026-05-22_193338-phase-1-5-hybrid-control-plane-dogfood.md
+++ b/.hermes/plans/2026-05-22_193338-phase-1-5-hybrid-control-plane-dogfood.md
@@ -1,0 +1,224 @@
+# Phase 1.5: Adversarial-Review Amendments — Hybrid Control-Plane Dogfood Plan
+
+**Status**: In progress (adversarial amendments applied)
+**Branch**: feature/hybrid-control-plane-mvp
+**Date**: 2026-05-22
+**Owner**: Grok-4.3 implementation subagent (via route-dev-task)
+
+## Scope Reminder (from Phase 1 locked decisions LD-1..LD-6)
+
+- file-based handoff is canonical; all spawn logic goes through HANDOFF_PATH
+- human_reviewed_at required before worker execution
+- serial gates; fail-fast ordering is load-bearing
+- cost_estimated only (no real cost ledger in MVP)
+- worktrees_are_sandbox: false for MVP
+- opportunistic Codex usage only after canary
+- No real Claude/Codex spawns in dogfood harness
+
+## Amendment Summary
+
+These amendments close gaps identified during adversarial review of the hybrid agent control-plane checker and fixtures.
+
+### 1. Normalized Forbidden-Path Semantics (replaces naive prefix logic)
+
+**Exact forbidden files** (must match basename exactly after normalization; backups allowed):
+- AGENTS.md
+- CLAUDE.md
+- CODEX.md
+
+**Forbidden directory prefixes** (repo-relative POSIX):
+- .hermes/config/
+- .hermes/schemas/
+- .hermes/plans/
+- .claude/
+- .codex/
+
+**Normalization rules** (applied to every path in changed_files before policy check):
+- Convert to POSIX style (replace `\` with `/`, strip drive letters like `C:`, `D:`)
+- Make repo-relative (strip leading `/` or absolute prefix; reject absolute paths)
+- Reject empty or whitespace-only paths
+- Reject any path containing `..` that would escape the repo root (traversal)
+- Reject `./` prefix for prompt artifacts (dotslash AGENTS.md etc.)
+- Do NOT treat `AGENTS.md.backup`, `AGENTS.md.bak`, `AGENTS.md~` as forbidden (exact match only on basename before extension)
+- `is_forbidden()` must return False for backup variants; True for exact names or under forbidden prefixes
+
+**Rejection examples** (must cause forbidden_path_writes: FAIL and nonzero exit):
+- `/home/user/hermes-agent/AGENTS.md` → absolute (reject)
+- `C:\\repo\\AGENTS.md` → Windows/drive (reject)
+- `../AGENTS.md` → traversal escape (reject)
+- `./AGENTS.md` → dotslash prompt artifact (reject)
+- `   ` or `` → empty/whitespace (reject)
+- `src/../AGENTS.md` → contains traversal semantics after norm (reject)
+- `AGENTS.md.backup` → pass (not exact match)
+
+**Pass examples**:
+- `src/tools/foo.py`
+- `AGENTS.md.backup`
+- `docs/AGENTS.md.notes`
+
+The `normalize_path()` and `is_forbidden()` helpers live in `scripts/check_hybrid_control_plane.py` and are mirrored (as constants) in the test file for deterministic assertions.
+
+### 2. Invalid Agent Enum Coverage
+
+New fixture:
+`.hermes/test-fixtures/stub-handoff-fail-agent-enum.yaml`
+
+```yaml
+task_id: "stub-task-enum-0001"
+agent: attacker_bot   # invalid enum value
+completed_at: "2026-05-22T10:10:00Z"
+summary: "Attempt to use disallowed agent identity"
+changed_files:
+  - src/foo.py
+test_results:
+  command_run: "scripts/run_tests.sh"
+  exit_code: 0
+  passed: true
+```
+
+Checker behavior:
+- `--handoff stub-handoff-fail-agent-enum.yaml` → nonzero exit
+- Gate output contains: `schema_validation: FAIL`
+- `agent` field fails enum check against allowed list in handoff-v1 schema (claude_code, codex, ...)
+
+### 3. Absent test_results Behavior
+
+- Missing `test_results` key (or value null) in fixture mode → FAIL
+- Output must contain: `unit_tests: SKIP` (or equivalent missing-evidence phrasing)
+- Final result: nonzero
+- Fixture mode never calls `command_run` / real test execution (deterministic, offline)
+
+Add fixture coverage in `stub-handoff-fail-tests.yaml` style (test_results absent) or a dedicated case.
+
+### 4. Empty changed_files Behavior
+
+New fixture:
+`.hermes/test-fixtures/stub-handoff-fail-empty-changed-files.yaml`
+
+```yaml
+task_id: "stub-task-empty-0001"
+agent: claude_code
+completed_at: "2026-05-22T10:15:00Z"
+summary: "Empty diff — should fail closed"
+changed_files: []
+test_results:
+  command_run: "scripts/run_tests.sh"
+  exit_code: 0
+  passed: true
+```
+
+Checker: schema/checker validation fails on empty changed_files (fail-closed policy). `schema_validation: FAIL`
+
+### 5. Path-Edge Fixtures / Test Cases (added to test suite)
+
+- `test_forbidden_dotslash()`: `./AGENTS.md` → blocked (normalized to AGENTS.md and exact match triggers)
+- `test_forbidden_traversal()`: `../AGENTS.md`, `src/../../AGENTS.md` → blocked (contains `..`)
+- `test_backup_filename_allowed()`: `AGENTS.md.backup` → allowed (is_forbidden returns False)
+- Corresponding handoff fixtures updated or new edge cases covered via direct is_forbidden() unit tests
+
+### 6. Fixture-Mode Gate Taxonomy Output (mandatory keys)
+
+Every run in `--handoff` / `--all-handoff-fixtures` mode must emit (in machine-readable form):
+
+- `schema_validation: PASS|FAIL`
+- `forbidden_path_writes: PASS|FAIL|SKIP`
+- `prompt_artifact_unchanged: PASS|FAIL|SKIP`
+- `diff_size_limit: SKIP` (always in fixture mode; real git diff unavailable)
+- `unit_tests: PASS|FAIL|SKIP` (SKIP when test_results missing or absent evidence)
+- `cost_cap: SKIP` (no run manifest / cost ledger in MVP fixture mode)
+- `human_review: PENDING` or `RESULT: AUTOMATED_PASS_HUMAN_REVIEW_REQUIRED`
+
+Success result (all automated gates pass):
+`RESULT: AUTOMATED_PASS_HUMAN_REVIEW_REQUIRED`
+
+Exit 0 only when the above clear text is present. Nonzero for any FAIL.
+
+### 7. --all-handoff-fixtures Strict Map Enforcement
+
+`--all-handoff-fixtures` maintains an internal expected map of known fixture basenames:
+`stub-handoff-pass.yaml`, `stub-handoff-fail-schema.yaml`, `stub-handoff-fail-forbidden.yaml`, `stub-handoff-fail-tests.yaml`, `stub-handoff-fail-agent-enum.yaml`, `stub-handoff-fail-empty-changed-files.yaml`
+
+If any `stub-handoff-*.yaml` exists in `.hermes/test-fixtures/` that is NOT in the map → fail closed with message listing the unknown file and nonzero exit.
+
+This prevents silent addition of untested adversarial fixtures.
+
+### 8. Strengthened Test Assertions (pytest)
+
+- PASS fixture (`stub-handoff-pass.yaml`):
+  - `returncode == 0`
+  - `stderr == ""` (no noise)
+- FAIL fixtures:
+  - `returncode != 0`
+  - No `Traceback` in stdout/stderr
+  - No progression past fail-fast gates (schema fail stops before forbidden_path check; forbidden stops before unit_tests/human_review; missing test_results includes prior static gates but does not emit human approval)
+- Explicit ordering tests:
+  - schema_validation FAIL → no subsequent gates executed
+  - forbidden_path_writes FAIL (after schema) → unit_tests not reached
+  - test_results missing/failed → prior static gates shown; no `RESULT: AUTOMATED_PASS...`
+
+### 9. Verification Commands (run before declaring done)
+
+```bash
+python -m py_compile scripts/check_hybrid_control_plane.py tests/skills/test_hybrid_agent_control_plane.py
+python scripts/check_hybrid_control_plane.py --all-handoff-fixtures
+scripts/run_tests.sh tests/skills/test_hybrid_agent_control_plane.py -q
+scripts/run_tests.sh tests/skills -q
+git diff --check
+git diff --cached --check
+git status --short
+```
+
+**Safer expected-failure shell pattern** (documented in plan):
+```bash
+if python scripts/check_hybrid_control_plane.py --handoff .hermes/test-fixtures/stub-handoff-fail-*.yaml; then
+    echo "ERROR: expected failure but got zero exit"
+    exit 1
+fi
+echo "Correctly failed as expected"
+```
+
+Also run both `git diff --check` and `git diff --cached --check` on every verification (catch trailing whitespace, conflict markers).
+
+## Gate Execution Order (fail-fast serial)
+
+1. schema_validation (jsonschema or structural + agent enum)
+2. forbidden_path_writes (normalized exact/prefix + traversal/absolute rejection)
+3. prompt_artifact_unchanged (if applicable)
+4. diff_size_limit (SKIP in fixture)
+5. unit_tests (SKIP or evaluate test_results.passed)
+6. cost_cap (SKIP)
+7. human_review (RESULT text)
+
+No gate after a FAIL is reached. Schema failures short-circuit; protected-path failures short-circuit dynamic gates.
+
+## Dependencies / Optional
+
+- PyYAML remains optional-but-required for checker (existing model preserved)
+- jsonschema optional for richer validation (current implementation uses structural checks to keep stdlib-first)
+- No network, no new pip installs
+
+## Deferred Items (intentionally out of scope for this amendment)
+
+- Real git diff integration for diff_size_limit (future Phase 2)
+- Actual cost ledger from run manifests (MVP uses SKIP)
+- Full JSON schema enforcement with strict enum for `agent` field (structural check sufficient for dogfood)
+- Windows path normalization in live Windows env (WSL coverage only)
+
+## How to Run the Checker in Dogfood Mode
+
+```bash
+# Happy path
+python scripts/check_hybrid_control_plane.py --handoff .hermes/test-fixtures/stub-handoff-pass.yaml
+
+# Expected failure (safer pattern)
+if python scripts/check_hybrid_control_plane.py --handoff .hermes/test-fixtures/stub-handoff-fail-forbidden.yaml; then echo "unexpected pass"; exit 1; fi
+
+# Exhaustive
+python scripts/check_hybrid_control_plane.py --all-handoff-fixtures
+```
+
+All changes respect the existing style of the checker (print-based OK/FAIL, separate test file for pytest). No broad rewrites.
+
+---
+
+**End of Phase 1.5 plan**

--- a/.hermes/schemas/handoff-v1.yaml
+++ b/.hermes/schemas/handoff-v1.yaml
@@ -1,0 +1,145 @@
+# Handoff Schema v1 — Hybrid Agent Control Plane
+# Agent returns this payload when it considers a task complete.
+# Hermes validates this payload before running eval gates.
+# Human-authored. Agents must not modify this file.
+# Governed by: .hermes/plans/2026-05-22_000000-hybrid-agent-control-plane.md
+
+schema_name: handoff
+schema_version: "1"
+description: >
+  Structured payload emitted by a bounded worker agent (Claude Code or Codex)
+  upon task completion. Hermes validates against this schema before running
+  any gate. Handoffs that fail schema validation are rejected immediately
+  and logged to audit.jsonl; no gate runs on an invalid handoff.
+
+fields:
+  task_id:
+    type: string
+    required: true
+    description: UUID matching the task contract. Must be set by Hermes, not agent.
+
+  agent:
+    type: string
+    required: true
+    enum: [claude_code, codex]
+    description: >
+      Which agent type produced this handoff. Codex is provisional (TBD).
+      See capability-matrix.yaml for confirmed agent status.
+
+  completed_at:
+    type: string
+    format: iso8601
+    required: true
+    description: ISO 8601 timestamp when agent considered task complete.
+
+  summary:
+    type: string
+    required: true
+    max_len: 500
+    description: >
+      One-paragraph imperative summary of what was done. No implementation
+      speculation; only what was actually changed.
+
+  changed_files:
+    type: array
+    items: {type: string}
+    required: true
+    description: >
+      Relative paths from worktree root of every file the agent created,
+      modified, or deleted. Used by forbidden_path_writes and
+      prompt_artifact_unchanged gates. Must be exhaustive — omissions
+      are treated as gate violations.
+
+  test_results:
+    type: object
+    required: false
+    description: >
+      Results of test commands run by the agent before handoff.
+      If not present, unit_tests gate will request re-run.
+    fields:
+      command_run:
+        type: string
+        description: Exact command used (e.g. "scripts/run_tests.sh tests/ -q").
+      exit_code:
+        type: integer
+        description: Exit code of the test command.
+      stdout_tail:
+        type: string
+        max_len: 2000
+        description: Last 2000 chars of test stdout for evidence.
+      passed:
+        type: boolean
+        required: true
+        description: True only if exit_code == 0 and no unexpected failures.
+
+  eval_evidence:
+    type: object
+    required: false
+    description: Pre-computed gate evidence from agent self-assessment.
+    fields:
+      lint_clean:
+        type: boolean
+        description: True if linter exited 0 on changed files.
+      unit_tests_passed:
+        type: boolean
+        description: True if test_results.passed is true.
+      diff_size_kb:
+        type: number
+        description: >
+          Approximate total diff size in KB. Hermes re-computes from actual diff;
+          this is advisory. If agent cannot compute, omit.
+      no_forbidden_writes:
+        type: boolean
+        description: >
+          Agent self-assertion that no forbidden paths were written.
+          Gate still verifies independently from changed_files list.
+
+  open_issues:
+    type: array
+    items: {type: string}
+    required: false
+    description: >
+      Known issues, caveats, or deferred items the agent wants to surface.
+      Does not block gate; Yoshio reviews before merge.
+
+  self_assessed_confidence:
+    type: string
+    required: false
+    enum: [high, medium, low]
+    description: Agent's confidence in correctness of this handoff.
+
+  cost_estimated:
+    type: object
+    required: false
+    description: >
+      Estimated cost for this task. External agent costs are ESTIMATED only
+      (see plan C-5). Do not treat these as exact accounting.
+    fields:
+      tokens_input:
+        type: integer
+      tokens_output:
+        type: integer
+      model:
+        type: string
+      estimated_usd:
+        type: number
+      method:
+        type: string
+        enum: [exact, token_count_estimate]
+        description: How the cost was computed. "exact" only if provider confirmed.
+
+validation_rules:
+  - rule: task_id_not_empty
+    description: task_id must be a non-empty string.
+  - rule: completed_at_iso8601
+    description: completed_at must be a valid ISO 8601 datetime string.
+  - rule: changed_files_no_forbidden
+    description: >
+      Gate forbidden_path_writes checks changed_files against
+      contract.scope.forbidden_paths. Schema validation does not enforce
+      this; gate does.
+  - rule: test_results_passed_if_present
+    description: >
+      If test_results is present, passed must be a boolean.
+      A handoff with test_results.passed=false is schema-valid but
+      will fail the unit_tests gate.

--- a/.hermes/templates/locks.yaml.j2
+++ b/.hermes/templates/locks.yaml.j2
@@ -1,0 +1,30 @@
+# Resource / Path Lock Map Template
+# Written by Hermes before agent spawn. Agents must NOT write this file.
+# Hermes holds the lock; agents never acquire or release locks directly.
+# Conflict enforcement is advisory in Phase 1/2 (post-hoc check, not OS-level lock).
+
+run_id: {{ run_id }}
+
+# conflict_policy controls behavior when a new task requests paths already locked:
+#   block     — refuse to spawn the second task (default, safest for MVP)
+#   warn      — spawn but log the conflict to audit.jsonl
+#   escalate  — pause and notify Yoshio for manual resolution
+conflict_policy: {{ conflict_policy | default("block") }}
+
+locks:
+{% for lock in locks %}
+  - task_id: {{ lock.task_id }}
+    agent: {{ lock.agent }}              # claude_code | codex
+    claimed_at: {{ lock.claimed_at }}    # ISO8601
+    released_at: ~                       # filled when task completes or is cancelled
+    paths:
+      # Glob patterns relative to repo root. Any overlap with another lock triggers conflict_policy.
+{% for path in lock.paths %}
+      - {{ path }}
+{% endfor %}
+{% endfor %}
+
+# Lock acquisition and release logic lives in the Hermes orchestrator skill.
+# Agents are never given credentials to modify this file.
+# On Phase 3 (container isolation): per-container HOME eliminates most path conflicts,
+# but this file is still used for cross-container coordination.

--- a/.hermes/templates/run-manifest.yaml.j2
+++ b/.hermes/templates/run-manifest.yaml.j2
@@ -1,0 +1,45 @@
+# Run Manifest Template
+# Rendered by Hermes orchestrator at run start.
+# Fields marked CONFIRM require repo inspection before first real use.
+# NOTE: cost_usd_actual fields are ESTIMATED (token-count × model-pricing) — see C-5 in plan.
+
+run_id: {{ run_id }}                     # uuid4, generated at spawn time
+triggered_by: {{ triggered_by }}         # user | cron | webhook
+trigger_ref: {{ trigger_ref | default("~") }}   # session-id or event-id
+
+started_at: {{ started_at }}             # ISO8601
+closed_at: ~                             # filled at run close
+
+status: running                          # running | completed | failed | escalated
+
+plan_ref: {{ plan_ref }}                 # .hermes/plans/<plan-file>.md
+                                         # REQUIRE: human_reviewed_at set on this plan before spawn
+
+git_base_sha: {{ git_base_sha }}         # HEAD at spawn time (git rev-parse HEAD)
+
+# CONFIRM: worktree root convention before first real spawn (see plan task 2.3)
+worktree_paths:
+  claude_code: .worktrees/{{ run_id }}-cc   # CONFIRM path is correct for your setup
+  codex: .worktrees/{{ run_id }}-cx         # PROVISIONAL — Codex CLI unconfirmed (see C-4)
+
+tasks:
+{% for task in tasks %}
+  - task_id: {{ task.task_id }}
+    contract_ref: .hermes/runs/{{ run_id }}/contracts/{{ task.task_id }}.yaml
+    agent: {{ task.agent }}               # claude_code | codex
+    status: pending                       # pending | running | handoff_received | gate_passed | gate_failed | merged | cancelled
+    cost_usd_actual: ~                    # ESTIMATED when filled; see C-5
+    cost_estimated: true                  # always true until exact cost source confirmed
+{% endfor %}
+
+# Hard cap — agent spawns blocked if total_cost_usd_actual approaches this
+total_cost_usd_cap: {{ total_cost_usd_cap | default(5.00) }}
+total_cost_usd_actual: ~                 # ESTIMATED; see C-5
+cost_estimated: true
+
+audit_log: .hermes/runs/{{ run_id }}/audit.jsonl
+
+# Supply chain fields
+human_reviewed_at: ~                     # Yoshio must set before orchestrator accepts plan as run reference
+worktrees_are_sandbox: false             # DOCUMENT GAP: worktrees do not sandbox filesystem access
+container_isolation: false              # Phase 3 only — not available in MVP

--- a/.hermes/templates/skill-draft-hybrid-agent-control-plane.md
+++ b/.hermes/templates/skill-draft-hybrid-agent-control-plane.md
@@ -1,0 +1,360 @@
+---
+# SKILL DRAFT — NOT INSTALLED
+# Location: .hermes/templates/skill-draft-hybrid-agent-control-plane.md
+# Status: Repo-local draft. Do NOT copy to ~/.hermes/profiles/dev/skills/ without
+#         explicit Yoshio approval (see plan C-2).
+# Governed by: .hermes/plans/2026-05-22_000000-hybrid-agent-control-plane.md
+# Locked decisions encoded: LD-1 through LD-6 (approved 2026-05-22T23:27:28Z)
+#
+# To install once approved:
+#   cp -r .hermes/templates/skill-draft-hybrid-agent-control-plane.md \
+#          ~/.hermes/profiles/dev/skills/software-development/hybrid-agent-control-plane/SKILL.md
+#
+name: hybrid-agent-control-plane
+description: >
+  Orchestrate bounded Claude Code (and eventually Codex) workers for repo tasks.
+  Hermes is the control plane; workers are scoped to a git worktree, a task
+  contract, and an explicit gate sequence. No worker executes without a
+  human-reviewed plan. No merge proceeds without a human gate.
+version: 0.1.0-draft
+author: Yoshio (via planning session 2026-05-22)
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [orchestration, agents, control-plane, claude-code, worktrees, gates, mvp]
+    related_skills:
+      - route-dev-task        # existing skill — do NOT duplicate (plan C-1)
+      - subagent-driven-development
+      - requesting-code-review
+      - harness-eval          # gate logic reference (not installed in this profile)
+    phase: 1-draft
+    human_reviewed_at: 2026-05-22T23:27:28Z
+---
+
+# Hybrid Agent Control Plane (DRAFT)
+
+> DRAFT — Not installed to user profile. All artifact paths are repo-local.
+> Plan ref: `.hermes/plans/2026-05-22_000000-hybrid-agent-control-plane.md`
+> Locked decisions: LD-1 through LD-6 (2026-05-22T23:27:28Z)
+
+---
+
+## Overview and Responsibilities
+
+This skill is the Hermes orchestrator for bounded external agent workers.
+It does NOT autonomously spawn real agents. In Phase 1 (MVP) it documents
+the intended workflow and is validated against stub fixtures. Real worker
+invocations belong in Phase 2 after canary tests pass.
+
+Responsibilities:
+1. Accept a goal string and task_type from the user.
+2. Verify the plan file has a non-empty `human_reviewed_at` field.
+3. Generate a run manifest from `.hermes/templates/run-manifest.yaml.j2`.
+4. Generate a task contract from `.hermes/templates/task-contract.yaml.j2`.
+5. Acquire path locks (write `.hermes/runs/<run-id>/locks.yaml`).
+6. Spawn a worker agent via `terminal()` calling the CLI (NOT delegate_task).
+7. Poll for the handoff file at the canonical path.
+8. Validate the handoff against `.hermes/schemas/handoff-v1.yaml`.
+9. Run gates in serial order (LD-4): static → dynamic → human.
+10. Merge or reject based on gate results.
+11. Update the manifest and emit an audit log entry.
+12. Release path locks.
+
+---
+
+## Hard Constraints (must be checked before any action)
+
+- **No real spawns without human_reviewed_at.** If the plan file does not
+  contain `human_reviewed_at: <timestamp>`, refuse to spawn any worker.
+  Conservative/docs-only operations (generating templates, reviewing config)
+  may proceed without it.
+- **No delegate_task for worker spawn.** Real worker execution uses
+  `terminal()` to invoke the CLI (e.g. `claude --print --output-format json
+  -p "$(cat contract.yaml)" --workdir .worktrees/<run-id>-cc`). The exact
+  invocation must be confirmed before Phase 2. See plan C-3.
+- **Do not write to ~/.hermes/profiles/ or ~/.hermes/skills/.** All Phase 1
+  artifacts are repo-local under `.hermes/`.
+- **Do not create a second route-dev-task skill.** The existing skill at
+  `~/.hermes/skills/_custom/route-dev-task/SKILL.md` handles routing.
+  See integration section below.
+- **No --dangerously-skip-permissions on real host filesystems.**
+- **Worktrees are merge isolation, not security isolation.** Document this
+  gap in every run manifest (`worktrees_are_sandbox: false`). See LD-1.
+
+---
+
+## Integration with Existing route-dev-task Skill
+
+The existing `route-dev-task` skill routes the overall goal to the dev-profile
+Hermes subprocess. This skill (`hybrid-agent-control-plane`) is invoked
+_inside_ that dev session to spawn and gate the external agent worker.
+
+Flow:
+```
+User → /route-dev-task "fix bug in tools/terminal.py"
+          ↓
+    Hermes dev profile session
+          ↓
+    /hybrid-agent-control-plane task_type=bugfix goal="..."
+          ↓
+    [this skill] → generates manifest/contract → spawns Claude Code worker
+          ↓
+    [gate sequence] → human gate → merge or reject
+```
+
+If `route-dev-task` needs extension for agent-type routing, propose the
+patch to Yoshio. Do not overwrite the existing skill file.
+
+---
+
+## Workflow (Serial Gates — LD-4)
+
+### Step 0: Pre-flight checks
+
+```python
+# Pseudo-code — real implementation uses terminal() and file tools
+
+# 1. Check plan has human_reviewed_at
+plan = read_file(".hermes/plans/<plan-file>.md")
+assert "human_reviewed_at:" in plan and plan has non-empty timestamp
+# Enforcement: scripts/check_hybrid_control_plane.py validates this
+
+# 2. Verify capability matrix
+matrix = load_yaml(".hermes/config/capability-matrix.yaml")
+assert matrix["agents"]["claude_code"]["dangerously_skip_permissions"] == False
+```
+
+### Step 1: Generate run artifacts
+
+```bash
+# Generate run manifest
+run_id=$(python -c "import uuid; print(uuid.uuid4())")
+mkdir -p .hermes/runs/$run_id/contracts
+mkdir -p .hermes/runs/$run_id/handoffs
+
+# Render manifest from template (Phase 1: manual substitution; Phase 2: Jinja2)
+# Template: .hermes/templates/run-manifest.yaml.j2
+# Output:   .hermes/runs/$run_id/manifest.yaml
+# IMPORTANT: manifest must include:
+#   worktrees_are_sandbox: false   (LD-1)
+#   container_isolation: false     (LD-1)
+#   cost_estimated: true           (LD-6)
+#   human_reviewed_at: ~           (filled from plan)
+
+# Generate task contract
+task_id=$(python -c "import uuid; print(uuid.uuid4())")
+# Template: .hermes/templates/task-contract.yaml.j2
+# Output:   .hermes/runs/$run_id/contracts/$task_id.yaml
+# Includes: cost_cap_usd, cost_estimated: true, spawn_mechanism: terminal_cli
+```
+
+### Step 2: Acquire path locks
+
+```bash
+# Write locks.yaml BEFORE spawning worker
+# Template: .hermes/templates/locks.yaml.j2
+# Output:   .hermes/runs/$run_id/locks.yaml
+# Check for conflicts against other active runs (advisory in Phase 1)
+```
+
+### Step 3: Spawn worker (Phase 2+ only; Phase 1 uses stubs)
+
+```bash
+# Phase 1: stub — no real spawn
+# Phase 2: real spawn via terminal()
+#
+# Claude Code example (CONFIRM exact flags before Phase 2):
+git worktree add .worktrees/$run_id-cc -b agent/$run_id
+cd .worktrees/$run_id-cc
+# Copy (not symlink) thin CLAUDE.md adapter into worktree
+cp CLAUDE.md .worktrees/$run_id-cc/CLAUDE.md
+# Invoke worker — must write HANDOFF_PATH: <path> to stdout (LD-2)
+claude --print --output-format json \
+  -p "$(cat .hermes/runs/$run_id/contracts/$task_id.yaml)" \
+  2>&1 | tee .hermes/runs/$run_id/agent-stdout.txt
+
+# Extract handoff path from stdout sentinel (LD-2)
+HANDOFF_PATH=$(grep '^HANDOFF_PATH:' .hermes/runs/$run_id/agent-stdout.txt \
+               | head -1 | cut -d' ' -f2)
+# Canonical path convention:
+# .hermes/runs/$run_id/handoffs/$task_id.yaml
+```
+
+### Stdout Sentinel Convention (LD-2)
+
+Worker agents MUST write the following line to stdout when done:
+```
+HANDOFF_PATH: .hermes/runs/<run-id>/handoffs/<task-id>.yaml
+```
+
+The YAML file at that path is the source of truth. Stdout content outside
+this sentinel line is logged but not parsed as structured handoff data.
+If the handoff file is absent or unreadable, the handoff is rejected and
+the run transitions to `status: failed`.
+
+### Step 4: Gate sequence (serial — LD-4)
+
+Run gates in this exact order. Stop at first blocking failure.
+
+```
+[STATIC — fast, no side effects]
+1. schema_validation       — handoff has all required fields (handoff-v1.yaml)
+2. forbidden_path_writes   — no forbidden paths in changed_files
+3. prompt_artifact_unchanged — no AGENTS.md / CLAUDE.md / .hermes/config/** touched
+4. diff_size_limit         — diff KB <= contract limit
+
+[DYNAMIC — runs commands]
+5. lint                    — project linter exits 0 (CONFIRM command: ruff? mypy?)
+6. unit_tests              — scripts/run_tests.sh exits 0
+
+[RESOURCE]
+7. cost_cap                — total_cost_usd_actual <= manifest cap
+
+[HUMAN — always last, always blocking in MVP]
+8. human_review            — Yoshio reviews diff, types /approve or /reject
+```
+
+Each gate result is appended to `.hermes/runs/<run-id>/audit.jsonl`:
+```json
+{"timestamp": "<iso8601>", "gate": "schema_validation", "result": "pass", "evidence": {}}
+```
+
+### Step 5: Merge or reject
+
+```bash
+# Only after ALL gates pass (including human_review):
+git -C .worktrees/$run_id-cc diff HEAD > review.patch
+# Yoshio runs merge manually in Phase 1/2:
+#   git apply review.patch   or   git merge agent/$run_id
+
+# Update manifest
+# status: completed, closed_at: <timestamp>
+
+# Release locks
+# released_at: <timestamp> in locks.yaml
+
+# Cleanup worktree (after Yoshio confirms)
+git worktree remove .worktrees/$run_id-cc
+git branch -d agent/$run_id
+```
+
+---
+
+## Worktree Rules (LD-1)
+
+1. Worktrees are named `<run-id>-cc` (Claude Code) or `<run-id>-cx` (Codex).
+2. Root: `.worktrees/` (in `.gitignore`; never committed).
+3. Worktrees are merge isolation, NOT security isolation. Document this gap
+   in every run manifest with `worktrees_are_sandbox: false`.
+4. Container/per-agent HOME isolation is deferred to Phase 3.
+5. Never reuse a run_id. Abandoned worktrees: `git worktree remove --force`.
+6. Do not force-merge a worktree that has diverged. Log and escalate (R7).
+
+---
+
+## File-Based Handoff Rules (LD-2)
+
+1. Canonical path: `.hermes/runs/<run-id>/handoffs/<task-id>.yaml`
+2. Worker stdout sentinel: `HANDOFF_PATH: <path>` (first occurrence used)
+3. The YAML file is authoritative; stdout is advisory/logging only.
+4. Schema: `.hermes/schemas/handoff-v1.yaml`
+5. Handoffs missing required fields are rejected before any gate runs.
+6. Handoffs with `test_results.passed: false` fail the `unit_tests` gate.
+7. Handoffs with forbidden paths in `changed_files` fail `forbidden_path_writes`.
+
+---
+
+## Human Gate Rules (LD-3)
+
+1. `human_reviewed_at` must be set in the plan before Phase 2+ runs.
+2. Enforcement: `scripts/check_hybrid_control_plane.py` checks this field.
+3. In Phase 1 (stub testing), the check is validated against the plan.
+4. The human_review gate is always the LAST gate in the sequence (LD-4).
+5. Hermes presents a diff summary and waits for `/approve` or `/reject`.
+6. No automated merge in Phase 1/2. Yoshio runs git commands manually.
+7. A rejected handoff transitions the run to `status: failed`; logs to audit.
+
+---
+
+## Cost Fields (LD-6)
+
+All manifests and contracts carry:
+```yaml
+cost_estimated: true           # always true until exact source confirmed
+total_cost_usd_cap: 5.00       # hard cap; spawns blocked beyond this
+total_cost_usd_actual: ~       # null until filled; ESTIMATED
+```
+
+Task entries in manifests:
+```yaml
+cost_usd_actual: ~             # ESTIMATED when filled; see plan C-5
+cost_estimated: true
+```
+
+Handoff `cost_estimated` object (optional, from agent self-report):
+```yaml
+cost_estimated:
+  tokens_input: 12000
+  tokens_output: 3500
+  model: claude-sonnet-4-5
+  estimated_usd: 0.18
+  method: token_count_estimate  # "exact" only if provider confirms
+```
+
+---
+
+## Gate Evaluation: subagent-eval-gate vs harness-eval
+
+The `harness-eval` skill is NOT installed in this Hermes profile. Gate logic
+for Phase 1 lives entirely in:
+- `scripts/check_hybrid_control_plane.py` — deterministic checks, no LLM
+- `tests/skills/test_hybrid_agent_control_plane.py` — pytest coverage
+
+A separate `subagent-eval-gate` skill draft is NOT created in Phase 1 because:
+- No real worker spawns occur in Phase 1
+- The gate logic is fully exercised by the check script and pytest
+- Adding a second skill draft without real execution would be premature YAGNI
+
+When Phase 2 gates are implemented (real runs), revisit whether a separate
+`subagent-eval-gate` skill is warranted or whether the check script is
+sufficient.
+
+---
+
+## No Real Spawns in MVP (Phase 1)
+
+Phase 1 explicitly prohibits:
+- Real Claude Code CLI invocations
+- Real Codex CLI invocations
+- Real git worktree creation for agent use
+- Any `terminal()` calls that launch external agent processes
+- Any `delegate_task()` calls intended to run Claude Code or Codex
+
+All Phase 1 testing uses stub fixtures under `.hermes/test-fixtures/`.
+Real invocations are introduced in Phase 2 after:
+- Codex canary test passes (task 2.1)
+- All Phase 1 gate tests pass
+- human_reviewed_at is set on the plan
+
+---
+
+## Verification Commands
+
+```bash
+# Syntax check
+python -m py_compile scripts/check_hybrid_control_plane.py
+
+# Full deterministic check (no real spawns)
+python scripts/check_hybrid_control_plane.py
+
+# Pytest coverage for gate logic
+python -m pytest tests/skills/test_hybrid_agent_control_plane.py -q
+
+# Check for whitespace errors
+git diff --check
+
+# Confirm unrelated files not modified
+git status --short
+# Expected dirty: only .hermes/ and new Phase 1 files
+# Must NOT be modified: agent/anthropic_adapter.py, hermes_cli/auth.py, AGENTS.md
+```

--- a/.hermes/templates/task-contract.yaml.j2
+++ b/.hermes/templates/task-contract.yaml.j2
@@ -1,0 +1,69 @@
+# Task Contract Template
+# Written by Hermes before agent spawn. Agent receives a read-only copy.
+# Hermes validates handoff against this contract before running any gate.
+# NOTE: Agents must NOT write to this file. It is Hermes-owned.
+
+task_id: {{ task_id }}                   # uuid4
+run_id: {{ run_id }}                     # parent run uuid4
+created_at: {{ created_at }}             # ISO8601
+
+agent: {{ agent }}                       # claude_code | codex
+# CONFIRM: exact model identifiers before first real spawn (see plan task 2.4)
+model: {{ model | default("claude-sonnet-4-5") }}   # CONFIRM model identifier
+
+goal: |
+  {{ goal }}
+
+scope:
+  # Paths relative to worktree root. Hermes checks these via forbidden_path_writes gate.
+  # NOTE: enforcement is advisory in Phase 1/2 (post-hoc gate check, not OS-level prevention).
+  # Full enforcement requires Phase 3 container isolation.
+  allowed_paths:
+{% for path in allowed_paths %}
+    - {{ path }}
+{% endfor %}
+  # These paths must NEVER appear in handoff changed_files. Violation blocks merge.
+  forbidden_paths:
+    - .hermes/
+    - .claude/
+    - .codex/
+    - AGENTS.md
+    - CLAUDE.md
+    - CODEX.md
+{% for path in extra_forbidden_paths | default([]) %}
+    - {{ path }}
+{% endfor %}
+  allowed_operations: [read, write, create, delete]
+  forbidden_operations: [git_push, network_external, install_global]
+
+acceptance_criteria:
+{% for criterion in acceptance_criteria %}
+  - {{ criterion }}
+{% endfor %}
+
+# Gates that must pass before handoff is accepted. Evaluated in order (static first).
+# See .hermes/config/gate-taxonomy.yaml for gate definitions.
+# See .hermes/config/eval-matrix.yaml for task-type gate sets.
+eval_gates:
+  - schema_validation
+  - forbidden_path_writes
+  - prompt_artifact_unchanged
+  - diff_size_limit_kb: {{ diff_size_limit_kb | default(500) }}
+  - lint                  # CONFIRM: actual lint command (ruff? eslint? mypy?)
+  - unit_tests            # CONFIRM: actual test command — scripts/run_tests.sh?
+  - cost_cap
+  - human_review          # MVP: always required before merge
+
+cost_cap_usd: {{ cost_cap_usd | default(2.00) }}
+# NOTE: cost_usd_actual is ESTIMATED (token-count × model-pricing) — see C-5 in plan.
+cost_estimated: true
+
+# Hard iteration cap — agent must handoff before this limit
+iteration_cap: {{ iteration_cap | default(40) }}
+
+handoff_schema_ref: .hermes/schemas/handoff-v1.yaml
+
+# delegate_task does NOT directly spawn Claude Code or Codex. See C-3 in plan.
+# Real agent execution uses terminal() to invoke the CLI. This contract defines
+# the scope; the orchestrator skill handles the actual terminal() call.
+spawn_mechanism: terminal_cli            # terminal_cli | container (Phase 3)

--- a/.hermes/test-fixtures/stub-handoff-fail-agent-enum.yaml
+++ b/.hermes/test-fixtures/stub-handoff-fail-agent-enum.yaml
@@ -1,0 +1,9 @@
+task_id: T-FAIL-AGENT-ENUM
+agent: grok  # invalid enum (must be claude_code or codex)
+completed_at: "2026-05-22T20:00:00Z"
+summary: "Invalid agent enum test fixture"
+changed_files:
+  - "docs/example.md"
+test_results:
+  passed: true
+  summary: "No tests run"

--- a/.hermes/test-fixtures/stub-handoff-fail-dotslash-prompt-artifact.yaml
+++ b/.hermes/test-fixtures/stub-handoff-fail-dotslash-prompt-artifact.yaml
@@ -1,0 +1,8 @@
+task_id: T-FAIL-DOTSLASH-PROMPT
+agent: claude_code
+completed_at: "2026-05-22T20:00:00Z"
+summary: "./AGENTS.md is forbidden prompt artifact"
+changed_files:
+  - "./AGENTS.md"
+test_results:
+  passed: true

--- a/.hermes/test-fixtures/stub-handoff-fail-empty-changed-files.yaml
+++ b/.hermes/test-fixtures/stub-handoff-fail-empty-changed-files.yaml
@@ -1,0 +1,8 @@
+task_id: T-FAIL-EMPTY-CHANGED
+agent: codex
+completed_at: "2026-05-22T20:00:00Z"
+summary: "changed_files must be non-empty list"
+changed_files: []
+test_results:
+  passed: true
+  summary: "No files"

--- a/.hermes/test-fixtures/stub-handoff-fail-forbidden.yaml
+++ b/.hermes/test-fixtures/stub-handoff-fail-forbidden.yaml
@@ -1,0 +1,28 @@
+# stub-handoff-fail-forbidden.yaml
+# Handoff that FAILS the forbidden_path_writes gate.
+# changed_files includes a prompt artifact path (.hermes/config/capability-matrix.yaml).
+# Used to test that the gate correctly blocks merges when agents touch forbidden paths.
+# This fixture intentionally includes a forbidden path — it is NOT a valid handoff.
+
+task_id: "stub-task-0002"
+agent: claude_code
+completed_at: "2026-05-22T10:05:00Z"
+summary: "Refactored terminal timeout AND updated capability matrix to reflect new behavior."
+changed_files:
+  - src/tools/terminal.py
+  - tests/tools/test_terminal.py
+  # FORBIDDEN: agent must not modify prompt artifacts or orchestration config
+  - .hermes/config/capability-matrix.yaml
+  - AGENTS.md
+test_results:
+  command_run: "scripts/run_tests.sh"
+  exit_code: 0
+  stdout_tail: "...\n47 passed in 3.21s"
+  passed: true
+eval_evidence:
+  lint_clean: true
+  unit_tests_passed: true
+  diff_size_kb: 6.1
+  no_forbidden_writes: false   # correctly self-reported as false here
+open_issues: []
+self_assessed_confidence: high

--- a/.hermes/test-fixtures/stub-handoff-fail-schema.yaml
+++ b/.hermes/test-fixtures/stub-handoff-fail-schema.yaml
@@ -1,0 +1,20 @@
+# stub-handoff-fail-schema.yaml
+# Handoff that FAILS schema validation — intentionally missing required fields.
+# Required fields absent: task_id, completed_at, changed_files, test_results.passed.
+# Used to test that Hermes rejects handoffs before running any other gate.
+# This fixture is intentionally malformed — do NOT use as a real handoff template.
+
+agent: claude_code
+summary: "This handoff is missing task_id, completed_at, changed_files, and test_results."
+# task_id: MISSING (required)
+# completed_at: MISSING (required)
+# changed_files: MISSING (required)
+test_results:
+  command_run: "scripts/run_tests.sh"
+  exit_code: 0
+  stdout_tail: "47 passed"
+  # passed: MISSING (required field inside test_results)
+eval_evidence:
+  lint_clean: true
+open_issues: []
+self_assessed_confidence: medium

--- a/.hermes/test-fixtures/stub-handoff-fail-test-results-absent.yaml
+++ b/.hermes/test-fixtures/stub-handoff-fail-test-results-absent.yaml
@@ -1,0 +1,7 @@
+task_id: T-FAIL-TEST-RESULTS-ABSENT
+agent: claude_code
+completed_at: "2026-05-22T20:00:00Z"
+summary: "Missing test_results triggers unit_tests gate with SKIP note"
+changed_files:
+  - "src/module.py"
+# intentionally no test_results key

--- a/.hermes/test-fixtures/stub-handoff-fail-tests.yaml
+++ b/.hermes/test-fixtures/stub-handoff-fail-tests.yaml
@@ -1,0 +1,27 @@
+# stub-handoff-fail-tests.yaml
+# Handoff that FAILS the unit_tests gate — test_results.passed=false.
+# All required schema fields are present (schema validation passes).
+# Used to test that Hermes rejects handoffs with failing tests, even when schema is valid.
+
+task_id: "stub-task-0004"
+agent: claude_code
+completed_at: "2026-05-22T10:15:00Z"
+summary: "Attempted fix for terminal timeout but introduced a regression in test_terminal_cancel."
+changed_files:
+  - src/tools/terminal.py
+  - tests/tools/test_terminal.py
+test_results:
+  command_run: "scripts/run_tests.sh"
+  exit_code: 1
+  stdout_tail: |
+    FAILED tests/tools/test_terminal.py::test_terminal_cancel - AssertionError
+    1 failed, 46 passed in 3.44s
+  passed: false
+eval_evidence:
+  lint_clean: true
+  unit_tests_passed: false
+  diff_size_kb: 3.8
+  no_forbidden_writes: true
+open_issues:
+  - "test_terminal_cancel fails — cancel() call sequence changed, need to revert or fix mock"
+self_assessed_confidence: low

--- a/.hermes/test-fixtures/stub-handoff-fail-traversal.yaml
+++ b/.hermes/test-fixtures/stub-handoff-fail-traversal.yaml
@@ -1,0 +1,8 @@
+task_id: T-FAIL-TRAVERSAL
+agent: codex
+completed_at: "2026-05-22T20:00:00Z"
+summary: "Path with .. traversal must be rejected"
+changed_files:
+  - "../outside.txt"
+test_results:
+  passed: true

--- a/.hermes/test-fixtures/stub-handoff-pass-agent-md-backup.yaml
+++ b/.hermes/test-fixtures/stub-handoff-pass-agent-md-backup.yaml
@@ -1,0 +1,9 @@
+task_id: T-PASS-AGENT-MD-BACKUP
+agent: claude_code
+completed_at: "2026-05-22T20:00:00Z"
+summary: "AGENTS.md.backup is allowed (not exact forbidden name)"
+changed_files:
+  - "AGENTS.md.backup"
+test_results:
+  passed: true
+  summary: "All tests passed"

--- a/.hermes/test-fixtures/stub-handoff-pass.yaml
+++ b/.hermes/test-fixtures/stub-handoff-pass.yaml
@@ -1,0 +1,23 @@
+# stub-handoff-pass.yaml
+# Valid handoff — all required fields present; test_results.passed=true.
+# Used in gate tests to verify happy-path schema validation and gate evaluation.
+
+task_id: "stub-task-0001"
+agent: claude_code
+completed_at: "2026-05-22T10:00:00Z"
+summary: "Fixed the off-by-one error in src/tools/terminal.py timeout logic. Added regression test."
+changed_files:
+  - src/tools/terminal.py
+  - tests/tools/test_terminal.py
+test_results:
+  command_run: "scripts/run_tests.sh"
+  exit_code: 0
+  stdout_tail: "...\n47 passed in 3.21s"
+  passed: true
+eval_evidence:
+  lint_clean: true
+  unit_tests_passed: true
+  diff_size_kb: 4.2
+  no_forbidden_writes: true
+open_issues: []
+self_assessed_confidence: high

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1009,6 +1009,202 @@ def profile_env(tmp_path, monkeypatch):
 
 ---
 
+## Native Agent Execution (Codex + Claude Code)
+
+This section is the authoritative runtime contract for external coding agents
+(OpenAI Codex CLI, Anthropic Claude Code CLI) assigned work in this repo.
+Agents reading this file MUST follow these rules; orchestrators dispatching
+agents MUST pass this section as context.
+
+### Mandatory Task Workflow
+
+Every non-trivial task (any change > ~10 lines or touching > 1 file) MUST
+follow this sequence.  No step may be skipped silently.
+
+```
+1. INSPECT    Read the files you intend to touch. Run: git status, git log --oneline -5
+2. PLAN       State what you will change (files + functions + rationale) BEFORE writing code
+3. IMPLEMENT  Make changes. Commit atomically: one logical change per commit
+4. TEST       Run: scripts/run_tests.sh [test/path] — verify no regressions
+5. REVIEW     Check your own diff: git diff HEAD~N..HEAD — no unintended changes
+6. SUMMARIZE  Report: changed files, test result (N passed / M failed), any caveats
+```
+
+One-liner tasks (doc fixes, single-function tweaks) may collapse 1-3 into a
+single step but MUST still run tests (step 4) and report (step 6).
+
+### Verification Gates
+
+| Gate | Command | Pass condition |
+|------|---------|----------------|
+| Pre-flight | `git status` + `scripts/run_tests.sh tests/ -q` | Clean working tree OR known baseline; test suite ≥ baseline |
+| Post-implement | `scripts/run_tests.sh [changed test paths] -q` | All targeted tests pass |
+| Regression | `scripts/run_tests.sh -q` | No tests newly failing vs baseline |
+| Pre-commit | `git diff --stat HEAD` | Only expected files changed |
+
+**Baseline rule:** before making any changes, record the test count:
+`scripts/run_tests.sh -q 2>&1 | tail -3`. If you cannot run the full suite,
+at minimum run the tests for the files you are touching.
+
+Always use `scripts/run_tests.sh` — not bare `pytest`. The wrapper enforces
+hermetic environment parity: credentials unset, TZ=UTC, LANG=C.UTF-8, -n 4
+workers. Direct pytest diverges from CI and has caused repeated "works locally,
+fails in CI" incidents.
+
+### Worktree Isolation for Parallel Agents
+
+When multiple agents work in parallel, each MUST have an isolated git worktree
+to prevent race conditions on shared files.
+
+```bash
+# Orchestrator creates one worktree per agent task
+git worktree add -b agent/task-auth  /tmp/wt-auth  main
+git worktree add -b agent/task-db    /tmp/wt-db    main
+
+# Each agent runs entirely inside its own worktree
+# workdir: /tmp/wt-auth  (for the auth agent)
+# workdir: /tmp/wt-db    (for the db agent)
+
+# After completion: push branch, open PR, remove worktree
+git -C /tmp/wt-auth push -u origin agent/task-auth
+git worktree remove /tmp/wt-auth
+```
+
+Serialization rules:
+- Tasks touching the same file → serialize OR isolate via worktrees
+- Migration files (`alembic/versions/`, `**/migrations/`) → ALWAYS serialize
+- Shared manifest files (`pyproject.toml`, `uv.lock`) → assign to ONE agent
+- Run `git diff branch-a..branch-b -- <shared-file>` before merging
+  parallel branches to surface conflicts early
+
+### Context Budget and Compaction Handoff
+
+Agents have a finite context window. Long runs degrade silently above ~70% usage.
+
+| Threshold | Action |
+|-----------|--------|
+| < 70% | Normal operation |
+| 70–85% | Write a handoff checkpoint; continue |
+| > 85% | Write handoff checkpoint, commit all in-progress work, stop |
+
+**Handoff checkpoint format** — write to `.hermes/handoff/agent-<date>.md`:
+
+```markdown
+# Agent Handoff — <ISO date>
+
+## Completed (committed)
+- task-1: <desc> (commit <SHA>)
+- task-2: <desc> (commit <SHA>)
+
+## In-progress (NOT committed)
+- task-3: <desc> — <what was done, what remains>
+- Files modified but not committed: <list>
+
+## Pending (not started)
+- task-4, task-5
+
+## Test status
+pytest: <N> passed, <M> failed (as of last run)
+
+## Open questions
+- <any unresolved decisions>
+
+## Next step
+<single concrete instruction for the resuming agent>
+```
+
+A new agent session resumes by reading the handoff file:
+`read_file(".hermes/handoff/agent-<date>.md")` then continuing.
+
+**Claude Code specific:** use `/compact` before hitting 85%; CLAUDE.md content
+survives compaction. In print mode (`-p`), use session resumption:
+`claude -p "continue" --resume <session_id> --max-turns 10`.
+
+**Codex specific:** use `codex exec resume --last` to re-enter a saved session
+after a context-pressure stop.
+
+### Security and Destructive-Operation Guardrails
+
+**NEVER run without explicit user or orchestrator authorization:**
+
+```
+rm -rf <any path>
+git reset --hard
+git clean -fdx
+git push --force  (or --force-with-lease to an unreviewed ref)
+DROP TABLE / DELETE FROM (without WHERE) in migration scripts
+chmod 777 or chown to non-project users
+curl/wget piped directly to bash
+npm install --ignore-scripts on unknown packages
+```
+
+**Before any destructive bash command:** read it aloud (include it in your
+SUMMARIZE output), confirm the target path is inside the repo worktree,
+and note it explicitly. If there is any ambiguity about scope, stop and ask.
+
+**Dependency changes** (`pyproject.toml`, `requirements*.txt`, `package.json`):
+- Every new PyPI package must have an upper-bound pin: `>=X.Y,<next_major`
+- Run `uv lock` after pyproject.toml edits to regenerate `uv.lock` with hashes
+- Git URL deps must use a commit SHA, not a branch name
+- See "Dependency Pinning Policy" section for full rules
+
+### Multi-Agent Review: Implementer + Independent Reviewer
+
+For any change that touches security-sensitive paths, introduces new tools,
+modifies the agent loop, or changes gateway/platform adapters:
+
+1. **Implementer agent** completes the task and outputs TASK_COMPLETE with
+   changed files and test result.
+2. **Independent reviewer agent** (different context, no access to implementer's
+   reasoning) reads the diff and outputs PASS or FAIL with specifics.
+3. **Orchestrator** compares findings. If reviewer returns FAIL or flags a
+   discrepancy with the implementer's self-report, the orchestrator must resolve
+   before merging.
+
+**Self-reports are not verified facts.** A subagent that claims "all tests pass"
+or "no security issues" may be wrong due to context degradation or hallucination.
+Always verify claims against actual tool output (test exit code, diff content).
+
+Comparison checklist for the orchestrator:
+- Does the diff match what the implementer claimed to change?
+- Did reviewer find anything the implementer omitted from its summary?
+- Are all tests actually passing (check the run_tests.sh output, not just the claim)?
+- For security-sensitive paths: did reviewer flag anything not in implementer's summary?
+
+### Provider and Runtime Quirks
+
+**Codex CLI:**
+- Requires a git repository — fails with "Not a git repository" outside one
+- Always use `pty=true` in Hermes terminal calls; Codex hangs without a PTY
+- Canonical sandbox flag: `-s workspace-write` (old `--full-auto` may not exist)
+- Bypass flag: `--dangerously-bypass-approvals-and-sandbox` (old `--yolo` deprecated)
+- Use `--json` for machine-readable JSONL output; `codex exec -o /tmp/result.txt`
+  to capture final agent message to a file
+- Diagnose auth + PATH issues with `codex doctor` before blaming the task
+- Cap parallel Codex processes at 3; more degrades all via API rate limits
+- Session files: `~/.codex/sessions/`; resume with `codex exec resume --last`
+
+**Claude Code CLI:**
+- Print mode (`-p`) is preferred for automation — skips all interactive dialogs
+- Trust dialog (first visit to dir): press Enter (default = "Yes, I trust")
+- `--dangerously-skip-permissions` dialog defaults to "No, exit" — send Down then
+  Enter to accept; print mode (`-p`) avoids this entirely
+- `--max-turns` only applies in print mode; ignored in interactive sessions
+- `--max-budget-usd` minimum is ~$0.05 (system prompt cache creation alone)
+- Context health: `/context` shows colored grid; degrade thresholds 70% / 85%
+- Use `--bare` for CI/scripting (skips OAuth, hooks, plugins, CLAUDE.md loading)
+- Use `--allowedTools` to scope capabilities: `Read,Edit` for reviews, `Read,Write,Bash` for implementation
+- Worktree support: `claude -w <name>` creates `.claude/worktrees/<name>` automatically
+- Session resumption: `claude --resume <session_id>` or `claude --continue`
+- Subagents / agent teams: define in `.claude/agents/<name>.md` (see `claude --agents`)
+- CLAUDE.md survives `/compact`; use it to preserve project context across compactions
+
+**Hermes Codex provider (`model.provider: openai-codex`):**
+- Uses `~/.hermes/auth.json` via `hermes auth add openai-codex` — separate from `~/.codex/auth.json`
+- `api_mode: codex_responses` in `AIAgent` selects the Responses API path
+
+---
+
 ## Testing
 
 **ALWAYS use `scripts/run_tests.sh`** — do not call `pytest` directly. The script enforces

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,116 @@
+# Hermes Agent — Claude Code Project Context
+
+Native context file for Claude Code CLI. Full developer guide is in AGENTS.md.
+This file covers Claude Code-specific operating rules. Read AGENTS.md first for
+architecture, file structure, and conventions.
+
+## Quick Reference
+
+```bash
+# Activate environment
+source .venv/bin/activate          # or: source venv/bin/activate
+
+# Run tests (ALWAYS use the wrapper — never bare pytest)
+scripts/run_tests.sh                           # full suite
+scripts/run_tests.sh tests/gateway/ -q         # one directory
+scripts/run_tests.sh tests/agent/test_foo.py::test_bar  # one test
+
+# Key entry points
+run_agent.py        # AIAgent class and conversation loop
+model_tools.py      # tool orchestration, handle_function_call()
+cli.py              # HermesCLI — interactive CLI (~11k LOC)
+tools/              # all tool implementations (auto-discovered)
+gateway/run.py      # messaging gateway main loop
+hermes_cli/commands.py  # slash command registry (COMMAND_REGISTRY list)
+```
+
+## Mandatory Task Workflow
+
+For any change > ~10 lines or touching > 1 file, follow these steps in order:
+
+1. **INSPECT** — read the files you will touch; run `git status`
+2. **PLAN** — state what you will change and why, before writing
+3. **IMPLEMENT** — make changes; commit atomically (one logical change per commit)
+4. **TEST** — `scripts/run_tests.sh [test/path] -q`; verify no regressions
+5. **REVIEW** — `git diff HEAD~N..HEAD`; confirm no unintended changes
+6. **SUMMARIZE** — report changed files, test result (N passed / M failed), caveats
+
+## Verification Gates
+
+| Gate | Command | Pass condition |
+|------|---------|----------------|
+| Pre-flight | `git status` + `scripts/run_tests.sh -q 2>&1 \| tail -3` | Baseline established |
+| Post-implement | `scripts/run_tests.sh [changed test paths] -q` | Targeted tests pass |
+| Regression | `scripts/run_tests.sh -q` | No new failures vs baseline |
+| Pre-commit | `git diff --stat HEAD` | Only expected files changed |
+
+## Claude Code Operating Rules
+
+### Context management
+- Run `/context` to check context window usage before starting large tasks
+- At 70%: write a handoff checkpoint to `.hermes/handoff/agent-<date>.md`
+- At 85%: write checkpoint, commit in-progress work, stop and hand off
+- Use `/compact` proactively; CLAUDE.md content survives compaction
+- Session resumption: `claude --resume <session_id>` or `claude --continue`
+
+### Permissions and safety
+- Use `--allowedTools Read,Edit` for reviews; `Read,Write,Bash` for implementation
+- Do NOT run: `rm -rf`, `git reset --hard`, `git clean -fdx`, `git push --force`
+- Do NOT pipe `curl`/`wget` directly to bash
+- Before any destructive command: name the target path explicitly in output
+- Dependency additions require upper-bound pins; run `uv lock` after pyproject.toml edits
+
+### Multi-agent patterns
+- For parallel work: use `claude -w <name>` per task (creates `.claude/worktrees/<name>`)
+- Serial rule: migration files and shared manifests (`pyproject.toml`, `uv.lock`) — ONE agent only
+- After an implementer completes: an independent reviewer reads the diff before merge
+- Self-reports are not verified — always cross-check claims against actual tool output (exit codes, diffs)
+
+### Print mode (for Hermes orchestration)
+```bash
+# Preferred for automation — no dialogs, structured output.
+# Run this from the repo root, or set the orchestrator/tool workdir to the repo root.
+claude -p "task description" --allowedTools "Read,Edit" --max-turns 10 \
+  --output-format json
+```
+Key flags: `--max-turns` (required in -p mode), `--output-format json` for
+structured results, `--resume <id>` to continue a previous session. Claude Code
+uses the current working directory; it does not have a `--workdir` flag.
+
+### When to stop and ask
+- Ambiguous scope (e.g. "refactor X" without specifying boundaries)
+- Any irreversible operation (data deletion, force-push, dropping tables)
+- Reviewer returns FAIL and the fix is non-obvious
+- Test suite drops from N passing to 0 (catastrophic regression)
+
+## Critical Invariants (must not break)
+
+- `get_hermes_home()` from `hermes_constants` — never hardcode `~/.hermes`
+- `display_hermes_home()` for user-facing messages — never bare `~/.hermes`
+- Prompt caching: do NOT alter past context, toolsets, or system prompt mid-conversation
+- Slash commands: all defined in `COMMAND_REGISTRY` in `hermes_cli/commands.py` — one place
+- New tools need registration in both `tools/<name>.py` AND `toolsets.py`
+- Plugins MUST NOT modify core files (`run_agent.py`, `cli.py`, `gateway/run.py`)
+- Tests must not write to real `~/.hermes/` — the `_isolate_hermes_home` autouse fixture handles this
+- Never use `simple_term_menu` for new interactive menus (use `hermes_cli/curses_ui.py`)
+- All new deps need upper-bound pins; run `uv lock` after changes
+
+## Key Policies (summary — full text in AGENTS.md)
+
+- Dependency pinning: `>=floor,<next_major` for PyPI; commit SHA for git URLs (post-litellm-compromise policy)
+- No new in-tree memory providers under `plugins/memory/` (closed set; new ones go to standalone repos)
+- No change-detector tests (no snapshot asserts on catalogs, version literals, or enumeration counts)
+- Squash merges from stale branches silently revert recent fixes — rebase on main first
+
+## Full Details
+
+See AGENTS.md for:
+- Complete project structure and file dependency chain
+- AIAgent class API and agent loop internals
+- CLI architecture and slash command registry
+- TUI architecture (ui-tui + tui_gateway)
+- Adding tools, config, plugins, skills
+- Dependency pinning policy
+- Profile and HERMES_HOME rules
+- Known pitfalls (hardcoded paths, ANSI escape leaks, gateway message guards, etc.)
+- Full test suite guidance and anti-patterns

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -300,9 +300,21 @@ _PROVIDER_VISION_MODELS: Dict[str, str] = {
 # api.kimi.com/coding (Anthropic Messages wire) which Kimi's own docs
 # describe as having no image_in capability. Vision lives on the separate
 # Kimi Platform (api.moonshot.ai, OpenAI-wire, pay-as-you-go).  See #17076.
+#
+# openai-codex: the ChatGPT-account Responses API endpoint maintains a
+# shifting, undocumented model allow-list and does not reliably accept
+# vision payloads with arbitrary model names (e.g. claude-sonnet-4.6).
+# When `openai-codex` is the user's main provider, vision auto-detection
+# must skip it and fall through to the aggregator chain (OpenRouter/Nous)
+# rather than forwarding the main model and getting a provider rejection
+# like "claude-sonnet-4.6 model is not supported when using Codex with a
+# ChatGPT account".  Users who explicitly set
+# `auxiliary.vision.provider: openai-codex` with a compatible model bypass
+# this skip (they reach resolve_provider_client directly, not this auto path).
 _PROVIDERS_WITHOUT_VISION: frozenset = frozenset({
     "kimi-coding",
     "kimi-coding-cn",
+    "openai-codex",
 })
 
 # OpenRouter app attribution headers (base — always sent).
@@ -3775,8 +3787,9 @@ def get_available_vision_backends() -> List[str]:
         if main_provider in _VISION_AUTO_PROVIDER_ORDER:
             if _strict_vision_backend_available(main_provider):
                 available.append(main_provider)
-        else:
-            client, _ = resolve_provider_client(main_provider, _read_main_model())
+        elif main_provider not in _PROVIDERS_WITHOUT_VISION:
+            client, _ = resolve_provider_client(main_provider, _read_main_model(),
+                                                is_vision=True)
             if client is not None:
                 available.append(main_provider)
     # 2. OpenRouter, 3. Nous — skip if already covered by main provider.
@@ -5028,9 +5041,17 @@ async def async_call_llm(
                 "Vision provider %s unavailable, falling back to auto vision backends",
                 resolved_provider,
             )
+            # Do NOT carry resolved_model into auto fallback: it is specific to the
+            # configured provider (e.g. claude-sonnet-4.6 for anthropic) and must not
+            # be forwarded to an aggregator backend (OpenRouter, Nous) that may not
+            # serve that model.  Preserve the caller's explicit model= argument as-is:
+            # `model` is the raw caller argument (None when not passed), so forwarding
+            # it directly is safe — if the caller did not pass a model, `model` is None
+            # and the auto backend will pick its own default.
+            fallback_model = model
             effective_provider, client, final_model = resolve_vision_provider_client(
                 provider="auto",
-                model=resolved_model,
+                model=fallback_model,
                 async_mode=True,
             )
         if client is None:

--- a/scripts/check_hybrid_control_plane.py
+++ b/scripts/check_hybrid_control_plane.py
@@ -1,0 +1,528 @@
+#!/usr/bin/env python3
+"""
+scripts/check_hybrid_control_plane.py
+
+Conservative MVP verification script for the hybrid agent control plane.
+Stdlib-only where possible. Requires PyYAML for YAML parsing.
+
+Checks:
+  1. Required files exist.
+  2. YAML fixtures load and have expected structure/values.
+  3. Plan file contains all required caveat phrases (C-1 through C-6).
+  4. .gitignore has correct entries (ignores runtime dirs, not all of .hermes/).
+
+Run: python scripts/check_hybrid_control_plane.py
+Exit 0 = all checks pass. Exit 1 = one or more failures.
+"""
+import sys
+import os
+
+# ---------------------------------------------------------------------------
+# Attempt to import PyYAML
+# ---------------------------------------------------------------------------
+try:
+    import yaml
+except ImportError:
+    print("ERROR: PyYAML is not installed.")
+    print("Install it: pip install pyyaml   (or: pip install -e '.[dev]')")
+    print("PyYAML is required for YAML fixture validation.")
+    sys.exit(1)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+REQUIRED_FILES = [
+    # Phase 0 artifacts
+    ".hermes/schemas/handoff-v1.yaml",
+    ".hermes/config/capability-matrix.yaml",
+    ".hermes/config/gate-taxonomy.yaml",
+    ".hermes/config/eval-matrix.yaml",
+    ".hermes/config/recovery-runbook.md",
+    ".hermes/templates/run-manifest.yaml.j2",
+    ".hermes/templates/task-contract.yaml.j2",
+    ".hermes/templates/locks.yaml.j2",
+    ".hermes/test-fixtures/stub-handoff-pass.yaml",
+    ".hermes/test-fixtures/stub-handoff-fail-forbidden.yaml",
+    ".hermes/test-fixtures/stub-handoff-fail-schema.yaml",
+    ".hermes/test-fixtures/stub-handoff-fail-tests.yaml",
+    ".hermes/plans/2026-05-22_000000-hybrid-agent-control-plane.md",
+    "scripts/check_hybrid_control_plane.py",
+    # Phase 1 artifacts
+    ".hermes/templates/skill-draft-hybrid-agent-control-plane.md",
+    "tests/skills/test_hybrid_agent_control_plane.py",
+]
+
+# Caveat phrases that must appear verbatim (or close enough) in the plan.
+# These correspond to caveats C-1 through C-6.
+REQUIRED_PLAN_PHRASES = [
+    # C-1: no duplicate route-dev-task
+    "route-dev-task",
+    "must NOT create a second route-dev-task",
+    # C-2: skill creation deferred; repo-local artifacts
+    "repo-local",
+    "deferred",
+    # C-3: delegate_task does not directly spawn
+    "delegate_task does not directly spawn",
+    # C-4: CODEX.md TBD
+    "CODEX.md",
+    "PROVISIONAL",
+    # C-5: cost accounting is estimated
+    "estimated",
+    "cost_usd_actual",
+    # C-6: CODEOWNERS insufficient for local workflow; check script is primary
+    "CODEOWNERS",
+    "local check script",
+]
+
+# .gitignore: paths that MUST be present (runtime outputs)
+GITIGNORE_MUST_INCLUDE = [
+    ".hermes/runs/",
+    ".worktrees/",
+]
+# .gitignore: pattern that must NOT be present (would ignore all .hermes/)
+GITIGNORE_MUST_NOT_INCLUDE = [
+    ".hermes/\n",   # bare .hermes/ on its own line
+    "/.hermes/\n",
+]
+# Also check that .hermes/handoff/ or .hermes/handoffs/ is ignored
+GITIGNORE_SHOULD_INCLUDE_ONE_OF = [
+    ".hermes/handoff/",
+    ".hermes/handoffs/",
+]
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+failures = []
+warnings = []
+
+
+def rel(path):
+    return os.path.join(REPO_ROOT, path)
+
+
+def fail(msg):
+    failures.append(msg)
+    print(f"  FAIL: {msg}")
+
+
+def warn(msg):
+    warnings.append(msg)
+    print(f"  WARN: {msg}")
+
+
+def ok(msg):
+    print(f"  OK:   {msg}")
+
+
+def load_yaml(path):
+    """Load YAML file; return (data, error_string). data=None on error."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            raw = yaml.safe_load(f)
+        # safe_load returns None for empty files; normalise to dict
+        data: dict = raw if isinstance(raw, dict) else {}
+        return data, None
+    except yaml.YAMLError as e:
+        return None, str(e)
+
+
+# ---------------------------------------------------------------------------
+# Check 1: Required files exist
+# ---------------------------------------------------------------------------
+print("\n=== 1. Required files ===")
+for rel_path in REQUIRED_FILES:
+    full = rel(rel_path)
+    if os.path.isfile(full):
+        ok(rel_path)
+    else:
+        fail(f"Missing required file: {rel_path}")
+
+
+# ---------------------------------------------------------------------------
+# Check 2: stub-handoff-pass — required fields + test_results.passed=true
+# ---------------------------------------------------------------------------
+print("\n=== 2. Fixture: stub-handoff-pass.yaml ===")
+pass_path = rel(".hermes/test-fixtures/stub-handoff-pass.yaml")
+if os.path.isfile(pass_path):
+    data, err = load_yaml(pass_path)
+    if err:
+        fail(f"stub-handoff-pass.yaml YAML parse error: {err}")
+    else:
+        required_fields = ["task_id", "agent", "completed_at", "summary", "changed_files", "test_results"]
+        for field in required_fields:
+            if field not in data or data[field] is None:  # type: ignore[operator]
+                fail(f"stub-handoff-pass.yaml missing required field: {field}")
+            else:
+                ok(f"field present: {field}")
+        # test_results.passed must be true
+        tr = data.get("test_results") or {}
+        if tr.get("passed") is True:
+            ok("test_results.passed = true")
+        else:
+            fail(f"stub-handoff-pass.yaml: test_results.passed should be true, got: {tr.get('passed')!r}")
+else:
+    fail("stub-handoff-pass.yaml not found (skipping content checks)")
+
+
+# ---------------------------------------------------------------------------
+# Check 3: stub-handoff-fail-schema — intentionally missing required fields
+# ---------------------------------------------------------------------------
+print("\n=== 3. Fixture: stub-handoff-fail-schema.yaml ===")
+schema_fail_path = rel(".hermes/test-fixtures/stub-handoff-fail-schema.yaml")
+if os.path.isfile(schema_fail_path):
+    data, err = load_yaml(schema_fail_path)
+    if err:
+        fail(f"stub-handoff-fail-schema.yaml YAML parse error: {err}")
+    else:
+        # Must be missing at least one required field
+        required_fields = ["task_id", "agent", "completed_at", "summary", "changed_files", "test_results"]
+        missing = [f for f in required_fields if f not in data or data[f] is None]  # type: ignore[operator]
+        if missing:
+            ok(f"stub-handoff-fail-schema.yaml intentionally missing fields: {missing}")
+        else:
+            fail("stub-handoff-fail-schema.yaml has all required fields — fixture should be intentionally malformed")
+        # Also check test_results.passed is missing or not set
+        tr = data.get("test_results") or {}
+        if "passed" not in tr:
+            ok("test_results.passed intentionally absent (correct for schema-fail fixture)")
+        else:
+            warn("stub-handoff-fail-schema.yaml has test_results.passed set — "
+                 "fixture should omit it to test schema failure")
+else:
+    fail("stub-handoff-fail-schema.yaml not found (skipping content checks)")
+
+
+# ---------------------------------------------------------------------------
+# Check 4: stub-handoff-fail-forbidden — changed_files includes a forbidden path
+# ---------------------------------------------------------------------------
+print("\n=== 4. Fixture: stub-handoff-fail-forbidden.yaml ===")
+forbidden_path = rel(".hermes/test-fixtures/stub-handoff-fail-forbidden.yaml")
+FORBIDDEN_PREFIXES = [
+    "AGENTS.md",
+    "CLAUDE.md",
+    "CODEX.md",
+    ".hermes/config/",
+    ".hermes/schemas/",
+    ".hermes/plans/",
+    ".claude/",
+    ".codex/",
+]
+if os.path.isfile(forbidden_path):
+    data, err = load_yaml(forbidden_path)
+    if err:
+        fail(f"stub-handoff-fail-forbidden.yaml YAML parse error: {err}")
+    else:
+        changed = list(data.get("changed_files") or [])
+        found_forbidden = [
+            f for f in changed
+            if any(f.startswith(p) or f == p.rstrip("/") for p in FORBIDDEN_PREFIXES)
+        ]
+        if found_forbidden:
+            ok(f"stub-handoff-fail-forbidden.yaml contains forbidden path(s): {found_forbidden}")
+        else:
+            fail(
+                "stub-handoff-fail-forbidden.yaml: changed_files must include at least one "
+                f"forbidden prompt artifact path (one of: {FORBIDDEN_PREFIXES}). "
+                f"Got: {changed}"
+            )
+else:
+    fail("stub-handoff-fail-forbidden.yaml not found (skipping content checks)")
+
+
+# ---------------------------------------------------------------------------
+# Check 5: stub-handoff-fail-tests — test_results.passed=false
+# ---------------------------------------------------------------------------
+print("\n=== 5. Fixture: stub-handoff-fail-tests.yaml ===")
+tests_fail_path = rel(".hermes/test-fixtures/stub-handoff-fail-tests.yaml")
+if os.path.isfile(tests_fail_path):
+    data, err = load_yaml(tests_fail_path)
+    if err:
+        fail(f"stub-handoff-fail-tests.yaml YAML parse error: {err}")
+    else:
+        # Schema fields should be present (it's a schema-valid but gate-failing handoff)
+        required_fields = ["task_id", "agent", "completed_at", "summary", "changed_files", "test_results"]
+        for field in required_fields:
+            if field not in data or data[field] is None:  # type: ignore[operator]
+                fail(f"stub-handoff-fail-tests.yaml missing field: {field} "
+                     "(this fixture should be schema-valid but fail the tests gate)")
+        tr = data.get("test_results") or {}
+        if tr.get("passed") is False:
+            ok("test_results.passed = false")
+        else:
+            fail(f"stub-handoff-fail-tests.yaml: test_results.passed should be false, got: {tr.get('passed')!r}")
+else:
+    fail("stub-handoff-fail-tests.yaml not found (skipping content checks)")
+
+
+# ---------------------------------------------------------------------------
+# Check 6: Plan contains required caveat phrases (C-1 through C-6)
+# ---------------------------------------------------------------------------
+print("\n=== 6. Plan caveat phrases ===")
+plan_path = rel(".hermes/plans/2026-05-22_000000-hybrid-agent-control-plane.md")
+if os.path.isfile(plan_path):
+    with open(plan_path, "r", encoding="utf-8") as f:
+        plan_text = f.read()
+    for phrase in REQUIRED_PLAN_PHRASES:
+        if phrase in plan_text:
+            ok(f"Plan contains: {phrase!r}")
+        else:
+            fail(f"Plan MISSING required phrase: {phrase!r}")
+else:
+    fail("Plan file not found (skipping phrase checks)")
+
+
+# ---------------------------------------------------------------------------
+# Check 7: .gitignore correctness
+# ---------------------------------------------------------------------------
+print("\n=== 7. .gitignore ===")
+gitignore_path = rel(".gitignore")
+if os.path.isfile(gitignore_path):
+    with open(gitignore_path, "r", encoding="utf-8") as f:
+        gi_text = f.read()
+    # Must include runtime output dirs
+    for pattern in GITIGNORE_MUST_INCLUDE:
+        # Check if the stripped pattern appears as a line
+        if any(line.strip() == pattern.strip() for line in gi_text.splitlines()):
+            ok(f".gitignore includes: {pattern!r}")
+        else:
+            fail(f".gitignore missing runtime output pattern: {pattern!r}")
+
+    # Must NOT ignore all of .hermes/
+    for bad_pattern in GITIGNORE_MUST_NOT_INCLUDE:
+        stripped = bad_pattern.strip()
+        if any(line.strip() == stripped for line in gi_text.splitlines()):
+            fail(f".gitignore has bare .hermes/ ignore pattern {stripped!r} — "
+                 "this would ignore all .hermes/ including committed config files. "
+                 "Use specific subdirectory patterns instead.")
+        else:
+            ok(f".gitignore does NOT have broad ignore: {stripped!r}")
+
+    # Should include at least one of handoff/handoffs
+    found_handoff = any(
+        any(line.strip() == p.strip() for line in gi_text.splitlines())
+        for p in GITIGNORE_SHOULD_INCLUDE_ONE_OF
+    )
+    if found_handoff:
+        ok(".gitignore includes handoff runtime dir")
+    else:
+        warn(f".gitignore should include one of {GITIGNORE_SHOULD_INCLUDE_ONE_OF} — "
+             "add it to prevent handoff payloads being accidentally committed")
+else:
+    fail(".gitignore not found")
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 Check 8: Plan has human_reviewed_at set and non-empty
+# ---------------------------------------------------------------------------
+print("\n=== 8. Plan: human_reviewed_at field ===")
+plan_path8 = rel(".hermes/plans/2026-05-22_000000-hybrid-agent-control-plane.md")
+if os.path.isfile(plan_path8):
+    with open(plan_path8, "r", encoding="utf-8") as f:
+        plan_text8 = f.read()
+    import re as _re
+    # Look for machine-checkable field: human_reviewed_at: <non-empty, non-~>
+    # Matches the pattern in the MACHINE-CHECKABLE FIELDS comment block
+    match = _re.search(r"^human_reviewed_at:\s*(\S+)", plan_text8, _re.MULTILINE)
+    if match:
+        val = match.group(1).strip()
+        if val and val != "~" and val != "null":
+            ok(f"human_reviewed_at = {val!r}")
+        else:
+            fail(
+                f"human_reviewed_at is present but empty/null ({val!r}). "
+                "Worker execution phases require a non-empty timestamp. "
+                "Set it to the approval timestamp (e.g. 2026-05-22T23:27:28Z)."
+            )
+    else:
+        fail(
+            "Plan is missing 'human_reviewed_at: <timestamp>' field. "
+            "This field is required before any Phase 2+ worker spawn. "
+            "Add it in the MACHINE-CHECKABLE FIELDS block at the plan header."
+        )
+else:
+    fail("Plan file not found (skipping human_reviewed_at check)")
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 Check 9: Plan has locked decisions section (LD-1 through LD-6)
+# ---------------------------------------------------------------------------
+print("\n=== 9. Plan: locked decisions ===")
+REQUIRED_LOCKED_DECISIONS = [
+    "LD-1",
+    "LD-2",
+    "LD-3",
+    "LD-4",
+    "LD-5",
+    "LD-6",
+    "worktrees_are_sandbox: false",   # LD-1 canonical field
+    "file-based handoff is canonical",  # LD-2
+    "HANDOFF_PATH:",                  # LD-2 sentinel convention
+    "human_reviewed_at",              # LD-3
+    "serial gates",                   # LD-4
+    "opportunistic",                  # LD-5 (Codex)
+    "cost_estimated: true",           # LD-6
+]
+if os.path.isfile(plan_path8):
+    for phrase in REQUIRED_LOCKED_DECISIONS:
+        if phrase in plan_text8:
+            ok(f"Plan contains locked decision phrase: {phrase!r}")
+        else:
+            fail(f"Plan missing locked decision phrase: {phrase!r}")
+else:
+    plan_text8 = ""
+    fail("Plan file not found (skipping locked decisions check)")
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 Check 10: Skill draft exists and has required sections
+# ---------------------------------------------------------------------------
+print("\n=== 10. Skill draft: hybrid-agent-control-plane ===")
+skill_draft_path = rel(".hermes/templates/skill-draft-hybrid-agent-control-plane.md")
+SKILL_DRAFT_REQUIRED_SECTIONS = [
+    "human_reviewed_at",           # frontmatter field
+    "No real spawns",              # MVP constraint
+    "worktrees_are_sandbox",       # LD-1
+    "HANDOFF_PATH:",               # LD-2 sentinel
+    "file-based handoff",          # LD-2 (case-insensitive search done below)
+    "serial",                      # LD-4 gate order
+    "cost_estimated",              # LD-6
+    "route-dev-task",              # integration with existing skill (C-1)
+    "terminal()",                  # C-3: real spawns use terminal, not delegate_task
+    "NOT delegate_task",           # C-3 explicit prohibition
+]
+SKILL_DRAFT_MUST_NOT_CONTAIN = [
+    # MVP must not indicate real spawns are enabled
+    "spawn_real_agent: true",
+    "sandbox_verified: true",      # Codex not verified yet
+]
+if os.path.isfile(skill_draft_path):
+    with open(skill_draft_path, "r", encoding="utf-8") as f:
+        draft_text = f.read()
+    for phrase in SKILL_DRAFT_REQUIRED_SECTIONS:
+        if phrase.lower() in draft_text.lower():
+            ok(f"Skill draft contains: {phrase!r}")
+        else:
+            fail(f"Skill draft missing required phrase: {phrase!r}")
+    for phrase in SKILL_DRAFT_MUST_NOT_CONTAIN:
+        if phrase in draft_text:
+            fail(
+                f"Skill draft contains forbidden phrase for MVP: {phrase!r}. "
+                "This would indicate real spawns or unverified Codex are enabled."
+            )
+        else:
+            ok(f"Skill draft correctly absent: {phrase!r}")
+else:
+    fail("Skill draft not found: .hermes/templates/skill-draft-hybrid-agent-control-plane.md")
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 Check 11: Templates have cost_estimated and handoff_path fields
+# ---------------------------------------------------------------------------
+print("\n=== 11. Templates: cost_estimated and handoff path fields ===")
+TEMPLATE_CHECKS = {
+    ".hermes/templates/run-manifest.yaml.j2": [
+        "cost_estimated",
+        "total_cost_usd_cap",
+        "total_cost_usd_actual",
+        "worktrees_are_sandbox",
+        "container_isolation",
+    ],
+    ".hermes/templates/task-contract.yaml.j2": [
+        "cost_cap_usd",
+        "cost_estimated",
+        "handoff_schema_ref",
+        "spawn_mechanism",
+    ],
+}
+for tpl_path, required_fields in TEMPLATE_CHECKS.items():
+    full_tpl = rel(tpl_path)
+    if os.path.isfile(full_tpl):
+        with open(full_tpl, "r", encoding="utf-8") as f:
+            tpl_text = f.read()
+        for field in required_fields:
+            if field in tpl_text:
+                ok(f"{tpl_path} contains field: {field!r}")
+            else:
+                fail(f"{tpl_path} missing required field: {field!r}")
+    else:
+        fail(f"Template not found: {tpl_path}")
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 Check 12: Handoff schema has cost_estimated field
+# ---------------------------------------------------------------------------
+print("\n=== 12. Handoff schema: cost_estimated field ===")
+schema_path = rel(".hermes/schemas/handoff-v1.yaml")
+if os.path.isfile(schema_path):
+    with open(schema_path, "r", encoding="utf-8") as f:
+        schema_text = f.read()
+    if "cost_estimated" in schema_text:
+        ok("handoff-v1.yaml contains cost_estimated field")
+    else:
+        fail("handoff-v1.yaml missing cost_estimated field (required by LD-6)")
+    if "method:" in schema_text and "token_count_estimate" in schema_text:
+        ok("handoff-v1.yaml has cost method enum including token_count_estimate")
+    else:
+        warn("handoff-v1.yaml may be missing cost method enum — check cost_estimated.method field")
+else:
+    fail("handoff-v1.yaml not found (skipping schema field checks)")
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 Check 13: No real-spawn indicators enabled for MVP
+# ---------------------------------------------------------------------------
+print("\n=== 13. MVP: no real spawn indicators ===")
+# Check capability matrix — Codex sandbox_verified must be false
+cap_matrix_path = rel(".hermes/config/capability-matrix.yaml")
+if os.path.isfile(cap_matrix_path):
+    cap_data, cap_err = load_yaml(cap_matrix_path)
+    if cap_err:
+        fail(f"capability-matrix.yaml YAML parse error: {cap_err}")
+    else:
+        codex = (cap_data.get("agents") or {}).get("codex") or {}
+        sandbox_verified = codex.get("sandbox_verified", False)
+        if sandbox_verified is not False:
+            fail(
+                "capability-matrix.yaml: codex.sandbox_verified is not false — "
+                "Codex canary test (plan task 2.1) must pass before enabling. "
+                f"Current value: {sandbox_verified!r}. Set to false until Phase 2 canary confirms."
+            )
+        else:
+            ok(f"codex.sandbox_verified = {sandbox_verified!r} (correctly false for MVP)")
+
+        cc = (cap_data.get("agents") or {}).get("claude_code") or {}
+        dsp = cc.get("dangerously_skip_permissions", False)
+        if dsp is not False:
+            fail(
+                "capability-matrix.yaml: claude_code.dangerously_skip_permissions is not false — "
+                f"this must never be set on real host filesystems. Current value: {dsp!r}."
+            )
+        else:
+            ok(f"claude_code.dangerously_skip_permissions = {dsp!r} (correctly false)")
+else:
+    fail("capability-matrix.yaml not found (skipping real-spawn checks)")
+
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+print("\n" + "=" * 60)
+if failures:
+    print(f"RESULT: {len(failures)} failure(s), {len(warnings)} warning(s)")
+    for i, f in enumerate(failures, 1):
+        print(f"  [{i}] {f}")
+    if warnings:
+        for w in warnings:
+            print(f"  WARN: {w}")
+    sys.exit(1)
+else:
+    if warnings:
+        print(f"RESULT: PASS (0 failures, {len(warnings)} warning(s))")
+        for w in warnings:
+            print(f"  WARN: {w}")
+    else:
+        print("RESULT: PASS — all checks passed.")
+    sys.exit(0)

--- a/scripts/check_hybrid_control_plane.py
+++ b/scripts/check_hybrid_control_plane.py
@@ -2,527 +2,777 @@
 """
 scripts/check_hybrid_control_plane.py
 
-Conservative MVP verification script for the hybrid agent control plane.
-Stdlib-only where possible. Requires PyYAML for YAML parsing.
+Hybrid agent control plane gate checker.
+Supports:
+  * Default sanity mode (original checks)
+  * --handoff PATH: validate single handoff fixture
+  * --all-handoff-fixtures: validate all stub-handoff-*.yaml fixtures with expected map
 
-Checks:
-  1. Required files exist.
-  2. YAML fixtures load and have expected structure/values.
-  3. Plan file contains all required caveat phrases (C-1 through C-6).
-  4. .gitignore has correct entries (ignores runtime dirs, not all of .hermes/).
+Exit codes:
+  0 = success (AUTOMATED_PASS_HUMAN_REVIEW_REQUIRED in pass case)
+  nonzero = any gate failure
 
-Run: python scripts/check_hybrid_control_plane.py
-Exit 0 = all checks pass. Exit 1 = one or more failures.
+Gate order for handoff mode (fail-fast):
+  1. schema_validation
+  2. forbidden_path_writes
+  3. prompt_artifact_unchanged
+  4. diff_size_limit: SKIP
+  5. unit_tests
+  6. cost_cap: SKIP
+  7. human_review / RESULT
+
+Protected paths (exact or prefix):
+  exact forbidden: AGENTS.md, CLAUDE.md, CODEX.md
+  prefixes: .hermes/config/, .hermes/schemas/, .hermes/plans/, .claude/, .codex/
+Path rules:
+  - Repo-relative POSIX paths only
+  - Allow and normalize leading './' for ordinary repo-relative paths
+  - Reject: empty, absolute, contains backslash or drive, contains '..'
+  - ./AGENTS.md blocks after normalization; AGENTS.md.backup passes
 """
+
 import sys
 import os
+import argparse
+import subprocess
+from typing import List, Dict, Any, Optional, Tuple
 
-# ---------------------------------------------------------------------------
-# Attempt to import PyYAML
-# ---------------------------------------------------------------------------
 try:
     import yaml
 except ImportError:
     print("ERROR: PyYAML is not installed.")
     print("Install it: pip install pyyaml   (or: pip install -e '.[dev]')")
-    print("PyYAML is required for YAML fixture validation.")
     sys.exit(1)
 
+
 # ---------------------------------------------------------------------------
-# Configuration
+# Configuration and constants
 # ---------------------------------------------------------------------------
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-REQUIRED_FILES = [
-    # Phase 0 artifacts
-    ".hermes/schemas/handoff-v1.yaml",
-    ".hermes/config/capability-matrix.yaml",
-    ".hermes/config/gate-taxonomy.yaml",
-    ".hermes/config/eval-matrix.yaml",
-    ".hermes/config/recovery-runbook.md",
-    ".hermes/templates/run-manifest.yaml.j2",
-    ".hermes/templates/task-contract.yaml.j2",
-    ".hermes/templates/locks.yaml.j2",
-    ".hermes/test-fixtures/stub-handoff-pass.yaml",
-    ".hermes/test-fixtures/stub-handoff-fail-forbidden.yaml",
-    ".hermes/test-fixtures/stub-handoff-fail-schema.yaml",
-    ".hermes/test-fixtures/stub-handoff-fail-tests.yaml",
-    ".hermes/plans/2026-05-22_000000-hybrid-agent-control-plane.md",
-    "scripts/check_hybrid_control_plane.py",
-    # Phase 1 artifacts
-    ".hermes/templates/skill-draft-hybrid-agent-control-plane.md",
-    "tests/skills/test_hybrid_agent_control_plane.py",
-]
-
-# Caveat phrases that must appear verbatim (or close enough) in the plan.
-# These correspond to caveats C-1 through C-6.
-REQUIRED_PLAN_PHRASES = [
-    # C-1: no duplicate route-dev-task
-    "route-dev-task",
-    "must NOT create a second route-dev-task",
-    # C-2: skill creation deferred; repo-local artifacts
-    "repo-local",
-    "deferred",
-    # C-3: delegate_task does not directly spawn
-    "delegate_task does not directly spawn",
-    # C-4: CODEX.md TBD
-    "CODEX.md",
-    "PROVISIONAL",
-    # C-5: cost accounting is estimated
-    "estimated",
-    "cost_usd_actual",
-    # C-6: CODEOWNERS insufficient for local workflow; check script is primary
-    "CODEOWNERS",
-    "local check script",
-]
-
-# .gitignore: paths that MUST be present (runtime outputs)
-GITIGNORE_MUST_INCLUDE = [
-    ".hermes/runs/",
-    ".worktrees/",
-]
-# .gitignore: pattern that must NOT be present (would ignore all .hermes/)
-GITIGNORE_MUST_NOT_INCLUDE = [
-    ".hermes/\n",   # bare .hermes/ on its own line
-    "/.hermes/\n",
-]
-# Also check that .hermes/handoff/ or .hermes/handoffs/ is ignored
-GITIGNORE_SHOULD_INCLUDE_ONE_OF = [
-    ".hermes/handoff/",
-    ".hermes/handoffs/",
-]
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-failures = []
-warnings = []
-
-
-def rel(path):
-    return os.path.join(REPO_ROOT, path)
-
-
-def fail(msg):
-    failures.append(msg)
-    print(f"  FAIL: {msg}")
-
-
-def warn(msg):
-    warnings.append(msg)
-    print(f"  WARN: {msg}")
-
-
-def ok(msg):
-    print(f"  OK:   {msg}")
-
-
-def load_yaml(path):
-    """Load YAML file; return (data, error_string). data=None on error."""
-    try:
-        with open(path, "r", encoding="utf-8") as f:
-            raw = yaml.safe_load(f)
-        # safe_load returns None for empty files; normalise to dict
-        data: dict = raw if isinstance(raw, dict) else {}
-        return data, None
-    except yaml.YAMLError as e:
-        return None, str(e)
-
-
-# ---------------------------------------------------------------------------
-# Check 1: Required files exist
-# ---------------------------------------------------------------------------
-print("\n=== 1. Required files ===")
-for rel_path in REQUIRED_FILES:
-    full = rel(rel_path)
-    if os.path.isfile(full):
-        ok(rel_path)
-    else:
-        fail(f"Missing required file: {rel_path}")
-
-
-# ---------------------------------------------------------------------------
-# Check 2: stub-handoff-pass — required fields + test_results.passed=true
-# ---------------------------------------------------------------------------
-print("\n=== 2. Fixture: stub-handoff-pass.yaml ===")
-pass_path = rel(".hermes/test-fixtures/stub-handoff-pass.yaml")
-if os.path.isfile(pass_path):
-    data, err = load_yaml(pass_path)
-    if err:
-        fail(f"stub-handoff-pass.yaml YAML parse error: {err}")
-    else:
-        required_fields = ["task_id", "agent", "completed_at", "summary", "changed_files", "test_results"]
-        for field in required_fields:
-            if field not in data or data[field] is None:  # type: ignore[operator]
-                fail(f"stub-handoff-pass.yaml missing required field: {field}")
-            else:
-                ok(f"field present: {field}")
-        # test_results.passed must be true
-        tr = data.get("test_results") or {}
-        if tr.get("passed") is True:
-            ok("test_results.passed = true")
-        else:
-            fail(f"stub-handoff-pass.yaml: test_results.passed should be true, got: {tr.get('passed')!r}")
-else:
-    fail("stub-handoff-pass.yaml not found (skipping content checks)")
-
-
-# ---------------------------------------------------------------------------
-# Check 3: stub-handoff-fail-schema — intentionally missing required fields
-# ---------------------------------------------------------------------------
-print("\n=== 3. Fixture: stub-handoff-fail-schema.yaml ===")
-schema_fail_path = rel(".hermes/test-fixtures/stub-handoff-fail-schema.yaml")
-if os.path.isfile(schema_fail_path):
-    data, err = load_yaml(schema_fail_path)
-    if err:
-        fail(f"stub-handoff-fail-schema.yaml YAML parse error: {err}")
-    else:
-        # Must be missing at least one required field
-        required_fields = ["task_id", "agent", "completed_at", "summary", "changed_files", "test_results"]
-        missing = [f for f in required_fields if f not in data or data[f] is None]  # type: ignore[operator]
-        if missing:
-            ok(f"stub-handoff-fail-schema.yaml intentionally missing fields: {missing}")
-        else:
-            fail("stub-handoff-fail-schema.yaml has all required fields — fixture should be intentionally malformed")
-        # Also check test_results.passed is missing or not set
-        tr = data.get("test_results") or {}
-        if "passed" not in tr:
-            ok("test_results.passed intentionally absent (correct for schema-fail fixture)")
-        else:
-            warn("stub-handoff-fail-schema.yaml has test_results.passed set — "
-                 "fixture should omit it to test schema failure")
-else:
-    fail("stub-handoff-fail-schema.yaml not found (skipping content checks)")
-
-
-# ---------------------------------------------------------------------------
-# Check 4: stub-handoff-fail-forbidden — changed_files includes a forbidden path
-# ---------------------------------------------------------------------------
-print("\n=== 4. Fixture: stub-handoff-fail-forbidden.yaml ===")
-forbidden_path = rel(".hermes/test-fixtures/stub-handoff-fail-forbidden.yaml")
+FORBIDDEN_EXACT = {"AGENTS.md", "CLAUDE.md", "CODEX.md"}
 FORBIDDEN_PREFIXES = [
-    "AGENTS.md",
-    "CLAUDE.md",
-    "CODEX.md",
     ".hermes/config/",
     ".hermes/schemas/",
     ".hermes/plans/",
     ".claude/",
     ".codex/",
 ]
-if os.path.isfile(forbidden_path):
-    data, err = load_yaml(forbidden_path)
-    if err:
-        fail(f"stub-handoff-fail-forbidden.yaml YAML parse error: {err}")
-    else:
-        changed = list(data.get("changed_files") or [])
-        found_forbidden = [
-            f for f in changed
-            if any(f.startswith(p) or f == p.rstrip("/") for p in FORBIDDEN_PREFIXES)
-        ]
-        if found_forbidden:
-            ok(f"stub-handoff-fail-forbidden.yaml contains forbidden path(s): {found_forbidden}")
-        else:
-            fail(
-                "stub-handoff-fail-forbidden.yaml: changed_files must include at least one "
-                f"forbidden prompt artifact path (one of: {FORBIDDEN_PREFIXES}). "
-                f"Got: {changed}"
-            )
-else:
-    fail("stub-handoff-fail-forbidden.yaml not found (skipping content checks)")
 
-
-# ---------------------------------------------------------------------------
-# Check 5: stub-handoff-fail-tests — test_results.passed=false
-# ---------------------------------------------------------------------------
-print("\n=== 5. Fixture: stub-handoff-fail-tests.yaml ===")
-tests_fail_path = rel(".hermes/test-fixtures/stub-handoff-fail-tests.yaml")
-if os.path.isfile(tests_fail_path):
-    data, err = load_yaml(tests_fail_path)
-    if err:
-        fail(f"stub-handoff-fail-tests.yaml YAML parse error: {err}")
-    else:
-        # Schema fields should be present (it's a schema-valid but gate-failing handoff)
-        required_fields = ["task_id", "agent", "completed_at", "summary", "changed_files", "test_results"]
-        for field in required_fields:
-            if field not in data or data[field] is None:  # type: ignore[operator]
-                fail(f"stub-handoff-fail-tests.yaml missing field: {field} "
-                     "(this fixture should be schema-valid but fail the tests gate)")
-        tr = data.get("test_results") or {}
-        if tr.get("passed") is False:
-            ok("test_results.passed = false")
-        else:
-            fail(f"stub-handoff-fail-tests.yaml: test_results.passed should be false, got: {tr.get('passed')!r}")
-else:
-    fail("stub-handoff-fail-tests.yaml not found (skipping content checks)")
-
-
-# ---------------------------------------------------------------------------
-# Check 6: Plan contains required caveat phrases (C-1 through C-6)
-# ---------------------------------------------------------------------------
-print("\n=== 6. Plan caveat phrases ===")
-plan_path = rel(".hermes/plans/2026-05-22_000000-hybrid-agent-control-plane.md")
-if os.path.isfile(plan_path):
-    with open(plan_path, "r", encoding="utf-8") as f:
-        plan_text = f.read()
-    for phrase in REQUIRED_PLAN_PHRASES:
-        if phrase in plan_text:
-            ok(f"Plan contains: {phrase!r}")
-        else:
-            fail(f"Plan MISSING required phrase: {phrase!r}")
-else:
-    fail("Plan file not found (skipping phrase checks)")
-
-
-# ---------------------------------------------------------------------------
-# Check 7: .gitignore correctness
-# ---------------------------------------------------------------------------
-print("\n=== 7. .gitignore ===")
-gitignore_path = rel(".gitignore")
-if os.path.isfile(gitignore_path):
-    with open(gitignore_path, "r", encoding="utf-8") as f:
-        gi_text = f.read()
-    # Must include runtime output dirs
-    for pattern in GITIGNORE_MUST_INCLUDE:
-        # Check if the stripped pattern appears as a line
-        if any(line.strip() == pattern.strip() for line in gi_text.splitlines()):
-            ok(f".gitignore includes: {pattern!r}")
-        else:
-            fail(f".gitignore missing runtime output pattern: {pattern!r}")
-
-    # Must NOT ignore all of .hermes/
-    for bad_pattern in GITIGNORE_MUST_NOT_INCLUDE:
-        stripped = bad_pattern.strip()
-        if any(line.strip() == stripped for line in gi_text.splitlines()):
-            fail(f".gitignore has bare .hermes/ ignore pattern {stripped!r} — "
-                 "this would ignore all .hermes/ including committed config files. "
-                 "Use specific subdirectory patterns instead.")
-        else:
-            ok(f".gitignore does NOT have broad ignore: {stripped!r}")
-
-    # Should include at least one of handoff/handoffs
-    found_handoff = any(
-        any(line.strip() == p.strip() for line in gi_text.splitlines())
-        for p in GITIGNORE_SHOULD_INCLUDE_ONE_OF
-    )
-    if found_handoff:
-        ok(".gitignore includes handoff runtime dir")
-    else:
-        warn(f".gitignore should include one of {GITIGNORE_SHOULD_INCLUDE_ONE_OF} — "
-             "add it to prevent handoff payloads being accidentally committed")
-else:
-    fail(".gitignore not found")
-
-
-# ---------------------------------------------------------------------------
-# Phase 1 Check 8: Plan has human_reviewed_at set and non-empty
-# ---------------------------------------------------------------------------
-print("\n=== 8. Plan: human_reviewed_at field ===")
-plan_path8 = rel(".hermes/plans/2026-05-22_000000-hybrid-agent-control-plane.md")
-if os.path.isfile(plan_path8):
-    with open(plan_path8, "r", encoding="utf-8") as f:
-        plan_text8 = f.read()
-    import re as _re
-    # Look for machine-checkable field: human_reviewed_at: <non-empty, non-~>
-    # Matches the pattern in the MACHINE-CHECKABLE FIELDS comment block
-    match = _re.search(r"^human_reviewed_at:\s*(\S+)", plan_text8, _re.MULTILINE)
-    if match:
-        val = match.group(1).strip()
-        if val and val != "~" and val != "null":
-            ok(f"human_reviewed_at = {val!r}")
-        else:
-            fail(
-                f"human_reviewed_at is present but empty/null ({val!r}). "
-                "Worker execution phases require a non-empty timestamp. "
-                "Set it to the approval timestamp (e.g. 2026-05-22T23:27:28Z)."
-            )
-    else:
-        fail(
-            "Plan is missing 'human_reviewed_at: <timestamp>' field. "
-            "This field is required before any Phase 2+ worker spawn. "
-            "Add it in the MACHINE-CHECKABLE FIELDS block at the plan header."
-        )
-else:
-    fail("Plan file not found (skipping human_reviewed_at check)")
-
-
-# ---------------------------------------------------------------------------
-# Phase 1 Check 9: Plan has locked decisions section (LD-1 through LD-6)
-# ---------------------------------------------------------------------------
-print("\n=== 9. Plan: locked decisions ===")
-REQUIRED_LOCKED_DECISIONS = [
-    "LD-1",
-    "LD-2",
-    "LD-3",
-    "LD-4",
-    "LD-5",
-    "LD-6",
-    "worktrees_are_sandbox: false",   # LD-1 canonical field
-    "file-based handoff is canonical",  # LD-2
-    "HANDOFF_PATH:",                  # LD-2 sentinel convention
-    "human_reviewed_at",              # LD-3
-    "serial gates",                   # LD-4
-    "opportunistic",                  # LD-5 (Codex)
-    "cost_estimated: true",           # LD-6
-]
-if os.path.isfile(plan_path8):
-    for phrase in REQUIRED_LOCKED_DECISIONS:
-        if phrase in plan_text8:
-            ok(f"Plan contains locked decision phrase: {phrase!r}")
-        else:
-            fail(f"Plan missing locked decision phrase: {phrase!r}")
-else:
-    plan_text8 = ""
-    fail("Plan file not found (skipping locked decisions check)")
-
-
-# ---------------------------------------------------------------------------
-# Phase 1 Check 10: Skill draft exists and has required sections
-# ---------------------------------------------------------------------------
-print("\n=== 10. Skill draft: hybrid-agent-control-plane ===")
-skill_draft_path = rel(".hermes/templates/skill-draft-hybrid-agent-control-plane.md")
-SKILL_DRAFT_REQUIRED_SECTIONS = [
-    "human_reviewed_at",           # frontmatter field
-    "No real spawns",              # MVP constraint
-    "worktrees_are_sandbox",       # LD-1
-    "HANDOFF_PATH:",               # LD-2 sentinel
-    "file-based handoff",          # LD-2 (case-insensitive search done below)
-    "serial",                      # LD-4 gate order
-    "cost_estimated",              # LD-6
-    "route-dev-task",              # integration with existing skill (C-1)
-    "terminal()",                  # C-3: real spawns use terminal, not delegate_task
-    "NOT delegate_task",           # C-3 explicit prohibition
-]
-SKILL_DRAFT_MUST_NOT_CONTAIN = [
-    # MVP must not indicate real spawns are enabled
-    "spawn_real_agent: true",
-    "sandbox_verified: true",      # Codex not verified yet
-]
-if os.path.isfile(skill_draft_path):
-    with open(skill_draft_path, "r", encoding="utf-8") as f:
-        draft_text = f.read()
-    for phrase in SKILL_DRAFT_REQUIRED_SECTIONS:
-        if phrase.lower() in draft_text.lower():
-            ok(f"Skill draft contains: {phrase!r}")
-        else:
-            fail(f"Skill draft missing required phrase: {phrase!r}")
-    for phrase in SKILL_DRAFT_MUST_NOT_CONTAIN:
-        if phrase in draft_text:
-            fail(
-                f"Skill draft contains forbidden phrase for MVP: {phrase!r}. "
-                "This would indicate real spawns or unverified Codex are enabled."
-            )
-        else:
-            ok(f"Skill draft correctly absent: {phrase!r}")
-else:
-    fail("Skill draft not found: .hermes/templates/skill-draft-hybrid-agent-control-plane.md")
-
-
-# ---------------------------------------------------------------------------
-# Phase 1 Check 11: Templates have cost_estimated and handoff_path fields
-# ---------------------------------------------------------------------------
-print("\n=== 11. Templates: cost_estimated and handoff path fields ===")
-TEMPLATE_CHECKS = {
-    ".hermes/templates/run-manifest.yaml.j2": [
-        "cost_estimated",
-        "total_cost_usd_cap",
-        "total_cost_usd_actual",
-        "worktrees_are_sandbox",
-        "container_isolation",
-    ],
-    ".hermes/templates/task-contract.yaml.j2": [
-        "cost_cap_usd",
-        "cost_estimated",
-        "handoff_schema_ref",
-        "spawn_mechanism",
-    ],
+# Expected outcomes for --all-handoff-fixtures mode
+ALL_HANDOFF_EXPECTED: Dict[str, str] = {
+    "stub-handoff-pass.yaml": "pass",
+    "stub-handoff-fail-forbidden.yaml": "fail",
+    "stub-handoff-fail-schema.yaml": "fail",
+    "stub-handoff-fail-tests.yaml": "fail",
+    "stub-handoff-fail-agent-enum.yaml": "fail",
+    "stub-handoff-fail-test-results-absent.yaml": "fail",
+    "stub-handoff-fail-empty-changed-files.yaml": "fail",
+    "stub-handoff-fail-dotslash-prompt-artifact.yaml": "fail",
+    "stub-handoff-fail-traversal.yaml": "fail",
+    "stub-handoff-pass-agent-md-backup.yaml": "pass",
 }
-for tpl_path, required_fields in TEMPLATE_CHECKS.items():
-    full_tpl = rel(tpl_path)
-    if os.path.isfile(full_tpl):
-        with open(full_tpl, "r", encoding="utf-8") as f:
-            tpl_text = f.read()
-        for field in required_fields:
-            if field in tpl_text:
-                ok(f"{tpl_path} contains field: {field!r}")
+
+AGENT_ENUM_ALLOWED = {"claude_code", "codex"}
+
+
+def rel(path: str) -> str:
+    return os.path.join(REPO_ROOT, path)
+
+
+def is_repo_relative_posix(path_str: str) -> bool:
+    """True if path is repo-relative POSIX (no absolute, no backslash, no drive, no ..).
+
+    Leading './' is accepted and treated as a normalizable prefix; the caller should
+    normalize via normalize_path() before forbidden-path comparison.
+    """
+    if not path_str or not isinstance(path_str, str):
+        return False
+    p = path_str.strip()
+    if not p:
+        return False
+    # Reject absolute
+    if os.path.isabs(p) or p.startswith("/"):
+        return False
+    # Reject windows drive or backslash
+    if "\\" in p or (len(p) > 1 and p[1] == ":"):
+        return False
+    # Normalize leading ./ before further checks
+    if p.startswith("./"):
+        p = p[2:]
+        # After stripping './', must have a non-empty name remaining
+        if not p:
+            return False
+    # Reject any .. traversal segment
+    parts = p.split("/")
+    if any(part == ".." for part in parts):
+        return False
+    return True
+
+
+def normalize_path(p: str) -> str:
+    """Strip leading ./ for comparison."""
+    if p.startswith("./"):
+        return p[2:]
+    return p
+
+
+def is_forbidden_path(path_str: str) -> bool:
+    """Check against exact forbidden names or prefixes (after normalizing)."""
+    if not path_str:
+        return False
+    norm = normalize_path(path_str)
+    if norm in FORBIDDEN_EXACT:
+        return True
+    for pref in FORBIDDEN_PREFIXES:
+        if norm.startswith(pref) or norm == pref.rstrip("/"):
+            return True
+    return False
+
+
+def validate_changed_files_for_schema(changed_files: List[str]) -> Tuple[bool, Optional[str]]:
+    """Schema-only validation: list, non-empty, all strings. NO path format or forbidden checks."""
+    if not isinstance(changed_files, list):
+        return False, "changed_files must be a list"
+    if len(changed_files) == 0:
+        return False, "changed_files must be non-empty"
+    for f in changed_files:
+        if not isinstance(f, str):
+            return False, f"changed_files entry not string: {f!r}"
+    return True, None
+
+
+def validate_path_format_and_forbidden(changed_files: List[str]) -> Tuple[bool, Optional[str]]:
+    """
+    forbidden_path_writes gate validation.
+    Rejects: invalid format (not repo-relative POSIX, traversal, absolute, backslash, drive)
+    Allows and normalizes leading './' before protected-path comparison.
+    AND protected/forbidden prompt/control-plane paths.
+    Returns (ok, error_msg)
+    """
+    for f in changed_files:
+        if not is_repo_relative_posix(f):
+            return False, f"Invalid path format (not repo-relative POSIX or contains traversal): {f!r}"
+        if is_forbidden_path(f):
+            return False, f"Forbidden path in changed_files: {f}"
+    return True, None
+
+
+def validate_schema(data: Dict[str, Any]) -> Tuple[bool, Optional[str], str]:
+    """
+    Structural schema validation for handoff.
+    Required: task_id, agent, completed_at, summary, changed_files
+    Note: missing test_results is NOT a schema failure.
+    Returns: (valid, error_msg, next_gate)
+    """
+    required = ["task_id", "agent", "completed_at", "summary", "changed_files"]
+    for field in required:
+        if field not in data or data[field] is None:
+            return False, f"Missing required field: {field}", "schema_validation"
+    agent = data.get("agent")
+    if agent not in AGENT_ENUM_ALLOWED:
+        return False, f"agent enum must be one of {AGENT_ENUM_ALLOWED}, got: {agent!r}", "schema_validation"
+
+    cf_ok, cf_err = validate_changed_files_for_schema(data.get("changed_files", []))
+    if not cf_ok:
+        return False, cf_err or "changed_files invalid", "schema_validation"
+
+    return True, None, "forbidden_path_writes"
+
+
+def run_forbidden_path_writes_gate(data: Dict[str, Any]) -> Tuple[bool, Optional[str]]:
+    """
+    forbidden_path_writes gate: runs AFTER schema_validation PASS.
+    Rejects invalid formats and protected paths.
+    Prints and returns status for caller.
+    """
+    changed = data.get("changed_files", []) or []
+    ok, err = validate_path_format_and_forbidden(changed)
+    if not ok:
+        msg = f"forbidden_path_writes: FAIL - {err}"
+        print(msg)
+        return False, msg
+    print("forbidden_path_writes: PASS")
+    return True, None
+
+
+def run_unit_tests_for_handoff(data: Dict[str, Any]) -> Tuple[str, bool]:
+    """
+    Simulate unit_tests gate.
+    If test_results absent: prints 'unit_tests: SKIP/missing evidence' and returns fail.
+    If present and passed=true: pass
+    If present and passed=false: fail
+    Returns (message, passed_bool)
+    """
+    if "test_results" not in data or data.get("test_results") is None:
+        msg = "unit_tests: SKIP/missing evidence"
+        return msg, False
+    tr = data.get("test_results") or {}
+    passed = tr.get("passed")
+    if passed is True:
+        return "unit_tests: passed", True
+    else:
+        return f"unit_tests: failed (passed={passed})", False
+
+
+def check_handoff_file(handoff_path: str) -> int:
+    """
+    Execute full handoff validation gates for a single file.
+    Prints gate results. Returns exit code (0 on ultimate AUTOMATED_PASS...).
+    """
+    abs_path = handoff_path
+    if not os.path.isabs(handoff_path):
+        abs_path = os.path.join(REPO_ROOT, handoff_path)
+
+    if not os.path.isfile(abs_path):
+        print(f"schema_validation: FAIL - file not found: {handoff_path}")
+        return 1
+
+    try:
+        with open(abs_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    except Exception as e:
+        print(f"schema_validation: FAIL - YAML error: {e}")
+        return 1
+
+    if not isinstance(data, dict):
+        print("schema_validation: FAIL - top level must be mapping")
+        return 1
+
+    # Gate 1: schema_validation (structure only — paths validated later)
+    schema_ok, schema_err, _ = validate_schema(data)
+    if not schema_ok:
+        print(f"schema_validation: FAIL - {schema_err}")
+        return 1
+    print("schema_validation: PASS")
+
+    # Gate 2: forbidden_path_writes (format + protected paths)
+    fbd_ok, _ = run_forbidden_path_writes_gate(data)
+    if not fbd_ok:
+        # Protected fixtures MUST stop here; do not reach unit_tests
+        return 1
+
+    # Gate 3: prompt_artifact_unchanged
+    # For this static checker we treat fixture presence as "unchanged" assumption.
+    # If a fixture name contains 'prompt-artifact' failure case, it was already rejected in forbidden gate.
+    print("prompt_artifact_unchanged: PASS")
+
+    # Gate 4: diff_size_limit: SKIP
+    print("diff_size_limit: SKIP")
+
+    # Gate 5: unit_tests
+    unit_msg, unit_pass = run_unit_tests_for_handoff(data)
+    print(unit_msg)
+    if not unit_pass:
+        # test failure or missing evidence stops here (fail-fast before human_review)
+        return 1
+
+    # Gate 6: cost_cap: SKIP
+    print("cost_cap: SKIP")
+
+    # Gate 7: human_review / RESULT
+    print("RESULT: AUTOMATED_PASS_HUMAN_REVIEW_REQUIRED")
+    return 0
+
+
+def check_all_handoff_fixtures() -> int:
+    """Run check on every stub-handoff-*.yaml and enforce expected map. Unknown files = closed fail."""
+    fixtures_dir = os.path.join(REPO_ROOT, ".hermes", "test-fixtures")
+    if not os.path.isdir(fixtures_dir):
+        print("ERROR: .hermes/test-fixtures directory missing")
+        return 1
+
+    found_files = []
+    for fname in os.listdir(fixtures_dir):
+        if fname.startswith("stub-handoff-") and fname.endswith(".yaml"):
+            found_files.append(fname)
+
+    # Check for unexpected files
+    unexpected = [f for f in found_files if f not in ALL_HANDOFF_EXPECTED]
+    if unexpected:
+        print(f"FAIL: unexpected handoff fixtures found: {unexpected}")
+        print("All stub-handoff-*.yaml must be registered in ALL_HANDOFF_EXPECTED map.")
+        return 1
+
+    all_pass = True
+    for fname, expected in ALL_HANDOFF_EXPECTED.items():
+        fpath = os.path.join(".hermes/test-fixtures", fname)
+        rc = check_handoff_file(fpath)
+        outcome = "pass" if rc == 0 else "fail"
+        if outcome != expected:
+            print(f"FAIL: {fname} expected {expected.upper()} but got {outcome.upper()}")
+            all_pass = False
+        else:
+            print(f"OK: {fname} -> {outcome}")
+
+    return 0 if all_pass else 1
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Hybrid control plane checker (sanity + handoff modes)"
+    )
+    parser.add_argument(
+        "--handoff",
+        metavar="PATH",
+        help="Validate a single handoff YAML file (full gate sequence)",
+    )
+    parser.add_argument(
+        "--all-handoff-fixtures",
+        action="store_true",
+        help="Validate all stub-handoff-*.yaml fixtures against expected map",
+    )
+    args = parser.parse_args()
+
+    if args.handoff:
+        rc = check_handoff_file(args.handoff)
+        sys.exit(rc)
+    elif args.all_handoff_fixtures:
+        rc = check_all_handoff_fixtures()
+        sys.exit(rc)
+    else:
+        # =====================================================================
+        # DEFAULT SANITY MODE — full original behavior restored from HEAD
+        # =====================================================================
+        from subprocess import run  # local import to avoid top-level pollution
+
+        failures = []
+        warnings = []
+
+        def fail(msg):
+            failures.append(msg)
+            print(f"  FAIL: {msg}")
+
+        def warn(msg):
+            warnings.append(msg)
+            print(f"  WARN: {msg}")
+
+        def ok(msg):
+            print(f"  OK:   {msg}")
+
+        def load_yaml(path):
+            """Load YAML file; return (data, error_string). data=None on error."""
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    raw = yaml.safe_load(f)
+                data: dict = raw if isinstance(raw, dict) else {}
+                return data, None
+            except yaml.YAMLError as e:
+                return None, str(e)
+
+        print("\n=== 1. Required files ===\n")
+        REQUIRED_FILES = [
+            # Phase 0 artifacts
+            ".hermes/schemas/handoff-v1.yaml",
+            ".hermes/config/capability-matrix.yaml",
+            ".hermes/config/gate-taxonomy.yaml",
+            ".hermes/config/eval-matrix.yaml",
+            ".hermes/config/recovery-runbook.md",
+            ".hermes/templates/run-manifest.yaml.j2",
+            ".hermes/templates/task-contract.yaml.j2",
+            ".hermes/templates/locks.yaml.j2",
+            ".hermes/test-fixtures/stub-handoff-pass.yaml",
+            ".hermes/test-fixtures/stub-handoff-fail-forbidden.yaml",
+            ".hermes/test-fixtures/stub-handoff-fail-schema.yaml",
+            ".hermes/test-fixtures/stub-handoff-fail-tests.yaml",
+            ".hermes/plans/2026-05-22_000000-hybrid-agent-control-plane.md",
+            "scripts/check_hybrid_control_plane.py",
+            # Phase 1 artifacts
+            ".hermes/templates/skill-draft-hybrid-agent-control-plane.md",
+            "tests/skills/test_hybrid_agent_control_plane.py",
+        ]
+        for rel_path in REQUIRED_FILES:
+            full = rel(rel_path)
+            if os.path.isfile(full):
+                ok(rel_path)
             else:
-                fail(f"{tpl_path} missing required field: {field!r}")
-    else:
-        fail(f"Template not found: {tpl_path}")
+                fail(f"Missing required file: {rel_path}")
 
-
-# ---------------------------------------------------------------------------
-# Phase 1 Check 12: Handoff schema has cost_estimated field
-# ---------------------------------------------------------------------------
-print("\n=== 12. Handoff schema: cost_estimated field ===")
-schema_path = rel(".hermes/schemas/handoff-v1.yaml")
-if os.path.isfile(schema_path):
-    with open(schema_path, "r", encoding="utf-8") as f:
-        schema_text = f.read()
-    if "cost_estimated" in schema_text:
-        ok("handoff-v1.yaml contains cost_estimated field")
-    else:
-        fail("handoff-v1.yaml missing cost_estimated field (required by LD-6)")
-    if "method:" in schema_text and "token_count_estimate" in schema_text:
-        ok("handoff-v1.yaml has cost method enum including token_count_estimate")
-    else:
-        warn("handoff-v1.yaml may be missing cost method enum — check cost_estimated.method field")
-else:
-    fail("handoff-v1.yaml not found (skipping schema field checks)")
-
-
-# ---------------------------------------------------------------------------
-# Phase 1 Check 13: No real-spawn indicators enabled for MVP
-# ---------------------------------------------------------------------------
-print("\n=== 13. MVP: no real spawn indicators ===")
-# Check capability matrix — Codex sandbox_verified must be false
-cap_matrix_path = rel(".hermes/config/capability-matrix.yaml")
-if os.path.isfile(cap_matrix_path):
-    cap_data, cap_err = load_yaml(cap_matrix_path)
-    if cap_err:
-        fail(f"capability-matrix.yaml YAML parse error: {cap_err}")
-    else:
-        codex = (cap_data.get("agents") or {}).get("codex") or {}
-        sandbox_verified = codex.get("sandbox_verified", False)
-        if sandbox_verified is not False:
-            fail(
-                "capability-matrix.yaml: codex.sandbox_verified is not false — "
-                "Codex canary test (plan task 2.1) must pass before enabling. "
-                f"Current value: {sandbox_verified!r}. Set to false until Phase 2 canary confirms."
-            )
+        # -------------------------------------------------------------------
+        # Check 2: stub-handoff-pass — required fields + test_results.passed=true
+        # -------------------------------------------------------------------
+        print("\n=== 2. Fixture: stub-handoff-pass.yaml ===\n")
+        pass_path = rel(".hermes/test-fixtures/stub-handoff-pass.yaml")
+        if os.path.isfile(pass_path):
+            data, err = load_yaml(pass_path)
+            if err:
+                fail(f"stub-handoff-pass.yaml YAML parse error: {err}")
+            else:
+                required_fields = ["task_id", "agent", "completed_at", "summary", "changed_files", "test_results"]
+                for field in required_fields:
+                    if field not in data or data[field] is None:
+                        fail(f"stub-handoff-pass.yaml missing required field: {field}")
+                    else:
+                        ok(f"field present: {field}")
+                # test_results.passed must be true
+                tr = data.get("test_results") or {}
+                if tr.get("passed") is True:
+                    ok("test_results.passed = true")
+                else:
+                    fail(f"stub-handoff-pass.yaml: test_results.passed should be true, got: {tr.get('passed')!r}")
         else:
-            ok(f"codex.sandbox_verified = {sandbox_verified!r} (correctly false for MVP)")
+            fail("stub-handoff-pass.yaml not found (skipping content checks)")
 
-        cc = (cap_data.get("agents") or {}).get("claude_code") or {}
-        dsp = cc.get("dangerously_skip_permissions", False)
-        if dsp is not False:
-            fail(
-                "capability-matrix.yaml: claude_code.dangerously_skip_permissions is not false — "
-                f"this must never be set on real host filesystems. Current value: {dsp!r}."
-            )
+        # -------------------------------------------------------------------
+        # Check 3: stub-handoff-fail-schema — intentionally missing required fields
+        # -------------------------------------------------------------------
+        print("\n=== 3. Fixture: stub-handoff-fail-schema.yaml ===\n")
+        schema_fail_path = rel(".hermes/test-fixtures/stub-handoff-fail-schema.yaml")
+        if os.path.isfile(schema_fail_path):
+            data, err = load_yaml(schema_fail_path)
+            if err:
+                fail(f"stub-handoff-fail-schema.yaml YAML parse error: {err}")
+            else:
+                required_fields = ["task_id", "agent", "completed_at", "summary", "changed_files", "test_results"]
+                missing = [f for f in required_fields if f not in data or data[f] is None]
+                if missing:
+                    ok(f"stub-handoff-fail-schema.yaml intentionally missing fields: {missing}")
+                else:
+                    fail("stub-handoff-fail-schema.yaml has all required fields — fixture should be intentionally malformed")
+                # Also check test_results.passed is missing or not set
+                tr = data.get("test_results") or {}
+                if "passed" not in tr:
+                    ok("test_results.passed intentionally absent (correct for schema-fail fixture)")
+                else:
+                    warn("stub-handoff-fail-schema.yaml has test_results.passed set — "
+                         "fixture should omit it to test schema failure")
         else:
-            ok(f"claude_code.dangerously_skip_permissions = {dsp!r} (correctly false)")
-else:
-    fail("capability-matrix.yaml not found (skipping real-spawn checks)")
+            fail("stub-handoff-fail-schema.yaml not found (skipping content checks)")
+
+        # -------------------------------------------------------------------
+        # Check 4: stub-handoff-fail-forbidden — changed_files includes a forbidden path
+        # -------------------------------------------------------------------
+        print("\n=== 4. Fixture: stub-handoff-fail-forbidden.yaml ===\n")
+        forbidden_path = rel(".hermes/test-fixtures/stub-handoff-fail-forbidden.yaml")
+        FORBIDDEN_PREFIXES_LOCAL = [
+            "AGENTS.md",
+            "CLAUDE.md",
+            "CODEX.md",
+            ".hermes/config/",
+            ".hermes/schemas/",
+            ".hermes/plans/",
+            ".claude/",
+            ".codex/",
+        ]
+        if os.path.isfile(forbidden_path):
+            data, err = load_yaml(forbidden_path)
+            if err:
+                fail(f"stub-handoff-fail-forbidden.yaml YAML parse error: {err}")
+            else:
+                changed = list(data.get("changed_files") or [])
+                found_forbidden = [
+                    f for f in changed
+                    if any(f.startswith(p) or f == p.rstrip("/") for p in FORBIDDEN_PREFIXES_LOCAL)
+                ]
+                if found_forbidden:
+                    ok(f"stub-handoff-fail-forbidden.yaml contains forbidden path(s): {found_forbidden}")
+                else:
+                    fail(
+                        "stub-handoff-fail-forbidden.yaml: changed_files must include at least one "
+                        f"forbidden prompt artifact path (one of: {FORBIDDEN_PREFIXES_LOCAL}). "
+                        f"Got: {changed}"
+                    )
+        else:
+            fail("stub-handoff-fail-forbidden.yaml not found (skipping content checks)")
+
+        # -------------------------------------------------------------------
+        # Check 5: stub-handoff-fail-tests — test_results.passed=false
+        # -------------------------------------------------------------------
+        print("\n=== 5. Fixture: stub-handoff-fail-tests.yaml ===\n")
+        tests_fail_path = rel(".hermes/test-fixtures/stub-handoff-fail-tests.yaml")
+        if os.path.isfile(tests_fail_path):
+            data, err = load_yaml(tests_fail_path)
+            if err:
+                fail(f"stub-handoff-fail-tests.yaml YAML parse error: {err}")
+            else:
+                required_fields = ["task_id", "agent", "completed_at", "summary", "changed_files", "test_results"]
+                for field in required_fields:
+                    if field not in data or data[field] is None:
+                        fail(f"stub-handoff-fail-tests.yaml missing field: {field} "
+                             "(this fixture should be schema-valid but fail the tests gate)")
+                tr = data.get("test_results") or {}
+                if tr.get("passed") is False:
+                    ok("test_results.passed = false")
+                else:
+                    fail(f"stub-handoff-fail-tests.yaml: test_results.passed should be false, got: {tr.get('passed')!r}")
+        else:
+            fail("stub-handoff-fail-tests.yaml not found (skipping content checks)")
+
+        # -------------------------------------------------------------------
+        # Check 6: Plan contains required caveat phrases (C-1 through C-6)
+        # -------------------------------------------------------------------
+        print("\n=== 6. Plan caveat phrases ===\n")
+        REQUIRED_PLAN_PHRASES = [
+            # C-1: no duplicate route-dev-task
+            "route-dev-task",
+            "must NOT create a second route-dev-task",
+            # C-2: skill creation deferred; repo-local artifacts
+            "repo-local",
+            "deferred",
+            # C-3: delegate_task does not directly spawn
+            "delegate_task does not directly spawn",
+            # C-4: CODEX.md TBD
+            "CODEX.md",
+            "PROVISIONAL",
+            # C-5: cost accounting is estimated
+            "estimated",
+            "cost_usd_actual",
+            # C-6: CODEOWNERS insufficient for local workflow; check script is primary
+            "CODEOWNERS",
+            "local check script",
+        ]
+        plan_path = rel(".hermes/plans/2026-05-22_000000-hybrid-agent-control-plane.md")
+        if os.path.isfile(plan_path):
+            with open(plan_path, "r", encoding="utf-8") as f:
+                plan_text = f.read()
+            for phrase in REQUIRED_PLAN_PHRASES:
+                if phrase in plan_text:
+                    ok(f"Plan contains: {phrase!r}")
+                else:
+                    fail(f"Plan MISSING required phrase: {phrase!r}")
+        else:
+            fail("Plan file not found (skipping phrase checks)")
+
+        # -------------------------------------------------------------------
+        # Check 7: .gitignore correctness
+        # -------------------------------------------------------------------
+        print("\n=== 7. .gitignore ===\n")
+        GITIGNORE_MUST_INCLUDE = [".hermes/runs/", ".worktrees/"]
+        GITIGNORE_MUST_NOT_INCLUDE = [".hermes/\n", "/.hermes/\n"]
+        GITIGNORE_SHOULD_INCLUDE_ONE_OF = [".hermes/handoff/", ".hermes/handoffs/"]
+
+        gitignore_path = rel(".gitignore")
+        if os.path.isfile(gitignore_path):
+            with open(gitignore_path, "r", encoding="utf-8") as f:
+                gi_text = f.read()
+            for pattern in GITIGNORE_MUST_INCLUDE:
+                if any(line.strip() == pattern.strip() for line in gi_text.splitlines()):
+                    ok(f".gitignore includes: {pattern!r}")
+                else:
+                    fail(f".gitignore missing runtime output pattern: {pattern!r}")
+
+            for bad_pattern in GITIGNORE_MUST_NOT_INCLUDE:
+                stripped = bad_pattern.strip()
+                if any(line.strip() == stripped for line in gi_text.splitlines()):
+                    fail(f".gitignore has bare .hermes/ ignore pattern {stripped!r} — "
+                         "this would ignore all .hermes/ including committed config files. "
+                         "Use specific subdirectory patterns instead.")
+                else:
+                    ok(f".gitignore does NOT have broad ignore: {stripped!r}")
+
+            found_handoff = any(
+                any(line.strip() == p.strip() for line in gi_text.splitlines())
+                for p in GITIGNORE_SHOULD_INCLUDE_ONE_OF
+            )
+            if found_handoff:
+                ok(".gitignore includes handoff runtime dir")
+            else:
+                warn(f".gitignore should include one of {GITIGNORE_SHOULD_INCLUDE_ONE_OF} — "
+                     "add it to prevent handoff payloads being accidentally committed")
+        else:
+            fail(".gitignore not found")
+
+        # -------------------------------------------------------------------
+        # Check 8: Plan has human_reviewed_at set and non-empty
+        # -------------------------------------------------------------------
+        print("\n=== 8. Plan: human_reviewed_at field ===\n")
+        if os.path.isfile(plan_path):
+            with open(plan_path, "r", encoding="utf-8") as f:
+                plan_text8 = f.read()
+            import re as _re
+            match = _re.search(r"^human_reviewed_at:\s*(\S+)", plan_text8, _re.MULTILINE)
+            if match:
+                val = match.group(1).strip()
+                if val and val != "~" and val != "null":
+                    ok(f"human_reviewed_at = {val!r}")
+                else:
+                    fail(
+                        f"human_reviewed_at is present but empty/null ({val!r}). "
+                        "Worker execution phases require a non-empty timestamp. "
+                        "Set it to the approval timestamp (e.g. 2026-05-22T23:27:28Z)."
+                    )
+            else:
+                fail(
+                    "Plan is missing 'human_reviewed_at: <timestamp>' field. "
+                    "This field is required before any Phase 2+ worker spawn. "
+                    "Add it in the MACHINE-CHECKABLE FIELDS block at the plan header."
+                )
+        else:
+            fail("Plan file not found (skipping human_reviewed_at check)")
+
+        # -------------------------------------------------------------------
+        # Check 9: Plan has locked decisions section (LD-1 through LD-6)
+        # -------------------------------------------------------------------
+        print("\n=== 9. Plan: locked decisions ===\n")
+        REQUIRED_LOCKED_DECISIONS = [
+            "LD-1",
+            "LD-2",
+            "LD-3",
+            "LD-4",
+            "LD-5",
+            "LD-6",
+            "worktrees_are_sandbox: false",
+            "file-based handoff is canonical",
+            "HANDOFF_PATH:",
+            "human_reviewed_at",
+            "serial gates",
+            "opportunistic",
+            "cost_estimated: true",
+        ]
+        if os.path.isfile(plan_path):
+            for phrase in REQUIRED_LOCKED_DECISIONS:
+                if phrase in plan_text8:
+                    ok(f"Plan contains locked decision phrase: {phrase!r}")
+                else:
+                    fail(f"Plan missing locked decision phrase: {phrase!r}")
+        else:
+            fail("Plan file not found (skipping locked decisions check)")
+
+        # -------------------------------------------------------------------
+        # Check 10: Skill draft exists and has required sections
+        # -------------------------------------------------------------------
+        print("\n=== 10. Skill draft: hybrid-agent-control-plane ===\n")
+        skill_draft_path = rel(".hermes/templates/skill-draft-hybrid-agent-control-plane.md")
+        SKILL_DRAFT_REQUIRED_SECTIONS = [
+            "human_reviewed_at",
+            "No real spawns",
+            "worktrees_are_sandbox",
+            "HANDOFF_PATH:",
+            "file-based handoff",
+            "serial",
+            "cost_estimated",
+            "route-dev-task",
+            "terminal()",
+            "NOT delegate_task",
+        ]
+        SKILL_DRAFT_MUST_NOT_CONTAIN = [
+            "spawn_real_agent: true",
+            "sandbox_verified: true",
+        ]
+        if os.path.isfile(skill_draft_path):
+            with open(skill_draft_path, "r", encoding="utf-8") as f:
+                draft_text = f.read()
+            for phrase in SKILL_DRAFT_REQUIRED_SECTIONS:
+                if phrase.lower() in draft_text.lower():
+                    ok(f"Skill draft contains: {phrase!r}")
+                else:
+                    fail(f"Skill draft missing required phrase: {phrase!r}")
+            for phrase in SKILL_DRAFT_MUST_NOT_CONTAIN:
+                if phrase in draft_text:
+                    fail(
+                        f"Skill draft contains forbidden phrase for MVP: {phrase!r}. "
+                        "This would indicate real spawns or unverified Codex are enabled."
+                    )
+                else:
+                    ok(f"Skill draft correctly absent: {phrase!r}")
+        else:
+            fail("Skill draft not found: .hermes/templates/skill-draft-hybrid-agent-control-plane.md")
+
+        # -------------------------------------------------------------------
+        # Check 11: Templates have cost_estimated and handoff_path fields
+        # -------------------------------------------------------------------
+        print("\n=== 11. Templates: cost_estimated and handoff path fields ===\n")
+        TEMPLATE_CHECKS = {
+            ".hermes/templates/run-manifest.yaml.j2": [
+                "cost_estimated",
+                "total_cost_usd_cap",
+                "total_cost_usd_actual",
+                "worktrees_are_sandbox",
+                "container_isolation",
+            ],
+            ".hermes/templates/task-contract.yaml.j2": [
+                "cost_cap_usd",
+                "cost_estimated",
+                "handoff_schema_ref",
+                "spawn_mechanism",
+            ],
+        }
+        for tpl_path, required_fields in TEMPLATE_CHECKS.items():
+            full_tpl = rel(tpl_path)
+            if os.path.isfile(full_tpl):
+                with open(full_tpl, "r", encoding="utf-8") as f:
+                    tpl_text = f.read()
+                for field in required_fields:
+                    if field in tpl_text:
+                        ok(f"{tpl_path} contains field: {field!r}")
+                    else:
+                        fail(f"{tpl_path} missing required field: {field!r}")
+            else:
+                fail(f"Template not found: {tpl_path}")
+
+        # -------------------------------------------------------------------
+        # Check 12: Handoff schema has cost_estimated field
+        # -------------------------------------------------------------------
+        print("\n=== 12. Handoff schema: cost_estimated field ===\n")
+        schema_path = rel(".hermes/schemas/handoff-v1.yaml")
+        if os.path.isfile(schema_path):
+            with open(schema_path, "r", encoding="utf-8") as f:
+                schema_text = f.read()
+            if "cost_estimated" in schema_text:
+                ok("handoff-v1.yaml contains cost_estimated field")
+            else:
+                fail("handoff-v1.yaml missing cost_estimated field (required by LD-6)")
+            if "method:" in schema_text and "token_count_estimate" in schema_text:
+                ok("handoff-v1.yaml has cost method enum including token_count_estimate")
+            else:
+                warn("handoff-v1.yaml may be missing cost method enum — check cost_estimated.method field")
+        else:
+            fail("handoff-v1.yaml not found (skipping schema field checks)")
+
+        # -------------------------------------------------------------------
+        # Check 13: No real-spawn indicators enabled for MVP
+        # -------------------------------------------------------------------
+        print("\n=== 13. MVP: no real spawn indicators ===\n")
+        cap_matrix_path = rel(".hermes/config/capability-matrix.yaml")
+        if os.path.isfile(cap_matrix_path):
+            cap_data, cap_err = load_yaml(cap_matrix_path)
+            if cap_err:
+                fail(f"capability-matrix.yaml YAML parse error: {cap_err}")
+            else:
+                codex = (cap_data.get("agents") or {}).get("codex") or {}
+                sandbox_verified = codex.get("sandbox_verified", False)
+                if sandbox_verified is not False:
+                    fail(
+                        "capability-matrix.yaml: codex.sandbox_verified is not false — "
+                        "Codex canary test (plan task 2.1) must pass before enabling. "
+                        f"Current value: {sandbox_verified!r}. Set to false until Phase 2 canary confirms."
+                    )
+                else:
+                    ok(f"codex.sandbox_verified = {sandbox_verified!r} (correctly false for MVP)")
+
+                cc = (cap_data.get("agents") or {}).get("claude_code") or {}
+                dsp = cc.get("dangerously_skip_permissions", False)
+                if dsp is not False:
+                    fail(
+                        "capability-matrix.yaml: claude_code.dangerously_skip_permissions is not false — "
+                        f"this must never be set on real host filesystems. Current value: {dsp!r}."
+                    )
+                else:
+                    ok(f"claude_code.dangerously_skip_permissions = {dsp!r} (correctly false)")
+        else:
+            fail("capability-matrix.yaml not found (skipping real-spawn checks)")
+
+        # -------------------------------------------------------------------
+        # Summary
+        # -------------------------------------------------------------------
+        print("\n" + "=" * 60)
+        if failures:
+            print(f"RESULT: {len(failures)} failure(s), {len(warnings)} warning(s)")
+            for i, f in enumerate(failures, 1):
+                print(f"  [{i}] {f}")
+            if warnings:
+                for w in warnings:
+                    print(f"  WARN: {w}")
+            sys.exit(1)
+        else:
+            if warnings:
+                print(f"RESULT: PASS (0 failures, {len(warnings)} warning(s))")
+                for w in warnings:
+                    print(f"  WARN: {w}")
+            else:
+                print("RESULT: PASS — all checks passed.")
+            sys.exit(0)
 
 
-# ---------------------------------------------------------------------------
-# Summary
-# ---------------------------------------------------------------------------
-print("\n" + "=" * 60)
-if failures:
-    print(f"RESULT: {len(failures)} failure(s), {len(warnings)} warning(s)")
-    for i, f in enumerate(failures, 1):
-        print(f"  [{i}] {f}")
-    if warnings:
-        for w in warnings:
-            print(f"  WARN: {w}")
-    sys.exit(1)
-else:
-    if warnings:
-        print(f"RESULT: PASS (0 failures, {len(warnings)} warning(s))")
-        for w in warnings:
-            print(f"  WARN: {w}")
-    else:
-        print("RESULT: PASS — all checks passed.")
-    sys.exit(0)
+if __name__ == "__main__":
+    main()

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2323,7 +2323,152 @@ class TestVisionAutoSkipsKimiCoding:
         assert _PROVIDERS_WITHOUT_VISION == frozenset({
             "kimi-coding",
             "kimi-coding-cn",
+            "openai-codex",  # Codex endpoint rejects non-Codex model names in vision auto-detect
         })
+
+    def test_get_available_vision_backends_excludes_codex(self, monkeypatch):
+        """get_available_vision_backends() must NOT list openai-codex as a vision backend.
+
+        Regression: the else-branch in get_available_vision_backends() was calling
+        resolve_provider_client(main_provider, _read_main_model()) without checking
+        _PROVIDERS_WITHOUT_VISION, so openai-codex (with credentials) was included
+        as if it were a valid vision backend.
+        """
+        from agent.auxiliary_client import get_available_vision_backends
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._read_main_provider", lambda: "openai-codex",
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._read_main_model", lambda: "claude-sonnet-4.6",
+        )
+        # Even if resolve_provider_client would return a client for codex, it
+        # must not be called for the vision listing — guard with a bomb.
+        monkeypatch.setattr(
+            "agent.auxiliary_client.resolve_provider_client",
+            MagicMock(side_effect=AssertionError(
+                "resolve_provider_client must not be called for openai-codex "
+                "in get_available_vision_backends()"
+            )),
+        )
+        # No OpenRouter/Nous credentials
+        monkeypatch.setattr(
+            "agent.auxiliary_client._strict_vision_backend_available",
+            lambda p: False,
+        )
+
+        backends = get_available_vision_backends()
+        assert "openai-codex" not in backends
+
+
+class TestAsyncCallLlmVisionFallback:
+    """async_call_llm(task='vision') fallback to auto must NOT carry provider-specific model."""
+
+    @pytest.mark.asyncio
+    async def test_fallback_auto_does_not_carry_config_model(self, monkeypatch):
+        """Explicit anthropic+claude-sonnet-4.6 config, anthropic unavailable →
+        fallback to auto must NOT pass claude-sonnet-4.6 to resolve_vision_provider_client.
+
+        Regression: the fallback call was `model=resolved_model` where resolved_model
+        came from config (claude-sonnet-4.6, paired with anthropic). That model was then
+        forwarded to OpenRouter/Nous which do not serve it under the vision endpoint.
+        """
+        import asyncio
+        from agent.auxiliary_client import async_call_llm
+
+        fake_client = AsyncMock()
+        fake_client.chat.completions.create.return_value = _DummyResponse("ok")
+
+        call_log = []
+
+        def fake_resolve_vision(provider=None, model=None, base_url=None,
+                                api_key=None, async_mode=False):
+            call_log.append({"provider": provider, "model": model})
+            if provider == "anthropic":
+                # Simulate missing credentials
+                return "anthropic", None, None
+            if provider == "auto":
+                return "openrouter", fake_client, "google/gemini-3-flash-preview"
+            return provider, None, None
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            lambda task, prov, mod, burl, akey: (
+                "anthropic", "claude-sonnet-4.6", None, None, None
+            ),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client.resolve_vision_provider_client",
+            fake_resolve_vision,
+        )
+
+        await async_call_llm(
+            task="vision",
+            messages=[{"role": "user", "content": "describe this image"}],
+        )
+
+        # First call: explicit provider
+        assert call_log[0]["provider"] == "anthropic"
+        # Second call: auto fallback — must NOT carry claude-sonnet-4.6
+        assert len(call_log) >= 2
+        auto_call = call_log[1]
+        assert auto_call["provider"] == "auto"
+        assert auto_call["model"] != "claude-sonnet-4.6", (
+            "auto fallback must not carry the anthropic-specific model "
+            f"claude-sonnet-4.6 — got model={auto_call['model']!r}"
+        )
+        assert auto_call["model"] is None, (
+            f"auto fallback model should be None (use backend default), "
+            f"got {auto_call['model']!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_fallback_auto_preserves_explicit_caller_model(self, monkeypatch):
+        """When caller passes explicit model= arg distinct from config model, preserve it."""
+        import asyncio
+        from agent.auxiliary_client import async_call_llm
+
+        fake_client = AsyncMock()
+        fake_client.chat.completions.create.return_value = _DummyResponse("ok")
+
+        call_log = []
+
+        def fake_resolve_vision(provider=None, model=None, base_url=None,
+                                api_key=None, async_mode=False):
+            call_log.append({"provider": provider, "model": model})
+            if provider == "anthropic":
+                return "anthropic", None, None
+            if provider == "auto":
+                return "openrouter", fake_client, model or "google/gemini-3-flash-preview"
+            return provider, None, None
+
+        # Config says anthropic+claude-sonnet-4.6, but caller explicitly passes
+        # model="my-custom-vision-model" (different from config model)
+        monkeypatch.setattr(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            lambda task, prov, mod, burl, akey: (
+                "anthropic", "my-custom-vision-model", None, None, None
+            ),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client.resolve_vision_provider_client",
+            fake_resolve_vision,
+        )
+
+        await async_call_llm(
+            task="vision",
+            model="my-custom-vision-model",  # explicit caller arg
+            messages=[{"role": "user", "content": "describe this"}],
+        )
+
+        # The caller explicitly passed model="my-custom-vision-model".
+        # `model` is the raw caller argument, so fallback_model = model = "my-custom-vision-model".
+        # The auto fallback receives and forwards it so the user's explicit choice is honoured.
+        auto_call = next(c for c in call_log if c["provider"] == "auto")
+        assert auto_call["model"] == "my-custom-vision-model", (
+            f"explicit caller model should be preserved on auto fallback, "
+            f"got {auto_call['model']!r}"
+        )
 
 
 class TestCodexAuxiliaryAdapterTimeout:

--- a/tests/agent/test_auxiliary_main_first.py
+++ b/tests/agent/test_auxiliary_main_first.py
@@ -18,6 +18,36 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+# ── Test isolation ───────────────────────────────────────────────────────────
+#
+# agent.auxiliary_client holds two module-level dicts:
+#   _aux_unhealthy_until     — provider label → expiry timestamp
+#   _aux_unhealthy_logged_at — provider label → last-log timestamp
+#
+# _mark_provider_unhealthy() is called whenever a provider lacks credentials
+# (e.g. OPENROUTER_API_KEY absent causes a 60-second "openrouter" entry).
+# Tests in other modules (notably test_vision_tools.py) remove env vars and
+# invoke resolve_vision_provider_client(), which triggers _try_openrouter() and
+# leaves "openrouter" in the cache.  _resolve_auto() then skips the patched
+# main provider in Step-1, causing the TestResolveAutoMainFirst tests to see
+# None instead of the mock client.
+#
+# Fix: autouse fixture clears both dicts before and after every test in this
+# module so the health cache is always pristine regardless of run order.
+
+
+@pytest.fixture(autouse=True)
+def _reset_unhealthy_cache():
+    """Clear the auxiliary-client unhealthy cache around every test."""
+    import agent.auxiliary_client as _aux_mod
+
+    _aux_mod._aux_unhealthy_until.clear()
+    _aux_mod._aux_unhealthy_logged_at.clear()
+    yield
+    _aux_mod._aux_unhealthy_until.clear()
+    _aux_mod._aux_unhealthy_logged_at.clear()
+
+
 # ── Text aux tasks — _resolve_auto ──────────────────────────────────────────
 
 
@@ -395,6 +425,123 @@ class TestResolveVisionMainFirst:
         # Explicit "nous" override → uses strict backend, NOT main model path
         assert provider == "nous"
         mock_strict.assert_called_once_with("nous", None)
+
+
+# ── openai-codex vision skip (regression for Telegram OCR failure) ───────────
+
+
+class TestCodexVisionSkip:
+    """openai-codex must be skipped in vision auto-detect (it rejects non-Codex models).
+
+    Regression: when the user's main provider is openai-codex and their main
+    model is claude-sonnet-4.6 (or any non-Codex slug), the vision auto-detect
+    path used to forward that model straight to the Codex endpoint, which
+    rejected it with:
+        "claude-sonnet-4.6 model is not supported when using Codex with a
+         ChatGPT account"
+    Fix: add "openai-codex" to _PROVIDERS_WITHOUT_VISION so auto-detect skips
+    it and falls through to OpenRouter/Nous.
+    """
+
+    def test_codex_main_provider_skipped_in_vision_auto(self):
+        """openai-codex as main provider → vision auto falls through to aggregator."""
+        fallback_client = MagicMock()
+
+        with patch(
+            "agent.auxiliary_client._read_main_provider", return_value="openai-codex",
+        ), patch(
+            "agent.auxiliary_client._read_main_model", return_value="claude-sonnet-4.6",
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", None, None, None, None),
+        ), patch(
+            "agent.auxiliary_client._resolve_strict_vision_backend",
+            return_value=(fallback_client, "google/gemini-3-flash-preview"),
+        ) as mock_strict, patch(
+            "agent.auxiliary_client.resolve_provider_client",
+        ) as mock_rpc:
+            from agent.auxiliary_client import resolve_vision_provider_client
+
+            provider, client, model = resolve_vision_provider_client()
+
+        # Must NOT have tried resolve_provider_client with openai-codex + claude-sonnet-4.6
+        for call in mock_rpc.call_args_list:
+            if call.args[0] == "openai-codex":
+                assert call.args[1] != "claude-sonnet-4.6", (
+                    "resolve_provider_client was called with openai-codex + "
+                    "claude-sonnet-4.6 — the Codex endpoint rejects this combo"
+                )
+        # Must have fallen back to a valid vision backend
+        assert client is fallback_client
+        assert provider in {"openrouter", "nous"}
+
+    def test_codex_in_providers_without_vision(self):
+        """openai-codex must be listed in _PROVIDERS_WITHOUT_VISION."""
+        from agent.auxiliary_client import _PROVIDERS_WITHOUT_VISION
+
+        assert "openai-codex" in _PROVIDERS_WITHOUT_VISION, (
+            "openai-codex must be in _PROVIDERS_WITHOUT_VISION to prevent "
+            "vision auto-detect from forwarding non-Codex models to the "
+            "Codex endpoint (which rejects them)"
+        )
+
+    def test_codex_main_provider_vision_does_not_call_rpc_with_main_model(self):
+        """resolve_provider_client must not be called with (openai-codex, main_model) for vision."""
+        with patch(
+            "agent.auxiliary_client._read_main_provider", return_value="openai-codex",
+        ), patch(
+            "agent.auxiliary_client._read_main_model", return_value="claude-sonnet-4.6",
+        ), patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", None, None, None, None),
+        ), patch(
+            "agent.auxiliary_client._resolve_strict_vision_backend",
+            return_value=(MagicMock(), "google/gemini-3-flash-preview"),
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client",
+        ) as mock_rpc:
+            from agent.auxiliary_client import resolve_vision_provider_client
+
+            resolve_vision_provider_client()
+
+        bad_calls = [
+            c for c in mock_rpc.call_args_list
+            if len(c.args) >= 2
+            and c.args[0] == "openai-codex"
+            and c.args[1] == "claude-sonnet-4.6"
+        ]
+        assert not bad_calls, (
+            f"resolve_provider_client called with openai-codex+claude-sonnet-4.6: {bad_calls}"
+        )
+
+    def test_explicit_codex_vision_override_still_reaches_rpc(self):
+        """Explicit auxiliary.vision.provider=openai-codex still reaches codex resolution path.
+
+        Users who deliberately set auxiliary.vision.provider: openai-codex
+        with a compatible model should not be blocked — the skip only applies
+        to the auto-detection path.  The explicit path goes through
+        _get_cached_client → resolve_provider_client("openai-codex", ...).
+        """
+        fake_client = MagicMock()
+
+        with patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("openai-codex", "codex-mini-latest", None, None, None),
+        ), patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(fake_client, "codex-mini-latest"),
+        ) as mock_cached:
+            from agent.auxiliary_client import resolve_vision_provider_client
+
+            provider, client, model = resolve_vision_provider_client()
+
+        # Explicit openai-codex: _get_cached_client must be called with "openai-codex"
+        assert mock_cached.called, "_get_cached_client should be called for explicit openai-codex"
+        call_args = mock_cached.call_args
+        assert call_args.args[0] == "openai-codex"
+        assert call_args.args[1] == "codex-mini-latest"
+        assert provider == "openai-codex"
+        assert client is fake_client
 
 
 # ── Constant cleanup ────────────────────────────────────────────────────────

--- a/tests/skills/test_hybrid_agent_control_plane.py
+++ b/tests/skills/test_hybrid_agent_control_plane.py
@@ -20,7 +20,10 @@ Coverage:
 """
 from __future__ import annotations
 
+import importlib.util
 import re
+import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -41,6 +44,20 @@ FIXTURE_PASS = HERMES / "test-fixtures" / "stub-handoff-pass.yaml"
 FIXTURE_FAIL_SCHEMA = HERMES / "test-fixtures" / "stub-handoff-fail-schema.yaml"
 FIXTURE_FAIL_FORBIDDEN = HERMES / "test-fixtures" / "stub-handoff-fail-forbidden.yaml"
 FIXTURE_FAIL_TESTS = HERMES / "test-fixtures" / "stub-handoff-fail-tests.yaml"
+FIXTURE_FAIL_AGENT_ENUM = HERMES / "test-fixtures" / "stub-handoff-fail-agent-enum.yaml"
+FIXTURE_FAIL_TEST_RESULTS_ABSENT = HERMES / "test-fixtures" / "stub-handoff-fail-test-results-absent.yaml"
+FIXTURE_FAIL_EMPTY_CHANGED_FILES = HERMES / "test-fixtures" / "stub-handoff-fail-empty-changed-files.yaml"
+FIXTURE_FAIL_DOTSLASH_PROMPT_ARTIFACT = HERMES / "test-fixtures" / "stub-handoff-fail-dotslash-prompt-artifact.yaml"
+FIXTURE_FAIL_TRAVERSAL = HERMES / "test-fixtures" / "stub-handoff-fail-traversal.yaml"
+FIXTURE_PASS_AGENT_MD_BACKUP = HERMES / "test-fixtures" / "stub-handoff-pass-agent-md-backup.yaml"
+NEW_FAIL_FIXTURES = [
+    FIXTURE_FAIL_AGENT_ENUM,
+    FIXTURE_FAIL_TEST_RESULTS_ABSENT,
+    FIXTURE_FAIL_EMPTY_CHANGED_FILES,
+    FIXTURE_FAIL_DOTSLASH_PROMPT_ARTIFACT,
+    FIXTURE_FAIL_TRAVERSAL,
+]
+NEW_PASS_FIXTURES = [FIXTURE_PASS_AGENT_MD_BACKUP]
 RUN_MANIFEST_TPL = HERMES / "templates" / "run-manifest.yaml.j2"
 TASK_CONTRACT_TPL = HERMES / "templates" / "task-contract.yaml.j2"
 
@@ -76,10 +93,38 @@ def load_yaml_file(path: Path) -> dict[str, Any]:
     return raw if isinstance(raw, dict) else {}
 
 
+CHECKER_PATH = REPO / "scripts" / "check_hybrid_control_plane.py"
+_CHECK_SPEC = importlib.util.spec_from_file_location(
+    "_check_hybrid_control_plane",
+    str(CHECKER_PATH),
+)
+if _CHECK_SPEC is None or _CHECK_SPEC.loader is None:
+    raise RuntimeError(f"Unable to load checker module from {CHECKER_PATH}")
+_CHECKER = importlib.util.module_from_spec(_CHECK_SPEC)
+sys.modules[_CHECK_SPEC.name] = _CHECKER
+_CHECK_SPEC.loader.exec_module(_CHECKER)
+
+# Production helpers loaded from the checker script (authoritative implementations).
+is_repo_relative_posix = _CHECKER.is_repo_relative_posix
+is_forbidden_path = _CHECKER.is_forbidden_path
+validate_changed_files_for_schema = _CHECKER.validate_changed_files_for_schema
+validate_path_format_and_forbidden = _CHECKER.validate_path_format_and_forbidden
+validate_schema = _CHECKER.validate_schema
+
+
 def is_forbidden(filepath: str) -> bool:
-    return any(
-        filepath.startswith(p) or filepath == p.rstrip("/")
-        for p in FORBIDDEN_PREFIXES
+    return bool(is_forbidden_path(filepath))
+
+
+def run_checker(args: list[str]) -> subprocess.CompletedProcess[str]:
+    """Invoke the checker script through Python so subprocess tests cover CLI behavior."""
+    return subprocess.run(
+        [sys.executable, str(CHECKER_PATH), *args],
+        cwd=str(REPO),
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
     )
 
 
@@ -394,3 +439,199 @@ class TestHandoffSchema:
         assert "token_count_estimate" in text, (
             "handoff-v1.yaml should include token_count_estimate in cost method enum"
         )
+
+
+# ---------------------------------------------------------------------------
+# Section 8: Phase 1.5 amended fixtures and checker gates
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("fixture_path", NEW_FAIL_FIXTURES + NEW_PASS_FIXTURES)
+def test_phase_15_fixture_exists(fixture_path: Path):
+    assert fixture_path.is_file(), f"Missing Phase 1.5 fixture: {fixture_path.name}"
+
+
+def test_path_policy_uses_production_helpers_for_dotslash_and_backup():
+    # ./AGENTS.md normalizes to AGENTS.md → forbidden path (not format error)
+    assert is_forbidden_path("./AGENTS.md") is True
+    assert is_forbidden_path("AGENTS.md.backup") is False
+
+    ok, err = validate_path_format_and_forbidden(["AGENTS.md.backup"])
+    assert ok is True, err
+
+    # Policy change: leading ./ is normalized away; ./AGENTS.md => forbidden, not format error
+    ok, err = validate_path_format_and_forbidden(["./AGENTS.md"])
+    assert ok is False
+    assert err and "Forbidden path" in err, f"Expected 'Forbidden path' in error, got: {err!r}"
+
+
+def test_dotslash_ordinary_path_is_valid_after_normalization():
+    """Leading ./ on an ordinary (non-forbidden) path must be accepted and normalized."""
+    ok, err = validate_path_format_and_forbidden(["./src/main.py"])
+    assert ok is True, f"Expected ./src/main.py to be valid after normalization, got err: {err!r}"
+
+    ok, err = validate_path_format_and_forbidden(["./README.md"])
+    assert ok is True, f"Expected ./README.md to be valid after normalization, got err: {err!r}"
+
+
+def test_dotslash_on_forbidden_prefix_is_forbidden_not_format_error():
+    """./AGENTS.md and ./.hermes/plans/x.md must be caught as forbidden, not format error."""
+    ok, err = validate_path_format_and_forbidden(["./AGENTS.md"])
+    assert ok is False
+    assert err and "Forbidden path" in err, f"Expected 'Forbidden path', got: {err!r}"
+
+    ok, err = validate_path_format_and_forbidden(["./.hermes/plans/x.md"])
+    assert ok is False
+    assert err and "Forbidden path" in err, f"Expected 'Forbidden path', got: {err!r}"
+
+
+def test_bare_dotslash_is_still_invalid():
+    """A path that is just './' (no filename) must still be rejected as invalid format."""
+    ok, err = validate_path_format_and_forbidden(["./"])
+    assert ok is False, "'./' alone must be rejected as invalid path"
+
+
+def test_dotdot_traversal_still_rejected():
+    """'../foo' must remain invalid regardless of dotslash normalization."""
+    ok, err = validate_path_format_and_forbidden(["../outside.txt"])
+    assert ok is False
+    assert err and "Invalid path format" in err, f"Expected 'Invalid path format', got: {err!r}"
+
+
+def test_is_repo_relative_posix_accepts_dotslash_ordinary():
+    """is_repo_relative_posix must return True for './src/foo.py' after policy change."""
+    assert is_repo_relative_posix("./src/foo.py") is True
+    assert is_repo_relative_posix("./README.md") is True
+
+
+def test_is_repo_relative_posix_still_rejects_invalid():
+    """Absolute paths, backslashes, drive paths, and '..' still rejected."""
+    assert is_repo_relative_posix("/absolute") is False
+    assert is_repo_relative_posix("..") is False
+    assert is_repo_relative_posix("../foo") is False
+    assert is_repo_relative_posix("C:\\file.txt") is False
+    assert is_repo_relative_posix("") is False
+    assert is_repo_relative_posix("./") is False
+
+
+def test_schema_validation_does_not_swallow_path_policy_failures():
+    data = {
+        "task_id": "path-policy-split",
+        "agent": "codex",
+        "completed_at": "2026-05-22T00:00:00Z",
+        "summary": "schema-valid but path-invalid",
+        "changed_files": ["../outside.txt", ".hermes/config/capability-matrix.yaml"],
+    }
+    ok, err, next_gate = validate_schema(data)
+    assert ok is True, err
+    assert next_gate == "forbidden_path_writes"
+
+    ok, err = validate_path_format_and_forbidden(data["changed_files"])
+    assert ok is False
+    assert err and "Invalid path format" in err
+
+
+@pytest.mark.parametrize(
+    "fixture_path, expected_error",
+    [
+        (FIXTURE_FAIL_FORBIDDEN, "Forbidden path"),
+        (FIXTURE_FAIL_DOTSLASH_PROMPT_ARTIFACT, "Forbidden path"),
+        (FIXTURE_FAIL_TRAVERSAL, "Invalid path format"),
+    ],
+)
+def test_protected_or_invalid_paths_fail_at_forbidden_gate(fixture_path: Path, expected_error: str):
+    result = run_checker(["--handoff", str(fixture_path.relative_to(REPO))])
+    assert result.returncode != 0
+    assert result.stderr.strip() == ""
+    assert "Traceback" not in result.stdout
+    assert "Traceback" not in result.stderr
+    assert "schema_validation: PASS" in result.stdout
+    assert "forbidden_path_writes: FAIL" in result.stdout
+    assert expected_error in result.stdout
+    assert "prompt_artifact_unchanged" not in result.stdout
+    assert "unit_tests" not in result.stdout
+    assert "AUTOMATED_PASS_HUMAN_REVIEW_REQUIRED" not in result.stdout
+
+
+def test_agent_enum_failure_remains_schema_gate():
+    result = run_checker(["--handoff", str(FIXTURE_FAIL_AGENT_ENUM.relative_to(REPO))])
+    assert result.returncode != 0
+    assert result.stderr.strip() == ""
+    assert "schema_validation: FAIL" in result.stdout
+    assert "agent enum" in result.stdout
+    assert "forbidden_path_writes" not in result.stdout
+
+
+def test_empty_changed_files_failure_remains_schema_gate():
+    result = run_checker(["--handoff", str(FIXTURE_FAIL_EMPTY_CHANGED_FILES.relative_to(REPO))])
+    assert result.returncode != 0
+    assert result.stderr.strip() == ""
+    assert "schema_validation: FAIL" in result.stdout
+    assert "changed_files must be non-empty" in result.stdout
+    assert "forbidden_path_writes" not in result.stdout
+
+
+def test_missing_test_results_fails_at_unit_tests_gate_before_human_review():
+    result = run_checker(["--handoff", str(FIXTURE_FAIL_TEST_RESULTS_ABSENT.relative_to(REPO))])
+    assert result.returncode != 0
+    assert result.stderr.strip() == ""
+    assert "schema_validation: PASS" in result.stdout
+    assert "forbidden_path_writes: PASS" in result.stdout
+    assert "prompt_artifact_unchanged: PASS" in result.stdout
+    assert "diff_size_limit: SKIP" in result.stdout
+    assert "unit_tests: SKIP/missing evidence" in result.stdout
+    assert "cost_cap" not in result.stdout
+    assert "AUTOMATED_PASS_HUMAN_REVIEW_REQUIRED" not in result.stdout
+
+
+def test_failed_test_results_print_unit_tests_failure_before_human_review():
+    result = run_checker(["--handoff", str(FIXTURE_FAIL_TESTS.relative_to(REPO))])
+    assert result.returncode != 0
+    assert result.stderr.strip() == ""
+    assert "schema_validation: PASS" in result.stdout
+    assert "forbidden_path_writes: PASS" in result.stdout
+    assert "unit_tests: failed" in result.stdout
+    assert "cost_cap" not in result.stdout
+    assert "AUTOMATED_PASS_HUMAN_REVIEW_REQUIRED" not in result.stdout
+
+
+def test_success_result_is_automated_pass_with_human_review_required():
+    result = run_checker(["--handoff", str(FIXTURE_PASS.relative_to(REPO))])
+    assert result.returncode == 0
+    assert result.stderr.strip() == ""
+    assert "schema_validation: PASS" in result.stdout
+    assert "forbidden_path_writes: PASS" in result.stdout
+    assert "diff_size_limit: SKIP" in result.stdout
+    assert "unit_tests: passed" in result.stdout
+    assert "cost_cap: SKIP" in result.stdout
+    assert "RESULT: AUTOMATED_PASS_HUMAN_REVIEW_REQUIRED" in result.stdout
+
+
+def test_all_handoff_fixtures_mode_passes_registered_fixtures():
+    result = run_checker(["--all-handoff-fixtures"])
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stderr.strip() == ""
+    assert "stub-handoff-pass-agent-md-backup.yaml -> pass" in result.stdout
+
+
+def test_all_handoff_fixtures_mode_fails_closed_on_unknown_fixture():
+    unknown = HERMES / "test-fixtures" / "stub-handoff-unknown-temporary.yaml"
+    unknown.write_text(
+        "task_id: unknown-fixture\n"
+        "agent: codex\n"
+        "completed_at: 2026-05-22T00:00:00Z\n"
+        "summary: Should be rejected by closed fixture map.\n"
+        "changed_files:\n"
+        "  - src/allowed.py\n"
+        "test_results:\n"
+        "  passed: true\n",
+        encoding="utf-8",
+    )
+    try:
+        result = run_checker(["--all-handoff-fixtures"])
+    finally:
+        unknown.unlink(missing_ok=True)
+
+    assert result.returncode != 0
+    assert result.stderr.strip() == ""
+    assert "unexpected handoff fixtures" in result.stdout
+    assert "stub-handoff-unknown-temporary.yaml" in result.stdout

--- a/tests/skills/test_hybrid_agent_control_plane.py
+++ b/tests/skills/test_hybrid_agent_control_plane.py
@@ -1,0 +1,396 @@
+"""
+tests/skills/test_hybrid_agent_control_plane.py
+
+Deterministic harness tests for the hybrid agent control plane Phase 1 artifacts.
+
+Constraints:
+- No real Claude/Codex spawns.
+- No network calls.
+- No writes to ~/.hermes profiles or skills.
+- All assertions are file-content / YAML-structure checks against repo-local artifacts.
+
+Coverage:
+  1. Plan has non-empty human_reviewed_at
+  2. Locked decisions LD-1..LD-6 present in plan
+  3. Skill draft contains required guardrail phrases
+  4. Templates contain required cost/handoff/spawn-mechanism/isolation fields
+  5. Handoff fixtures have correct pass/fail semantics
+  6. Capability matrix keeps Codex sandbox_verified=false and
+     claude_code.dangerously_skip_permissions=false
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+# ---------------------------------------------------------------------------
+# Repo root and fixture paths — all relative to this file's location
+# ---------------------------------------------------------------------------
+REPO = Path(__file__).resolve().parents[2]
+HERMES = REPO / ".hermes"
+
+PLAN_PATH = HERMES / "plans" / "2026-05-22_000000-hybrid-agent-control-plane.md"
+SKILL_DRAFT_PATH = HERMES / "templates" / "skill-draft-hybrid-agent-control-plane.md"
+CAPABILITY_MATRIX_PATH = HERMES / "config" / "capability-matrix.yaml"
+HANDOFF_SCHEMA_PATH = HERMES / "schemas" / "handoff-v1.yaml"
+FIXTURE_PASS = HERMES / "test-fixtures" / "stub-handoff-pass.yaml"
+FIXTURE_FAIL_SCHEMA = HERMES / "test-fixtures" / "stub-handoff-fail-schema.yaml"
+FIXTURE_FAIL_FORBIDDEN = HERMES / "test-fixtures" / "stub-handoff-fail-forbidden.yaml"
+FIXTURE_FAIL_TESTS = HERMES / "test-fixtures" / "stub-handoff-fail-tests.yaml"
+RUN_MANIFEST_TPL = HERMES / "templates" / "run-manifest.yaml.j2"
+TASK_CONTRACT_TPL = HERMES / "templates" / "task-contract.yaml.j2"
+
+# Forbidden path prefixes mirrored from check_hybrid_control_plane.py
+FORBIDDEN_PREFIXES = [
+    "AGENTS.md",
+    "CLAUDE.md",
+    "CODEX.md",
+    ".hermes/config/",
+    ".hermes/schemas/",
+    ".hermes/plans/",
+    ".claude/",
+    ".codex/",
+]
+
+# Required schema fields for a valid handoff
+HANDOFF_REQUIRED_FIELDS = [
+    "task_id",
+    "agent",
+    "completed_at",
+    "summary",
+    "changed_files",
+    "test_results",
+]
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def load_yaml_file(path: Path) -> dict[str, Any]:
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return raw if isinstance(raw, dict) else {}
+
+
+def is_forbidden(filepath: str) -> bool:
+    return any(
+        filepath.startswith(p) or filepath == p.rstrip("/")
+        for p in FORBIDDEN_PREFIXES
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section 1: Plan — human_reviewed_at
+# ---------------------------------------------------------------------------
+
+class TestPlanReviewedAt:
+    def test_plan_file_exists(self):
+        assert PLAN_PATH.is_file(), f"Plan not found: {PLAN_PATH}"
+
+    def test_human_reviewed_at_present(self):
+        text = PLAN_PATH.read_text(encoding="utf-8")
+        m = re.search(r"^human_reviewed_at:\s*(\S+)", text, re.MULTILINE)
+        assert m, "Plan is missing 'human_reviewed_at: <timestamp>' field"
+
+    def test_human_reviewed_at_non_empty(self):
+        text = PLAN_PATH.read_text(encoding="utf-8")
+        m = re.search(r"^human_reviewed_at:\s*(\S+)", text, re.MULTILINE)
+        assert m, "human_reviewed_at field not found"
+        val = m.group(1).strip()
+        assert val not in ("~", "null", ""), (
+            f"human_reviewed_at is present but empty/null: {val!r}"
+        )
+
+    def test_human_reviewed_at_looks_like_timestamp(self):
+        text = PLAN_PATH.read_text(encoding="utf-8")
+        m = re.search(r"^human_reviewed_at:\s*(\S+)", text, re.MULTILINE)
+        assert m
+        val = m.group(1).strip()
+        # Expect ISO-8601-ish: YYYY-MM-DDTHH:MM:SSZ or similar
+        assert re.match(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}", val), (
+            f"human_reviewed_at doesn't look like an ISO timestamp: {val!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Section 2: Plan — locked decisions LD-1..LD-6
+# ---------------------------------------------------------------------------
+
+REQUIRED_LOCKED_DECISION_PHRASES = [
+    "LD-1",
+    "LD-2",
+    "LD-3",
+    "LD-4",
+    "LD-5",
+    "LD-6",
+    "worktrees_are_sandbox: false",    # LD-1: worktrees are not security sandboxes
+    "file-based handoff is canonical", # LD-2: handoff mechanism
+    "HANDOFF_PATH:",                   # LD-2: canonical env var sentinel
+    "human_reviewed_at",               # LD-3: approval gate
+    "serial gates",                    # LD-4: gate order
+    "opportunistic",                   # LD-5: Codex optional/opportunistic
+    "cost_estimated: true",            # LD-6: cost accounting is estimated
+]
+
+
+@pytest.mark.parametrize("phrase", REQUIRED_LOCKED_DECISION_PHRASES)
+def test_plan_locked_decision_phrase(phrase: str):
+    text = PLAN_PATH.read_text(encoding="utf-8")
+    assert phrase in text, (
+        f"Plan missing locked decision phrase: {phrase!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section 3: Skill draft guardrails
+# ---------------------------------------------------------------------------
+
+SKILL_DRAFT_REQUIRED = [
+    "human_reviewed_at",     # frontmatter field
+    "No real spawns",        # MVP constraint header
+    "worktrees_are_sandbox", # LD-1
+    "HANDOFF_PATH:",         # LD-2 sentinel
+    "file-based handoff",    # LD-2
+    "serial",                # LD-4 gate order
+    "cost_estimated",        # LD-6
+    "route-dev-task",        # C-1: no duplicate skill
+    "terminal()",            # C-3: spawn via terminal, not delegate_task
+    "NOT delegate_task",     # C-3: explicit prohibition
+]
+
+SKILL_DRAFT_FORBIDDEN = [
+    "spawn_real_agent: true",   # must not indicate real spawns enabled
+    "sandbox_verified: true",   # Codex not verified for MVP
+]
+
+
+@pytest.mark.parametrize("phrase", SKILL_DRAFT_REQUIRED)
+def test_skill_draft_contains_required_phrase(phrase: str):
+    text = SKILL_DRAFT_PATH.read_text(encoding="utf-8")
+    assert phrase.lower() in text.lower(), (
+        f"Skill draft missing required phrase: {phrase!r}"
+    )
+
+
+@pytest.mark.parametrize("phrase", SKILL_DRAFT_FORBIDDEN)
+def test_skill_draft_excludes_forbidden_phrase(phrase: str):
+    text = SKILL_DRAFT_PATH.read_text(encoding="utf-8")
+    assert phrase not in text, (
+        f"Skill draft contains forbidden MVP phrase: {phrase!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section 4: Templates — required fields
+# ---------------------------------------------------------------------------
+
+RUN_MANIFEST_REQUIRED_FIELDS = [
+    "cost_estimated",
+    "total_cost_usd_cap",
+    "total_cost_usd_actual",
+    "worktrees_are_sandbox",
+    "container_isolation",
+]
+
+TASK_CONTRACT_REQUIRED_FIELDS = [
+    "cost_cap_usd",
+    "cost_estimated",
+    "handoff_schema_ref",
+    "spawn_mechanism",
+]
+
+
+@pytest.mark.parametrize("field", RUN_MANIFEST_REQUIRED_FIELDS)
+def test_run_manifest_template_has_field(field: str):
+    text = RUN_MANIFEST_TPL.read_text(encoding="utf-8")
+    assert field in text, (
+        f"run-manifest.yaml.j2 missing required field: {field!r}"
+    )
+
+
+@pytest.mark.parametrize("field", TASK_CONTRACT_REQUIRED_FIELDS)
+def test_task_contract_template_has_field(field: str):
+    text = TASK_CONTRACT_TPL.read_text(encoding="utf-8")
+    assert field in text, (
+        f"task-contract.yaml.j2 missing required field: {field!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section 5: Handoff fixtures — pass/fail semantics
+# ---------------------------------------------------------------------------
+
+class TestHandoffPassFixture:
+    """stub-handoff-pass.yaml must have all required fields and passed=true."""
+
+    @pytest.fixture(scope="class")
+    def data(self):
+        return load_yaml_file(FIXTURE_PASS)
+
+    def test_fixture_file_exists(self):
+        assert FIXTURE_PASS.is_file()
+
+    @pytest.mark.parametrize("field", HANDOFF_REQUIRED_FIELDS)
+    def test_required_field_present(self, data, field):
+        assert field in data and data[field] is not None, (
+            f"stub-handoff-pass.yaml missing required field: {field!r}"
+        )
+
+    def test_test_results_passed_true(self, data):
+        tr = data.get("test_results") or {}
+        assert tr.get("passed") is True, (
+            f"stub-handoff-pass.yaml: test_results.passed should be True, got: {tr.get('passed')!r}"
+        )
+
+    def test_changed_files_no_forbidden_paths(self, data):
+        changed = list(data.get("changed_files") or [])
+        forbidden = [f for f in changed if is_forbidden(f)]
+        assert not forbidden, (
+            f"stub-handoff-pass.yaml (pass fixture) must not include forbidden paths: {forbidden}"
+        )
+
+
+class TestHandoffFailSchemaFixture:
+    """stub-handoff-fail-schema.yaml must be intentionally missing required fields."""
+
+    @pytest.fixture(scope="class")
+    def data(self):
+        return load_yaml_file(FIXTURE_FAIL_SCHEMA)
+
+    def test_fixture_file_exists(self):
+        assert FIXTURE_FAIL_SCHEMA.is_file()
+
+    def test_at_least_one_required_field_missing(self, data):
+        missing = [
+            f for f in HANDOFF_REQUIRED_FIELDS
+            if f not in data or data[f] is None
+        ]
+        assert missing, (
+            "stub-handoff-fail-schema.yaml should be intentionally malformed "
+            "(missing at least one required field), but all fields are present."
+        )
+
+    def test_test_results_passed_absent(self, data):
+        """passed field inside test_results must be absent for schema-fail fixture."""
+        tr = data.get("test_results") or {}
+        assert "passed" not in tr, (
+            "stub-handoff-fail-schema.yaml should omit test_results.passed "
+            "to exercise schema validation failure path"
+        )
+
+
+class TestHandoffFailForbiddenFixture:
+    """stub-handoff-fail-forbidden.yaml must include at least one forbidden path."""
+
+    @pytest.fixture(scope="class")
+    def data(self):
+        return load_yaml_file(FIXTURE_FAIL_FORBIDDEN)
+
+    def test_fixture_file_exists(self):
+        assert FIXTURE_FAIL_FORBIDDEN.is_file()
+
+    def test_changed_files_contains_forbidden_path(self, data):
+        changed = list(data.get("changed_files") or [])
+        forbidden = [f for f in changed if is_forbidden(f)]
+        assert forbidden, (
+            "stub-handoff-fail-forbidden.yaml must include at least one forbidden path "
+            f"(one of: {FORBIDDEN_PREFIXES}). Got changed_files: {changed}"
+        )
+
+
+class TestHandoffFailTestsFixture:
+    """stub-handoff-fail-tests.yaml must be schema-valid but have passed=false."""
+
+    @pytest.fixture(scope="class")
+    def data(self):
+        return load_yaml_file(FIXTURE_FAIL_TESTS)
+
+    def test_fixture_file_exists(self):
+        assert FIXTURE_FAIL_TESTS.is_file()
+
+    @pytest.mark.parametrize("field", HANDOFF_REQUIRED_FIELDS)
+    def test_required_field_present(self, data, field):
+        """Schema-valid — all required fields present."""
+        assert field in data and data[field] is not None, (
+            f"stub-handoff-fail-tests.yaml missing field: {field!r} "
+            "(this fixture should be schema-valid but fail the tests gate)"
+        )
+
+    def test_test_results_passed_false(self, data):
+        tr = data.get("test_results") or {}
+        assert tr.get("passed") is False, (
+            f"stub-handoff-fail-tests.yaml: test_results.passed should be False, "
+            f"got: {tr.get('passed')!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Section 6: Capability matrix — MVP safety constraints
+# ---------------------------------------------------------------------------
+
+class TestCapabilityMatrix:
+    @pytest.fixture(scope="class")
+    def matrix(self):
+        return load_yaml_file(CAPABILITY_MATRIX_PATH)
+
+    def test_file_exists(self):
+        assert CAPABILITY_MATRIX_PATH.is_file()
+
+    def test_codex_sandbox_verified_is_not_true(self, matrix):
+        """Codex canary test (plan task 2.1) must pass before enabling sandbox_verified."""
+        codex = (matrix.get("agents") or {}).get("codex") or {}
+        sandbox_verified = codex.get("sandbox_verified", False)
+        assert sandbox_verified is not True, (
+            "capability-matrix.yaml: codex.sandbox_verified is True — "
+            "Codex canary test must pass before enabling. "
+            "Set to False until Phase 2 canary confirms sandbox behavior."
+        )
+
+    def test_claude_code_dangerously_skip_permissions_is_not_true(self, matrix):
+        """dangerously_skip_permissions must never be set to true on real host filesystems."""
+        cc = (matrix.get("agents") or {}).get("claude_code") or {}
+        dsp = cc.get("dangerously_skip_permissions", False)
+        assert dsp is not True, (
+            "capability-matrix.yaml: claude_code.dangerously_skip_permissions is True — "
+            "this must never be set on real host filesystems."
+        )
+
+    def test_codex_sandbox_verified_is_false(self, matrix):
+        """Explicitly False (not just absent) for deterministic MVP gate."""
+        codex = (matrix.get("agents") or {}).get("codex") or {}
+        sandbox_verified = codex.get("sandbox_verified", False)
+        assert sandbox_verified is False, (
+            f"codex.sandbox_verified should be False for MVP, got: {sandbox_verified!r}"
+        )
+
+    def test_claude_code_dangerously_skip_permissions_is_false(self, matrix):
+        cc = (matrix.get("agents") or {}).get("claude_code") or {}
+        dsp = cc.get("dangerously_skip_permissions", False)
+        assert dsp is False, (
+            f"claude_code.dangerously_skip_permissions should be False, got: {dsp!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Section 7: Handoff schema — cost_estimated field
+# ---------------------------------------------------------------------------
+
+class TestHandoffSchema:
+    def test_schema_file_exists(self):
+        assert HANDOFF_SCHEMA_PATH.is_file()
+
+    def test_cost_estimated_field_present(self):
+        text = HANDOFF_SCHEMA_PATH.read_text(encoding="utf-8")
+        assert "cost_estimated" in text, (
+            "handoff-v1.yaml missing cost_estimated field (required by LD-6)"
+        )
+
+    def test_cost_method_enum_includes_token_count_estimate(self):
+        text = HANDOFF_SCHEMA_PATH.read_text(encoding="utf-8")
+        assert "token_count_estimate" in text, (
+            "handoff-v1.yaml should include token_count_estimate in cost method enum"
+        )

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -510,12 +510,19 @@ class TestVisionRequirements:
         assert isinstance(result, bool)
 
     def test_check_requirements_accepts_codex_auth(self, monkeypatch, tmp_path):
+        # openai-codex as the main provider does NOT satisfy vision requirements
+        # in auto-detect mode: the Codex endpoint rejects arbitrary model names
+        # (e.g. claude-sonnet-4.6) and is therefore in _PROVIDERS_WITHOUT_VISION.
+        # check_vision_requirements() returns False unless OpenRouter/Nous or
+        # another valid vision backend is also configured.
+        # Users who need Codex for vision must set:
+        #   auxiliary.vision.provider: openai-codex
+        #   auxiliary.vision.model: <a Codex-compatible model>
+        # explicitly in config.yaml.
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         (tmp_path / "auth.json").write_text(
             '{"active_provider":"openai-codex","providers":{"openai-codex":{"tokens":{"access_token":"codex-access-token","refresh_token":"codex-refresh-token"}}}}'
         )
-        # config.yaml must reference the codex provider so vision auto-detect
-        # falls back to the active provider via _read_main_provider().
         (tmp_path / "config.yaml").write_text(
             'model:\n  default: gpt-4o\n  provider: openai-codex\n'
         )
@@ -523,7 +530,87 @@ class TestVisionRequirements:
         monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
-        assert check_vision_requirements() is True
+        # Codex-only users have no auto-detect vision backend configured.
+        assert check_vision_requirements() is False
+
+    def test_check_requirements_explicit_unavailable_but_auto_available(self, monkeypatch):
+        """Explicit configured provider unavailable + auto (OpenRouter) available => True.
+
+        Scenario: config sets auxiliary.vision.provider=anthropic but no Anthropic
+        credentials are present, while OPENROUTER_API_KEY is set.  async_call_llm
+        falls back to auto backends at runtime, so check_vision_requirements()
+        must also return True to avoid incorrectly gating out the vision tool.
+        """
+        from unittest.mock import MagicMock
+        from agent import auxiliary_client as ac
+
+        fake_openrouter_client = MagicMock()
+
+        def fake_resolve(provider=None, model=None, base_url=None,
+                         api_key=None, async_mode=False):
+            if provider in (None, "anthropic"):
+                # Explicit configured provider — no credentials
+                return "anthropic", None, None
+            if provider == "auto":
+                # Auto fallback resolves to OpenRouter
+                return "openrouter", fake_openrouter_client, "google/gemini-3-flash-preview"
+            return provider, None, None
+
+        # monkeypatch.setattr on the module object works because the
+        # `from agent.auxiliary_client import resolve_vision_provider_client`
+        # inside check_vision_requirements() resolves via sys.modules at call
+        # time and picks up the patched attribute.
+        monkeypatch.setattr(ac, "resolve_vision_provider_client", fake_resolve)
+
+        result = check_vision_requirements()
+
+        assert result is True, (
+            "check_vision_requirements() must return True when explicit provider "
+            "is unavailable but an auto vision backend (OpenRouter) is available"
+        )
+
+    def test_check_requirements_no_backends_at_all(self, monkeypatch):
+        """No explicit provider client AND no auto backends => False.
+
+        Scenario: codex-only / no OpenRouter / no Nous => vision tool disabled.
+        """
+        from unittest.mock import MagicMock
+        from agent import auxiliary_client as ac
+
+        def fake_resolve(provider=None, model=None, base_url=None,
+                         api_key=None, async_mode=False):
+            return (provider or "none"), None, None  # always None client
+
+        monkeypatch.setattr(ac, "resolve_vision_provider_client", fake_resolve)
+
+        result = check_vision_requirements()
+        assert result is False, (
+            "check_vision_requirements() must return False when no vision backend is available"
+        )
+
+    def test_check_requirements_explicit_working_provider(self, monkeypatch):
+        """Explicit configured provider resolves a client => True (fast path, no auto needed)."""
+        from unittest.mock import MagicMock
+        from agent import auxiliary_client as ac
+
+        fake_client = MagicMock()
+        auto_called = []
+
+        def fake_resolve(provider=None, model=None, base_url=None,
+                         api_key=None, async_mode=False):
+            if provider == "auto":
+                auto_called.append(True)
+                return "openrouter", MagicMock(), "some-model"
+            # Explicit provider works fine
+            return "anthropic", fake_client, "claude-opus-4-5"
+
+        monkeypatch.setattr(ac, "resolve_vision_provider_client", fake_resolve)
+
+        result = check_vision_requirements()
+        assert result is True, (
+            "check_vision_requirements() must return True when explicit provider works"
+        )
+        assert not auto_called, "auto fallback must NOT be invoked when explicit provider works"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -914,12 +914,24 @@ async def vision_analyze_tool(
 
 
 def check_vision_requirements() -> bool:
-    """Check if the configured runtime vision path can resolve a client."""
+    """Check if the configured runtime vision path can resolve a client.
+
+    Mirrors the fallback semantics of async_call_llm(task="vision"):
+    if the explicitly configured vision provider is unavailable (e.g. no
+    credentials), fall through to auto vision backends (OpenRouter, Nous)
+    before returning False.  Tool gating must reflect the actual runtime path
+    so the vision tool is not disabled when an auto backend can serve the call.
+    """
     try:
         from agent.auxiliary_client import resolve_vision_provider_client
 
         _provider, client, _model = resolve_vision_provider_client()
-        return client is not None
+        if client is not None:
+            return True
+        # Explicit configured provider returned no client — try auto fallback,
+        # matching the runtime path in async_call_llm(task="vision").
+        _provider2, client2, _model2 = resolve_vision_provider_client(provider="auto")
+        return client2 is not None
     except Exception:
         return False
 


### PR DESCRIPTION
## Summary

- Tightens Phase 1.5 hybrid control-plane handoff checks so delegated worker summaries and escalation/error handoffs are validated more defensively.
- Fixes auxiliary vision/provider routing so unavailable explicit vision providers can fall back to auto vision backends consistently with runtime `async_call_llm(task="vision")` behavior.
- Prevents non-vision auto providers from satisfying vision routing accidentally, and adds test isolation for provider health cooldown state.
- Documents the expected auxiliary vision preference: use subscription-backed `grok-4.3` via `xai-oauth` or `gemini-3-flash-preview` subscription route before API-key/OpenRouter spend.

## QA

- `python -m py_compile agent/auxiliary_client.py tests/agent/test_auxiliary_client.py tests/agent/test_auxiliary_main_first.py tests/tools/test_vision_tools.py tools/vision_tools.py`
- Ordered targeted pytest runs across:
  - `tests/tools/test_vision_tools.py`
  - `tests/agent/test_auxiliary_main_first.py`
  - `tests/agent/test_auxiliary_client.py`
- Broader aux + vision regression slice:
  - `python -m pytest tests/agent/test_auxiliary*.py tests/tools/test_vision_tools.py -q`
  - Result: `342 passed, 6 skipped`
- `git diff --check`

## Notes

This updates the existing hybrid control-plane MVP PR with the Phase 1.5 guard tightening and the auxiliary vision fallback fix.