### PR TITLE
ci: harden lint workflow head ref handling

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,12 +51,19 @@ jobs:
 
       - name: Determine base ref
         id: base
+        # PR-derived expressions are routed through step-level env vars
+        # so a malicious fork branch name (e.g. ``$(curl evil)``) cannot
+        # break out of the surrounding quotes when GitHub Actions
+        # interpolates ``${{ ... }}`` before bash parses the script.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF_INPUT: ${{ github.base_ref }}
         run: |
           # For PRs, diff against the merge base with the target branch.
           # For pushes to main, diff against the previous commit on main.
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_SHA=$(git merge-base "origin/${{ github.base_ref }}" HEAD)
-            BASE_REF="origin/${{ github.base_ref }}"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            BASE_SHA=$(git merge-base "origin/$BASE_REF_INPUT" HEAD)
+            BASE_REF="origin/$BASE_REF_INPUT"
           else
             BASE_SHA=$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)
             BASE_REF="HEAD~1"
@@ -103,14 +110,20 @@ jobs:
           echo "base ty:   $(wc -c < .lint-reports/base/ty.json) bytes"
 
       - name: Generate diff summary
+        # PR-derived branch names reach the script as plain ``"$VAR"``
+        # data — never as ``${{ ... }}`` substitutions inside the shell.
+        # See the ``Determine base ref`` step above for the rationale.
+        env:
+          BASE_REF: ${{ steps.base.outputs.ref }}
+          HEAD_REF: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
         run: |
           python scripts/lint_diff.py \
             --base-ruff .lint-reports/base/ruff.json \
             --head-ruff .lint-reports/head/ruff.json \
             --base-ty   .lint-reports/base/ty.json \
             --head-ty   .lint-reports/head/ty.json \
-            --base-ref  "${{ steps.base.outputs.ref }}" \
-            --head-ref  "${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}" \
+            --base-ref  "$BASE_REF" \
+            --head-ref  "$HEAD_REF" \
             --output    .lint-reports/summary.md
           cat .lint-reports/summary.md >> "$GITHUB_STEP_SUMMARY"
 

--- a/tests/test_lint_config.py
+++ b/tests/test_lint_config.py
@@ -113,3 +113,74 @@ class TestLintWorkflow:
             pytest.fail(f"lint.yml is not valid YAML: {exc}")
         assert isinstance(parsed, dict)
         assert "jobs" in parsed
+
+    def test_lint_diff_run_blocks_avoid_untrusted_interpolation(self):
+        """No ``run:`` block in the ``lint-diff`` job may interpolate
+        PR-derived fields directly via ``${{ github.head_ref }}``,
+        ``${{ github.base_ref }}``, ``${{ github.ref_name }}``, or
+        ``${{ github.event.pull_request.* / issue.* / comment.* }}``.
+
+        Expression interpolation happens *before* bash sees the script,
+        so a fork branch name like ``$(curl evil)`` or
+        ``"; rm -rf "$HOME"; echo "`` breaks out of the surrounding
+        quotes when pasted in. The safe pattern is to bind the value to
+        a step-level ``env:`` variable and reference it via
+        ``"$VAR"`` from the shell — see the ``Determine base ref`` and
+        ``Generate diff summary`` steps for the worked example.
+
+        Scoped to the ``lint-diff`` job: ``ruff-blocking`` and
+        ``windows-footguns`` do not read PR-controlled fields. A
+        repo-wide invariant test (applied across every workflow) is
+        deliberately deferred to a future PR to keep this change
+        narrow.
+        """
+        import re
+        import yaml
+
+        content = self.WORKFLOW_PATH.read_text(encoding="utf-8")
+        parsed = yaml.safe_load(content)
+        lint_diff = parsed.get("jobs", {}).get("lint-diff")
+        assert lint_diff is not None, (
+            "lint.yml no longer defines a ``lint-diff`` job; if the "
+            "job was renamed, update this test (and the plan referenced "
+            "above) to point at the new name."
+        )
+
+        # Match the forbidden field names anywhere inside a ``run:``
+        # string — they may sit inside a ternary
+        # (``${{ X && github.head_ref || github.ref_name }}``) rather
+        # than at the start of the expression.  The hardened workflow
+        # binds these to ``env:`` mappings, so they should never appear
+        # in a ``run:`` block at all.
+        forbidden = re.compile(
+            r"github\.("
+            r"head_ref"
+            r"|base_ref"
+            r"|ref_name"
+            r"|event\.(pull_request|issue|comment)\."
+            r")"
+        )
+
+        offenders = []
+        for step in lint_diff.get("steps", []) or []:
+            run = step.get("run")
+            if not isinstance(run, str):
+                continue
+            for match in forbidden.finditer(run):
+                offenders.append(
+                    (step.get("name", "<unnamed step>"), match.group(0))
+                )
+
+        assert not offenders, (
+            "lint-diff job has ``run:`` block(s) interpolating PR-derived "
+            "fields directly:\n"
+            + "\n".join(
+                f"  step={name!r} expression={expr!r}"
+                for name, expr in offenders
+            )
+            + "\n\nMove the expression into a step-level ``env:`` mapping "
+            "and reference the bound variable via ``\"$VAR\"`` in the "
+            "shell. PR branch names can contain ``$()``, backticks, and "
+            "``\"``-terminated payloads; expression interpolation pastes "
+            "those characters into the script before bash parses it."
+        )


