### PR TITLE
feat(acp): add configurable ACP tool output detail

### DIFF
--- a/acp_adapter/edit_approval.py
+++ b/acp_adapter/edit_approval.py
@@ -227,7 +227,6 @@ def build_acp_edit_tool_call(proposal: EditProposal):
                 new_text=proposal.new_text,
             )
         ],
-        raw_input={"tool": proposal.tool_name, "arguments": proposal.arguments},
     )
 
 

--- a/acp_adapter/events.py
+++ b/acp_adapter/events.py
@@ -118,6 +118,7 @@ def make_tool_progress_cb(
     tool_call_ids: Dict[str, Deque[str]],
     tool_call_meta: Dict[str, Dict[str, Any]],
     edit_approval_policy_getter: Callable[[], tuple[str, str | None]] | None = None,
+    output_policy_getter: Callable[[], Any] | None = None,
 ) -> Callable:
     """Create a ``tool_progress_callback`` for AIAgent.
 
@@ -176,7 +177,8 @@ def make_tool_progress_cb(
             except Exception:
                 logger.debug("Failed to prepare auto-approved ACP edit diff for %s", name, exc_info=True)
 
-        update = build_tool_start(tc_id, name, args, edit_diff=edit_diff)
+        output_policy = output_policy_getter() if output_policy_getter is not None else None
+        update = build_tool_start(tc_id, name, args, edit_diff=edit_diff, output_policy=output_policy)
         _send_update(conn, session_id, loop, update)
 
     return _tool_progress
@@ -212,6 +214,7 @@ def make_step_cb(
     loop: asyncio.AbstractEventLoop,
     tool_call_ids: Dict[str, Deque[str]],
     tool_call_meta: Dict[str, Dict[str, Any]],
+    output_policy_getter: Callable[[], Any] | None = None,
 ) -> Callable:
     """Create a ``step_callback`` for AIAgent.
 
@@ -241,12 +244,14 @@ def make_step_cb(
                 if tool_name and queue:
                     tc_id = queue.popleft()
                     meta = tool_call_meta.pop(tc_id, {})
+                    output_policy = output_policy_getter() if output_policy_getter is not None else None
                     update = build_tool_complete(
                         tc_id,
                         tool_name,
                         result=str(result) if result is not None else None,
                         function_args=function_args or meta.get("args"),
                         snapshot=meta.get("snapshot"),
+                        output_policy=output_policy,
                     )
                     _send_update(conn, session_id, loop, update)
                     if tool_name == "todo":

--- a/acp_adapter/output_policy.py
+++ b/acp_adapter/output_policy.py
@@ -1,0 +1,139 @@
+"""ACP output-detail policy helpers.
+
+The ACP adapter keeps UI-facing transcript rendering separate from the
+model-facing tool result. The default stays compact and human-readable, while
+clients can explicitly request fuller visible transcript content.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+import os
+
+ACPOutputDetail = Literal["condensed", "full"]
+
+VALID_OUTPUT_DETAILS: tuple[ACPOutputDetail, ...] = ("condensed", "full")
+DEFAULT_OUTPUT_DETAIL: ACPOutputDetail = "condensed"
+DEFAULT_RESOURCE_MAX_BYTES = 512 * 1024
+
+
+@dataclass(frozen=True)
+class ACPOutputPolicy:
+    """Resolved ACP output policy for one session/render operation."""
+
+    detail: ACPOutputDetail = DEFAULT_OUTPUT_DETAIL
+    resource_max_bytes: int = DEFAULT_RESOURCE_MAX_BYTES
+
+    @property
+    def full_visible_output(self) -> bool:
+        return self.detail == "full"
+
+
+def parse_output_detail(value: Any) -> ACPOutputDetail | None:
+    """Return a normalized output detail, or None when the value is invalid."""
+
+    raw = str(value or "").strip().lower().replace("-", "_")
+    aliases = {
+        "compact": "condensed",
+        "summary": "condensed",
+        "summarized": "condensed",
+        "summarised": "condensed",
+        "verbose": "full",
+        "expanded": "full",
+    }
+    raw = aliases.get(raw, raw)
+    if raw in VALID_OUTPUT_DETAILS:
+        return raw  # type: ignore[return-value]
+    return None
+
+
+def normalize_output_detail(value: Any, *, default: ACPOutputDetail = DEFAULT_OUTPUT_DETAIL) -> ACPOutputDetail:
+    """Normalize a user/client supplied output detail value."""
+
+    parsed = parse_output_detail(value)
+    if parsed is not None:
+        return parsed
+    return default
+
+
+def _coerce_int(value: Any, default: int | None, *, minimum: int | None = None) -> int | None:
+    if value is None or value == "":
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    if parsed <= 0:
+        return default
+    if minimum is not None and parsed < minimum:
+        return minimum
+    return parsed
+
+
+def _config_acp_output(config: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(config, dict):
+        return {}
+    acp_cfg = config.get("acp")
+    if not isinstance(acp_cfg, dict):
+        return {}
+    output_cfg = acp_cfg.get("output")
+    return output_cfg if isinstance(output_cfg, dict) else {}
+
+
+def resolve_acp_output_policy(
+    *,
+    session_detail: Any = None,
+    config: dict[str, Any] | None = None,
+    env: dict[str, str] | None = None,
+) -> ACPOutputPolicy:
+    """Resolve ACP output policy with session > env > config > default precedence."""
+
+    env_map = os.environ if env is None else env
+    cfg = _config_acp_output(config)
+
+    detail = normalize_output_detail(cfg.get("detail"), default=DEFAULT_OUTPUT_DETAIL)
+
+    env_detail = env_map.get("HERMES_ACP_TOOL_OUTPUT_DETAIL") or env_map.get("HERMES_ACP_OUTPUT_DETAIL")
+    if env_detail:
+        detail = normalize_output_detail(env_detail, default=detail)
+    if session_detail:
+        detail = normalize_output_detail(session_detail, default=detail)
+
+    resource_max = _coerce_int(cfg.get("resource_max_bytes"), DEFAULT_RESOURCE_MAX_BYTES, minimum=1)
+    if env_map.get("HERMES_ACP_RESOURCE_MAX_BYTES") is not None:
+        resource_max = _coerce_int(env_map.get("HERMES_ACP_RESOURCE_MAX_BYTES"), resource_max, minimum=1)
+    if resource_max is None or resource_max <= 0:
+        resource_max = DEFAULT_RESOURCE_MAX_BYTES
+
+    return ACPOutputPolicy(
+        detail=detail,
+        resource_max_bytes=resource_max,
+    )
+
+
+def load_acp_output_policy(*, session_detail: Any = None) -> ACPOutputPolicy:
+    """Resolve policy from the live Hermes config plus env/session overrides."""
+
+    try:
+        from hermes_cli.config import load_config
+
+        config = load_config()
+    except Exception:
+        config = None
+    return resolve_acp_output_policy(session_detail=session_detail, config=config)
+
+
+def should_advertise_output_config(config: dict[str, Any] | None = None) -> bool:
+    """Return whether ACP responses should advertise configOptions.
+
+    Default is false for compatibility with clients where configOptions compete
+    with the model picker. The server still accepts `session/set_config_option`
+    for advanced clients even when this is false.
+    """
+
+    cfg = _config_acp_output(config)
+    value = cfg.get("advertise_config_option", False)
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}

--- a/acp_adapter/permissions.py
+++ b/acp_adapter/permissions.py
@@ -88,7 +88,6 @@ def _build_permission_tool_call(command: str, description: str):
         kind="execute",
         status="pending",
         content=[_acp.tool_content(_acp.text_block(content_text))],
-        raw_input={"command": command, "description": description},
     )
 
 

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -49,6 +49,8 @@ from acp.schema import (
     SessionForkCapabilities,
     SessionInfoUpdate,
     SessionListCapabilities,
+    SessionConfigOptionSelect,
+    SessionConfigSelectOption,
     SessionMode,
     SessionModeState,
     SessionModelState,
@@ -63,6 +65,12 @@ from acp.schema import (
 )
 
 from acp_adapter.auth import TERMINAL_SETUP_AUTH_METHOD_ID, build_auth_methods, detect_provider
+from acp_adapter.output_policy import (
+    ACPOutputPolicy,
+    parse_output_detail,
+    resolve_acp_output_policy,
+    should_advertise_output_config,
+)
 from acp_adapter.events import (
     _build_plan_update_from_todo_result,
     make_message_cb,
@@ -100,6 +108,12 @@ _TEXT_RESOURCE_MIME_TYPES = {
     "application/toml",
     "application/sql",
 }
+
+
+def _resource_max_bytes(output_policy: ACPOutputPolicy | None = None) -> int:
+    if isinstance(output_policy, ACPOutputPolicy):
+        return max(1, int(output_policy.resource_max_bytes or _MAX_ACP_RESOURCE_BYTES))
+    return _MAX_ACP_RESOURCE_BYTES
 
 
 def _resource_display_name(uri: str, name: str | None = None, title: str | None = None) -> str:
@@ -193,6 +207,14 @@ def _decode_text_bytes(data: bytes, mime_type: str | None) -> str | None:
     return data.decode("utf-8", errors="replace")
 
 
+def _cap_text_resource_body(text: str, cap: int) -> tuple[str, str | None]:
+    """Cap embedded text resources by UTF-8 byte length without splitting codepoints."""
+    data = text.encode("utf-8", errors="replace")
+    if len(data) <= cap:
+        return text, None
+    return data[:cap].decode("utf-8", errors="ignore"), f"truncated to {cap} of {len(data)} bytes"
+
+
 def _format_resource_text(
     *,
     uri: str,
@@ -208,7 +230,10 @@ def _format_resource_text(
     return f"{header}\nURI: {uri}\n\n{body}"
 
 
-def _resource_link_to_parts(block: ResourceContentBlock) -> list[dict[str, Any]]:
+def _resource_link_to_parts(
+    block: ResourceContentBlock,
+    output_policy: ACPOutputPolicy | None = None,
+) -> list[dict[str, Any]]:
     """Convert an ACP resource_link block to OpenAI content parts.
 
     Returns a list of {"type": "text", ...} and/or {"type": "image_url", ...}
@@ -223,6 +248,7 @@ def _resource_link_to_parts(block: ResourceContentBlock) -> list[dict[str, Any]]
     name = str(getattr(block, "name", "") or "").strip() or None
     title = str(getattr(block, "title", "") or "").strip() or None
     mime_type = str(getattr(block, "mime_type", "") or "").strip() or None
+    cap = _resource_max_bytes(output_policy)
     path = _path_from_file_uri(uri)
 
     if path is None:
@@ -242,14 +268,14 @@ def _resource_link_to_parts(block: ResourceContentBlock) -> list[dict[str, Any]]
     if image_mime and _is_image_resource(image_mime):
         try:
             size = path.stat().st_size
-            if size > _MAX_ACP_RESOURCE_BYTES:
+            if size > cap:
                 return [{
                     "type": "text",
                     "text": _format_resource_text(
                         uri=uri,
                         name=name,
                         title=title,
-                        body=f"[Image too large to inline: {size} bytes, cap={_MAX_ACP_RESOURCE_BYTES}]",
+                        body=f"[Image too large to inline: {size} bytes, cap={cap}]",
                     ),
                 }]
             with path.open("rb") as fh:
@@ -273,7 +299,7 @@ def _resource_link_to_parts(block: ResourceContentBlock) -> list[dict[str, Any]]
 
     try:
         size = path.stat().st_size
-        read_size = min(size, _MAX_ACP_RESOURCE_BYTES)
+        read_size = min(size, cap)
         with path.open("rb") as fh:
             data = fh.read(read_size)
         text = _decode_text_bytes(data, mime_type)
@@ -288,8 +314,8 @@ def _resource_link_to_parts(block: ResourceContentBlock) -> list[dict[str, Any]]
                 ),
             }]
         note = None
-        if size > _MAX_ACP_RESOURCE_BYTES:
-            note = f"truncated to {_MAX_ACP_RESOURCE_BYTES} of {size} bytes"
+        if size > cap:
+            note = f"truncated to {cap} of {size} bytes"
         return [{
             "type": "text",
             "text": _format_resource_text(uri=uri, name=name, title=title, body=text, note=note),
@@ -307,16 +333,21 @@ def _resource_link_to_parts(block: ResourceContentBlock) -> list[dict[str, Any]]
         }]
 
 
-def _embedded_resource_to_parts(block: EmbeddedResourceContentBlock) -> list[dict[str, Any]]:
+def _embedded_resource_to_parts(
+    block: EmbeddedResourceContentBlock,
+    output_policy: ACPOutputPolicy | None = None,
+) -> list[dict[str, Any]]:
     resource = getattr(block, "resource", None)
     if resource is None:
         return []
 
     uri = str(getattr(resource, "uri", "") or "").strip()
     mime_type = str(getattr(resource, "mime_type", "") or "").strip() or None
