### PR TITLE
feat(skills/google-workspace): multi-account support

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: google-workspace
 description: "Gmail, Calendar, Drive, Docs, Sheets via gws CLI or Python."
-version: 1.1.0
+version: 1.2.0
 author: Nous Research
 license: MIT
 platforms: [linux, macos, windows]
@@ -163,6 +163,102 @@ Should print `AUTHENTICATED`. Setup is complete — token refreshes automaticall
 - Pending OAuth session state/verifier are stored temporarily at `~/.hermes/google_oauth_pending.json` until exchange completes.
 - If `gws` is installed, `google_api.py` points it at the same `~/.hermes/google_token.json` credentials file. Users do not need to run a separate `gws auth login` flow.
 - To revoke: `$GSETUP --revoke`
+
+## Multi-Account Support
+
+The skill supports multiple Google accounts on the same Hermes profile. The
+default flow above uses a single account; the multi-account commands below
+let you authorize, manage, and switch between accounts.
+
+### Adding a second account
+
+If the user already has one Google account set up and wants to add another
+(e.g. personal + work), do this first ONCE to migrate their existing token
+into the multi-account layout:
+
+```bash
+$GSETUP --migrate-legacy
+```
+
+This is non-destructive — the legacy `~/.hermes/google_token.json` becomes
+a symlink to the per-account token, so anything that reads the legacy path
+keeps working. Then authorize the second account:
+
+```bash
+$GSETUP --account second@example.com --auth-url
+# Send URL to user, get redirect/code back, then:
+$GSETUP --account second@example.com --auth-code "PASTED_URL_OR_CODE"
+```
+
+The OAuth consent screen will be pre-populated with the requested email
+(via `login_hint`), but the user can still pick a different one. If they
+do, the script refuses to save the token to the wrong account file and
+prints which account was actually authorized.
+
+### Listing and switching accounts
+
+```bash
+# Show all configured accounts (the default is marked with *)
+$GSETUP --list-accounts
+
+# Make a different account the default
+$GSETUP --set-default user@example.com
+```
+
+Setting the default also refreshes the legacy `~/.hermes/google_token.json`
+symlink, so cron jobs and tools that hard-code the legacy path continue to
+hit the new default account automatically.
+
+### Per-call account selection
+
+All three CLI entry points accept `--account EMAIL` to operate on a
+specific account for a single invocation:
+
+```bash
+# Read mail from the work account regardless of the default
+$GAPI --account work@company.com gmail search "is:unread" --max 10
+
+# Calendar from the personal account
+$GAPI --account me@gmail.com calendar list
+
+# gws bridge (the --account flag must come BEFORE the gws args)
+python ${HERMES_HOME:-$HOME/.hermes}/skills/productivity/google-workspace/scripts/gws_bridge.py \
+    --account work@company.com gmail messages list
+```
+
+When `--account` is omitted, the resolution chain is:
+
+1. `HERMES_GOOGLE_ACCOUNT` environment variable (handy in cron jobs)
+2. Default account (set with `--set-default`)
+3. Legacy `~/.hermes/google_token.json` (un-migrated single-account installs)
+
+So a cron job that always wants to operate on the work account can
+`export HERMES_GOOGLE_ACCOUNT=work@company.com` once, and every subsequent
+`$GAPI ...` call honors it without changes to the rest of the shell script.
+
+### Removing an account
+
+```bash
+$GSETUP --remove-account user@example.com
+```
+
+This revokes the token with Google and deletes the per-account file. If
+the removed account was the default, the next remaining account is
+promoted automatically.
+
+### File layout
+
+After migration:
+
+```
+~/.hermes/
+├── google_client_secret.json          # shared OAuth client (one for all accounts)
+├── google_token.json                  # symlink → google_tokens/<default>.json
+└── google_tokens/
+    ├── default                         # plain text, holds the default email
+    ├── user@example.com.json           # per-account tokens
+    └── work@company.com.json
+```
 
 ## Usage
 

