### PR TITLE
feat(provider): add TrueFoundry AI Gateway

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -116,6 +116,14 @@
 # HERMES_QWEN_BASE_URL=https://portal.qwen.ai/v1
 
 # =============================================================================
+# LLM PROVIDER (TrueFoundry)
+# =============================================================================
+# TrueFoundry AI Gateway — 1000+ models, bring your own key, develop and govern from one place
+# Get your key at: https://gateway.truefoundry.ai
+# TFY_API_KEY=
+# TFY_BASE_URL=                                   # Your TrueFoundry gateway endpoint
+
+# =============================================================================
 # LLM PROVIDER (Xiaomi MiMo)
 # =============================================================================
 # Xiaomi MiMo models (mimo-v2-pro, mimo-v2-omni, mimo-v2-flash).

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -64,6 +64,7 @@ _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "tencent", "tokenhub", "tencent-cloud", "tencentmaas",
     "arcee-ai", "arceeai",
     "gmi-cloud", "gmicloud",
+    "truefoundry", "tfy", "truefoundry-gateway",
     "xai", "x-ai", "x.ai", "grok",
     "nvidia", "nim", "nvidia-nim", "nemotron",
     "qwen-portal", "novita-ai", "novitaai",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -957,6 +957,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("azure-foundry",  "Azure Foundry",            "Azure Foundry (OpenAI-style or Anthropic-style endpoint — your Azure AI deployment)"),
     ProviderEntry("ai-gateway",     "Vercel AI Gateway",        "Vercel AI Gateway"),
     ProviderEntry("qwen-oauth",     "Qwen OAuth (Portal)",      "Qwen OAuth (reuses local Qwen CLI login)"),
+    ProviderEntry("truefoundry",    "TrueFoundry",              "TrueFoundry AI Gateway (OpenAI-compatible proxy, 1000+ models, BYO key)"),
 ]
 
 # Auto-extend CANONICAL_PROVIDERS with any provider registered in providers/
@@ -1007,6 +1008,8 @@ _PROVIDER_ALIASES = {
     "arceeai": "arcee",
     "gmi-cloud": "gmi",
     "gmicloud": "gmi",
+    "tfy": "truefoundry",
+    "truefoundry-gateway": "truefoundry",
     "minimax-china": "minimax-cn",
     "minimax_cn": "minimax-cn",
     "minimax-portal": "minimax-oauth",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -207,6 +207,11 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="openai_chat",  # default; overridden by api_mode in config
         base_url_env_var="AZURE_FOUNDRY_BASE_URL",
     ),
