### PR TITLE
fix(p1): guard Kanban autocreate and gateway cron loops

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5028,6 +5028,19 @@ def gateway_command(args):
         sys.exit(1)
 
 
+def _refuse_gateway_lifecycle_from_gateway(subcmd: str) -> None:
+    """Prevent gateway-hosted tools from killing their own runtime."""
+    if subcmd not in {"stop", "restart"}:
+        return
+    if os.environ.get("_HERMES_GATEWAY") != "1":
+        return
+    if os.environ.get("HERMES_ALLOW_GATEWAY_LIFECYCLE_FROM_GATEWAY") == "1":
+        return
+    print_error(f"Refusing to {subcmd} the gateway from inside the running gateway process.")
+    print("Run this command from an external shell instead, or use the gateway /update flow.")
+    sys.exit(1)
+
+
 def _gateway_command_inner(args):
     subcmd = getattr(args, 'gateway_command', None)
     
@@ -5042,6 +5055,8 @@ def _gateway_command_inner(args):
     if subcmd == "setup":
         gateway_setup()
         return
+
+    _refuse_gateway_lifecycle_from_gateway(subcmd)
 
     # Service management commands
     if subcmd == "install":

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -872,7 +872,7 @@ def kanban_command(args: argparse.Namespace) -> int:
     # schema creation; `create` / `list` / every other command would
     # error out on a fresh install.
     try:
-        kb.init_db()
+        kb.init_db(allow_create=False)
     except Exception as exc:
         print(f"kanban: could not initialize database: {exc}", file=sys.stderr)
         _restore_board_env()

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1005,10 +1005,38 @@ def _validate_sqlite_header(path: Path) -> None:
     )
 
 
+def _validate_board_db_autocreate_allowed(path: Path, board: Optional[str], *, allow_create: bool) -> None:
+    """Refuse implicit recreation of missing/empty non-default board DBs.
+
+    The default board keeps fresh-install ergonomics. Named boards, however,
+    represent existing project state: if their DB file disappeared or was
+    truncated, silently running SQLite schema creation yields a valid but empty
+    board and makes data loss look like success.
+    """
+    slug = _normalize_board_slug(board)
+    if slug is None or slug == DEFAULT_BOARD or allow_create:
+        return
+    try:
+        stat = path.stat()
+    except FileNotFoundError as exc:
+        raise sqlite3.DatabaseError(
+            f"refusing to auto-create missing kanban DB for board {slug!r}: {path}. "
+            "Run `hermes kanban init` only after restoring/backing up the board DB."
+        ) from exc
+    except OSError:
+        return
+    if stat.st_size == 0:
+        raise sqlite3.DatabaseError(
+            f"refusing to auto-create empty/truncated kanban DB for board {slug!r}: {path}. "
+            "Restore from backup or run explicit `hermes kanban init` after preserving the damaged file."
+        )
+
+
 def connect(
     db_path: Optional[Path] = None,
     *,
     board: Optional[str] = None,
+    allow_create: bool = True,
 ) -> sqlite3.Connection:
     """Open (and initialize if needed) the kanban DB.
 
@@ -1030,8 +1058,13 @@ def connect(
     """
     if db_path is not None:
         path = db_path
+        resolved_board = _normalize_board_slug(board)
     else:
-        path = kanban_db_path(board=board)
+        resolved_board = _normalize_board_slug(board)
+        if resolved_board is None:
+            resolved_board = get_current_board()
+        path = kanban_db_path(board=resolved_board)
+    _validate_board_db_autocreate_allowed(path, resolved_board, allow_create=allow_create)
     path.parent.mkdir(parents=True, exist_ok=True)
     _validate_sqlite_header(path)
     resolved = str(path.resolve())