+    cap = _resource_max_bytes(output_policy)
 
     if isinstance(resource, TextResourceContents):
-        return [{"type": "text", "text": _format_resource_text(uri=uri, body=resource.text)}]
+        body, note = _cap_text_resource_body(resource.text, cap)
+        return [{"type": "text", "text": _format_resource_text(uri=uri, body=body, note=note)}]
 
     if isinstance(resource, BlobResourceContents):
         blob = resource.blob or ""
@@ -327,12 +358,12 @@ def _embedded_resource_to_parts(block: EmbeddedResourceContentBlock) -> list[dic
 
         # Image blobs go through as image_url so vision models can see them.
         if _is_image_resource(mime_type):
-            if len(data) > _MAX_ACP_RESOURCE_BYTES:
+            if len(data) > cap:
                 return [{
                     "type": "text",
                     "text": _format_resource_text(
                         uri=uri,
-                        body=f"[Embedded image too large to inline: {len(data)} bytes, cap={_MAX_ACP_RESOURCE_BYTES}]",
+                        body=f"[Embedded image too large to inline: {len(data)} bytes, cap={cap}]",
                     ),
                 }]
             display = _resource_display_name(uri)
@@ -341,13 +372,13 @@ def _embedded_resource_to_parts(block: EmbeddedResourceContentBlock) -> list[dic
                 {"type": "image_url", "image_url": {"url": _image_data_url(data, mime_type or "image/png")}},
             ]
 
-        text = _decode_text_bytes(data[:_MAX_ACP_RESOURCE_BYTES], mime_type)
+        text = _decode_text_bytes(data[:cap], mime_type)
         if text is None:
             body = f"[Binary embedded file omitted: {len(data)} bytes, mime={mime_type or 'unknown'}]"
         else:
             body = text
-            if len(data) > _MAX_ACP_RESOURCE_BYTES:
-                body += f"\n\n[Truncated to {_MAX_ACP_RESOURCE_BYTES} of {len(data)} bytes]"
+            if len(data) > cap:
+                body += f"\n\n[Truncated to {cap} of {len(data)} bytes]"
         return [{"type": "text", "text": _format_resource_text(uri=uri, body=body)}]
 
     text = getattr(resource, "text", None)
@@ -399,6 +430,7 @@ def _content_blocks_to_openai_user_content(
         | ResourceContentBlock
         | EmbeddedResourceContentBlock
     ],
+    output_policy: ACPOutputPolicy | None = None,
 ) -> str | list[dict[str, Any]]:
     """Convert ACP prompt blocks into a Hermes/OpenAI-compatible user content payload."""
     parts: list[dict[str, Any]] = []
@@ -416,14 +448,14 @@ def _content_blocks_to_openai_user_content(
                 parts.append(image_part)
             continue
         if isinstance(block, ResourceContentBlock):
-            resource_parts = _resource_link_to_parts(block)
+            resource_parts = _resource_link_to_parts(block, output_policy=output_policy)
             for part in resource_parts:
                 parts.append(part)
                 if part.get("type") == "text":
                     text_parts.append(part["text"])
             continue
         if isinstance(block, EmbeddedResourceContentBlock):
-            resource_parts = _embedded_resource_to_parts(block)
+            resource_parts = _embedded_resource_to_parts(block, output_policy=output_policy)
             for part in resource_parts:
                 parts.append(part)
                 if part.get("type") == "text":
@@ -500,6 +532,12 @@ class HermesACPAgent(acp.Agent):
     )
 
     _EDIT_APPROVAL_POLICY_CONFIG_ID = "edit_approval_policy"
+    _ACP_OUTPUT_DETAIL_CONFIG_IDS = {
+        "acp_output_detail",
+        "tool_output_detail",
+        "acp_tool_output_detail",
+        "output_detail",
+    }
     _EDIT_APPROVAL_POLICY_DEFAULT = "ask"
     _MODE_DEFAULT = "default"
     _MODE_ACCEPT_EDITS = "accept_edits"
@@ -563,6 +601,54 @@ class HermesACPAgent(acp.Agent):
         mode = str(getattr(state, "mode", "") or self._MODE_DEFAULT)
         policy = self._MODE_TO_EDIT_APPROVAL_POLICY.get(mode, self._EDIT_APPROVAL_POLICY_DEFAULT)
         return policy, state.cwd
+
+    @staticmethod
+    def _load_config_for_output_policy() -> dict[str, Any] | None:
+        try:
+            from hermes_cli.config import load_config
+
+            return load_config()
+        except Exception:
+            return None
+
+    def _output_policy_for_state(self, state: SessionState | None) -> ACPOutputPolicy:
+        return resolve_acp_output_policy(
+            session_detail=getattr(state, "output_detail", "") if state is not None else None,
+            config=self._load_config_for_output_policy(),
+        )
+
+    def _session_config_options(self, state: SessionState | None) -> list[Any] | None:
+        config = self._load_config_for_output_policy()
+        if not should_advertise_output_config(config):
+            return None
+        output_policy = resolve_acp_output_policy(
+            session_detail=getattr(state, "output_detail", "") if state is not None else None,
+            config=config,
+        )
+        return [
+            SessionConfigOptionSelect(
+                id="acp_output_detail",
+                name="Tool Output Detail",
+                description=(
+                    "Controls ACP-visible tool output detail: condensed summaries "
+                    "or expanded visible content."
+                ),
+                type="select",
+                current_value=output_policy.detail,
+                options=[
+                    SessionConfigSelectOption(
+                        value="condensed",
+                        name="Condensed",
+                        description="Readable summaries and default truncation.",
+                    ),
+                    SessionConfigSelectOption(
+                        value="full",
+                        name="Full",
+                        description="Expanded visible content where supported.",
+                    ),
+                ],
+            )
+        ]
 
     @staticmethod
     def _encode_model_choice(provider: str | None, model: str | None) -> str:
@@ -993,6 +1079,7 @@ class HermesACPAgent(acp.Agent):
             return
 
         active_tool_calls: dict[str, tuple[str, dict[str, Any]]] = {}
+        output_policy = self._output_policy_for_state(state)
 
         async def _send(update: Any) -> bool:
             try:
@@ -1038,7 +1125,14 @@ class HermesACPAgent(acp.Agent):
                             continue
                         tool_name, args = self._history_tool_call_name_args(tool_call)
                         active_tool_calls[tool_call_id] = (tool_name, args)
-                        if not await _send(build_tool_start(tool_call_id, tool_name, args)):
+                        if not await _send(
+                            build_tool_start(
+                                tool_call_id,
+                                tool_name,
+                                args,
+                                output_policy=output_policy,
+                            )
+                        ):
                             return
                 continue
 
@@ -1058,6 +1152,7 @@ class HermesACPAgent(acp.Agent):
                         tool_name,
                         result=result_text,
                         function_args=function_args,
+                        output_policy=output_policy,
                     )
                 ):
                     return
@@ -1079,6 +1174,7 @@ class HermesACPAgent(acp.Agent):
         self._schedule_usage_update(state)
         return NewSessionResponse(
             session_id=state.session_id,
+            config_options=self._session_config_options(state),
             models=self._build_model_state(state),
             modes=self._session_modes(state),
         )
@@ -1123,6 +1219,7 @@ class HermesACPAgent(acp.Agent):
         self._schedule_available_commands_update(session_id)
         self._schedule_usage_update(state)
         return LoadSessionResponse(
+            config_options=self._session_config_options(state),
             models=self._build_model_state(state),
             modes=self._session_modes(state),
         )
@@ -1155,6 +1252,7 @@ class HermesACPAgent(acp.Agent):
         self._schedule_available_commands_update(state.session_id)
         self._schedule_usage_update(state)
         return ResumeSessionResponse(
+            config_options=self._session_config_options(state),
             models=self._build_model_state(state),
             modes=self._session_modes(state),
         )
@@ -1189,6 +1287,7 @@ class HermesACPAgent(acp.Agent):
             self._schedule_available_commands_update(new_id)
         return ForkSessionResponse(
             session_id=new_id,
+            config_options=self._session_config_options(state) if state is not None else None,
             models=self._build_model_state(state) if state is not None else None,
             modes=self._session_modes(state) if state is not None else None,
         )
@@ -1259,7 +1358,8 @@ class HermesACPAgent(acp.Agent):
             return PromptResponse(stop_reason="refusal")
 
         user_text = _extract_text(prompt).strip()
-        user_content = _content_blocks_to_openai_user_content(prompt)
+        output_policy = self._output_policy_for_state(state)
+        user_content = _content_blocks_to_openai_user_content(prompt, output_policy=output_policy)
         text_only_prompt = all(isinstance(block, TextContentBlock) for block in prompt)
         has_content = bool(user_text) or (
             isinstance(user_content, list) and bool(user_content)
@@ -1354,9 +1454,17 @@ class HermesACPAgent(acp.Agent):
                 tool_call_ids,
                 tool_call_meta,
                 edit_approval_policy_getter=lambda: self._edit_approval_policy_for_state(state),
+                output_policy_getter=lambda: self._output_policy_for_state(state),
             )
             reasoning_cb = make_thinking_cb(conn, session_id, loop)
-            step_cb = make_step_cb(conn, session_id, loop, tool_call_ids, tool_call_meta)
+            step_cb = make_step_cb(
+                conn,
+                session_id,
+                loop,
+                tool_call_ids,
+                tool_call_meta,
+                output_policy_getter=lambda: self._output_policy_for_state(state),
+            )
             message_cb = make_message_cb(conn, session_id, loop)
 
             def stream_delta_cb(text: str) -> None:
@@ -1937,6 +2045,16 @@ class HermesACPAgent(acp.Agent):
         if str(config_id) == self._EDIT_APPROVAL_POLICY_CONFIG_ID:
             mode = self._EDIT_APPROVAL_POLICY_TO_MODE.get(str(value), self._MODE_DEFAULT)
             setattr(state, "mode", mode)
+        elif str(config_id) in self._ACP_OUTPUT_DETAIL_CONFIG_IDS:
+            normalized_detail = parse_output_detail(value)
+            if normalized_detail is not None:
+                setattr(state, "output_detail", normalized_detail)
+            else:
+                logger.warning(
+                    "Session %s: ignored invalid ACP output detail config value %r",
+                    session_id,
+                    value,
+                )
         else:
             options = getattr(state, "config_options", None)
             if not isinstance(options, dict):
@@ -1945,4 +2063,4 @@ class HermesACPAgent(acp.Agent):
             setattr(state, "config_options", options)
         self.session_manager.save_session(session_id)
         logger.info("Session %s: config option %s updated", session_id, config_id)
-        return SetSessionConfigOptionResponse(config_options=[])
+        return SetSessionConfigOptionResponse(config_options=self._session_config_options(state) or [])

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -181,6 +181,7 @@ class SessionState:
     runtime_lock: Any = field(default_factory=Lock)
     current_prompt_text: str = ""
     interrupted_prompt_text: str = ""
+    output_detail: str = ""
 
 
 class SessionManager:
@@ -272,6 +273,7 @@ class SessionManager:
             model=getattr(agent, "model", original.model) or original.model,
             history=copy.deepcopy(original.history),
             cancel_event=threading.Event(),
+            output_detail=getattr(original, "output_detail", ""),
         )
         with self._lock:
             self._sessions[new_id] = state
@@ -442,6 +444,9 @@ class SessionManager:
             session_meta["base_url"] = base_url.strip()
         if isinstance(api_mode, str) and api_mode.strip():
             session_meta["api_mode"] = api_mode.strip()
+        output_detail = getattr(state, "output_detail", "")
+        if isinstance(output_detail, str) and output_detail.strip():
+            session_meta["acp_output_detail"] = output_detail.strip()
         cwd_json = json.dumps(session_meta)
 
         try:
@@ -452,7 +457,7 @@ class SessionManager:
                     session_id=state.session_id,
                     source="acp",
                     model=model_str,
-                    model_config={"cwd": state.cwd},
+                    model_config=session_meta,
                 )
             else:
                 # Update model_config (contains cwd) if changed.
@@ -499,6 +504,7 @@ class SessionManager:
         requested_provider = row.get("billing_provider")
         restored_base_url = row.get("billing_base_url")
         restored_api_mode = None
+        restored_output_detail = ""
         mc = row.get("model_config")
         if mc:
             try:
@@ -508,6 +514,7 @@ class SessionManager:
                     requested_provider = meta.get("provider") or requested_provider
                     restored_base_url = meta.get("base_url") or restored_base_url
                     restored_api_mode = meta.get("api_mode") or restored_api_mode
