### PR TITLE
security: restrict default webhook toolset capabilities

### DIFF
--- a/toolsets.py
+++ b/toolsets.py
@@ -72,6 +72,16 @@ _HERMES_CORE_TOOLS = [
     "computer_use",
 ]
 
+# Webhook events may originate from untrusted third-party content (for example,
+# public PR titles/comments). Keep the default webhook toolset intentionally
+# constrained to avoid local file/system execution by prompt injection.
+_HERMES_WEBHOOK_SAFE_TOOLS = [
+    "web_search",
+    "web_extract",
+    "vision_analyze",
+    "clarify",
+]
+
 
 # Core toolset definitions
 # These can include individual tools or reference other toolsets
@@ -523,7 +533,7 @@ TOOLSETS = {
 
     "hermes-webhook": {
         "description": "Webhook toolset - receive and process external webhook events",
-        "tools": _HERMES_CORE_TOOLS,
+        "tools": _HERMES_WEBHOOK_SAFE_TOOLS,
         "includes": []
     },
 


### PR DESCRIPTION
### Motivation
- Webhook-originated messages are authenticated by route HMAC but can contain attacker-controlled fields (e.g., public PR titles/comments) that should not receive full local/system capabilities by default.
- The previous `hermes-webhook` mapping exposed `_HERMES_CORE_TOOLS`, including terminal/file/execute/cron tools, increasing prompt-injection blast radius when handling externally-sourced webhook payloads.

### Description
- Introduce a constrained default set `_HERMES_WEBHOOK_SAFE_TOOLS` containing only `web_search`, `web_extract`, `vision_analyze`, and `clarify` for webhook-originated sessions.
- Wire the `hermes-webhook` toolset to use `_HERMES_WEBHOOK_SAFE_TOOLS` instead of `_HERMES_CORE_TOOLS` to apply least-privilege defaults for webhooks.
- This is a minimal hardening that preserves webhook delivery and enrichment while removing default access to high-risk local capabilities; operators can explicitly opt into broader toolsets via configuration.

### Testing
- Ran a local validation using `python - <<'PY'` to resolve `hermes-webhook` and asserted that `terminal`, `read_file`, `execute_code`, and `cronjob` are not present, and the check passed.
- No other automated test suites were run as part of this change; the update is intentionally minimal to avoid behavioral regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10915c3cfc8325b6cad8398cbfb937)