+    "truefoundry": HermesOverlay(
+        transport="openai_chat",
+        extra_env_vars=("TFY_API_KEY",),
+        base_url_env_var="TFY_BASE_URL",
+    ),
     "bedrock": HermesOverlay(
         transport="bedrock_converse",
         auth_type="aws_sdk",
@@ -352,6 +357,10 @@ ALIASES: Dict[str, str] = {
     # gmi
     "gmi-cloud": "gmi",
     "gmicloud": "gmi",
+
+    # truefoundry
+    "tfy": "truefoundry",
+    "truefoundry-gateway": "truefoundry",
 
     # Local server aliases → virtual "local" concept (resolved via user config)
     "lmstudio": "lmstudio",

--- a/plugins/model-providers/truefoundry/__init__.py
+++ b/plugins/model-providers/truefoundry/__init__.py
@@ -1,0 +1,18 @@
+"""TrueFoundry AI Gateway provider profile."""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+truefoundry = ProviderProfile(
+    name="truefoundry",
+    aliases=("tfy", "truefoundry-gateway"),
+    display_name="TrueFoundry",
+    description="TrueFoundry AI Gateway (OpenAI-compatible proxy, 1000+ models, BYO key)",
+    signup_url="https://gateway.truefoundry.ai",
+    env_vars=("TFY_API_KEY", "TFY_BASE_URL"),
+    base_url="",
+    auth_type="api_key",
+    fallback_models=(),
+)
+
+register_provider(truefoundry)

--- a/plugins/model-providers/truefoundry/plugin.yaml
+++ b/plugins/model-providers/truefoundry/plugin.yaml
@@ -1,0 +1,5 @@
+name: truefoundry-provider
+kind: model-provider
+version: 1.0.0
+description: TrueFoundry AI Gateway
+author: Nous Research

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -1320,3 +1320,51 @@ class TestMinimaxOAuthProvider:
         from agent.auxiliary_client import _API_KEY_PROVIDER_AUX_MODELS
         assert "minimax-oauth" in _API_KEY_PROVIDER_AUX_MODELS
         assert _API_KEY_PROVIDER_AUX_MODELS["minimax-oauth"]  # non-empty
+
+
+class TestTrueFoundryProvider:
+    """Tests for TrueFoundry AI Gateway — an OpenAI-compatible proxy."""
+
+    def test_truefoundry_profile_loads(self):
+        from providers import get_provider_profile
+        profile = get_provider_profile("truefoundry")
+        assert profile is not None
+        assert profile.name == "truefoundry"
+        assert profile.display_name == "TrueFoundry"
+        assert "TFY_API_KEY" in profile.env_vars
+
+    def test_truefoundry_aliases(self):
+        from providers import get_provider_profile
+        profile = get_provider_profile("truefoundry")
+        assert "tfy" in profile.aliases
+        assert "truefoundry-gateway" in profile.aliases
+
+    def test_truefoundry_alias_resolves(self):
+        assert resolve_provider("tfy") == "truefoundry"
+        assert resolve_provider("truefoundry-gateway") == "truefoundry"
+
+    def test_truefoundry_in_provider_registry(self):
+        """Auto-registration from ProviderProfile should expose TrueFoundry."""
+        assert "truefoundry" in PROVIDER_REGISTRY
+        pconfig = PROVIDER_REGISTRY["truefoundry"]
+        assert pconfig.auth_type == "api_key"
+        assert pconfig.id == "truefoundry"
+        assert pconfig.api_key_env_vars == ("TFY_API_KEY",)
+        assert pconfig.base_url_env_var == "TFY_BASE_URL"
+
+    def test_truefoundry_aliases_in_registry(self):
+        assert "tfy" in PROVIDER_REGISTRY
+        assert "truefoundry-gateway" in PROVIDER_REGISTRY
+
+    def test_truefoundry_label(self):
+        from hermes_cli.models import _PROVIDER_LABELS
+        assert "truefoundry" in _PROVIDER_LABELS
+        assert _PROVIDER_LABELS["truefoundry"] == "TrueFoundry"
+
+    def test_truefoundry_credential_resolution(self, monkeypatch):
+        monkeypatch.setenv("TFY_API_KEY", "test-tfy-key")
+        monkeypatch.setenv("TFY_BASE_URL", "https://gw.example.com/v1")
+        result = resolve_api_key_provider_credentials("truefoundry")
+        assert result["api_key"] == "test-tfy-key"
+        assert result["base_url"] == "https://gw.example.com/v1"
+        assert result["provider"] == "truefoundry"

--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -47,13 +47,13 @@ def test_bundled_plugins_discovered():
 
 
 def test_all_34_profiles_register():
-    """After discovery, the registry must contain exactly 34 distinct profiles."""
+    """After discovery, the registry must contain exactly 35 distinct profiles."""
     _clear_provider_caches()
     from providers import list_providers
 
     profiles = list_providers()
     names = sorted(p.name for p in profiles)
-    assert len(names) == 34, f"Expected 34 profiles, got {len(names)}: {names}"
+    assert len(names) == 35, f"Expected 35 profiles, got {len(names)}: {names}"
 
     # Spot-check representative providers from different categories
     for required in (

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -27,6 +27,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **Kimi / Moonshot (China)** | `KIMI_CN_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding-cn`; aliases: `kimi-cn`, `moonshot-cn`) |
 | **Arcee AI** | `ARCEEAI_API_KEY` in `~/.hermes/.env` (provider: `arcee`; aliases: `arcee-ai`, `arceeai`) |
 | **GMI Cloud** | `GMI_API_KEY` in `~/.hermes/.env` (provider: `gmi`; aliases: `gmi-cloud`, `gmicloud`) |
+| **TrueFoundry** | `TFY_API_KEY` + `TFY_BASE_URL` in `~/.hermes/.env` (provider: `truefoundry`; aliases: `tfy`, `truefoundry-gateway` — 1000+ models, BYO key, unified governance) |
 | **MiniMax** | `MINIMAX_API_KEY` in `~/.hermes/.env` (provider: `minimax`) |
 | **MiniMax China** | `MINIMAX_CN_API_KEY` in `~/.hermes/.env` (provider: `minimax-cn`) |
 | **xAI (Grok) — Responses API** | `XAI_API_KEY` in `~/.hermes/.env` (provider: `xai`) |

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -93,7 +93,7 @@ Common options:
 | `-q`, `--query "..."` | One-shot, non-interactive prompt. |
 | `-m`, `--model <model>` | Override the model for this run. |
 | `-t`, `--toolsets <csv>` | Enable a comma-separated set of toolsets. |
-| `--provider <provider>` | Force a provider: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot-acp`, `copilot`, `anthropic`, `gemini`, `google-gemini-cli`, `huggingface`, `novita`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `alibaba`, `alibaba-coding-plan` (alias `alibaba_coding`), `deepseek`, `nvidia`, `ollama-cloud`, `xai` (alias `grok`), `xai-oauth` (alias `grok-oauth`), `qwen-oauth`, `bedrock`, `opencode-zen`, `opencode-go`, `ai-gateway`, `azure-foundry`, `lmstudio`, `stepfun`, `tencent-tokenhub` (alias `tencent`, `tokenhub`). |
+| `--provider <provider>` | Force a provider: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot-acp`, `copilot`, `anthropic`, `gemini`, `google-gemini-cli`, `huggingface`, `novita`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `truefoundry` (alias `tfy`), `alibaba`, `alibaba-coding-plan` (alias `alibaba_coding`), `deepseek`, `nvidia`, `ollama-cloud`, `xai` (alias `grok`), `xai-oauth` (alias `grok-oauth`), `qwen-oauth`, `bedrock`, `opencode-zen`, `opencode-go`, `ai-gateway`, `azure-foundry`, `lmstudio`, `stepfun`, `tencent-tokenhub` (alias `tencent`, `tokenhub`). |
 | `-s`, `--skills <name>` | Preload one or more skills for the session (can be repeated or comma-separated). |
 | `-v`, `--verbose` | Verbose output. |
 | `-Q`, `--quiet` | Programmatic mode: suppress banner/spinner/tool previews. |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -40,6 +40,8 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 | `ARCEE_BASE_URL` | Override Arcee base URL (default: `https://api.arcee.ai/api/v1`) |
 | `GMI_API_KEY` | GMI Cloud API key ([gmicloud.ai](https://www.gmicloud.ai/)) |
 | `GMI_BASE_URL` | Override GMI Cloud base URL (default: `https://api.gmi-serving.com/v1`) |
+| `TFY_API_KEY` | TrueFoundry AI Gateway API key ([gateway.truefoundry.ai](https://gateway.truefoundry.ai)) |
+| `TFY_BASE_URL` | TrueFoundry gateway URL (required — your deployment's OpenAI-compatible endpoint) |
 | `MINIMAX_API_KEY` | MiniMax API key — global endpoint ([minimax.io](https://www.minimax.io)). **Not used by `minimax-oauth`** (OAuth path uses browser login instead). |
 | `MINIMAX_BASE_URL` | Override MiniMax base URL (default: `https://api.minimax.io/anthropic` — Hermes uses MiniMax's Anthropic Messages-compatible endpoint). **Not used by `minimax-oauth`**. |
 | `MINIMAX_CN_API_KEY` | MiniMax API key — China endpoint ([minimaxi.com](https://www.minimaxi.com)). **Not used by `minimax-oauth`** (OAuth path uses browser login instead). |
@@ -113,7 +115,7 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 
 | Variable | Description |
 |----------|-------------|
-| `HERMES_INFERENCE_PROVIDER` | Override provider selection: `auto`, `custom`, `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `huggingface`, `novita`, `gemini`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth` (browser OAuth login — no API key required; see [MiniMax OAuth guide](../guides/minimax-oauth.md)), `kilocode`, `xiaomi`, `arcee`, `gmi`, `stepfun`, `alibaba`, `alibaba-coding-plan` (alias `alibaba_coding`), `deepseek`, `nvidia`, `ollama-cloud`, `xai` (alias `grok`), `xai-oauth` (browser OAuth login for SuperGrok subscribers — no API key required; see [xAI Grok OAuth guide](../guides/xai-grok-oauth.md)), `google-gemini-cli`, `qwen-oauth`, `bedrock`, `opencode-zen`, `opencode-go`, `ai-gateway`, `tencent-tokenhub` (default: `auto`) |
+| `HERMES_INFERENCE_PROVIDER` | Override provider selection: `auto`, `custom`, `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `huggingface`, `novita`, `gemini`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth` (browser OAuth login — no API key required; see [MiniMax OAuth guide](../guides/minimax-oauth.md)), `kilocode`, `xiaomi`, `arcee`, `gmi`, `truefoundry` (alias `tfy`), `stepfun`, `alibaba`, `alibaba-coding-plan` (alias `alibaba_coding`), `deepseek`, `nvidia`, `ollama-cloud`, `xai` (alias `grok`), `xai-oauth` (browser OAuth login for SuperGrok subscribers — no API key required; see [xAI Grok OAuth guide](../guides/xai-grok-oauth.md)), `google-gemini-cli`, `qwen-oauth`, `bedrock`, `opencode-zen`, `opencode-go`, `ai-gateway`, `tencent-tokenhub` (default: `auto`) |
 | `HERMES_PORTAL_BASE_URL` | Override Nous Portal URL (for development/testing) |
 | `NOUS_INFERENCE_BASE_URL` | Override Nous inference API URL |
 | `HERMES_NOUS_MIN_KEY_TTL_SECONDS` | Min agent key TTL before re-mint (default: 1800 = 30min) |


### PR DESCRIPTION
## What does this PR do?

Adds TrueFoundry AI Gateway as a first-class model provider. TrueFoundry is an OpenAI-compatible proxy that supports 1000+ models with bring-your-own-key and unified governance.

Provider ID: `truefoundry` (aliases: `tfy`, `truefoundry-gateway`)

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/model-providers/truefoundry/{__init__.py,plugin.yaml}` — plugin profile (`TFY_API_KEY`, `TFY_BASE_URL`)
- `hermes_cli/providers.py` — `HERMES_OVERLAYS` entry + `ALIASES`
- `hermes_cli/models.py` — `CANONICAL_PROVIDERS` + `_PROVIDER_ALIASES`
- `agent/model_metadata.py` — `_PROVIDER_PREFIXES` (model name parsing)
- `.env.example` — env var documentation
- `website/docs/integrations/providers.md` — provider table
- `website/docs/reference/environment-variables.md` — env var reference + `HERMES_INFERENCE_PROVIDER` list
- `website/docs/reference/cli-commands.md` — `--provider` flag list
- `tests/providers/test_plugin_discovery.py` — bump expected provider count 34→35
- `tests/hermes_cli/test_api_key_providers.py` — `TestTrueFoundryProvider` (7 tests)

## How to Test

1. Set env vars:
   ```bash
   export TFY_API_KEY=your-key
   export TFY_BASE_URL=https://your-gateway-url/v1
   ```
2. Run `hermes model --provider truefoundry` — should prompt for model selection
3. Or run `hermes setup` — TrueFoundry appears in the provider picker
4. Alias works: `hermes model --provider tfy`
5. Run tests:
   ```bash
   pytest tests/hermes_cli/test_api_key_providers.py::TestTrueFoundryProvider tests/providers/ -v
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.3.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Validation

| Test suite | Result |
|---|---|
| `TestTrueFoundryProvider` (7 tests) | 7/7 pass |
| `tests/providers/` (plugin discovery + all profiles) | 93/93 pass |
| `tests/hermes_cli/test_runtime_provider_resolution.py` | 128/128 pass |
| `tests/agent/test_model_metadata.py` | 102/102 pass |
| Full provider test surface | 330/330 pass |