+                    restored_output_detail = str(meta.get("acp_output_detail") or "").strip()
             except (json.JSONDecodeError, TypeError):
                 pass
 
@@ -540,6 +547,7 @@ class SessionManager:
             model=model or getattr(agent, "model", "") or "",
             history=history,
             cancel_event=threading.Event(),
+            output_detail=restored_output_detail,
         )
         with self._lock:
             self._sessions[session_id] = state

--- a/acp_adapter/tools.py
+++ b/acp_adapter/tools.py
@@ -14,6 +14,8 @@ from acp.schema import (
     ToolKind,
 )
 
+from .output_policy import ACPOutputPolicy, load_acp_output_policy
+
 # ---------------------------------------------------------------------------
 # Map hermes tool names -> ACP ToolKind
 # ---------------------------------------------------------------------------
@@ -246,6 +248,61 @@ def _truncate_text(text: str, limit: int = 5000) -> str:
     return text[: max(0, limit - 100)] + f"\n... ({len(text)} chars total, truncated)"
 
 
+def _policy_or_default(output_policy: ACPOutputPolicy | None = None) -> ACPOutputPolicy:
+    return output_policy if isinstance(output_policy, ACPOutputPolicy) else load_acp_output_policy()
+
+
+def _is_full_output(output_policy: ACPOutputPolicy | None) -> bool:
+    return _policy_or_default(output_policy).full_visible_output
+
+
+def _truncate_for_policy(
+    text: str,
+    output_policy: ACPOutputPolicy | None,
+    *,
+    condensed_limit: int = 5000,
+    full_limit: int | None = None,
+) -> str:
+    """Apply ACP-visible truncation according to the resolved output policy."""
+
+    policy = _policy_or_default(output_policy)
+    if policy.full_visible_output:
+        if full_limit is None or full_limit <= 0:
+            return text
+        return _truncate_text(text, limit=full_limit)
+    return _truncate_text(text, limit=condensed_limit)
+
+
+def _limit_sequence(values: list[Any], output_policy: ACPOutputPolicy | None, *, condensed_limit: int) -> list[Any]:
+    if _is_full_output(output_policy):
+        return values
+    return values[:condensed_limit]
+
+
+def _json_dumps_compact(value: Any, *, indent: int | None = None) -> str:
+    return json.dumps(value, ensure_ascii=False, indent=indent, default=str)
+
+
+def _raw_input_for_policy(
+    tool_name: str,
+    arguments: Dict[str, Any],
+    output_policy: ACPOutputPolicy | None,
+) -> Any | None:
+    """Hermes ACP tool starts keep raw protocol fields omitted by policy."""
+
+    return None
+
+
+def _raw_output_for_policy(
+    tool_name: str,
+    result: Optional[str],
+    output_policy: ACPOutputPolicy | None,
+) -> Any | None:
+    """Hermes ACP tool completions keep raw protocol fields omitted by policy."""
+
+    return None
+
+
 def _fenced_text(text: str, language: str = "") -> str:
     """Return a Markdown fence that cannot be broken by backticks in text."""
     longest = max((len(run) for run in text.split("`")[1::2]), default=0)
@@ -285,7 +342,11 @@ def _format_todo_result(result: Optional[str]) -> Optional[str]:
     return "\n".join(lines)
 
 
-def _format_read_file_result(result: Optional[str], args: Optional[Dict[str, Any]]) -> Optional[str]:
+def _format_read_file_result(
+    result: Optional[str],
+    args: Optional[Dict[str, Any]],
+    output_policy: ACPOutputPolicy | None = None,
+) -> Optional[str]:
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
         return None
