### PR TITLE
fix(cli): fall back to raw Copilot catalog token

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2641,8 +2641,8 @@ def resolve_fast_mode_overrides(model_id: Optional[str]) -> dict[str, Any] | Non
     return {"service_tier": "priority"}
 
 
-def _resolve_copilot_catalog_api_key() -> str:
-    """Best-effort GitHub token for fetching the Copilot model catalog.
+def _resolve_copilot_catalog_api_key_candidates() -> list[str]:
+    """Best-effort GitHub tokens for fetching the Copilot model catalog.
 
     Resolution order:
       1. ``resolve_api_key_provider_credentials("copilot")`` — env vars
@@ -2657,9 +2657,11 @@ def _resolve_copilot_catalog_api_key() -> str:
     Without (2), users whose only Copilot credential is in the pool see
     the ``/model`` picker fall back to a stale hardcoded list because the
     live catalog fetch silently 401s. To avoid wedging on a malformed pool
-    entry, each candidate is exchanged via ``exchange_copilot_token`` —
-    only entries that actually exchange successfully are returned, so a
-    later valid entry is reachable when an earlier one is unsupported.
+    entry, each candidate is exchanged via ``exchange_copilot_token`` first,
+    so a later valid entry is reachable when an earlier one is unsupported.
+    If no exchange succeeds, validated raw pool tokens are returned in pool
+    order as catalog-only fallbacks because ``/models`` can accept raw
+    Copilot credentials even when ``/copilot_internal/v2/token`` is unavailable.
     """
     try:
         from hermes_cli.auth import resolve_api_key_provider_credentials
@@ -2667,7 +2669,7 @@ def _resolve_copilot_catalog_api_key() -> str:
         creds = resolve_api_key_provider_credentials("copilot")
         api_key = str(creds.get("api_key") or "").strip()
         if api_key:
-            return api_key
+            return [api_key]
     except Exception:
         pass
 
@@ -2678,6 +2680,7 @@ def _resolve_copilot_catalog_api_key() -> str:
             validate_copilot_token,
         )
 
+        raw_catalog_fallbacks: list[str] = []
         for entry in read_credential_pool("copilot"):
             if not isinstance(entry, dict):
                 continue
@@ -2690,13 +2693,37 @@ def _resolve_copilot_catalog_api_key() -> str:
             try:
                 api_token, _expires_at = exchange_copilot_token(raw)
             except Exception:
+                if raw not in raw_catalog_fallbacks:
+                    raw_catalog_fallbacks.append(raw)
                 continue
             if api_token:
-                return api_token
+                return [api_token]
+            if raw not in raw_catalog_fallbacks:
+                raw_catalog_fallbacks.append(raw)
+        if raw_catalog_fallbacks:
+            return raw_catalog_fallbacks
     except Exception:
         pass
 
-    return ""
+    return []
+
+
+def _resolve_copilot_catalog_api_key() -> str:
+    """Return the first Copilot catalog credential candidate, if any."""
+    candidates = _resolve_copilot_catalog_api_key_candidates()
+    return candidates[0] if candidates else ""
+
+
+def _fetch_first_copilot_catalog() -> Optional[list[str]]:
+    """Try Copilot catalog credentials in order until one returns models."""
+    for api_key in _resolve_copilot_catalog_api_key_candidates():
+        try:
+            live = _fetch_github_models(api_key)
+        except Exception:
+            continue
+        if live:
+            return live
+    return None
 
 
 # Providers where models.dev is treated as authoritative: curated static
@@ -2844,7 +2871,7 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
         return list(_PROVIDER_MODELS.get("xai-oauth", _PROVIDER_MODELS.get("xai", [])))
     if normalized in {"copilot", "copilot-acp"}:
         try:
-            live = _fetch_github_models(_resolve_copilot_catalog_api_key())
+            live = _fetch_first_copilot_catalog()
             if live:
                 return live
         except Exception:

--- a/tests/hermes_cli/test_copilot_catalog_oauth_fallback.py
+++ b/tests/hermes_cli/test_copilot_catalog_oauth_fallback.py
@@ -10,9 +10,14 @@ only consulted env vars / ``gh auth token`` and never read the
 credential pool.
 """
 
+import json
 from unittest.mock import patch
 
-from hermes_cli.models import _resolve_copilot_catalog_api_key
+from hermes_cli.models import (
+    _resolve_copilot_catalog_api_key,
+    _resolve_copilot_catalog_api_key_candidates,
+    provider_model_ids,
+)
 
 
 class TestCopilotCatalogApiKeyResolution:
@@ -61,5 +66,97 @@ class TestCopilotCatalogApiKeyResolution:
             assert _resolve_copilot_catalog_api_key() == "tid_from_second"
             assert attempts == ["gho_unsupported_account", "gho_valid_token"]
 
+    def test_all_pool_entries_fail_exchange_returns_raw_catalog_fallback(self):
+        """All exchanges fail → return first valid raw token so /models can try it."""
+        with patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            return_value={"api_key": ""},
+        ), patch(
+            "hermes_cli.auth.read_credential_pool",
+            return_value=[
+                {"access_token": "gho_expired_a"},
+                {"access_token": "gho_expired_b"},
+            ],
+        ), patch(
+            "hermes_cli.copilot_auth.exchange_copilot_token",
+            side_effect=ValueError("Copilot token exchange failed"),
+        ):
+            assert _resolve_copilot_catalog_api_key() == "gho_expired_a"
 
