### PR TITLE
chore(release): map Linux2010 github email

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -464,6 +464,7 @@ AUTHOR_MAP = {
     "xiewenxuan462@gmail.com": "yule975",
     "yiweimeng.dlut@hotmail.com": "meng93",
     "hakanerten02@hotmail.com": "teyrebaz33",
+    "linux2010@github.com": "Linux2010",
     "linux2010@users.noreply.github.com": "Linux2010",
     "elmatadorgh@users.noreply.github.com": "elmatadorgh",
     "coktinbaran5@gmail.com": "elmatadorgh",

--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -52,8 +52,16 @@ class TestSupportsMediaInToolResults:
     def test_gemini_3_yes(self):
         assert _supports_media_in_tool_results("google", "gemini-3-flash-preview") is True
 
-    def test_gemini_2_no(self):
-        assert _supports_media_in_tool_results("google", "gemini-2.5-pro") is False
+    def test_gemini_2_5_yes(self):
+        assert _supports_media_in_tool_results("google", "gemini-2.5-pro") is True
+
+    def test_gemini_2_0_yes(self):
+        assert _supports_media_in_tool_results("google", "gemini-2.0-flash") is True
+
+    def test_gemini_old_no(self):
+        # Pre-2.0 Gemini variants do not support multimodal tool results
+        assert _supports_media_in_tool_results("google", "gemini-1.5-pro") is False
+        assert _supports_media_in_tool_results("google", "gemini-pro") is False
 
     def test_unknown_provider_conservative_no(self):
         assert _supports_media_in_tool_results("brand-new-provider", "any-model") is False

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -461,12 +461,16 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
         return True
 
     # Gemini — gate on model name; older Gemini variants did not support
-    # multimodal functionResponse. Gemini 3.x does.
+    # multimodal functionResponse. Gemini 3.x and 2.x do.
     if p in {"google", "gemini", "google-gemini", "google-vertex-gemini"}:
         if not isinstance(model, str):
             return False
         m = model.strip().lower()
         if "gemini-3" in m or "gemini-pro-3" in m or "gemini-flash-3" in m:
+            return True
+        # Gemini 2.5+ and 2.0+ also support multimodal tool results
+        # via the OpenAI-compatible endpoint.
+        if "gemini-2.5" in m or "gemini-2.0" in m:
             return True
         return False
 


### PR DESCRIPTION
## Summary\n- Supersedes/repairs #30712 CI by adding the missing AUTHOR_MAP entry for linux2010@github.com.\n- Keeps the Gemini media-tool-result support change from #30712 intact.\n\n## Test Plan\n- Local reproduction of .github/workflows/contributor-check.yml attribution logic: all new emails mapped\n- python -m pytest -o addopts='' tests/tools/test_vision_native_fast_path.py\n\nNotes: I could not push directly to the original contributor branch (#30712) because this checkout has read-only permission on NousResearch/hermes-agent.