### PR TITLE
fix(discord): load libopus from DISCORD_OPUS_LIBRARY + SONAME fallbacks so Discord voice works on NixOS (#30723)

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -601,29 +601,16 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.error("[%s] discord.py not installed. Run: pip install discord.py", self.name)
             return False
 
-        # Load opus codec for voice channel support
-        if not discord.opus.is_loaded():
-            import ctypes.util
-            opus_path = ctypes.util.find_library("opus")
-            # ctypes.util.find_library fails on macOS with Homebrew-installed libs,
-            # so fall back to known Homebrew paths if needed.
-            if not opus_path:
-                _homebrew_paths = (
-                    "/opt/homebrew/lib/libopus.dylib",  # Apple Silicon
-                    "/usr/local/lib/libopus.dylib",     # Intel Mac
-                )
-                if sys.platform == "darwin":
-                    for _hp in _homebrew_paths:
-                        if os.path.isfile(_hp):
-                            opus_path = _hp
-                            break
-            if opus_path:
-                try:
-                    discord.opus.load_opus(opus_path)
-                except Exception:
-                    logger.warning("Opus codec found at %s but failed to load", opus_path)
-            if not discord.opus.is_loaded():
-                logger.warning("Opus codec not found — voice channel playback disabled")
+        # Load opus codec for voice channel support. The resolver lives
+        # in plugins.platforms.discord.opus_loader and honours
+        # DISCORD_OPUS_LIBRARY first (NixOS / Nix-store layouts where
+        # ctypes.util.find_library returns None — issue #30723), then
+        # falls back through ctypes discovery and per-platform candidate
+        # paths. Returning False is non-fatal: text features still work,
+        # only voice playback is disabled and the warning explains the
+        # exact fix.
+        from plugins.platforms.discord.opus_loader import ensure_discord_opus_loaded
+        ensure_discord_opus_loaded(discord_module=discord)
 
         if not self.config.token:
             logger.error("[%s] No bot token configured", self.name)

--- a/plugins/platforms/discord/opus_loader.py
+++ b/plugins/platforms/discord/opus_loader.py
@@ -1,0 +1,226 @@
+"""Opus codec loading for Discord voice support.
+
+Centralises libopus discovery so the Discord adapter and the
+``scripts/discord-voice-doctor.py`` diagnostic share a single resolution
+strategy. The loader is dependency-injectable so unit tests can drive
+every branch (NixOS-style ``find_library`` returns ``None``, env-var
+override, per-platform fallbacks) without touching the host system.
+
+Resolution order (#30723):
+
+    1. ``discord.opus.is_loaded()`` — short-circuit if already loaded.
+    2. ``DISCORD_OPUS_LIBRARY`` environment variable — full path
+       override. This is the recommended fix for NixOS / Nix-store
+       layouts where ``ctypes.util.find_library("opus")`` returns
+       ``None`` because libopus lives under a Nix store path that is
+       not in the linker cache.
+    3. ``ctypes.util.find_library("opus")`` — existing automatic
+       discovery (works on most distros + macOS with the system
+       linker, works on macOS-Homebrew via the Apple-Silicon linker
+       cache, doesn't work on NixOS).
+    4. Platform-specific candidate list — bare library names like
+       ``libopus.so.0`` (resolved via the dynamic linker) plus a small
+       set of absolute paths matching distro conventions (mirrors the
+       doctor-script list so the two stay in sync).
+
+Failures during individual candidate loads are logged at DEBUG and
+swallowed so the next candidate can be tried. If every candidate
+fails, a single WARNING with the full attempt list and an explicit
+``DISCORD_OPUS_LIBRARY=...`` hint is emitted.
+"""
+
+from __future__ import annotations
+
+import ctypes.util
+import logging
+import os
+import os.path
+import sys
+from typing import Any, List, Mapping, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+# Environment variable name — exported for tests and doctor script so
+# the string lives in exactly one place.
+OPUS_LIBRARY_ENV_VAR = "DISCORD_OPUS_LIBRARY"
+
+
+# Bare library names tried via the dynamic linker on Linux-family
+# platforms. ``libopus.so.0`` is the runtime SONAME shipped by the
+# ``libopus0`` package on Debian/Ubuntu and most other distros;
+# ``libopus.so`` is the unversioned symlink installed by the ``-dev``
+# package.
+_LINUX_LIB_NAMES: Tuple[str, ...] = (
+    "libopus.so.0",
+    "libopus.so",
+)
+
+
+# Absolute paths kept here as a last-resort fallback when both
+# ``DISCORD_OPUS_LIBRARY`` and ``ctypes.util.find_library`` fail.
+# Mirrors the list in ``scripts/discord-voice-doctor.py``.
+_LINUX_FALLBACK_PATHS: Tuple[str, ...] = (
+    "/usr/lib/x86_64-linux-gnu/libopus.so.0",   # Debian/Ubuntu x86_64
+    "/usr/lib/aarch64-linux-gnu/libopus.so.0",  # Debian/Ubuntu arm64
+    "/usr/lib/libopus.so",                       # Arch Linux
+    "/usr/lib64/libopus.so",                     # RHEL / Fedora 64-bit
+    "/usr/lib/libopus.so.0",                     # generic
+)
+
+
+_DARWIN_FALLBACK_PATHS: Tuple[str, ...] = (
+    "/opt/homebrew/lib/libopus.dylib",  # Apple Silicon (default brew prefix)
+    "/usr/local/lib/libopus.dylib",     # Intel Mac
+)
+
+
+def _candidates_for_platform(platform: str) -> List[str]:
+    """Return the ordered list of platform-specific candidates to try
+    AFTER the env-var override and ``ctypes.util.find_library`` have
+    been consulted. The DISCORD_OPUS_LIBRARY override is handled in
+    :func:`ensure_discord_opus_loaded` directly so it stays
+    cross-platform."""
+    if platform == "darwin":
+        return list(_DARWIN_FALLBACK_PATHS)
+    if platform == "win32":
+        # discord.py bundles ``libopus-0.x64.dll`` / ``libopus-0.x86.dll``
+        # on Windows and loads them transparently in ``discord.opus`` at
+        # import time, so once ``is_loaded()`` returns True we're done.
+        # Nothing useful to add here.
+        return []
+    # Linux + every other Unix-like platform (FreeBSD, NixOS-on-Linux, …).
+    return [*_LINUX_LIB_NAMES, *_LINUX_FALLBACK_PATHS]
+
+
+def _build_unavailable_hint(attempts: List[Tuple[str, str]]) -> str:
+    """Build the user-facing 'libopus not loadable' diagnostic.
+
+    Kept as a separate function so tests can assert the exact phrasing
+    without having to fake out a logger.
+    """
+    base = (
+        "Discord voice playback requires libopus. Hermes could not "
+        f"locate or load it. Set {OPUS_LIBRARY_ENV_VAR} to the full "
+        "path of libopus.so (Linux/NixOS) or libopus.dylib (macOS) and "
+        "restart. See issue #30723 for the NixOS rationale."
+    )
+    if not attempts:
+        return f"{base} No candidates were available to try."
+    formatted = ", ".join(f"{candidate!r}: {reason}" for candidate, reason in attempts)
+    return f"{base} Attempted candidates: {formatted}"
+
+
+def ensure_discord_opus_loaded(
+    *,
+    discord_module: Any = None,
+    platform: Optional[str] = None,
+    env: Optional[Mapping[str, str]] = None,
+    isfile=os.path.isfile,
+    find_library=ctypes.util.find_library,
+) -> bool:
+    """Load libopus for discord.py voice support and return ``True`` on success.
+
+    All external dependencies are injectable so tests can exercise every
+    branch in isolation:
+
+    :param discord_module: defaults to ``import discord`` lazily. Tests
+        should pass a stub exposing ``opus.is_loaded()`` and
+        ``opus.load_opus(name)``.
+    :param platform: defaults to ``sys.platform``. Tests pass
+        ``"linux"`` / ``"darwin"`` / ``"win32"`` directly.
+    :param env: defaults to ``os.environ``. Tests pass a plain dict.
+    :param isfile: defaults to ``os.path.isfile``. Tests stub it to
+        simulate which absolute paths exist on disk.
+    :param find_library: defaults to ``ctypes.util.find_library``. Tests
+        return ``None`` (the NixOS case) or a fake path.
+
+    The return value indicates whether ``discord.opus.is_loaded()`` ends
+    up ``True``. The function never raises for individual candidate
+    failures; it logs them at DEBUG and proceeds. A single WARNING is
+    emitted at the end if no candidate succeeded.
+    """
+    if discord_module is None:
+        try:
+            import discord as discord_module  # type: ignore[no-redef]
+        except ImportError:
+            logger.warning(
+                "Cannot load Opus codec — discord.py is not installed. "
+                "Install with: pip install 'discord.py[voice]'"
+            )
+            return False
+
+    # Already loaded — common in long-running bots where connect() runs
+    # more than once (reconnects, multi-bot setups, etc.).
+    if discord_module.opus.is_loaded():
+        return True
+
+    if platform is None:
+        platform = sys.platform
+    if env is None:
+        env = os.environ
+
+    candidates: List[str] = []
+
+    # 1. User-provided override (#30723 — NixOS recommended path).
+    override = env.get(OPUS_LIBRARY_ENV_VAR)
+    if override:
+        candidates.append(override)
+
+    # 2. ctypes.util.find_library — the existing strategy. Wrapped in
+    # try/except because some exotic ctypes shims raise instead of
+    # returning ``None``.
+    try:
+        discovered = find_library("opus")
+    except Exception as exc:
+        logger.debug(
+            "ctypes.util.find_library('opus') raised %s: %s",
+            type(exc).__name__,
+            exc,
+        )
+        discovered = None
+    if discovered:
+        candidates.append(discovered)
+
+    # 3. Platform-specific candidates. Absolute paths are gated by an
+    # existence check (so we don't log a misleading "load failed"
+    # warning for paths that don't exist on this distro). Bare names
+    # are always tried — the dynamic linker resolves them.
+    for candidate in _candidates_for_platform(platform):
+        if os.path.isabs(candidate):
+            try:
+                if not isfile(candidate):
+                    continue
+            except Exception:
+                continue
+        candidates.append(candidate)
+
+    # Dedup while preserving order — the override and ``find_library``
+    # may both return the same path.
+    seen: set[str] = set()
+    ordered: List[str] = []
+    for candidate in candidates:
+        if candidate not in seen:
+            seen.add(candidate)
+            ordered.append(candidate)
+
+    attempts: List[Tuple[str, str]] = []
+    for candidate in ordered:
+        try:
+            discord_module.opus.load_opus(candidate)
+        except Exception as exc:
+            attempts.append((candidate, f"{type(exc).__name__}: {exc}"))
+            logger.debug(
+                "discord.opus.load_opus(%r) failed: %s: %s",
+                candidate,
+                type(exc).__name__,
+                exc,
+            )
+            continue
+        if discord_module.opus.is_loaded():
+            logger.info("Loaded Discord Opus library from %s", candidate)
+            return True
+        attempts.append((candidate, "is_loaded() returned False after load_opus"))
+
+    logger.warning("%s", _build_unavailable_hint(attempts))
+    return False

--- a/scripts/discord-voice-doctor.py
+++ b/scripts/discord-voice-doctor.py
@@ -123,35 +123,27 @@ def check_system_tools():
     section("System Tools")
     ok = True
 
-    # Opus codec
+    # Opus codec — delegate to the shared loader so the doctor script
+    # and the runtime adapter see the same resolution order (#30723).
     if _discord_available:
         try:
             import discord
-            opus_loaded = discord.opus.is_loaded()
-            if not opus_loaded:
-                import ctypes.util
-                opus_path = ctypes.util.find_library("opus")
-                if not opus_path:
-                    # Platform-specific fallback paths
-                    candidates = [
-                        "/opt/homebrew/lib/libopus.dylib",   # macOS Apple Silicon
-                        "/usr/local/lib/libopus.dylib",      # macOS Intel
-                        "/usr/lib/x86_64-linux-gnu/libopus.so.0",  # Debian/Ubuntu x86
-                        "/usr/lib/aarch64-linux-gnu/libopus.so.0", # Debian/Ubuntu ARM
-                        "/usr/lib/libopus.so",               # Arch Linux
-                        "/usr/lib64/libopus.so",             # RHEL/Fedora
-                    ]
-                    for p in candidates:
-                        if os.path.isfile(p):
-                            opus_path = p
-                            break
-                if opus_path:
-                    discord.opus.load_opus(opus_path)
-                    opus_loaded = discord.opus.is_loaded()
+            from plugins.platforms.discord.opus_loader import (
+                OPUS_LIBRARY_ENV_VAR,
+                ensure_discord_opus_loaded,
+            )
+
+            override_path = os.getenv(OPUS_LIBRARY_ENV_VAR)
+            opus_loaded = ensure_discord_opus_loaded(discord_module=discord)
             if opus_loaded:
-                check("Opus codec", True)
+                detail = f"loaded from {override_path}" if override_path else None
+                check("Opus codec", True, detail or "")
             else:
-                check("Opus codec", False, "brew install opus / apt install libopus0")
+                hint = (
+                    f"set {OPUS_LIBRARY_ENV_VAR}=/path/to/libopus.so "
+                    "(NixOS) or brew install opus / apt install libopus0"
+                )
+                check("Opus codec", False, hint)
                 ok = False
         except Exception as e:
             check("Opus codec", False, str(e))

--- a/tests/gateway/test_discord_opus.py
+++ b/tests/gateway/test_discord_opus.py
@@ -1,33 +1,66 @@
-"""Tests for Discord Opus codec loading — must use ctypes.util.find_library."""
+"""Tests for Discord Opus codec loading.
+
+The loader logic lives in ``plugins.platforms.discord.opus_loader`` and
+is shared between the runtime adapter and the doctor script. These
+tests assert source-level invariants only:
+
+  * The shared helper is the resolution path used by ``DiscordAdapter.connect``.
+  * The helper continues to consult ``ctypes.util.find_library`` and
+    carry a macOS Homebrew fallback (preserves pre-#30723 behaviour).
+  * The voice-decode error path still logs instead of swallowing
+    exceptions silently.
+
+Behavioural assertions (env-var priority, NixOS scenarios, error
+messaging) live in ``tests/plugins/platforms/discord/test_opus_loader_30723.py``
+where they can drive the helper with mocks.
+"""
 
 import inspect
 
 
 class TestOpusFindLibrary:
-    """Opus loading must try ctypes.util.find_library first, with platform fallback."""
+    """Opus loading must use ctypes.util.find_library, with platform fallback."""
 
     def test_uses_find_library_first(self):
-        """find_library must be the primary lookup strategy."""
-        from plugins.platforms.discord.adapter import DiscordAdapter
-        source = inspect.getsource(DiscordAdapter.connect)
+        """find_library must be the primary lookup strategy used by the
+        shared loader. The adapter delegates to the loader (#30723), so
+        we assert against the loader source rather than ``connect()``."""
+        from plugins.platforms.discord import opus_loader
+        source = inspect.getsource(opus_loader)
         assert "find_library" in source, \
             "Opus loading must use ctypes.util.find_library"
 
     def test_homebrew_fallback_is_conditional(self):
-        """Homebrew paths must only be tried when find_library returns None."""
-        from plugins.platforms.discord.adapter import DiscordAdapter
-        source = inspect.getsource(DiscordAdapter.connect)
-        # Homebrew fallback must exist
+        """Homebrew paths must only be tried on Darwin, AFTER
+        find_library has been consulted. The check inspects the
+        loader's platform-specific candidate function."""
+        from plugins.platforms.discord import opus_loader
+        source = inspect.getsource(opus_loader)
         assert "/opt/homebrew" in source or "homebrew" in source, \
             "Opus loading should have macOS Homebrew fallback"
-        # find_library must appear BEFORE any Homebrew path
+        # find_library must appear BEFORE any Homebrew path in the
+        # combined module source — the loader uses find_library in
+        # ensure_discord_opus_loaded() (top) and the Homebrew paths
+        # live in the _DARWIN_FALLBACK_PATHS tuple (bottom).
         fl_idx = source.index("find_library")
         hb_idx = source.index("/opt/homebrew")
         assert fl_idx < hb_idx, \
             "find_library must be tried before Homebrew fallback paths"
-        # Fallback must be guarded by platform check
-        assert "sys.platform" in source or "darwin" in source, \
+        # Fallback must be guarded by a platform check — the
+        # _candidates_for_platform helper routes only Darwin into the
+        # Homebrew bucket.
+        assert "darwin" in source, \
             "Homebrew fallback must be guarded by macOS platform check"
+
+    def test_adapter_delegates_to_shared_loader(self):
+        """DiscordAdapter.connect must route Opus loading through the
+        shared helper, not re-implement it inline (#30723)."""
+        from plugins.platforms.discord.adapter import DiscordAdapter
+        source = inspect.getsource(DiscordAdapter.connect)
+        assert "ensure_discord_opus_loaded" in source, (
+            "connect() must call ensure_discord_opus_loaded so the "
+            "doctor script and the runtime stay in sync"
+        )
 
     def test_opus_decode_error_logged(self):
         """Opus decode failure must log the error, not silently return."""

--- a/tests/gateway/test_discord_opus_loader_30723.py
+++ b/tests/gateway/test_discord_opus_loader_30723.py
@@ -1,0 +1,550 @@
+"""Behavioural regression tests for ``ensure_discord_opus_loaded`` (#30723).
+
+The pre-#30723 Discord adapter relied on ``ctypes.util.find_library("opus")``
+plus a macOS-only Homebrew fallback. On NixOS that lookup returns
+``None`` because libopus lives in a Nix store path that is not in the
+linker cache, and the adapter would silently disable voice playback.
+
+The shared loader in ``plugins.platforms.discord.opus_loader``:
+
+  1. Honours ``DISCORD_OPUS_LIBRARY`` first — the recommended NixOS fix.
+  2. Falls back through ``ctypes.util.find_library``.
+  3. Then walks a per-platform candidate list (bare SONAMES for the
+     dynamic linker plus distro absolute paths).
+  4. Emits a single WARNING with the full attempt list pointing at
+     ``DISCORD_OPUS_LIBRARY`` if every candidate failed.
+
+These tests pin every branch with mocks so they run identically on
+macOS / Linux / Windows CI runners.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import List, Tuple
+from unittest.mock import MagicMock
+
+import pytest
+
+from plugins.platforms.discord.opus_loader import (
+    OPUS_LIBRARY_ENV_VAR,
+    _build_unavailable_hint,
+    _candidates_for_platform,
+    ensure_discord_opus_loaded,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Fixtures
+# ──────────────────────────────────────────────────────────────────────
+def _make_discord_stub(load_succeeds_for: List[str] | None = None) -> MagicMock:
+    """Build a stub mimicking the surface of the ``discord`` module
+    that the loader uses: ``discord.opus.is_loaded()`` and
+    ``discord.opus.load_opus(name)``.
+
+    ``load_succeeds_for`` is the list of candidate names that should
+    "succeed" — calling ``load_opus(name)`` flips ``is_loaded`` to
+    True. Every other name raises ``OSError`` (matching the real
+    ``discord.py`` behaviour for a missing shared object).
+    """
+    state = {"loaded": False}
+    success_set = set(load_succeeds_for or [])
+
+    stub = MagicMock(name="discord")
+    stub.opus = MagicMock(name="discord.opus")
+    stub.opus.is_loaded = lambda: state["loaded"]
+
+    def fake_load(name: str) -> None:
+        if name in success_set:
+            state["loaded"] = True
+            return
+        raise OSError(f"{name}: cannot open shared object file: No such file or directory")
+
+    stub.opus.load_opus = MagicMock(side_effect=fake_load)
+    return stub
+
+
+@pytest.fixture
+def fake_isfile():
+    """Stub ``os.path.isfile`` — only paths in ``existing`` exist."""
+    def factory(existing: set[str]):
+        def _isfile(path: str) -> bool:
+            return path in existing
+        return _isfile
+    return factory
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 1. Short-circuit when already loaded
+# ──────────────────────────────────────────────────────────────────────
+class TestAlreadyLoadedShortCircuit:
+    def test_returns_true_without_touching_env_or_find_library(self) -> None:
+        discord_stub = MagicMock()
+        discord_stub.opus.is_loaded.return_value = True
+
+        find_lib = MagicMock(return_value=None)
+        env: dict[str, str] = {OPUS_LIBRARY_ENV_VAR: "/should/not/be/read"}
+
+        assert ensure_discord_opus_loaded(
+            discord_module=discord_stub,
+            platform="linux",
+            env=env,
+            isfile=lambda _: False,
+            find_library=find_lib,
+        ) is True
+
+        discord_stub.opus.load_opus.assert_not_called()
+        find_lib.assert_not_called()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 2. DISCORD_OPUS_LIBRARY override is tried FIRST
+# ──────────────────────────────────────────────────────────────────────
+class TestEnvVarOverrideHasPriority:
+    """#30723: ``DISCORD_OPUS_LIBRARY`` must beat ctypes discovery so
+    NixOS users who paste the Nix-store path always win."""
+
+    def test_override_loaded_before_find_library_called(self) -> None:
+        nix_path = "/nix/store/abc-libopus-1.4/lib/libopus.so"
+        stub = _make_discord_stub(load_succeeds_for=[nix_path])
+        find_lib = MagicMock(return_value="/usr/lib/libopus.so.0")
+
+        ok = ensure_discord_opus_loaded(
+            discord_module=stub,
+            platform="linux",
+            env={OPUS_LIBRARY_ENV_VAR: nix_path},
+            isfile=lambda _: True,
+            find_library=find_lib,
+        )
+
+        assert ok is True
+        # Override is the FIRST load attempt — confirm by inspecting
+        # the call list rather than just call count, because other
+        # candidates would never get reached if the first one wins.
+        first_attempt = stub.opus.load_opus.call_args_list[0][0][0]
+        assert first_attempt == nix_path
+
+    def test_override_used_even_when_find_library_succeeds(self) -> None:
+        """The user setting ``DISCORD_OPUS_LIBRARY`` is an explicit
+        statement of intent — Hermes must not silently prefer the
+        ``find_library`` result over it."""
+        nix_path = "/nix/store/abc/libopus.so"
+        distro_path = "/usr/lib/x86_64-linux-gnu/libopus.so.0"
+        stub = _make_discord_stub(load_succeeds_for=[nix_path, distro_path])
+
+        ensure_discord_opus_loaded(
+            discord_module=stub,
+            platform="linux",
+            env={OPUS_LIBRARY_ENV_VAR: nix_path},
+            isfile=lambda _: True,
+            find_library=lambda _name: distro_path,
+        )
+
+        first_attempt = stub.opus.load_opus.call_args_list[0][0][0]
+        assert first_attempt == nix_path
+
+    def test_empty_override_falls_through_to_find_library(self) -> None:
+        """An empty string env var must not be tried as a candidate —
+        Linux ``CDLL("")`` would link the current process and is
+        nonsense for libopus."""
+        stub = _make_discord_stub(load_succeeds_for=["libopus.so.0"])
+
+        ensure_discord_opus_loaded(
+            discord_module=stub,
+            platform="linux",
+            env={OPUS_LIBRARY_ENV_VAR: ""},
+            isfile=lambda _: False,
+            find_library=lambda _name: None,
+        )
+
+        attempted = [call[0][0] for call in stub.opus.load_opus.call_args_list]
+        assert "" not in attempted
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 3. NixOS scenario — find_library returns None, no DISCORD_OPUS_LIBRARY
+# ──────────────────────────────────────────────────────────────────────
+class TestNixOsScenarioWithoutOverride:
+    """The exact failure mode reproduced in the #30723 issue body:
+    ``ctypes.util.find_library("opus")`` returns ``None`` AND the user
+    hasn't set ``DISCORD_OPUS_LIBRARY`` yet. The loader must still try
+    the bare SONAMES via the dynamic linker so a non-Nix Linux user
+    isn't punished for not setting the env var."""
+
+    def test_bare_libopus_so_0_is_tried_when_find_library_returns_none(
+        self,
+    ) -> None:
+        stub = _make_discord_stub(load_succeeds_for=["libopus.so.0"])
+
+        ok = ensure_discord_opus_loaded(
+            discord_module=stub,
+            platform="linux",
+            env={},
+            isfile=lambda _: False,
+            find_library=lambda _name: None,
+        )
+
+        assert ok is True
+        attempted = [call[0][0] for call in stub.opus.load_opus.call_args_list]
+        assert "libopus.so.0" in attempted
+
+    def test_fully_unloadable_returns_false_and_warns_with_env_hint(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        stub = _make_discord_stub(load_succeeds_for=[])
+
+        caplog.set_level(logging.WARNING, logger="plugins.platforms.discord.opus_loader")
+        ok = ensure_discord_opus_loaded(
+            discord_module=stub,
+            platform="linux",
+            env={},
+            isfile=lambda _: False,
+            find_library=lambda _name: None,
+        )
+
+        assert ok is False
+        # The warning must point the user at the env-var fix and cite
+        # the issue so a future grep for "#30723" lands here.
+        joined = " ".join(record.getMessage() for record in caplog.records)
+        assert OPUS_LIBRARY_ENV_VAR in joined
+        assert "#30723" in joined
+
+    def test_attempt_list_in_warning_includes_failure_reasons(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Operators triaging a voice-failure should see exactly which
+        names were tried and why each one failed."""
+        stub = _make_discord_stub(load_succeeds_for=[])
+
+        caplog.set_level(logging.WARNING, logger="plugins.platforms.discord.opus_loader")
+        ensure_discord_opus_loaded(
+            discord_module=stub,
+            platform="linux",
+            env={},
+            isfile=lambda _: False,
+            find_library=lambda _name: None,
+        )
+
+        joined = " ".join(record.getMessage() for record in caplog.records)
+        assert "libopus.so.0" in joined
+        assert "OSError" in joined or "cannot open shared object" in joined
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 4. macOS Homebrew fallback preserved
+# ──────────────────────────────────────────────────────────────────────
+class TestMacosHomebrewFallbackPreserved:
+    """Pre-#30723 behaviour: when ``ctypes.util.find_library`` fails on
+    macOS, the loader still falls back to the Apple-Silicon / Intel
+    Homebrew default prefixes. The refactor must not regress this."""
+
+    def test_apple_silicon_homebrew_path_is_tried(
+        self, fake_isfile,
+    ) -> None:
+        brew_path = "/opt/homebrew/lib/libopus.dylib"
+        stub = _make_discord_stub(load_succeeds_for=[brew_path])
+
+        ok = ensure_discord_opus_loaded(
+            discord_module=stub,
+            platform="darwin",
+            env={},
+            isfile=fake_isfile({brew_path}),
+            find_library=lambda _name: None,
+        )
+
+        assert ok is True
+        first_attempt = stub.opus.load_opus.call_args_list[0][0][0]
+        assert first_attempt == brew_path
+
+    def test_intel_mac_path_used_when_apple_silicon_absent(
+        self, fake_isfile,
+    ) -> None:
+        intel_path = "/usr/local/lib/libopus.dylib"
+        stub = _make_discord_stub(load_succeeds_for=[intel_path])
+
+        ok = ensure_discord_opus_loaded(
+            discord_module=stub,
+            platform="darwin",
+            env={},
+            isfile=fake_isfile({intel_path}),
+            find_library=lambda _name: None,
+        )
+
+        assert ok is True
+        attempted = [call[0][0] for call in stub.opus.load_opus.call_args_list]
+        assert intel_path in attempted
+        assert "/opt/homebrew/lib/libopus.dylib" not in attempted, (
+            "absolute paths that don't exist must not be tried"
+        )
+
+    def test_linux_paths_are_not_tried_on_darwin(self, fake_isfile) -> None:
+        """A regression where the Linux candidate list leaked into the
+        macOS branch would generate noisy ``OSError: cannot open shared
+        object`` warnings on every Mac startup."""
+        stub = _make_discord_stub(load_succeeds_for=[])
+        # All darwin and linux candidates absent.
+        ensure_discord_opus_loaded(
+            discord_module=stub,
+            platform="darwin",
+            env={},
+            isfile=fake_isfile(set()),
+            find_library=lambda _name: None,
+        )
+        attempted = [call[0][0] for call in stub.opus.load_opus.call_args_list]
+        assert "libopus.so.0" not in attempted
+        assert "libopus.so" not in attempted
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 5. Linux distro fallback list
+# ──────────────────────────────────────────────────────────────────────
+class TestLinuxDistroFallback:
+    @pytest.mark.parametrize(
+        "distro_path",
+        [
+            "/usr/lib/x86_64-linux-gnu/libopus.so.0",
+            "/usr/lib/aarch64-linux-gnu/libopus.so.0",
+            "/usr/lib/libopus.so",
+            "/usr/lib64/libopus.so",
+            "/usr/lib/libopus.so.0",
+        ],
+    )
+    def test_distro_path_loaded_when_present(
+        self, fake_isfile, distro_path: str,
+    ) -> None:
+        """For each distro convention, the loader must succeed when only
+        that specific path exists. Drives the entire
+        ``_LINUX_FALLBACK_PATHS`` tuple."""
+        # No bare SONAMEs available on the dynamic linker either, so
+        # the only thing that can succeed is the absolute path.
+        stub = _make_discord_stub(load_succeeds_for=[distro_path])
+
+        ok = ensure_discord_opus_loaded(
+            discord_module=stub,
+            platform="linux",
+            env={},
+            isfile=fake_isfile({distro_path}),
+            find_library=lambda _name: None,
+        )
+
+        assert ok is True
+        attempted = [call[0][0] for call in stub.opus.load_opus.call_args_list]
+        assert distro_path in attempted
+
+    def test_absent_absolute_paths_are_not_attempted(
+        self, fake_isfile,
+    ) -> None:
+        """Absolute paths must be gated by ``isfile`` so a load failure
+        only fires for paths that actually exist — otherwise distro CI
+        runners log a wall of misleading OSErrors on every startup."""
+        stub = _make_discord_stub(load_succeeds_for=[])
+
+        ensure_discord_opus_loaded(
+            discord_module=stub,
+            platform="linux",
+            env={},
+            isfile=fake_isfile(set()),
+            find_library=lambda _name: None,
+        )
+
+        attempted = [call[0][0] for call in stub.opus.load_opus.call_args_list]
+        # Bare SONAMEs are always tried (the dynamic linker resolves them).
+        assert "libopus.so.0" in attempted
+        assert "libopus.so" in attempted
+        # Absolute paths that don't exist must NOT have been tried.
+        for absolute in (
+            "/usr/lib/x86_64-linux-gnu/libopus.so.0",
+            "/usr/lib/aarch64-linux-gnu/libopus.so.0",
+            "/usr/lib/libopus.so",
+            "/usr/lib64/libopus.so",
+            "/usr/lib/libopus.so.0",
+        ):
+            assert absolute not in attempted
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 6. Robustness — find_library raising, dedup, etc.
+# ──────────────────────────────────────────────────────────────────────
+class TestRobustness:
+    def test_find_library_raising_does_not_propagate(self) -> None:
+        """Exotic ctypes shims (Termux, some embedded Linuxes) raise
+        instead of returning ``None``. The loader must trap and
+        continue to the platform fallbacks."""
+        stub = _make_discord_stub(load_succeeds_for=["libopus.so.0"])
+
+        def boom(_name: str) -> str:
+            raise RuntimeError("find_library is unsupported on this platform")
+
+        ok = ensure_discord_opus_loaded(
+            discord_module=stub,
+            platform="linux",
+            env={},
+            isfile=lambda _: False,
+            find_library=boom,
+        )
+
+        assert ok is True
+
+    def test_duplicate_paths_only_attempted_once(self) -> None:
+        """If ``DISCORD_OPUS_LIBRARY`` and ``find_library`` return the
+        same path, the loader must not attempt it twice (would create
+        confusing duplicate WARNING entries on failure)."""
+        path = "/usr/lib/libopus.so.0"
+        stub = _make_discord_stub(load_succeeds_for=[])
+
+        ensure_discord_opus_loaded(
+            discord_module=stub,
+            platform="linux",
+            env={OPUS_LIBRARY_ENV_VAR: path},
+            isfile=lambda p: p == path,
+            find_library=lambda _name: path,
+        )
+
+        attempts_for_path = [
+            call for call in stub.opus.load_opus.call_args_list
+            if call[0][0] == path
+        ]
+        assert len(attempts_for_path) == 1
+
+    def test_isfile_raising_on_one_path_does_not_abort_loop(
+        self,
+    ) -> None:
+        """A racing ``stat()`` failure on one path must not block the
+        remaining candidates from being tried."""
+        bad_path = "/usr/lib/x86_64-linux-gnu/libopus.so.0"
+        good_path = "/usr/lib64/libopus.so"
+
+        def isfile(p: str) -> bool:
+            if p == bad_path:
+                raise PermissionError("EACCES")
+            return p == good_path
+
+        stub = _make_discord_stub(load_succeeds_for=[good_path])
+
+        ok = ensure_discord_opus_loaded(
+            discord_module=stub,
+            platform="linux",
+            env={},
+            isfile=isfile,
+            find_library=lambda _name: None,
+        )
+
+        assert ok is True
+
+    def test_missing_discord_module_returns_false_without_raising(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When discord.py is not installed and no stub is injected,
+        the loader must fail closed with a clear log message, not
+        ``ImportError``-up-the-stack."""
+        import sys
+        # Hide discord from the loader's lazy import.
+        monkeypatch.setitem(sys.modules, "discord", None)
+        ok = ensure_discord_opus_loaded(
+            platform="linux",
+            env={},
+            isfile=lambda _: False,
+            find_library=lambda _name: None,
+        )
+        assert ok is False
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 7. _candidates_for_platform — direct unit coverage
+# ──────────────────────────────────────────────────────────────────────
+class TestCandidatesForPlatform:
+    def test_darwin_returns_only_dylib_paths(self) -> None:
+        candidates = _candidates_for_platform("darwin")
+        assert all(c.endswith(".dylib") for c in candidates)
+        assert "/opt/homebrew/lib/libopus.dylib" in candidates
+        assert "/usr/local/lib/libopus.dylib" in candidates
+
+    def test_linux_starts_with_bare_sonames(self) -> None:
+        """The dynamic linker resolves bare SONAMEs against the runtime
+        cache; trying them first means we don't false-fail on systems
+        where the absolute path moved but ld.so.cache still resolves."""
+        candidates = _candidates_for_platform("linux")
+        assert candidates[0] == "libopus.so.0"
+        assert candidates[1] == "libopus.so"
+
+    def test_win32_returns_empty(self) -> None:
+        """discord.py bundles libopus DLLs on Windows; nothing to add."""
+        assert _candidates_for_platform("win32") == []
+
+    def test_unknown_unix_platform_falls_through_to_linux_list(
+        self,
+    ) -> None:
+        """FreeBSD / NixOS / Termux — none of these are ``darwin`` or
+        ``win32``, so they should reuse the Linux candidate list."""
+        assert _candidates_for_platform("freebsd13") == _candidates_for_platform("linux")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 8. _build_unavailable_hint — message shape
+# ──────────────────────────────────────────────────────────────────────
+class TestUnavailableHint:
+    def test_no_attempts_message_is_actionable(self) -> None:
+        msg = _build_unavailable_hint([])
+        assert OPUS_LIBRARY_ENV_VAR in msg
+        assert "#30723" in msg
+        assert "No candidates" in msg
+
+    def test_attempts_list_renders_candidate_and_reason(self) -> None:
+        attempts: List[Tuple[str, str]] = [
+            ("libopus.so.0", "OSError: cannot open shared object file"),
+            ("/nix/store/abc/libopus.so", "OSError: missing"),
+        ]
+        msg = _build_unavailable_hint(attempts)
+        assert "libopus.so.0" in msg
+        assert "/nix/store/abc/libopus.so" in msg
+        assert "cannot open shared object file" in msg
+
+    def test_hint_mentions_both_linux_and_macos_artifacts(self) -> None:
+        """The hint is the only thing the user sees, so it should
+        cover both Linux (libopus.so) and macOS (libopus.dylib) so
+        cross-platform users don't have to figure out the right
+        extension."""
+        msg = _build_unavailable_hint([])
+        assert "libopus.so" in msg
+        assert "libopus.dylib" in msg
+
+
+# ──────────────────────────────────────────────────────────────────────
+# 9. Public API surface
+# ──────────────────────────────────────────────────────────────────────
+class TestModuleSurface:
+    def test_env_var_name_is_stable(self) -> None:
+        """Operators wire ``DISCORD_OPUS_LIBRARY`` into their .env /
+        Nix module — the constant name and value are part of the
+        public contract, not internal trivia."""
+        assert OPUS_LIBRARY_ENV_VAR == "DISCORD_OPUS_LIBRARY"
+
+    def test_doctor_script_imports_the_same_helper(self) -> None:
+        """``scripts/discord-voice-doctor.py`` and the adapter must
+        share the loader so a NixOS user's diagnosis matches their
+        runtime behaviour."""
+        from pathlib import Path
+        doctor = Path(__file__).resolve().parents[2] / "scripts" / "discord-voice-doctor.py"
+        text = doctor.read_text()
+        assert "ensure_discord_opus_loaded" in text
+        assert "OPUS_LIBRARY_ENV_VAR" in text
+
+    def test_loader_module_is_importable_without_discord_installed(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Importing the loader module must not require discord.py —
+        it's the discoverable-on-failure path; ``import opus_loader``
+        itself can't trip the user before they even start the bot."""
+        import sys
+        monkeypatch.setitem(sys.modules, "discord", None)
+        # Re-importing the module surface; the lazy ``import discord``
+        # lives inside ensure_discord_opus_loaded(), not at module top.
+        import importlib
+        import plugins.platforms.discord.opus_loader as loader
+        importlib.reload(loader)
+        assert hasattr(loader, "ensure_discord_opus_loaded")
+        assert hasattr(loader, "OPUS_LIBRARY_ENV_VAR")


### PR DESCRIPTION
## What does this PR do?

Fixes Discord voice playback on NixOS (and any other Linux distro where libopus lives outside the dynamic-linker cache) by introducing a shared Opus loader that honours `DISCORD_OPUS_LIBRARY` first, then falls back through `ctypes.util.find_library`, bare SONAMEs, and a per-platform absolute-path list. Both the runtime adapter and the `discord-voice-doctor.py` diagnostic now go through the same resolver so they can't disagree.

Before:

- `DiscordAdapter.connect()` called `ctypes.util.find_library("opus")` directly. On NixOS that returns `None` because libopus is installed under `/nix/store/<hash>-libopus-1.x/lib/libopus.so` and is not registered in the linker cache.
- The only fallback was a macOS Homebrew probe (`/opt/homebrew/lib/libopus.dylib`, `/usr/local/lib/libopus.dylib`). Linux distros got nothing — even bare `libopus.so.0` (the SONAME shipped by `libopus0` on Debian/Ubuntu and almost every other distro) was never tried.
- The user had no env-var lever: even if they knew the full Nix store path, there was no way to feed it to Hermes short of editing `adapter.py`.
- Failure message was a single `"Opus codec not found — voice channel playback disabled"` line with zero diagnostic detail (which paths were tried, what errors fired, how to fix it).
- `scripts/discord-voice-doctor.py` carried its own inlined copy of the same logic with a slightly different fallback list, so the doctor could report "Opus codec ✓" on a NixOS box while the runtime adapter then silently failed.

After:

- New helper `plugins/platforms/discord/opus_loader.py` with `ensure_discord_opus_loaded()`. Resolution order:
  1. `discord.opus.is_loaded()` — short-circuit.
  2. `DISCORD_OPUS_LIBRARY` env var (highest user-controlled priority — the recommended NixOS fix per the issue body).
  3. `ctypes.util.find_library("opus")` — existing strategy, untouched on systems where it already works.
  4. Per-platform candidate list:
     - **Linux / Unix**: bare `libopus.so.0` then `libopus.so` (resolved via the dynamic linker — works on most distros even when `find_library` doesn't), then five distro absolute paths gated by `os.path.isfile`.
     - **macOS**: Homebrew paths (Apple Silicon + Intel), gated by `isfile` — preserves pre-#30723 behaviour byte-for-byte.
     - **Windows**: empty — discord.py bundles `libopus-0.x64.dll` and loads it transparently at import time.
- Single WARNING on full failure that names `DISCORD_OPUS_LIBRARY`, mentions both `libopus.so` (Linux) and `libopus.dylib` (macOS), cites issue #30723, and lists every candidate it tried plus the `OSError` / reason for each — enough to triage from logs alone.
- `DiscordAdapter.connect()` is now a single `ensure_discord_opus_loaded(discord_module=discord)` call. The doctor script also delegates to the same helper, so a NixOS user's `python scripts/discord-voice-doctor.py` output matches the runtime behaviour exactly.
- Backwards-compatible for every existing platform: macOS Homebrew users see no behaviour change, Linux users with `apt install libopus0` already work via `find_library`, the only change for them is the SONAME fallback layer that prevents a NixOS-style regression on other distros.

## Related Issue

Fixes #30723.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/discord/opus_loader.py` (+226 lines, new file) — shared `ensure_discord_opus_loaded()` helper, the module-level constant `OPUS_LIBRARY_ENV_VAR = "DISCORD_OPUS_LIBRARY"`, the platform-routing helper `_candidates_for_platform()`, and the failure-message builder `_build_unavailable_hint()`. All external dependencies (`discord` module, `sys.platform`, `os.environ`, `os.path.isfile`, `ctypes.util.find_library`) are injectable as keyword arguments so unit tests can drive every branch deterministically on any host. The `discord` import is lazy inside the helper so the module is import-safe even without discord.py installed (returns False with a clear log line in that case).
- `plugins/platforms/discord/adapter.py` (~L604–L612, −23 / +10) — replace the inline `ctypes.util.find_library("opus")` + macOS Homebrew block at `DiscordAdapter.connect` with a single `ensure_discord_opus_loaded(discord_module=discord)` call. Return value intentionally ignored — voice unavailability is non-fatal, the loader's WARNING explains the exact fix to the operator.
- `scripts/discord-voice-doctor.py` (~L121–L150, −24 / +16) — replace the inlined Opus probe with the same `ensure_discord_opus_loaded()` call. The doctor now reports a NixOS-aware "✗" with the exact `DISCORD_OPUS_LIBRARY` hint and, when the env var is set, an extra `loaded from <path>` detail line so the user can confirm their override actually worked. The two sites (adapter + doctor) can no longer drift.
- `tests/gateway/test_discord_opus.py` (~+45 / −12) — retarget the three pre-#30723 source-inspection tests. `test_uses_find_library_first` and `test_homebrew_fallback_is_conditional` now inspect `plugins.platforms.discord.opus_loader` instead of `DiscordAdapter.connect`, because the adapter no longer carries the literal `find_library` / `/opt/homebrew` strings inline. Added a new `test_adapter_delegates_to_shared_loader` that asserts `connect()` calls `ensure_discord_opus_loaded` — a future inline re-implementation would fire it. `test_opus_decode_error_logged` is unrelated (asserts the `VoiceReceiver._on_packet` decode path still logs) and unchanged.
- `tests/gateway/test_discord_opus_loader_30723.py` (+550 lines, new file) — 30 behavioural regression tests across 9 classes covering the loader from every angle:
  - `TestAlreadyLoadedShortCircuit` — when `discord.opus.is_loaded()` is already true, the loader returns without touching env, find_library, or load_opus.
  - `TestEnvVarOverrideHasPriority` — `DISCORD_OPUS_LIBRARY` beats find_library even when find_library succeeds; empty-string overrides fall through (never try `ctypes.CDLL("")`).
  - `TestNixOsScenarioWithoutOverride` — the exact #30723 repro: `find_library("opus")` returns `None`, no env var set, the bare `libopus.so.0` SONAME is still tried via the dynamic linker; the failure WARNING includes `DISCORD_OPUS_LIBRARY`, `#30723`, and per-candidate failure reasons.
  - `TestMacosHomebrewFallbackPreserved` — Apple-Silicon and Intel Homebrew paths both still load when present; absent absolute paths are not attempted (no noisy `OSError` warnings on every startup); Linux SONAMEs don't leak into the macOS branch.
  - `TestLinuxDistroFallback` — parametrised across the five distro absolute paths in `_LINUX_FALLBACK_PATHS`. Absolute paths are gated by `isfile` so absent ones never reach `load_opus`.
  - `TestRobustness` — exotic edge cases: `find_library` raising instead of returning `None` (Termux / some embedded Linuxes); deduping when env var and find_library return the same path; one path's `stat()` raising `PermissionError` not blocking remaining candidates; discord.py not installed failing closed with a clear log line.
  - `TestCandidatesForPlatform` — direct unit coverage of the platform routing (darwin / linux / win32 / unknown-Unix-falls-through-to-linux).
  - `TestUnavailableHint` — the WARNING shape: names the env var, cites #30723, lists per-candidate reasons, mentions both `libopus.so` and `libopus.dylib`.
  - `TestModuleSurface` — the env-var name constant is stable, the doctor script imports the same helper (drift detector), and the loader module is importable even when discord.py is absent.

No other code is touched. The macOS Homebrew loading path, the Windows discord.py bundled-DLL path, and the `VoiceReceiver` / `voice_client` runtime code are all behaviour-identical to before.

## How to Test

1. Check out this branch and ensure `.venv` is set up: `python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[all,dev]"`
2. Run the new regression tests on their own:
   ```
   scripts/run_tests.sh tests/gateway/test_discord_opus_loader_30723.py -v
   ```
   Expected: 30 passed.
3. Run the Discord-voice sweep to confirm no cross-file regressions:
   ```
   scripts/run_tests.sh tests/gateway/test_discord_opus.py tests/gateway/test_discord_opus_loader_30723.py tests/gateway/test_discord_connect.py tests/gateway/test_voice_command.py tests/gateway/test_discord_imports.py
   ```
   Expected: 232 passed.
4. NixOS manual repro (matches the issue body):
   - On a NixOS host with `libopus` installed: `python -c "import ctypes.util; print(ctypes.util.find_library('opus'))"` → `None` (the root cause).
   - Without the fix: Hermes Discord bot joins a voice channel and silently fails to play audio; log shows `"Opus codec not found — voice channel playback disabled"`.
   - With the fix and no env var set: log shows `"Loaded Discord Opus library from libopus.so.0"` if the SONAME resolves via the dynamic linker, otherwise a WARNING naming `DISCORD_OPUS_LIBRARY` and `#30723`.
   - With the fix and `DISCORD_OPUS_LIBRARY=/nix/store/<hash>-libopus-1.4/lib/libopus.so` exported (or written into `~/.hermes/.env`): log shows `"Loaded Discord Opus library from /nix/store/..."` and voice playback works.
5. Doctor-script verification:
   ```
   python scripts/discord-voice-doctor.py
   ```
   On a healthy machine: `✓ Opus codec`. With `DISCORD_OPUS_LIBRARY=/path/to/libopus.so` exported: `✓ Opus codec  (loaded from /path/to/libopus.so)`. On a NixOS box with no env var: `✗ Opus codec  (set DISCORD_OPUS_LIBRARY=/path/to/libopus.so (NixOS) or brew install opus / apt install libopus0)` — matches what the adapter would do at runtime.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(discord): ...` + `test(discord): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/gateway/test_discord_opus_loader_30723.py` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.2 (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A as code change. The loader module's docstring documents the resolution order and cites #30723; the `OPUS_LIBRARY_ENV_VAR` constant is the public knob. The repo's NixOS packaging docs (if/when they land) can reference `DISCORD_OPUS_LIBRARY` directly.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A. `DISCORD_OPUS_LIBRARY` is an environment variable (read from `os.environ` directly), consistent with `DISCORD_ALLOWED_USERS` / `DISCORD_ALLOWED_ROLES` / etc. that already live alongside it in `~/.hermes/.env`.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A. The discord adapter's plugin interface, voice-channel lifecycle, and codec loading contract are byte-identical; only the internal resolver moved.
