### PR TITLE
feat(update): add --no-restart flag to defer gateway reload

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9197,6 +9197,15 @@ def _cmd_update_impl(args, gateway_mode: bool):
             except OSError:
                 pass
 
+        # Allow callers to defer the gateway restart via --no-restart.
+        if getattr(args, "no_restart", False):
+            print("  ℹ Skipping gateway restart (--no-restart)")
+            print("    Restart later with: hermes gateway restart")
+            print()
+            print("Tip: You can now select a provider and model:")
+            print("  hermes model              # Select provider and model")
+            return
+
         # Auto-restart ALL gateways after update.
         # The code update (git pull) is shared across all profiles, so every
         # running gateway needs restarting to pick up the new code.
@@ -13252,6 +13261,16 @@ Examples:
         action="store_true",
         default=False,
         help="Windows: proceed with the update even when another hermes.exe is detected. The concurrent process will likely cause WinError 32 warnings and may leave a reboot-deferred .exe replacement.",
+    )
+    update_parser.add_argument(
+        "--no-restart",
+        action="store_true",
+        default=False,
+        help=(
+            "Skip the automatic gateway restart after a successful update. "
+            "Useful when an external scheduler (systemd timer, CI) wants to "
+            "coordinate the restart itself. Restart later with: hermes gateway restart"
+        ),
     )
     update_parser.set_defaults(func=cmd_update)
 


### PR DESCRIPTION
## Summary

Add a `--no-restart` flag to `hermes update` that suppresses the automatic gateway reload at the end of the update.

```
hermes update --no-restart
# coordinate the reload yourself
hermes gateway restart
```

## Motivation

External automation (systemd timers, CI pipelines, orchestration scripts) often needs to delay the gateway reload until a safe moment — for example, after any in-flight cron deliveries have completed. Without this flag, the only workaround was an unofficial environment variable.

## Changes

- `hermes_cli/main.py`: add `--no-restart` argparse flag (consistent with the existing `--no-backup` style) and gate the auto-reload block behind it
- No behaviour change when the flag is absent

## Testing

- `hermes update --no-restart` prints the skip notice and exits before the gateway reload block
- `hermes update` (without the flag) behaves identically to before