### PR TITLE
feat(gateway): add quiet status and typing controls

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -35,6 +35,10 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     "show_reasoning": False,
     "tool_preview_length": 0,
     "streaming": None,  # None = follow top-level streaming config
+    # Agent status_callback notices include context compression and provider
+    # retry/timeout messages. Enabled by default for transparency; messaging
+    # platforms can disable them with display.platforms.<platform>.status_messages.
+    "status_messages": True,
     # When true, delete tool-progress / "Still working..." / status bubbles
     # after the final response lands on platforms that support message
     # deletion (e.g. Telegram). Off by default — progress is still shown
@@ -190,9 +194,9 @@ def _normalise(setting: str, value: Any) -> Any:
         if value is True:
             return "all"
         return str(value).lower()
-    if setting in {"show_reasoning", "streaming"}:
+    if setting in {"show_reasoning", "streaming", "status_messages"}:
         if isinstance(value, str):
-            return value.lower() in {"true", "1", "yes", "on"}
+            return value.strip().lower() in {"true", "1", "yes", "on"}
         return bool(value)
     if setting == "cleanup_progress":
         if isinstance(value, str):

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -19,7 +19,7 @@ import uuid
 from abc import ABC, abstractmethod
 from urllib.parse import urlsplit
 
-from utils import normalize_proxy_url
+from utils import is_truthy_value, normalize_proxy_url
 
 logger = logging.getLogger(__name__)
 
@@ -1348,6 +1348,10 @@ class BasePlatformAdapter(ABC):
         # Chats where typing indicator is paused (e.g. during approval waits).
         # _keep_typing skips send_typing when the chat_id is in this set.
         self._typing_paused: set = set()
+        self._typing_indicators_enabled = is_truthy_value(
+            (getattr(config, "extra", None) or {}).get("typing_indicators"),
+            default=True,
+        )
 
     @property
     def message_len_fn(self) -> Callable[[str], int]:
@@ -3094,23 +3098,28 @@ class BasePlatformAdapter(ABC):
         interrupt_event = self._active_sessions.get(session_key) or asyncio.Event()
         self._active_sessions[session_key] = interrupt_event
         
-        # Start continuous typing indicator (refreshes every 2 seconds)
+        # Start continuous typing indicator (refreshes every 2 seconds), unless
+        # disabled for this platform via platforms.<name>.extra.typing_indicators.
         _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
-        _keep_typing_kwargs = {"metadata": _thread_metadata}
-        try:
-            _keep_typing_sig = inspect.signature(self._keep_typing)
-        except (TypeError, ValueError):
-            _keep_typing_sig = None
-        if _keep_typing_sig is None or "stop_event" in _keep_typing_sig.parameters:
-            _keep_typing_kwargs["stop_event"] = interrupt_event
-        typing_task = asyncio.create_task(
-            self._keep_typing(
-                event.source.chat_id,
-                **_keep_typing_kwargs,
+        typing_task = None
+        if self._typing_indicators_enabled:
+            _keep_typing_kwargs = {"metadata": _thread_metadata}
+            try:
+                _keep_typing_sig = inspect.signature(self._keep_typing)
+            except (TypeError, ValueError):
+                _keep_typing_sig = None
+            if _keep_typing_sig is None or "stop_event" in _keep_typing_sig.parameters:
+                _keep_typing_kwargs["stop_event"] = interrupt_event
+            typing_task = asyncio.create_task(
+                self._keep_typing(
+                    event.source.chat_id,
+                    **_keep_typing_kwargs,
+                )
             )
-        )
 
         async def _stop_typing_task() -> None:
+            if typing_task is None:
+                return
             typing_task.cancel()
             try:
                 await asyncio.wait_for(asyncio.shield(typing_task), timeout=0.5)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15501,6 +15501,9 @@ class GatewayRunner:
                 default=True,
             )
         )
+        status_messages_enabled = bool(
+            resolve_display_setting(user_config, platform_key, "status_messages", True)
+        )
         
         # Queue for progress messages (thread-safe)
         progress_queue = queue.Queue() if tool_progress_enabled else None
@@ -16046,7 +16049,7 @@ class GatewayRunner:
             _status_thread_metadata = self._thread_metadata_for_source(source, event_message_id) if _progress_thread_id else None
 
         def _status_callback_sync(event_type: str, message: str) -> None:
-            if not _status_adapter or not _run_still_current():
+            if not status_messages_enabled or not _status_adapter or not _run_still_current():
                 return
             prepared_message = _prepare_gateway_status_message(
                 source.platform,
@@ -16322,7 +16325,7 @@ class GatewayRunner:
             agent.step_callback = _step_callback_sync if _hooks_ref.loaded_hooks else None
             agent.stream_delta_callback = _stream_delta_cb
             agent.interim_assistant_callback = _interim_assistant_cb if _want_interim_messages else None
-            agent.status_callback = _status_callback_sync
+            agent.status_callback = _status_callback_sync if status_messages_enabled else None
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides") or {}

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -55,6 +55,12 @@ class TestResolveDisplaySetting:
         # Unknown platform, no config → global default "all"
         assert resolve_display_setting(config, "unknown_platform", "tool_progress") == "all"
 
+    def test_status_messages_default_to_enabled(self):
+        """Agent status messages stay enabled unless quiet configs disable them."""
+        from gateway.display_config import resolve_display_setting
+
+        assert resolve_display_setting({}, "telegram", "status_messages") is True
+
     def test_fallback_parameter_used_last(self):
         """Explicit fallback is used when nothing else matches."""
         from gateway.display_config import resolve_display_setting
@@ -170,6 +176,13 @@ class TestYAMLNormalisation:
 
         config = {"display": {"platforms": {"slack": {"tool_progress": False}}}}
         assert resolve_display_setting(config, "slack", "tool_progress") == "off"
+
+    def test_status_messages_string_false(self):
+        """String false disables status messages instead of staying truthy."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {"display": {"status_messages": " false "}}
+        assert resolve_display_setting(config, "telegram", "status_messages") is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_platform_typing_indicators.py
+++ b/tests/gateway/test_platform_typing_indicators.py
@@ -1,0 +1,56 @@
+import asyncio
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, SendResult
+from gateway.session import SessionSource, build_session_key
+
+
+class CountingTypingAdapter(BasePlatformAdapter):
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, Platform.TELEGRAM)
+        self.typing_calls = 0
+        self.sent_messages = []
+
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        pass
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent_messages.append((chat_id, content, reply_to, metadata))
+        return SendResult(success=True, message_id="sent-1")
+
+    async def send_typing(self, chat_id, metadata=None):
+        self.typing_calls += 1
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+
+def _run_typing_scenario(extra):
+    async def run_scenario():
+        adapter = CountingTypingAdapter(PlatformConfig(enabled=True, token="test", extra=extra))
+
+        async def handler(event):
+            await asyncio.sleep(0.05)
+            return "done"
+
+        adapter.set_message_handler(handler)
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm")
+        event = MessageEvent(text="hello", source=source, message_id="m1")
+
+        await adapter._process_message_background(event, build_session_key(source))
+
+        assert adapter.sent_messages
+        return adapter.typing_calls
+
+    return asyncio.run(run_scenario())
+
+
+def test_platform_extra_can_disable_typing_indicator_loop():
+    assert _run_typing_scenario({"typing_indicators": False}) == 0
+
+
+def test_platform_extra_string_false_can_disable_typing_indicator_loop():
+    assert _run_typing_scenario({"typing_indicators": "false"}) == 0

--- a/tests/gateway/test_run_cleanup_progress.py
+++ b/tests/gateway/test_run_cleanup_progress.py
@@ -131,6 +131,24 @@ class FailingAgent:
         }
 
 
+class StatusAgent:
+    """Emits a user-visible agent status message."""
+
+    def __init__(self, **kwargs):
+        self.status_callback = kwargs.get("status_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.status_callback
+        if cb is not None:
+            cb(
+                "lifecycle",
+                "ℹ️ Preparing your request...",
+            )
+            time.sleep(0.05)
+        return {"final_response": "done", "messages": [], "api_calls": 1}
+
+
 def _make_runner(adapter):
     gateway_run = importlib.import_module("gateway.run")
     GatewayRunner = gateway_run.GatewayRunner
@@ -154,7 +172,15 @@ def _make_runner(adapter):
     return runner
 
 
-def _install_fakes(monkeypatch, agent_cls, *, cleanup_on: bool):
+def _install_fakes(
+    monkeypatch,
+    agent_cls,
+    *,
+    cleanup_on: bool,
+    platform: Platform = Platform.TELEGRAM,
+    platform_display: dict | None = None,
+    global_display: dict | None = None,
+):
     """Wire up the module stubs every _run_agent test needs."""
     monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
 
@@ -170,17 +196,26 @@ def _install_fakes(monkeypatch, agent_cls, *, cleanup_on: bool):
     gateway_run = importlib.import_module("gateway.run")
     monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
 
-    # Wire the per-platform cleanup_progress flag via the config loader the
-    # gateway actually reads (``_load_gateway_config`` returns user config).
-    cfg = {
-        "display": {
-            "platforms": {
-                "telegram": {"cleanup_progress": True},
-            }
-        }
-    } if cleanup_on else {}
+    # Wire display flags via the config loader the gateway actually reads
+    # (``_load_gateway_config`` returns user config).
+    display = dict(global_display or {})
+    current_platform_display = {}
+    if cleanup_on:
+        current_platform_display["cleanup_progress"] = True
+    if platform_display:
+        current_platform_display.update(platform_display)
+    if current_platform_display:
+        display.setdefault("platforms", {})[platform.value] = current_platform_display
+    cfg = {"display": display} if display else {}
     monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: cfg)
     return gateway_run
+
+
+async def _wait_for_sent(adapter: CleanupCaptureAdapter, expected: int = 1) -> None:
+    for _ in range(20):
+        if len(adapter.sent) >= expected:
+            return
+        await asyncio.sleep(0.01)
 
 
 # ---------------------------------------------------------------------------
@@ -219,6 +254,142 @@ async def test_cleanup_off_by_default_leaves_bubbles(monkeypatch, tmp_path):
         for _ in range(10):
             await asyncio.sleep(0.01)
     assert adapter.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_status_messages_enabled_by_default(monkeypatch, tmp_path):
+    """User-visible status notices are sent unless explicitly disabled."""
+    adapter = CleanupCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = _install_fakes(monkeypatch, StatusAgent, cleanup_on=False)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="-1001")
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-1",
+        session_key="agent:main:telegram:group:-1001",
+    )
+
+    assert result["final_response"] == "done"
+    await _wait_for_sent(adapter)
+    assert any("Preparing your request" in item["content"] for item in adapter.sent)
+
+
+@pytest.mark.asyncio
+async def test_status_messages_can_be_disabled_per_platform(monkeypatch, tmp_path):
+    """Telegram quiet mode can suppress raw compression/provider status bubbles."""
+    adapter = CleanupCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = _install_fakes(
+        monkeypatch,
+        StatusAgent,
+        cleanup_on=False,
+        platform_display={"status_messages": False},
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="-1001")
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-1",
+        session_key="agent:main:telegram:group:-1001",
+    )
+
+    assert result["final_response"] == "done"
+    await asyncio.sleep(0.1)
+    assert adapter.sent == []
+
+
+@pytest.mark.asyncio
+async def test_status_messages_can_be_disabled_globally(monkeypatch, tmp_path):
+    """Global display.status_messages false suppresses status bubbles."""
+    adapter = CleanupCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = _install_fakes(
+        monkeypatch,
+        StatusAgent,
+        cleanup_on=False,
+        global_display={"status_messages": False},
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="-1001")
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-1",
+        session_key="agent:main:telegram:group:-1001",
+    )
+
+    assert result["final_response"] == "done"
+    await asyncio.sleep(0.1)
+    assert adapter.sent == []
+
+
+@pytest.mark.asyncio
+async def test_status_messages_enabled_for_webhook_by_default(monkeypatch, tmp_path):
+    """Webhook status delivery remains opt-out, matching the default true setting."""
+    adapter = CleanupCaptureAdapter(platform=Platform.WEBHOOK)
+    runner = _make_runner(adapter)
+    gateway_run = _install_fakes(
+        monkeypatch,
+        StatusAgent,
+        cleanup_on=False,
+        platform=Platform.WEBHOOK,
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    source = SessionSource(platform=Platform.WEBHOOK, chat_id="webhook:job-1", chat_type="webhook")
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-1",
+        session_key="agent:main:webhook:job-1",
+    )
+
+    assert result["final_response"] == "done"
+    await _wait_for_sent(adapter)
+    assert any("Preparing your request" in item["content"] for item in adapter.sent)
+
+
+@pytest.mark.asyncio
+async def test_status_messages_can_be_disabled_for_webhook(monkeypatch, tmp_path):
+    """display.platforms.webhook.status_messages false is honored."""
+    adapter = CleanupCaptureAdapter(platform=Platform.WEBHOOK)
+    runner = _make_runner(adapter)
+    gateway_run = _install_fakes(
+        monkeypatch,
+        StatusAgent,
+        cleanup_on=False,
+        platform=Platform.WEBHOOK,
+        platform_display={"status_messages": False},
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    source = SessionSource(platform=Platform.WEBHOOK, chat_id="webhook:job-1", chat_type="webhook")
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-1",
+        session_key="agent:main:webhook:job-1",
+    )
+
+    assert result["final_response"] == "done"
+    await asyncio.sleep(0.1)
+    assert adapter.sent == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add `display.status_messages` / per-platform `display.platforms.<platform>.status_messages` to suppress agent status-callback bubbles while preserving default visibility
- add `platforms.<name>.extra.typing_indicators` to disable the continuous typing loop per platform, defaulting to existing behavior
- cover Telegram/global/webhook status-message behavior and typing indicator opt-out cases

## Test plan
- `.venv/bin/python -m pytest tests/gateway/test_display_config.py tests/gateway/test_run_cleanup_progress.py tests/gateway/test_platform_typing_indicators.py -q -o addopts=`
- `git diff --check`
- `.venv/bin/python -m py_compile gateway/display_config.py gateway/platforms/base.py gateway/run.py tests/gateway/test_display_config.py tests/gateway/test_run_cleanup_progress.py tests/gateway/test_platform_typing_indicators.py`
- added-line static scan for secrets/shell injection/eval/pickle/SQL formatting
- independent pre-commit review and focused re-review passed