### PR TITLE
feat: add Wetfish Baader FPS capture plugin

### DIFF
--- a/.hermes/plans/2026-05-22-labour-pulse-parked-status.md
+++ b/.hermes/plans/2026-05-22-labour-pulse-parked-status.md
@@ -1,0 +1,42 @@
+# Pulse Parked Status
+
+Parked: 2026-05-22
+
+Status: Finalised plan parked pending explicit Kanban build approval.
+
+Plan file: `.hermes/plans/2026-05-22-labour-pulse-review-plan.md`
+
+Git status: not applicable — `.hermes/plans` is outside a project git repository in this session; no repo commit/push was performed.
+
+Final decisions:
+
+- Product name is **Pulse**, not Labour Pulse.
+- V1 Roll Call exceptions: Sick, Absent, AWOL, Early finish.
+- Early finish requires time-left and reason.
+- Team leads can record workstation changes; no individual login required for V1.
+- V1 Pulse views include Daily Pulse, Season Pulse, and Manager Pulse.
+- Comparison target: Manning Pulse vs any available Nova Planning plan vs this FY, with working days per month and rostering drill-down to hours.
+- Cost fields are planning/reference only, not live payroll. No formal payroll-style approval gate is required.
+- Lu Ee can approve non-critical Pulse blockers.
+
+Repo creation note:
+
+- Repo creation has not yet been approved/completed.
+- Recommended default is a dedicated Pulse repo for the visibility layer, separate from Manning Board and Nova Planner.
+- Proposed name: `mimiimimmimi/pulse` or `mimiimimmimi/wetfish-pulse`.
+- Repo setup should be the first build card after planner approval, before feature coding.
+
+Need Armi / Need Lu Ee blocker handling:
+
+Need Armi input for repo architecture/name disagreement, live/production deployment, gateway/Hermes routing, tunnel/DNS/Cloudflare/auth/security, host shutdown/hardware, payroll-interpretation risk, Excel replacement, Nerve scope expansion, or sensitive data leaving Wetfish control.
+
+Need Lu Ee input for non-critical Pulse workflow, wording, card priority, UAT, and source-mapping choices.
+
+Do not block overnight for visual polish, final threshold tuning, incomplete cost-model detail, scenario naming, or follow-on Area/Scenario Pulse structure if a safe labelled default exists.
+
+Next start point after approval:
+
+1. Create Kanban planner card.
+2. Planner converts finalised plan into executable build cards and blocker handling.
+3. Repo setup card creates/verifies the approved Pulse repo scaffold and CI.
+4. No production/live changes until reviewer/UAT approval.

