### PR TITLE
fix(security): restrict dashboard websockets to loopback clients

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3293,19 +3293,11 @@ _VALID_CHANNEL_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost", "testclient"})
 
 
-def _is_public_bind() -> bool:
-    """True when bound to all-interfaces (operator used --insecure)."""
-    return getattr(app.state, "bound_host", "") in {"0.0.0.0", "::"}
-
-
 def _ws_client_is_allowed(ws: "WebSocket") -> bool:
     """Check if the WebSocket client IP is acceptable.
 
-    Allows loopback always; allows any IP when bound to all-interfaces
-    (--insecure mode, guarded by session token auth).
+    Allows loopback clients only.
     """
-    if _is_public_bind():
-        return True
     client_host = ws.client.host if ws.client else ""
     if not client_host:
         return True


### PR DESCRIPTION
### Motivation
- Close an RCE attack path where an attacker reachable on a public bind could fetch the injected dashboard session token from the unauthenticated SPA and use it to open a `/api/ws` WebSocket and invoke JSON-RPC methods.
- Reintroduce a conservative admission policy for dashboard WebSockets so token disclosure in the HTML cannot be used by remote peers to reach the TUI control plane.

### Description
- Enforce loopback-only WebSocket admission by updating `_ws_client_is_allowed()` in `hermes_cli/web_server.py` to accept only loopback peers (`127.0.0.1`, `::1`, `localhost`, `testclient`).
- Remove the public-bind bypass that previously returned `True` when `app.state.bound_host` was `0.0.0.0`/`::` so binding publicly no longer grants blanket WS access.
- Preserve existing session token checks on WebSocket endpoints so the token validation remains intact.

### Testing
- Compiled the modified file with `python -m py_compile hermes_cli/web_server.py`, which succeeded.
- Attempted to run `python -m pytest tests/test_dashboard_web_server.py -q` but `pytest` is not available in the current environment, so the test run was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f654011b08325a086b5abb72f4489)