### PR TITLE
fix: persist last_run_at and completed_count in cron fast-forward path

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -9,6 +9,7 @@ import copy
 import json
 import logging
 import shutil
+import time
 import tempfile
 import threading
 import os
@@ -449,6 +450,38 @@ def save_jobs(jobs: List[Dict[str, Any]]):
         raise
 
 
+def _save_jobs_with_retry(jobs: List[Dict[str, Any]], job_id: str,
+                          max_retries: int = 3, base_delay: float = 0.05):
+    """Persist jobs with exponential backoff on transient IO failures.
+
+    On terminal failure logs an ERROR containing the job_id and timestamp.
+    """
+    last_exception: Exception = RuntimeError("save_jobs_with_retry invoked without attempting save")
+    for attempt in range(max_retries + 1):
+        try:
+            save_jobs(jobs)
+            return
+        except (OSError, IOError) as exc:
+            last_exception = exc
+            if attempt < max_retries:
+                delay = base_delay * (2 ** attempt)
+                logger.warning(
+                    "save_jobs failed for job '%s' (attempt %d/%d): %s — "
+                    "retrying in %.3fs",
+                    job_id, attempt + 1, max_retries + 1, exc, delay,
+                )
+                time.sleep(delay)
+            else:
+                break
+    # Terminal failure — all retries exhausted
+    now = _hermes_now().isoformat()
+    logger.error(
+        "Terminal failure persisting job state for '%s' at %s: %s",
+        job_id, now, last_exception,
+    )
+    raise last_exception
+
+
 def _normalize_workdir(workdir: Optional[str]) -> Optional[str]:
     """Normalize and validate a cron job workdir.
 
@@ -886,7 +919,7 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                     if times is not None and times > 0 and completed >= times:
                         # Remove the job (limit reached)
                         jobs.pop(i)
-                        save_jobs(jobs)
+                        _save_jobs_with_retry(jobs, job_id)
                         return
                 
                 # Compute next run
@@ -921,7 +954,7 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                 elif job.get("state") != "paused":
                     job["state"] = "scheduled"
 
-                save_jobs(jobs)
+                _save_jobs_with_retry(jobs, job_id)
                 return
 
         logger.warning("mark_job_run: job_id %s not found, skipping save", job_id)

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1078,6 +1078,15 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                     # Update the job in storage
                     for rj in raw_jobs:
                         if rj["id"] == job["id"]:
+                            rj["last_run_at"] = now.isoformat()
+                            if rj.get("repeat"):
+                                rj["repeat"]["completed"] = rj["repeat"].get("completed", 0) + 1
+                                times = rj["repeat"].get("times")
+                                if times is not None and times > 0 and rj["repeat"]["completed"] >= times:
+                                    # Fast-forward hit repeat limit — remove the job
+                                    raw_jobs = [j for j in raw_jobs if j["id"] != job["id"]]
+                                    needs_save = True
+                                    break
                             rj["next_run_at"] = new_next
                             needs_save = True
                             break

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -559,6 +559,42 @@ class TestMarkJobRun:
         assert updated["enabled"] is False
         assert updated["state"] == "completed"
 
+    def test_retry_on_transient_save_failure(self, tmp_cron_dir, monkeypatch):
+        """save_jobs failures should be retried with exponential backoff."""
+        job = create_job(prompt="Retry me", schedule="every 1h")
+        call_count = 0
+        original_save = save_jobs
+
+        def flaky_save(jobs_list):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise OSError("disk full")
+            original_save(jobs_list)
+
+        monkeypatch.setattr("cron.jobs.save_jobs", flaky_save)
+        mark_job_run(job["id"], success=True)
+        assert call_count == 3
+        updated = get_job(job["id"])
+        assert updated["last_status"] == "ok"
+
+    def test_terminal_failure_logs_error(self, tmp_cron_dir, caplog, monkeypatch):
+        """When all retries are exhausted, an ERROR log with job_id and timestamp is emitted."""
+        job = create_job(prompt="Doomed", schedule="every 1h")
+        monkeypatch.setattr("cron.jobs.save_jobs", lambda _jobs: (_ for _ in ()).throw(OSError("read-only filesystem")))
+
+        with pytest.raises(OSError):
+            mark_job_run(job["id"], success=True)
+
+        error_records = [r for r in caplog.records if r.levelname == "ERROR"]
+        assert error_records, "Expected at least one ERROR log record"
+        msg = error_records[-1].getMessage()
+        assert job["id"] in msg, f"ERROR log should contain job_id: {msg}"
+        # Timestamp is included in the message (ISO format from _hermes_now)
+        import re
+        assert re.search(r"\d{4}-\d{2}-\d{2}T", msg), f"ERROR log should contain ISO timestamp: {msg}"
+        assert "read-only filesystem" in msg, f"ERROR log should contain exception details: {msg}"
+
 
 class TestAdvanceNextRun:
     """Tests for advance_next_run() — crash-safety for recurring jobs."""

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -700,6 +700,7 @@ class TestGetDueJobs:
         """Recurring jobs past their dynamic grace window are fast-forwarded, not fired.
 
         For an hourly job, grace = 30 min. Setting 35 min late exceeds the window.
+        State must still be updated (last_run_at, completed_count) for consistency.
         """
         job = create_job(prompt="Stale", schedule="every 1h")
         # Force next_run_at to 35 minutes ago (beyond the 30-min grace for hourly)
@@ -714,6 +715,22 @@ class TestGetDueJobs:
         from cron.jobs import _ensure_aware, _hermes_now
         next_dt = _ensure_aware(datetime.fromisoformat(updated["next_run_at"]))
         assert next_dt > _hermes_now()
+        # State should reflect the skipped run
+        assert updated["last_run_at"] is not None, "last_run_at not set after fast-forward"
+        assert updated["repeat"]["completed"] == 1, f"completed count wrong: {updated['repeat']['completed']}"
+
+    def test_stale_fast_forward_repeat_limit_removes_job(self, tmp_cron_dir):
+        """Fast-forwarding a job that hits its repeat limit should remove it."""
+        job = create_job(prompt="Limited", schedule="every 1h", repeat=1)
+        # Force next_run_at to 35 minutes ago so it fast-forwards
+        jobs = load_jobs()
+        jobs[0]["next_run_at"] = (datetime.now() - timedelta(minutes=35)).isoformat()
+        save_jobs(jobs)
+
+        due = get_due_jobs()
+        assert len(due) == 0
+        # Job should be removed because repeat limit (1) was hit
+        assert get_job(job["id"]) is None, "Job should have been removed after fast-forward hit repeat limit"
 
     def test_future_not_returned(self, tmp_cron_dir):
         create_job(prompt="Not yet", schedule="every 1h")


### PR DESCRIPTION
When a recurring job is stale (past its grace window) and gets fast-forwarded to the next future run, update last_run_at and increment repeat.completed so that jobs.json stays consistent even when actual execution is skipped.

Also handle the repeat-limit case: if fast-forwarding causes completed >= times, remove the job (same behaviour as mark_job_run).

Fixes kanban task t_d437aa54.