### PR TITLE
fix: guard json.loads() against non-JSON HTTP responses

### DIFF
--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -87,7 +87,10 @@ def _discord_request(
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             if resp.status == 204:
                 return None
-            return json.loads(resp.read().decode("utf-8"))
+            try:
+                return json.loads(resp.read().decode("utf-8"))
+            except json.JSONDecodeError as jde:
+                raise DiscordAPIError(0, f"Invalid JSON response: {jde}") from jde
     except urllib.error.HTTPError as e:
         error_body = ""
         try:

--- a/tools/osv_check.py
+++ b/tools/osv_check.py
@@ -148,7 +148,11 @@ def _query_osv(
     )
 
     with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
-        result = json.loads(resp.read())
+        try:
+            result = json.loads(resp.read())
+        except json.JSONDecodeError:
+            logger.debug("OSV API returned non-JSON response for %s", package)
+            return []
 
     vulns = result.get("vulns", [])
     # Only malware advisories — ignore regular CVEs


### PR DESCRIPTION
## Problem
When HTTP APIs return non-JSON responses (HTML error pages, 502/503 gateway errors), `json.loads()` raises `json.JSONDecodeError` which propagates unhandled to the caller, causing crashes.

Two locations affected:
1. **`tools/osv_check.py`** — `_query_osv()` parses OSV API responses without catching JSONDecodeError. If the API returns an HTML error page, the entire osv-check tool crashes.
2. **`tools/discord_tool.py`** — `_discord_api_request()` only catches `HTTPError` but not `JSONDecodeError`. If Discord returns a 200 with non-JSON body (rate limit HTML, maintenance page), the error propagates without context.

## Fix
- `osv_check.py`: Wrapped `json.loads()` in `try/except json.JSONDecodeError`, returning empty list (no advisories) on parse failure
- `discord_tool.py`: Added nested `try/except json.JSONDecodeError` that raises `DiscordAPIError` with context, consistent with existing error handling

## Before vs After
| Location | Before | After |
|----------|--------|-------|
| osv_check.py | Crash on non-JSON | Returns empty list, logs debug |
| discord_tool.py | Unhandled JSONDecodeError | Raises DiscordAPIError with context |

## Tests
- `python -m py_compile tools/osv_check.py` ✓
- `python -m py_compile tools/discord_tool.py` ✓
