### PR TITLE
feat: support user-installed context engine plugins via $HERMES_HOME/plugins/

### DIFF
--- a/plugins/context_engine/__init__.py
+++ b/plugins/context_engine/__init__.py
@@ -1,13 +1,15 @@
 """Context engine plugin discovery.
 
-Scans ``plugins/context_engine/<name>/`` directories for context engine
-plugins.  Each subdirectory must contain ``__init__.py`` with a class
-implementing the ContextEngine ABC.
+Scans two directories for context engine plugins:
 
-Context engines are separate from the general plugin system — they live
-in the repo and are always available without user installation.  Only ONE
-can be active at a time, selected via ``context.engine`` in config.yaml.
-The default engine is ``"compressor"`` (the built-in ContextCompressor).
+1. Bundled engines: ``plugins/context_engine/<name>/`` (shipped with hermes-agent)
+2. User-installed engines: ``$HERMES_HOME/plugins/<name>/``
+
+Each subdirectory must contain ``__init__.py`` with a class implementing
+the ContextEngine ABC.  Only ONE can be active at a time, selected via
+``context.engine`` in config.yaml.  The default engine is ``"compressor"``
+(the built-in ContextCompressor).  Bundled engines take precedence on
+name collisions.
 
 Usage:
     from plugins.context_engine import discover_context_engines, load_context_engine
@@ -30,48 +32,116 @@ logger = logging.getLogger(__name__)
 _CONTEXT_ENGINE_PLUGINS_DIR = Path(__file__).parent
 
 
+# ---------------------------------------------------------------------------
+# Directory helpers
+# ---------------------------------------------------------------------------
+
+def _get_user_plugins_dir() -> Optional[Path]:
+    """Return ``$HERMES_HOME/plugins/`` or None if unavailable."""
+    try:
+        from hermes_constants import get_hermes_home
+        d = get_hermes_home() / "plugins"
+        return d if d.is_dir() else None
+    except Exception:
+        return None
+
+
+def _is_context_engine_dir(path: Path) -> bool:
+    """Heuristic: does *path* look like a context engine plugin?
+
+    Checks for ``ContextEngine`` or ``register_context_engine`` in the
+    ``__init__.py`` source.  Cheap text scan — no import needed.
+    """
+    init_file = path / "__init__.py"
+    if not init_file.exists():
+        return False
+    try:
+        source = init_file.read_text(errors="replace")[:8192]
+        return "ContextEngine" in source or "register_context_engine" in source
+    except Exception:
+        return False
+
+
+def _find_engine_dir(name: str) -> Optional[Path]:
+    """Resolve a context engine name to its directory.
+
+    Checks bundled first, then user-installed.
+    """
+    # Bundled
+    bundled = _CONTEXT_ENGINE_PLUGINS_DIR / name
+    if bundled.is_dir() and (bundled / "__init__.py").exists():
+        return bundled
+    # User-installed
+    user_dir = _get_user_plugins_dir()
+    if user_dir:
+        user = user_dir / name
+        if user.is_dir() and _is_context_engine_dir(user):
+            return user
+    return None
+
+
 def discover_context_engines() -> List[Tuple[str, str, bool]]:
-    """Scan plugins/context_engine/ for available engines.
+    """Scan bundled and user-installed directories for available engines.
 
     Returns list of (name, description, is_available) tuples.
     Does NOT import the engines — just reads plugin.yaml for metadata
     and does a lightweight availability check.
+    Bundled engines take precedence on name collisions.
     """
-    results = []
-    if not _CONTEXT_ENGINE_PLUGINS_DIR.is_dir():
-        return results
+    results: List[Tuple[str, str, bool]] = []
+    seen: set = set()
 
-    for child in sorted(_CONTEXT_ENGINE_PLUGINS_DIR.iterdir()):
-        if not child.is_dir() or child.name.startswith(("_", ".")):
-            continue
-        init_file = child / "__init__.py"
-        if not init_file.exists():
-            continue
+    def _scan_dir(scan_dir: Path) -> None:
+        if not scan_dir.is_dir():
+            return
+        for child in sorted(scan_dir.iterdir()):
+            if not child.is_dir() or child.name.startswith(("_", ".")):
+                continue
+            if child.name in seen:
+                continue  # bundled takes precedence
+            init_file = child / "__init__.py"
+            if not init_file.exists():
+                continue
 
-        # Read description from plugin.yaml if available
-        desc = ""
-        yaml_file = child / "plugin.yaml"
-        if yaml_file.exists():
+            # For user plugins, filter non-context-engine dirs
+            if scan_dir != _CONTEXT_ENGINE_PLUGINS_DIR:
+                if not _is_context_engine_dir(child):
+                    continue
+
+            seen.add(child.name)
+
+            # Read description from plugin.yaml if available
+            desc = ""
+            yaml_file = child / "plugin.yaml"
+            if yaml_file.exists():
+                try:
+                    import yaml
+                    with open(yaml_file, encoding="utf-8-sig") as f:
+                        meta = yaml.safe_load(f) or {}
+                    desc = meta.get("description", "")
+                except Exception:
+                    pass
+
+            # Quick availability check
+            available = True
             try:
-                import yaml
-                with open(yaml_file, encoding="utf-8-sig") as f:
-                    meta = yaml.safe_load(f) or {}
-                desc = meta.get("description", "")
+                engine = _load_engine_from_dir(child)
+                if engine is None:
+                    available = False
+                elif hasattr(engine, "is_available"):
+                    available = engine.is_available()
             except Exception:
-                pass
-
-        # Quick availability check — try loading and calling is_available()
-        available = True
-        try:
-            engine = _load_engine_from_dir(child)
-            if engine is None:
                 available = False
-            elif hasattr(engine, "is_available"):
-                available = engine.is_available()
-        except Exception:
-            available = False
 
-        results.append((child.name, desc, available))
+            results.append((child.name, desc, available))
+
+    # 1. Bundled engines (plugins/context_engine/<name>/)
+    _scan_dir(_CONTEXT_ENGINE_PLUGINS_DIR)
+
+    # 2. User-installed engines ($HERMES_HOME/plugins/<name>/)
+    user_dir = _get_user_plugins_dir()
+    if user_dir:
+        _scan_dir(user_dir)
 
     return results
 
@@ -79,18 +149,26 @@ def discover_context_engines() -> List[Tuple[str, str, bool]]:
 def load_context_engine(name: str) -> Optional["ContextEngine"]:
     """Load and return a ContextEngine instance by name.
 
+    Checks both bundled (``plugins/context_engine/<name>/``) and
+    user-installed (``$HERMES_HOME/plugins/<name>/``) directories.
+    Bundled takes precedence on name collisions.
+
     Returns None if the engine is not found or fails to load.
     """
-    engine_dir = _CONTEXT_ENGINE_PLUGINS_DIR / name
-    if not engine_dir.is_dir():
-        logger.debug("Context engine '%s' not found in %s", name, _CONTEXT_ENGINE_PLUGINS_DIR)
+    engine_dir = _find_engine_dir(name)
+    if not engine_dir:
+        logger.debug(
+            "Context engine '%s' not found in bundled or user plugins", name
+        )
         return None
 
     try:
         engine = _load_engine_from_dir(engine_dir)
         if engine:
             return engine
-        logger.warning("Context engine '%s' loaded but no engine instance found", name)
+        logger.warning(
+            "Context engine '%s' loaded but no engine instance found", name
+        )
         return None
     except Exception as e:
         logger.warning("Failed to load context engine '%s': %s", name, e)
@@ -105,7 +183,17 @@ def _load_engine_from_dir(engine_dir: Path) -> Optional["ContextEngine"]:
     - A top-level class that extends ContextEngine — we instantiate it
     """
     name = engine_dir.name
-    module_name = f"plugins.context_engine.{name}"
+    # Use a separate namespace for user-installed plugins so they don't
+    # collide with bundled engines in sys.modules.
+    _is_bundled = (
+        _CONTEXT_ENGINE_PLUGINS_DIR in engine_dir.parents
+        or engine_dir.parent == _CONTEXT_ENGINE_PLUGINS_DIR
+    )
+    module_name = (
+        f"plugins.context_engine.{name}"
+        if _is_bundled
+        else f"_hermes_user_context_engine.{name}"
+    )
     init_file = engine_dir / "__init__.py"
 
     if not init_file.exists():


### PR DESCRIPTION
## Problem

Context engine plugins (`plugins/context_engine/__init__.py`) only support a single discovery path: `plugins/context_engine/<name>/` inside the source tree. This is inconsistent with memory providers, which already scan both bundled (`plugins/memory/<name>/`) and user-installed (`$HERMES_HOME/plugins/<name>/`) directories.

Practical impact: user-installed context engines that live outside the hermes-agent git worktree (e.g., development symlinks) get destroyed by `hermes update` because `git stash --include-untracked` picks up untracked symlinks and `git reset --hard` discards them on stash-apply conflicts.

## Solution

Mirror the memory provider discovery model:

- Add `_get_user_plugins_dir()` — profile-aware `$HERMES_HOME/plugins/` resolver
- Add `_is_context_engine_dir()` — cheap text-scan heuristic (looks for `ContextEngine` or `register_context_engine` in `__init__.py`)
- Add `_find_engine_dir(name)` — resolves bundled first, then user path, with bundled taking precedence
- Update `discover_context_engines()` to scan both directories
- Update `load_context_engine()` to use `_find_engine_dir()`
- User-installed engines get isolated module namespace (`_hermes_user_context_engine.*`) to avoid `sys.modules` collisions

## Behavior

- Backward-compatible: existing bundled engines load exactly as before
- Name collisions: bundled takes precedence (first-seen-wins, bundled scanned first)
- User dirs are filtered by `_is_context_engine_dir()` so non-engine plugins (memory providers, general plugins) in the same `$HERMES_HOME/plugins/` directory are skipped
- Symlinks work: `ln -s /path/to/engine ~/.hermes/profiles/main/plugins/spc_ctx` survives `hermes update`

## Files changed

| File | Lines | Change |
|------|-------|--------|
| `plugins/context_engine/__init__.py` | +132 -44 | User-level discovery support |