### PR TITLE
feat(inbox): add Hermes Inbox API surface E.1

### DIFF
--- a/hermes_cli/inbox_routes.py
+++ b/hermes_cli/inbox_routes.py
@@ -1,0 +1,248 @@
+"""Hermes Inbox HTTP API routes.
+
+Exposes the Hermes inbox backend as a JSON HTTP API under /api/inbox/.
+
+Endpoints:
+    GET  /inbox/list          — list messages (cursor pag, newest-first, filter)
+    GET  /inbox/get/{id}      — get one message by id
+    POST /inbox/mark-read     — mark one or batch messages as read
+    GET  /inbox/unread-count  — count unread messages
+
+Schema: hermes.inbox.message.v1
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query
+
+from hermes_constants import get_hermes_home
+
+# ---------------------------------------------------------------------------
+# Inbox backend (copied from hermes-mcp-server app/tools/hermes_inbox.py)
+# ---------------------------------------------------------------------------
+
+INBOX_SUBDIR = "_control/agents/hermes/queue/inbox"
+VALID_LEVELS = frozenset({"info", "warning", "error"})
+
+
+class HermesInboxError(RuntimeError):
+    """Raised when an inbox message is invalid or cannot be written/read."""
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _safe_message_id(source: str, run_id: str) -> str:
+    prefix = f"{source}-{run_id}".replace("/", "-").replace(" ", "-")
+    return f"{prefix}-{uuid.uuid4().hex[:8]}"
+
+
+def _message_path(inbox_dir: Path, message_id: str) -> Path:
+    if not message_id or "/" in message_id or ".." in message_id:
+        raise HermesInboxError("invalid_message_id")
+    return inbox_dir / f"{message_id}.json"
+
+
+def _get_inbox_dir() -> Path:
+    return Path(get_hermes_home()) / INBOX_SUBDIR
+
+
+def _read_message_file(path: Path) -> dict[str, Any] | None:
+    try:
+        message = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+    if message.get("schema") != "hermes.inbox.message.v1":
+        return None
+    message["_path"] = str(path)
+    return message
+
+
+def list_inbox_messages(
+    *,
+    inbox_dir: Path,
+    limit: int = 20,
+    cursor: str | None = None,
+    unread_only: bool = False,
+    source: str | None = None,
+    level: str | None = None,
+) -> dict[str, Any]:
+    """Read recent inbox messages, newest first, with optional filters + cursor pagination."""
+    root = Path(inbox_dir)
+    if not root.exists():
+        return {"messages": [], "next_cursor": None, "total": 0}
+
+    if limit <= 0:
+        return {"messages": [], "next_cursor": None, "total": 0}
+
+    # Collect all messages, newest first. Cursor is the 0-based index of the
+    # last item on the previous page, encoded as a string. We skip all items
+    # at or before that index.
+    all_messages: list[tuple[float, str, dict[str, Any]]] = []
+    for path in sorted(root.glob("*.json"), key=lambda p: (-p.stat().st_mtime, p.name)):
+        message = _read_message_file(path)
+        if message is None:
+            continue
+        if unread_only and bool(message.get("read")):
+            continue
+        if source is not None and message.get("source") != source:
+            continue
+        if level is not None and message.get("level") != level:
+            continue
+        all_messages.append((path.stat().st_mtime, path.name, message))
+
+    total = len(all_messages)  # save before slicing
+    # Apply cursor (cursor = 0-based index of last item on previous page)
+    offset = 0
+    if cursor:
+        try:
+            offset = int(cursor) + 1
+        except ValueError:
+            pass  # Invalid cursor, return from start
+    all_messages = all_messages[offset:]
+
+    # Slice page
+    page_messages = all_messages[:limit]
+    next_cursor: str | None = None
+    if len(all_messages) > limit:
+        next_cursor = str(offset + limit)  # skip all items on this page on next call
+
+    messages = [msg for _, _, msg in page_messages]
+
+    return {
+        "messages": messages,
+        "next_cursor": next_cursor,
+        "total": total,
+    }
+
+
+def get_inbox_message(*, inbox_dir: Path, message_id: str) -> dict[str, Any] | None:
+    """Return one inbox message by id, or None if absent/invalid."""
+    path = _message_path(inbox_dir, message_id)
+    if not path.exists():
+        return None
+    return _read_message_file(path)
+
+
+def mark_inbox_message_read(*, inbox_dir: Path, message_id: str) -> dict[str, Any]:
+    """Mark one inbox message as read."""
+    path = _message_path(inbox_dir, message_id)
+    if not path.exists():
+        raise HermesInboxError("message_not_found")
+    message = _read_message_file(path)
+    if message is None:
+        raise HermesInboxError("invalid_message_file")
+    message.pop("_path", None)
+    message["read"] = True
+    message["read_at"] = _utc_now()
+    path.write_text(json.dumps(message, indent=2, ensure_ascii=False), encoding="utf-8")
+    return {"ok": True, "message_path": str(path), "message": message}
+
+
+def get_unread_count(*, inbox_dir: Path) -> int:
+    """Count unread messages."""
+    root = Path(inbox_dir)
+    if not root.exists():
+        return 0
+    count = 0
+    for path in root.glob("*.json"):
+        message = _read_message_file(path)
+        if message and not bool(message.get("read")):
+            count += 1
+    return count
+
+
+# ---------------------------------------------------------------------------
+# FastAPI router
+# ---------------------------------------------------------------------------
+
+router = APIRouter(tags=["inbox"])
+
+
+@router.get("/list")
+def inbox_list(
+    limit: int = Query(default=20, ge=1, le=100),
+    cursor: str | None = Query(default=None),
+    unread_only: bool = Query(default=False),
+    source: str | None = Query(default=None),
+    level: str | None = Query(default=None),
+) -> dict[str, Any]:
+    """List inbox messages, newest-first, with cursor pagination and filters."""
+    if level is not None and level not in VALID_LEVELS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid level. Must be one of: {', '.join(sorted(VALID_LEVELS))}",
+        )
+    inbox_dir = _get_inbox_dir()
+    return list_inbox_messages(
+        inbox_dir=inbox_dir,
+        limit=limit,
+        cursor=cursor,
+        unread_only=unread_only,
+        source=source,
+        level=level,
+    )
+
+
+@router.get("/get/{message_id}")
+def inbox_get(message_id: str) -> dict[str, Any]:
+    """Get a single inbox message by id."""
+    inbox_dir = _get_inbox_dir()
+    message = get_inbox_message(inbox_dir=inbox_dir, message_id=message_id)
+    if message is None:
+        raise HTTPException(status_code=404, detail="message_not_found")
+    return message
+
+
+@router.post("/mark-read")
+def inbox_mark_read(body: dict[str, Any]) -> dict[str, Any]:
+    """Mark one or many messages as read.
+
+    Body: {"message_ids": ["id1", "id2"]}  — batch
+    Body: {"message_id": "id"}             — single
+    """
+    inbox_dir = _get_inbox_dir()
+    message_ids: list[str] = []
+
+    if "message_ids" in body:
+        if not isinstance(body["message_ids"], list):
+            raise HTTPException(status_code=400, detail="message_ids must be a list")
+        message_ids = body["message_ids"]
+    elif "message_id" in body:
+        message_ids = [body["message_id"]]
+    else:
+        raise HTTPException(
+            status_code=400,
+            detail="Provide either 'message_id' or 'message_ids' in body",
+        )
+
+    if not message_ids:
+        raise HTTPException(status_code=400, detail="empty message_ids list")
+
+    results: list[dict[str, Any]] = []
+    errors: list[dict[str, str]] = []
+    for mid in message_ids:
+        try:
+            results.append(mark_inbox_message_read(inbox_dir=inbox_dir, message_id=mid))
+        except HermesInboxError as exc:
+            errors.append({"message_id": mid, "error": str(exc)})
+
+    return {
+        "ok": len(errors) == 0,
+        "marked_count": len(results),
+        "results": results,
+        "errors": errors,
+    }
+
+
+@router.get("/unread-count")
+def inbox_unread_count() -> dict[str, Any]:
+    """Return the count of unread messages."""
+    inbox_dir = _get_inbox_dir()
+    return {"unread_count": get_unread_count(inbox_dir=inbox_dir)}

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4511,6 +4511,10 @@ def _mount_plugin_api_routes():
 # Mount plugin API routes before the SPA catch-all.
 _mount_plugin_api_routes()
 
+# Inbox API routes (Stage E.1)
+from hermes_cli.inbox_routes import router as inbox_router
+app.include_router(inbox_router, prefix="/api/inbox")
+
 mount_spa(app)
 
 

--- a/tests/test_inbox_routes.py
+++ b/tests/test_inbox_routes.py
@@ -1,0 +1,282 @@
+"""Tests for Hermes inbox HTTP routes."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Helpers (usable with both fixture and direct patch)
+# ---------------------------------------------------------------------------
+
+def make_test_message(
+    message_id: str,
+    *,
+    source: str = "test_agent",
+    run_id: str = "run-1",
+    level: str = "info",
+    read: bool = False,
+) -> dict:
+    return {
+        "schema": "hermes.inbox.message.v1",
+        "message_id": message_id,
+        "source": source,
+        "run_id": run_id,
+        "level": level,
+        "title": "Test",
+        "summary": "Test message",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "read": read,
+        "payload": {},
+    }
+
+
+def write_message(inbox_dir: Path, message_id: str, read: bool = False) -> Path:
+    """Write a test message file into inbox_dir (which is already the full inbox path)."""
+    msg = make_test_message(message_id, read=read)
+    path = inbox_dir / f"{message_id}.json"
+    path.write_text(json.dumps(msg), encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def inbox_dir(tmp_path: Path) -> Path:
+    """Temp inbox dir matching HERMES_HOME / INBOX_SUBDIR."""
+    d = tmp_path / "_control/agents/hermes/queue/inbox"
+    d.mkdir(parents=True)
+    return d
+
+
+@pytest.fixture
+def client(inbox_dir: Path) -> TestClient:
+    """TestClient with HERMES_HOME overridden so _get_inbox_dir() resolves to inbox_dir."""
+    from hermes_cli.inbox_routes import router
+    from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+    from fastapi import FastAPI
+
+    # inbox_dir = HERMES_HOME / "_control/agents/hermes/queue/inbox"
+    # inbox_dir.parents[4] = HERMES_HOME = tmp_path
+    token = set_hermes_home_override(str(inbox_dir.parents[4]))
+    try:
+        app = FastAPI()
+        app.include_router(router, prefix="/api/inbox")
+        yield TestClient(app)
+    finally:
+        reset_hermes_home_override(token)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_message(inbox_dir: Path, message_id: str, read: bool = False) -> Path:
+    """Write a test message file. inbox_dir is already the full inbox path."""
+    msg = make_test_message(message_id, read=read)
+    path = inbox_dir / f"{message_id}.json"
+    path.write_text(json.dumps(msg), encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# GET /api/inbox/list
+# ---------------------------------------------------------------------------
+
+def test_list_empty(client: TestClient) -> None:
+    r = client.get("/api/inbox/list")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["messages"] == []
+    assert data["next_cursor"] is None
+
+
+def test_list_returns_messages_newest_first(client: TestClient, inbox_dir: Path) -> None:
+    # Write two messages
+    _write_message(inbox_dir, "msg-old")
+    _write_message(inbox_dir, "msg-new")
+    r = client.get("/api/inbox/list")
+    assert r.status_code == 200
+    data = r.json()
+    assert len(data["messages"]) == 2
+    # Newest first
+    assert data["messages"][0]["message_id"] == "msg-new"
+    assert data["messages"][1]["message_id"] == "msg-old"
+
+
+def test_list_respects_limit(client: TestClient, inbox_dir: Path) -> None:
+    import os, time
+
+    # Write all files first, then set distinct mtimes deterministically via os.utime
+    paths = []
+    for i in range(5):
+        _write_message(inbox_dir, f"msg-{i}")
+        paths.append(inbox_dir / f"msg-{i}.json")
+    base = time.time()
+    for i, p in enumerate(paths):
+        ts = base - i
+        os.utime(p, (ts, ts))
+
+    r = client.get("/api/inbox/list?limit=2")
+    assert r.status_code == 200
+    data = r.json()
+    assert len(data["messages"]) == 2
+    assert data["next_cursor"] is not None
+
+
+def test_list_cursor_pagination(client: TestClient, inbox_dir: Path) -> None:
+    import os, time
+
+    # Write all files first, then set distinct mtimes deterministically via os.utime
+    paths = []
+    for i in range(5):
+        _write_message(inbox_dir, f"msg-{i}")
+        paths.append(inbox_dir / f"msg-{i}.json")
+    base = time.time()
+    for i, p in enumerate(paths):
+        ts = base - i
+        os.utime(p, (ts, ts))
+
+    r1 = client.get("/api/inbox/list?limit=2")
+    cursor = r1.json()["next_cursor"]
+    assert cursor is not None
+    r2 = client.get(f"/api/inbox/list?limit=2&cursor={cursor}")
+    assert r2.status_code == 200
+    data = r2.json()
+    assert len(data["messages"]) == 2, f"page2 msgs={len(data['messages'])}, total={data['total']}"
+    # No more pages
+    assert data["next_cursor"] is None, f"page2 cursor={data['next_cursor']}, total={data['total']}"
+
+
+def test_list_unread_only_filter(client: TestClient, inbox_dir: Path) -> None:
+    _write_message(inbox_dir, "msg-read", read=True)
+    _write_message(inbox_dir, "msg-unread", read=False)
+    r = client.get("/api/inbox/list?unread_only=true")
+    assert r.status_code == 200
+    data = r.json()
+    assert len(data["messages"]) == 1
+    assert data["messages"][0]["message_id"] == "msg-unread"
+
+
+def test_list_source_filter(client: TestClient, inbox_dir: Path) -> None:
+    msg1 = {
+        "schema": "hermes.inbox.message.v1",
+        "message_id": "msg-a",
+        "source": "agent_a",
+        "run_id": "run-1",
+        "level": "info",
+        "title": "A",
+        "summary": "A",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "read": False,
+        "payload": {},
+    }
+    msg2 = {
+        **msg1,
+        "message_id": "msg-b",
+        "source": "agent_b",
+    }
+    (inbox_dir / "msg-a.json").write_text(json.dumps(msg1), encoding="utf-8")
+    (inbox_dir / "msg-b.json").write_text(json.dumps(msg2), encoding="utf-8")
+    r = client.get("/api/inbox/list?source=agent_a")
+    assert r.status_code == 200
+    data = r.json()
+    assert len(data["messages"]) == 1
+    assert data["messages"][0]["source"] == "agent_a"
+
+
+def test_list_invalid_level_returns_400(client: TestClient) -> None:
+    r = client.get("/api/inbox/list?level=debug")
+    assert r.status_code == 400
+    assert "level" in r.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# GET /api/inbox/get/{message_id}
+# ---------------------------------------------------------------------------
+
+def test_get_found(client: TestClient, inbox_dir: Path) -> None:
+    _write_message(inbox_dir, "msg-1")
+    r = client.get("/api/inbox/get/msg-1")
+    assert r.status_code == 200
+    assert r.json()["message_id"] == "msg-1"
+
+
+def test_get_not_found_returns_404(client: TestClient) -> None:
+    r = client.get("/api/inbox/get/nonexistent")
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /api/inbox/mark-read
+# ---------------------------------------------------------------------------
+
+def test_mark_read_single(client: TestClient, inbox_dir: Path) -> None:
+    _write_message(inbox_dir, "msg-1", read=False)
+    r = client.post("/api/inbox/mark-read", json={"message_id": "msg-1"})
+    assert r.status_code == 200
+    data = r.json()
+    assert data["ok"] is True
+    assert data["marked_count"] == 1
+    # Verify file was updated
+    msg_path = inbox_dir / "msg-1.json"
+    stored = json.loads(msg_path.read_text(encoding="utf-8"))
+    assert stored["read"] is True
+    assert stored.get("read_at") is not None
+
+
+def test_mark_read_batch(client: TestClient, inbox_dir: Path) -> None:
+    _write_message(inbox_dir, "msg-1", read=False)
+    _write_message(inbox_dir, "msg-2", read=False)
+    r = client.post("/api/inbox/mark-read", json={"message_ids": ["msg-1", "msg-2"]})
+    assert r.status_code == 200
+    data = r.json()
+    assert data["ok"] is True
+    assert data["marked_count"] == 2
+
+
+def test_mark_read_none_provided_returns_400(client: TestClient) -> None:
+    r = client.post("/api/inbox/mark-read", json={})
+    assert r.status_code == 400
+
+
+def test_mark_read_missing_id_returns_400(client: TestClient) -> None:
+    r = client.post("/api/inbox/mark-read", json={"message_ids": []})
+    assert r.status_code == 400
+
+
+def test_mark_read_partial_errors(client: TestClient, inbox_dir: Path) -> None:
+    _write_message(inbox_dir, "msg-good", read=False)
+    r = client.post("/api/inbox/mark-read", json={"message_ids": ["msg-good", "msg-missing"]})
+    assert r.status_code == 200
+    data = r.json()
+    assert data["ok"] is False
+    assert data["marked_count"] == 1
+    assert len(data["errors"]) == 1
+    assert data["errors"][0]["message_id"] == "msg-missing"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/inbox/unread-count
+# ---------------------------------------------------------------------------
+
+def test_unread_count_empty(client: TestClient) -> None:
+    r = client.get("/api/inbox/unread-count")
+    assert r.status_code == 200
+    assert r.json()["unread_count"] == 0
+
+
+def test_unread_count_with_messages(client: TestClient, inbox_dir: Path) -> None:
+    _write_message(inbox_dir, "msg-read", read=True)
+    _write_message(inbox_dir, "msg-unread-1", read=False)
+    _write_message(inbox_dir, "msg-unread-2", read=False)
+    r = client.get("/api/inbox/unread-count")
+    assert r.status_code == 200
+    assert r.json()["unread_count"] == 2


### PR DESCRIPTION
## Summary
Add Hermes Inbox HTTP API Surface (Stage E.1).
Endpoints:
- GET /api/inbox/list
- GET /api/inbox/get/{message_id}
- POST /api/inbox/mark-read
- GET /api/inbox/unread-count
Features:
- newest-first ordering
- cursor pagination (deterministic index-based)
- unread_only / source / level filters
- batch mark-read
- schema validation (hermes.inbox.message.v1)
## Tests
16 tests passing — pytest tests/test_inbox_routes.py -q
## Safety
- PR-only, no deployment changes
- no workflow/settings/secrets changes
