### PR TITLE
fix(kanban): guard corrupted board DB auto-init (Fixes #30687)

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -914,11 +914,12 @@ def kanban_command(args: argparse.Namespace) -> int:
     # schema creation; `create` / `list` / every other command would
     # error out on a fresh install.
     with board_scope:
-        try:
-            kb.init_db()
-        except Exception as exc:
-            print(f"kanban: could not initialize database: {exc}", file=sys.stderr)
-            return 1
+        if action != "init":
+            try:
+                kb.init_db()
+            except Exception as exc:
+                print(f"kanban: could not initialize database: {exc}", file=sys.stderr)
+                return 1
 
         handlers = {
             "init":     _cmd_init,
@@ -1220,7 +1221,7 @@ def _parse_duration(val) -> Optional[int]:
 
 
 def _cmd_init(args: argparse.Namespace) -> int:
-    path = kb.init_db()
+    path = kb.init_db(allow_recreate=True)
     print(f"Kanban DB initialized at {path}")
 
     # Seed bundled skills (e.g. kanban-worker) into the active profile so

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -630,7 +630,7 @@ def create_board(
         default_workdir=default_workdir,
     )
     # Touch the DB so list_boards() sees it immediately.
-    init_db(board=normed)
+    init_db(board=normed, allow_recreate=True)
     return meta
 
 
@@ -1412,10 +1412,88 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
     raise KanbanDbCorruptError(resolved, backup, reason)
 
 
+def _resolved_board_slug(board: Optional[str]) -> Optional[str]:
+    """Return the board slug a non-explicit DB path is meant to serve."""
+    slug = _normalize_board_slug(board)
+    if slug is not None:
+        return slug
+    try:
+        return get_current_board()
+    except Exception:
+        return None
+
+
+def _has_tasks_table(path: Path) -> bool:
+    uri = path.resolve().as_uri() + "?mode=ro"
+    with contextlib.closing(sqlite3.connect(uri, uri=True)) as probe:
+        row = probe.execute(
+            "SELECT 1 FROM sqlite_master "
+            "WHERE type = 'table' AND name = 'tasks' LIMIT 1"
+        ).fetchone()
+    return row is not None
+
+
+def _guard_against_suspicious_auto_init(
+    path: Path,
+    *,
+    board_slug: Optional[str],
+    known_board_before_open: bool,
+    path_existed_before_open: bool,
+    allow_recreate: bool,
+) -> None:
+    """Refuse implicit schema creation when it would mask lost board data."""
+    if allow_recreate:
+        return
+    if not path_existed_before_open:
+        if known_board_before_open and board_slug != DEFAULT_BOARD:
+            raise sqlite3.DatabaseError(
+                "refusing to initialize missing Kanban DB for existing board "
+                f"{board_slug!r} at {path}. This can hide board data loss; "
+                "restore the database from backup or run "
+                f"`hermes kanban --board {board_slug} init` only if you "
+                "intentionally want to create an empty board."
+            )
+        return
+
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return
+    if size == 0:
+        board_hint = f" for board {board_slug!r}" if board_slug else ""
+        init_hint = (
+            f"`hermes kanban --board {board_slug} init`"
+            if board_slug and board_slug != DEFAULT_BOARD
+            else "`hermes kanban init`"
+        )
+        raise sqlite3.DatabaseError(
+            f"refusing to initialize empty Kanban DB{board_hint} at {path}. "
+            "A zero-byte database can indicate truncation or a failed write; "
+            f"restore it from backup or run {init_hint} only if you "
+            "intentionally want to create an empty board."
+        )
+
+    if not _has_tasks_table(path):
+        board_hint = f" for board {board_slug!r}" if board_slug else ""
+        init_hint = (
+            f"`hermes kanban --board {board_slug} init`"
+            if board_slug and board_slug != DEFAULT_BOARD
+            else "`hermes kanban init`"
+        )
+        raise sqlite3.DatabaseError(
+            f"refusing to initialize Kanban DB{board_hint} at {path}: "
+            "SQLite file is missing the required 'tasks' table. This can "
+            "mean the board DB is corrupted or an alternate/top-level DB was "
+            f"selected by mistake; restore the expected DB or run {init_hint} "
+            "only if you intentionally want to create an empty board."
+        )
+
+
 def connect(
     db_path: Optional[Path] = None,
     *,
     board: Optional[str] = None,
+    allow_recreate: bool = False,
 ) -> sqlite3.Connection:
     """Open (and initialize if needed) the kanban DB.
 
@@ -1434,11 +1512,30 @@ def connect(
     * Neither → :func:`kanban_db_path` resolves via
       ``HERMES_KANBAN_DB`` env → ``HERMES_KANBAN_BOARD`` env →
       ``<root>/kanban/current`` → ``default``.
+
+    ``allow_recreate`` is reserved for explicit initialization paths such as
+    ``hermes kanban init`` and ``create_board``. Normal command auto-init
+    refuses empty or schema-less DB files for known boards so a corrupted board
+    cannot be silently replaced with a fresh empty schema.
     """
+    guard_board_slug: Optional[str] = None
+    known_board_before_open = False
+    path_existed_before_open = False
+
     if db_path is not None:
         path = db_path
+        if board is not None:
+            guard_board_slug = _resolved_board_slug(board)
+            known_board_before_open = (
+                board_exists(guard_board_slug) if guard_board_slug else False
+            )
     else:
+        guard_board_slug = _resolved_board_slug(board)
+        known_board_before_open = (
+            board_exists(guard_board_slug) if guard_board_slug else False
+        )
         path = kanban_db_path(board=board)
+    path_existed_before_open = path.exists()
     path.parent.mkdir(parents=True, exist_ok=True)
     with _cross_process_init_lock(path):
         # Cheap byte-level check first — catches the #29507 TLS-overwrite shape
@@ -1448,6 +1545,13 @@ def connect(
         # pages, broken internal metadata). Cached per-path after first success
         # via _INITIALIZED_PATHS so it only runs once per process per path.
         _guard_existing_db_is_healthy(path)
+        _guard_against_suspicious_auto_init(
+            path,
+            board_slug=guard_board_slug,
+            known_board_before_open=known_board_before_open,
+            path_existed_before_open=path_existed_before_open,
+            allow_recreate=allow_recreate,
+        )
         resolved = str(path.resolve())
         conn = _sqlite_connect(path)
         try:
@@ -1528,6 +1632,7 @@ def init_db(
     db_path: Optional[Path] = None,
     *,
     board: Optional[str] = None,
+    allow_recreate: bool = False,
 ) -> Path:
     """Create the schema if it doesn't exist; return the path used.
 
@@ -1538,6 +1643,10 @@ def init_db(
     may have drifted — tests that write legacy event kinds directly,
     external tools that upgrade an old DB file — can call this to
     force re-migration.
+
+    Set ``allow_recreate`` only for explicit user intent to initialize a
+    missing/empty board DB. The default keeps command startup from masking
+    board data loss.
     """
     if db_path is not None:
         path = db_path
@@ -1549,7 +1658,7 @@ def init_db(
     # schema + migration pass unconditionally.
     with _INIT_LOCK:
         _INITIALIZED_PATHS.discard(resolved)
-    with contextlib.closing(connect(path)):
+    with contextlib.closing(connect(path, board=board, allow_recreate=allow_recreate)):
         pass
     return path
 

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import os
+import sqlite3
 import subprocess
 import sys
 from pathlib import Path
@@ -546,6 +547,49 @@ class TestCLI:
         ghost.mkdir(parents=True)
         r = _cli(["--board", "ghost", "list"], env_extra=env)
         assert "does not exist" in r.stderr
+
+    def test_list_refuses_empty_db_for_current_board(self, tmp_path):
+        env = {"HERMES_HOME": str(tmp_path)}
+        board = tmp_path / "kanban" / "boards" / "incident"
+        board.mkdir(parents=True)
+        (board / "board.json").write_text(
+            json.dumps({"slug": "incident", "name": "Incident"}) + "\n",
+            encoding="utf-8",
+        )
+        db_path = board / "kanban.db"
+        db_path.touch()
+        current = tmp_path / "kanban" / "current"
+        current.write_text("incident\n", encoding="utf-8")
+
+        r = _cli(["list"], env_extra=env)
+
+        assert "could not initialize database" in r.stderr
+        assert "zero-byte database" in r.stderr
+        assert db_path.read_bytes() == b""
+
+    def test_init_allows_recreate_for_existing_empty_board_db(self, tmp_path):
+        env = {"HERMES_HOME": str(tmp_path)}
+        board = tmp_path / "kanban" / "boards" / "incident"
+        board.mkdir(parents=True)
+        (board / "board.json").write_text(
+            json.dumps({"slug": "incident", "name": "Incident"}) + "\n",
+            encoding="utf-8",
+        )
+        db_path = board / "kanban.db"
+        db_path.touch()
+
+        r = _cli(["--board", "incident", "init"], env_extra=env)
+
+        assert r.returncode == 0, r.stderr
+        assert "Kanban DB initialized" in r.stdout
+        with sqlite3.connect(str(db_path)) as conn:
+            tables = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'table'"
+                )
+            }
+        assert "tasks" in tables
 
     def test_boards_rm_archives(self, tmp_path):
         env = {"HERMES_HOME": str(tmp_path)}

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -109,6 +109,120 @@ def test_connect_rejects_tls_record_in_sqlite_header(tmp_path, monkeypatch):
     assert "53 51 4c 69 74 17 03 03 00 13" in msg
 
 
+def test_connect_refuses_zero_byte_db_for_existing_named_board(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+
+    board = kb.board_dir("incident")
+    board.mkdir(parents=True)
+    kb.write_board_metadata("incident", name="Incident")
+    db_path = board / "kanban.db"
+    db_path.touch()
+
+    with pytest.raises(sqlite3.DatabaseError) as exc_info:
+        kb.connect(board="incident")
+
+    msg = str(exc_info.value)
+    assert "refusing to initialize empty Kanban DB for board 'incident'" in msg
+    assert "zero-byte database" in msg
+    assert db_path.read_bytes() == b""
+
+
+def test_connect_refuses_schema_less_sqlite_for_existing_named_board(
+    tmp_path, monkeypatch,
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+
+    board = kb.board_dir("incident")
+    board.mkdir(parents=True)
+    kb.write_board_metadata("incident", name="Incident")
+    db_path = board / "kanban.db"
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.execute("CREATE TABLE unrelated (id INTEGER PRIMARY KEY)")
+
+    with pytest.raises(sqlite3.DatabaseError) as exc_info:
+        kb.connect(board="incident")
+
+    msg = str(exc_info.value)
+    assert "missing the required 'tasks' table" in msg
+    with sqlite3.connect(str(db_path)) as conn:
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+        }
+    assert tables == {"unrelated"}
+
+
+def test_connect_refuses_alternate_empty_db_for_existing_current_board(
+    tmp_path, monkeypatch,
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+
+    kb.create_board("incident")
+    canonical = kb.kanban_db_path(board="incident")
+    kb.set_current_board("incident")
+    alternate = home / "kanban.db"
+    alternate.touch()
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(alternate))
+
+    with pytest.raises(sqlite3.DatabaseError) as exc_info:
+        kb.connect()
+
+    msg = str(exc_info.value)
+    assert "refusing to initialize empty Kanban DB for board 'incident'" in msg
+    assert str(alternate) in msg
+    assert canonical.exists()
+
+
+def test_init_db_allow_recreate_initializes_known_empty_named_board(
+    tmp_path, monkeypatch,
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+
+    board = kb.board_dir("incident")
+    board.mkdir(parents=True)
+    kb.write_board_metadata("incident", name="Incident")
+    db_path = board / "kanban.db"
+    db_path.touch()
+
+    kb.init_db(board="incident", allow_recreate=True)
+
+    with sqlite3.connect(str(db_path)) as conn:
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+        }
+    assert "tasks" in tables
+    assert "task_events" in tables
+
+
 def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
     """Legacy DBs missing additive indexed columns must migrate cleanly.
 


### PR DESCRIPTION
## Summary

Fixes #30687.

Kanban command startup still auto-initializes the DB so fresh installs work, but that same path was unsafe for an existing board whose DB had been truncated or replaced with a schema-less SQLite file. In that case `connect()` could create the full schema and let commands continue against an empty board.

This change adds a DB-open guard before schema creation:
- existing zero-byte Kanban DBs fail with a clear error instead of being initialized
- existing SQLite files that are missing the required `tasks` table fail before `CREATE TABLE IF NOT EXISTS`
- known named boards whose DB path is missing fail during automatic command startup
- `hermes kanban init` and `create_board()` pass an explicit `allow_recreate` flag, so deliberate initialization still works

The check also catches the risky alternate/top-level DB case: an existing current board plus an empty `HERMES_KANBAN_DB` target no longer becomes a new empty board by accident.

## Tests

- `scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_boards.py`
  - 221 passed
- `/Users/dejain/nvidia/oss/hermes-agent/.venv/bin/ruff check hermes_cli/kanban.py hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_boards.py`
  - passed

## Notes

- Platform tested: macOS local dev environment.
- This does not attempt SQLite page recovery or backups; it only prevents the silent auto-recreation path and leaves explicit recovery/init decisions to the user.
