### PR TITLE
fix(tui): include devDependencies in npm install for esbuild

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1353,7 +1353,7 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
         if not os.environ.get("HERMES_QUIET"):
             print("Installing TUI dependencies…")
         result = subprocess.run(
-            [npm, "install", "--silent", "--no-fund", "--no-audit", "--progress=false"],
+            [npm, "install", "--include=dev", "--silent", "--no-fund", "--no-audit", "--progress=false"],
             cwd=str(tui_dir),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,


### PR DESCRIPTION
## Bug

`hermes --tui` fails during the TUI build step with:

```
ERR_MODULE_NOT_FOUND: Cannot find package 'esbuild'
```

## Root Cause

In `hermes_cli/main.py`, the `_make_tui_argv()` function runs:

```
npm install --silent --no-fund --no-audit --progress=false
```

When `CI=1` is set in the environment (which the agent itself sets), npm skips devDependencies by default. `esbuild` is declared as a devDependency in `ui-tui/package.json` but is required at build time by `scripts/build.mjs`. Since it is never installed, the build fails.

## Fix

Add `--include=dev` to the npm install command so that devDependencies are always installed regardless of the `CI` environment variable:

```diff
- [npm, "install", "--silent", "--no-fund", "--no-audit", "--progress=false"],
+ [npm, "install", "--include=dev", "--silent", "--no-fund", "--no-audit", "--progress=false"],
```

## Testing

Verified that with this flag, `npm install` correctly installs `esbuild` and the TUI build (`node scripts/build.mjs`) succeeds even when `CI=1` is set.