### PR TITLE
fix(docker): keep dashboard side-process loopback by default

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -111,7 +111,7 @@ fi
 #
 # Toggled by HERMES_DASHBOARD=1 (also accepts "true"/"yes", case-insensitive).
 # Host/port/TUI can be overridden via:
-#   HERMES_DASHBOARD_HOST  (default 0.0.0.0 — exposed outside the container)
+#   HERMES_DASHBOARD_HOST  (default 127.0.0.1 — loopback only)
 #   HERMES_DASHBOARD_PORT  (default 9119, matches `hermes dashboard` default)
 #   HERMES_DASHBOARD_TUI   (already honored by `hermes dashboard` itself)
 #
@@ -122,16 +122,9 @@ fi
 # cleanup is needed.
 case "${HERMES_DASHBOARD:-}" in
     1|true|TRUE|True|yes|YES|Yes)
-        dash_host="${HERMES_DASHBOARD_HOST:-0.0.0.0}"
+        dash_host="${HERMES_DASHBOARD_HOST:-127.0.0.1}"
         dash_port="${HERMES_DASHBOARD_PORT:-9119}"
         dash_args=(--host "$dash_host" --port "$dash_port" --no-open)
-        # Binding to anything other than localhost requires --insecure — the
-        # dashboard refuses otherwise because it exposes API keys.  Inside a
-        # container this is the expected deployment (host reaches it via
-        # published port), so opt in automatically.
-        if [ "$dash_host" != "127.0.0.1" ] && [ "$dash_host" != "localhost" ]; then
-            dash_args+=(--insecure)
-        fi
         echo "Starting hermes dashboard on ${dash_host}:${dash_port} (background)"
         # Prefix dashboard output so it's distinguishable from the main
         # process in `docker logs`.  stdbuf keeps the pipe line-buffered.

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -60,7 +60,7 @@ Opening any port on an internet facing machine is a security risk. You should no
 
 ## Running the dashboard
 
-The built-in web dashboard runs as an optional side-process inside the same container as the gateway. Set `HERMES_DASHBOARD=1` and expose port `9119` alongside the gateway's `8642`:
+The built-in web dashboard runs as an optional side-process inside the same container as the gateway. Set `HERMES_DASHBOARD=1` to run the dashboard on container loopback (`127.0.0.1`) by default:
 
 ```sh
 docker run -d \
@@ -68,7 +68,6 @@ docker run -d \
   --restart unless-stopped \
   -v ~/.hermes:/opt/data \
   -p 8642:8642 \
-  -p 9119:9119 \
   -e HERMES_DASHBOARD=1 \
   nousresearch/hermes-agent gateway run
 ```
@@ -78,11 +77,11 @@ The entrypoint starts `hermes dashboard` in the background (running as the non-r
 | Environment variable | Description | Default |
 |---------------------|-------------|---------|
 | `HERMES_DASHBOARD` | Set to `1` (or `true` / `yes`) to launch the dashboard alongside the main command | *(unset — dashboard not started)* |
-| `HERMES_DASHBOARD_HOST` | Bind address for the dashboard HTTP server | `0.0.0.0` |
+| `HERMES_DASHBOARD_HOST` | Bind address for the dashboard HTTP server | `127.0.0.1` |
 | `HERMES_DASHBOARD_PORT` | Port for the dashboard HTTP server | `9119` |
 | `HERMES_DASHBOARD_TUI` | Set to `1` to expose the in-browser Chat tab (embedded `hermes --tui` via PTY/WebSocket) | *(unset)* |
 
-The default `HERMES_DASHBOARD_HOST=0.0.0.0` is required for the host to reach the dashboard through the published port; the entrypoint automatically passes `--insecure` to `hermes dashboard` in that case. Override to `127.0.0.1` if you want to restrict the dashboard to in-container access only (e.g. behind a reverse proxy in a sidecar).
+By default, the dashboard stays on loopback to avoid exposing the unauthenticated web surface over the network. To publish it intentionally, set `HERMES_DASHBOARD_HOST=0.0.0.0` and configure your own trusted network boundary/reverse proxy. In that case you must explicitly add `--insecure` behavior by passing host/flags in your command path (the entrypoint no longer auto-enables insecure mode).
 
 :::note
 The dashboard side-process is **not supervised** — if it crashes, it stays down until the container restarts. Running it as a separate container is not supported: the dashboard's gateway-liveness detection requires a shared PID namespace with the gateway process.


### PR DESCRIPTION
### Motivation
- Prevent accidental network exposure of the unauthenticated dashboard (and the injected SPA session token) when `HERMES_DASHBOARD=1` is used in containers by restoring a loopback-only default and removing entrypoint auto-enabling of `--insecure`.

### Description
- Change the dashboard side-process default bind host from `0.0.0.0` to `127.0.0.1` in `docker/entrypoint.sh` so the side-process listens on loopback by default. 
- Remove the entrypoint logic that automatically appended `--insecure` for non-loopback binds so publishing the dashboard now requires an explicit user decision. 
- Update `website/docs/user-guide/docker.md` to reflect the loopback-default behavior, remove the default `-p 9119:9119` example, and document that publishing the dashboard is an explicit, advanced action.

### Testing
- Performed a shell syntax check with `bash -n docker/entrypoint.sh` which succeeded. 
- Verified the intended diffs with `git diff -- docker/entrypoint.sh website/docs/user-guide/docker.md` and committed the changes as `fix(docker): keep dashboard side-process loopback by default`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f6386cc948325a31188407808ea61)