### PR TITLE
fix(gateway): remove Discord role allowlist blanket authorization

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6214,18 +6214,6 @@ class GatewayRunner:
             if allow_bots_var and os.getenv(allow_bots_var, "none").lower().strip() in {"mentions", "all"}:
                 return True
 
-        # Discord role-based access (DISCORD_ALLOWED_ROLES): the adapter's
-        # on_message pre-filter already verified role membership — if the
-        # message reached here, the user passed that check. Authorize
-        # directly to avoid the "no allowlists configured" branch below
-        # rejecting role-only setups where DISCORD_ALLOWED_USERS is empty
-        # (issue #7871).
-        if (
-            source.platform == Platform.DISCORD
-            and os.getenv("DISCORD_ALLOWED_ROLES", "").strip()
-        ):
-            return True
-
         # Check pairing store (always checked, regardless of allowlists)
         platform_name = source.platform.value if source.platform else ""
         if self.pairing_store.is_approved(platform_name, user_id):


### PR DESCRIPTION
### Motivation
- Close an authorization bypass where `GatewayRunner._is_user_authorized` returned `True` for any Discord event whenever `DISCORD_ALLOWED_ROLES` was non-empty, which allowed slash commands and synthetic voice events to bypass role checks.
- Preserve the intended policy that Discord authorization decisions are made per-event by the adapter (`_is_allowed_user`, slash authorization, and component view checks) and by the existing gateway allowlist logic.

### Description
- Remove the Discord-specific shortcut in `GatewayRunner._is_user_authorized` that unconditionally returned `True` when `DISCORD_ALLOWED_ROLES` was set, restoring the normal authorization flow to reach adapter/slash/component checks.
- Make no other behavioral changes to existing allowlist/allow-all flags, pairing checks, or per-platform env var logic; this is a deletion-only, minimal fix in `gateway/run.py`.

### Testing
- Searched the codebase for related symbols with `rg` to confirm adapter-side checks and UI component gating were already present and to locate affected call sites (`DISCORD_ALLOWED_ROLES`, `ExecApprovalView`, `_is_user_authorized`).
- Attempted to run the targeted test `tests/gateway/test_discord_roles_dm_scope.py` with `pytest`, but automated test execution in this environment failed due to missing test dependencies/plugins (`pytest-timeout` addopts) and missing `pyyaml`, so tests could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a101d57d3588325ac46969083099d75)