### PR TITLE
fix(state): retry transient SQLite WAL setup failures (Fixes #30576)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -545,6 +545,14 @@ _WAL_INCOMPAT_MARKERS = (
     "not authorized",         # Some FUSE mounts block WAL pragma outright
     "disk i/o error",         # ZFS SHM corruption under concurrent connections
 )
+_SQLITE_TRANSIENT_BUSY_MARKERS = (
+    "database is locked",
+    "database table is locked",
+    "database is busy",
+    "database schema is locked",
+)
+_WAL_SETUP_MAX_ATTEMPTS = 3
+_WAL_SETUP_RETRY_DELAY_S = 1.0
 
 # Upper bound for the write-ahead log. SQLite defaults to -1 (unlimited),
 # which lets state.db-wal keep the high-water mark of the largest-ever
@@ -1042,61 +1050,56 @@ def apply_wal_with_fallback(
             )
         return actual
 
-    try:
-        # ``PRAGMA journal_mode=WAL`` is a query-that-sets: it RETURNS the
-        # resulting journal mode. Network filesystems that refuse WAL by
-        # *raising* SQLITE_PROTOCOL ("locking protocol") are handled in the
-        # except branch below. But macOS NFS — and SMB/CIFS, and the AgentFS
-        # NFS overlay — refuse the switch WITHOUT raising: the pragma simply
-        # returns the still-effective mode (e.g. ``delete``). Trust the
-        # returned row, not the mere absence of an exception; otherwise we
-        # report a false ``"wal"`` AND skip the fallback WARNING, leaving the
-        # DB silently in DELETE (reader-blocks-writer) with no signal.
-        row = conn.execute("PRAGMA journal_mode=WAL").fetchone()
-        mode = str(row[0]).strip().lower() if row and row[0] is not None else ""
-        if mode == "wal":
-            _apply_wal_size_limit(conn)
-            _apply_macos_checkpoint_barrier(conn)
-            _enforce_macos_synchronous_full(conn)
-            return "wal"
-        # Silent refusal (macOS NFS / SMB / AgentFS overlay): WAL was not
-        # honored, but nothing raised.
-        silent_exc = WalUnsupportedError(
-            f"journal_mode=WAL refused without raising (still {mode!r})"
-        )
-        if require_wal:
-            raise silent_exc
-        _log_wal_fallback_once(db_label, silent_exc)
-        return mode or "delete"
-    except sqlite3.OperationalError as exc:
-        # The require_wal silent-refusal raise above is a WalUnsupportedError
-        # (an OperationalError subclass) and lands here — propagate it
-        # unchanged rather than re-running it through the marker logic.
-        if isinstance(exc, WalUnsupportedError):
-            raise
-        msg = str(exc).lower()
-        if not any(marker in msg for marker in _WAL_INCOMPAT_MARKERS):
-            # Unrelated OperationalError — don't silently swallow.
-            raise
-        # ``disk i/o error`` is ambiguous: on ZFS / APFS-CoW it is a
-        # deterministic WAL-incompatibility (SHM corruption under concurrent
-        # connection bursts — #55305, #71498), but it can also be a one-shot
-        # transient EIO (page-cache pressure, brief lock contention).
-        # Treating a transient EIO as a permanent downgrade signal produced
-        # the mixed-journal-mode corruption pattern fixed in 5c49cd0ed0
-        # (process A downgrades to DELETE while sibling processes set WAL).
-        # Disambiguate by retrying the pragma a couple of times: transient
-        # EIO clears and we return "wal"; the deterministic filesystem cases
-        # keep failing and fall through to the guarded DELETE fallback.
-        if "disk i/o error" in msg:
-            for _ in range(2):
+    fallback_exc: Optional[sqlite3.OperationalError] = None
+    for attempt in range(_WAL_SETUP_MAX_ATTEMPTS):
+        try:
+            # ``PRAGMA journal_mode=WAL`` is a query-that-sets: it RETURNS the
+            # resulting journal mode. Network filesystems that refuse WAL can
+            # raise, or silently return the still-effective mode. Busy/locked
+            # failures are retried as transient contention, but persistent
+            # busy/locked failures are re-raised rather than downgraded.
+            row = conn.execute("PRAGMA journal_mode=WAL").fetchone()
+            mode = (
+                str(row[0]).strip().lower()
+                if row and row[0] is not None
+                else ""
+            )
+            if mode == "wal":
+                _apply_wal_size_limit(conn)
+                _apply_macos_checkpoint_barrier(conn)
+                _enforce_macos_synchronous_full(conn)
+                return "wal"
+            silent_exc = WalUnsupportedError(
+                f"journal_mode=WAL refused without raising (still {mode!r})"
+            )
+            if require_wal:
+                raise silent_exc
+            _log_wal_fallback_once(db_label, silent_exc)
+            return mode or "delete"
+        except sqlite3.OperationalError as exc:
+            if isinstance(exc, WalUnsupportedError):
+                raise
+            msg = str(exc).lower()
+            is_transient = any(
+                marker in msg for marker in _SQLITE_TRANSIENT_BUSY_MARKERS
+            )
+            if is_transient and attempt < _WAL_SETUP_MAX_ATTEMPTS - 1:
+                time.sleep(_WAL_SETUP_RETRY_DELAY_S)
+                continue
+            if is_transient:
+                raise
+            if not any(marker in msg for marker in _WAL_INCOMPAT_MARKERS):
+                # Unrelated OperationalError — don't silently swallow.
+                raise
+            fallback_exc = exc
+            if "disk i/o error" in msg and attempt < _WAL_SETUP_MAX_ATTEMPTS - 1:
                 time.sleep(0.05)
                 try:
                     row = conn.execute("PRAGMA journal_mode=WAL").fetchone()
                 except sqlite3.OperationalError as retry_exc:
                     if "disk i/o error" not in str(retry_exc).lower():
                         raise
