### PR TITLE
feat(stt): support remote audio URL transcription (Fixes #30657)

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1862,6 +1862,10 @@ DEFAULT_CONFIG = {
             "model": "",  # empty = first stt-tagged model from the live catalog
             # "base_url": "",  # override DEEPINFRA_BASE_URL for STT only
         },
+        "remote_audio": {
+            "max_download_bytes": 250 * 1024 * 1024,
+            "chunk_bytes": 20 * 1024 * 1024,
+        },
     },
 
     "voice": {

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1550,6 +1550,10 @@ DEFAULT_CONFIG = {
             "model": "",  # empty = first stt-tagged model from the live catalog
             # "base_url": "",  # override DEEPINFRA_BASE_URL for STT only
         },
+        "remote_audio": {
+            "max_download_bytes": 250 * 1024 * 1024,
+            "chunk_bytes": 20 * 1024 * 1024,
+        },
     },
 
     "voice": {

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -216,6 +216,262 @@ class TestTranscribeGroq:
         assert "language" not in kwargs
 
 
+class TestRemoteAudioUrl:
+    def test_groq_remote_url_resolves_redirect_before_transcribing(self, monkeypatch):
+        monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
+
+        class FakeResponse:
+            status_code = 200
+            url = "https://cdn.example.test/final.mp3"
+            headers = {"Content-Type": "audio/mpeg", "Content-Length": "13"}
+            text = ""
+
+            def close(self):
+                pass
+
+        class FakeSession:
+            def __init__(self):
+                self.head_calls = []
+                self.get_calls = []
+
+            def head(self, url, **kwargs):
+                self.head_calls.append((url, kwargs))
+                return FakeResponse()
+
+            def get(self, url, **kwargs):
+                self.get_calls.append((url, kwargs))
+                raise AssertionError("GET fallback should not run when HEAD succeeds")
+
+            def close(self):
+                pass
+
+        fake_session = FakeSession()
+        captured_post = {}
+
+        def fake_post(url, **kwargs):
+            captured_post["url"] = url
+            captured_post["kwargs"] = kwargs
+            response = MagicMock()
+            response.status_code = 200
+            response.text = "hello remote"
+            return response
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={"provider": "groq"}), \
+             patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("tools.transcription_tools.is_safe_url", return_value=True), \
+             patch("requests.Session", return_value=fake_session), \
+             patch("requests.post", side_effect=fake_post):
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio("https://media.example.test/redirect")
+
+        assert result["success"] is True
+        assert result["transcript"] == "hello remote"
+        assert result["provider"] == "groq"
+        assert result["source_url"] == "https://cdn.example.test/final.mp3"
+        assert fake_session.head_calls == [
+            ("https://media.example.test/redirect", {"allow_redirects": False, "timeout": (5, 30)})
+        ]
+        assert fake_session.get_calls == []
+        assert captured_post["url"].endswith("/audio/transcriptions")
+        post_files = captured_post["kwargs"]["files"]
+        assert post_files["url"] == (None, "https://cdn.example.test/final.mp3")
+        assert "file" not in post_files
+
+    def test_remote_audio_probe_blocks_private_initial_url(self):
+        from tools.transcription_tools import _probe_remote_audio_url
+
+        with patch("tools.transcription_tools.is_safe_url", return_value=False):
+            result = _probe_remote_audio_url("http://127.0.0.1/audio.mp3")
+
+        assert result["success"] is False
+        assert "URL safety policy" in result["error"]
+
+    def test_remote_audio_probe_blocks_redirect_to_private_url(self):
+        class FakeResponse:
+            def __init__(self, status_code, url, headers=None):
+                self.status_code = status_code
+                self.url = url
+                self.headers = headers or {}
+                self.text = ""
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
+        class FakeSession:
+            def __init__(self):
+                self.head_calls = []
+
+            def head(self, url, **kwargs):
+                self.head_calls.append((url, kwargs))
+                if len(self.head_calls) == 1:
+                    return FakeResponse(
+                        302,
+                        "https://media.example.test/audio",
+                        {"Location": "http://127.0.0.1/audio.mp3"},
+                    )
+                return FakeResponse(200, url, {"Content-Type": "audio/mpeg"})
+
+            def get(self, url, **kwargs):
+                raise AssertionError("GET fallback should not run after unsafe redirect")
+
+            def close(self):
+                pass
+
+        fake_session = FakeSession()
+
+        def fake_is_safe_url(url):
+            return not str(url).startswith("http://127.0.0.1")
+
+        with patch("tools.transcription_tools.is_safe_url", side_effect=fake_is_safe_url), \
+             patch("requests.Session", return_value=fake_session):
+            from tools.transcription_tools import _probe_remote_audio_url
+            result = _probe_remote_audio_url("https://media.example.test/audio")
+
+        assert result["success"] is False
+        assert "URL safety policy" in result["error"]
+        assert fake_session.head_calls == [
+            ("https://media.example.test/audio", {"allow_redirects": False, "timeout": (5, 30)})
+        ]
+
+    def test_remote_audio_limits_use_config_values(self):
+        from tools.transcription_tools import MAX_FILE_SIZE, _remote_audio_limits
+
+        max_download, chunk = _remote_audio_limits(
+            {
+                "remote_audio": {
+                    "max_download_bytes": 123,
+                    "chunk_bytes": MAX_FILE_SIZE * 2,
+                }
+            }
+        )
+
+        assert max_download == 123
+        assert chunk == MAX_FILE_SIZE - 1024 * 1024
+
+    def test_remote_audio_limits_ignore_env_overrides(self, monkeypatch):
+        monkeypatch.setenv("HERMES_STT_REMOTE_AUDIO_MAX_BYTES", "123")
+        monkeypatch.setenv("HERMES_STT_REMOTE_AUDIO_CHUNK_BYTES", "456")
+
+        from tools.transcription_tools import (
+            DEFAULT_REMOTE_AUDIO_CHUNK_SIZE,
+            DEFAULT_REMOTE_AUDIO_MAX_DOWNLOAD_SIZE,
+            _remote_audio_limits,
+        )
+
+        assert _remote_audio_limits({}) == (
+            DEFAULT_REMOTE_AUDIO_MAX_DOWNLOAD_SIZE,
+            DEFAULT_REMOTE_AUDIO_CHUNK_SIZE,
+        )
+
+    def test_ffprobe_duration_uses_subprocess_safeguards(self):
+        captured = {}
+
+        def fake_run(command, **kwargs):
+            captured["command"] = command
+            captured["kwargs"] = kwargs
+            return subprocess.CompletedProcess(command, 0, stdout="12.5\n", stderr="")
+
+        with patch("tools.transcription_tools._find_ffprobe_binary", return_value="/usr/bin/ffprobe"), \
+             patch("tools.transcription_tools.windows_hide_flags", return_value=0), \
+             patch("tools.transcription_tools.subprocess.run", side_effect=fake_run):
+            from tools.transcription_tools import _probe_audio_duration_for_chunk
+            duration, error = _probe_audio_duration_for_chunk("/tmp/audio.mp3")
+
+        assert error is None
+        assert duration == 12.5
+        assert captured["kwargs"]["timeout"] == 300
+        assert captured["kwargs"]["stdin"] == subprocess.DEVNULL
+        assert captured["kwargs"]["creationflags"] == 0
+
+    def test_ffmpeg_split_uses_subprocess_safeguards(self, tmp_path):
+        from tools.transcription_tools import MAX_FILE_SIZE, _split_audio_file_for_stt
+
+        audio_path = tmp_path / "large.mp3"
+        audio_path.write_bytes(b"0" * (MAX_FILE_SIZE + 1))
+        captured = {}
+
+        def fake_run(command, **kwargs):
+            captured["command"] = command
+            captured["kwargs"] = kwargs
+            output_pattern = command[-1]
+            output_dir = os.path.dirname(output_pattern)
+            os.makedirs(output_dir, exist_ok=True)
+            with open(os.path.join(output_dir, "chunk-000.mp3"), "wb") as handle:
+                handle.write(b"audio")
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+        with patch("tools.transcription_tools._find_ffmpeg_binary", return_value="/usr/bin/ffmpeg"), \
+             patch("tools.transcription_tools._probe_audio_duration_for_chunk", return_value=(60.0, None)), \
+             patch("tools.transcription_tools.windows_hide_flags", return_value=0), \
+             patch("tools.transcription_tools.subprocess.run", side_effect=fake_run):
+            chunks, error = _split_audio_file_for_stt(str(audio_path), str(tmp_path / "chunks"))
+
+        assert error is None
+        assert chunks
+        assert captured["kwargs"]["timeout"] == 300
+        assert captured["kwargs"]["stdin"] == subprocess.DEVNULL
+        assert captured["kwargs"]["creationflags"] == 0
+
+    def test_local_file_path_keeps_existing_file_upload_path(self, sample_ogg):
+        with patch("tools.transcription_tools._load_stt_config", return_value={"provider": "groq"}), \
+             patch("tools.transcription_tools._get_provider", return_value="groq"), \
+             patch("tools.transcription_tools._probe_remote_audio_url") as mock_probe, \
+             patch(
+                 "tools.transcription_tools._transcribe_groq",
+                 return_value={"success": True, "transcript": "local", "provider": "groq"},
+             ) as mock_groq:
+            from tools.transcription_tools import transcribe_audio, DEFAULT_GROQ_STT_MODEL
+            result = transcribe_audio(sample_ogg)
+
+        assert result["success"] is True
+        mock_probe.assert_not_called()
+        mock_groq.assert_called_once_with(
+            sample_ogg,
+            DEFAULT_GROQ_STT_MODEL,
+            language=None,
+            prompt=None,
+        )
+
+    def test_large_remote_audio_uses_chunk_fallback(self, tmp_path):
+        from tools.transcription_tools import MAX_FILE_SIZE
+
+        big_audio = tmp_path / "big.mp3"
+        with open(big_audio, "wb") as handle:
+            handle.truncate(MAX_FILE_SIZE + 1)
+
+        probe = {
+            "success": True,
+            "url": "https://cdn.example.test/big.mp3",
+            "content_type": "audio/mpeg",
+            "content_length": MAX_FILE_SIZE + 1,
+        }
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={"provider": "groq"}), \
+             patch("tools.transcription_tools._get_provider", return_value="groq"), \
+             patch("tools.transcription_tools._probe_remote_audio_url", return_value=probe), \
+             patch("tools.transcription_tools._download_remote_audio", return_value=(str(big_audio), None)), \
+             patch("tools.transcription_tools._transcribe_groq_remote_url") as mock_direct_url, \
+             patch(
+                 "tools.transcription_tools._transcribe_audio_file_chunks",
+                 return_value={
+                     "success": True,
+                     "transcript": "chunk one\nchunk two",
+                     "provider": "groq",
+                     "chunks": 2,
+                 },
+             ) as mock_chunks:
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio("https://example.test/big")
+
+        assert result["success"] is True
+        assert result["chunks"] == 2
+        mock_direct_url.assert_not_called()
+        mock_chunks.assert_called_once()
+        assert mock_chunks.call_args[0][0] == str(big_audio)
+        assert mock_chunks.call_args[0][1] == "groq"
+
+
 # ============================================================================
 # _transcribe_openai — additional tests
 # ============================================================================

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -202,6 +202,242 @@ class TestTranscribeGroq:
         assert "language" not in kwargs
 
 
