### PR TITLE
feat(gateway): add structured metadata for /goal status notices

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21126,18 +21126,81 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
 
 
-    async def _send_goal_status_notice(self, source: Any, message: str) -> None:
+    @staticmethod
+    def _goal_status_event_type(decision: Dict[str, Any]) -> str:
+        """Map a GoalManager decision to the public goal_event type."""
+        status = str(decision.get("status") or "").strip().lower()
+        verdict = str(decision.get("verdict") or "").strip().lower()
+        if status == "done" or verdict == "done":
+            return "done"
+        if status == "paused":
+            return "paused"
+        if decision.get("should_continue"):
+            return "continue"
+        return verdict or status or "status"
+
+    def _build_goal_status_event(
+        self,
+        *,
+        decision: Dict[str, Any],
+        goal_state: Any,
+        raw_text: str,
+    ) -> Dict[str, Any]:
+        """Return structured metadata for a /goal judge status notice."""
+        event: Dict[str, Any] = {
+            "contract": "hermes.goal_event.v1",
+            "event_type": self._goal_status_event_type(decision),
+            "status": decision.get("status"),
+            "reason": decision.get("reason") or "",
+            "raw_text": raw_text,
+        }
+        verdict = decision.get("verdict")
+        if verdict:
+            event["verdict"] = verdict
+
+        if goal_state is not None:
+            event["turn"] = {
+                "used": int(getattr(goal_state, "turns_used", 0) or 0),
+                "max": int(getattr(goal_state, "max_turns", 0) or 0),
+            }
+            goal = getattr(goal_state, "goal", None)
+            if goal:
+                event["goal"] = goal
+            pause_reason = getattr(goal_state, "paused_reason", None)
+            if pause_reason:
+                event["pause_reason"] = pause_reason
+
+        return event
+
+    def _goal_status_notice_metadata(
+        self,
+        source: Any,
+        goal_event: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Merge thread routing metadata with optional /goal event metadata."""
+        try:
+            metadata = self._thread_metadata_for_source(source) or {}
+        except Exception:
+            metadata = {}
+        if goal_event:
+            metadata = dict(metadata)
+            metadata["goal_event"] = goal_event
+        return metadata or None
+
+    async def _send_goal_status_notice(
+        self,
+        source: Any,
+        message: str,
+        *,
+        goal_event: Optional[Dict[str, Any]] = None,
+    ) -> None:
         """Send a /goal judge status line back to the originating chat/thread."""
         adapter = self._adapter_for_source(source)
         if not adapter:
             logger.debug("goal continuation: no adapter for %s", getattr(source, "platform", None))
             return
 
-        try:
-            metadata = self._thread_metadata_for_source(source)
-        except Exception:
-            metadata = None
-
+        metadata = self._goal_status_notice_metadata(source, goal_event)
         result = await adapter.send(source.chat_id, message, metadata=metadata)
         if result is not None and not getattr(result, "success", True):
             logger.warning(
@@ -21145,7 +21208,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 getattr(result, "error", "unknown error"),
             )
 
-    async def _defer_goal_status_notice_after_delivery(self, source: Any, message: str) -> None:
+    async def _defer_goal_status_notice_after_delivery(
+        self,
+        source: Any,
+        message: str,
+        *,
+        goal_event: Optional[Dict[str, Any]] = None,
+    ) -> None:
         """Send a /goal status line after the main response is delivered.
 
         The gateway message handler returns the agent response to the platform
@@ -21162,7 +21231,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         async def _deliver() -> None:
             try:
-                await self._send_goal_status_notice(source, message)
+                await self._send_goal_status_notice(source, message, goal_event=goal_event)
             except Exception as exc:
                 logger.warning("goal continuation: status send failed: %s", exc, exc_info=True)
 
@@ -21252,7 +21321,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # an awaited post-delivery callback preserves delivery reliability
         # without reversing the user-visible ordering.
         if msg and source is not None:
-            await self._defer_goal_status_notice_after_delivery(source, msg)
+            goal_event = self._build_goal_status_event(
+                decision=decision,
+                goal_state=getattr(mgr, "state", None),
+                raw_text=msg,
+            )
+            await self._defer_goal_status_notice_after_delivery(source, msg, goal_event=goal_event)
 
         if not decision.get("should_continue"):
             return

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18564,18 +18564,81 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
 
 
-    async def _send_goal_status_notice(self, source: Any, message: str) -> None:
+    @staticmethod
+    def _goal_status_event_type(decision: Dict[str, Any]) -> str:
+        """Map a GoalManager decision to the public goal_event type."""
+        status = str(decision.get("status") or "").strip().lower()
+        verdict = str(decision.get("verdict") or "").strip().lower()
+        if status == "done" or verdict == "done":
+            return "done"
+        if status == "paused":
+            return "paused"
+        if decision.get("should_continue"):
+            return "continue"
+        return verdict or status or "status"
+
+    def _build_goal_status_event(
+        self,
+        *,
+        decision: Dict[str, Any],
+        goal_state: Any,
+        raw_text: str,
+    ) -> Dict[str, Any]:
+        """Return structured metadata for a /goal judge status notice."""
+        event: Dict[str, Any] = {
+            "contract": "hermes.goal_event.v1",
+            "event_type": self._goal_status_event_type(decision),
+            "status": decision.get("status"),
+            "reason": decision.get("reason") or "",
+            "raw_text": raw_text,
+        }
+        verdict = decision.get("verdict")
+        if verdict:
+            event["verdict"] = verdict
+
+        if goal_state is not None:
+            event["turn"] = {
+                "used": int(getattr(goal_state, "turns_used", 0) or 0),
+                "max": int(getattr(goal_state, "max_turns", 0) or 0),
+            }
+            goal = getattr(goal_state, "goal", None)
+            if goal:
+                event["goal"] = goal
+            pause_reason = getattr(goal_state, "paused_reason", None)
+            if pause_reason:
+                event["pause_reason"] = pause_reason
+
+        return event
+
+    def _goal_status_notice_metadata(
+        self,
+        source: Any,
+        goal_event: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Merge thread routing metadata with optional /goal event metadata."""
+        try:
+            metadata = self._thread_metadata_for_source(source) or {}
+        except Exception:
+            metadata = {}
+        if goal_event:
+            metadata = dict(metadata)
+            metadata["goal_event"] = goal_event
+        return metadata or None
+
+    async def _send_goal_status_notice(
+        self,
+        source: Any,
+        message: str,
+        *,
+        goal_event: Optional[Dict[str, Any]] = None,
+    ) -> None:
         """Send a /goal judge status line back to the originating chat/thread."""
         adapter = self._adapter_for_source(source)
         if not adapter:
             logger.debug("goal continuation: no adapter for %s", getattr(source, "platform", None))
             return
 
-        try:
-            metadata = self._thread_metadata_for_source(source)
-        except Exception:
-            metadata = None
-
+        metadata = self._goal_status_notice_metadata(source, goal_event)
         result = await adapter.send(source.chat_id, message, metadata=metadata)
         if result is not None and not getattr(result, "success", True):
             logger.warning(
@@ -18583,7 +18646,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 getattr(result, "error", "unknown error"),
             )
 
-    async def _defer_goal_status_notice_after_delivery(self, source: Any, message: str) -> None:
+    async def _defer_goal_status_notice_after_delivery(
+        self,
+        source: Any,
+        message: str,
+        *,
+        goal_event: Optional[Dict[str, Any]] = None,
+    ) -> None:
         """Send a /goal status line after the main response is delivered.
 
         The gateway message handler returns the agent response to the platform
@@ -18600,7 +18669,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         async def _deliver() -> None:
             try:
-                await self._send_goal_status_notice(source, message)
+                await self._send_goal_status_notice(source, message, goal_event=goal_event)
             except Exception as exc:
                 logger.warning("goal continuation: status send failed: %s", exc, exc_info=True)
 
@@ -18679,7 +18748,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # an awaited post-delivery callback preserves delivery reliability
         # without reversing the user-visible ordering.
         if msg and source is not None:
-            await self._defer_goal_status_notice_after_delivery(source, msg)
+            goal_event = self._build_goal_status_event(
+                decision=decision,
+                goal_state=getattr(mgr, "state", None),
+                raw_text=msg,
+            )
+            await self._defer_goal_status_notice_after_delivery(source, msg, goal_event=goal_event)
 
         if not decision.get("should_continue"):
             return

--- a/tests/gateway/test_goal_status_notice.py
+++ b/tests/gateway/test_goal_status_notice.py
@@ -41,6 +41,81 @@ def _goal_continuation_event(source, goal="finish the task"):
 
 
 @pytest.mark.asyncio
+async def test_goal_status_notice_uses_adapter_send_with_thread_metadata():
+    """Regression: /goal judge status must use BasePlatformAdapter.send().
+
+    The old implementation checked for a non-existent send_message() method,
+    so the goal could be marked done in state_meta without the visible
+    "✓ Goal achieved" status line being delivered to Discord/Telegram.
+    """
+    runner = GatewayRunner.__new__(GatewayRunner)
+    adapter = FakeAdapter()
+    runner.adapters = {Platform.DISCORD: adapter}
+
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="parent-channel",
+        thread_id="thread-123",
+    )
+
+    goal_event = {
+        "contract": "hermes.goal_event.v1",
+        "event_type": "done",
+        "status": "done",
+        "reason": "done",
+        "raw_text": "✓ Goal achieved: done",
+    }
+
+    await runner._send_goal_status_notice(
+        source,
+        "✓ Goal achieved: done",
+        goal_event=goal_event,
+    )
+
+    assert adapter.calls == [
+        {
+            "chat_id": "parent-channel",
+            "content": "✓ Goal achieved: done",
+            "reply_to": None,
+            "metadata": {"thread_id": "thread-123", "goal_event": goal_event},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_goal_status_notice_uses_profile_routed_adapter():
+    """Multiplexed profile replies must use the source-routed adapter.
+
+    A direct ``self.adapters.get(source.platform)`` lookup would pick the
+    default-profile adapter and misroute the goal notice.
+    """
+    runner = GatewayRunner.__new__(GatewayRunner)
+    default_adapter = FakeAdapter()
+    profile_adapter = FakeAdapter()
+    runner.adapters = {Platform.DISCORD: default_adapter}
+    runner._adapter_for_source = lambda source: profile_adapter
+
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="profile-channel",
+        thread_id="thread-123",
+        profile="secondary",
+    )
+
+    await runner._send_goal_status_notice(source, "✓ Goal achieved: done")
+
+    assert default_adapter.calls == []
+    assert profile_adapter.calls == [
+        {
+            "chat_id": "profile-channel",
+            "content": "✓ Goal achieved: done",
+            "reply_to": None,
+            "metadata": {"thread_id": "thread-123"},
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_goal_status_notice_defers_until_post_delivery_callback():
     """Regression: goal status must appear after the agent's visible reply.
 
@@ -60,7 +135,19 @@ async def test_goal_status_notice_defers_until_post_delivery_callback():
         user_id="user-1",
     )
 
-    await runner._defer_goal_status_notice_after_delivery(source, "✓ Goal achieved: done")
+    goal_event = {
+        "contract": "hermes.goal_event.v1",
+        "event_type": "done",
+        "status": "done",
+        "reason": "done",
+        "raw_text": "✓ Goal achieved: done",
+    }
+
+    await runner._defer_goal_status_notice_after_delivery(
+        source,
+        "✓ Goal achieved: done",
+        goal_event=goal_event,
+    )
 
     assert adapter.calls == []
     assert len(adapter.callbacks) == 1
@@ -75,8 +162,7 @@ async def test_goal_status_notice_defers_until_post_delivery_callback():
             "chat_id": "parent-channel",
             "content": "✓ Goal achieved: done",
             "reply_to": None,
-            "metadata": {"thread_id": "thread-123"},
+            "metadata": {"thread_id": "thread-123", "goal_event": goal_event},
         }
     ]
-
 

--- a/tests/gateway/test_goal_verdict_send.py
+++ b/tests/gateway/test_goal_verdict_send.py
@@ -108,6 +108,48 @@ async def _drain_until(condition, timeout=5.0):
         await asyncio.sleep(0.01)
 
 
+def _sent_goal_event(adapter: _RecordingAdapter) -> dict:
+    metadata = adapter.sends[0]["metadata"]
+    assert metadata is not None
+    event = metadata.get("goal_event")
+    assert event is not None
+    return event
+
+
+@pytest.mark.asyncio
+async def test_goal_verdict_done_sent_via_adapter_send(hermes_home):
+    """When the judge says done, the '✓ Goal achieved' message must reach
+    the user through the adapter's ``send()`` method."""
+    runner, adapter, session_entry, src = _make_runner_with_adapter()
+
+    from hermes_cli.goals import GoalManager
+
+    mgr = GoalManager(session_entry.session_id)
+    mgr.set("ship the feature")
+
+    with patch("hermes_cli.goals.judge_goal", return_value=("done", "the feature shipped", False, None, False)):
+        await runner._post_turn_goal_continuation(
+            session_entry=session_entry,
+            source=src,
+            final_response="I shipped the feature.",
+        )
+        await _drain_until(lambda: adapter.sends)
+
+    assert len(adapter.sends) == 1, f"expected 1 send, got {len(adapter.sends)}: {adapter.sends}"
+    msg = adapter.sends[0]
+    assert msg["chat_id"] == "c1"
+    assert "Goal achieved" in msg["content"]
+    assert "the feature shipped" in msg["content"]
+    goal_event = _sent_goal_event(adapter)
+    assert goal_event["contract"] == "hermes.goal_event.v1"
+    assert goal_event["event_type"] == "done"
+    assert goal_event["status"] == "done"
+    assert goal_event["turn"] == {"used": 1, "max": 20}
+    assert goal_event["reason"] == "the feature shipped"
+    assert goal_event["raw_text"] == msg["content"]
+    assert goal_event["goal"] == "ship the feature"
+
+
 @pytest.mark.asyncio
 async def test_goal_verdict_continue_enqueues_continuation(hermes_home):
     """When the judge says continue, both the 'continuing' status and the
@@ -131,7 +173,15 @@ async def test_goal_verdict_continue_enqueues_continuation(hermes_home):
 
     # Status line sent back
     assert len(adapter.sends) == 1
-    assert "Continuing toward goal" in adapter.sends[0]["content"]
+    content = adapter.sends[0]["content"]
+    assert "Continuing toward goal" in content
+    goal_event = _sent_goal_event(adapter)
+    assert goal_event["event_type"] == "continue"
+    assert goal_event["status"] == "active"
+    assert goal_event["turn"] == {"used": 1, "max": 20}
+    assert goal_event["reason"] == "still needs work"
+    assert goal_event["raw_text"] == content
+    assert goal_event["goal"] == "polish the docs"
     # Continuation prompt enqueued for next turn
     assert adapter._pending_messages, "continuation prompt must be enqueued in pending_messages"
 
@@ -161,7 +211,14 @@ async def test_goal_verdict_budget_exhausted_sends_pause(hermes_home):
     content = adapter.sends[0]["content"]
     assert "paused" in content.lower()
     assert "turns used" in content.lower()
+    goal_event = _sent_goal_event(adapter)
+    assert goal_event["event_type"] == "paused"
+    assert goal_event["status"] == "paused"
+    assert goal_event["turn"]["used"] >= goal_event["turn"]["max"]
+    assert goal_event["turn"]["max"] == 2
+    assert goal_event["reason"] == "keep going"
+    assert goal_event["raw_text"] == content
+    assert goal_event["goal"] == "tiny goal"
+    assert "turn budget exhausted" in goal_event["pause_reason"]
     # No continuation enqueued when budget is exhausted
     assert not adapter._pending_messages
-
-

--- a/tests/gateway/test_goal_verdict_send.py
+++ b/tests/gateway/test_goal_verdict_send.py
@@ -96,6 +96,49 @@ def _make_runner_with_adapter(session_id: str = None):
     return runner, adapter, session_entry, src
 
 
+def _sent_goal_event(adapter: _RecordingAdapter) -> dict:
+    metadata = adapter.sends[0]["metadata"]
+    assert metadata is not None
+    event = metadata.get("goal_event")
+    assert event is not None
+    return event
+
+
+@pytest.mark.asyncio
+async def test_goal_verdict_done_sent_via_adapter_send(hermes_home):
+    """When the judge says done, the '✓ Goal achieved' message must reach
+    the user through the adapter's ``send()`` method."""
+    runner, adapter, session_entry, src = _make_runner_with_adapter()
+
+    from hermes_cli.goals import GoalManager
+
+    mgr = GoalManager(session_entry.session_id)
+    mgr.set("ship the feature")
+
+    with patch("hermes_cli.goals.judge_goal", return_value=("done", "the feature shipped", False, None, False)):
+        await runner._post_turn_goal_continuation(
+            session_entry=session_entry,
+            source=src,
+            final_response="I shipped the feature.",
+        )
+        # fire-and-forget create_task — give the loop a tick
+        await asyncio.sleep(0.05)
+
+    assert len(adapter.sends) == 1, f"expected 1 send, got {len(adapter.sends)}: {adapter.sends}"
+    msg = adapter.sends[0]
+    assert msg["chat_id"] == "c1"
+    assert "Goal achieved" in msg["content"]
+    assert "the feature shipped" in msg["content"]
+    goal_event = _sent_goal_event(adapter)
+    assert goal_event["contract"] == "hermes.goal_event.v1"
+    assert goal_event["event_type"] == "done"
+    assert goal_event["status"] == "done"
+    assert goal_event["turn"] == {"used": 1, "max": 20}
+    assert goal_event["reason"] == "the feature shipped"
+    assert goal_event["raw_text"] == msg["content"]
+    assert goal_event["goal"] == "ship the feature"
+
+
 @pytest.mark.asyncio
 async def test_goal_verdict_continue_enqueues_continuation(hermes_home):
     """When the judge says continue, both the 'continuing' status and the
@@ -119,7 +162,15 @@ async def test_goal_verdict_continue_enqueues_continuation(hermes_home):
 
     # Status line sent back
     assert len(adapter.sends) == 1
-    assert "Continuing toward goal" in adapter.sends[0]["content"]
+    content = adapter.sends[0]["content"]
+    assert "Continuing toward goal" in content
+    goal_event = _sent_goal_event(adapter)
+    assert goal_event["event_type"] == "continue"
+    assert goal_event["status"] == "active"
+    assert goal_event["turn"] == {"used": 1, "max": 20}
+    assert goal_event["reason"] == "still needs work"
+    assert goal_event["raw_text"] == content
+    assert goal_event["goal"] == "polish the docs"
     # Continuation prompt enqueued for next turn
     assert adapter._pending_messages, "continuation prompt must be enqueued in pending_messages"
 
@@ -149,7 +200,15 @@ async def test_goal_verdict_budget_exhausted_sends_pause(hermes_home):
     content = adapter.sends[0]["content"]
     assert "paused" in content.lower()
     assert "turns used" in content.lower()
+    goal_event = _sent_goal_event(adapter)
+    assert goal_event["event_type"] == "paused"
+    assert goal_event["status"] == "paused"
+    assert goal_event["turn"]["used"] >= goal_event["turn"]["max"]
+    assert goal_event["turn"]["max"] == 2
+    assert goal_event["reason"] == "keep going"
+    assert goal_event["raw_text"] == content
+    assert goal_event["goal"] == "tiny goal"
+    assert "turn budget exhausted" in goal_event["pause_reason"]
     # No continuation enqueued when budget is exhausted
     assert not adapter._pending_messages
-
 


### PR DESCRIPTION
## Summary

- Add a stable `metadata.goal_event` contract (`hermes.goal_event.v1`) to gateway `/goal` judge status notices.
- Preserve the existing human-readable status notice text and thread-routing metadata while adding structured event fields for adapters, dashboards, and audit clients.
- Cover done, continue, and paused/budget status notices in focused gateway tests.

Fixes #30577

## Behavior

Existing adapters still receive the same visible text, such as `✓ Goal achieved: ...` and `↻ Continuing toward goal (...): ...`. The metadata now includes structured fields such as `event_type`, `status`, `turn.used`, `turn.max`, `reason`, `raw_text`, and the active goal text when available.

## Validation

- `scripts/run_tests.sh tests/gateway/test_goal_status_notice.py tests/gateway/test_goal_verdict_send.py` — 8 tests passed.
- `.venv/bin/python -m ruff check gateway/run.py tests/gateway/test_goal_status_notice.py tests/gateway/test_goal_verdict_send.py` — passed.

## Compatibility

- Additive metadata only; no adapter rendering behavior is required to change.
- Thread metadata remains preserved alongside `goal_event`.
- No Telegram inline keyboard, provider, MCP, STT, Kanban, state DB, checkpoint, or file tool changes.