### PR TITLE
fix(mcp): stagger idle keepalive probes

### DIFF
--- a/tests/tools/test_mcp_capability_gating.py
+++ b/tests/tools/test_mcp_capability_gating.py
@@ -129,11 +129,14 @@ class TestKeepaliveProbe:
 
         import tools.mcp_tool as mcp_mod
         orig = mcp_mod.asyncio.wait
+        orig_jitter = mcp_mod._mcp_keepalive_jitter_seconds
         mcp_mod.asyncio.wait = fake_wait
+        mcp_mod._mcp_keepalive_jitter_seconds = lambda _name: 0.0
         try:
             return await task._wait_for_lifecycle_event()
         finally:
             mcp_mod.asyncio.wait = orig
+            mcp_mod._mcp_keepalive_jitter_seconds = orig_jitter
 
     async def test_keepalive_uses_ping_for_prompt_only_server(self):
         task = MCPServerTask("test")
@@ -376,5 +379,4 @@ class TestKeepaliveProbeFallback:
         await task._discover_tools()
 
         assert task._ping_unsupported is False
-
 

--- a/tests/tools/test_mcp_capability_gating.py
+++ b/tests/tools/test_mcp_capability_gating.py
@@ -102,11 +102,14 @@ class TestKeepaliveProbe:
 
         import tools.mcp_tool as mcp_mod
         orig = mcp_mod.asyncio.wait
+        orig_jitter = mcp_mod._mcp_keepalive_jitter_seconds
         mcp_mod.asyncio.wait = fake_wait
+        mcp_mod._mcp_keepalive_jitter_seconds = lambda _name: 0.0
         try:
             return await task._wait_for_lifecycle_event()
         finally:
             mcp_mod.asyncio.wait = orig
+            mcp_mod._mcp_keepalive_jitter_seconds = orig_jitter
 
     async def test_keepalive_uses_ping_for_prompt_only_server(self):
         task = MCPServerTask("test")
@@ -162,11 +165,14 @@ class TestKeepaliveInterval:
 
         import tools.mcp_tool as mcp_mod
         orig = mcp_mod.asyncio.wait
+        orig_jitter = mcp_mod._mcp_keepalive_jitter_seconds
         mcp_mod.asyncio.wait = fake_wait
+        mcp_mod._mcp_keepalive_jitter_seconds = lambda _name: 0.0
         try:
             await task._wait_for_lifecycle_event()
         finally:
             mcp_mod.asyncio.wait = orig
+            mcp_mod._mcp_keepalive_jitter_seconds = orig_jitter
         return captured["timeout"]
 
     @pytest.mark.asyncio
@@ -188,13 +194,16 @@ class TestKeepaliveInterval:
 def _mcp_error(code, message="boom"):
     """Build a real MCPError carrying a JSON-RPC error code.
 
-    mcp 2.0 renamed ``McpError`` to ``MCPError`` and replaced its
-    ``ErrorData`` positional with flat ``code`` / ``message`` arguments. The
-    ``.error.code`` attribute ``_is_method_not_found_error`` inspects survives
-    unchanged, which is the point of the structural check.
+    mcp versions expose either ``McpError(ErrorData(...))`` or
+    ``MCPError(code=..., message=...)``. The ``.error.code`` attribute
+    ``_is_method_not_found_error`` inspects survives unchanged, which is the
+    point of the structural check.
     """
-    from mcp.shared.exceptions import MCPError
-    return MCPError(code=code, message=message)
+    from mcp.shared import exceptions
+
+    if hasattr(exceptions, "MCPError"):
+        return exceptions.MCPError(code=code, message=message)
+    return exceptions.McpError(exceptions.ErrorData(code=code, message=message))
 
 
 class TestMethodNotFoundDetection:
@@ -294,5 +303,3 @@ class TestKeepaliveProbeFallback:
         await task._discover_tools()
 
         assert task._ping_unsupported is False
-
-