### PR DESCRIPTION
## What does this PR do?

Routes PR-derived GitHub Actions expressions (`github.head_ref`, `github.base_ref`, `github.ref_name`) through step-level `env:` mappings in the `lint-diff` job of `.github/workflows/lint.yml` so they reach bash as ordinary `"$VAR"` data instead of being interpolated into the shell script before bash parses it.

A fork PR branch name can contain `$()`, backticks, or `"`-terminating payloads. GitHub Actions evaluates `${{ ... }}` *before* the runner shell sees the script, so direct interpolation in `run:` blocks lets fork PRs break out of the surrounding quotes and execute arbitrary shell inside the lint-diff job. Fork PR tokens are read-only and no secrets are exposed in this step, so this is CI hardening, not a private-security advisory, but worth fixing on first sight: once compute is attacker-controlled, exfil and downstream-confusion chains open up cheaply.

The same offender pattern affected three lines in `lint.yml`. All three are hardened in this PR — splitting them would leave half the surface exposed for the same review overhead.

## Related Issue

Fixes #30825

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `.github/workflows/lint.yml`
  - **Determine base ref** step: binds `EVENT_NAME: ${{ github.event_name }}` and `BASE_REF_INPUT: ${{ github.base_ref }}` to step-level `env:`, references via `"$EVENT_NAME"` / `"$BASE_REF_INPUT"`.
  - **Generate diff summary** step: binds `BASE_REF: ${{ steps.base.outputs.ref }}` and `HEAD_REF: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}` to step-level `env:`, references via `"$BASE_REF"` / `"$HEAD_REF"`.
  - `ruff-blocking` and `windows-footguns` jobs are untouched (they do not read PR-controlled fields).
- `tests/test_lint_config.py`
  - Adds `TestLintWorkflow::test_lint_diff_run_blocks_avoid_untrusted_interpolation` — parses the workflow YAML, walks `jobs.lint-diff.steps`, and fails if any `run:` block references `github.head_ref|base_ref|ref_name|event.(pull_request|issue|comment).*`. Failure message names the offending step + expression and points the reader at the safe pattern.

## How to Test

1. `scripts/run_tests.sh tests/test_lint_config.py` — all 6 tests pass (5 existing + 1 new).
2. `grep -nE 'github\.(head_ref|base_ref|ref_name)' .github/workflows/lint.yml` — expressions appear only inside `env:` mappings, never in `run:` blocks.
3. CI on this PR runs the `lint-diff` job to completion and posts the diff-summary PR comment with correct base/head branch labels.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched for existing PRs; no duplicate.
- [x] My PR contains only changes related to this fix.
- [x] I've run `scripts/run_tests.sh tests/test_lint_config.py` and all tests pass.
- [x] I've added a regression test that fails if a future change reintroduces a direct `${{ github.head_ref|base_ref|ref_name }}` interpolation in a `lint-diff` `run:` block.
- [x] Tested on Linux (Ubuntu 24.04 worktree).

### Documentation & Housekeeping

- [x] N/A — internal CI hardening, no user-facing docs affected.
- [x] N/A — no config keys changed.
- [x] N/A — no architecture or workflow changes for contributors.
- [x] N/A — workflow change is platform-agnostic.
- [x] N/A — no tool descriptions / schemas changed.

## Notes for Reviewer

- The env-mapping approach is the pattern GitHub recommends in [Security hardening for GitHub Actions → "Using an intermediate environment variable"](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable).
- The regression test is scoped to the `lint-diff` job intentionally — a repo-wide invariant test would gate every future workflow that reads PR fields, even safely, and belongs in its own focused PR.
- `github.event_name` is kept in the forbidden-free set because it is an enum value (`pull_request`, `push`, etc.), not attacker-controlled.