### PR TITLE
fix: preserve blank line spacing in TUI pager overlay

### DIFF
--- a/ui-tui/src/components/appOverlays.tsx
+++ b/ui-tui/src/components/appOverlays.tsx
@@ -160,7 +160,7 @@ export function FloatingOverlays({
             )}
 
             {overlay.pager.lines.slice(overlay.pager.offset, overlay.pager.offset + pagerPageSize).map((line, i) => (
-              <Text key={i}>{line}</Text>
+              <Text key={i}>{line || ' '}</Text>
             ))}
 
             <Box marginTop={1}>


### PR DESCRIPTION
## Problem
In the interactive TUI, `/cron list` (and other pager-displayed output) renders jobs with no visible spacing between them. Empty lines in the output collapse to zero-height `<Text>` nodes in Ink, losing the intended visual separation.

Fixes #30782

## Root Cause
`appOverlays.tsx` renders each pager line as `<Text>{line}</Text>`. When `line` is an empty string `""`, Ink renders a zero-height Text node that takes no vertical space.

## Fix
Changed line 163 in `ui-tui/src/components/appOverlays.tsx`:
```diff
- <Text key={i}>{line}</Text>
+ <Text key={i}>{line || ' '}</Text>
```

Empty lines now render as a single space character, which occupies one row of vertical space in the terminal, preserving the visual separation between output blocks.

## Before vs After
| Before | After |
|--------|-------|
| Empty lines collapse to 0px height | Empty lines render as 1-row vertical space |
| /cron list jobs appear crowded | /cron list jobs clearly separated |

## Tests
- 1-line change in TypeScript — no behavioral side effects