--- a/tests/tools/test_mcp_reconnect_signal.py
+++ b/tests/tools/test_mcp_reconnect_signal.py
@@ -7,6 +7,8 @@ reconnect with fresh credentials. This file exercises the signal plumbing
 in isolation from the full stdio/http transport machinery.
 """
 import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -55,3 +57,54 @@ async def test_wait_for_lifecycle_event_shutdown_wins_when_both_set():
     task._reconnect_event.set()
     reason = await task._wait_for_lifecycle_event()
     assert reason == "shutdown"
+
+
+def test_keepalive_jitter_is_stable_and_bounded(monkeypatch):
+    """Per-server keepalive jitter is deterministic and within the cap."""
+    import tools.mcp_tool as mcp_tool
+
+    monkeypatch.setattr(mcp_tool, "_MCP_KEEPALIVE_MAX_JITTER_SECONDS", 15.0)
+
+    first = mcp_tool._mcp_keepalive_jitter_seconds("github")
+    second = mcp_tool._mcp_keepalive_jitter_seconds("github")
+
+    assert first == second
+    assert 0.0 <= first <= 15.0
+
+
+@pytest.mark.asyncio
+async def test_wait_for_lifecycle_event_jitters_before_keepalive(monkeypatch):
+    """Idle keepalive probes wait the per-server jitter before list_tools."""
+    import tools.mcp_tool as mcp_tool
+    from tools.mcp_tool import MCPServerTask
+
+    task = MCPServerTask("github")
+
+    async def fake_list_tools():
+        task._shutdown_event.set()
+
+    task.initialize_result = SimpleNamespace(
+        capabilities=SimpleNamespace(tools=SimpleNamespace())
+    )
+    task.session = type(
+        "Session",
+        (),
+        {
+            "send_ping": AsyncMock(side_effect=Exception("Unknown method: ping")),
+            "list_tools": AsyncMock(side_effect=fake_list_tools),
+        },
+    )()
+
+    task._config["keepalive_interval"] = 0.01
+    monkeypatch.setattr(mcp_tool, "_MIN_KEEPALIVE_INTERVAL", 0.001)
+    monkeypatch.setattr(mcp_tool, "_mcp_keepalive_jitter_seconds", lambda _name: 0.05)
+
+    waiter = asyncio.create_task(task._wait_for_lifecycle_event())
+    await asyncio.sleep(0.025)
+    task.session.list_tools.assert_not_awaited()
+
+    reason = await asyncio.wait_for(waiter, timeout=0.2)
+
+    assert reason == "shutdown"
+    task.session.send_ping.assert_awaited_once()
+    task.session.list_tools.assert_awaited_once()

--- a/tests/tools/test_mcp_reconnect_signal.py
+++ b/tests/tools/test_mcp_reconnect_signal.py
@@ -7,6 +7,8 @@ reconnect with fresh credentials. This file exercises the signal plumbing
 in isolation from the full stdio/http transport machinery.
 """
 import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -31,3 +33,53 @@ async def test_wait_for_lifecycle_event_shutdown_wins_when_both_set():
     task._reconnect_event.set()
     reason = await task._wait_for_lifecycle_event()
     assert reason == "shutdown"