@@ -1070,6 +1103,7 @@ def init_db(
     db_path: Optional[Path] = None,
     *,
     board: Optional[str] = None,
+    allow_create: bool = True,
 ) -> Path:
     """Create the schema if it doesn't exist; return the path used.
 
@@ -1091,7 +1125,7 @@ def init_db(
     # schema + migration pass unconditionally.
     with _INIT_LOCK:
         _INITIALIZED_PATHS.discard(resolved)
-    with contextlib.closing(connect(path)):
+    with contextlib.closing(connect(path, board=board, allow_create=allow_create)):
         pass
     return path
 

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -542,3 +542,36 @@ class TestRunJobEnvVarCleanup:
         assert os.environ.get("HERMES_SESSION_PLATFORM") is None
         assert os.environ.get("HERMES_SESSION_CHAT_ID") is None
         assert os.environ.get("HERMES_SESSION_CHAT_NAME") is None
+
+
+def test_cron_prompt_rejects_gateway_lifecycle_restart(cron_env):
+    from tools.cronjob_tools import cronjob
+
+    result = json.loads(cronjob(
+        action="create",
+        prompt="Run maintenance, then hermes gateway restart",
+        schedule="30m",
+        name="bad-gateway-restart",
+    ))
+
+    assert result["success"] is False
+    assert "gateway lifecycle" in result["error"]
+
+
+def test_cron_script_rejects_gateway_lifecycle_restart(cron_env):
+    from tools.cronjob_tools import cronjob
+
+    script = cron_env / "scripts" / "restart_gateway.sh"
+    script.write_text("#!/usr/bin/env bash\nhermes gateway restart\n", encoding="utf-8")
+
+    result = json.loads(cronjob(
+        action="create",
+        prompt="Run script",
+        schedule="30m",
+        script="restart_gateway.sh",
+        name="bad-script-restart",
+    ))
+
+    assert result["success"] is False
+    assert "Script 'restart_gateway.sh' is unsafe" in result["error"]
+    assert "gateway lifecycle" in result["error"]

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -703,3 +703,20 @@ def test_module_has_logger():
     """Verify module has a logger instance (regression guard for #27154)."""
     assert hasattr(gateway, "logger")
     assert gateway.logger.name == "hermes_cli.gateway"
+
+
+def test_gateway_lifecycle_refuses_inside_gateway_env(monkeypatch, capsys):
+    monkeypatch.setenv("_HERMES_GATEWAY", "1")
+    monkeypatch.delenv("HERMES_ALLOW_GATEWAY_LIFECYCLE_FROM_GATEWAY", raising=False)
+
+    with pytest.raises(SystemExit) as exc_info:
+        gateway._refuse_gateway_lifecycle_from_gateway("restart")
+
+    assert exc_info.value.code == 1
+    out = capsys.readouterr().out
+    assert "Refusing to restart the gateway" in out
+
+
+def test_gateway_lifecycle_allows_external_shell(monkeypatch):
+    monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+    gateway._refuse_gateway_lifecycle_from_gateway("restart")

--- a/tests/hermes_cli/test_kanban_db_init.py
+++ b/tests/hermes_cli/test_kanban_db_init.py
@@ -36,3 +36,41 @@ def test_connect_initialization_is_thread_safe(tmp_path, monkeypatch):
     with kb.connect(board="default") as conn:
         cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
     assert "max_retries" in cols
+
+
+def test_auto_init_refuses_missing_named_board_db(tmp_path, monkeypatch):
+    import pytest
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    kb.write_board_metadata("project")
+    db_path = kb.kanban_db_path(board="project")
+    assert not db_path.exists()
+
+    with pytest.raises(Exception, match="refusing to auto-create missing kanban DB"):
+        kb.init_db(board="project", allow_create=False)
+    assert not db_path.exists()
+
+    kb.init_db(board="project")
+    assert db_path.exists()
+
+
+def test_auto_init_refuses_empty_named_board_db(tmp_path, monkeypatch):
+    import pytest
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    kb.write_board_metadata("project")
+    db_path = kb.kanban_db_path(board="project")
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    db_path.write_bytes(b"")
+
+    with pytest.raises(Exception, match="refusing to auto-create empty/truncated kanban DB"):
+        kb.init_db(board="project", allow_create=False)
+    assert db_path.read_bytes() == b""

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -65,6 +65,14 @@ _CRON_EXFIL_COMMAND_PATTERNS = [
     (rf'curl\s+[^\n]*(?:-H|--header)\s+["\']Authorization:\s*(?:Bearer|token)\s+{_CRON_SECRET_VAR_RE}["\']', "exfil_curl_auth_header"),
 ]
 
+_CRON_GATEWAY_LIFECYCLE_PATTERNS = [
+    (r'\bhermes\s+gateway\s+(?:restart|stop|start)\b', "hermes_gateway_lifecycle"),
+    (r'\bhermes\s+update\b', "hermes_update_gateway_restart"),
+    (r'\blaunchctl\s+(?:kickstart|unload|load|stop)\b[^\n]*(?:ai\.hermes|hermes)', "launchctl_hermes_lifecycle"),
+    (r'\bsystemctl\s+(?:--user\s+)?(?:restart|stop)\b[^\n]*(?:hermes|gateway)', "systemctl_hermes_lifecycle"),
+    (r'\b(?:kill|pkill|killall)\b[^\n]*(?:hermes|gateway)', "kill_hermes_gateway"),
+]
+
 _CRON_INVISIBLE_CHARS = {
     '\u200b', '\u200c', '\u200d', '\u2060', '\ufeff',
     '\u202a', '\u202b', '\u202c', '\u202d', '\u202e',
@@ -137,6 +145,12 @@ def _scan_cron_prompt(prompt: str) -> str:
     for pattern, pid in _CRON_EXFIL_COMMAND_PATTERNS:
         if re.search(pattern, prompt_to_scan, re.IGNORECASE):
             return f"Blocked: prompt matches threat pattern '{pid}'. Cron prompts must not contain injection or exfiltration payloads."
+    for pattern, pid in _CRON_GATEWAY_LIFECYCLE_PATTERNS:
+        if re.search(pattern, prompt_to_scan, re.IGNORECASE):
+            return (
+                f"Blocked: prompt matches gateway lifecycle pattern '{pid}'. "
+                "Cron jobs must not restart/stop the gateway that runs them; run lifecycle commands from an external shell."
+            )
     return ""
 
 
@@ -287,6 +301,17 @@ def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
         return (
             f"Script path escapes the scripts directory via traversal: {raw!r}"
         )
+
+    script_path = scripts_dir / raw
+    if script_path.exists() and script_path.is_file():
+        try:
+            script_text = script_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            script_text = ""
+        if script_text:
+            lifecycle_error = _scan_cron_prompt(script_text)
+            if lifecycle_error:
+                return f"Script {raw!r} is unsafe: {lifecycle_error}"
 
     return None
 


### PR DESCRIPTION
## Summary

Fixes two P1 Chief-of-Staff/support signals:

- #30687: prevent implicit recreation of missing/empty named Kanban board DBs during auto-init.
- #30719: block gateway lifecycle cron payloads and refuse `hermes gateway stop|restart` from inside the running gateway process.

## Changes

- Add `allow_create` guard to Kanban DB init/connect.
- Keep fresh default-board creation and explicit `hermes kanban init` behavior intact.
- Make CLI auto-init use `allow_create=False`, so stale current-board pointers or missing/truncated named board DBs fail closed instead of creating an empty board.
- Add cron prompt/script lifecycle scanners for `hermes gateway restart|stop|start`, `hermes update`, launchctl/systemctl Hermes lifecycle calls, and kill/pkill/killall against Hermes/gateway.
- Add gateway runtime guard using `_HERMES_GATEWAY=1` to refuse self stop/restart from gateway-hosted tool calls, with explicit env override for break-glass.

## Tests

- `PYTHONDONTWRITEBYTECODE=1 pytest -o addopts='' tests/hermes_cli/test_kanban_db_init.py tests/cron/test_cron_script.py::test_cron_prompt_rejects_gateway_lifecycle_restart tests/cron/test_cron_script.py::test_cron_script_rejects_gateway_lifecycle_restart tests/hermes_cli/test_gateway.py::test_gateway_lifecycle_refuses_inside_gateway_env tests/hermes_cli/test_gateway.py::test_gateway_lifecycle_allows_external_shell -q`
- `python3 -m py_compile hermes_cli/kanban_db.py hermes_cli/kanban.py tools/cronjob_tools.py hermes_cli/gateway.py`
- `git diff --check`

## Notes

This intentionally does not implement the broader shutdown loop detector from #30719; this PR covers the small, high-ROI defenses 1 + 2 and the immediate Kanban fail-closed path.
