### PR TITLE
fix(runtime): enforce gateway budgets and context spill guards

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -190,6 +190,9 @@ def init_agent(
 
     agent.model = model
     agent.max_iterations = max_iterations
+    agent._configured_max_iterations = max_iterations
+    agent._last_resolved_turn_max_iterations = max_iterations
+    agent._external_turn_ceiling_active = max_iterations <= 8
     # Shared iteration budget — parent creates, children inherit.
     # Consumed by every LLM turn across parent + all subagents.
     agent.iteration_budget = iteration_budget or IterationBudget(max_iterations)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1922,6 +1922,15 @@ def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optiona
                 cfg_base_url = (model_cfg.get("base_url") or "").strip().rstrip("/")
                 if cfg_base_url:
                     base_url = cfg_base_url
+        # Also honor providers.anthropic.base_url so the fallback chain
+        # routes through a local Anthropic-compatible proxy when anthropic
+        # is the secondary provider (top-level model.provider differs).
+        if base_url == _ANTHROPIC_DEFAULT_BASE_URL:
+            providers_cfg = cfg.get("providers") or {}
+            anth_cfg = providers_cfg.get("anthropic") or {}
+            anth_base_url = str(anth_cfg.get("base_url") or "").strip().rstrip("/")
+            if anth_base_url:
+                base_url = anth_base_url
     except Exception:
         pass
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -741,10 +741,12 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # (not substring) — see GHSA-76xc-57q6-vm5m.
         if fb_base_url_hint and base_url_host_matches(fb_base_url_hint, "ollama.com") and not fb_api_key_hint:
             fb_api_key_hint = os.getenv("OLLAMA_API_KEY") or None
+        fb_api_mode_hint = (fb.get("api_mode") or "").strip() or None
         fb_client, _resolved_fb_model = resolve_provider_client(
             fb_provider, model=fb_model, raw_codex=True,
             explicit_base_url=fb_base_url_hint,
-            explicit_api_key=fb_api_key_hint)
+            explicit_api_key=fb_api_key_hint,
+            api_mode=fb_api_mode_hint)
         if fb_client is None:
             logging.warning(
                 "Fallback to %s failed: provider not configured",
@@ -758,7 +760,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             pass
 
         # Determine api_mode from provider / base URL / model
-        fb_api_mode = "chat_completions"
+        fb_api_mode = (fb.get("api_mode") or "").strip() or "chat_completions"
         fb_base_url = str(fb_client.base_url)
         _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
         if fb_provider == "openai-codex":

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -694,6 +694,43 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
     if not fb_provider or not fb_model:
         return agent._try_activate_fallback()  # skip invalid, try next
 
+    # Fallback must never receive a raw oversized payload.  The current
+    # request pressure is captured immediately before the primary provider
+    # call; if it exceeds this fallback's smaller context window, skip this
+    # fallback instead of amplifying a context failure into fake quota/auth
+    # errors.
+    pressure = getattr(agent, "_last_request_pressure", None)
+    if isinstance(pressure, dict):
+        try:
+            from agent.model_metadata import get_model_context_length
+            fb_ctx_for_guard = get_model_context_length(
+                fb_model,
+                base_url=str(fb.get("base_url") or ""),
+                api_key=str(fb.get("api_key") or ""),
+                provider=fb_provider,
+                config_context_length=None,
+            )
+            fb_threshold = min(180000, int((fb_ctx_for_guard or 200000) * 0.70))
+            if int(pressure.get("approx_tokens") or 0) >= fb_threshold:
+                logging.warning(
+                    "Fallback skip: request too large for fallback %s/%s (~%s tokens >= %s). Refusing raw oversized fallback.",
+                    fb_provider,
+                    fb_model,
+                    pressure.get("approx_tokens"),
+                    fb_threshold,
+                )
+                agent._fallback_disabled_due_to_context_size = True
+                return agent._try_activate_fallback(reason=reason)
+        except Exception as guard_exc:
+            logging.warning(
+                "Fallback skip: context-size guard failed for %s/%s (%s). Refusing raw fallback for safety.",
+                fb_provider,
+                fb_model,
+                guard_exc,
+            )
+            agent._fallback_disabled_due_to_context_size = True
+            return agent._try_activate_fallback(reason=reason)
+
     # Skip entries that resolve to the current (provider, model) — falling
     # back to the same backend that just failed loops the failure. Compare
     # base_url too so two distinct custom_providers entries pointing at the

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -293,9 +293,9 @@ def compress_context(
     if summary_error:
         if getattr(agent, "_last_compression_summary_warning", None) != summary_error:
             agent._last_compression_summary_warning = summary_error
-            agent._emit_warning(
-                f"⚠ Compression summary failed: {summary_error}. "
-                "Inserted a fallback context marker."
+            logger.warning(
+                "Compression summary failed during context compaction; fallback marker inserted internally: %s",
+                summary_error,
             )
     else:
         # No hard failure — but did the configured aux model error out
@@ -309,10 +309,10 @@ def compress_context(
             _aux_key = (_aux_fail_model, _aux_fail_err)
             if getattr(agent, "_last_aux_fallback_warning_key", None) != _aux_key:
                 agent._last_aux_fallback_warning_key = _aux_key
-                agent._emit_warning(
-                    f"ℹ Configured compression model '{_aux_fail_model}' failed "
-                    f"({_aux_fail_err or 'unknown error'}). Recovered using main model — "
-                    "check auxiliary.compression.model in config.yaml."
+                logger.warning(
+                    "Configured compression model %r failed during context compaction; recovered using main model: %s",
+                    _aux_fail_model,
+                    _aux_fail_err or "unknown error",
                 )
 
     todo_snapshot = agent._todo_store.format_for_injection()

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -33,7 +33,7 @@ from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.iteration_budget import IterationBudget
-from agent.memory_manager import build_memory_context_block
+from agent.memory_manager import build_memory_context_block, sanitize_context
 from agent.message_sanitization import (
     _repair_tool_call_arguments,
     _sanitize_messages_non_ascii,
@@ -3857,6 +3857,9 @@ def run_conversation(
         except Exception as _ver_err:
             logger.debug("file-mutation verifier footer failed: %s", _ver_err)
 
+    if final_response and not interrupted:
+        final_response = sanitize_context(final_response).strip()
+
     # Plugin hook: transform_llm_output
     # Fired once per turn after the tool-calling loop completes.
     # Plugins can transform the LLM's output text before it's returned.
@@ -3873,7 +3876,7 @@ def run_conversation(
             )
             for _hook_result in _transform_results:
                 if isinstance(_hook_result, str) and _hook_result:
-                    final_response = _hook_result
+                    final_response = sanitize_context(_hook_result).strip()
                     break  # First non-empty string wins
         except Exception as exc:
             logger.warning("transform_llm_output hook failed: %s", exc)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -462,6 +462,22 @@ def run_conversation(
     except Exception as exc:
         logger.warning("pre_llm_call hook failed: %s", exc)
 
+    # Core app/product ship-mode routing guard. Like plugin context, this is
+    # injected into the current API request only; it is not persisted and does
+    # not alter the cached system prompt. That makes the guard deterministic
+    # without breaking prefix caching or transcript cleanliness.
+    _ship_mode_routing_context = ""
+    try:
+        from agent.ship_mode_guard import build_ship_mode_routing_context
+        _ship_mode_routing_context = build_ship_mode_routing_context(
+            original_user_message,
+            conversation_history,
+            platform=getattr(agent, "platform", None) or "",
+            valid_tool_names=getattr(agent, "valid_tool_names", set()) or set(),
+        )
+    except Exception as exc:
+        logger.debug("ship-mode routing guard failed: %s", exc)
+
     # Main conversation loop
     api_call_count = 0
     final_response = None
@@ -695,6 +711,8 @@ def run_conversation(
                         _injections.append(_fenced)
                 if _plugin_user_context:
                     _injections.append(_plugin_user_context)
+                if _ship_mode_routing_context:
+                    _injections.append(_ship_mode_routing_context)
                 try:
                     classification = getattr(agent, "_last_turn_budget_classification", "")
                     delegate_depth = int(getattr(agent, "_delegate_depth", 0) or 0)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -212,7 +212,10 @@ def run_conversation(
     # NOTE: _turns_since_memory and _iters_since_skill are NOT reset here.
     # They are initialized in __init__ and must persist across run_conversation
     # calls so that nudge logic accumulates correctly in CLI mode.
-    agent.iteration_budget = IterationBudget(agent.max_iterations)
+    turn_max_iterations = agent._resolve_turn_max_iterations(user_message, conversation_history) if hasattr(agent, "_resolve_turn_max_iterations") else agent.max_iterations
+    agent.max_iterations = turn_max_iterations
+    agent._last_resolved_turn_max_iterations = turn_max_iterations
+    agent.iteration_budget = IterationBudget(turn_max_iterations)
 
     # Log conversation turn start for debugging/observability
     _preview_text = _summarize_user_message_for_log(user_message)
@@ -690,6 +693,18 @@ def run_conversation(
                         _injections.append(_fenced)
                 if _plugin_user_context:
                     _injections.append(_plugin_user_context)
+                try:
+                    classification = getattr(agent, "_last_turn_budget_classification", "")
+                    delegate_depth = int(getattr(agent, "_delegate_depth", 0) or 0)
+                    if (
+                        "delegate_task" in getattr(agent, "valid_tool_names", set())
+                        and delegate_depth == 0
+                        and classification in {"coding", "ship_mode"}
+                    ):
+                        from agent.prompt_builder import DELEGATION_COMPLEX_TASK_NUDGE
+                        _injections.append(DELEGATION_COMPLEX_TASK_NUDGE)
+                except Exception:
+                    pass
                 if _injections:
                     _base = api_msg.get("content", "")
                     if isinstance(_base, str):
@@ -922,6 +937,61 @@ def run_conversation(
                     _sanitize_structure_non_ascii(api_kwargs)
                 if agent.api_mode == "codex_responses":
                     api_kwargs = agent._get_transport().preflight_kwargs(api_kwargs, allow_stream=False)
+
+                # Final pre-API request-size guard. Gateway spill should catch
+                # poisoned sessions earlier, but system prompts, tools, memory,
+                # plugin context, native images, and provider transforms can
+                # inflate the actual request after gateway preflight. Fail closed
+                # before any provider or fallback sees the raw payload.
+                try:
+                    from gateway.context_spill import request_pressure_from_api_kwargs
+                    _ctx_len = getattr(getattr(agent, "context_compressor", None), "context_length", 200000)
+                    _pressure = request_pressure_from_api_kwargs(api_kwargs, context_length=_ctx_len)
+                    agent._last_request_pressure = _pressure
+                    if _pressure.get("too_large"):
+                        _guard_error = (
+                            "Hermes pre-API request-size guard blocked an oversized internal payload before provider call: "
+                            f"~{_pressure.get('approx_tokens')} estimated tokens, "
+                            f"{_pressure.get('request_bytes')} bytes; guard threshold {_pressure.get('threshold_tokens')} tokens. "
+                            "No provider call was made. Gateway context spill/quarantine should reduce this session before retry."
+                        )
+                        logger.error(_guard_error)
+                        return {
+                            "final_response": None,
+                            "messages": messages,
+                            "api_calls": api_call_count,
+                            "completed": False,
+                            "failed": True,
+                            "partial": True,
+                            "error": _guard_error,
+                            "request_size_guard": _pressure,
+                        }
+                except Exception as _guard_exc:
+                    if type(_guard_exc).__name__ == "SystemExit":
+                        raise
+                    _guard_error = (
+                        "Pre-API request size guard failed closed before provider call: "
+                        f"{type(_guard_exc).__name__}: {_guard_exc}. "
+                        "I did not send the request to a model."
+                    )
+                    logger.error(_guard_error)
+                    agent._last_request_pressure = {
+                        "approx_tokens": 0,
+                        "request_bytes": 0,
+                        "context_length": 0,
+                        "threshold_tokens": 0,
+                        "too_large": True,
+                    }
+                    return {
+                        "final_response": None,
+                        "messages": messages,
+                        "api_calls": api_call_count,
+                        "completed": False,
+                        "failed": True,
+                        "partial": True,
+                        "error": _guard_error,
+                        "request_size_guard": agent._last_request_pressure,
+                    }
 
                 try:
                     from hermes_cli.plugins import invoke_hook as _invoke_hook

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -212,6 +212,8 @@ def run_conversation(
     # NOTE: _turns_since_memory and _iters_since_skill are NOT reset here.
     # They are initialized in __init__ and must persist across run_conversation
     # calls so that nudge logic accumulates correctly in CLI mode.
+    if not hasattr(agent, "_configured_max_iterations"):
+        agent._configured_max_iterations = int(getattr(agent, "max_iterations", 90) or 90)
     turn_max_iterations = agent._resolve_turn_max_iterations(user_message, conversation_history) if hasattr(agent, "_resolve_turn_max_iterations") else agent.max_iterations
     agent.max_iterations = turn_max_iterations
     agent._last_resolved_turn_max_iterations = turn_max_iterations

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -177,6 +177,9 @@ _CONTEXT_OVERFLOW_PATTERNS = [
     "context window",
     "prompt is too long",
     "prompt exceeds max length",
+    "request buffer limit",
+    "exceeded request buffer limit",
+    "pre-api request size guard",
     "max_tokens",
     "maximum number of tokens",
     # vLLM / local inference server patterns

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -45,15 +45,36 @@ _INTERNAL_CONTEXT_RE = re.compile(
     r'<\s*memory-context\s*>[\s\S]*?</\s*memory-context\s*>',
     re.IGNORECASE,
 )
+_UNTERMINATED_INTERNAL_CONTEXT_RE = re.compile(
+    r'<\s*memory-context\s*>\s*'
+    r'\[System note:\s*The following is recalled memory context,\s*NOT new user input\.'
+    r'[\s\S]*$',
+    re.IGNORECASE,
+)
 _INTERNAL_NOTE_RE = re.compile(
     r'\[System note:\s*The following is recalled memory context,\s*NOT new user input\.\s*Treat as (?:informational background data|authoritative reference data[^\]]*)\.\]\s*',
+    re.IGNORECASE,
+)
+_LEADING_COMPACTION_FALLBACK_RE = re.compile(
+    r'^\s*\[CONTEXT COMPACTION\s+[^\]]*\]'
+    r'[\s\S]*?'
+    r'(?:Summary generation was unavailable\.[^\n]*(?:\n|$))'
+    r'(?:[^\n]*removed to free context space[^\n]*(?:\n|$))?'
+    r'(?:[^\n]*messages contained earlier work[^\n]*(?:\n|$))?',
+    re.IGNORECASE,
+)
+_LEADING_GATEWAY_SYSTEM_NOTE_RE = re.compile(
+    r'^\s*\[System note:\s*Your previous turn(?: in this session)? (?:was interrupted|in this session was interrupted)[^\]]*\]\s*',
     re.IGNORECASE,
 )
 
 
 def sanitize_context(text: str) -> str:
     """Strip fence tags, injected context blocks, and system notes from provider output."""
+    text = _LEADING_COMPACTION_FALLBACK_RE.sub('', text)
+    text = _LEADING_GATEWAY_SYSTEM_NOTE_RE.sub('', text)
     text = _INTERNAL_CONTEXT_RE.sub('', text)
+    text = _UNTERMINATED_INTERNAL_CONTEXT_RE.sub('', text)
     text = _INTERNAL_NOTE_RE.sub('', text)
     text = _FENCE_TAG_RE.sub('', text)
     return text

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -251,6 +251,23 @@ KANBAN_GUIDANCE = (
     "cross-agent handoffs that outlive one API loop."
 )
 
+DELEGATION_GUIDANCE = (
+    "# Delegation tool guidance\n"
+    "Use `delegate_task` only for bounded, synchronous subtasks that benefit "
+    "from isolated reasoning or parallel review. Do not use it for simple chat, "
+    "one-off checks, single-file reads, or tiny follow-ups. Do not use it for "
+    "durable work that must outlive the current turn; use cron, Kanban, or a "
+    "tracked background process for that. When delegating, pass all necessary "
+    "context explicitly and verify any child-reported side effects yourself."
+)
+
+DELEGATION_COMPLEX_TASK_NUDGE = (
+    "Complex coding/runtime/audit work is in progress. If independent lanes "
+    "would materially speed up verification or reduce context bloat, use "
+    "`delegate_task` for bounded parallel subtasks. Do not delegate trivial "
+    "checks or durable/background work."
+)
+
 TOOL_USE_ENFORCEMENT_GUIDANCE = (
     "# Tool-use enforcement\n"
     "You MUST use your tools to take action — do not describe what you would do "

--- a/agent/ship_mode_guard.py
+++ b/agent/ship_mode_guard.py
@@ -1,0 +1,144 @@
+"""Deterministic routing guard for serious app/product ship requests.
+
+This is intentionally cheap and conservative. It does not try to solve the
+request; it only decides whether a turn needs the app-ship/Kanban operating
+loop made explicit at API-call time so it is not dependent on the model
+remembering an optional skill from prior context.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Any, Iterable, Mapping, Sequence
+
+
+_SHIP_MODE_GUARD_MARKER = "Ship-mode routing guard"
+
+_TINY_FIX_RE = re.compile(
+    r"\b(fix|change|update|rename|tweak|adjust)\b.{0,80}\b(typo|copy|text|label|wording|readme|comment|color|colour|padding|margin)\b",
+    re.IGNORECASE | re.DOTALL,
+)
+
+_PLANNING_QUESTION_RE = re.compile(r"^\s*(what|why|how|should|could|would|is|are)\b", re.IGNORECASE)
+
+_ACTION_TERMS = (
+    "build", "ship", "implement", "finish", "create", "make", "launch",
+    "wire", "add", "restore", "repair", "redesign", "migrate", "port",
+)
+
+_SERIOUS_SCOPE_TERMS = (
+    "app", "feature", "product", "prd", "full-stack", "full stack",
+    "frontend", "backend", "api", "database", "db", "ui", "ux",
+    "runtime", "preview", "deploy", "deployment", "release", "workflow",
+    "onboarding", "dashboard", "agent", "kanban", "obsidian", "source-of-truth",
+)
+
+_HEAVY_TERMS = (
+    "end-to-end", "e2e", "ship", "shipped", "all the way", "don't stop",
+    "dont stop", "no stopping", "finish it", "full", "complete", "production",
+    "verify", "verified", "smoke-test", "smoke test", "review", "external review",
+    "multi-agent", "parallel", "background", "kanban", "preview",
+)
+
+_EXPLICIT_TRIGGERS = (
+    "app ship mode", "ship mode", "ship this end-to-end", "ship this end to end",
+    "build this app", "build me an app", "build an app", "new app mode",
+    "finish this end-to-end", "finish this end to end", "full app-dev",
+    "full app dev", "do not stop", "don't stop", "dont stop",
+)
+
+
+def _lower_text(value: Any) -> str:
+    return str(value or "").lower()
+
+
+def _history_text(conversation_history: Sequence[Mapping[str, Any]] | None, *, limit: int = 8) -> str:
+    if not conversation_history:
+        return ""
+    parts: list[str] = []
+    for msg in list(conversation_history)[-limit:]:
+        if not isinstance(msg, Mapping):
+            continue
+        content = msg.get("content", "")
+        if isinstance(content, str):
+            parts.append(content[:500])
+    return "\n".join(parts)
+
+
+def is_serious_app_ship_request(
+    user_message: str,
+    conversation_history: Sequence[Mapping[str, Any]] | None = None,
+) -> bool:
+    """Return True for app/product build requests that need ship-mode routing.
+
+    The detector is conservative by design:
+    - explicit ship/app-mode phrases always match;
+    - otherwise it requires an action, an app/product/dev scope marker, and a
+      heavy/durable marker, with recent history allowed to provide scope;
+    - tiny one-file/copy fixes and question-only planning prompts are excluded.
+    """
+    text = _lower_text(user_message)
+    if not text or _SHIP_MODE_GUARD_MARKER.lower() in text:
+        return False
+    if _TINY_FIX_RE.search(text):
+        return False
+    if _PLANNING_QUESTION_RE.search(text) and not any(trigger in text for trigger in _EXPLICIT_TRIGGERS):
+        return False
+
+    recent = _lower_text(_history_text(conversation_history))
+    combined = f"{text}\n{recent}"
+
+    if any(trigger in text for trigger in _EXPLICIT_TRIGGERS):
+        return True
+
+    has_action = any(re.search(rf"\b{re.escape(term)}\b", text) for term in _ACTION_TERMS)
+    if not has_action:
+        return False
+
+    has_scope = any(term in combined for term in _SERIOUS_SCOPE_TERMS)
+    has_heavy = any(term in combined for term in _HEAVY_TERMS)
+
+    return bool(has_scope and has_heavy)
+
+
+def build_ship_mode_routing_context(
+    user_message: str,
+    conversation_history: Sequence[Mapping[str, Any]] | None = None,
+    *,
+    platform: str | None = None,
+    valid_tool_names: Iterable[str] | None = None,
+) -> str:
+    """Build the API-only routing nudge for serious ship-mode turns.
+
+    Returns an empty string when the turn should proceed normally. The context
+    is intended to be appended to the current user message at API-call time, not
+    persisted to transcripts and not added to the cached system prompt.
+    """
+    platform_key = (platform or "").lower().strip()
+    if platform_key == "cron" or os.getenv("HERMES_KANBAN_TASK"):
+        return ""
+    if not is_serious_app_ship_request(user_message, conversation_history):
+        return ""
+
+    tools = set(valid_tool_names or [])
+    todo_phrase = "Use the todo tool" if "todo" in tools else "Write a concrete todo list"
+    kanban_phrase = (
+        "route durable/parallel lanes into Kanban tasks when appropriate"
+        if "kanban_create" in tools or "kanban_show" in tools
+        else "route durable/parallel lanes into Kanban or explicit worker tasks when appropriate"
+    )
+
+    return (
+        f"[{_SHIP_MODE_GUARD_MARKER}: this request matches serious app/build/product execution. "
+        "Treat app-ship-mode/Kanban operating rules as mandatory for this turn, even if the skill was not previously loaded. "
+        f"{todo_phrase} before implementation; resolve source-of-truth/PRD/Obsidian/repo context before coding; "
+        f"{kanban_phrase}; preserve the requested scope instead of shrinking it; verify real runtime behavior and run review before claiming shipped. "
+        "Tiny/single-file fixes are intentionally excluded from this guard.]"
+    )
+
+
+__all__ = [
+    "build_ship_mode_routing_context",
+    "is_serious_app_ship_request",
+]

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -248,16 +248,13 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     _skill_commands_platform = _resolve_skill_commands_platform()
     _skill_commands = {}
     try:
-        from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, _get_disabled_skill_names
-        from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
+        from tools.skills_tool import _parse_frontmatter, skill_matches_platform, _get_disabled_skill_names, _skill_search_dirs
+        from agent.skill_utils import iter_skill_index_files
         disabled = _get_disabled_skill_names()
         seen_names: set = set()
 
-        # Scan local dir first, then external dirs
-        dirs_to_scan = []
-        if SKILLS_DIR.exists():
-            dirs_to_scan.append(SKILLS_DIR)
-        dirs_to_scan.extend(get_external_skills_dirs())
+        # Scan profile, external dirs, then bundled fallback (profile wins by seen_names).
+        dirs_to_scan = _skill_search_dirs()
 
         for scan_dir in dirs_to_scan:
             for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -29,6 +29,8 @@ from typing import Any, Dict, List, Optional
 
 from agent.prompt_builder import (
     DEFAULT_AGENT_IDENTITY,
+    DELEGATION_COMPLEX_TASK_NUDGE,
+    DELEGATION_GUIDANCE,
     GOOGLE_MODEL_OPERATIONAL_GUIDANCE,
     HERMES_AGENT_HELP_GUIDANCE,
     KANBAN_GUIDANCE,
@@ -114,6 +116,8 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # this block.
     if "kanban_show" in agent.valid_tool_names:
         tool_guidance.append(KANBAN_GUIDANCE)
+    if "delegate_task" in agent.valid_tool_names:
+        tool_guidance.append(DELEGATION_GUIDANCE)
     if tool_guidance:
         stable_parts.append(" ".join(tool_guidance))
 

--- a/cli.py
+++ b/cli.py
@@ -329,7 +329,16 @@ def load_cli_config() -> Dict[str, Any]:
             "threshold": 0.50,    # Compress at 50% of model's context limit
         },
         "agent": {
-            "max_turns": 90,  # Default max tool-calling iterations (shared with subagents)
+            "max_turns": 90,  # Legacy global default; per-surface turn_budgets shape runtime caps.
+            "turn_budgets": {
+                "cli": 16,
+                "gateway": 32,
+                "api_server": 32,
+                "cron": 90,
+                "lightweight_followup": 6,
+                "coding": 90,
+                "ship_mode": 128,
+            },
             "verbose": False,
             "system_prompt": "",
             "prefill_messages_file": "",
@@ -386,7 +395,7 @@ def load_cli_config() -> Dict[str, Any]:
             },
         },
         "delegation": {
-            "max_iterations": 45,  # Max tool-calling turns per child agent
+            "max_iterations": 90,  # Max tool-calling turns per child agent
             "model": "",       # Subagent model override (empty = inherit parent model)
             "provider": "",    # Subagent provider override (empty = inherit parent provider)
             "base_url": "",    # Direct OpenAI-compatible endpoint for subagents
@@ -470,6 +479,28 @@ def load_cli_config() -> Dict[str, Any]:
                 and agent_file_config.get("max_turns") is not None
             ):
                 defaults["agent"]["max_turns"] = file_config["max_turns"]
+
+            # Preserve legacy non-default max_turns configs. The built-in CLI
+            # default includes turn_budgets.cli=16; if an older user config only
+            # sets max_turns: N, leaving that default budget in the merged dict
+            # would incorrectly shadow the user's explicit global override.
+            agent_file_config = file_config.get("agent")
+            effective_agent_max_turns = defaults.get("agent", {}).get("max_turns")
+            if (
+                (
+                    isinstance(agent_file_config, dict)
+                    and "turn_budgets" not in agent_file_config
+                )
+                and effective_agent_max_turns not in (None, 90, "90")
+            ) or (
+                "max_turns" in file_config
+                and not (
+                    isinstance(agent_file_config, dict)
+                    and "turn_budgets" in agent_file_config
+                )
+                and effective_agent_max_turns not in (None, 90, "90")
+            ):
+                defaults["agent"].pop("turn_budgets", None)
         except Exception as e:
             logger.warning("Failed to load cli-config.yaml: %s", e)
 
@@ -2666,20 +2697,14 @@ class HermesCLI:
             self.api_key = api_key or os.getenv("OPENROUTER_API_KEY") or os.getenv("OPENAI_API_KEY")
         else:
             self.api_key = api_key or os.getenv("OPENAI_API_KEY") or os.getenv("OPENROUTER_API_KEY")
-        # Max turns priority: CLI arg > config file > env var > default
+        # Max turns priority: CLI arg > task-shaped CLI budget resolver.
+        # The resolver preserves legacy non-default global overrides but keeps
+        # ordinary CLI sessions small when the global default is still 90.
         if max_turns is not None:  # CLI arg was explicitly set
             self.max_turns = max_turns
-        elif CLI_CONFIG["agent"].get("max_turns"):
-            self.max_turns = CLI_CONFIG["agent"]["max_turns"]
-        elif CLI_CONFIG.get("max_turns"):  # Backwards compat: root-level max_turns
-            self.max_turns = CLI_CONFIG["max_turns"]
-        elif os.getenv("HERMES_MAX_ITERATIONS"):
-            try:
-                self.max_turns = int(os.getenv("HERMES_MAX_ITERATIONS", ""))
-            except (TypeError, ValueError):
-                self.max_turns = 90
         else:
-            self.max_turns = 90
+            from hermes_cli.config import resolve_agent_max_turns
+            self.max_turns = resolve_agent_max_turns(CLI_CONFIG, mode="cli")
         
         # Parse and validate toolsets
         self.enabled_toolsets = toolsets

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -22,6 +22,7 @@ from typing import Optional, Dict, List, Any, Union
 logger = logging.getLogger(__name__)
 
 from hermes_time import now as _hermes_now
+from hermes_cli.runtime_safety import ONESHOT_GRACE_SECONDS, is_expired_oneshot
 from utils import atomic_replace
 
 try:
@@ -912,6 +913,38 @@ def advance_next_run(job_id: str) -> bool:
         return False
 
 
+def expire_stale_oneshot_jobs(now: Optional[datetime] = None) -> List[Dict[str, Any]]:
+    """Disable stale, unrun one-shot jobs without deleting their records.
+
+    One-shot jobs are recoverable only inside ``ONESHOT_GRACE_SECONDS``. After
+    that, a gateway restart/startup tick must not execute them; mark them as
+    expired so status/doctor can surface what happened.
+    """
+    with _jobs_file_lock:
+        return _expire_stale_oneshot_jobs_locked(now=now)
+
+
+def _expire_stale_oneshot_jobs_locked(now: Optional[datetime] = None) -> List[Dict[str, Any]]:
+    if now is None:
+        now = _hermes_now()
+    raw_jobs = load_jobs()
+    expired: List[Dict[str, Any]] = []
+    changed = False
+    for job in raw_jobs:
+        if not is_expired_oneshot(job, now, grace_seconds=ONESHOT_GRACE_SECONDS):
+            continue
+        job["enabled"] = False
+        job["state"] = "expired"
+        job["expired_at"] = now.isoformat()
+        job["next_run_at"] = None
+        job["last_error"] = "one-shot expired before scheduler startup/tick"
+        expired.append(_normalize_job_record(job))
+        changed = True
+    if changed:
+        save_jobs(raw_jobs)
+    return expired
+
+
 def get_due_jobs() -> List[Dict[str, Any]]:
     """Get all jobs that are due to run now.
 
@@ -927,6 +960,9 @@ def get_due_jobs() -> List[Dict[str, Any]]:
 def _get_due_jobs_locked() -> List[Dict[str, Any]]:
     """Inner implementation of get_due_jobs(); must be called with _jobs_file_lock held."""
     now = _hermes_now()
+    expired = _expire_stale_oneshot_jobs_locked(now=now)
+    if expired:
+        logger.info("Expired %d stale one-shot cron job(s) before due selection", len(expired))
     raw_jobs = load_jobs()
     jobs = [_apply_skill_fields(j) for j in copy.deepcopy(raw_jobs)]
     due = []

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1346,8 +1346,9 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                     logger.warning("Job '%s': failed to parse prefill messages file '%s': %s", job_id, pfpath, e)
                     prefill_messages = None
 
-        # Max iterations
-        max_iterations = _cfg.get("agent", {}).get("max_turns") or _cfg.get("max_turns") or 90
+        # Max iterations: cron keeps the durable-worker budget, not the gateway/chat cap.
+        from hermes_cli.config import resolve_agent_max_turns
+        max_iterations = resolve_agent_max_turns(_cfg, mode="cron")
 
         # Provider routing
         pr = _cfg.get("provider_routing", {})

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -759,6 +759,20 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
     if not path.is_file():
         return False, f"Script path is not a file: {path}"
 
+    try:
+        from hermes_cli.runtime_safety import classify_gateway_control_text
+
+        script_body = path.read_text(encoding="utf-8", errors="ignore")[:20000]
+        gateway_reason = classify_gateway_control_text(script_body)
+        if gateway_reason and gateway_reason != "gateway_control_adjacent":
+            return False, (
+                "BLOCKED: cron script contains Hermes gateway lifecycle control "
+                f"({gateway_reason}). Run gateway stop/restart/kill commands manually "
+                "outside cron after explicit review."
+            )
+    except Exception as exc:
+        logger.debug("Failed to scan cron script for gateway lifecycle controls: %s", exc)
+
     script_timeout = _get_script_timeout()
 
     # Pick an interpreter by extension.  Bash for .sh/.bash, Python for

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -949,6 +949,9 @@ def load_gateway_config() -> GatewayConfig:
                 hbl = discord_cfg.get("history_backfill_limit")
                 if hbl is not None and not os.getenv("DISCORD_HISTORY_BACKFILL_LIMIT"):
                     os.environ["DISCORD_HISTORY_BACKFILL_LIMIT"] = str(hbl)
+                hbmc = discord_cfg.get("history_backfill_max_chars")
+                if hbmc is not None and not os.getenv("DISCORD_HISTORY_BACKFILL_MAX_CHARS"):
+                    os.environ["DISCORD_HISTORY_BACKFILL_MAX_CHARS"] = str(hbmc)
                 # allow_mentions: granular control over what the bot can ping.
                 # Safe defaults (no @everyone/roles) are applied in the adapter;
                 # these YAML keys only override when set and let users opt back

--- a/gateway/context_spill.py
+++ b/gateway/context_spill.py
@@ -161,7 +161,13 @@ def load_context_spill_config(
     allow_unsafe = bool(allow_unsafe_paths or raw_cfg.get("allow_unsafe_paths") or env_unsafe)
 
     wiki_dir = _resolve_path(raw_cfg.get("wiki_dir"), "~/wiki/outputs/gateway-context-spills")
-    raw_state_dir = _resolve_path(raw_cfg.get("raw_state_dir"), str(hermes_home / "state" / "context-spills"))
+    raw_state_value = raw_cfg.get("raw_state_dir")
+    # DEFAULT_CONFIG historically stores ~/.hermes explicitly. In profile or
+    # custom-HERMES_HOME runs, treat that bundled default as "under this active
+    # Hermes home" instead of validating it against the wrong home directory.
+    if raw_state_value in (None, "~/.hermes/state/context-spills"):
+        raw_state_value = str(hermes_home / "state" / "context-spills")
+    raw_state_dir = _resolve_path(raw_state_value, str(hermes_home / "state" / "context-spills"))
     _validate_spill_paths(wiki_dir, raw_state_dir, hermes_home, allow_unsafe=allow_unsafe)
 
     return ContextSpillConfig(
@@ -590,9 +596,13 @@ def request_pressure_from_api_kwargs(api_kwargs: dict[str, Any], *, context_leng
     """Estimate final provider request pressure from built API kwargs."""
     messages = api_kwargs.get("messages") if isinstance(api_kwargs, dict) else []
     if not isinstance(messages, list):
-        messages = api_kwargs.get("input") if isinstance(api_kwargs, dict) else []
-    if not isinstance(messages, list):
-        messages = []
+        request_input = api_kwargs.get("input") if isinstance(api_kwargs, dict) else []
+        if isinstance(request_input, list):
+            messages = request_input
+        elif request_input is None:
+            messages = []
+        else:
+            messages = [{"role": "user", "content": request_input}]
     tools = api_kwargs.get("tools") if isinstance(api_kwargs, dict) else None
     system_prompt = ""
     if messages and isinstance(messages[0], dict) and messages[0].get("role") == "system":

--- a/gateway/context_spill.py
+++ b/gateway/context_spill.py
@@ -1,0 +1,628 @@
+"""Gateway context spill and quarantine helpers.
+
+Deterministic admission control for gateway sessions that have grown too
+large to send safely to an LLM.  This module is intentionally file-only: it
+must not call auxiliary models while deciding or writing a spill.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+from agent.model_metadata import estimate_messages_tokens_rough
+from hermes_constants import get_hermes_home
+
+
+_DEFAULT_HARD_TOKEN_LIMIT = 180_000
+_DEFAULT_HARD_MESSAGE_LIMIT = 180
+_DEFAULT_HARD_CHAR_LIMIT = 500_000
+_DEFAULT_REQUEST_BYTE_LIMIT = 1_800_000
+_DEFAULT_EXCERPT_CHARS = 24_000
+_DEFAULT_RECOVERY_ASK_CHARS = 2_000
+_MAX_RECOVERY_MESSAGE_CHARS = 4_000
+_MAX_USER_NOTICE_CHARS = 500
+_MAX_TRANSCRIPT_MESSAGE_CHARS = 1_200
+_MAX_TOOL_EXCERPT_CHARS = 500
+_DEFAULT_TOOL_SCHEMA_OVERHEAD_TOKENS = 20_000
+_DEFAULT_IMAGE_TOKEN_BUDGET = 2_000
+
+
+@dataclass(frozen=True)
+class ContextSpillConfig:
+    enabled: bool = True
+    mode: str = "enforce"
+    wiki_dir: Path = Path("~/wiki/outputs/gateway-context-spills")
+    raw_state_dir: Path = Path("~/.hermes/state/context-spills")
+    token_threshold_ratio: float = 0.70
+    hard_token_limit: int = _DEFAULT_HARD_TOKEN_LIMIT
+    hard_message_limit: int = _DEFAULT_HARD_MESSAGE_LIMIT
+    hard_char_limit: int = _DEFAULT_HARD_CHAR_LIMIT
+    hard_request_byte_limit: int = _DEFAULT_REQUEST_BYTE_LIMIT
+    include_raw_state: bool = True
+    include_redacted_wiki_excerpt_chars: int = _DEFAULT_EXCERPT_CHARS
+    reset_live_session: bool = True
+    notify_user: bool = True
+    fallback_safe: bool = True
+    retention_days: int = 30
+    allow_unsafe_paths: bool = False
+
+
+@dataclass(frozen=True)
+class ContextSpillDecision:
+    should_spill: bool
+    reason: str
+    approx_tokens: int
+    char_count: int
+    message_count: int
+    threshold_tokens: int
+    request_bytes: int = 0
+    stage: str = "unknown"
+
+
+@dataclass(frozen=True)
+class ContextSpillResult:
+    spill_id: str
+    wiki_path: Optional[Path]
+    raw_path: Optional[Path]
+    manifest_path: Optional[Path]
+    recovery_message: str
+    user_notice: str
+    decision: ContextSpillDecision
+
+
+class ContextSpillWriteError(RuntimeError):
+    """Raised when a required spill artifact cannot be written safely."""
+
+
+def _coerce_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return str(value).strip().lower() in {"1", "true", "yes", "on", "enforce"}
+
+
+def _coerce_int(value: Any, default: int, *, minimum: int = 0) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed >= minimum else default
+
+
+def _coerce_ratio(value: Any, default: float) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    if parsed <= 0 or parsed > 1:
+        return default
+    return parsed
+
+
+def _resolve_path(value: Any, default: str) -> Path:
+    raw = str(value or default)
+    return Path(os.path.expandvars(os.path.expanduser(raw))).resolve()
+
+
+def _path_is_under(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def _validate_spill_paths(wiki_dir: Path, raw_dir: Path, hermes_home: Path, *, allow_unsafe: bool) -> None:
+    if allow_unsafe:
+        return
+    home_wiki = (Path.home() / "wiki").resolve()
+    default_raw_root = (hermes_home / "state" / "context-spills").resolve()
+    if wiki_dir.exists() and wiki_dir.is_symlink():
+        raise ValueError(f"gateway_context_spill.wiki_dir cannot be a symlink: {wiki_dir}")
+    if raw_dir.exists() and raw_dir.is_symlink():
+        raise ValueError(f"gateway_context_spill.raw_state_dir cannot be a symlink: {raw_dir}")
+    if not _path_is_under(wiki_dir, home_wiki):
+        raise ValueError(f"gateway_context_spill.wiki_dir must stay under {home_wiki}: {wiki_dir}")
+    if not _path_is_under(raw_dir, default_raw_root):
+        raise ValueError(f"gateway_context_spill.raw_state_dir must stay under {default_raw_root}: {raw_dir}")
+
+
+def load_context_spill_config(
+    user_config: Optional[dict[str, Any]] = None,
+    hermes_home: Optional[Path] = None,
+    *,
+    allow_unsafe_paths: bool = False,
+) -> ContextSpillConfig:
+    """Load and validate gateway context-spill config from config.yaml data."""
+    hermes_home = Path(hermes_home or get_hermes_home()).resolve()
+    user_config = user_config or {}
+    raw_cfg = user_config.get("gateway_context_spill", {})
+    if raw_cfg is None:
+        raw_cfg = {}
+    if not isinstance(raw_cfg, dict):
+        raw_cfg = {}
+
+    mode = str(raw_cfg.get("mode") or "enforce").strip().lower()
+    if mode not in {"enforce", "shadow", "off"}:
+        mode = "enforce"
+    enabled = _coerce_bool(raw_cfg.get("enabled"), True) and mode != "off"
+    env_unsafe = os.getenv("HERMES_CONTEXT_SPILL_ALLOW_UNSAFE_PATHS", "").strip().lower() in {"1", "true", "yes"}
+    allow_unsafe = bool(allow_unsafe_paths or raw_cfg.get("allow_unsafe_paths") or env_unsafe)
+
+    wiki_dir = _resolve_path(raw_cfg.get("wiki_dir"), "~/wiki/outputs/gateway-context-spills")
+    raw_state_dir = _resolve_path(raw_cfg.get("raw_state_dir"), str(hermes_home / "state" / "context-spills"))
+    _validate_spill_paths(wiki_dir, raw_state_dir, hermes_home, allow_unsafe=allow_unsafe)
+
+    return ContextSpillConfig(
+        enabled=enabled,
+        mode=mode,
+        wiki_dir=wiki_dir,
+        raw_state_dir=raw_state_dir,
+        token_threshold_ratio=_coerce_ratio(raw_cfg.get("token_threshold_ratio"), 0.70),
+        hard_token_limit=_coerce_int(raw_cfg.get("hard_token_limit"), _DEFAULT_HARD_TOKEN_LIMIT, minimum=1),
+        hard_message_limit=_coerce_int(raw_cfg.get("hard_message_limit"), _DEFAULT_HARD_MESSAGE_LIMIT, minimum=1),
+        hard_char_limit=_coerce_int(raw_cfg.get("hard_char_limit"), _DEFAULT_HARD_CHAR_LIMIT, minimum=1),
+        hard_request_byte_limit=_coerce_int(raw_cfg.get("hard_request_byte_limit"), _DEFAULT_REQUEST_BYTE_LIMIT, minimum=1),
+        include_raw_state=_coerce_bool(raw_cfg.get("include_raw_state"), True),
+        include_redacted_wiki_excerpt_chars=_coerce_int(raw_cfg.get("include_redacted_wiki_excerpt_chars"), _DEFAULT_EXCERPT_CHARS, minimum=0),
+        reset_live_session=_coerce_bool(raw_cfg.get("reset_live_session"), True),
+        notify_user=_coerce_bool(raw_cfg.get("notify_user"), True),
+        fallback_safe=_coerce_bool(raw_cfg.get("fallback_safe"), True),
+        retention_days=_coerce_int(raw_cfg.get("retention_days"), 30, minimum=1),
+        allow_unsafe_paths=allow_unsafe,
+    )
+
+
+def _message_content_chars(value: Any) -> int:
+    if isinstance(value, str):
+        return len(value)
+    return len(json.dumps(value, ensure_ascii=False, default=str))
+
+
+def estimate_gateway_payload(
+    history: list[dict[str, Any]],
+    message_text: str = "",
+    *,
+    system_prompt: str = "",
+    channel_prompt: str = "",
+    tool_schema_count: int = 0,
+    image_count: int = 0,
+    extra_overhead_tokens: int = _DEFAULT_TOOL_SCHEMA_OVERHEAD_TOKENS,
+) -> tuple[int, int, int, int]:
+    """Return rough tokens, chars, message count, and request bytes."""
+    safe_history = history if isinstance(history, list) else []
+    current = []
+    if message_text:
+        current.append({"role": "user", "content": message_text})
+    messages = safe_history + current
+    approx_tokens = estimate_messages_tokens_rough(messages)
+    approx_tokens += max(0, int(extra_overhead_tokens or 0))
+    approx_tokens += max(0, int(tool_schema_count or 0)) * 750
+    approx_tokens += max(0, int(image_count or 0)) * _DEFAULT_IMAGE_TOKEN_BUDGET
+    approx_tokens += max(0, (len(system_prompt or "") + len(channel_prompt or "")) // 4)
+
+    char_count = sum(_message_content_chars(m) for m in safe_history)
+    char_count += len(message_text or "") + len(system_prompt or "") + len(channel_prompt or "")
+    message_count = len(safe_history) + (1 if message_text else 0)
+    request_bytes = len(json.dumps(messages, ensure_ascii=False, default=str).encode("utf-8", "ignore"))
+    request_bytes += len((system_prompt or "").encode("utf-8", "ignore"))
+    request_bytes += len((channel_prompt or "").encode("utf-8", "ignore"))
+    return approx_tokens, char_count, message_count, request_bytes
+
+
+def decide_context_spill(
+    history: list[dict[str, Any]],
+    message_text: str = "",
+    *,
+    context_length: int,
+    config: ContextSpillConfig,
+    stage: str = "unknown",
+    system_prompt: str = "",
+    channel_prompt: str = "",
+    tool_schema_count: int = 0,
+    image_count: int = 0,
+    extra_overhead_tokens: int = _DEFAULT_TOOL_SCHEMA_OVERHEAD_TOKENS,
+) -> ContextSpillDecision:
+    """Decide whether the gateway must spill/quarantine before model call."""
+    context_length = int(context_length or 200_000)
+    threshold_tokens = max(1, min(config.hard_token_limit, max(50_000, int(context_length * config.token_threshold_ratio))))
+    approx_tokens, char_count, message_count, request_bytes = estimate_gateway_payload(
+        history,
+        message_text,
+        system_prompt=system_prompt,
+        channel_prompt=channel_prompt,
+        tool_schema_count=tool_schema_count,
+        image_count=image_count,
+        extra_overhead_tokens=extra_overhead_tokens,
+    )
+    reasons: list[str] = []
+    if message_count >= config.hard_message_limit:
+        reasons.append(f"message_limit:{message_count}>={config.hard_message_limit}")
+    if approx_tokens >= threshold_tokens:
+        reasons.append(f"token_limit:{approx_tokens}>={threshold_tokens}")
+    if char_count >= config.hard_char_limit:
+        reasons.append(f"char_limit:{char_count}>={config.hard_char_limit}")
+    if request_bytes >= config.hard_request_byte_limit:
+        reasons.append(f"request_byte_limit:{request_bytes}>={config.hard_request_byte_limit}")
+    return ContextSpillDecision(
+        should_spill=bool(config.enabled and reasons),
+        reason=",".join(reasons) if reasons else "within_limits",
+        approx_tokens=approx_tokens,
+        char_count=char_count,
+        message_count=message_count,
+        threshold_tokens=threshold_tokens,
+        request_bytes=request_bytes,
+        stage=stage,
+    )
+
+
+def _slug(value: str, max_len: int = 48) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9._-]+", "-", value or "session").strip("-._")
+    return (slug or "session")[:max_len]
+
+
+def _atomic_write_text(path: Path, text: str, *, mode: int = 0o644) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    tmp_path = Path(tmp_name)
+    try:
+        os.fchmod(fd, mode)
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, path)
+        try:
+            dir_fd = os.open(str(path.parent), os.O_RDONLY)
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)
+        except OSError:
+            pass
+    except BaseException:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any], *, mode: int = 0o600) -> None:
+    _atomic_write_text(path, json.dumps(payload, ensure_ascii=False, indent=2, default=str), mode=mode)
+
+
+def _redact(text: str) -> str:
+    from agent.redact import redact_sensitive_text
+    return redact_sensitive_text(text or "", force=True)
+
+
+def _metadata_for(source: Any, session_entry: Any) -> dict[str, Any]:
+    platform = getattr(getattr(source, "platform", None), "value", None) or str(getattr(source, "platform", "") or "")
+    return {
+        "platform": platform,
+        "chat_id": getattr(source, "chat_id", None),
+        "thread_id": getattr(source, "thread_id", None),
+        "user_id": getattr(source, "user_id", None),
+        "chat_type": getattr(source, "chat_type", None),
+        "session_key": getattr(session_entry, "session_key", None),
+        "session_id": getattr(session_entry, "session_id", None),
+    }
+
+
+def _compact_prior_gateway_handoff(text: str) -> str:
+    stripped = text.lstrip()
+    if not stripped.startswith("[GATEWAY HANDOFF]"):
+        return text
+    lines = stripped.splitlines()
+    kept: list[str] = []
+    for line in lines:
+        kept.append(line)
+        if line.startswith("Current user ask"):
+            break
+    ask_lines: list[str] = []
+    in_ask = False
+    for line in lines:
+        if line.startswith("Current user ask"):
+            in_ask = True
+            continue
+        if in_ask and line.startswith("Instructions:"):
+            break
+        if in_ask:
+            ask_lines.append(line)
+    ask = "\n".join(ask_lines).strip()
+    if ask:
+        return "\n".join(kept) + f"\n{ask[:_MAX_TRANSCRIPT_MESSAGE_CHARS]}\n[prior gateway handoff body omitted; use its linked wiki handoff if needed]"
+    return "[prior gateway handoff omitted; use its linked wiki handoff if needed]"
+
+
+def _compact_tool_excerpt(text: str) -> str:
+    prefix = "[tool output omitted from wiki handoff; raw 0600 bundle preserves full content]"
+    if not text:
+        return prefix
+    tool_name = "tool"
+    try:
+        payload = json.loads(text)
+        if isinstance(payload, dict):
+            for key in ("tool", "name", "function", "recipient_name"):
+                value = payload.get(key)
+                if isinstance(value, str) and value.strip():
+                    tool_name = value.strip()
+                    break
+            error = payload.get("error")
+            if error:
+                err = str(error)[:_MAX_TOOL_EXCERPT_CHARS]
+                return f"[{tool_name} output omitted from wiki handoff; raw 0600 bundle preserves full content]\nerror: {err}"
+    except Exception:
+        pass
+    return f"[{tool_name} output omitted from wiki handoff; {len(text)} chars; raw 0600 bundle preserves full content]"
+
+
+def _message_excerpt_text(role: str, content: Any) -> str:
+    text = content if isinstance(content, str) else json.dumps(content, ensure_ascii=False, default=str)
+    role_norm = (role or "").lower()
+    if role_norm == "tool":
+        return _compact_tool_excerpt(text)
+    text = _compact_prior_gateway_handoff(text)
+    if len(text) > _MAX_TRANSCRIPT_MESSAGE_CHARS:
+        return text[:_MAX_TRANSCRIPT_MESSAGE_CHARS] + f"\n[… {len(text) - _MAX_TRANSCRIPT_MESSAGE_CHARS} chars omitted from wiki excerpt; raw bundle preserves full content]"
+    return text
+
+
+def _render_transcript_excerpt(history: list[dict[str, Any]], max_chars: int) -> str:
+    if max_chars <= 0:
+        return ""
+    if not history:
+        return "(empty)"
+    lines: list[str] = []
+    head = history[:12]
+    tail = history[-12:] if len(history) > 24 else []
+    selected = head + ([{"role": "system", "content": f"... {len(history) - 24} messages omitted ..."}] if tail else []) + tail
+    for idx, msg in enumerate(selected, 1):
+        role = msg.get("role", "unknown") if isinstance(msg, dict) else "unknown"
+        content = msg.get("content", "") if isinstance(msg, dict) else str(msg)
+        text = _message_excerpt_text(str(role), content)
+        lines.append(f"## {idx}. {role}\n\n{text}")
+    excerpt = "\n\n".join(lines)
+    return excerpt[:max_chars]
+
+
+def _render_wiki_markdown(
+    *,
+    spill_id: str,
+    timestamp: str,
+    history: list[dict[str, Any]],
+    message_text: str,
+    metadata: dict[str, Any],
+    decision: ContextSpillDecision,
+    raw_path: Optional[Path],
+    config: ContextSpillConfig,
+) -> str:
+    current_ask = _redact(_compact_prior_gateway_handoff(message_text or "(empty)"))[: config.include_redacted_wiki_excerpt_chars]
+    transcript_excerpt = _redact(_render_transcript_excerpt(history, config.include_redacted_wiki_excerpt_chars))
+    return (
+        f"# Gateway context spill — {timestamp[:10]} — {_slug(str(metadata.get('session_key') or 'session'))}\n\n"
+        "This handoff is source of truth for recovering this gateway session; do not replay the raw transcript into a model.\n\n"
+        f"- Spill ID: `{spill_id}`\n"
+        f"- Original session id: `{metadata.get('session_id')}`\n"
+        f"- Session key: `{metadata.get('session_key')}`\n"
+        f"- Platform: `{metadata.get('platform')}`\n"
+        f"- Chat/thread: `{metadata.get('chat_id')}` / `{metadata.get('thread_id')}`\n"
+        f"- Stage: `{decision.stage}`\n"
+        f"- Reason: `{decision.reason}`\n"
+        f"- Approx tokens: `{decision.approx_tokens}`\n"
+        f"- Threshold tokens: `{decision.threshold_tokens}`\n"
+        f"- Messages/chars/request bytes: `{decision.message_count}` / `{decision.char_count}` / `{decision.request_bytes}`\n"
+        f"- Raw local bundle: `{raw_path if raw_path else 'none'}`\n\n"
+        "## Current user ask (redacted)\n\n"
+        f"```text\n{current_ask}\n```\n\n"
+        "## Recovery instructions\n\n"
+        "1. Continue from this handoff.\n"
+        "2. Do not ask the user to repeat themselves.\n"
+        "3. Use this wiki handoff for older context.\n"
+        "4. Do not load or paste the raw full transcript into a model.\n\n"
+        "## Redacted transcript excerpt\n\n"
+        f"{transcript_excerpt}\n"
+    )
+
+
+def _build_recovery_message(
+    *,
+    spill_id: str,
+    wiki_path: Optional[Path],
+    raw_path: Optional[Path],
+    old_session_id: str,
+    reason: str,
+    current_ask: str,
+) -> str:
+    try:
+        redacted_ask = _redact(_compact_prior_gateway_handoff(current_ask or ""))[:_DEFAULT_RECOVERY_ASK_CHARS]
+    except Exception:
+        redacted_ask = "[redaction failed; ask omitted]"
+    message = (
+        "[GATEWAY HANDOFF]\n"
+        "The prior gateway session exceeded safe context limits and was spilled before model call.\n"
+        f"- Spill ID: {spill_id}\n"
+        f"- Wiki handoff: {wiki_path if wiki_path else 'none'}\n"
+        f"- Raw local bundle: {raw_path if raw_path else 'none'}\n"
+        f"- Original session id: {old_session_id}\n"
+        f"- Reason: {reason}\n\n"
+        "Current user ask, redacted excerpt:\n"
+        f"{redacted_ask}\n\n"
+        "Instructions:\n"
+        "1. Continue from this handoff.\n"
+        "2. Do not ask the user to repeat themselves.\n"
+        "3. If older context is needed, read the wiki handoff file with file tools.\n"
+        "4. Do not load or paste the raw full transcript into the model.\n"
+    )
+    return message[:_MAX_RECOVERY_MESSAGE_CHARS]
+
+
+def _build_user_notice(wiki_path: Optional[Path], raw_path: Optional[Path]) -> str:
+    target = str(wiki_path) if wiki_path else f"raw local spill only: {raw_path}"
+    notice = (
+        "Context was too large to send safely. I wrote a recovery handoff and reset this lane so it can continue without replaying the broken transcript:\n"
+        f"{target}"
+    )
+    try:
+        notice = _redact(notice)
+    except Exception:
+        notice = "Context was too large to send safely. I wrote a local recovery handoff and reset this lane."
+    return notice[:_MAX_USER_NOTICE_CHARS]
+
+
+def write_context_spill(
+    *,
+    history: list[dict[str, Any]],
+    message_text: str,
+    source: Any,
+    session_entry: Any,
+    decision: ContextSpillDecision,
+    config: ContextSpillConfig,
+) -> ContextSpillResult:
+    """Write raw/wiki spill artifacts and return the reduced handoff message.
+
+    Raw write is load-bearing when enabled.  If raw cannot be written, callers
+    must fail closed and avoid calling a model with the oversized payload.
+    """
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    session_key = str(getattr(session_entry, "session_key", "session") or "session")
+    old_session_id = str(getattr(session_entry, "session_id", "") or "")
+    spill_id = f"{timestamp}-{_slug(session_key, 24)}-{uuid.uuid4().hex[:8]}"
+    metadata = _metadata_for(source, session_entry)
+
+    config.raw_state_dir.mkdir(parents=True, exist_ok=True)
+    os.chmod(config.raw_state_dir, 0o700)
+    manifest_dir = config.raw_state_dir / "manifests"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    os.chmod(manifest_dir, 0o700)
+
+    raw_path: Optional[Path] = None
+    if config.include_raw_state:
+        raw_path = config.raw_state_dir / f"{spill_id}.json"
+        raw_payload = {
+            "spill_id": spill_id,
+            "timestamp": timestamp,
+            "metadata": metadata,
+            "decision": asdict(decision),
+            "history": history,
+            "message_text": message_text,
+        }
+        try:
+            _atomic_write_json(raw_path, raw_payload, mode=0o600)
+        except Exception as exc:
+            raise ContextSpillWriteError(f"raw spill write failed: {type(exc).__name__}: {exc}") from exc
+
+    wiki_path: Optional[Path] = None
+    wiki_error: Optional[str] = None
+    try:
+        wiki_path = config.wiki_dir / f"{spill_id}.md"
+        markdown = _render_wiki_markdown(
+            spill_id=spill_id,
+            timestamp=timestamp,
+            history=history,
+            message_text=message_text,
+            metadata=metadata,
+            decision=decision,
+            raw_path=raw_path,
+            config=config,
+        )
+        _atomic_write_text(wiki_path, markdown, mode=0o644)
+    except Exception as exc:
+        wiki_error = f"wiki handoff blocked: {type(exc).__name__}: {exc}"
+        wiki_path = None
+        if raw_path is None:
+            raise ContextSpillWriteError(wiki_error) from exc
+
+    manifest_path = manifest_dir / f"{spill_id}.json"
+    manifest = {
+        "spill_id": spill_id,
+        "timestamp": timestamp,
+        "session_id": old_session_id,
+        "session_key": session_key,
+        "wiki_path": str(wiki_path) if wiki_path else None,
+        "raw_path": str(raw_path) if raw_path else None,
+        "reason": decision.reason,
+        "stage": decision.stage,
+        "wiki_error": wiki_error,
+    }
+    try:
+        _atomic_write_json(manifest_path, manifest, mode=0o600)
+    except Exception as exc:
+        raise ContextSpillWriteError(f"manifest write failed: {type(exc).__name__}: {exc}") from exc
+
+    recovery_message = _build_recovery_message(
+        spill_id=spill_id,
+        wiki_path=wiki_path,
+        raw_path=raw_path,
+        old_session_id=old_session_id,
+        reason=decision.reason,
+        current_ask=message_text,
+    )
+    if wiki_error and not wiki_path:
+        recovery_message += "\n[System note: wiki handoff was blocked by redaction/path safety; use the raw local bundle only if explicitly needed and do not paste it wholesale.]"
+        recovery_message = recovery_message[:_MAX_RECOVERY_MESSAGE_CHARS]
+    user_notice = _build_user_notice(wiki_path, raw_path) if config.notify_user else ""
+
+    return ContextSpillResult(
+        spill_id=spill_id,
+        wiki_path=wiki_path,
+        raw_path=raw_path,
+        manifest_path=manifest_path,
+        recovery_message=recovery_message,
+        user_notice=user_notice,
+        decision=decision,
+    )
+
+
+def request_pressure_from_api_kwargs(api_kwargs: dict[str, Any], *, context_length: int) -> dict[str, int | bool]:
+    """Estimate final provider request pressure from built API kwargs."""
+    messages = api_kwargs.get("messages") if isinstance(api_kwargs, dict) else []
+    if not isinstance(messages, list):
+        messages = api_kwargs.get("input") if isinstance(api_kwargs, dict) else []
+    if not isinstance(messages, list):
+        messages = []
+    tools = api_kwargs.get("tools") if isinstance(api_kwargs, dict) else None
+    system_prompt = ""
+    if messages and isinstance(messages[0], dict) and messages[0].get("role") == "system":
+        system_prompt = str(messages[0].get("content") or "")
+    try:
+        from agent.model_metadata import estimate_request_tokens_rough
+        approx_tokens = estimate_request_tokens_rough(
+            messages,
+            system_prompt=system_prompt,
+            tools=tools if isinstance(tools, list) else None,
+        )
+    except Exception:
+        approx_tokens = estimate_messages_tokens_rough(messages)
+    try:
+        request_bytes = len(json.dumps(api_kwargs, ensure_ascii=False, default=str).encode("utf-8", "ignore"))
+    except Exception:
+        request_bytes = len(str(api_kwargs).encode("utf-8", "ignore"))
+    context_length = int(context_length or 200_000)
+    # This is an agent-level final guard over the *actual* provider request,
+    # not the gateway transcript-spill threshold.  Do not cap large-context
+    # models at the historical 180k gateway spill default — that produces a
+    # false "context exceeded" failure for models whose usable window is larger
+    # (for example Codex-routed GPT-5.5 at ~272k).  The byte limit below still
+    # catches real transport/request-buffer hazards.
+    threshold_tokens = max(1, int(context_length * 0.90))
+    too_large = approx_tokens >= threshold_tokens or request_bytes >= _DEFAULT_REQUEST_BYTE_LIMIT
+    return {
+        "approx_tokens": int(approx_tokens),
+        "request_bytes": int(request_bytes),
+        "context_length": int(context_length),
+        "threshold_tokens": int(threshold_tokens),
+        "too_large": bool(too_large),
+    }

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -875,6 +875,7 @@ class APIServerAdapter(BasePlatformAdapter):
         """
         from run_agent import AIAgent
         from gateway.run import _resolve_runtime_agent_kwargs, _resolve_gateway_model, _load_gateway_config, GatewayRunner
+        from hermes_cli.config import resolve_agent_max_turns
         from hermes_cli.tools_config import _get_platform_tools
 
         runtime_kwargs = _resolve_runtime_agent_kwargs()
@@ -884,7 +885,7 @@ class APIServerAdapter(BasePlatformAdapter):
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
 
-        max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+        max_iterations = resolve_agent_max_turns(user_config, mode="api_server")
 
         # Load fallback provider chain so the API server platform has the
         # same fallback behaviour as Telegram/Discord/Slack (fixes #4954).

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3672,6 +3672,25 @@ class DiscordAdapter(BasePlatformAdapter):
         except (ValueError, TypeError):
             return 50
 
+    def _discord_history_backfill_max_chars(self) -> int:
+        configured = self.config.extra.get("history_backfill_max_chars")
+        if configured is not None:
+            try:
+                return int(configured)
+            except (ValueError, TypeError):
+                pass
+        raw = os.getenv("DISCORD_HISTORY_BACKFILL_MAX_CHARS", "12000")
+        try:
+            return int(raw)
+        except (ValueError, TypeError):
+            return 12000
+
+    @staticmethod
+    def _truncate_context_line(line: str, max_chars: int) -> str:
+        if max_chars <= 0 or len(line) <= max_chars:
+            return line
+        return line[: max(0, max_chars - 14)].rstrip() + " ...[truncated]"
+
     async def _fetch_channel_context(
         self,
         channel: Any,
@@ -3694,6 +3713,10 @@ class DiscordAdapter(BasePlatformAdapter):
         limit = self._discord_history_backfill_limit()
         if limit <= 0:
             return ""
+        max_chars = self._discord_history_backfill_max_chars()
+        if max_chars <= 0:
+            return ""
+        max_line_chars = max(240, min(1800, max_chars // max(1, limit)))
 
         # Determine which bot messages to include in context
         allow_bots_raw = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
@@ -3755,14 +3778,27 @@ class DiscordAdapter(BasePlatformAdapter):
                 name = msg.author.display_name
                 if getattr(msg.author, "bot", False):
                     name = f"{name} [bot]"
-                collected.append(f"[{name}] {content}")
+                line = self._truncate_context_line(f"[{name}] {content}", max_line_chars)
+                collected.append(line)
 
             if not collected:
                 return ""
 
             # channel.history returns newest-first (oldest_first=False); reverse for chronological order
             collected.reverse()
-            return "[Recent channel messages]\n" + "\n".join(collected)
+            budget = max(0, max_chars - len("[Recent channel messages]\n"))
+            bounded: list[str] = []
+            used = 0
+            for line in reversed(collected):
+                cost = len(line) + (1 if bounded else 0)
+                if used + cost > budget:
+                    break
+                bounded.append(line)
+                used += cost
+            bounded.reverse()
+            if not bounded:
+                return ""
+            return "[Recent channel messages]\n" + "\n".join(bounded)
 
         except discord.Forbidden:
             logger.debug("[%s] Missing permissions to fetch channel history", self.name)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -731,6 +731,7 @@ def _try_resolve_fallback_provider() -> dict | None:
             try:
                 runtime = resolve_runtime_provider(
                     requested=entry.get("provider"),
+                    target_model=entry.get("model"),
                     explicit_base_url=entry.get("base_url"),
                     explicit_api_key=entry.get("api_key"),
                 )
@@ -743,7 +744,7 @@ def _try_resolve_fallback_provider() -> dict | None:
                     "api_key": runtime.get("api_key"),
                     "base_url": runtime.get("base_url"),
                     "provider": runtime.get("provider"),
-                    "api_mode": runtime.get("api_mode"),
+                    "api_mode": entry.get("api_mode") or runtime.get("api_mode"),
                     "command": runtime.get("command"),
                     "args": list(runtime.get("args") or []),
                     "credential_pool": runtime.get("credential_pool"),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7576,8 +7576,6 @@ class GatewayRunner:
                         f"{_compress_token_threshold:,}",
                     )
 
-                    _hyg_meta = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
-
                     try:
                         from run_agent import AIAgent
 
@@ -7652,55 +7650,30 @@ class GatewayRunner:
 
                                     # If summary generation failed, the
                                     # compressor inserted a static fallback
-                                    # placeholder and the dropped turns are
-                                    # gone for good.  Surface a visible
-                                    # warning to the gateway user — agent.log
-                                    # alone is invisible on TG/Discord/etc.
+                                    # placeholder. Keep this in logs only;
+                                    # surfacing compressor internals in chat
+                                    # pollutes the user thread and looks like
+                                    # agent output.
                                     _comp = getattr(_hyg_agent, "context_compressor", None)
                                     if _comp is not None and getattr(_comp, "_last_summary_fallback_used", False):
                                         _dropped = getattr(_comp, "_last_summary_dropped_count", 0)
                                         _err = getattr(_comp, "_last_summary_error", None) or "unknown error"
-                                        _warn_msg = (
-                                            "⚠️ Context compression summary failed "
-                                            f"({_err}). {_dropped} historical message(s) "
-                                            "were removed and replaced with a placeholder. "
-                                            "Earlier context is no longer recoverable. "
-                                            "Consider /reset for a clean session, or check "
-                                            "your auxiliary.compression model configuration."
+                                        logger.warning(
+                                            "Session hygiene compression summary failed; inserted fallback marker internally; dropped=%s error=%s",
+                                            _dropped,
+                                            _err,
                                         )
-                                        try:
-                                            _adapter = self.adapters.get(source.platform)
-                                            if _adapter and source.chat_id:
-                                                await _adapter.send(source.chat_id, _warn_msg, metadata=_hyg_meta)
-                                        except Exception as _werr:
-                                            logger.warning(
-                                                "Failed to deliver compression-failure warning to user: %s",
-                                                _werr,
-                                            )
-                                    # Separately: if the user's CONFIGURED aux
+                                    # Separately: if the user's configured aux
                                     # model failed and we recovered by falling
-                                    # back to the main model, tell them — a
-                                    # misconfigured auxiliary.compression.model
-                                    # is something only they can fix, and
-                                    # silent recovery would hide it.
+                                    # back to the main model, log it only.
                                     elif _comp is not None and getattr(_comp, "_last_aux_model_failure_model", None):
                                         _aux_model = getattr(_comp, "_last_aux_model_failure_model", "")
                                         _aux_err = getattr(_comp, "_last_aux_model_failure_error", None) or "unknown error"
-                                        _aux_msg = (
-                                            f"ℹ️ Configured compression model `{_aux_model}` "
-                                            f"failed ({_aux_err}). Recovered using your main "
-                                            "model — context is intact — but you may want to "
-                                            "check `auxiliary.compression.model` in config.yaml."
+                                        logger.warning(
+                                            "Session hygiene configured compression model %r failed; recovered using main model: %s",
+                                            _aux_model,
+                                            _aux_err,
                                         )
-                                        try:
-                                            _adapter = self.adapters.get(source.platform)
-                                            if _adapter and source.chat_id:
-                                                await _adapter.send(source.chat_id, _aux_msg, metadata=_hyg_meta)
-                                        except Exception as _werr:
-                                            logger.warning(
-                                                "Failed to deliver aux-model-fallback notice to user: %s",
-                                                _werr,
-                                            )
                                 finally:
                                     # Evict the cached agent so the next turn
                                     # rebuilds its system prompt from current

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -388,6 +388,30 @@ _env_path = _hermes_home / '.env'
 load_hermes_dotenv(hermes_home=_hermes_home, project_env=Path(__file__).resolve().parents[1] / '.env')
 
 
+def _resolve_gateway_max_iterations_from_config(cfg: dict | None, platform_key: str = "gateway") -> int:
+    """Resolve the live gateway/platform budget from config.yaml."""
+    try:
+        from hermes_cli.config import resolve_agent_max_turns
+        return resolve_agent_max_turns(cfg or {}, mode=platform_key or "gateway")
+    except Exception:
+        return 90
+
+
+def _has_configured_gateway_iteration_budget(cfg: dict | None, platform_key: str = "gateway") -> bool:
+    agent_cfg = (cfg or {}).get("agent", {}) if isinstance(cfg, dict) else {}
+    if not isinstance(agent_cfg, dict):
+        return False
+    if "max_turns" in agent_cfg:
+        return True
+    budgets = agent_cfg.get("turn_budgets")
+    if not isinstance(budgets, dict):
+        return False
+    surface = (platform_key or "gateway").strip().lower()
+    if surface in {"discord", "telegram", "slack", "whatsapp", "signal", "matrix", "mattermost", "sms", "email", "feishu", "dingtalk", "wecom", "weixin", "bluebubbles", "qqbot", "yuanbao", "webhook", "homeassistant"}:
+        surface = "gateway"
+    return budgets.get(surface) is not None or budgets.get("gateway") is not None
+
+
 def _reload_runtime_env_preserving_config_authority() -> None:
     """Reload .env for fresh credentials without letting stale .env override config.
 
@@ -396,26 +420,25 @@ def _reload_runtime_env_preserving_config_authority() -> None:
     settings such as agent.max_turns; otherwise a stale HERMES_MAX_ITERATIONS in
     .env can replace the startup bridge on later turns.
     """
+    cfg = _load_gateway_config()
+    config_owns_budget = _has_configured_gateway_iteration_budget(cfg, "gateway")
+    resolved_budget = (
+        _resolve_gateway_max_iterations_from_config(cfg, "gateway")
+        if config_owns_budget
+        else None
+    )
+
     load_hermes_dotenv(
         hermes_home=_hermes_home,
         project_env=Path(__file__).resolve().parents[1] / '.env',
     )
 
-    config_path = _hermes_home / 'config.yaml'
-    if not config_path.exists():
-        return
-    try:
-        import yaml as _yaml
-        with open(config_path, encoding="utf-8") as f:
-            cfg = _yaml.safe_load(f) or {}
-        from hermes_cli.config import _expand_env_vars
-        cfg = _expand_env_vars(cfg)
-    except Exception:
-        return
-
-    agent_cfg = cfg.get("agent", {})
-    if isinstance(agent_cfg, dict) and "max_turns" in agent_cfg:
-        os.environ["HERMES_MAX_ITERATIONS"] = str(agent_cfg["max_turns"])
+    # Reload .env for credentials, then restore config authority for the legacy
+    # env var consumed by older gateway/tool paths. This is the resolver output
+    # for the gateway surface (turn_budgets.gateway when present, otherwise a
+    # non-default explicit agent.max_turns), not a blind max_turns mirror.
+    if resolved_budget is not None:
+        os.environ["HERMES_MAX_ITERATIONS"] = str(resolved_budget)
 
 
 _DOCKER_VOLUME_SPEC_RE = re.compile(r"^(?P<host>.+):(?P<container>/[^:]+?)(?::(?P<options>[^:]+))?$")
@@ -525,16 +548,16 @@ if _config_path.exists():
                     os.environ[_env_map["base_url"]] = _base_url
                 if _api_key:
                     os.environ[_env_map["api_key"]] = _api_key
-        # config.yaml is the documented, authoritative source for these
-        # settings — it unconditionally wins over .env values. Previously
-        # the guards below read `if X not in os.environ` and let stale
-        # .env entries (e.g. HERMES_MAX_ITERATIONS=60 written by an old
-        # `hermes setup` run) silently shadow the user's current config.
-        # See PR #18413 / the 60-vs-500 max_turns incident.
+        # config.yaml remains authoritative for gateway runtime settings.
+        # Bridge the resolved gateway budget (turn_budgets.gateway when set,
+        # otherwise an explicit non-default legacy max_turns) for legacy env
+        # consumers; do not blindly mirror the global max_turns.
+        if _has_configured_gateway_iteration_budget(_cfg, "gateway"):
+            os.environ["HERMES_MAX_ITERATIONS"] = str(
+                _resolve_gateway_max_iterations_from_config(_cfg, "gateway")
+            )
         _agent_cfg = _cfg.get("agent", {})
         if _agent_cfg and isinstance(_agent_cfg, dict):
-            if "max_turns" in _agent_cfg:
-                os.environ["HERMES_MAX_ITERATIONS"] = str(_agent_cfg["max_turns"])
             if "gateway_timeout" in _agent_cfg:
                 os.environ["HERMES_AGENT_TIMEOUT"] = str(_agent_cfg["gateway_timeout"])
             if "gateway_timeout_warning" in _agent_cfg:
@@ -632,6 +655,7 @@ from gateway.config import (
 from gateway.session import (
     SessionStore,
     SessionSource,
+    SessionEntry,
     SessionContext,
     build_session_context,
     build_session_context_prompt,
@@ -729,12 +753,21 @@ def _try_resolve_fallback_provider() -> dict | None:
             if not isinstance(entry, dict):
                 continue
             try:
-                runtime = resolve_runtime_provider(
-                    requested=entry.get("provider"),
-                    target_model=entry.get("model"),
-                    explicit_base_url=entry.get("base_url"),
-                    explicit_api_key=entry.get("api_key"),
-                )
+                try:
+                    runtime = resolve_runtime_provider(
+                        requested=entry.get("provider"),
+                        target_model=entry.get("model"),
+                        explicit_base_url=entry.get("base_url"),
+                        explicit_api_key=entry.get("api_key"),
+                    )
+                except TypeError as type_exc:
+                    if "target_model" not in str(type_exc):
+                        raise
+                    runtime = resolve_runtime_provider(
+                        requested=entry.get("provider"),
+                        explicit_base_url=entry.get("base_url"),
+                        explicit_api_key=entry.get("api_key"),
+                    )
                 logger.info(
                     "Fallback provider resolved: %s model=%s",
                     runtime.get("provider"),
@@ -1092,6 +1125,11 @@ def _normalize_empty_agent_response(
 
     if agent_result.get("failed"):
         error_detail = agent_result.get("error", "unknown error")
+        if agent_result.get("request_size_guard"):
+            return (
+                "⚠️ Hermes blocked an oversized internal request before any model call. "
+                "This is a gateway/request-shaping guard, not proof that the conversation exceeded the model context."
+            )
         error_str = str(error_detail).lower()
         is_context_failure = any(
             p in error_str
@@ -1254,6 +1292,7 @@ class GatewayRunner:
         self._pending_native_image_paths_by_session: Dict[str, List[str]] = {}
         self._busy_ack_ts: Dict[str, float] = {}  # last busy-ack timestamp per session (debounce)
         self._session_run_generation: Dict[str, int] = {}
+        self._context_spill_locks: Dict[str, asyncio.Lock] = {}
         # LRU cache of live SessionSources keyed by session_key. Used by
         # fallback routing paths (shutdown notifications, synthetic
         # background-process events) when the persisted origin is missing
@@ -3246,10 +3285,13 @@ class GatewayRunner:
         try:
             with self.session_store._lock:  # noqa: SLF001 — snapshot under lock
                 self.session_store._ensure_loaded_locked()  # noqa: SLF001
+                quarantine_index = self.session_store._read_quarantine_index_locked()  # noqa: SLF001
                 candidates = [
                     entry for entry in self.session_store._entries.values()  # noqa: SLF001
                     if entry.resume_pending
                     and not entry.suspended
+                    and not entry.quarantined
+                    and str(entry.session_id) not in quarantine_index
                     and entry.origin is not None
                     and entry.resume_reason in self._AUTO_RESUME_REASONS
                 ]
@@ -3333,10 +3375,9 @@ class GatewayRunner:
         # config.yaml → env bridge did the right thing at a glance (instead
         # of silently running at a stale .env value for weeks).
         try:
-            _effective_max_iter = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+            _effective_max_iter = _resolve_gateway_max_iterations_from_config(_load_gateway_config(), "gateway")
             logger.info(
-                "Agent budget: max_iterations=%d (agent.max_turns from config.yaml, "
-                "or HERMES_MAX_ITERATIONS from .env, or default 90)",
+                "Agent budget: gateway max_iterations=%d (agent.turn_budgets.gateway/config resolver)",
                 _effective_max_iter,
             )
         except Exception:
@@ -7214,6 +7255,269 @@ class GatewayRunner:
                 pass
         return source
 
+    def _context_spill_lock_for_session(self, session_key: str) -> asyncio.Lock:
+        locks = getattr(self, "_context_spill_locks", None)
+        if locks is None:
+            locks = {}
+            self._context_spill_locks = locks
+        lock = locks.get(session_key)
+        if lock is None:
+            lock = asyncio.Lock()
+            locks[session_key] = lock
+        return lock
+
+    def _effective_gateway_context_length(self, source: SessionSource, session_key: str, user_config: dict) -> int:
+        from agent.model_metadata import get_model_context_length
+
+        model = getattr(self, "_model", "") or ""
+        runtime = {}
+        config_ctx = None
+        model_cfg = user_config.get("model", {}) if isinstance(user_config, dict) else {}
+        if isinstance(model_cfg, dict):
+            try:
+                raw_ctx = model_cfg.get("context_length")
+                config_ctx = int(raw_ctx) if raw_ctx is not None else None
+            except (TypeError, ValueError):
+                config_ctx = None
+        try:
+            model, runtime = self._resolve_session_agent_runtime(
+                source=source,
+                session_key=session_key,
+                user_config=user_config if isinstance(user_config, dict) else None,
+            )
+        except Exception:
+            runtime = {}
+        ctx = get_model_context_length(
+            model,
+            base_url=runtime.get("base_url") or getattr(self, "_base_url", "") or "",
+            api_key=runtime.get("api_key") or "",
+            provider=runtime.get("provider") or "",
+            config_context_length=config_ctx,
+        )
+        fb_cfg = user_config.get("fallback_providers") or user_config.get("fallback_model") if isinstance(user_config, dict) else None
+        fb_list = fb_cfg if isinstance(fb_cfg, list) else ([fb_cfg] if isinstance(fb_cfg, dict) else [])
+        for fb in fb_list:
+            if not isinstance(fb, dict):
+                continue
+            fb_model = str(fb.get("model") or "").strip()
+            if not fb_model:
+                continue
+            try:
+                fb_ctx = get_model_context_length(
+                    fb_model,
+                    base_url=str(fb.get("base_url") or ""),
+                    api_key=str(fb.get("api_key") or ""),
+                    provider=str(fb.get("provider") or ""),
+                    config_context_length=None,
+                )
+                if fb_ctx:
+                    ctx = min(ctx, fb_ctx)
+            except Exception:
+                pass
+        return int(ctx or 200000)
+
+    async def _maybe_spill_gateway_context(
+        self,
+        *,
+        history: list,
+        message_text: str,
+        source: SessionSource,
+        session_entry: SessionEntry,
+        session_key: str,
+        stage: str,
+        context_prompt: str = "",
+        channel_prompt: str = "",
+    ):
+        from gateway.context_spill import (
+            ContextSpillWriteError,
+            decide_context_spill,
+            load_context_spill_config,
+            write_context_spill,
+        )
+        from hermes_constants import get_hermes_home
+
+        user_config = _load_gateway_config()
+        spill_config = load_context_spill_config(user_config, get_hermes_home())
+        if not spill_config.enabled:
+            return None
+        context_length = self._effective_gateway_context_length(source, session_key, user_config)
+        decision = decide_context_spill(
+            history if isinstance(history, list) else [],
+            message_text or "",
+            context_length=context_length,
+            config=spill_config,
+            stage=stage,
+            system_prompt=context_prompt or "",
+            channel_prompt=channel_prompt or "",
+        )
+        if not decision.should_spill:
+            return None
+        if spill_config.mode == "shadow":
+            logger.warning(
+                "Gateway context spill shadow hit: session=%s stage=%s reason=%s tokens=%s messages=%s chars=%s bytes=%s",
+                session_entry.session_id,
+                stage,
+                decision.reason,
+                decision.approx_tokens,
+                decision.message_count,
+                decision.char_count,
+                decision.request_bytes,
+            )
+            return None
+        result = write_context_spill(
+            history=history if isinstance(history, list) else [],
+            message_text=message_text or "",
+            source=source,
+            session_entry=session_entry,
+            decision=decision,
+            config=spill_config,
+        )
+        new_entry = self.session_store.spill_and_reset_session(
+            session_key,
+            old_session_id=session_entry.session_id,
+            spill_id=result.spill_id,
+            wiki_path=str(result.wiki_path) if result.wiki_path else None,
+            raw_path=str(result.raw_path) if result.raw_path else None,
+            reason=decision.reason,
+        )
+        if new_entry is None:
+            raise ContextSpillWriteError("session reset failed after spill write")
+        self._evict_cached_agent(session_key)
+        self._session_model_overrides.pop(session_key, None)
+        self._set_session_reasoning_override(session_key, None)
+        if hasattr(self, "_pending_model_notes"):
+            self._pending_model_notes.pop(session_key, None)
+        logger.warning(
+            "Gateway context spill enforced: old_session=%s new_session=%s spill=%s stage=%s reason=%s",
+            session_entry.session_id,
+            new_entry.session_id,
+            result.spill_id,
+            stage,
+            decision.reason,
+        )
+        return result, new_entry
+
+    async def _spill_gateway_context_after_request_guard(
+        self,
+        *,
+        history: list,
+        message_text: str,
+        source: SessionSource,
+        session_entry: SessionEntry,
+        session_key: str,
+        agent_result: dict,
+        context_prompt: str = "",
+        channel_prompt: str = "",
+    ):
+        """Persist a final pre-API guard hit before resetting/retrying.
+
+        Gateway Stage A/B preflight catches oversized persisted transcripts and
+        inbound expansions.  The agent-level guard can still trip after system
+        prompt, memory, tool schemas, or provider transport transforms inflate
+        the *actual* request.  In that path we must not fall back to the legacy
+        compression-exhausted reset, because that loses the current ask and
+        leaves no quarantine record for the old session id.
+        """
+        from gateway.context_spill import (
+            ContextSpillDecision,
+            ContextSpillWriteError,
+            estimate_gateway_payload,
+            load_context_spill_config,
+            write_context_spill,
+        )
+        from hermes_constants import get_hermes_home
+
+        user_config = _load_gateway_config()
+        spill_config = load_context_spill_config(user_config, get_hermes_home())
+        if not spill_config.enabled:
+            return None
+
+        pressure = agent_result.get("request_size_guard") if isinstance(agent_result, dict) else None
+        pressure = pressure if isinstance(pressure, dict) else {}
+        approx_est, char_count, message_count, request_bytes_est = estimate_gateway_payload(
+            history if isinstance(history, list) else [],
+            message_text or "",
+            system_prompt=context_prompt or "",
+            channel_prompt=channel_prompt or "",
+            extra_overhead_tokens=0,
+        )
+        try:
+            approx_tokens = int(pressure.get("approx_tokens") or approx_est)
+        except (TypeError, ValueError):
+            approx_tokens = approx_est
+        try:
+            request_bytes = int(pressure.get("request_bytes") or request_bytes_est)
+        except (TypeError, ValueError):
+            request_bytes = request_bytes_est
+        try:
+            threshold_tokens = int(pressure.get("threshold_tokens") or 0)
+        except (TypeError, ValueError):
+            threshold_tokens = 0
+        if threshold_tokens <= 0:
+            context_length = self._effective_gateway_context_length(source, session_key, user_config)
+            threshold_tokens = max(
+                1,
+                min(
+                    spill_config.hard_token_limit,
+                    max(50_000, int(context_length * spill_config.token_threshold_ratio)),
+                ),
+            )
+
+        decision = ContextSpillDecision(
+            should_spill=True,
+            reason=(
+                "pre_api_request_guard:"
+                f"{approx_tokens}>={threshold_tokens};bytes={request_bytes}"
+            ),
+            approx_tokens=approx_tokens,
+            char_count=char_count,
+            message_count=message_count,
+            threshold_tokens=threshold_tokens,
+            request_bytes=request_bytes,
+            stage="pre_api_guard",
+        )
+        if spill_config.mode == "shadow":
+            logger.warning(
+                "Gateway context spill shadow hit after pre-api guard: session=%s reason=%s tokens=%s bytes=%s",
+                session_entry.session_id,
+                decision.reason,
+                decision.approx_tokens,
+                decision.request_bytes,
+            )
+            return None
+
+        result = write_context_spill(
+            history=history if isinstance(history, list) else [],
+            message_text=message_text or "",
+            source=source,
+            session_entry=session_entry,
+            decision=decision,
+            config=spill_config,
+        )
+        new_entry = self.session_store.spill_and_reset_session(
+            session_key,
+            old_session_id=session_entry.session_id,
+            spill_id=result.spill_id,
+            wiki_path=str(result.wiki_path) if result.wiki_path else None,
+            raw_path=str(result.raw_path) if result.raw_path else None,
+            reason=decision.reason,
+        )
+        if new_entry is None:
+            raise ContextSpillWriteError("session reset failed after pre-api guard spill write")
+        self._evict_cached_agent(session_key)
+        self._session_model_overrides.pop(session_key, None)
+        self._set_session_reasoning_override(session_key, None)
+        if hasattr(self, "_pending_model_notes"):
+            self._pending_model_notes.pop(session_key, None)
+        logger.warning(
+            "Gateway context spill enforced after pre-api guard: old_session=%s new_session=%s spill=%s reason=%s",
+            session_entry.session_id,
+            new_entry.session_id,
+            result.spill_id,
+            decision.reason,
+        )
+        return result, new_entry
+
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""
         _msg_start_time = time.time()
@@ -7401,7 +7705,8 @@ class GatewayRunner:
 
         # Load conversation history from transcript
         history = self.session_store.load_transcript(session_entry.session_id)
-        
+        spill_recovery_message = None
+
         # -----------------------------------------------------------------
         # Session hygiene: auto-compress pathologically large transcripts
         #
@@ -7687,6 +7992,54 @@ class GatewayRunner:
                             "Session hygiene auto-compress failed: %s", e
                         )
 
+        # Stage A context-spill preflight: history-only, after hygiene has
+        # had a chance to summarize a large but valid transcript. Context
+        # spill is a last-resort quarantine, not the normal long-dev-thread
+        # memory mechanism.
+        try:
+            async with self._context_spill_lock_for_session(session_key):
+                stage_a = await self._maybe_spill_gateway_context(
+                    history=history,
+                    message_text=event.text or "",
+                    source=source,
+                    session_entry=session_entry,
+                    session_key=session_key,
+                    stage="history",
+                    context_prompt=context_prompt,
+                    channel_prompt=event.channel_prompt or "",
+                )
+        except Exception as spill_exc:
+            from gateway.context_spill import ContextSpillWriteError
+            if isinstance(spill_exc, ContextSpillWriteError):
+                logger.error("Gateway context spill failed closed before model call: %s", spill_exc)
+                adapter = self.adapters.get(source.platform)
+                if adapter:
+                    await adapter.send(
+                        source.chat_id,
+                        "Context was too large to send safely, but the recovery spill could not be written. I did not send the oversized transcript to a model.",
+                        metadata=self._thread_metadata_for_source(source),
+                    )
+                return
+            raise
+        if stage_a is not None:
+            spill_result, session_entry = stage_a
+            history = []
+            spill_recovery_message = spill_result.recovery_message
+            context = build_session_context(source, self.config, session_entry)
+            _redact_pii = bool(getattr(self.config, "redact_pii", False))
+            context_prompt = build_session_context_prompt(context, redact_pii=_redact_pii)
+            if spill_result.user_notice:
+                adapter = self.adapters.get(source.platform)
+                if adapter:
+                    try:
+                        await adapter.send(
+                            source.chat_id,
+                            spill_result.user_notice,
+                            metadata=self._thread_metadata_for_source(source),
+                        )
+                    except Exception as notice_exc:
+                        logger.debug("Context spill user notice failed: %s", notice_exc)
+
         # First-message onboarding -- only on the very first interaction ever
         if not history and not self.session_store.has_any_sessions():
             context_prompt += (
@@ -7743,13 +8096,62 @@ class GatewayRunner:
         # attachments (documents, audio, etc.) are not sent to the vision
         # tool even when they appear in the same message.
         # -----------------------------------------------------------------
-        message_text = await self._prepare_inbound_message_text(
-            event=event,
-            source=source,
-            history=history,
-        )
-        if message_text is None:
-            return
+        if spill_recovery_message is not None:
+            message_text = spill_recovery_message
+        else:
+            message_text = await self._prepare_inbound_message_text(
+                event=event,
+                source=source,
+                history=history,
+            )
+            if message_text is None:
+                return
+
+            # Stage B context-spill preflight: actual model-facing inbound
+            # text, including backfill/reply/doc/image/context-reference expansion.
+            try:
+                async with self._context_spill_lock_for_session(session_key):
+                    stage_b = await self._maybe_spill_gateway_context(
+                        history=history,
+                        message_text=message_text,
+                        source=source,
+                        session_entry=session_entry,
+                        session_key=session_key,
+                        stage="inbound",
+                        context_prompt=context_prompt,
+                        channel_prompt=event.channel_prompt or "",
+                    )
+            except Exception as spill_exc:
+                from gateway.context_spill import ContextSpillWriteError
+                if isinstance(spill_exc, ContextSpillWriteError):
+                    logger.error("Gateway context spill failed closed before model call: %s", spill_exc)
+                    adapter = self.adapters.get(source.platform)
+                    if adapter:
+                        await adapter.send(
+                            source.chat_id,
+                            "Context was too large to send safely, but the recovery spill could not be written. I did not send the oversized transcript to a model.",
+                            metadata=self._thread_metadata_for_source(source),
+                        )
+                    return
+                raise
+            if stage_b is not None:
+                spill_result, session_entry = stage_b
+                history = []
+                message_text = spill_result.recovery_message
+                context = build_session_context(source, self.config, session_entry)
+                _redact_pii = bool(getattr(self.config, "redact_pii", False))
+                context_prompt = build_session_context_prompt(context, redact_pii=_redact_pii)
+                if spill_result.user_notice:
+                    adapter = self.adapters.get(source.platform)
+                    if adapter:
+                        try:
+                            await adapter.send(
+                                source.chat_id,
+                                spill_result.user_notice,
+                                metadata=self._thread_metadata_for_source(source),
+                            )
+                        except Exception as notice_exc:
+                            logger.debug("Context spill user notice failed: %s", notice_exc)
 
         # Bind this gateway run generation to the adapter's active-session
         # event so deferred post-delivery callbacks can be released by the
@@ -7783,6 +8185,70 @@ class GatewayRunner:
                 event_message_id=self._reply_anchor_for_event(event),
                 channel_prompt=event.channel_prompt,
             )
+
+            # One bounded retry: the first run may fail at the agent's final
+            # pre-API guard after tool schemas/memory/system prompt inflate the
+            # request. Spill/quarantine the old transcript, then retry exactly
+            # once with the small recovery handoff. If that reduced retry still
+            # trips the guard, the normal fail-closed error path below reports it
+            # without looping.
+            if agent_result.get("request_size_guard") and session_entry and session_key:
+                try:
+                    async with self._context_spill_lock_for_session(session_key):
+                        post_guard_spill = await self._spill_gateway_context_after_request_guard(
+                            history=history,
+                            message_text=message_text,
+                            source=source,
+                            session_entry=session_entry,
+                            session_key=session_key,
+                            agent_result=agent_result,
+                            context_prompt=context_prompt,
+                            channel_prompt=event.channel_prompt or "",
+                        )
+                except Exception as spill_exc:
+                    from gateway.context_spill import ContextSpillWriteError
+                    if isinstance(spill_exc, ContextSpillWriteError):
+                        logger.error("Gateway post-agent context spill failed closed before retry: %s", spill_exc)
+                        adapter = self.adapters.get(source.platform)
+                        if adapter:
+                            await adapter.send(
+                                source.chat_id,
+                                "Context was too large to send safely, but the recovery spill could not be written. I did not send the oversized transcript to a model or retry it.",
+                                metadata=self._thread_metadata_for_source(source),
+                            )
+                        return None
+                    raise
+
+                if post_guard_spill is not None:
+                    spill_result, session_entry = post_guard_spill
+                    history = []
+                    message_text = spill_result.recovery_message
+                    context = build_session_context(source, self.config, session_entry)
+                    _redact_pii = bool(getattr(self.config, "redact_pii", False))
+                    context_prompt = build_session_context_prompt(context, redact_pii=_redact_pii)
+                    if spill_result.user_notice:
+                        adapter = self.adapters.get(source.platform)
+                        if adapter:
+                            try:
+                                await adapter.send(
+                                    source.chat_id,
+                                    spill_result.user_notice,
+                                    metadata=self._thread_metadata_for_source(source),
+                                )
+                            except Exception as notice_exc:
+                                logger.debug("Context spill user notice failed: %s", notice_exc)
+
+                    agent_result = await self._run_agent(
+                        message=message_text,
+                        context_prompt=context_prompt,
+                        history=history,
+                        source=source,
+                        session_id=session_entry.session_id,
+                        session_key=session_key,
+                        run_generation=run_generation,
+                        event_message_id=self._reply_anchor_for_event(event),
+                        channel_prompt=event.channel_prompt,
+                    )
 
             # Stop persistent typing indicator now that the agent is done
             try:
@@ -7972,12 +8438,14 @@ class GatewayRunner:
             # own context-length classifier.
             is_context_overflow_failure = agent_failed_early and (
                 bool(agent_result.get("compression_exhausted"))
+                or bool(agent_result.get("request_size_guard"))
                 or any(p in _err_str_for_classify for p in (
                     "context length", "context size", "context window",
                     "maximum context", "token limit", "too many tokens",
                     "reduce the length", "exceeds the limit",
                     "request entity too large", "prompt is too long",
                     "payload too large", "input is too long",
+                    "request buffer limit", "exceeded request buffer limit",
                 ))
                 or ("400" in _err_str_for_classify and len(history) > 50)
             )
@@ -7998,7 +8466,12 @@ class GatewayRunner:
             # large to process.  Auto-reset it so the next message starts
             # fresh instead of replaying the same oversized context in an
             # infinite fail loop.  (#9893)
-            if agent_result.get("compression_exhausted") and session_entry and session_key:
+            if (
+                agent_result.get("compression_exhausted")
+                and not agent_result.get("request_size_guard")
+                and session_entry
+                and session_key
+            ):
                 logger.info(
                     "Auto-resetting session %s after compression exhaustion.",
                     session_entry.session_id,
@@ -10707,7 +11180,7 @@ class GatewayRunner:
             disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
 
             pr = self._provider_routing
-            max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+            max_iterations = _resolve_gateway_max_iterations_from_config(user_config, platform_key)
             reasoning_config = self._resolve_session_reasoning_config(source=source)
             self._reasoning_config = reasoning_config
             self._service_tier = self._load_service_tier()
@@ -15180,9 +15653,6 @@ class GatewayRunner:
             # (concurrency-safe). Keep os.environ as fallback for CLI/cron.
             os.environ["HERMES_SESSION_KEY"] = session_key or ""
 
-            # Read from env var or use default (same as CLI)
-            max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
-            
             # Map platform enum to the platform hint key the agent understands.
             # Platform.LOCAL ("local") maps to "cli"; others pass through as-is.
             platform_key = "cli" if source.platform == Platform.LOCAL else source.platform.value
@@ -15200,6 +15670,7 @@ class GatewayRunner:
             # keys may change without restart). Keep config.yaml authoritative for
             # runtime budget settings bridged into env vars.
             _reload_runtime_env_preserving_config_authority()
+            max_iterations = _resolve_gateway_max_iterations_from_config(user_config, platform_key)
 
             try:
                 model, runtime_kwargs = self._resolve_session_agent_runtime(
@@ -15409,6 +15880,10 @@ class GatewayRunner:
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides") or {}
+            agent._configured_max_iterations = max_iterations
+            agent.max_iterations = max_iterations
+            agent._last_resolved_turn_max_iterations = None
+            agent._external_turn_ceiling_active = False
 
             _bg_review_release = threading.Event()
             _bg_review_pending: list[str] = []

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -421,24 +421,18 @@ def _reload_runtime_env_preserving_config_authority() -> None:
     .env can replace the startup bridge on later turns.
     """
     cfg = _load_gateway_config()
-    config_owns_budget = _has_configured_gateway_iteration_budget(cfg, "gateway")
-    resolved_budget = (
-        _resolve_gateway_max_iterations_from_config(cfg, "gateway")
-        if config_owns_budget
-        else None
-    )
+    resolved_budget = _resolve_gateway_max_iterations_from_config(cfg, "gateway")
 
     load_hermes_dotenv(
         hermes_home=_hermes_home,
         project_env=Path(__file__).resolve().parents[1] / '.env',
     )
 
-    # Reload .env for credentials, then restore config authority for the legacy
-    # env var consumed by older gateway/tool paths. This is the resolver output
-    # for the gateway surface (turn_budgets.gateway when present, otherwise a
-    # non-default explicit agent.max_turns), not a blind max_turns mirror.
-    if resolved_budget is not None:
-        os.environ["HERMES_MAX_ITERATIONS"] = str(resolved_budget)
+    # Reload .env for credentials, then restore config/default authority for
+    # the legacy env var consumed by older gateway/tool paths. Even if config
+    # is partial or omits agent.turn_budgets, the task-shaped gateway default
+    # must beat a stale .env HERMES_MAX_ITERATIONS.
+    os.environ["HERMES_MAX_ITERATIONS"] = str(resolved_budget)
 
 
 _DOCKER_VOLUME_SPEC_RE = re.compile(r"^(?P<host>.+):(?P<container>/[^:]+?)(?::(?P<options>[^:]+))?$")
@@ -548,14 +542,13 @@ if _config_path.exists():
                     os.environ[_env_map["base_url"]] = _base_url
                 if _api_key:
                     os.environ[_env_map["api_key"]] = _api_key
-        # config.yaml remains authoritative for gateway runtime settings.
+        # config.yaml/defaults remain authoritative for gateway runtime settings.
         # Bridge the resolved gateway budget (turn_budgets.gateway when set,
-        # otherwise an explicit non-default legacy max_turns) for legacy env
-        # consumers; do not blindly mirror the global max_turns.
-        if _has_configured_gateway_iteration_budget(_cfg, "gateway"):
-            os.environ["HERMES_MAX_ITERATIONS"] = str(
-                _resolve_gateway_max_iterations_from_config(_cfg, "gateway")
-            )
+        # otherwise explicit legacy max_turns or the gateway default) for legacy
+        # env consumers; never let stale .env HERMES_MAX_ITERATIONS win.
+        os.environ["HERMES_MAX_ITERATIONS"] = str(
+            _resolve_gateway_max_iterations_from_config(_cfg, "gateway")
+        )
         _agent_cfg = _cfg.get("agent", {})
         if _agent_cfg and isinstance(_agent_cfg, dict):
             if "gateway_timeout" in _agent_cfg:
@@ -7372,21 +7365,24 @@ class GatewayRunner:
             decision=decision,
             config=spill_config,
         )
-        new_entry = self.session_store.spill_and_reset_session(
-            session_key,
-            old_session_id=session_entry.session_id,
-            spill_id=result.spill_id,
-            wiki_path=str(result.wiki_path) if result.wiki_path else None,
-            raw_path=str(result.raw_path) if result.raw_path else None,
-            reason=decision.reason,
-        )
-        if new_entry is None:
-            raise ContextSpillWriteError("session reset failed after spill write")
-        self._evict_cached_agent(session_key)
-        self._session_model_overrides.pop(session_key, None)
-        self._set_session_reasoning_override(session_key, None)
-        if hasattr(self, "_pending_model_notes"):
-            self._pending_model_notes.pop(session_key, None)
+        if spill_config.reset_live_session:
+            new_entry = self.session_store.spill_and_reset_session(
+                session_key,
+                old_session_id=session_entry.session_id,
+                spill_id=result.spill_id,
+                wiki_path=str(result.wiki_path) if result.wiki_path else None,
+                raw_path=str(result.raw_path) if result.raw_path else None,
+                reason=decision.reason,
+            )
+            if new_entry is None:
+                raise ContextSpillWriteError("session reset failed after spill write")
+            self._evict_cached_agent(session_key)
+            self._session_model_overrides.pop(session_key, None)
+            self._set_session_reasoning_override(session_key, None)
+            if hasattr(self, "_pending_model_notes"):
+                self._pending_model_notes.pop(session_key, None)
+        else:
+            new_entry = session_entry
         logger.warning(
             "Gateway context spill enforced: old_session=%s new_session=%s spill=%s stage=%s reason=%s",
             session_entry.session_id,
@@ -7494,21 +7490,24 @@ class GatewayRunner:
             decision=decision,
             config=spill_config,
         )
-        new_entry = self.session_store.spill_and_reset_session(
-            session_key,
-            old_session_id=session_entry.session_id,
-            spill_id=result.spill_id,
-            wiki_path=str(result.wiki_path) if result.wiki_path else None,
-            raw_path=str(result.raw_path) if result.raw_path else None,
-            reason=decision.reason,
-        )
-        if new_entry is None:
-            raise ContextSpillWriteError("session reset failed after pre-api guard spill write")
-        self._evict_cached_agent(session_key)
-        self._session_model_overrides.pop(session_key, None)
-        self._set_session_reasoning_override(session_key, None)
-        if hasattr(self, "_pending_model_notes"):
-            self._pending_model_notes.pop(session_key, None)
+        if spill_config.reset_live_session:
+            new_entry = self.session_store.spill_and_reset_session(
+                session_key,
+                old_session_id=session_entry.session_id,
+                spill_id=result.spill_id,
+                wiki_path=str(result.wiki_path) if result.wiki_path else None,
+                raw_path=str(result.raw_path) if result.raw_path else None,
+                reason=decision.reason,
+            )
+            if new_entry is None:
+                raise ContextSpillWriteError("session reset failed after pre-api guard spill write")
+            self._evict_cached_agent(session_key)
+            self._session_model_overrides.pop(session_key, None)
+            self._set_session_reasoning_override(session_key, None)
+            if hasattr(self, "_pending_model_notes"):
+                self._pending_model_notes.pop(session_key, None)
+        else:
+            new_entry = session_entry
         logger.warning(
             "Gateway context spill enforced after pre-api guard: old_session=%s new_session=%s spill=%s reason=%s",
             session_entry.session_id,

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -21,6 +21,117 @@ from typing import Dict, List, Optional, Any
 
 logger = logging.getLogger(__name__)
 
+_CONTEXT_COMPACTION_MARKER = "[CONTEXT COMPACTION"
+_CONTEXT_COMPACTION_END_MARKER = "--- END OF CONTEXT SUMMARY"
+_GATEWAY_HANDOFF_MARKER = "[GATEWAY HANDOFF]"
+_TOOL_REPLAY_FULL_RECENT_MESSAGES = 12
+_MAX_OLD_TOOL_REPLAY_CHARS = 1200
+
+
+def _compact_replayed_handoff_content(content: Any) -> Any:
+    """Keep gateway/compaction handoffs from becoming permanent context bloat.
+
+    Gateway spill recovery and context-compaction handoff blocks are useful once:
+    the next model call needs them to recover.  If persisted verbatim, long
+    Discord threads replay them forever and every subsequent compaction/spill
+    inherits the previous handoff.  That was the nichamilton.info failure mode:
+    the handoff itself became the new runaway context.
+
+    Preserve the live user ask after the handoff when present; otherwise keep a
+    small pointer/summary marker.  This is replay-only/persistence hygiene, not
+    deletion of the original forensic spill files.
+    """
+    if not isinstance(content, str) or not content:
+        return content
+    if _CONTEXT_COMPACTION_MARKER not in content and not content.lstrip().startswith(_GATEWAY_HANDOFF_MARKER):
+        return content
+
+    text = content.strip()
+
+    # If a compacted summary was prepended to a real follow-up, keep only the
+    # real follow-up after the explicit end marker.
+    if _CONTEXT_COMPACTION_END_MARKER in text:
+        _before, after = text.rsplit(_CONTEXT_COMPACTION_END_MARKER, 1)
+        after = after.strip()
+        after = after.lstrip(" —-\n\t")
+        if after:
+            return (
+                "[prior context-compaction handoff omitted from replay; "
+                "it was already consumed on the recovery turn]\n\n"
+                f"{after}"
+            )
+
+    # Keep gateway spill coordinates/current ask, but drop any nested compacted
+    # transcript summary that followed it.
+    if text.startswith(_GATEWAY_HANDOFF_MARKER):
+        lines = text.splitlines()
+        kept: List[str] = []
+        in_current_ask = False
+        for line in lines:
+            if line.startswith(_CONTEXT_COMPACTION_MARKER):
+                break
+            kept.append(line)
+            if line.startswith("Current user ask"):
+                in_current_ask = True
+            elif in_current_ask and line.startswith("Instructions:"):
+                break
+        compact = "\n".join(kept).strip()
+        if compact:
+            return compact + "\n[prior nested context summary omitted from replay; use linked wiki handoff if needed]"
+
+    return "[prior context-compaction handoff omitted from replay; already consumed on the recovery turn]"
+
+
+def _compact_replayed_handoff_message(message: Dict[str, Any]) -> Dict[str, Any]:
+    if not isinstance(message, dict):
+        return message
+    if message.get("role") not in {"user", "assistant"}:
+        return message
+    content = message.get("content")
+    compacted = _compact_replayed_handoff_content(content)
+    if compacted is content:
+        return message
+    return {**message, "content": compacted}
+
+
+def _compact_replayed_messages_for_context(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Apply replay-only hygiene to loaded gateway transcripts.
+
+    Long Discord dev threads accumulate large tool outputs that were useful at
+    execution time but should not be resent forever. Keep the recent tail intact
+    for immediate continuity; compact older tool blobs to a pointer so they can
+    be rerun/read again if exact output matters.
+    """
+    if not messages:
+        return messages
+    total = len(messages)
+    compacted_messages: List[Dict[str, Any]] = []
+    preserve_from = max(0, total - _TOOL_REPLAY_FULL_RECENT_MESSAGES)
+    for idx, msg in enumerate(messages):
+        if not isinstance(msg, dict):
+            compacted_messages.append(msg)
+            continue
+        entry = _compact_replayed_handoff_message(msg)
+        content = entry.get("content")
+        if (
+            entry.get("role") == "tool"
+            and idx < preserve_from
+            and isinstance(content, str)
+            and len(content) > _MAX_OLD_TOOL_REPLAY_CHARS
+        ):
+            tool_name = entry.get("tool_name") or entry.get("name") or "tool"
+            preview = content[:800].rstrip()
+            entry = {
+                **entry,
+                "content": (
+                    f"[{tool_name} output compacted from replay; {len(content)} chars; "
+                    "rerun the tool or read the source file if exact output is needed.]\n"
+                    f"{preview}"
+                ),
+            }
+        compacted_messages.append(entry)
+    return compacted_messages
+
 
 def _now() -> datetime:
     """Return the current local time."""
@@ -491,6 +602,16 @@ class SessionEntry:
     resume_reason: Optional[str] = None  # e.g. "restart_timeout"
     last_resume_marked_at: Optional[datetime] = None
 
+    # Context-spill quarantine metadata.  A quarantined entry must never
+    # replay its historical transcript into a model; it resets to a fresh lane
+    # with a small handoff pointer instead.
+    quarantined: bool = False
+    quarantine_reason: Optional[str] = None
+    quarantine_spill_path: Optional[str] = None
+    quarantine_raw_path: Optional[str] = None
+    quarantined_at: Optional[datetime] = None
+    quarantine_old_session_id: Optional[str] = None
+
     def to_dict(self) -> Dict[str, Any]:
         result = {
             "session_key": self.session_key,
@@ -517,6 +638,16 @@ class SessionEntry:
                 if self.last_resume_marked_at
                 else None
             ),
+            "quarantined": self.quarantined,
+            "quarantine_reason": self.quarantine_reason,
+            "quarantine_spill_path": self.quarantine_spill_path,
+            "quarantine_raw_path": self.quarantine_raw_path,
+            "quarantined_at": (
+                self.quarantined_at.isoformat()
+                if self.quarantined_at
+                else None
+            ),
+            "quarantine_old_session_id": self.quarantine_old_session_id,
             "is_fresh_reset": self.is_fresh_reset,
             "was_auto_reset": self.was_auto_reset,
             "auto_reset_reason": self.auto_reset_reason,
@@ -547,6 +678,14 @@ class SessionEntry:
             except (TypeError, ValueError):
                 last_resume_marked_at = None
 
+        quarantined_at = None
+        _qa = data.get("quarantined_at")
+        if _qa:
+            try:
+                quarantined_at = datetime.fromisoformat(_qa)
+            except (TypeError, ValueError):
+                quarantined_at = None
+
         return cls(
             session_key=data["session_key"],
             session_id=data["session_id"],
@@ -569,6 +708,12 @@ class SessionEntry:
             resume_pending=data.get("resume_pending", False),
             resume_reason=data.get("resume_reason"),
             last_resume_marked_at=last_resume_marked_at,
+            quarantined=data.get("quarantined", False),
+            quarantine_reason=data.get("quarantine_reason"),
+            quarantine_spill_path=data.get("quarantine_spill_path"),
+            quarantine_raw_path=data.get("quarantine_raw_path"),
+            quarantined_at=quarantined_at,
+            quarantine_old_session_id=data.get("quarantine_old_session_id"),
             is_fresh_reset=data.get("is_fresh_reset", False),
             was_auto_reset=data.get("was_auto_reset", False),
             auto_reset_reason=data.get("auto_reset_reason"),
@@ -740,6 +885,136 @@ class SessionStore:
             except OSError as e:
                 logger.debug("Could not remove temp file %s: %s", tmp_path, e)
             raise
+
+    def _quarantine_index_path(self, raw_state_dir: Optional[str | Path] = None) -> Path:
+        base = Path(raw_state_dir) if raw_state_dir else (self.sessions_dir.parent / "state" / "context-spills")
+        return base / "quarantined_sessions.json"
+
+    def _read_quarantine_index_locked(self, raw_state_dir: Optional[str | Path] = None) -> Dict[str, Any]:
+        path = self._quarantine_index_path(raw_state_dir)
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            return data if isinstance(data, dict) else {}
+        except FileNotFoundError:
+            return {}
+        except Exception as exc:
+            logger.debug("Failed to read quarantine index %s: %s", path, exc)
+            return {}
+
+    def _write_quarantine_index_locked(self, data: Dict[str, Any], raw_state_dir: Optional[str | Path] = None) -> None:
+        path = self._quarantine_index_path(raw_state_dir)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            os.chmod(path.parent, 0o700)
+        except OSError:
+            pass
+        import tempfile
+        fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp", prefix=".quarantine_")
+        try:
+            os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2, ensure_ascii=False)
+                f.flush()
+                os.fsync(f.fileno())
+            atomic_replace(tmp_path, path)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+
+    def is_session_quarantined(self, session_id: str, raw_state_dir: Optional[str | Path] = None) -> bool:
+        if not session_id:
+            return False
+        with self._lock:
+            return str(session_id) in self._read_quarantine_index_locked(raw_state_dir)
+
+    def get_session_quarantine(self, session_id: str, raw_state_dir: Optional[str | Path] = None) -> Optional[Dict[str, Any]]:
+        if not session_id:
+            return None
+        with self._lock:
+            record = self._read_quarantine_index_locked(raw_state_dir).get(str(session_id))
+            return record if isinstance(record, dict) else None
+
+    def spill_and_reset_session(
+        self,
+        session_key: str,
+        *,
+        old_session_id: str,
+        spill_id: str,
+        wiki_path: Optional[str],
+        raw_path: Optional[str],
+        reason: str,
+    ) -> Optional[SessionEntry]:
+        """Atomically record quarantine metadata and reset the active lane."""
+        db_end_session_id = None
+        db_create_kwargs = None
+        new_entry = None
+        now = _now()
+        with self._lock:
+            self._ensure_loaded_locked()
+            old_entry = self._entries.get(session_key)
+            if old_entry is None:
+                return None
+            old_session_id = old_session_id or old_entry.session_id
+            # The quarantine index is a control-plane guard, not part of the
+            # raw spill bundle. Keep it at SessionStore's canonical default path
+            # so every replay gate (/resume, startup auto-resume,
+            # mark_resume_pending) reads the same index even if raw spill files
+            # are configured in a subdirectory.
+            index = self._read_quarantine_index_locked()
+            index[old_session_id] = {
+                "session_id": old_session_id,
+                "session_key": session_key,
+                "spill_id": spill_id,
+                "wiki_path": wiki_path,
+                "raw_path": raw_path,
+                "reason": reason,
+                "quarantined_at": now.isoformat(),
+            }
+            self._write_quarantine_index_locked(index)
+
+            db_end_session_id = old_session_id
+            session_id = f"{now.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
+            new_entry = SessionEntry(
+                session_key=session_key,
+                session_id=session_id,
+                created_at=now,
+                updated_at=now,
+                origin=old_entry.origin,
+                display_name=old_entry.display_name,
+                platform=old_entry.platform,
+                chat_type=old_entry.chat_type,
+                was_auto_reset=True,
+                auto_reset_reason="quarantined",
+                is_fresh_reset=True,
+                quarantined=False,
+                quarantine_reason=reason,
+                quarantine_spill_path=wiki_path,
+                quarantine_raw_path=raw_path,
+                quarantine_old_session_id=old_session_id,
+            )
+            self._entries[session_key] = new_entry
+            self._save()
+            db_create_kwargs = {
+                "session_id": session_id,
+                "source": old_entry.platform.value if old_entry.platform else "unknown",
+                "user_id": old_entry.origin.user_id if old_entry.origin else None,
+            }
+
+        if self._db and db_end_session_id:
+            try:
+                self._db.end_session(db_end_session_id, "context_spill_quarantine")
+            except Exception as e:
+                logger.debug("Session DB operation failed: %s", e)
+        if self._db and db_create_kwargs:
+            try:
+                self._db.create_session(**db_create_kwargs)
+            except Exception as e:
+                logger.debug("Session DB operation failed: %s", e)
+        return new_entry
     
     def _generate_session_key(self, source: SessionSource) -> str:
         """Generate a session key from a source."""
@@ -884,7 +1159,9 @@ class SessionStore:
                 # so repeated interrupted restarts that escalate via the
                 # existing ``.restart_failure_counts`` stuck-loop counter
                 # still converge to a clean slate.
-                if entry.suspended:
+                if entry.quarantined or entry.session_id in self._read_quarantine_index_locked():
+                    reset_reason = "quarantined"
+                elif entry.suspended:
                     reset_reason = "suspended"
                 elif entry.resume_pending:
                     # Restart-interrupted session: preserve the session_id
@@ -1005,7 +1282,7 @@ class SessionStore:
                 entry = self._entries[session_key]
                 # Never override an explicit ``suspended`` — that is a hard
                 # forced-wipe signal (from /stop or stuck-loop escalation).
-                if entry.suspended:
+                if entry.suspended or entry.quarantined or entry.session_id in self._read_quarantine_index_locked():
                     return False
                 entry.resume_pending = True
                 entry.resume_reason = reason
@@ -1118,6 +1395,8 @@ class SessionStore:
             for entry in self._entries.values():
                 if entry.resume_pending:
                     continue
+                if entry.quarantined or entry.session_id in self._read_quarantine_index_locked():
+                    continue
                 if not entry.suspended and entry.updated_at >= cutoff:
                     entry.resume_pending = True
                     entry.resume_reason = "restart_interrupted"
@@ -1197,6 +1476,14 @@ class SessionStore:
             if session_key not in self._entries:
                 return None
 
+            if target_session_id in self._read_quarantine_index_locked():
+                logger.warning(
+                    "Refusing to switch %s to quarantined session %s",
+                    session_key,
+                    target_session_id,
+                )
+                return None
+
             old_entry = self._entries[session_key]
 
             # Don't switch if already on that session
@@ -1261,6 +1548,8 @@ class SessionStore:
                      via its own _flush_messages_to_session_db(), preventing
                      the duplicate-write bug (#860).
         """
+        message = _compact_replayed_handoff_message(message)
+
         # Write to SQLite (unless the agent already handled it)
         if self._db and not skip_db:
             try:
@@ -1297,6 +1586,8 @@ class SessionStore:
         Used by /retry, /undo, and /compress to persist modified conversation history.
         Rewrites both SQLite and legacy JSONL storage.
         """
+        messages = [_compact_replayed_handoff_message(msg) for msg in messages]
+
         # SQLite: replace atomically so a mid-rewrite failure doesn't leave
         # the session half-empty in the DB while JSONL still has history.
         if self._db:
@@ -1355,9 +1646,9 @@ class SessionStore:
                     "using JSONL (legacy session not yet fully migrated)",
                     session_id, len(jsonl_messages), len(db_messages),
                 )
-            return jsonl_messages
+            return _compact_replayed_messages_for_context(jsonl_messages)
 
-        return db_messages
+        return _compact_replayed_messages_for_context(db_messages)
 
 
 def build_session_context(

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -138,6 +138,19 @@ def _now() -> datetime:
     return datetime.now()
 
 
+RESUME_PENDING_TTL_SECONDS = int(os.getenv("HERMES_RESUME_PENDING_TTL_SECONDS", "600"))
+
+
+def _resume_pending_is_fresh(entry: "SessionEntry", max_age_seconds: int = RESUME_PENDING_TTL_SECONDS) -> bool:
+    marked = entry.last_resume_marked_at
+    if marked is None:
+        return False
+    try:
+        return (_now() - marked).total_seconds() <= max_age_seconds
+    except Exception:
+        return False
+
+
 # ---------------------------------------------------------------------------
 # PII redaction helpers
 # ---------------------------------------------------------------------------
@@ -1164,15 +1177,17 @@ class SessionStore:
                 elif entry.suspended:
                     reset_reason = "suspended"
                 elif entry.resume_pending:
-                    # Restart-interrupted session: preserve the session_id
-                    # and return the existing entry so the transcript
-                    # reloads intact.  ``resume_pending`` is cleared after
-                    # the NEXT successful turn completes (not here), which
-                    # means a re-interrupted retry keeps trying — the
-                    # stuck-loop counter handles terminal escalation.
-                    entry.updated_at = now
-                    self._save()
-                    return entry
+                    # Restart-interrupted session: preserve the session_id only
+                    # while the marker is fresh. Stale/malformed flags are
+                    # cleared so old restart/kill work cannot replay forever.
+                    if _resume_pending_is_fresh(entry):
+                        entry.updated_at = now
+                        self._save()
+                        return entry
+                    entry.resume_pending = False
+                    entry.resume_reason = None
+                    entry.last_resume_marked_at = None
+                    reset_reason = self._should_reset(entry, source)
                 else:
                     reset_reason = self._should_reset(entry, source)
                 if not reset_reason:
@@ -1311,6 +1326,24 @@ class SessionStore:
             self._save()
             return True
 
+    def clear_stale_resume_pending(self, max_age_seconds: int = RESUME_PENDING_TTL_SECONDS) -> int:
+        """Clear stale resume_pending flags without deleting session history."""
+        cleared = 0
+        with self._lock:
+            self._ensure_loaded_locked()
+            for entry in self._entries.values():
+                if not entry.resume_pending:
+                    continue
+                if _resume_pending_is_fresh(entry, max_age_seconds=max_age_seconds):
+                    continue
+                entry.resume_pending = False
+                entry.resume_reason = None
+                entry.last_resume_marked_at = None
+                cleared += 1
+            if cleared:
+                self._save()
+        return cleared
+
     def prune_old_entries(self, max_age_days: int) -> int:
         """Drop SessionEntry records older than max_age_days.
 
@@ -1390,11 +1423,17 @@ class SessionStore:
 
         cutoff = _now() - timedelta(seconds=max_age_seconds)
         count = 0
+        changed = False
         with self._lock:
             self._ensure_loaded_locked()
             for entry in self._entries.values():
                 if entry.resume_pending:
-                    continue
+                    if _resume_pending_is_fresh(entry):
+                        continue
+                    entry.resume_pending = False
+                    entry.resume_reason = None
+                    entry.last_resume_marked_at = None
+                    changed = True
                 if entry.quarantined or entry.session_id in self._read_quarantine_index_locked():
                     continue
                 if not entry.suspended and entry.updated_at >= cutoff:
@@ -1402,7 +1441,8 @@ class SessionStore:
                     entry.resume_reason = "restart_interrupted"
                     entry.last_resume_marked_at = _now()
                     count += 1
-            if count:
+                    changed = True
+            if changed:
                 self._save()
         return count
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -99,10 +99,16 @@ def resolve_agent_max_turns(
             value = _positive_int(raw)
             if value is not None and value != 90:
                 return value
-        env_map = env if env is not None else os.environ
-        value = _positive_int(env_map.get("HERMES_MAX_ITERATIONS") if env_map else None)
-        if value is not None and value != 90:
-            return value
+
+        # HERMES_MAX_ITERATIONS is a legacy env fallback, not a surface-budget
+        # authority. Do not let a stale .env value shadow known task-shaped
+        # defaults (cli=16, gateway=32, cron=90, etc.) when config is missing
+        # or partial; that is the exact failure mode this resolver prevents.
+        if mode_key not in defaults:
+            env_map = env if env is not None else os.environ
+            value = _positive_int(env_map.get("HERMES_MAX_ITERATIONS") if env_map else None)
+            if value is not None and value != 90:
+                return value
 
     return defaults.get(mode_key) or _positive_int(agent_cfg.get("max_turns") if isinstance(agent_cfg, dict) else None) or 90
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -28,6 +28,85 @@ from typing import Dict, Any, Optional, List, Tuple
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_AGENT_TURN_BUDGETS = {
+    "cli": 16,
+    "gateway": 32,
+    "api_server": 32,
+    "cron": 90,
+    "lightweight_followup": 6,
+    "coding": 90,
+    "ship_mode": 128,
+}
+
+_MESSAGING_GATEWAY_MODES = {
+    "discord", "telegram", "slack", "whatsapp", "signal", "matrix",
+    "mattermost", "sms", "email", "feishu", "dingtalk", "wecom",
+    "weixin", "bluebubbles", "qqbot", "yuanbao", "webhook",
+    "homeassistant", "gateway",
+}
+
+
+def get_default_agent_turn_budgets() -> Dict[str, int]:
+    return dict(DEFAULT_AGENT_TURN_BUDGETS)
+
+
+def _normalize_agent_turn_budget_mode(mode: str | None) -> str:
+    key = (mode or "cli").strip().lower()
+    if key == "local":
+        return "cli"
+    if key in _MESSAGING_GATEWAY_MODES:
+        return "gateway"
+    return key
+
+
+def _positive_int(value: Any) -> Optional[int]:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def resolve_agent_max_turns(
+    config: Dict[str, Any] | None,
+    *,
+    mode: str = "cli",
+    env: Dict[str, str] | None = None,
+    include_legacy_global_override: bool = True,
+) -> int:
+    """Resolve the effective tool-loop budget for a runtime surface.
+
+    Per-surface budgets win. Legacy global max_turns/HERMES_MAX_ITERATIONS are
+    only compatibility fallbacks so one old blunt knob cannot make Discord,
+    cron, CLI, and API-server turns all behave the same.
+    """
+    cfg = config if isinstance(config, dict) else {}
+    agent_cfg = cfg.get("agent") if isinstance(cfg.get("agent"), dict) else {}
+    mode_key = _normalize_agent_turn_budget_mode(mode)
+
+    budgets = agent_cfg.get("turn_budgets") if isinstance(agent_cfg, dict) else None
+    if isinstance(budgets, dict):
+        for key in (mode_key, "gateway" if mode_key in _MESSAGING_GATEWAY_MODES else None):
+            if not key:
+                continue
+            value = _positive_int(budgets.get(key))
+            if value is not None:
+                return value
+
+    defaults = get_default_agent_turn_budgets()
+    if include_legacy_global_override:
+        for raw in (agent_cfg.get("max_turns") if isinstance(agent_cfg, dict) else None, cfg.get("max_turns")):
+            value = _positive_int(raw)
+            if value is not None and value != 90:
+                return value
+        env_map = env if env is not None else os.environ
+        value = _positive_int(env_map.get("HERMES_MAX_ITERATIONS") if env_map else None)
+        if value is not None and value != 90:
+            return value
+
+    return defaults.get(mode_key) or _positive_int(agent_cfg.get("max_turns") if isinstance(agent_cfg, dict) else None) or 90
+
+
 # Track which (config_path, mtime_ns, size) tuples we've already warned about
 # so concurrent CLI/gateway loads of a broken config.yaml don't spam stderr
 # every time. Cleared automatically when the file changes (different mtime).
@@ -471,6 +550,23 @@ DEFAULT_CONFIG = {
     "model": "",
     "providers": {},
     "fallback_providers": [],
+    "gateway_context_spill": {
+        "enabled": True,
+        "mode": "enforce",
+        "wiki_dir": "~/wiki/outputs/gateway-context-spills",
+        "raw_state_dir": "~/.hermes/state/context-spills",
+        "token_threshold_ratio": 0.70,
+        "hard_token_limit": 180000,
+        "hard_message_limit": 180,
+        "hard_char_limit": 500000,
+        "hard_request_byte_limit": 1800000,
+        "include_raw_state": True,
+        "include_redacted_wiki_excerpt_chars": 24000,
+        "reset_live_session": True,
+        "notify_user": True,
+        "fallback_safe": True,
+        "retention_days": 30,
+    },
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
     "agent": {
@@ -553,6 +649,7 @@ DEFAULT_CONFIG = {
         # only controls how inbound user images are presented.
         "image_input_mode": "auto",
         "disabled_toolsets": [],
+        "turn_budgets": get_default_agent_turn_budgets(),
     },
     
     "terminal": {
@@ -1180,7 +1277,7 @@ DEFAULT_CONFIG = {
         # extras" without silently stripping MCP tools the parent already has.
         # Set to false for strict intersection.
         "inherit_mcp_toolsets": True,
-        "max_iterations": 50,  # per-subagent iteration cap (each subagent gets its own budget,
+        "max_iterations": 90,  # per-subagent iteration cap (each subagent gets its own budget,
                                # independent of the parent's max_iterations)
         "child_timeout_seconds": 600,  # wall-clock timeout for each child agent (floor 30s,
                                        # no ceiling). High-reasoning models on large tasks
@@ -3204,7 +3301,7 @@ def check_config_version() -> Tuple[int, int]:
 # Fields that are valid at root level of config.yaml
 _KNOWN_ROOT_KEYS = {
     "_config_version", "model", "providers", "fallback_model",
-    "fallback_providers", "credential_pool_strategies", "toolsets",
+    "fallback_providers", "gateway_context_spill", "credential_pool_strategies", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
     "auxiliary", "custom_providers", "context", "memory", "gateway",
     "sessions",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1418,6 +1418,7 @@ DEFAULT_CONFIG = {
         "thread_require_mention": False,  # If True, require @mention in threads too (multi-bot threads)
         "history_backfill": True,         # If True, prepend recent channel scrollback when bot is triggered (recovers messages missed while require_mention gated them out)
         "history_backfill_limit": 50,     # Max number of recent messages to scan when assembling the backfill block
+        "history_backfill_max_chars": 12000,  # Hard cap for prepended scrollback so one giant prompt cannot poison the next task
         "reactions": True,             # Add 👀/✅/❌ reactions to messages during processing
         "channel_prompts": {},         # Per-channel ephemeral system prompts (forum parents apply to child threads)
         # Opt-in DM role-based auth (#12136). By default, DISCORD_ALLOWED_ROLES

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -367,6 +367,7 @@ def run_doctor(args):
     issues = []
     manual_issues = []  # issues that can't be auto-fixed
     fixed_count = 0
+    active_runtime_provider = ""
 
     print()
     print(color("┌─────────────────────────────────────────────────────────┐", Colors.CYAN))
@@ -593,6 +594,7 @@ def run_doctor(args):
                     provider_ids_to_accept.add(runtime_provider)
                 except Exception:
                     runtime_provider = provider
+            active_runtime_provider = runtime_provider or provider or ""
 
             catalog_provider = provider
             if (
@@ -1661,6 +1663,23 @@ def run_doctor(args):
 
     # Clear the "Running …" line and print all results in submission order.
     print("\r" + " " * 70 + "\r", end="")
+
+    def _is_inactive_optional_provider_issue(label: str, issue: str) -> bool:
+        """Do not promote optional provider-key failures into final issues.
+
+        The row still prints as a warning/failure, but an invalid Gemini key
+        should not make doctor fail when the active runtime is GPT/Codex and
+        Gemini OAuth is not configured. Switching to Gemini will still be caught
+        by the configured-provider credential checks above.
+        """
+        normalized_label = (label or "").strip().lower()
+        active = (active_runtime_provider or "").strip().lower()
+        if "gemini" in normalized_label and not (
+            "gemini" in active or active in {"google", "google-ai"}
+        ):
+            return True
+        return False
+
     for _r in _results:
         for _glyph, _label, _detail in _r.lines:
             if _detail:
@@ -1671,6 +1690,8 @@ def run_doctor(args):
         if _issues_to_add and _has_healthy_oauth_fallback_for_apikey_provider(_r.label):
             _issues_to_add = []
         for _issue in _issues_to_add:
+            if _is_inactive_optional_provider_issue(_r.label, _issue):
+                continue
             issues.append(_issue)
 
     # =========================================================================
@@ -1699,10 +1720,8 @@ def run_doctor(args):
             else:
                 check_warn(item["name"], "(system dependency not met)")
 
-        # Count disabled tools with API key requirements
-        api_disabled = [u for u in unavailable if (u.get("missing_vars") or u.get("env_vars"))]
-        if api_disabled:
-            issues.append("Run 'hermes setup' to configure missing API keys for full tool access")
+        # Missing API keys disable optional toolsets, but they are not runtime
+        # health issues for installs that do not use those tools.
     except Exception as e:
         check_warn("Could not check tool availability", f"({e})")
     

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -173,7 +173,7 @@ def _has_healthy_oauth_fallback_for_apikey_provider(provider_label: str) -> bool
             return bool((get_minimax_oauth_auth_status() or {}).get("logged_in"))
         except Exception:
             return False
-    if normalized == "xai":
+    if normalized in {"xai", "xai / grok", "grok"}:
         try:
             from hermes_cli.auth import get_xai_oauth_auth_status
             return bool((get_xai_oauth_auth_status() or {}).get("logged_in"))
@@ -812,6 +812,10 @@ def run_doctor(args):
             if codex_status.get("error"):
                 check_info(codex_status["error"])
 
+        def _runtime_uses_provider(*provider_markers: str) -> bool:
+            active = (active_runtime_provider or "").strip().lower()
+            return any(marker in active for marker in provider_markers)
+
         gemini_status = get_gemini_oauth_auth_status()
         if gemini_status.get("logged_in"):
             email = gemini_status.get("email") or ""
@@ -823,15 +827,19 @@ def run_doctor(args):
                 pieces.append(f"project={project}")
             suffix = f" ({', '.join(pieces)})" if pieces else ""
             check_ok("Google Gemini OAuth", f"(logged in{suffix})")
-        else:
+        elif _runtime_uses_provider("gemini", "google"):
             check_warn("Google Gemini OAuth", "(not logged in)")
+        else:
+            check_info("Google Gemini OAuth not logged in (optional; inactive provider)")
 
         minimax_status = get_minimax_oauth_auth_status()
         if minimax_status.get("logged_in"):
             region = minimax_status.get("region", "global")
             check_ok("MiniMax OAuth", f"(logged in, region={region})")
-        else:
+        elif _runtime_uses_provider("minimax"):
             check_warn("MiniMax OAuth", "(not logged in)")
+        else:
+            check_info("MiniMax OAuth not logged in (optional; inactive provider)")
     except Exception as e:
         check_warn("Auth provider status", f"(could not check: {e})")
 

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -987,6 +987,47 @@ def run_doctor(args):
     _check_gateway_service_linger(issues)
 
     # =========================================================================
+    # Runtime Safety
+    # =========================================================================
+    print()
+    print(color("◆ Runtime Safety", Colors.CYAN, Colors.BOLD))
+    try:
+        from hermes_cli.runtime_safety import build_runtime_safety_report
+        report = build_runtime_safety_report()
+        counts = report["counts"]
+        if counts["unsafe_gateway_control_due"]:
+            check_fail("Unsafe gateway-control cron job due", f"({counts['unsafe_gateway_control_due']} due)")
+            issues.append("Disable or rewrite due cron jobs that can stop/restart/kill hermes-gateway")
+        else:
+            check_ok("No unsafe gateway-control cron jobs due")
+        if counts["stale_resume_pending"]:
+            check_fail("Stale resume_pending session flags", f"({counts['stale_resume_pending']} stale)")
+            issues.append("Clear stale gateway resume_pending flags before long dev work")
+        else:
+            check_ok("No stale resume_pending flags")
+        if counts["unsafe_gateway_control_scheduled"]:
+            check_warn("Scheduled gateway-control cron jobs", f"({counts['unsafe_gateway_control_scheduled']} scheduled)")
+        if counts["gateway_control_adjacent"]:
+            check_info(f"Gateway-control-adjacent cron jobs: {counts['gateway_control_adjacent']}")
+        if counts["expired_oneshot"]:
+            check_warn("Expired one-shot cron jobs", f"({counts['expired_oneshot']} expired records)")
+        for row in report.get("cron_risks", [])[:5]:
+            check_info(
+                f"cron {row.get('severity')} {row.get('reason')}: "
+                f"id={row.get('job_id')} name={row.get('name')} "
+                f"state={row.get('state')} schedule={row.get('schedule')} "
+                f"script={row.get('script') or '-'}"
+            )
+        for row in report.get("stale_resume_pending", [])[:5]:
+            check_info(
+                f"resume {row.get('reason')}: session={row.get('session_key_hash')} "
+                f"age={row.get('age_seconds')}s ttl={row.get('ttl_seconds')}s"
+            )
+    except Exception as e:
+        check_fail("Runtime safety scan failed", f"({e})")
+        issues.append("Runtime safety scan failed; inspect cron/jobs.json and sessions.json")
+
+    # =========================================================================
     # Check: Command installation (hermes bin symlink)
     # =========================================================================
     if sys.platform != "win32":

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4145,6 +4145,11 @@ def _default_spawn(
     # board slug still forces it to the right directory.
     resolved_board = _normalize_board_slug(board) or get_current_board()
     env["HERMES_KANBAN_BOARD"] = resolved_board
+    # Workers are durable task executors, not live Discord turns. Downstream
+    # prompt/memory/runtime code can use this to avoid pulling chat scrollback
+    # or interactive gateway affordances into long-running app-dev work.
+    env["HERMES_WORKER_CONTEXT"] = "kanban"
+    env["HERMES_CONTEXT_LANE"] = "worker"
     # HERMES_PROFILE is the author the kanban_comment tool defaults to.
     # `hermes -p <assignee>` activates the profile, but the env var is
     # what the tool reads — set it explicitly here so comments are

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5577,6 +5577,13 @@ def cmd_doctor(args):
     run_doctor(args)
 
 
+def cmd_preflight(args):
+    """Run long-task runtime preflight checks."""
+    from hermes_cli.preflight import run_preflight
+
+    return run_preflight(args)
+
+
 def cmd_dump(args):
     """Dump setup summary for support/debugging."""
     from hermes_cli.dump import run_dump
@@ -10724,6 +10731,23 @@ def main():
         ),
     )
     doctor_parser.set_defaults(func=cmd_doctor)
+
+    # =========================================================================
+    # preflight command
+    # =========================================================================
+    preflight_parser = subparsers.add_parser(
+        "preflight",
+        help="Run long-task runtime safety checks",
+        description="Check Hermes runtime safety before long-running app-dev or maintenance work",
+    )
+    preflight_parser.add_argument(
+        "--mode",
+        choices=("app-dev", "hermes-maintenance"),
+        default="app-dev",
+        help="Expected task lane for workspace classification",
+    )
+    preflight_parser.add_argument("--json", action="store_true", help="Print JSON output")
+    preflight_parser.set_defaults(func=cmd_preflight)
 
     # =========================================================================
     # dump command

--- a/hermes_cli/preflight.py
+++ b/hermes_cli/preflight.py
@@ -1,0 +1,174 @@
+"""Preflight checks for long-running dev and Hermes maintenance tasks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+from hermes_cli.runtime_safety import build_runtime_safety_report
+
+
+@dataclass
+class PreflightCheck:
+    name: str
+    ok: bool
+    severity: str
+    detail: str
+
+
+@dataclass
+class PreflightReport:
+    ok: bool
+    mode: str
+    classification: str
+    checks: list[PreflightCheck]
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "mode": self.mode,
+            "classification": self.classification,
+            "checks": [asdict(check) for check in self.checks],
+        }
+
+
+def _run(args: list[str], timeout: float = 3.0) -> subprocess.CompletedProcess:
+    return subprocess.run(args, capture_output=True, text=True, timeout=timeout)
+
+
+def classify_workspace(cwd: str | Path | None = None) -> str:
+    path = Path(cwd or os.getcwd()).resolve()
+    try:
+        repo = Path(__file__).resolve().parents[1]
+        if path == repo or repo in path.parents:
+            return "hermes-maintenance"
+    except Exception:
+        pass
+    return "app-dev"
+
+
+def check_gateway() -> PreflightCheck:
+    if shutil.which("systemctl") is None:
+        return PreflightCheck("gateway", True, "info", "systemctl unavailable; skipped")
+    try:
+        result = _run([
+            "systemctl", "--user", "show", "hermes-gateway",
+            "-p", "ActiveState", "-p", "SubState", "-p", "TimeoutStopUSec", "--no-pager",
+        ])
+    except Exception as exc:
+        return PreflightCheck("gateway", False, "blocker", f"could not query gateway: {exc}")
+    out = result.stdout or ""
+    ok = result.returncode == 0 and "ActiveState=active" in out and "SubState=running" in out
+    detail = "active/running" if ok else "gateway not active/running"
+    if "TimeoutStopUSec=" in out:
+        timeout_line = next((line for line in out.splitlines() if line.startswith("TimeoutStopUSec=")), "")
+        if timeout_line:
+            detail += f" {timeout_line}"
+    return PreflightCheck("gateway", ok, "blocker" if not ok else "ok", detail)
+
+
+def check_runtime_safety() -> list[PreflightCheck]:
+    report = build_runtime_safety_report()
+    counts = report["counts"]
+    checks = [
+        PreflightCheck(
+            "unsafe_due_cron",
+            counts["unsafe_gateway_control_due"] == 0,
+            "blocker" if counts["unsafe_gateway_control_due"] else "ok",
+            f"due unsafe gateway-control cron jobs: {counts['unsafe_gateway_control_due']}",
+        ),
+        PreflightCheck(
+            "stale_resume_pending",
+            counts["stale_resume_pending"] == 0,
+            "blocker" if counts["stale_resume_pending"] else "ok",
+            f"stale resume_pending flags: {counts['stale_resume_pending']}",
+        ),
+    ]
+    scheduled = counts["unsafe_gateway_control_scheduled"] + counts["gateway_control_adjacent"]
+    checks.append(
+        PreflightCheck(
+            "scheduled_gateway_control",
+            True,
+            "warn" if scheduled else "ok",
+            f"scheduled/adjacent gateway-control cron jobs: {scheduled}",
+        )
+    )
+    return checks
+
+
+def check_kanban() -> PreflightCheck:
+    home = get_hermes_home()
+    candidates = [home / "kanban.db"]
+    board = os.environ.get("HERMES_KANBAN_BOARD")
+    if board:
+        candidates.insert(0, Path(board))
+    existing = [p for p in candidates if p.exists()]
+    if not existing:
+        return PreflightCheck("kanban", True, "info", "no kanban db found; skipped")
+    bad = []
+    for path in existing:
+        try:
+            conn = sqlite3.connect(str(path))
+            value = conn.execute("PRAGMA integrity_check").fetchone()[0]
+            conn.close()
+            if value != "ok":
+                bad.append(f"{path}: {value}")
+        except Exception as exc:
+            bad.append(f"{path}: {exc}")
+    return PreflightCheck("kanban", not bad, "blocker" if bad else "ok", "; ".join(bad) if bad else "integrity ok")
+
+
+def check_disk_memory() -> list[PreflightCheck]:
+    usage = shutil.disk_usage(str(get_hermes_home()))
+    disk_ok = usage.free >= 5 * 1024 * 1024 * 1024
+    checks = [PreflightCheck("disk", disk_ok, "blocker" if not disk_ok else "ok", f"free_gb={usage.free / (1024**3):.1f}")]
+    mem_available_kb = None
+    try:
+        for line in Path("/proc/meminfo").read_text(encoding="utf-8").splitlines():
+            if line.startswith("MemAvailable:"):
+                mem_available_kb = int(line.split()[1])
+                break
+    except Exception:
+        pass
+    if mem_available_kb is None:
+        checks.append(PreflightCheck("memory", True, "info", "MemAvailable unavailable; skipped"))
+    else:
+        mem_ok = mem_available_kb >= 1_000_000
+        checks.append(PreflightCheck("memory", mem_ok, "blocker" if not mem_ok else "ok", f"available_mb={mem_available_kb // 1024}"))
+    return checks
+
+
+def build_preflight_report(mode: str = "app-dev") -> PreflightReport:
+    classification = classify_workspace()
+    checks: list[PreflightCheck] = []
+    checks.append(check_gateway())
+    checks.extend(check_runtime_safety())
+    checks.append(check_kanban())
+    checks.extend(check_disk_memory())
+    if mode == "hermes-maintenance" and classification != "hermes-maintenance":
+        checks.append(PreflightCheck("workspace_mode", False, "blocker", f"cwd classified as {classification}, expected hermes-maintenance"))
+    else:
+        checks.append(PreflightCheck("workspace_mode", True, "ok", f"cwd classified as {classification}"))
+    ok = all(check.ok or check.severity in {"warn", "info"} for check in checks)
+    return PreflightReport(ok=ok, mode=mode, classification=classification, checks=checks)
+
+
+def run_preflight(args: argparse.Namespace) -> int:
+    mode = getattr(args, "mode", "app-dev") or "app-dev"
+    report = build_preflight_report(mode=mode)
+    if getattr(args, "json", False):
+        print(json.dumps(report.to_json(), indent=2, sort_keys=True))
+    else:
+        print(f"Hermes preflight: {'PASS' if report.ok else 'FAIL'} mode={report.mode} classification={report.classification}")
+        for check in report.checks:
+            marker = "✓" if check.ok else "✗"
+            print(f"  {marker} {check.name}: {check.detail}")
+    return 0 if report.ok else 1

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -263,6 +263,16 @@ def _resolve_runtime_from_pool_entry(
         cfg_base_url = ""
         if cfg_provider == "anthropic":
             cfg_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
+        # Also honor providers.anthropic.base_url for setups where anthropic
+        # is a fallback/secondary provider (top-level model.provider differs),
+        # but do not override a non-default base URL stored on the credential.
+        if not cfg_base_url and (not base_url or base_url.rstrip("/") == "https://api.anthropic.com"):
+            try:
+                _providers_cfg = load_config().get("providers") or {}
+                _anth_cfg = _providers_cfg.get("anthropic") or {}
+                cfg_base_url = str(_anth_cfg.get("base_url") or "").strip().rstrip("/")
+            except Exception:
+                pass
         base_url = cfg_base_url or base_url or "https://api.anthropic.com"
     elif provider == "openrouter":
         base_url = base_url or OPENROUTER_BASE_URL
@@ -829,6 +839,13 @@ def _resolve_explicit_runtime(
         cfg_base_url = ""
         if cfg_provider == "anthropic":
             cfg_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
+        if not cfg_base_url:
+            try:
+                _providers_cfg = load_config().get("providers") or {}
+                _anth_cfg = _providers_cfg.get("anthropic") or {}
+                cfg_base_url = str(_anth_cfg.get("base_url") or "").strip().rstrip("/")
+            except Exception:
+                pass
         base_url = explicit_base_url or cfg_base_url or "https://api.anthropic.com"
         api_key = explicit_api_key
         if not api_key:

--- a/hermes_cli/runtime_safety.py
+++ b/hermes_cli/runtime_safety.py
@@ -33,11 +33,18 @@ _READONLY_JOURNAL_RE = re.compile(
 _MUTATING_GATEWAY_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = tuple(
     (re.compile(pattern, re.IGNORECASE | re.DOTALL), reason)
     for pattern, reason in (
-        (r"\bsystemctl\s+(?:--user\s+)?(?:restart|stop|kill|disable|mask|try-restart|reload-or-restart)\b[^\n;|&]*\bhermes-gateway(?:\.service)?\b", "systemctl_gateway_lifecycle"),
-        (r"\bhermes\s+gateway\s+(?:stop|restart)\b", "hermes_gateway_lifecycle"),
+        (
+            r"\bsystemctl\b(?=[^\n;|&]*\b(?:restart|stop|kill|disable|mask|try-restart|reload-or-restart)\b)(?=[^\n;|&]*\bhermes-gateway(?:\.service)?\b)[^\n;|&]*",
+            "systemctl_gateway_lifecycle",
+        ),
+        (r"\bhermes\s+gateway\s+(?:stop|restart|update)\b", "hermes_gateway_lifecycle"),
         (r"\bhermes\s+update\b", "hermes_update_gateway_restart"),
         (r"\b(?:pkill|killall)\b[^\n]*\b(?:hermes(?:-gateway)?|gateway\.run|gateway/run\.py)\b", "name_based_gateway_kill"),
         (r"\bkill\b[^\n]*(?:-9|-KILL|-SIGKILL|-s\s+(?:9|KILL|SIGKILL))[^\n]*(?:\$\([^)]*hermes-gateway[^)]*\)|`[^`]*hermes-gateway[^`]*`)", "gateway_pid_sigkill"),
+        (
+            r"(?=.*\bhermes-gateway(?:\.service)?\b)(?=.*\bkill\b[^\n;|&]*(?:-9|-KILL|-SIGKILL|-s\s+(?:9|KILL|SIGKILL)))(?=.*\bMainPID\b)",
+            "gateway_pid_sigkill",
+        ),
     )
 )
 
@@ -225,6 +232,9 @@ def classify_cron_job(job: dict[str, Any], now: datetime | None = None) -> CronR
         _safe_text(job.get(key))
         for key in ("name", "script", "prompt")
     )
+    script_body = _script_body_for_scan(job.get("script"))
+    if script_body:
+        scan_text = f"{scan_text}\n{script_body}"
     reason = classify_gateway_control_text(scan_text)
     if not reason:
         return None

--- a/hermes_cli/runtime_safety.py
+++ b/hermes_cli/runtime_safety.py
@@ -1,0 +1,347 @@
+"""Runtime safety scanners for cron, gateway control, and resume state.
+
+This module is intentionally display-safe: scanner result objects never carry raw
+cron prompts or secret-bearing command text.  Callers may inspect source records
+for classification, but status/doctor/preflight should only print the sanitized
+fields exposed here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass, asdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from hermes_constants import get_hermes_home
+
+ONESHOT_GRACE_SECONDS = 120
+RESUME_PENDING_TTL_SECONDS = 10 * 60
+
+_GATEWAY_SERVICE_RE = re.compile(r"\bhermes-gateway(?:\.service)?\b", re.IGNORECASE)
+_READONLY_SYSTEMCTL_RE = re.compile(
+    r"\bsystemctl\s+(?:--user\s+)?(?:status|show|is-active|is-enabled|list-units)\b[^\n;|&]*\bhermes-gateway(?:\.service)?\b",
+    re.IGNORECASE,
+)
+_READONLY_HERMES_GATEWAY_RE = re.compile(r"\bhermes\s+gateway\s+status\b", re.IGNORECASE)
+_READONLY_JOURNAL_RE = re.compile(
+    r"\bjournalctl\b[^\n;|&]*\b(?:-u\s+)?hermes-gateway(?:\.service)?\b",
+    re.IGNORECASE,
+)
+_MUTATING_GATEWAY_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = tuple(
+    (re.compile(pattern, re.IGNORECASE | re.DOTALL), reason)
+    for pattern, reason in (
+        (r"\bsystemctl\s+(?:--user\s+)?(?:restart|stop|kill|disable|mask|try-restart|reload-or-restart)\b[^\n;|&]*\bhermes-gateway(?:\.service)?\b", "systemctl_gateway_lifecycle"),
+        (r"\bhermes\s+gateway\s+(?:stop|restart)\b", "hermes_gateway_lifecycle"),
+        (r"\bhermes\s+update\b", "hermes_update_gateway_restart"),
+        (r"\b(?:pkill|killall)\b[^\n]*\b(?:hermes(?:-gateway)?|gateway\.run|gateway/run\.py)\b", "name_based_gateway_kill"),
+        (r"\bkill\b[^\n]*(?:-9|-KILL|-SIGKILL|-s\s+(?:9|KILL|SIGKILL))[^\n]*(?:\$\([^)]*hermes-gateway[^)]*\)|`[^`]*hermes-gateway[^`]*`)", "gateway_pid_sigkill"),
+    )
+)
+
+
+@dataclass(frozen=True)
+class CronRisk:
+    job_id: str
+    name: str
+    enabled: bool
+    state: str
+    schedule_kind: str
+    schedule: str
+    next_run_at: str | None
+    reason: str
+    severity: str
+    script: str | None = None
+    no_agent: bool = False
+
+    def to_display(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc).astimezone()
+
+
+def _parse_dt(value: Any) -> datetime | None:
+    if not value or not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(text)
+    except (TypeError, ValueError):
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(_now().tzinfo)
+
+
+def _safe_text(value: Any, fallback: str = "") -> str:
+    if value is None:
+        return fallback
+    return str(value)
+
+
+def _short_hash(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8", errors="ignore")).hexdigest()[:12]
+
+
+def _schedule_kind(job: dict[str, Any]) -> str:
+    schedule = job.get("schedule")
+    if isinstance(schedule, dict):
+        return _safe_text(schedule.get("kind"), "unknown") or "unknown"
+    return "unknown"
+
+
+def _schedule_display(job: dict[str, Any]) -> str:
+    display = _safe_text(job.get("schedule_display")).strip()
+    if display:
+        return display
+    schedule = job.get("schedule")
+    if isinstance(schedule, dict):
+        for key in ("display", "expr", "run_at", "value"):
+            text = _safe_text(schedule.get(key)).strip()
+            if text:
+                return text
+    return "?"
+
+
+def sanitize_script_path(value: Any) -> str | None:
+    if not value:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        return Path(text).name if not Path(text).is_absolute() else str(Path(text).name)
+    except Exception:
+        return text.split("/")[-1][-80:]
+
+
+def sanitize_job_for_display(job: dict[str, Any], *, reason: str = "", severity: str = "info") -> dict[str, Any]:
+    """Return a prompt-free, secret-minimized cron job display object."""
+    return {
+        "job_id": _safe_text(job.get("id"), "unknown"),
+        "name": (_safe_text(job.get("name"), "cron job").strip() or "cron job")[:80],
+        "enabled": bool(job.get("enabled", True)),
+        "state": (_safe_text(job.get("state"), "scheduled").strip() or "scheduled")[:40],
+        "schedule_kind": _schedule_kind(job),
+        "schedule": _schedule_display(job)[:120],
+        "next_run_at": _safe_text(job.get("next_run_at"), "") or None,
+        "reason": reason,
+        "severity": severity,
+        "script": sanitize_script_path(job.get("script")),
+        "no_agent": bool(job.get("no_agent", False)),
+    }
+
+
+def _script_body_for_scan(script: Any, *, max_chars: int = 20000) -> str:
+    """Best-effort read of a cron script body for lifecycle-command scanning.
+
+    Cron script paths are constrained to HERMES_HOME/scripts by the scheduler;
+    mirror that boundary here and never return the body to callers. The text is
+    only fed into classifiers so a harmless-looking script name cannot hide a
+    `systemctl kill hermes-gateway.service` payload.
+    """
+    if not script:
+        return ""
+    try:
+        scripts_dir = (get_hermes_home() / "scripts").resolve()
+        raw = Path(str(script).strip()).expanduser()
+        path = raw.resolve() if raw.is_absolute() else (scripts_dir / raw).resolve()
+        path.relative_to(scripts_dir)
+        if not path.is_file():
+            return ""
+        return path.read_text(encoding="utf-8", errors="ignore")[:max_chars]
+    except Exception:
+        return ""
+
+
+def classify_gateway_control_text(text: Any) -> str | None:
+    """Classify text as mutating gateway control, adjacent, or safe/none."""
+    if not text:
+        return None
+    raw = str(text)
+    if not raw.strip():
+        return None
+    if (
+        _READONLY_SYSTEMCTL_RE.search(raw)
+        or _READONLY_HERMES_GATEWAY_RE.search(raw)
+        or _READONLY_JOURNAL_RE.search(raw)
+    ) and not any(pattern.search(raw) for pattern, _reason in _MUTATING_GATEWAY_PATTERNS):
+        return None
+    for pattern, reason in _MUTATING_GATEWAY_PATTERNS:
+        if pattern.search(raw):
+            return reason
+    lowered = raw.lower()
+    if "hermes-gateway" in lowered or "hermes gateway" in lowered:
+        if any(word in lowered for word in ("restart", "stop", "kill", "sigkill", "disable", "mask")):
+            return "gateway_control_adjacent"
+    return None
+
+
+def is_job_due(job: dict[str, Any], now: datetime | None = None) -> bool:
+    if now is None:
+        now = _now()
+    if not job.get("enabled", True):
+        return False
+    next_run = _parse_dt(job.get("next_run_at"))
+    return bool(next_run and next_run <= now)
+
+
+def is_expired_oneshot(job: dict[str, Any], now: datetime | None = None, grace_seconds: int = ONESHOT_GRACE_SECONDS) -> bool:
+    if now is None:
+        now = _now()
+    schedule = job.get("schedule") or {}
+    if not isinstance(schedule, dict) or schedule.get("kind") != "once":
+        return False
+    if not job.get("enabled", True):
+        return False
+    if job.get("last_run_at"):
+        return False
+    run_at = _parse_dt(job.get("next_run_at")) or _parse_dt(schedule.get("run_at"))
+    if run_at is None:
+        return False
+    return run_at < now - timedelta(seconds=grace_seconds)
+
+
+def classify_cron_job(job: dict[str, Any], now: datetime | None = None) -> CronRisk | None:
+    if now is None:
+        now = _now()
+    display = sanitize_job_for_display(job)
+    if is_expired_oneshot(job, now):
+        return CronRisk(**{**display, "reason": "expired_oneshot", "severity": "warning"})
+
+    scan_text = "\n".join(
+        _safe_text(job.get(key))
+        for key in ("name", "script", "prompt")
+    )
+    reason = classify_gateway_control_text(scan_text)
+    if not reason:
+        return None
+
+    enabled = bool(job.get("enabled", True))
+    due = is_job_due(job, now)
+    if enabled and due and reason != "gateway_control_adjacent":
+        severity = "critical"
+        public_reason = "unsafe_gateway_control_due"
+    elif enabled and reason != "gateway_control_adjacent":
+        severity = "warning"
+        public_reason = "unsafe_gateway_control_scheduled"
+    elif reason == "gateway_control_adjacent":
+        severity = "info" if not enabled else "warning"
+        public_reason = "gateway_control_adjacent"
+    else:
+        severity = "warning"
+        public_reason = "unsafe_gateway_control_disabled"
+    return CronRisk(**{**display, "reason": public_reason, "severity": severity})
+
+
+def scan_cron_jobs(jobs: Iterable[dict[str, Any]], now: datetime | None = None) -> list[CronRisk]:
+    if now is None:
+        now = _now()
+    risks: list[CronRisk] = []
+    for job in jobs:
+        try:
+            risk = classify_cron_job(job, now)
+        except Exception:
+            risk = CronRisk(
+                job_id=_safe_text(job.get("id"), "unknown") if isinstance(job, dict) else "unknown",
+                name="cron job",
+                enabled=False,
+                state="unknown",
+                schedule_kind="unknown",
+                schedule="?",
+                next_run_at=None,
+                reason="safety_scan_error",
+                severity="critical",
+                script=None,
+                no_agent=False,
+            )
+        if risk:
+            risks.append(risk)
+    return risks
+
+
+def load_cron_jobs_for_scan() -> list[dict[str, Any]]:
+    path = get_hermes_home() / "cron" / "jobs.json"
+    try:
+        import json
+        data = json.loads(path.read_text(encoding="utf-8"))
+        jobs = data.get("jobs", [])
+        return jobs if isinstance(jobs, list) else []
+    except FileNotFoundError:
+        return []
+    except Exception:
+        return []
+
+
+def load_session_entries_for_scan() -> list[dict[str, Any]]:
+    path = get_hermes_home() / "sessions" / "sessions.json"
+    try:
+        import json
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            return []
+        return [entry for entry in data.values() if isinstance(entry, dict)]
+    except FileNotFoundError:
+        return []
+    except Exception:
+        return []
+
+
+def scan_resume_pending_sessions(
+    session_entries: Iterable[dict[str, Any]],
+    now: datetime | None = None,
+    ttl_seconds: int = RESUME_PENDING_TTL_SECONDS,
+) -> list[dict[str, Any]]:
+    if now is None:
+        now = _now()
+    stale: list[dict[str, Any]] = []
+    for entry in session_entries:
+        if not isinstance(entry, dict) or not entry.get("resume_pending"):
+            continue
+        marked = _parse_dt(entry.get("last_resume_marked_at"))
+        if marked is None:
+            age = None
+            reason = "stale_resume_pending_missing_timestamp"
+        else:
+            age = max(0, int((now - marked).total_seconds()))
+            if age <= ttl_seconds:
+                continue
+            reason = "stale_resume_pending"
+        key = _safe_text(entry.get("session_key"), "")
+        stale.append({
+            "session_key_hash": _short_hash(key) if key else "unknown",
+            "session_id": _safe_text(entry.get("session_id"), "unknown")[:80],
+            "platform": _safe_text(entry.get("platform"), "unknown")[:40],
+            "reason": reason,
+            "age_seconds": age,
+            "ttl_seconds": ttl_seconds,
+        })
+    return stale
+
+
+def build_runtime_safety_report(now: datetime | None = None) -> dict[str, Any]:
+    if now is None:
+        now = _now()
+    cron_risks = scan_cron_jobs(load_cron_jobs_for_scan(), now)
+    stale_resume = scan_resume_pending_sessions(load_session_entries_for_scan(), now)
+    counts = {
+        "unsafe_gateway_control_due": sum(1 for r in cron_risks if r.reason == "unsafe_gateway_control_due"),
+        "unsafe_gateway_control_scheduled": sum(1 for r in cron_risks if r.reason == "unsafe_gateway_control_scheduled"),
+        "gateway_control_adjacent": sum(1 for r in cron_risks if r.reason == "gateway_control_adjacent"),
+        "expired_oneshot": sum(1 for r in cron_risks if r.reason == "expired_oneshot"),
+        "stale_resume_pending": len(stale_resume),
+    }
+    return {
+        "ok": counts["unsafe_gateway_control_due"] == 0 and counts["stale_resume_pending"] == 0,
+        "counts": counts,
+        "cron_risks": [r.to_display() for r in cron_risks],
+        "stale_resume_pending": stale_resume,
+    }

--- a/hermes_cli/runtime_safety.py
+++ b/hermes_cli/runtime_safety.py
@@ -77,7 +77,11 @@ def _parse_dt(value: Any) -> datetime | None:
     except (TypeError, ValueError):
         return None
     if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
+        # Hermes session timestamps are written as local naive datetimes.
+        # Treating them as UTC makes fresh/stale checks wrong by the local UTC
+        # offset and can hide old resume_pending flags from preflight.
+        local_tz = _now().tzinfo or timezone.utc
+        dt = dt.replace(tzinfo=local_tz)
     return dt.astimezone(_now().tzinfo)
 
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1760,11 +1760,19 @@ def setup_terminal_backend(config: dict):
 
 def _apply_default_agent_settings(config: dict):
     """Apply recommended defaults for all agent settings without prompting."""
-    config.setdefault("agent", {})["max_turns"] = 90
-    # config.yaml is the authoritative source for max_turns; the gateway
-    # bridges it into HERMES_MAX_ITERATIONS at startup. We no longer write
-    # to .env to avoid the dual-source inconsistency that caused the
-    # 60-vs-500 bug (stale .env entry silently shadowing config.yaml).
+    agent_cfg = config.setdefault("agent", {})
+    agent_cfg["max_turns"] = 90
+    agent_cfg.setdefault("turn_budgets", {
+        "cli": 16,
+        "gateway": 32,
+        "api_server": 32,
+        "cron": 90,
+        "lightweight_followup": 6,
+        "coding": 90,
+        "ship_mode": 128,
+    })
+    # config.yaml is authoritative for task-shaped turn budgets. Do not
+    # persist HERMES_MAX_ITERATIONS; stale env caps caused prior runtime lies.
     remove_env_value("HERMES_MAX_ITERATIONS")
 
     config.setdefault("display", {})["tool_progress"] = "all"
@@ -1810,9 +1818,8 @@ def setup_agent_settings(config: dict):
         max_iter = int(max_iter_str)
         if max_iter > 0:
             # Write to config.yaml (authoritative) only. Also clean up any
-            # stale .env entry from earlier setup runs — the gateway's
-            # bridge in gateway/run.py now unconditionally derives
-            # HERMES_MAX_ITERATIONS from agent.max_turns at startup.
+            # stale .env entry from earlier setup runs. Runtime surfaces now
+            # resolve task-shaped budgets directly from config.yaml.
             config.setdefault("agent", {})["max_turns"] = max_iter
             config.pop("max_turns", None)
             remove_env_value("HERMES_MAX_ITERATIONS")

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -163,12 +163,15 @@ def show_status(args):
             continue
         value = _resolve_env(env_ref)
         has_key = bool(value)
-        display = redact_key(value) if not show_all else value
+        # `--all` means show all status sections, not raw credentials. Never
+        # print full secrets in status output; copy/pasted diagnostics often
+        # land in agent transcripts or Discord.
+        display = redact_key(value)
         print(f"  {name:<12}  {check_mark(has_key)} {display}")
 
     from hermes_cli.auth import get_anthropic_key
     anthropic_value = get_anthropic_key()
-    anthropic_display = redact_key(anthropic_value) if not show_all else anthropic_value
+    anthropic_display = redact_key(anthropic_value)
     print(f"  {'Anthropic':<12}  {check_mark(bool(anthropic_value))} {anthropic_display}")
 
     # =========================================================================

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -531,6 +531,42 @@ def show_status(args):
         print("  Active:       0")
 
     # =========================================================================
+    # Runtime Safety
+    # =========================================================================
+    print()
+    print(color("◆ Runtime Safety", Colors.CYAN, Colors.BOLD))
+    try:
+        from hermes_cli.runtime_safety import build_runtime_safety_report
+        report = build_runtime_safety_report()
+        counts = report["counts"]
+        ok = report.get("ok", False)
+        print(
+            f"  Safety:      {check_mark(ok)} "
+            f"due_gateway={counts['unsafe_gateway_control_due']} "
+            f"scheduled_gateway={counts['unsafe_gateway_control_scheduled']} "
+            f"adjacent={counts['gateway_control_adjacent']} "
+            f"expired_oneshot={counts['expired_oneshot']} "
+            f"stale_resume={counts['stale_resume_pending']}"
+        )
+        rows = report.get("cron_risks", [])[:5]
+        for row in rows:
+            print(
+                "  Cron risk:   "
+                f"{row.get('severity')} {row.get('reason')} "
+                f"id={row.get('job_id')} name={row.get('name')} "
+                f"state={row.get('state')} schedule={row.get('schedule')} "
+                f"script={row.get('script') or '-'}"
+            )
+        for row in report.get("stale_resume_pending", [])[:5]:
+            print(
+                "  Resume risk: "
+                f"{row.get('reason')} session={row.get('session_key_hash')} "
+                f"age={row.get('age_seconds')}s ttl={row.get('ttl_seconds')}s"
+            )
+    except Exception as e:
+        print(f"  Safety:      {check_mark(False)} error reading runtime safety ({e})")
+
+    # =========================================================================
     # Deep checks
     # =========================================================================
     if deep:

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -574,19 +574,16 @@ class HonchoMemoryProvider(MemoryProvider):
         parts = []
 
         # ----- Layer 1: Base context (representation + card) -----
-        # On first call, fetch synchronously so turn 1 isn't empty.
-        # After that, serve from cache and refresh in background on cadence.
+        # Never perform first-turn Honcho I/O synchronously. Serve cached
+        # context immediately; if empty, trigger a background refresh and let a
+        # later turn consume it.
         with self._base_context_lock:
-            if self._base_context_cache is None:
-                # First call — synchronous fetch
-                try:
-                    ctx = self._manager.get_prefetch_context(self._session_key)
-                    self._base_context_cache = self._format_first_turn_context(ctx) if ctx else ""
-                    self._last_context_turn = self._turn_count
-                except Exception as e:
-                    logger.debug("Honcho base context fetch failed: %s", e)
-                    self._base_context_cache = ""
-            base_context = self._base_context_cache
+            base_context = self._base_context_cache or ""
+        if not base_context and self._manager:
+            try:
+                self._manager.prefetch_context(self._session_key, query)
+            except Exception as e:
+                logger.debug("Honcho base context prefetch failed: %s", e)
 
         # Check if background context prefetch has a fresher result
         if self._manager:
@@ -644,16 +641,8 @@ class HonchoMemoryProvider(MemoryProvider):
                 target=_run_first_turn, daemon=True, name="honcho-prefetch-first"
             )
             self._prefetch_thread.start()
-            self._prefetch_thread.join(timeout=_first_turn_timeout)
-            if self._prefetch_thread.is_alive():
-                logger.debug(
-                    "Honcho first-turn dialectic still running after %.1fs — "
-                    "will surface on next turn",
-                    _first_turn_timeout,
-                )
+            logger.debug("Honcho first-turn dialectic started in background")
 
-        if self._prefetch_thread and self._prefetch_thread.is_alive():
-            self._prefetch_thread.join(timeout=3.0)
         with self._prefetch_lock:
             dialectic_result = self._prefetch_result
             fired_at = self._prefetch_result_fired_at
@@ -1125,6 +1114,8 @@ class HonchoMemoryProvider(MemoryProvider):
         """
         if self._cron_skipped:
             return
+        if self._config and getattr(self._config, "save_messages", True) is False:
+            return
         if not self._manager or not self._session_key:
             return
 
@@ -1139,7 +1130,7 @@ class HonchoMemoryProvider(MemoryProvider):
                     session.add_message("user", chunk)
                 for chunk in self._chunk_message(clean_assistant_content, msg_limit):
                     session.add_message("assistant", chunk)
-                self._manager._flush_session(session)
+                self._manager.save(session)
             except Exception as e:
                 logger.debug("Honcho sync_turn failed: %s", e)
 
@@ -1183,6 +1174,8 @@ class HonchoMemoryProvider(MemoryProvider):
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         """Flush all pending messages to Honcho on session end."""
         if self._cron_skipped:
+            return
+        if self._config and getattr(self._config, "save_messages", True) is False:
             return
         if not self._manager:
             return
@@ -1312,7 +1305,7 @@ class HonchoMemoryProvider(MemoryProvider):
             if t and t.is_alive():
                 t.join(timeout=5.0)
         # Flush any remaining messages
-        if self._manager:
+        if self._manager and not (self._config and getattr(self._config, "save_messages", True) is False):
             try:
                 self._manager.flush_all()
             except Exception:

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -598,6 +598,16 @@ class HonchoMemoryProvider(MemoryProvider):
         if base_context:
             parts.append(base_context)
 
+        # dialecticCadence <= 0 explicitly disables the Honcho LLM supplement.
+        # Keep base context injection alive, but do not start first-turn or
+        # background .chat() calls. This is the fast path for gateway sessions
+        # where Honcho read/context is wanted but slow dialectic calls should
+        # not add latency or warning noise.
+        if self._dialectic_cadence <= 0:
+            if not parts:
+                return ""
+            return self._truncate_to_budget("\n\n".join(parts))
+
         # ----- Layer 2: Dialectic supplement -----
         # On the very first turn, no queue_prefetch() has run yet so the
         # dialectic result is empty.  Run with a bounded timeout so a slow
@@ -715,6 +725,11 @@ class HonchoMemoryProvider(MemoryProvider):
                 self._manager.prefetch_context(self._session_key, query)
             except Exception as e:
                 logger.debug("Honcho context prefetch failed: %s", e)
+
+        # dialecticCadence <= 0 explicitly disables Honcho LLM supplement
+        # prefetches while preserving the base context refresh above.
+        if self._dialectic_cadence <= 0:
+            return
 
         # ----- Dialectic prefetch (supplement layer) -----
         # Thread-alive guard with stale-thread recovery: a hung Honcho call

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -161,7 +161,7 @@ def _parse_dialectic_depth_levels(host_val, root_val, depth: int) -> list[str] |
 # run_conversation; without a cap the agent can block indefinitely when
 # the Honcho backend is unreachable, preventing the gateway from
 # delivering the already-generated response.
-_DEFAULT_HTTP_TIMEOUT = 30.0
+_DEFAULT_HTTP_TIMEOUT = 4.0
 
 
 def _resolve_optional_float(*values: Any) -> float | None:
@@ -249,6 +249,9 @@ class HonchoClientConfig:
     base_url: str | None = None
     # Optional request timeout in seconds for Honcho SDK HTTP calls
     timeout: float | None = None
+    # SDK retry count. Default is zero so Hermes does not block the reply path
+    # behind Honcho retry backoff when memory is slow or unreachable.
+    max_retries: int = 0
     # Identity
     peer_name: str | None = None
     ai_peer: str = "hermes"
@@ -333,6 +336,11 @@ class HonchoClientConfig:
         api_key = os.environ.get("HONCHO_API_KEY")
         base_url = os.environ.get("HONCHO_BASE_URL", "").strip() or None
         timeout = _resolve_optional_float(os.environ.get("HONCHO_TIMEOUT"))
+        max_retries = _parse_int_config(
+            os.environ.get("HONCHO_MAX_RETRIES"),
+            None,
+            0,
+        )
         return cls(
             host=resolved_host,
             workspace_id=workspace_id,
@@ -340,6 +348,7 @@ class HonchoClientConfig:
             environment=os.environ.get("HONCHO_ENVIRONMENT", "production"),
             base_url=base_url,
             timeout=timeout,
+            max_retries=max_retries,
             ai_peer=resolved_host,
             enabled=bool(api_key or base_url),
         )
@@ -405,6 +414,15 @@ class HonchoClientConfig:
             raw.get("requestTimeout"),
             os.environ.get("HONCHO_TIMEOUT"),
         )
+        max_retries = _parse_int_config(
+            host_block.get("maxRetries")
+            if host_block.get("maxRetries") is not None
+            else host_block.get("max_retries"),
+            raw.get("maxRetries")
+            if raw.get("maxRetries") is not None
+            else raw.get("max_retries", os.environ.get("HONCHO_MAX_RETRIES")),
+            0,
+        )
 
         # Auto-enable when API key or base_url is present (unless explicitly disabled)
         # Host-level enabled wins, then root-level, then auto-enable if key/url exists.
@@ -451,6 +469,7 @@ class HonchoClientConfig:
             environment=environment,
             base_url=base_url,
             timeout=timeout,
+            max_retries=max_retries,
             peer_name=host_block.get("peerName") or raw.get("peerName"),
             ai_peer=ai_peer,
             pin_peer_name=_resolve_bool(
@@ -717,6 +736,7 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
     # requiring the server to live on localhost.
     resolved_base_url = config.base_url
     resolved_timeout = config.timeout
+    resolved_max_retries = config.max_retries
     if not resolved_base_url or resolved_timeout is None:
         try:
             from hermes_cli.config import load_config
@@ -730,6 +750,11 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
                         honcho_cfg.get("timeout"),
                         honcho_cfg.get("request_timeout"),
                     )
+                resolved_max_retries = _parse_int_config(
+                    honcho_cfg.get("maxRetries"),
+                    honcho_cfg.get("max_retries"),
+                    resolved_max_retries,
+                )
         except Exception:
             pass
 
@@ -771,6 +796,7 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
         kwargs["base_url"] = resolved_base_url
     if resolved_timeout is not None:
         kwargs["timeout"] = resolved_timeout
+    kwargs["max_retries"] = resolved_max_retries
 
     _honcho_client = Honcho(**kwargs)
 

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -102,6 +102,7 @@ class HonchoSessionManager:
         # Write frequency state
         write_frequency = (config.write_frequency if config else "async")
         self._write_frequency = write_frequency
+        self._save_messages = bool(getattr(config, "save_messages", True)) if config else True
         self._turn_counter: int = 0
 
         # Prefetch cache: session_key → last context result (consumed once per turn).
@@ -137,7 +138,7 @@ class HonchoSessionManager:
         # Async write queue — started lazily on first enqueue
         self._async_queue: queue.Queue | None = None
         self._async_thread: threading.Thread | None = None
-        if write_frequency == "async":
+        if self._save_messages and write_frequency == "async":
             self._async_queue = queue.Queue()
             self._async_thread = threading.Thread(
                 target=self._async_writer_loop,
@@ -348,6 +349,8 @@ class HonchoSessionManager:
 
     def _flush_session(self, session: HonchoSession) -> bool:
         """Internal: write unsynced messages to Honcho synchronously."""
+        if not self._save_messages:
+            return True
         if not session.messages:
             return True
 
@@ -433,6 +436,8 @@ class HonchoSessionManager:
           "session" — defer until flush_session() is called explicitly
           N (int)   — flush every N turns
         """
+        if not self._save_messages:
+            return
         self._turn_counter += 1
         wf = self._write_frequency
 
@@ -454,6 +459,8 @@ class HonchoSessionManager:
         Called at session end for "session" write_frequency, or to force
         a sync before process exit regardless of mode.
         """
+        if not self._save_messages:
+            return
         with self._cache_lock:
             sessions = list(self._cache.values())
         for session in sessions:

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -229,6 +229,18 @@ class HonchoSessionManager:
                 session_id, e,
             )
 
+        # Loading existing messages is only needed when Hermes is using Honcho
+        # as a transcript store. Nic's low-latency/no-write mode keeps
+        # saveMessages=false, so a session.context() call here is pure overhead
+        # and can create scary non-fatal timeout warnings on the hot tool path.
+        if not self._save_messages:
+            logger.debug(
+                "Honcho session '%s' loaded; skipped existing-message context fetch because saveMessages=false",
+                session_id,
+            )
+            self._sessions_cache[session_id] = session
+            return session, []
+
         # Load existing messages via context() - single call for messages + metadata
         existing_messages = []
         try:
@@ -1014,17 +1026,23 @@ class HonchoSessionManager:
         """
         Fetch a peer card — a curated list of key facts.
 
-        Fast, no LLM reasoning. Returns raw structured facts Honcho has
-        inferred about the target peer (name, role, preferences, patterns).
-        Empty list if unavailable.
+        Fast, no LLM reasoning. Prefer the target peer's own card so manual
+        honcho_profile(card=...) updates read back immediately. Fall back to
+        the observer/target view for Honcho installations where the SDK stores
+        cards as observer-specific conclusions.
         """
         session = self._cache.get(session_key)
         if not session:
             return []
 
         try:
-            observer_peer_id, target_peer_id = self._resolve_observer_target(session, peer)
-            return self._fetch_peer_card(observer_peer_id, target=target_peer_id)
+            target_peer_id = self._resolve_peer_id(session, peer)
+            direct_card = self._fetch_peer_card(target_peer_id)
+            if direct_card:
+                return direct_card
+
+            observer_peer_id, observer_target_peer_id = self._resolve_observer_target(session, peer)
+            return self._fetch_peer_card(observer_peer_id, target=observer_target_peer_id)
         except Exception as e:
             logger.debug("Failed to fetch peer card from Honcho: %s", e)
             return []

--- a/plugins/web/exa/provider.py
+++ b/plugins/web/exa/provider.py
@@ -122,11 +122,22 @@ class ExaWebSearchProvider(WebSearchProvider):
                 return {"success": False, "error": "Interrupted"}
 
             logger.info("Exa search: '%s' (limit=%d)", query, limit)
-            response = _get_exa_client().search(
-                query,
-                num_results=limit,
-                contents={"highlights": True},
-            )
+            client = _get_exa_client()
+            try:
+                response = client.search(
+                    query,
+                    num_results=limit,
+                    contents={"highlights": True},
+                )
+            except Exception as exc:  # noqa: BLE001 — retry plain search when highlights quota fails
+                message = str(exc)
+                if "NO_MORE_CREDITS" not in message and "402" not in message:
+                    raise
+                logger.info(
+                    "Exa search with highlights failed (%s); retrying plain search",
+                    message,
+                )
+                response = client.search(query, num_results=limit)
 
             web_results = []
             for i, result in enumerate(response.results or []):

--- a/run_agent.py
+++ b/run_agent.py
@@ -3870,6 +3870,17 @@ class AIAgent:
         if casual and not any(k in text for k in ("why", "broken", "slow", "performance", "not working")):
             return "surface"
 
+        # Code-level app-ship guard: serious app/product build requests get
+        # ship-mode budget even when the model has not remembered or loaded the
+        # app-ship-mode skill. The helper is conservative so tiny fixes and
+        # question-only planning turns do not get hijacked.
+        try:
+            from agent.ship_mode_guard import is_serious_app_ship_request
+            if is_serious_app_ship_request(user_message, conversation_history):
+                return "ship_mode"
+        except Exception:
+            pass
+
         dev_context = any(k in combined for k in (
             "repo", "branch", "commit", "diff", "test", "pytest", "build", "runtime", "gateway",
             "discord", "kanban", "cron", "aivs", "ssw", "sku", "nextjs", "ui", "ux", "scrape",

--- a/run_agent.py
+++ b/run_agent.py
@@ -129,6 +129,7 @@ from agent.prompt_builder import (
     MEMORY_GUIDANCE, SESSION_SEARCH_GUIDANCE, SKILLS_GUIDANCE,
     HERMES_AGENT_HELP_GUIDANCE,
     KANBAN_GUIDANCE,
+    DELEGATION_GUIDANCE, DELEGATION_COMPLEX_TASK_NUDGE,
     build_nous_subscription_prompt,
 )
 from agent.model_metadata import (
@@ -335,6 +336,10 @@ class AIAgent:
         "[hermes-agent: tool call arguments were corrupted in this session and "
         "have been dropped to keep the conversation alive. See issue #15236.]"
     )
+    _DEFAULT_LIGHTWEIGHT_TURN_MAX = 6
+    _DEFAULT_SIMPLE_CHECK_TURN_MAX = 8
+    _DEFAULT_CODING_TURN_MAX = 90
+    _DEFAULT_SHIP_MODE_TURN_MAX = 128
 
     @property
     def base_url(self) -> str:
@@ -3844,6 +3849,91 @@ class AIAgent:
         """Forwarder — see ``agent.chat_completion_helpers.handle_max_iterations``."""
         from agent.chat_completion_helpers import handle_max_iterations
         return handle_max_iterations(self, messages, api_call_count)
+
+    def _turn_budget_classification(self, user_message: str, conversation_history: Optional[List[Dict[str, Any]]] = None) -> str:
+        """Classify this turn for budget shaping.
+
+        Keep this cheap/deterministic: it decides whether a gateway control turn
+        deserves coding/ship capacity, not what work to do.
+        """
+        text = (user_message or "").lower()
+        recent = ""
+        try:
+            if conversation_history:
+                tail = conversation_history[-8:]
+                recent = "\n".join(str(m.get("content", ""))[:500] for m in tail if isinstance(m, dict)).lower()
+        except Exception:
+            recent = ""
+        combined = f"{text}\n{recent}"
+
+        casual = ("?" in text and not any(v in text for v in ("fix", "implement", "ship", "patch", "build", "debug", "test", "verify", "restart", "deploy")))
+        if casual and not any(k in text for k in ("why", "broken", "slow", "performance", "not working")):
+            return "surface"
+
+        dev_context = any(k in combined for k in (
+            "repo", "branch", "commit", "diff", "test", "pytest", "build", "runtime", "gateway",
+            "discord", "kanban", "cron", "aivs", "ssw", "sku", "nextjs", "ui", "ux", "scrape",
+            "browser", "obsidian", "honcho", "database", "sqlite", "db", "vps", "service", "systemd",
+        ))
+        action = any(k in text for k in (
+            "fix", "implement", "patch", "ship", "build", "debug", "repair", "restore", "verify",
+            "test", "restart", "deploy", "wire", "configure", "make", "do it", "continue", "finish",
+            "use", "raise", "increase",
+        ))
+        ship_intent = any(k in text for k in (
+            "ship", "finish", "end-to-end", "e2e", "no stopping", "don't stop", "dont stop",
+            "all the way", "autonomous", "long running", "deep", "use 128", "128 iterations",
+            "make a plan and fix", "fix this", "fix thjs", "implement these fixes",
+            "use 128", "128 iterations", "choking iteration", "iteration to 32",
+        ))
+        heavy = any(k in combined for k in (
+            "scrape", "scraping", "import", "qa", "visual", "browser use", "background", "kanban",
+            "database", "migration", "multi-file", "preview", "deploy", "smoke", "design", "full app-dev",
+        ))
+
+        if dev_context and action and (ship_intent or heavy):
+            return "ship_mode"
+        if dev_context and action:
+            return "coding"
+        if action and any(k in text for k in ("code", "app", "ui", "bug", "performance")):
+            return "coding"
+        if text.startswith(("check ", "status ", "show ")) or text in {"status", "check"}:
+            return "simple_check"
+        return "surface"
+
+    def _resolve_turn_max_iterations(self, user_message: str, conversation_history: Optional[List[Dict[str, Any]]] = None) -> int:
+        configured = int(getattr(self, "_configured_max_iterations", getattr(self, "max_iterations", 90)) or 90)
+        if getattr(self, "_external_turn_ceiling_active", False):
+            self._last_turn_budget_classification = "external_ceiling"
+            return configured
+
+        platform = (getattr(self, "platform", "") or "").lower()
+        if platform == "cron" or os.getenv("HERMES_KANBAN_TASK"):
+            self._last_turn_budget_classification = "durable_worker"
+            return configured
+
+        try:
+            from hermes_cli.config import load_config, resolve_agent_max_turns
+            cfg = load_config()
+            coding = resolve_agent_max_turns(cfg, mode="coding", include_legacy_global_override=False)
+            ship = resolve_agent_max_turns(cfg, mode="ship_mode", include_legacy_global_override=False)
+            lightweight = resolve_agent_max_turns(cfg, mode="lightweight_followup", include_legacy_global_override=False)
+        except Exception:
+            coding, ship, lightweight = self._DEFAULT_CODING_TURN_MAX, self._DEFAULT_SHIP_MODE_TURN_MAX, self._DEFAULT_LIGHTWEIGHT_TURN_MAX
+
+        classification = self._turn_budget_classification(user_message, conversation_history)
+        self._last_turn_budget_classification = classification
+        if classification == "ship_mode":
+            return max(configured, ship)
+        if classification == "coding":
+            return max(configured, coding)
+        if classification == "simple_check":
+            return min(configured, self._DEFAULT_SIMPLE_CHECK_TURN_MAX)
+        if platform in {"discord", "telegram", "slack", "matrix", "gateway"}:
+            text = (user_message or "").strip()
+            if len(text) < 240 and "?" not in text and not any(k in text.lower() for k in ("fix", "implement", "patch", "build", "debug", "verify", "restart", "deploy")):
+                return min(configured, lightweight)
+        return configured
 
     def run_conversation(
         self,

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -347,6 +347,80 @@ class TestAnthropicOAuthFlag:
         assert model == "claude-haiku-4-5-20251001"
         assert mock_build.call_args.args[0] == "sk-ant-oat01-pooled"
 
+    def test_secondary_anthropic_provider_uses_provider_base_url(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "model": {"provider": "openai-codex", "default": "gpt-5.5"},
+                "providers": {"anthropic": {"base_url": "http://127.0.0.1:42069"}},
+            },
+        )
+        with (
+            patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)),
+            patch("agent.anthropic_adapter.resolve_anthropic_token", return_value="sk-ant...local"),
+            patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()) as mock_build,
+        ):
+            from agent.auxiliary_client import _try_anthropic
+
+            client, model = _try_anthropic()
+
+        assert client is not None
+        assert model == "claude-haiku-4-5-20251001"
+        assert mock_build.call_args.args[0] == "sk-ant...local"
+        assert mock_build.call_args.args[1] == "http://127.0.0.1:42069"
+
+    def test_secondary_anthropic_provider_uses_provider_base_url_for_pool_default_url(self, monkeypatch):
+        class _Entry:
+            access_token = "sk-ant-oat01-pooled"
+            base_url = "https://api.anthropic.com"
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "model": {"provider": "openai-codex", "default": "gpt-5.5"},
+                "providers": {"anthropic": {"base_url": "http://127.0.0.1:42069"}},
+            },
+        )
+        with (
+            patch("agent.auxiliary_client._select_pool_entry", return_value=(True, _Entry())),
+            patch("agent.anthropic_adapter.resolve_anthropic_token", side_effect=AssertionError("legacy path should not run")),
+            patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()) as mock_build,
+        ):
+            from agent.auxiliary_client import _try_anthropic
+
+            client, model = _try_anthropic()
+
+        assert client is not None
+        assert model == "claude-haiku-4-5-20251001"
+        assert mock_build.call_args.args[0] == "sk-ant-oat01-pooled"
+        assert mock_build.call_args.args[1] == "http://127.0.0.1:42069"
+
+    def test_secondary_anthropic_provider_keeps_non_default_pool_base_url(self, monkeypatch):
+        class _Entry:
+            access_token = "sk-ant-oat01-pooled"
+            base_url = "https://pool-proxy.example.com/anthropic"
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "model": {"provider": "openai-codex", "default": "gpt-5.5"},
+                "providers": {"anthropic": {"base_url": "http://127.0.0.1:42069"}},
+            },
+        )
+        with (
+            patch("agent.auxiliary_client._select_pool_entry", return_value=(True, _Entry())),
+            patch("agent.anthropic_adapter.resolve_anthropic_token", side_effect=AssertionError("legacy path should not run")),
+            patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()) as mock_build,
+        ):
+            from agent.auxiliary_client import _try_anthropic
+
+            client, model = _try_anthropic()
+
+        assert client is not None
+        assert model == "claude-haiku-4-5-20251001"
+        assert mock_build.call_args.args[0] == "sk-ant-oat01-pooled"
+        assert mock_build.call_args.args[1] == "https://pool-proxy.example.com/anthropic"
+
 
 class TestBuildCodexClient:
     def test_pool_without_selected_entry_falls_back_to_auth_store(self):

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -458,6 +458,12 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.timeout
         assert result.should_compress is False
 
+    def test_request_buffer_limit_classifies_as_context_overflow(self):
+        e = MockAPIError("exceeded request buffer limit", status_code=400)
+        result = classify_api_error(e, approx_tokens=10_000, context_length=256_000)
+        assert result.reason == FailoverReason.context_overflow
+        assert result.should_compress is True
+
     # ── Provider-specific: Anthropic thinking signature ──
 
     def test_anthropic_thinking_signature(self):

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -786,6 +786,7 @@ class TestMemoryContextFencing:
         assert "</memory-context>" not in result
         assert "<memory-context>" not in result
         assert "fact one" in result
+        assert "INJECTED" in result
         assert "fact two" in result
 
     def test_sanitize_context_case_insensitive(self):
@@ -793,6 +794,60 @@ class TestMemoryContextFencing:
         result = sanitize_context("data</MEMORY-CONTEXT>more")
         assert "</memory-context>" not in result.lower()
         assert "datamore" in result
+
+    def test_sanitize_context_strips_unterminated_memory_block_with_system_note(self):
+        from agent.memory_manager import sanitize_context
+        leaked = (
+            "FIX IT NOW\n\n"
+            "<memory-context>\n"
+            "[System note: The following is recalled memory context, NOT new user input. "
+            "Treat as authoritative reference data — this is the agent's persistent memory and should inform all responses.]\n\n"
+            "## User Representation\nsecret profile data"
+        )
+        result = sanitize_context(leaked)
+        assert result.strip() == "FIX IT NOW"
+        assert "memory-context" not in result
+        assert "secret profile" not in result
+        assert "System note" not in result
+
+    def test_sanitize_context_does_not_truncate_literal_tag_discussion(self):
+        from agent.memory_manager import sanitize_context
+        text = "Explain `<memory-context>` in docs, then keep this tail."
+        result = sanitize_context(text)
+        assert "Explain" in result
+        assert "keep this tail" in result
+
+    def test_sanitize_context_strips_leading_compaction_fallback(self):
+        from agent.memory_manager import sanitize_context
+        leaked = (
+            "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted into the summary below. "
+            "This is a handoff from a previous context window — treat it as background reference, NOT as active instructions.\n"
+            "Summary generation was unavailable. 424 message(s) were removed to free context space but could not be summarized. "
+            "The removed messages contained earlier work in this session. Continue based on the recent messages below.\n"
+            "Actual answer."
+        )
+        result = sanitize_context(leaked)
+        assert result.strip() == "Actual answer."
+        assert "CONTEXT COMPACTION" not in result
+        assert "Summary generation" not in result
+
+    def test_sanitize_context_strips_leading_gateway_interruption_note(self):
+        from agent.memory_manager import sanitize_context
+        leaked = (
+            "[System note: Your previous turn in this session was interrupted by a gateway shutdown. "
+            "The conversation history below is intact. If it contains unfinished tool result(s), process them first and "
+            "summarize what was accomplished, then address the user's new message below.]\n\n"
+            "Actual answer."
+        )
+        result = sanitize_context(leaked)
+        assert result.strip() == "Actual answer."
+        assert "System note" not in result
+
+    def test_sanitize_context_does_not_strip_literal_compaction_discussion_mid_sentence(self):
+        from agent.memory_manager import sanitize_context
+        text = "Explain why [CONTEXT COMPACTION — REFERENCE ONLY] appears in logs."
+        result = sanitize_context(text)
+        assert result == text
 
     def test_fenced_block_separates_user_from_recall(self):
         from agent.memory_manager import build_memory_context_block

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -21,6 +21,8 @@ from agent.prompt_builder import (
     build_environment_hints,
     CONTEXT_FILE_MAX_CHARS,
     DEFAULT_AGENT_IDENTITY,
+    DELEGATION_GUIDANCE,
+    DELEGATION_COMPLEX_TASK_NUDGE,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
     OPENAI_MODEL_EXECUTION_GUIDANCE,
@@ -38,6 +40,11 @@ from hermes_cli.nous_subscription import NousFeatureState, NousSubscriptionFeatu
 
 
 class TestGuidanceConstants:
+    def test_delegation_guidance_exports_cleanly(self):
+        assert "delegate_task" in DELEGATION_GUIDANCE
+        assert "durable" in DELEGATION_GUIDANCE
+        assert "delegate_task" in DELEGATION_COMPLEX_TASK_NUDGE
+
     def test_memory_guidance_discourages_task_logs(self):
         assert "durable facts" in MEMORY_GUIDANCE
         assert "Do NOT save task progress" in MEMORY_GUIDANCE

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -20,7 +20,17 @@ def _make_cli(env_overrides=None, config_overrides=None, **kwargs):
             "provider": "auto",
         },
         "display": {"compact": False, "tool_progress": "all"},
-        "agent": {},
+        "agent": {
+            "turn_budgets": {
+                "cli": 16,
+                "gateway": 32,
+                "api_server": 32,
+                "cron": 90,
+                "lightweight_followup": 6,
+                "coding": 90,
+                "ship_mode": 128,
+            }
+        },
         "terminal": {"env_type": "local"},
     }
     if config_overrides:
@@ -60,7 +70,7 @@ class TestMaxTurnsResolution:
     def test_default_max_turns_is_integer(self):
         cli = _make_cli()
         assert isinstance(cli.max_turns, int)
-        assert cli.max_turns == 90
+        assert cli.max_turns == 16
 
     def test_explicit_max_turns_honored(self):
         cli = _make_cli(max_turns=25)
@@ -69,26 +79,37 @@ class TestMaxTurnsResolution:
     def test_none_max_turns_gets_default(self):
         cli = _make_cli(max_turns=None)
         assert isinstance(cli.max_turns, int)
-        assert cli.max_turns == 90
+        assert cli.max_turns == 16
 
     def test_env_var_max_turns(self):
         """Env var is used when config file doesn't set max_turns."""
-        cli_obj = _make_cli(env_overrides={"HERMES_MAX_ITERATIONS": "42"})
+        cli_obj = _make_cli(
+            env_overrides={"HERMES_MAX_ITERATIONS": "42"},
+            config_overrides={"agent": {}},
+        )
         assert cli_obj.max_turns == 42
 
     def test_invalid_env_var_max_turns_falls_back_to_default(self):
         """Invalid env values should not crash CLI init."""
         cli_obj = _make_cli(env_overrides={"HERMES_MAX_ITERATIONS": "not-a-number"})
-        assert cli_obj.max_turns == 90
+        assert cli_obj.max_turns == 16
 
     def test_legacy_root_max_turns_is_used_when_agent_key_exists_without_value(self):
         cli_obj = _make_cli(config_overrides={"agent": {}, "max_turns": 77})
         assert cli_obj.max_turns == 77
 
+    def test_explicit_cli_turn_budget_wins_over_legacy_global(self):
+        cli_obj = _make_cli(
+            config_overrides={
+                "agent": {"max_turns": 77, "turn_budgets": {"cli": 16}}
+            }
+        )
+        assert cli_obj.max_turns == 16
+
     def test_max_turns_never_none_for_agent(self):
         """The value passed to AIAgent must never be None (causes TypeError in run_conversation)."""
         cli = _make_cli()
-        assert isinstance(cli.max_turns, int) and cli.max_turns == 90
+        assert isinstance(cli.max_turns, int) and cli.max_turns == 16
 
 
 class TestVerboseAndToolProgress:

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -82,12 +82,12 @@ class TestMaxTurnsResolution:
         assert cli.max_turns == 16
 
     def test_env_var_max_turns(self):
-        """Env var is used when config file doesn't set max_turns."""
+        """Stale legacy env var does not shadow the known CLI default."""
         cli_obj = _make_cli(
             env_overrides={"HERMES_MAX_ITERATIONS": "42"},
             config_overrides={"agent": {}},
         )
-        assert cli_obj.max_turns == 42
+        assert cli_obj.max_turns == 16
 
     def test_invalid_env_var_max_turns_falls_back_to_default(self):
         """Invalid env values should not crash CLI init."""

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -174,6 +174,59 @@ class TestRunJobScript:
         parsed = json.loads(output)
         assert parsed["new_prs"][0]["number"] == 42
 
+    def test_blocks_gateway_lifecycle_script_before_execution(self, cron_env, monkeypatch):
+        from cron import scheduler as sched_mod
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "unsafe.sh"
+        script.write_text("systemctl --no-pager --user restart hermes-gateway.service\n")
+
+        def fail_run(*_args, **_kwargs):
+            raise AssertionError("unsafe cron script should not execute")
+
+        monkeypatch.setattr(sched_mod.subprocess, "run", fail_run)
+
+        success, output = _run_job_script(str(script))
+
+        assert success is False
+        assert "BLOCKED" in output
+        assert "systemctl_gateway_lifecycle" in output
+
+    def test_adjacent_alert_only_script_still_executes(self, cron_env):
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "alert_only.py"
+        script.write_text("""
+print('hermes-gateway memory guard: never restarts the gateway')
+""")
+
+        success, output = _run_job_script(str(script))
+
+        assert success is True
+        assert "never restarts" in output
+
+    def test_runtime_safety_scans_script_body_not_just_name(self, cron_env):
+        from datetime import datetime, timedelta, timezone
+
+        from hermes_cli.runtime_safety import classify_cron_job
+
+        script = cron_env / "scripts" / "innocent_name.sh"
+        script.write_text("systemctl --user kill hermes-gateway.service\n")
+        now = datetime.now(timezone.utc)
+        risk = classify_cron_job({
+            "id": "job-1",
+            "name": "safe looking job",
+            "enabled": True,
+            "state": "scheduled",
+            "schedule": {"kind": "interval", "value": 30, "unit": "m"},
+            "next_run_at": (now + timedelta(minutes=30)).isoformat(),
+            "script": str(script),
+        }, now)
+
+        assert risk is not None
+        assert risk.reason == "unsafe_gateway_control_scheduled"
+        assert risk.script == "innocent_name.sh"
+
 
 class TestBuildJobPromptWithScript:
     """Test that script output is injected into the prompt."""

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -953,3 +953,27 @@ class TestSaveJobOutput:
         assert output_file.exists()
         assert output_file.read_text() == "# Results\nEverything ok."
         assert "test123" in str(output_file)
+
+
+def test_get_due_jobs_expires_stale_oneshot_before_execution(tmp_path, monkeypatch):
+    from cron import jobs as jobs_mod
+
+    jobs_file = tmp_path / "jobs.json"
+    monkeypatch.setattr(jobs_mod, "JOBS_FILE", jobs_file)
+    stale_run_at = (datetime.now(timezone.utc) - timedelta(minutes=10)).isoformat()
+    jobs_mod.save_jobs([
+        {
+            "id": "old-once",
+            "name": "old once",
+            "enabled": True,
+            "schedule": {"kind": "once", "run_at": stale_run_at},
+            "next_run_at": stale_run_at,
+            "prompt": "do not run",
+        }
+    ])
+
+    assert jobs_mod.get_due_jobs() == []
+    saved = jobs_mod.load_jobs()[0]
+    assert saved["enabled"] is False
+    assert saved["state"] == "expired"
+    assert saved["next_run_at"] is None

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -416,18 +416,21 @@ class TestLoadGatewayConfig:
         config_path.write_text(
             "discord:\n"
             "  history_backfill: true\n"
-            "  history_backfill_limit: 17\n",
+            "  history_backfill_limit: 17\n"
+            "  history_backfill_max_chars: 4096\n",
             encoding="utf-8",
         )
 
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
         monkeypatch.delenv("DISCORD_HISTORY_BACKFILL", raising=False)
         monkeypatch.delenv("DISCORD_HISTORY_BACKFILL_LIMIT", raising=False)
+        monkeypatch.delenv("DISCORD_HISTORY_BACKFILL_MAX_CHARS", raising=False)
 
         load_gateway_config()
 
         assert os.getenv("DISCORD_HISTORY_BACKFILL") == "true"
         assert os.getenv("DISCORD_HISTORY_BACKFILL_LIMIT") == "17"
+        assert os.getenv("DISCORD_HISTORY_BACKFILL_MAX_CHARS") == "4096"
 
     def test_bridges_telegram_channel_prompts_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"

--- a/tests/gateway/test_config_env_bridge_authority.py
+++ b/tests/gateway/test_config_env_bridge_authority.py
@@ -152,15 +152,15 @@ def test_config_timezone_wins_over_stale_env(hermes_home: Path) -> None:
     assert env.get("HERMES_TIMEZONE") == "America/Los_Angeles"
 
 
-def test_env_value_survives_when_config_omits_key(hermes_home: Path) -> None:
-    """If config.yaml doesn't set max_turns, .env value must still pass through.
+def test_gateway_default_wins_when_config_omits_key(hermes_home: Path) -> None:
+    """Partial config must still stamp the resolved gateway default.
 
-    The bridge only overwrites when the config key is present — an absent
-    config key should NOT clobber the .env value.
+    A stale .env HERMES_MAX_ITERATIONS must not shadow task-shaped defaults
+    just because config.yaml omits the legacy max_turns key.
     """
     _write_config(hermes_home, agent_cfg={})  # no max_turns
     _write_env(hermes_home, {"HERMES_MAX_ITERATIONS": "123"})
 
     env = _run_gateway_import(hermes_home, initial_env={})
 
-    assert env.get("HERMES_MAX_ITERATIONS") == "123"
+    assert env.get("HERMES_MAX_ITERATIONS") == "32"

--- a/tests/gateway/test_context_spill.py
+++ b/tests/gateway/test_context_spill.py
@@ -207,6 +207,15 @@ def test_request_pressure_guard_blocks_large_payload():
     assert pressure["too_large"] is True
 
 
+def test_request_pressure_guard_counts_scalar_input_payload():
+    pressure = request_pressure_from_api_kwargs(
+        {"model": "responses", "input": "x" * 240_000, "tools": []},
+        context_length=64_000,
+    )
+    assert pressure["too_large"] is True
+    assert pressure["approx_tokens"] > 0
+
+
 def test_request_pressure_guard_uses_large_model_context_not_180k_cap():
     # Regression for Codex-routed GPT-5.5: ~183k estimated tokens is below
     # 90% of a 272k context window, so the final pre-API guard must not call it
@@ -323,6 +332,16 @@ def test_load_context_spill_config_known_defaults_with_temp_paths(tmp_path):
     assert cfg.hard_message_limit == 180
 
 
+def test_load_context_spill_config_rehomes_bundled_raw_state_default(tmp_path):
+    hermes_home = tmp_path / "profile-home"
+    cfg = load_context_spill_config(
+        {"gateway_context_spill": {"raw_state_dir": "~/.hermes/state/context-spills"}},
+        hermes_home,
+        allow_unsafe_paths=True,
+    )
+    assert cfg.raw_state_dir == hermes_home / "state" / "context-spills"
+
+
 @pytest.mark.asyncio
 async def test_pre_api_guard_spill_preserves_ask_and_quarantines_old_session(monkeypatch, tmp_path):
     from gateway.run import GatewayRunner
@@ -343,7 +362,8 @@ async def test_pre_api_guard_spill_preserves_ask_and_quarantines_old_session(mon
     runner._session_model_overrides = {}
     runner._session_reasoning_overrides = {}
     runner._pending_model_notes = {}
-    runner._agent_cache_lock = None
+    runner._agent_cache = __import__("collections").OrderedDict()
+    runner._agent_cache_lock = __import__("threading").Lock()
 
     raw_dir = tmp_path / "state" / "context-spills" / "custom-raw"
     monkeypatch.setattr(
@@ -381,6 +401,67 @@ async def test_pre_api_guard_spill_preserves_ask_and_quarantines_old_session(mon
     assert new_entry.session_id != old_sid
     assert store.is_session_quarantined(old_sid) is True
     assert store.switch_session(entry.session_key, old_sid) is None
+
+
+@pytest.mark.asyncio
+async def test_pre_api_guard_spill_respects_reset_live_session_false(monkeypatch, tmp_path):
+    from gateway.run import GatewayRunner
+    import gateway.run as gateway_run
+
+    source = _source()
+    gw_cfg = GatewayConfig(platforms={Platform.DISCORD: PlatformConfig(enabled=True, token="x")})
+    gw_cfg.sessions_dir = tmp_path / "sessions"
+    store = SessionStore(gw_cfg.sessions_dir, gw_cfg)
+    store._db = None
+    entry = store.get_or_create_session(source)
+    old_sid = entry.session_id
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = gw_cfg
+    runner.session_store = store
+    runner.adapters = {}
+    runner._session_model_overrides = {}
+    runner._session_reasoning_overrides = {}
+    runner._pending_model_notes = {}
+    runner._agent_cache = __import__("collections").OrderedDict()
+    runner._agent_cache_lock = __import__("threading").Lock()
+
+    raw_dir = tmp_path / "state" / "context-spills" / "custom-raw"
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "gateway_context_spill": {
+                "wiki_dir": str(tmp_path / "wiki" / "outputs" / "gateway-context-spills"),
+                "raw_state_dir": str(raw_dir),
+                "allow_unsafe_paths": True,
+                "reset_live_session": False,
+            }
+        },
+    )
+
+    spill = await runner._spill_gateway_context_after_request_guard(
+        history=[{"role": "user", "content": "old transcript"}],
+        message_text="keep this lane open",
+        source=source,
+        session_entry=entry,
+        session_key=entry.session_key,
+        agent_result={
+            "request_size_guard": {
+                "approx_tokens": 190_000,
+                "request_bytes": 2_000_000,
+                "threshold_tokens": 180_000,
+            }
+        },
+        context_prompt="system prompt",
+        channel_prompt="",
+    )
+
+    assert spill is not None
+    result, new_entry = spill
+    assert result.raw_path and result.raw_path.exists()
+    assert new_entry.session_id == old_sid
+    assert store.is_session_quarantined(old_sid) is False
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_context_spill.py
+++ b/tests/gateway/test_context_spill.py
@@ -1,0 +1,431 @@
+import json
+import os
+import stat
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+from typing import Any
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.context_spill import (
+    ContextSpillConfig,
+    ContextSpillWriteError,
+    decide_context_spill,
+    load_context_spill_config,
+    request_pressure_from_api_kwargs,
+    write_context_spill,
+)
+from gateway.session import SessionEntry, SessionSource, SessionStore, build_session_key
+
+
+def _source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="chat-1",
+        thread_id="thread-1",
+        user_id="user-1",
+        chat_type="group",
+        chat_name="Test Chat",
+    )
+
+
+def _entry(source=None, session_id="old-session") -> SessionEntry:
+    source = source or _source()
+    return SessionEntry(
+        session_key=build_session_key(source),
+        session_id=session_id,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=source.platform,
+        chat_type=source.chat_type,
+    )
+
+
+def _config(tmp_path: Path, **overrides) -> ContextSpillConfig:
+    values: dict[str, Any] = dict(
+        wiki_dir=tmp_path / "wiki" / "outputs" / "gateway-context-spills",
+        raw_state_dir=tmp_path / "state" / "context-spills",
+        allow_unsafe_paths=True,
+    )
+    values.update(overrides)
+    return ContextSpillConfig(**values)
+
+
+def test_decision_trips_on_message_count(tmp_path):
+    cfg = _config(tmp_path, hard_message_limit=180, hard_token_limit=999999)
+    history = [{"role": "user", "content": "x"} for _ in range(181)]
+    decision = decide_context_spill(history, "", context_length=256000, config=cfg, stage="history")
+    assert decision.should_spill is True
+    assert "message_limit" in decision.reason
+
+
+def test_decision_trips_on_token_threshold(tmp_path):
+    cfg = _config(tmp_path, hard_message_limit=999, token_threshold_ratio=0.10, hard_token_limit=20_000)
+    history = [{"role": "user", "content": "x" * 20_000} for _ in range(20)]
+    decision = decide_context_spill(history, "", context_length=256000, config=cfg, stage="history")
+    assert decision.should_spill is True
+    assert "token_limit" in decision.reason
+
+
+def test_decision_trips_on_current_backfill_size(tmp_path):
+    cfg = _config(tmp_path, hard_char_limit=50_000, hard_message_limit=999, hard_token_limit=999999)
+    message = "[Recent channel messages]\n" + ("large backfill\n" * 5000)
+    decision = decide_context_spill([], message, context_length=256000, config=cfg, stage="inbound")
+    assert decision.should_spill is True
+    assert "char_limit" in decision.reason or "token_limit" in decision.reason
+
+
+def test_write_context_spill_writes_redacted_wiki_raw_manifest_permissions(tmp_path):
+    cfg = _config(tmp_path)
+    source = _source()
+    entry = _entry(source)
+    history = [
+        {"role": "user", "content": "OPENAI_API_KEY=sk-testsecret000000000000000000000000"},
+        {"role": "assistant", "content": "Authorization: Bearer ghp_secretsecretsecretsecretsecret"},
+    ]
+    decision = decide_context_spill(history, "current ask", context_length=256000, config=cfg, stage="history")
+    result = write_context_spill(
+        history=history,
+        message_text="current ask",
+        source=source,
+        session_entry=entry,
+        decision=decision,
+        config=cfg,
+    )
+
+    assert result.wiki_path and result.wiki_path.exists()
+    assert result.raw_path and result.raw_path.exists()
+    assert result.manifest_path and result.manifest_path.exists()
+    wiki_text = result.wiki_path.read_text()
+    assert "sk-testsecret000000000000000000000000" not in wiki_text
+    assert "ghp_secretsecretsecretsecretsecret" not in wiki_text
+    raw_payload = json.loads(result.raw_path.read_text())
+    assert raw_payload["history"][0]["content"].startswith("OPENAI_API_KEY=sk-test")
+    if os.name != "nt":
+        assert stat.S_IMODE(result.raw_path.stat().st_mode) == 0o600
+        assert stat.S_IMODE((tmp_path / "state" / "context-spills").stat().st_mode) == 0o700
+    assert len(result.recovery_message) < 4000
+    assert "current ask" in result.recovery_message
+    assert "OPENAI_API_KEY" not in result.recovery_message
+    assert len(result.user_notice) <= 500
+
+
+def test_write_context_spill_redaction_fail_closed_with_raw(monkeypatch, tmp_path):
+    cfg = _config(tmp_path)
+    source = _source()
+    entry = _entry(source)
+    decision = decide_context_spill([], "ask", context_length=1, config=cfg, stage="inbound")
+
+    def boom(_text, *, force=False, code_file=False):
+        raise RuntimeError("redaction down")
+
+    monkeypatch.setattr("agent.redact.redact_sensitive_text", boom)
+    result = write_context_spill(
+        history=[{"role": "user", "content": "secret"}],
+        message_text="ask",
+        source=source,
+        session_entry=entry,
+        decision=decision,
+        config=cfg,
+    )
+    assert result.raw_path and result.raw_path.exists()
+    assert result.wiki_path is None
+    assert "raw local bundle" in result.recovery_message
+
+
+def test_raw_unavailable_fails_closed(monkeypatch, tmp_path):
+    cfg = _config(tmp_path)
+    source = _source()
+    entry = _entry(source)
+    decision = decide_context_spill([], "ask", context_length=1, config=cfg, stage="inbound")
+
+    def fail_json(*args, **kwargs):
+        raise PermissionError("no write")
+
+    monkeypatch.setattr("gateway.context_spill._atomic_write_json", fail_json)
+    with pytest.raises(ContextSpillWriteError):
+        write_context_spill(
+            history=[],
+            message_text="ask",
+            source=source,
+            session_entry=entry,
+            decision=decision,
+            config=cfg,
+        )
+
+
+def test_session_store_spill_and_reset_quarantines_old_session(tmp_path):
+    source = _source()
+    gw_cfg = GatewayConfig(platforms={Platform.DISCORD: PlatformConfig(enabled=True, token="x")})
+    gw_cfg.sessions_dir = tmp_path / "sessions"
+    store = SessionStore(gw_cfg.sessions_dir, gw_cfg)
+    store._db = None
+    entry = store.get_or_create_session(source)
+    old_sid = entry.session_id
+    raw_path = tmp_path / "state" / "context-spills" / "spill.json"
+    new_entry = store.spill_and_reset_session(
+        entry.session_key,
+        old_session_id=old_sid,
+        spill_id="spill-1",
+        wiki_path=str(tmp_path / "wiki" / "spill.md"),
+        raw_path=str(raw_path),
+        reason="message_limit",
+    )
+    assert new_entry is not None
+    assert new_entry.session_id != old_sid
+    assert store.is_session_quarantined(old_sid) is True
+    assert store.switch_session(entry.session_key, old_sid) is None
+    assert store.mark_resume_pending(entry.session_key) is True  # new lane is safe
+
+
+def test_quarantined_active_entry_beats_resume_pending(tmp_path):
+    source = _source()
+    gw_cfg = GatewayConfig(platforms={Platform.DISCORD: PlatformConfig(enabled=True, token="x")})
+    gw_cfg.sessions_dir = tmp_path / "sessions"
+    store = SessionStore(gw_cfg.sessions_dir, gw_cfg)
+    store._db = None
+    entry = store.get_or_create_session(source)
+    entry.quarantined = True
+    entry.resume_pending = True
+    store._save()
+    fresh = store.get_or_create_session(source)
+    assert fresh.session_id != entry.session_id
+    assert fresh.auto_reset_reason == "quarantined"
+
+
+def test_request_pressure_guard_blocks_large_payload():
+    api_kwargs = {
+        "model": "small",
+        "messages": [{"role": "user", "content": "x" * 240_000}],
+        "tools": [{"type": "function", "function": {"name": "t", "parameters": {"description": "y" * 120_000}}}],
+    }
+    pressure = request_pressure_from_api_kwargs(api_kwargs, context_length=64_000)
+    assert pressure["too_large"] is True
+
+
+def test_request_pressure_guard_uses_large_model_context_not_180k_cap():
+    # Regression for Codex-routed GPT-5.5: ~183k estimated tokens is below
+    # 90% of a 272k context window, so the final pre-API guard must not call it
+    # "too large" just because the old gateway spill default was 180k.
+    api_kwargs = {
+        "model": "gpt-5.5",
+        "messages": [{"role": "user", "content": "x" * 734_000}],
+        "tools": [],
+    }
+    pressure = request_pressure_from_api_kwargs(api_kwargs, context_length=272_000)
+    assert 180_000 <= pressure["approx_tokens"] < pressure["threshold_tokens"]
+    assert pressure["threshold_tokens"] == 244_800
+    assert pressure["too_large"] is False
+
+
+def test_request_guard_failure_copy_does_not_claim_model_context_exceeded():
+    from gateway.run import _normalize_empty_agent_response
+
+    response = _normalize_empty_agent_response(
+        {
+            "failed": True,
+            "partial": True,
+            "error": "Hermes pre-API request-size guard blocked an oversized internal payload",
+            "request_size_guard": {"approx_tokens": 183_599, "threshold_tokens": 244_800},
+        },
+        "",
+        history_len=80,
+    )
+
+    assert "gateway/request-shaping guard" in response
+    assert "not proof" in response
+    assert "model context" in response
+    assert "Session too large" not in response
+
+
+def test_write_context_spill_collapses_nested_handoff_and_tool_output(tmp_path):
+    cfg = _config(tmp_path, include_redacted_wiki_excerpt_chars=24_000)
+    source = _source()
+    entry = _entry(source)
+    huge_skill_body = "SKILL_BODY_OMITTED_SHOULD_NOT_APPEAR " * 1000
+    prior_handoff = "\n".join(
+        [
+            "[GATEWAY HANDOFF]",
+            "The prior gateway session exceeded safe context limits and was spilled before model call.",
+            "- Spill ID: prior-spill",
+            f"- Wiki handoff: {tmp_path}/prior.md",
+            "Current user ask, redacted excerpt:",
+            "fix the app",
+            "Instructions:",
+            "1. Continue from this handoff.",
+            huge_skill_body,
+        ]
+    )
+    history = [
+        {"role": "user", "content": prior_handoff},
+        {"role": "tool", "content": json.dumps({"name": "skill_view", "content": huge_skill_body})},
+        {"role": "assistant", "content": "continuing"},
+    ]
+    decision = decide_context_spill(history, "why is this happening", context_length=256000, config=cfg, stage="history")
+
+    result = write_context_spill(
+        history=history,
+        message_text="why is this happening",
+        source=source,
+        session_entry=entry,
+        decision=decision,
+        config=cfg,
+    )
+
+    assert result.wiki_path and result.wiki_path.exists()
+    wiki_text = result.wiki_path.read_text()
+    assert "SKILL_BODY_OMITTED_SHOULD_NOT_APPEAR" not in wiki_text
+    assert "prior gateway handoff body omitted" in wiki_text
+    assert "skill_view output omitted" in wiki_text or "tool output omitted" in wiki_text
+    assert len(wiki_text) < 30_000
+    assert result.raw_path is not None
+    raw_payload = json.loads(result.raw_path.read_text())
+    assert "SKILL_BODY_OMITTED_SHOULD_NOT_APPEAR" in raw_payload["history"][1]["content"]
+
+
+def test_write_context_spill_respects_notify_user_false(tmp_path):
+    cfg = _config(tmp_path, notify_user=False)
+    source = _source()
+    entry = _entry(source)
+    decision = decide_context_spill([], "ask", context_length=1, config=cfg, stage="history")
+
+    result = write_context_spill(
+        history=[],
+        message_text="ask",
+        source=source,
+        session_entry=entry,
+        decision=decision,
+        config=cfg,
+    )
+
+    assert result.user_notice == ""
+    assert result.recovery_message
+    assert result.raw_path and result.raw_path.exists()
+
+
+def test_load_context_spill_config_known_defaults_with_temp_paths(tmp_path):
+    cfg = load_context_spill_config(
+        {
+            "gateway_context_spill": {
+                "wiki_dir": str(tmp_path / "wiki" / "outputs" / "gateway-context-spills"),
+                "raw_state_dir": str(tmp_path / "state" / "context-spills"),
+            }
+        },
+        tmp_path,
+        allow_unsafe_paths=True,
+    )
+    assert cfg.enabled is True
+    assert cfg.mode == "enforce"
+    assert cfg.hard_message_limit == 180
+
+
+@pytest.mark.asyncio
+async def test_pre_api_guard_spill_preserves_ask_and_quarantines_old_session(monkeypatch, tmp_path):
+    from gateway.run import GatewayRunner
+    import gateway.run as gateway_run
+
+    source = _source()
+    gw_cfg = GatewayConfig(platforms={Platform.DISCORD: PlatformConfig(enabled=True, token="x")})
+    gw_cfg.sessions_dir = tmp_path / "sessions"
+    store = SessionStore(gw_cfg.sessions_dir, gw_cfg)
+    store._db = None
+    entry = store.get_or_create_session(source)
+    old_sid = entry.session_id
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = gw_cfg
+    runner.session_store = store
+    runner.adapters = {}
+    runner._session_model_overrides = {}
+    runner._session_reasoning_overrides = {}
+    runner._pending_model_notes = {}
+    runner._agent_cache_lock = None
+
+    raw_dir = tmp_path / "state" / "context-spills" / "custom-raw"
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "gateway_context_spill": {
+                "wiki_dir": str(tmp_path / "wiki" / "outputs" / "gateway-context-spills"),
+                "raw_state_dir": str(raw_dir),
+                "allow_unsafe_paths": True,
+            }
+        },
+    )
+
+    result, new_entry = await runner._spill_gateway_context_after_request_guard(
+        history=[{"role": "user", "content": "old transcript"}],
+        message_text="do not lose this current ask",
+        source=source,
+        session_entry=entry,
+        session_key=entry.session_key,
+        agent_result={
+            "request_size_guard": {
+                "approx_tokens": 190_000,
+                "request_bytes": 2_000_000,
+                "threshold_tokens": 180_000,
+            }
+        },
+        context_prompt="system prompt that inflated the final request",
+        channel_prompt="",
+    )
+
+    assert result.raw_path and result.raw_path.exists()
+    assert result.wiki_path and result.wiki_path.exists()
+    assert "do not lose this current ask" in result.recovery_message
+    assert new_entry.session_id != old_sid
+    assert store.is_session_quarantined(old_sid) is True
+    assert store.switch_session(entry.session_key, old_sid) is None
+
+
+@pytest.mark.asyncio
+async def test_startup_auto_resume_skips_quarantined_session_ids(tmp_path):
+    from gateway.run import GatewayRunner
+
+    source = _source()
+    gw_cfg = GatewayConfig(platforms={Platform.DISCORD: PlatformConfig(enabled=True, token="x")})
+    gw_cfg.sessions_dir = tmp_path / "sessions"
+    store = SessionStore(gw_cfg.sessions_dir, gw_cfg)
+    store._db = None
+    entry = store.get_or_create_session(source)
+    entry.resume_pending = True
+    entry.resume_reason = "restart_timeout"
+    entry.last_resume_marked_at = datetime.now()
+    entry.origin = source
+    raw_dir = tmp_path / "state" / "context-spills"
+    with store._lock:
+        index = store._read_quarantine_index_locked()
+        index[entry.session_id] = {
+            "session_key": entry.session_key,
+            "spill_id": "spill-1",
+            "wiki_path": str(tmp_path / "wiki" / "spill.md"),
+            "raw_path": str(raw_dir / "spill.json"),
+            "reason": "pre_api_request_guard",
+            "quarantined_at": datetime.now().isoformat(),
+        }
+        store._write_quarantine_index_locked(index)
+        store._save()
+
+    class RecordingAdapter:
+        def __init__(self):
+            self.events = []
+
+        async def handle_message(self, event):
+            self.events.append(event)
+
+    adapter = RecordingAdapter()
+    runner = object.__new__(GatewayRunner)
+    runner.config = gw_cfg
+    runner.session_store = store
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._background_tasks = set()
+
+    scheduled = runner._schedule_resume_pending_sessions()
+
+    assert scheduled == 0
+    assert adapter.events == []

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -686,6 +686,27 @@ async def test_fetch_channel_context_skips_other_bots_when_allow_bots_none(adapt
 
     assert result == "[Recent channel messages]\n[Alice] human note"
 
+@pytest.mark.asyncio
+async def test_fetch_channel_context_caps_total_backfill_chars(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "none")
+    adapter.config.extra["history_backfill_limit"] = 10
+    adapter.config.extra["history_backfill_max_chars"] = 320
+
+    human = SimpleNamespace(id=56, display_name="Alice", name="Alice", bot=False)
+    channel = FakeHistoryChannel(
+        [
+            make_history_message(author=human, content="old " + ("x" * 500), msg_id=1),
+            make_history_message(author=human, content="new " + ("y" * 500), msg_id=2),
+        ],
+        channel_id=123,
+    )
+
+    result = await adapter._fetch_channel_context(channel, before=make_message(channel=channel, content="trigger"))
+
+    assert len(result) <= 320
+    assert "...[truncated]" in result
+    assert "new " in result
+
 
 @pytest.mark.asyncio
 async def test_fetch_channel_context_uses_cache_to_narrow_window(adapter, monkeypatch):

--- a/tests/gateway/test_runtime_env_reload_config_authority.py
+++ b/tests/gateway/test_runtime_env_reload_config_authority.py
@@ -37,7 +37,7 @@ def test_reload_runtime_env_preserves_config_max_turns(tmp_path: Path, monkeypat
     assert os.environ["HERMES_MAX_ITERATIONS"] == "9000"
 
 
-def test_reload_runtime_env_keeps_env_max_iterations_when_config_omits_key(
+def test_reload_runtime_env_reasserts_gateway_default_when_config_omits_key(
     tmp_path: Path, monkeypatch
 ) -> None:
     hermes_home = tmp_path / ".hermes"
@@ -50,4 +50,4 @@ def test_reload_runtime_env_keeps_env_max_iterations_when_config_omits_key(
 
     gateway_run._reload_runtime_env_preserving_config_authority()
 
-    assert os.environ["HERMES_MAX_ITERATIONS"] == "123"
+    assert os.environ["HERMES_MAX_ITERATIONS"] == "32"

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -396,11 +396,10 @@ async def test_session_hygiene_messages_stay_in_originating_topic(monkeypatch, t
 
 
 @pytest.mark.asyncio
-async def test_session_hygiene_warns_user_when_summary_generation_fails(monkeypatch, tmp_path):
+async def test_session_hygiene_logs_only_when_summary_generation_fails(monkeypatch, tmp_path, caplog):
     """When auxiliary compression's summary LLM call fails, the compressor
     inserts a static fallback and the dropped turns are unrecoverable.
-    Gateway must surface a visible ⚠️ warning to the user, including
-    thread_id metadata so it lands in the originating topic/thread."""
+    Gateway must not surface compressor internals to the user thread."""
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
     monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
@@ -478,6 +477,7 @@ async def test_session_hygiene_warns_user_when_summary_generation_fails(monkeypa
         lambda *_args, **_kwargs: 100,
     )
     monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "795544298")
+    caplog.set_level("WARNING", logger="gateway.run")
 
     event = MessageEvent(
         text="hello",
@@ -494,30 +494,19 @@ async def test_session_hygiene_warns_user_when_summary_generation_fails(monkeypa
     result = await runner._handle_message(event)
 
     assert result == "ok"
-    # The compressor reported summary-failure → exactly one warning
-    # message must have been delivered to the user.
     warning_messages = [s for s in adapter.sent if "Context compression summary failed" in s["content"]]
-    assert len(warning_messages) == 1, (
-        f"Expected 1 compression-failure warning, got {len(warning_messages)}: {adapter.sent}"
-    )
-    warn = warning_messages[0]
-    # Warning must include the dropped count and the underlying error.
-    assert "42" in warn["content"]
-    assert "404" in warn["content"]
-    # Warning must land in the originating topic/thread, not the main channel.
-    assert warn["chat_id"] == "-1001"
-    assert warn["metadata"] == {"thread_id": "17585"}
+    assert warning_messages == []
+    assert "Session hygiene compression summary failed" in caplog.text
+    assert "dropped=42" in caplog.text
+    assert "404 model not found" in caplog.text
 
     FakeCompressAgentWithSummaryFailure.last_instance.close.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_session_hygiene_informs_user_when_aux_model_fails_but_recovers(monkeypatch, tmp_path):
-    """When the user's configured ``auxiliary.compression.model`` errors out
-    and we recover via the main model, compression succeeds but the user's
-    config is still broken.  Gateway hygiene must surface an ℹ note so the
-    user knows to fix ``auxiliary.compression.model`` — silent recovery
-    hides a misconfig only they can resolve."""
+async def test_session_hygiene_logs_only_when_aux_model_fails_but_recovers(monkeypatch, tmp_path, caplog):
+    """When the configured aux compression model fails and main-model fallback works,
+    gateway hygiene should log the recovery without posting internals to chat."""
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
     monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
@@ -597,6 +586,7 @@ async def test_session_hygiene_informs_user_when_aux_model_fails_but_recovers(mo
         lambda *_args, **_kwargs: 100,
     )
     monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "795544298")
+    caplog.set_level("WARNING", logger="gateway.run")
 
     event = MessageEvent(
         text="hello",
@@ -616,21 +606,15 @@ async def test_session_hygiene_informs_user_when_aux_model_fails_but_recovers(mo
     # No ⚠️ hard-failure warning (that's for dropped turns)
     hard_warnings = [s for s in adapter.sent if "Context compression summary failed" in s["content"]]
     assert len(hard_warnings) == 0, adapter.sent
-    # But an ℹ note about the configured aux model must be delivered.
+    # Aux-model recovery stays in logs; do not pollute the user thread.
     aux_notes = [
         s for s in adapter.sent
         if "Configured compression model" in s["content"]
     ]
-    assert len(aux_notes) == 1, (
-        f"Expected 1 aux-model fallback notice, got {len(aux_notes)}: {adapter.sent}"
-    )
-    note = aux_notes[0]
-    assert "gemini-3-flash-preview" in note["content"]
-    assert "404" in note["content"]
-    assert "auxiliary.compression.model" in note["content"]
-    # Note must land in the originating topic/thread.
-    assert note["chat_id"] == "-1001"
-    assert note["metadata"] == {"thread_id": "17585"}
+    assert aux_notes == []
+    assert "configured compression model" in caplog.text.lower()
+    assert "gemini-3-flash-preview" in caplog.text
+    assert "404 model not found" in caplog.text
 
     FakeCompressAgentWithAuxRecovery.last_instance.close.assert_called_once()
 

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1223,3 +1223,18 @@ class TestDoctorXaiOAuthStatus:
         # None → {} → logged_in falsy → shows not-logged-in warn
         assert "xAI OAuth" in out
         assert "(not logged in)" in out
+
+
+def test_run_doctor_does_not_promote_inactive_gemini_key_to_issue(monkeypatch, tmp_path):
+    out = _run_doctor_with_healthy_oauth_fallback(
+        monkeypatch,
+        tmp_path,
+        env_key="GOOGLE_API_KEY",
+        bad_key="bad-gemini-key",
+        failing_host="googleapis.com",
+        gemini_oauth_status={},
+        minimax_oauth_status={},
+    )
+
+    assert "invalid API key" in out
+    assert "Check GOOGLE_API_KEY in .env" not in out

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -59,6 +59,115 @@ def test_resolve_runtime_provider_anthropic_pool_respects_config_base_url(monkey
     assert resolved["base_url"] == "https://proxy.example.com/anthropic"
 
 
+def test_resolve_runtime_provider_anthropic_pool_respects_provider_base_url_when_secondary(monkeypatch):
+    class _Entry:
+        access_token = "pool-token"
+        source = "manual"
+        base_url = "https://api.anthropic.com"
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "anthropic")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "openai-codex",
+            "default": "gpt-5.5",
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "model": {"provider": "openai-codex", "default": "gpt-5.5"},
+            "providers": {"anthropic": {"base_url": "http://127.0.0.1:42069"}},
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+
+    resolved = rp.resolve_runtime_provider(requested="anthropic")
+
+    assert resolved["provider"] == "anthropic"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["api_key"] == "pool-token"
+    assert resolved["base_url"] == "http://127.0.0.1:42069"
+
+
+def test_resolve_runtime_provider_anthropic_pool_keeps_non_default_pool_base_url(monkeypatch):
+    class _Entry:
+        access_token = "pool-token"
+        source = "manual"
+        base_url = "https://pool-proxy.example.com/anthropic"
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "anthropic")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "openai-codex",
+            "default": "gpt-5.5",
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "model": {"provider": "openai-codex", "default": "gpt-5.5"},
+            "providers": {"anthropic": {"base_url": "http://127.0.0.1:42069"}},
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+
+    resolved = rp.resolve_runtime_provider(requested="anthropic")
+
+    assert resolved["provider"] == "anthropic"
+    assert resolved["base_url"] == "https://pool-proxy.example.com/anthropic"
+
+
+def test_resolve_runtime_provider_anthropic_explicit_respects_provider_base_url_when_secondary(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "anthropic")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "openai-codex",
+            "default": "gpt-5.5",
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "model": {"provider": "openai-codex", "default": "gpt-5.5"},
+            "providers": {"anthropic": {"base_url": "http://127.0.0.1:42069"}},
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="anthropic",
+        explicit_api_key="anthropic-explicit-token",
+    )
+
+    assert resolved["provider"] == "anthropic"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["api_key"] == "anthropic-explicit-token"
+    assert resolved["base_url"] == "http://127.0.0.1:42069"
+    assert resolved["source"] == "explicit"
+
+
 def test_resolve_runtime_provider_anthropic_explicit_override_skips_pool(monkeypatch):
     def _unexpected_pool(provider):
         raise AssertionError(f"load_pool should not be called for {provider}")

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -59,6 +59,47 @@ def test_resolve_runtime_provider_anthropic_pool_respects_config_base_url(monkey
     assert resolved["base_url"] == "https://proxy.example.com/anthropic"
 
 
+def test_resolve_runtime_provider_anthropic_model_base_url_beats_provider_fallback(monkeypatch):
+    class _Entry:
+        access_token = "pool-token"
+        source = "manual"
+        base_url = "https://api.anthropic.com"
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "anthropic")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "anthropic",
+            "base_url": "https://model-proxy.example.com/anthropic",
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "model": {
+                "provider": "anthropic",
+                "base_url": "https://model-proxy.example.com/anthropic",
+            },
+            "providers": {"anthropic": {"base_url": "http://127.0.0.1:42069"}},
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+
+    resolved = rp.resolve_runtime_provider(requested="anthropic")
+
+    assert resolved["provider"] == "anthropic"
+    assert resolved["base_url"] == "https://model-proxy.example.com/anthropic"
+
+
 def test_resolve_runtime_provider_anthropic_pool_respects_provider_base_url_when_secondary(monkeypatch):
     class _Entry:
         access_token = "pool-token"

--- a/tests/hermes_cli/test_runtime_safety.py
+++ b/tests/hermes_cli/test_runtime_safety.py
@@ -1,0 +1,23 @@
+from datetime import datetime, timedelta
+
+from hermes_cli.runtime_safety import scan_resume_pending_sessions
+
+
+def test_naive_resume_pending_timestamp_is_local_time():
+    now = datetime.now().astimezone()
+    marked = (datetime.now() - timedelta(seconds=900)).isoformat()
+
+    stale = scan_resume_pending_sessions(
+        [{
+            "session_key": "agent:main:discord:thread:1",
+            "session_id": "s1",
+            "platform": "discord",
+            "resume_pending": True,
+            "last_resume_marked_at": marked,
+        }],
+        now=now,
+        ttl_seconds=600,
+    )
+
+    assert stale
+    assert stale[0]["reason"] == "stale_resume_pending"

--- a/tests/hermes_cli/test_turn_budget_resolver.py
+++ b/tests/hermes_cli/test_turn_budget_resolver.py
@@ -1,0 +1,52 @@
+from hermes_cli.config import get_default_agent_turn_budgets, resolve_agent_max_turns
+
+
+def test_default_task_shaped_budgets():
+    defaults = get_default_agent_turn_budgets()
+    assert defaults["gateway"] == 32
+    assert defaults["api_server"] == 32
+    assert defaults["cli"] == 16
+    assert defaults["lightweight_followup"] == 6
+    assert defaults["coding"] == 90
+    assert defaults["ship_mode"] == 128
+    assert defaults["cron"] == 90
+
+
+def test_per_surface_budget_wins_over_legacy_global_and_env():
+    cfg = {
+        "agent": {
+            "max_turns": 256,
+            "turn_budgets": {"gateway": 32, "api_server": 31, "cli": 16},
+        }
+    }
+    env = {"HERMES_MAX_ITERATIONS": "512"}
+    assert resolve_agent_max_turns(cfg, mode="discord", env=env) == 32
+    assert resolve_agent_max_turns(cfg, mode="gateway", env=env) == 32
+    assert resolve_agent_max_turns(cfg, mode="api_server", env=env) == 31
+    assert resolve_agent_max_turns(cfg, mode="local", env=env) == 16
+
+
+def test_non_default_legacy_global_is_compat_fallback_only_when_no_surface_budget():
+    cfg = {"agent": {"max_turns": 77}}
+    assert resolve_agent_max_turns(cfg, mode="gateway", env={}) == 77
+
+
+def test_legacy_default_90_does_not_override_task_defaults_or_lightweight():
+    cfg = {"agent": {"max_turns": 90}}
+    env = {"HERMES_MAX_ITERATIONS": "90"}
+    assert resolve_agent_max_turns(cfg, mode="gateway", env=env) == 32
+    assert resolve_agent_max_turns(cfg, mode="cli", env=env) == 16
+    assert (
+        resolve_agent_max_turns(
+            cfg,
+            mode="lightweight_followup",
+            env={"HERMES_MAX_ITERATIONS": "256"},
+            include_legacy_global_override=False,
+        )
+        == 6
+    )
+
+
+def test_cron_uses_durable_worker_budget():
+    cfg = {"agent": {"max_turns": 90, "turn_budgets": {"gateway": 32, "cron": 120}}}
+    assert resolve_agent_max_turns(cfg, mode="cron", env={}) == 120

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -278,6 +278,31 @@ class TestFromGlobalConfig:
         config = HonchoClientConfig.from_global_config(config_path=config_file)
         assert config.timeout == 82.5
 
+    def test_max_retries_defaults_to_zero(self, tmp_path):
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({"apiKey": "***"}))
+
+        config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.max_retries == 0
+
+    def test_max_retries_from_camel_config(self, tmp_path):
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({"apiKey": "***", "maxRetries": 2}))
+
+        config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.max_retries == 2
+
+    def test_max_retries_host_block_wins(self, tmp_path):
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({
+            "apiKey": "***",
+            "maxRetries": 3,
+            "hosts": {"hermes": {"maxRetries": 0}},
+        }))
+
+        config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.max_retries == 0
+
 
 class TestResolveSessionName:
     def test_manual_override(self):
@@ -652,6 +677,28 @@ class TestGetHonchoClient:
         assert client is fake_honcho
         mock_honcho.assert_called_once()
         assert mock_honcho.call_args.kwargs["timeout"] == _DEFAULT_HTTP_TIMEOUT
+        assert mock_honcho.call_args.kwargs["max_retries"] == 0
+
+    @pytest.mark.skipif(
+        not importlib.util.find_spec("honcho"),
+        reason="honcho SDK not installed"
+    )
+    def test_passes_max_retries_from_config(self):
+        fake_honcho = MagicMock(name="Honcho")
+        cfg = HonchoClientConfig(
+            api_key="test-key",
+            max_retries=2,
+            workspace_id="hermes",
+            environment="production",
+        )
+
+        with patch("honcho.Honcho", return_value=fake_honcho) as mock_honcho, \
+             patch("hermes_cli.config.load_config", return_value={}):
+            client = get_honcho_client(cfg)
+
+        assert client is fake_honcho
+        mock_honcho.assert_called_once()
+        assert mock_honcho.call_args.kwargs["max_retries"] == 2
 
     @pytest.mark.skipif(
         not importlib.util.find_spec("honcho"),

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -180,6 +180,22 @@ class TestManagerCacheOps:
         assert mgr._turn_counter == 0
         mgr._flush_session.assert_not_called()
 
+    def test_shutdown_save_messages_false_does_not_flush(self):
+        from plugins.memory.honcho.client import HonchoClientConfig
+
+        cfg = HonchoClientConfig(write_frequency="async", save_messages=False)
+        mgr = HonchoSessionManager(config=cfg)
+        session = HonchoSession(key="k", user_peer_id="u", assistant_peer_id="a", honcho_session_id="s")
+        session.add_message("user", "hi")
+        mgr._cache[session.key] = session
+        mgr.flush_all = MagicMock()
+        mgr._flush_session = MagicMock(return_value=True)
+
+        mgr.shutdown()
+
+        mgr.flush_all.assert_not_called()
+        mgr._flush_session.assert_not_called()
+
     def test_save_enabled_async_enqueues_without_direct_flush(self):
         from plugins.memory.honcho.client import HonchoClientConfig
 

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 from plugins.memory.honcho.session import (
     HonchoSession,
     HonchoSessionManager,
+    _ASYNC_SHUTDOWN,
 )
 from plugins.memory.honcho import HonchoMemoryProvider
 
@@ -162,6 +163,44 @@ class TestFormatMigrationTranscript:
 
 
 class TestManagerCacheOps:
+    def test_save_messages_false_disables_writer_and_save(self):
+        from plugins.memory.honcho.client import HonchoClientConfig
+
+        cfg = HonchoClientConfig(write_frequency="async", save_messages=False)
+        mgr = HonchoSessionManager(config=cfg)
+        session = HonchoSession(key="k", user_peer_id="u", assistant_peer_id="a", honcho_session_id="s")
+        session.add_message("user", "hi")
+        mgr._flush_session = MagicMock(return_value=True)
+
+        mgr.save(session)
+        mgr.flush_all()
+
+        assert mgr._async_queue is None
+        assert mgr._async_thread is None
+        assert mgr._turn_counter == 0
+        mgr._flush_session.assert_not_called()
+
+    def test_save_enabled_async_enqueues_without_direct_flush(self):
+        from plugins.memory.honcho.client import HonchoClientConfig
+
+        cfg = HonchoClientConfig(write_frequency="async", save_messages=True)
+        mgr = HonchoSessionManager(config=cfg)
+        real_queue = mgr._async_queue
+        session = HonchoSession(key="k", user_peer_id="u", assistant_peer_id="a", honcho_session_id="s")
+        mgr._flush_session = MagicMock(return_value=True)
+        mgr._async_queue = MagicMock()
+
+        try:
+            mgr.save(session)
+
+            assert mgr._turn_counter == 1
+            mgr._async_queue.put.assert_called_once_with(session)
+            mgr._flush_session.assert_not_called()
+        finally:
+            if real_queue is not None and mgr._async_thread is not None:
+                real_queue.put(_ASYNC_SHUTDOWN)
+                mgr._async_thread.join(timeout=2.0)
+
     def test_delete_cached_session(self):
         mgr = HonchoSessionManager()
         session = HonchoSession(
@@ -557,6 +596,30 @@ class TestConcludeToolDispatch:
 
         assert session.add_message.call_args_list[0].args == ("user", "hello")
         assert session.add_message.call_args_list[1].args == ("assistant", "Visible answer")
+        provider._manager.save.assert_called_once_with(session)
+        provider._manager._flush_session.assert_not_called()
+
+    def test_sync_turn_save_messages_false_skips_all_writes(self):
+        provider = HonchoMemoryProvider()
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+        provider._cron_skipped = False
+        provider._config = SimpleNamespace(message_max_chars=25000, save_messages=False)
+
+        provider.sync_turn("user", "assistant")
+
+        provider._manager.get_or_create.assert_not_called()
+        provider._manager.save.assert_not_called()
+        provider._manager._flush_session.assert_not_called()
+
+    def test_on_session_end_save_messages_false_skips_flush(self):
+        provider = HonchoMemoryProvider()
+        provider._manager = MagicMock()
+        provider._config = SimpleNamespace(save_messages=False)
+
+        provider.on_session_end([{"role": "user", "content": "hi"}])
+
+        provider._manager.flush_all.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -913,6 +976,44 @@ class TestDialecticCadenceDefaults:
 
 class TestBaseContextSummary:
     """Base context injection should include session summary when available."""
+
+    def test_prefetch_does_not_block_on_first_base_context_fetch(self):
+        provider = HonchoMemoryProvider()
+        provider._recall_mode = "hybrid"
+        provider._session_key = "test"
+        provider._manager = MagicMock()
+        provider._manager.pop_context_result.return_value = {}
+        provider._base_context_cache = None
+        provider._turn_count = 1
+        provider._last_dialectic_turn = 0
+        provider._config = SimpleNamespace(context_tokens=None)
+
+        assert provider.prefetch("substantive request") == ""
+
+        provider._manager.get_prefetch_context.assert_not_called()
+        provider._manager.prefetch_context.assert_called_once_with("test", "substantive request")
+
+    def test_prefetch_does_not_join_first_turn_dialectic_thread(self):
+        import time
+
+        provider = HonchoMemoryProvider()
+        provider._recall_mode = "hybrid"
+        provider._session_key = "test"
+        provider._manager = MagicMock()
+        provider._manager.pop_context_result.return_value = {}
+        provider._manager.dialectic_query.side_effect = lambda *a, **kw: time.sleep(0.25) or "late"
+        provider._base_context_cache = None
+        provider._turn_count = 1
+        provider._last_dialectic_turn = -999
+        provider._config = SimpleNamespace(context_tokens=None, timeout=1)
+
+        start = time.monotonic()
+        assert provider.prefetch("substantive request") == ""
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 0.2
+        assert provider._prefetch_thread is not None
+        provider._prefetch_thread.join(timeout=1.0)
 
     def test_format_includes_summary(self):
         """Session summary should appear first in the formatted context."""

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -217,6 +217,26 @@ class TestManagerCacheOps:
                 real_queue.put(_ASYNC_SHUTDOWN)
                 mgr._async_thread.join(timeout=2.0)
 
+    def test_save_messages_false_skips_existing_context_fetch_on_session_create(self):
+        from plugins.memory.honcho.client import HonchoClientConfig
+
+        cfg = HonchoClientConfig(write_frequency="async", save_messages=False)
+        fake_honcho = MagicMock()
+        fake_session = MagicMock()
+        fake_session.context.side_effect = AssertionError("context should not be fetched")
+        fake_session.get_peer_configuration.return_value = SimpleNamespace(
+            observe_me=None,
+            observe_others=None,
+        )
+        fake_honcho.session.return_value = fake_session
+        fake_honcho.peer.side_effect = lambda peer_id: SimpleNamespace(id=peer_id)
+
+        mgr = HonchoSessionManager(honcho=fake_honcho, config=cfg)
+        session = mgr.get_or_create("discord:123")
+
+        assert session.messages == []
+        fake_session.context.assert_not_called()
+
     def test_delete_cached_session(self):
         mgr = HonchoSessionManager()
         session = HonchoSession(
@@ -258,11 +278,23 @@ class TestPeerLookupHelpers:
         mgr._cache[session.key] = session
         return mgr, session
 
-    def test_get_peer_card_uses_direct_peer_lookup(self):
+    def test_get_peer_card_prefers_target_peer_own_card(self):
         mgr, session = self._make_cached_manager()
+        user_peer = MagicMock()
+        user_peer.get_card.return_value = ["Name: Robert"]
+        mgr._get_or_create_peer = MagicMock(return_value=user_peer)
+
+        assert mgr.get_peer_card(session.key) == ["Name: Robert"]
+        mgr._get_or_create_peer.assert_called_once_with(session.user_peer_id)
+        user_peer.get_card.assert_called_once_with()
+
+    def test_get_peer_card_falls_back_to_observer_target_card(self):
+        mgr, session = self._make_cached_manager()
+        user_peer = MagicMock()
+        user_peer.get_card.return_value = []
         assistant_peer = MagicMock()
         assistant_peer.get_card.return_value = ["Name: Robert"]
-        mgr._get_or_create_peer = MagicMock(return_value=assistant_peer)
+        mgr._get_or_create_peer = MagicMock(side_effect=[user_peer, assistant_peer])
 
         assert mgr.get_peer_card(session.key) == ["Name: Robert"]
         assistant_peer.get_card.assert_called_once_with(target=session.user_peer_id)
@@ -1030,6 +1062,42 @@ class TestBaseContextSummary:
         assert elapsed < 0.2
         assert provider._prefetch_thread is not None
         provider._prefetch_thread.join(timeout=1.0)
+
+    def test_dialectic_cadence_zero_disables_first_turn_dialectic_but_keeps_base_context(self):
+        provider = HonchoMemoryProvider()
+        provider._recall_mode = "hybrid"
+        provider._session_key = "test"
+        provider._manager = MagicMock()
+        provider._manager.pop_context_result.return_value = {}
+        provider._base_context_cache = "## User Representation\nBase context"
+        provider._turn_count = 1
+        provider._last_dialectic_turn = -999
+        provider._dialectic_cadence = 0
+        provider._config = SimpleNamespace(context_tokens=None, timeout=1)
+
+        result = provider.prefetch("substantive request")
+
+        assert "Base context" in result
+        assert provider._prefetch_thread is None
+        provider._manager.dialectic_query.assert_not_called()
+
+    def test_dialectic_cadence_zero_queue_prefetch_refreshes_context_only(self):
+        provider = HonchoMemoryProvider()
+        provider._recall_mode = "hybrid"
+        provider._session_key = "test"
+        provider._manager = MagicMock()
+        provider._turn_count = 3
+        provider._last_context_turn = 0
+        provider._context_cadence = 3
+        provider._last_dialectic_turn = -999
+        provider._dialectic_cadence = 0
+        provider._config = SimpleNamespace(context_tokens=None, timeout=1)
+
+        provider.queue_prefetch("substantive request")
+
+        provider._manager.prefetch_context.assert_called_once_with("test", "substantive request")
+        assert provider._prefetch_thread is None
+        provider._manager.dialectic_query.assert_not_called()
 
     def test_format_includes_summary(self):
         """Session summary should appear first in the formatted context."""

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -156,6 +156,38 @@ class TestFallbackChainAdvancement:
             assert agent._try_activate_fallback() is True
             assert agent.model == "gpt-4o"
 
+    def test_oversized_request_skips_fallback_without_resolving_client(self):
+        fbs = [{"provider": "openai", "model": "gpt-4o"}]
+        agent = _make_agent(fallback_model=fbs)
+        setattr(agent, "_last_request_pressure", {
+            "approx_tokens": 100_000,
+            "request_bytes": 900_000,
+            "too_large": False,
+        })
+        with (
+            patch("agent.model_metadata.get_model_context_length", return_value=64_000),
+            patch("agent.auxiliary_client.resolve_provider_client") as mock_rpc,
+        ):
+            assert agent._try_activate_fallback() is False
+            mock_rpc.assert_not_called()
+            assert getattr(agent, "_fallback_disabled_due_to_context_size") is True
+
+    def test_fallback_guard_failure_skips_fallback_closed(self):
+        fbs = [{"provider": "openai", "model": "gpt-4o"}]
+        agent = _make_agent(fallback_model=fbs)
+        setattr(agent, "_last_request_pressure", {
+            "approx_tokens": 1,
+            "request_bytes": 1,
+            "too_large": False,
+        })
+        with (
+            patch("agent.model_metadata.get_model_context_length", side_effect=RuntimeError("metadata down")),
+            patch("agent.auxiliary_client.resolve_provider_client") as mock_rpc,
+        ):
+            assert agent._try_activate_fallback() is False
+            mock_rpc.assert_not_called()
+            assert getattr(agent, "_fallback_disabled_due_to_context_size") is True
+
     def test_resolves_key_env_for_fallback_provider(self):
         fbs = [
             {

--- a/tests/run_agent/test_ship_mode_routing_guard.py
+++ b/tests/run_agent/test_ship_mode_routing_guard.py
@@ -1,0 +1,141 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names: str) -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _mock_response(content="ok"):
+    msg = SimpleNamespace(content=content, tool_calls=None, reasoning=None, reasoning_content=None, reasoning_details=None)
+    choice = SimpleNamespace(message=msg, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+BUDGET_CONFIG = {
+    "agent": {
+        "max_turns": 32,
+        "turn_budgets": {
+            "gateway": 32,
+            "lightweight_followup": 6,
+            "coding": 90,
+            "ship_mode": 128,
+            "cron": 90,
+        },
+    }
+}
+
+
+def _agent(platform="discord", configured=32):
+    agent = AIAgent.__new__(AIAgent)
+    setattr(agent, "platform", platform)
+    setattr(agent, "max_iterations", configured)
+    setattr(agent, "_configured_max_iterations", configured)
+    setattr(agent, "_external_turn_ceiling_active", False)
+    setattr(agent, "_last_resolved_turn_max_iterations", configured)
+    return agent
+
+
+def test_serious_app_build_request_gets_ship_mode_guard():
+    from agent.ship_mode_guard import build_ship_mode_routing_context
+
+    ctx = build_ship_mode_routing_context(
+        "Build this app end-to-end, boot it, smoke-test it, and ship the preview"
+    )
+
+    assert ctx
+    assert "Ship-mode routing guard" in ctx
+    assert "todo" in ctx
+    assert "source-of-truth" in ctx
+    assert "Kanban" in ctx
+    assert "review" in ctx
+
+
+def test_tiny_fix_does_not_get_ship_mode_guard():
+    from agent.ship_mode_guard import build_ship_mode_routing_context
+
+    assert build_ship_mode_routing_context("fix typo in README") == ""
+    assert build_ship_mode_routing_context("change the button copy to Continue") == ""
+    assert build_ship_mode_routing_context("what should we build next?") == ""
+
+
+def test_product_feature_ship_request_escalates_to_ship_budget(monkeypatch):
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: BUDGET_CONFIG)
+    agent = _agent()
+
+    result = agent._resolve_turn_max_iterations(
+        "Implement the product onboarding feature across UI and API, verify the preview, and don't stop"
+    )
+
+    assert result == 128
+    assert agent._last_turn_budget_classification == "ship_mode"
+
+
+def test_tiny_fix_stays_out_of_ship_mode(monkeypatch):
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: BUDGET_CONFIG)
+    agent = _agent()
+
+    result = agent._resolve_turn_max_iterations("fix typo in README")
+
+    assert result != 128
+    assert agent._last_turn_budget_classification != "ship_mode"
+
+
+def test_ship_mode_guard_is_injected_into_api_only_message(monkeypatch):
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: BUDGET_CONFIG)
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("todo", "delegate_task")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            provider="test",
+            max_iterations=2,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            platform="discord",
+        )
+
+    agent.client = MagicMock()
+    agent.client.chat.completions.create.return_value = _mock_response("ok")
+    agent._cached_system_prompt = "You are helpful."
+
+    result = agent.run_conversation(
+        "Build this app end-to-end, boot it, smoke-test it, and ship the preview",
+        conversation_history=[],
+    )
+
+    sent_messages = agent.client.chat.completions.create.call_args.kwargs["messages"]
+    sent_user = [m for m in sent_messages if m.get("role") == "user"][-1]["content"]
+    assert "Ship-mode routing guard" in sent_user
+    assert "Use the todo tool" in sent_user
+    assert "source-of-truth" in sent_user
+
+    stored_user = [m for m in result["messages"] if m.get("role") == "user"][-1]["content"]
+    assert "Ship-mode routing guard" not in stored_user
+
+
+def test_kanban_worker_does_not_get_nested_ship_mode_guard(monkeypatch):
+    from agent.ship_mode_guard import build_ship_mode_routing_context
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_worker")
+
+    assert build_ship_mode_routing_context(
+        "Build this app end-to-end and ship it", platform="discord"
+    ) == ""

--- a/tests/run_agent/test_turn_iteration_budgets.py
+++ b/tests/run_agent/test_turn_iteration_budgets.py
@@ -1,0 +1,101 @@
+from run_agent import AIAgent
+
+
+BUDGET_CONFIG = {
+    "agent": {
+        "max_turns": 90,
+        "turn_budgets": {
+            "gateway": 32,
+            "lightweight_followup": 6,
+            "coding": 90,
+            "ship_mode": 128,
+            "cron": 90,
+        },
+    }
+}
+
+
+def _agent(platform="discord", configured=32, external=False):
+    agent = AIAgent.__new__(AIAgent)
+    setattr(agent, "platform", platform)
+    setattr(agent, "max_iterations", configured)
+    setattr(agent, "_configured_max_iterations", configured)
+    setattr(agent, "_external_turn_ceiling_active", external)
+    setattr(agent, "_last_resolved_turn_max_iterations", configured)
+    return agent
+
+
+def test_passive_gateway_question_does_not_escalate(monkeypatch):
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: BUDGET_CONFIG)
+    agent = _agent()
+    history = [{"role": "user", "content": "Fix the gateway runtime and run tests"}]
+    assert agent._resolve_turn_max_iterations("what changed in gateway?", history) == 32
+    assert agent._last_turn_budget_classification == "surface"
+
+
+def test_lightweight_followup_stays_small_even_after_coding_history(monkeypatch):
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: BUDGET_CONFIG)
+    agent = _agent()
+    history = [{"role": "user", "content": "Implement the runtime gateway budget fix"}]
+    assert agent._resolve_turn_max_iterations("ok", history) == 6
+
+
+def test_simple_check_stays_tiny(monkeypatch):
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: BUDGET_CONFIG)
+    agent = _agent()
+    assert agent._resolve_turn_max_iterations("check status") == 8
+    assert agent._last_turn_budget_classification == "simple_check"
+
+
+def test_coding_turn_escalates_to_coding_budget(monkeypatch):
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: BUDGET_CONFIG)
+    agent = _agent()
+    assert agent._resolve_turn_max_iterations("fix the gateway runtime bug and run tests") == 90
+    assert agent._last_turn_budget_classification == "coding"
+
+
+def test_ship_mode_turn_escalates_to_ship_budget(monkeypatch):
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: BUDGET_CONFIG)
+    agent = _agent()
+    history = [{"role": "user", "content": "We are fixing Hermes runtime budgets and gateway performance"}]
+    assert agent._resolve_turn_max_iterations("use 128 iterations if needed and ship this", history) == 128
+    assert agent._last_turn_budget_classification == "ship_mode"
+
+
+def test_fix_it_uses_recent_runtime_context_for_ship_mode(monkeypatch):
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: BUDGET_CONFIG)
+    agent = _agent()
+    history = [{"role": "user", "content": "Hermes gateway runtime performance is broken; implement the full app-dev fix"}]
+    assert agent._resolve_turn_max_iterations("fix it", history) == 128
+
+
+def test_external_ceiling_is_not_reexpanded(monkeypatch):
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: BUDGET_CONFIG)
+    agent = _agent(configured=4, external=True)
+    assert agent._resolve_turn_max_iterations("fix the gateway runtime bug") == 4
+    assert agent._last_turn_budget_classification == "external_ceiling"
+
+
+def test_gateway_refresh_clears_external_ceiling_shape(monkeypatch):
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: BUDGET_CONFIG)
+    agent = _agent(configured=4, external=True)
+    assert agent._resolve_turn_max_iterations("fix the gateway runtime bug") == 4
+
+    # Gateway cached-agent refresh should set a new configured base and clear the external ceiling.
+    setattr(agent, "_configured_max_iterations", 32)
+    setattr(agent, "max_iterations", 32)
+    setattr(agent, "_last_resolved_turn_max_iterations", None)
+    setattr(agent, "_external_turn_ceiling_active", False)
+
+    assert agent._resolve_turn_max_iterations("fix the gateway runtime bug and run tests") == 90
+
+
+def test_cron_and_kanban_keep_configured_worker_budget(monkeypatch):
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: BUDGET_CONFIG)
+    cron_agent = _agent(platform="cron", configured=90)
+    assert cron_agent._resolve_turn_max_iterations("ok") == 90
+    assert cron_agent._last_turn_budget_classification == "durable_worker"
+
+    kanban_agent = _agent(platform="discord", configured=90)
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-123")
+    assert kanban_agent._resolve_turn_max_iterations("ok") == 90

--- a/tests/tools/test_gateway_control_guard.py
+++ b/tests/tools/test_gateway_control_guard.py
@@ -1,0 +1,47 @@
+from tools.gateway_control_guard import (
+    approve_gateway_control_command,
+    check_gateway_control_guard,
+    clear_gateway_control_approvals,
+)
+
+
+def teardown_function():
+    clear_gateway_control_approvals()
+
+
+def test_cron_blocks_gateway_lifecycle_command(monkeypatch):
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+
+    decision = check_gateway_control_guard(
+        "systemctl --user restart hermes-gateway.service",
+        "session-a",
+    )
+
+    assert decision.is_gateway_control is True
+    assert decision.approved is False
+    assert "not allowed from cron" in (decision.message or "")
+
+
+def test_exact_session_approval_allows_matching_gateway_command(monkeypatch):
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+    command = "systemctl --user restart hermes-gateway.service"
+
+    blocked = check_gateway_control_guard(command, "session-a")
+    approve_gateway_control_command("session-a", command)
+    approved = check_gateway_control_guard(command, "session-a")
+    other = check_gateway_control_guard(command + " --no-block", "session-a")
+
+    assert blocked.is_gateway_control is True
+    assert blocked.approved is False
+    assert approved.approved is True
+    assert other.approved is False
+
+
+def test_readonly_gateway_status_is_not_blocked():
+    decision = check_gateway_control_guard(
+        "systemctl --user status hermes-gateway.service",
+        "session-a",
+    )
+
+    assert decision.is_gateway_control is False
+    assert decision.approved is True

--- a/tests/tools/test_gateway_control_guard.py
+++ b/tests/tools/test_gateway_control_guard.py
@@ -22,6 +22,54 @@ def test_cron_blocks_gateway_lifecycle_command(monkeypatch):
     assert "not allowed from cron" in (decision.message or "")
 
 
+def test_blocks_systemctl_options_before_gateway_lifecycle(monkeypatch):
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+
+    decision = check_gateway_control_guard(
+        "systemctl --no-pager --user restart hermes-gateway.service",
+        "session-a",
+    )
+
+    assert decision.is_gateway_control is True
+    assert decision.approved is False
+    assert decision.reason == "systemctl_gateway_lifecycle"
+
+
+def test_blocks_mainpid_sigkill_compound(monkeypatch):
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+
+    decision = check_gateway_control_guard(
+        "PID=$(systemctl --user show hermes-gateway.service -p MainPID --value); kill -9 \"$PID\"",
+        "session-a",
+    )
+
+    assert decision.is_gateway_control is True
+    assert decision.approved is False
+    assert decision.reason == "gateway_pid_sigkill"
+
+
+def test_blocks_hermes_gateway_update(monkeypatch):
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+
+    decision = check_gateway_control_guard("hermes gateway update", "session-a")
+
+    assert decision.is_gateway_control is True
+    assert decision.approved is False
+
+
+def test_adjacent_gateway_lifecycle_text_blocks_not_yolo(monkeypatch):
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+
+    decision = check_gateway_control_guard(
+        "please stop hermes-gateway.service now",
+        "session-a",
+    )
+
+    assert decision.is_gateway_control is True
+    assert decision.approved is False
+    assert decision.reason == "gateway_control_adjacent"
+
+
 def test_exact_session_approval_allows_matching_gateway_command(monkeypatch):
     monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
     command = "systemctl --user restart hermes-gateway.service"

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -87,6 +87,8 @@ _HARDLINE_BLOCK = [
     "exec shutdown",
     "nohup reboot",
     "setsid poweroff",
+    "sh -c 'reboot'",
+    "bash -c \"shutdown -h now\"",
 ]
 
 
@@ -113,6 +115,7 @@ _HARDLINE_ALLOW = [
     "cat /dev/urandom | head -c 10",
     # Unrelated commands that happen to contain the trigger word
     "grep 'shutdown' logs.txt",
+    "tail -200 ~/.hermes/logs/gateway.log | grep -iE 'compress|shutdown|reboot|error'",
     "echo reboot",
     "echo '# init 0 in comment'",
     "cat rebooting.log",

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -525,6 +525,87 @@ class TestSkillView:
             skill["name"] for skill in list_result["skills"]
         ]
 
+    def test_bundled_skill_is_fallback_when_profile_copy_absent(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        profile_skills = home / "skills"
+        profile_skills.mkdir(parents=True)
+        bundled_skills = tmp_path / "bundled"
+        _make_skill(bundled_skills, "bundled-only", category="creative")
+
+        monkeypatch.setenv("HERMES_BUNDLED_SKILLS", str(bundled_skills))
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", profile_skills),
+            patch("tools.skills_tool.get_hermes_home", return_value=home),
+        ):
+            raw = skill_view("bundled-only")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["name"] == "bundled-only"
+        assert str(bundled_skills) in result["skill_dir"]
+
+    def test_bundled_fallback_matches_frontmatter_name_when_dir_differs(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        profile_skills = home / "skills"
+        profile_skills.mkdir(parents=True)
+        bundled_skills = tmp_path / "bundled"
+        _make_skill(bundled_skills, "creative-ideation", frontmatter_extra="name: ideation\n", category="creative")
+
+        monkeypatch.setenv("HERMES_BUNDLED_SKILLS", str(bundled_skills))
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", profile_skills),
+            patch("tools.skills_tool.get_hermes_home", return_value=home),
+        ):
+            raw = skill_view("ideation")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["name"] == "ideation"
+        assert str(bundled_skills) in result["skill_dir"]
+
+    def test_profile_skill_shadows_bundled_copy_without_ambiguity(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        profile_skills = home / "skills"
+        profile_skills.mkdir(parents=True)
+        bundled_skills = tmp_path / "bundled"
+        _make_skill(profile_skills, "humanizer", body="profile version")
+        _make_skill(bundled_skills, "humanizer", body="bundled version")
+
+        monkeypatch.setenv("HERMES_BUNDLED_SKILLS", str(bundled_skills))
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", profile_skills),
+            patch("tools.skills_tool.get_hermes_home", return_value=home),
+        ):
+            raw = skill_view("humanizer")
+            listed = json.loads(skills_list())
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert "profile version" in result["content"]
+        assert "bundled version" not in result["content"]
+        assert [s["name"] for s in listed["skills"]].count("humanizer") == 1
+
+    def test_archive_flat_markdown_does_not_shadow_bundled_skill(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        profile_skills = home / "skills"
+        archive = profile_skills / ".archive" / "old" / "templates"
+        archive.mkdir(parents=True)
+        (archive / "spotify.md").write_text("archived flat markdown")
+        bundled_skills = tmp_path / "bundled"
+        _make_skill(bundled_skills, "spotify", body="bundled skill")
+
+        monkeypatch.setenv("HERMES_BUNDLED_SKILLS", str(bundled_skills))
+        with (
+            patch("tools.skills_tool.SKILLS_DIR", profile_skills),
+            patch("tools.skills_tool.get_hermes_home", return_value=home),
+        ):
+            raw = skill_view("spotify")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert "bundled skill" in result["content"]
+        assert "archived flat markdown" not in result["content"]
+
 
 class TestSkillViewSecureSetupOnLoad:
     def test_requests_missing_required_env_and_continues(self, tmp_path, monkeypatch):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -217,6 +217,7 @@ HARDLINE_PATTERNS = [
     (_CMDPOS + r'init\s+[06]\b', "init 0/6 (shutdown/reboot)"),
     (_CMDPOS + r'systemctl\s+(poweroff|reboot|halt|kexec)\b', "systemctl poweroff/reboot"),
     (_CMDPOS + r'telinit\s+[06]\b', "telinit 0/6 (shutdown/reboot)"),
+    (r'\b(?:ba)?sh\s+-c\s*[\'"`][^\'"`\n]*\b(?:shutdown|reboot|halt|poweroff|init\s+[06]|telinit\s+[06]|systemctl\s+(?:poweroff|reboot|halt|kexec))\b', "shell -c system shutdown/reboot"),
 ]
 
 # Pre-compiled variant used by the hot-path matcher. Building these at module
@@ -266,6 +267,20 @@ def _check_sudo_stdin_guard(command: str) -> tuple:
     return (False, None)
 
 
+def _mask_quoted_literals_for_hardline(command: str) -> str:
+    """Mask quoted text before hardline matching when it is data, not code.
+
+    Hardline shutdown/reboot patterns anchor on command separators such as
+    pipes. A grep regex like ``grep -iE 'shutdown|reboot'`` contains a pipe
+    inside a quoted argument; treating that as shell syntax false-blocks safe
+    log inspection. Keep shell-eval forms unmasked so ``sh -c 'reboot'`` still
+    hits the blocklist.
+    """
+    if re.search(r'\b(?:ba)?sh\s+-c\s*[\'"`]', command, re.IGNORECASE):
+        return command
+    return re.sub(r"'[^']*'|\"[^\"]*\"", "''", command)
+
+
 def detect_hardline_command(command: str) -> tuple:
     """Check if a command matches the unconditional hardline blocklist.
 
@@ -273,6 +288,7 @@ def detect_hardline_command(command: str) -> tuple:
         (is_hardline, description) or (False, None)
     """
     normalized = _normalize_command_for_detection(command).lower()
+    normalized = _mask_quoted_literals_for_hardline(normalized)
     for pattern_re, description in HARDLINE_PATTERNS_COMPILED:
         if pattern_re.search(normalized):
             return (True, description)

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -627,6 +627,11 @@ def clear_session(session_key: str) -> None:
         _session_yolo.discard(session_key)
         _pending.pop(session_key, None)
         entries = _gateway_queues.pop(session_key, [])
+    try:
+        from tools.gateway_control_guard import clear_gateway_control_approvals
+        clear_gateway_control_approvals(session_key)
+    except Exception:
+        pass
     for entry in entries:
         # Session-boundary cleanup should cancel any blocked approval waits
         # immediately so the old run can unwind instead of idling until timeout.
@@ -954,6 +959,18 @@ def check_dangerous_command(command: str, env_type: str,
         logger.warning("Hardline block: %s (command: %s)", hardline_desc, command[:200])
         return _hardline_block_result(hardline_desc)
 
+    # Gateway lifecycle commands get a stricter exact-command/session guard
+    # than ordinary dangerous commands. Cron and yolo must not be able to kill
+    # the live gateway by default.
+    from tools.gateway_control_guard import (
+        check_gateway_control_guard,
+        gateway_control_block_result,
+    )
+    gateway_decision = check_gateway_control_guard(command, get_current_session_key())
+    if gateway_decision.is_gateway_control and not gateway_decision.approved:
+        logger.warning("Gateway-control block: %s (command: %s)", gateway_decision.reason, command[:200])
+        return gateway_control_block_result(gateway_decision)
+
     # --yolo: bypass all approval prompts. Gateway /yolo is session-scoped;
     # CLI --yolo remains process-scoped via the env var for local use.
     if is_truthy_value(os.getenv("HERMES_YOLO_MODE")) or is_current_session_yolo_enabled():
@@ -1088,6 +1105,18 @@ def check_all_command_guards(command: str, env_type: str,
         logger.warning("Sudo stdin guard block: %s (command: %s)",
                        sudo_guess_desc, command[:200])
         return _sudo_stdin_block_result(sudo_guess_desc)
+
+    # Gateway lifecycle protection is also below yolo/off/cron approve-mode:
+    # killing or restarting hermes-gateway from a cron/agent context can abort
+    # active work and corrupt session continuity.
+    from tools.gateway_control_guard import (
+        check_gateway_control_guard,
+        gateway_control_block_result,
+    )
+    gateway_decision = check_gateway_control_guard(command, get_current_session_key())
+    if gateway_decision.is_gateway_control and not gateway_decision.approved:
+        logger.warning("Gateway-control block: %s (command: %s)", gateway_decision.reason, command[:200])
+        return gateway_control_block_result(gateway_decision)
 
     # --yolo or approvals.mode=off: bypass all approval prompts.
     # Gateway /yolo is session-scoped; CLI --yolo remains process-scoped.

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -509,7 +509,7 @@ def _preserve_parent_mcp_toolsets(
     return preserved
 
 
-DEFAULT_MAX_ITERATIONS = 50
+DEFAULT_MAX_ITERATIONS = 90
 DEFAULT_CHILD_TIMEOUT = 600  # seconds before a child agent is considered stuck
 _HEARTBEAT_INTERVAL = 30  # seconds between parent activity heartbeats during delegation
 # Stale-heartbeat thresholds. A child with no API-call progress is either:
@@ -1000,7 +1000,7 @@ def _build_child_agent(
     )
 
     # Each subagent gets its own iteration budget capped at max_iterations
-    # (configurable via delegation.max_iterations, default 50).  This means
+    # (configurable via delegation.max_iterations, default 90).  This means
     # total iterations across parent + subagents can exceed the parent's
     # max_iterations.  The user controls the per-subagent cap in config.yaml.
 

--- a/tools/gateway_control_guard.py
+++ b/tools/gateway_control_guard.py
@@ -1,0 +1,110 @@
+"""Hard guard for commands that mutate the live Hermes gateway service.
+
+Normal dangerous-command approval and yolo mode are not enough for commands that
+stop, restart, or SIGKILL the gateway running the agent.  This guard is exact
+command + session scoped, short-lived, and blocks cron by default.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from hermes_cli.runtime_safety import classify_gateway_control_text
+from utils import env_var_enabled
+
+GATEWAY_CONTROL_TTL_SECONDS = 10 * 60
+
+_lock = threading.Lock()
+_approvals: dict[tuple[str, str], float] = {}
+
+
+@dataclass(frozen=True)
+class GatewayControlDecision:
+    is_gateway_control: bool
+    approved: bool
+    reason: str | None = None
+    message: str | None = None
+
+
+def command_hash(command: str) -> str:
+    return hashlib.sha256((command or "").encode("utf-8", errors="ignore")).hexdigest()
+
+
+def approve_gateway_control_command(
+    session_key: str,
+    command: str,
+    *,
+    ttl_seconds: int = GATEWAY_CONTROL_TTL_SECONDS,
+) -> str:
+    """Create a fresh exact-command approval for tests/explicit control flows."""
+    digest = command_hash(command)
+    expires_at = time.time() + max(1, int(ttl_seconds))
+    with _lock:
+        _approvals[(session_key or "default", digest)] = expires_at
+    return digest
+
+
+def clear_gateway_control_approvals(session_key: str | None = None) -> None:
+    with _lock:
+        if session_key is None:
+            _approvals.clear()
+        else:
+            for key in list(_approvals):
+                if key[0] == session_key:
+                    _approvals.pop(key, None)
+
+
+def has_fresh_gateway_control_approval(session_key: str, command: str, *, now: float | None = None) -> bool:
+    if now is None:
+        now = time.time()
+    digest = command_hash(command)
+    key = (session_key or "default", digest)
+    with _lock:
+        expires_at = _approvals.get(key)
+        if not expires_at:
+            return False
+        if expires_at < now:
+            _approvals.pop(key, None)
+            return False
+        return True
+
+
+def check_gateway_control_guard(command: str, session_key: str, *, cron: bool | None = None) -> GatewayControlDecision:
+    reason = classify_gateway_control_text(command)
+    if not reason or reason == "gateway_control_adjacent":
+        return GatewayControlDecision(False, True)
+    if cron is None:
+        cron = env_var_enabled("HERMES_CRON_SESSION") or os.getenv("HERMES_CRON_SESSION") == "1"
+    if cron:
+        return GatewayControlDecision(
+            True,
+            False,
+            reason,
+            "BLOCKED: Hermes gateway lifecycle command is not allowed from cron. "
+            "Run gateway stop/restart/kill commands manually outside cron after explicit review.",
+        )
+    if has_fresh_gateway_control_approval(session_key, command):
+        return GatewayControlDecision(True, True, reason, None)
+    return GatewayControlDecision(
+        True,
+        False,
+        reason,
+        "BLOCKED: Hermes gateway lifecycle command requires a fresh explicit gateway-control approval "
+        "for this exact command and session. Do not retry automatically; run it manually or issue an "
+        "explicit approval token from a trusted control flow.",
+    )
+
+
+def gateway_control_block_result(decision: GatewayControlDecision) -> dict[str, Any]:
+    return {
+        "approved": False,
+        "hardline": True,
+        "gateway_control": True,
+        "description": decision.reason or "gateway_control",
+        "message": decision.message or "BLOCKED: Hermes gateway lifecycle command blocked.",
+    }

--- a/tools/gateway_control_guard.py
+++ b/tools/gateway_control_guard.py
@@ -76,7 +76,7 @@ def has_fresh_gateway_control_approval(session_key: str, command: str, *, now: f
 
 def check_gateway_control_guard(command: str, session_key: str, *, cron: bool | None = None) -> GatewayControlDecision:
     reason = classify_gateway_control_text(command)
-    if not reason or reason == "gateway_control_adjacent":
+    if not reason:
         return GatewayControlDecision(False, True)
     if cron is None:
         cron = env_var_enabled("HERMES_CRON_SESSION") or os.getenv("HERMES_CRON_SESSION") == "1"

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -451,15 +451,8 @@ def _get_category_from_path(skill_path: Path) -> Optional[str]:
     For paths like: ~/.hermes/skills/mlops/axolotl/SKILL.md -> "mlops"
     Also works for external skill dirs configured via skills.external_dirs.
     """
-    # Try the module-level SKILLS_DIR first (respects monkeypatching in tests),
-    # then fall back to external dirs from config.
-    dirs_to_check = [SKILLS_DIR]
-    try:
-        from agent.skill_utils import get_external_skills_dirs
-        dirs_to_check.extend(get_external_skills_dirs())
-    except Exception:
-        pass
-    for skills_dir in dirs_to_check:
+    # Try all known skill roots in precedence order: profile, external, bundled fallback.
+    for skills_dir in _skill_search_dirs():
         try:
             rel_path = skill_path.relative_to(skills_dir)
             parts = rel_path.parts
@@ -547,6 +540,53 @@ def _is_skill_disabled(name: str, platform: str = None) -> bool:
         return False
 
 
+def _bundled_skills_dir() -> Optional[Path]:
+    """Return the repo/package bundled skills dir when available."""
+    override = os.getenv("HERMES_BUNDLED_SKILLS", "").strip()
+    bundled = Path(override).expanduser() if override else Path(__file__).resolve().parents[1] / "skills"
+    return bundled if bundled.is_dir() else None
+
+
+def _should_include_bundled_skills() -> bool:
+    """Only include bundled fallback for the real profile skills dir.
+
+    Tests often monkeypatch ``SKILLS_DIR`` to a tmpdir; including the checkout's
+    bundled catalog there would make empty-dir tests see hundreds of skills.
+    """
+    try:
+        return SKILLS_DIR.resolve() == (get_hermes_home() / "skills").resolve()
+    except Exception:
+        return False
+
+
+def _skill_search_dirs(*, include_bundled: bool = True) -> List[Path]:
+    """Return skill roots in precedence order: profile, external, bundled fallback."""
+    from agent.skill_utils import get_external_skills_dirs
+
+    dirs: List[Path] = []
+    if SKILLS_DIR.exists():
+        dirs.append(SKILLS_DIR)
+    dirs.extend(get_external_skills_dirs())
+
+    if include_bundled and _should_include_bundled_skills():
+        bundled = _bundled_skills_dir()
+        if bundled is not None:
+            dirs.append(bundled)
+
+    result: List[Path] = []
+    seen: set[Path] = set()
+    for root in dirs:
+        try:
+            key = root.resolve()
+        except Exception:
+            key = root
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(root)
+    return result
+
+
 def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     """Recursively find all skills in ~/.hermes/skills/ and external dirs.
 
@@ -558,7 +598,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     Returns:
         List of skill metadata dicts (name, description, category).
     """
-    from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
+    from agent.skill_utils import iter_skill_index_files
 
     skills = []
     seen_names: set = set()
@@ -566,11 +606,8 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     # Load disabled set once (not per-skill)
     disabled = set() if skip_disabled else _get_disabled_skill_names()
 
-    # Scan local dir first, then external dirs (local takes precedence)
-    dirs_to_scan = []
-    if SKILLS_DIR.exists():
-        dirs_to_scan.append(SKILLS_DIR)
-    dirs_to_scan.extend(get_external_skills_dirs())
+    # Scan profile, external dirs, then bundled fallback (profile wins by seen_names).
+    dirs_to_scan = _skill_search_dirs()
 
     for scan_dir in dirs_to_scan:
         for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
@@ -937,13 +974,24 @@ def skill_view(
             if bare:
                 local_category_name = f"{namespace}/{bare}"
 
-        from agent.skill_utils import get_external_skills_dirs
+        from agent.skill_utils import iter_skill_index_files
 
-        # Build list of all skill directories to search
-        all_dirs = []
-        if SKILLS_DIR.exists():
-            all_dirs.append(SKILLS_DIR)
-        all_dirs.extend(get_external_skills_dirs())
+        # Search profile/external dirs first. Bundled repo skills are a fallback
+        # so removing a byte-identical profile copy does not break exact
+        # skill_view("name"), while user/external overrides still win.
+        primary_dirs = _skill_search_dirs(include_bundled=False)
+        bundled_dirs: List[Path] = []
+        if _should_include_bundled_skills():
+            bundled = _bundled_skills_dir()
+            if bundled is not None:
+                try:
+                    primary_keys = {d.resolve() for d in primary_dirs}
+                    if bundled.resolve() not in primary_keys:
+                        bundled_dirs.append(bundled)
+                except Exception:
+                    if bundled not in primary_dirs:
+                        bundled_dirs.append(bundled)
+        all_dirs = primary_dirs + bundled_dirs
 
         if not all_dirs:
             return json.dumps(
@@ -957,56 +1005,78 @@ def skill_view(
         skill_dir = None
         skill_md = None
 
-        # Collision detection: collect ALL candidates across every dir using
-        # every lookup strategy (direct path, recursive by parent dir name,
-        # legacy flat <name>.md). If more than one matches, refuse and tell
-        # the caller — silent shadowing of a local skill by a same-named
-        # external skill is a real bug class (`/skills` shows one, agent
-        # loaded the other) so we surface it loudly instead of guessing.
-        from agent.skill_utils import iter_skill_index_files
+        def _collect_candidates(search_dirs: List[Path]) -> List[Tuple[Optional[Path], Path]]:
+            candidates: List[Tuple[Optional[Path], Path]] = []  # (skill_dir, skill_md)
+            seen_md: set = set()
 
-        candidates: List[Tuple[Optional[Path], Path]] = []  # (skill_dir, skill_md)
-        seen_md: set = set()
+            def _record(sd: Optional[Path], smd: Path) -> None:
+                try:
+                    key = smd.resolve()
+                except Exception:
+                    key = smd
+                if key in seen_md:
+                    return
+                seen_md.add(key)
+                candidates.append((sd, smd))
 
-        def _record(sd: Optional[Path], smd: Path) -> None:
-            try:
-                key = smd.resolve()
-            except Exception:
-                key = smd
-            if key in seen_md:
-                return
-            seen_md.add(key)
-            candidates.append((sd, smd))
+            # Prefer real skill directories/SKILL.md entries over legacy flat
+            # markdown files. Otherwise bundled support files like
+            # popular-web-designs/templates/spotify.md collide with the real
+            # spotify/SKILL.md skill.
+            for search_dir in search_dirs:
+                # Strategy 1: direct path (e.g., "mlops/axolotl" or bare "axolotl"
+                # at the top of the dir).
+                direct_path = search_dir / name
+                if direct_path.is_dir() and (direct_path / "SKILL.md").exists():
+                    _record(direct_path, direct_path / "SKILL.md")
+                elif direct_path.with_suffix(".md").exists():
+                    _record(None, direct_path.with_suffix(".md"))
 
-        for search_dir in all_dirs:
-            # Strategy 1: direct path (e.g., "mlops/axolotl" or bare "axolotl"
-            # at the top of the dir).
-            direct_path = search_dir / name
-            if direct_path.is_dir() and (direct_path / "SKILL.md").exists():
-                _record(direct_path, direct_path / "SKILL.md")
-            elif direct_path.with_suffix(".md").exists():
-                _record(None, direct_path.with_suffix(".md"))
+                # Strategy 1b: categorized form for plugin namespace fall-through
+                # (e.g., a "myplugin:explore" name with no plugin registered also
+                # tries the on-disk path "myplugin/explore").
+                if local_category_name:
+                    categorized_path = search_dir / local_category_name
+                    if categorized_path.is_dir() and (categorized_path / "SKILL.md").exists():
+                        _record(categorized_path, categorized_path / "SKILL.md")
+                    elif categorized_path.with_suffix(".md").exists():
+                        _record(None, categorized_path.with_suffix(".md"))
 
-            # Strategy 1b: categorized form for plugin namespace fall-through
-            # (e.g., a "myplugin:explore" name with no plugin registered also
-            # tries the on-disk path "myplugin/explore").
-            if local_category_name:
-                categorized_path = search_dir / local_category_name
-                if categorized_path.is_dir() and (categorized_path / "SKILL.md").exists():
-                    _record(categorized_path, categorized_path / "SKILL.md")
-                elif categorized_path.with_suffix(".md").exists():
-                    _record(None, categorized_path.with_suffix(".md"))
+                # Strategy 2: recursive SKILL.md by directory or frontmatter name
+                # (catches categorized skills whose directory differs from name).
+                for found_skill_md in iter_skill_index_files(search_dir, "SKILL.md"):
+                    if found_skill_md.parent.name == name:
+                        _record(found_skill_md.parent, found_skill_md)
+                        continue
+                    try:
+                        _frontmatter, _ = _parse_frontmatter(
+                            found_skill_md.read_text(encoding="utf-8")[:4000]
+                        )
+                    except Exception:
+                        continue
+                    if str(_frontmatter.get("name") or "") == name:
+                        _record(found_skill_md.parent, found_skill_md)
 
-            # Strategy 2: recursive by directory name (catches nested skills
-            # like "foundations/runtime/explore-codebase" called by bare name).
-            for found_skill_md in iter_skill_index_files(search_dir, "SKILL.md"):
-                if found_skill_md.parent.name == name:
-                    _record(found_skill_md.parent, found_skill_md)
+            if candidates:
+                return candidates
 
             # Strategy 3: legacy flat <name>.md files anywhere under the dir.
-            for found_md in search_dir.rglob(f"{name}.md"):
-                if found_md.name != "SKILL.md":
-                    _record(None, found_md)
+            # Only use this when no SKILL.md candidate exists in this search tier.
+            for search_dir in search_dirs:
+                for found_md in search_dir.rglob(f"{name}.md"):
+                    try:
+                        rel_parts = found_md.relative_to(search_dir).parts
+                    except ValueError:
+                        rel_parts = found_md.parts
+                    if any(part in _EXCLUDED_SKILL_DIRS for part in rel_parts):
+                        continue
+                    if found_md.name != "SKILL.md":
+                        _record(None, found_md)
+            return candidates
+
+        candidates = _collect_candidates(primary_dirs)
+        if not candidates and bundled_dirs:
+            candidates = _collect_candidates(bundled_dirs)
 
         if len(candidates) > 1:
             paths = [str(smd) for _, smd in candidates]
@@ -1019,7 +1089,7 @@ def skill_view(
                     "success": False,
                     "error": (
                         f"Ambiguous skill name '{name}': {len(candidates)} skills "
-                        "match across your local skills dir and external_dirs. "
+                        "match across your profile, external, or bundled skill roots. "
                         "Refusing to guess — load one explicitly by its categorized path."
                     ),
                     "matches": paths,


### PR DESCRIPTION
## Summary
- enforce configured turn budgets across gateway, CLI, API, cron, setup, and delegation
- keep stale .env HERMES_MAX_ITERATIONS from overriding explicit config
- add gateway context-spill guards and related regression coverage
- harden Honcho/Exa/provider fallback/error-classifier paths from the runtime repair pass

## Test Plan
- python -m py_compile touched runtime/gateway/config/delegate/honcho/exa/context-spill files
- python -m pytest targeted runtime/gateway/CLI/Honcho/provider/context-spill suite: 480 passed
- broader targeted suite before final commit: 631 passed

Note: full tests were started but abandoned after ~46m because they were still running under the live gateway process and causing system pressure; focused regression suite is green.