### PR TITLE
fix(batch-runner): reject path-like run names

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -46,6 +46,21 @@ from rich.console import Console
 logger = logging.getLogger(__name__)
 import fire
 
+
+def _validate_run_name(run_name: str) -> str:
+    """Reject path-like run names so batch outputs stay under ./data/."""
+    value = (run_name or "").strip()
+    if not value:
+        raise ValueError("run_name must not be empty")
+    candidate = Path(value)
+    if candidate.is_absolute():
+        raise ValueError("run_name must be a simple name, not an absolute path")
+    if any(part in {"..", "."} for part in candidate.parts):
+        raise ValueError("run_name must not contain path traversal components")
+    if len(candidate.parts) != 1:
+        raise ValueError("run_name must not contain path separators")
+    return value
+
 from run_agent import AIAgent
 from toolset_distributions import (
     list_distributions, 
@@ -583,7 +598,7 @@ class BatchRunner:
         """
         self.dataset_file = Path(dataset_file)
         self.batch_size = batch_size
-        self.run_name = run_name
+        self.run_name = _validate_run_name(run_name)
         self.distribution = distribution
         self.max_iterations = max_iterations
         self.base_url = base_url
@@ -608,7 +623,7 @@ class BatchRunner:
             raise ValueError(f"Unknown distribution: {distribution}. Available: {list(list_distributions().keys())}")
         
         # Setup output directory
-        self.output_dir = Path("data") / run_name
+        self.output_dir = Path("data") / self.run_name
         self.output_dir.mkdir(parents=True, exist_ok=True)
         
         # Checkpoint file

--- a/tests/test_batch_runner_checkpoint.py
+++ b/tests/test_batch_runner_checkpoint.py
@@ -12,7 +12,7 @@ import pytest
 import sys
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from batch_runner import BatchRunner, _process_batch_worker
+from batch_runner import BatchRunner, _process_batch_worker, _validate_run_name
 
 
 @pytest.fixture
@@ -28,6 +28,16 @@ def runner(tmp_path):
     r.output_file = output_file
     r.prompts_file = prompts_file
     return r
+
+
+class TestRunNameValidation:
+    def test_accepts_simple_name(self):
+        assert _validate_run_name("test_run") == "test_run"
+
+    @pytest.mark.parametrize("value", ["../escape", "nested/run", "/tmp/run", ""])
+    def test_rejects_path_like_names(self, value):
+        with pytest.raises(ValueError):
+            _validate_run_name(value)
 
 
 class TestSaveCheckpoint:


### PR DESCRIPTION
## Summary
- validate `run_name` before using it to build the batch output directory
- reject absolute paths, traversal components, and path separators
- add regression coverage for accepted vs rejected run names

## Why
`BatchRunner` currently writes outputs to `Path("data") / run_name` with no validation. Because `run_name` is CLI-controlled, values like `../outside` or `/tmp/owned` can redirect checkpoints and artifacts outside the intended `./data/` tree.

That creates a local path traversal / arbitrary write primitive for batch-runner invocations that pass untrusted parameters.

## Testing
- inspect `batch_runner.py`
- inspect `tests/test_batch_runner_checkpoint.py`
- `pytest -q tests/test_batch_runner_checkpoint.py` *(not run here: `pytest` unavailable in this environment)*
