### PR TITLE
fix(send_message): split comma-separated SLACK_BOT_TOKEN before use

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -289,7 +289,7 @@ def _handle_send(args):
                             return data["channel"]["id"]
                         return None
             from model_tools import _run_async
-            dm_channel = _run_async(_open_slack_dm(pconfig.token, chat_id))
+            dm_channel = _run_async(_open_slack_dm(pconfig.token.split(",")[0].strip(), chat_id))
             if dm_channel:
                 chat_id = dm_channel
             else:
@@ -751,7 +751,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     last_result = None
     for chunk in chunks:
         if platform == Platform.SLACK:
-            result = await _send_slack(pconfig.token, chat_id, chunk)
+            result = await _send_slack(pconfig.token.split(",")[0].strip(), chat_id, chunk)
         elif platform == Platform.WHATSAPP:
             result = await _send_whatsapp(pconfig.extra, chat_id, chunk)
         elif platform == Platform.SIGNAL:


### PR DESCRIPTION
## Summary

When `SLACK_BOT_TOKEN` is set to a comma-separated list of tokens (the multi-workspace pattern that `gateway/platforms/slack.py:529` already supports for the gateway-reply path), the native `send_message` tool currently passes the raw `pconfig.token` string — `"xoxb-A,xoxb-B"` — straight into `Authorization: Bearer …`. Slack rejects this as `invalid_auth`, so every call from the `send_message` tool fails on multi-workspace setups.

This is most likely to bite users on **Enterprise Grid**, where the documented setup is one app installed at the org level + workspace-scoped installs alongside it (with the org token listed first so it can post to any workspace in the enterprise).

## Affected call sites

Both in `tools/send_message_tool.py`:

| Line | Call |
|---|---|
| 292 | `_open_slack_dm(pconfig.token, chat_id)` (DM resolution when chat_id starts with `U…`) |
| 754 | `_send_slack(pconfig.token, chat_id, chunk)` (channel send) |

`_send_slack` (line 1038) does `headers = {"Authorization": f"Bearer {token}", …}` — so the raw comma-separated string becomes a malformed bearer header → `invalid_auth`.

## Important: the gateway-reply path is unaffected

`gateway/platforms/slack.py` splits the comma at line 529 (`bot_tokens = [t.strip() for t in raw_token.split(",") if t.strip()]`) and builds a `_team_clients[team_id] → AsyncWebClient` map. Bolt's middleware uses this map to pick the per-event team's token for replies — so multi-workspace setups have always been able to *reply* fine. Only the LLM-initiated `send_message` outbound path bypasses the adapter and hits the bug.

## Reproducing

1. Set `SLACK_BOT_TOKEN=xoxb-A,xoxb-B` where both tokens `auth.test` clean individually (Enterprise Grid org install + workspace install is the canonical case).
2. Connect Hermes to Slack as usual; `[Slack] Authenticated as @<agent>` shows both tokens succeed.
3. Run: `hermes -p <agent> -z "Use the send_message tool to send 'test' to slack:C…"`.

**Pre-fix:** `{"error": "Slack API error: invalid_auth"}`
**Post-fix:** `{"success": true, "platform": "slack", "chat_id": "C…", "message_id": "…"}`

## The fix

Take the first token from the comma-separated list at the call sites — same shape `slack.py` already uses internally (`bot_tokens[0]` after splitting). The first token is, by convention, the highest-scoped (the org-level token in the Enterprise Grid pattern), which can `chat.postMessage` to any channel in the enterprise the app is installed in.

```diff
- dm_channel = _run_async(_open_slack_dm(pconfig.token, chat_id))
+ dm_channel = _run_async(_open_slack_dm(pconfig.token.split(",")[0].strip(), chat_id))

- result = await _send_slack(pconfig.token, chat_id, chunk)
+ result = await _send_slack(pconfig.token.split(",")[0].strip(), chat_id, chunk)
```

Minimal + conservative; mirrors the adapter's existing split.

A more sophisticated future improvement could look up the channel's team via `conversations.info` and pick the matching workspace-specific client (the way the adapter's `_get_client` does for the reply path). I left that out of this PR to keep the patch tight; happy to follow up if you'd like that flavor instead.

## Test plan

- [x] Applied as a local patch on four agents on Hermes 0.14.0 (Enterprise Grid + workspace install pattern, two comma-separated tokens). `send_message` returns `{"success": true, …}` for all of them, including channels in workspaces neither token is workspace-scoped to (the org-level primary token reaches them via Enterprise Grid).
- [x] No regression in gateway-reply behavior (Bolt's per-event token routing continues to use `_team_clients` correctly).
- [x] No regression for single-token setups (`"xoxb-A".split(",")[0].strip() == "xoxb-A"`).

## Context

We discovered + locally patched this during a per-mini agent migration where Hermes is the harness for a fleet of solution-scoped ops agents on macOS minis (Enterprise Grid). Happy to chat if you want any additional reproduction info or want me to extend the fix.

🤖 Submitted by Claude Opus 4.7