--- a/.hermes/plans/2026-05-22-labour-pulse-review-plan.md
+++ b/.hermes/plans/2026-05-22-labour-pulse-review-plan.md
@@ -1,0 +1,455 @@
+# Pulse Finalised Plan
+
+> **Status:** Finalised and parked pending explicit Kanban build approval.
+> **Build gate:** Do not dispatch coder/reviewer/ops build cards until Armi approves the Kanban build. Production/live remains untouched unless separately approved.
+> **Overnight rule:** Include Need Armi / Need Lu Ee blocker handling in the first Kanban planner card.
+
+## 1. Purpose
+
+Pulse is the Wetfish labour-performance visibility programme.
+
+It will connect:
+
+- Manning Board / Roll Call actuals
+- Nova Planner roster and process-flow forecasts
+- FY Plan / Plan Book approved baseline
+- planning/reference labour cost assumptions, allowances, productivity, and variance drivers
+
+The goal is to make labour performance clear enough for daily management, season tracking, and future planning — without depending only on manual Excel reconciliation.
+
+Short vision:
+
+> Pulse shows the labour heartbeat. Nerve later becomes the local-first planning brain and watchdog.
+
+## 2. Why we are building it
+
+Current labour planning and performance visibility is spread across multiple tools and files:
+
+- Manning Board shows planned/actual floor placement.
+- Team leaders know attendance exceptions and movements.
+- Nova Planner will model forecast staffing and roster cost.
+- Plan Book / FY Plan holds the approved budget baseline.
+- Excel currently carries much of the planning/reconciliation burden.
+
+This creates risk:
+
+- overspend is seen too late;
+- hidden costs such as allowance creep are hard to call out early;
+- actual labour movement is not always connected back to cost/productivity;
+- future FY planning depends too much on manual spreadsheet maintenance;
+- managers do not always have one clear view of actual vs forecast vs plan.
+
+Pulse is intended to close that gap.
+
+## 3. Product boundary
+
+Pulse is one master programme, but it must be built in phases. Do not build it as one giant app/card.
+
+System ownership:
+
+- **Manning Board / Roll Call** owns Manning Actual:
+  - actual attendance;
+  - employee ID;
+  - workstation ID;
+  - workstation assignment/change events;
+  - Roll Call completion and exceptions.
+
+- **Nova Planner** owns Nova Forecast:
+  - process-flow staffing;
+  - roster model;
+  - forecast paid hours;
+  - forecast labour spend;
+  - scenario versions.
+
+- **FY Plan / Plan Book** owns the approved baseline:
+  - approved target hours/spend;
+  - approved output assumptions;
+  - next-FY or season baseline.
+
+- **Pulse** owns visibility:
+  - actual vs forecast vs plan;
+  - variance explanation;
+  - source freshness;
+  - Pulse Cards and manager views.
+
+- **Nerve** is future scope:
+  - watchdog;
+  - cost-risk early warnings;
+  - local-first AI summaries;
+  - next-FY planning replacement pathway.
+
+## 4. Naming standard
+
+Use Pulse naming consistently.
+
+Approved naming:
+
+- Pulse Programme
+- Pulse
+- Pulse Board
+- Pulse Cards
+- Daily Pulse
+- Season Pulse
+- Manager Pulse
+- Area Pulse
+- Scenario Pulse
+- Pulse Drivers
+- Nerve
+
+Avoid:
+
+- Labour Pulse
+- Scoreboard
+- Race
+
+## 5. Finalised V1 decisions
+
+- V1 Roll Call exceptions are confirmed:
+  - Sick
+  - Absent
+  - AWOL
+  - Early finish
+- Early finish must require **time left** and **reason**.
+- Team leads can record workstation changes, but **no individual login is required** for V1.
+- V1 Pulse views include all three:
+  - Daily Pulse
+  - Season Pulse
+  - Manager Pulse
+- Comparison target: **Manning Pulse vs any available plan in Nova Planning vs this FY**, with working days per month and rostering drill-down to hours.
+- Cost fields are planning/reference only, not live payroll. No formal payroll-style approval gate is required.
+- Lu Ee can approve non-critical Pulse blockers.
+
+## 6. View wording
+
+- **Daily Pulse:** today/shift view — what happened today, exceptions, labour hours/spend, source freshness.
+- **Season Pulse:** month/season projection — whether we are tracking to save or overspend vs this FY.
+- **Manager Pulse:** simplified manager/SET summary — key cards only, less operational detail.
+
+The planner card may sequence delivery internally, but the approved V1 scope includes all three.
+
+## 7. Cost-field wording
+
+Cost fields are planning/reference components, not live payroll.
+
+Planner should propose a practical V1 set such as:
+
+- paid hours;
+- rostered hours;
+- variance hours;
+- base labour cost estimate;
+- allowance estimate / allowance creep flag;
+- overtime or penalty estimate if available;
+- cost per kg / KGPMH where source data is available.
+
+## 8. Phase roadmap
+
+### Phase 1 — Manning Actual / Roll Call foundation
+
+Goal: capture reliable daily actual labour data without slowing team leads down.
+
+Scope:
+
+- Build Roll Call inside Manning Board Manager.
+- Team leads mark exceptions only after factory start.
+- Assigned staff not marked as exceptions default to **at work**.
+- Annual leave is handled pre-shift in Manning Board setup.
+- Capture confirmed V1 exception types.
+- Early finish captures time-left and reason.
+- Store employee ID and workstation ID.
+- Team leads can record workstation changes without individual login.
+- Store workstation movement/change history as event rows.
+
+Important data model rule:
+
+Do **not** create columns like `change_1`, `change_2`, `change_3`.
+
+Use event rows instead:
+
+```text
+workstation_change_id
+employee_id
+date
+time
+workstation_pre_change
+workstation_post_change
+recorded_by
+recorded_at
+source
+```
+
+Acceptance criteria:
+
+- Roll Call can be completed quickly by workstation/area.
+- Unmarked assigned staff are treated as present.
+- Early finish records time-left and reason.
+- Exception records are auditable.
+- Workstation changes create event rows.
+- Data can later feed Pulse and Nerve.
+
+### Phase 2 — Nova Forecast / roster-costing foundation
+
+Goal: turn planned process staffing into forecast labour hours and spend.
+
+Scope:
+
+- Nova Planner models process-flow staffing.
+- Add/confirm roster costing assumptions as planning/reference settings.
+- Calculate forecast paid hours.
+- Calculate forecast labour spend.
+- Support named scenario versions.
+- Keep Nova Forecast separate from actual Roll Call records.
+- Support drill-down from monthly working days and rostering into hours.
+
+Acceptance criteria:
+
+- Nova can produce forecast hours/spend by scenario.
+- Forecast can be compared against this FY and Manning Actual / Manning Pulse.
+- Monthly working days and roster assumptions can drill down into hours.
+- Scenarios are versioned and not overwritten silently.
+
+### Phase 3 — FY Plan / Plan Book baseline link
+
+Goal: define the approved target baseline that Pulse compares against.
+
+Scope:
+
+- Identify the baseline fields needed from FY Plan / Plan Book.
+- Map output, labour, cost, working days/month, rostering, and productivity assumptions.
+- Preserve the current Excel file as source/reference during V1.
+- Do not replace Excel until Pulse/Nerve is proven and separately approved.
+
+Acceptance criteria:
+
+- Pulse can compare against an approved baseline.
+- Baseline source and date are visible.
+- Import/entry is auditable.
+- Excel remains the fallback until replacement criteria are approved.
+
+### Phase 4 — Pulse visibility layer
+
+Goal: give managers one clear view of actual vs forecast vs plan.
+
+Scope:
+
+- Build Pulse Board as an interactive grid/canvas.
+- Build draggable Pulse Cards.
+- Show Daily Pulse, Season Pulse, and Manager Pulse in V1.
+- Show Pulse Drivers explaining variances.
+- Include source health/freshness indicators.
+
+Initial Pulse Cards:
+
+- Labour Hours
+- Labour Spend
+- Roll Call Completion
+- Roll Call Exceptions
+- Workstation/Area Variance
+- KGPMH/Productivity
+- Source Health/Freshness
+- Season Pulse Projection
+- Scenario Pulse Comparison
+- Allowance / Hidden Cost Watch
+
+Acceptance criteria:
+
+- Manager can see actual vs forecast vs plan.
+- Every major variance has a Pulse Driver.
+- Source freshness is visible.
+- Hidden cost drift is surfaced, not buried.
+- Cards are clear enough for daily use.
+
+### Phase 5 — Nerve-ready foundation
+
+Goal: ensure Pulse data can later support Nerve without rebuilding the foundation.
+
+Scope:
+
+- Store clean events.
+- Keep audit trails.
+- Track source freshness.
+- Preserve semantic IDs for employees, workstations, shifts, scenarios, and cost assumptions.
+- Keep sensitive data local-first.
+- Use deterministic rules first; AI summaries later.
+
+Nerve watchdog future role:
+
+- call out app/system/source-health risks;
+- call out early signs of labour overspend;
+- detect hidden cost drift such as allowance creep;
+- monitor overtime/penalty drift;
+- compare rostered hours vs paid hours;
+- detect repeated exceptions;
+- flag workstation changes that create paid-hour waste;
+- explain unexplained variance between Manning Actual, Nova Forecast, and FY Plan.
+
+Long-term Nerve planning vision:
+
+- become the accurate, close-to-realistic next-FY planning tool;
+- eventually replace the current Excel-based FY planning file;
+- combine real Manning Actual history, Nova Forecast models, FY Plan baselines, cost assumptions, allowances, productivity, and scenario logic;
+- replace Excel only when the tool is trusted, auditable, maintainable, and accurate enough for FY planning conversations.
+
+Acceptance criteria:
+
+- Pulse stores data in a way Nerve can monitor later.
+- Sensitive employee/cost data remains local-first by default.
+- Nerve vision is documented but not confused with V1 Pulse build scope.
+
+## 9. Repository / project setup decision
+
+Repo creation has not yet been approved or completed. Add this as an explicit pre-build gate before any coding work.
+
+Recommended default: create a dedicated GitHub repository for the Pulse visibility layer, because Pulse is a separate product boundary from Manning Board and Nova Planner even though it consumes their data.
+
+Proposed repo:
+
+```text
+mimiimimmimi/pulse
+```
+
+Alternative names if Armi prefers Wetfish prefixing:
+
+```text
+mimiimimmimi/wetfish-pulse
+mimiimimmimi/Wetfish-Pulse
+```
+
+Repo ownership boundaries:
+
+- **Manning Board repo:** Roll Call actual attendance and workstation event capture.
+- **Nova Planner repo:** process-flow forecast, roster costing, scenario plan outputs.
+- **Pulse repo:** Pulse Board, Daily Pulse, Season Pulse, Manager Pulse, comparison layer, source-health display, and Pulse Drivers.
+- **Future Nerve repo/app:** only when Nerve becomes its own product; do not create it during Pulse V1 unless separately approved.
+
+Initial Pulse repo scaffold should include:
+
+- `README.md` explaining purpose, boundaries, and data sources.
+- `CLAUDE.md` with Wetfish role boundaries and startup context.
+- `docs/PARKED_STATUS.md` or `docs/plans/` containing this finalised plan and next start point.
+- backend skeleton for comparison/data-contract APIs.
+- frontend skeleton for Daily Pulse, Season Pulse, and Manager Pulse.
+- tests for data-contract parsing and comparison calculations.
+- CI workflow for backend tests and frontend build.
+- `.gitignore` protecting local data, secrets, exports, and generated files.
+- deployment notes for staging only.
+
+Repo creation gate:
+
+1. Armi approves repo name.
+2. Create GitHub repo and local clone on the Hermes Mac/project workspace.
+3. Add initial scaffold and plan docs.
+4. Push first commit and verify CI.
+5. Only then dispatch coding cards against the repo.
+
+Do not bury Pulse inside Manning Board by default. Roll Call changes belong in Manning Board, but the Pulse visibility layer should have its own repo unless Armi explicitly chooses a different architecture.
+
+## 10. Potential blockers and escalation rules
+
+This section must be copied into the first Kanban planner card and used during any overnight build. The goal is to keep work moving without repeatedly asking Armi unless a real approval/input gate is hit.
+
+### Needs Armi input
+
+Only escalate to Armi for blockers that materially change risk, scope, live systems, security, or the business direction.
+
+1. **Repo name / architecture approval** — if the team cannot proceed with the default `mimiimimmimi/pulse` repo or there is disagreement about a separate Pulse repo vs embedding Pulse inside Manning/Nova.
+2. **Live or production deployment** — any move from staging/test to live, any production data write path, or any visible change to a live Wetfish Portal card.
+3. **Gateway restart / Hermes routing** — any Hermes gateway restart, tool routing change, model/provider change, or anything affecting Hermes operation.
+4. **Tunnel, DNS, Cloudflare, auth, or security changes** — new public hostname, Cloudflare route, Access policy, credential, auth model, or security-sensitive config.
+5. **Host shutdown / hardware / network actions** — any shutdown, reboot, power-cycle, host migration, or risky runtime service action.
+6. **Payroll-like interpretation risk** — if a cost calculation could be mistaken for live payroll, wage advice, or official payroll approval rather than planning/reference only.
+7. **Excel replacement decision** — any attempt to retire, supersede, or replace the current FY Excel file. Pulse/Nerve replacement is future vision only until separately approved.
+8. **Scope expansion into Nerve** — if builders start implementing Nerve AI/watchdog features instead of keeping Nerve as future-ready design.
+9. **Sensitive data leaves Wetfish control** — any proposal to send employee-linked records, payroll/cost assumptions, raw logs, screenshots, or audit trails to external/cloud AI or third-party services.
+
+### Needs Lu Ee input
+
+Lu Ee can approve non-critical Pulse blockers and user/workflow details. Escalate these to Lu Ee first unless they also hit an Armi-only gate above.
+
+1. **Roll Call workflow details** — screen wording, team-lead flow, phone/QR shortcut vs Manager view, and whether the flow is fast enough.
+2. **Exception wording and options** — display wording for Sick, Absent, AWOL, Early finish, time-left, and reason fields.
+3. **Manager Pulse wording** — whether variance wording is clear, fair, and suitable for manager/SET review.
+4. **Pulse Card priority** — which cards are must-have for first staging if time is limited.
+5. **UAT feedback** — usability, layout, labels, and whether staging is understandable enough for Armi review.
+6. **Non-critical source mapping choices** — display names, grouping, and drill-down labels where the business meaning is clear and no live/security gate is involved.
+
+### Do not block overnight for these if a safe default exists
+
+- Exact visual polish of cards, provided the data and wording are not misleading.
+- Final threshold tuning for amber/red warnings; use conservative placeholders and mark as configurable.
+- Perfect cost model completeness; start with planning/reference fields and show source/assumption labels.
+- Scenario naming conventions; planner can propose clear names and reviewer can refine.
+- Area Pulse or Scenario Pulse implementation; these are follow-on structures unless explicitly pulled into V1.
+
+### Technical blockers to record clearly
+
+If any of these occur, record evidence in the Kanban card and continue with the next safe task if possible:
+
+- Manning Board actuals do not yet expose required fields.
+- Nova Planning does not yet expose a usable plan/scenario output.
+- FY baseline requires manual mapping from Excel/Plan Book before comparison.
+- Working-days-per-month or rostering assumptions are missing.
+- Cross-app API/data contracts are not ready.
+- Staging cannot be exposed without tunnel/DNS/auth changes.
+- Public staging health is green but browser/data smoke fails.
+
+### Overnight reporting rule
+
+For overnight work, report only:
+
+- ready staging links;
+- real blockers needing Armi/Lu Ee input;
+- completed build/review milestones;
+- final parked summary.
+
+Do not send repeated technical noise or multiple duplicate blocker alerts.
+
+## 11. Suggested Kanban build sequence after approval
+
+Only create Kanban build cards after Armi approves this finalised parked plan.
+
+Recommended card order:
+
+1. **Planner card:** confirm repo architecture, final Pulse V1 build scope, data contracts, blocker list, and acceptance criteria for Daily Pulse, Season Pulse, and Manager Pulse.
+2. **Repo setup card:** create/verify the approved Pulse repo scaffold, push first commit, and verify CI before feature coding.
+3. **Manning/Roll Call coder card:** implement Roll Call actuals and workstation event history in the Manning Board repo.
+4. **Reviewer card:** verify Roll Call data model, UX speed, audit, and source safety.
+5. **Nova planner/costing card:** define roster-costing assumptions and scenario output contract in/for Nova Planner.
+6. **FY Plan baseline card:** map first baseline import/entry path.
+7. **Pulse Board prototype card:** build Daily Pulse, Season Pulse, Manager Pulse, Pulse Cards, and source freshness display.
+8. **Reviewer card:** check calculations, naming, wording, source boundaries, and non-payroll wording.
+9. **Ops/staging card:** stage only after reviewer approval.
+10. **Senior tester/UAT card:** Lu Ee/Armi review usability before live.
+
+## 12. Build gates
+
+Do not start coding until these are answered or explicitly deferred:
+
+1. Repo name/architecture is approved and the initial Pulse repo is created/scaffolded.
+2. Need Armi / Need Lu Ee blocker rules are copied into the Kanban planner card and accepted as the overnight escalation rule.
+3. V1 Roll Call exception list is confirmed: Sick, Absent, AWOL, Early finish.
+4. Early finish must capture time-left and reason.
+5. Team leads can record workstation changes; no individual login required for V1.
+6. V1 Pulse view scope is confirmed: include Daily Pulse, Season Pulse, and Manager Pulse.
+7. First comparison target is confirmed: Manning Pulse vs available Nova Planning plan vs this FY, with working days per month and rostering drill-down to hours.
+8. Planner should propose V1 cost fields; no approval gate is required because this is not a live payroll system.
+9. Lu Ee can approve non-critical blockers for this project.
+
+## 13. Parked status
+
+Parked on 2026-05-22 after Armi finalised the review answers and requested blocker handling.
+
+Next start point after approval: create the Kanban planner card first. The planner must convert this plan into executable build cards, copy in the Need Armi / Need Lu Ee blocker rules, confirm blocker handling, and keep production/live untouched until reviewer/UAT approval.
+
+## 14. Approval wording
+
+If approved to start Kanban build, Armi can reply:
+
+```text
+Approved: start Pulse Kanban build from the finalised parked plan. Start with planner card and keep production untouched until review/UAT approval.
+```
+
+If changes are needed, reply with:
+
+```text
+Change Pulse plan: [write changes here]
+```