+
+
+def test_keepalive_jitter_is_stable_and_bounded(monkeypatch):
+    """Per-server keepalive jitter is deterministic and within the cap."""
+    import tools.mcp_tool as mcp_tool
+
+    monkeypatch.setattr(mcp_tool, "_MCP_KEEPALIVE_MAX_JITTER_SECONDS", 15.0)
+
+    first = mcp_tool._mcp_keepalive_jitter_seconds("github")
+    second = mcp_tool._mcp_keepalive_jitter_seconds("github")
+
+    assert first == second
+    assert 0.0 <= first <= 15.0
+
+
+@pytest.mark.asyncio
+async def test_wait_for_lifecycle_event_phases_without_extending_cadence(monkeypatch):
+    """Keepalive phase spread cannot extend the configured probe interval."""
+    import tools.mcp_tool as mcp_tool
+    from tools.mcp_tool import MCPServerTask
+
+    task = MCPServerTask("github")
+
+    async def fake_list_tools():
+        task._shutdown_event.set()
+
+    task.initialize_result = SimpleNamespace(
+        capabilities=SimpleNamespace(tools=SimpleNamespace())
+    )
+    task.session = type(
+        "Session",
+        (),
+        {
+            "send_ping": AsyncMock(side_effect=Exception("Unknown method: ping")),
+            "list_tools": AsyncMock(side_effect=fake_list_tools),
+        },
+    )()
+
+    task._config["keepalive_interval"] = 0.01
+    monkeypatch.setattr(mcp_tool, "_MIN_KEEPALIVE_INTERVAL", 0.001)
+    monkeypatch.setattr(mcp_tool, "_mcp_keepalive_jitter_seconds", lambda _name: 0.05)
+
+    waiter = asyncio.create_task(task._wait_for_lifecycle_event())
+    await asyncio.sleep(0.04)
+
+    reason = await asyncio.wait_for(waiter, timeout=0.2)
+
+    assert reason == "shutdown"
+    task.session.send_ping.assert_awaited_once()
+    task.session.list_tools.assert_awaited_once()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -94,6 +94,7 @@ import contextvars
 import concurrent.futures
 import errno
 import fnmatch
+import hashlib
 import inspect
 import json
 import logging
@@ -360,6 +361,7 @@ def _jittered(seconds: float) -> float:
 # stops a misconfigured tiny interval from busy-looping the keepalive.
 _DEFAULT_KEEPALIVE_INTERVAL = 180  # seconds between liveness pings
 _MIN_KEEPALIVE_INTERVAL = 5        # clamp floor for configured intervals