@@ -309,10 +370,13 @@ def _format_read_file_result(result: Optional[str], args: Optional[Dict[str, Any
     # Hermes read_file output is line-numbered with `|`. If we send it as raw
     # Markdown, Zed can interpret pipes as tables and collapse the layout.
     # Fence the payload so file lines stay readable and literal.
-    return _truncate_text(f"{header}\n\n{_fenced_text(content)}")
+    return _truncate_for_policy(f"{header}\n\n{_fenced_text(content)}", output_policy, condensed_limit=5000)
 
 
-def _format_search_files_result(result: Optional[str]) -> Optional[str]:
+def _format_search_files_result(
+    result: Optional[str],
+    output_policy: ACPOutputPolicy | None = None,
+) -> Optional[str]:
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
         return None
@@ -320,28 +384,30 @@ def _format_search_files_result(result: Optional[str]) -> Optional[str]:
     files = data.get("files")
     if isinstance(files, list):
         total = data.get("total_count", len(files))
-        shown = min(len(files), 20)
+        shown_files = _limit_sequence(files, output_policy, condensed_limit=20)
+        shown = len(shown_files)
         truncated = bool(data.get("truncated")) or len(files) > shown
         lines = [
             "File search results",
             f"Found {total} file{'s' if total != 1 else ''}; showing {shown}.",
             "",
         ]
-        for path in files[:shown]:
+        for path in shown_files:
             lines.append(f"- {path}")
         if truncated:
             lines.extend([
                 "",
                 "Results truncated. Narrow the search, add path/file_glob, or use offset to page.",
             ])
-        return _truncate_text("\n".join(lines), limit=7000)
+        return _truncate_for_policy("\n".join(lines), output_policy, condensed_limit=7000)
 
     matches = data.get("matches")
     if not isinstance(matches, list):
         return None
 
     total = data.get("total_count", len(matches))
-    shown = min(len(matches), 12)
+    shown_matches = _limit_sequence(matches, output_policy, condensed_limit=12)
+    shown = len(shown_matches)
     truncated = bool(data.get("truncated")) or len(matches) > shown
     lines = [
         "Search results",
@@ -349,7 +415,7 @@ def _format_search_files_result(result: Optional[str]) -> Optional[str]:
         "",
     ]
 
-    for match in matches[:shown]:
+    for match in shown_matches:
         if not isinstance(match, dict):
             lines.append(f"- {match}")
             continue
@@ -360,7 +426,7 @@ def _format_search_files_result(result: Optional[str]) -> Optional[str]:
         loc = f"{path}:{line}" if line else path
         lines.append(f"- {loc}")
         if content:
-            snippet = _truncate_text(" ".join(content.split()), 300)
+            snippet = _truncate_for_policy(" ".join(content.split()), output_policy, condensed_limit=300)
             lines.append(f"  {snippet}")
 
     if truncated:
@@ -368,10 +434,13 @@ def _format_search_files_result(result: Optional[str]) -> Optional[str]:
             "",
             "Results truncated. Narrow the search, add file_glob, or use offset to page.",
         ])
-    return _truncate_text("\n".join(lines), limit=7000)
+    return _truncate_for_policy("\n".join(lines), output_policy, condensed_limit=7000)
 
 
-def _format_execute_code_result(result: Optional[str]) -> Optional[str]:
+def _format_execute_code_result(
+    result: Optional[str],
+    output_policy: ACPOutputPolicy | None = None,
+) -> Optional[str]:
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
         return result if isinstance(result, str) and result.strip() else None
@@ -383,7 +452,7 @@ def _format_execute_code_result(result: Optional[str]) -> Optional[str]:
         parts.extend(["", "Output:", output])
     if error:
         parts.extend(["", "Error:", error])
-    return _truncate_text("\n".join(parts))
+    return _truncate_for_policy("\n".join(parts), output_policy, condensed_limit=5000)
 
 
 def _extract_markdown_headings(content: str, limit: int = 8) -> list[str]:
@@ -399,7 +468,10 @@ def _extract_markdown_headings(content: str, limit: int = 8) -> list[str]:
     return headings
 
 
-def _format_skill_view_result(result: Optional[str]) -> Optional[str]:
+def _format_skill_view_result(
+    result: Optional[str],
+    output_policy: ACPOutputPolicy | None = None,
+) -> Optional[str]:
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
         return None
@@ -425,14 +497,21 @@ def _format_skill_view_result(result: Optional[str]) -> Optional[str]:
         lines.extend(["", "**Sections**"])
         lines.extend(f"- {heading}" for heading in headings)
 
-    lines.extend([
-        "",
-        "_Full skill content is available to the agent but hidden here to keep ACP readable._",
-    ])
-    return "\n".join(lines)
+    if content and _is_full_output(output_policy):
+        lines.extend(["", "**Content**", "", _fenced_text(content, "markdown")])
+    else:
+        lines.extend([
+            "",
+            "_Full skill content is available to the agent but hidden here to keep ACP readable._",
+        ])
+    return _truncate_for_policy("\n".join(lines), output_policy, condensed_limit=5000)
 
 
-def _format_skill_manage_result(result: Optional[str], args: Optional[Dict[str, Any]]) -> Optional[str]:
+def _format_skill_manage_result(
+    result: Optional[str],
+    args: Optional[Dict[str, Any]],
+    output_policy: ACPOutputPolicy | None = None,
+) -> Optional[str]:
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
         return None
@@ -459,18 +538,29 @@ def _format_skill_manage_result(result: Optional[str], args: Optional[Dict[str, 
     if path:
         lines.append(f"- **Path:** `{path}`")
 
-    return "\n".join(lines)
+    if _is_full_output(output_policy):
+        for key in ("diff", "content", "file_content"):
+            value = data.get(key)
+            if isinstance(value, str) and value.strip():
+                language = "diff" if key == "diff" else ""
+                lines.extend(["", f"**{key}:**", _fenced_text(value, language)])
+
+    return _truncate_for_policy("\n".join(lines), output_policy, condensed_limit=5000)
 
 
-def _format_web_search_result(result: Optional[str]) -> Optional[str]:
+def _format_web_search_result(
+    result: Optional[str],
+    output_policy: ACPOutputPolicy | None = None,
+) -> Optional[str]:
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
         return None
     web = data.get("data", {}).get("web") if isinstance(data.get("data"), dict) else data.get("web")
     if not isinstance(web, list):
         return None
+    shown_web = _limit_sequence(web, output_policy, condensed_limit=10)
     lines = [f"Web results: {len(web)}"]
-    for item in web[:10]:
+    for item in shown_web:
         if not isinstance(item, dict):
             continue
         title = str(item.get("title") or item.get("url") or "result").strip()
@@ -479,11 +569,16 @@ def _format_web_search_result(result: Optional[str]) -> Optional[str]:
         lines.append(f"• {title}" + (f" — {url}" if url else ""))
         if desc:
             lines.append(f"  {desc}")
-    return _truncate_text("\n".join(lines))
+    if len(shown_web) < len(web):
+        lines.append(f"... {len(web) - len(shown_web)} more result(s)")
+    return _truncate_for_policy("\n".join(lines), output_policy, condensed_limit=5000)
 
 
-def _format_web_extract_result(result: Optional[str]) -> Optional[str]:
-    """Return only web_extract errors for ACP; success stays compact via title."""
+def _format_web_extract_result(
+    result: Optional[str],
+    output_policy: ACPOutputPolicy | None = None,
+) -> Optional[str]:
+    """Format web_extract results according to ACP output policy."""
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
         return None
@@ -494,26 +589,48 @@ def _format_web_extract_result(result: Optional[str]) -> Optional[str]:
         return None
 
     failures: list[str] = []
-    for item in results[:10]:
+    successes: list[str] = []
+    for item in results:
         if not isinstance(item, dict):
             continue
         error = str(item.get("error") or "").strip()
-        if not error or error in {"None", "null"}:
-            continue
         url = str(item.get("url") or "").strip()
         title = str(item.get("title") or url or "Untitled").strip()
-        failures.append(
-            f"- {title}" + (f" — {url}" if url and url != title else "") + f"\n  Error: {_truncate_text(error, limit=500)}"
-        )
+        if error and error not in {"None", "null"}:
+            failures.append(
+                f"- {title}" + (f" — {url}" if url and url != title else "") + f"\n  Error: {_truncate_for_policy(error, output_policy, condensed_limit=500)}"
+            )
+            continue
+        if _is_full_output(output_policy):
+            content = str(item.get("content") or item.get("text") or "").strip()
+            body = f"## {title}" + (f"\n{url}" if url and url != title else "")
+            if content:
+                body += f"\n\n{_fenced_text(content, 'markdown')}"
+            successes.append(body)
+
+    if _is_full_output(output_policy):
+        lines = [f"Web extract results: {len(results)}"]
+        if successes:
+            lines.extend(["", *successes])
+        if failures:
+            lines.extend(["", f"Failures: {len(failures)}", *failures])
+        return _truncate_for_policy("\n".join(lines), output_policy, condensed_limit=5000)
 
     if not failures:
         return None
+    shown_failures = _limit_sequence(failures, output_policy, condensed_limit=10)
     lines = [f"Web extract failed for {len(failures)} URL{'s' if len(failures) != 1 else ''}"]
-    lines.extend(failures)
+    lines.extend(shown_failures)
+    if len(failures) > len(shown_failures):
+        lines.append(f"... {len(failures) - len(shown_failures)} more failure(s)")
     return "\n".join(lines)
 
 
-def _format_process_result(result: Optional[str], args: Optional[Dict[str, Any]]) -> Optional[str]:
+def _format_process_result(
+    result: Optional[str],
+    args: Optional[Dict[str, Any]],
+    output_policy: ACPOutputPolicy | None = None,
+) -> Optional[str]:
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
         return result if isinstance(result, str) and result.strip() else None
@@ -522,8 +639,9 @@ def _format_process_result(result: Optional[str], args: Optional[Dict[str, Any]]
     action = str((args or {}).get("action") or "process").strip() or "process"
     if isinstance(data.get("processes"), list):
         processes = data["processes"]
+        shown_processes = _limit_sequence(processes, output_policy, condensed_limit=20)
         lines = [f"Processes: {len(processes)}"]
-        for proc in processes[:20]:
+        for proc in shown_processes:
             if not isinstance(proc, dict):
                 lines.append(f"- {proc}")
                 continue
@@ -537,10 +655,11 @@ def _format_process_result(result: Optional[str], args: Optional[Dict[str, Any]]
                 bits.append(f"pid {pid}")
             if code is not None:
                 bits.append(f"exit {code}")
-            lines.append(f"- `{sid}` — {', '.join(bits)}" + (f" — {cmd[:120]}" if cmd else ""))
-        if len(processes) > 20:
-            lines.append(f"... {len(processes) - 20} more process(es)")
-        return "\n".join(lines)
+            command_text = cmd if _is_full_output(output_policy) else cmd[:120]
+            lines.append(f"- `{sid}` — {', '.join(bits)}" + (f" — {command_text}" if command_text else ""))
+        if len(processes) > len(shown_processes):
+            lines.append(f"... {len(processes) - len(shown_processes)} more process(es)")
+        return _truncate_for_policy("\n".join(lines), output_policy, condensed_limit=5000)
 
     status = str(data.get("status") or data.get("state") or action).strip()
     sid = str(data.get("session_id") or (args or {}).get("session_id") or "").strip()
@@ -551,16 +670,19 @@ def _format_process_result(result: Optional[str], args: Optional[Dict[str, Any]]
     output = data.get("output") or data.get("new_output") or data.get("log") or data.get("stdout")
     error = data.get("error") or data.get("stderr")
     if output:
-        lines.extend(["", "Output:", _truncate_text(str(output), limit=5000)])
+        lines.extend(["", "Output:", _truncate_for_policy(str(output), output_policy, condensed_limit=5000)])
     if error:
-        lines.extend(["", "Error:", _truncate_text(str(error), limit=2000)])
+        lines.extend(["", "Error:", _truncate_for_policy(str(error), output_policy, condensed_limit=2000)])
     msg = data.get("message")
     if msg and not output and not error:
         lines.append(str(msg))
-    return _truncate_text("\n".join(lines), limit=7000)
+    return _truncate_for_policy("\n".join(lines), output_policy, condensed_limit=7000)
 
 
-def _format_delegate_result(result: Optional[str]) -> Optional[str]:
+def _format_delegate_result(
+    result: Optional[str],
+    output_policy: ACPOutputPolicy | None = None,
+) -> Optional[str]:
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
         return None
@@ -595,18 +717,26 @@ def _format_delegate_result(result: Optional[str]) -> Optional[str]:
         summary = str(item.get("summary") or "").strip()
         error = str(item.get("error") or "").strip()
         if summary:
-            lines.append(_truncate_text(summary, limit=1200))
+            lines.append(_truncate_for_policy(summary, output_policy, condensed_limit=1200))
         if error:
-            lines.append("Error: " + _truncate_text(error, limit=800))
+            lines.append("Error: " + _truncate_for_policy(error, output_policy, condensed_limit=800))
         trace = item.get("tool_trace")
         if isinstance(trace, list) and trace:
             names = [str(t.get("tool") or "?") for t in trace if isinstance(t, dict)]
             if names:
-                lines.append("Tools: " + ", ".join(names[:12]) + (f" (+{len(names)-12})" if len(names) > 12 else ""))
-    return _truncate_text("\n".join(lines), limit=8000)
+                if _is_full_output(output_policy):
+                    lines.append("Tools: " + ", ".join(names))
+                else:
+                    shown_names = _limit_sequence(names, output_policy, condensed_limit=12)
+                    suffix = f" (+{len(names) - len(shown_names)})" if len(names) > len(shown_names) else ""
+                    lines.append("Tools: " + ", ".join(shown_names) + suffix)
+    return _truncate_for_policy("\n".join(lines), output_policy, condensed_limit=8000)
 
 
-def _format_session_search_result(result: Optional[str]) -> Optional[str]:
+def _format_session_search_result(
+    result: Optional[str],
+    output_policy: ACPOutputPolicy | None = None,
+) -> Optional[str]:
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
         return None
@@ -633,11 +763,15 @@ def _format_session_search_result(result: Optional[str]) -> Optional[str]:
         lines.append(f"- **{title}** (`{sid}`)" + (f" — {meta}" if meta else ""))
         summary = str(item.get("summary") or item.get("preview") or "").strip()
         if summary:
-            lines.append("  " + _truncate_text(" ".join(summary.split()), limit=500))
-    return _truncate_text("\n".join(lines), limit=7000)
+            lines.append("  " + _truncate_for_policy(" ".join(summary.split()), output_policy, condensed_limit=500))
+    return _truncate_for_policy("\n".join(lines), output_policy, condensed_limit=7000)
 
 
-def _format_memory_result(result: Optional[str], args: Optional[Dict[str, Any]]) -> Optional[str]:
+def _format_memory_result(
+    result: Optional[str],
+    args: Optional[Dict[str, Any]],
+    output_policy: ACPOutputPolicy | None = None,
+) -> Optional[str]:
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
         return None
@@ -648,7 +782,8 @@ def _format_memory_result(result: Optional[str], args: Optional[Dict[str, Any]])
         matches = data.get("matches")
         if isinstance(matches, list) and matches:
             lines.append("Matches:")
-            lines.extend(f"- {_truncate_text(str(m), 160)}" for m in matches[:5])
+            shown_matches = _limit_sequence(matches, output_policy, condensed_limit=5)
+            lines.extend(f"- {_truncate_for_policy(str(m), output_policy, condensed_limit=160)}" for m in shown_matches)
         return "\n".join(lines)
     lines = [f"✅ Memory {action} saved ({target})"]
     if data.get("message"):
@@ -657,14 +792,24 @@ def _format_memory_result(result: Optional[str], args: Optional[Dict[str, Any]])
         lines.append(f"Entries: {data.get('entry_count')}")
     if data.get("usage"):
         lines.append(f"Usage: {data.get('usage')}")
-    # Avoid dumping all memory entries into ACP UI; show only the explicit new value preview.
-    preview = str((args or {}).get("content") or (args or {}).get("old_text") or "").strip()
-    if preview:
-        lines.append("Preview: " + _truncate_text(preview, limit=300))
-    return "\n".join(lines)
+    # Avoid dumping all memory entries into ACP UI by default; full mode is an
+    # explicit debugging/auditing opt-in.
+    if _is_full_output(output_policy) and isinstance(data.get("entries"), list):
+        lines.append("Stored entries:")
+        lines.extend(f"- {entry}" for entry in data["entries"])
+    else:
+        preview = str((args or {}).get("content") or (args or {}).get("old_text") or "").strip()
+        if preview:
+            lines.append("Preview: " + _truncate_for_policy(preview, output_policy, condensed_limit=300))
+    return _truncate_for_policy("\n".join(lines), output_policy, condensed_limit=5000)
 
 
-def _format_edit_result(tool_name: str, result: Optional[str], args: Optional[Dict[str, Any]]) -> Optional[str]:
+def _format_edit_result(
+    tool_name: str,
+    result: Optional[str],
+    args: Optional[Dict[str, Any]],
+    output_policy: ACPOutputPolicy | None = None,
+) -> Optional[str]:
     data = _json_loads_maybe(result)
     path = str((args or {}).get("path") or "file").strip()
     if isinstance(data, dict):
@@ -680,14 +825,25 @@ def _format_edit_result(tool_name: str, result: Optional[str], args: Optional[Di
         if data.get("files_modified"):
             files = data.get("files_modified")
             if isinstance(files, list):
-                lines.append("Files: " + ", ".join(f"`{f}`" for f in files[:8]))
-        return "\n".join(lines)
+                shown_files = _limit_sequence(files, output_policy, condensed_limit=8)
+                lines.append("Files: " + ", ".join(f"`{f}`" for f in shown_files))
+        if _is_full_output(output_policy):
+            for key in ("diff", "content", "output"):
+                value = data.get(key)
+                if isinstance(value, str) and value.strip():
+                    lines.extend(["", f"**{key}:**", _fenced_text(value, "diff" if key == "diff" else "")])
+        return _truncate_for_policy("\n".join(lines), output_policy, condensed_limit=5000)
     if isinstance(result, str) and result.strip():
-        return _truncate_text(result, limit=3000)
+        return _truncate_for_policy(result, output_policy, condensed_limit=3000)
     return f"✅ {tool_name} completed" + (f" for `{path}`" if path else "")
 
 
-def _format_browser_result(tool_name: str, result: Optional[str], args: Optional[Dict[str, Any]]) -> Optional[str]:
+def _format_browser_result(
+    tool_name: str,
+    result: Optional[str],
+    args: Optional[Dict[str, Any]],
+    output_policy: ACPOutputPolicy | None = None,
+) -> Optional[str]:
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
         return result if isinstance(result, str) and result.strip() else None
@@ -696,24 +852,35 @@ def _format_browser_result(tool_name: str, result: Optional[str], args: Optional
     if tool_name == "browser_get_images":
         images = data.get("images") or data.get("data")
         if isinstance(images, list):
+            shown_images = _limit_sequence(images, output_policy, condensed_limit=12)
             lines = [f"Images found: {len(images)}"]
-            for img in images[:12]:
+            for img in shown_images:
                 if isinstance(img, dict):
                     alt = str(img.get("alt") or "").strip()
                     url = str(img.get("url") or img.get("src") or "").strip()
                     lines.append(f"- {alt or 'image'}" + (f" — {url}" if url else ""))
-            return _truncate_text("\n".join(lines), limit=5000)
+            if len(shown_images) < len(images):
+                lines.append(f"... {len(images) - len(shown_images)} more image(s)")
+            return _truncate_for_policy("\n".join(lines), output_policy, condensed_limit=5000)
     title = str(data.get("title") or data.get("url") or data.get("status") or tool_name)
     text = str(data.get("text") or data.get("content") or data.get("snapshot") or data.get("analysis") or data.get("message") or "").strip()
     lines = [title]
     if data.get("url") and data.get("url") != title:
         lines.append(str(data.get("url")))
     if text:
-        lines.extend(["", _truncate_text(text, limit=5000)])
-    return _truncate_text("\n".join(lines), limit=7000)
+        lines.extend(["", _truncate_for_policy(text, output_policy, condensed_limit=5000)])
+    return _truncate_for_policy("\n".join(lines), output_policy, condensed_limit=7000)
 
 
-def _format_media_or_cron_result(tool_name: str, result: Optional[str]) -> Optional[str]:
+def _format_media_or_cron_result(
+    tool_name: str,
+    result: Optional[str],
+    output_policy: ACPOutputPolicy | None = None,
+) -> Optional[str]:
+    if _is_full_output(output_policy):
+        generic = _format_generic_structured_result(tool_name, result, output_policy=output_policy)
+        if generic:
+            return generic
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
         return result if isinstance(result, str) and result.strip() else None
@@ -821,10 +988,19 @@ def _format_generic_structured_result(
     result: Optional[str],
     *,
     fallback_to_text: bool = True,
+    output_policy: ACPOutputPolicy | None = None,
 ) -> Optional[str]:
     data = _json_loads_maybe(result)
     if not isinstance(data, (dict, list)):
-        return result if fallback_to_text and isinstance(result, str) and result.strip() else None
+        if fallback_to_text and isinstance(result, str) and result.strip():
+            return _truncate_for_policy(result, output_policy, condensed_limit=5000)
+        return None
+    if _is_full_output(output_policy):
+        return _truncate_for_policy(
+            f"{tool_name} full result\n\n{_fenced_text(_json_dumps_compact(data, indent=2), 'json')}",
+            output_policy,
+            condensed_limit=7000,
+        )
     if isinstance(data, list):
         lines = [f"{tool_name}: {len(data)} item{'s' if len(data) != 1 else ''}"]
         for item in data[:12]:
@@ -872,34 +1048,35 @@ def _build_polished_completion_content(
     tool_name: str,
     result: Optional[str],
     function_args: Optional[Dict[str, Any]],
+    output_policy: ACPOutputPolicy | None = None,
 ) -> Optional[List[Any]]:
     formatter = {
         "todo": lambda: _format_todo_result(result),
-        "read_file": lambda: _format_read_file_result(result, function_args),
-        "write_file": lambda: _format_edit_result(tool_name, result, function_args),
-        "patch": lambda: _format_edit_result(tool_name, result, function_args),
-        "search_files": lambda: _format_search_files_result(result),
-        "execute_code": lambda: _format_execute_code_result(result),
-        "process": lambda: _format_process_result(result, function_args),
-        "delegate_task": lambda: _format_delegate_result(result),
-        "session_search": lambda: _format_session_search_result(result),
-        "memory": lambda: _format_memory_result(result, function_args),
-        "skill_view": lambda: _format_skill_view_result(result),
-        "skill_manage": lambda: _format_skill_manage_result(result, function_args),
-        "web_search": lambda: _format_web_search_result(result),
-        "web_extract": lambda: _format_web_extract_result(result),
-        "browser_navigate": lambda: _format_browser_result(tool_name, result, function_args),
-        "browser_snapshot": lambda: _format_browser_result(tool_name, result, function_args),
-        "browser_vision": lambda: _format_browser_result(tool_name, result, function_args),
-        "browser_get_images": lambda: _format_browser_result(tool_name, result, function_args),
-        "vision_analyze": lambda: _format_media_or_cron_result(tool_name, result),
-        "image_generate": lambda: _format_media_or_cron_result(tool_name, result),
-        "cronjob": lambda: _format_media_or_cron_result(tool_name, result),
+        "read_file": lambda: _format_read_file_result(result, function_args, output_policy),
+        "write_file": lambda: _format_edit_result(tool_name, result, function_args, output_policy),
+        "patch": lambda: _format_edit_result(tool_name, result, function_args, output_policy),
+        "search_files": lambda: _format_search_files_result(result, output_policy),
+        "execute_code": lambda: _format_execute_code_result(result, output_policy),
+        "process": lambda: _format_process_result(result, function_args, output_policy),
+        "delegate_task": lambda: _format_delegate_result(result, output_policy),
+        "session_search": lambda: _format_session_search_result(result, output_policy),
+        "memory": lambda: _format_memory_result(result, function_args, output_policy),
+        "skill_view": lambda: _format_skill_view_result(result, output_policy),
+        "skill_manage": lambda: _format_skill_manage_result(result, function_args, output_policy),
+        "web_search": lambda: _format_web_search_result(result, output_policy),
+        "web_extract": lambda: _format_web_extract_result(result, output_policy),
+        "browser_navigate": lambda: _format_browser_result(tool_name, result, function_args, output_policy),
+        "browser_snapshot": lambda: _format_browser_result(tool_name, result, function_args, output_policy),
+        "browser_vision": lambda: _format_browser_result(tool_name, result, function_args, output_policy),
+        "browser_get_images": lambda: _format_browser_result(tool_name, result, function_args, output_policy),
+        "vision_analyze": lambda: _format_media_or_cron_result(tool_name, result, output_policy),
+        "image_generate": lambda: _format_media_or_cron_result(tool_name, result, output_policy),
+        "cronjob": lambda: _format_media_or_cron_result(tool_name, result, output_policy),
     }.get(tool_name)
     if formatter is None and tool_name in _POLISHED_TOOLS:
-        formatter = lambda: _format_generic_structured_result(tool_name, result)
+        formatter = lambda: _format_generic_structured_result(tool_name, result, output_policy=output_policy)
     if formatter is None:
-        text = _format_generic_structured_result(tool_name, result, fallback_to_text=False)
+        text = _format_generic_structured_result(tool_name, result, fallback_to_text=False, output_policy=output_policy)
     else:
         text = formatter()
     if not text:
@@ -1045,13 +1222,12 @@ def _build_tool_complete_content(
     *,
     function_args: Optional[Dict[str, Any]] = None,
     snapshot: Any = None,
+    output_policy: ACPOutputPolicy | None = None,
 ) -> List[Any]:
     """Build structured ACP completion content, falling back to plain text."""
-    display_result = result or ""
-    if len(display_result) > 5000:
-        display_result = display_result[:4900] + f"\n... ({len(result)} chars total, truncated)"
+    display_result = _truncate_for_policy(result or "", output_policy, condensed_limit=5000)
 
-    if tool_name == "skill_manage":
+    if tool_name == "skill_manage" and not _is_full_output(output_policy):
         try:
             from agent.display import extract_edit_diff
 
@@ -1068,7 +1244,7 @@ def _build_tool_complete_content(
         except Exception:
             pass
 
-    polished_content = _build_polished_completion_content(tool_name, result, function_args)
+    polished_content = _build_polished_completion_content(tool_name, result, function_args, output_policy)
     if polished_content:
         return polished_content
 
@@ -1086,11 +1262,23 @@ def build_tool_start(
     arguments: Dict[str, Any],
     *,
     edit_diff: Any = None,
+    output_policy: ACPOutputPolicy | None = None,
 ) -> ToolCallStart:
     """Create a ToolCallStart event for the given hermes tool invocation."""
     kind = get_tool_kind(tool_name)
     title = build_tool_title(tool_name, arguments)
     locations = extract_locations(arguments)
+    raw_input = _raw_input_for_policy(tool_name, arguments, output_policy)
+
+    def _start(content: Optional[List[Any]]) -> ToolCallStart:
+        return acp.start_tool_call(
+            tool_call_id,
+            title,
+            kind=kind,
+            content=content,
+            locations=locations,
+            raw_input=raw_input,
+        )
 
     if tool_name == "patch":
         if edit_diff is not None:
@@ -1105,9 +1293,7 @@ def build_tool_start(
             mode = arguments.get("mode", "replace")
             path = arguments.get("path") or "patch input"
             content = [_text(f"Preparing {mode} edit for {path}. Approval prompt shows the diff.")]
-        return acp.start_tool_call(
-            tool_call_id, title, kind=kind, content=content, locations=locations,
-        )
+        return _start(content)
 
     if tool_name == "write_file":
         if edit_diff is not None:
@@ -1121,24 +1307,18 @@ def build_tool_start(
         else:
             path = arguments.get("path", "")
             content = [_text(f"Preparing write to {path}. Approval prompt shows the diff." if path else "Preparing file write. Approval prompt shows the diff.")]
-        return acp.start_tool_call(
-            tool_call_id, title, kind=kind, content=content, locations=locations,
-        )
+        return _start(content)
 
     if tool_name == "terminal":
         command = arguments.get("command", "")
         content = [_text(f"$ {command}")]
-        return acp.start_tool_call(
-            tool_call_id, title, kind=kind, content=content, locations=locations,
-        )
+        return _start(content)
 
     if tool_name == "read_file":
         # The title and location already identify the file. Sending a synthetic
         # "Reading ..." content block makes Zed render an unhelpful Output
         # section before the real file contents arrive on completion.
-        return acp.start_tool_call(
-            tool_call_id, title, kind=kind, content=None, locations=locations,
-        )
+        return _start(None)
 
     if tool_name == "search_files":
         pattern = arguments.get("pattern", "")
@@ -1146,33 +1326,28 @@ def build_tool_start(
         search_path = arguments.get("path")
         where = f" in {search_path}" if search_path else ""
         content = [_text(f"Searching for '{pattern}' ({target}){where}")]
-        return acp.start_tool_call(
-            tool_call_id, title, kind=kind, content=content, locations=locations,
-        )
+        return _start(content)
 
     if tool_name == "todo":
         items = arguments.get("todos")
         if isinstance(items, list):
             preview_lines = ["Updating todo list", ""]
-            for item in items[:8]:
+            shown_items = _limit_sequence(items, output_policy, condensed_limit=8)
+            for item in shown_items:
                 if isinstance(item, dict):
                     preview_lines.append(f"- {item.get('status', 'pending')}: {item.get('content', item.get('id', ''))}")
-            if len(items) > 8:
-                preview_lines.append(f"... {len(items) - 8} more")
+            if len(items) > len(shown_items):
+                preview_lines.append(f"... {len(items) - len(shown_items)} more")
             content = [_text("\n".join(preview_lines))]
         else:
             content = [_text("Reading todo list")]
-        return acp.start_tool_call(
-            tool_call_id, title, kind=kind, content=content, locations=locations,
-        )
+        return _start(content)
 
     if tool_name == "skill_view":
         name = str(arguments.get("name") or "?").strip() or "?"
         file_path = str(arguments.get("file_path") or "SKILL.md").strip() or "SKILL.md"
         content = [_text(f"Loading skill '{name}' ({file_path})")]
-        return acp.start_tool_call(
-            tool_call_id, title, kind=kind, content=content, locations=locations,
-        )
+        return _start(content)
 
     if tool_name == "skill_manage":
         action = str(arguments.get("action") or "manage").strip() or "manage"
@@ -1205,31 +1380,23 @@ def build_tool_start(
         else:
             content = [_text(f"Running skill_manage action '{action}' on skill '{name}' ({file_path})")]
 
-        return acp.start_tool_call(
-            tool_call_id, title, kind=kind, content=content, locations=locations,
-        )
+        return _start(content)
 
     if tool_name == "execute_code":
         code = str(arguments.get("code") or "").strip()
-        preview = code[:1200] + (f"\n... ({len(code)} chars total, truncated)" if len(code) > 1200 else "")
+        preview = _truncate_for_policy(code, output_policy, condensed_limit=1200)
         content = [_text(f"Running Python helper script:\n\n```python\n{preview}\n```" if preview else "Running Python helper script")]
-        return acp.start_tool_call(
-            tool_call_id, title, kind=kind, content=content, locations=locations,
-        )
+        return _start(content)
 
     if tool_name == "web_search":
         query = str(arguments.get("query") or "").strip()
         content = [_text(f"Searching the web for: {query}" if query else "Searching the web")]
-        return acp.start_tool_call(
-            tool_call_id, title, kind=kind, content=content, locations=locations,
-        )
+        return _start(content)
 
     if tool_name == "web_extract":
         # The title identifies the URL(s). Avoid a duplicate content block so
         # Zed renders this like read_file: compact start, concise completion.
-        return acp.start_tool_call(
-            tool_call_id, title, kind=kind, content=None, locations=locations,
-        )
+        return _start(None)
 
     if tool_name == "process":
         action = str(arguments.get("action") or "").strip() or "manage"
@@ -1237,37 +1404,32 @@ def build_tool_start(
         data_preview = str(arguments.get("data") or "").strip()
         text = f"Process action: {action}" + (f"\nSession: {sid}" if sid else "")
         if data_preview:
-            text += "\nInput: " + _truncate_text(data_preview, limit=500)
+            text += "\nInput: " + _truncate_for_policy(data_preview, output_policy, condensed_limit=500)
         content = [_text(text)]
-        return acp.start_tool_call(
-            tool_call_id, title, kind=kind, content=content, locations=locations,
-        )
+        return _start(content)
 
     if tool_name == "delegate_task":
         tasks = arguments.get("tasks")
         if isinstance(tasks, list) and tasks:
             lines = [f"Delegating {len(tasks)} tasks", ""]
-            for i, task in enumerate(tasks[:8], 1):
+            shown_tasks = _limit_sequence(tasks, output_policy, condensed_limit=8)
+            for i, task in enumerate(shown_tasks, 1):
                 if isinstance(task, dict):
                     goal = str(task.get("goal") or "").strip()
                     role = str(task.get("role") or "").strip()
-                    lines.append(f"{i}. " + _truncate_text(goal, limit=160) + (f" ({role})" if role else ""))
-            if len(tasks) > 8:
-                lines.append(f"... {len(tasks) - 8} more")
+                    lines.append(f"{i}. " + _truncate_for_policy(goal, output_policy, condensed_limit=160) + (f" ({role})" if role else ""))
+            if len(tasks) > len(shown_tasks):
+                lines.append(f"... {len(tasks) - len(shown_tasks)} more")
             content = [_text("\n".join(lines))]
         else:
             goal = str(arguments.get("goal") or "").strip()
-            content = [_text("Delegating task" + (f":\n{_truncate_text(goal, limit=800)}" if goal else ""))]
-        return acp.start_tool_call(
-            tool_call_id, title, kind=kind, content=content, locations=locations,
-        )
+            content = [_text("Delegating task" + (f":\n{_truncate_for_policy(goal, output_policy, condensed_limit=800)}" if goal else ""))]
+        return _start(content)
 
     if tool_name == "session_search":
         query = str(arguments.get("query") or "").strip()
         content = [_text(f"Searching past sessions for: {query}" if query else "Loading recent sessions")]
-        return acp.start_tool_call(
-            tool_call_id, title, kind=kind, content=content, locations=locations,
-        )
+        return _start(content)
 
     if tool_name == "memory":
         action = str(arguments.get("action") or "manage").strip() or "manage"
@@ -1275,26 +1437,20 @@ def build_tool_start(
         preview = str(arguments.get("content") or arguments.get("old_text") or "").strip()
         text = f"Memory {action} ({target})"
         if preview:
-            text += "\nPreview: " + _truncate_text(preview, limit=500)
+            text += "\nPreview: " + _truncate_for_policy(preview, output_policy, condensed_limit=500)
         content = [_text(text)]
-        return acp.start_tool_call(
-            tool_call_id, title, kind=kind, content=content, locations=locations,
-        )
+        return _start(content)
 
     if tool_name in _POLISHED_TOOLS:
         try:
             args_text = json.dumps(arguments, indent=2, default=str)
         except (TypeError, ValueError):
             args_text = str(arguments)
-        content = [_text(_truncate_text(args_text, limit=1200))]
-        return acp.start_tool_call(
-            tool_call_id, title, kind=kind, content=content, locations=locations,
-        )
+        content = [_text(_truncate_for_policy(args_text, output_policy, condensed_limit=1200))]
+        return _start(content)
 
     if not arguments:
-        return acp.start_tool_call(
-            tool_call_id, title, kind=kind, content=None, locations=locations, raw_input=None,
-        )
+        return _start(None)
 
     # Generic fallback
     try:
@@ -1302,10 +1458,7 @@ def build_tool_start(
     except (TypeError, ValueError):
         args_text = str(arguments)
     content = [acp.tool_content(acp.text_block(args_text))]
-    return acp.start_tool_call(
-        tool_call_id, title, kind=kind, content=content, locations=locations,
-        raw_input=None if tool_name in _POLISHED_TOOLS else arguments,
-    )
+    return _start(content)
 
 
 def _is_structured_json_result(result: Optional[str]) -> bool:
@@ -1318,11 +1471,12 @@ def build_tool_complete(
     result: Optional[str] = None,
     function_args: Optional[Dict[str, Any]] = None,
     snapshot: Any = None,
+    output_policy: ACPOutputPolicy | None = None,
 ) -> ToolCallProgress:
     """Create a ToolCallUpdate (progress) event for a completed tool call."""
     kind = get_tool_kind(tool_name)
-    if tool_name == "web_extract":
-        error_text = _format_web_extract_result(result)
+    if tool_name == "web_extract" and not _is_full_output(output_policy):
+        error_text = _format_web_extract_result(result, output_policy)
         content = [_text(error_text)] if error_text else None
     else:
         content = _build_tool_complete_content(
@@ -1330,13 +1484,14 @@ def build_tool_complete(
             result,
             function_args=function_args,
             snapshot=snapshot,
+            output_policy=output_policy,
         )
     return acp.update_tool_call(
         tool_call_id,
         kind=kind,
         status="failed" if _tool_result_failed(result, tool_name) else "completed",
         content=content,
-        raw_output=None if tool_name in _POLISHED_TOOLS or _is_structured_json_result(result) else result,
+        raw_output=_raw_output_for_policy(tool_name, result, output_policy),
     )
 
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -814,6 +814,18 @@ platform_toolsets:
 #       log_level: "info"       # audit verbosity
 
 # =============================================================================
+# ACP (Agent Client Protocol) Adapter
+# =============================================================================
+# Controls editor/client-visible ACP transcript rendering only; model-facing
+# tool-output limits stay governed by the normal tool_output settings.
+acp:
+  output:
+    detail: "condensed"          # condensed | full
+    resource_max_bytes: 524288   # Prompt resource/attachment inline cap (512 KiB)
+    advertise_config_option: false
+                                  # true lets ACP clients discover a Tool Output Detail picker.
+
+# =============================================================================
 # Voice Transcription (Speech-to-Text)
 # =============================================================================
 # Automatically transcribe voice messages on messaging platforms.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -773,6 +773,21 @@ DEFAULT_CONFIG = {
         "max_line_length": 2000,
     },
 
+    # ACP adapter display policy. This controls editor/client-visible ACP
+    # protocol rendering only; it does not change model-facing tool output caps.
+    # - detail: condensed (default polished summaries), full (expanded visible
+    #   content).
+    # - advertise_config_option: kept off by default so clients like Zed keep the
+    #   model picker prominent; advanced clients may still call
+    #   session/set_config_option(tool_output_detail, ...).
+    "acp": {
+        "output": {
+            "detail": "condensed",
+            "resource_max_bytes": 512 * 1024,
+            "advertise_config_option": False,
+        },
+    },
+
     # Tool loop guardrails nudge models when they repeat failed or
     # non-progressing tool calls. Soft warnings are always-on by default;
     # hard stops are opt-in so interactive CLI/TUI sessions keep flowing.

--- a/tests/acp/test_edit_approval.py
+++ b/tests/acp/test_edit_approval.py
@@ -33,7 +33,7 @@ def test_acp_permission_tool_call_uses_edit_kind_and_diff_content():
 
     assert tool_call.kind == "edit"
     assert tool_call.status == "pending"
-    assert tool_call.rawInput == {"tool": "write_file", "arguments": proposal.arguments}
+    assert tool_call.rawInput is None
     assert len(tool_call.content) == 1
     diff = tool_call.content[0]
     assert diff.path == "demo.txt"

--- a/tests/acp/test_events.py
+++ b/tests/acp/test_events.py
@@ -11,6 +11,7 @@ import pytest
 import acp
 from acp.schema import AgentPlanUpdate, ToolCallStart, ToolCallProgress, AgentThoughtChunk, AgentMessageChunk
 
+from acp_adapter.output_policy import ACPOutputPolicy
 from acp_adapter.events import (
     _build_plan_update_from_todo_result,
     _send_update,
@@ -101,6 +102,28 @@ class TestToolProgressCallback:
             cb("tool.started", "terminal", "$ echo hi", None)
 
         assert "terminal" in tool_call_ids
+
+    def test_output_policy_getter_reaches_tool_start(self, mock_conn, event_loop_fixture):
+        tool_call_ids = {}
+        tool_call_meta = {}
+        loop = event_loop_fixture
+        policy = ACPOutputPolicy(detail="full")
+
+        with patch("acp_adapter.events.make_tool_call_id", return_value="tc-full-start"), \
+             patch("acp_adapter.events._send_update") as mock_send:
+            cb = make_tool_progress_cb(
+                mock_conn,
+                "session-1",
+                loop,
+                tool_call_ids,
+                tool_call_meta,
+                output_policy_getter=lambda: policy,
+            )
+            cb("tool.started", "skill_view", None, {"name": "github-pitfalls"})
+
+        update = mock_send.call_args.args[3]
+        assert isinstance(update, ToolCallStart)
+        assert update.raw_input is None
 
     def test_duplicate_same_name_tool_calls_use_fifo_ids(self, mock_conn, event_loop_fixture):
         """Multiple same-name tool calls should be tracked independently in order."""
@@ -232,7 +255,12 @@ class TestStepCallback:
             cb(1, [{"name": "terminal", "result": '{"output": "hello"}'}])
 
         mock_btc.assert_called_once_with(
-            "tc-xyz789", "terminal", result='{"output": "hello"}', function_args=None, snapshot=None
+            "tc-xyz789",
+            "terminal",
+            result='{"output": "hello"}',
+            function_args=None,
+            snapshot=None,
+            output_policy=None,
         )
 
     def test_none_result_passed_through(self, mock_conn, event_loop_fixture):
@@ -252,7 +280,9 @@ class TestStepCallback:
 
             cb(1, [{"name": "web_search", "result": None}])
 
-        mock_btc.assert_called_once_with("tc-aaa", "web_search", result=None, function_args=None, snapshot=None)
+        mock_btc.assert_called_once_with(
+            "tc-aaa", "web_search", result=None, function_args=None, snapshot=None, output_policy=None
+        )
 
     def test_step_callback_passes_arguments_and_snapshot(self, mock_conn, event_loop_fixture):
         from collections import deque
@@ -277,7 +307,38 @@ class TestStepCallback:
             result='{"bytes_written": 23}',
             function_args={"path": "diff-test.txt"},
             snapshot="snap",
+            output_policy=None,
         )
+
+    def test_output_policy_getter_reaches_tool_completion(self, mock_conn, event_loop_fixture):
+        from collections import deque
+
+        policy = ACPOutputPolicy(detail="full")
+        tool_call_ids = {"skill_view": deque(["tc-full-complete"])}
+        tool_call_meta = {"tc-full-complete": {"args": {"name": "github-pitfalls"}, "snapshot": None}}
+        loop = event_loop_fixture
+        cb = make_step_cb(
+            mock_conn,
+            "session-1",
+            loop,
+            tool_call_ids,
+            tool_call_meta,
+            output_policy_getter=lambda: policy,
+        )
+
+        with patch("acp_adapter.events._send_update") as mock_send, \
+             patch("acp_adapter.events.build_tool_complete") as mock_btc:
+            cb(1, [{"name": "skill_view", "result": '{"content":"full skill text"}'}])
+
+        mock_btc.assert_called_once_with(
+            "tc-full-complete",
+            "skill_view",
+            result='{"content":"full skill text"}',
+            function_args={"name": "github-pitfalls"},
+            snapshot=None,
+            output_policy=policy,
+        )
+        mock_send.assert_called_once()
 
     def test_tool_progress_captures_snapshot_metadata(self, mock_conn, event_loop_fixture):
         tool_call_ids = {}

--- a/tests/acp/test_mcp_e2e.py
+++ b/tests/acp/test_mcp_e2e.py
@@ -3,7 +3,7 @@
 Exercises the full flow through the ACP server layer:
   new_session(mcpServers) → MCP tools registered → prompt() →
     tool_progress_callback (ToolCallStart) →
-    step_callback with results (ToolCallUpdate with rawOutput) →
+    step_callback with results (ToolCallUpdate with human-readable content) →
     session_update events arrive at the mock client
 """
 
@@ -173,7 +173,7 @@ class TestMcpRegistrationE2E:
         assert isinstance(start_event, ToolCallStart)
         assert start_event.title.startswith("terminal:")
 
-        # Should have at least one ToolCallUpdate (completion) with rawOutput
+        # Should have at least one ToolCallUpdate (completion) with readable content.
         assert len(completions) >= 1, f"Expected ToolCallUpdate, got updates: {[getattr(u, 'session_update', '?') for u in updates]}"
         complete_event = completions[0]
         assert isinstance(complete_event, ToolCallProgress)

--- a/tests/acp/test_permissions.py
+++ b/tests/acp/test_permissions.py
@@ -81,10 +81,7 @@ class TestApprovalBridge:
         content_text = tool_call.content[0].content.text
         assert "$ rm -rf /" in content_text
         assert "dangerous command" in content_text
-        assert tool_call.raw_input == {
-            "command": "rm -rf /",
-            "description": "dangerous command",
-        }
+        assert tool_call.raw_input is None
         assert option_ids == [
             "allow_once",
             "allow_session",

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -70,6 +70,61 @@ async def test_new_session_exposes_edit_approvals_as_modes_not_config_options(ag
 
 
 @pytest.mark.asyncio
+async def test_new_session_can_advertise_output_detail_config_option(agent, monkeypatch):
+    monkeypatch.setattr(
+        HermesACPAgent,
+        "_load_config_for_output_policy",
+        staticmethod(lambda: {"acp": {"output": {"advertise_config_option": True}}}),
+    )
+
+    resp = await agent.new_session(cwd="/tmp")
+
+    assert resp.config_options is not None
+    assert len(resp.config_options) == 1
+    option = resp.config_options[0]
+    assert option.id == "acp_output_detail"
+    assert option.name == "Tool Output Detail"
+    assert option.current_value == "condensed"
+    assert [item.value for item in option.options] == ["condensed", "full"]
+
+
+@pytest.mark.asyncio
+async def test_set_config_option_returns_advertised_output_detail_state(agent, monkeypatch):
+    monkeypatch.setattr(
+        HermesACPAgent,
+        "_load_config_for_output_policy",
+        staticmethod(lambda: {"acp": {"output": {"advertise_config_option": True}}}),
+    )
+    resp = await agent.new_session(cwd="/tmp")
+
+    update = await agent.set_config_option("acp_output_detail", resp.session_id, "full")
+
+    assert isinstance(update, SetSessionConfigOptionResponse)
+    assert len(update.config_options) == 1
+    assert update.config_options[0].id == "acp_output_detail"
+    assert update.config_options[0].current_value == "full"
+
+
+@pytest.mark.asyncio
+async def test_load_resume_and_fork_include_advertised_output_detail(agent, monkeypatch):
+    monkeypatch.setattr(
+        HermesACPAgent,
+        "_load_config_for_output_policy",
+        staticmethod(lambda: {"acp": {"output": {"advertise_config_option": True}}}),
+    )
+    resp = await agent.new_session(cwd="/tmp")
+    await agent.set_config_option("acp_output_detail", resp.session_id, "full")
+
+    load_resp = await agent.load_session(cwd="/tmp", session_id=resp.session_id)
+    resume_resp = await agent.resume_session(cwd="/tmp", session_id=resp.session_id)
+    fork_resp = await agent.fork_session(cwd="/tmp", session_id=resp.session_id)
+
+    assert load_resp.config_options[0].current_value == "full"
+    assert resume_resp.config_options[0].current_value == "full"
+    assert fork_resp.config_options[0].current_value == "full"
+
+
+@pytest.mark.asyncio
 async def test_set_config_option_persists_edit_approval_policy_without_advertising_config(agent):
     resp = await agent.new_session(cwd="/tmp")
     update = await agent.set_config_option(
@@ -82,6 +137,106 @@ async def test_set_config_option_persists_edit_approval_policy_without_advertisi
     assert isinstance(update, SetSessionConfigOptionResponse)
     assert update.config_options == []
     assert getattr(state, "mode", None) == "accept_edits"
+
+
+@pytest.mark.asyncio
+async def test_set_config_option_persists_acp_output_detail_without_advertising_config(agent):
+    resp = await agent.new_session(cwd="/tmp")
+
+    update = await agent.set_config_option(
+        "acp_output_detail",
+        resp.session_id,
+        "full",
+    )
+    state = agent.session_manager.get_session(resp.session_id)
+
+    assert isinstance(update, SetSessionConfigOptionResponse)
+    assert update.config_options == []
+    assert getattr(state, "output_detail", None) == "full"
+
+
+@pytest.mark.asyncio
+async def test_set_config_option_ignores_raw_acp_output_detail(agent, monkeypatch):
+    monkeypatch.setenv("HERMES_ACP_OUTPUT_DETAIL", "full")
+    resp = await agent.new_session(cwd="/tmp")
+
+    update = await agent.set_config_option(
+        "acp_output_detail",
+        resp.session_id,
+        "raw",
+    )
+    state = agent.session_manager.get_session(resp.session_id)
+
+    assert isinstance(update, SetSessionConfigOptionResponse)
+    assert update.config_options == []
+    assert getattr(state, "output_detail", "") == ""
+    assert agent._output_policy_for_state(state).detail == "full"
+
+
+@pytest.mark.asyncio
+async def test_set_config_option_ignores_invalid_acp_output_detail(agent, monkeypatch):
+    monkeypatch.setenv("HERMES_ACP_OUTPUT_DETAIL", "full")
+    resp = await agent.new_session(cwd="/tmp")
+
+    update = await agent.set_config_option(
+        "acp_output_detail",
+        resp.session_id,
+        "bogus",
+    )
+    state = agent.session_manager.get_session(resp.session_id)
+
+    assert isinstance(update, SetSessionConfigOptionResponse)
+    assert update.config_options == []
+    assert getattr(state, "output_detail", "") == ""
+    assert agent._output_policy_for_state(state).detail == "full"
+
+
+@pytest.mark.asyncio
+async def test_load_session_replay_uses_session_output_policy(agent):
+    mock_conn = MagicMock(spec=acp.Client)
+    mock_conn.session_update = AsyncMock()
+    agent._conn = mock_conn
+
+    new_resp = await agent.new_session(cwd="/tmp")
+    await agent.set_config_option("acp_output_detail", new_resp.session_id, "full")
+    state = agent.session_manager.get_session(new_resp.session_id)
+    state.history = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_skill_1",
+                    "type": "function",
+                    "function": {
+                        "name": "skill_view",
+                        "arguments": '{"name":"github-pitfalls"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_skill_1",
+            "content": '{"success":true,"name":"github-pitfalls","content":"# GitHub Pitfalls\\nRaw replay body"}',
+        },
+    ]
+
+    mock_conn.session_update.reset_mock()
+    resp = await agent.load_session(cwd="/tmp", session_id=new_resp.session_id)
+
+    assert isinstance(resp, LoadSessionResponse)
+    tool_updates = [
+        call.kwargs["update"]
+        for call in mock_conn.session_update.await_args_list
+        if getattr(call.kwargs.get("update"), "session_update", None)
+        in {"tool_call", "tool_call_update"}
+    ]
+    assert isinstance(tool_updates[0], ToolCallStart)
+    assert tool_updates[0].raw_input is None
+    assert isinstance(tool_updates[1], ToolCallProgress)
+    assert tool_updates[1].raw_output is None
+    assert "Raw replay body" in tool_updates[1].content[0].content.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -289,6 +289,7 @@ class TestPersistence:
     def test_get_session_restores_from_db(self, manager):
         """Simulate process restart: create session, drop from memory, get again."""
         state = manager.create_session(cwd="/work")
+        state.output_detail = "full"
         state.history.append({"role": "user", "content": "hello"})
         state.history.append({"role": "assistant", "content": "hi there"})
         manager.save_session(state.session_id)
@@ -304,6 +305,7 @@ class TestPersistence:
         assert restored is not None
         assert restored.session_id == sid
         assert restored.cwd == "/work"
+        assert restored.output_detail == "full"
         assert len(restored.history) == 2
         assert restored.history[0]["content"] == "hello"
         assert restored.history[1]["content"] == "hi there"
@@ -414,6 +416,28 @@ class TestPersistence:
         assert len(forked.history) == 1
         assert forked.history[0]["content"] == "context"
         assert forked.session_id != original.session_id
+
+    def test_fork_session_persists_output_detail(self, manager):
+        original = manager.create_session(cwd="/base")
+        original.output_detail = "full"
+        manager.save_session(original.session_id)
+
+        forked = manager.fork_session(original.session_id, cwd="/fork")
+        assert forked is not None
+        assert forked.output_detail == "full"
+
+        db = manager._get_db()
+        row = db.get_session(forked.session_id)
+        mc = json.loads(row["model_config"])
+        assert mc["cwd"] == "/fork"
+        assert mc["acp_output_detail"] == "full"
+
+        with manager._lock:
+            del manager._sessions[forked.session_id]
+
+        restored = manager.get_session(forked.session_id)
+        assert restored is not None
+        assert restored.output_detail == "full"
 
     def test_update_cwd_restores_from_db(self, manager):
         state = manager.create_session(cwd="/old")

--- a/tests/acp/test_tools.py
+++ b/tests/acp/test_tools.py
@@ -1,8 +1,14 @@
 """Tests for acp_adapter.tools — tool kind mapping and ACP content building."""
 
+import json
+
 import pytest
 
 from acp_adapter.edit_approval import EditProposal
+from acp_adapter.output_policy import (
+    ACPOutputPolicy,
+    resolve_acp_output_policy,
+)
 from acp_adapter.tools import (
     TOOL_KIND_MAP,
     build_tool_complete,
@@ -266,6 +272,64 @@ class TestBuildToolStart:
         assert "print('hello')" in result.content[0].content.text
         assert result.raw_input is None
 
+    def test_build_tool_start_condensed_policy_truncates_large_previews(self):
+        code = "print('start')\n" + ("x" * 1500) + "\nprint('CONDENSED_SENTINEL')"
+
+        result = build_tool_start(
+            "tc-code-condensed",
+            "execute_code",
+            {"code": code},
+            output_policy=ACPOutputPolicy(detail="condensed"),
+        )
+
+        text = result.content[0].content.text
+        assert "truncated" in text
+        assert "CONDENSED_SENTINEL" not in text
+        assert result.raw_input is None
+
+    def test_build_tool_start_full_policy_keeps_large_previews(self):
+        long_code = "print('start')\n" + ("x" * 1500) + "\nprint('FULL_CODE_SENTINEL')"
+        process_input = ("y" * 700) + "FULL_PROCESS_SENTINEL"
+        delegate_goal = ("z" * 900) + "FULL_DELEGATE_SENTINEL"
+        memory_text = ("m" * 700) + "FULL_MEMORY_SENTINEL"
+        polished_payload = ("p" * 1500) + "FULL_POLISHED_SENTINEL"
+        policy = ACPOutputPolicy(detail="full")
+
+        code_start = build_tool_start("tc-code-full", "execute_code", {"code": long_code}, output_policy=policy)
+        process_start = build_tool_start("tc-process-full", "process", {"action": "submit", "data": process_input}, output_policy=policy)
+        delegate_start = build_tool_start("tc-delegate-full", "delegate_task", {"goal": delegate_goal}, output_policy=policy)
+        memory_start = build_tool_start("tc-memory-full", "memory", {"action": "add", "target": "memory", "content": memory_text}, output_policy=policy)
+        polished_start = build_tool_start("tc-polished-full", "browser_navigate", {"url": "https://example.com", "payload": polished_payload}, output_policy=policy)
+
+        assert "FULL_CODE_SENTINEL" in code_start.content[0].content.text
+        assert "FULL_PROCESS_SENTINEL" in process_start.content[0].content.text
+        assert "FULL_DELEGATE_SENTINEL" in delegate_start.content[0].content.text
+        assert "FULL_MEMORY_SENTINEL" in memory_start.content[0].content.text
+        assert "FULL_POLISHED_SENTINEL" in polished_start.content[0].content.text
+        assert all(
+            "truncated" not in event.content[0].content.text
+            for event in [code_start, process_start, delegate_start, memory_start, polished_start]
+        )
+
+    def test_build_tool_start_full_policy_keeps_all_preview_items(self):
+        policy = ACPOutputPolicy(detail="full")
+        todo_items = [
+            {"id": f"item-{i}", "content": f"Todo item {i}", "status": "pending"}
+            for i in range(12)
+        ]
+        delegate_tasks = [
+            {"goal": f"Delegate task {i}", "role": "leaf"}
+            for i in range(12)
+        ]
+
+        todo_start = build_tool_start("tc-todo-full", "todo", {"todos": todo_items}, output_policy=policy)
+        delegate_start = build_tool_start("tc-delegate-batch-full", "delegate_task", {"tasks": delegate_tasks}, output_policy=policy)
+
+        assert "Todo item 11" in todo_start.content[0].content.text
+        assert "Delegate task 11" in delegate_start.content[0].content.text
+        assert "more" not in todo_start.content[0].content.text
+        assert "more" not in delegate_start.content[0].content.text
+
     def test_build_tool_start_for_skill_manage_patch_shows_diff(self):
         result = build_tool_start(
             "tc-skill-manage",
@@ -292,6 +356,19 @@ class TestBuildToolStart:
         result = build_tool_start("tc-5", "some_tool", args)
         assert isinstance(result, ToolCallStart)
         assert result.kind == "other"
+        assert result.raw_input is None
+
+    def test_legacy_raw_output_detail_is_not_supported(self):
+        policy = resolve_acp_output_policy(
+            config={"acp": {"output": {"detail": "raw"}}},
+            env={
+                "HERMES_ACP_TOOL_OUTPUT_DETAIL": "raw",
+                "HERMES_ACP_RAW_OUTPUT": "true",
+                "HERMES_ACP_RAW_CHAR_LIMIT": "50",
+            },
+        )
+
+        assert policy.detail == "condensed"
 
 
 # ---------------------------------------------------------------------------
@@ -336,6 +413,87 @@ class TestBuildToolComplete:
         assert "GitHub Pitfalls" in text
         assert "Use gh carefully" not in text
         assert "Full skill content is available to the agent" in text
+        assert result.raw_output is None
+
+    def test_build_tool_complete_omits_plain_text_raw_output_by_default(self):
+        result = build_tool_complete(
+            "tc-plugin-plain",
+            "some_plugin_tool",
+            "plain plugin output that should stay out of raw fields",
+        )
+
+        assert "plain plugin output" in result.content[0].content.text
+        assert result.raw_output is None
+
+    def test_legacy_raw_output_env_does_not_populate_protocol_raw_fields(self):
+        policy = resolve_acp_output_policy(env={"HERMES_ACP_RAW_OUTPUT": "true"})
+        result = build_tool_complete(
+            "tc-plugin-legacy-raw-env",
+            "some_plugin_tool",
+            '{"ok": true, "content": "client visible only"}',
+            output_policy=policy,
+        )
+
+        assert policy.detail == "condensed"
+        assert result.raw_output is None
+
+    def test_build_tool_complete_full_policy_shows_full_skill_content(self):
+        result = build_tool_complete(
+            "tc-skill-full",
+            "skill_view",
+            json.dumps(
+                {
+                    "success": True,
+                    "name": "github-pitfalls",
+                    "description": "GitHub gotchas",
+                    "content": "# GitHub Pitfalls\nUse gh carefully.\nFULL UNIQUE LINE",
+                }
+            ),
+            output_policy=ACPOutputPolicy(detail="full"),
+        )
+
+        text = result.content[0].content.text
+        assert "FULL UNIQUE LINE" in text
+        assert "```markdown" in text
+        assert "Full skill content is available to the agent" not in text
+        assert result.raw_output is None
+
+    def test_build_tool_complete_full_policy_does_not_condense_large_read_file(self):
+        long_content = "1|" + ("x" * 6000)
+        result = build_tool_complete(
+            "tc-read-full",
+            "read_file",
+            json.dumps({"content": long_content, "total_lines": 1}),
+            function_args={"path": "README.md"},
+            output_policy=ACPOutputPolicy(detail="full"),
+        )
+
+        text = result.content[0].content.text
+        assert len(text) > 6000
+        assert "truncated" not in text
+
+    def test_build_tool_complete_full_policy_shows_successful_web_extract_content(self):
+        result = build_tool_complete(
+            "tc-web-extract-full",
+            "web_extract",
+            json.dumps(
+                {
+                    "results": [
+                        {
+                            "url": "https://example.com",
+                            "title": "Example",
+                            "content": "# Intro\nThis is extracted content.",
+                        }
+                    ]
+                }
+            ),
+            output_policy=ACPOutputPolicy(detail="full"),
+        )
+
+        text = result.content[0].content.text
+        assert "Web extract results" in text
+        assert "https://example.com" in text
+        assert "This is extracted content" in text
         assert result.raw_output is None
 
     def test_build_tool_complete_for_execute_code_formats_output(self):

--- a/tests/acp_adapter/test_acp_images.py
+++ b/tests/acp_adapter/test_acp_images.py
@@ -10,6 +10,7 @@ from acp.schema import (
     TextResourceContents,
 )
 
+from acp_adapter.output_policy import ACPOutputPolicy
 from acp_adapter.server import HermesACPAgent, _content_blocks_to_openai_user_content
 
 
@@ -59,6 +60,27 @@ def test_acp_resource_link_file_is_inlined_as_text(tmp_path):
     )
 
 
+def test_acp_resource_policy_controls_text_file_inline_cap(tmp_path):
+    attached = tmp_path / "large-notes.md"
+    attached.write_text("abcdef", encoding="utf-8")
+
+    content = _content_blocks_to_openai_user_content(
+        [
+            ResourceContentBlock(
+                type="resource_link",
+                name="large-notes.md",
+                uri=attached.as_uri(),
+                mimeType="text/markdown",
+            )
+        ],
+        output_policy=ACPOutputPolicy(detail="full", resource_max_bytes=3),
+    )
+
+    assert "abc" in content
+    assert "def" not in content
+    assert "truncated to 3 of 6 bytes" in content
+
+
 def test_acp_embedded_text_resource_is_inlined_as_text():
     content = _content_blocks_to_openai_user_content([
         EmbeddedResourceContentBlock(
@@ -76,6 +98,26 @@ def test_acp_embedded_text_resource_is_inlined_as_text():
         "URI: file:///workspace/todo.txt\n\n"
         "first\nsecond"
     )
+
+
+def test_acp_embedded_text_resource_respects_resource_cap():
+    content = _content_blocks_to_openai_user_content(
+        [
+            EmbeddedResourceContentBlock(
+                type="resource",
+                resource=TextResourceContents(
+                    uri="file:///workspace/todo.txt",
+                    mimeType="text/plain",
+                    text="abcdef",
+                ),
+            ),
+        ],
+        output_policy=ACPOutputPolicy(detail="full", resource_max_bytes=3),
+    )
+
+    assert "abc" in content
+    assert "def" not in content
+    assert "truncated to 3 of 6 bytes" in content
 
 
 @pytest.mark.asyncio
@@ -116,6 +158,28 @@ def test_acp_resource_link_image_file_is_inlined_as_image_url(tmp_path):
     assert content[2]["type"] == "image_url"
     expected_url = "data:image/png;base64," + base64.b64encode(_ONE_PX_PNG).decode("ascii")
     assert content[2]["image_url"]["url"] == expected_url
+
+
+def test_acp_resource_link_image_file_respects_resource_cap(tmp_path):
+    attached = tmp_path / "shot.png"
+    attached.write_bytes(_ONE_PX_PNG)
+
+    content = _content_blocks_to_openai_user_content(
+        [
+            ResourceContentBlock(
+                type="resource_link",
+                name="shot.png",
+                uri=attached.as_uri(),
+                mimeType="image/png",
+            )
+        ],
+        output_policy=ACPOutputPolicy(detail="full", resource_max_bytes=3),
+    )
+
+    assert isinstance(content, str)
+    assert "Image too large to inline" in content
+    assert "cap=3" in content
+    assert "data:image/png;base64" not in content
 
 
 def test_acp_resource_link_image_mime_inferred_from_suffix(tmp_path):

--- a/website/docs/developer-guide/acp-internals.md
+++ b/website/docs/developer-guide/acp-internals.md
@@ -111,6 +111,26 @@ Examples:
 - `read_file` / `search_files` -> text previews
 - large results -> truncated text blocks for UI safety
 
+### Output detail policy
+
+`acp_adapter/output_policy.py` resolves ACP-visible output detail independently from the model-facing tool result. The resolved `ACPOutputPolicy` is threaded through:
+
+- `build_tool_start()` and `build_tool_complete()` in `acp_adapter/tools.py`
+- live `make_tool_progress_cb()` and `make_step_cb()` in `acp_adapter/events.py`
+- history replay in `HermesACPAgent._replay_session_history()`
+- prompt resource conversion in `_content_blocks_to_openai_user_content()`
+- session persistence/restore/fork through `SessionState.output_detail`
+- optional advertised `SessionConfigOptionSelect` responses when `acp.output.advertise_config_option` is enabled
+
+Resolution order is session override, then environment, then `acp.output` config, then the built-in `condensed` default. This keeps existing editor UX compact unless the client explicitly asks for more detail.
+
+Mode semantics:
+
+- `condensed`: preserve polished summaries and existing default truncation/suppression. ACP raw fields are omitted by default.
+- `full`: expand all ACP-controlled visible tool-start and tool-completion content while still respecting resource/model safety caps. ACP raw fields remain omitted; this mode only changes transcript-visible content.
+
+Resource inlining has its own `resource_max_bytes` cap because it affects prompt payload size and binary/image validity, not just transcript readability. Full output detail does not remove binary omission or resource safety behavior, and it cannot reconstruct content already paged/truncated by a tool before the ACP adapter sees the result. Invalid session output-detail values are ignored rather than normalized to `condensed`, so a bad client value cannot silently downgrade an env/config default.
+
 ## Session lifecycle
 
 ```text

--- a/website/docs/user-guide/features/acp.md
+++ b/website/docs/user-guide/features/acp.md
@@ -190,6 +190,38 @@ ACP mode uses the same Hermes configuration as the CLI:
 
 Provider resolution uses Hermes' normal runtime resolver, so ACP inherits the currently configured provider and credentials. Hermes also advertises a terminal auth method (`--setup`) for first-run registry clients; this opens Hermes' interactive model/provider setup.
 
+### Tool output detail
+
+ACP tool output is **condensed by default**. Hermes keeps the editor transcript readable by showing polished summaries for large/noisy tools such as `skill_view`, `read_file`, `web_extract`, `process`, browser snapshots, and structured JSON results.
+
+Clients or users can opt into more visible transcript detail with ACP output detail modes:
+
+| Mode | Visible transcript content | ACP raw fields |
+|---|---|---|
+| `condensed` | Polished summaries and existing truncation/default compact behavior | Raw fields stay omitted by default |
+| `full` | Full ACP-controlled visible content for tool starts/completions, including full `skill_view`, `web_extract`, tool-input previews, and JSON/text results returned by tools | Raw fields stay omitted |
+
+Global default in `~/.hermes/config.yaml`:
+
+```yaml
+acp:
+  output:
+    detail: condensed        # condensed | full
+    resource_max_bytes: 524288
+    advertise_config_option: false  # true lets ACP clients discover a Tool Output Detail picker
+```
+
+Environment overrides are useful for debugging or CI:
+
+```bash
+HERMES_ACP_TOOL_OUTPUT_DETAIL=full hermes acp
+HERMES_ACP_RESOURCE_MAX_BYTES=1048576 hermes acp
+```
+
+ACP clients can also set the mode per session with `session/set_config_option` using `acp_output_detail`, `tool_output_detail`, `acp_tool_output_detail`, or `output_detail` and a value of `condensed` or `full`. Session-scoped choices override env/config defaults and are persisted with ACP session metadata for replay/load/fork; invalid values are ignored so they do not silently downgrade an env/config default.
+
+`resource_max_bytes` controls ACP prompt resource/attachment inlining and is intentionally separate from tool transcript detail. It keeps binary/image and very large resource payloads bounded even when visible tool output is `full`; `full` also cannot recover data that an underlying tool already paged or truncated before returning it.
+
 ## Session behavior
 
 ACP sessions are tracked by the ACP adapter's in-memory session manager while the server is running.


### PR DESCRIPTION
## What does this PR do?

Adds an ACP output policy for editor/client-visible tool transcript detail, with the existing compact presentation preserved as the default.

The issue shows up most visibly with `skill_view`, but the same truncation/preview behavior exists across multiple ACP-polished tool surfaces. This implements the fix at the ACP adapter policy layer instead of special-casing one tool:

- `condensed` remains the default polished transcript mode.
- `full` opts into expanded ACP-visible tool start and result content wherever the adapter controls formatting.
- ACP resource/prompt-attachment safety caps remain separate and still apply.
- Raw/debug ACP protocol fields stay out of the user-facing approval surface.

## Related Issue

Fixes #30557

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Added `acp_adapter/output_policy.py` to resolve ACP output detail from config, environment, and session config, with supported user-facing modes limited to `condensed` and `full`.
- Wired output policy through the ACP server/session/event paths so clients can opt into `full` while invalid or legacy values are ignored instead of downgrading safer defaults.
- Applied the policy across ACP-visible tool formatting in `acp_adapter/tools.py`, including `skill_view`, structured tool argument/result previews, tool-start summaries, list caps, `todo`, `delegate_task`, `execute_code`, `process`, `memory`, and web/delegation result summaries.
- Kept `resource_max_bytes` independent from transcript detail so binary/image/resource safety behavior remains bounded even in `full` mode.
- Removed raw protocol payload exposure from permission/edit approval pseudo-tool calls so approvals show the polished visible surface rather than raw inputs.
- Added config defaults/example coverage in `hermes_cli/config.py` and `cli-config.yaml.example`.
- Updated ACP user and developer docs to explain `condensed` vs `full`, session/client opt-in, environment overrides, and the remaining upstream/resource truncation caveats.
- Added/updated ACP tests for policy resolution, session persistence, advertised config options, condensed/full tool formatting differences, resource caps, and raw-field omission in approval surfaces.

## How to Test

1. Start Hermes ACP with default config and verify ACP tool transcripts remain condensed/polished.
2. Start Hermes ACP with either config or environment opt-in, for example:
   ```bash
   HERMES_ACP_TOOL_OUTPUT_DETAIL=full hermes acp
   ```
3. In an ACP client, run tools with long visible output such as `skill_view`, `read_file`, `todo`, or delegated/tool-result summaries and verify `full` expands the ACP-visible content while `condensed` keeps summaries compact.
4. Trigger terminal/edit approval flows and verify approval cards do not include raw protocol input payloads.

Validated locally:

- [x] `./scripts/run_tests.sh tests/acp tests/acp_adapter` — 315 tests passed
- [x] `git diff --check origin/main...HEAD`
- [x] `python scripts/check-windows-footguns.py --diff origin/main` — no Windows footguns found
- [x] `python -m hermes_cli.main acp --check` — `Hermes ACP check OK`
- [x] Parsed `cli-config.yaml.example` with PyYAML after adding the ACP example section

Manual interactive editor/client smoke test was not run.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant project-standard ACP test suite with `scripts/run_tests.sh`
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux / Arch

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/features/acp.md`, `website/docs/developer-guide/acp-internals.md`)
- [x] I've updated `cli-config.yaml.example` for the new ACP output config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` updates are N/A; this does not change contribution workflow or agent architecture guidance
- [x] I've considered cross-platform impact and ran the Windows footgun checker
- [x] Tool descriptions/schemas are N/A; this changes ACP adapter presentation, not model-facing tool schemas

## Screenshots / Logs

N/A — no visual UI screenshot. Test and smoke-check output is summarized above.
