### PR TITLE
fix(cli): quote env values only when needed

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4807,6 +4807,26 @@ def _check_non_ascii_credential(key: str, value: str) -> str:
     return sanitized
 
 
+_ENV_VALUE_SAFE_RE = re.compile(r"^[A-Za-z0-9_./:@%+=,\-]*$")
+
+
+def _format_env_assignment_value(value: str) -> str:
+    """Return a .env-safe representation for ``value``.
+
+    Keep the historical unquoted format for simple values so existing config
+    files and tests stay stable. Quote only when a value contains characters
+    that .env parsers can treat specially (notably ``#`` comments or
+    whitespace). Prefer single quotes because python-dotenv preserves ``${...}``
+    literally inside them.
+    """
+    if _ENV_VALUE_SAFE_RE.match(value):
+        return value
+    if "'" not in value:
+        return f"'{value}'"
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
 def save_env_value(key: str, value: str):
     """Save or update a value in ~/.hermes/.env."""
     if is_managed():
@@ -4832,9 +4852,9 @@ def save_env_value(key: str, value: str):
         # Sanitize on every read: split concatenated keys, drop stale placeholders
         lines = _sanitize_env_lines(lines)
 
-    # Quote the value so that special characters (#, $, etc.) are not
-    # interpreted by python-dotenv or shell-based .env loaders.
-    _line = f'{key}="{value}"\n'
+    # Quote only when needed so special characters such as # are preserved by
+    # python-dotenv while simple historical KEY=value output remains stable.
+    _line = f"{key}={_format_env_assignment_value(value)}\n"
 
     # Find and update or append
     found = False

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4832,11 +4832,15 @@ def save_env_value(key: str, value: str):
         # Sanitize on every read: split concatenated keys, drop stale placeholders
         lines = _sanitize_env_lines(lines)
 
+    # Quote the value so that special characters (#, $, etc.) are not
+    # interpreted by python-dotenv or shell-based .env loaders.
+    _line = f'{key}="{value}"\n'
+
     # Find and update or append
     found = False
     for i, line in enumerate(lines):
         if line.strip().startswith(f"{key}="):
-            lines[i] = f"{key}={value}\n"
+            lines[i] = _line
             found = True
             break
 
@@ -4844,7 +4848,7 @@ def save_env_value(key: str, value: str):
         # Ensure there's a newline at the end of the file before appending
         if lines and not lines[-1].endswith("\n"):
             lines[-1] += "\n"
-        lines.append(f"{key}={value}\n")
+        lines.append(_line)
     
     fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix='.tmp', prefix='.env_')
     # Preserve original permissions so Docker volume mounts aren't clobbered.

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -214,8 +214,18 @@ class TestSaveEnvValueSecure:
     def test_save_env_value_updates_process_environment(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}, clear=False):
             os.environ.pop("TENOR_API_KEY", None)
-            save_env_value("TENOR_API_KEY", "sk-test-secret")
-            assert os.environ["TENOR_API_KEY"] == "sk-test-secret"
+            save_env_value("TENOR_API_KEY", "***")
+            assert os.environ["TENOR_API_KEY"] == "***"
+
+    def test_save_env_value_quotes_hash_values_only_when_needed(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}, clear=False):
+            os.environ.pop("TENOR_API_KEY", None)
+            save_env_value("TENOR_API_KEY", "abc#def")
+
+            env_content = (tmp_path / ".env").read_text(encoding="utf-8")
+            assert "TENOR_API_KEY='abc#def'" in env_content
+            assert load_env()["TENOR_API_KEY"] == "abc#def"
+            assert os.environ["TENOR_API_KEY"] == "abc#def"
 
     def test_save_env_value_hardens_file_permissions_on_posix(self, tmp_path):
         if os.name == "nt":


### PR DESCRIPTION
## Summary\n- Supersedes/repairs #30724 by preserving simple KEY=value writes while quoting values that need protection, such as values containing # or whitespace.\n- Adds regression coverage for # characters in .env values.\n\n## Test Plan\n- python -m pytest tests/hermes_cli/test_config.py tests/hermes_cli/test_set_config_value.py\n- python -m pytest tests/gateway/test_teams.py tests/hermes_cli/test_spotify_auth.py\n- python -m ruff check hermes_cli/config.py tests/hermes_cli/test_config.py\n- git diff --check\n\nNotes: I could not push directly to the original contributor branch (#30724) because this checkout has read-only permission on NousResearch/hermes-agent.