### PR TITLE
fix(tools): block write_file after truncated reads

### DIFF
--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -14,6 +14,7 @@ import time
 import unittest
 from unittest.mock import patch, MagicMock
 
+from tools import file_state
 from tools.file_tools import (
     read_file_tool,
     write_file_tool,
@@ -34,17 +35,23 @@ from tools.file_tools import (
 
 class _FakeReadResult:
     """Minimal stand-in for FileOperations.read_file return value."""
-    def __init__(self, content="line1\nline2\n", total_lines=2, file_size=100):
+    def __init__(
+        self, content="line1\nline2\n", total_lines=2, file_size=100, truncated=False
+    ):
         self.content = content
         self._total_lines = total_lines
         self._file_size = file_size
+        self._truncated = truncated
 
     def to_dict(self):
-        return {
+        result = {
             "content": self.content,
             "total_lines": self._total_lines,
             "file_size": self._file_size,
         }
+        if self._truncated:
+            result["truncated"] = True
+        return result
 
 
 def _make_fake_ops(content="hello\n", total_lines=1, file_size=6):
@@ -561,6 +568,90 @@ class TestLargeFileHint(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# Partial-read overwrite guard
+# ---------------------------------------------------------------------------
+
+class TestPartialReadOverwriteGuard(unittest.TestCase):
+    """write_file must not replace a file after only a truncated read."""
+
+    def setUp(self):
+        _read_tracker.clear()
+        file_state.get_registry().clear()
+        self._tmpdir = tempfile.mkdtemp()
+        self._tmpfile = os.path.join(self._tmpdir, "partial_guard.txt")
+        with open(self._tmpfile, "w") as f:
+            f.write("line 1\nline 2\nline 3\n")
+
+    def tearDown(self):
+        _read_tracker.clear()
+        file_state.get_registry().clear()
+        try:
+            os.unlink(self._tmpfile)
+            os.rmdir(self._tmpdir)
+        except OSError:
+            pass
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_write_rejects_after_truncated_read(self, mock_ops):
+        fake = MagicMock()
+        fake.read_file.return_value = _FakeReadResult(
+            content="line 1\n",
+            total_lines=3,
+            file_size=21,
+            truncated=True,
+        )
+        fake.write_file = MagicMock()
+        mock_ops.return_value = fake
+
+        read_result = json.loads(read_file_tool(self._tmpfile, limit=1, task_id="partial"))
+        self.assertTrue(read_result.get("truncated"))
+
+        write_result = json.loads(write_file_tool(
+            self._tmpfile,
+            "line 1\n",
+            task_id="partial",
+        ))
+
+        self.assertIn("error", write_result)
+        self.assertIn("partial/truncated", write_result["error"])
+        fake.write_file.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_full_reread_clears_partial_write_block(self, mock_ops):
+        fake = MagicMock()
+        fake.read_file.side_effect = [
+            _FakeReadResult(
+                content="line 1\n",
+                total_lines=3,
+                file_size=21,
+                truncated=True,
+            ),
+            _FakeReadResult(
+                content="line 1\nline 2\nline 3\n",
+                total_lines=3,
+                file_size=21,
+                truncated=False,
+            ),
+        ]
+        fake.write_file.return_value = MagicMock(
+            to_dict=lambda: {"success": True, "path": self._tmpfile}
+        )
+        mock_ops.return_value = fake
+
+        read_file_tool(self._tmpfile, limit=1, task_id="partial")
+        read_file_tool(self._tmpfile, limit=10, task_id="partial")
+
+        write_result = json.loads(write_file_tool(
+            self._tmpfile,
+            "line 1\nline 2\nline 3\nline 4\n",
+            task_id="partial",
+        ))
+
+        self.assertNotIn("error", write_result)
+        self.assertTrue(write_result.get("success"))
+
+
+# ---------------------------------------------------------------------------
 # Config override
 # ---------------------------------------------------------------------------
 
@@ -677,18 +768,18 @@ class TestWriteInvalidatesDedup(unittest.TestCase):
 
         # Read with different offsets to populate multiple dedup entries.
         read_file_tool(self._tmpfile, offset=1, limit=100, task_id="off")
-        read_file_tool(self._tmpfile, offset=50, limit=100, task_id="off")
+        read_file_tool(self._tmpfile, offset=1, limit=200, task_id="off")
 
         # Write — should invalidate BOTH dedup entries.
         write_file_tool(self._tmpfile, "replaced\n", task_id="off")
 
         # Both reads should return fresh content.
         r1 = json.loads(read_file_tool(self._tmpfile, offset=1, limit=100, task_id="off"))
-        r2 = json.loads(read_file_tool(self._tmpfile, offset=50, limit=100, task_id="off"))
+        r2 = json.loads(read_file_tool(self._tmpfile, offset=1, limit=200, task_id="off"))
         self.assertNotEqual(r1.get("dedup"), True,
                             "offset=1 should not dedup after write")
         self.assertNotEqual(r2.get("dedup"), True,
-                            "offset=50 should not dedup after write")
+                            "limit=200 should not dedup after write")
 
     @patch("tools.file_tools._get_file_ops")
     def test_write_does_not_invalidate_other_files(self, mock_ops):

--- a/tests/tools/test_file_state_registry.py
+++ b/tests/tools/test_file_state_registry.py
@@ -88,6 +88,13 @@ class FileStateRegistryUnitTests(unittest.TestCase):
         self.assertIsNotNone(warn)
         self.assertIn("partial", warn.lower())
 
+    def test_read_was_partial_tracks_latest_read(self):
+        p = self._mk()
+        file_state.record_read("A", p, partial=True)
+        self.assertTrue(file_state.read_was_partial("A", p))
+        file_state.record_read("A", p, partial=False)
+        self.assertFalse(file_state.read_was_partial("A", p))
+
     def test_external_mtime_drift_flagged(self):
         p = self._mk()
         file_state.record_read("A", p)

--- a/tools/file_state.py
+++ b/tools/file_state.py
@@ -19,6 +19,8 @@ Three public hooks are used by the file tools:
   * ``record_read(task_id, path, *, partial)`` — called by read_file
   * ``note_write(task_id, path)`` — called after write_file / patch
   * ``check_stale(task_id, path)`` — called BEFORE write_file / patch
+  * ``read_was_partial(task_id, path)`` — helper for blocking full overwrites
+    after a truncated or paginated read
 
 Plus ``lock_path(path)`` — a context-manager returning a per-path lock to
 wrap the whole read→modify→write block. And ``writes_since(task_id,
@@ -43,8 +45,9 @@ from typing import Dict, Iterable, List, Optional, Tuple
 
 # ── Public stamp type ────────────────────────────────────────────────
 # (mtime, read_ts, partial).  partial=True when read_file returned a
-# windowed view (offset > 1 or limit < total_lines) — writes that happen
-# after a partial read should still warn so the model re-reads in full.
+# windowed view (offset > 1 or limit < total_lines). Full-file overwrites
+# should be blocked after a partial read; other edit paths can surface a
+# warning so the model re-reads in full.
 ReadStamp = Tuple[float, float, bool]
 
 # Number of resolved-path entries retained per agent.  Bounded to keep
@@ -214,6 +217,14 @@ class FileStateRegistry:
 
         return None
 
+    def read_was_partial(self, task_id: str, resolved: str) -> bool:
+        """Return True when this task only saw a partial view of *resolved*."""
+        if _disabled():
+            return False
+        with self._state_lock:
+            stamp = self._reads.get(task_id, {}).get(resolved)
+        return bool(stamp and stamp[2])
+
     # ── Reminder helper for delegate_tool ───────────────────────────
     def writes_since(
         self,
@@ -304,6 +315,10 @@ def check_stale(task_id: str, resolved_or_path: str | Path) -> Optional[str]:
     return _registry.check_stale(task_id, str(resolved_or_path))
 
 
+def read_was_partial(task_id: str, resolved_or_path: str | Path) -> bool:
+    return _registry.read_was_partial(task_id, str(resolved_or_path))
+
+
 def lock_path(resolved_or_path: str | Path):
     return _registry.lock_path(str(resolved_or_path))
 
@@ -326,6 +341,7 @@ __all__ = [
     "record_read",
     "note_write",
     "check_stale",
+    "read_was_partial",
     "lock_path",
     "writes_since",
     "known_reads",

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -790,6 +790,27 @@ def _check_file_staleness(filepath: str, task_id: str) -> str | None:
     return None
 
 
+def _partial_read_overwrite_error(
+    filepath: str, task_id: str, resolved: str | None = None
+) -> str | None:
+    """Return an error if write_file would overwrite from partial context."""
+    try:
+        resolved = resolved or str(_resolve_path_for_task(filepath, task_id))
+    except (OSError, ValueError):
+        return None
+    try:
+        if file_state.read_was_partial(task_id, resolved):
+            return (
+                f"Refusing to overwrite {filepath}: this task last read only a "
+                "partial/truncated view of the file. Re-read the whole file "
+                "with offset=1 and a limit that covers total_lines before "
+                "calling write_file."
+            )
+    except Exception:
+        logger.debug("file_state.read_was_partial failed", exc_info=True)
+    return None
+
+
 def write_file_tool(path: str, content: str, task_id: str = "default") -> str:
     """Write content to a file."""
     sensitive_err = _check_sensitive_path(path, task_id)
@@ -808,6 +829,10 @@ def write_file_tool(path: str, content: str, task_id: str = "default") -> str:
             _resolved = str(_resolve_path_for_task(path, task_id))
         except Exception:
             _resolved = None
+
+        partial_read_err = _partial_read_overwrite_error(path, task_id, _resolved)
+        if partial_read_err:
+            return tool_error(partial_read_err)
 
         if _resolved is None:
             stale_warning = _check_file_staleness(path, task_id)
@@ -1042,7 +1067,7 @@ READ_FILE_SCHEMA = {
 
 WRITE_FILE_SCHEMA = {
     "name": "write_file",
-    "description": "Write content to a file, completely replacing existing content. Use this instead of echo/cat heredoc in terminal. Creates parent directories automatically. OVERWRITES the entire file — use 'patch' for targeted edits. Auto-runs syntax checks on .py/.json/.yaml/.toml and other linted languages; only NEW errors introduced by this write are surfaced (pre-existing errors are filtered out).",
+    "description": "Write content to a file, completely replacing existing content. Use this instead of echo/cat heredoc in terminal. Creates parent directories automatically. OVERWRITES the entire file — use 'patch' for targeted edits. Refuses to overwrite a file after a truncated/paginated read_file result until the file is read fully. Auto-runs syntax checks on .py/.json/.yaml/.toml and other linted languages; only NEW errors introduced by this write are surfaced (pre-existing errors are filtered out).",
     "parameters": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
## Summary

Fixes #30655 by preventing a full-file overwrite when the same task has only seen a truncated or paginated `read_file` view of that file.

The existing file-state registry already records `partial=True` for `read_file` calls that use pagination or return `truncated`. This PR adds a small `read_was_partial()` helper and makes `write_file` fail fast instead of replacing the file from incomplete context. A subsequent full read clears the guard, so the safe path is: re-read the whole file, then write.

This targets the actual data-corruption path from the report: a worker read the first 500 lines of a larger file, wrote back that partial content, and committed the truncated file to git.

## Changes

- Add `file_state.read_was_partial()` to query whether the current task last read only a partial view of a path
- Block `write_file` full overwrites after a truncated or paginated `read_file` of the same file
- Update the `write_file` tool description so models see the refusal condition at tool-call time
- Add regression coverage for blocking partial-read overwrites and allowing writes after a full re-read

## Validation

- `HERMES_HOME=/tmp/hermes-agent-test-home ./.venv/bin/python -m pytest tests/tools/test_file_read_guards.py tests/tools/test_file_state_registry.py -q` -> 53 passed
- `HERMES_HOME=/tmp/hermes-agent-test-home ./.venv/bin/python -m pytest tests/tools/test_file_staleness.py -q` -> 11 passed
- `HERMES_HOME=/tmp/hermes-agent-test-home ./.venv/bin/python -m pytest tests/tools/test_file_operations_edge_cases.py -q` -> 35 passed
- `HERMES_HOME=/tmp/hermes-agent-test-home ./.venv/bin/python -m pytest tests/tools/test_file_tools.py -q` -> 29 passed
- `./.venv/bin/ruff check tools/file_tools.py tools/file_state.py tests/tools/test_file_read_guards.py tests/tools/test_file_state_registry.py` -> passed
- `git diff --check` -> passed