### PR TITLE
fix(agent): bind memory/skill review counters to actual spawn (#30812)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -436,7 +436,18 @@ def run_conversation(
         agent._turns_since_memory += 1
         if agent._turns_since_memory >= agent._memory_nudge_interval:
             _should_review_memory = True
-            agent._turns_since_memory = 0
+            # #30812 — DO NOT reset ``_turns_since_memory`` here.
+            # The counter must stay where it is until the background
+            # review thread actually spawns near the end of this
+            # function: if ``run_conversation`` exits early
+            # (interrupt, no ``final_response``, an exception in the
+            # iteration loop), the gate at the spawn site will skip
+            # the review and the counter we've spent here would be
+            # gone for nothing — the user would have to wait another
+            # ``_memory_nudge_interval`` turns before the next review
+            # is even considered. Pinning the reset to the actual
+            # spawn keeps consumption "bound to the review thread" as
+            # the reporter requested.
 
     # Add user message
     user_msg = {"role": "user", "content": user_message}
@@ -4140,7 +4151,13 @@ def run_conversation(
             and agent._iters_since_skill >= agent._skill_nudge_interval
             and "skill_manage" in agent.valid_tool_names):
         _should_review_skills = True
-        agent._iters_since_skill = 0
+        # #30812 — like ``_turns_since_memory`` above, do not reset the
+        # skill counter here.  The reset must be bound to the actual
+        # ``_spawn_background_review`` call below, otherwise a turn
+        # that satisfies the cadence but skips the spawn gate (no
+        # ``final_response`` / interrupted) silently consumes the
+        # counter and the user has to wait another full interval
+        # before the skill review is considered again.
 
     # External memory provider: sync the completed turn + queue next prefetch.
     agent._sync_external_memory_for_turn(
@@ -4159,7 +4176,20 @@ def run_conversation(
                 review_skills=_should_review_skills,
             )
         except Exception:
-            pass  # Background review is best-effort
+            # Background review is best-effort.  Keep both counters
+            # where they are so the next turn re-attempts the spawn
+            # instead of silently rolling the cadence forward (#30812).
+            pass
+        else:
+            # Spawn succeeded — only NOW do we consume the cadence
+            # counters that gated this turn's review.  Each counter is
+            # reset independently because ``_spawn_background_review``
+            # can carry one or both review flags and we want the same
+            # accounting either way (#30812).
+            if _should_review_memory:
+                agent._turns_since_memory = 0
+            if _should_review_skills:
+                agent._iters_since_skill = 0
 
     # Note: Memory provider on_session_end() + shutdown_all() are NOT
     # called here — run_conversation() is called once per user message in

--- a/tests/run_agent/test_review_counter_consumption_30812.py
+++ b/tests/run_agent/test_review_counter_consumption_30812.py
@@ -1,0 +1,538 @@
+"""Regression tests for #30812 — review-cadence counters bound to spawn.
+
+Before this fix, ``conversation_loop.run_conversation`` reset the
+``_turns_since_memory`` counter the moment ``_should_review_memory``
+crossed its threshold (near the top of the function), and likewise
+reset ``_iters_since_skill`` the moment ``_should_review_skills``
+flipped True (just before the spawn block). The actual
+``_spawn_background_review`` call runs near the end of the function
+behind a stricter gate (``final_response and not interrupted and
+(...)``). If the iteration loop bailed out before producing a
+``final_response`` (user interrupt, exception, API failure), the
+counters had already been spent and the user lost an entire nudge
+interval before the cadence considered the review again.
+
+The fix moves both resets into the ``else`` branch of the existing
+``try`` around ``_spawn_background_review`` so the consumption is
+bound to the actual spawn:
+
+* spawn succeeds → only the counter(s) whose flag we passed in get
+  reset, mirroring the per-flag decision made earlier;
+* spawn raises → both counters stay where they are so the next turn
+  re-attempts instead of silently rolling the cadence forward;
+* gate skipped (no final_response / interrupted) → counters stay so
+  the next turn satisfies the cadence again immediately.
+
+These tests pin every branch of that contract.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Test helpers (mirror tests/run_agent/test_tool_call_guardrail_runtime.py)
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def _make_tool_defs(*names: str) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _mock_tool_call(name: str = "web_search", arguments: str = "{}", call_id: str | None = None):
+    return SimpleNamespace(
+        id=call_id or f"call_{uuid.uuid4().hex[:8]}",
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _mock_response(content: str = "Hello", finish_reason: str = "stop", tool_calls=None):
+    msg = SimpleNamespace(content=content, tool_calls=tool_calls)
+    choice = SimpleNamespace(message=msg, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def _make_agent(
+    *tool_names: str,
+    memory_nudge_interval: int = 3,
+    skill_nudge_interval: int = 3,
+    has_memory_store: bool = True,
+) -> AIAgent:
+    """Build a minimal AIAgent wired so the run_conversation cadence
+    branches reach the spawn site.
+
+    ``memory_nudge_interval`` / ``skill_nudge_interval`` are kept low
+    (default 3) so tests can drive the cadence in a handful of fake
+    turns without bloating the LLM-mock side_effect list.
+
+    ``has_memory_store`` toggles the ``agent._memory_store`` guard in
+    ``run_conversation`` — when False the memory branch is short-
+    circuited even if "memory" is in ``valid_tool_names`` (mirrors a
+    config where the user has memory off entirely).
+    """
+    tool_names = tool_names or ("web_search", "memory", "skill_manage")
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs(*tool_names)),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            max_iterations=10,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    # Re-seed the cadence config — ``skip_memory=True`` zeros these.
+    agent._memory_nudge_interval = memory_nudge_interval
+    agent._skill_nudge_interval = skill_nudge_interval
+    agent._turns_since_memory = 0
+    agent._iters_since_skill = 0
+    agent._user_turn_count = 0
+    if has_memory_store:
+        # ``run_conversation`` only checks truthiness, never the type.
+        agent._memory_store = MagicMock(name="memory_store_stub")
+    else:
+        agent._memory_store = None
+    # Make sure both tool names are in the valid set even if a caller
+    # narrowed ``tool_names`` — the cadence guards only read this set.
+    agent.valid_tool_names = set(agent.valid_tool_names) | {"memory", "skill_manage"}
+    return agent
+
+
+def _drive_clean_turn(agent: AIAgent, *, spawn_mock=None, response_text: str = "done"):
+    """Run a single ``run_conversation`` turn that returns ``response_text``
+    cleanly (no tool calls, no interrupt).  Returns the result dict.
+
+    If ``spawn_mock`` is provided it patches
+    ``_spawn_background_review`` so tests can assert call args / side-
+    effects without actually launching a thread.
+    """
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(content=response_text, finish_reason="stop", tool_calls=None)
+    ]
+    spawn_ctx = (
+        patch.object(agent, "_spawn_background_review", spawn_mock)
+        if spawn_mock is not None
+        else patch.object(agent, "_spawn_background_review")
+    )
+    with (
+        spawn_ctx as spawn_patch,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("hello")
+    return result, spawn_patch
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Memory cadence
+# ────────────────────────────────────────────────────────────────────────────
+
+
+class TestMemoryCadenceBoundToSpawn:
+
+    def test_memory_counter_resets_only_after_successful_spawn(self):
+        """Happy path: cadence threshold met, spawn succeeds → reset to 0.
+
+        Pre-fix this was already the observable outcome (the early
+        reset happened either way), so this test guards against the
+        FIX over-correcting — moving the reset to the spawn site must
+        still produce a zero counter after a normal trigger turn.
+        """
+        agent = _make_agent(memory_nudge_interval=3)
+        # Seed the counter just below threshold so this turn crosses it.
+        agent._turns_since_memory = 2
+
+        result, spawn_patch = _drive_clean_turn(agent)
+
+        assert result["final_response"] == "done"
+        spawn_patch.assert_called_once()
+        kwargs = spawn_patch.call_args.kwargs
+        assert kwargs["review_memory"] is True
+        assert agent._turns_since_memory == 0, (
+            "Successful spawn should still reset the memory cadence counter"
+        )
+
+    def test_memory_counter_stays_when_spawn_raises(self):
+        """If ``_spawn_background_review`` raises, the cadence must
+        NOT advance — the user's review is being deferred, not lost.
+        """
+        agent = _make_agent(memory_nudge_interval=3)
+        agent._turns_since_memory = 2
+
+        result, spawn_patch = _drive_clean_turn(
+            agent,
+            spawn_mock=MagicMock(side_effect=RuntimeError("spawn blew up")),
+        )
+
+        assert result["final_response"] == "done"
+        spawn_patch.assert_called_once()
+        # Counter stays at threshold (3 = 2 + 1) so the next turn
+        # immediately re-satisfies the cadence and re-attempts.
+        assert agent._turns_since_memory == 3, (
+            f"Counter advanced despite spawn failure; got: "
+            f"{agent._turns_since_memory}"
+        )
+
+    def test_memory_counter_stays_when_loop_interrupted_before_final_response(self):
+        """The #30812 reproduction: interrupt fires inside the
+        iteration loop before any ``final_response`` is produced.
+        ``_spawn_background_review`` is skipped by the gate; the
+        counter must NOT be reset so the next turn re-fires.
+        """
+        agent = _make_agent(memory_nudge_interval=3)
+        agent._turns_since_memory = 2
+        # Pre-arm the interrupt so the very first iteration aborts.
+        agent._interrupt_requested = True
+        agent._interrupt_message = "user pressed ctrl-c"
+
+        with (
+            patch.object(agent, "_spawn_background_review") as spawn_patch,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        spawn_patch.assert_not_called(), (
+            "spawn gate should have skipped the review on interrupt"
+        )
+        assert result.get("interrupted") is True
+        assert agent._turns_since_memory == 3, (
+            "Counter wasted on an interrupted turn — the #30812 bug. "
+            f"Got: {agent._turns_since_memory}"
+        )
+
+    def test_memory_counter_increments_without_resetting_below_threshold(self):
+        """Sub-threshold turns must still advance the counter — the
+        fix only changes WHEN the reset happens, not the increment.
+        """
+        agent = _make_agent(memory_nudge_interval=5)
+        agent._turns_since_memory = 2  # well below threshold (5)
+
+        result, spawn_patch = _drive_clean_turn(agent)
+
+        spawn_patch.assert_not_called()
+        assert result["final_response"] == "done"
+        # Incremented from 2 → 3, NOT reset.
+        assert agent._turns_since_memory == 3
+
+    def test_memory_counter_accumulates_across_failed_then_successful_turns(self):
+        """End-to-end behavior the user reported: a failed trigger turn
+        followed by a clean turn fires the review on turn 2, not turn N
+        intervals later.
+        """
+        agent = _make_agent(memory_nudge_interval=3)
+        agent._turns_since_memory = 2
+        agent._interrupt_requested = True
+
+        # Turn 1 — interrupted before any final_response.
+        with (
+            patch.object(agent, "_spawn_background_review") as spawn_t1,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            agent.run_conversation("first try")
+
+        spawn_t1.assert_not_called()
+        assert agent._turns_since_memory == 3
+
+        # Turn 2 — clean. Counter ticks 3 → 4, still ≥ interval (3),
+        # so cadence triggers again; spawn fires and resets to 0.
+        # ``clear_interrupt`` is called at the end of every turn by
+        # run_conversation, so we don't need to re-arm anything.
+        result, spawn_t2 = _drive_clean_turn(agent)
+        spawn_t2.assert_called_once()
+        assert result["final_response"] == "done"
+        assert agent._turns_since_memory == 0
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Skill cadence — same contract as memory, separate counter
+# ────────────────────────────────────────────────────────────────────────────
+
+
+class TestSkillCadenceBoundToSpawn:
+
+    def test_skill_counter_resets_only_after_successful_spawn(self):
+        """Happy path: skill cadence threshold met, spawn succeeds."""
+        agent = _make_agent(memory_nudge_interval=1000, skill_nudge_interval=3)
+        agent._iters_since_skill = 5  # already past threshold
+
+        result, spawn_patch = _drive_clean_turn(agent)
+
+        assert result["final_response"] == "done"
+        spawn_patch.assert_called_once()
+        kwargs = spawn_patch.call_args.kwargs
+        assert kwargs["review_skills"] is True
+        assert agent._iters_since_skill == 0
+
+    def test_skill_counter_stays_when_spawn_raises(self):
+        agent = _make_agent(memory_nudge_interval=1000, skill_nudge_interval=3)
+        agent._iters_since_skill = 5
+
+        result, spawn_patch = _drive_clean_turn(
+            agent,
+            spawn_mock=MagicMock(side_effect=RuntimeError("spawn blew up")),
+        )
+
+        assert result["final_response"] == "done"
+        # Counter NOT reset to 0 by the fix.  Note that the in-iteration
+        # increment at the top of each loop pass (``_iters_since_skill
+        # += 1``) still fires — the fix only removes the EAGER reset
+        # to 0, it doesn't suppress the normal per-iteration counting.
+        # 1 iteration ran (one mocked API response), so 5 → 6.
+        assert agent._iters_since_skill == 6, (
+            f"Skill counter unexpectedly reset on spawn failure; got: "
+            f"{agent._iters_since_skill}"
+        )
+
+    def test_skill_counter_stays_when_loop_interrupted_before_final_response(self):
+        agent = _make_agent(memory_nudge_interval=1000, skill_nudge_interval=3)
+        agent._iters_since_skill = 5
+        agent._interrupt_requested = True
+
+        with (
+            patch.object(agent, "_spawn_background_review") as spawn_patch,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        spawn_patch.assert_not_called()
+        assert result.get("interrupted") is True
+        assert agent._iters_since_skill == 5
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Independence — resetting one counter must not touch the other
+# ────────────────────────────────────────────────────────────────────────────
+
+
+class TestCountersResetIndependently:
+
+    def test_only_memory_triggered_does_not_reset_skill_counter(self):
+        """Memory cadence met, skill cadence below threshold — only the
+        memory counter should reset, the skill counter should keep its
+        natural in-iteration increment without being clobbered to 0.
+        """
+        agent = _make_agent(memory_nudge_interval=3, skill_nudge_interval=100)
+        agent._turns_since_memory = 2  # crosses to 3 → triggers
+        agent._iters_since_skill = 7   # nowhere near 100
+
+        result, spawn_patch = _drive_clean_turn(agent)
+
+        spawn_patch.assert_called_once()
+        kwargs = spawn_patch.call_args.kwargs
+        assert kwargs["review_memory"] is True
+        assert kwargs["review_skills"] is False
+        assert agent._turns_since_memory == 0
+        # Skill counter advanced naturally (7 → 8) but was NOT reset.
+        # Pre-fix the eager reset adjacent to ``_should_review_skills``
+        # would have clobbered this to 0 even though only memory fired.
+        assert agent._iters_since_skill == 8, (
+            "Skill counter was reset despite its cadence not firing — "
+            "would silently push the skill review further into the "
+            "future on every memory-only review turn."
+        )
+        assert result["final_response"] == "done"
+
+    def test_only_skill_triggered_does_not_reset_memory_counter(self):
+        """Symmetric test: only the skill cadence fires this turn."""
+        agent = _make_agent(memory_nudge_interval=100, skill_nudge_interval=3)
+        agent._turns_since_memory = 7
+        agent._iters_since_skill = 5
+
+        result, spawn_patch = _drive_clean_turn(agent)
+
+        spawn_patch.assert_called_once()
+        kwargs = spawn_patch.call_args.kwargs
+        assert kwargs["review_memory"] is False
+        assert kwargs["review_skills"] is True
+        assert agent._iters_since_skill == 0
+        # Memory counter still advances by one because the cadence
+        # increment is unconditional — it just doesn't get reset.
+        assert agent._turns_since_memory == 8, (
+            "Memory counter was reset despite its cadence not firing"
+        )
+        assert result["final_response"] == "done"
+
+    def test_both_triggered_resets_both(self):
+        """When both cadences fire on the same turn, both counters
+        reset together after a successful spawn.
+        """
+        agent = _make_agent(memory_nudge_interval=3, skill_nudge_interval=3)
+        agent._turns_since_memory = 2
+        agent._iters_since_skill = 5
+
+        result, spawn_patch = _drive_clean_turn(agent)
+
+        spawn_patch.assert_called_once()
+        kwargs = spawn_patch.call_args.kwargs
+        assert kwargs["review_memory"] is True
+        assert kwargs["review_skills"] is True
+        assert agent._turns_since_memory == 0
+        assert agent._iters_since_skill == 0
+        assert result["final_response"] == "done"
+
+    def test_both_triggered_but_spawn_raises_resets_neither(self):
+        """The ``else`` branch only runs when the ``try`` block exits
+        normally.  A raise must leave BOTH counters intact.
+        """
+        agent = _make_agent(memory_nudge_interval=3, skill_nudge_interval=3)
+        agent._turns_since_memory = 2
+        agent._iters_since_skill = 5
+
+        result, spawn_patch = _drive_clean_turn(
+            agent,
+            spawn_mock=MagicMock(side_effect=RuntimeError("nope")),
+        )
+
+        spawn_patch.assert_called_once()
+        assert agent._turns_since_memory == 3
+        # Skill counter advanced naturally during the iteration loop
+        # (5 → 6) but was NOT reset to 0 by the fix.
+        assert agent._iters_since_skill == 6
+        assert result["final_response"] == "done", (
+            "Spawn raising is still a best-effort path — the user's "
+            "turn must still complete normally."
+        )
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Contract pin: the conversation_loop file no longer resets eagerly
+# ────────────────────────────────────────────────────────────────────────────
+
+
+class TestConversationLoopWiring:
+    """Static checks that pin the structural change — a future
+    refactor that re-introduces an eager reset in the cadence-decision
+    blocks would silently re-create #30812 without flipping any of the
+    behavioral tests above (because the *current* clean-path tests
+    would still pass).  These guard against that regression.
+    """
+
+    def test_no_eager_reset_in_memory_decision_block(self):
+        from pathlib import Path
+        source = Path("agent/conversation_loop.py").read_text()
+        # Locate the decision block by its decision flag, then verify
+        # the eager-reset assignment is no longer next to it.
+        idx = source.find("_should_review_memory = True")
+        assert idx != -1, "Memory decision block disappeared"
+        # Inspect the ~600 characters after the flag set.  The old buggy
+        # pattern was a literal ``agent._turns_since_memory = 0``
+        # adjacent to the flag set.  The new code puts the reset much
+        # later in the file, inside the spawn ``else`` branch.
+        window = source[idx:idx + 600]
+        assert "agent._turns_since_memory = 0" not in window, (
+            "Found eager memory-counter reset adjacent to the decision "
+            "block — re-introduces #30812. Move the reset to the "
+            "_spawn_background_review else-branch."
+        )
+
+    def test_no_eager_reset_in_skill_decision_block(self):
+        from pathlib import Path
+        source = Path("agent/conversation_loop.py").read_text()
+        idx = source.find("_should_review_skills = True")
+        assert idx != -1, "Skill decision block disappeared"
+        window = source[idx:idx + 400]
+        assert "agent._iters_since_skill = 0" not in window, (
+            "Found eager skill-counter reset adjacent to the decision "
+            "block — re-introduces #30812."
+        )
+
+    def test_reset_lives_in_spawn_else_branch(self):
+        """The reset must be in the ``else`` of the spawn ``try`` so it
+        runs only when ``_spawn_background_review`` returned cleanly.
+        """
+        from pathlib import Path
+        source = Path("agent/conversation_loop.py").read_text()
+        # Find the spawn block by its function name; an ``else`` must
+        # follow the matching ``except`` and the two resets must live
+        # underneath the ``else``.
+        spawn_idx = source.find("agent._spawn_background_review")
+        assert spawn_idx != -1
+        # Look for both resets after the spawn block within a few
+        # hundred lines.
+        after = source[spawn_idx:spawn_idx + 1500]
+        assert "agent._turns_since_memory = 0" in after, (
+            "Memory counter reset not found in the spawn try/except/else "
+            "region — fix may have been reverted."
+        )
+        assert "agent._iters_since_skill = 0" in after, (
+            "Skill counter reset not found in the spawn try/except/else "
+            "region — fix may have been reverted."
+        )
+        # The reset must be conditional on the per-flag check so that
+        # the independence guarantees above hold.
+        assert "if _should_review_memory:" in after
+        assert "if _should_review_skills:" in after
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Hydration interaction — fix must not regress #22357
+# ────────────────────────────────────────────────────────────────────────────
+
+
+class TestHydrationStillWorks:
+
+    def test_hydration_block_still_seeds_counter_on_fresh_agent(self):
+        """The CLI-mode hydration block runs only when
+        ``conversation_history`` is non-empty and ``_user_turn_count==0``
+        — both my change AND the original code leave that branch alone,
+        so a freshly built agent (gateway cache miss, idle eviction)
+        must still pick up the right value from prior history.
+        """
+        agent = _make_agent(memory_nudge_interval=10)
+        # Seed by replaying the hydration math the function performs:
+        # 7 prior user turns, interval 10 → counter should land at 7.
+        history = []
+        for i in range(7):
+            history.append({"role": "user", "content": f"q{i}"})
+            history.append({"role": "assistant", "content": f"a{i}"})
+        agent.client.chat.completions.create.side_effect = [
+            _mock_response(content="ok", finish_reason="stop", tool_calls=None)
+        ]
+        with (
+            patch.object(agent, "_spawn_background_review") as spawn_patch,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            agent.run_conversation("hello", conversation_history=history)
+
+        # 7 (hydrated) + 1 (this turn's increment) = 8, still below
+        # interval 10 → no spawn, no reset.
+        spawn_patch.assert_not_called()
+        assert agent._turns_since_memory == 8


### PR DESCRIPTION
## What does this PR do?

Fixes #30812: in `agent/conversation_loop.py`, the cadence counters that gate the background memory and skill review (`_turns_since_memory`, `_iters_since_skill`) were reset the moment the `_should_review_*` flag flipped to True — which happens hundreds of lines before the actual spawn gate (`if final_response and not interrupted and …`). If `run_conversation` exits early in any of the non-success paths between those two points (user interrupt, no `final_response` produced, an exception inside the iteration loop), the counter is at 0 but no review thread was started. The user then has to wait another full `_memory_nudge_interval` / `_skill_nudge_interval` turns before the cadence even considers the review again — quietly missing a review the user was due for.

This PR moves both resets into the `else` branch of the existing `try` around `_spawn_background_review`, so the consumption is bound to the actual spawn (per-flag, mirroring the per-flag decision made earlier), and adds a 16-test regression suite pinning every branch of the new contract.

## Related Issue

Closes #30812

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/conversation_loop.py` (+33, −3):
  - Removed the early `agent._turns_since_memory = 0` immediately after the cadence check, with an inline comment explaining why the reset has moved.
  - Removed the early `agent._iters_since_skill = 0` in the post-loop skill check, with the same explanation.
  - Split the existing `try` around `_spawn_background_review` into `try / except / else` so the reset only fires when the spawn returned without raising — consumption is now bound to the review thread.
  - Each counter is reset independently based on which review flag was actually passed in (`_should_review_memory` resets `_turns_since_memory`, `_should_review_skills` resets `_iters_since_skill`), so a turn that triggers only one of the two doesn't accidentally consume the other's cadence.
  - If `_spawn_background_review` raises (best-effort path), both counters stay where they are and the next turn re-attempts the spawn instead of silently rolling the cadence forward.

- `tests/run_agent/test_review_counter_consumption_30812.py` (+538, new file) — 16 tests across five classes:
  - `TestMemoryCadenceBoundToSpawn` (5): happy-path reset, spawn-raises keeps counter at threshold, interrupted-before-`final_response` keeps counter (the reporter's exact scenario), sub-threshold turns still increment, and end-to-end failed-trigger → clean-next-turn fires the review on turn 2 instead of N intervals later.
  - `TestSkillCadenceBoundToSpawn` (3): symmetric coverage for `_iters_since_skill` — the asserts account for the existing in-iteration `+= 1` so a future change to that increment fails noisily here.
  - `TestCountersResetIndependently` (4): per-flag reset guarantee — only-memory-triggered does not touch the skill counter, only-skill-triggered does not touch the memory counter, both-triggered resets both, both-triggered with spawn raising resets neither.
  - `TestConversationLoopWiring` (3): structural pins that read `agent/conversation_loop.py` and assert the cadence decision blocks no longer contain an eager `= 0` reset (so re-introducing one would fail loudly), and the post-spawn region DOES contain both resets plus the two per-flag `if` guards.
  - `TestHydrationStillWorks` (1): the #22357 CLI-mode hydration block (`_user_turn_count == 0` plus prior history) keeps seeding `_turns_since_memory` from a freshly built agent so this change does not regress the gateway cache-miss / idle-eviction flow.

## How to Test

1. Run the new regression suite on its own:
   ```sh
   scripts/run_tests.sh tests/run_agent/test_review_counter_consumption_30812.py -v
   ```
   Expected: 16 passed.

2. Run the broader agent + cadence sweep to confirm no cross-file regressions (memory-nudge hydration, tool-call guardrail, full run_agent suite):
   ```sh
   scripts/run_tests.sh tests/run_agent/test_memory_nudge_counter_hydration.py \
       tests/run_agent/test_review_counter_consumption_30812.py \
       tests/run_agent/test_tool_call_guardrail_runtime.py \
       tests/run_agent/test_run_agent.py
   ```
   Expected: 370 passed.

3. Manual reproduction of the original bug (matches the issue body):
   1. Set a short memory nudge interval so you don't have to run 10 turns:
      ```yaml
      memory:
        nudge_interval: 3
      ```
   2. Run `hermes` in CLI mode (no hydration) and send 2 normal turns so the counter is primed at 2.
   3. On what would be turn 3 (the trigger turn), interrupt mid-iteration (`Ctrl-C`) before the model returns a `final_response`.
   4. Send turn 4 normally and watch `_turns_since_memory`:
      - **Before this PR**: counter starts back at 0 because turn 3 ate it; you'd have to do 3 more clean turns before the review fires again.
      - **After this PR**: counter stays at 3 after the interrupted turn, turn 4 satisfies the cadence (4 ≥ 3) again, and the review fires as soon as turn 4 finishes cleanly.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(agent): …`, `test(agent): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/run_agent/test_review_counter_consumption_30812.py` and all tests pass (16/16)
- [x] I've added tests for my changes (16 new test cases across 5 classes — see `tests/run_agent/test_review_counter_consumption_30812.py`)
- [x] I've tested on my platform: macOS 15.2 (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; inline comments cite #30812 so future readers see the rationale at the call sites
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure control-flow rearrangement, no platform-specific surface touched; tests are hermetic (mocked LLM, no real network or filesystem)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/run_agent/test_review_counter_consumption_30812.py -v
16 passed in 8.20s

$ scripts/run_tests.sh tests/run_agent/test_memory_nudge_counter_hydration.py \
    tests/run_agent/test_review_counter_consumption_30812.py \
    tests/run_agent/test_tool_call_guardrail_runtime.py \
    tests/run_agent/test_run_agent.py
370 passed in 174.73s (0:02:54)
```

Pre-existing failures (verified on `upstream/main` without this change): `tests/agent/lsp/test_client_e2e.py`, `tests/agent/test_anthropic_adapter.py::TestRunOauthSetupToken`, `tests/agent/test_shell_hooks.py::TestCallbackSubprocess::test_timeout_returns_none` — all unrelated to the cadence counters.
