### PR TITLE
fix(cli): resolve direct model aliases in chat query mode

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2916,6 +2916,28 @@ class HermesCLI:
         _model_config = CLI_CONFIG.get("model", {})
         _config_model = (_model_config.get("default") or _model_config.get("model") or "") if isinstance(_model_config, dict) else (_model_config or "")
         _DEFAULT_CONFIG_MODEL = ""
+
+        # Direct model aliases (config.yaml `model_aliases:` / `model.aliases:`)
+        # must work in the normal `hermes chat -q -m <alias>` path, not only in
+        # the top-level `hermes -z` one-shot helper.  Without this, a default
+        # provider like openai-codex receives the alias string verbatim and
+        # rejects it as an unsupported model.  Translate the model ID always;
+        # only fill provider/base_url when the caller did not explicitly set
+        # them.
+        if model:
+            try:
+                from hermes_cli import model_switch as _ms
+                _ms._ensure_direct_aliases()
+                _direct = _ms.DIRECT_ALIASES.get(str(model).strip().lower())
+            except Exception:
+                _direct = None
+            if _direct is not None:
+                model = _direct.model
+                if not provider:
+                    provider = _direct.provider
+                if _direct.base_url and not base_url:
+                    base_url = _direct.base_url
+
         self.model = model or _config_model or _DEFAULT_CONFIG_MODEL
         # Auto-detect model from local server if still on default
         if self.model == _DEFAULT_CONFIG_MODEL:


### PR DESCRIPTION
## Summary
- resolve config-defined direct model aliases in the normal `hermes chat -q -m <alias>` path
- preserve explicit provider/base_url overrides while translating alias model IDs
- keeps local Ollama aliases from being sent to the default provider such as OpenAI Codex

## Test Plan
- `venv/bin/python -m pytest tests/hermes_cli/test_ollama_cloud_auth.py -q -o 'addopts='`
- `hermes chat -m local-gemma4-31b -q 'Reply exactly: LOCAL_ALIAS_OK' --toolsets safe -Q --ignore-rules`
- `hermes chat -m local-qwen-coder-35b-nvfp4 -q 'Reply exactly: LOCAL_CODER_ALIAS_OK' --toolsets safe -Q --ignore-rules`
- `hermes chat -q 'Reply exactly: DEFAULT_STILL_OK' --toolsets safe -Q --ignore-rules`