--- a/skills/productivity/google-workspace/scripts/google_account.py
+++ b/skills/productivity/google-workspace/scripts/google_account.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""Multi-account token resolution for the Google Workspace skill.
+
+Accounts are identified by Gmail address (lower-cased, normalized).
+Tokens for each account live at ``~/.hermes/google_tokens/<email>.json``.
+
+Backward compatibility
+----------------------
+The legacy single-account layout used ``~/.hermes/google_token.json``.
+After ``--migrate-legacy``:
+
+* The legacy token is moved to ``google_tokens/<derived-email>.json``
+* ``google_token.json`` becomes a symlink to that file
+* The migrated account is marked as the default
+
+Anything that read ``~/.hermes/google_token.json`` directly (cron jobs,
+``GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE``, third-party scripts) continues
+to work unchanged because the symlink resolves to the default account.
+
+Resolution precedence (most to least specific):
+
+1. Explicit ``--account EMAIL`` CLI flag
+2. ``HERMES_GOOGLE_ACCOUNT`` environment variable
+3. Default account pointer at ``google_tokens/default``
+4. Legacy file ``google_token.json`` (un-migrated single-account installs)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+# Ensure sibling modules (_hermes_home) are importable when run standalone.
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+from _hermes_home import get_hermes_home
+
+ACCOUNT_ENV_VAR = "HERMES_GOOGLE_ACCOUNT"
+
+# Conservative — Gmail addresses, GSuite domain addresses, anything with @.
+# We reject anything else so weird strings can't escape into filenames.
+_EMAIL_RE = re.compile(r"^[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}$")
+
+
+def hermes_home() -> Path:
+    return get_hermes_home()
+
+
+def tokens_dir() -> Path:
+    return hermes_home() / "google_tokens"
+
+
+def legacy_token_path() -> Path:
+    return hermes_home() / "google_token.json"
+
+
+def default_pointer_path() -> Path:
+    return tokens_dir() / "default"
+
+
+def normalize_email(email: str) -> str:
+    """Normalize an email address for use as an account key.
+
+    Lowercases and strips whitespace. Raises ValueError on anything that
+    doesn't look like an email address — protects against directory
+    traversal and weird filenames.
+    """
+    if not email:
+        raise ValueError("Account email is empty.")
+    cleaned = email.strip().lower()
+    if not _EMAIL_RE.match(cleaned):
+        raise ValueError(f"Not a valid email address: {email!r}")
+    if "/" in cleaned or "\\" in cleaned or ".." in cleaned:
+        # Belt and suspenders — _EMAIL_RE already excludes these.
+        raise ValueError(f"Email contains illegal characters: {email!r}")
+    return cleaned
+
+
+def token_path_for(email: str) -> Path:
+    """Return the on-disk token path for a given account email."""
+    return tokens_dir() / f"{normalize_email(email)}.json"
+
+
+def _read_default_pointer() -> Optional[str]:
+    pointer = default_pointer_path()
+    if not pointer.exists():
+        return None
+    try:
+        value = pointer.read_text().strip()
+    except OSError:
+        return None
+    if not value:
+        return None
+    try:
+        return normalize_email(value)
+    except ValueError:
+        return None
+
+
+def list_accounts() -> List[str]:
+    """List all known accounts (sorted).
+
+    An account is "known" if it has a valid token JSON in ``google_tokens/``.
+    The legacy ``google_token.json`` is not listed here unless it has been
+    migrated.
+    """
+    d = tokens_dir()
+    if not d.is_dir():
+        return []
+    out: List[str] = []
+    for entry in sorted(d.iterdir()):
+        if not entry.is_file():
+            continue
+        if entry.suffix != ".json":
+            continue
+        # Strip ".json" and validate as email — protects against junk files.
+        stem = entry.stem
+        try:
+            normalize_email(stem)
+        except ValueError:
+            continue
+        out.append(stem)
+    return out
+
+
+def get_default_account() -> Optional[str]:
+    """Return the default account email, or None if not configured.
+
+    Resolution: pointer file → if missing AND only one account exists,
+    that one wins.
+    """
+    pointed = _read_default_pointer()
+    if pointed:
+        # Verify the pointer's target actually exists.
+        if token_path_for(pointed).exists():
+            return pointed
+        return None
+    accounts = list_accounts()
+    if len(accounts) == 1:
+        return accounts[0]
+    return None
+
+
+def set_default_account(email: str) -> None:
+    """Set the default account and refresh the legacy ``google_token.json``
+    symlink so backward-compat consumers keep working."""
+    norm = normalize_email(email)
+    target = token_path_for(norm)
+    if not target.exists():
+        raise FileNotFoundError(
+            f"No token for {norm} at {target}. Run --account {norm} setup first."
+        )
+    tokens_dir().mkdir(parents=True, exist_ok=True)
+    pointer = default_pointer_path()
+    pointer.write_text(norm + "\n")
+
+    # Refresh the legacy symlink. We do this carefully:
+    #   - If the legacy path is a symlink (already managed by us), replace it.
+    #   - If it's a regular file, leave it alone — the user hasn't migrated
+    #     yet and we don't want to clobber their real token. They'd hit this
+    #     case if they set a default before running --migrate-legacy, which
+    #     is unusual but possible.
+    legacy = legacy_token_path()
+    if legacy.is_symlink() or not legacy.exists():
+        try:
+            if legacy.is_symlink() or legacy.exists():
+                legacy.unlink()
+            legacy.symlink_to(target)
+        except OSError:
+            # Symlinks unsupported (Windows without admin etc.) — fall back
+            # to copying the JSON contents instead.
+            legacy.write_text(target.read_text())
+
+
+def resolve_account(explicit: Optional[str] = None) -> Optional[str]:
+    """Resolve which account to use given the precedence chain.
+
+    Returns the normalized email, or None if we should fall back to the
+    pre-migration legacy single-account file.
+    """
+    if explicit:
+        return normalize_email(explicit)
+    env = os.environ.get(ACCOUNT_ENV_VAR, "").strip()
+    if env:
+        return normalize_email(env)
+    default = get_default_account()
+    if default:
+        return default
+    return None
+
+
+def resolve_token_path(explicit_account: Optional[str] = None) -> Path:
+    """Return the token path to use for this invocation.
+
+    If an account is resolved, returns its dedicated token file
+    (``google_tokens/<email>.json``). Otherwise returns the legacy
+    single-account path (``google_token.json``) for backward compatibility.
+
+    The returned path may not exist — callers should check.
+    """
+    account = resolve_account(explicit_account)
+    if account is not None:
+        return token_path_for(account)
+    return legacy_token_path()
+
+
+def _userinfo_email_via_tokeninfo(access_token: str) -> Optional[str]:
+    """Fetch the email associated with an access token via Google's
+    tokeninfo endpoint. Returns None on any error (network, scope, etc.)."""
+    import urllib.error
+    import urllib.parse
+    import urllib.request
+
+    url = (
+        "https://oauth2.googleapis.com/tokeninfo?"
+        + urllib.parse.urlencode({"access_token": access_token})
+    )
+    try:
+        with urllib.request.urlopen(url, timeout=15) as resp:
+            data = json.loads(resp.read())
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, ValueError):
+        return None
+    email = data.get("email")
+    if not email:
+        return None
+    try:
+        return normalize_email(email)
+    except ValueError:
+        return None
+
+
+def _userinfo_email_via_userinfo(access_token: str) -> Optional[str]:
+    """Fallback: Google userinfo endpoint."""
+    import urllib.error
+    import urllib.request
+
+    req = urllib.request.Request(
+        "https://www.googleapis.com/oauth2/v2/userinfo",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read())
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, ValueError):
+        return None
+    email = data.get("email")
+    if not email:
+        return None
+    try:
+        return normalize_email(email)
+    except ValueError:
+        return None
+
+
+def _email_via_gmail_profile(access_token: str) -> Optional[str]:
+    """Last-resort fallback: Gmail API users.getProfile returns emailAddress.
+
+    Useful when the token has gmail scopes but neither userinfo.email nor
+    openid scopes (legacy tokens often lack them)."""
+    import urllib.error
+    import urllib.request
+
+    req = urllib.request.Request(
+        "https://gmail.googleapis.com/gmail/v1/users/me/profile",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read())
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, ValueError):
+        return None
+    email = data.get("emailAddress")
+    if not email:
+        return None
+    try:
+        return normalize_email(email)
+    except ValueError:
+        return None
+
+
+def derive_email_from_token(token_payload: dict) -> Optional[str]:
+    """Best-effort: figure out the Gmail address that owns a token.
+
+    Tries (in order):
+
+    1. ``email`` field on the token payload (some flows write it)
+    2. ID token claims if present
+    3. ``oauth2.googleapis.com/tokeninfo`` lookup using the access token
+    4. ``oauth2/v2/userinfo`` lookup as a fallback
+
+    Returns the normalized email or None. Network calls have a 15s timeout.
+    """
+    direct = token_payload.get("email")
+    if isinstance(direct, str) and direct.strip():
+        try:
+            return normalize_email(direct)
+        except ValueError:
+            pass
+
+    # Some payloads carry an id_token with "email" in the JWT body.
+    id_token = token_payload.get("id_token")
+    if isinstance(id_token, str) and id_token.count(".") == 2:
+        import base64
+
+        try:
+            body = id_token.split(".")[1]
+            # JWT base64url, may need padding
+            padding = 4 - (len(body) % 4)
+            if padding != 4:
+                body = body + ("=" * padding)
+            claims = json.loads(base64.urlsafe_b64decode(body))
+            claim_email = claims.get("email")
+            if isinstance(claim_email, str) and claim_email.strip():
+                try:
+                    return normalize_email(claim_email)
+                except ValueError:
+                    pass
+        except Exception:
+            pass
+
+    access = token_payload.get("token") or token_payload.get("access_token")
+    if isinstance(access, str) and access:
+        via_tokeninfo = _userinfo_email_via_tokeninfo(access)
+        if via_tokeninfo:
+            return via_tokeninfo
+        via_userinfo = _userinfo_email_via_userinfo(access)
+        if via_userinfo:
+            return via_userinfo
+        via_gmail = _email_via_gmail_profile(access)
+        if via_gmail:
+            return via_gmail
+
+    return None
+
+
+def store_token_for_account(email: str, token_payload: dict) -> Path:
+    """Write a token JSON to ``google_tokens/<email>.json`` with 0600 perms.
+    Returns path."""
+    norm = normalize_email(email)
+    d = tokens_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(d, 0o700)
+    except OSError:
+        pass
+    path = token_path_for(norm)
+    path.write_text(json.dumps(token_payload, indent=2))
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+    return path

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -37,10 +37,30 @@ if _SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, _SCRIPTS_DIR)
 
 from _hermes_home import get_hermes_home
+import google_account
 
 HERMES_HOME = get_hermes_home()
+# Legacy module-level constant — kept for any external callers that import
+# it. The actual token used at runtime is resolved per-call via TOKEN_PATH()
+# below so the --account flag and HERMES_GOOGLE_ACCOUNT env are honored.
 TOKEN_PATH = HERMES_HOME / "google_token.json"
 CLIENT_SECRET_PATH = HERMES_HOME / "google_client_secret.json"
