### PR TITLE
fix(cli): quote .env writes, widen Gemini vision allowlist, propagate skills install exit code

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4807,6 +4807,36 @@ def _check_non_ascii_credential(key: str, value: str) -> str:
     return sanitized
 
 
+# Characters that are safe to write to a .env file without any quoting.
+# Anything else (whitespace, `#`, `"`, `'`, `$`, `\`, etc.) must be quoted
+# so the value round-trips correctly through python-dotenv.
+_ENV_VALUE_SAFE_RE = re.compile(r"^[A-Za-z0-9_\-./:@+=,]*$")
+
+
+def _quote_env_value(value: str) -> str:
+    """Format a value for writing to a .env file.
+
+    Most tokens are alphanumeric and need no quoting, but values containing
+    characters that dotenv parsers treat specially (notably `#`, which starts
+    a comment) must be wrapped so they round-trip correctly. We prefer single
+    quotes because dotenv treats them as literal (no escape processing and no
+    `$VAR` expansion). When the value itself contains a single quote we fall
+    back to double quotes and escape `\\`, `"`, and `$`.
+    """
+    if not value:
+        return ""
+    if _ENV_VALUE_SAFE_RE.match(value):
+        return value
+    if "'" not in value:
+        return f"'{value}'"
+    escaped = (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("$", "\\$")
+    )
+    return f'"{escaped}"'
+
+
 def save_env_value(key: str, value: str):
     """Save or update a value in ~/.hermes/.env."""
     if is_managed():
@@ -4832,11 +4862,13 @@ def save_env_value(key: str, value: str):
         # Sanitize on every read: split concatenated keys, drop stale placeholders
         lines = _sanitize_env_lines(lines)
 
+    formatted_value = _quote_env_value(value)
+
     # Find and update or append
     found = False
     for i, line in enumerate(lines):
         if line.strip().startswith(f"{key}="):
-            lines[i] = f"{key}={value}\n"
+            lines[i] = f"{key}={formatted_value}\n"
             found = True
             break
 
@@ -4844,7 +4876,7 @@ def save_env_value(key: str, value: str):
         # Ensure there's a newline at the end of the file before appending
         if lines and not lines[-1].endswith("\n"):
             lines[-1] += "\n"
-        lines.append(f"{key}={value}\n")
+        lines.append(f"{key}={formatted_value}\n")
     
     fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix='.tmp', prefix='.env_')
     # Preserve original permissions so Docker volume mounts aren't clobbered.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12360,10 +12360,17 @@ Examples:
             from hermes_cli.skills_config import skills_command as skills_config_command
 
             skills_config_command(args)
-        else:
-            from hermes_cli.skills_hub import skills_command
+            return
 
-            skills_command(args)
+        from hermes_cli.skills_hub import skills_command
+
+        rc = skills_command(args)
+        # Surface failures (e.g. unresolvable identifier on `skills install`)
+        # via a non-zero process exit so shell chains, CI, and bulk-install
+        # scripts can detect the failure. Successful runs return 0 and fall
+        # through without touching the exit code.
+        if isinstance(rc, int) and rc != 0:
+            sys.exit(rc)
 
     skills_parser.set_defaults(func=cmd_skills)
 

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -414,7 +414,7 @@ def do_browse(page: int = 1, page_size: int = 20, source: str = "all",
 def do_install(identifier: str, category: str = "", force: bool = False,
                console: Optional[Console] = None, skip_confirm: bool = False,
                invalidate_cache: bool = True,
-               name_override: str = "") -> None:
+               name_override: str = "") -> int:
     """Fetch, quarantine, scan, confirm, and install a skill.
 
     ``name_override`` lets non-interactive callers (slash commands, gateway,
@@ -423,6 +423,12 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     triggers a prompt instead; ``skip_confirm=True`` means "non-interactive"
     (so pair it with ``name_override`` when installing from a URL that has
     no frontmatter).
+
+    Returns 0 on a successful install (including a no-op when the skill is
+    already installed and ``--force`` was not requested) and 1 on any failure
+    that should be surfaced to shell scripts and CI runners via a non-zero
+    exit code — unresolvable identifier, fetch failure, security scan
+    rejection, or user cancellation at the confirmation prompt.
     """
     from tools.skills_hub import (
         GitHubAuth, create_source_router, ensure_hub_dirs,
@@ -441,7 +447,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     if "/" not in identifier:
         identifier = _resolve_short_name(identifier, sources, c)
         if not identifier:
-            return
+            return 1
 
     c.print(f"\n[bold]Fetching:[/] {identifier}")
 
@@ -465,7 +471,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
             )
         else:
             c.print()
