### PR TITLE
fix(vision): add Gemini 2.5+ and 2.0+ to _supports_media_in_tool_results allowlist (#30704)

### DIFF
--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -52,8 +52,15 @@ class TestSupportsMediaInToolResults:
     def test_gemini_3_yes(self):
         assert _supports_media_in_tool_results("google", "gemini-3-flash-preview") is True
 
-    def test_gemini_2_no(self):
-        assert _supports_media_in_tool_results("google", "gemini-2.5-pro") is False
+    def test_gemini_2_5_yes(self):
+        assert _supports_media_in_tool_results("google", "gemini-2.5-pro") is True
+
+    def test_gemini_2_0_yes(self):
+        assert _supports_media_in_tool_results("google", "gemini-2.0-flash") is True
+
+    def test_gemini_older_no(self):
+        # Pre-2.0 Gemini does NOT support multimodal tool results
+        assert _supports_media_in_tool_results("google", "gemini-1.5-pro") is False
 
     def test_unknown_provider_conservative_no(self):
         assert _supports_media_in_tool_results("brand-new-provider", "any-model") is False

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -429,7 +429,7 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
         ``image_url`` parts.
       * OpenAI Responses (``openai-codex``): ``function_call_output.output``
         accepts an array of ``input_text``/``input_image`` items.
-      * Gemini 3 (and proxied via aggregators): supports multimodal tool
+      * Gemini 2.0+ and 3.x (and proxied via aggregators): supports multimodal tool
         results. Older Gemini does NOT.
 
     For unknown / legacy providers we conservatively return False — the
@@ -467,6 +467,10 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
             return False
         m = model.strip().lower()
         if "gemini-3" in m or "gemini-pro-3" in m or "gemini-flash-3" in m:
+            return True
+        # Gemini 2.5+ and 2.0+ also support multimodal tool results via the
+        # OpenAI-compatible endpoint. Verified May-2026 with gemini-2.5-flash.
+        if "gemini-2.5" in m or "gemini-2.0" in m:
             return True
         return False
 


### PR DESCRIPTION
## Summary

Fixes #30704 — Gemini 2.5+ and 2.0+ models support multimodal tool results via the OpenAI-compatible endpoint, but `_supports_media_in_tool_results()` in `tools/vision_tools.py` only returned `True` for Gemini 3.x models. This caused `vision_analyze` to use the legacy aux-LLM text path for Gemini 2.5/2.0, even though they support native vision input.

## Root Cause

The model-name check (lines 465–471) only matched `gemini-3`, `gemini-pro-3`, and `gemini-flash-3` patterns. Gemini 2.5-flash and 2.0-flash were falling through to `return False`.

## Fix

Add `gemini-2.5` and `gemini-2.0` model name pattern checks alongside the existing `gemini-3` check. Pre-2.0 Gemini (e.g. `gemini-1.5-pro`) still returns `False`.

## Changes

| File | Change |
|------|--------|
| `tools/vision_tools.py` | Add `gemini-2.5` and `gemini-2.0` to allowlist; update docstring |
| `tests/tools/test_vision_native_fast_path.py` | Replace `test_gemini_2_no` with `test_gemini_2_5_yes` + `test_gemini_2_0_yes`; add `test_gemini_older_no` |

## Test Results

\`\`\`
python3 -m pytest tests/tools/test_vision_native_fast_path.py -v -o "addopts=" --tb=short
20 passed in 1.20s
\`\`\`

## Verification

- ✅ Gemini 3.x still returns True (no regression)
- ✅ Gemini 2.5-pro now returns True (was False)
- ✅ Gemini 2.0-flash now returns True (was False)  
- ✅ Gemini 1.5-pro still returns False (pre-2.0 excluded)
- ✅ All other providers unchanged