### PR TITLE
fix(tui): label completed reasoning distinctly

### DIFF
--- a/ui-tui/src/__tests__/thinkingLabel.test.ts
+++ b/ui-tui/src/__tests__/thinkingLabel.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest'
+
+import { thinkingHeaderLabel } from '../components/thinking.js'
+
+describe('thinkingHeaderLabel', () => {
+  it('distinguishes live thinking from completed reasoning', () => {
+    expect(thinkingHeaderLabel(true)).toBe('Thinking')
+    expect(thinkingHeaderLabel(false)).toBe('Reasoning')
+  })
+})

--- a/ui-tui/src/components/thinking.tsx
+++ b/ui-tui/src/components/thinking.tsx
@@ -47,6 +47,8 @@ const fmtElapsed = (ms: number) => {
   return sec < 10 ? `${sec.toFixed(1)}s` : `${Math.round(sec)}s`
 }
 
+export const thinkingHeaderLabel = (thinkingLive: boolean) => (thinkingLive ? 'Thinking' : 'Reasoning')
+
 type TreeBranch = 'mid' | 'last'
 type TreeRails = readonly boolean[]
 
@@ -888,6 +890,7 @@ export const ToolTrail = memo(function ToolTrail({
   const hasMeta = meta.length > 0
   const hasThinking = !!cot || reasoningActive || reasoningStreaming
   const thinkingLive = reasoningActive || reasoningStreaming
+  const thinkingLabel = thinkingHeaderLabel(thinkingLive)
 
   const tokenCount =
     reasoningTokens && reasoningTokens > 0 ? reasoningTokens : reasoning ? estimateTokensRough(reasoning) : 0
@@ -1015,11 +1018,11 @@ export const ToolTrail = memo(function ToolTrail({
             <Text color={t.color.accent}>{openThinking ? '▾ ' : '▸ '}</Text>
             {thinkingLive ? (
               <Text bold color={t.color.text}>
-                Thinking
+                {thinkingLabel}
               </Text>
             ) : (
               <Text color={t.color.muted} dim>
-                Thinking
+                {thinkingLabel}
               </Text>
             )}
             {thinkingTokensLabel ? (


### PR DESCRIPTION
## What does this PR do?

Changes the completed TUI reasoning trail header from `Thinking` to `Reasoning`, while keeping live reasoning labeled `Thinking`.

The backend already marks the turn idle on `message.complete`, but completed reasoning can remain visible as a saved trail message. Before this change, both live and completed states rendered the same `Thinking` label, so a completed turn could look like active inference was still happening.

## Related Issue

Support thread report from Bertl. No GitHub issue exists.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `ui-tui/src/components/thinking.tsx`: adds a small `thinkingHeaderLabel()` helper and renders completed/non-live reasoning as `Reasoning`.
- `ui-tui/src/__tests__/thinkingLabel.test.ts`: covers the live vs completed label distinction.

## How to Test

1. Run `cd ui-tui && npx vitest run --maxWorkers 4 --testTimeout 15000 src/__tests__/thinkingLabel.test.ts src/__tests__/createGatewayEventHandler.test.ts src/__tests__/reasoning.test.ts`.
2. Run `cd ui-tui && npx eslint src/components/thinking.tsx src/__tests__/thinkingLabel.test.ts`.
3. Run `cd ui-tui && npm run build`.
4. In the TUI, complete a turn that leaves reasoning visible. Live reasoning should say `Thinking`; saved completed reasoning should say `Reasoning`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 / Linux checkout, UI-TUI targeted test/build path

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted UI-TUI checks passed:

- `npx vitest run --maxWorkers 4 --testTimeout 15000 src/__tests__/thinkingLabel.test.ts src/__tests__/createGatewayEventHandler.test.ts src/__tests__/reasoning.test.ts`
- `npx eslint src/components/thinking.tsx src/__tests__/thinkingLabel.test.ts`
- `npm run build`

Full pytest suite not run per local operator constraint for this change.
