### PR TITLE
fix(kanban): allow columns to wrap in dashboard to prevent hidden columns

### DIFF
--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -64,17 +64,13 @@
 
 .hermes-kanban-columns {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.75rem;
   align-items: start;
-  overflow-x: auto;
-  scrollbar-width: none;
-}
-.hermes-kanban-columns::-webkit-scrollbar {
-  display: none;
 }
 
 .hermes-kanban-column {
-  flex: 0 0 280px;
+  flex: 0 0 250px;
   display: flex;
   flex-direction: column;
   background: color-mix(in srgb, var(--color-card) 85%, transparent);


### PR DESCRIPTION
The Kanban board columns were set to a fixed width with horizontal overflow and a hidden scrollbar. This caused columns to be 'hidden' off-screen at 100% zoom on many monitors.

This PR changes .hermes-kanban-columns to use flex-wrap: wrap and removes the overflow-x: auto restriction, allowing columns to flow to the next line when space is limited.

Fixes UI layout issues for users with standard viewport widths.