### PR TITLE
Add hint when auto-detect may select wrong provider on timeout

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2334,6 +2334,21 @@ def run_conversation(
                         force=True,
                     )
 
+                # Hint when auto-detect may have selected the wrong provider.
+                # Only on first timeout/connection error and only when multiple
+                # providers have API keys configured.
+                if retry_count == 1 and ("timed out" in error_msg or "timeout" in error_msg or "connection" in error_msg):
+                    try:
+                        from hermes_cli.runtime_provider import _check_ambiguous_auto_detect
+                        _ambig = _check_ambiguous_auto_detect()
+                        if _ambig:
+                            agent._vprint(
+                                f"{agent.log_prefix}   💡 {_ambig}",
+                                force=True,
+                            )
+                    except Exception:
+                        pass
+
                 # Check for interrupt before deciding to retry
                 if agent._interrupt_requested:
                     agent._vprint(f"{agent.log_prefix}⚡ Interrupt detected during error handling, aborting retries.", force=True)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1483,7 +1483,12 @@ def resolve_provider(
     if has_usable_secret(os.getenv("OPENAI_API_KEY")) or has_usable_secret(os.getenv("OPENROUTER_API_KEY")):
         return "openrouter"
 
-    # Auto-detect API-key providers by checking their env vars
+    # Auto-detect API-key providers by checking their env vars.
+    # Collect all candidates first so we can warn when multiple providers
+    # have keys — a common source of mis-routing (e.g. gemini selected
+    # over zai because it appears earlier in PROVIDER_REGISTRY).
+    _auto_skip = {"copilot", "lmstudio"}
+    _auto_candidates: list[str] = []
     for pid, pconfig in PROVIDER_REGISTRY.items():
         if pconfig.auth_type != "api_key":
             continue
@@ -1493,11 +1498,22 @@ def resolve_provider(
         # whose availability isn't implied by LM_API_KEY presence (it may be
         # offline, and the no-auth setup uses a placeholder value), so it
         # also requires explicit selection.
-        if pid in {"copilot", "lmstudio"}:
+        if pid in _auto_skip:
             continue
         for env_var in pconfig.api_key_env_vars:
             if has_usable_secret(os.getenv(env_var, "")):
-                return pid
+                _auto_candidates.append(pid)
+                break
+    if len(_auto_candidates) > 1:
+        logger.warning(
+            "Multiple providers have API keys configured (%s) but no explicit "
+            "provider set. Using '%s' (first match). "
+            "Set model.provider in config.yaml to disambiguate.",
+            ", ".join(_auto_candidates),
+            _auto_candidates[0],
+        )
+    if _auto_candidates:
+        return _auto_candidates[0]
 
     # AWS Bedrock — detect via boto3 credential chain (IAM roles, SSO, env vars).
     # This runs after API-key providers so explicit keys always win.

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -9,6 +9,30 @@ from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
+
+def _check_ambiguous_auto_detect() -> str:
+    """Check if multiple providers have API keys, returning a warning string
+    if so (empty string otherwise).  Called only when provider=auto."""
+    candidates: list[str] = []
+    skip = {"copilot", "lmstudio"}
+    for pid, pconfig in PROVIDER_REGISTRY.items():
+        if pconfig.auth_type != "api_key":
+            continue
+        if pid in skip:
+            continue
+        for env_var in pconfig.api_key_env_vars:
+            if has_usable_secret(os.getenv(env_var, "")):
+                candidates.append(pid)
+                break
+    if len(candidates) > 1:
+        return (
+            f"Multiple providers have API keys ({', '.join(candidates)}) "
+            f"but no explicit provider set. Using '{candidates[0]}' (first match). "
+            f"Set model.provider in config.yaml to disambiguate."
+        )
+    return ""
+
+
 from hermes_cli import auth as auth_mod
 from agent.credential_pool import CredentialPool, PooledCredential, get_custom_provider_pool_key, load_pool
 from hermes_cli.auth import (

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 
 from hermes_cli import runtime_provider as rp
@@ -2701,3 +2703,77 @@ def test_host_derived_key_helper_basic_cases():
     for k in ("DEEPSEEK_API_KEY", "GROQ_API_KEY", "MISTRAL_API_KEY",
               "OPENAI_API_KEY", "OPENROUTER_API_KEY"):
         _os.environ.pop(k, None)
+
+
+# =============================================================================
+# resolve_provider("auto") — ambiguous multi-provider warning
+# =============================================================================
+
+
+def test_resolve_provider_auto_warns_on_multiple_keys(monkeypatch, caplog):
+    """When multiple providers have API keys, auto-detect should still return
+    the first match but emit a warning so the user knows to set model.provider."""
+    import hermes_cli.auth as auth_mod
+
+    # Clear all provider keys first
+    for _key in (
+        "OPENAI_API_KEY", "OPENROUTER_API_KEY",
+        "GOOGLE_API_KEY", "GEMINI_API_KEY",
+        "GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY",
+        "KIMI_API_KEY", "KIMI_CODING_API_KEY",
+        "DEEPSEEK_API_KEY", "ANTHROPIC_API_KEY",
+        "STEPFUN_API_KEY", "MINIMAX_API_KEY",
+        "ARCEE_API_KEY", "GMI_API_KEY",
+        "LM_API_KEY", "COPILOT_GITHUB_TOKEN",
+        "GH_TOKEN", "GITHUB_TOKEN",
+        "XIAOMI_API_KEY", "TENCENT_TOKENHUB_API_KEY",
+    ):
+        monkeypatch.delenv(_key, raising=False)
+
+    # Clear auth store so OAuth providers don't interfere
+    monkeypatch.setattr(auth_mod, "_load_auth_store", lambda: {})
+
+    # Set keys for both gemini and zai
+    monkeypatch.setenv("GEMINI_API_KEY", "gemini-key-12345")
+    monkeypatch.setenv("GLM_API_KEY", "glm-key-12345")
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.auth"):
+        result = auth_mod.resolve_provider("auto")
+
+    # gemini comes before zai in PROVIDER_REGISTRY → first match
+    assert result == "gemini"
+
+    # But a warning must have been logged
+    assert "Multiple providers have API keys configured" in caplog.text
+
+
+def test_resolve_provider_auto_single_key_no_warning(monkeypatch, caplog):
+    """When only one provider has an API key, auto-detect should return it
+    without any warning."""
+    import hermes_cli.auth as auth_mod
+
+    # Clear all provider keys first
+    for _key in (
+        "OPENAI_API_KEY", "OPENROUTER_API_KEY",
+        "GOOGLE_API_KEY", "GEMINI_API_KEY",
+        "GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY",
+        "KIMI_API_KEY", "KIMI_CODING_API_KEY",
+        "DEEPSEEK_API_KEY", "ANTHROPIC_API_KEY",
+        "STEPFUN_API_KEY", "MINIMAX_API_KEY",
+        "ARCEE_API_KEY", "GMI_API_KEY",
+        "LM_API_KEY", "COPILOT_GITHUB_TOKEN",
+        "GH_TOKEN", "GITHUB_TOKEN",
+        "XIAOMI_API_KEY", "TENCENT_TOKENHUB_API_KEY",
+    ):
+        monkeypatch.delenv(_key, raising=False)
+
+    monkeypatch.setattr(auth_mod, "_load_auth_store", lambda: {})
+
+    # Only zai has a key
+    monkeypatch.setenv("GLM_API_KEY", "glm-key-12345")
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.auth"):
+        result = auth_mod.resolve_provider("auto")
+
+    assert result == "zai"
+    assert "Multiple providers" not in caplog.text


### PR DESCRIPTION
## Problem

When `model.provider` is not explicitly set in config.yaml, auto-detect scans `PROVIDER_REGISTRY` for providers whose API key env vars are set. When multiple providers have keys (e.g. both `GEMINI_API_KEY` and `GLM_API_KEY`), it silently picks the first match in registry order. If the wrong provider is selected, the model name is sent to an incompatible endpoint.

**Example misconfiguration:**

```yaml
# config.yaml
model: glm-5.1          # no explicit provider set
```

```bash
# .env — both keys present
GLM_API_KEY=sk-...
GEMINI_API_KEY=AIza...
```

**User sees a confusing timeout loop:**

```
⚠️ No response from provider for 180s (model: glm-5.1, context: ~4,796 tokens). Reconnecting...
⚠️  API call failed (attempt 1/3): GeminiAPIError
   🔌 Provider: gemini  Model: glm-5.1
   🌐 Endpoint: https://generativelanguage.googleapis.com/v1beta
   📝 Error: Gemini streaming request failed: timed out
```

The error output shows `Provider: gemini` and `Model: glm-5.1` but users may not realize they mismatch — they might assume it's just network latency.

## Solution

Add a post-failure hint after the first API call failure when multiple provider keys are detected. Only shown on timeout/connection errors, only on the first retry attempt, only when multiple providers have API keys.

```
⚠️  API call failed (attempt 1/3): GeminiAPIError
   🔌 Provider: gemini  Model: glm-5.1
   🌐 Endpoint: https://generativelanguage.googleapis.com/v1beta
   📝 Error: Gemini streaming request failed: timed out
   ⏱️  Elapsed: 210.11s  Context: 2 msgs, ~4,796 tokens
   💡 Multiple providers have API keys (gemini, zai) but no explicit provider set. Using 'gemini' (first match). Set model.provider in config.yaml to disambiguate.
⏳ Retrying in 2.4s (attempt 1/3)...
```

**User fix:**

```yaml
model:
  provider: zai
  default: glm-5.1
```

## Design decisions

- **Post-failure only, not at startup**: A startup warning would fire for all users with multiple API keys even when auto-detect works correctly. Showing the hint only on actual failures avoids noise.
- **First retry only** (`retry_count == 1`): Shown once after the first failure, not repeated on subsequent retries.
- **Timeout/connection errors only**: Auth errors (401/403) and rate limits (429) have clear causes — the ambiguous-provider scenario only manifests as timeouts when the model name doesn't exist on the selected endpoint.
- **No behavioral changes**: Provider selection (first match) is unchanged. Only observability improves.
- **Low invasiveness**: Follows the existing actionable-hint pattern (same as OpenRouter "no tool endpoints" hint in conversation_loop.py).

## Files changed

- `hermes_cli/auth.py` — auto-detect loop collects all candidates, logs warning when >1 found
- `hermes_cli/runtime_provider.py` — `_check_ambiguous_auto_detect()` helper
- `agent/conversation_loop.py` — post-failure hint on first timeout (retry_count==1)
- `tests/hermes_cli/test_runtime_provider_resolution.py` — 2 new tests

## How to test

With the misconfiguration above (multiple provider keys + no explicit `model.provider`), start hermes chat and send any message. On the first API failure, the 💡 hint will appear after the error details.