### PR TITLE
fix: emit guardrail halt message to client before closing stream

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3434,6 +3434,19 @@ def run_conversation(
                         f"⚠️ Tool guardrail halted {decision.tool_name}: {decision.code}"
                     )
                     messages.append({"role": "assistant", "content": final_response})
+                    # Emit the halt message to the client so it's not
+                    # indistinguishable from a crash.  The stream display
+                    # was flushed (callback(None)) before tool execution,
+                    # but the callback is still alive — fire the text
+                    # through it so SSE/TUI clients see the explanation.
+                    if final_response:
+                        agent._safe_print(f"\n{final_response}\n")
+                        if agent.stream_delta_callback:
+                            try:
+                                agent.stream_delta_callback(final_response)
+                                agent.stream_delta_callback(None)
+                            except Exception:
+                                pass
                     break
 
                 # Reset per-turn retry counters after successful tool


### PR DESCRIPTION
## Problem
When the tool loop guardrail fires (max_tool_failures, repeated failures, etc.), the turn exits with `guardrail_halt` but no final assistant message is emitted to the client. The SSE stream closes silently — from the user's perspective (especially via API/SSE clients like Open WebUI), the conversation just goes silent with no explanation. Indistinguishable from a crash.

Fixes #30770

## Root Cause
In `agent/conversation_loop.py`, the guardrail halt path (line ~3429):
1. Generates `final_response` via `_toolguard_controlled_halt_response(decision)`
2. Appends it to internal `messages` history
3. Breaks out of the loop

But the `stream_delta_callback(None)` at line 3423 (display flush before tool execution) already closed the display stream. The `final_response` was never emitted to the client — only stored in internal history.

## Fix
After generating the halt message, emit it through both channels:
- `agent._safe_print()` — for CLI/TUI users
- `agent.stream_delta_callback(final_response)` — for SSE/API clients (Open WebUI, etc.)

The `stream_delta_callback(None)` is a display flush, not a hard close — the callback is still alive and can accept new text.

## Before vs After
| Before | After |
|--------|-------|
| SSE stream closes with no message | SSE stream emits halt explanation before closing |
| TUI shows nothing | TUI prints halt message |
| Indistinguishable from crash | Clear explanation of why agent stopped |

## Tests
- `python -m py_compile agent/conversation_loop.py` ✓
- Existing guardrail tests should still pass (they check internal state, not stream output)