+    def test_all_pool_entries_fail_exchange_returns_raw_candidates_in_pool_order(self):
+        """Catalog probing must be able to try later raw pool entries."""
+        with patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            return_value={"api_key": ""},
+        ), patch(
+            "hermes_cli.auth.read_credential_pool",
+            return_value=[
+                {"access_token": "gho_expired_a"},
+                {"access_token": "gho_expired_b"},
+            ],
+        ), patch(
+            "hermes_cli.copilot_auth.exchange_copilot_token",
+            side_effect=ValueError("Copilot token exchange failed"),
+        ):
+            assert _resolve_copilot_catalog_api_key_candidates() == [
+                "gho_expired_a",
+                "gho_expired_b",
+            ]
+
+    def test_provider_model_ids_uses_raw_pool_token_when_exchange_fails(self):
+        """If token exchange fails but /models accepts the raw token, use the live catalog."""
+        attempted: list[str] = []
+
+        def fake_fetch(api_key):
+            attempted.append(api_key)
+            return ["gpt-5.5", "claude-sonnet-4.6"]
+
+        with patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            return_value={"api_key": ""},
+        ), patch(
+            "hermes_cli.auth.read_credential_pool",
+            return_value=[{"access_token": "gho_raw_catalog_token"}],
+        ), patch(
+            "hermes_cli.copilot_auth.exchange_copilot_token",
+            side_effect=ValueError("Copilot token exchange failed: HTTP Error 404"),
+        ), patch(
+            "hermes_cli.models._fetch_github_models",
+            side_effect=fake_fetch,
+        ):
+            assert provider_model_ids("copilot") == ["gpt-5.5", "claude-sonnet-4.6"]
+
+        assert attempted == ["gho_raw_catalog_token"]
+
+    def test_provider_model_ids_tries_later_raw_pool_token_when_first_fails_models(self):
+        """A syntactically valid raw pool[0] must not wedge pool[1]."""
+        attempted: list[str] = []
+
+        def fake_fetch(api_key):
+            attempted.append(api_key)
+            if api_key == "gho_raw_first":
+                return None
+            if api_key == "gho_raw_second":
+                return ["gpt-5.5", "claude-sonnet-4.6"]
+            raise AssertionError(f"unexpected api key {api_key}")
+
+        with patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            return_value={"api_key": ""},
+        ), patch(
+            "hermes_cli.auth.read_credential_pool",
+            return_value=[
+                {"access_token": "gho_raw_first"},
+                {"access_token": "gho_raw_second"},
+            ],
+        ), patch(
+            "hermes_cli.copilot_auth.exchange_copilot_token",
+            side_effect=ValueError("Copilot token exchange failed: HTTP Error 404"),
+        ), patch(
+            "hermes_cli.models._fetch_github_models",
+            side_effect=fake_fetch,
+        ):
+            assert provider_model_ids("copilot") == ["gpt-5.5", "claude-sonnet-4.6"]
+
+        assert attempted == ["gho_raw_first", "gho_raw_second"]
 


### PR DESCRIPTION
## Summary

Fixes #30624.

When the Copilot model picker resolves tokens from `credential_pool.copilot[]`, it still prefers the exchanged `/copilot_internal/v2/token` API token. If every exchange fails after token validation, the picker now tries validated raw pool tokens against `https://api.githubcopilot.com/models` in pool order until one returns a live catalog.

This keeps runtime token behavior unchanged and limits the raw-token fallback to model-catalog discovery.

## Root Cause

`_resolve_copilot_catalog_api_key()` returned only one catalog token. Since `validate_copilot_token()` is syntactic, the first raw pool token could pass local validation but fail `/models`, while a later pool token would have worked. `provider_model_ids("copilot")` had no way to try that later candidate and fell back to the stale curated list.

## Review update

- Preserved exchanged-token preference.
- Added an internal ordered candidate helper for Copilot catalog credentials.
- Updated the picker to try raw fallback candidates in pool order until one returns models.
- Added a regression where raw pool[0] fails `/models` and raw pool[1] succeeds.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_copilot_catalog_oauth_fallback.py tests/hermes_cli/test_model_validation.py::TestProviderModelIds tests/hermes_cli/test_copilot_in_model_list.py`, passed
- `uv run --extra dev ruff check hermes_cli/models.py tests/hermes_cli/test_copilot_catalog_oauth_fallback.py tests/hermes_cli/test_copilot_in_model_list.py`, passed
- `git diff --check`, clean

## Notes

- The test wrapper is file-granular. For `tests/hermes_cli/test_model_validation.py::TestProviderModelIds`, it ran the file with `-k TestProviderModelIds`.
- The first wrapper invocation happened before this linked worktree's dev dependencies were installed and failed with `no virtualenv with pytest found`. After `uv run --extra dev` prepared the environment, the same wrapper command passed.
