### PR TITLE
fix(gateway): match MEDIA tags with case-insensitive file extensions

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2159,7 +2159,8 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?''',
+            re.IGNORECASE
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()


### PR DESCRIPTION
## Summary

The `media_pattern` regex in `gateway/platforms/base.py` matches `MEDIA:<path>` tags to extract
media files from agent responses. The regex's file-extension group (`png|jpe?g|gif|...`) is
compiled **case-sensitively**, so files with uppercase extensions like `photo.JPG` or `image.PNG`
never match. The tag is then silently stripped downstream, producing empty or garbled messages.

## Fix

Add `re.IGNORECASE` to the `re.compile()` call so that both `photo.jpg` and `photo.JPG` are
recognised as valid media paths.

## Testing

- All 21 existing `test_platform_base.py` media tests pass.
- Verified locally that uppercase extensions (`.JPG`, `.PNG`, `.PDF`, `.OGG`, `.MP4`) now match.
- Lowercase and mixed-case extensions also work correctly.

Closes #30526