-                    exc = retry_exc
+                    fallback_exc = retry_exc
                     continue
                 mode = (
                     str(row[0]).strip().lower()
@@ -1108,17 +1111,20 @@ def apply_wal_with_fallback(
                     _apply_macos_checkpoint_barrier(conn)
                     _enforce_macos_synchronous_full(conn)
                     return "wal"
-                break
+                # WAL was still refused without raising; fall through to the
+                # guarded DELETE fallback below.
         # Don't downgrade if another process already set WAL on disk, or if
         # the mode cannot be verified at all (probe blocked by a concurrent
         # opener's locks) — ownership is not provably exclusive either way.
         existing = _on_disk_journal_mode(conn)
         if existing == "wal" or existing is None:
-            raise
+            raise fallback_exc or sqlite3.OperationalError(
+                "could not initialize WAL journal mode"
+            )
         if require_wal:
             # Caller mandates WAL — fail loudly instead of degrading to DELETE.
-            raise WalUnsupportedError(str(exc)) from exc
-        _log_wal_fallback_once(db_label, exc)
+            raise WalUnsupportedError(str(fallback_exc)) from fallback_exc
+        _log_wal_fallback_once(db_label, fallback_exc)
         _set_journal_mode_no_wait(conn, "DELETE")
         return "delete"
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -443,6 +443,14 @@ _WAL_INCOMPAT_MARKERS = (
     "not authorized",         # Some FUSE mounts block WAL pragma outright
     "disk i/o error",         # ZFS SHM corruption under concurrent connections
 )
+_SQLITE_TRANSIENT_BUSY_MARKERS = (
+    "database is locked",
+    "database table is locked",
+    "database is busy",
+    "database schema is locked",
+)
+_WAL_SETUP_MAX_ATTEMPTS = 3
+_WAL_SETUP_RETRY_DELAY_S = 1.0
 
 # Last SessionDB() init error, per-process.  Surfaced in /resume and
 # related slash-command error strings so users know WHY the DB is
@@ -875,60 +883,53 @@ def apply_wal_with_fallback(
             )
         return actual
 
-    try:
-        # ``PRAGMA journal_mode=WAL`` is a query-that-sets: it RETURNS the
-        # resulting journal mode. Network filesystems that refuse WAL by
-        # *raising* SQLITE_PROTOCOL ("locking protocol") are handled in the
-        # except branch below. But macOS NFS — and SMB/CIFS, and the AgentFS
-        # NFS overlay — refuse the switch WITHOUT raising: the pragma simply
-        # returns the still-effective mode (e.g. ``delete``). Trust the
-        # returned row, not the mere absence of an exception; otherwise we
-        # report a false ``"wal"`` AND skip the fallback WARNING, leaving the
-        # DB silently in DELETE (reader-blocks-writer) with no signal.
-        row = conn.execute("PRAGMA journal_mode=WAL").fetchone()
-        mode = str(row[0]).strip().lower() if row and row[0] is not None else ""
-        if mode == "wal":
-            _apply_macos_checkpoint_barrier(conn)
-            _enforce_macos_synchronous_full(conn)
-            return "wal"
-        # Silent refusal (macOS NFS / SMB / AgentFS overlay): WAL was not
-        # honored, but nothing raised.
-        silent_exc = WalUnsupportedError(
-            f"journal_mode=WAL refused without raising (still {mode!r})"
-        )
-        if require_wal:
-            raise silent_exc
-        _log_wal_fallback_once(db_label, silent_exc)
-        return mode or "delete"
-    except sqlite3.OperationalError as exc:
-        # The require_wal silent-refusal raise above is a WalUnsupportedError
-        # (an OperationalError subclass) and lands here — propagate it
-        # unchanged rather than re-running it through the marker logic.
-        if isinstance(exc, WalUnsupportedError):
-            raise
-        msg = str(exc).lower()
-        if not any(marker in msg for marker in _WAL_INCOMPAT_MARKERS):
-            # Unrelated OperationalError — don't silently swallow.
-            raise
-        # ``disk i/o error`` is ambiguous: on ZFS / APFS-CoW it is a
-        # deterministic WAL-incompatibility (SHM corruption under concurrent
-        # connection bursts — #55305, #71498), but it can also be a one-shot
-        # transient EIO (page-cache pressure, brief lock contention).
-        # Treating a transient EIO as a permanent downgrade signal produced
-        # the mixed-journal-mode corruption pattern fixed in 5c49cd0ed0
-        # (process A downgrades to DELETE while sibling processes set WAL).
-        # Disambiguate by retrying the pragma a couple of times: transient
-        # EIO clears and we return "wal"; the deterministic filesystem cases
-        # keep failing and fall through to the guarded DELETE fallback.
-        if "disk i/o error" in msg:
-            for _ in range(2):
+    fallback_exc: Optional[sqlite3.OperationalError] = None
+    for attempt in range(_WAL_SETUP_MAX_ATTEMPTS):
+        try:
+            # ``PRAGMA journal_mode=WAL`` is a query-that-sets: it RETURNS the
+            # resulting journal mode. Network filesystems can refuse WAL by
+            # raising, or silently by returning the still-effective mode.
+            row = conn.execute("PRAGMA journal_mode=WAL").fetchone()
+            mode = (
+                str(row[0]).strip().lower()
+                if row and row[0] is not None
+                else ""
+            )
+            if mode == "wal":
+                _apply_macos_checkpoint_barrier(conn)
+                _enforce_macos_synchronous_full(conn)
+                return "wal"
+            silent_exc = WalUnsupportedError(
+                f"journal_mode=WAL refused without raising (still {mode!r})"
+            )
+            if require_wal:
+                raise silent_exc
+            _log_wal_fallback_once(db_label, silent_exc)
+            return mode or "delete"
+        except sqlite3.OperationalError as exc:
+            if isinstance(exc, WalUnsupportedError):
+                raise
+            msg = str(exc).lower()
+            is_transient = any(
+                marker in msg for marker in _SQLITE_TRANSIENT_BUSY_MARKERS
+            )
+            if is_transient and attempt < _WAL_SETUP_MAX_ATTEMPTS - 1:
+                time.sleep(_WAL_SETUP_RETRY_DELAY_S)
+                continue
+            if is_transient:
+                raise
+            if not any(marker in msg for marker in _WAL_INCOMPAT_MARKERS):
+                # Unrelated OperationalError — don't silently swallow.
+                raise
+            fallback_exc = exc
+            if "disk i/o error" in msg and attempt < _WAL_SETUP_MAX_ATTEMPTS - 1:
                 time.sleep(0.05)
                 try:
                     row = conn.execute("PRAGMA journal_mode=WAL").fetchone()
                 except sqlite3.OperationalError as retry_exc:
                     if "disk i/o error" not in str(retry_exc).lower():
                         raise
-                    exc = retry_exc
+                    fallback_exc = retry_exc
                     continue
                 mode = (
                     str(row[0]).strip().lower()
@@ -945,11 +946,13 @@ def apply_wal_with_fallback(
         # opener's locks) — ownership is not provably exclusive either way.
         existing = _on_disk_journal_mode(conn)
         if existing == "wal" or existing is None:
-            raise
+            raise fallback_exc or sqlite3.OperationalError(
+                "could not initialize WAL journal mode"
+            )
         if require_wal:
             # Caller mandates WAL — fail loudly instead of degrading to DELETE.
-            raise WalUnsupportedError(str(exc)) from exc
-        _log_wal_fallback_once(db_label, exc)
+            raise WalUnsupportedError(str(fallback_exc)) from fallback_exc
+        _log_wal_fallback_once(db_label, fallback_exc)
         _set_journal_mode_no_wait(conn, "DELETE")
         return "delete"
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2729,7 +2729,6 @@ class TestFTS5ToolCallMigration:
         finally:
             session_db.close()
 
-
 class TestFTSExternalContentMigration:
     """v23 migration: inline-mode FTS tables (v11-v22) are rebuilt as
     external-content tables, and role='tool' rows are excluded from the
@@ -3290,7 +3289,6 @@ class TestFTSExternalContentMigration:
             ).fetchone() is None
         finally:
             db.close()
-
 
 
 # ---------------------------------------------------------------------------
@@ -4090,6 +4088,10 @@ class TestLoneSurrogatePersistence:
         db.append_message("s1", "user", "turn text")
         assert db.set_latest_user_api_content("s1", "turn text", self.DIRTY) == 1
 
+    def test_session_title_survives_lone_surrogate(self, db):
+        db.create_session("s1", source="cli")
+        assert db.set_session_title("s1", "title \ud835 bad") is True
+        assert db.get_session("s1")["title"] == "title \ufffd bad"
 
 
 class TestDisplayMetadataPersistence:
@@ -4203,7 +4205,6 @@ class TestDisplayMetadataReadPaths:
             assert target.get_messages("s1")[0]["display_metadata"] == self.META
         finally:
             target.close()
-
 
 
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2589,7 +2589,6 @@ class TestFTS5ToolCallMigration:
         finally:
             session_db.close()
 
-
 class TestFTSExternalContentMigration:
     """v23 migration: inline-mode FTS tables (v11-v22) are rebuilt as
     external-content tables, and role='tool' rows are excluded from the
@@ -3036,7 +3035,6 @@ class TestFTSExternalContentMigration:
             assert hits[0]["role"] == "tool"
         finally:
             db.close()
-
 
 
 # ---------------------------------------------------------------------------
@@ -3693,6 +3691,10 @@ class TestLoneSurrogatePersistence:
         db.append_message("s1", "user", "turn text")
         assert db.set_latest_user_api_content("s1", "turn text", self.DIRTY) == 1
 
+    def test_session_title_survives_lone_surrogate(self, db):
+        db.create_session("s1", source="cli")
+        assert db.set_session_title("s1", "title \ud835 bad") is True
+        assert db.get_session("s1")["title"] == "title \ufffd bad"
 
 
 class TestDisplayMetadataPersistence:
@@ -3806,7 +3808,6 @@ class TestDisplayMetadataReadPaths:
             assert target.get_messages("s1")[0]["display_metadata"] == self.META
         finally:
             target.close()
-
 
 
 

--- a/tests/test_hermes_state_wal_fallback.py
+++ b/tests/test_hermes_state_wal_fallback.py
@@ -45,6 +45,24 @@ def _make_blocking_factory(reason: str, attempt_counter: list):
     return _WalBlockingConnection
 
 
+def _make_flaky_factory(
+    reason: str,
+    failures_before_success: int,
+    attempt_counter: list,
+):
+    """Return a connection subclass that fails WAL setup a fixed number of times."""
+
+    class _WalFlakyConnection(sqlite3.Connection):
+        def execute(self, sql, *args, **kwargs):  # type: ignore[override]
+            if "journal_mode=wal" in sql.lower().replace(" ", ""):
+                attempt_counter[0] += 1
+                if attempt_counter[0] <= failures_before_success:
+                    raise sqlite3.OperationalError(reason)
+            return super().execute(sql, *args, **kwargs)
+
+    return _WalFlakyConnection
+
+
 def _open_blocking(path, reason="locking protocol", **kwargs):
     """Open a connection whose WAL pragma raises ``reason``.
 
@@ -75,6 +93,13 @@ def _make_silent_noop_factory(returned_mode: str = "delete"):
             return super().execute(sql, *args, **kwargs)
 
     return _WalSilentNoOpConnection
+
+
+def _open_flaky(path, reason, failures_before_success, **kwargs):
+    """Open a connection whose WAL pragma fails before eventually succeeding."""
+    attempts = [0]
+    factory = _make_flaky_factory(reason, failures_before_success, attempts)
+    return sqlite3.connect(str(path), factory=factory, **kwargs), attempts
 
 
 @pytest.fixture(autouse=True)
@@ -200,6 +225,36 @@ class TestApplyWalWithFallback:
         assert apply_wal_with_fallback(conn) == "wal"
         assert attempts[0] == 2, "the retry must have re-attempted the pragma"
         assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+
+    def test_retries_busy_wal_setup_then_succeeds(self, tmp_path):
+        """Transient busy/locked WAL setup failures are retried before success."""
+        conn, attempts = _open_flaky(
+            tmp_path / "busy_then_ok.db",
+            reason="database is locked",
+            failures_before_success=2,
+            isolation_level=None,
+        )
+        with patch("hermes_state.time.sleep") as sleep_mock:
+            mode = apply_wal_with_fallback(conn)
+
+        assert mode == "wal"
+        assert attempts[0] == 3
+        assert sleep_mock.call_count == 2
+        conn.close()
+
+    def test_reraises_busy_wal_setup_after_bounded_retries(self, tmp_path):
+        """Persistent busy/locked WAL setup failures are not converted to DELETE."""
+        conn, attempts = _open_blocking(
+            tmp_path / "always_busy.db",
+            reason="database is locked",
+            isolation_level=None,
+        )
+        with patch("hermes_state.time.sleep") as sleep_mock:
+            with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+                apply_wal_with_fallback(conn)
+
+        assert attempts[0] == hermes_state._WAL_SETUP_MAX_ATTEMPTS
+        assert sleep_mock.call_count == hermes_state._WAL_SETUP_MAX_ATTEMPTS - 1
         conn.close()
 
     def test_persistent_disk_io_error_falls_back_to_delete(self, tmp_path, caplog):


### PR DESCRIPTION
## Summary

Fixes #30576.

- Retry `PRAGMA journal_mode=WAL` up to three times for transient SQLite busy or locked setup failures.
- Re-raise persistent busy or locked failures instead of downgrading the database to DELETE mode.
- Keep the existing WAL-to-DELETE fallback for known incompatible filesystems, and preserve the current macOS checkpoint and synchronous durability behavior.

## Why

The state database already retries write transactions after SQLite returns busy or locked errors. WAL setup still made a single attempt, so short-lived lock contention during startup could fail the whole state database initialization.

Retrying the idempotent WAL setup path gives SQLite a chance to settle without changing the connection timeout or weakening the existing filesystem fallback rules.

## Overlap Check

Before changing code, I checked issue #30576 and searched PRs for #30576, SQLite WAL, BTRFS, busy timeout, retry, and state DB lock wording. I found adjacent WAL maintenance and corruption PRs, but none covering this focused WAL setup retry path. This PR avoids checkpoint, synchronous, doctor, and connection-timeout changes.

## Validation

- `scripts/run_tests.sh tests/test_hermes_state_wal_fallback.py tests/test_hermes_state.py tests/test_sqlite_lock_safe_inspection.py`, 492 passed, 0 failed
- `uv run --extra dev ruff check hermes_state.py tests/test_hermes_state.py tests/test_hermes_state_wal_fallback.py tests/test_sqlite_lock_safe_inspection.py`, passed
- `git diff --check upstream/main...HEAD`, clean
