### PR TITLE
feat(kanban): add read-only reconcile classifier

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -25,6 +25,7 @@ from typing import Any, Optional
 
 from hermes_cli import kanban_db as kb
 from hermes_cli import kanban_swarm as ks
+from hermes_cli import kanban_reconciler as krec
 from hermes_cli.profiles import get_active_profile_name, get_profile_dir, seed_profile_skills
 
 
@@ -477,6 +478,19 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="Emit JSON (structured) instead of the default human table",
     )
 
+    # --- reconcile (read-only deterministic stalled-transition actions) ---
+    p_reconcile = sub.add_parser(
+        "reconcile",
+        help="Classify stalled-transition actions without mutating the board",
+    )
+    p_reconcile.add_argument("--json", action="store_true", help="Emit structured JSON")
+    p_reconcile.add_argument(
+        "--ready-age-seconds",
+        type=int,
+        default=15 * 60,
+        help="Classify ready/review tasks older than this threshold (default: 900)",
+    )
+
     # --- link / unlink ---
     p_link = sub.add_parser("link", help="Add a parent->child dependency")
     p_link.add_argument("parent_id")
@@ -871,12 +885,13 @@ def kanban_command(args: argparse.Namespace) -> int:
     # HERMES_HOME. Previously only `init` and `daemon` triggered
     # schema creation; `create` / `list` / every other command would
     # error out on a fresh install.
