### PR TITLE
fix(gateway): queue follow-ups while delegate subagents run

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2372,6 +2372,23 @@ class GatewayRunner:
         return depth
 
     @staticmethod
+    def _agent_has_active_children(agent: Any) -> bool:
+        """Return True when an agent is currently waiting on delegate_task children."""
+        if not agent or agent is _AGENT_PENDING_SENTINEL:
+            return False
+        children = getattr(agent, "_active_children", None)
+        if not isinstance(children, list):
+            return False
+        lock = getattr(agent, "_active_children_lock", None)
+        if lock is not None:
+            try:
+                with lock:
+                    return any(child is not None for child in children)
+            except Exception:
+                pass
+        return any(child is not None for child in children)
+
+    @staticmethod
     def _is_goal_continuation_event(event_or_text: Any) -> bool:
         """Return True for synthetic /goal continuation turns.
 
@@ -2913,6 +2930,15 @@ class GatewayRunner:
             if not steered:
                 # Fall back to queue (merge into pending messages, no interrupt)
                 effective_mode = "queue"
+        elif (
+            effective_mode == "interrupt"
+            and self._agent_has_active_children(running_agent)
+        ):
+            logger.debug(
+                "Gateway busy interrupt converted to queue for %s: delegate_task child active",
+                session_key,
+            )
+            effective_mode = "queue"
 
         # Store the message so it's processed as the next turn after the
         # current run finishes (or is interrupted).  Skip this for a
@@ -7046,6 +7072,14 @@ class GatewayRunner:
                 logger.debug("PRIORITY steer-fallback-to-queue for session %s", _quick_key)
                 self._queue_or_replace_pending_event(_quick_key, event)
                 return None
+            if self._agent_has_active_children(running_agent):
+                logger.debug(
+                    "PRIORITY interrupt converted to queue for %s: delegate_task child active",
+                    _quick_key,
+                )
+                self._queue_or_replace_pending_event(_quick_key, event)
+                return None
+
             logger.debug("PRIORITY interrupt for session %s", _quick_key)
             running_agent.interrupt(event.text)
             # NOTE: self._pending_messages was write-only (never consumed).

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -63,6 +63,7 @@ def _make_runner():
     runner._running_agents = {}
     runner._running_agents_ts = {}
     runner._pending_messages = {}
+    runner._queued_events = {}
     runner._busy_ack_ts = {}
     runner._draining = False
     runner.adapters = {}
@@ -116,6 +117,31 @@ class TestBusySessionAck:
         assert sk in adapter._pending_messages
         assert adapter._pending_messages[sk] is event
         assert sk not in runner._pending_messages
+        running_agent.interrupt.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handle_message_interrupt_mode_queues_when_delegate_child_is_active(self):
+        """Default interrupt mode must not propagate follow-ups into active delegates."""
+        from gateway.run import GatewayRunner
+
+        runner, _sentinel = _make_runner()
+        adapter = _make_adapter()
+
+        event = _make_event(text="let the delegate finish first")
+        sk = build_session_key(event.source)
+
+        child = MagicMock()
+        running_agent = MagicMock()
+        running_agent._active_children = [child]
+        running_agent._active_children_lock = None
+        runner._busy_input_mode = "interrupt"
+        runner._running_agents[sk] = running_agent
+        runner.adapters[event.source.platform] = adapter
+
+        result = await GatewayRunner._handle_message(runner, event)
+
+        assert result is None
+        assert adapter._pending_messages[sk] is event
         running_agent.interrupt.assert_not_called()
 
     @pytest.mark.asyncio
@@ -270,6 +296,62 @@ class TestBusySessionAck:
         call_kwargs = adapter._send_with_retry.call_args
         content = call_kwargs.kwargs.get("content") or call_kwargs[1].get("content", "")
         assert "Queued for the next turn" in content
+
+    @pytest.mark.asyncio
+    async def test_interrupt_mode_queues_when_delegate_child_is_active(self):
+        """User follow-ups during delegate_task must not kill active subagents."""
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+
+        event = _make_event(text="keep this for after the subagent")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        child = MagicMock()
+        agent = MagicMock()
+        agent._active_children = [child]
+        agent._active_children_lock = None
+        agent.get_activity_summary.return_value = {
+            "api_call_count": 4,
+            "max_iterations": 60,
+            "current_tool": "delegate_task",
+            "last_activity_ts": time.time(),
+            "last_activity_desc": "delegate_task",
+            "seconds_since_activity": 0.2,
+        }
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time() - 60
+
+        result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is True
+        agent.interrupt.assert_not_called()
+        assert adapter._pending_messages[sk] is event
+        content = adapter._send_with_retry.call_args.kwargs.get("content", "")
+        assert "Queued for the next turn" in content
+        assert "Interrupting" not in content
+
+    @pytest.mark.asyncio
+    async def test_interrupt_mode_still_interrupts_without_delegate_child(self):
+        """Normal interrupt-mode behavior is unchanged outside delegation."""
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+
+        event = _make_event(text="interrupt the regular turn")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        agent._active_children = []
+        agent._active_children_lock = None
+        runner._running_agents[sk] = agent
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        agent.interrupt.assert_called_once_with("interrupt the regular turn")
+        assert adapter._pending_messages[sk] is event
 
     @pytest.mark.asyncio
     async def test_debounce_suppresses_rapid_acks(self):


### PR DESCRIPTION
## Summary
- detect active delegate_task children before applying busy interrupt mode
- queue conversational follow-ups while a delegate child is running so the subagent is not killed
- preserve normal interrupt behavior when no delegate child is active

Fixes #30170

## Tests
- .venv/bin/python -m pytest tests/gateway/test_busy_session_ack.py -q
- .venv/bin/python -m pytest tests/gateway/test_busy_session_auth_bypass.py -q
- .venv/bin/python -m pytest tests/run_agent/test_interrupt_propagation.py -q