--- a/plugins/wetfish_baader_fps_capture/README.md
+++ b/plugins/wetfish_baader_fps_capture/README.md
@@ -1,0 +1,114 @@
+# wetfish_baader_fps_capture
+
+Opt-in Hermes Agent plugin that turns Telegram Baader status messages into
+HTTP POSTs against the Wetfish FPS pi-server `/api/readings` endpoint.
+
+This is a **Wetfish-internal workflow plugin**. It is shipped with the repo
+in disabled form: until both the plugin entry and its config block are
+enabled, the hook is dormant.
+
+## What it does
+
+When a message arrives on the gateway's `pre_gateway_dispatch` hook:
+
+1. If the platform / chat_id / thread_id / sender_id do not match this
+   plugin's config, the hook returns `None` and the message continues to
+   normal agent dispatch.
+2. If the message *does* match but doesn't look like a Baader update
+   (no "baader", no "fps", no line beginning with `192`/`212`), it also
+   returns `None` so normal chat still reaches the agent.
+3. Matching Baader entries are parsed, POSTed to `/api/readings` with the
+   `X-FPS-PIN` header read from the configured env var, and confirmed via
+   `GET /api/state`. The hook returns `{"action": "skip"}` so the agent
+   does not also reply.
+
+## Message format
+
+One reading per line. Order of `<id> <label> <value> ...` is fixed at the
+id, but the label/value pairs can appear in any order on the line.
+
+```
+192 fish 82 cups 105 avg 2.7 issue infeed gaps
+212 fish 48 cups 130 avg 1.3 issue ok
+```
+
+Tolerated label aliases:
+
+| Field          | Accepted labels                       |
+|----------------|---------------------------------------|
+| `fishPerMin`   | `fish`, `fish/min`, `fpm`             |
+| `cupsPerMin`   | `cups`, `cups/min`, `cpm`             |
+| `avgWeightKg`  | `avg`, `average`, `weight`, `kg`      |
+| (free comment) | `issue`, `comment`, `note`, `notes`   |
+
+All three numeric fields are required for this workflow. Incomplete
+entries get a compact reply naming the missing field; nothing is POSTed.
+Cups/min is **not optional here**, even though the FPS API would accept a
+reading without it.
+
+## Configuration
+
+Enable the plugin in `~/.hermes/config.yaml`:
+
+```yaml
+plugins:
+  enabled:
+    - wetfish_baader_fps_capture
+
+wetfish:
+  baader_fps_capture:
+    # Top-level kill switch. If false (or this block is missing), the
+    # hook returns None on every event.
+    enabled: true
+
+    # FPS pi-server base URL. Trailing slash optional.
+    fps_api_base_url: "http://127.0.0.1:8090"
+
+    # Name of the env var that holds the X-FPS-PIN value. The value is
+    # never read from config and never logged.
+    fps_pin_env: "FPS_SAVE_PIN"
+
+    # POST/GET timeout. Verify GET uses the same timeout.
+    request_timeout_seconds: 5
+
+    # After POST, GET /api/state and confirm the reading was persisted.
+    verify_after_post: true
+
+    # Reserved: alternate verify path via history CSV.
+    verify_via_history_csv: false
+
+    telegram:
+      # Exact match. Must include the leading "-" for Telegram supergroups.
+      chat_ids: ["-1001234567890"]
+      # Optional. Empty list == accept any thread in the chat.
+      thread_ids: ["17585"]
+      # Optional. Empty list == accept any sender in the chat/thread.
+      sender_ids: ["armi_telegram_id", "zion_telegram_id"]
+
+      # Currently unused (reserved for a future prefix-only ack mode).
+      reply_on_unmatched_prefix: false
+      accepted_prefixes: ["baader", "fps", "192", "212"]
+```
+
+The pin itself goes in the environment, **not** in config. Example
+systemd unit excerpt:
+
+```
+Environment=FPS_SAVE_PIN=********
+```
+
+## Rollback
+
+Remove `wetfish_baader_fps_capture` from `plugins.enabled` (or set
+`wetfish.baader_fps_capture.enabled: false`) and restart the gateway.
+There is no on-disk state and no migration. The FPS pi-server is
+untouched by this plugin's removal.
+
+## What is NOT in scope
+
+- No production deployment is performed by this plugin or this PR.
+- No edits to the FPS pi-server. The capture hook only consumes its
+  documented public API surface.
+- No write to any platform other than Telegram.
+- No agent slash commands. The agent never sees a successfully-captured
+  message (the hook returns `skip`).