-    try:
-        kb.init_db()
-    except Exception as exc:
-        print(f"kanban: could not initialize database: {exc}", file=sys.stderr)
-        _restore_board_env()
-        return 1
+    if action != "reconcile":
+        try:
+            kb.init_db()
+        except Exception as exc:
+            print(f"kanban: could not initialize database: {exc}", file=sys.stderr)
+            _restore_board_env()
+            return 1
 
     handlers = {
         "init":     _cmd_init,
@@ -890,6 +905,7 @@ def kanban_command(args: argparse.Namespace) -> int:
         "reassign": _cmd_reassign,
         "diagnostics": _cmd_diagnostics,
         "diag":     _cmd_diagnostics,
+        "reconcile": _cmd_reconcile,
         "link":     _cmd_link,
         "unlink":   _cmd_unlink,
         "claim":    _cmd_claim,
@@ -935,6 +951,19 @@ def kanban_command(args: argparse.Namespace) -> int:
 # ---------------------------------------------------------------------------
 # Handlers
 # ---------------------------------------------------------------------------
+
+
+def _cmd_reconcile(args: argparse.Namespace) -> int:
+    result = krec.run_reconciler(
+        board=getattr(args, "board", None),
+        ready_age_seconds=max(1, int(getattr(args, "ready_age_seconds", 900) or 900)),
+    )
+    if getattr(args, "json", False):
+        print(json.dumps(result, indent=2, ensure_ascii=False, default=str))
+    else:
+        print(krec.format_reconcile_text(result))
+    return 1 if result.get("error") else 0
+
 
 def _profile_author() -> str:
     """Best-effort author name for an interactive CLI call."""

--- a/hermes_cli/kanban_reconciler.py
+++ b/hermes_cli/kanban_reconciler.py
@@ -1,0 +1,462 @@
+"""Read-only Kanban stalled-transition reconciler.
+
+Phase 1A intentionally does not mutate the board.  It classifies the same
+families of orchestration stalls that the board doctor can observe, but returns
+explicit action records suitable for Jensen/operator decision queues.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import sqlite3
+import tempfile
+import time
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from hermes_cli import kanban_db as kb
+
+
+@dataclass(frozen=True)
+class ReconcileAction:
+    kind: str
+    task_id: Optional[str]
+    severity: str
+    reason: str
+    safe_to_apply: bool
+    signature: str
+    details: dict[str, Any]
+
+
+_SEVERITY_RANK = {"critical": 0, "error": 1, "warning": 2, "info": 3}
+
+
+def _pid_alive(pid: Any) -> bool:
+    if not pid:
+        return False
+    try:
+        os.kill(int(pid), 0)
+        return True
+    except OSError:
+        return False
+    except Exception:
+        return False
+
+
+def _jsonable(value: Any) -> Any:
+    try:
+        json.dumps(value)
+        return value
+    except TypeError:
+        return str(value)
+
+
+def _signature(kind: str, task_id: Optional[str], material: dict[str, Any]) -> str:
+    canonical = json.dumps(
+        {k: _jsonable(v) for k, v in sorted(material.items())},
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    digest = hashlib.sha1(canonical.encode("utf-8")).hexdigest()[:12]
+    return f"{kind}:{task_id or 'board'}:{digest}"
+
+
+def _action(
+    kind: str,
+    task_id: Optional[str],
+    severity: str,
+    reason: str,
+    *,
+    safe_to_apply: bool = False,
+    details: Optional[dict[str, Any]] = None,
+) -> ReconcileAction:
+    clean_details = dict(details or {})
+    return ReconcileAction(
+        kind=kind,
+        task_id=task_id,
+        severity=severity,
+        reason=reason,
+        safe_to_apply=bool(safe_to_apply),
+        signature=_signature(kind, task_id, clean_details),
+        details=clean_details,
+    )
+
+
+def _sort_actions(actions: list[ReconcileAction]) -> list[ReconcileAction]:
+    return sorted(
+        actions,
+        key=lambda a: (
+            _SEVERITY_RANK.get(a.severity, 99),
+            a.kind,
+            a.task_id or "",
+            a.signature,
+        ),
+    )
+
+
+def _profile_spawnable(profile: Optional[str]) -> bool:
+    if not profile:
+        return False
+    try:
+        from hermes_cli.profiles import profile_exists
+    except Exception:
+        # Preserve dispatcher health semantics: if we cannot introspect
+        # profiles, do not classify assigned work as nonspawnable.
+        return True
+    try:
+        return bool(profile_exists(profile))
+    except Exception:
+        return True
+
+
+def _has_sdlc_review_skill() -> bool:
+    """Best-effort local inventory check for the legacy review skill.
+
+    Phase 1A never blocks on this.  It is used only to produce a diagnostic
+    action when review work exists and the hard-coded review skill cannot be
+    found in the usual root/profile skill stores.
+    """
+    roots: list[Path] = []
+    try:
+        from hermes_constants import get_default_hermes_root, get_hermes_home
+        default_root = get_default_hermes_root()
+        roots.append(default_root / "skills")
+        roots.append(get_hermes_home() / "skills")
+        profiles_root = default_root / "profiles"
+        if profiles_root.is_dir():
+            roots.extend(p / "skills" for p in profiles_root.iterdir() if p.is_dir())
+    except Exception:
+        roots.append(Path.home() / ".hermes" / "skills")
+
+    seen: set[Path] = set()
+    for root in roots:
+        try:
+            resolved = root.resolve()
+        except OSError:
+            resolved = root
+        if resolved in seen or not root.is_dir():
+            continue
+        seen.add(resolved)
+        direct = root / "sdlc-review" / "SKILL.md"
+        if direct.is_file():
+            return True
+        try:
+            for candidate in root.rglob("sdlc-review/SKILL.md"):
+                if candidate.is_file():
+                    return True
+        except OSError:
+            continue
+    return False
+
+
+def _host_prefix() -> str:
+    try:
+        return f"{kb._claimer_id().split(':', 1)[0]}:"
+    except Exception:
+        return ""
+
+
+def _snapshot_sidecar(path: Path, suffix: str) -> Path:
+    return path.with_name(path.name + suffix)
+
+
+@contextmanager
+def _snapshot_connect(path: Path):
+    """Query a filesystem snapshot so live reconcile creates no DB sidecars.
+
+    Opening a WAL-mode SQLite database via ``mode=ro`` can still create
+    transient ``-wal``/``-shm`` files next to the live board.  Phase 1A's
+    contract is stricter: classify only and leave the live DB path untouched.
+    Copying the main DB and any existing sidecars into a temp dir confines any
+    SQLite bookkeeping to the snapshot.
+    """
+    with tempfile.TemporaryDirectory(prefix="hermes-kanban-reconcile-") as tmp:
+        snap = Path(tmp) / path.name
+        shutil.copy2(path, snap)
+        for suffix in ("-wal", "-shm"):
+            src = _snapshot_sidecar(path, suffix)
+            if src.exists():
+                shutil.copy2(src, _snapshot_sidecar(snap, suffix))
+        conn = sqlite3.connect(snap)
+        conn.row_factory = sqlite3.Row
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+
+def _table_has_column(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    try:
+        rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    except sqlite3.Error:
+        return False
+    return any(row["name"] == column for row in rows)
+
+
+def collect_reconcile_actions(
+    conn: sqlite3.Connection,
+    *,
+    ready_age_seconds: int = 15 * 60,
+    now: Optional[int] = None,
+) -> list[ReconcileAction]:
+    """Classify actionable stalled-transition signals without writing."""
+    as_of = int(now if now is not None else time.time())
+    ready_age_seconds = max(1, int(ready_age_seconds or 900))
+    actions: list[ReconcileAction] = []
+    host_prefix = _host_prefix()
+
+    # Running tasks: split dead/expired/stale-heartbeat observations so a
+    # heartbeat warning alone never becomes reclaim authority.
+    for row in conn.execute(
+        """
+        SELECT id, title, assignee, worker_pid, claim_lock, claim_expires,
+               last_heartbeat_at, current_run_id, started_at
+          FROM tasks
+         WHERE status = 'running'
+         ORDER BY started_at, created_at, id
+        """
+    ):
+        pid_alive = _pid_alive(row["worker_pid"])
+        claim_expires = row["claim_expires"]
+        expired = bool(claim_expires and int(claim_expires) < as_of)
+        hb = row["last_heartbeat_at"]
+        heartbeat_age = (as_of - int(hb)) if hb is not None else None
+        stale_hb = bool(heartbeat_age is not None and heartbeat_age > 15 * 60)
+        base = {
+            "assignee": row["assignee"],
+            "worker_pid": row["worker_pid"],
+            "pid_alive": pid_alive,
+            "claim_lock": row["claim_lock"],
+            "claim_expires": claim_expires,
+            "last_heartbeat_at": hb,
+            "current_run_id": row["current_run_id"],
+        }
+        if not pid_alive:
+            # Safe only when this is clearly a host-local worker claim or no
+            # pid was ever recorded.  The dry-run record remains advisory.
+            lock = row["claim_lock"] or ""
+            host_local = bool(host_prefix and lock.startswith(host_prefix))
+            safe = host_local or row["worker_pid"] is None
+            actions.append(_action(
+                "dead_running_candidate",
+                row["id"],
+                "critical",
+                "running task has no live worker PID",
+                safe_to_apply=safe,
+                details={**base, "host_local": host_local},
+            ))
+        if expired:
+            actions.append(_action(
+                "expired_claim_candidate",
+                row["id"],
+                "warning",
+                "running task claim has expired",
+                safe_to_apply=False,
+                details={**base, "seconds_expired": as_of - int(claim_expires)},
+            ))
+        if stale_hb:
+            actions.append(_action(
+                "stale_heartbeat_observed",
+                row["id"],
+                "warning",
+                "running task heartbeat is older than the advisory threshold",
+                safe_to_apply=False,
+                details={**base, "heartbeat_age_seconds": heartbeat_age},
+            ))
+
+    # Stale run metadata: run row still marked running but no longer the
+    # current task run.  Phase 1A reports only; Phase 1B may clean this up.
+    for row in conn.execute(
+        """
+        SELECT r.id AS run_id, r.task_id, r.profile, r.worker_pid, r.started_at,
+               t.status AS task_status, t.current_run_id
+          FROM task_runs r
+          JOIN tasks t ON t.id = r.task_id
+         WHERE r.status = 'running'
+           AND (t.status != 'running' OR t.current_run_id IS NULL OR t.current_run_id != r.id)
+         ORDER BY r.started_at DESC, r.id DESC
+        """
+    ):
+        actions.append(_action(
+            "stale_run_metadata",
+            row["task_id"],
+            "warning",
+            "task_run is marked running but is not the task current active run",
+            safe_to_apply=False,
+            details={
+                "run_id": row["run_id"],
+                "profile": row["profile"],
+                "worker_pid": row["worker_pid"],
+                "pid_alive": _pid_alive(row["worker_pid"]),
+                "task_status": row["task_status"],
+                "current_run_id": row["current_run_id"],
+            },
+        ))
+
+    # Blocked tasks whose dependency parents are all terminal need an explicit
+    # Jensen/reviewer decision, not automatic unblocking.
+    dependency_filter = (
+        "AND COALESCE(l.relation_type, 'dependency') = 'dependency'"
+        if _table_has_column(conn, "task_links", "relation_type")
+        else ""
+    )
+    for row in conn.execute(
+        f"""
+        SELECT c.id, c.title, c.assignee, COUNT(l.parent_id) AS parents,
+               SUM(CASE WHEN p.status IN ('done','archived') THEN 1 ELSE 0 END) AS terminal_parents,
+               GROUP_CONCAT(p.id || ':' || p.status, ', ') AS parent_state
+          FROM tasks c
+          JOIN task_links l ON l.child_id = c.id
+          JOIN tasks p ON p.id = l.parent_id
+         WHERE c.status = 'blocked'
+           {dependency_filter}
+         GROUP BY c.id
+        HAVING parents > 0 AND parents = terminal_parents
+         ORDER BY c.created_at, c.id
+        """
+    ):
+        actions.append(_action(
+            "blocked_with_completed_parents_decision",
+            row["id"],
+            "warning",
+            "blocked task has all dependency parents completed; explicit unblock/re-review decision needed",
+            safe_to_apply=False,
+            details={
+                "assignee": row["assignee"],
+                "parents": row["parent_state"],
+                "parent_count": row["parents"],
+            },
+        ))
+
+    for status in ("ready", "review"):
+        for row in conn.execute(
+            """
+            SELECT id, title, assignee, created_at
+              FROM tasks
+             WHERE status = ? AND claim_lock IS NULL
+             ORDER BY created_at, id
+            """,
+            (status,),
+        ):
+            age = as_of - int(row["created_at"])
+            if age < ready_age_seconds:
+                continue
+            spawnable = _profile_spawnable(row["assignee"])
+            kind = f"old_{status}_{'spawnable' if spawnable else 'nonspawnable'}"
+            actions.append(_action(
+                kind,
+                row["id"],
+                "warning" if spawnable else "info",
+                f"{status} task has not been claimed within threshold",
+                safe_to_apply=False,
+                details={
+                    "assignee": row["assignee"],
+                    "age_seconds": age,
+                    "created_at": row["created_at"],
+                    "spawnable_profile": spawnable,
+                },
+            ))
+
+    review_count = int(conn.execute(
+        "SELECT COUNT(*) FROM tasks WHERE status = 'review'"
+    ).fetchone()[0])
+    if review_count and not _has_sdlc_review_skill():
+        actions.append(_action(
+            "review_skill_provenance_missing",
+            None,
+            "warning",
+            "review dispatch injects sdlc-review, but the skill was not found locally; diagnostic only",
+            safe_to_apply=False,
+            details={"review_task_count": review_count, "skill": "sdlc-review"},
+        ))
+
+    return _sort_actions(actions)
+
+
+def actions_to_dicts(actions: list[ReconcileAction]) -> list[dict[str, Any]]:
+    return [asdict(action) for action in actions]
+
+
+def run_reconciler(
+    *,
+    board: Optional[str] = None,
+    ready_age_seconds: int = 15 * 60,
+    now: Optional[int] = None,
+) -> dict[str, Any]:
+    path = kb.kanban_db_path(board=board)
+    as_of = int(now if now is not None else time.time())
+    resolved_board = board or kb.get_current_board()
+    if not path.exists():
+        return {
+            "ok": False,
+            "board": resolved_board,
+            "db_path": str(path),
+            "actions": [],
+            "as_of": as_of,
+            "mutation_applied": False,
+            "error": {
+                "kind": "kanban_db_missing",
+                "message": "Kanban DB does not exist; run `hermes kanban init` before reconciling this board.",
+            },
+        }
+    with _snapshot_connect(path) as conn:
+        actions = collect_reconcile_actions(
+            conn,
+            ready_age_seconds=ready_age_seconds,
+            now=as_of,
+        )
+    return {
+        "ok": not actions,
+        "board": resolved_board,
+        "db_path": str(path),
+        "actions": actions_to_dicts(actions),
+        "as_of": as_of,
+        "mutation_applied": False,
+    }
+
+
+def format_reconcile_text(result: dict[str, Any]) -> str:
+    if result.get("error"):
+        err = result.get("error") or {}
+        return (
+            f"Kanban reconcile: {err.get('kind', 'error')} on {result.get('board')} "
+            f"({result.get('db_path')}): {err.get('message', '')}"
+        )
+
+    actions = result.get("actions") or []
+    if not actions:
+        return f"Kanban reconcile: no stalled-transition actions ({result.get('board')})"
+
+    grouped: dict[tuple[str, str], int] = {}
+    for action in actions:
+        key = (str(action.get("severity")), str(action.get("kind")))
+        grouped[key] = grouped.get(key, 0) + 1
+
+    lines = [
+        f"Kanban reconcile: {len(actions)} action(s) on {result.get('board')} ({result.get('db_path')})",
+        "Summary:",
+    ]
+    for (severity, kind), count in sorted(
+        grouped.items(),
+        key=lambda item: (_SEVERITY_RANK.get(item[0][0], 99), item[0][1]),
+    ):
+        lines.append(f"- {severity.upper()} {kind}: {count}")
+
+    lines.append("Actions:")
+    for action in actions:
+        loc = action.get("task_id") or "board"
+        safe = "safe" if action.get("safe_to_apply") else "decision-only"
+        lines.append(
+            f"- {str(action.get('severity')).upper()} {action.get('kind')} "
+            f"[{loc}] ({safe}): {action.get('reason')}"
+        )
+        lines.append(f"  signature: {action.get('signature')}")
+        details = action.get("details") or {}
+        if details:
+            lines.append("  details: " + json.dumps(details, sort_keys=True, default=str))
+    return "\n".join(lines)

--- a/tests/hermes_cli/test_kanban_reconciler.py
+++ b/tests/hermes_cli/test_kanban_reconciler.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as kc
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_reconciler as rec
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _kinds(result: dict) -> set[str]:
+    return {action["kind"] for action in result["actions"]}
+
+
+def _actions(result: dict, kind: str) -> list[dict]:
+    return [action for action in result["actions"] if action["kind"] == kind]
+
+
+def test_reconcile_cli_reports_missing_db_without_traceback(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    db_path = kb.kanban_db_path()
+    assert not db_path.exists()
+
+    result = rec.run_reconciler(now=1_700_000_000)
+    assert result["ok"] is False
+    assert result["mutation_applied"] is False
+    assert result["error"]["kind"] == "kanban_db_missing"
+    assert not db_path.exists()
+
+    env = dict(os.environ, HERMES_HOME=str(home))
+    proc = subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "kanban", "reconcile", "--json"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=30,
+        env=env,
+    )
+    assert proc.returncode == 0
+    assert "Traceback" not in proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["error"]["kind"] == "kanban_db_missing"
+    assert payload["mutation_applied"] is False
+    assert not db_path.exists()
+
+
+def test_reconciler_reports_no_actions_for_healthy_board(kanban_home):
+    result = rec.run_reconciler(now=1_700_000_000)
+
+    assert result["mutation_applied"] is False
+    assert result["actions"] == []
+    assert result["ok"] is True
+
+
+def test_reconciler_splits_dead_expired_and_stale_heartbeat(kanban_home):
+    now = 1_700_000_000
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="running", assignee="engineer")
+        conn.execute(
+            """
+            UPDATE tasks
+               SET status = 'running', worker_pid = ?, claim_lock = ?,
+                   claim_expires = ?, last_heartbeat_at = ?, started_at = ?
+             WHERE id = ?
+            """,
+            (99999999, "otherhost:claim", now - 60, now - 3600, now - 7200, task_id),
+        )
+
+    result = rec.run_reconciler(now=now)
+    kinds = _kinds(result)
+
+    assert "dead_running_candidate" in kinds
+    assert "expired_claim_candidate" in kinds
+    assert "stale_heartbeat_observed" in kinds
+    assert _actions(result, "stale_heartbeat_observed")[0]["safe_to_apply"] is False
+    # Cross-host dead candidates remain advisory in Phase 1A.
+    assert _actions(result, "dead_running_candidate")[0]["safe_to_apply"] is False
+
+
+def test_stale_heartbeat_only_is_advisory_not_safe_to_apply(kanban_home):
+    now = 1_700_000_000
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="running", assignee="engineer")
+        conn.execute(
+            """
+            UPDATE tasks
+               SET status = 'running', worker_pid = ?, claim_lock = ?,
+                   claim_expires = ?, last_heartbeat_at = ?, started_at = ?
+             WHERE id = ?
+            """,
+            (os.getpid(), "localhost:claim", now + 3600, now - 3600, now - 7200, task_id),
+        )
+
+    result = rec.run_reconciler(now=now)
+    stale = _actions(result, "stale_heartbeat_observed")
+
+    assert len(stale) == 1
+    assert stale[0]["task_id"] == task_id
+    assert stale[0]["safe_to_apply"] is False
+    assert "dead_running_candidate" not in _kinds(result)
+
+
+def test_blocked_with_completed_parents_is_decision_only(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="engineer")
+        child = kb.create_task(conn, title="child", assignee="reviewer")
+        kb.complete_task(conn, parent, summary="done")
+        kb.block_task(conn, child, reason="waiting on remediation")
+        conn.execute(
+            "INSERT INTO task_links(parent_id, child_id) VALUES (?, ?)",
+            (parent, child),
+        )
+
+    result = rec.run_reconciler(now=1_700_000_000)
+    actions = _actions(result, "blocked_with_completed_parents_decision")
+
+    assert len(actions) == 1
+    assert actions[0]["task_id"] == child
+    assert actions[0]["safe_to_apply"] is False
+    assert actions[0]["signature"].startswith(
+        f"blocked_with_completed_parents_decision:{child}:"
+    )
+
+
+def test_stale_run_metadata_is_reported_without_task_mutation(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="done task", assignee="engineer")
+        kb.complete_task(conn, task_id, summary="done")
+        run_id = conn.execute(
+            """
+            INSERT INTO task_runs(task_id, profile, status, worker_pid, started_at)
+            VALUES (?, 'engineer', 'running', 99999999, ?)
+            """,
+            (task_id, 1),
+        ).lastrowid
+
+    result = rec.run_reconciler(now=1_700_000_000)
+    actions = _actions(result, "stale_run_metadata")
+
+    assert len(actions) == 1
+    assert actions[0]["details"]["run_id"] == run_id
+    assert actions[0]["safe_to_apply"] is False
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "done"
+
+
+def test_old_ready_and_review_spawnable_classification(kanban_home, monkeypatch):
+    now = 1_700_000_000
+    monkeypatch.setattr(rec, "_profile_spawnable", lambda profile: profile == "engineer")
+    with kb.connect() as conn:
+        ready = kb.create_task(conn, title="ready", assignee="engineer")
+        blocked_ready = kb.create_task(conn, title="ready nonspawn", assignee="not-a-profile")
+        review = kb.create_task(conn, title="review", assignee="engineer")
+        review_nonspawn = kb.create_task(conn, title="review nonspawn", assignee="not-a-profile")
+        conn.execute(
+            "UPDATE tasks SET status = 'ready', created_at = ? WHERE id IN (?, ?)",
+            (now - 3600, ready, blocked_ready),
+        )
+        conn.execute(
+            "UPDATE tasks SET status = 'review', created_at = ? WHERE id IN (?, ?)",
+            (now - 3600, review, review_nonspawn),
+        )
+
+    result = rec.run_reconciler(now=now, ready_age_seconds=60)
+    kinds = _kinds(result)
+
+    assert "old_ready_spawnable" in kinds
+    assert "old_ready_nonspawnable" in kinds
+    assert "old_review_spawnable" in kinds
+    assert "old_review_nonspawnable" in kinds
+
+
+def test_review_skill_provenance_missing_is_diagnostic_only(kanban_home, monkeypatch):
+    monkeypatch.setattr(rec, "_has_sdlc_review_skill", lambda: False)
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="review", assignee="reviewer")
+        conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (task_id,))
+
+    result = rec.run_reconciler(now=1_700_000_000)
+    actions = _actions(result, "review_skill_provenance_missing")
+
+    assert len(actions) == 1
+    assert actions[0]["task_id"] is None
+    assert actions[0]["safe_to_apply"] is False
+    assert actions[0]["details"]["skill"] == "sdlc-review"
+
+
+def test_reconcile_cli_json_is_read_only(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="engineer")
+        child = kb.create_task(conn, title="child", assignee="reviewer")
+        kb.complete_task(conn, parent, summary="done")
+        kb.block_task(conn, child, reason="waiting")
+        conn.execute(
+            "INSERT INTO task_links(parent_id, child_id) VALUES (?, ?)",
+            (parent, child),
+        )
+
+    db_path = kb.kanban_db_path()
+    # Force setup writes into the main DB, then remove absent sidecars so this
+    # regression proves reconcile itself does not create WAL/SHM files.
+    with kb.connect() as conn:
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    for sidecar in (db_path.with_name(db_path.name + "-wal"), db_path.with_name(db_path.name + "-shm")):
+        if sidecar.exists():
+            sidecar.unlink()
+
+    before = hashlib.sha256(db_path.read_bytes()).hexdigest()
+    wal_before = db_path.with_name(db_path.name + "-wal").exists()
+    shm_before = db_path.with_name(db_path.name + "-shm").exists()
+
+    out = kc.run_slash("reconcile --json")
+    payload = json.loads(out)
+
+    after = hashlib.sha256(db_path.read_bytes()).hexdigest()
+    assert before == after
+    assert db_path.with_name(db_path.name + "-wal").exists() == wal_before
+    assert db_path.with_name(db_path.name + "-shm").exists() == shm_before
+    assert payload["mutation_applied"] is False
+    assert "blocked_with_completed_parents_decision" in _kinds(payload)
+
+
+def test_reconcile_cli_text_groups_actions(kanban_home):
+    now = int(time.time())
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="ready", assignee="missing-profile")
+        conn.execute("UPDATE tasks SET created_at = ? WHERE id = ?", (now - 3600, task_id))
+
+    out = kc.run_slash("reconcile --ready-age-seconds 60")
+
+    assert "Kanban reconcile:" in out
+    assert "Summary:" in out
+    assert "old_ready_nonspawnable" in out
+
+
+def test_reconcile_cli_exposes_no_apply_option(kanban_home):
+    proc = subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "kanban", "reconcile", "--help"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=30,
+        env=dict(os.environ, HERMES_HOME=str(kanban_home)),
+    )
+
+    assert proc.returncode == 0
+    assert "--apply" not in proc.stdout
+    assert "reclaim" not in proc.stdout.lower()
+    assert "unblock" not in proc.stdout.lower()
+
+
+def test_reconciler_module_has_no_board_mutation_primitives():
+    source = Path(rec.__file__).read_text()
+    forbidden_tokens = [
+        "UPDATE ",
+        "INSERT ",
+        "DELETE ",
+        "write_txn",
+        "init_db(",
+        "claim_task(",
+        "complete_task(",
+        "block_task(",
+        "unblock_task(",
+        "reclaim_task(",
+        "release_stale_claims(",
+        "detect_crashed_workers(",
+        "add_profile_event_sub(",
+        "_append_event(",
+    ]
+    for token in forbidden_tokens:
+        assert token not in source


### PR DESCRIPTION
## Summary
Adds a read-only kanban reconcile command that classifies stalled-transition candidates without changing board state. The reconcile path returns deterministic action records for operator/Jensen decision-making and uses a temporary DB snapshot so live SQLite DB/WAL/SHM files are not touched.

## Ticket / Context
No Jira ticket. Context: Hermes adversarial orchestration audit Phase 1A remediation. Boris approved only the narrow read-first/read-only reconcile slice: no apply path, no auto-reclaim, no auto-unblock, and no review-lane `sdlc-review` enforcement.

## Changes
- Added `hermes_cli/kanban_reconciler.py` with deterministic `ReconcileAction` classification.
- Added `hermes kanban reconcile --json --ready-age-seconds N`.
- Skipped `kb.init_db()` for reconcile so the command can stay diagnostic/read-only.
- Added a controlled `kanban_db_missing` diagnostic for fresh homes / missing board DBs, without creating the DB or tracebacking.
- Classifies dead running candidates, expired claims, stale heartbeat observations, stale run metadata, blocked tasks with completed parents, old ready/review work, and diagnostic-only review skill provenance gaps.
- Added focused reconciler tests, including regressions for missing DB handling and no WAL/SHM sidecar creation.

## Verification
- Passed: `/Users/ctao/.hermes/hermes-agent/venv/bin/python -m py_compile hermes_cli/kanban_reconciler.py hermes_cli/kanban.py`
- Passed: `/Users/ctao/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_kanban_reconciler.py tests/hermes_cli/test_kanban_cli.py -q -o 'addopts='` — 58 passed
- Passed: missing-DB CLI diagnostic via `python -m hermes_cli.main kanban reconcile --json`
  - exit 0
  - stderr empty
  - JSON `error.kind=kanban_db_missing`
  - `kanban.db` not created
  - `mutation_applied=false`
- Passed: initialized temp-board CLI dry-run via `python -m hermes_cli.main kanban reconcile --json`
  - exit 0
  - DB SHA unchanged
  - WAL/SHM sidecars absent before and absent after
  - `mutation_applied=false`
  - detected `blocked_with_completed_parents_decision`

## Test Plan
- Review the reconcile action taxonomy and confirm stale heartbeat / blocked-with-completed-parents actions remain decision-only.
- Run the focused pytest targets above.
- Optionally run `hermes kanban reconcile --json` against a local board and confirm `mutation_applied=false` plus unchanged DB hash/sidecar state.

## Risks / Follow-ups
- Before any future Phase 1B apply path, add or prove stronger snapshot consistency under concurrent board writes.
- Do not add auto-unblock, dispatcher auto-apply, or `sdlc-review` enforcement without a new Boris review.
- The reconcile snapshot uses a temp copy of DB/WAL/SHM; this is intentionally conservative for read-only diagnostics.

## Review Summary
- Boris initially blocked an earlier local implementation because `kb.connect(readonly=True)` could create live SQLite WAL/SHM sidecars.
- That blocker was remediated by switching reconcile to query a temp snapshot.
- Boris then blocked the first pushed commit because fresh homes without `kanban.db` tracebacked; this PR now returns a structured `kanban_db_missing` diagnostic without creating DB files.
- Final Boris verdict on PR #30710 commit `593d4c07aaf1b6ef9bad6a800734dd943ad5420d`: ACCEPT.

## Review Readiness
- Boris verdict: accepted for human review.
- Reviewed PR: https://github.com/NousResearch/hermes-agent/pull/30710
- Reviewed commit: `593d4c07aaf1b6ef9bad6a800734dd943ad5420d`
- Blockers: none remaining; prior sidecar and fresh-home blockers resolved.
- Verification checked: py_compile, focused pytest (58 passed), missing-DB diagnostic, initialized-board no-sidecar dry-run, no-apply/no-mutation guard tests.
- Acceptance artifact: Boris final review in Hermes Slack thread/session for “Hermes — Adversarial Orchestration System Audit”.

## Screenshots / UI Notes
- No visual changes.