-        return
+        return 1
 
     # URL-sourced skills may arrive with an empty name when SKILL.md has no
     # ``name:`` in frontmatter AND the URL path doesn't yield a valid
@@ -482,7 +488,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
                 "Must be a lowercase identifier (letters, digits, hyphens, "
                 "underscores; starts with a letter).\n"
             )
-            return
+            return 1
         elif skip_confirm:
             # Non-interactive surface (slash command / TUI / gateway). Can't
             # prompt — emit an actionable error.
@@ -497,14 +503,14 @@ def do_install(identifier: str, category: str = "", force: bool = False,
                 "[dim]Or ask the SKILL.md's author to add a `name:` field to "
                 "its YAML frontmatter.[/]\n"
             )
-            return
+            return 1
         else:
             # Interactive TTY — prompt.
             url = bundle_meta.get("url") or identifier
             chosen = _prompt_for_skill_name(c, url)
             if not chosen:
                 c.print("[dim]Installation cancelled.[/]\n")
-                return
+                return 1
             bundle.name = chosen
             bundle_meta["awaiting_name"] = False
         # Keep SkillMeta in sync so downstream "already installed" checks,
@@ -532,7 +538,9 @@ def do_install(identifier: str, category: str = "", force: bool = False,
         c.print(f"[yellow]Warning:[/] '{bundle.name}' is already installed at {existing['install_path']}")
         if not force:
             c.print("Use --force to reinstall.\n")
-            return
+            # The requested skill is present on disk, so the caller's intent
+            # ("ensure this skill is installed") is satisfied — exit 0.
+            return 0
 
     extra_metadata = dict(getattr(meta, "extra", {}) or {})
     extra_metadata.update(getattr(bundle, "metadata", {}) or {})
@@ -545,7 +553,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
         from tools.skills_hub import append_audit_log
         append_audit_log("BLOCKED", bundle.name, bundle.source,
                          bundle.trust_level, "invalid_path", str(exc))
-        return
+        return 1
     c.print(f"[dim]Quarantined to {q_path.relative_to(q_path.parent.parent.parent)}[/]")
 
     # Scan
@@ -564,7 +572,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
         append_audit_log("BLOCKED", bundle.name, bundle.source,
                          bundle.trust_level, result.verdict,
                          f"{len(result.findings)}_findings")
-        return
+        return 1
 
     if extra_metadata:
         metadata_lines = _format_extra_metadata_lines(extra_metadata)
@@ -602,7 +610,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
         if answer not in {"y", "yes"}:
             c.print("[dim]Installation cancelled.[/]\n")
             shutil.rmtree(q_path, ignore_errors=True)
-            return
+            return 1
 
     # Install
     try:
@@ -613,7 +621,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
         from tools.skills_hub import append_audit_log
         append_audit_log("BLOCKED", bundle.name, bundle.source,
                          bundle.trust_level, "invalid_path", str(exc))
-        return
+        return 1
     from tools.skills_hub import SKILLS_DIR
     c.print(f"[bold green]Installed:[/] {install_dir.relative_to(SKILLS_DIR)}")
     c.print(f"[dim]Files: {', '.join(bundle.files.keys())}[/]\n")
@@ -628,6 +636,8 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     else:
         c.print("[dim]Skill will be available in your next session.[/]")
         c.print("[dim]Use /reset to start a new session now, or --now to activate immediately (invalidates prompt cache).[/]\n")
+
+    return 0
 
 
 def do_inspect(identifier: str, console: Optional[Console] = None) -> None:
@@ -1319,8 +1329,14 @@ def do_snapshot_import(input_path: str, force: bool = False,
 # CLI argparse entry point
 # ---------------------------------------------------------------------------
 
-def skills_command(args) -> None:
-    """Router for `hermes skills <subcommand>` — called from hermes_cli/main.py."""
+def skills_command(args) -> int:
+    """Router for `hermes skills <subcommand>` — called from hermes_cli/main.py.
+
+    Returns an int exit code so the top-level dispatcher can surface failures
+    (e.g. an unresolvable skill identifier on ``hermes skills install``) via a
+    non-zero process exit, instead of silently exiting 0 and breaking shell
+    chains like ``hermes skills install foo && hermes skills run foo``.
+    """
     action = getattr(args, "skills_action", None)
 
     if action == "browse":
@@ -1328,9 +1344,11 @@ def skills_command(args) -> None:
     elif action == "search":
         do_search(args.query, source=args.source, limit=args.limit)
     elif action == "install":
-        do_install(args.identifier, category=args.category, force=args.force,
-                   skip_confirm=getattr(args, "yes", False),
-                   name_override=getattr(args, "name", "") or "")
+        return int(do_install(
+            args.identifier, category=args.category, force=args.force,
+            skip_confirm=getattr(args, "yes", False),
+            name_override=getattr(args, "name", "") or "",
+        ) or 0)
     elif action == "inspect":
         do_inspect(args.identifier)
     elif action == "list":
@@ -1368,11 +1386,13 @@ def skills_command(args) -> None:
         repo = getattr(args, "repo", "") or getattr(args, "name", "")
         if not tap_action:
             _console.print("Usage: hermes skills tap [list|add|remove]\n")
-            return
+            return 0
         do_tap(tap_action, repo=repo)
     else:
         _console.print("Usage: hermes skills [browse|search|install|inspect|list|check|update|audit|uninstall|reset|publish|snapshot|tap]\n")
         _console.print("Run 'hermes skills <command> --help' for details.\n")
+
+    return 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -20,6 +20,7 @@ from hermes_cli.config import (
     save_env_value_secure,
     sanitize_env_file,
     _sanitize_env_lines,
+    _quote_env_value,
 )
 
 
@@ -225,6 +226,80 @@ class TestSaveEnvValueSecure:
             save_env_value("TENOR_API_KEY", "sk-test-secret")
             env_mode = (tmp_path / ".env").stat().st_mode & 0o777
             assert env_mode == 0o600
+
+
+class TestQuoteEnvValue:
+    """Unit tests for the .env value quoting helper.
+
+    Regression coverage for issue #30355: unquoted values containing ``#``
+    (or whitespace, quotes, ``$``) get truncated or mangled when the file is
+    re-read by python-dotenv. ``_quote_env_value`` must produce output that
+    round-trips through ``load_env`` to the original string.
+    """
+
+    def test_plain_value_is_not_quoted(self):
+        assert _quote_env_value("sk-ant-oat01-abcDEF123") == "sk-ant-oat01-abcDEF123"
+
+    def test_empty_value_is_empty(self):
+        assert _quote_env_value("") == ""
+
+    def test_hash_in_value_is_single_quoted(self):
+        # The bug from the issue: `#` would otherwise be treated as a comment
+        # start by python-dotenv, truncating the value.
+        assert _quote_env_value("sk-ant-oat01-abc#xyz") == "'sk-ant-oat01-abc#xyz'"
+
+    def test_whitespace_in_value_is_quoted(self):
+        assert _quote_env_value("two words") == "'two words'"
+
+    def test_dollar_sign_uses_literal_single_quotes(self):
+        # Single quotes prevent python-dotenv variable expansion of ``$VAR``.
+        assert _quote_env_value("abc$VAR123") == "'abc$VAR123'"
+
+    def test_single_quote_in_value_uses_double_quotes_with_escapes(self):
+        # When the value itself contains ``'`` we can't use single-quoting,
+        # so we fall back to double quotes and escape ``$`` and ``\``.
+        assert _quote_env_value("it's-fine") == '"it\'s-fine"'
+        assert _quote_env_value("it's $VAR") == '"it\'s \\$VAR"'
+
+    def test_save_env_value_roundtrips_value_with_hash(self, tmp_path):
+        """End-to-end: a token containing ``#`` survives a write/read cycle."""
+        token = "sk-ant-oat01-abc#xyz456"
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}, clear=False):
+            os.environ.pop("ANTHROPIC_TOKEN", None)
+            save_env_value("ANTHROPIC_TOKEN", token)
+            env_values = load_env()
+            assert env_values["ANTHROPIC_TOKEN"] == token
+
+    def test_save_env_value_roundtrips_value_with_dollar(self, tmp_path):
+        """Values containing ``$`` must not undergo variable expansion."""
+        token = "tok-$NOT_A_VAR-tail"
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}, clear=False):
+            os.environ.pop("OPENAI_API_KEY", None)
+            save_env_value("OPENAI_API_KEY", token)
+            env_values = load_env()
+            assert env_values["OPENAI_API_KEY"] == token
+
+    def test_save_env_value_roundtrips_value_with_single_quote(self, tmp_path):
+        """A single quote in the value triggers the double-quoted branch."""
+        token = "tok-with-it's-apostrophe"
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}, clear=False):
+            os.environ.pop("CUSTOM_TOKEN", None)
+            save_env_value("CUSTOM_TOKEN", token)
+            env_values = load_env()
+            assert env_values["CUSTOM_TOKEN"] == token
+
+    def test_dotenv_parses_quoted_hash_value(self, tmp_path):
+        """python-dotenv (the parser used by env_loader on startup) must see
+        the full unquoted value, not the pre-``#`` truncation it was producing
+        on unquoted writes."""
+        from dotenv import dotenv_values
+
+        token = "sk-ant-oat01-abc#xyz456"
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}, clear=False):
+            os.environ.pop("ANTHROPIC_TOKEN", None)
+            save_env_value("ANTHROPIC_TOKEN", token)
+            parsed = dotenv_values(tmp_path / ".env")
+            assert parsed["ANTHROPIC_TOKEN"] == token
 
 
 class TestRemoveEnvValue:

--- a/tests/hermes_cli/test_skills_install_exit_code.py
+++ b/tests/hermes_cli/test_skills_install_exit_code.py
@@ -1,0 +1,118 @@
+"""
+Regression coverage for issue #30631.
+
+`hermes skills install <unresolvable>` used to print a friendly "no match"
+message to stdout and then exit 0 — silently breaking shell chains like
+``hermes skills install foo && hermes skills run foo`` and bulk-install
+loops that rely on the exit code to detect typos.
+
+These tests pin three behaviours:
+
+* ``do_install`` returns a non-zero int when the identifier cannot be
+  resolved or fetched.
+* The CLI argparse path (``cmd_skills``) propagates that int to the process
+  exit via ``sys.exit``.
+* Successful and "already-installed" paths still exit 0.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_cli.skills_hub import do_install
+
+
+class _FakeSource:
+    """Minimal source-router stand-in: no skills exist."""
+
+    is_rate_limited = False
+
+    def __init__(self):
+        self.github = None
+
+    def inspect(self, identifier):  # noqa: ARG002
+        return None
+
+    def fetch(self, identifier):  # noqa: ARG002
+        return None
+
+
+@patch("tools.skills_hub.create_source_router", return_value=[_FakeSource()])
+@patch("tools.skills_hub.GitHubAuth", return_value=MagicMock())
+@patch("tools.skills_hub.ensure_hub_dirs")
+@patch("tools.skills_hub.unified_search", return_value=[])
+def test_do_install_returns_nonzero_when_identifier_unresolvable(
+    _unified, _ensure, _auth, _router
+):
+    """Short name with no search hits → exit code 1."""
+    rc = do_install("definitely-not-a-real-skill-zzz", skip_confirm=True)
+    assert rc == 1
+
+
+@patch("tools.skills_hub.create_source_router", return_value=[_FakeSource()])
+@patch("tools.skills_hub.GitHubAuth", return_value=MagicMock())
+@patch("tools.skills_hub.ensure_hub_dirs")
+def test_do_install_returns_nonzero_when_fetch_fails(_ensure, _auth, _router):
+    """Fully-qualified identifier that no source can fetch → exit code 1."""
+    rc = do_install("official/email/does-not-exist", skip_confirm=True)
+    assert rc == 1
+
+
+def test_cli_skills_install_exits_nonzero_on_resolution_failure(monkeypatch):
+    """End-to-end: the CLI surfaces the non-zero exit code to the process."""
+    from hermes_cli.main import main
+
+    # Stub the inner command so we don't hit the real network / GitHub API.
+    def fake_skills_command(args):  # noqa: ARG001
+        return 1
+
+    monkeypatch.setattr("hermes_cli.skills_hub.skills_command", fake_skills_command)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "skills", "install", "definitely-not-a-real-skill-zzz", "--yes"],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+
+    assert exc_info.value.code == 1
+
+
+def test_cli_skills_install_exits_zero_on_success(monkeypatch):
+    """A successful install must not blow up with SystemExit(0) noise."""
+    from hermes_cli.main import main
+
+    def fake_skills_command(args):  # noqa: ARG001
+        return 0
+
+    monkeypatch.setattr("hermes_cli.skills_hub.skills_command", fake_skills_command)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "skills", "install", "official/email/agentmail", "--yes"],
+    )
+
+    # Should not raise SystemExit.
+    main()
+
+
+def test_cli_skills_install_handles_none_return(monkeypatch):
+    """Defensive: legacy stubs returning None still treated as success."""
+    from hermes_cli.main import main
+
+    def fake_skills_command(args):  # noqa: ARG001
+        return None
+
+    monkeypatch.setattr("hermes_cli.skills_hub.skills_command", fake_skills_command)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "skills", "install", "test/skill"],
+    )
+
+    # Should not raise SystemExit.
+    main()

--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -52,8 +52,23 @@ class TestSupportsMediaInToolResults:
     def test_gemini_3_yes(self):
         assert _supports_media_in_tool_results("google", "gemini-3-flash-preview") is True
 
-    def test_gemini_2_no(self):
-        assert _supports_media_in_tool_results("google", "gemini-2.5-pro") is False
+    def test_gemini_2_5_yes(self):
+        # Issue #30704: Gemini 2.5 accepts multimodal tool results via the
+        # OpenAI-compatible endpoint; the legacy allowlist incorrectly forced
+        # callers onto the auxiliary text pipeline.
+        assert _supports_media_in_tool_results("google", "gemini-2.5-pro") is True
+        assert _supports_media_in_tool_results("gemini", "gemini-2.5-flash") is True
+        assert _supports_media_in_tool_results("google-gemini", "gemini-2.5-pro-exp") is True
+
+    def test_gemini_2_0_yes(self):
+        assert _supports_media_in_tool_results("google", "gemini-2.0-flash") is True
+        assert _supports_media_in_tool_results("gemini", "gemini-2.0-flash-exp") is True
+
+    def test_gemini_legacy_no(self):
+        # True legacy (1.x) Gemini variants never supported multimodal
+        # functionResponse and must still fall back to the auxiliary pipeline.
+        assert _supports_media_in_tool_results("google", "gemini-1.5-pro") is False
+        assert _supports_media_in_tool_results("google", "gemini-pro") is False
 
     def test_unknown_provider_conservative_no(self):
         assert _supports_media_in_tool_results("brand-new-provider", "any-model") is False

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -460,13 +460,21 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
     if p in {"openai", "openai-chat", "openai-codex", "azure-openai"}:
         return True
 
-    # Gemini — gate on model name; older Gemini variants did not support
-    # multimodal functionResponse. Gemini 3.x does.
+    # Gemini — gate on model name; truly legacy Gemini variants (1.x) did not
+    # support multimodal functionResponse. Gemini 2.0+ accepts multimodal tool
+    # results via the OpenAI-compatible endpoint, and the native v1beta API
+    # supports it from 2.5 onward; 3.x supports it everywhere.
     if p in {"google", "gemini", "google-gemini", "google-vertex-gemini"}:
         if not isinstance(model, str):
             return False
         m = model.strip().lower()
-        if "gemini-3" in m or "gemini-pro-3" in m or "gemini-flash-3" in m:
+        if (
+            "gemini-3" in m
+            or "gemini-pro-3" in m
+            or "gemini-flash-3" in m
+            or "gemini-2.5" in m
+            or "gemini-2.0" in m
+        ):
             return True
         return False
 


### PR DESCRIPTION
## Summary

Bundles three small, independent CLI / configuration bug fixes that share
a surface (the `hermes_cli` package). Each issue has clear root cause,
narrow blast radius, and dedicated regression tests.

| Issue | Bug | Fix |
| --- | --- | --- |
| #30355 | OAuth tokens containing `#` are truncated when re-read from `~/.hermes/.env`. | Quote values when writing `.env` so dotenv-special characters survive the round trip. |
| #30704 | Gemini 2.5 / 2.0 incorrectly fall back to the auxiliary text vision pipeline because the allowlist only matches `gemini-3*`. | Extend `_supports_media_in_tool_results` to recognise current-gen Gemini. |
| #30631 | `hermes skills install <unresolvable>` prints an error and then exits **0**, silently breaking shell chains and CI loops. | Return an `int` exit code from `do_install` / `skills_command` and forward non-zero codes via `sys.exit` in `cmd_skills`. |

## Details

### `fix(env): quote values written to ~/.hermes/.env`  (closes #30355)

`save_env_value` previously emitted `KEY=VALUE` verbatim. When the value
contained `#` (which python-dotenv treats as a comment start) everything
after the hash was dropped on the next load, producing 401s from
Anthropic and similar provider-side failures.

A new `_quote_env_value` helper picks the minimal valid form:

* Bare for the safe subset (`[A-Za-z0-9_\-./:@+=,]`), matching the
  legacy on-disk format for the overwhelmingly common token shapes.
* Single quotes for values containing `#`, whitespace, `$`, backslash,
  or `"` — chosen because dotenv treats single-quoted strings as
  literal (no escape processing, no `$VAR` expansion), which is exactly
  what we want for opaque credentials.
* Double quotes with `\\`, `\"`, `\$` escapes when the value itself
  contains `'`.

Verified end-to-end through both `load_env()` (Hermes's internal naive
parser) and `dotenv_values()` (python-dotenv).

### `fix(vision): allow Gemini 2.x in the native tool-result allowlist`  (closes #30704)

`tools/vision_tools.py:_supports_media_in_tool_results` only matched
`gemini-3*`. As reported in the issue, Gemini 2.5+ accepts multimodal
tool results through the OpenAI-compatible endpoint, and 2.0+ does so as
well — verified upstream with a direct `curl` to `generativelanguage`.

The fix widens the allowlist to `gemini-2.0` and `gemini-2.5`; truly
legacy 1.x variants remain `False`.

### `fix(skills): exit non-zero on `skills install` resolution failure`  (closes #30631)

`do_install` returned `None` on every early-return path. Wrapped in the
argparse dispatcher, those `None`s became exit-0 process terminations
even when the resolver had clearly printed "No skill named X found in
any source".

Changes:

* `do_install` now returns `int` (0 success, 1 failure). All ten
  early-return paths are explicitly annotated:
  * `1` for unresolvable identifier, fetch failure, invalid `--name`,
    quarantine error, security scan rejection, install error, or user
    cancellation at the confirmation prompt;
  * `0` for "already installed and `--force` not supplied" — the
    caller's intent ("ensure this skill is present") is satisfied.
* `skills_command` propagates that int to its return value.
* `cmd_skills` in `hermes_cli/main.py` calls `sys.exit(rc)` when the
  result is non-zero, leaving zero/None paths untouched so unrelated
  subcommands (and the existing tests that mock `skills_command` to
  return `None`) continue to work.

The slash-command path (`/skills install` inside chat) still discards
the return value, so a failed lookup no longer kills the process inside
an interactive session.

## Tests

* `tests/hermes_cli/test_config.py::TestQuoteEnvValue` — 10 new tests
  covering the helper, the write/read round trip via `load_env`, and a
  cross-check against `python-dotenv` (the actual parser in the bug
  report).
* `tests/tools/test_vision_native_fast_path.py::TestSupportsMediaInToolResults`
  — flipped the stale `gemini-2.5-pro` assertion and added explicit
  coverage for `gemini-2.5*`, `gemini-2.0*`, and a 1.x negative case.
* `tests/hermes_cli/test_skills_install_exit_code.py` — new file with
  five tests: unresolvable identifier returns 1, unfetchable identifier
  returns 1, the CLI surfaces the non-zero exit via `SystemExit`,
  successful installs do not raise, and `None` returns (legacy stubs in
  the existing `test_skills_install_flags.py`) still pass through.

```
$ venv/bin/python -m pytest tests/hermes_cli/test_config.py \
    tests/hermes_cli/test_skills_install_flags.py \
    tests/hermes_cli/test_skills_install_exit_code.py \
    tests/hermes_cli/test_skills_skip_confirm.py \
    tests/tools/test_vision_native_fast_path.py \
    tests/tools/test_vision_tools.py \
    tests/hermes_cli/test_env_loader.py \
    tests/hermes_cli/test_env_sanitize_on_load.py
======================== 182 passed, 6 skipped in 5.15s ========================
```

## Test plan

- [ ] On a fresh checkout, paste an OAuth token containing `#` via
      `hermes model` → reopen the CLI → `hermes status` shows the token
      authenticated (no 401).
- [ ] `hermes vision analyze <image>` with `HERMES_INFERENCE_MODEL=gemini-2.5-flash`
      takes the native fast path (no aux-LLM call in the debug log).
- [ ] `hermes skills install definitely-not-a-real-skill-zzz --yes; echo $?`
      prints the resolver error and exits `1`.
- [ ] `hermes skills install official/email/agentmail --yes && echo OK`
      still chains correctly on a successful install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)