### PR TITLE
fix(moonshot): normalise union type arrays in _fill_missing_type to prevent TypeError

### DIFF
--- a/agent/moonshot_schema.py
+++ b/agent/moonshot_schema.py
@@ -165,7 +165,22 @@ def _repair_schema(node: Any, is_schema: bool = True) -> Any:
 
 
 def _fill_missing_type(node: Dict[str, Any]) -> Dict[str, Any]:
-    """Infer a reasonable ``type`` if this schema node has none."""
+    """Infer a reasonable ``type`` if this schema node has none.
+
+    Handles JSON Schema union types where ``type`` is a list like
+    ``["number", "string"]``.  Moonshot does not accept union type arrays —
+    we keep the first concrete (non-null) type and discard the rest.
+    """
+    node_type = node.get("type")
+    # Guard: list types (e.g. ["number", "string"]) are not hashable and
+    # cannot be tested with `not in {None, ""}`.  Normalise to the first
+    # non-null element so the rest of the pipeline sees a plain string type.
+    if isinstance(node_type, list):
+        concrete = next(
+            (t for t in node_type if t not in (None, "null", "")),
+            "string",
+        )
+        return {**node, "type": concrete}
     if "type" in node and node["type"] not in {None, ""}:
         return node
 

--- a/tests/agent/test_moonshot_schema.py
+++ b/tests/agent/test_moonshot_schema.py
@@ -560,3 +560,124 @@ class TestEnumNullStripping:
         assert db_type["type"] == "string"
         assert db_type["enum"] == ["mysql", "postgresql"], \
             "null/empty enum values must be stripped after anyOf collapse"
+
+
+class TestUnionTypeList:
+    """Regression: ``type: ["number", "string"]`` must not crash with
+    ``TypeError: unhashable type: 'list'`` (issue #30095).
+
+    JSON Schema allows ``type`` to be an array of allowed types, but
+    Python lists are not hashable and cannot be tested for membership in
+    ``{None, ""}``.  The fix normalises list types to the first concrete
+    (non-null) type before the set membership check.
+    """
+
+    def test_union_type_number_string_normalises_to_first(self):
+        """``type: ["number", "string"]`` → ``type: "number"``."""
+        params = {
+            "type": "object",
+            "properties": {
+                "limit": {
+                    "type": ["number", "string"],
+                    "description": "Max results",
+                },
+            },
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        assert out["properties"]["limit"]["type"] == "number"
+
+    def test_union_type_string_integer(self):
+        """``type: ["string", "integer"]`` → ``type: "string"``."""
+        params = {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "type": ["string", "integer"],
+                    "description": "flexible value",
+                },
+            },
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        assert out["properties"]["value"]["type"] == "string"
+
+    def test_union_type_with_null_skips_null(self):
+        """``type: ["null", "string"]`` → ``type: "string"`` (null skipped)."""
+        params = {
+            "type": "object",
+            "properties": {
+                "maybe": {
+                    "type": ["null", "string"],
+                    "description": "nullable value",
+                },
+            },
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        assert out["properties"]["maybe"]["type"] == "string"
+
+    def test_union_type_all_null_falls_back_to_string(self):
+        """``type: ["null"]`` → falls back to ``"string"``."""
+        params = {
+            "type": "object",
+            "properties": {
+                "empty": {
+                    "type": ["null"],
+                    "description": "only null",
+                },
+            },
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        assert out["properties"]["empty"]["type"] == "string"
+
+    def test_union_type_preserves_other_keys(self):
+        """Non-type keys like description must survive the normalisation."""
+        params = {
+            "type": "object",
+            "properties": {
+                "field": {
+                    "type": ["integer", "string"],
+                    "description": "An ID or name",
+                    "default": 0,
+                },
+            },
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        field = out["properties"]["field"]
+        assert field["type"] == "integer"
+        assert field["description"] == "An ID or name"
+        assert field["default"] == 0
+
+    def test_union_type_in_nested_property(self):
+        """Union type in a nested object property is also normalised."""
+        params = {
+            "type": "object",
+            "properties": {
+                "config": {
+                    "type": "object",
+                    "properties": {
+                        "timeout": {
+                            "type": ["number", "string"],
+                            "description": "seconds or human-readable",
+                        },
+                    },
+                },
+            },
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        assert out["properties"]["config"]["properties"]["timeout"]["type"] == "number"
+
+    def test_union_type_in_array_items(self):
+        """Union type in array items schema is also normalised."""
+        params = {
+            "type": "object",
+            "properties": {
+                "values": {
+                    "type": "array",
+                    "items": {
+                        "type": ["boolean", "string"],
+                        "description": "mixed items",
+                    },
+                },
+            },
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        assert out["properties"]["values"]["items"]["type"] == "boolean"


### PR DESCRIPTION
## Fix #30095

### Problem
When using `kimi-k2.6` (or any Moonshot model), any tool whose JSON Schema uses a union type array (`"type": ["number", "string"]`) causes a crash inside `sanitize_moonshot_tools()`:

```
TypeError: unhashable type: 'list'
```

This is a hard crash — the agent cannot call any tool that has a union-typed parameter.

### Root Cause
`_fill_missing_type()` in `agent/moonshot_schema.py` line 169:

```python
if "type" in node and node["type"] not in {None, ""}:
```

When `node["type"]` is a Python `list` (e.g. `["number", "string"]`), the `not in {None, ""}` set membership test raises `TypeError` because Python lists are not hashable.

### Fix
Added a guard at the top of `_fill_missing_type()` that detects list types and normalises to the first concrete (non-null) type. Moonshot does not accept union type arrays anyway — it requires a single scalar type — so this is both correct and safe.

```python
if isinstance(node_type, list):
    concrete = next(
        (t for t in node_type if t not in (None, "null", "")),
        "string",
    )
    return {**node, "type": concrete}
```

### Testing
- **7 new regression tests** in `TestUnionTypeList`:
  - `["number", "string"]` → `"number"`
  - `["string", "integer"]` → `"string"`
  - `["null", "string"]` → `"string"` (null skipped)
  - `["null"]` → `"string"` (all-null fallback)
  - Key preservation (description, default)
  - Nested properties
  - Array items
- **All 49 tests pass** (42 existing + 7 new)