### PR TITLE
feat: harden legacy bot migration paths

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -331,6 +331,12 @@ BROWSER_INACTIVITY_TIMEOUT=120
 # Slack allowed users (comma-separated Slack user IDs)
 # SLACK_ALLOWED_USERS=
 
+# Slack allowed channels/DMs (comma-separated channel IDs). When
+# SLACK_RESTRICT_DM_CHANNELS=true, DMs are also limited to this set; useful for
+# private cutovers where App/Assistant DMs should not open fallback bot DMs.
+# SLACK_ALLOWED_CHANNELS=
+# SLACK_RESTRICT_DM_CHANNELS=false
+
 # =============================================================================
 # TELEGRAM INTEGRATION
 # =============================================================================

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -874,10 +874,22 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             )
         argv = [_bash, str(path)]
     else:
-        argv = [sys.executable, str(path)]
+        # When the Windows gateway is launched hidden via pythonw.exe, using
+        # sys.executable for cron scripts silently drops stdout/stderr. Cron
+        # scripts rely on captured stdout, so run them with the console
+        # interpreter from the same venv when available.
+        python_executable = sys.executable
+        if sys.platform == "win32":
+            current_python = Path(sys.executable)
+            if current_python.name.lower() == "pythonw.exe":
+                console_python = current_python.with_name("python.exe")
+                if console_python.exists():
+                    python_executable = str(console_python)
+        argv = [python_executable, str(path)]
 
     run_env = os.environ.copy()
     run_env["HERMES_HOME"] = str(_get_hermes_home())
+
     try:
         from hermes_constants import get_subprocess_home
 

--- a/docs/plans/2026-05-23-legacy-bot-migration-hardening.md
+++ b/docs/plans/2026-05-23-legacy-bot-migration-hardening.md
@@ -1,0 +1,163 @@
+# Legacy bot migration hardening deep dive
+
+Date: 2026-05-23
+Branch: `feat/legacy-bot-migration-hardening`
+
+This document captures the technical design that came out of migrating a
+legacy operations bot into Hermes. It is intentionally sanitized: no token
+values, private channel IDs, credentials, organization names, or customer data
+belong here.
+
+## Goal
+
+Move a long-running Slack/Telegram operations bot into Hermes without losing
+alerting, scheduled summaries, delivery parity, or least-privilege controls.
+The migration should favor Hermes primitives instead of carrying forward a
+bespoke bot runtime.
+
+## Legacy feature classes mapped to Hermes
+
+| Legacy behavior | Hermes primitive | Why |
+| --- | --- | --- |
+| Daily Slack digest | Cron job with a pre-run collector script and LLM prompt | Collector is deterministic; summary remains model-generated. |
+| Issue tracker watcher | `no_agent=True` cron script | Empty stdout means silent all-clear; non-empty stdout is the alert. |
+| Standup prep | Prompt-only cron job with skills/toolsets | Mostly synthesis across existing sources. |
+| End-of-day recap | Cron job with `context_from` and/or compact context script | Chains daily digest + watcher state into one recap. |
+| Runbooks/triage procedures | Hermes skills | Procedural knowledge loads on demand and stays reusable. |
+| Platform chat adapters | Hermes gateway | Avoids maintaining bespoke Slack/Telegram bot loops. |
+| Deterministic watchdogs | `~/.hermes/scripts/*.py` + cron | Keeps side effects explicit and stdout-driven. |
+
+## Runtime architecture
+
+```text
+Slack / Telegram / other gateway adapters
+            │
+            ▼
+Hermes gateway + scheduler tick
+            │
+            ├── prompt-only cron jobs
+            │       └── LLM synthesizes final delivery
+            │
+            ├── script + agent cron jobs
+            │       ├── script collects compact ASCII-safe context
+            │       └── LLM summarizes with attached skills/toolsets
+            │
+            └── no-agent watchdog jobs
+                    ├── empty stdout → silent
+                    ├── non-empty stdout → delivered verbatim
+                    └── non-zero exit → error alert
+```
+
+The important migration invariant is that deterministic checks should not need
+an LLM to decide whether to wake the user. They should emit nothing when there
+is nothing to say.
+
+## Key integration lessons
+
+### 1. Windows hidden-gateway cron must not use `pythonw.exe` for child scripts
+
+When the gateway is launched hidden from Windows Task Scheduler, `sys.executable`
+can be `pythonw.exe`. Child cron scripts spawned with that interpreter can run
+successfully while stdout/stderr disappears, which breaks both `no_agent=True`
+watchdogs and script-output injection for agent-mode cron jobs.
+
+Branch change:
+
+- `cron/scheduler.py` now detects `pythonw.exe` on Windows and uses sibling
+  `python.exe` for Python cron scripts when available.
+- `tests/cron/test_cron_script.py` adds a regression test for the interpreter
+  selection.
+
+### 2. Slack App/Assistant DM surfaces need safe fallback and stronger gating
+
+Slack can deliver inbound Socket Mode events from DM-like App/Assistant channel
+IDs that are readable but not postable with `chat.postMessage`; Slack returns
+`channel_not_found` on replies. During cutover, that made replies appear silent
+or caused fallback attempts to open normal bot DMs.
+
+Branch change:
+
+- `gateway/platforms/slack.py` records DM channel → user mappings from inbound
+  events.
+- `send()` retries `channel_not_found` DM sends by opening the user's normal bot
+  DM with `conversations.open()` and drops the invalid thread timestamp.
+- The fallback refuses non-allowed users before opening a DM.
+- `SLACK_RESTRICT_DM_CHANNELS=true` / `slack.restrict_dm_channels: true` lets
+  `SLACK_ALLOWED_CHANNELS` apply to DMs as well as public/private channels.
+- `tests/gateway/test_slack.py` covers fallback routing, non-allowed-user
+  refusal, and DM channel restriction.
+
+### 3. Private cutovers need both outbound and inbound controls
+
+A cron delivery target like `slack:<home-dm>` controls where scheduled output is
+sent, but the Slack app may still receive inbound events from other channels or
+App Home surfaces. A safe cutover needs:
+
+- `SLACK_ALLOWED_USERS`
+- `SLACK_ALLOWED_CHANNELS`
+- `SLACK_RESTRICT_DM_CHANNELS=true` when pinning to one DM/channel
+- platform-specific smoke tests before recurring jobs are resumed
+
+### 4. Large/non-ASCII collector output should be bounded and ASCII-safe
+
+Hidden Windows scheduler output capture is less forgiving than direct script
+execution. The digest collector should emit bounded, sanitized text rather than
+large raw Slack JSON. The wrapper pattern is:
+
+```python
+out = raw_text.encode("ascii", "backslashreplace").decode("ascii")
+sys.stdout.write(out[:MAX_BYTES])
+```
+
+### 5. End-of-day jobs should consume compact upstream context
+
+The EOD recap should not re-query every source at delivery time. It should read
+compact output from upstream jobs and produce a concise recap. This avoids
+runaway tool usage and prevents fabrication when upstream credentials are
+missing.
+
+## Cutover workflow
+
+1. Inventory the legacy bot and classify each feature by behavior, not by file.
+2. Move reusable procedures into skills.
+3. Move deterministic checks into scripts.
+4. Create staged cron jobs with explicit delivery targets.
+5. Align the gateway service `HERMES_HOME` with the CLI home that owns scripts,
+   skills, cron jobs, and state.
+6. Validate provider credentials with direct API smoke tests, then validate live
+   Hermes adapter delivery.
+7. Run local-only cron clones before enabling recurring delivery.
+8. Resume jobs one at a time.
+9. Stop the legacy bot only after parity is verified and rollback is known.
+
+## Security model
+
+- No secrets in repo docs, logs, skills, memory, or status reports.
+- Prefer scoped platform tokens and explicit allowlists.
+- Default to private delivery targets during cutover.
+- Keep mutation-capable jobs off unless the user explicitly authorizes them.
+- Treat Slack/Telegram test sends as delivery verification only, not as a reason
+  to broaden app access.
+
+## Branch contents
+
+The initial Hermes branch contains generic hardening needed by the migration:
+
+- Cron child-script interpreter fix for hidden Windows gateways.
+- Slack non-postable DM fallback with allowlist enforcement.
+- Slack DM/channel restriction knob for private cutovers.
+- WhatsApp QR image output support for reliable QR pairing from gateway/PTY
+  workflows.
+- Documentation and regression tests for the above.
+
+## Follow-up work
+
+Potential upstreamable migration primitives:
+
+1. A `hermes migrate bot` helper that scaffolds scripts, skills, and cron jobs
+   from a manifest.
+2. A safe delivery smoke-test command that creates a temporary no-agent cron job,
+   runs it, verifies persisted output, and removes it.
+3. A shared watcher-state library for `seen`, `ack`, `realert_after`, and
+   quiet-hours behavior across migrated watchdog scripts.
+4. A first-class compact-context convention for agent-mode cron chains.

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -925,6 +925,8 @@ def load_gateway_config() -> GatewayConfig:
                     if isinstance(ac, list):
                         ac = ",".join(str(v) for v in ac)
                     os.environ["SLACK_ALLOWED_CHANNELS"] = str(ac)
