### PR TITLE
test(model-switch): make custom provider picker tests hermetic

### DIFF
--- a/tests/hermes_cli/test_list_picker_providers.py
+++ b/tests/hermes_cli/test_list_picker_providers.py
@@ -230,6 +230,7 @@ def test_current_custom_endpoint_passthrough_marks_current_row(monkeypatch):
     monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
     monkeypatch.setattr("hermes_cli.models.fetch_openrouter_models",
                         lambda *a, **kw: [])
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *a, **kw: [])
 
     result = model_switch.list_picker_providers(
         current_provider="custom:ollama",

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -18,6 +18,11 @@ _MOCK_VALIDATION = {
 }
 
 
+def _mock_empty_live_model_catalog(monkeypatch):
+    """Keep custom-provider picker tests independent of local model servers."""
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *args, **kwargs: [])
+
+
 def test_list_authenticated_providers_includes_custom_providers(monkeypatch):
     """No-args /model menus should include saved custom_providers entries."""
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
@@ -265,6 +270,7 @@ def test_list_authenticated_providers_groups_same_endpoint(monkeypatch):
     returned as a single picker row with all their models merged."""
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
     monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    _mock_empty_live_model_catalog(monkeypatch)
 
     providers = list_authenticated_providers(
         current_provider="custom",
@@ -300,6 +306,7 @@ def test_list_authenticated_providers_current_endpoint_uses_current_slug(monkeyp
     the corrupt bare "custom" (see #17478)."""
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
     monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    _mock_empty_live_model_catalog(monkeypatch)
 
     providers = list_authenticated_providers(
         current_provider="custom:ollama",
@@ -326,6 +333,7 @@ def test_list_authenticated_providers_bare_custom_slug_recovers(monkeypatch):
     ``custom:<name>`` form so the picker stays usable."""
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
     monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    _mock_empty_live_model_catalog(monkeypatch)
 
     providers = list_authenticated_providers(
         current_provider="custom",
@@ -351,6 +359,7 @@ def test_list_authenticated_providers_distinct_endpoints_stay_separate(monkeypat
     even if some display names happen to be similar."""
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
     monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    _mock_empty_live_model_catalog(monkeypatch)
 
     providers = list_authenticated_providers(
         user_providers={},
@@ -408,6 +417,7 @@ def test_list_authenticated_providers_total_models_reflects_grouped_count(monkey
     the full count, and every grouped model appears in the list."""
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
     monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    _mock_empty_live_model_catalog(monkeypatch)
 
     entries = [
         {"name": f"Ollama \u2014 Model {i}", "base_url": "http://localhost:11434/v1",


### PR DESCRIPTION
## Summary

- Mock live `/v1/models` discovery in custom-provider picker tests that use `api_key: "ollama"` against `localhost:11434` fixtures.
- Keep those tests asserting their explicit fixture model lists instead of whatever local Ollama/LM Studio server happens to be running on a developer machine.
- Cover both the direct `list_authenticated_providers` tests and the `list_picker_providers` passthrough regression.

## Root Cause

`list_authenticated_providers()` intentionally probes custom provider endpoints when an `api_key` is present. Several tests used `api_key: "ollama"` plus `http://localhost:11434/v1`, so a real local model server could replace the configured fixture models with the live `/models` catalog and make assertions fail nondeterministically.

## Related Issue

Fixes #30604

## Test Plan

- `venv\\Scripts\\python.exe -m pytest -o addopts= tests\\hermes_cli\\test_model_switch_custom_providers.py tests\\hermes_cli\\test_list_picker_providers.py -q` — 28 passed
- `venv\\Scripts\\python.exe -m ruff check tests\\hermes_cli\\test_model_switch_custom_providers.py tests\\hermes_cli\\test_list_picker_providers.py` — passed
- `git diff --check -- tests\\hermes_cli\\test_model_switch_custom_providers.py tests\\hermes_cli\\test_list_picker_providers.py` — passed

## Notes

A broader `tests/hermes_cli -k "model_switch or list_picker or custom_provider"` run is blocked on Windows during collection because Python here has no `_curses` module; that happens before test selection and is unrelated to this patch.