### PR TITLE
fix(cli): quote .env values to preserve special characters like #

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -6211,11 +6211,15 @@ def save_env_value(key: str, value: str):
         # Sanitize on every read: split concatenated keys, drop stale placeholders
         lines = _sanitize_env_lines(lines)
 
+    # Quote the value so that special characters (#, $, etc.) are not
+    # interpreted by python-dotenv or shell-based .env loaders.
+    _line = f'{key}="{value}"\n'
+
     # Find and update or append
     found = False
     for i, line in enumerate(lines):
         if line.strip().startswith(f"{key}="):
-            lines[i] = f"{key}={value}\n"
+            lines[i] = _line
             found = True
             break
 
@@ -6223,7 +6227,7 @@ def save_env_value(key: str, value: str):
         # Ensure there's a newline at the end of the file before appending
         if lines and not lines[-1].endswith("\n"):
             lines[-1] += "\n"
-        lines.append(f"{key}={value}\n")
+        lines.append(_line)
     
     fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix='.tmp', prefix='.env_')
     # Preserve original permissions so Docker volume mounts aren't clobbered.


### PR DESCRIPTION
## Summary

When Hermes saves an API key or OAuth token to `~/.hermes/.env`, the value is written **unquoted**:
```
ANTHROPIC_TOKEN=abc123#secret
```

The project also uses `python-dotenv` (`hermes_cli/env_loader.py`) to load `.env` files.
`python-dotenv` treats `#` as an inline comment delimiter, so it reads only `abc123` — everything
after `#` is discarded. The truncated token then causes HTTP 401 authentication failures.

## Fix

Wrap values in double quotes when writing to `.env`:
```
ANTHROPIC_TOKEN="abc123#secret"
```

The existing `load_env()` parser already strips surrounding quotes (`value.strip().strip('"\'')`),
so no changes are needed on the read path.

## Testing

- Verified locally that values containing `#`, `$`, and spaces are correctly preserved round-trip
  through both `load_env()` and `python-dotenv`.
- All 78 existing `test_tools_config.py` tests pass.
- All 7 existing `test_env_loader_secret_sources.py` tests pass.

Closes #30355
