### PR TITLE
fix(discord): support progress message cleanup

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1621,6 +1621,34 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.error("[%s] Failed to edit Discord message %s: %s", self.name, message_id, e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
+    async def delete_message(self, chat_id: str, message_id: str) -> bool:
+        """Delete a previously sent Discord message.
+
+        Used by gateway progress cleanup so temporary tool-progress bubbles can
+        be swept away after the final response is delivered.  Returns ``False``
+        on any platform/API failure so callers can treat cleanup as best-effort.
+        """
+        if not self._client:
+            return False
+        try:
+            channel = self._client.get_channel(int(chat_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(chat_id))
+            if not channel:
+                return False
+            msg = await channel.fetch_message(int(message_id))
+            await msg.delete()
+            return True
+        except Exception as e:  # pragma: no cover - defensive logging
+            logger.debug(
+                "[%s] Failed to delete Discord message %s: %s",
+                self.name,
+                message_id,
+                e,
+                exc_info=True,
+            )
+            return False
+
     async def _send_file_attachment(
         self,
         chat_id: str,

--- a/tests/gateway/test_stream_consumer_fresh_final.py
+++ b/tests/gateway/test_stream_consumer_fresh_final.py
@@ -213,16 +213,28 @@ class TestStreamingConfigFreshFinalField:
         assert restored.fresh_final_after_seconds == 90.0
 
 
-class TestTelegramAdapterDeleteMessage:
-    """Contract: Telegram adapter implements ``delete_message``."""
+class TestPlatformDeleteMessageContracts:
+    """Contract: adapters used for cleanup implement ``delete_message``."""
 
-    def test_delete_message_method_exists(self):
+    def test_telegram_delete_message_method_exists(self):
         telegram = pytest.importorskip("gateway.platforms.telegram")
         import inspect
         cls = telegram.TelegramAdapter
         assert hasattr(cls, "delete_message"), (
             "TelegramAdapter.delete_message is required for the fresh-final "
             "cleanup path (openclaw/openclaw#72038 port)."
+        )
+        sig = inspect.signature(cls.delete_message)
+        params = list(sig.parameters)
+        assert params[:3] == ["self", "chat_id", "message_id"]
+
+    def test_discord_delete_message_method_exists(self):
+        discord_adapter = pytest.importorskip("plugins.platforms.discord.adapter")
+        import inspect
+        cls = discord_adapter.DiscordAdapter
+        assert hasattr(cls, "delete_message"), (
+            "DiscordAdapter.delete_message is required for temporary tool-progress "
+            "cleanup when display.platforms.discord.cleanup_progress is enabled."
         )
         sig = inspect.signature(cls.delete_message)
         params = list(sig.parameters)


### PR DESCRIPTION
## Summary
- Add best-effort Discord message deletion support for temporary gateway progress messages
- Extend the cleanup contract test to cover the Discord plugin adapter

## Test Plan
- `python -m py_compile plugins/platforms/discord/adapter.py gateway/run.py gateway/config.py`
- `python -m pytest tests/gateway/test_stream_consumer_fresh_final.py -q -o 'addopts='`
