### PR TITLE
fix(tui): stabilize resize and IME rendering

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/components/ScrollBox.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/components/ScrollBox.tsx
@@ -10,6 +10,28 @@ import { markCommitStart } from '../reconciler.js'
 import type { Styles } from '../styles.js'
 
 import Box from './Box.js'
+
+const scrollContentHeight = (content: DOMElement | undefined): number => {
+  if (!content) {
+    return 0
+  }
+
+  let bottom = content.yogaNode?.getComputedHeight() ?? 0
+
+  for (const child of content.childNodes) {
+    const el = child as DOMElement
+    const yoga = el.yogaNode
+
+    if (!yoga) {
+      continue
+    }
+
+    bottom = Math.max(bottom, yoga.getComputedTop() + scrollContentHeight(el))
+  }
+
+  return bottom
+}
+
 export type ScrollBoxHandle = {
   scrollTo: (y: number) => void
   scrollBy: (dy: number) => void
@@ -200,7 +222,7 @@ function ScrollBox({ children, ref, stickyScroll, ...style }: PropsWithChildren<
       getFreshScrollHeight() {
         const content = domRef.current?.childNodes[0] as DOMElement | undefined
 
-        return content?.yogaNode?.getComputedHeight() ?? domRef.current?.scrollHeight ?? 0
+        return Math.max(scrollContentHeight(content), domRef.current?.scrollHeight ?? 0)
       },
       getViewportHeight() {
         return domRef.current?.scrollViewportHeight ?? 0

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -304,6 +304,7 @@ export default class Ink {
   // expensive tree rebuild defers.
   private pendingResizeRender = false
   private resizeSettleTimer: ReturnType<typeof setTimeout> | null = null
+  private resizeLateSettleTimer: ReturnType<typeof setTimeout> | null = null
 
   // Fold synchronous re-entry (selection fanout, onFrame callback)
   // into one follow-up microtask instead of stacking renders.
@@ -519,6 +520,11 @@ export default class Ink {
       this.resizeSettleTimer = null
     }
 
+    if (this.resizeLateSettleTimer !== null) {
+      clearTimeout(this.resizeLateSettleTimer)
+      this.resizeLateSettleTimer = null
+    }
+
     // Alt screen: reset frame buffers so the next render repaints from
     // scratch (prevFrameContaminated → every cell written, wrapped in
     // BSU/ESU — old content stays visible until the new frame swaps
@@ -573,6 +579,11 @@ export default class Ink {
       this.resizeSettleTimer = null
     }
 
+    if (this.resizeLateSettleTimer !== null) {
+      clearTimeout(this.resizeLateSettleTimer)
+      this.resizeLateSettleTimer = null
+    }
+
     // Mouse tracking — DISABLE first so we land in the exact preset state
     // even if an external app/terminal/tmux left DEC 1003 hover asserted.
     // DISABLE_MOUSE_TRACKING is idempotent (resets all four modes
@@ -582,8 +593,20 @@ export default class Ink {
     this.resetFramesForAltScreen()
     this.needsEraseBeforePaint = true
 
-    this.resizeSettleTimer = setTimeout(() => {
-      this.resizeSettleTimer = null
+    this.resizeSettleTimer = this.scheduleAltScreenResizeHeal(160, 'resizeSettleTimer')
+    this.resizeLateSettleTimer = this.scheduleAltScreenResizeHeal(360, 'resizeLateSettleTimer')
+  }
+
+  private scheduleAltScreenResizeHeal(
+    delayMs: number,
+    field: 'resizeSettleTimer' | 'resizeLateSettleTimer'
+  ): ReturnType<typeof setTimeout> {
+    return setTimeout(() => {
+      if (field === 'resizeSettleTimer') {
+        this.resizeSettleTimer = null
+      } else {
+        this.resizeLateSettleTimer = null
+      }
 
       if (!this.canAltScreenRepaint()) {
         return
@@ -592,7 +615,7 @@ export default class Ink {
       this.resetFramesForAltScreen()
       this.needsEraseBeforePaint = true
       this.render(this.currentNode!)
-    }, 160)
+    }, delayMs)
   }
 
   resolveExitPromise: () => void = () => {}
@@ -2431,6 +2454,11 @@ export default class Ink {
     if (this.resizeSettleTimer !== null) {
       clearTimeout(this.resizeSettleTimer)
       this.resizeSettleTimer = null
+    }
+
+    if (this.resizeLateSettleTimer !== null) {
+      clearTimeout(this.resizeLateSettleTimer)
+      this.resizeLateSettleTimer = null
     }
 
     reconciler.updateContainerSync(null, this.container, null, noop)

--- a/ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts
@@ -22,6 +22,26 @@ function isXtermJsHost(): boolean {
   return process.env.TERM_PROGRAM === 'vscode' || isXtermJs()
 }
 
+function scrollContentHeight(content: DOMElement | undefined): number {
+  if (!content) {
+    return 0
+  }
+
+  let bottom = content.yogaNode?.getComputedHeight() ?? 0
+
+  for (const child of content.childNodes) {
+    const childYoga = (child as DOMElement).yogaNode
+
+    if (!childYoga) {
+      continue
+    }
+
+    bottom = Math.max(bottom, childYoga.getComputedTop() + scrollContentHeight(child as DOMElement))
+  }
+
+  return bottom
+}
+
 // Per-frame scratch: set when any node's yoga position/size differs from
 // its cached value, or a child was removed. Read by ink.tsx to decide
 // whether the full-damage sledgehammer (PR #20120) is needed this frame.
@@ -711,7 +731,7 @@ function renderNodeToOutput(
         // within the viewport (equal to the scroll container's
         // paddingTop), and innerHeight already subtracts padding, so
         // including it double-counts padding and inflates maxScroll.
-        const scrollHeight = contentYoga?.getComputedHeight() ?? 0
+        const scrollHeight = scrollContentHeight(content)
         // Capture previous scroll bounds BEFORE overwriting — the at-bottom
         // follow check compares against last frame's max.
         const prevScrollHeight = node.scrollHeight ?? scrollHeight

--- a/ui-tui/packages/hermes-ink/src/ink/scrollbox-overflow.test.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/scrollbox-overflow.test.tsx
@@ -1,0 +1,67 @@
+import { PassThrough } from 'stream'
+
+import React, { useLayoutEffect, useRef } from 'react'
+import { describe, expect, it } from 'vitest'
+
+import Box from './components/Box.js'
+import ScrollBox, { type ScrollBoxHandle } from './components/ScrollBox.js'
+import Text from './components/Text.js'
+import { renderSync } from './root.js'
+
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+const makeStreams = () => {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+
+  Object.assign(stdout, { columns: 80, isTTY: false, rows: 12 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', () => {})
+
+  return { stderr, stdin, stdout }
+}
+
+function TallOverflowHarness({ expose }: { expose: React.MutableRefObject<ScrollBoxHandle | null> }) {
+  const scrollRef = useRef<ScrollBoxHandle | null>(null)
+
+  useLayoutEffect(() => {
+    expose.current = scrollRef.current
+  })
+
+  return (
+    <ScrollBox height={10} ref={scrollRef} stickyScroll>
+      <Box flexDirection="column">
+        <Box flexShrink={0} height={40}>
+          <Text>tall overflow child</Text>
+        </Box>
+      </Box>
+    </ScrollBox>
+  )
+}
+
+describe('ScrollBox overflow height', () => {
+  it('counts overflowing child extents in scrollHeight', async () => {
+    const expose = { current: null as ScrollBoxHandle | null }
+    const streams = makeStreams()
+
+    const instance = renderSync(<TallOverflowHarness expose={expose} />, {
+      patchConsole: false,
+      stderr: streams.stderr as NodeJS.WriteStream,
+      stdin: streams.stdin as NodeJS.ReadStream,
+      stdout: streams.stdout as NodeJS.WriteStream
+    })
+
+    try {
+      await delay(30)
+
+      expect(expose.current!.getViewportHeight()).toBe(10)
+      expect(expose.current!.getScrollHeight()).toBe(40)
+      expect(expose.current!.getFreshScrollHeight()).toBe(40)
+    } finally {
+      instance.unmount()
+      instance.cleanup()
+    }
+  })
+})

--- a/ui-tui/src/__tests__/textInputWrap.test.ts
+++ b/ui-tui/src/__tests__/textInputWrap.test.ts
@@ -2,7 +2,13 @@ import { wrapAnsi } from '@hermes/ink'
 import { describe, expect, it } from 'vitest'
 
 import { offsetFromPosition } from '../components/textInput.js'
-import { composerPromptWidth, cursorLayout, inputVisualHeight, stableComposerColumns } from '../lib/inputMetrics.js'
+import {
+  composerPromptWidth,
+  cursorLayout,
+  inputVisualHeight,
+  stableComposerColumns,
+  terminalCursorLayout
+} from '../lib/inputMetrics.js'
 
 // Helper: compute the "end of text" position that wrap-ansi would render
 // the input to. This is what Ink's <Text wrap="wrap"> uses, so cursorLayout
@@ -98,6 +104,21 @@ describe('input metrics helpers', () => {
     expect(inputVisualHeight('one\ntwo', 40)).toBe(2)
     // Multi-line wrap case sanity
     expect(inputVisualHeight('hello world', 8)).toBe(2)
+  })
+
+  it('can reserve a native-cursor row at exact-width boundaries for Apple Terminal IME preedit', () => {
+    const env = { TERM_PROGRAM: 'Apple_Terminal' }
+
+    expect(cursorLayout('abcdefgh', 8, 8)).toEqual({ column: 8, line: 0 })
+    expect(terminalCursorLayout('abcdefgh', 8, 8, env)).toEqual({ column: 0, line: 1 })
+    expect(inputVisualHeight('abcdefgh', 8, env)).toBe(2)
+  })
+
+  it('keeps wrap-ansi parity for native cursor layout on terminals without the wrap guard', () => {
+    const env = { TERM_PROGRAM: 'iTerm.app' }
+
+    expect(terminalCursorLayout('abcdefgh', 8, 8, env)).toEqual(cursorLayout('abcdefgh', 8, 8))
+    expect(inputVisualHeight('abcdefgh', 8, env)).toBe(1)
   })
 
   it('counts the prompt gap as its own cell', () => {

--- a/ui-tui/src/__tests__/virtualHeights.test.ts
+++ b/ui-tui/src/__tests__/virtualHeights.test.ts
@@ -24,6 +24,13 @@ describe('virtual height estimates', () => {
     expect(estimatedMsgHeight(msg, 26, { compact: false, details: false, userPrompt: 'Ψ >' })).toBe(4)
   })
 
+  it('counts wide CJK cells and mixed skill names like the terminal renderer', () => {
+    const text = '不对 不是这个skill，应该是一个叫 launched-site-analytics 这个skill 你应该有在你全局目录下看看'
+
+    expect(wrappedLines(text, 42)).toBe(3)
+    expect(estimatedMsgHeight({ role: 'user', text }, 50, { compact: false, details: false, userPrompt: '❯' })).toBe(5)
+  })
+
   it('includes detail sections when visible', () => {
     const msg: Msg = { role: 'assistant', text: 'ok', thinking: 'line 1\nline 2', tools: ['Tool A', 'Tool B'] }
 

--- a/ui-tui/src/__tests__/virtualHistoryOffsetCache.test.ts
+++ b/ui-tui/src/__tests__/virtualHistoryOffsetCache.test.ts
@@ -41,7 +41,11 @@ const mountedSpan = (items: readonly Item[], virtualHistory: ReturnType<typeof u
   return { bottom: virtualHistory.topSpacer + height, top: virtualHistory.topSpacer }
 }
 
-const viewportIsMounted = (items: readonly Item[], virtualHistory: ReturnType<typeof useVirtualHistory>, scroll: ScrollBoxHandle) => {
+const viewportIsMounted = (
+  items: readonly Item[],
+  virtualHistory: ReturnType<typeof useVirtualHistory>,
+  scroll: ScrollBoxHandle
+) => {
   const span = mountedSpan(items, virtualHistory)
   const top = scroll.getScrollTop()
   const bottom = top + scroll.getViewportHeight()
@@ -49,14 +53,25 @@ const viewportIsMounted = (items: readonly Item[], virtualHistory: ReturnType<ty
   return top >= span.top && bottom <= span.bottom
 }
 
-function Harness({ expose, items }: { expose: React.MutableRefObject<Exposed | null>; items: readonly Item[] }) {
+function Harness({
+  columns = 80,
+  expose,
+  items,
+  viewportHeightHint = 0
+}: {
+  columns?: number
+  expose: React.MutableRefObject<Exposed | null>
+  items: readonly Item[]
+  viewportHeightHint?: number
+}) {
   const scrollRef = useRef<ScrollBoxHandle | null>(null)
 
-  const virtualHistory = useVirtualHistory(scrollRef, items, 80, {
+  const virtualHistory = useVirtualHistory(scrollRef, items, columns, {
     coldStartCount: 16,
     estimateHeight: index => items[index]?.height ?? 1,
     maxMounted: 16,
-    overscan: 2
+    overscan: 2,
+    viewportHeightHint
   })
 
   useLayoutEffect(() => {
@@ -147,6 +162,112 @@ describe('useVirtualHistory offset cache reuse', () => {
 
       expect(scroll.getPendingDelta()).toBe(0)
       expect(viewportIsMounted(afterShrink, expose.current!.virtualHistory, scroll)).toBe(true)
+    } finally {
+      instance.unmount()
+      instance.cleanup()
+    }
+  })
+
+  it('mounts enough sticky tail rows immediately when a resize reports a taller viewport before ScrollBox measurement catches up', async () => {
+    const items = Array.from({ length: 40 }, (_, index) => ({ height: 1, key: `row${index}` }))
+    const expose = { current: null as Exposed | null }
+    const streams = makeStreams()
+
+    const instance = renderSync(React.createElement(Harness, { expose, items, viewportHeightHint: 10 }), {
+      patchConsole: false,
+      stderr: streams.stderr as NodeJS.WriteStream,
+      stdin: streams.stdin as NodeJS.ReadStream,
+      stdout: streams.stdout as NodeJS.WriteStream
+    })
+
+    try {
+      await delay(20)
+
+      instance.rerender(React.createElement(Harness, { expose, items, viewportHeightHint: 24 }))
+      await delay(20)
+
+      const vh = expose.current!.virtualHistory
+
+      expect(vh.end).toBe(items.length)
+      expect(vh.end - vh.start).toBeGreaterThanOrEqual(16)
+    } finally {
+      instance.unmount()
+      instance.cleanup()
+    }
+  })
+
+  it('restores sticky mode after a manual scroll returns to the bottom before resize', async () => {
+    const items = Array.from({ length: 40 }, (_, index) => ({ height: 2, key: `row${index}` }))
+    const expose = { current: null as Exposed | null }
+    const streams = makeStreams()
+
+    const instance = renderSync(React.createElement(Harness, { expose, items, viewportHeightHint: 10 }), {
+      patchConsole: false,
+      stderr: streams.stderr as NodeJS.WriteStream,
+      stdin: streams.stdin as NodeJS.ReadStream,
+      stdout: streams.stdout as NodeJS.WriteStream
+    })
+
+    try {
+      await delay(40)
+
+      const scroll = expose.current!.scroll!
+      expect(scroll.isSticky()).toBe(true)
+
+      scroll.scrollBy(-4)
+      await delay(80)
+      expect(scroll.isSticky()).toBe(false)
+
+      scroll.scrollBy(400)
+      await delay(160)
+
+      expect(scroll.getPendingDelta()).toBe(0)
+      expect(scroll.getScrollTop()).toBe(scroll.getScrollHeight() - scroll.getViewportHeight())
+      expect(scroll.isSticky()).toBe(true)
+
+      instance.rerender(React.createElement(Harness, { expose, items, columns: 120, viewportHeightHint: 10 }))
+      await delay(40)
+
+      expect(expose.current!.virtualHistory.end).toBe(items.length)
+      expect(viewportIsMounted(items, expose.current!.virtualHistory, scroll)).toBe(true)
+    } finally {
+      instance.unmount()
+      instance.cleanup()
+    }
+  })
+
+  it('keeps the tail mounted across narrow-then-wide height changes while sticky', async () => {
+    const wide = Array.from({ length: 40 }, (_, index) => ({ height: 2, key: `row${index}` }))
+    const narrow = wide.map(item => ({ ...item, height: 5 }))
+    const expose = { current: null as Exposed | null }
+    const streams = makeStreams()
+
+    const instance = renderSync(
+      React.createElement(Harness, { columns: 120, expose, items: wide, viewportHeightHint: 10 }),
+      {
+        patchConsole: false,
+        stderr: streams.stderr as NodeJS.WriteStream,
+        stdin: streams.stdin as NodeJS.ReadStream,
+        stdout: streams.stdout as NodeJS.WriteStream
+      }
+    )
+
+    try {
+      await delay(40)
+
+      const scroll = expose.current!.scroll!
+
+      instance.rerender(React.createElement(Harness, { columns: 60, expose, items: narrow, viewportHeightHint: 10 }))
+      await delay(60)
+      expect(expose.current!.virtualHistory.end).toBe(narrow.length)
+      expect(expose.current!.virtualHistory.bottomSpacer).toBe(0)
+      expect(viewportIsMounted(narrow, expose.current!.virtualHistory, scroll)).toBe(true)
+
+      instance.rerender(React.createElement(Harness, { columns: 120, expose, items: wide, viewportHeightHint: 10 }))
+      await delay(60)
+      expect(expose.current!.virtualHistory.end).toBe(wide.length)
+      expect(expose.current!.virtualHistory.bottomSpacer).toBe(0)
+      expect(viewportIsMounted(wide, expose.current!.virtualHistory, scroll)).toBe(true)
     } finally {
       instance.unmount()
       instance.cleanup()

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -74,13 +74,17 @@ export function useMainApp(gw: GatewayClient) {
   const { exit } = useApp()
   const { stdout } = useStdout()
   const [cols, setCols] = useState(stdout?.columns ?? 80)
+  const [rows, setRows] = useState(stdout?.rows ?? 24)
 
   useEffect(() => {
     if (!stdout) {
       return
     }
 
-    const sync = () => setCols(stdout.columns ?? 80)
+    const sync = () => {
+      setCols(stdout.columns ?? 80)
+      setRows(stdout.rows ?? 24)
+    }
 
     stdout.on('resize', sync)
 
@@ -297,7 +301,8 @@ export function useMainApp(gw: GatewayClient) {
     estimateHeight: estimateRowHeight,
     initialHeights: heightCache,
     liveTailActive: turnLiveTailActive,
-    onHeightsChange: syncHeightCache
+    onHeightsChange: syncHeightCache,
+    viewportHeightHint: rows
   })
 
   const scrollWithSelection = useCallback(
@@ -376,11 +381,14 @@ export function useMainApp(gw: GatewayClient) {
     process.exit(0)
   }, [exit, gw])
 
-  const dieWithCode = useCallback((code: number) => {
-    gw.kill()
-    exit()
-    process.exit(code)
-  }, [exit, gw])
+  const dieWithCode = useCallback(
+    (code: number) => {
+      gw.kill()
+      exit()
+      process.exit(code)
+    },
+    [exit, gw]
+  )
 
   const session = useSessionLifecycle({
     colsRef,

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -100,10 +100,17 @@ const TranscriptPane = memo(function TranscriptPane({
         stickyScroll
       >
         <Box flexDirection="column" paddingX={1}>
-          {transcript.virtualHistory.topSpacer > 0 ? <Box height={transcript.virtualHistory.topSpacer} /> : null}
+          {transcript.virtualHistory.topSpacer > 0 ? (
+            <Box flexShrink={0} height={transcript.virtualHistory.topSpacer} />
+          ) : null}
 
           {transcript.virtualRows.slice(transcript.virtualHistory.start, transcript.virtualHistory.end).map(row => (
-            <Box flexDirection="column" key={row.key} ref={transcript.virtualHistory.measureRef(row.key)}>
+            <Box
+              flexDirection="column"
+              flexShrink={0}
+              key={row.key}
+              ref={transcript.virtualHistory.measureRef(row.key)}
+            >
               {row.msg.role === 'user' && firstUserIdx >= 0 && row.index > firstUserIdx && (
                 <Box marginTop={1}>
                   <Text color={ui.theme.color.border}>───</Text>
@@ -134,7 +141,9 @@ const TranscriptPane = memo(function TranscriptPane({
             </Box>
           ))}
 
-          {transcript.virtualHistory.bottomSpacer > 0 ? <Box height={transcript.virtualHistory.bottomSpacer} /> : null}
+          {transcript.virtualHistory.bottomSpacer > 0 ? (
+            <Box flexShrink={0} height={transcript.virtualHistory.bottomSpacer} />
+          ) : null}
 
           <StreamingAssistant
             cols={composer.cols}
@@ -169,11 +178,17 @@ const ComposerPane = memo(function ComposerPane({
   const ui = useStore($uiState)
   const isBlocked = useStore($isBlocked)
   const sh = (composer.inputBuf[0] ?? composer.input).startsWith('!')
-  const promptText = composerPromptText(ui.theme.brand.prompt, ui.info?.profile_name, sh, TERMUX_TUI_MODE, composer.cols)
+  const promptText = composerPromptText(
+    ui.theme.brand.prompt,
+    ui.info?.profile_name,
+    sh,
+    TERMUX_TUI_MODE,
+    composer.cols
+  )
   const promptWidth = composerPromptWidth(promptText)
   const promptBlank = ' '.repeat(promptWidth)
   const inputColumns = stableComposerColumns(composer.cols, promptWidth, TERMUX_TUI_MODE)
-  const inputHeight = inputVisualHeight(composer.input, inputColumns)
+  const inputHeight = inputVisualHeight(composer.input, inputColumns, process.env)
   const inputMouseRef = useRef<null | TextInputMouseApi>(null)
 
   const captureInputDrag = (e: GutterMouseEvent) => {

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -4,7 +4,7 @@ import { type MutableRefObject, useEffect, useMemo, useRef, useState } from 'rea
 
 import { setInputSelection } from '../app/inputSelectionStore.js'
 import { readClipboardText, writeClipboardText } from '../lib/clipboard.js'
-import { cursorLayout, offsetFromPosition } from '../lib/inputMetrics.js'
+import { cursorLayout, offsetFromPosition, terminalCursorLayout } from '../lib/inputMetrics.js'
 import {
   DEFAULT_VOICE_RECORD_KEY,
   isActionMod,
@@ -24,7 +24,8 @@ type InkExt = typeof Ink & {
 }
 
 const ink = Ink as unknown as InkExt
-const { Box, Text, useStdin, useInput, useStdout, stringWidth, useCursorAdvance, useDeclaredCursor, useTerminalFocus } = ink
+const { Box, Text, useStdin, useInput, useStdout, stringWidth, useCursorAdvance, useDeclaredCursor, useTerminalFocus } =
+  ink
 
 const ESC = '\x1b'
 const INV = `${ESC}[7m`
@@ -307,7 +308,9 @@ export function supportsFastEchoTerminal(env: NodeJS.ProcessEnv = process.env): 
   // stale paints at soft-wrap boundaries on tall/narrow viewports. Keep this
   // off by default in Termux mode; allow explicit opt-in for local debugging.
   if (isTermuxTuiMode(env)) {
-    const override = String(env.HERMES_TUI_TERMUX_FAST_ECHO ?? '').trim().toLowerCase()
+    const override = String(env.HERMES_TUI_TERMUX_FAST_ECHO ?? '')
+      .trim()
+      .toLowerCase()
     if (override) {
       return /^(?:1|true|yes|on)$/i.test(override)
     }
@@ -442,7 +445,7 @@ export function TextInput({
   // for layout. The cursorLayout call is cheap (one wrap-text pass
   // over a single-line string in the common case), so dropping useMemo
   // is fine.
-  const layout = cursorLayout(display, curRef.current, columns)
+  const layout = terminalCursorLayout(display, curRef.current, columns, process.env)
 
   const boxRef = useDeclaredCursor({
     line: layout.line,
@@ -594,7 +597,8 @@ export function TextInput({
     }, 16)
   }
 
-  const canFastEchoBase = () => supportsFastEchoTerminal() && focus && termFocus && !selected && !mask && !!stdout?.isTTY
+  const canFastEchoBase = () =>
+    supportsFastEchoTerminal() && focus && termFocus && !selected && !mask && !!stdout?.isTTY
 
   const canFastAppend = (current: string, cursor: number, text: string) =>
     canFastEchoBase() && canFastAppendShape(current, cursor, text, columns, lineWidthRef.current)
@@ -1201,9 +1205,7 @@ interface TextInputProps {
   voiceRecordKey?: ParsedVoiceRecordKey
 }
 
-export type RightClickDecision =
-  | { action: 'copy'; text: string }
-  | { action: 'paste' }
+export type RightClickDecision = { action: 'copy'; text: string } | { action: 'paste' }
 
 /**
  * Decide what right-click should do on the composer:

--- a/ui-tui/src/hooks/useVirtualHistory.ts
+++ b/ui-tui/src/hooks/useVirtualHistory.ts
@@ -107,7 +107,8 @@ export function useVirtualHistory(
     onHeightsChange,
     overscan = OVERSCAN,
     maxMounted = MAX_MOUNTED,
-    coldStartCount = COLD_START
+    coldStartCount = COLD_START,
+    viewportHeightHint = 0
   }: VirtualHistoryOptions = {}
 ) {
   const nodes = useRef(new Map<string, unknown>())
@@ -157,16 +158,24 @@ export function useVirtualHistory(
 
   if (prevColumns.current !== columns && prevColumns.current > 0 && columns > 0) {
     const ratio = prevColumns.current / columns
+    const stickyNow = scrollRef.current?.isSticky() ?? true
 
     prevColumns.current = columns
 
-    for (const [k, h] of heights.current) {
-      heights.current.set(k, Math.max(1, Math.round(h * ratio)))
+    if (stickyNow) {
+      prevRange.current = null
+      freezeRenders.current = 0
+      skipMeasurement.current = false
+    } else {
+      for (const [k, h] of heights.current) {
+        heights.current.set(k, Math.max(1, Math.round(h * ratio)))
+      }
+
+      skipMeasurement.current = true
+      freezeRenders.current = FREEZE_RENDERS
     }
 
     offsetVersion.current++
-    skipMeasurement.current = true
-    freezeRenders.current = FREEZE_RENDERS
   }
 
   useLayoutEffect(() => {
@@ -242,7 +251,7 @@ export function useVirtualHistory(
   const top = Math.max(0, scrollRef.current?.getScrollTop() ?? 0)
   const pendingDelta = scrollRef.current?.getPendingDelta() ?? 0
   const target = Math.max(0, top + pendingDelta)
-  const vp = Math.max(0, scrollRef.current?.getViewportHeight() ?? 0)
+  const vp = Math.max(0, scrollRef.current?.getViewportHeight() ?? 0, Math.floor(viewportHeightHint))
   const sticky = scrollRef.current?.isSticky() ?? true
   const recentManual = Date.now() - (scrollRef.current?.getLastManualScrollAt() ?? 0) < 1200
 
@@ -533,4 +542,5 @@ interface VirtualHistoryOptions {
   maxMounted?: number
   onHeightsChange?: (heights: ReadonlyMap<string, number>) => void
   overscan?: number
+  viewportHeightHint?: number
 }

--- a/ui-tui/src/lib/inputMetrics.ts
+++ b/ui-tui/src/lib/inputMetrics.ts
@@ -144,6 +144,36 @@ export function cursorLayout(value: string, cursor: number, cols: number) {
   return { column, line: lineIndex }
 }
 
+export function needsNativeCursorWrapGuard(env: NodeJS.ProcessEnv = {}): boolean {
+  const override = String(env.HERMES_TUI_NATIVE_CURSOR_WRAP_GUARD ?? '')
+    .trim()
+    .toLowerCase()
+
+  if (override) {
+    return /^(?:1|true|yes|on)$/i.test(override)
+  }
+
+  return (env.TERM_PROGRAM ?? '').trim() === 'Apple_Terminal'
+}
+
+/**
+ * Layout for the physical terminal cursor, not for rendered text.
+ *
+ * Keep cursorLayout() in strict wrap-ansi parity for painting, but avoid
+ * parking the native cursor in the terminal's pending-wrap column on hosts
+ * whose IME preedit renderer treats that state inconsistently.
+ */
+export function terminalCursorLayout(value: string, cursor: number, cols: number, env: NodeJS.ProcessEnv = {}) {
+  const layout = cursorLayout(value, cursor, cols)
+  const width = Math.max(1, cols)
+
+  if (needsNativeCursorWrapGuard(env) && layout.column >= width) {
+    return { column: 0, line: layout.line + 1 }
+  }
+
+  return layout
+}
+
 export function offsetFromPosition(value: string, row: number, col: number, cols: number) {
   if (!value.length) {
     return 0
@@ -165,8 +195,8 @@ export function offsetFromPosition(value: string, row: number, col: number, cols
   return target.end
 }
 
-export function inputVisualHeight(value: string, columns: number) {
-  return cursorLayout(value, value.length, columns).line + 1
+export function inputVisualHeight(value: string, columns: number, env: NodeJS.ProcessEnv = {}) {
+  return terminalCursorLayout(value, value.length, columns, env).line + 1
 }
 
 export function composerPromptWidth(promptText: string) {

--- a/ui-tui/src/lib/virtualHeights.ts
+++ b/ui-tui/src/lib/virtualHeights.ts
@@ -1,5 +1,7 @@
 import type { Msg } from '../types.js'
 
+import { wrapAnsi } from '@hermes/ink'
+
 import { TERMUX_TUI_MODE } from '../config/env.js'
 import { transcriptBodyWidth } from './inputMetrics.js'
 
@@ -48,22 +50,14 @@ export const wrappedLines = (text: string, width: number, maxLines: number = MAX
   // cannot increase n any further once n is already past maxLines, so
   // bail. Saves O(text) walks on multi-megabyte single-line messages.
   const budget = Math.min(text.length, maxLines * w + maxLines)
-  let n = 0
-  let start = 0
 
-  for (let i = 0; i <= budget; i++) {
-    if (i === text.length || i === budget || text.charCodeAt(i) === 10) {
-      const rows = Math.max(1, Math.ceil((i - start) / w))
-      n += rows >= maxLines - n ? maxLines - n : rows
-      start = i + 1
-
-      if (n >= maxLines) {
-        return maxLines
-      }
-    }
+  if (text.length > budget) {
+    return maxLines
   }
 
-  return n
+  const lines = wrapAnsi(text || ' ', w, { hard: true, trim: false }).split('\n').length
+
+  return Math.min(maxLines, Math.max(1, lines))
 }
 
 export const estimatedMsgHeight = (


### PR DESCRIPTION
Fixes #18449
Refs #5221
Refs #24137

## Summary

This patch tightens several related TUI rendering paths that can leave the visible transcript or composer in an inconsistent state after terminal resize or IME-heavy input.

- add a second delayed alt-screen resize heal so late terminal reflow artifacts are cleared after the first repaint
- separate rendered input layout from native terminal cursor layout for Apple Terminal pending-wrap/IME preedit behavior
- make virtual transcript height estimates use the same wrap-ansi semantics as rendered text, including CJK/mixed-width text
- pass terminal row count into virtual history so sticky tail ranges mount enough rows immediately after resize, before ScrollBox measurement catches up
- compute ScrollBox scroll height from descendant extents, not only the wrapper Yoga height, so oversized transcript rows are not clipped after resize
- keep virtual transcript rows/spacers from flex-shrinking, preventing resize from poisoning measured row heights with viewport-sized values

## Why

The existing fixes cover pieces of the problem, but resize and IME paths can still diverge:

- rapid or late terminal resize can leave stale physical cells after Hermes believes the screen is clean
- Apple Terminal IME preedit can render at the wrong position when the native cursor is parked in a pending-wrap column
- virtual transcript rows can under-mount after resize when the viewport height changes before measurement state catches up
- mixed CJK + long token text can be underestimated if height estimates count JS chars instead of terminal cells/wrap behavior
- after a completed response, reversing terminal width changes or scrolling away/back could expose blank/clipped tail content because ScrollBox treated an overflowing child as only viewport-height

## Manual verification

I reproduced the issue locally in a Chinese-language workflow using Apple Terminal with Chinese/CJK mixed output and long Chinese input containing ASCII skill names. Before this patch, resizing the terminal could truncate the visible transcript tail, and submitted Chinese input could leave stale/overlapping text in the composer area. I also reproduced the later post-response case where output looks correct until the terminal is resized in the opposite direction or scrolled away/back to the bottom. After rebuilding and restarting the local Hermes TUI, the same Chinese environment no longer reproduces those rendering artifacts: output remains visible after terminal resize, reverse resize, and scroll-back-to-bottom, and Chinese/mixed-width submitted input no longer overlaps the prompt/composer area.

## Tests

- `npm test -- --run packages/hermes-ink/src/ink/scrollbox-overflow.test.tsx src/__tests__/virtualHistoryOffsetCache.test.ts src/__tests__/virtualHeights.test.ts src/__tests__/textInputWrap.test.ts src/__tests__/textInputFastEcho.test.ts src/__tests__/cursorDriftRegression.test.ts packages/hermes-ink/src/ink/terminal.test.ts packages/hermes-ink/src/ink/log-update.test.ts`
- `npx prettier --check ui-tui/src/hooks/useVirtualHistory.ts ui-tui/src/app/useMainApp.ts ui-tui/src/__tests__/virtualHistoryOffsetCache.test.ts ui-tui/src/lib/virtualHeights.ts ui-tui/src/lib/inputMetrics.ts ui-tui/src/components/textInput.tsx ui-tui/src/components/appLayout.tsx ui-tui/packages/hermes-ink/src/ink/ink.tsx ui-tui/packages/hermes-ink/src/ink/components/ScrollBox.tsx ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts ui-tui/packages/hermes-ink/src/ink/scrollbox-overflow.test.tsx`
- `npm run build`

Note: `npm run type-check` still fails on pre-existing `packages/hermes-ink/src/utils/execFileNoThrow.ts` Node overload errors unrelated to this patch.