### PR TITLE
fix(state): wrap DELETE journal_mode fallback in try/except to survive APFS double-failure

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -169,15 +169,22 @@ def apply_wal_with_fallback(
     the SQLite default and no PRAGMA we issued ever succeeded.
 
     On WAL-incompatible filesystems (NFS, SMB, some FUSE), SQLite raises
-    ``OperationalError("locking protocol")`` when setting WAL.  We fall
-    back to DELETE mode — the pre-WAL default, which works on NFS — and
-    log one WARNING explaining why.  On some filesystems (e.g. APFS
-    external SSDs under heavy contention) BOTH ``PRAGMA journal_mode=WAL``
-    and ``PRAGMA journal_mode=DELETE`` raise ``disk I/O error``; we log
-    a second WARNING and continue with whatever the connection's
-    journal_mode actually is (typically the SQLite default ``delete``),
-    because the connection is still usable for reads/writes and
-    propagating would crash every caller.
+    ``OperationalError("locking protocol")`` (or ``"not authorized"``) when
+    setting WAL.  We fall back to DELETE mode — the pre-WAL default, which
+    works on NFS — and log one WARNING explaining why.  A bare transient
+    ``disk I/O error`` on the WAL pragma alone is NOT treated as a WAL-incompat
+    marker and is re-raised so the caller can retry (downgrading on transient
+    EIO risks mixed-journal-mode cross-process corruption — see
+    ``_WAL_INCOMPAT_MARKERS`` and tests/test_hermes_state_wal_fallback.py::
+    test_reraises_on_disk_io_error).
+
+    When WAL fails for a recognized incompat reason and the ``DELETE``
+    fallback pragma *also* raises (e.g. APFS external SSDs under heavy
+    contention raising ``disk I/O error`` on the DELETE pragma), we log a
+    second WARNING and continue with whatever the connection's journal_mode
+    actually is (typically the SQLite default ``delete``), because the
+    connection is still usable for reads/writes and propagating would crash
+    every caller.
 
     The WARNING is deduplicated per ``db_label``: repeated connections
     to the same underlying DB (e.g. kanban_db.connect() which is called

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -70,7 +70,7 @@ _last_init_error_lock = threading.Lock()
 # hermes_cli/kanban_db.py for ~30 call sites) would re-log the same
 # filesystem-incompat warning on every connection, filling errors.log.
 _wal_fallback_warned_paths: set[str] = set()
-_wal_delete_fallback_failed_paths: set[str] = set()
+_wal_delete_fallback_failed_db_labels: set[str] = set()
 _wal_fallback_warned_lock = threading.Lock()
 
 _FTS_TRIGGERS = (
@@ -162,12 +162,22 @@ def apply_wal_with_fallback(
 ) -> str:
     """Set ``journal_mode=WAL`` on ``conn``, falling back to DELETE on failure.
 
-    Returns the journal mode actually set (``"wal"`` or ``"delete"``).
+    Returns the journal mode now in effect on the connection
+    (``"wal"`` or ``"delete"``).  In the rare both-pragmas-fail case
+    (see below), the value is read back from ``PRAGMA journal_mode``;
+    if even that read fails, ``"delete"`` is returned because that is
+    the SQLite default and no PRAGMA we issued ever succeeded.
 
     On WAL-incompatible filesystems (NFS, SMB, some FUSE), SQLite raises
     ``OperationalError("locking protocol")`` when setting WAL.  We fall
     back to DELETE mode — the pre-WAL default, which works on NFS — and
-    log one WARNING explaining why.
+    log one WARNING explaining why.  On some filesystems (e.g. APFS
+    external SSDs under heavy contention) BOTH ``PRAGMA journal_mode=WAL``
+    and ``PRAGMA journal_mode=DELETE`` raise ``disk I/O error``; we log
+    a second WARNING and continue with whatever the connection's
+    journal_mode actually is (typically the SQLite default ``delete``),
+    because the connection is still usable for reads/writes and
+    propagating would crash every caller.
 
     The WARNING is deduplicated per ``db_label``: repeated connections
     to the same underlying DB (e.g. kanban_db.connect() which is called
@@ -213,6 +223,15 @@ def apply_wal_with_fallback(
             # memory store) when in practice the connection is still
             # usable for reads/writes.  Log once and continue.
             _log_wal_delete_fallback_failed_once(db_label, exc, delete_exc)
+            # Honor the docstring contract: return the journal_mode
+            # actually in effect, not a guess.  If the read also fails,
+            # fall through to "delete" (SQLite's default) below.
+            try:
+                row = conn.execute("PRAGMA journal_mode").fetchone()
+                if row and row[0]:
+                    return str(row[0]).lower()
+            except sqlite3.OperationalError:
+                pass
         return "delete"
 
 
@@ -252,9 +271,9 @@ def _log_wal_delete_fallback_failed_once(
     so kanban_db.connect()'s per-operation pattern doesn't flood the log.
     """
     with _wal_fallback_warned_lock:
-        if db_label in _wal_delete_fallback_failed_paths:
+        if db_label in _wal_delete_fallback_failed_db_labels:
             return
-        _wal_delete_fallback_failed_paths.add(db_label)
+        _wal_delete_fallback_failed_db_labels.add(db_label)
     logger.warning(
         "%s: both WAL and DELETE journal_mode failed "
         "(WAL: %s; DELETE: %s) — continuing with the connection's "

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -70,6 +70,7 @@ _last_init_error_lock = threading.Lock()
 # hermes_cli/kanban_db.py for ~30 call sites) would re-log the same
 # filesystem-incompat warning on every connection, filling errors.log.
 _wal_fallback_warned_paths: set[str] = set()
+_wal_delete_fallback_failed_paths: set[str] = set()
 _wal_fallback_warned_lock = threading.Lock()
 
 _FTS_TRIGGERS = (
@@ -201,7 +202,17 @@ def apply_wal_with_fallback(
         if existing == "wal":
             raise
         _log_wal_fallback_once(db_label, exc)
-        conn.execute("PRAGMA journal_mode=DELETE")
+        try:
+            conn.execute("PRAGMA journal_mode=DELETE")
+        except sqlite3.OperationalError as delete_exc:
+            # Some filesystems (e.g. APFS external SSDs under heavy
+            # contention) reject BOTH WAL and DELETE journal_mode pragmas
+            # with "disk I/O error".  The connection's default journal
+            # mode is already DELETE, so propagating this would crash
+            # every caller (SessionDB, kanban_db, ResponseStore, holographic
+            # memory store) when in practice the connection is still
+            # usable for reads/writes.  Log once and continue.
+            _log_wal_delete_fallback_failed_once(db_label, exc, delete_exc)
         return "delete"
 
 
@@ -225,6 +236,36 @@ def _log_wal_fallback_once(db_label: str, exc: Exception) -> None:
         db_label,
         exc,
     )
+
+
+def _log_wal_delete_fallback_failed_once(
+    db_label: str,
+    wal_exc: Exception,
+    delete_exc: Exception,
+) -> None:
+    """Log a single WARNING per (process, db_label) when both WAL and DELETE fail.
+
+    Observed on APFS external SSDs where both ``PRAGMA journal_mode=WAL``
+    and ``PRAGMA journal_mode=DELETE`` raise ``disk I/O error``.  The
+    connection's default journal mode is already DELETE, so reads/writes
+    still work; we just couldn't change the pragma.  Dedup on db_label
+    so kanban_db.connect()'s per-operation pattern doesn't flood the log.
+    """
+    with _wal_fallback_warned_lock:
+        if db_label in _wal_delete_fallback_failed_paths:
+            return
+        _wal_delete_fallback_failed_paths.add(db_label)
+    logger.warning(
+        "%s: both WAL and DELETE journal_mode failed "
+        "(WAL: %s; DELETE: %s) — continuing with the connection's "
+        "default journal mode.  Typically seen on APFS external SSDs "
+        "under heavy contention.  This warning fires once per process "
+        "per database.",
+        db_label,
+        wal_exc,
+        delete_exc,
+    )
+
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (

--- a/tests/test_hermes_state_wal_fallback.py
+++ b/tests/test_hermes_state_wal_fallback.py
@@ -226,36 +226,51 @@ class TestApplyWalWithFallback:
         )
 
     def test_falls_back_when_delete_pragma_also_fails(self, tmp_path, caplog):
-        """APFS external SSDs reject both WAL and DELETE — must not crash callers.
+        """WAL-incompat FS that ALSO rejects DELETE — must not crash callers.
 
-        The connection's default journal_mode is already DELETE, so the
-        connection is still usable; propagating the DELETE failure would
-        crash SessionDB / kanban_db / ResponseStore / holographic memory.
-        Returns ``"delete"`` and logs one WARNING per db_label.
+        Scenario: ``PRAGMA journal_mode=WAL`` raises a recognized WAL-incompat
+        marker (``locking protocol``), so the code legitimately falls back to
+        DELETE.  But the DELETE pragma *also* raises ``disk I/O error`` (observed
+        on APFS external SSDs under heavy contention).  The connection's default
+        journal_mode is already DELETE, so it is still usable; propagating the
+        DELETE failure would crash SessionDB / kanban_db / ResponseStore /
+        holographic memory.  Returns ``"delete"`` and logs one WARNING per
+        db_label.
+
+        Note: a *bare* ``disk I/O error`` on the WAL pragma alone must instead
+        re-raise (transient EIO is not a permanent WAL-incompat marker — see
+        ``test_reraises_on_disk_io_error``).  This test therefore drives WAL
+        with ``locking protocol`` and only DELETE with ``disk I/O error``.
         """
-        attempts = [0]
+        delete_attempts = [0]
 
-        class _BothPragmasFailConnection(sqlite3.Connection):
+        class _DeletePragmaFailsConnection(sqlite3.Connection):
             def execute(self, sql, *args, **kwargs):  # type: ignore[override]
-                if "journal_mode" in sql.lower():
-                    attempts[0] += 1
+                lowered = sql.lower().replace(" ", "")
+                if "journal_mode=wal" in lowered:
+                    raise sqlite3.OperationalError("locking protocol")
+                if "journal_mode=delete" in lowered:
+                    delete_attempts[0] += 1
+                    raise sqlite3.OperationalError("disk I/O error")
+                # Bare PRAGMA journal_mode reads (probe, on-disk check,
+                # contract read-back) also fail with disk I/O error so the
+                # function falls through to the "delete" default.
+                if "journal_mode" in lowered:
                     raise sqlite3.OperationalError("disk I/O error")
                 return super().execute(sql, *args, **kwargs)
 
         conn = sqlite3.connect(
             str(tmp_path / "apfs.db"),
-            factory=_BothPragmasFailConnection,
+            factory=_DeletePragmaFailsConnection,
             isolation_level=None,
         )
         with caplog.at_level("WARNING", logger="hermes_state"):
             mode = apply_wal_with_fallback(conn, db_label="apfs-test.db")
 
         assert mode == "delete"
-        # Three journal_mode SQL calls: set WAL, set DELETE, then the
-        # PRAGMA journal_mode read-back used to honor the docstring
-        # contract when both writes fail (also blocked by the factory,
-        # which causes the function to fall through to "delete").
-        assert attempts[0] == 3
+        # The DELETE pragma was attempted exactly once (its failure is what
+        # this test exercises).
+        assert delete_attempts[0] == 1
 
         # Two warnings: one for WAL fallback, one for DELETE-also-failed
         msgs = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
@@ -289,9 +304,15 @@ class TestApplyWalWithFallback:
         class _WritesFailReadsSucceedConnection(sqlite3.Connection):
             def execute(self, sql, *args, **kwargs):  # type: ignore[override]
                 # Block PRAGMA WRITES (journal_mode=X) but allow the
-                # bare PRAGMA READ (journal_mode without `=`).
-                lowered = sql.lower().strip()
-                if "journal_mode=" in lowered:
+                # bare PRAGMA READ (journal_mode without `=`).  WAL fails
+                # with a recognized WAL-incompat marker so the fallback
+                # engages (a bare "disk I/O error" on WAL would re-raise —
+                # see test_reraises_on_disk_io_error); DELETE fails with
+                # disk I/O error to drive the both-fail read-back path.
+                lowered = sql.lower().replace(" ", "")
+                if "journal_mode=wal" in lowered:
+                    raise sqlite3.OperationalError("locking protocol")
+                if "journal_mode=delete" in lowered:
                     raise sqlite3.OperationalError("disk I/O error")
                 return super().execute(sql, *args, **kwargs)
 
@@ -326,7 +347,13 @@ class TestApplyWalWithFallback:
 
         class _BothPragmasFailConnection(sqlite3.Connection):
             def execute(self, sql, *args, **kwargs):  # type: ignore[override]
-                if "journal_mode" in sql.lower():
+                lowered = sql.lower().replace(" ", "")
+                # WAL fails with a recognized WAL-incompat marker (so the
+                # fallback engages); DELETE and bare reads fail with disk
+                # I/O error (so the function falls through to "delete").
+                if "journal_mode=wal" in lowered:
+                    raise sqlite3.OperationalError("locking protocol")
+                if "journal_mode" in lowered:
                     raise sqlite3.OperationalError("disk I/O error")
                 return super().execute(sql, *args, **kwargs)
 
@@ -449,7 +476,14 @@ class TestGetLastInitError:
 
         class _BothPragmasFailConnection(sqlite3.Connection):
             def execute(self, sql, *args, **kwargs):  # type: ignore[override]
-                if "journal_mode" in sql.lower():
+                lowered = sql.lower().replace(" ", "")
+                # WAL fails with a recognized WAL-incompat marker (engages
+                # the fallback); DELETE and bare journal_mode reads fail with
+                # disk I/O error.  apply_wal_with_fallback must absorb all of
+                # this and let SessionDB.__init__ proceed.
+                if "journal_mode=wal" in lowered:
+                    raise sqlite3.OperationalError("locking protocol")
+                if "journal_mode" in lowered:
                     raise sqlite3.OperationalError("disk I/O error")
                 return super().execute(sql, *args, **kwargs)
 

--- a/tests/test_hermes_state_wal_fallback.py
+++ b/tests/test_hermes_state_wal_fallback.py
@@ -67,10 +67,10 @@ def _reset_last_init_error():
 def _reset_wal_fallback_warned_paths():
     """Reset the WAL-fallback warned-paths set so dedup doesn't leak between tests."""
     hermes_state._wal_fallback_warned_paths.clear()
-    hermes_state._wal_delete_fallback_failed_paths.clear()
+    hermes_state._wal_delete_fallback_failed_db_labels.clear()
     yield
     hermes_state._wal_fallback_warned_paths.clear()
-    hermes_state._wal_delete_fallback_failed_paths.clear()
+    hermes_state._wal_delete_fallback_failed_db_labels.clear()
 
 
 class TestApplyWalWithFallback:
@@ -251,14 +251,17 @@ class TestApplyWalWithFallback:
             mode = apply_wal_with_fallback(conn, db_label="apfs-test.db")
 
         assert mode == "delete"
-        # Both pragmas were attempted
-        assert attempts[0] == 2
+        # Three journal_mode SQL calls: set WAL, set DELETE, then the
+        # PRAGMA journal_mode read-back used to honor the docstring
+        # contract when both writes fail (also blocked by the factory,
+        # which causes the function to fall through to "delete").
+        assert attempts[0] == 3
 
         # Two warnings: one for WAL fallback, one for DELETE-also-failed
         msgs = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
         wal_warnings = [m for m in msgs if "apfs-test.db" in m and "WAL" in m]
         delete_warnings = [
-            m for m in msgs if "apfs-test.db" in m and "DELETE journal_mode failed" in m
+            m for m in msgs if "apfs-test.db" in m and "both WAL and DELETE journal_mode failed" in m
         ]
         assert len(wal_warnings) >= 1
         assert len(delete_warnings) == 1
@@ -268,6 +271,48 @@ class TestApplyWalWithFallback:
         conn.execute("CREATE TABLE t (x INTEGER)")
         conn.execute("INSERT INTO t VALUES (1)")
         assert list(conn.execute("SELECT x FROM t"))[0][0] == 1
+        conn.close()
+
+    def test_both_pragmas_fail_but_readback_reports_actual_mode(self, tmp_path, caplog):
+        """When both PRAGMA writes fail but PRAGMA journal_mode READ succeeds,
+        the function returns the connection's actual journal_mode — honoring
+        the docstring contract that the returned value reflects reality.
+
+        Regression guard for Copilot's "contract violation" finding on
+        #30823: previously the function returned a hardcoded ``"delete"``
+        even when the DELETE PRAGMA had raised.  On a connection whose
+        underlying journal_mode is something other than ``delete`` (e.g.
+        a previously-set ``memory`` mode that survived the failed writes),
+        that string was a lie.
+        """
+
+        class _WritesFailReadsSucceedConnection(sqlite3.Connection):
+            def execute(self, sql, *args, **kwargs):  # type: ignore[override]
+                # Block PRAGMA WRITES (journal_mode=X) but allow the
+                # bare PRAGMA READ (journal_mode without `=`).
+                lowered = sql.lower().strip()
+                if "journal_mode=" in lowered:
+                    raise sqlite3.OperationalError("disk I/O error")
+                return super().execute(sql, *args, **kwargs)
+
+        conn = sqlite3.connect(
+            str(tmp_path / "readback.db"),
+            factory=_WritesFailReadsSucceedConnection,
+            isolation_level=None,
+        )
+        with caplog.at_level("WARNING", logger="hermes_state"):
+            mode = apply_wal_with_fallback(conn, db_label="readback.db")
+
+        # On a fresh SQLite connection the default journal_mode is "delete";
+        # the read-back returns it.  The important contract guarantee is
+        # that the function consulted the connection rather than guessing.
+        assert mode == "delete"
+        # And the both-fail warning still fired.
+        msgs = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+        assert any(
+            "readback.db" in m and "both WAL and DELETE journal_mode failed" in m
+            for m in msgs
+        )
         conn.close()
 
     def test_delete_fallback_failure_warning_deduplicated_per_db_label(
@@ -300,7 +345,7 @@ class TestApplyWalWithFallback:
             r for r in caplog.records
             if r.levelname == "WARNING"
             and "apfs-shared.db" in r.getMessage()
-            and "DELETE journal_mode failed" in r.getMessage()
+            and "both WAL and DELETE journal_mode failed" in r.getMessage()
         ]
         assert len(delete_warnings) == 1, (
             f"Expected 1 deduplicated DELETE-failed warning, got {len(delete_warnings)}"

--- a/tests/test_hermes_state_wal_fallback.py
+++ b/tests/test_hermes_state_wal_fallback.py
@@ -67,8 +67,10 @@ def _reset_last_init_error():
 def _reset_wal_fallback_warned_paths():
     """Reset the WAL-fallback warned-paths set so dedup doesn't leak between tests."""
     hermes_state._wal_fallback_warned_paths.clear()
+    hermes_state._wal_delete_fallback_failed_paths.clear()
     yield
     hermes_state._wal_fallback_warned_paths.clear()
+    hermes_state._wal_delete_fallback_failed_paths.clear()
 
 
 class TestApplyWalWithFallback:
@@ -223,6 +225,87 @@ class TestApplyWalWithFallback:
             f"{[r.getMessage() for r in warnings]}"
         )
 
+    def test_falls_back_when_delete_pragma_also_fails(self, tmp_path, caplog):
+        """APFS external SSDs reject both WAL and DELETE — must not crash callers.
+
+        The connection's default journal_mode is already DELETE, so the
+        connection is still usable; propagating the DELETE failure would
+        crash SessionDB / kanban_db / ResponseStore / holographic memory.
+        Returns ``"delete"`` and logs one WARNING per db_label.
+        """
+        attempts = [0]
+
+        class _BothPragmasFailConnection(sqlite3.Connection):
+            def execute(self, sql, *args, **kwargs):  # type: ignore[override]
+                if "journal_mode" in sql.lower():
+                    attempts[0] += 1
+                    raise sqlite3.OperationalError("disk I/O error")
+                return super().execute(sql, *args, **kwargs)
+
+        conn = sqlite3.connect(
+            str(tmp_path / "apfs.db"),
+            factory=_BothPragmasFailConnection,
+            isolation_level=None,
+        )
+        with caplog.at_level("WARNING", logger="hermes_state"):
+            mode = apply_wal_with_fallback(conn, db_label="apfs-test.db")
+
+        assert mode == "delete"
+        # Both pragmas were attempted
+        assert attempts[0] == 2
+
+        # Two warnings: one for WAL fallback, one for DELETE-also-failed
+        msgs = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+        wal_warnings = [m for m in msgs if "apfs-test.db" in m and "WAL" in m]
+        delete_warnings = [
+            m for m in msgs if "apfs-test.db" in m and "DELETE journal_mode failed" in m
+        ]
+        assert len(wal_warnings) >= 1
+        assert len(delete_warnings) == 1
+        assert "disk I/O error" in delete_warnings[0]
+
+        # Connection is still usable for non-journal_mode SQL
+        conn.execute("CREATE TABLE t (x INTEGER)")
+        conn.execute("INSERT INTO t VALUES (1)")
+        assert list(conn.execute("SELECT x FROM t"))[0][0] == 1
+        conn.close()
+
+    def test_delete_fallback_failure_warning_deduplicated_per_db_label(
+        self, tmp_path, caplog
+    ):
+        """Repeated calls with the same db_label log exactly ONE DELETE-failed warning.
+
+        kanban_db.connect() runs on every kanban operation; without dedup,
+        APFS-external-SSD users would see hundreds of identical warnings.
+        """
+
+        class _BothPragmasFailConnection(sqlite3.Connection):
+            def execute(self, sql, *args, **kwargs):  # type: ignore[override]
+                if "journal_mode" in sql.lower():
+                    raise sqlite3.OperationalError("disk I/O error")
+                return super().execute(sql, *args, **kwargs)
+
+        with caplog.at_level("WARNING", logger="hermes_state"):
+            for i in range(3):
+                conn = sqlite3.connect(
+                    str(tmp_path / f"apfs-dup-{i}.db"),
+                    factory=_BothPragmasFailConnection,
+                    isolation_level=None,
+                )
+                mode = apply_wal_with_fallback(conn, db_label="apfs-shared.db")
+                assert mode == "delete"
+                conn.close()
+
+        delete_warnings = [
+            r for r in caplog.records
+            if r.levelname == "WARNING"
+            and "apfs-shared.db" in r.getMessage()
+            and "DELETE journal_mode failed" in r.getMessage()
+        ]
+        assert len(delete_warnings) == 1, (
+            f"Expected 1 deduplicated DELETE-failed warning, got {len(delete_warnings)}"
+        )
+
     def test_warning_fires_independently_per_db_label(self, tmp_path, caplog):
         """Different db_labels each get their own one warning (not globally dedup'd)."""
         with caplog.at_level("WARNING", logger="hermes_state"):
@@ -280,24 +363,24 @@ class TestGetLastInitError:
     def test_captures_cause_on_failed_init(self, tmp_path):
         """When SessionDB() raises, the cause is preserved for slash commands.
 
-        Simulates a filesystem where BOTH WAL and DELETE journal modes fail —
-        e.g. a read-only mount where no ``PRAGMA journal_mode=X`` works.  The
-        fallback tries DELETE and also gets rejected; the exception bubbles
-        out of ``SessionDB.__init__`` and the cause is captured.
+        Simulates a filesystem failure unrelated to the WAL fallback path —
+        e.g. ``foreign_keys=ON`` rejected by a read-only or seriously
+        damaged DB.  The exception bubbles out of ``SessionDB.__init__``
+        and the cause is captured for /resume to surface.
         """
         target = tmp_path / "broken.db"
         real_connect = sqlite3.connect
 
-        class _BothPragmasFailConnection(sqlite3.Connection):
+        class _ForeignKeysFailConnection(sqlite3.Connection):
             def execute(self, sql, *args, **kwargs):  # type: ignore[override]
-                if "journal_mode" in sql.lower():
+                if "foreign_keys" in sql.lower():
                     raise sqlite3.OperationalError(
-                        "locking protocol: read-only filesystem"
+                        "attempt to write a readonly database"
                     )
                 return super().execute(sql, *args, **kwargs)
 
         def gated_connect(*args, **kwargs):
-            return real_connect(str(target), factory=_BothPragmasFailConnection, **kwargs)
+            return real_connect(str(target), factory=_ForeignKeysFailConnection, **kwargs)
 
         with patch("hermes_state.sqlite3.connect", side_effect=gated_connect):
             with pytest.raises(sqlite3.OperationalError):
@@ -306,7 +389,43 @@ class TestGetLastInitError:
         cause = get_last_init_error()
         assert cause is not None
         assert "OperationalError" in cause
-        assert "locking protocol" in cause
+        assert "readonly" in cause
+
+    def test_sessiondb_survives_when_both_journal_pragmas_fail(self, tmp_path):
+        """APFS external SSDs reject both journal_mode pragmas — SessionDB must survive.
+
+        Regression guard for #30816: before the fix, the uncaught DELETE
+        fallback inside ``apply_wal_with_fallback`` propagated out of
+        ``SessionDB.__init__`` and every caller (/resume, /title, /history,
+        kanban dispatcher, ResponseStore, holographic memory) silently broke.
+        """
+        target = tmp_path / "apfs.db"
+        real_connect = sqlite3.connect
+
+        class _BothPragmasFailConnection(sqlite3.Connection):
+            def execute(self, sql, *args, **kwargs):  # type: ignore[override]
+                if "journal_mode" in sql.lower():
+                    raise sqlite3.OperationalError("disk I/O error")
+                return super().execute(sql, *args, **kwargs)
+
+        def gated_connect(*args, **kwargs):
+            return real_connect(
+                str(target), factory=_BothPragmasFailConnection, **kwargs
+            )
+
+        with patch("hermes_state.sqlite3.connect", side_effect=gated_connect):
+            db = SessionDB(db_path=target)
+
+        try:
+            # SessionDB initialized successfully despite both pragmas failing
+            assert get_last_init_error() is None
+            # End-to-end write/read still works
+            db.create_session(session_id="s30816", source="cli", model="test")
+            sess = db.get_session("s30816")
+            assert sess is not None
+            assert sess["source"] == "cli"
+        finally:
+            db.close()
 
 
 class TestFormatSessionDbUnavailable:


### PR DESCRIPTION
## What does this PR do?

When `apply_wal_with_fallback()` in `hermes_state.py` falls back to `PRAGMA journal_mode=DELETE` on a WAL-incompatible filesystem (NFS / SMB / FUSE), and the DELETE pragma *also* fails — observed on APFS external SSDs raising `disk I/O error` for both pragma calls — the inner `OperationalError` was uncaught and propagated out.  Every caller of `apply_wal_with_fallback` then crashed at init time:

- `SessionDB.__init__` (`hermes_state.py:354`) → `_session_db = None`, breaks `/resume`, `/title`, `/history`, `/branch`, session search
- `hermes_cli/kanban_db.py::connect()` → kanban dispatcher crashes every 60s when the dashboard is open
- `gateway/platforms/api_server.py:349` → ResponseStore unavailable
- `plugins/memory/holographic/store.py:134` → holographic memory store fails

The connection's default journal mode is already DELETE (SQLite's pre-WAL default), so the connection is still usable for reads/writes even when the explicit pragma is rejected.  This change wraps the DELETE pragma in `try/except`, logs a dedup'd WARNING per `db_label` when both fail, and returns `"delete"` so callers keep running.

## Related Issue

Fixes #30816

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_state.py` — wrap the inner `conn.execute(\"PRAGMA journal_mode=DELETE\")` in `try/except sqlite3.OperationalError`; log a dedup'd WARNING via the new `_log_wal_delete_fallback_failed_once` helper (mirrors the existing per-db_label dedup pattern used by `_log_wal_fallback_once`).  No behavior change on the WAL-only-fails path.
- `tests/test_hermes_state_wal_fallback.py` — adds `test_falls_back_when_delete_pragma_also_fails` (verifies mode==\"delete\", both pragmas attempted, two distinct warnings, connection still usable), `test_delete_fallback_failure_warning_deduplicated_per_db_label` (regression guard for log-spam under `kanban_db.connect()`'s per-operation pattern), and `test_sessiondb_survives_when_both_journal_pragmas_fail` (E2E: `SessionDB()` initializes and round-trips a session despite both pragmas failing).  Reworks the existing `test_captures_cause_on_failed_init` to fail through `PRAGMA foreign_keys=ON` instead of `journal_mode` so it still exercises the `_set_last_init_error` capture path under the new behavior.

## How to Test

1. Repro the original bug by reverting just the `try/except` around the DELETE pragma:
   ```
   uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout python3 -m pytest tests/test_hermes_state_wal_fallback.py -v
   ```
   The three new tests fail with `sqlite3.OperationalError: disk I/O error` propagating out of `apply_wal_with_fallback`.
2. Restore the fix and re-run — all 18 tests pass.
3. Adjacent coverage:
   ```
   uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout python3 -m pytest tests/test_hermes_state_wal_fallback.py tests/hermes_cli/test_kanban_db.py -v
   ```
   177 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; the new helper carries its own docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — fix is observed on macOS APFS but applies cross-platform; the WAL→DELETE→default cascade is OS-agnostic
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

Orthogonal to @SimoKiihamaki's [#30654](https://github.com/NousResearch/hermes-agent/pull/30654), which targets a different SQLite issue (#30636, SIGTERM-induced WAL corruption) by adding `synchronous=FULL` *after* the WAL pragma succeeds and switching `close()` to `wal_checkpoint(TRUNCATE)`.  Both PRs touch `apply_wal_with_fallback` but on different lines (their addition lives on the WAL-success path; mine lives inside the DELETE-fallback `except` block), so they merge cleanly.

> Audited siblings: `apply_wal_with_fallback` is the single shared WAL→DELETE entry point used by `SessionDB`, `hermes_cli/kanban_db.py::connect()`, `gateway/platforms/api_server.py:349`, and `plugins/memory/holographic/store.py:134`.  All four callers benefit from the fix without additional changes.  No widening needed.