### PR TITLE
fix(gateway): honor key_env in auth-failure fallback resolution

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -901,10 +901,17 @@ def _try_resolve_fallback_provider() -> dict | None:
             if not isinstance(entry, dict):
                 continue
             try:
+                explicit_api_key = entry.get("api_key")
+                if not explicit_api_key:
+                    key_env = str(
+                        entry.get("key_env") or entry.get("api_key_env") or ""
+                    ).strip()
+                    if key_env:
+                        explicit_api_key = os.getenv(key_env, "").strip() or None
                 runtime = resolve_runtime_provider(
                     requested=entry.get("provider"),
                     explicit_base_url=entry.get("base_url"),
-                    explicit_api_key=entry.get("api_key"),
+                    explicit_api_key=explicit_api_key,
                 )
                 logger.info(
                     "Fallback provider resolved: %s model=%s",

--- a/tests/gateway/test_session_model_override_routing.py
+++ b/tests/gateway/test_session_model_override_routing.py
@@ -218,3 +218,46 @@ fallback_providers:
     assert runtime_kwargs["provider"] == "openrouter"
     assert runtime_kwargs["api_key"] == "sk-openrouter"
 
+
+def test_gateway_auth_fallback_resolves_key_env_for_custom_provider(tmp_path, monkeypatch):
+    """Auth-failure fallback should honor key_env/api_key_env custom-endpoint hints."""
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        """
+fallback_providers:
+  - provider: custom
+    model: fallback-model
+    base_url: https://fallback.example/v1
+    key_env: MY_FALLBACK_KEY
+""".lstrip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setenv("MY_FALLBACK_KEY", "env-secret")
+
+    def fake_resolve_runtime_provider(*, requested=None, explicit_base_url=None, explicit_api_key=None):
+        assert requested == "custom"
+        assert explicit_base_url == "https://fallback.example/v1"
+        assert explicit_api_key == "env-secret"
+        return {
+            "api_key": explicit_api_key,
+            "base_url": explicit_base_url,
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "command": None,
+            "args": [],
+            "credential_pool": None,
+        }
+
+    import hermes_cli.runtime_provider as runtime_provider
+
+    monkeypatch.setattr(runtime_provider, "resolve_runtime_provider", fake_resolve_runtime_provider)
+
+    runtime_kwargs = gateway_run._try_resolve_fallback_provider()
+
+    assert runtime_kwargs is not None
+    assert runtime_kwargs["provider"] == "custom"
+    assert runtime_kwargs["api_key"] == "env-secret"
+    assert runtime_kwargs["base_url"] == "https://fallback.example/v1"
+    assert runtime_kwargs["model"] == "fallback-model"
+


### PR DESCRIPTION
## Summary

Fix gateway auth-failure fallback so custom fallback providers honor `key_env` / `api_key_env` when resolving credentials.

Previously, the gateway’s `_try_resolve_fallback_provider()` only forwarded inline `api_key` and `base_url` to `resolve_runtime_provider()`. That broke documented fallback configs like:

```yaml
fallback_providers:
  - provider: custom
    model: my-model
    base_url: https://example/v1
    key_env: MY_API_KEY
```

## What changed

- Read `key_env` and `api_key_env` in `gateway.run._try_resolve_fallback_provider()`
- Resolve the env var value before calling `resolve_runtime_provider()`
- Add a gateway regression test covering custom fallback + `key_env`

## Why

The docs already advertise `key_env` for custom fallback providers, but the gateway auth-failure fallback path ignored it. As a result, gateway failover could use the wrong auth source or fall through as if no key was configured.

## Tests

Ran with the repo-preferred wrapper:

- `scripts/run_tests.sh tests/gateway/test_session_model_override_routing.py -q`
  - Result: passed 
- `scripts/run_tests.sh tests/run_agent/test_provider_fallback.py::TestFallbackChainAdvancement::test_resolves_key_env_for_fallback_provider -q`
  - Result: passed

## Notes

This is a narrow fix in the gateway auth-failure fallback path only. It does not change normal runtime provider resolution or the main agent fallback chain behavior.