### PR TITLE
fix(copilot): sanitize Gemini tool schemas

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -9,14 +9,16 @@ which has provider-specific conditionals for max_tokens defaults,
 reasoning configuration, temperature handling, and extra_body assembly.
 """
 
+import copy
 import json
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
 from agent.lmstudio_reasoning import resolve_lmstudio_effort
 from agent.moonshot_schema import is_moonshot_model, sanitize_moonshot_tools
 from agent.prompt_builder import DEVELOPER_ROLE_MODELS
 from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall, Usage
+from utils import base_url_host_matches
 
 
 def _static_prompt_instructions(messages: list[dict[str, Any]]) -> str:
@@ -81,6 +83,184 @@ def _reasoning_config_for_model(model: str, reasoning_config: dict | None) -> di
         normalized["effort"] = "max"
         return normalized
     return reasoning_config
+
+
+_COPILOT_GEMINI_SCHEMA_MAP_KEYS = frozenset(
+    {"properties", "patternProperties", "$defs", "definitions"}
+)
+_COPILOT_GEMINI_SCHEMA_LIST_KEYS = frozenset(
+    {"anyOf", "oneOf", "allOf", "prefixItems"}
+)
+_COPILOT_GEMINI_SCHEMA_NODE_KEYS = frozenset(
+    {"items", "contains", "not", "additionalProperties", "propertyNames"}
+)
+_COPILOT_PROVIDER_NAMES = frozenset(
+    {"copilot", "github-copilot", "github-models", "github-model", "github"}
+)
+
+
+def _is_gemini_model(model: Any) -> bool:
+    normalized = str(model or "").strip().lower()
+    if not normalized:
+        return False
+    parts = normalized.replace(":", "/").split("/")
+    return any(part.startswith("gemini") for part in parts)
+
+
+def _is_copilot_base_url(base_url: Any) -> bool:
+    return base_url_host_matches(str(base_url or ""), "githubcopilot.com")
+
+
+def _should_sanitize_copilot_gemini_tools(
+    model: Any,
+    *,
+    profile: Any = None,
+    params: dict[str, Any] | None = None,
+) -> bool:
+    if not _is_gemini_model(model):
+        return False
+
+    params = params or {}
+    profile_name = str(getattr(profile, "name", "") or "").strip().lower()
+    if profile_name in _COPILOT_PROVIDER_NAMES:
+        return True
+
+    provider_name = str(params.get("provider_name") or "").strip().lower()
+    if provider_name in _COPILOT_PROVIDER_NAMES:
+        return True
+
+    return _is_copilot_base_url(params.get("base_url"))
+
+
+def _schema_note(description: Any, note: str) -> str:
+    existing = description if isinstance(description, str) else ""
+    if note in existing:
+        return existing
+    if existing:
+        separator = "" if existing.endswith((" ", "\n")) else " "
+        return f"{existing}{separator}{note}"
+    return note
+
+
+def _format_schema_value(value: Any) -> str:
+    try:
+        return json.dumps(value, ensure_ascii=True)
+    except TypeError:
+        return str(value)
+
+
+def _collapse_type_union(type_value: list[Any]) -> str:
+    members = [
+        item.strip().lower()
+        for item in type_value
+        if isinstance(item, str) and item.strip()
+    ]
+    non_null = [item for item in members if item != "null"]
+    if not non_null:
+        return "string"
+    if "string" in non_null:
+        return "string"
+    if "number" in non_null:
+        return "number"
+    return non_null[0]
+
+
+def _sanitize_copilot_gemini_schema_node(node: Any) -> tuple[Any, bool]:
+    if isinstance(node, list):
+        changed = False
+        sanitized_list = []
+        for item in node:
+            sanitized, item_changed = _sanitize_copilot_gemini_schema_node(item)
+            sanitized_list.append(sanitized)
+            changed = changed or item_changed
+        return sanitized_list, changed
+
+    if not isinstance(node, dict):
+        return node, False
+
+    sanitized: dict[str, Any] = {}
+    changed = False
+    for key, value in node.items():
+        if key in _COPILOT_GEMINI_SCHEMA_MAP_KEYS and isinstance(value, dict):
+            mapped: dict[Any, Any] = {}
+            for sub_key, sub_value in value.items():
+                sub_sanitized, sub_changed = _sanitize_copilot_gemini_schema_node(
+                    sub_value
+                )
+                mapped[sub_key] = sub_sanitized
+                changed = changed or sub_changed
+            sanitized[key] = mapped
+        elif key in _COPILOT_GEMINI_SCHEMA_LIST_KEYS and isinstance(value, list):
+            items = []
+            for item in value:
+                item_sanitized, item_changed = _sanitize_copilot_gemini_schema_node(
+                    item
+                )
+                items.append(item_sanitized)
+                changed = changed or item_changed
+            sanitized[key] = items
+        elif key in _COPILOT_GEMINI_SCHEMA_NODE_KEYS and isinstance(value, dict):
+            nested, nested_changed = _sanitize_copilot_gemini_schema_node(value)
+            sanitized[key] = nested
+            changed = changed or nested_changed
+        else:
+            sanitized[key] = value
+
+    enum_value = sanitized.get("enum")
+    if isinstance(enum_value, list) and any(
+        not isinstance(item, str) for item in enum_value
+    ):
+        allowed = ", ".join(_format_schema_value(item) for item in enum_value)
+        sanitized.pop("enum", None)
+        sanitized["description"] = _schema_note(
+            sanitized.get("description"),
+            f"Allowed values: {allowed}.",
+        )
+        changed = True
+
+    type_value = sanitized.get("type")
+    if isinstance(type_value, list):
+        original_types = [
+            item.strip().lower()
+            for item in type_value
+            if isinstance(item, str) and item.strip()
+        ]
+        sanitized["type"] = _collapse_type_union(type_value)
+        if original_types:
+            display = " or ".join(dict.fromkeys(t for t in original_types if t != "null"))
+            if display:
+                sanitized["description"] = _schema_note(
+                    sanitized.get("description"),
+                    f"Accepts {display}.",
+                )
+        changed = True
+
+    return sanitized, changed
+
+
+def _sanitize_copilot_gemini_tools(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Normalize tool schemas for Copilot-hosted Gemini chat completions.
+
+    Copilot's Gemini chat-completions endpoint rejects two OpenAI JSON Schema
+    shapes that other providers accept: non-string enum values and type unions
+    expressed as arrays.  Keep the repair local to Copilot Gemini requests.
+    """
+    sanitized = copy.deepcopy(tools)
+    changed = False
+
+    for tool in sanitized:
+        if not isinstance(tool, dict):
+            continue
+        fn = tool.get("function")
+        if not isinstance(fn, dict):
+            continue
+        params = fn.get("parameters")
+        new_params, params_changed = _sanitize_copilot_gemini_schema_node(params)
+        if params_changed:
+            fn["parameters"] = new_params
+            changed = True
+
+    return sanitized if changed else tools
 
 
 def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> dict | None:
@@ -442,6 +622,8 @@ class ChatCompletionsTransport(ProviderTransport):
             # etc.) compatible, in addition to direct moonshot.ai endpoints.
             if is_moonshot_model(model):
                 tools = sanitize_moonshot_tools(tools)
+            elif _should_sanitize_copilot_gemini_tools(model, params=params):
+                tools = _sanitize_copilot_gemini_tools(tools)
             api_kwargs["tools"] = tools
 
         # max_tokens resolution — priority: ephemeral > user > provider default
@@ -635,6 +817,10 @@ class ChatCompletionsTransport(ProviderTransport):
         if tools:
             if is_moonshot_model(model):
                 tools = sanitize_moonshot_tools(tools)
+            elif _should_sanitize_copilot_gemini_tools(
+                model, profile=profile, params=params
+            ):
+                tools = _sanitize_copilot_gemini_tools(tools)
             api_kwargs["tools"] = tools
 
         # max_tokens resolution — priority: ephemeral > user > profile default

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -17,6 +17,37 @@ def transport():
     return get_transport("chat_completions")
 
 
+def _copilot_gemini_problem_tools():
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": "copilot_gemini_schema_probe",
+                "description": "Probe schema",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "action": {
+                            "type": "string",
+                            "enum": ["search_members", "fetch_messages", "create_thread"],
+                        },
+                        "auto_archive_duration": {
+                            "type": "integer",
+                            "enum": [60, 1440, 4320, 10080],
+                            "description": "Thread archive duration in minutes.",
+                        },
+                        "time_from": {
+                            "type": ["number", "string"],
+                            "description": "Lower time bound.",
+                        },
+                    },
+                    "required": ["action"],
+                },
+            },
+        }
+    ]
+
+
 class TestChatCompletionsBasic:
 
 
@@ -357,6 +388,99 @@ class TestChatCompletionsKimi:
         )
         # The parameters dict is passed through untouched (no synthetic type)
         assert "type" not in kw["tools"][0]["function"]["parameters"]["properties"]["q"]
