### PR TITLE
fix(vision): add Gemini 2.5+ and 2.0+ to _supports_media_in_tool_results (#30704)

### DIFF
--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -50,8 +50,16 @@ class TestSupportsMediaInToolResults:
     def test_gemini_3_yes(self):
         assert _supports_media_in_tool_results("google", "gemini-3-flash-preview") is True
 
-    def test_gemini_2_no(self):
-        assert _supports_media_in_tool_results("google", "gemini-2.5-pro") is False
+    def test_gemini_2_5_yes(self):
+        assert _supports_media_in_tool_results("google", "gemini-2.5-pro") is True
+
+    def test_gemini_2_0_yes(self):
+        assert _supports_media_in_tool_results("google", "gemini-2.0-flash") is True
+
+    def test_gemini_old_no(self):
+        # Pre-2.0 Gemini variants do not support multimodal tool results
+        assert _supports_media_in_tool_results("google", "gemini-1.5-pro") is False
+        assert _supports_media_in_tool_results("google", "gemini-pro") is False
 
     def test_unknown_provider_conservative_no(self):
         assert _supports_media_in_tool_results("brand-new-provider", "any-model") is False

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -806,12 +806,16 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
         return True
 
     # Gemini — gate on model name; older Gemini variants did not support
-    # multimodal functionResponse. Gemini 3.x does.
+    # multimodal functionResponse. Gemini 3.x and 2.x do.
     if p in {"google", "gemini", "google-gemini", "google-vertex-gemini"}:
         if not isinstance(model, str):
             return False
         m = model.strip().lower()
         if "gemini-3" in m or "gemini-pro-3" in m or "gemini-flash-3" in m:
+            return True
+        # Gemini 2.5+ and 2.0+ also support multimodal tool results
+        # via the OpenAI-compatible endpoint.
+        if "gemini-2.5" in m or "gemini-2.0" in m:
             return True
         return False
 


### PR DESCRIPTION
## What broke
`_supports_media_in_tool_results()` in `tools/vision_tools.py` only returns `True` for Gemini 3.x models, so Gemini 2.5-flash, 2.5-pro, and 2.0-flash fall back to the legacy text pipeline even though they support native vision input via the OpenAI-compatible endpoint.

## Root cause
The Gemini branch in `_supports_media_in_tool_results()` (lines 465-471) only checks for `gemini-3`, `gemini-pro-3`, and `gemini-flash-3`. Gemini 2.5+ and 2.0+ models were not included in the allowlist.

## Why this fix is minimal
Two-line addition in the Gemini branch: check for `gemini-2.5` and `gemini-2.0` substrings before the `return False`. No changes to other providers, no changes to the vision tool result construction, no API surface changes.

## What I tested
Updated `tests/tools/test_vision_native_fast_path.py`:
- `test_gemini_2_5_yes` — verifies `gemini-2.5-pro` returns `True`
- `test_gemini_2_0_yes` — verifies `gemini-2.0-flash` returns `True`
- `test_gemini_old_no` — verifies pre-2.0 variants (`gemini-1.5-pro`, `gemini-pro`) still return `False`

Existing `test_gemini_3_yes` and other provider tests remain unchanged.

## What I intentionally did not change
- Any non-Gemini provider paths
- `_build_native_vision_tool_result()` implementation
- Vision tool routing logic beyond the allowlist check