### PR TITLE
ISA-000: Document PR title convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -870,6 +870,20 @@ Include:
 - **What platforms** you tested on
 - Reference any related issues
 
+### PR title
+
+Use an ISA-prefixed title that includes the task number when one is available:
+
+```text
+ISA-999: Title of PR
+```
+
+If there is no specific task number for the change, use `ISA-000`:
+
+```text
+ISA-000: Title of PR
+```
+
 ### Commit messages
 
 We use [Conventional Commits](https://www.conventionalcommits.org/):

--- a/website/docs/developer-guide/contributing.md
+++ b/website/docs/developer-guide/contributing.md
@@ -198,6 +198,20 @@ Include:
 - **What platforms** you tested on
 - Reference any related issues
 
+### PR Title
+
+Use an ISA-prefixed title that includes the task number when one is available:
+
+```text
+ISA-999: Title of PR
+```
+
+If there is no specific task number for the change, use `ISA-000`:
+
+```text
+ISA-000: Title of PR
+```
+
 ### Commit Messages
 
 We use [Conventional Commits](https://www.conventionalcommits.org/):


### PR DESCRIPTION
## Summary
- Add the ISA-prefixed PR title convention to the root contributing guide
- Mirror the same guidance in the website developer contributing docs
- Include both ISA-999 and ISA-000 title examples

## Test Plan
- python assertion script verifying both examples are present in both docs
- git diff --check