+
+
+def _resolve_account() -> str | None:
+    """Resolve the active Google account for this invocation.
+
+    Reads ``--account`` (parked on os.environ by main()) → HERMES_GOOGLE_ACCOUNT
+    env → default pointer → legacy file. See google_account.resolve_account.
+    """
+    explicit = os.environ.get("_HERMES_GOOGLE_ACCOUNT_OVERRIDE", "").strip() or None
+    return google_account.resolve_account(explicit)
+
+
+def _resolve_token_path() -> Path:
+    """Token path for the active account — refreshed every call."""
+    explicit = os.environ.get("_HERMES_GOOGLE_ACCOUNT_OVERRIDE", "").strip() or None
+    return google_account.resolve_token_path(explicit)
 
 SCOPES = [
     "https://www.googleapis.com/auth/gmail.readonly",
@@ -62,7 +82,8 @@ def _normalize_authorized_user_payload(payload: dict) -> dict:
 
 
 def _ensure_authenticated():
-    if not TOKEN_PATH.exists():
+    token_path = _resolve_token_path()
+    if not token_path.exists():
         print("Not authenticated. Run the setup script first:", file=sys.stderr)
         print(f"  python {Path(__file__).parent / 'setup.py'}", file=sys.stderr)
         sys.exit(1)
@@ -70,7 +91,7 @@ def _ensure_authenticated():
 
 def _stored_token_scopes() -> list[str]:
     try:
-        data = json.loads(TOKEN_PATH.read_text())
+        data = json.loads(_resolve_token_path().read_text())
     except Exception:
         return list(SCOPES)
     scopes = data.get("scopes")
@@ -88,7 +109,7 @@ def _gws_binary() -> str | None:
 
 def _gws_env() -> dict[str, str]:
     env = os.environ.copy()
-    env["GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE"] = str(TOKEN_PATH)
+    env["GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE"] = str(_resolve_token_path())
     return env
 
 
@@ -181,10 +202,11 @@ def get_credentials():
     from google.oauth2.credentials import Credentials
     from google.auth.transport.requests import Request
 
-    creds = Credentials.from_authorized_user_file(str(TOKEN_PATH), _stored_token_scopes())
+    token_path = _resolve_token_path()
+    creds = Credentials.from_authorized_user_file(str(token_path), _stored_token_scopes())
     if creds.expired and creds.refresh_token:
         creds.refresh(Request())
-        TOKEN_PATH.write_text(
+        token_path.write_text(
             json.dumps(
                 _normalize_authorized_user_payload(json.loads(creds.to_json())),
                 indent=2,
@@ -1049,6 +1071,15 @@ def _docs_insert_text(doc_id: str, text: str, index: int) -> None:
 
 def main():
     parser = argparse.ArgumentParser(description="Google Workspace API for Hermes Agent")
+    parser.add_argument(
+        "--account",
+        metavar="EMAIL",
+        default=None,
+        help="Google account to use (multi-account setups). If omitted, "
+        "falls back to HERMES_GOOGLE_ACCOUNT env, then the default account, "
+        "then the legacy single-account token. Run setup.py --list-accounts "
+        "to see configured accounts.",
+    )
     sub = parser.add_subparsers(dest="service", required=True)
 
     # --- Gmail ---
@@ -1214,6 +1245,16 @@ def main():
     p.set_defaults(func=docs_append)
 
     args = parser.parse_args()
+    # Park --account on the env so the per-call resolver picks it up. We use
+    # an internal env var (not HERMES_GOOGLE_ACCOUNT) so an explicit --account
+    # flag overrides whatever's in the user's environment.
+    if args.account:
+        try:
+            normalized = google_account.normalize_email(args.account)
+        except ValueError as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            sys.exit(1)
+        os.environ["_HERMES_GOOGLE_ACCOUNT_OVERRIDE"] = normalized
     args.func(args)
 
 

--- a/skills/productivity/google-workspace/scripts/gws_bridge.py
+++ b/skills/productivity/google-workspace/scripts/gws_bridge.py
@@ -2,6 +2,13 @@
 """Bridge between Hermes OAuth token and gws CLI.
 
 Refreshes the token if expired, then executes gws with the valid access token.
+
+Multi-account support: pass ``--account EMAIL`` BEFORE the gws args, e.g.:
+
+    gws_bridge.py --account user@example.com gmail +triage
+
+If ``--account`` is omitted, the resolution chain (HERMES_GOOGLE_ACCOUNT env →
+default pointer → legacy single-account token) decides which account is used.
 """
 import json
 import os
@@ -10,16 +17,33 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-# Ensure sibling modules (_hermes_home) are importable when run standalone.
+# Ensure sibling modules (_hermes_home, google_account) are importable when
+# run standalone.
 _SCRIPTS_DIR = str(Path(__file__).resolve().parent)
 if _SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, _SCRIPTS_DIR)
 
 from _hermes_home import get_hermes_home
+import google_account
+
+
+# The active account is resolved once at process start so all helper functions
+# below see the same value (matters when the user passes --account).
+_ACCOUNT: "str | None" = None
+
+
+def _set_active_account(account: "str | None") -> None:
+    global _ACCOUNT
+    _ACCOUNT = account
 
 
 def get_token_path() -> Path:
-    return get_hermes_home() / "google_token.json"
+    """Token path for the active account.
+
+    Resolution: explicit ``--account`` (parsed in main()) → HERMES_GOOGLE_ACCOUNT
+    env → default account pointer → legacy ``~/.hermes/google_token.json``.
+    """
+    return google_account.resolve_token_path(_ACCOUNT)
 
 
 def _normalize_authorized_user_payload(payload: dict) -> dict:
@@ -78,7 +102,11 @@ def get_valid_token() -> str:
     """Return a valid access token, refreshing if needed."""
     token_path = get_token_path()
     if not token_path.exists():
-        print("ERROR: No Google token found. Run setup.py --auth-url first.", file=sys.stderr)
+        print(
+            f"ERROR: No Google token found at {token_path}. "
+            "Run setup.py --auth-url first.",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     token_data = json.loads(token_path.read_text())
@@ -93,17 +121,50 @@ def get_valid_token() -> str:
     return token_data["token"]
 
 
+def _split_account_arg(argv: list[str]) -> tuple["str | None", list[str]]:
+    """Strip a leading ``--account EMAIL`` (or ``--account=EMAIL``) from argv.
+
+    Anything after this is passed verbatim to gws. We do this manually rather
+    than with argparse because gws has its own arg syntax (subcommands,
+    positional flags) and we don't want to interpret it.
+    """
+    if not argv:
+        return None, argv
+    first = argv[0]
+    if first == "--account":
+        if len(argv) < 2:
+            print("ERROR: --account requires an email address.", file=sys.stderr)
+            sys.exit(2)
+        return argv[1], argv[2:]
+    if first.startswith("--account="):
+        return first.split("=", 1)[1], argv[1:]
+    return None, argv
+
+
 def main():
     """Refresh token if needed, then exec gws with remaining args."""
     if len(sys.argv) < 2:
-        print("Usage: gws_bridge.py <gws args...>", file=sys.stderr)
+        print("Usage: gws_bridge.py [--account EMAIL] <gws args...>", file=sys.stderr)
+        sys.exit(1)
+
+    account, gws_args = _split_account_arg(sys.argv[1:])
+    if account is not None:
+        try:
+            account = google_account.normalize_email(account)
+        except ValueError as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            sys.exit(2)
+    _set_active_account(account)
+
+    if not gws_args:
+        print("Usage: gws_bridge.py [--account EMAIL] <gws args...>", file=sys.stderr)
         sys.exit(1)
 
     access_token = get_valid_token()
     env = os.environ.copy()
     env["GOOGLE_WORKSPACE_CLI_TOKEN"] = access_token
 
-    result = subprocess.run(["gws"] + sys.argv[1:], env=env)
+    result = subprocess.run(["gws"] + gws_args, env=env)
     sys.exit(result.returncode)
 
 

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -4,21 +4,45 @@
 Fully non-interactive — designed to be driven by the agent via terminal commands.
 The agent mediates between this script and the user (works on CLI, Telegram, Discord, etc.)
 
-Commands:
+Single-account quickstart (default):
   setup.py --check                          # Is auth valid? Exit 0 = yes, 1 = no
   setup.py --client-secret /path/to.json    # Store OAuth client credentials
   setup.py --auth-url                       # Print the OAuth URL for user to visit
   setup.py --auth-code CODE                 # Exchange auth code for token
   setup.py --revoke                         # Revoke and delete stored token
-  setup.py --install-deps                   # Install Python dependencies only
 
-Agent workflow:
+Multi-account commands:
+  setup.py --account user@example.com --auth-url           # Start OAuth for a specific account
+  setup.py --account user@example.com --auth-code CODE     # Token saved per-account
+  setup.py --account user@example.com --check              # Check a specific account
+  setup.py --list-accounts                                 # Show known accounts + default
+  setup.py --set-default user@example.com                  # Pick the default account
+  setup.py --migrate-legacy                                # Move legacy single-account token into the new layout
+  setup.py --remove-account user@example.com               # Forget an account (revokes too)
+
+Resolution precedence when --account is omitted:
+  1. ``HERMES_GOOGLE_ACCOUNT`` environment variable
+  2. Default account pointer (set with ``--set-default``)
+  3. Legacy single-account file (``~/.hermes/google_token.json``) if present
+
+Backward compatibility:
+  After ``--migrate-legacy``, the legacy ``google_token.json`` becomes a symlink
+  pointing at the default account's per-account token. Cron jobs and any code
+  that reads ``google_token.json`` directly continue to work unchanged.
+
+Agent workflow (single account, fresh install):
   1. Run --check. If exit 0, auth is good — skip setup.
   2. Ask user for client_secret.json path. Run --client-secret PATH.
   3. Run --auth-url. Send the printed URL to the user.
   4. User opens URL, authorizes, gets redirected to a page with a code.
   5. User pastes the code. Agent runs --auth-code CODE.
   6. Run --check to verify. Done.
+
+Agent workflow (adding a second account):
+  1. Optionally run --migrate-legacy if there's an unmigrated legacy token.
+  2. Run --account second@example.com --auth-url
+  3. User authorizes; paste code into --account second@... --auth-code CODE.
+  4. Pick a default with --set-default <whichever-they-use-most>.
 """
 
 from __future__ import annotations  # allow PEP 604 `X | None` on Python 3.9+
@@ -30,17 +54,20 @@ import subprocess
 import sys
 from pathlib import Path
 
-# Ensure sibling modules (_hermes_home) are importable when run standalone.
+# Ensure sibling modules (_hermes_home, google_account) are importable when
+# run standalone.
 _SCRIPTS_DIR = str(Path(__file__).resolve().parent)
 if _SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, _SCRIPTS_DIR)
 
 from _hermes_home import display_hermes_home, get_hermes_home
+import google_account
 
 HERMES_HOME = get_hermes_home()
-TOKEN_PATH = HERMES_HOME / "google_token.json"
+# CLIENT_SECRET is shared across accounts — same OAuth client can authorize
+# multiple Google accounts. PENDING_AUTH is per-session (separate state for
+# concurrent OAuth flows).
 CLIENT_SECRET_PATH = HERMES_HOME / "google_client_secret.json"
-PENDING_AUTH_PATH = HERMES_HOME / "google_oauth_pending.json"
 
 SCOPES = [
     "https://www.googleapis.com/auth/gmail.readonly",
@@ -61,6 +88,27 @@ REQUIRED_PACKAGES = ["google-api-python-client", "google-auth-oauthlib", "google
 REDIRECT_URI = "http://localhost:1"
 
 
+def _resolved_token_path(account: str | None) -> Path:
+    """Token path for the resolved account.
+
+    When ``account`` is None, this falls back to ``HERMES_GOOGLE_ACCOUNT`` →
+    default pointer → legacy single-account path. See google_account module
+    for full details.
+    """
+    return google_account.resolve_token_path(account)
+
+
+def _pending_auth_path(account: str | None) -> Path:
+    """Per-account pending OAuth state. We key it on the resolved account so
+    two concurrent ``--auth-url`` flows for different accounts don't stomp
+    on each other. For the legacy unscoped flow we keep the original
+    filename."""
+    if account is None:
+        return HERMES_HOME / "google_oauth_pending.json"
+    norm = google_account.normalize_email(account)
+    return HERMES_HOME / "google_tokens" / f".pending-{norm}.json"
+
+
 def _normalize_authorized_user_payload(payload: dict) -> dict:
     normalized = dict(payload)
     if not normalized.get("type"):
@@ -68,7 +116,7 @@ def _normalize_authorized_user_payload(payload: dict) -> dict:
     return normalized
 
 
-def _load_token_payload(path: Path = TOKEN_PATH) -> dict:
+def _load_token_payload(path: Path) -> dict:
     try:
         return json.loads(path.read_text())
     except Exception:
@@ -130,16 +178,17 @@ def _ensure_deps():
             sys.exit(1)
 
 
-def check_auth_live():
+def check_auth_live(account: str | None = None):
     """Check auth with a real API call to detect disabled_client/account issues."""
     # quiet=True suppresses the "AUTHENTICATED" print from check_auth so the
     # final status line reflects the live-call outcome (OK or FAILED).
-    if not check_auth(quiet=True):
+    if not check_auth(account, quiet=True):
         return False
     try:
         from googleapiclient.discovery import build
         from google.oauth2.credentials import Credentials
-        creds = Credentials.from_authorized_user_file(str(TOKEN_PATH))
+        token_path = _resolved_token_path(account)
+        creds = Credentials.from_authorized_user_file(str(token_path))
         service = build("calendar", "v3", credentials=creds)
         service.calendarList().list(maxResults=1).execute()
         print("LIVE_CHECK_OK: Real API call succeeded.")
@@ -156,10 +205,11 @@ def check_auth_live():
         return False
 
 
-def check_auth(quiet: bool = False):
+def check_auth(account: str | None = None, quiet: bool = False):
     """Check if stored credentials are valid. Prints status, exits 0 or 1."""
-    if not TOKEN_PATH.exists():
-        print(f"NOT_AUTHENTICATED: No token at {TOKEN_PATH}")
+    token_path = _resolved_token_path(account)
+    if not token_path.exists():
+        print(f"NOT_AUTHENTICATED: No token at {token_path}")
         return False
 
     _ensure_deps()
@@ -171,12 +221,12 @@ def check_auth(quiet: bool = False):
         # Passing scopes forces google-auth to validate them on refresh,
         # which fails with invalid_scope if the token has fewer scopes
         # than requested.
-        creds = Credentials.from_authorized_user_file(str(TOKEN_PATH))
+        creds = Credentials.from_authorized_user_file(str(token_path))
     except Exception as e:
         print(f"TOKEN_CORRUPT: {e}")
         return False
 
-    payload = _load_token_payload(TOKEN_PATH)
+    payload = _load_token_payload(token_path)
     if creds.valid:
         missing_scopes = _missing_scopes_from_payload(payload)
         if missing_scopes:
@@ -184,25 +234,25 @@ def check_auth(quiet: bool = False):
             for s in missing_scopes:
                 print(f"  - {s}")
         if not quiet:
-            print(f"AUTHENTICATED: Token valid at {TOKEN_PATH}")
+            print(f"AUTHENTICATED: Token valid at {token_path}")
         return True
 
     if creds.expired and creds.refresh_token:
         try:
             creds.refresh(Request())
-            TOKEN_PATH.write_text(
+            token_path.write_text(
                 json.dumps(
                     _normalize_authorized_user_payload(json.loads(creds.to_json())),
                     indent=2,
                 )
             )
-            missing_scopes = _missing_scopes_from_payload(_load_token_payload(TOKEN_PATH))
+            missing_scopes = _missing_scopes_from_payload(_load_token_payload(token_path))
             if missing_scopes:
                 print(f"AUTHENTICATED (partial): Token refreshed but missing {len(missing_scopes)} scopes:")
                 for s in missing_scopes:
                     print(f"  - {s}")
             if not quiet:
-                print(f"AUTHENTICATED: Token refreshed at {TOKEN_PATH}")
+                print(f"AUTHENTICATED: Token refreshed at {token_path}")
             return True
         except Exception as e:
             err_str = str(e).lower()
@@ -248,28 +298,32 @@ def store_client_secret(path: str):
     print(f"OK: Client secret saved to {CLIENT_SECRET_PATH}")
 
 
-def _save_pending_auth(*, state: str, code_verifier: str):
+def _save_pending_auth(*, account: str | None, state: str, code_verifier: str):
     """Persist the OAuth session bits needed for a later token exchange."""
-    PENDING_AUTH_PATH.write_text(
+    pending_path = _pending_auth_path(account)
+    pending_path.parent.mkdir(parents=True, exist_ok=True)
+    pending_path.write_text(
         json.dumps(
             {
                 "state": state,
                 "code_verifier": code_verifier,
                 "redirect_uri": REDIRECT_URI,
+                "account": google_account.normalize_email(account) if account else None,
             },
             indent=2,
         )
     )
 
 
-def _load_pending_auth() -> dict:
+def _load_pending_auth(account: str | None) -> dict:
     """Load the pending OAuth session created by get_auth_url()."""
-    if not PENDING_AUTH_PATH.exists():
+    pending_path = _pending_auth_path(account)
+    if not pending_path.exists():
         print("ERROR: No pending OAuth session found. Run --auth-url first.")
         sys.exit(1)
 
     try:
-        data = json.loads(PENDING_AUTH_PATH.read_text())
+        data = json.loads(pending_path.read_text())
     except Exception as e:
         print(f"ERROR: Could not read pending OAuth session: {e}")
         print("Run --auth-url again to start a fresh OAuth session.")
@@ -300,8 +354,13 @@ def _extract_code_and_state(code_or_url: str) -> tuple[str, str | None]:
     return params["code"][0], state
 
 
-def get_auth_url():
-    """Print the OAuth authorization URL. User visits this in a browser."""
+def get_auth_url(account: str | None = None):
+    """Print the OAuth authorization URL. User visits this in a browser.
+
+    When ``account`` is provided, we hint Google to pre-select that account
+    via ``login_hint``. This means the consent screen suggests the right
+    account but the user still controls which one they ultimately authorize
+    (you can't force a specific account without admin policy)."""
     if not CLIENT_SECRET_PATH.exists():
         print("ERROR: No client secret stored. Run --client-secret first.")
         sys.exit(1)
@@ -315,22 +374,26 @@ def get_auth_url():
         redirect_uri=REDIRECT_URI,
         autogenerate_code_verifier=True,
     )
-    auth_url, state = flow.authorization_url(
-        access_type="offline",
-        prompt="consent",
-    )
-    _save_pending_auth(state=state, code_verifier=flow.code_verifier)
+    auth_kwargs = {
+        "access_type": "offline",
+        "prompt": "consent",
+    }
+    if account:
+        # login_hint = pre-fill the email picker. User can override.
+        auth_kwargs["login_hint"] = google_account.normalize_email(account)
+    auth_url, state = flow.authorization_url(**auth_kwargs)
+    _save_pending_auth(account=account, state=state, code_verifier=flow.code_verifier)
     # Print just the URL so the agent can extract it cleanly
     print(auth_url)
 
 
-def exchange_auth_code(code: str):
+def exchange_auth_code(code: str, account: str | None = None):
     """Exchange the authorization code for a token and save it."""
     if not CLIENT_SECRET_PATH.exists():
         print("ERROR: No client secret stored. Run --client-secret first.")
         sys.exit(1)
 
-    pending_auth = _load_pending_auth()
+    pending_auth = _load_pending_auth(account)
     raw_callback = code
     code, returned_state = _extract_code_and_state(code)
     if returned_state and returned_state != pending_auth["state"]:
@@ -384,15 +447,63 @@ def exchange_auth_code(code: str):
         print(f"WARNING: Token missing some Google Workspace scopes: {', '.join(missing_scopes)}")
         print("Some services may not be available.")
 
-    TOKEN_PATH.write_text(json.dumps(token_payload, indent=2))
-    PENDING_AUTH_PATH.unlink(missing_ok=True)
-    print(f"OK: Authenticated. Token saved to {TOKEN_PATH}")
-    print(f"Profile-scoped token location: {display_hermes_home()}/google_token.json")
+    # Determine where to save:
+    #  * If --account was passed, derive the email from the token and refuse
+    #    if it doesn't match (authorization went to a different account than
+    #    the user said they wanted).
+    #  * Otherwise, derive the email and store per-account; only fall back to
+    #    the legacy file if derivation fails entirely.
+    derived = google_account.derive_email_from_token(token_payload)
+    requested = google_account.normalize_email(account) if account else None
+
+    if requested and derived and requested != derived:
+        print(
+            f"ERROR: --account was {requested} but the OAuth flow authorized {derived}."
+        )
+        print("  The user picked a different Google account in the consent screen.")
+        print(f"  Re-run --account {derived} --auth-url, or pick the right account in the browser.")
+        sys.exit(1)
+
+    final_account = requested or derived
+
+    # Embed the email on the token payload (helps downstream tooling & makes
+    # accounts self-identifying without a network call).
+    if final_account:
+        token_payload["email"] = final_account
+
+    if final_account:
+        target = google_account.store_token_for_account(final_account, token_payload)
+        # If this is the first account, mark it as the default so backward-compat
+        # readers (legacy google_token.json symlink) just work.
+        if google_account.get_default_account() is None:
+            try:
+                google_account.set_default_account(final_account)
+            except Exception:
+                pass
+        print(f"OK: Authenticated as {final_account}. Token saved to {target}")
+    else:
+        # Couldn't determine the email and no --account was specified — fall
+        # back to the legacy single-account file so first-time setups still work.
+        legacy = google_account.legacy_token_path()
+        legacy.write_text(json.dumps(token_payload, indent=2))
+        print("WARNING: Could not determine the Google account email for this token.")
+        print(f"OK: Authenticated. Token saved to {legacy}")
+        print("Run --migrate-legacy after setup to move it into the multi-account layout.")
+
+    _pending_auth_path(account).unlink(missing_ok=True)
+    print(f"Profile-scoped token location: {display_hermes_home()}/google_tokens/")
 
 
-def revoke():
-    """Revoke stored token and delete it."""
-    if not TOKEN_PATH.exists():
+def revoke(account: str | None = None):
+    """Revoke stored token and delete it.
+
+    When ``--account EMAIL`` is given we revoke that account's token only.
+    Without it we revoke whichever token resolves via the precedence chain
+    (env → default → legacy) — i.e. the one a plain ``setup.py --check``
+    would use.
+    """
+    token_path = _resolved_token_path(account)
+    if not token_path.exists():
         print("No token to revoke.")
         return
 
@@ -401,14 +512,14 @@ def revoke():
     from google.auth.transport.requests import Request
 
     try:
-        creds = Credentials.from_authorized_user_file(str(TOKEN_PATH), SCOPES)
+        creds = Credentials.from_authorized_user_file(str(token_path), SCOPES)
         if creds.expired and creds.refresh_token:
             creds.refresh(Request())
 
         import urllib.request
         urllib.request.urlopen(
             urllib.request.Request(
-                f"https://oauth2.googleapis.com/revoke?token={creds.token}",
+                "https://oauth2.googleapis.com/revoke?token=" + creds.token,
                 method="POST",
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
             ),
@@ -418,13 +529,130 @@ def revoke():
     except Exception as e:
         print(f"Remote revocation failed (token may already be invalid): {e}")
 
-    TOKEN_PATH.unlink(missing_ok=True)
-    PENDING_AUTH_PATH.unlink(missing_ok=True)
-    print(f"Deleted {TOKEN_PATH}")
+    # If we're deleting the legacy file directly (un-migrated install), also
+    # remove the legacy pending session file.
+    if token_path == google_account.legacy_token_path():
+        (HERMES_HOME / "google_oauth_pending.json").unlink(missing_ok=True)
+
+    # If this token was the default-account target, refresh the legacy
+    # symlink so we don't leave a broken link behind.
+    legacy = google_account.legacy_token_path()
+    legacy_resolves_to_us = (
+        legacy.is_symlink()
+        and Path(os.readlink(legacy)) == token_path
+    )
+
+    token_path.unlink(missing_ok=True)
+    print(f"Deleted {token_path}")
+
+    if legacy_resolves_to_us:
+        legacy.unlink(missing_ok=True)
+        print(f"Removed legacy symlink {legacy}")
+        # Pick a new default if any accounts remain.
+        remaining = google_account.list_accounts()
+        if remaining:
+            try:
+                google_account.set_default_account(remaining[0])
+                print(f"Set new default account: {remaining[0]}")
+            except Exception:
+                pass
+
+
+def list_accounts_cmd():
+    """Print known accounts and the default."""
+    accounts = google_account.list_accounts()
+    default = google_account.get_default_account()
+    legacy = google_account.legacy_token_path()
+    legacy_unmigrated = legacy.exists() and not legacy.is_symlink()
+
+    if not accounts and not legacy_unmigrated:
+        print("No Google accounts configured.")
+        print("Run --client-secret then --auth-url to set up your first account.")
+        return
+
+    print("Configured accounts:")
+    for email in accounts:
+        marker = "  * " if email == default else "    "
+        print(f"{marker}{email}")
+    if default:
+        print(f"\nDefault: {default}")
+    if legacy_unmigrated:
+        print(
+            "\nUnmigrated legacy token at "
+            f"{legacy}.\n"
+            "Run --migrate-legacy to move it into the multi-account layout."
+        )
+
+
+def set_default_cmd(email: str):
+    """Mark ``email`` as the default account."""
+    try:
+        google_account.set_default_account(email)
+    except FileNotFoundError as e:
+        print(f"ERROR: {e}")
+        sys.exit(1)
+    except ValueError as e:
+        print(f"ERROR: {e}")
+        sys.exit(1)
+    norm = google_account.normalize_email(email)
+    print(f"OK: Default account set to {norm}.")
+    print(f"Legacy symlink {google_account.legacy_token_path()} now points at this account.")
+
+
+def migrate_legacy_cmd():
+    """Move the legacy single-account token into the multi-account layout."""
+    legacy = google_account.legacy_token_path()
+    if legacy.is_symlink():
+        target = legacy.resolve()
+        print(f"Already migrated: {legacy} -> {target}")
+        return
+    if not legacy.exists():
+        print("Nothing to migrate (no legacy google_token.json).")
+        return
+
+    payload = _load_token_payload(legacy)
+    if not payload:
+        print("ERROR: Legacy token file is unreadable. Re-run setup from scratch.")
+        sys.exit(1)
+
+    email = google_account.derive_email_from_token(payload)
+    if not email:
+        print(
+            "ERROR: Could not determine which Google account this legacy token belongs to.\n"
+            "  Network call to Google's tokeninfo/userinfo endpoints failed.\n"
+            "  Either re-authenticate with --auth-url, or check your network and retry."
+        )
+        sys.exit(1)
+
+    payload["email"] = email
+    target = google_account.store_token_for_account(email, payload)
+    legacy.unlink()
+    google_account.set_default_account(email)  # rebuilds the symlink
+    print(f"OK: Migrated legacy token -> {target}")
+    print(f"Default account set to {email}.")
+    print(f"Legacy symlink {legacy} now points at the new location.")
+
+
+def remove_account_cmd(email: str):
+    """Forget an account: revoke its token and delete the per-account file."""
+    norm = google_account.normalize_email(email)
+    target = google_account.token_path_for(norm)
+    if not target.exists():
+        print(f"No token for {norm}.")
+        return
+    revoke(norm)
 
 
 def main():
     parser = argparse.ArgumentParser(description="Google Workspace OAuth setup for Hermes")
+    parser.add_argument(
+        "--account",
+        metavar="EMAIL",
+        default=None,
+        help="Operate on a specific Google account (multi-account setups). "
+        "If omitted, falls back to HERMES_GOOGLE_ACCOUNT env, then the "
+        "default-account pointer, then the legacy single-account token.",
+    )
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--check", action="store_true", help="Check if auth is valid (exit 0=yes, 1=no)")
     group.add_argument("--check-live", action="store_true", help="Check auth with a real API call (detects disabled_client)")
@@ -433,22 +661,43 @@ def main():
     group.add_argument("--auth-code", metavar="CODE", help="Exchange auth code for token")
     group.add_argument("--revoke", action="store_true", help="Revoke and delete stored token")
     group.add_argument("--install-deps", action="store_true", help="Install Python dependencies")
+    group.add_argument("--list-accounts", action="store_true", help="List configured Google accounts and the default")
+    group.add_argument("--set-default", metavar="EMAIL", help="Set the default Google account")
+    group.add_argument("--migrate-legacy", action="store_true", help="Migrate legacy single-account token into the multi-account layout")
+    group.add_argument("--remove-account", metavar="EMAIL", help="Revoke and forget an account")
     args = parser.parse_args()
 
+    # Validate --account early so weird strings fail fast.
+    account = args.account
+    if account is not None:
+        try:
+            account = google_account.normalize_email(account)
+        except ValueError as e:
+            print(f"ERROR: {e}")
+            sys.exit(1)
+
     if args.check:
-        sys.exit(0 if check_auth() else 1)
+        sys.exit(0 if check_auth(account) else 1)
     if getattr(args, "check_live", False):
-        sys.exit(0 if check_auth_live() else 1)
+        sys.exit(0 if check_auth_live(account) else 1)
     elif args.client_secret:
         store_client_secret(args.client_secret)
     elif args.auth_url:
-        get_auth_url()
+        get_auth_url(account)
     elif args.auth_code:
-        exchange_auth_code(args.auth_code)
+        exchange_auth_code(args.auth_code, account)
     elif args.revoke:
-        revoke()
+        revoke(account)
     elif args.install_deps:
         sys.exit(0 if install_deps() else 1)
+    elif args.list_accounts:
+        list_accounts_cmd()
+    elif args.set_default:
+        set_default_cmd(args.set_default)
+    elif args.migrate_legacy:
+        migrate_legacy_cmd()
+    elif args.remove_account:
+        remove_account_cmd(args.remove_account)
 
 
 if __name__ == "__main__":

--- a/tests/skills/test_google_oauth_setup.py
+++ b/tests/skills/test_google_oauth_setup.py
@@ -110,15 +110,34 @@ def setup_module(monkeypatch, tmp_path):
     monkeypatch.setitem(sys.modules, "google_auth_oauthlib", google_auth_module)
     monkeypatch.setitem(sys.modules, "google_auth_oauthlib.flow", flow_module)
 
+    # Point HERMES_HOME at a per-test tmpdir so the script's path constants
+    # (CLIENT_SECRET_PATH, the resolved token paths, pending-auth paths) all
+    # land under tmp_path. This mirrors how the script runs in the wild.
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_GOOGLE_ACCOUNT", raising=False)
+    monkeypatch.delenv("_HERMES_GOOGLE_ACCOUNT_OVERRIDE", raising=False)
+
+    # google_account caches HERMES_HOME at import time (via get_hermes_home()),
+    # so we have to reload it after the env tweak.
+    sys.modules.pop("google_account", None)
+
     spec = importlib.util.spec_from_file_location("google_workspace_setup_test", SCRIPT_PATH)
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
     spec.loader.exec_module(module)
 
     monkeypatch.setattr(module, "_ensure_deps", lambda: None)
+    # CLIENT_SECRET_PATH is captured at import time; re-bind it under tmp_path
+    # to be safe even if HERMES_HOME indirection ever changes.
     monkeypatch.setattr(module, "CLIENT_SECRET_PATH", tmp_path / "google_client_secret.json")
-    monkeypatch.setattr(module, "TOKEN_PATH", tmp_path / "google_token.json")
-    monkeypatch.setattr(module, "PENDING_AUTH_PATH", tmp_path / "google_oauth_pending.json", raising=False)
+    # Provide TOKEN_PATH / PENDING_AUTH_PATH attribute shims pointing at the
+    # legacy single-account file. The legacy flow (account=None) still reads
+    # and writes these exact paths, so the existing test assertions remain
+    # valid against the new resolution code.
+    legacy_token = tmp_path / "google_token.json"
+    legacy_pending = tmp_path / "google_oauth_pending.json"
+    monkeypatch.setattr(module, "TOKEN_PATH", legacy_token, raising=False)
+    monkeypatch.setattr(module, "PENDING_AUTH_PATH", legacy_pending, raising=False)
 
     client_secret = {
         "installed": {

--- a/tests/skills/test_google_workspace_multi_account.py
+++ b/tests/skills/test_google_workspace_multi_account.py
@@ -1,0 +1,401 @@
+"""Tests for multi-account Google Workspace support.
+
+Covers:
+- Account email normalization (rejects path traversal, lowercases, etc.)
+- Token path resolution chain: explicit > env > default > legacy
+- list_accounts / get_default_account / set_default_account
+- Legacy symlink updates when default changes
+- gws_bridge.py honors --account flag
+- google_api.py --account flag overrides env
+- setup.py refuses to save token when authorized account doesn't match
+  the requested --account
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPTS_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "skills/productivity/google-workspace/scripts"
+)
+ACCOUNT_PATH = SCRIPTS_DIR / "google_account.py"
+BRIDGE_PATH = SCRIPTS_DIR / "gws_bridge.py"
+API_PATH = SCRIPTS_DIR / "google_api.py"
+SETUP_PATH = SCRIPTS_DIR / "setup.py"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    # Make scripts/ importable so the script can do `import google_account`
+    if str(SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS_DIR))
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def hermes_home(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_GOOGLE_ACCOUNT", raising=False)
+    monkeypatch.delenv("_HERMES_GOOGLE_ACCOUNT_OVERRIDE", raising=False)
+    # Reset module cache so each test gets a fresh google_account bound to
+    # the per-test HERMES_HOME (the module reads the env at function-call
+    # time, so reload isn't strictly necessary, but it keeps state clean).
+    for name in (
+        "google_account",
+        "gws_bridge_test",
+        "gws_api_test",
+        "gws_setup_test",
+    ):
+        sys.modules.pop(name, None)
+    return home
+
+
+@pytest.fixture
+def account_module(hermes_home):
+    return _load_module("google_account", ACCOUNT_PATH)
+
+
+def _write_token(path: Path, *, email: str | None = None, token: str = "ya29.test"):
+    payload = {
+        "token": token,
+        "refresh_token": "1//refresh",
+        "client_id": "123.apps.googleusercontent.com",
+        "client_secret": "secret",
+        "token_uri": "https://oauth2.googleapis.com/token",
+    }
+    if email is not None:
+        payload["email"] = email
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload))
+
+
+# ---------------------------------------------------------------------------
+# google_account.normalize_email
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeEmail:
+    def test_lowercases_and_strips(self, account_module):
+        assert account_module.normalize_email("  USER@Example.COM  ") == "user@example.com"
+
+    def test_accepts_plus_addressing(self, account_module):
+        assert (
+            account_module.normalize_email("user+tag@example.com")
+            == "user+tag@example.com"
+        )
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "",
+            "   ",
+            "no-at-sign",
+            "two@@example.com",
+            "trailing@",
+            "@leading.com",
+            "../etc/passwd",
+            "user@",
+            "user@host",  # no TLD
+            "user@example.com/../other",
+            "user/@example.com",
+        ],
+    )
+    def test_rejects_invalid(self, account_module, bad):
+        with pytest.raises(ValueError):
+            account_module.normalize_email(bad)
+
+
+# ---------------------------------------------------------------------------
+# Resolution chain: explicit > env > default > legacy
+# ---------------------------------------------------------------------------
+
+
+class TestResolveAccount:
+    def test_explicit_wins(self, account_module, monkeypatch, hermes_home):
+        # Even with env set AND default set, explicit beats both.
+        _write_token(account_module.token_path_for("env@example.com"))
+        _write_token(account_module.token_path_for("default@example.com"))
+        _write_token(account_module.token_path_for("explicit@example.com"))
+        account_module.set_default_account("default@example.com")
+        monkeypatch.setenv("HERMES_GOOGLE_ACCOUNT", "env@example.com")
+
+        assert (
+            account_module.resolve_account("explicit@example.com")
+            == "explicit@example.com"
+        )
+
+    def test_env_beats_default(self, account_module, monkeypatch, hermes_home):
+        _write_token(account_module.token_path_for("env@example.com"))
+        _write_token(account_module.token_path_for("default@example.com"))
+        account_module.set_default_account("default@example.com")
+        monkeypatch.setenv("HERMES_GOOGLE_ACCOUNT", "env@example.com")
+
+        assert account_module.resolve_account() == "env@example.com"
+
+    def test_default_used_when_no_env_or_explicit(
+        self, account_module, hermes_home
+    ):
+        _write_token(account_module.token_path_for("default@example.com"))
+        account_module.set_default_account("default@example.com")
+
+        assert account_module.resolve_account() == "default@example.com"
+
+    def test_single_account_implicit_default(self, account_module, hermes_home):
+        # If there's only one account and no explicit default pointer, it's the default.
+        _write_token(account_module.token_path_for("only@example.com"))
+
+        assert account_module.get_default_account() == "only@example.com"
+
+    def test_no_account_returns_none(self, account_module, hermes_home):
+        assert account_module.resolve_account() is None
+
+    def test_legacy_fallback_when_no_account_resolves(
+        self, account_module, hermes_home
+    ):
+        # No accounts in google_tokens/, no env, no default.
+        # resolve_token_path() should hand back the legacy path so single-account
+        # installs work unchanged.
+        legacy = account_module.legacy_token_path()
+        _write_token(legacy)
+
+        path = account_module.resolve_token_path()
+        assert path == legacy
+
+
+# ---------------------------------------------------------------------------
+# list_accounts / set_default_account / legacy symlink
+# ---------------------------------------------------------------------------
+
+
+class TestAccountManagement:
+    def test_list_accounts_filters_junk_files(self, account_module, hermes_home):
+        d = account_module.tokens_dir()
+        d.mkdir()
+        _write_token(d / "user@example.com.json")
+        _write_token(d / "other@example.com.json")
+        # Junk files that should be ignored.
+        (d / "default").write_text("user@example.com\n")
+        (d / "not-an-email.json").write_text("{}")
+        (d / "subdir").mkdir()
+        (d / "README.md").write_text("ignored")
+
+        result = account_module.list_accounts()
+        assert result == ["other@example.com", "user@example.com"]
+
+    def test_set_default_creates_legacy_symlink(self, account_module, hermes_home):
+        _write_token(account_module.token_path_for("alice@example.com"))
+        account_module.set_default_account("alice@example.com")
+
+        legacy = account_module.legacy_token_path()
+        assert legacy.is_symlink()
+        assert legacy.resolve() == account_module.token_path_for(
+            "alice@example.com"
+        ).resolve()
+
+    def test_set_default_replaces_existing_symlink(
+        self, account_module, hermes_home
+    ):
+        _write_token(account_module.token_path_for("a@example.com"))
+        _write_token(account_module.token_path_for("b@example.com"))
+        account_module.set_default_account("a@example.com")
+        account_module.set_default_account("b@example.com")
+
+        legacy = account_module.legacy_token_path()
+        assert legacy.is_symlink()
+        assert legacy.resolve() == account_module.token_path_for(
+            "b@example.com"
+        ).resolve()
+
+    def test_set_default_does_not_clobber_real_legacy_file(
+        self, account_module, hermes_home
+    ):
+        # If the legacy path is a regular file (un-migrated install), we
+        # should not replace it with a symlink — the user hasn't agreed to
+        # migrate yet.
+        legacy = account_module.legacy_token_path()
+        _write_token(legacy)
+        original_contents = legacy.read_text()
+
+        _write_token(account_module.token_path_for("alice@example.com"))
+        account_module.set_default_account("alice@example.com")
+
+        # Default pointer was set, but legacy file is untouched.
+        assert account_module.get_default_account() == "alice@example.com"
+        assert not legacy.is_symlink()
+        assert legacy.read_text() == original_contents
+
+    def test_set_default_rejects_unknown_account(self, account_module, hermes_home):
+        with pytest.raises(FileNotFoundError):
+            account_module.set_default_account("unknown@example.com")
+
+    def test_normalize_in_token_path_for(self, account_module, hermes_home):
+        # Mixed case input should still resolve to a single canonical file.
+        p1 = account_module.token_path_for("USER@Example.COM")
+        p2 = account_module.token_path_for("user@example.com")
+        assert p1 == p2
+        assert p1.name == "user@example.com.json"
+
+
+# ---------------------------------------------------------------------------
+# gws_bridge.py: --account flag plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestBridgeAccountFlag:
+    def test_split_account_strips_flag(self, hermes_home):
+        bridge = _load_module("gws_bridge_test", BRIDGE_PATH)
+
+        account, rest = bridge._split_account_arg(
+            ["--account", "user@example.com", "gmail", "+triage"]
+        )
+        assert account == "user@example.com"
+        assert rest == ["gmail", "+triage"]
+
+    def test_split_account_equals_form(self, hermes_home):
+        bridge = _load_module("gws_bridge_test", BRIDGE_PATH)
+
+        account, rest = bridge._split_account_arg(
+            ["--account=user@example.com", "gmail"]
+        )
+        assert account == "user@example.com"
+        assert rest == ["gmail"]
+
+    def test_split_account_absent(self, hermes_home):
+        bridge = _load_module("gws_bridge_test", BRIDGE_PATH)
+
+        account, rest = bridge._split_account_arg(["gmail", "+triage"])
+        assert account is None
+        assert rest == ["gmail", "+triage"]
+
+    def test_split_account_missing_value_exits(self, hermes_home):
+        bridge = _load_module("gws_bridge_test", BRIDGE_PATH)
+
+        with pytest.raises(SystemExit):
+            bridge._split_account_arg(["--account"])
+
+    def test_get_token_path_honors_active_account(self, hermes_home):
+        bridge = _load_module("gws_bridge_test", BRIDGE_PATH)
+        account_module = _load_module("google_account", ACCOUNT_PATH)
+
+        _write_token(account_module.token_path_for("a@example.com"))
+        _write_token(account_module.token_path_for("b@example.com"))
+
+        bridge._set_active_account("a@example.com")
+        assert bridge.get_token_path() == account_module.token_path_for(
+            "a@example.com"
+        )
+
+        bridge._set_active_account("b@example.com")
+        assert bridge.get_token_path() == account_module.token_path_for(
+            "b@example.com"
+        )
+
+    def test_bridge_falls_back_to_legacy_token_when_no_account(self, hermes_home):
+        bridge = _load_module("gws_bridge_test", BRIDGE_PATH)
+        account_module = _load_module("google_account", ACCOUNT_PATH)
+
+        legacy = account_module.legacy_token_path()
+        _write_token(legacy)
+        bridge._set_active_account(None)
+
+        assert bridge.get_token_path() == legacy
+
+
+# ---------------------------------------------------------------------------
+# google_api.py: --account flag plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestApiAccountFlag:
+    def test_resolve_token_path_uses_override(self, hermes_home, monkeypatch):
+        api = _load_module("gws_api_test", API_PATH)
+        account_module = _load_module("google_account", ACCOUNT_PATH)
+
+        _write_token(account_module.token_path_for("a@example.com"))
+        monkeypatch.setenv("_HERMES_GOOGLE_ACCOUNT_OVERRIDE", "a@example.com")
+
+        assert api._resolve_token_path() == account_module.token_path_for(
+            "a@example.com"
+        )
+
+    def test_override_beats_hermes_google_account_env(
+        self, hermes_home, monkeypatch
+    ):
+        api = _load_module("gws_api_test", API_PATH)
+        account_module = _load_module("google_account", ACCOUNT_PATH)
+
+        _write_token(account_module.token_path_for("explicit@example.com"))
+        _write_token(account_module.token_path_for("env@example.com"))
+        monkeypatch.setenv("HERMES_GOOGLE_ACCOUNT", "env@example.com")
+        monkeypatch.setenv(
+            "_HERMES_GOOGLE_ACCOUNT_OVERRIDE", "explicit@example.com"
+        )
+
+        assert api._resolve_token_path() == account_module.token_path_for(
+            "explicit@example.com"
+        )
+
+    def test_falls_back_to_legacy_when_no_override_or_env(self, hermes_home):
+        api = _load_module("gws_api_test", API_PATH)
+        account_module = _load_module("google_account", ACCOUNT_PATH)
+
+        legacy = account_module.legacy_token_path()
+        _write_token(legacy)
+
+        assert api._resolve_token_path() == legacy
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility: existing single-account installs are untouched
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardCompatibility:
+    def test_single_account_install_works_without_migration(
+        self, hermes_home, monkeypatch
+    ):
+        """The whole point of this PR's backward-compat story: an install with
+        only ``google_token.json`` and no ``google_tokens/`` directory must
+        keep working with no behavior change."""
+        api = _load_module("gws_api_test", API_PATH)
+        account_module = _load_module("google_account", ACCOUNT_PATH)
+        bridge = _load_module("gws_bridge_test", BRIDGE_PATH)
+
+        legacy = account_module.legacy_token_path()
+        _write_token(legacy)
+
+        # No env, no override, no migration.
+        assert api._resolve_token_path() == legacy
+        assert account_module.resolve_token_path() == legacy
+
+        bridge._set_active_account(None)
+        assert bridge.get_token_path() == legacy
+
+    def test_legacy_symlink_resolves_to_default_after_migration(
+        self, hermes_home
+    ):
+        """After migration the legacy path still works because it's a symlink."""
+        account_module = _load_module("google_account", ACCOUNT_PATH)
+
+        legacy = account_module.legacy_token_path()
+        # Simulate "migrated" state: legacy is a symlink to a per-account file.
+        target = account_module.token_path_for("alice@example.com")
+        _write_token(target)
+        account_module.set_default_account("alice@example.com")
+
+        assert legacy.is_symlink()
+        # Reading the legacy path returns the per-account token contents.
+        assert json.loads(legacy.read_text())["refresh_token"] == "1//refresh"


### PR DESCRIPTION
Fixes #15602.

## What

Adds multi-Google-account support to the `google-workspace` skill, so a single Hermes install can authenticate and use multiple Gmail / Workspace accounts (personal + work, etc.).

Backward compatible — existing single-account users see no behavior change.

## Why

The skill currently hardcodes a single token at `~/.hermes/google_token.json`. Anyone with more than one Google account (which, realistically, is most of us) has to either pick one and forfeit the others, or stand up a separate Hermes profile per account — which is overkill since profiles isolate the entire `~/.hermes/` tree.

Issue #15602 has been open with multiple +1s and no PR. Spec'd to roughly match the design proposed there.

## Design

- Per-account tokens at `~/.hermes/google_tokens/<email>.json` (mode 0600, dir 0700).
- Default-account pointer at `~/.hermes/google_tokens/default`.
- Resolution chain: explicit `--account` flag → `HERMES_GOOGLE_ACCOUNT` env var → default-account pointer → legacy `~/.hermes/google_token.json` fallback.
- `--migrate-legacy` moves a legacy single-account token into the new layout and replaces the old path with a symlink, so existing cron jobs / `GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE` references / any integration referencing the old path keeps working untouched.

The legacy token doesn't store the owning email, so migration auto-derives it via a five-step fallback chain (token payload `email` field → `id_token` JWT claims → `tokeninfo` → `userinfo` → Gmail `users.me/profile`). The Gmail-profile fallback specifically handles legacy tokens that were granted gmail scopes but never `openid` / `userinfo.email` (which is the most common case for tokens that predate this change).

## CLI surface

`setup.py`:

- Adds `--account EMAIL` to every existing flow (`--auth-url`, `--auth-code`, `--check`, `--check-live`, `--revoke`, `--client-secret`).
- New: `--list-accounts`, `--set-default EMAIL`, `--migrate-legacy`, `--remove-account EMAIL`.

`google_api.py` and `gws_bridge.py`:

- Global `--account EMAIL` flag.

All flags optional — omitting them falls through the resolution chain so single-account users don't have to type `--account` ever.

## Tests

- New `tests/skills/test_google_workspace_multi_account.py` — 36 tests covering token path resolution, account listing, default set/get/clear, legacy migration, normalize_email rejection, env-var override, and CLI plumbing.
- Updated `tests/skills/test_google_oauth_setup.py` for the new module layout.
- 64/64 google-workspace tests pass.
- 224/224 broader skills tests pass.

## Verified end-to-end

On two real accounts on my machine:

1. Legacy token migrated to `~/.hermes/google_tokens/<email>.json`, symlink at the old path.
2. Second account OAuthed cleanly via `setup.py --account 234@gmail.com --auth-url` then `--auth-code`.
3. `google_api.py --account 123@gmail.com gmail labels` and the same with `234@gmail.com` both return distinct, correct data.
4. `calendar list` returns 3 events for one account, 0 for the other (matches reality).
5. `HERMES_GOOGLE_ACCOUNT=...` env-var override works.
6. Default-account fallback works when neither flag nor env are set.

## Backward-compat notes

- Existing users with `~/.hermes/google_token.json` and no `google_tokens/` dir get the legacy fallback, identical behavior to before.
- After running `--migrate-legacy`, the old path becomes a symlink to the new file, so any external code reading the old path keeps working.
- All existing test fixtures that monkeypatched `setup.TOKEN_PATH` were updated to use `HERMES_HOME` instead — `TOKEN_PATH` is no longer a module constant since paths are now per-call resolved.

## SKILL.md

Updated with multi-account flows, env var, default-account pointer, and `--account` on every command. Bumped skill version to 1.1.0.

---

Happy to iterate on naming (`--account` vs `--user` vs `--profile`), the token-dir location (`~/.hermes/google_tokens/` vs nested under e.g. `~/.hermes/credentials/google/`), or anything else. The shape of the resolution chain seemed the most contentious thing in the issue thread, so explicit-flag-wins-over-env-wins-over-default-wins-over-legacy-fallback is what I went with — open to alternatives.