+                if "restrict_dm_channels" in slack_cfg and not os.getenv("SLACK_RESTRICT_DM_CHANNELS"):
+                    os.environ["SLACK_RESTRICT_DM_CHANNELS"] = str(slack_cfg["restrict_dm_channels"]).lower()
 
             # Discord settings → env vars (env vars take precedence)
             discord_cfg = yaml_cfg.get("discord", {})

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -15,6 +15,7 @@ import logging
 import os
 import re
 import time
+from collections import OrderedDict
 from dataclasses import dataclass, field
 from typing import Dict, Optional, Any, Tuple, List
 
@@ -62,14 +63,18 @@ _slash_user_id: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
     "_slash_user_id", default=None,
 )
 
+_MAX_DM_USER_CACHE_SIZE = 1024
+
 
 @dataclass
 class _ThreadContextCache:
     """Cache entry for fetched thread context."""
+
     content: str
     fetched_at: float = field(default_factory=time.monotonic)
     message_count: int = 0
     parent_text: str = ""  # Raw text of the thread parent (for reply_to_text injection)
+
 
 
 def check_slack_requirements() -> bool:
@@ -319,18 +324,24 @@ class SlackAdapter(BasePlatformAdapter):
         # Slack Assistant/App surfaces can emit DM-like channel IDs that the bot
         # can read from Socket Mode but cannot post back to with chat.postMessage
         # (Slack returns channel_not_found). The user_id lets send() open the
-        # normal bot DM as a safe fallback instead of going silent.
-        self._dm_user_by_channel: Dict[str, str] = {}
+        # normal bot DM as a safe fallback instead of going silent. Bound the
+        # cache so transient App/Assistant DM surfaces cannot grow memory without
+        # limit in long-lived gateways.
+        self._dm_user_by_channel: OrderedDict[str, str] = OrderedDict()
+
         # Dedup cache: prevents duplicate bot responses when Socket Mode
         # reconnects redeliver events.
         self._dedup = MessageDeduplicator()
+
         # Track pending approval message_ts → resolved flag to prevent
         # double-clicks on approval buttons.
         self._approval_resolved: Dict[str, bool] = {}
+
         # Track timestamps of messages sent by the bot so we can respond
         # to thread replies even without an explicit @mention.
         self._bot_message_ts: set = set()
         self._BOT_TS_MAX = 5000  # cap to avoid unbounded growth
+
         # Track threads where the bot has been @mentioned — once mentioned,
         # respond to ALL subsequent messages in that thread automatically.
         self._mentioned_threads: set = set()
