### PR TITLE
fix(checkpoint): avoid ty panic in pruning loops

### DIFF
--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -912,7 +912,7 @@ class CheckpointManager:
                 result["empty"] = True
         return result
 
-    def restore(self, working_dir: str, commit_hash: str, file_path: str = None) -> Dict:
+    def restore(self, working_dir: str, commit_hash: str, file_path: Optional[str] = None) -> Dict:
         """Restore files to a checkpoint state."""
         hash_err = _validate_commit_hash(commit_hash)
         if hash_err:
@@ -1214,10 +1214,10 @@ class CheckpointManager:
                 ["log", "--format=%s", "-1", sha], store, working_dir,
             )
             commit_msg = msg if ok_msg and msg else "checkpoint"
-            args = ["commit-tree", tree_sha, "-m", commit_msg, "--no-gpg-sign"]
+            args: List[str] = ["commit-tree", tree_sha]
             if new_parent is not None:
-                args = ["commit-tree", tree_sha, "-p", new_parent,
-                        "-m", commit_msg, "--no-gpg-sign"]
+                args.extend(["-p", new_parent])
+            args.extend(["-m", commit_msg, "--no-gpg-sign"])
             ok_commit, new_sha, _ = _run_git(args, store, working_dir)
             if not ok_commit or not new_sha:
                 return
@@ -1300,10 +1300,10 @@ class CheckpointManager:
                         ["log", "--format=%s", "-1", sha], store, str(store.parent),
                     )
                     commit_msg = msg if ok_msg and msg else "checkpoint"
-                    args = ["commit-tree", tree_sha, "-m", commit_msg, "--no-gpg-sign"]
+                    args: List[str] = ["commit-tree", tree_sha]
                     if new_parent is not None:
-                        args = ["commit-tree", tree_sha, "-p", new_parent,
-                                "-m", commit_msg, "--no-gpg-sign"]
+                        args.extend(["-p", new_parent])
+                    args.extend(["-m", commit_msg, "--no-gpg-sign"])
                     ok_commit, new_sha, _ = _run_git(args, store, str(store.parent))
                     if not ok_commit or not new_sha:
                         fail = True
@@ -1721,10 +1721,10 @@ def prune_checkpoints(
                             ["log", "--format=%s", "-1", sha], store, str(base),
                         )
                         msg = m if ok_m and m else "checkpoint"
-                        args = ["commit-tree", tsha, "-m", msg, "--no-gpg-sign"]
+                        args: List[str] = ["commit-tree", tsha]
                         if new_parent is not None:
-                            args = ["commit-tree", tsha, "-p", new_parent,
-                                    "-m", msg, "--no-gpg-sign"]
+                            args.extend(["-p", new_parent])
+                        args.extend(["-m", msg, "--no-gpg-sign"])
                         ok_cm, new_sha, _ = _run_git(args, store, str(base))
                         if not ok_cm or not new_sha:
                             fail = True

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -1067,7 +1067,7 @@ class CheckpointManager:
         self,
         working_dir: str,
         commit_hash: str,
-        file_path: str = None,
+        file_path: Optional[str] = None,
         safe: bool = False,
     ) -> Dict:
         """Restore files to a checkpoint state.
@@ -1429,10 +1429,10 @@ class CheckpointManager:
                 ["log", "--format=%s", "-1", sha], store, working_dir,
             )
             commit_msg = msg if ok_msg and msg else "checkpoint"
-            args = ["commit-tree", tree_sha, "-m", commit_msg, "--no-gpg-sign"]
+            args: List[str] = ["commit-tree", tree_sha]
             if new_parent is not None:
-                args = ["commit-tree", tree_sha, "-p", new_parent,
-                        "-m", commit_msg, "--no-gpg-sign"]
+                args.extend(["-p", new_parent])
+            args.extend(["-m", commit_msg, "--no-gpg-sign"])
             ok_commit, new_sha, _ = _run_git(args, store, working_dir)
             if not ok_commit or not new_sha:
                 return
@@ -1515,10 +1515,10 @@ class CheckpointManager:
                         ["log", "--format=%s", "-1", sha], store, str(store.parent),
                     )
                     commit_msg = msg if ok_msg and msg else "checkpoint"
-                    args = ["commit-tree", tree_sha, "-m", commit_msg, "--no-gpg-sign"]
+                    args: List[str] = ["commit-tree", tree_sha]
                     if new_parent is not None:
-                        args = ["commit-tree", tree_sha, "-p", new_parent,
-                                "-m", commit_msg, "--no-gpg-sign"]
+                        args.extend(["-p", new_parent])
+                    args.extend(["-m", commit_msg, "--no-gpg-sign"])
                     ok_commit, new_sha, _ = _run_git(args, store, str(store.parent))
                     if not ok_commit or not new_sha:
                         fail = True
@@ -1936,10 +1936,10 @@ def prune_checkpoints(
                             ["log", "--format=%s", "-1", sha], store, str(base),
                         )
                         msg = m if ok_m and m else "checkpoint"
-                        args = ["commit-tree", tsha, "-m", msg, "--no-gpg-sign"]
+                        args: List[str] = ["commit-tree", tsha]
                         if new_parent is not None:
-                            args = ["commit-tree", tsha, "-p", new_parent,
-                                    "-m", msg, "--no-gpg-sign"]
+                            args.extend(["-p", new_parent])
+                        args.extend(["-m", msg, "--no-gpg-sign"])
                         ok_cm, new_sha, _ = _run_git(args, store, str(base))
                         if not ok_cm or not new_sha:
                             fail = True


### PR DESCRIPTION
## Summary
- Avoid the `ty==0.0.21` checker panic in `tools/checkpoint_manager.py` by keeping pruning-loop command lists as one typed list that is extended instead of reassigned between different literal shapes.
- Mark `restore(..., file_path=None)` as `Optional[str]`, matching the existing runtime behavior and removing the newer ty parameter-default diagnostic.
- Preserve the generated git command ordering and checkpoint runtime behavior.

Fixes #30606.

## Validation
- `uv tool run ty==0.0.21 check tools/checkpoint_manager.py` -> `All checks passed!`
- `uv tool run ty==0.0.21 check --output-format gitlab --exit-zero tools/checkpoint_manager.py` -> `[]`
- `uv tool run ty check tools/checkpoint_manager.py` -> `All checks passed!`
- `uv tool run ruff check tools/checkpoint_manager.py` -> `All checks passed!`
- `env -i PATH="$PATH" HOME="$HOME" TZ=UTC LANG=C.UTF-8 LC_ALL=C.UTF-8 PYTHONHASHSEED=0 /Users/dejain/nvidia/oss/hermes-agent/.venv/bin/python -m pytest tests/tools/test_checkpoint_manager.py -q` -> `77 passed in 19.25s`

Note: `scripts/run_tests.sh tests/tools/test_checkpoint_manager.py` could not run in this linked worktree because it has no local `.venv` or `venv`, so the focused pytest fallback used the main checkout's existing `.venv` interpreter with the same clean-env settings.