+
+    def test_copilot_gemini_sanitizes_integer_enum_and_type_union(self, transport):
+        """Copilot-hosted Gemini rejects integer enums and type arrays."""
+        from providers import get_provider_profile
+
+        tools = _copilot_gemini_problem_tools()
+        kw = transport.build_kwargs(
+            model="gemini-3.5-flash",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=tools,
+            provider_profile=get_provider_profile("copilot"),
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+
+        props = kw["tools"][0]["function"]["parameters"]["properties"]
+        assert props["action"]["enum"] == [
+            "search_members",
+            "fetch_messages",
+            "create_thread",
+        ]
+        assert props["auto_archive_duration"]["type"] == "integer"
+        assert "enum" not in props["auto_archive_duration"]
+        assert "Allowed values: 60, 1440, 4320, 10080." in (
+            props["auto_archive_duration"]["description"]
+        )
+        assert props["time_from"]["type"] == "string"
+        assert "Accepts number or string." in props["time_from"]["description"]
+
+        original_props = tools[0]["function"]["parameters"]["properties"]
+        assert original_props["auto_archive_duration"]["enum"] == [
+            60,
+            1440,
+            4320,
+            10080,
+        ]
+        assert original_props["time_from"]["type"] == ["number", "string"]
+
+    def test_copilot_non_gemini_tools_keep_original_schema(self, transport):
+        """Copilot models outside the Gemini family keep the OpenAI schema."""
+        from providers import get_provider_profile
+
+        tools = _copilot_gemini_problem_tools()
+        kw = transport.build_kwargs(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=tools,
+            provider_profile=get_provider_profile("copilot"),
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+
+        props = kw["tools"][0]["function"]["parameters"]["properties"]
+        assert props["auto_archive_duration"]["enum"] == [60, 1440, 4320, 10080]
+        assert props["time_from"]["type"] == ["number", "string"]
+
+    def test_non_copilot_gemini_tools_keep_original_schema(self, transport):
+        """The Copilot Gemini repair must not weaken other provider schemas."""
+        from providers import get_provider_profile
+
+        tools = _copilot_gemini_problem_tools()
+        kw = transport.build_kwargs(
+            model="google/gemini-3.5-flash",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=tools,
+            provider_profile=get_provider_profile("openrouter"),
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+
+        props = kw["tools"][0]["function"]["parameters"]["properties"]
+        assert props["auto_archive_duration"]["enum"] == [60, 1440, 4320, 10080]
+        assert props["time_from"]["type"] == ["number", "string"]
+
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "https://api.githubcopilot.com",
+            "https://api.enterprise.githubcopilot.com",
+        ],
+    )
+    def test_copilot_gemini_custom_base_url_is_sanitized(self, transport, base_url):
+        """Custom entries pointed at Copilot endpoints get the same repair."""
+        tools = _copilot_gemini_problem_tools()
+        kw = transport.build_kwargs(
+            model="gemini-3.5-flash",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=tools,
+            base_url=base_url,
+            provider_name="custom",
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+
+        props = kw["tools"][0]["function"]["parameters"]["properties"]
+        assert "enum" not in props["auto_archive_duration"]
+        assert props["time_from"]["type"] == "string"
 
 
 class TestChatCompletionsLmStudioReasoning:


### PR DESCRIPTION
## Summary
- Detect Copilot-hosted Gemini chat-completions requests.
- Normalize unsupported tool-schema shapes for that provider path: non-string enums move into descriptions, and type arrays collapse to an accepted scalar type.
- Match both public and enterprise Copilot base URLs, including `api.enterprise.githubcopilot.com`.
- Leave non-Gemini Copilot requests and non-Copilot Gemini providers unchanged.

Fixes #30676.

## Review update
- Addressed the sweeper review by replacing the exact `api.githubcopilot.com` check with the shared Copilot host matcher.
- Added a custom enterprise base URL regression test.

## Validation
- `scripts/run_tests.sh tests/agent/transports/test_chat_completions.py`, 96 passed
- `uv run --extra dev ruff check agent/transports/chat_completions.py tests/agent/transports/test_chat_completions.py`, passed
- `git diff --check upstream/main...HEAD`, clean

## Notes
- The first wrapper invocation happened before this linked worktree's dev dependencies were installed and failed with `No module named pytest`. After `uv run --extra dev` prepared the environment, the same wrapper command passed.