+class TestRemoteAudioUrl:
+    def test_groq_remote_url_resolves_redirect_before_transcribing(self, monkeypatch):
+        monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
+
+        class FakeResponse:
+            status_code = 200
+            url = "https://cdn.example.test/final.mp3"
+            headers = {"Content-Type": "audio/mpeg", "Content-Length": "13"}
+            text = ""
+
+            def close(self):
+                pass
+
+        class FakeSession:
+            def __init__(self):
+                self.head_calls = []
+                self.get_calls = []
+
+            def head(self, url, **kwargs):
+                self.head_calls.append((url, kwargs))
+                return FakeResponse()
+
+            def get(self, url, **kwargs):
+                self.get_calls.append((url, kwargs))
+                raise AssertionError("GET fallback should not run when HEAD succeeds")
+
+            def close(self):
+                pass
+
+        fake_session = FakeSession()
+        captured_post = {}
+
+        def fake_post(url, **kwargs):
+            captured_post["url"] = url
+            captured_post["kwargs"] = kwargs
+            response = MagicMock()
+            response.status_code = 200
+            response.text = "hello remote"
+            return response
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={"provider": "groq"}), \
+             patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("tools.transcription_tools.is_safe_url", return_value=True), \
+             patch("requests.Session", return_value=fake_session), \
+             patch("requests.post", side_effect=fake_post):
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio("https://media.example.test/redirect")
+
+        assert result["success"] is True
+        assert result["transcript"] == "hello remote"
+        assert result["provider"] == "groq"
+        assert result["source_url"] == "https://cdn.example.test/final.mp3"
+        assert fake_session.head_calls == [
+            ("https://media.example.test/redirect", {"allow_redirects": False, "timeout": (5, 30)})
+        ]
+        assert fake_session.get_calls == []
+        assert captured_post["url"].endswith("/audio/transcriptions")
+        post_files = captured_post["kwargs"]["files"]
+        assert post_files["url"] == (None, "https://cdn.example.test/final.mp3")
+        assert "file" not in post_files
+
+    def test_remote_audio_probe_blocks_private_initial_url(self):
+        from tools.transcription_tools import _probe_remote_audio_url
+
+        with patch("tools.transcription_tools.is_safe_url", return_value=False):
+            result = _probe_remote_audio_url("http://127.0.0.1/audio.mp3")
+
+        assert result["success"] is False
+        assert "URL safety policy" in result["error"]
+
+    def test_remote_audio_probe_blocks_redirect_to_private_url(self):
+        class FakeResponse:
+            def __init__(self, status_code, url, headers=None):
+                self.status_code = status_code
+                self.url = url
+                self.headers = headers or {}
+                self.text = ""
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
+        class FakeSession:
+            def __init__(self):
+                self.head_calls = []
+
+            def head(self, url, **kwargs):
+                self.head_calls.append((url, kwargs))
+                if len(self.head_calls) == 1:
+                    return FakeResponse(
+                        302,
+                        "https://media.example.test/audio",
+                        {"Location": "http://127.0.0.1/audio.mp3"},
+                    )
+                return FakeResponse(200, url, {"Content-Type": "audio/mpeg"})
+
+            def get(self, url, **kwargs):
+                raise AssertionError("GET fallback should not run after unsafe redirect")
+
+            def close(self):
+                pass
+
+        fake_session = FakeSession()
+
+        def fake_is_safe_url(url):
+            return not str(url).startswith("http://127.0.0.1")
+
+        with patch("tools.transcription_tools.is_safe_url", side_effect=fake_is_safe_url), \
+             patch("requests.Session", return_value=fake_session):
+            from tools.transcription_tools import _probe_remote_audio_url
+            result = _probe_remote_audio_url("https://media.example.test/audio")
+
+        assert result["success"] is False
+        assert "URL safety policy" in result["error"]
+        assert fake_session.head_calls == [
+            ("https://media.example.test/audio", {"allow_redirects": False, "timeout": (5, 30)})
+        ]
+
+    def test_remote_audio_limits_use_config_values(self):
+        from tools.transcription_tools import MAX_FILE_SIZE, _remote_audio_limits
+
+        max_download, chunk = _remote_audio_limits(
+            {
+                "remote_audio": {
+                    "max_download_bytes": 123,
+                    "chunk_bytes": MAX_FILE_SIZE * 2,
+                }
+            }
+        )
+
+        assert max_download == 123
+        assert chunk == MAX_FILE_SIZE - 1024 * 1024
+
+    def test_ffprobe_duration_uses_subprocess_safeguards(self):
+        captured = {}
+
+        def fake_run(command, **kwargs):
+            captured["command"] = command
+            captured["kwargs"] = kwargs
+            return subprocess.CompletedProcess(command, 0, stdout="12.5\n", stderr="")
+
+        with patch("tools.transcription_tools._find_ffprobe_binary", return_value="/usr/bin/ffprobe"), \
+             patch("tools.transcription_tools.windows_hide_flags", return_value=0), \
+             patch("tools.transcription_tools.subprocess.run", side_effect=fake_run):
+            from tools.transcription_tools import _probe_audio_duration
+            duration, error = _probe_audio_duration("/tmp/audio.mp3")
+
+        assert error is None
+        assert duration == 12.5
+        assert captured["kwargs"]["timeout"] == 300
+        assert captured["kwargs"]["stdin"] == subprocess.DEVNULL
+        assert captured["kwargs"]["creationflags"] == 0
+
+    def test_ffmpeg_split_uses_subprocess_safeguards(self, tmp_path):
+        from tools.transcription_tools import MAX_FILE_SIZE, _split_audio_file_for_stt
+
+        audio_path = tmp_path / "large.mp3"
+        audio_path.write_bytes(b"0" * (MAX_FILE_SIZE + 1))
+        captured = {}
+
+        def fake_run(command, **kwargs):
+            captured["command"] = command
+            captured["kwargs"] = kwargs
+            output_pattern = command[-1]
+            output_dir = os.path.dirname(output_pattern)
+            os.makedirs(output_dir, exist_ok=True)
+            with open(os.path.join(output_dir, "chunk-000.mp3"), "wb") as handle:
+                handle.write(b"audio")
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+        with patch("tools.transcription_tools._find_ffmpeg_binary", return_value="/usr/bin/ffmpeg"), \
+             patch("tools.transcription_tools._probe_audio_duration", return_value=(60.0, None)), \
+             patch("tools.transcription_tools.windows_hide_flags", return_value=0), \
+             patch("tools.transcription_tools.subprocess.run", side_effect=fake_run):
+            chunks, error = _split_audio_file_for_stt(str(audio_path), str(tmp_path / "chunks"))
+
+        assert error is None
+        assert chunks
+        assert captured["kwargs"]["timeout"] == 300
+        assert captured["kwargs"]["stdin"] == subprocess.DEVNULL
+        assert captured["kwargs"]["creationflags"] == 0
+
+    def test_local_file_path_keeps_existing_file_upload_path(self, sample_ogg):
+        with patch("tools.transcription_tools._load_stt_config", return_value={"provider": "groq"}), \
+             patch("tools.transcription_tools._get_provider", return_value="groq"), \
+             patch("tools.transcription_tools._probe_remote_audio_url") as mock_probe, \
+             patch(
+                 "tools.transcription_tools._transcribe_groq",
+                 return_value={"success": True, "transcript": "local", "provider": "groq"},
+             ) as mock_groq:
+            from tools.transcription_tools import transcribe_audio, DEFAULT_GROQ_STT_MODEL
+            result = transcribe_audio(sample_ogg)
+
+        assert result["success"] is True
+        mock_probe.assert_not_called()
+        mock_groq.assert_called_once_with(sample_ogg, DEFAULT_GROQ_STT_MODEL)
+
+    def test_large_remote_audio_uses_chunk_fallback(self, tmp_path):
+        from tools.transcription_tools import MAX_FILE_SIZE
+
+        big_audio = tmp_path / "big.mp3"
+        with open(big_audio, "wb") as handle:
+            handle.truncate(MAX_FILE_SIZE + 1)
+
+        probe = {
+            "success": True,
+            "url": "https://cdn.example.test/big.mp3",
+            "content_type": "audio/mpeg",
+            "content_length": MAX_FILE_SIZE + 1,
+        }
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={"provider": "groq"}), \
+             patch("tools.transcription_tools._get_provider", return_value="groq"), \
+             patch("tools.transcription_tools._probe_remote_audio_url", return_value=probe), \
+             patch("tools.transcription_tools._download_remote_audio", return_value=(str(big_audio), None)), \
+             patch("tools.transcription_tools._transcribe_groq_remote_url") as mock_direct_url, \
+             patch(
+                 "tools.transcription_tools._transcribe_audio_file_chunks",
+                 return_value={
+                     "success": True,
+                     "transcript": "chunk one\nchunk two",
+                     "provider": "groq",
+                     "chunks": 2,
+                 },
+             ) as mock_chunks:
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio("https://example.test/big")
+
+        assert result["success"] is True
+        assert result["chunks"] == 2
+        mock_direct_url.assert_not_called()
+        mock_chunks.assert_called_once()
+        assert mock_chunks.call_args[0][0] == str(big_audio)
+        assert mock_chunks.call_args[0][1] == "groq"
+
+
 # ============================================================================
 # _transcribe_openai — additional tests
 # ============================================================================

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -39,8 +39,8 @@ import tempfile
 import threading
 import time
 from pathlib import Path
