### PR TITLE
test(cli): isolate model picker Ollama probes (Fixes #30604)

### DIFF
--- a/tests/hermes_cli/test_list_picker_providers.py
+++ b/tests/hermes_cli/test_list_picker_providers.py
@@ -19,6 +19,12 @@ import pytest
 from hermes_cli import model_switch
 
 
+@pytest.fixture(autouse=True)
+def _disable_live_custom_provider_model_probe(monkeypatch):
+    """Keep custom-provider picker fixtures independent of local model servers."""
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *_a, **_kw: None)
+
+
 def _make_provider(slug, name=None, models=None, *, is_current=False,
                    is_user_defined=False, source="built-in", api_url=None):
     """Build a dict shaped like ``list_authenticated_providers`` output."""

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -6,6 +6,7 @@ only looked at `providers:`.
 """
 
 import hermes_cli.providers as providers_mod
+import pytest
 from hermes_cli.model_switch import list_authenticated_providers, switch_model
 from hermes_cli.providers import resolve_provider_full
 
@@ -16,6 +17,12 @@ _MOCK_VALIDATION = {
     "recognized": True,
     "message": None,
 }
+
+
+@pytest.fixture(autouse=True)
+def _disable_live_custom_provider_model_probe(monkeypatch):
+    """Keep custom-provider picker fixtures independent of local model servers."""
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *_a, **_kw: None)
 
 
 def test_list_authenticated_providers_includes_custom_providers(monkeypatch):


### PR DESCRIPTION
## Summary

- Disable live OpenAI-compatible `/models` probing by default in the affected custom-provider picker tests.
- Keep the explicit live-discovery test covered by letting it override the default mock with its own fake catalog.

## Root cause

The failing fixtures use `api_key: "ollama"` with `http://localhost:11434/v1`. `list_authenticated_providers()` treats that as permission to probe `/models`, so a developer's local Ollama server can replace the small fixture model list with the live local catalog.

## Why this layer

Runtime discovery for credentialed custom providers is intentional. These tests are checking grouping, slug recovery, and picker passthrough behavior, so the safest fix is to make the tests hermetic instead of changing production model-picker behavior.

Fixes #30604

## Validation

- `env OLLAMA_API_KEY=ollama OLLAMA_BASE_URL=http://localhost:11434/v1 scripts/run_tests.sh tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_list_picker_providers.py`
  - 28 tests passed, 0 failed

Platform tested: macOS local checkout.
