### PR TITLE
fix(gateway): support Windows drive-letter paths in MEDIA: tags and extract_local_files

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2159,7 +2159,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:[A-Za-z]:[\\/]|~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()
@@ -2225,7 +2225,7 @@ class BasePlatformAdapter(ABC):
         #             and relative paths (./foo.png)
         # (?:~/|/)    anchors to absolute or home-relative paths
         path_re = re.compile(
-            r'(?<![/:\w.])(?:~/|/)(?:[\w.\-]+/)*[\w.\-]+\.(?:' + ext_part + r')\b',
+            r'(?<![/:\w.])(?:[A-Za-z]:[\\/]|~/|/)(?:[\w.\-]+[\\/])*[\w.\-]+\.(?:' + ext_part + r')\b',
             re.IGNORECASE,
         )
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11152,6 +11152,7 @@ class GatewayRunner:
         that the normal _process_message_background path would have caught.
         """
         from pathlib import Path
+
         from urllib.parse import quote as _quote
 
         try:
@@ -16516,7 +16517,7 @@ class GatewayRunner:
                     _hc = _hm.get("content", "")
                     if "MEDIA:" in _hc:
                         _TOOL_MEDIA_RE = re.compile(
-                            r'MEDIA:((?:/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
+                            r'MEDIA:((?:[A-Za-z]:[\\/]|/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
                             r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
                             r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
                             r'txt|csv|apk|ipa))',
@@ -16812,7 +16813,7 @@ class GatewayRunner:
                         content = msg.get("content", "")
                         if "MEDIA:" in content:
                             _TOOL_MEDIA_RE = re.compile(
-                                r'MEDIA:((?:/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
+                                r'MEDIA:((?:[A-Za-z]:[\\/]|/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
                                 r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
                                 r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
                                 r'txt|csv|apk|ipa))',

--- a/tests/gateway/test_extract_local_files.py
+++ b/tests/gateway/test_extract_local_files.py
@@ -338,8 +338,30 @@ class TestEdgeCases:
         assert paths == []
 
     def test_windows_path_not_matched(self):
-        """Windows-style paths should not match."""
-        paths, _ = _extract("See C:\\Users\\test\\image.png")
+        """Bare drive letter without path separator should not match."""
+        paths, _ = _extract("See C:Users without slash")
+        assert paths == []
+
+    def test_windows_backslash_path_matched(self):
+        """Windows drive-letter paths with backslashes should match."""
+        paths, _ = _extract("See C:\\Users\\test\\image.png here")
+        assert paths == ["C:\\Users\\test\\image.png"]
+
+    def test_windows_forward_slash_path_matched(self):
+        """Windows drive-letter paths with forward slashes should match."""
+        paths, _ = _extract("See D:/dev/project/screenshot.png here")
+        assert paths == ["D:/dev/project/screenshot.png"]
+
+    def test_windows_path_cleaned_from_text(self):
+        """Windows path should be removed from cleaned text."""
+        paths, cleaned = _extract("Check D:\\reports\\chart.pdf for data")
+        assert paths == ["D:\\reports\\chart.pdf"]
+        assert "D:\\reports\\chart.pdf" not in cleaned
+        assert "Check" in cleaned
+
+    def test_windows_network_path_not_matched(self):
+        """UNC network paths (\\\\server\\share) should not match as drive-letter paths."""
+        paths, _ = _extract("File at \\\\server\\share\\file.png")
         assert paths == []
 
     def test_relative_path_not_matched(self):

--- a/tests/gateway/test_media_extraction.py
+++ b/tests/gateway/test_media_extraction.py
@@ -180,5 +180,63 @@ class TestMediaExtraction:
         assert len(unique) == 2  # After dedup: same.ogg and different.ogg
 
 
+
+class TestWindowsPathMediaExtraction:
+    """Tests for MEDIA tag extraction with Windows drive-letter paths."""
+
+    def test_windows_backslash_path(self):
+        """MEDIA:D:\\path\\file.png should be extracted on Windows."""
+        from gateway.platforms.base import BasePlatformAdapter
+        media_files, cleaned = BasePlatformAdapter.extract_media(
+            "Check this MEDIA:D:\\dev\\test.png out"
+        )
+        assert len(media_files) == 1
+        path, is_voice = media_files[0]
+        assert path.endswith("test.png")
+        assert "D:" in path
+        assert not is_voice
+        assert "MEDIA:" not in cleaned
+
+    def test_windows_forward_slash_path(self):
+        """MEDIA:C:/Users/file.png should be extracted on Windows."""
+        from gateway.platforms.base import BasePlatformAdapter
+        media_files, cleaned = BasePlatformAdapter.extract_media(
+            "Here MEDIA:C:/Users/file.png now"
+        )
+        assert len(media_files) == 1
+        path, is_voice = media_files[0]
+        assert path.endswith("file.png")
+
+    def test_unix_abs_path_still_works(self):
+        """Unix absolute paths should still work after the fix."""
+        from gateway.platforms.base import BasePlatformAdapter
+        media_files, cleaned = BasePlatformAdapter.extract_media(
+            "MEDIA:/tmp/audio.ogg here"
+        )
+        assert len(media_files) == 1
+        path, is_voice = media_files[0]
+        assert path.endswith("audio.ogg")
+
+    def test_unix_home_path_still_works(self):
+        """Unix home-relative paths should still work after the fix."""
+        from gateway.platforms.base import BasePlatformAdapter
+        media_files, cleaned = BasePlatformAdapter.extract_media(
+            "Check MEDIA:~/docs/report.pdf out"
+        )
+        assert len(media_files) == 1
+        path, is_voice = media_files[0]
+        assert path.endswith("report.pdf")
+
+    def test_http_url_not_matched_as_windows_path(self):
+        """MEDIA:http://example.com/img.png should not match as drive-letter path."""
+        from gateway.platforms.base import BasePlatformAdapter
+        media_files, cleaned = BasePlatformAdapter.extract_media(
+            "MEDIA:http://example.com/img.png"
+        )
+        # Should not match — the trailing assertion rejects URLs
+        assert len(media_files) == 0
+
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What does this PR do?

Fixes Windows drive-letter path support for `MEDIA:` tags and `extract_local_files`.  
On Windows, paths like `MEDIA:D:\path\to\file.png` and bare paths like `D:\dev\...\screen.png` were silently ignored because the regex patterns only matched Unix-style paths (`/abs/path` or `~/home/path`).

## Related Issue

N/A (no existing issue — discovered during Discord file attachment testing on Windows)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py` — `extract_media()`: `(?:~/|/)` → `(?:[A-Za-z]:[\\/]|~/|/)`
- `gateway/platforms/base.py` — `extract_local_files()`: prefix + `/` → `[\\/]` path separator
- `gateway/run.py` — `_TOOL_MEDIA_RE` (×2): `(?:/|~\/)` → `(?:[A-Za-z]:[\\/]|/|~\/)`
- `tests/gateway/test_extract_local_files.py` — 5 new Windows path tests
- `tests/gateway/test_media_extraction.py` — 6 new Windows/Unix/URL tests

## How to Test

1. On Windows with a Discord bot configured, send `MEDIA:D:\path\to\image.png` via send_message
2. Verify the file is delivered as a native attachment (not raw text)
3. Verify bare paths like `D:\dev\...\file.pdf` are detected in responses
4. Run `pytest tests/gateway/test_extract_local_files.py tests/gateway/test_media_extraction.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls)
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 10

### Documentation & Housekeeping

- [x] I've considered cross-platform impact (Windows, macOS) — N/A (no regression)
- [x] I've updated tool descriptions/schemas — N/A