### PR TITLE
fix(mcp): use ps --ppid as primary child PID detection on WSL2

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2101,10 +2101,24 @@ _orphan_stdio_pids: set = set()
 def _snapshot_child_pids() -> set:
     """Return a set of current child process PIDs.
 
-    Uses /proc on Linux, falls back to psutil, then empty set.
-    Used by _run_stdio to identify the subprocess spawned by stdio_client.
+    Uses ps --ppid on WSL2 (where /proc/children is broken for
+    multi-threaded processes), falls back to /proc on other Linux,
+    then psutil, then empty set.
     """
     my_pid = os.getpid()
+
+    # Try `ps --ppid` first — works on WSL2 where /proc/children
+    # returns empty for multi-threaded processes (Hermes has 12+ threads).
+    try:
+        import subprocess
+        result = subprocess.run(
+            ["ps", "--ppid", str(my_pid), "-o", "pid=", "--no-headers"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return {int(p) for p in result.stdout.split()}
+    except Exception:
+        pass
 
     # Linux: read from /proc
     try:


### PR DESCRIPTION
## Problem

On **WSL2**, \`/proc/<pid>/task/<pid>/children\` returns **empty for multi-threaded processes**. Hermes has 12+ threads, so \`_snapshot_child_pids()\` always returns an empty set on WSL2.

This means MCP server subprocess PIDs (spawned via \`stdio_client\`) are **never registered in \`_stdio_pids\`**, and thus never cleaned up on shutdown or reconnection. Over a day of use, this accumulates **dozens of orphaned MCP server processes** that waste memory and hold file handles.

## Fix

Add \`ps --ppid\` as the **primary** child PID detection method, before falling back to \`/proc/children\` and then \`psutil\`.

\`ps --ppid\`:
- Works correctly on WSL2 (confirmed on kernel 6.6.87.2-microsoft-standard-WSL2)
- Available on all POSIX systems (Linux, macOS, WSL)
- Parses the real process tree, not the per-task children file
- Gracefully degraded on failure (wrapped in try/except)

## Testing

- Verified \`ps --ppid <hermes_pid>\` returns correct children on WSL2
- \`_snapshot_child_pids()\` now correctly tracks MCP server PIDs
- Shutdown properly kills tracked children (0 orphans after cycle)
- Existing \`test_mcp_stability.py\` tests pass (snapshot returns a set of ints)

## Notes

\`psutil\` was already added as a fallback in \`cc38282b0\` for native Windows support, but on WSL2 the \`/proc\` method executes first (and returns empty), so the psutil fallback is never reached within the event loop thread. Moving \`ps --ppid\` to the primary position fixes the WSL2 case without regressing other platforms.