### PR TITLE
fix(agent): cap projected codex exec output to prevent context bloat

### DIFF
--- a/agent/transports/codex_event_projector.py
+++ b/agent/transports/codex_event_projector.py
@@ -33,6 +33,14 @@ import json
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
+# Cap for projected `commandExecution` output. Codex's `aggregatedOutput` is
+# unbounded — a wide grep/find can dump hundreds of KB straight into the model
+# context window. The mcp/dynamic/opaque projections below already truncate
+# their results; the exec path was missing the same guard. ~10k chars keeps a
+# useful head of the output without blowing up the window — and matches the
+# order of magnitude of the other projections' caps ([:4000]/[:1500]).
+_MAX_EXEC_OUTPUT = 10000
+
 
 def _deterministic_call_id(item_type: str, item_id: str) -> str:
     """Stable id for tool_call message correlation.
@@ -166,6 +174,13 @@ class CodexEventProjector:
         exit_code = item.get("exitCode")
         if exit_code is not None and exit_code != 0:
             output = f"[exit {exit_code}]\n{output}"
+        if len(output) > _MAX_EXEC_OUTPUT:
+            total = len(output)
+            output = (
+                output[:_MAX_EXEC_OUTPUT]
+                + f"\n\n[... output truncated: {total} chars total, "
+                f"capped at {_MAX_EXEC_OUTPUT} ]"
+            )
         tool_msg = {
             "role": "tool",
             "tool_call_id": call_id,

--- a/tests/agent/transports/test_codex_event_projector.py
+++ b/tests/agent/transports/test_codex_event_projector.py
@@ -12,6 +12,7 @@ import pytest
 from agent.transports.codex_event_projector import (
     CodexEventProjector,
     ProjectionResult,
+    _MAX_EXEC_OUTPUT,
     _deterministic_call_id,
     _format_tool_args,
 )
@@ -123,6 +124,54 @@ class TestCommandExecutionProjection:
         a = p1.project(COMMAND_EXEC_COMPLETED).messages
         b = p2.project(COMMAND_EXEC_COMPLETED).messages
         assert a[0]["tool_calls"][0]["id"] == b[0]["tool_calls"][0]["id"]
+
+
+class TestCommandExecutionOutputCap:
+    """`commandExecution.aggregatedOutput` is unbounded in codex — the
+    projector must cap it so a wide grep/find can't dump hundreds of KB
+    into the context window (the other tool-result paths already truncate)."""
+
+    @staticmethod
+    def _exec_notif(output: str, exit_code: int = 0) -> dict:
+        return {
+            "method": "item/completed",
+            "params": {"item": {
+                "type": "commandExecution", "id": "cap-test",
+                "command": "grep -rn x .", "cwd": "/tmp",
+                "aggregatedOutput": output, "exitCode": exit_code,
+            }},
+        }
+
+    def test_huge_output_is_capped(self) -> None:
+        huge = "x" * 500_000
+        tool = CodexEventProjector().project(self._exec_notif(huge)).messages[1]
+        assert len(tool["content"]) < len(huge) // 10
+        assert "truncated" in tool["content"]
+
+    def test_small_output_passes_through_unchanged(self) -> None:
+        small = "hello world\n"
+        tool = CodexEventProjector().project(self._exec_notif(small)).messages[1]
+        assert tool["content"] == small
+
+    def test_output_exactly_at_cap_not_truncated(self) -> None:
+        exact = "x" * _MAX_EXEC_OUTPUT
+        tool = CodexEventProjector().project(self._exec_notif(exact)).messages[1]
+        assert tool["content"] == exact
+
+    def test_truncation_marker_reports_original_size(self) -> None:
+        content = CodexEventProjector().project(
+            self._exec_notif("y" * 100_000)
+        ).messages[1]["content"]
+        assert "truncated" in content
+        assert "100000" in content  # original length surfaced to the agent
+
+    def test_exit_annotation_survives_truncation(self) -> None:
+        # Non-zero exit prepends `[exit N]`; truncation keeps the head, so the
+        # annotation must remain visible to the agent.
+        content = CodexEventProjector().project(
+            self._exec_notif("z" * 100_000, exit_code=2)
+        ).messages[1]["content"]
+        assert content.startswith("[exit 2]")
 
 
 class TestAgentMessageProjection:


### PR DESCRIPTION
## What does this PR do?

`CodexEventProjector._project_command` was copying codex's `aggregatedOutput` into the projected tool-result message verbatim, with no upper bound. Every other tool-result projection in the same file already truncates its payload — `mcp` and `dynamic` cap at `[:4000]`, `mcp` errors at `[:1000]`, `opaque` at `[:1500]`. Only the `commandExecution` path was unbounded.

Under the `codex_app_server` runtime a single wide `grep`/`find` produces a multi-hundred-KB `aggregatedOutput`, which the projector then pushed into the messages list — and thus the model context window — in one turn. In a recent local session this drove the context to ~500k tokens in four exchanges.

This PR caps the projected exec output at `_MAX_EXEC_OUTPUT` (10k chars) and adds tests.

## Related Issue

None — first reported here.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/transports/codex_event_projector.py`
  - Add module-level `_MAX_EXEC_OUTPUT = 10000` with an explanatory comment.
  - In `_project_command`, when `len(output) > _MAX_EXEC_OUTPUT`, keep the **head** (so a non-zero `[exit N]` annotation that gets prepended just before this point stays visible) and append a short marker reporting the original size.
- `tests/agent/transports/test_codex_event_projector.py`
  - Add `TestCommandExecutionOutputCap` (5 tests): huge output is capped, small output passes through unchanged, exact-boundary output is not truncated, truncation marker reports original size, `[exit N]` annotation survives truncation.
  - Import `_MAX_EXEC_OUTPUT` from the projector as the single source of truth (matches the file's existing convention of importing private helpers like `_deterministic_call_id`).

## How to Test

```bash
pytest tests/agent/transports/test_codex_event_projector.py -v
```

Expected: **28 passed** (23 pre-existing + 5 new in `TestCommandExecutionOutputCap`). Ran locally on macOS 26.3.1 / Python 3.14.4: `28 passed in 0.12s`.

The change is purely additive: outputs at or below the cap are byte-for-byte identical to the previous behavior, so no existing test in the file changes outcome.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran only the affected file (`tests/agent/transports/test_codex_event_projector.py`, 28/28 pass). The projector module is stdlib-only and self-contained; this 14-line additive change cannot affect other tests. Happy to run the full suite if a maintainer prefers.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3.1 / Python 3.14.4. The bug itself was first observed on Linux under the `codex_app_server` runtime; the fix is platform-independent (pure stdlib).

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (the new constant carries an inline explanatory comment; no public docs touched)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (cap is a code constant, not a config key)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (no platform-specific code; `len()` / slice / f-string only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (internal projection of runtime events; not a Hermes tool schema)

## Screenshots / Logs

```
tests/agent/transports/test_codex_event_projector.py::TestCommandExecutionOutputCap::test_huge_output_is_capped PASSED
tests/agent/transports/test_codex_event_projector.py::TestCommandExecutionOutputCap::test_small_output_passes_through_unchanged PASSED
tests/agent/transports/test_codex_event_projector.py::TestCommandExecutionOutputCap::test_output_exactly_at_cap_not_truncated PASSED
tests/agent/transports/test_codex_event_projector.py::TestCommandExecutionOutputCap::test_truncation_marker_reports_original_size PASSED
tests/agent/transports/test_codex_event_projector.py::TestCommandExecutionOutputCap::test_exit_annotation_survives_truncation PASSED
============================== 28 passed in 0.12s ==============================
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
