### PR TITLE
fix(gateway): stop enabling dingtalk allow-all during setup

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4018,15 +4018,11 @@ def _setup_dingtalk():
         client_id, client_secret = result
         save_env_value("DINGTALK_CLIENT_ID", client_id)
         save_env_value("DINGTALK_CLIENT_SECRET", client_secret)
-        save_env_value("DINGTALK_ALLOW_ALL_USERS", "true")
         print()
         print_success(f"{emoji} {label} configured via QR scan!")
     else:
         # ── Manual entry ──
         _setup_standard_platform(dingtalk_platform)
-        # Also enable allow-all by default for convenience
-        if get_env_value("DINGTALK_CLIENT_ID"):
-            save_env_value("DINGTALK_ALLOW_ALL_USERS", "true")
 
 
 def _setup_wecom():


### PR DESCRIPTION
### Motivation
- A recent change to the DingTalk setup flow unconditionally wrote `DINGTALK_ALLOW_ALL_USERS=true` after QR or manual credential setup, which effectively authorizes every DingTalk sender and bypasses pairing/allowlist protections.
- This patch restores a deny-by-default posture so operators must explicitly opt in to open access rather than the setup silently enabling it.

### Description
- Remove the unconditional `save_env_value("DINGTALK_ALLOW_ALL_USERS", "true")` call from the DingTalk QR-code setup path in `hermes_cli/gateway.py`.
- Remove the manual-setup post-step that auto-enabled `DINGTALK_ALLOW_ALL_USERS` after standard credential entry in `hermes_cli/gateway.py`.
- Preserve all other credential-saving behavior (`DINGTALK_CLIENT_ID` / `DINGTALK_CLIENT_SECRET`) and do not change gateway authorization logic so existing allowlist/pairing checks remain in effect.

### Testing
- `python -m py_compile hermes_cli/gateway.py` was run and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a101e7394888325b1b273fb44d9f7f1)