### PR TITLE
fix(feishu): require webhook auth secret and honor config extras

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1514,8 +1514,10 @@ class FeishuAdapter(BasePlatformAdapter):
             connection_mode=str(
                 extra.get("connection_mode") or os.getenv("FEISHU_CONNECTION_MODE", "websocket")
             ).strip().lower(),
-            encrypt_key=os.getenv("FEISHU_ENCRYPT_KEY", "").strip(),
-            verification_token=os.getenv("FEISHU_VERIFICATION_TOKEN", "").strip(),
+            encrypt_key=str(extra.get("encrypt_key") or os.getenv("FEISHU_ENCRYPT_KEY", "")).strip(),
+            verification_token=str(
+                extra.get("verification_token") or os.getenv("FEISHU_VERIFICATION_TOKEN", "")
+            ).strip(),
             group_policy=os.getenv("FEISHU_GROUP_POLICY", "allowlist").strip().lower(),
             allowed_group_users=frozenset(
                 item.strip()
@@ -1640,6 +1642,11 @@ class FeishuAdapter(BasePlatformAdapter):
             logger.error(
                 "[Feishu] Unsupported FEISHU_CONNECTION_MODE=%s. Supported modes: websocket, webhook.",
                 self._connection_mode,
+            )
+            return False
+        if self._connection_mode == "webhook" and not (self._verification_token or self._encrypt_key):
+            logger.error(
+                "[Feishu] Webhook mode requires FEISHU_VERIFICATION_TOKEN or FEISHU_ENCRYPT_KEY."
             )
             return False
 

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -3192,6 +3192,39 @@ class TestWebhookSecurity(unittest.TestCase):
         self.assertEqual(response.status, 401)
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_webhook_connect_requires_inbound_auth_secret(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(
+            PlatformConfig(
+                enabled=True,
+                extra={"app_id": "cli_app", "app_secret": "secret_app", "connection_mode": "webhook"},
+            )
+        )
+        self.assertFalse(asyncio.run(adapter.connect()))
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_webhook_loads_auth_secrets_from_platform_extra(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(
+            PlatformConfig(
+                enabled=True,
+                extra={
+                    "app_id": "cli_app",
+                    "app_secret": "secret_app",
+                    "connection_mode": "webhook",
+                    "verification_token": "token_from_extra",
+                    "encrypt_key": "encrypt_from_extra",
+                },
+            )
+        )
+        self.assertEqual(adapter._verification_token, "token_from_extra")
+        self.assertEqual(adapter._encrypt_key, "encrypt_from_extra")
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_webhook_url_verification_challenge_passes_without_signature(self):
         """Challenge requests must succeed even when no encrypt_key is set."""
         from gateway.config import PlatformConfig


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated Feishu webhook events from being accepted and routed into the gateway, which allowed attacker-controlled payloads to impersonate allowlisted or paired users.
- The adapter previously read `encrypt_key` / `verification_token` only from environment variables and ignored `PlatformConfig.extra`, causing config-provided webhook secrets to be ineffective.
- Webhook mode could start with neither inbound auth mechanism configured, leaving the endpoint fail-open.

### Description
- Read `encrypt_key` and `verification_token` from `PlatformConfig.extra` (with the existing environment-variable fallback) so YAML-configured secrets are honored (`gateway/platforms/feishu.py`).
- Add a fail-closed guard in `FeishuAdapter.connect()` that refuses to start in `webhook` mode unless at least one inbound auth mechanism (`verification_token` or `encrypt_key`) is configured (`gateway/platforms/feishu.py`).
- Add two regression tests to cover the regression: `test_webhook_connect_requires_inbound_auth_secret` and `test_webhook_loads_auth_secrets_from_platform_extra` (`tests/gateway/test_feishu.py`).

### Testing
- Attempted to run the new/targeted Feishu webhook tests with `pytest` in this environment, but collection/execution failed due to local environment constraints: the repository `addopts` requires a pytest timeout plugin and the venv lacks `PyYAML` (`ModuleNotFoundError: No module named 'yaml'`), so tests could not be executed here.
- The new tests are present in `tests/gateway/test_feishu.py` and assert that `connect()` refuses webhook-mode startup without auth secrets and that secrets provided via `PlatformConfig.extra` populate the adapter fields; these should pass in CI once dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10a38e51148325ad01d5e63ae21f09)