### PR TITLE
fix(gateway): reset iteration_budget on cached agent reuse

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14940,6 +14940,10 @@ class GatewayRunner:
             agent._last_activity_ts = time.time()
             agent._last_activity_desc = "starting new turn (cached)"
         agent._api_call_count = 0
+        # Reset iteration budget so goal continuation turns get a fresh budget
+        if hasattr(agent, 'iteration_budget') and agent.iteration_budget is not None:
+            with agent.iteration_budget._lock:
+                agent.iteration_budget._used = 0
 
     def _release_evicted_agent_soft(self, agent: Any) -> None:
         """Soft cleanup for cache-evicted agents — preserves session tool state.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16857,6 +16857,20 @@ class GatewayRunner:
                     entry.session_id = agent.session_id
                     self.session_store._save()
 
+                # Migrate goal state from the old session to the new one
+                # so /goal continuation survives context compression.
+                try:
+                    from hermes_cli.goals import load_goal, save_goal
+                    old_goal = load_goal(session_id)
+                    if old_goal and old_goal.status == "active":
+                        save_goal(agent.session_id, old_goal)
+                        logger.info(
+                            "Goal state migrated: %s → %s",
+                            session_id, agent.session_id,
+                        )
+                except Exception as _goal_migrate_exc:
+                    logger.debug("Goal migration failed during session split: %s", _goal_migrate_exc)
+
                 # If this is a Telegram DM and source.thread_id was lost during
                 # the session split (synthetic / recovered event), restore it
                 # from the binding so _thread_metadata_for_source produces the


### PR DESCRIPTION
## What does this PR do?

Two bugs that cause /goal continuation to silently break in gateway mode.
Bug 1: iteration_budget not reset on cached agent reuse
_init_cached_agent_for_turn resets api_call_count to 0 but does not reset iteration_budget._used. When a turn exhausts the iteration budget, the next goal continuation turn immediately exits because iteration_budget.remaining == 0, even though api_call_count was correctly reset.
Bug 2: goal state lost on session split
When context compression splits a session (new session_id), the goal state stored under goal:<old_session_id> becomes unreachable. _post_turn_goal_continuation queries the new session_id, finds no active goal (is_active() returns False), and silently drops the continuation. This is the more common trigger since long goal runs frequently hit compression.



## Related Issue

Fixes # — no existing issue filed.

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

gateway/run.py (_init_cached_agent_for_turn): Reset iteration_budget._used = 0 alongside the existing agent._api_call_count = 0 reset.
gateway/run.py (session split detection): Migrate goal state from old session_id to new session_id when compression triggers a session split.

- 

## How to Test

1. In gateway mode, set /goal <some multi-step task that requires many tool calls>
2. Let the agent run until either iteration budget is exhausted or context compression triggers a session split
3. Before fix (iteration_budget): continuation turn immediately exits with "Iteration budget exhausted" even though api_call_count was reset
4. Before fix (session split): continuation never triggers — goal is silently abandoned after the compressed response is delivered
5. After fix: continuation turn runs normally in both cases

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- Ubuntu 22.04 (gateway mode with lark) -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
- [x] N/A — no documentation, config, or architecture changes needed

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->
### Bug 2: Goal state lost on session split — production log
```
05:53:14 Turn ended: reason=max_iterations_reached(150/150) budget=80/150
05:53:14 Session split detected: 20260523_042621_42ff6e1d → 20260523_054937_a9eef0 (compression)
05:53:14 response ready → Sending response to oc_d6811c7e771cae572770497c560abe1c
05:53:14 → bg-review turn started (not goal continuation)
05:54:59 bg-review turn ended
06:55:56 Agent cache idle-TTL evict (idle=3782s)
         ← No goal continuation ever fired — goal silently abandoned
```
Key observation: budget=80/150 was not exhausted, yet no goal continuation was enqueued after the session split. The goal state stored under goal:<old_session_id> became unreachable from the new session.

### Bug 1: iteration_budget not reset — code evidence
No direct log trigger yet, but the bug follows from the code:
```
# agent/conversation_loop.py:644
while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
    ...
    elif not agent.iteration_budget.consume():  # ← returns False when budget exhausted
        break

# gateway/run.py:14945 (before fix)
agent._api_call_count = 0
# ← Missing: agent.iteration_budget._used = 0
```

When a turn exhausts iteration_budget without triggering compression, the next goal continuation turn exits immediately because iteration_budget.remaining == 0 despite api_call_count being correctly reset.