--- a/plugins/wetfish_baader_fps_capture/__init__.py
+++ b/plugins/wetfish_baader_fps_capture/__init__.py
@@ -1,0 +1,153 @@
+"""wetfish_baader_fps_capture — bundled opt-in Telegram capture plugin.
+
+Hooks ``pre_gateway_dispatch`` and, for narrowly-gated Telegram chats,
+parses Baader 192/212 readings out of free-form messages and forwards them
+to the Wetfish FPS pi-server's ``/api/readings`` endpoint. Out-of-scope
+messages and free-form chat in the same channel pass through untouched
+(the hook returns ``None`` and the gateway continues to normal dispatch).
+
+All the testable logic lives in :mod:`.capture`. This file is just the
+glue: real HTTP via stdlib ``urllib`` and reply-sending that schedules
+``adapter.send`` on the running event loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import urllib.error
+import urllib.request
+from typing import Any, Dict, Optional, Tuple
+
+from . import capture as _capture
+
+
+logger = logging.getLogger(__name__)
+
+
+def _http_request(
+    url: str,
+    *,
+    method: str,
+    headers: Dict[str, str],
+    body: Optional[bytes],
+    timeout: float,
+) -> Tuple[int, Any]:
+    """Perform an HTTP request. Returns (status, parsed-json-or-text).
+
+    Wraps urllib so HTTPError (4xx/5xx) is returned as (status, body) rather
+    than raised. Other network errors propagate as exceptions for the
+    caller to catch and convert to a safe user-facing hint.
+    """
+    req = urllib.request.Request(url, data=body, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read()
+            status = resp.status
+    except urllib.error.HTTPError as exc:
+        raw = exc.read() if hasattr(exc, "read") else b""
+        status = exc.code
+    text = raw.decode("utf-8", errors="replace") if raw else ""
+    try:
+        return status, json.loads(text) if text else None
+    except ValueError:
+        return status, text
+
+
+def _http_post(url: str, *, headers: Dict[str, str], json_body: Any, timeout: float):
+    body = json.dumps(json_body).encode("utf-8")
+    return _http_request(
+        url, method="POST", headers=headers, body=body, timeout=timeout
+    )
+
+
+def _http_get(url: str, *, headers: Dict[str, str], timeout: float):
+    return _http_request(
+        url, method="GET", headers=headers, body=None, timeout=timeout
+    )
+
+
+def _make_reply(gateway: Any, event: Any):
+    """Build the reply callable bound to this event's chat/thread.
+
+    Replies are scheduled fire-and-forget on the running asyncio loop. If
+    no loop is running (defensive — pre_gateway_dispatch always fires
+    inside the gateway's loop in production), the reply is logged and
+    dropped rather than blocking the hook.
+    """
+    source = getattr(event, "source", None)
+
+    def _reply(text: str) -> None:
+        if source is None:
+            return
+        adapter = None
+        adapters = getattr(gateway, "adapters", None) or {}
+        platform = getattr(source, "platform", None)
+        if platform is not None:
+            adapter = adapters.get(platform)
+        if adapter is None:
+            logger.debug(
+                "wetfish_baader_fps_capture: no adapter for platform=%s; "
+                "dropping reply",
+                getattr(platform, "value", platform),
+            )
+            return
+        send = getattr(adapter, "send", None)
+        if send is None:
+            return
+        # Telegram threads: send back into the same forum topic.
+        metadata = {}
+        thread_id = getattr(source, "thread_id", None)
+        if thread_id:
+            metadata["message_thread_id"] = thread_id
+        try:
+            coro = send(
+                source.chat_id,
+                text,
+                reply_to=getattr(source, "message_id", None) or getattr(event, "message_id", None),
+                metadata=metadata or None,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "wetfish_baader_fps_capture: adapter.send sync setup failed: %s",
+                type(exc).__name__,
+            )
+            return
+        if asyncio.iscoroutine(coro):
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                logger.debug(
+                    "wetfish_baader_fps_capture: no running loop; "
+                    "discarding reply"
+                )
+                coro.close()
+                return
+            loop.create_task(coro)
+
+    return _reply
+
+
+def _hook(event: Any = None, gateway: Any = None, session_store: Any = None, **_) -> Optional[Dict[str, Any]]:
+    cfg = _capture.load_capture_config()
+    if not cfg or not cfg.get("enabled"):
+        return None
+    try:
+        return _capture.process_event(
+            event,
+            cfg=cfg,
+            http_post=_http_post,
+            http_get=_http_get,
+            reply=_make_reply(gateway, event),
+        )
+    except Exception as exc:  # noqa: BLE001 — never let a plugin break dispatch
+        logger.warning(
+            "wetfish_baader_fps_capture hook raised: %s",
+            type(exc).__name__,
+        )
+        return None
+
+
+def register(ctx) -> None:
+    ctx.register_hook("pre_gateway_dispatch", _hook)

--- a/plugins/wetfish_baader_fps_capture/__init__.py
+++ b/plugins/wetfish_baader_fps_capture/__init__.py
@@ -26,6 +26,13 @@ from . import capture as _capture
 logger = logging.getLogger(__name__)
 
 
+# Stable, non-secret product-style User-Agent for outbound FPS API requests.
+# Wetfish ops found that the FPS pi-server returns HTTP 403 to urllib's
+# default (no User-Agent) but HTTP 200 with a normal product UA, so this is
+# required for the plugin to function against live FPS.
+USER_AGENT = "HermesWetfishBaaderFpsCapture/1.0"
+
+
 def _http_request(
     url: str,
     *,
@@ -40,7 +47,10 @@ def _http_request(
     than raised. Other network errors propagate as exceptions for the
     caller to catch and convert to a safe user-facing hint.
     """
-    req = urllib.request.Request(url, data=body, headers=headers, method=method)
+    merged_headers = {"User-Agent": USER_AGENT, **headers}
+    req = urllib.request.Request(
+        url, data=body, headers=merged_headers, method=method
+    )
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             raw = resp.read()

--- a/plugins/wetfish_baader_fps_capture/capture.py
+++ b/plugins/wetfish_baader_fps_capture/capture.py
@@ -1,0 +1,546 @@
+"""Pure logic for the wetfish_baader_fps_capture plugin.
+
+This module is split out from ``__init__.py`` so it can be unit-tested
+without importing the whole hermes plugin runtime. Three layers:
+
+  * ``parse_message`` — tolerant text-to-readings parser.
+  * ``match_event``  — config gating (platform / chat_id / thread_id /
+                       sender_id / enabled).
+  * ``process_event`` — orchestrator. Injects HTTP + reply callables so
+                       tests can exercise the full path without network.
+
+The plugin shell in ``__init__.py`` wires real HTTP + a real reply that
+schedules ``adapter.send`` on the running event loop.
+
+Secret handling note: the FPS pin is read from an env var (whose *name*
+is configured, not the value). It is only placed into the outbound HTTP
+header — never into log lines, reply text, or recorded exception messages.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+
+logger = logging.getLogger(__name__)
+
+
+SUPPORTED_BAADER_IDS = ("192", "212")
+
+# Label aliases. All matching is case-insensitive on lowercased tokens.
+_FISH_LABELS = {"fish/min", "fpm", "fish"}
+_CUPS_LABELS = {"cups/min", "cpm", "cups"}
+_AVG_LABELS = {"avg", "average", "weight", "kg"}
+_NOTE_LABELS = {"issue", "comment", "note", "notes"}
+
+# Tokenizer: split on whitespace. Keep "fish/min", "cups/min" as single
+# tokens (slashes already preserved). Strip trailing punctuation.
+_TOKEN_RE = re.compile(r"[\s,]+")
+_NUMBER_RE = re.compile(r"^-?\d+(?:\.\d+)?$")
+
+
+@dataclass
+class ParseResult:
+    readings: List[Dict[str, Any]] = field(default_factory=list)
+    errors: List[Dict[str, Any]] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+def _classify_label(token: str) -> Optional[str]:
+    """Return the canonical field name for a label token, or None."""
+    t = token.lower().rstrip(":")
+    if t in _FISH_LABELS:
+        return "fishPerMin"
+    if t in _CUPS_LABELS:
+        return "cupsPerMin"
+    if t in _AVG_LABELS:
+        return "avgWeightKg"
+    if t in _NOTE_LABELS:
+        return "_note"
+    return None
+
+
+def _coerce_number(token: str) -> Optional[float]:
+    if not _NUMBER_RE.match(token):
+        return None
+    try:
+        val = float(token)
+    except ValueError:
+        return None
+    if val.is_integer():
+        return int(val)
+    return val
+
+
+def _parse_line(line: str) -> Optional[Dict[str, Any]]:
+    """Parse a single Baader line.
+
+    Returns either a fully populated reading dict, a dict with a
+    ``"_missing"`` key listing field names that were absent, or a dict
+    with an ``"_ambiguous"`` key listing field names that were specified
+    more than once on the same line (e.g. ``fish 82 fish 99`` or
+    ``fish 82 fpm 83``). Returns ``None`` if the line is not a Baader
+    reading at all (e.g. doesn't start with a supported id).
+    """
+    stripped = line.strip()
+    if not stripped:
+        return None
+
+    tokens = [t for t in _TOKEN_RE.split(stripped) if t]
+    if not tokens:
+        return None
+
+    head = tokens[0].rstrip(":,.")
+    if head not in SUPPORTED_BAADER_IDS:
+        return None
+
+    reading: Dict[str, Any] = {"baaderId": head}
+    note_parts: List[str] = []
+    in_note = False
+    ambiguous: List[str] = []
+
+    def _assign(field_name: str, value: Any) -> None:
+        if field_name in reading:
+            if field_name not in ambiguous:
+                ambiguous.append(field_name)
+            return
+        reading[field_name] = value
+
+    # Scan token pairs. We accept both "label number" and "number label"
+    # ordering. Note labels consume the rest of the line.
+    i = 1
+    while i < len(tokens):
+        tok = tokens[i].rstrip(":,.")
+        if in_note:
+            note_parts.append(tokens[i])
+            i += 1
+            continue
+
+        field_name = _classify_label(tok)
+        if field_name == "_note":
+            in_note = True
+            i += 1
+            continue
+        if field_name is not None:
+            # label-first: peek next token for a number
+            if i + 1 < len(tokens):
+                num = _coerce_number(tokens[i + 1].rstrip(":,."))
+                if num is not None:
+                    _assign(field_name, num)
+                    i += 2
+                    continue
+            i += 1
+            continue
+
+        # token is not a label: maybe number-then-label
+        num = _coerce_number(tok)
+        if num is not None and i + 1 < len(tokens):
+            label_after = _classify_label(tokens[i + 1].rstrip(":,."))
+            if label_after and label_after != "_note":
+                _assign(label_after, num)
+                i += 2
+                continue
+        # Unrecognised token — skip.
+        i += 1
+
+    if note_parts:
+        reading["_note"] = " ".join(note_parts)
+
+    if ambiguous:
+        # Ambiguous lines are never saved; do not also report missing.
+        return {"baaderId": head, "_ambiguous": ambiguous}
+
+    missing: List[str] = []
+    for required in ("fishPerMin", "cupsPerMin", "avgWeightKg"):
+        if required not in reading:
+            missing.append(required)
+    if missing:
+        return {"baaderId": head, "_missing": missing}
+
+    return reading
+
+
+def parse_message(text: str) -> ParseResult:
+    """Parse a free-form Telegram message into Baader readings.
+
+    Each line is parsed independently. Lines whose first token is not a
+    supported Baader id are silently ignored (treated as commentary).
+    Lines that *start* with a supported Baader id but are missing any of
+    fish/min, cups/min, or avg kg become an error entry naming the missing
+    fields.
+    """
+    result = ParseResult()
+    if not text:
+        return result
+    for line in text.splitlines():
+        parsed = _parse_line(line)
+        if parsed is None:
+            continue
+        if "_ambiguous" in parsed:
+            result.errors.append(
+                {"baaderId": parsed["baaderId"], "ambiguous": parsed["_ambiguous"]}
+            )
+        elif "_missing" in parsed:
+            result.errors.append(
+                {"baaderId": parsed["baaderId"], "missing": parsed["_missing"]}
+            )
+        else:
+            # Drop optional note from FPS payload — endpoint doesn't accept it.
+            parsed.pop("_note", None)
+            result.readings.append(parsed)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Config gating
+# ---------------------------------------------------------------------------
+
+def _str_list(value: Any) -> List[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(v) for v in value]
+
+
+def match_event(event: Any, cfg: Dict[str, Any]) -> bool:
+    """Decide whether this event is in scope for capture.
+
+    Gating is exact-match on chat_id, optional thread_id, optional
+    sender_id. Empty filter lists mean "any". Anything that fails returns
+    False — the gateway then continues to normal agent dispatch.
+    """
+    if not isinstance(cfg, dict) or not cfg.get("enabled"):
+        return False
+    if event is None:
+        return False
+    text = getattr(event, "text", "") or ""
+    if not text.strip():
+        return False
+    source = getattr(event, "source", None)
+    if source is None:
+        return False
+
+    platform_obj = getattr(source, "platform", None)
+    platform_name = getattr(platform_obj, "value", None) or str(platform_obj or "")
+    if platform_name != "telegram":
+        return False
+
+    tg = cfg.get("telegram") or {}
+    chat_ids = _str_list(tg.get("chat_ids"))
+    if not chat_ids:
+        # No chat_ids configured == nothing matches (fail-closed).
+        return False
+    if str(getattr(source, "chat_id", "")) not in chat_ids:
+        return False
+
+    thread_ids = _str_list(tg.get("thread_ids"))
+    if thread_ids:
+        if str(getattr(source, "thread_id", "") or "") not in thread_ids:
+            return False
+
+    sender_ids = _str_list(tg.get("sender_ids"))
+    if sender_ids:
+        if str(getattr(source, "user_id", "") or "") not in sender_ids:
+            return False
+
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _looks_like_baader_attempt(text: str) -> bool:
+    """Cheap pre-filter: does the message *look* like a baader update?
+
+    We only consume in-scope messages that look intended for capture; this
+    keeps normal agent chat in the same channel flowing to the agent.
+    """
+    if not text:
+        return False
+    lowered = text.lower()
+    if "baader" in lowered or "fps" in lowered:
+        return True
+    # Lines that begin with a supported id are the canonical format.
+    for line in text.splitlines():
+        first = line.strip().split(":", 1)[0].split(maxsplit=1)
+        if first and first[0].rstrip(",.") in SUPPORTED_BAADER_IDS:
+            return True
+    return False
+
+
+def _fmt_missing_help(errors: List[Dict[str, Any]]) -> str:
+    """Compact help reply for incomplete or ambiguous readings.
+
+    Reports both missing fields (none provided on the line) and ambiguous
+    fields (the same metric specified more than once, including via
+    different aliases — e.g. ``fish 82 fpm 83``).
+    """
+    lines = ["Baader entry needs a fix:"]
+    for err in errors:
+        baader_id = err.get("baaderId", "?")
+        missing = err.get("missing") or []
+        ambiguous = err.get("ambiguous") or []
+        if missing:
+            lines.append(f"  {baader_id}: missing {', '.join(missing)}")
+        if ambiguous:
+            lines.append(
+                f"  {baader_id}: ambiguous {', '.join(ambiguous)} "
+                f"(multiple values given)"
+            )
+    lines.append("Format: 192 fish 82 cups 105 avg 2.7")
+    return "\n".join(lines)
+
+
+def _fmt_saved(reading: Dict[str, Any]) -> str:
+    return (
+        f"Saved baader{reading['baaderId']}: "
+        f"fish/min={reading['fishPerMin']}, "
+        f"cups/min={reading['cupsPerMin']}, "
+        f"avg={reading['avgWeightKg']} kg"
+    )
+
+
+def _fmt_post_failure(reading: Dict[str, Any], hint: str) -> str:
+    return (
+        f"Failed to save baader{reading['baaderId']} reading: {hint}. "
+        f"Please retry or save manually in the FPS UI."
+    )
+
+
+def _fmt_verify_warning(reading: Dict[str, Any]) -> str:
+    return (
+        f"Baader{reading['baaderId']} saved but verification did not match — "
+        f"please double-check via the FPS UI."
+    )
+
+
+def _verify_state(
+    reading: Dict[str, Any],
+    state_body: Any,
+) -> bool:
+    """Confirm /api/state shows the values we just posted (within rounding)."""
+    if not isinstance(state_body, dict):
+        return False
+    readings = state_body.get("readings") if isinstance(state_body.get("readings"), dict) else None
+    if not readings:
+        return False
+    entry = readings.get(f"baader{reading['baaderId']}")
+    if not isinstance(entry, dict):
+        return False
+    # Compare numerics with a small tolerance to avoid float-eq false alarms.
+    def _close(a, b):
+        try:
+            return abs(float(a) - float(b)) < 0.01
+        except (TypeError, ValueError):
+            return False
+    if not _close(entry.get("fishPerMin"), reading["fishPerMin"]):
+        return False
+    if not _close(entry.get("avgWeightKg"), reading["avgWeightKg"]):
+        return False
+    cups = entry.get("cupsPerMin")
+    if cups is not None and not _close(cups, reading["cupsPerMin"]):
+        return False
+    return True
+
+
+def _resolve_pin(cfg: Dict[str, Any]) -> Optional[str]:
+    env_name = cfg.get("fps_pin_env") or "FPS_SAVE_PIN"
+    pin = os.environ.get(str(env_name))
+    if not pin:
+        return None
+    return pin
+
+
+def _safe_status_hint(status: int) -> str:
+    """Compact non-secret hint for a non-2xx HTTP status."""
+    if status == 401:
+        return "auth rejected (HTTP 401)"
+    if status == 400:
+        return "request rejected (HTTP 400)"
+    if 500 <= status < 600:
+        return f"server error (HTTP {status})"
+    return f"HTTP {status}"
+
+
+def process_event(
+    event: Any,
+    *,
+    cfg: Dict[str, Any],
+    http_post: Callable[..., Tuple[int, Any]],
+    http_get: Callable[..., Tuple[int, Any]],
+    reply: Callable[[str], None],
+    now: Optional[Callable[[], str]] = None,
+) -> Optional[Dict[str, Any]]:
+    """Main entry point. Returns ``{"action": "skip"}`` when handled, else None.
+
+    The skip action prevents the gateway from continuing to normal agent
+    dispatch. We only return skip for messages we actually intend to
+    handle (in-scope AND look like a Baader entry). Out-of-scope messages
+    and free-form chat return None.
+    """
+    if not match_event(event, cfg):
+        return None
+
+    text = (event.text or "").strip()
+    if not _looks_like_baader_attempt(text):
+        # In-scope sender/chat but not a baader message — let normal dispatch
+        # handle it. Don't consume.
+        return None
+
+    parsed = parse_message(text)
+
+    if not parsed.readings and not parsed.errors:
+        # Looked like an attempt but had nothing parseable.
+        reply("Couldn't read any Baader values from that message.\n"
+              "Format: 192 fish 82 cups 105 avg 2.7")
+        return {"action": "skip", "reason": "baader_fps_capture"}
+
+    if parsed.errors:
+        reply(_fmt_missing_help(parsed.errors))
+        # If there's a mix (some valid, some invalid), still POST the valid
+        # ones below — fall through.
+        if not parsed.readings:
+            return {"action": "skip", "reason": "baader_fps_capture"}
+
+    pin = _resolve_pin(cfg)
+    base_url = str(cfg.get("fps_api_base_url") or "").rstrip("/")
+    timeout = float(cfg.get("request_timeout_seconds") or 5)
+    verify = bool(cfg.get("verify_after_post"))
+
+    if not pin:
+        logger.warning(
+            "wetfish_baader_fps_capture: FPS pin env var unset; cannot POST"
+        )
+        reply("Cannot save: FPS pin is not configured on the bot. "
+              "Set the configured env var and retry.")
+        return {"action": "skip", "reason": "baader_fps_capture"}
+    if not base_url:
+        logger.warning(
+            "wetfish_baader_fps_capture: fps_api_base_url unset; cannot POST"
+        )
+        reply("Cannot save: FPS API URL is not configured on the bot.")
+        return {"action": "skip", "reason": "baader_fps_capture"}
+
+    now_fn = now or _now_iso
+
+    for reading in parsed.readings:
+        payload = {
+            "reading": {
+                "baaderId": reading["baaderId"],
+                "fishPerMin": reading["fishPerMin"],
+                "cupsPerMin": reading["cupsPerMin"],
+                "avgWeightKg": reading["avgWeightKg"],
+                "ts": now_fn(),
+            }
+        }
+        url = f"{base_url}/api/readings"
+        headers = {
+            "Content-Type": "application/json",
+            "X-FPS-PIN": pin,
+        }
+        try:
+            status, body = http_post(
+                url,
+                headers=headers,
+                json_body=payload,
+                timeout=timeout,
+            )
+        except Exception as exc:  # noqa: BLE001 — converted to safe hint below
+            # Critical: never put the exception object (or its repr) into a
+            # log line or user reply — it could contain headers/values.
+            logger.warning(
+                "wetfish_baader_fps_capture: POST to /api/readings failed "
+                "for baader%s: %s",
+                reading["baaderId"],
+                type(exc).__name__,
+            )
+            reply(_fmt_post_failure(reading, "network error"))
+            continue
+
+        if status < 200 or status >= 300:
+            logger.warning(
+                "wetfish_baader_fps_capture: POST to /api/readings returned "
+                "%s for baader%s",
+                status,
+                reading["baaderId"],
+            )
+            reply(_fmt_post_failure(reading, _safe_status_hint(status)))
+            continue
+
+        # FPS may return HTTP 2xx with a JSON body that doesn't confirm
+        # success (ok missing, ok=false, ok=None, ok="false", etc.). Only
+        # treat dict bodies where ok is exactly True as a successful save.
+        # Non-dict bodies (legacy/empty responses) are left to the verify
+        # step below.
+        if isinstance(body, dict) and body.get("ok") is not True:
+            logger.warning(
+                "wetfish_baader_fps_capture: POST to /api/readings returned "
+                "%s without ok=true for baader%s",
+                status,
+                reading["baaderId"],
+            )
+            reply(_fmt_post_failure(reading, "server did not confirm save"))
+            continue
+
+        if verify:
+            try:
+                vstatus, vbody = http_get(
+                    f"{base_url}/api/state",
+                    headers={"Accept": "application/json"},
+                    timeout=timeout,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.debug(
+                    "wetfish_baader_fps_capture: verify GET failed for "
+                    "baader%s: %s",
+                    reading["baaderId"],
+                    type(exc).__name__,
+                )
+                reply(_fmt_verify_warning(reading))
+                continue
+            if vstatus != 200 or not _verify_state(reading, vbody):
+                reply(_fmt_verify_warning(reading))
+                continue
+
+        reply(_fmt_saved(reading))
+
+    return {"action": "skip", "reason": "baader_fps_capture"}
+
+
+# ---------------------------------------------------------------------------
+# Config loader
+# ---------------------------------------------------------------------------
+
+def load_capture_config() -> Dict[str, Any]:
+    """Read ``wetfish.baader_fps_capture`` from hermes config.yaml.
+
+    Returns an empty dict on any failure (no config / parse error / shape
+    mismatch). Callers must check ``enabled`` themselves before acting.
+    """
+    try:
+        from hermes_cli.config import cfg_get, load_config
+    except Exception as exc:
+        logger.debug("hermes_cli.config not importable: %s", exc)
+        return {}
+    try:
+        cfg = load_config()
+    except Exception as exc:
+        logger.debug("load_config failed: %s", exc)
+        return {}
+    section = cfg_get(cfg, "wetfish", "baader_fps_capture", default={})
+    if not isinstance(section, dict):
+        return {}
+    return section

--- a/plugins/wetfish_baader_fps_capture/plugin.yaml
+++ b/plugins/wetfish_baader_fps_capture/plugin.yaml
@@ -1,0 +1,9 @@
+name: wetfish_baader_fps_capture
+version: 0.1.0
+description: "Opt-in Wetfish capture hook: parses Baader 192/212 Telegram updates and forwards them to the FPS pi-server /api/readings endpoint. Telegram-only, gated by chat_id/thread_id/sender_id."
+author: "Wetfish / Hermes Agent"
+kind: standalone
+provides_hooks:
+  - pre_gateway_dispatch
+requires_env:
+  - FPS_SAVE_PIN

--- a/tests/plugins/test_wetfish_baader_fps_capture.py
+++ b/tests/plugins/test_wetfish_baader_fps_capture.py
@@ -18,10 +18,13 @@ Covers the bundled opt-in plugin at ``plugins/wetfish_baader_fps_capture/``:
 
 from __future__ import annotations
 
+import importlib
 import importlib.util
+import json
 import sys
 import types
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -46,6 +49,11 @@ def _load_capture():
     sys.modules[mod_name] = module
     spec.loader.exec_module(module)
     return module
+
+
+def _load_plugin_shell():
+    """Import the plugin package (the __init__.py shell with _http_post/_http_get)."""
+    return importlib.import_module("plugins.wetfish_baader_fps_capture")
 
 
 def _make_event(
@@ -745,3 +753,129 @@ class TestProcessEvent:
         # Verify ran and Saved reply went out.
         assert len(http.gets) == 1
         assert any("saved baader" in s.lower() for s in replies.sent)
+
+
+# ---------------------------------------------------------------------------
+# HTTP helper tests (User-Agent + header propagation)
+# ---------------------------------------------------------------------------
+
+class _FakeUrlopenResponse:
+    def __init__(self, status: int, body: bytes):
+        self.status = status
+        self._body = body
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class TestHttpHelpersUserAgent:
+    """Wetfish ops found that the live FPS endpoint returns HTTP 403 when
+    urllib sends no User-Agent. Both _http_post and _http_get must include
+    a stable product-style User-Agent on every outbound request, alongside
+    any caller-supplied headers (including the secret X-FPS-PIN).
+    """
+
+    def test_http_post_includes_user_agent_and_pin(self):
+        plugin = _load_plugin_shell()
+        captured = {}
+
+        def _fake_urlopen(req, timeout):
+            captured["req"] = req
+            captured["timeout"] = timeout
+            return _FakeUrlopenResponse(200, b'{"ok": true}')
+
+        with patch.object(plugin.urllib.request, "urlopen", _fake_urlopen):
+            status, body = plugin._http_post(
+                "http://127.0.0.1:8090/api/readings",
+                headers={"Content-Type": "application/json", "X-FPS-PIN": SENTINEL_PIN},
+                json_body={"reading": {"baaderId": "192"}},
+                timeout=5,
+            )
+
+        assert status == 200
+        assert body == {"ok": True}
+        req = captured["req"]
+        assert req.get_method() == "POST"
+        # urllib stores headers title-cased on first capitalize.
+        assert req.get_header("User-agent") == plugin.USER_AGENT
+        assert req.get_header("X-fps-pin") == SENTINEL_PIN
+        assert req.get_header("Content-type") == "application/json"
+        # Body must be the JSON-encoded payload.
+        assert json.loads(req.data.decode("utf-8")) == {"reading": {"baaderId": "192"}}
+
+    def test_http_get_includes_user_agent(self):
+        plugin = _load_plugin_shell()
+        captured = {}
+
+        def _fake_urlopen(req, timeout):
+            captured["req"] = req
+            return _FakeUrlopenResponse(200, b'{"readings": {}}')
+
+        with patch.object(plugin.urllib.request, "urlopen", _fake_urlopen):
+            status, body = plugin._http_get(
+                "http://127.0.0.1:8090/api/state",
+                headers={"Accept": "application/json"},
+                timeout=5,
+            )
+
+        assert status == 200
+        assert body == {"readings": {}}
+        req = captured["req"]
+        assert req.get_method() == "GET"
+        assert req.get_header("User-agent") == plugin.USER_AGENT
+        assert req.get_header("Accept") == "application/json"
+        # GET must not carry the secret pin.
+        assert req.get_header("X-fps-pin") is None
+        assert req.data is None
+
+    def test_user_agent_is_stable_non_secret_product_string(self):
+        plugin = _load_plugin_shell()
+        # Stable identifier, not derived from any secret. Must be a non-empty
+        # product-style token so the FPS server's UA check accepts it.
+        ua = plugin.USER_AGENT
+        assert isinstance(ua, str) and ua
+        assert "/" in ua  # product/version shape
+        assert SENTINEL_PIN not in ua
+
+    def test_caller_supplied_user_agent_overrides_default(self):
+        """If a future caller needs a different UA, it should win over the default."""
+        plugin = _load_plugin_shell()
+        captured = {}
+
+        def _fake_urlopen(req, timeout):
+            captured["req"] = req
+            return _FakeUrlopenResponse(200, b"")
+
+        with patch.object(plugin.urllib.request, "urlopen", _fake_urlopen):
+            plugin._http_get(
+                "http://127.0.0.1:8090/api/state",
+                headers={"User-Agent": "OverrideAgent/9.9"},
+                timeout=5,
+            )
+
+        assert captured["req"].get_header("User-agent") == "OverrideAgent/9.9"
+
+    def test_http_helpers_do_not_log_pin(self, caplog):
+        plugin = _load_plugin_shell()
+
+        def _fake_urlopen(req, timeout):
+            return _FakeUrlopenResponse(200, b'{"ok": true}')
+
+        with caplog.at_level("DEBUG"), patch.object(
+            plugin.urllib.request, "urlopen", _fake_urlopen
+        ):
+            plugin._http_post(
+                "http://127.0.0.1:8090/api/readings",
+                headers={"Content-Type": "application/json", "X-FPS-PIN": SENTINEL_PIN},
+                json_body={"reading": {"baaderId": "192"}},
+                timeout=5,
+            )
+
+        log_text = "\n".join(rec.getMessage() for rec in caplog.records)
+        assert SENTINEL_PIN not in log_text

--- a/tests/plugins/test_wetfish_baader_fps_capture.py
+++ b/tests/plugins/test_wetfish_baader_fps_capture.py
@@ -1,0 +1,747 @@
+"""Tests for the wetfish_baader_fps_capture plugin.
+
+Covers the bundled opt-in plugin at ``plugins/wetfish_baader_fps_capture/``:
+
+  * ``capture.parse_message``: tolerant parser for "192 fish 82 cups 105 avg 2.7"
+    style lines, including multi-reading messages and named missing-field
+    errors for incomplete entries.
+  * ``capture.match_event``: config gating by platform / chat_id / thread_id /
+    sender_id and enabled flag.
+  * ``capture.process_event``: end-to-end hook orchestration with injected
+    HTTP + reply callables. In-scope valid messages POST readings to the FPS
+    API and return ``{"action": "skip"}``; in-scope invalid messages send a
+    compact help reply and still return skip; out-of-scope messages return
+    ``None`` and never POST.
+  * Secret hygiene: FPS pin must never appear in replies or in the recorded
+    POST URL/body even on failure.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_DIR = REPO_ROOT / "plugins" / "wetfish_baader_fps_capture"
+SENTINEL_PIN = "super-secret-pin"
+
+
+def _load_capture():
+    """Import the plugin's capture module directly from the repo path."""
+    mod_name = "wetfish_baader_fps_capture_under_test"
+    cached = sys.modules.get(mod_name)
+    if cached is not None:
+        return cached
+    spec = importlib.util.spec_from_file_location(
+        mod_name, PLUGIN_DIR / "capture.py"
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load capture module from {PLUGIN_DIR}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_event(
+    *,
+    text: str,
+    platform: str = "telegram",
+    chat_id: str = "-1001234567890",
+    thread_id: str | None = "17585",
+    user_id: str = "armi_telegram_id",
+    message_id: str = "m1",
+):
+    """Build a minimal MessageEvent-like object for tests.
+
+    We use SimpleNamespace rather than importing the real MessageEvent because
+    the test isolates the parser/gating logic from gateway internals.
+    The shape mirrors gateway.platforms.base.MessageEvent + gateway.session
+    SessionSource fields used by ``match_event``/``process_event``.
+    """
+    source = types.SimpleNamespace(
+        platform=types.SimpleNamespace(value=platform),
+        chat_id=chat_id,
+        thread_id=thread_id,
+        user_id=user_id,
+        message_id=message_id,
+        chat_type="group",
+    )
+    return types.SimpleNamespace(
+        text=text,
+        source=source,
+        message_id=message_id,
+    )
+
+
+def _default_cfg():
+    return {
+        "enabled": True,
+        "fps_api_base_url": "http://127.0.0.1:8090",
+        "fps_pin_env": "FPS_SAVE_PIN",
+        "request_timeout_seconds": 5,
+        "verify_after_post": True,
+        "verify_via_history_csv": False,
+        "telegram": {
+            "chat_ids": ["-1001234567890"],
+            "thread_ids": ["17585"],
+            "sender_ids": ["armi_telegram_id", "zion_telegram_id"],
+            "reply_on_unmatched_prefix": False,
+            "accepted_prefixes": ["baader", "fps", "192", "212"],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Parser tests
+# ---------------------------------------------------------------------------
+
+class TestParseMessage:
+    def test_parses_two_readings_one_per_line(self):
+        capture = _load_capture()
+        text = (
+            "192 fish 82 cups 105 avg 2.7 issue infeed gaps\n"
+            "212 fish 48 cups 130 avg 1.3 issue ok"
+        )
+        result = capture.parse_message(text)
+        assert result.errors == []
+        assert len(result.readings) == 2
+
+        r1 = result.readings[0]
+        assert r1["baaderId"] == "192"
+        assert r1["fishPerMin"] == 82
+        assert r1["cupsPerMin"] == 105
+        assert r1["avgWeightKg"] == 2.7
+
+        r2 = result.readings[1]
+        assert r2["baaderId"] == "212"
+        assert r2["fishPerMin"] == 48
+        assert r2["cupsPerMin"] == 130
+        assert r2["avgWeightKg"] == 1.3
+
+    def test_accepts_alternate_labels(self):
+        capture = _load_capture()
+        text = "192 fpm 90 cpm 110 weight 2.4"
+        result = capture.parse_message(text)
+        assert result.errors == []
+        assert result.readings[0]["fishPerMin"] == 90
+        assert result.readings[0]["cupsPerMin"] == 110
+        assert result.readings[0]["avgWeightKg"] == 2.4
+
+    def test_rejects_missing_cups_per_min(self):
+        capture = _load_capture()
+        text = "192 fish 82 avg 2.7"
+        result = capture.parse_message(text)
+        assert result.readings == []
+        assert len(result.errors) == 1
+        err = result.errors[0]
+        assert err["baaderId"] == "192"
+        assert "cupsPerMin" in err["missing"]
+        # Must NOT inflate the error with avg kg (which was present).
+        assert "avgWeightKg" not in err["missing"]
+
+    def test_rejects_missing_avg_weight(self):
+        capture = _load_capture()
+        text = "212 fish 48 cups 130"
+        result = capture.parse_message(text)
+        assert result.readings == []
+        assert len(result.errors) == 1
+        err = result.errors[0]
+        assert err["baaderId"] == "212"
+        assert "avgWeightKg" in err["missing"]
+
+    def test_rejects_missing_fish_per_min(self):
+        capture = _load_capture()
+        text = "212 cups 130 avg 1.3"
+        result = capture.parse_message(text)
+        assert result.readings == []
+        err = result.errors[0]
+        assert err["baaderId"] == "212"
+        assert "fishPerMin" in err["missing"]
+
+    def test_ignores_non_baader_lines(self):
+        capture = _load_capture()
+        text = "hello team\n192 fish 82 cups 105 avg 2.7\nrandom note"
+        result = capture.parse_message(text)
+        assert len(result.readings) == 1
+        assert result.errors == []
+        assert result.readings[0]["baaderId"] == "192"
+
+    def test_unsupported_baader_id_is_ignored(self):
+        capture = _load_capture()
+        # 198 is not a real baader on this line; treat as comment.
+        text = "198 fish 50 cups 60 avg 1.0"
+        result = capture.parse_message(text)
+        assert result.readings == []
+        assert result.errors == []
+
+    def test_empty_text_returns_nothing(self):
+        capture = _load_capture()
+        result = capture.parse_message("")
+        assert result.readings == []
+        assert result.errors == []
+
+    def test_rejects_duplicate_fish_same_alias(self):
+        """Reviewer blocker: ``fish 82 fish 99`` is ambiguous; do not save."""
+        capture = _load_capture()
+        text = "192 fish 82 fish 99 cups 105 avg 2.7"
+        result = capture.parse_message(text)
+        assert result.readings == []
+        assert len(result.errors) == 1
+        err = result.errors[0]
+        assert err["baaderId"] == "192"
+        ambiguous = err.get("ambiguous") or []
+        assert "fishPerMin" in ambiguous
+
+    def test_rejects_duplicate_fish_different_alias(self):
+        """``fish 82 fpm 83`` — duplicate via different aliases is also ambiguous."""
+        capture = _load_capture()
+        text = "192 fish 82 fpm 83 cups 105 avg 2.7"
+        result = capture.parse_message(text)
+        assert result.readings == []
+        assert len(result.errors) == 1
+        err = result.errors[0]
+        assert err["baaderId"] == "192"
+        assert "fishPerMin" in (err.get("ambiguous") or [])
+
+    def test_rejects_duplicate_cups_different_alias(self):
+        capture = _load_capture()
+        text = "212 fish 48 cups 105 cpm 106 avg 1.3"
+        result = capture.parse_message(text)
+        assert result.readings == []
+        assert len(result.errors) == 1
+        err = result.errors[0]
+        assert err["baaderId"] == "212"
+        assert "cupsPerMin" in (err.get("ambiguous") or [])
+
+    def test_rejects_duplicate_avg_different_alias(self):
+        capture = _load_capture()
+        text = "192 fish 82 cups 105 avg 2.7 weight 2.8"
+        result = capture.parse_message(text)
+        assert result.readings == []
+        assert len(result.errors) == 1
+        err = result.errors[0]
+        assert err["baaderId"] == "192"
+        assert "avgWeightKg" in (err.get("ambiguous") or [])
+
+    def test_duplicate_does_not_silently_take_first_value(self):
+        """The reviewer's exact repro: must NOT save fishPerMin=82 silently."""
+        capture = _load_capture()
+        text = "192 fish 82 fish 99 cups 105 avg 2.7"
+        result = capture.parse_message(text)
+        assert not any(r.get("fishPerMin") == 82 for r in result.readings)
+        assert result.readings == []
+
+
+# ---------------------------------------------------------------------------
+# Gating tests
+# ---------------------------------------------------------------------------
+
+class TestMatchEvent:
+    def test_matches_in_scope_event(self):
+        capture = _load_capture()
+        ev = _make_event(text="192 fish 82 cups 105 avg 2.7")
+        assert capture.match_event(ev, _default_cfg()) is True
+
+    def test_rejects_wrong_platform(self):
+        capture = _load_capture()
+        ev = _make_event(text="192 fish 82 cups 105 avg 2.7", platform="discord")
+        assert capture.match_event(ev, _default_cfg()) is False
+
+    def test_rejects_wrong_chat(self):
+        capture = _load_capture()
+        ev = _make_event(text="192 fish 82 cups 105 avg 2.7", chat_id="-9999")
+        assert capture.match_event(ev, _default_cfg()) is False
+
+    def test_rejects_wrong_thread(self):
+        capture = _load_capture()
+        ev = _make_event(text="192 fish 82 cups 105 avg 2.7", thread_id="42")
+        assert capture.match_event(ev, _default_cfg()) is False
+
+    def test_rejects_wrong_sender(self):
+        capture = _load_capture()
+        ev = _make_event(
+            text="192 fish 82 cups 105 avg 2.7", user_id="someone_else"
+        )
+        assert capture.match_event(ev, _default_cfg()) is False
+
+    def test_rejects_when_disabled(self):
+        capture = _load_capture()
+        cfg = _default_cfg()
+        cfg["enabled"] = False
+        ev = _make_event(text="192 fish 82 cups 105 avg 2.7")
+        assert capture.match_event(ev, cfg) is False
+
+    def test_rejects_empty_text(self):
+        capture = _load_capture()
+        ev = _make_event(text="")
+        assert capture.match_event(ev, _default_cfg()) is False
+
+    def test_accepts_when_thread_filter_unset(self):
+        """An empty thread_ids list means: accept any thread."""
+        capture = _load_capture()
+        cfg = _default_cfg()
+        cfg["telegram"]["thread_ids"] = []
+        ev = _make_event(text="192 fish 82 cups 105 avg 2.7", thread_id="99999")
+        assert capture.match_event(ev, cfg) is True
+
+    def test_accepts_when_sender_filter_unset(self):
+        """An empty sender_ids list means: accept any sender."""
+        capture = _load_capture()
+        cfg = _default_cfg()
+        cfg["telegram"]["sender_ids"] = []
+        ev = _make_event(text="192 fish 82 cups 105 avg 2.7", user_id="nobody")
+        assert capture.match_event(ev, cfg) is True
+
+
+# ---------------------------------------------------------------------------
+# process_event orchestration tests
+# ---------------------------------------------------------------------------
+
+class _FakeHttp:
+    """Records POST/GET calls and replies according to a script."""
+
+    def __init__(
+        self,
+        *,
+        post_status: int = 200,
+        post_body=None,
+        state_body=None,
+        raise_on_post: bool = False,
+        raise_on_get: bool = False,
+    ):
+        self.posts: list[dict] = []
+        self.gets: list[dict] = []
+        self._post_status = post_status
+        # Use None as the sentinel so an explicit empty dict / falsy body
+        # (e.g. ``{}`` for "missing ok" tests) is preserved rather than
+        # silently replaced by the default success body.
+        self._post_body = {"ok": True} if post_body is None else post_body
+        self._state_body = state_body or {
+            "readings": {
+                "baader192": {"fishPerMin": 82, "avgWeightKg": 2.7, "cupsPerMin": 105},
+            }
+        }
+        self._raise_on_post = raise_on_post
+        self._raise_on_get = raise_on_get
+
+    def post(self, url, *, headers, json_body, timeout):
+        self.posts.append(
+            {"url": url, "headers": dict(headers), "json": json_body, "timeout": timeout}
+        )
+        if self._raise_on_post:
+            raise RuntimeError(
+                f"network unreachable; pin={SENTINEL_PIN}"
+            )
+        return self._post_status, self._post_body
+
+    def get(self, url, *, headers, timeout):
+        self.gets.append({"url": url, "headers": dict(headers), "timeout": timeout})
+        if self._raise_on_get:
+            raise RuntimeError("verify boom")
+        return 200, self._state_body
+
+
+class _Replies:
+    def __init__(self):
+        self.sent: list[str] = []
+
+    def __call__(self, text: str) -> None:
+        self.sent.append(text)
+
+
+class TestProcessEvent:
+    def test_valid_single_reading_posts_and_replies(self, monkeypatch):
+        capture = _load_capture()
+        monkeypatch.setenv("FPS_SAVE_PIN", SENTINEL_PIN)
+
+        http = _FakeHttp()
+        replies = _Replies()
+        ev = _make_event(text="192 fish 82 cups 105 avg 2.7")
+
+        result = capture.process_event(
+            ev,
+            cfg=_default_cfg(),
+            http_post=http.post,
+            http_get=http.get,
+            reply=replies,
+        )
+        assert result == {"action": "skip", "reason": "baader_fps_capture"}
+
+        assert len(http.posts) == 1
+        post = http.posts[0]
+        assert post["url"].endswith("/api/readings")
+        assert post["headers"]["X-FPS-PIN"] == SENTINEL_PIN
+        reading = post["json"]["reading"]
+        assert reading["baaderId"] == "192"
+        assert reading["fishPerMin"] == 82
+        assert reading["cupsPerMin"] == 105
+        assert reading["avgWeightKg"] == 2.7
+        assert "ts" in reading  # ISO timestamp added
+
+        # Verified once
+        assert len(http.gets) == 1
+        assert http.gets[0]["url"].endswith("/api/state")
+
+        # User received a saved confirmation
+        assert any("saved" in s.lower() or "ok" in s.lower() for s in replies.sent)
+
+    def test_valid_two_readings_posts_twice(self, monkeypatch):
+        capture = _load_capture()
+        monkeypatch.setenv("FPS_SAVE_PIN", SENTINEL_PIN)
+
+        http = _FakeHttp(state_body={
+            "readings": {
+                "baader192": {"fishPerMin": 82, "avgWeightKg": 2.7, "cupsPerMin": 105},
+                "baader212": {"fishPerMin": 48, "avgWeightKg": 1.3, "cupsPerMin": 130},
+            }
+        })
+        replies = _Replies()
+        ev = _make_event(text=(
+            "192 fish 82 cups 105 avg 2.7\n"
+            "212 fish 48 cups 130 avg 1.3"
+        ))
+
+        result = capture.process_event(
+            ev,
+            cfg=_default_cfg(),
+            http_post=http.post,
+            http_get=http.get,
+            reply=replies,
+        )
+        assert result == {"action": "skip", "reason": "baader_fps_capture"}
+
+        assert len(http.posts) == 2
+        baader_ids = sorted(p["json"]["reading"]["baaderId"] for p in http.posts)
+        assert baader_ids == ["192", "212"]
+
+    def test_incomplete_reading_sends_help_and_skips(self, monkeypatch):
+        capture = _load_capture()
+        monkeypatch.setenv("FPS_SAVE_PIN", SENTINEL_PIN)
+
+        http = _FakeHttp()
+        replies = _Replies()
+        # Missing avg weight
+        ev = _make_event(text="212 fish 48 cups 130")
+
+        result = capture.process_event(
+            ev,
+            cfg=_default_cfg(),
+            http_post=http.post,
+            http_get=http.get,
+            reply=replies,
+        )
+        assert result == {"action": "skip", "reason": "baader_fps_capture"}
+        # No POST attempted with an incomplete reading
+        assert http.posts == []
+        # A compact reply is sent that names the missing field
+        assert replies.sent
+        joined = "\n".join(replies.sent).lower()
+        assert "avgweightkg" in joined or "avg" in joined
+        # Reply does not leak the pin
+        assert SENTINEL_PIN not in joined
+
+    def test_out_of_scope_returns_none(self, monkeypatch):
+        capture = _load_capture()
+        monkeypatch.setenv("FPS_SAVE_PIN", SENTINEL_PIN)
+
+        http = _FakeHttp()
+        replies = _Replies()
+        # Wrong sender => out of scope
+        ev = _make_event(
+            text="192 fish 82 cups 105 avg 2.7", user_id="someone_else"
+        )
+
+        result = capture.process_event(
+            ev,
+            cfg=_default_cfg(),
+            http_post=http.post,
+            http_get=http.get,
+            reply=replies,
+        )
+        assert result is None
+        assert http.posts == []
+        assert http.gets == []
+        assert replies.sent == []
+
+    def test_no_baader_text_in_scope_returns_none(self, monkeypatch):
+        """In-scope channel/sender but the message has no baader payload.
+
+        We must not consume normal agent chat — return None so the gateway
+        falls through to the agent.
+        """
+        capture = _load_capture()
+        monkeypatch.setenv("FPS_SAVE_PIN", SENTINEL_PIN)
+
+        http = _FakeHttp()
+        replies = _Replies()
+        ev = _make_event(text="hey team how's it going?")
+
+        result = capture.process_event(
+            ev,
+            cfg=_default_cfg(),
+            http_post=http.post,
+            http_get=http.get,
+            reply=replies,
+        )
+        assert result is None
+        assert http.posts == []
+        assert replies.sent == []
+
+    def test_post_failure_reply_does_not_leak_pin(self, monkeypatch):
+        capture = _load_capture()
+        monkeypatch.setenv("FPS_SAVE_PIN", SENTINEL_PIN)
+
+        http = _FakeHttp(raise_on_post=True)
+        replies = _Replies()
+        ev = _make_event(text="192 fish 82 cups 105 avg 2.7")
+
+        result = capture.process_event(
+            ev,
+            cfg=_default_cfg(),
+            http_post=http.post,
+            http_get=http.get,
+            reply=replies,
+        )
+        assert result == {"action": "skip", "reason": "baader_fps_capture"}
+        # A failure reply went out
+        assert replies.sent
+        joined = "\n".join(replies.sent)
+        assert SENTINEL_PIN not in joined
+        # User-visible failure must be compact and not contain the raw
+        # exception (which embedded the pin in the test).
+        for reply in replies.sent:
+            assert "RuntimeError" not in reply
+            assert "Traceback" not in reply
+
+    def test_post_500_reply_does_not_leak_pin(self, monkeypatch):
+        capture = _load_capture()
+        monkeypatch.setenv("FPS_SAVE_PIN", SENTINEL_PIN)
+
+        http = _FakeHttp(post_status=500, post_body={"error": "boom"})
+        replies = _Replies()
+        ev = _make_event(text="192 fish 82 cups 105 avg 2.7")
+
+        result = capture.process_event(
+            ev,
+            cfg=_default_cfg(),
+            http_post=http.post,
+            http_get=http.get,
+            reply=replies,
+        )
+        assert result == {"action": "skip", "reason": "baader_fps_capture"}
+        joined = "\n".join(replies.sent)
+        assert SENTINEL_PIN not in joined
+
+    def test_verify_mismatch_warns_but_does_not_leak_pin(self, monkeypatch):
+        capture = _load_capture()
+        monkeypatch.setenv("FPS_SAVE_PIN", SENTINEL_PIN)
+
+        # POST succeeds, but verify returns a state where the reading
+        # doesn't match what we posted.
+        http = _FakeHttp(state_body={
+            "readings": {
+                "baader192": {"fishPerMin": 1, "avgWeightKg": 0.1, "cupsPerMin": 1},
+            }
+        })
+        replies = _Replies()
+        ev = _make_event(text="192 fish 82 cups 105 avg 2.7")
+
+        capture.process_event(
+            ev,
+            cfg=_default_cfg(),
+            http_post=http.post,
+            http_get=http.get,
+            reply=replies,
+        )
+        joined = "\n".join(replies.sent)
+        assert SENTINEL_PIN not in joined
+        # Some indication that verification didn't match.
+        assert any(
+            "verif" in r.lower() or "mismatch" in r.lower() for r in replies.sent
+        )
+
+    def test_pin_not_in_logs_or_exceptions(self, monkeypatch, caplog):
+        capture = _load_capture()
+        monkeypatch.setenv("FPS_SAVE_PIN", SENTINEL_PIN)
+        http = _FakeHttp(raise_on_post=True)
+        replies = _Replies()
+        ev = _make_event(text="192 fish 82 cups 105 avg 2.7")
+
+        with caplog.at_level("DEBUG"):
+            capture.process_event(
+                ev,
+                cfg=_default_cfg(),
+                http_post=http.post,
+                http_get=http.get,
+                reply=replies,
+            )
+        log_text = "\n".join(rec.getMessage() for rec in caplog.records)
+        assert SENTINEL_PIN not in log_text
+
+    def test_missing_pin_env_blocks_post(self, monkeypatch):
+        capture = _load_capture()
+        monkeypatch.delenv("FPS_SAVE_PIN", raising=False)
+        http = _FakeHttp()
+        replies = _Replies()
+        ev = _make_event(text="192 fish 82 cups 105 avg 2.7")
+        result = capture.process_event(
+            ev,
+            cfg=_default_cfg(),
+            http_post=http.post,
+            http_get=http.get,
+            reply=replies,
+        )
+        # In-scope, so we still skip + reply, but never call POST without a pin.
+        assert result == {"action": "skip", "reason": "baader_fps_capture"}
+        assert http.posts == []
+        assert replies.sent
+
+    def test_ambiguous_duplicate_does_not_post(self, monkeypatch):
+        """Reviewer blocker: ambiguous line must skip without POSTing."""
+        capture = _load_capture()
+        monkeypatch.setenv("FPS_SAVE_PIN", SENTINEL_PIN)
+
+        http = _FakeHttp()
+        replies = _Replies()
+        ev = _make_event(text="192 fish 82 fish 99 cups 105 avg 2.7")
+
+        result = capture.process_event(
+            ev,
+            cfg=_default_cfg(),
+            http_post=http.post,
+            http_get=http.get,
+            reply=replies,
+        )
+        assert result == {"action": "skip", "reason": "baader_fps_capture"}
+        assert http.posts == []
+        assert replies.sent
+        joined = "\n".join(replies.sent).lower()
+        # Compact guidance must name which field was ambiguous.
+        assert "ambiguous" in joined or "duplicate" in joined
+        assert "fish" in joined or "fishpermin" in joined
+        # No "Saved" confirmation must go out for an ambiguous line.
+        assert not any("saved baader" in s.lower() for s in replies.sent)
+        # Reply must not leak the pin.
+        assert SENTINEL_PIN not in joined
+
+    def test_post_200_ok_false_is_failure(self, monkeypatch):
+        """Reviewer blocker: HTTP 200 with {"ok": false} is a failure."""
+        capture = _load_capture()
+        monkeypatch.setenv("FPS_SAVE_PIN", SENTINEL_PIN)
+
+        http = _FakeHttp(post_status=200, post_body={"ok": False})
+        replies = _Replies()
+        ev = _make_event(text="192 fish 82 cups 105 avg 2.7")
+
+        result = capture.process_event(
+            ev,
+            cfg=_default_cfg(),
+            http_post=http.post,
+            http_get=http.get,
+            reply=replies,
+        )
+        assert result == {"action": "skip", "reason": "baader_fps_capture"}
+        # The POST happened
+        assert len(http.posts) == 1
+        # Must NOT verify, must NOT emit "Saved" confirmation.
+        assert http.gets == []
+        joined_lower = "\n".join(replies.sent).lower()
+        assert "saved baader" not in joined_lower
+        # A failure reply must have gone out.
+        assert any(
+            "failed" in s.lower() or "could not" in s.lower() or "couldn't" in s.lower()
+            for s in replies.sent
+        )
+        # Reply must not leak the pin.
+        assert SENTINEL_PIN not in "\n".join(replies.sent)
+
+    @pytest.mark.parametrize(
+        "post_body",
+        [
+            {},  # missing ok entirely
+            {"status": "ok"},  # ok missing, other fields present
+            {"ok": None},  # ok is None
+            {"ok": "false"},  # ok is the string "false"
+            {"ok": "true"},  # ok is the string "true" — still not exactly True
+            {"ok": 1},  # truthy but not exactly True
+            {"ok": 0},  # falsy non-False
+        ],
+        ids=[
+            "missing_ok",
+            "ok_absent_other_fields",
+            "ok_none",
+            "ok_string_false",
+            "ok_string_true",
+            "ok_int_one",
+            "ok_int_zero",
+        ],
+    )
+    def test_post_200_dict_body_without_ok_true_is_failure(
+        self, monkeypatch, post_body
+    ):
+        """HTTP 2xx with dict body where ok is not exactly True is a failure.
+
+        Reviewer blocker: previously only ``ok is False`` was treated as
+        failure, so missing/None/truthy-non-True values silently passed and
+        produced a (misleading) "Saved" reply.
+        """
+        capture = _load_capture()
+        monkeypatch.setenv("FPS_SAVE_PIN", SENTINEL_PIN)
+
+        http = _FakeHttp(post_status=200, post_body=post_body)
+        replies = _Replies()
+        ev = _make_event(text="192 fish 82 cups 105 avg 2.7")
+
+        result = capture.process_event(
+            ev,
+            cfg=_default_cfg(),
+            http_post=http.post,
+            http_get=http.get,
+            reply=replies,
+        )
+        assert result == {"action": "skip", "reason": "baader_fps_capture"}
+        # POST attempted exactly once.
+        assert len(http.posts) == 1
+        # Must NOT verify (no GET) and must NOT emit a "Saved" confirmation.
+        assert http.gets == []
+        joined = "\n".join(replies.sent)
+        assert "Saved baader" not in joined
+        assert "saved baader" not in joined.lower()
+        # Compact failure reply went out.
+        assert replies.sent
+        assert any(
+            "failed" in s.lower() or "could not" in s.lower() or "couldn't" in s.lower()
+            for s in replies.sent
+        )
+        # Reply must not leak the pin and must not contain raw body content.
+        assert SENTINEL_PIN not in joined
+        for reply in replies.sent:
+            assert "Traceback" not in reply
+
+    def test_post_201_dict_body_with_ok_true_succeeds(self, monkeypatch):
+        """Sanity: a 2xx response with ok=True still saves and verifies."""
+        capture = _load_capture()
+        monkeypatch.setenv("FPS_SAVE_PIN", SENTINEL_PIN)
+
+        http = _FakeHttp(post_status=201, post_body={"ok": True})
+        replies = _Replies()
+        ev = _make_event(text="192 fish 82 cups 105 avg 2.7")
+
+        result = capture.process_event(
+            ev,
+            cfg=_default_cfg(),
+            http_post=http.post,
+            http_get=http.get,
+            reply=replies,
+        )
+        assert result == {"action": "skip", "reason": "baader_fps_capture"}
+        assert len(http.posts) == 1
+        # Verify ran and Saved reply went out.
+        assert len(http.gets) == 1
+        assert any("saved baader" in s.lower() for s in replies.sent)


### PR DESCRIPTION
## Summary
- Add opt-in Wetfish Baader/FPS Telegram capture plugin.
- Parse Baader 192/212 updates and forward readings to the Wetfish FPS endpoint.
- Add a stable non-secret product User-Agent for live FPS compatibility.
- Include focused tests for parsing, plugin behavior, HTTP headers, and secret-safe logging.

## Test Plan
- `python -m pytest tests/plugins/test_wetfish_baader_fps_capture.py -q -o 'addopts='`

## Notes for review
- Plugin is opt-in and gated by config/allowlists.
- No raw FPS PIN or Telegram token is committed.
- Local Wetfish/Pulse planning handoff docs are included under `.hermes/plans/` for traceability.