-from typing import Optional, Dict, Any
-from urllib.parse import urljoin
+from typing import Optional, Dict, Any, List
+from urllib.parse import urljoin, urlparse
 
 from hermes_cli._subprocess_compat import windows_hide_flags
 from utils import is_truthy_value
@@ -50,6 +50,7 @@ from tools.tool_backend_helpers import (
     nous_tool_gateway_unavailable_message,
     resolve_openai_audio_api_key,
 )
+from tools.url_safety import is_safe_url
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +83,7 @@ def _resolve_provider_key(env_var: str, provider_id: str) -> str:
     except ImportError:  # pragma: no cover — helpers are in-repo
         return str(get_env_value(env_var) or "").strip()
     return resolve_provider_secret(env_var, provider_id, env_getter=get_env_value)
+
 
 # ---------------------------------------------------------------------------
 # Optional imports — graceful degradation
@@ -126,6 +128,11 @@ ELEVENLABS_STT_BASE_URL = os.getenv("ELEVENLABS_STT_BASE_URL", "https://api.elev
 SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg", ".oga", ".opus", ".aac", ".flac", ".caf"}
 LOCAL_NATIVE_AUDIO_FORMATS = {".wav", ".aiff", ".aif"}
 MAX_FILE_SIZE = 25 * 1024 * 1024  # 25 MB
+DEFAULT_REMOTE_AUDIO_MAX_DOWNLOAD_SIZE = 250 * 1024 * 1024
+DEFAULT_REMOTE_AUDIO_CHUNK_SIZE = 20 * 1024 * 1024
+REMOTE_AUDIO_TIMEOUT = (5, 30)
+REMOTE_AUDIO_MAX_REDIRECTS = 10
+REMOTE_AUDIO_REDIRECT_STATUSES = {301, 302, 303, 307, 308}
 
 # Known model sets for auto-correction
 OPENAI_MODELS = {"whisper-1", "gpt-4o-mini-transcribe", "gpt-4o-transcribe", "gpt-transcribe"}
@@ -420,6 +427,30 @@ def _get_stt_section(stt_config: Dict[str, Any], name: str) -> Dict[str, Any]:
         return {}
     section = stt_config.get(name)
     return section if isinstance(section, dict) else {}
+
+
+def _positive_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(str(value).strip())
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _remote_audio_limits(stt_config: Optional[Dict[str, Any]] = None) -> tuple[int, int]:
+    if stt_config is None:
+        stt_config = _load_stt_config()
+
+    remote_cfg = _get_stt_section(stt_config, "remote_audio")
+    max_download_bytes = _positive_int(
+        remote_cfg.get("max_download_bytes"),
+        DEFAULT_REMOTE_AUDIO_MAX_DOWNLOAD_SIZE,
+    )
+    chunk_bytes = min(
+        _positive_int(remote_cfg.get("chunk_bytes"), DEFAULT_REMOTE_AUDIO_CHUNK_SIZE),
+        MAX_FILE_SIZE - 1024 * 1024,
+    )
+    return max_download_bytes, chunk_bytes
 
 
 def _get_named_stt_provider_config(
@@ -1599,6 +1630,568 @@ def _prepare_audio_for_transcription(
             "error": f"Failed to convert .silk audio for transcription: {exc}",
         }
 
+
+def _is_remote_audio_url(value: str) -> bool:
+    parsed = urlparse(str(value).strip())
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
+def _parse_content_length(headers: Any) -> Optional[int]:
+    raw_length = headers.get("Content-Length") if headers else None
+    if raw_length:
+        try:
+            return int(raw_length)
+        except (TypeError, ValueError):
+            pass
+
+    content_range = headers.get("Content-Range") if headers else None
+    if content_range and "/" in content_range:
+        _, _, total = content_range.rpartition("/")
+        if total and total != "*":
+            try:
+                return int(total)
+            except ValueError:
+                return None
+    return None
+
+
+def _looks_like_audio_content_type(content_type: str) -> bool:
+    normalized = content_type.split(";", 1)[0].strip().lower()
+    return (
+        normalized.startswith("audio/")
+        or normalized in {"video/mp4", "video/mpeg", "video/webm", "application/ogg", "application/octet-stream"}
+    )
+
+
+def _guess_remote_audio_suffix(url: str, content_type: str = "") -> str:
+    suffix = Path(urlparse(url).path).suffix.lower()
+    if suffix in SUPPORTED_FORMATS:
+        return suffix
+
+    normalized_type = content_type.split(";", 1)[0].strip().lower()
+    content_type_suffixes = {
+        "audio/aac": ".aac",
+        "audio/flac": ".flac",
+        "audio/m4a": ".m4a",
+        "audio/mp4": ".m4a",
+        "audio/mpeg": ".mp3",
+        "audio/mp3": ".mp3",
+        "audio/ogg": ".ogg",
+        "audio/wav": ".wav",
+        "audio/wave": ".wav",
+        "audio/webm": ".webm",
+        "video/mp4": ".mp4",
+        "video/webm": ".webm",
+        "application/ogg": ".ogg",
+    }
+    return content_type_suffixes.get(normalized_type, ".mp3")
+
+
+def _validate_remote_audio_metadata(info: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if not info.get("success"):
+        return {
+            "success": False,
+            "transcript": "",
+            "error": info.get("error") or "Failed to resolve remote audio URL",
+        }
+
+    final_url = str(info.get("url") or "")
+    if not _is_remote_audio_url(final_url):
+        return {
+            "success": False,
+            "transcript": "",
+            "error": "Remote audio redirects must resolve to an http(s) URL",
+        }
+
+    suffix = Path(urlparse(final_url).path).suffix.lower()
+    content_type = str(info.get("content_type") or "")
+    if suffix and suffix not in SUPPORTED_FORMATS and not _looks_like_audio_content_type(content_type):
+        return {
+            "success": False,
+            "transcript": "",
+            "error": f"Unsupported remote audio format: {suffix}. Supported: {', '.join(sorted(SUPPORTED_FORMATS))}",
+        }
+    if content_type and not suffix and not _looks_like_audio_content_type(content_type):
+        return {
+            "success": False,
+            "transcript": "",
+            "error": f"Remote URL does not look like audio (Content-Type: {content_type})",
+        }
+    return None
+
+
+def _blocked_remote_audio_url_error(url: str) -> str:
+    return f"Remote audio URL is blocked by URL safety policy: {url}"
+
+
+def _safe_remote_audio_request(
+    session: Any,
+    method: str,
+    audio_url: str,
+    **kwargs: Any,
+) -> tuple[Optional[Any], Optional[str]]:
+    """Run a remote audio request while validating each redirect target."""
+    current_url = audio_url
+    request_method = getattr(session, method.lower())
+    for _ in range(REMOTE_AUDIO_MAX_REDIRECTS + 1):
+        if not _is_remote_audio_url(current_url):
+            return None, "Remote audio redirects must resolve to an http(s) URL"
+        if not is_safe_url(current_url):
+            return None, _blocked_remote_audio_url_error(current_url)
+
+        response = request_method(current_url, allow_redirects=False, **kwargs)
+        final_url = str(getattr(response, "url", current_url) or current_url)
+        if not is_safe_url(final_url):
+            response.close()
+            return None, _blocked_remote_audio_url_error(final_url)
+
+        location = response.headers.get("Location") if response.headers else None
+        if response.status_code in REMOTE_AUDIO_REDIRECT_STATUSES and location:
+            next_url = urljoin(final_url, location)
+            response.close()
+            current_url = next_url
+            continue
+
+        return response, None
+
+    return None, "Remote audio redirects exceeded safe redirect limit"
+
+
+def _probe_remote_audio_url(audio_url: str) -> Dict[str, Any]:
+    """Resolve redirects and gather cheap metadata for an http(s) audio URL."""
+    if not _is_remote_audio_url(audio_url):
+        return {
+            "success": False,
+            "url": audio_url,
+            "error": "Remote audio URL must use http or https",
+        }
+
+    try:
+        import requests
+    except ImportError:
+        return {
+            "success": False,
+            "url": audio_url,
+            "error": "requests package not installed",
+        }
+
+    session = requests.Session()
+    last_error = ""
+    try:
+        try:
+            response, safety_error = _safe_remote_audio_request(
+                session,
+                "HEAD",
+                audio_url,
+                timeout=REMOTE_AUDIO_TIMEOUT,
+            )
+            if safety_error:
+                return {"success": False, "url": audio_url, "error": safety_error}
+            if 200 <= response.status_code < 400:
+                try:
+                    return {
+                        "success": True,
+                        "url": response.url,
+                        "content_type": response.headers.get("Content-Type", ""),
+                        "content_length": _parse_content_length(response.headers),
+                    }
+                finally:
+                    response.close()
+            last_error = f"HEAD returned HTTP {response.status_code}"
+            response.close()
+        except requests.RequestException as exc:
+            last_error = str(exc)
+
+        response, safety_error = _safe_remote_audio_request(
+            session,
+            "GET",
+            audio_url,
+            headers={"Range": "bytes=0-0"},
+            stream=True,
+            timeout=REMOTE_AUDIO_TIMEOUT,
+        )
+        if safety_error:
+            return {"success": False, "url": audio_url, "error": safety_error}
+        try:
+            if response.status_code not in {200, 206}:
+                detail = response.text[:200] if response.text else last_error
+                return {
+                    "success": False,
+                    "url": audio_url,
+                    "error": f"Remote audio probe failed (HTTP {response.status_code}): {detail}",
+                }
+
+            return {
+                "success": True,
+                "url": response.url,
+                "content_type": response.headers.get("Content-Type", ""),
+                "content_length": _parse_content_length(response.headers),
+            }
+        finally:
+            response.close()
+    except requests.RequestException as exc:
+        detail = f"{last_error}; {exc}" if last_error else str(exc)
+        return {
+            "success": False,
+            "url": audio_url,
+            "error": f"Remote audio probe failed: {detail}",
+        }
+    finally:
+        session.close()
+
+
+def _download_remote_audio(
+    audio_url: str,
+    work_dir: str,
+    *,
+    size_hint: Optional[int] = None,
+    content_type: str = "",
+    max_download_bytes: Optional[int] = None,
+) -> tuple[Optional[str], Optional[str]]:
+    if max_download_bytes is None:
+        max_download_bytes, _ = _remote_audio_limits()
+
+    if size_hint is not None and size_hint > max_download_bytes:
+        return (
+            None,
+            (
+                f"Remote audio is too large to download safely: "
+                f"{size_hint / (1024 * 1024):.1f}MB "
+                f"(max {max_download_bytes / (1024 * 1024):.0f}MB)"
+            ),
+        )
+
+    try:
+        import requests
+    except ImportError:
+        return None, "requests package not installed"
+
+    session = requests.Session()
+    response = None
+    output_path: Optional[Path] = None
+    try:
+        response, safety_error = _safe_remote_audio_request(
+            session,
+            "GET",
+            audio_url,
+            stream=True,
+            timeout=REMOTE_AUDIO_TIMEOUT,
+        )
+        if safety_error:
+            return None, safety_error
+        if response.status_code < 200 or response.status_code >= 300:
+            detail = response.text[:200] if response.text else ""
+            return None, f"Remote audio download failed (HTTP {response.status_code}): {detail}"
+
+        final_url = response.url
+        if not _is_remote_audio_url(final_url):
+            return None, "Remote audio redirects must resolve to an http(s) URL"
+
+        response_length = _parse_content_length(response.headers)
+        if response_length is not None and response_length > max_download_bytes:
+            return (
+                None,
+                (
+                    f"Remote audio is too large to download safely: "
+                    f"{response_length / (1024 * 1024):.1f}MB "
+                    f"(max {max_download_bytes / (1024 * 1024):.0f}MB)"
+                ),
+            )
+
+        response_type = response.headers.get("Content-Type", "") or content_type
+        suffix = _guess_remote_audio_suffix(final_url, response_type)
+        output_path = Path(work_dir) / f"remote-audio{suffix}"
+        total = 0
+        with open(output_path, "wb") as handle:
+            for chunk in response.iter_content(chunk_size=1024 * 1024):
+                if not chunk:
+                    continue
+                total += len(chunk)
+                if total > max_download_bytes:
+                    return (
+                        None,
+                        (
+                            f"Remote audio exceeded safe download limit "
+                            f"({max_download_bytes / (1024 * 1024):.0f}MB)"
+                        ),
+                    )
+                handle.write(chunk)
+
+        return str(output_path), None
+    except requests.RequestException as exc:
+        return None, f"Remote audio download failed: {exc}"
+    except OSError as exc:
+        return None, f"Failed to write remote audio download: {exc}"
+    finally:
+        if response is not None:
+            response.close()
+        session.close()
+        if output_path is not None and output_path.exists() and output_path.stat().st_size == 0:
+            output_path.unlink(missing_ok=True)
+
+
+def _find_ffprobe_binary() -> Optional[str]:
+    return _find_binary("ffprobe")
+
+
+def _probe_audio_duration_for_chunk(file_path: str) -> tuple[Optional[float], Optional[str]]:
+    ffprobe = _find_ffprobe_binary()
+    if not ffprobe:
+        return None, "Chunk fallback requires ffprobe, but ffprobe was not found"
+
+    command = [
+        ffprobe,
+        "-v",
+        "error",
+        "-show_entries",
+        "format=duration",
+        "-of",
+        "default=noprint_wrappers=1:nokey=1",
+        file_path,
+    ]
+    try:
+        result = subprocess.run(
+            command,
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=300,
+            stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
+        )
+        duration = float(result.stdout.strip())
+        if duration <= 0:
+            return None, "Could not determine a positive audio duration for chunk fallback"
+        return duration, None
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, ValueError) as exc:
+        return None, f"Failed to inspect audio duration for chunk fallback: {exc}"
+
+
+def _split_audio_file_for_stt(
+    file_path: str,
+    work_dir: str,
+    *,
+    max_chunk_bytes: int = DEFAULT_REMOTE_AUDIO_CHUNK_SIZE,
+) -> tuple[List[str], Optional[str]]:
+    audio_path = Path(file_path)
+    try:
+        file_size = audio_path.stat().st_size
+    except OSError as exc:
+        return [], f"Failed to inspect audio file for chunk fallback: {exc}"
+
+    if file_size <= MAX_FILE_SIZE:
+        return [file_path], None
+
+    ffmpeg = _find_ffmpeg_binary()
+    if not ffmpeg:
+        return [], "Chunk fallback requires ffmpeg, but ffmpeg was not found"
+
+    duration, duration_error = _probe_audio_duration_for_chunk(file_path)
+    if duration_error:
+        return [], duration_error
+
+    target_bytes = min(max_chunk_bytes, MAX_FILE_SIZE - 1024 * 1024)
+    segment_seconds = max(10, int(duration * target_bytes / file_size * 0.85))
+    suffix = audio_path.suffix.lower() if audio_path.suffix.lower() in SUPPORTED_FORMATS else ".mp3"
+
+    for attempt in range(4):
+        chunks_dir = Path(work_dir) / f"chunks-{attempt}"
+        chunks_dir.mkdir(parents=True, exist_ok=True)
+        output_pattern = str(chunks_dir / f"chunk-%03d{suffix}")
+        command = [
+            ffmpeg,
+            "-y",
+            "-i",
+            file_path,
+            "-map",
+            "0:a:0",
+            "-vn",
+            "-f",
+            "segment",
+            "-segment_time",
+            str(segment_seconds),
+            "-reset_timestamps",
+            "1",
+            "-c",
+            "copy",
+            output_pattern,
+        ]
+        try:
+            subprocess.run(
+                command,
+                check=True,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=300,
+                stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
+            )
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+            stderr = getattr(exc, "stderr", "") or ""
+            stdout = getattr(exc, "stdout", "") or ""
+            details = stderr.strip() or stdout.strip() or str(exc)
+            return [], f"Failed to split audio for chunk fallback: {details}"
+
+        chunks = sorted(str(path) for path in chunks_dir.glob(f"*{suffix}"))
+        if not chunks:
+            return [], "Chunk fallback did not produce any audio chunks"
+
+        largest_chunk = max(Path(path).stat().st_size for path in chunks)
+        if largest_chunk <= MAX_FILE_SIZE:
+            return chunks, None
+
+        segment_seconds = max(5, int(segment_seconds * target_bytes / largest_chunk * 0.8))
+
+    return [], "Chunk fallback could not produce chunks below the provider size limit"
+
+
+def _looks_like_provider_size_limit_error(message: str) -> bool:
+    lowered = str(message).lower()
+    return any(
+        marker in lowered
+        for marker in (
+            "too large",
+            "size limit",
+            "maximum file",
+            "maximum content",
+            "payload too large",
+            "413",
+        )
+    )
+
+
+def _transcribe_audio_file_chunks(
+    file_path: str,
+    provider: str,
+    stt_config: dict,
+    model: Optional[str],
+    *,
+    max_chunk_bytes: Optional[int] = None,
+) -> Dict[str, Any]:
+    with tempfile.TemporaryDirectory(prefix="hermes-stt-chunks-") as chunk_dir:
+        if max_chunk_bytes is None:
+            _, max_chunk_bytes = _remote_audio_limits(stt_config)
+        chunks, chunk_error = _split_audio_file_for_stt(
+            file_path,
+            chunk_dir,
+            max_chunk_bytes=max_chunk_bytes,
+        )
+        if chunk_error:
+            return {"success": False, "transcript": "", "error": chunk_error}
+
+        transcripts: List[str] = []
+        for index, chunk_path in enumerate(chunks, start=1):
+            result = _transcribe_prepared_audio(chunk_path, model)
+            if not result.get("success"):
+                return {
+                    "success": False,
+                    "transcript": "\n".join(transcripts).strip(),
+                    "provider": provider,
+                    "error": (
+                        f"Chunk {index}/{len(chunks)} transcription failed: "
+                        f"{result.get('error', 'unknown error')}"
+                    ),
+                }
+            transcript = str(result.get("transcript") or "").strip()
+            if transcript:
+                transcripts.append(transcript)
+
+        return {
+            "success": True,
+            "transcript": "\n".join(transcripts).strip(),
+            "provider": provider,
+            "chunks": len(chunks),
+        }
+
+
+def _no_stt_provider_error() -> Dict[str, Any]:
+    return {
+        "success": False,
+        "transcript": "",
+        "error": (
+            "No STT provider available. Install faster-whisper for free local "
+            f"transcription, configure {LOCAL_STT_COMMAND_ENV} or install a local whisper CLI, "
+            "set GROQ_API_KEY for free Groq Whisper, set MISTRAL_API_KEY for Mistral "
+            "Voxtral Transcribe, configure xAI OAuth or set XAI_API_KEY for xAI Grok STT, "
+            "set ELEVENLABS_API_KEY for ElevenLabs Scribe, or set VOICE_TOOLS_OPENAI_KEY "
+            "or OPENAI_API_KEY for the OpenAI Whisper API."
+        ),
+    }
+
+
+def _transcribe_remote_audio_url(audio_url: str, model: Optional[str] = None) -> Dict[str, Any]:
+    """Resolve and transcribe a remote http(s) audio URL."""
+    stt_config = _load_stt_config()
+    if not is_stt_enabled(stt_config):
+        return {
+            "success": False,
+            "transcript": "",
+            "error": "STT is disabled in config.yaml (stt.enabled: false).",
+        }
+
+    provider = _get_provider(stt_config)
+    if provider == "none":
+        return _no_stt_provider_error()
+
+    probe = _probe_remote_audio_url(audio_url)
+    metadata_error = _validate_remote_audio_metadata(probe)
+    if metadata_error:
+        return metadata_error
+
+    final_url = str(probe["url"])
+    content_type = str(probe.get("content_type") or "")
+    content_length = probe.get("content_length")
+    max_download_bytes, max_chunk_bytes = _remote_audio_limits(stt_config)
+
+    if provider == "groq":
+        model_name = model or DEFAULT_GROQ_STT_MODEL
+        if content_length is None or content_length <= MAX_FILE_SIZE:
+            direct_result = _transcribe_groq_remote_url(final_url, model_name)
+            if direct_result.get("success"):
+                direct_result["source_url"] = final_url
+                return direct_result
+            if not _looks_like_provider_size_limit_error(str(direct_result.get("error") or "")):
+                return direct_result
+
+    with tempfile.TemporaryDirectory(prefix="hermes-stt-remote-") as work_dir:
+        downloaded_path, download_error = _download_remote_audio(
+            final_url,
+            work_dir,
+            size_hint=content_length if isinstance(content_length, int) else None,
+            content_type=content_type,
+            max_download_bytes=max_download_bytes,
+        )
+        if download_error:
+            return {"success": False, "transcript": "", "error": download_error}
+        if downloaded_path is None:
+            return {"success": False, "transcript": "", "error": "Remote audio download failed"}
+
+        try:
+            downloaded_size = Path(downloaded_path).stat().st_size
+        except OSError as exc:
+            return {"success": False, "transcript": "", "error": f"Failed to inspect downloaded audio: {exc}"}
+
+        if downloaded_size > MAX_FILE_SIZE:
+            return _transcribe_audio_file_chunks(
+                downloaded_path,
+                provider,
+                stt_config,
+                model,
+                max_chunk_bytes=max_chunk_bytes,
+            )
+
+        validation_error = _validate_audio_file(downloaded_path)
+        if validation_error:
+            return validation_error
+        result = _transcribe_prepared_audio(downloaded_path, model)
+        if result.get("success"):
+            result["source_url"] = final_url
+        return result
+
 # ---------------------------------------------------------------------------
 # Provider: local (faster-whisper)
 # ---------------------------------------------------------------------------
@@ -2249,6 +2842,65 @@ def _transcribe_groq(
         logger.error("Groq transcription failed: %s", e, exc_info=True)
         return {"success": False, "transcript": "", "error": f"Transcription failed: {e}"}
 
+
+def _transcribe_groq_remote_url(audio_url: str, model_name: str) -> Dict[str, Any]:
+    """Transcribe a resolved remote audio URL using Groq's URL input."""
+    api_key = get_env_value("GROQ_API_KEY")
+    if not api_key:
+        return {"success": False, "transcript": "", "error": "GROQ_API_KEY not set"}
+
+    if model_name in OPENAI_MODELS:
+        logger.info("Model %s not available on Groq, using %s", model_name, DEFAULT_GROQ_STT_MODEL)
+        model_name = DEFAULT_GROQ_STT_MODEL
+
+    try:
+        import requests
+    except ImportError:
+        return {"success": False, "transcript": "", "error": "requests package not installed"}
+
+    try:
+        response = requests.post(
+            f"{GROQ_BASE_URL.rstrip('/')}/audio/transcriptions",
+            headers={"Authorization": f"Bearer {api_key}"},
+            files={
+                "model": (None, model_name),
+                "url": (None, audio_url),
+                "response_format": (None, "text"),
+            },
+            timeout=120,
+        )
+        if response.status_code != 200:
+            detail = ""
+            try:
+                error_body = response.json()
+                detail = error_body.get("error", {}).get("message", "") or response.text[:300]
+            except Exception:
+                detail = response.text[:300]
+            return {
+                "success": False,
+                "transcript": "",
+                "error": f"Groq STT API error (HTTP {response.status_code}): {detail}",
+            }
+
+        transcript_text = response.text.strip()
+        logger.info(
+            "Transcribed remote URL via Groq API (%s, %d chars)",
+            model_name,
+            len(transcript_text),
+        )
+
+        return {"success": True, "transcript": transcript_text, "provider": "groq"}
+
+    except requests.ConnectionError as e:
+        return {"success": False, "transcript": "", "error": f"Connection error: {e}"}
+    except requests.Timeout as e:
+        return {"success": False, "transcript": "", "error": f"Request timeout: {e}"}
+    except requests.RequestException as e:
+        return {"success": False, "transcript": "", "error": f"API error: {e}"}
+    except Exception as e:
+        logger.error("Groq remote URL transcription failed: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"Transcription failed: {e}"}
+
 # ---------------------------------------------------------------------------
 # Provider: openai (Whisper API)
 # ---------------------------------------------------------------------------
@@ -2393,6 +3045,8 @@ def _transcribe_mistral(
 
     try:
         try:
+            from mistralai.client import Mistral
+        except ImportError:
             from tools.lazy_deps import ensure as _lazy_ensure
             _lazy_ensure("stt.mistral", prompt=False)
         except Exception:
@@ -3094,7 +3748,6 @@ def _dispatch_stt_provider(
         )
 
     if provider == "xai":
-        # xAI Grok STT doesn't use a model parameter — pass through for logging
         model_name = model or "grok-stt"
         return _transcribe_xai(
             file_path, model_name, language=language, prompt=prompt,
@@ -3199,12 +3852,14 @@ def transcribe_audio(
     model: Optional[str] = None,
     source: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Safely validate, preprocess supported inputs, and dispatch transcription.
+    """Safely validate, preprocess supported inputs or remote URLs, and dispatch transcription.
 
     ``source`` is an optional caller-surface label (e.g. ``"gateway"``,
     ``"voice_mode"``) forwarded to the ``pre_transcription`` plugin hook for
     observability. Not used for dispatch.
     """
+    if _is_remote_audio_url(file_path):
+        return _transcribe_remote_audio_url(file_path, model)
     # Refuse to feed a credential / secret store (auth.json, .env, OAuth
     # tokens, mcp-tokens/, ...) to an STT provider — before ANY validation or
     # preprocessing, so the refusal names the real reason rather than a

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -39,8 +39,8 @@ import tempfile
 import threading
 import time
 from pathlib import Path
-from typing import Optional, Dict, Any
-from urllib.parse import urljoin
+from typing import Optional, Dict, Any, List
+from urllib.parse import urljoin, urlparse
 
 from hermes_cli._subprocess_compat import windows_hide_flags
 from utils import is_truthy_value
@@ -50,6 +50,7 @@ from tools.tool_backend_helpers import (
     nous_tool_gateway_unavailable_message,
     resolve_openai_audio_api_key,
 )
+from tools.url_safety import is_safe_url
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +83,14 @@ def _resolve_provider_key(env_var: str, provider_id: str) -> str:
     except ImportError:  # pragma: no cover — helpers are in-repo
         return str(get_env_value(env_var) or "").strip()
     return resolve_provider_secret(env_var, provider_id, env_getter=get_env_value)
+
+
+def _get_int_env(name: str, default: int) -> int:
+    try:
+        value = int(os.getenv(name, "").strip())
+    except ValueError:
+        return default
+    return value if value > 0 else default
 
 # ---------------------------------------------------------------------------
 # Optional imports — graceful degradation
@@ -126,6 +135,19 @@ ELEVENLABS_STT_BASE_URL = os.getenv("ELEVENLABS_STT_BASE_URL", "https://api.elev
 SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg", ".oga", ".opus", ".aac", ".flac", ".caf"}
 LOCAL_NATIVE_AUDIO_FORMATS = {".wav", ".aiff", ".aif"}
 MAX_FILE_SIZE = 25 * 1024 * 1024  # 25 MB
+DEFAULT_REMOTE_AUDIO_MAX_DOWNLOAD_SIZE = 250 * 1024 * 1024
+DEFAULT_REMOTE_AUDIO_CHUNK_SIZE = 20 * 1024 * 1024
+REMOTE_AUDIO_MAX_DOWNLOAD_SIZE = _get_int_env(
+    "HERMES_STT_REMOTE_AUDIO_MAX_BYTES",
+    DEFAULT_REMOTE_AUDIO_MAX_DOWNLOAD_SIZE,
+)
+REMOTE_AUDIO_CHUNK_SIZE = min(
+    _get_int_env("HERMES_STT_REMOTE_AUDIO_CHUNK_BYTES", DEFAULT_REMOTE_AUDIO_CHUNK_SIZE),
+    MAX_FILE_SIZE - 1024 * 1024,
+)
+REMOTE_AUDIO_TIMEOUT = (5, 30)
+REMOTE_AUDIO_MAX_REDIRECTS = 10
+REMOTE_AUDIO_REDIRECT_STATUSES = {301, 302, 303, 307, 308}
 
 # Known model sets for auto-correction
 OPENAI_MODELS = {"whisper-1", "gpt-4o-mini-transcribe", "gpt-4o-transcribe", "gpt-transcribe"}
@@ -382,6 +404,30 @@ def _get_stt_section(stt_config: Dict[str, Any], name: str) -> Dict[str, Any]:
         return {}
     section = stt_config.get(name)
     return section if isinstance(section, dict) else {}
+
+
+def _positive_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(str(value).strip())
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _remote_audio_limits(stt_config: Optional[Dict[str, Any]] = None) -> tuple[int, int]:
+    if stt_config is None:
+        stt_config = _load_stt_config()
+
+    remote_cfg = _get_stt_section(stt_config, "remote_audio")
+    max_download_bytes = _positive_int(
+        remote_cfg.get("max_download_bytes"),
+        REMOTE_AUDIO_MAX_DOWNLOAD_SIZE,
+    )
+    chunk_bytes = min(
+        _positive_int(remote_cfg.get("chunk_bytes"), REMOTE_AUDIO_CHUNK_SIZE),
+        MAX_FILE_SIZE - 1024 * 1024,
+    )
+    return max_download_bytes, chunk_bytes
 
 
 def _get_named_stt_provider_config(
@@ -1373,6 +1419,568 @@ def _prepare_audio_for_transcription(
             "error": f"Failed to convert .silk audio for transcription: {exc}",
         }
 
+
+def _is_remote_audio_url(value: str) -> bool:
+    parsed = urlparse(str(value).strip())
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
+def _parse_content_length(headers: Any) -> Optional[int]:
+    raw_length = headers.get("Content-Length") if headers else None
+    if raw_length:
+        try:
+            return int(raw_length)
+        except (TypeError, ValueError):
+            pass
+
+    content_range = headers.get("Content-Range") if headers else None
+    if content_range and "/" in content_range:
+        _, _, total = content_range.rpartition("/")
+        if total and total != "*":
+            try:
+                return int(total)
+            except ValueError:
+                return None
+    return None
+
+
+def _looks_like_audio_content_type(content_type: str) -> bool:
+    normalized = content_type.split(";", 1)[0].strip().lower()
+    return (
+        normalized.startswith("audio/")
+        or normalized in {"video/mp4", "video/mpeg", "video/webm", "application/ogg", "application/octet-stream"}
+    )
+
+
+def _guess_remote_audio_suffix(url: str, content_type: str = "") -> str:
+    suffix = Path(urlparse(url).path).suffix.lower()
+    if suffix in SUPPORTED_FORMATS:
+        return suffix
+
+    normalized_type = content_type.split(";", 1)[0].strip().lower()
+    content_type_suffixes = {
+        "audio/aac": ".aac",
+        "audio/flac": ".flac",
+        "audio/m4a": ".m4a",
+        "audio/mp4": ".m4a",
+        "audio/mpeg": ".mp3",
+        "audio/mp3": ".mp3",
+        "audio/ogg": ".ogg",
+        "audio/wav": ".wav",
+        "audio/wave": ".wav",
+        "audio/webm": ".webm",
+        "video/mp4": ".mp4",
+        "video/webm": ".webm",
+        "application/ogg": ".ogg",
+    }
+    return content_type_suffixes.get(normalized_type, ".mp3")
+
+
+def _validate_remote_audio_metadata(info: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if not info.get("success"):
+        return {
+            "success": False,
+            "transcript": "",
+            "error": info.get("error") or "Failed to resolve remote audio URL",
+        }
+
+    final_url = str(info.get("url") or "")
+    if not _is_remote_audio_url(final_url):
+        return {
+            "success": False,
+            "transcript": "",
+            "error": "Remote audio redirects must resolve to an http(s) URL",
+        }
+
+    suffix = Path(urlparse(final_url).path).suffix.lower()
+    content_type = str(info.get("content_type") or "")
+    if suffix and suffix not in SUPPORTED_FORMATS and not _looks_like_audio_content_type(content_type):
+        return {
+            "success": False,
+            "transcript": "",
+            "error": f"Unsupported remote audio format: {suffix}. Supported: {', '.join(sorted(SUPPORTED_FORMATS))}",
+        }
+    if content_type and not suffix and not _looks_like_audio_content_type(content_type):
+        return {
+            "success": False,
+            "transcript": "",
+            "error": f"Remote URL does not look like audio (Content-Type: {content_type})",
+        }
+    return None
+
+
+def _blocked_remote_audio_url_error(url: str) -> str:
+    return f"Remote audio URL is blocked by URL safety policy: {url}"
+
+
+def _safe_remote_audio_request(
+    session: Any,
+    method: str,
+    audio_url: str,
+    **kwargs: Any,
+) -> tuple[Optional[Any], Optional[str]]:
+    """Run a remote audio request while validating each redirect target."""
+    current_url = audio_url
+    request_method = getattr(session, method.lower())
+    for _ in range(REMOTE_AUDIO_MAX_REDIRECTS + 1):
+        if not _is_remote_audio_url(current_url):
+            return None, "Remote audio redirects must resolve to an http(s) URL"
+        if not is_safe_url(current_url):
+            return None, _blocked_remote_audio_url_error(current_url)
+
+        response = request_method(current_url, allow_redirects=False, **kwargs)
+        final_url = str(getattr(response, "url", current_url) or current_url)
+        if not is_safe_url(final_url):
+            response.close()
+            return None, _blocked_remote_audio_url_error(final_url)
+
+        location = response.headers.get("Location") if response.headers else None
+        if response.status_code in REMOTE_AUDIO_REDIRECT_STATUSES and location:
+            next_url = urljoin(final_url, location)
+            response.close()
+            current_url = next_url
+            continue
+
+        return response, None
+
+    return None, "Remote audio redirects exceeded safe redirect limit"
+
+
+def _probe_remote_audio_url(audio_url: str) -> Dict[str, Any]:
+    """Resolve redirects and gather cheap metadata for an http(s) audio URL."""
+    if not _is_remote_audio_url(audio_url):
+        return {
+            "success": False,
+            "url": audio_url,
+            "error": "Remote audio URL must use http or https",
+        }
+
+    try:
+        import requests
+    except ImportError:
+        return {
+            "success": False,
+            "url": audio_url,
+            "error": "requests package not installed",
+        }
+
+    session = requests.Session()
+    last_error = ""
+    try:
+        try:
+            response, safety_error = _safe_remote_audio_request(
+                session,
+                "HEAD",
+                audio_url,
+                timeout=REMOTE_AUDIO_TIMEOUT,
+            )
+            if safety_error:
+                return {"success": False, "url": audio_url, "error": safety_error}
+            if 200 <= response.status_code < 400:
+                try:
+                    return {
+                        "success": True,
+                        "url": response.url,
+                        "content_type": response.headers.get("Content-Type", ""),
+                        "content_length": _parse_content_length(response.headers),
+                    }
+                finally:
+                    response.close()
+            last_error = f"HEAD returned HTTP {response.status_code}"
+            response.close()
+        except requests.RequestException as exc:
+            last_error = str(exc)
+
+        response, safety_error = _safe_remote_audio_request(
+            session,
+            "GET",
+            audio_url,
+            headers={"Range": "bytes=0-0"},
+            stream=True,
+            timeout=REMOTE_AUDIO_TIMEOUT,
+        )
+        if safety_error:
+            return {"success": False, "url": audio_url, "error": safety_error}
+        try:
+            if response.status_code not in {200, 206}:
+                detail = response.text[:200] if response.text else last_error
+                return {
+                    "success": False,
+                    "url": audio_url,
+                    "error": f"Remote audio probe failed (HTTP {response.status_code}): {detail}",
+                }
+
+            return {
+                "success": True,
+                "url": response.url,
+                "content_type": response.headers.get("Content-Type", ""),
+                "content_length": _parse_content_length(response.headers),
+            }
+        finally:
+            response.close()
+    except requests.RequestException as exc:
+        detail = f"{last_error}; {exc}" if last_error else str(exc)
+        return {
+            "success": False,
+            "url": audio_url,
+            "error": f"Remote audio probe failed: {detail}",
+        }
+    finally:
+        session.close()
+
+
+def _download_remote_audio(
+    audio_url: str,
+    work_dir: str,
+    *,
+    size_hint: Optional[int] = None,
+    content_type: str = "",
+    max_download_bytes: Optional[int] = None,
+) -> tuple[Optional[str], Optional[str]]:
+    if max_download_bytes is None:
+        max_download_bytes, _ = _remote_audio_limits()
+
+    if size_hint is not None and size_hint > max_download_bytes:
+        return (
+            None,
+            (
+                f"Remote audio is too large to download safely: "
+                f"{size_hint / (1024 * 1024):.1f}MB "
+                f"(max {max_download_bytes / (1024 * 1024):.0f}MB)"
+            ),
+        )
+
+    try:
+        import requests
+    except ImportError:
+        return None, "requests package not installed"
+
+    session = requests.Session()
+    response = None
+    output_path: Optional[Path] = None
+    try:
+        response, safety_error = _safe_remote_audio_request(
+            session,
+            "GET",
+            audio_url,
+            stream=True,
+            timeout=REMOTE_AUDIO_TIMEOUT,
+        )
+        if safety_error:
+            return None, safety_error
+        if response.status_code < 200 or response.status_code >= 300:
+            detail = response.text[:200] if response.text else ""
+            return None, f"Remote audio download failed (HTTP {response.status_code}): {detail}"
+
+        final_url = response.url
+        if not _is_remote_audio_url(final_url):
+            return None, "Remote audio redirects must resolve to an http(s) URL"
+
+        response_length = _parse_content_length(response.headers)
+        if response_length is not None and response_length > max_download_bytes:
+            return (
+                None,
+                (
+                    f"Remote audio is too large to download safely: "
+                    f"{response_length / (1024 * 1024):.1f}MB "
+                    f"(max {max_download_bytes / (1024 * 1024):.0f}MB)"
+                ),
+            )
+
+        response_type = response.headers.get("Content-Type", "") or content_type
+        suffix = _guess_remote_audio_suffix(final_url, response_type)
+        output_path = Path(work_dir) / f"remote-audio{suffix}"
+        total = 0
+        with open(output_path, "wb") as handle:
+            for chunk in response.iter_content(chunk_size=1024 * 1024):
+                if not chunk:
+                    continue
+                total += len(chunk)
+                if total > max_download_bytes:
+                    return (
+                        None,
+                        (
+                            f"Remote audio exceeded safe download limit "
+                            f"({max_download_bytes / (1024 * 1024):.0f}MB)"
+                        ),
+                    )
+                handle.write(chunk)
+
+        return str(output_path), None
+    except requests.RequestException as exc:
+        return None, f"Remote audio download failed: {exc}"
+    except OSError as exc:
+        return None, f"Failed to write remote audio download: {exc}"
+    finally:
+        if response is not None:
+            response.close()
+        session.close()
+        if output_path is not None and output_path.exists() and output_path.stat().st_size == 0:
+            output_path.unlink(missing_ok=True)
+
+
+def _find_ffprobe_binary() -> Optional[str]:
+    return _find_binary("ffprobe")
+
+
+def _probe_audio_duration(file_path: str) -> tuple[Optional[float], Optional[str]]:
+    ffprobe = _find_ffprobe_binary()
+    if not ffprobe:
+        return None, "Chunk fallback requires ffprobe, but ffprobe was not found"
+
+    command = [
+        ffprobe,
+        "-v",
+        "error",
+        "-show_entries",
+        "format=duration",
+        "-of",
+        "default=noprint_wrappers=1:nokey=1",
+        file_path,
+    ]
+    try:
+        result = subprocess.run(
+            command,
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=300,
+            stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
+        )
+        duration = float(result.stdout.strip())
+        if duration <= 0:
+            return None, "Could not determine a positive audio duration for chunk fallback"
+        return duration, None
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, ValueError) as exc:
+        return None, f"Failed to inspect audio duration for chunk fallback: {exc}"
+
+
+def _split_audio_file_for_stt(
+    file_path: str,
+    work_dir: str,
+    *,
+    max_chunk_bytes: int = REMOTE_AUDIO_CHUNK_SIZE,
+) -> tuple[List[str], Optional[str]]:
+    audio_path = Path(file_path)
+    try:
+        file_size = audio_path.stat().st_size
+    except OSError as exc:
+        return [], f"Failed to inspect audio file for chunk fallback: {exc}"
+
+    if file_size <= MAX_FILE_SIZE:
+        return [file_path], None
+
+    ffmpeg = _find_ffmpeg_binary()
+    if not ffmpeg:
+        return [], "Chunk fallback requires ffmpeg, but ffmpeg was not found"
+
+    duration, duration_error = _probe_audio_duration(file_path)
+    if duration_error:
+        return [], duration_error
+
+    target_bytes = min(max_chunk_bytes, MAX_FILE_SIZE - 1024 * 1024)
+    segment_seconds = max(10, int(duration * target_bytes / file_size * 0.85))
+    suffix = audio_path.suffix.lower() if audio_path.suffix.lower() in SUPPORTED_FORMATS else ".mp3"
+
+    for attempt in range(4):
+        chunks_dir = Path(work_dir) / f"chunks-{attempt}"
+        chunks_dir.mkdir(parents=True, exist_ok=True)
+        output_pattern = str(chunks_dir / f"chunk-%03d{suffix}")
+        command = [
+            ffmpeg,
+            "-y",
+            "-i",
+            file_path,
+            "-map",
+            "0:a:0",
+            "-vn",
+            "-f",
+            "segment",
+            "-segment_time",
+            str(segment_seconds),
+            "-reset_timestamps",
+            "1",
+            "-c",
+            "copy",
+            output_pattern,
+        ]
+        try:
+            subprocess.run(
+                command,
+                check=True,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=300,
+                stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
+            )
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+            stderr = getattr(exc, "stderr", "") or ""
+            stdout = getattr(exc, "stdout", "") or ""
+            details = stderr.strip() or stdout.strip() or str(exc)
+            return [], f"Failed to split audio for chunk fallback: {details}"
+
+        chunks = sorted(str(path) for path in chunks_dir.glob(f"*{suffix}"))
+        if not chunks:
+            return [], "Chunk fallback did not produce any audio chunks"
+
+        largest_chunk = max(Path(path).stat().st_size for path in chunks)
+        if largest_chunk <= MAX_FILE_SIZE:
+            return chunks, None
+
+        segment_seconds = max(5, int(segment_seconds * target_bytes / largest_chunk * 0.8))
+
+    return [], "Chunk fallback could not produce chunks below the provider size limit"
+
+
+def _looks_like_provider_size_limit_error(message: str) -> bool:
+    lowered = str(message).lower()
+    return any(
+        marker in lowered
+        for marker in (
+            "too large",
+            "size limit",
+            "maximum file",
+            "maximum content",
+            "payload too large",
+            "413",
+        )
+    )
+
+
+def _transcribe_audio_file_chunks(
+    file_path: str,
+    provider: str,
+    stt_config: dict,
+    model: Optional[str],
+    *,
+    max_chunk_bytes: Optional[int] = None,
+) -> Dict[str, Any]:
+    with tempfile.TemporaryDirectory(prefix="hermes-stt-chunks-") as chunk_dir:
+        if max_chunk_bytes is None:
+            _, max_chunk_bytes = _remote_audio_limits(stt_config)
+        chunks, chunk_error = _split_audio_file_for_stt(
+            file_path,
+            chunk_dir,
+            max_chunk_bytes=max_chunk_bytes,
+        )
+        if chunk_error:
+            return {"success": False, "transcript": "", "error": chunk_error}
+
+        transcripts: List[str] = []
+        for index, chunk_path in enumerate(chunks, start=1):
+            result = _transcribe_prepared_audio(chunk_path, model)
+            if not result.get("success"):
+                return {
+                    "success": False,
+                    "transcript": "\n".join(transcripts).strip(),
+                    "provider": provider,
+                    "error": (
+                        f"Chunk {index}/{len(chunks)} transcription failed: "
+                        f"{result.get('error', 'unknown error')}"
+                    ),
+                }
+            transcript = str(result.get("transcript") or "").strip()
+            if transcript:
+                transcripts.append(transcript)
+
+        return {
+            "success": True,
+            "transcript": "\n".join(transcripts).strip(),
+            "provider": provider,
+            "chunks": len(chunks),
+        }
+
+
+def _no_stt_provider_error() -> Dict[str, Any]:
+    return {
+        "success": False,
+        "transcript": "",
+        "error": (
+            "No STT provider available. Install faster-whisper for free local "
+            f"transcription, configure {LOCAL_STT_COMMAND_ENV} or install a local whisper CLI, "
+            "set GROQ_API_KEY for free Groq Whisper, set MISTRAL_API_KEY for Mistral "
+            "Voxtral Transcribe, configure xAI OAuth or set XAI_API_KEY for xAI Grok STT, "
+            "set ELEVENLABS_API_KEY for ElevenLabs Scribe, or set VOICE_TOOLS_OPENAI_KEY "
+            "or OPENAI_API_KEY for the OpenAI Whisper API."
+        ),
+    }
+
+
+def _transcribe_remote_audio_url(audio_url: str, model: Optional[str] = None) -> Dict[str, Any]:
+    """Resolve and transcribe a remote http(s) audio URL."""
+    stt_config = _load_stt_config()
+    if not is_stt_enabled(stt_config):
+        return {
+            "success": False,
+            "transcript": "",
+            "error": "STT is disabled in config.yaml (stt.enabled: false).",
+        }
+
+    provider = _get_provider(stt_config)
+    if provider == "none":
+        return _no_stt_provider_error()
+
+    probe = _probe_remote_audio_url(audio_url)
+    metadata_error = _validate_remote_audio_metadata(probe)
+    if metadata_error:
+        return metadata_error
+
+    final_url = str(probe["url"])
+    content_type = str(probe.get("content_type") or "")
+    content_length = probe.get("content_length")
+    max_download_bytes, max_chunk_bytes = _remote_audio_limits(stt_config)
+
+    if provider == "groq":
+        model_name = model or DEFAULT_GROQ_STT_MODEL
+        if content_length is None or content_length <= MAX_FILE_SIZE:
+            direct_result = _transcribe_groq_remote_url(final_url, model_name)
+            if direct_result.get("success"):
+                direct_result["source_url"] = final_url
+                return direct_result
+            if not _looks_like_provider_size_limit_error(str(direct_result.get("error") or "")):
+                return direct_result
+
+    with tempfile.TemporaryDirectory(prefix="hermes-stt-remote-") as work_dir:
+        downloaded_path, download_error = _download_remote_audio(
+            final_url,
+            work_dir,
+            size_hint=content_length if isinstance(content_length, int) else None,
+            content_type=content_type,
+            max_download_bytes=max_download_bytes,
+        )
+        if download_error:
+            return {"success": False, "transcript": "", "error": download_error}
+        if downloaded_path is None:
+            return {"success": False, "transcript": "", "error": "Remote audio download failed"}
+
+        try:
+            downloaded_size = Path(downloaded_path).stat().st_size
+        except OSError as exc:
+            return {"success": False, "transcript": "", "error": f"Failed to inspect downloaded audio: {exc}"}
+
+        if downloaded_size > MAX_FILE_SIZE:
+            return _transcribe_audio_file_chunks(
+                downloaded_path,
+                provider,
+                stt_config,
+                model,
+                max_chunk_bytes=max_chunk_bytes,
+            )
+
+        validation_error = _validate_audio_file(downloaded_path)
+        if validation_error:
+            return validation_error
+        result = _transcribe_prepared_audio(downloaded_path, model)
+        if result.get("success"):
+            result["source_url"] = final_url
+        return result
+
 # ---------------------------------------------------------------------------
 # Provider: local (faster-whisper)
 # ---------------------------------------------------------------------------
@@ -1884,6 +2492,65 @@ def _transcribe_groq(file_path: str, model_name: str) -> Dict[str, Any]:
         logger.error("Groq transcription failed: %s", e, exc_info=True)
         return {"success": False, "transcript": "", "error": f"Transcription failed: {e}"}
 
+
+def _transcribe_groq_remote_url(audio_url: str, model_name: str) -> Dict[str, Any]:
+    """Transcribe a resolved remote audio URL using Groq's URL input."""
+    api_key = get_env_value("GROQ_API_KEY")
+    if not api_key:
+        return {"success": False, "transcript": "", "error": "GROQ_API_KEY not set"}
+
+    if model_name in OPENAI_MODELS:
+        logger.info("Model %s not available on Groq, using %s", model_name, DEFAULT_GROQ_STT_MODEL)
+        model_name = DEFAULT_GROQ_STT_MODEL
+
+    try:
+        import requests
+    except ImportError:
+        return {"success": False, "transcript": "", "error": "requests package not installed"}
+
+    try:
+        response = requests.post(
+            f"{GROQ_BASE_URL.rstrip('/')}/audio/transcriptions",
+            headers={"Authorization": f"Bearer {api_key}"},
+            files={
+                "model": (None, model_name),
+                "url": (None, audio_url),
+                "response_format": (None, "text"),
+            },
+            timeout=120,
+        )
+        if response.status_code != 200:
+            detail = ""
+            try:
+                error_body = response.json()
+                detail = error_body.get("error", {}).get("message", "") or response.text[:300]
+            except Exception:
+                detail = response.text[:300]
+            return {
+                "success": False,
+                "transcript": "",
+                "error": f"Groq STT API error (HTTP {response.status_code}): {detail}",
+            }
+
+        transcript_text = response.text.strip()
+        logger.info(
+            "Transcribed remote URL via Groq API (%s, %d chars)",
+            model_name,
+            len(transcript_text),
+        )
+
+        return {"success": True, "transcript": transcript_text, "provider": "groq"}
+
+    except requests.ConnectionError as e:
+        return {"success": False, "transcript": "", "error": f"Connection error: {e}"}
+    except requests.Timeout as e:
+        return {"success": False, "transcript": "", "error": f"Request timeout: {e}"}
+    except requests.RequestException as e:
+        return {"success": False, "transcript": "", "error": f"API error: {e}"}
+    except Exception as e:
+        logger.error("Groq remote URL transcription failed: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"Transcription failed: {e}"}
+
 # ---------------------------------------------------------------------------
 # Provider: openai (Whisper API)
 # ---------------------------------------------------------------------------
@@ -2015,6 +2682,8 @@ def _transcribe_mistral(file_path: str, model_name: str) -> Dict[str, Any]:
 
     try:
         try:
+            from mistralai.client import Mistral
+        except ImportError:
             from tools.lazy_deps import ensure as _lazy_ensure
             _lazy_ensure("stt.mistral", prompt=False)
         except Exception:
@@ -2440,7 +3109,6 @@ def _transcribe_prepared_audio(file_path: str, model: Optional[str] = None) -> D
         return _transcribe_mistral(file_path, model_name)
 
     if provider == "xai":
-        # xAI Grok STT doesn't use a model parameter — pass through for logging
         model_name = model or "grok-stt"
         return _transcribe_xai(file_path, model_name)
 
@@ -2522,7 +3190,10 @@ def _transcribe_prepared_audio(file_path: str, model: Optional[str] = None) -> D
 
 
 def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, Any]:
-    """Safely validate, preprocess supported inputs, and dispatch transcription."""
+    """Safely validate, preprocess supported inputs or remote URLs, and dispatch transcription."""
+    if _is_remote_audio_url(file_path):
+        return _transcribe_remote_audio_url(file_path, model)
+
     # Refuse to feed a credential / secret store (auth.json, .env, OAuth
     # tokens, mcp-tokens/, ...) to an STT provider — before ANY validation or
     # preprocessing, so the refusal names the real reason rather than a


### PR DESCRIPTION
## Summary
- Accept http(s) audio URLs in `transcribe_audio` before local path validation.
- Resolve and validate remote audio redirects before transcription using the shared URL safety policy.
- For Groq, send the resolved URL through the multipart `url` field when it is under the provider size limit.
- Download remote audio only when needed, with a bounded download cap and ffmpeg/ffprobe chunk fallback for oversized remote files.
- Move remote audio size limits into `stt.remote_audio` config defaults while keeping the existing env vars as compatibility fallbacks.
- Keep existing local file validation and local upload behavior unchanged.

## Validation
- `scripts/run_tests.sh tests/tools/test_transcription_tools.py tests/tools/test_transcription.py tests/tools/test_transcription_dotenv_fallback.py`
  - 153 passed, 0 failed
- `uv run --extra dev ruff check tools/transcription_tools.py hermes_cli/config.py tests/tools/test_transcription_tools.py tests/tools/test_transcription.py tests/tools/test_transcription_dotenv_fallback.py`
  - All checks passed
- `git diff --check upstream/main...HEAD`
  - Clean

## Platform
- macOS, Python 3.11 via the repo dev environment

## Notes
- Scope is limited to STT URL handling, remote audio config defaults, and focused tests.
- Remote URL handling is restricted to http(s). Each redirect hop is checked before it is followed.
- Downloads default to a 250 MB cap and chunk fallback defaults to 20 MB chunks.

Fixes #30657