+_MCP_KEEPALIVE_MAX_JITTER_SECONDS = 15.0
 
 # Environment variables that are safe to pass to stdio subprocesses
 _SAFE_ENV_KEYS = frozenset({
@@ -435,6 +437,22 @@ def _env_ref_name(ref: str) -> str:
 # ---------------------------------------------------------------------------
 # Security helpers
 # ---------------------------------------------------------------------------
+
+def _mcp_keepalive_jitter_seconds(server_name: str) -> float:
+    """Return a stable per-server delay before idle keepalive probes.
+
+    Laptop sleep/wake can resume every MCP server's expired keepalive timer in
+    the same event-loop tick. A small deterministic delay spreads the follow-up
+    ``list_tools`` probes and any reconnects without making behavior random.
+    """
+    if _MCP_KEEPALIVE_MAX_JITTER_SECONDS <= 0:
+        return 0.0
+    digest = hashlib.blake2s(
+        str(server_name).encode("utf-8", errors="replace"),
+        digest_size=4,
+    ).digest()
+    bucket = int.from_bytes(digest, "big") / 0xFFFFFFFF
+    return bucket * _MCP_KEEPALIVE_MAX_JITTER_SECONDS
 
 def _build_safe_env(user_env: Optional[dict]) -> dict:
     """Build a filtered environment dict for stdio subprocesses.
@@ -2294,6 +2312,19 @@ class MCPServerTask:
                 # tool-capable server that doesn't implement it answers -32601;
                 # in that case fall back to the pre-ping ``list_tools`` probe
                 # for the rest of this connection rather than reconnect-looping.
+                # When a laptop resumes after sleep, all expired keepalive
+                # timers can wake in the same loop tick; spread probes by
+                # server name to avoid a reconnect storm.
+                jitter = _mcp_keepalive_jitter_seconds(self.name)
+                if jitter > 0:
+                    done, _pending = await asyncio.wait(
+                        {shutdown_task, reconnect_task},
+                        timeout=jitter,
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+                    if done:
+                        break
+
                 if self.session:
                     try:
                         await self._keepalive_probe()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -99,6 +99,7 @@ import contextvars
 import concurrent.futures
 import errno
 import fnmatch
+import hashlib
 import inspect
 import json
 import logging
@@ -609,6 +610,7 @@ def _jittered(seconds: float) -> float:
 # stops a misconfigured tiny interval from busy-looping the keepalive.
 _DEFAULT_KEEPALIVE_INTERVAL = 180  # seconds between liveness pings
 _MIN_KEEPALIVE_INTERVAL = 5        # clamp floor for configured intervals
+_MCP_KEEPALIVE_MAX_JITTER_SECONDS = 15.0
 
 # Final shutdown gives pending MCP-loop tasks one bounded cancellation cycle
 # before closing their owning loop. Cooperative parked/reconnect waiters finish
@@ -731,6 +733,22 @@ def _context_var_value(ref: str) -> Optional[str]:
 # ---------------------------------------------------------------------------
 # Security helpers
 # ---------------------------------------------------------------------------
+
+def _mcp_keepalive_jitter_seconds(server_name: str) -> float:
+    """Return a stable per-server delay before idle keepalive probes.
+
+    Laptop sleep/wake can resume every MCP server's expired keepalive timer in
+    the same event-loop tick. A small deterministic delay spreads the follow-up
+    ``list_tools`` probes and any reconnects without making behavior random.
+    """
+    if _MCP_KEEPALIVE_MAX_JITTER_SECONDS <= 0:
+        return 0.0
+    digest = hashlib.blake2s(
+        str(server_name).encode("utf-8", errors="replace"),
+        digest_size=4,
+    ).digest()
+    bucket = int.from_bytes(digest, "big") / 0xFFFFFFFF
+    return bucket * _MCP_KEEPALIVE_MAX_JITTER_SECONDS
 
 def _build_safe_env(user_env: Optional[dict]) -> dict:
     """Build a filtered environment dict for stdio subprocesses.
@@ -3058,7 +3076,11 @@ class MCPServerTask:
                     self._mark_stdio_recycled(recycle_reason)
                     return "recycle"
 
-                timeout = keepalive_interval
+                phase_jitter = min(
+                    _mcp_keepalive_jitter_seconds(self.name),
+                    keepalive_interval,
+                )
+                timeout = max(0.0, keepalive_interval - phase_jitter)
                 recycle_deadline = self._next_stdio_recycle_deadline()
                 if recycle_deadline is not None:
                     timeout = max(0.0, min(timeout, recycle_deadline - time.monotonic()))
@@ -3081,6 +3103,29 @@ class MCPServerTask:
                 # is in flight (#48069): the stdio session is a single
                 # JSON-RPC stream and a concurrent ping/list_tools can wedge
                 # the in-flight request. A busy server is provably alive.
+                # When a laptop resumes after sleep, expired keepalive timers
+                # can wake in the same loop tick. A deterministic phase spreads
+                # probes by server name, but is subtracted from the prior wait
+                # so the configured keepalive interval remains the upper bound.
+                if phase_jitter > 0:
+                    if recycle_deadline is not None:
+                        phase_jitter = max(
+                            0.0,
+                            min(phase_jitter, recycle_deadline - time.monotonic()),
+                        )
+                    done, _pending = await asyncio.wait(
+                        {shutdown_task, reconnect_task},
+                        timeout=phase_jitter,
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+                    if done:
+                        break
+
+                recycle_reason = self._stdio_recycle_reason()
+                if recycle_reason is not None:
+                    self._mark_stdio_recycled(recycle_reason)
+                    return "recycle"
+
                 if self.session:
                     if self._rpc_lock.locked() or any(
                         not t.done() for t in self._inflight_tasks


### PR DESCRIPTION
## Summary
- add a stable per-server jitter before idle MCP keepalive probes
- keep shutdown/reconnect signals responsive during the jitter window
- cover the jitter helper and delayed keepalive behavior with focused tests

Fixes #30268.

## Validation
- `uv run --extra dev scripts/run_tests.sh tests/tools/test_mcp_reconnect_signal.py tests/tools/test_mcp_tool.py` — 201 passed
- `uv run --extra dev ruff check tools/mcp_tool.py tests/tools/test_mcp_reconnect_signal.py` — passed

## Notes
- The validation environment used Python 3.14.3 because this checkout did not already have the project’s preferred Python 3.11 virtualenv. The change is limited to asyncio timing logic and unit tests.