@@ -761,10 +772,26 @@ class SlackAdapter(BasePlatformAdapter):
             return self._team_clients[team_id]
         return self._app.client  # fallback to primary
 
+    def _remember_dm_user(self, channel_id: str, user_id: str) -> None:
+        """Remember a bounded DM channel → user mapping for fallback routing."""
+        if not channel_id or not user_id or not str(channel_id).startswith("D"):
+            return
+        key = str(channel_id)
+        if key in self._dm_user_by_channel:
+            self._dm_user_by_channel.move_to_end(key)
+        self._dm_user_by_channel[key] = str(user_id)
+        while len(self._dm_user_by_channel) > _MAX_DM_USER_CACHE_SIZE:
+            self._dm_user_by_channel.popitem(last=False)
+
     @staticmethod
     def _slack_error_code(exc: Exception) -> str:
         """Extract a Slack API error code from SlackApiError-like exceptions."""
         response = getattr(exc, "response", None)
+        response_data = getattr(response, "data", None)
+        if isinstance(response_data, dict):
+            error = response_data.get("error")
+            if error:
+                return str(error)
         if hasattr(response, "get"):
             try:
                 error = response.get("error")
@@ -820,7 +847,7 @@ class SlackAdapter(BasePlatformAdapter):
             )
             return None
 
-        self._dm_user_by_channel[str(fallback_chat_id)] = str(user_id)
+        self._remember_dm_user(str(fallback_chat_id), str(user_id))
         team_id = self._channel_team.get(chat_id)
         if team_id:
             self._channel_team[str(fallback_chat_id)] = team_id
@@ -2045,7 +2072,7 @@ class SlackAdapter(BasePlatformAdapter):
             channel_type = "im"
         is_dm = channel_type in {"im", "mpim"}  # Both 1:1 and group DMs
         if is_dm and channel_id and user_id:
-            self._dm_user_by_channel[channel_id] = user_id
+            self._remember_dm_user(channel_id, user_id)
 
         # Build thread_ts for session keying.
         # In channels: fall back to ts so each top-level @mention starts a
@@ -2925,7 +2952,7 @@ class SlackAdapter(BasePlatformAdapter):
         # session key.
         is_dm = str(channel_id).startswith("D")
         if is_dm and channel_id and user_id:
-            self._dm_user_by_channel[channel_id] = user_id
+            self._remember_dm_user(channel_id, user_id)
         source = self.build_source(
             chat_id=channel_id,
             chat_type="dm" if is_dm else "group",

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -315,6 +315,12 @@ class SlackAdapter(BasePlatformAdapter):
         self._team_clients: Dict[str, Any] = {}   # team_id → WebClient
         self._team_bot_user_ids: Dict[str, str] = {}          # team_id → bot_user_id
         self._channel_team: Dict[str, str] = {}                # channel_id → team_id
+        # DM channel → user_id mapping learned from inbound message/slash events.
+        # Slack Assistant/App surfaces can emit DM-like channel IDs that the bot
+        # can read from Socket Mode but cannot post back to with chat.postMessage
+        # (Slack returns channel_not_found). The user_id lets send() open the
+        # normal bot DM as a safe fallback instead of going silent.
+        self._dm_user_by_channel: Dict[str, str] = {}
         # Dedup cache: prevents duplicate bot responses when Socket Mode
         # reconnects redeliver events.
         self._dedup = MessageDeduplicator()
@@ -755,6 +761,103 @@ class SlackAdapter(BasePlatformAdapter):
             return self._team_clients[team_id]
         return self._app.client  # fallback to primary
 
+    @staticmethod
+    def _slack_error_code(exc: Exception) -> str:
+        """Extract a Slack API error code from SlackApiError-like exceptions."""
+        response = getattr(exc, "response", None)
+        if hasattr(response, "get"):
+            try:
+                error = response.get("error")
+                if error:
+                    return str(error)
+            except Exception:
+                pass
+        message = str(exc)
+        if "channel_not_found" in message:
+            return "channel_not_found"
+        return ""
+
+    async def _fallback_dm_channel_for_unpostable_channel(
+        self,
+        chat_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
+        """Open the user's normal bot DM when a DM-like channel is not postable."""
+        if not str(chat_id).startswith("D"):
+            return None
+
+        md = metadata or {}
+        user_id = (
+            md.get("slack_user_id")
+            or md.get("user_id")
+            or self._dm_user_by_channel.get(chat_id)
+        )
+        if not user_id:
+            return None
+        if not self._slack_user_allowed(str(user_id)):
+            logger.info(
+                "[Slack] Refusing DM fallback for non-allowed user: %s",
+                user_id,
+            )
+            return None
+
+        result = await self._get_client(chat_id).conversations_open(users=str(user_id))
+        channel = result.get("channel", {}) if hasattr(result, "get") else {}
+        fallback_chat_id = channel.get("id") if isinstance(channel, dict) else None
+        if not fallback_chat_id or fallback_chat_id == chat_id:
+            return None
+
+        allowed_channels = self._slack_allowed_channels()
+        if (
+            self._slack_restrict_dm_channels()
+            and allowed_channels
+            and "*" not in allowed_channels
+            and str(fallback_chat_id) not in allowed_channels
+        ):
+            logger.info(
+                "[Slack] Refusing DM fallback to non-allowed DM channel: %s",
+                fallback_chat_id,
+            )
+            return None
+
+        self._dm_user_by_channel[str(fallback_chat_id)] = str(user_id)
+        team_id = self._channel_team.get(chat_id)
+        if team_id:
+            self._channel_team[str(fallback_chat_id)] = team_id
+        logger.warning(
+            "[Slack] Channel %s is not postable; rerouting DM response to opened DM %s",
+            chat_id,
+            fallback_chat_id,
+        )
+        return str(fallback_chat_id)
+
+    async def _chat_post_message_with_dm_fallback(
+        self,
+        chat_id: str,
+        kwargs: Dict[str, Any],
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        """Post a message, falling back from non-postable assistant DMs if needed."""
+        try:
+            return await self._get_client(chat_id).chat_postMessage(**kwargs)
+        except Exception as exc:
+            if self._slack_error_code(exc) != "channel_not_found":
+                raise
+            fallback_chat_id = await self._fallback_dm_channel_for_unpostable_channel(
+                chat_id,
+                metadata,
+            )
+            if not fallback_chat_id:
+                raise
+
+            fallback_kwargs = dict(kwargs)
+            fallback_kwargs["channel"] = fallback_chat_id
+            # The original thread_ts belongs to the non-postable assistant/App
+            # surface channel. It is invalid in the newly opened normal DM.
+            fallback_kwargs.pop("thread_ts", None)
+            fallback_kwargs.pop("reply_broadcast", None)
+            return await self._get_client(fallback_chat_id).chat_postMessage(**fallback_kwargs)
+
     async def send(
         self,
         chat_id: str,
@@ -803,7 +906,11 @@ class SlackAdapter(BasePlatformAdapter):
                     if broadcast and i == 0:
                         kwargs["reply_broadcast"] = True
 
-                last_result = await self._get_client(chat_id).chat_postMessage(**kwargs)
+                last_result = await self._chat_post_message_with_dm_fallback(
+                    chat_id,
+                    kwargs,
+                    metadata,
+                )
 
             # Clear Slack Assistant status as soon as the final message is posted.
             if thread_ts:
@@ -1919,6 +2026,9 @@ class SlackAdapter(BasePlatformAdapter):
         user_id = event.get("user") or assistant_meta.get("user_id", "")
         if not channel_id:
             channel_id = assistant_meta.get("channel_id", "")
+        if not self._slack_user_allowed(str(user_id or "")):
+            logger.info("[Slack] Ignoring message from non-allowed user: %s", user_id or "<missing>")
+            return
         team_id = (
             event.get("team")
             or event.get("team_id")
@@ -1934,6 +2044,8 @@ class SlackAdapter(BasePlatformAdapter):
         if not channel_type and channel_id.startswith("D"):
             channel_type = "im"
         is_dm = channel_type in {"im", "mpim"}  # Both 1:1 and group DMs
+        if is_dm and channel_id and user_id:
+            self._dm_user_by_channel[channel_id] = user_id
 
         # Build thread_ts for session keying.
         # In channels: fall back to ts so each top-level @mention starts a
@@ -1962,12 +2074,18 @@ class SlackAdapter(BasePlatformAdapter):
         event_thread_ts = event.get("thread_ts")
         is_thread_reply = bool(event_thread_ts and event_thread_ts != ts)
 
+        allowed_channels = self._slack_allowed_channels()
+        if allowed_channels and (
+            not is_dm or self._slack_restrict_dm_channels()
+        ) and channel_id not in allowed_channels:
+            logger.info(
+                "[Slack] Ignoring message in non-allowed %s: %s",
+                "DM" if is_dm else "channel",
+                channel_id,
+            )
+            return
+
         if not is_dm and bot_uid:
-            # Check allowed channels — if set, only respond in these channels (whitelist)
-            allowed_channels = self._slack_allowed_channels()
-            if allowed_channels and channel_id not in allowed_channels:
-                logger.debug("[Slack] Ignoring message in non-allowed channel: %s", channel_id)
-                return
 
             if channel_id in self._slack_free_response_channels():
                 pass  # Free-response channel — always process
@@ -2806,6 +2924,8 @@ class SlackAdapter(BasePlatformAdapter):
         # keep group semantics so different users do not collide into one
         # session key.
         is_dm = str(channel_id).startswith("D")
+        if is_dm and channel_id and user_id:
+            self._dm_user_by_channel[channel_id] = user_id
         source = self.build_source(
             chat_id=channel_id,
             chat_type="dm" if is_dm else "group",
@@ -2966,6 +3086,19 @@ class SlackAdapter(BasePlatformAdapter):
 
     # ── Channel mention gating ─────────────────────────────────────────────
 
+    def _slack_user_allowed(self, user_id: str) -> bool:
+        """Return whether a Slack sender is allowed past the adapter.
+
+        gateway.run has its own allowlist check, but doing a Slack-side prefilter
+        prevents App/Assistant surface oddities and DM fallback paths from ever
+        opening or messaging a non-allowed user's normal DM.
+        """
+        raw = os.getenv("SLACK_ALLOWED_USERS", "").strip()
+        if not raw:
+            return True
+        allowed = {part.strip() for part in raw.split(",") if part.strip()}
+        return "*" in allowed or bool(user_id and user_id in allowed)
+
     def _slack_require_mention(self) -> bool:
         """Return whether channel messages require an explicit bot mention.
 
@@ -3014,14 +3147,29 @@ class SlackAdapter(BasePlatformAdapter):
         """Return the whitelist of channel IDs the bot will respond in.
 
         When non-empty, messages from channels NOT in this set are silently
-        ignored — even if the bot is @mentioned.  DMs are never filtered.
-        Empty set means no restriction (fully backward compatible).
+        ignored — even if the bot is @mentioned.  DMs are filtered too when
+        ``SLACK_RESTRICT_DM_CHANNELS=true`` or
+        ``platforms.slack.extra.restrict_dm_channels`` is truthy.  Empty set
+        means no restriction (fully backward compatible).
         """
         raw = self.config.extra.get("allowed_channels")
-        if raw is None:
+        if raw is None or (isinstance(raw, str) and not raw.strip()):
             raw = os.getenv("SLACK_ALLOWED_CHANNELS", "")
         if isinstance(raw, list):
             return {str(part).strip() for part in raw if str(part).strip()}
         if isinstance(raw, str) and raw.strip():
             return {part.strip() for part in raw.split(",") if part.strip()}
         return set()
+
+    def _slack_restrict_dm_channels(self) -> bool:
+        """Return whether allowed_channels should also gate Slack DMs.
+
+        Slack App/Assistant surfaces can emit non-postable DM-like channel IDs.
+        If the adapter processes those, every progress/edit fallback may open a
+        normal bot DM and spam the user.  Keep legacy behavior by default, but
+        let operators pin Slack processing to an explicit home DM/channel.
+        """
+        raw = self.config.extra.get("restrict_dm_channels")
+        if raw is None:
+            raw = os.getenv("SLACK_RESTRICT_DM_CHANNELS", "false")
+        return str(raw).strip().lower() in {"1", "true", "yes", "on"}

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -23,7 +23,7 @@ import express from 'express';
 import { Boom } from '@hapi/boom';
 import pino from 'pino';
 import path from 'path';
-import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync, unlinkSync, chmodSync } from 'fs';
+import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync, unlinkSync, chmodSync, renameSync } from 'fs';
 import { randomBytes } from 'crypto';
 import { execSync } from 'child_process';
 import { tmpdir } from 'os';
@@ -65,10 +65,16 @@ const CHUNK_DELAY_MS = parseInt(process.env.WHATSAPP_CHUNK_DELAY_MS || '300', 10
 // fires. Fail fast instead so the gateway can surface a real error and retry.
 const SEND_TIMEOUT_MS = parseInt(process.env.WHATSAPP_SEND_TIMEOUT_MS || '60000', 10);
 let qrImageActive = false;
+let qrImageGeneration = 0;
+const qrTempImages = new Set();
 
 function cleanupQrImage() {
-  if (!qrImageActive) return;
+  qrImageGeneration += 1;
   try { unlinkSync(WHATSAPP_QR_IMAGE); } catch {}
+  for (const tmpImage of qrTempImages) {
+    try { unlinkSync(tmpImage); } catch {}
+  }
+  qrTempImages.clear();
   qrImageActive = false;
 }
 
@@ -225,13 +231,28 @@ async function startSocket() {
       console.log('\n📱 Scan this QR code with WhatsApp on your phone:\n');
       qrcode.generate(qr, { small: true });
       cleanupQrImage();
-      QRCode.toFile(WHATSAPP_QR_IMAGE, qr, { errorCorrectionLevel: 'M', margin: 2, width: 512 })
+      const qrGeneration = ++qrImageGeneration;
+      const qrTempImage = `${WHATSAPP_QR_IMAGE}.${process.pid}.${qrGeneration}.tmp`;
+      qrTempImages.add(qrTempImage);
+      qrImageActive = true;
+      QRCode.toFile(qrTempImage, qr, { errorCorrectionLevel: 'M', margin: 2, width: 512 })
         .then(() => {
-          try { chmodSync(WHATSAPP_QR_IMAGE, 0o600); } catch {}
-          qrImageActive = true;
+          qrTempImages.delete(qrTempImage);
+          if (qrGeneration !== qrImageGeneration || connectionState === 'connected') {
+            try { unlinkSync(qrTempImage); } catch {}
+            if (qrGeneration === qrImageGeneration) qrImageActive = false;
+            return;
+          }
+          try { chmodSync(qrTempImage, 0o600); } catch {}
+          renameSync(qrTempImage, WHATSAPP_QR_IMAGE);
           console.log(`\nQR image saved to: ${WHATSAPP_QR_IMAGE}`);
         })
-        .catch((err) => console.log(`\n⚠️  Could not write QR image: ${err.message}`));
+        .catch((err) => {
+          qrTempImages.delete(qrTempImage);
+          if (qrGeneration === qrImageGeneration) qrImageActive = false;
+          try { unlinkSync(qrTempImage); } catch {}
+          console.log(`\n⚠️  Could not write QR image: ${err.message}`);
+        });
       console.log('\nWaiting for scan...\n');
     }
 

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -23,11 +23,12 @@ import express from 'express';
 import { Boom } from '@hapi/boom';
 import pino from 'pino';
 import path from 'path';
-import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync, unlinkSync } from 'fs';
+import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync, unlinkSync, chmodSync } from 'fs';
 import { randomBytes } from 'crypto';
 import { execSync } from 'child_process';
 import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
+import QRCode from 'qrcode';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 
 // Parse CLI args
@@ -45,6 +46,7 @@ const WHATSAPP_DEBUG =
 
 const PORT = parseInt(getArg('port', '3000'), 10);
 const SESSION_DIR = getArg('session', path.join(process.env.HOME || '~', '.hermes', 'whatsapp', 'session'));
+const WHATSAPP_QR_IMAGE = getArg('qr-image', process.env.WHATSAPP_QR_IMAGE || path.join(path.dirname(SESSION_DIR), 'latest-qr.png'));
 const IMAGE_CACHE_DIR = path.join(process.env.HOME || '~', '.hermes', 'image_cache');
 const DOCUMENT_CACHE_DIR = path.join(process.env.HOME || '~', '.hermes', 'document_cache');
 const AUDIO_CACHE_DIR = path.join(process.env.HOME || '~', '.hermes', 'audio_cache');
@@ -62,6 +64,22 @@ const CHUNK_DELAY_MS = parseInt(process.env.WHATSAPP_CHUNK_DELAY_MS || '300', 10
 // which pins the bridge's HTTP handler until the upstream aiohttp timeout
 // fires. Fail fast instead so the gateway can surface a real error and retry.
 const SEND_TIMEOUT_MS = parseInt(process.env.WHATSAPP_SEND_TIMEOUT_MS || '60000', 10);
+let qrImageActive = false;
+
+function cleanupQrImage() {
+  if (!qrImageActive) return;
+  try { unlinkSync(WHATSAPP_QR_IMAGE); } catch {}
+  qrImageActive = false;
+}
+
+function exitAfterCleanup(code) {
+  cleanupQrImage();
+  process.exit(code);
+}
+
+process.once('SIGINT', () => exitAfterCleanup(130));
+process.once('SIGTERM', () => exitAfterCleanup(143));
+process.once('exit', cleanupQrImage);
 
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -206,6 +224,14 @@ async function startSocket() {
     if (qr) {
       console.log('\n📱 Scan this QR code with WhatsApp on your phone:\n');
       qrcode.generate(qr, { small: true });
+      cleanupQrImage();
+      QRCode.toFile(WHATSAPP_QR_IMAGE, qr, { errorCorrectionLevel: 'M', margin: 2, width: 512 })
+        .then(() => {
+          try { chmodSync(WHATSAPP_QR_IMAGE, 0o600); } catch {}
+          qrImageActive = true;
+          console.log(`\nQR image saved to: ${WHATSAPP_QR_IMAGE}`);
+        })
+        .catch((err) => console.log(`\n⚠️  Could not write QR image: ${err.message}`));
       console.log('\nWaiting for scan...\n');
     }
 
@@ -228,6 +254,7 @@ async function startSocket() {
     } else if (connection === 'open') {
       connectionState = 'connected';
       console.log('✅ WhatsApp connected!');
+      cleanupQrImage();
       if (PAIR_ONLY) {
         console.log('✅ Pairing complete. Credentials saved.');
         // Give Baileys a moment to flush creds, then exit cleanly

--- a/scripts/whatsapp-bridge/package-lock.json
+++ b/scripts/whatsapp-bridge/package-lock.json
@@ -8,9 +8,10 @@
       "name": "hermes-whatsapp-bridge",
       "version": "1.0.0",
       "dependencies": {
-        "@whiskeysockets/baileys": "WhiskeySockets/Baileys#01047debd81beb20da7b7779b08edcb06aa03770",
+        "@whiskeysockets/baileys": "7.0.0-rc13",
         "express": "^4.21.0",
         "pino": "^9.0.0",
+        "qrcode": "1.5.4",
         "qrcode-terminal": "^0.12.0"
       }
     },
@@ -623,9 +624,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
@@ -714,32 +715,31 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@whiskeysockets/baileys": {
-      "name": "baileys",
-      "version": "7.0.0-rc.9",
-      "resolved": "git+ssh://git@github.com/WhiskeySockets/Baileys.git#01047debd81beb20da7b7779b08edcb06aa03770",
-      "integrity": "sha512-letWyB96JHD6NdqpAiseOfaUBi13u8AhiRcKSRqcVjc5Vw5xoPTZGvVnw8K/NvGBFAvyLJkwim9Mjvwzhx/SlA==",
+      "version": "7.0.0-rc13",
+      "resolved": "https://registry.npmjs.org/@whiskeysockets/baileys/-/baileys-7.0.0-rc13.tgz",
+      "integrity": "sha512-8JPc8gaaCRykkjW2jxLGQ7/RZGrc7awO7WU+QJocf58eSUI9jAdcuYLynzhAbyU4UWvJJsHImZ+5E/JaZj5ypA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@cacheable/node-cache": "^1.4.0",
         "@hapi/boom": "^9.1.3",
         "async-mutex": "^0.5.0",
-        "libsignal": "git+https://github.com/whiskeysockets/libsignal-node",
+        "libsignal": "^6.0.0",
         "lru-cache": "^11.1.0",
-        "music-metadata": "^11.7.0",
+        "music-metadata": "^11.12.3",
         "p-queue": "^9.0.0",
         "pino": "^9.6",
-        "protobufjs": "^7.2.4",
-        "whatsapp-rust-bridge": "0.5.2",
+        "protobufjs": "^7.5.6",
+        "whatsapp-rust-bridge": "0.5.4",
         "ws": "^8.13.0"
       },
       "engines": {
@@ -747,7 +747,7 @@
       },
       "peerDependencies": {
         "audio-decode": "^2.1.3",
-        "jimp": "^1.6.0",
+        "jimp": "^1.6.1",
         "link-preview-js": "^3.0.0",
         "sharp": "*"
       },
@@ -774,6 +774,30 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/array-flatten": {
@@ -890,6 +914,44 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -941,6 +1003,15 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -970,6 +1041,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -988,6 +1065,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -1132,6 +1215,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -1157,6 +1253,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -1317,6 +1422,15 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/keyv": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
@@ -1327,13 +1441,25 @@
       }
     },
     "node_modules/libsignal": {
-      "name": "@whiskeysockets/libsignal-node",
-      "version": "2.0.1",
-      "resolved": "git+ssh://git@github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/libsignal/-/libsignal-6.0.0.tgz",
+      "integrity": "sha512-d/5V3YFtDljbFMufz4ncyUYGYhJl+vzAe+c2EFFBQ6bz1h8Q3IOMEGXYMzlibU60I+e8GagMMpji18iez3P1hA==",
       "license": "GPL-3.0",
       "dependencies": {
         "curve25519-js": "^0.0.4",
-        "protobufjs": "6.8.8"
+        "protobufjs": "^7.5.5"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/long": {
@@ -1522,6 +1648,33 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/p-queue": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.2.0.tgz",
@@ -1550,6 +1703,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1557,6 +1719,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-to-regexp": {
@@ -1602,6 +1773,15 @@
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
     },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/process-warning": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
@@ -1619,16 +1799,16 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.0.tgz",
-      "integrity": "sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
+      "integrity": "sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
         "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/eventemitter": "^1.1.1",
         "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
         "@protobufjs/inquire": "^1.1.2",
@@ -1672,6 +1852,23 @@
       "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
       "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
       "license": "MIT"
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/qrcode-terminal": {
       "version": "0.12.0",
@@ -1734,6 +1931,21 @@
       "engines": {
         "node": ">= 12.13.0"
       }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -1827,6 +2039,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -1978,6 +2196,32 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strtok3": {
       "version": "10.3.5",
       "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
@@ -2071,9 +2315,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -2104,16 +2348,36 @@
       }
     },
     "node_modules/whatsapp-rust-bridge": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.5.2.tgz",
-      "integrity": "sha512-6KBRNvxg6WMIwZ/euA8qVzj16qxMBzLllfmaJIP1JGAAfSvwn6nr8JDOMXeqpXPEOl71UfOG+79JwKEoT2b1Fw==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/whatsapp-rust-bridge/-/whatsapp-rust-bridge-0.5.4.tgz",
+      "integrity": "sha512-yYO1qSs0Fe7tGtnxOFHomocUD6IZtoAgmA4oDFyGIRZ67D3QZk3w7swA6XXFXNQngiyrg2k7tul6IrM3eUFh7A==",
       "license": "MIT"
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
     },
     "node_modules/win-guid": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/win-guid/-/win-guid-0.2.1.tgz",
       "integrity": "sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A==",
       "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/ws": {
       "version": "8.20.1",
@@ -2134,6 +2398,47 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     }
   }

--- a/scripts/whatsapp-bridge/package.json
+++ b/scripts/whatsapp-bridge/package.json
@@ -8,10 +8,11 @@
     "start": "node bridge.js"
   },
   "dependencies": {
-    "@whiskeysockets/baileys": "WhiskeySockets/Baileys#01047debd81beb20da7b7779b08edcb06aa03770",
+    "@whiskeysockets/baileys": "7.0.0-rc13",
     "express": "^4.21.0",
-    "qrcode-terminal": "^0.12.0",
-    "pino": "^9.0.0"
+    "pino": "^9.0.0",
+    "qrcode": "1.5.4",
+    "qrcode-terminal": "^0.12.0"
   },
   "overrides": {
     "protobufjs": "^7.5.5"

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -174,6 +174,46 @@ class TestRunJobScript:
         parsed = json.loads(output)
         assert parsed["new_prs"][0]["number"] == 42
 
+    def test_windows_pythonw_gateway_uses_console_python_for_stdout(self, cron_env, tmp_path, monkeypatch):
+        """Hidden Windows gateways run under pythonw.exe; cron scripts need python.exe.
+
+        A migrated digest exposed this because script stdout was empty
+        only under the hidden gateway scheduler path.  Verify the scheduler swaps
+        sibling python.exe in before spawning .py scripts.
+        """
+        import cron.scheduler as sched_mod
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "stdout_required.py"
+        script.write_text('print("cron stdout matters")\n')
+        pythonw = tmp_path / "pythonw.exe"
+        python = tmp_path / "python.exe"
+        pythonw.write_text("placeholder")
+        python.write_text("placeholder")
+
+        class _Completed:
+            stdout = "captured\n"
+            stderr = ""
+            returncode = 0
+
+        calls = []
+
+        def fake_run(argv, **kwargs):
+            calls.append((argv, kwargs))
+            return _Completed()
+
+        monkeypatch.setattr(sched_mod.sys, "platform", "win32")
+        monkeypatch.setattr(sched_mod.sys, "executable", str(pythonw))
+        monkeypatch.setattr(sched_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(sched_mod, "windows_hide_flags", lambda: 0)
+
+        success, output = _run_job_script(str(script))
+
+        assert success is True
+        assert output == "captured"
+        assert calls[0][0][0] == str(python)
+        assert calls[0][0][1] == str(script.resolve())
+
 
 class TestBuildJobPromptWithScript:
     """Test that script output is injected into the prompt."""

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -98,12 +98,19 @@ def _redirect_cache(tmp_path, monkeypatch):
     monkeypatch.delenv("SLACK_RESTRICT_DM_CHANNELS", raising=False)
 
 
+class _FakeSlackResponse:
+    """SlackResponse-like object exposing error data via .data."""
+
+    def __init__(self, error: str):
+        self.data = {"error": error}
+
+
 class _FakeSlackApiError(Exception):
-    """Minimal SlackApiError stand-in with response.get('error')."""
+    """Minimal SlackApiError stand-in with SlackResponse-like .response.data."""
 
     def __init__(self, error: str):
         super().__init__(f"Slack API error: {error}")
-        self.response = {"error": error}
+        self.response = _FakeSlackResponse(error)
 
 
 # ---------------------------------------------------------------------------
@@ -2491,6 +2498,18 @@ class TestMessageSplitting:
 
 
 class TestInaccessibleDmFallback:
+    def test_slack_error_code_reads_slack_response_data(self):
+        assert SlackAdapter._slack_error_code(_FakeSlackApiError("channel_not_found")) == "channel_not_found"
+
+    def test_dm_user_map_is_bounded(self, adapter, monkeypatch):
+        monkeypatch.setattr(_slack_mod, "_MAX_DM_USER_CACHE_SIZE", 2)
+
+        adapter._remember_dm_user("D_ONE", "U1")
+        adapter._remember_dm_user("D_TWO", "U2")
+        adapter._remember_dm_user("D_THREE", "U3")
+
+        assert list(adapter._dm_user_by_channel) == ["D_TWO", "D_THREE"]
+
     @pytest.mark.asyncio
     async def test_dm_message_records_user_for_send_fallback(self, adapter):
         adapter._resolve_user_name = AsyncMock(return_value="Test User")

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -86,10 +86,24 @@ def adapter():
 
 @pytest.fixture(autouse=True)
 def _redirect_cache(tmp_path, monkeypatch):
-    """Point document cache to tmp_path so tests don't touch ~/.hermes."""
+    """Point document cache to tmp_path and isolate Slack env knobs."""
     monkeypatch.setattr(
         "gateway.platforms.base.DOCUMENT_CACHE_DIR", tmp_path / "doc_cache"
     )
+    # The developer's real gateway may be locked to one Slack user/channel.
+    # Unit tests build synthetic events from many fake users/channels, so clear
+    # these env-level gates unless an individual test opts into them.
+    monkeypatch.delenv("SLACK_ALLOWED_USERS", raising=False)
+    monkeypatch.delenv("SLACK_ALLOWED_CHANNELS", raising=False)
+    monkeypatch.delenv("SLACK_RESTRICT_DM_CHANNELS", raising=False)
+
+
+class _FakeSlackApiError(Exception):
+    """Minimal SlackApiError stand-in with response.get('error')."""
+
+    def __init__(self, error: str):
+        super().__init__(f"Slack API error: {error}")
+        self.response = {"error": error}
 
 
 # ---------------------------------------------------------------------------
@@ -2474,6 +2488,101 @@ class TestMessageSplitting:
         await adapter.send("C123", "See [Foo](https://en.wikipedia.org/wiki/Foo_(bar))")
         kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
         assert "<https://en.wikipedia.org/wiki/Foo_(bar)|Foo>" in kwargs["text"]
+
+
+class TestInaccessibleDmFallback:
+    @pytest.mark.asyncio
+    async def test_dm_message_records_user_for_send_fallback(self, adapter):
+        adapter._resolve_user_name = AsyncMock(return_value="Test User")
+        event = {
+            "type": "message",
+            "channel": "D_BAD",
+            "channel_type": "im",
+            "user": "U123",
+            "text": "hello",
+            "ts": "1779464112.265589",
+            "team": "T123",
+        }
+
+        await adapter._handle_slack_message(event)
+
+        assert adapter._dm_user_by_channel["D_BAD"] == "U123"
+
+    @pytest.mark.asyncio
+    async def test_send_reroutes_channel_not_found_dm_to_open_user_dm(self, adapter):
+        adapter._dm_user_by_channel["D_BAD"] = "U123"
+        adapter._app.client.chat_postMessage = AsyncMock(
+            side_effect=[
+                _FakeSlackApiError("channel_not_found"),
+                {"ts": "fallback_ts"},
+            ]
+        )
+        adapter._app.client.conversations_open = AsyncMock(
+            return_value={"channel": {"id": "D_GOOD"}}
+        )
+
+        result = await adapter.send(
+            "D_BAD",
+            "hello",
+            metadata={"thread_id": "1779464112.265589"},
+        )
+
+        assert result.success
+        assert result.message_id == "fallback_ts"
+        adapter._app.client.conversations_open.assert_awaited_once_with(users="U123")
+        first_call = adapter._app.client.chat_postMessage.await_args_list[0].kwargs
+        assert first_call["channel"] == "D_BAD"
+        assert first_call["thread_ts"] == "1779464112.265589"
+        fallback_call = adapter._app.client.chat_postMessage.await_args_list[1].kwargs
+        assert fallback_call["channel"] == "D_GOOD"
+        assert "thread_ts" not in fallback_call
+
+    @pytest.mark.asyncio
+    async def test_dm_fallback_refuses_non_allowed_user(self, adapter, monkeypatch):
+        monkeypatch.setenv("SLACK_ALLOWED_USERS", "U_ALLOWED")
+        adapter._dm_user_by_channel["D_BAD"] = "U_BLOCKED"
+        adapter._app.client.conversations_open = AsyncMock(
+            return_value={"channel": {"id": "D_SHOULD_NOT_OPEN"}}
+        )
+
+        fallback = await adapter._fallback_dm_channel_for_unpostable_channel("D_BAD")
+
+        assert fallback is None
+        adapter._app.client.conversations_open.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_dm_fallback_honors_restricted_dm_channel_allowlist(self, adapter, monkeypatch):
+        monkeypatch.setenv("SLACK_ALLOWED_CHANNELS", "D_ALLOWED")
+        monkeypatch.setenv("SLACK_RESTRICT_DM_CHANNELS", "true")
+        adapter._dm_user_by_channel["D_BAD"] = "U123"
+        adapter._app.client.conversations_open = AsyncMock(
+            return_value={"channel": {"id": "D_OTHER"}}
+        )
+
+        fallback = await adapter._fallback_dm_channel_for_unpostable_channel("D_BAD")
+
+        assert fallback is None
+        adapter._app.client.conversations_open.assert_awaited_once_with(users="U123")
+        assert "D_OTHER" not in adapter._dm_user_by_channel
+
+    @pytest.mark.asyncio
+    async def test_allowed_channels_can_restrict_dm_surfaces(self, adapter, monkeypatch):
+        monkeypatch.setenv("SLACK_ALLOWED_CHANNELS", "D_HOME")
+        monkeypatch.setenv("SLACK_RESTRICT_DM_CHANNELS", "true")
+        adapter._resolve_user_name = AsyncMock(return_value="Test User")
+        event = {
+            "type": "message",
+            "channel": "D_OTHER",
+            "channel_type": "im",
+            "user": "U123",
+            "text": "hello",
+            "ts": "1779464112.265589",
+            "team": "T123",
+        }
+
+        await adapter._handle_slack_message(event)
+
+        adapter.handle_message.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Use console `python.exe` for Windows cron child scripts when the gateway is running under `pythonw.exe`, so stdout/stderr capture remains reliable.
- Add safe Slack DM fallback for non-postable App/Assistant DM surfaces, with user and DM-channel allowlist enforcement.
- Add WhatsApp QR image output for easier pairing, with cleanup and restrictive file permissions.
- Document the generic legacy-bot migration hardening patterns and add regression coverage.

## Test plan
- `env HERMES_HOME="$TMP_HOME" venv/Scripts/python.exe -m pytest tests/cron/test_cron_script.py tests/gateway/test_slack.py -q --tb=short -o addopts='' -p no:timeout`
- `venv/Scripts/python.exe -m py_compile cron/scheduler.py gateway/config.py gateway/platforms/slack.py tests/cron/test_cron_script.py tests/gateway/test_slack.py`
- `node --check scripts/whatsapp-bridge/bridge.js`
- `git diff --check origin/main...HEAD`
