### PR TITLE
fix(feishu): map audio messages to VOICE for STT transcription (#30822)

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3365,7 +3365,7 @@ class FeishuAdapter(BasePlatformAdapter):
     def _should_batch_media_event(self, event: MessageEvent) -> bool:
         return bool(
             event.media_urls
-            and event.message_type in {MessageType.PHOTO, MessageType.VIDEO, MessageType.DOCUMENT, MessageType.AUDIO}
+            and event.message_type in {MessageType.PHOTO, MessageType.VIDEO, MessageType.DOCUMENT, MessageType.VOICE}
         )
 
     def _media_batch_key(self, event: MessageEvent) -> str:
@@ -3813,7 +3813,7 @@ class FeishuAdapter(BasePlatformAdapter):
         text = normalized.text_content
 
         if (
-            inbound_type in {MessageType.DOCUMENT, MessageType.AUDIO, MessageType.VIDEO, MessageType.PHOTO}
+            inbound_type in {MessageType.DOCUMENT, MessageType.VOICE, MessageType.VIDEO, MessageType.PHOTO}
             and len(media_urls) == 1
             and normalized.preferred_message_type in {"document", "audio"}
         ):
@@ -3860,7 +3860,7 @@ class FeishuAdapter(BasePlatformAdapter):
         if normalized.startswith("image/"):
             return MessageType.PHOTO
         if normalized.startswith("audio/"):
-            return MessageType.AUDIO
+            return MessageType.VOICE
         if normalized.startswith("video/"):
             return MessageType.VIDEO
         return default
@@ -3874,7 +3874,7 @@ class FeishuAdapter(BasePlatformAdapter):
         if preferred == "photo":
             return self._resolve_media_message_type(media_types[0] if media_types else "", default=MessageType.PHOTO)
         if preferred == "audio":
-            return self._resolve_media_message_type(media_types[0] if media_types else "", default=MessageType.AUDIO)
+            return self._resolve_media_message_type(media_types[0] if media_types else "", default=MessageType.VOICE)
         if preferred == "document":
             return self._resolve_media_message_type(media_types[0] if media_types else "", default=MessageType.DOCUMENT)
         return MessageType.TEXT

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1490,8 +1490,36 @@ class TestAdapterBehavior(unittest.TestCase):
         text, msg_type, media_urls, media_types, _mentions = asyncio.run(adapter._extract_message_content(message))
 
         self.assertEqual(text, "")
-        self.assertEqual(msg_type.value, "audio")
+        self.assertEqual(msg_type.value, "voice")
         self.assertEqual(media_urls, ["/tmp/feishu-audio.ogg"])
+        self.assertEqual(media_types, ["audio/ogg"])
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_audio_message_maps_to_voice_for_stt(self):
+        """Feishu audio messages should map to MessageType.VOICE so they go
+        through the STT pipeline, not MessageType.AUDIO which is treated as
+        a file attachment.  Regression test for #30822."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.base import MessageType
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._download_feishu_message_resource = AsyncMock(
+            return_value=("/tmp/voice.ogg", "audio/ogg")
+        )
+        message = SimpleNamespace(
+            message_type="audio",
+            content='{"file_key":"voice_key","file_name":"voice.ogg"}',
+            message_id="om_voice",
+        )
+
+        text, msg_type, media_urls, media_types, _mentions = asyncio.run(
+            adapter._extract_message_content(message)
+        )
+
+        # Must be VOICE (STT pipeline), not AUDIO (file attachment)
+        self.assertEqual(msg_type, MessageType.VOICE)
+        self.assertEqual(media_urls, ["/tmp/voice.ogg"])
         self.assertEqual(media_types, ["audio/ogg"])
 
     @patch.dict(os.environ, {}, clear=True)


### PR DESCRIPTION
## What broke
Feishu voice messages (Opus/OGG) are classified as `MessageType.AUDIO`. After the Telegram audio/voice split, `MessageType.AUDIO` is treated as a file attachment and skips STT transcription entirely. Since Feishu has no separate `VOICE` message type, all voice messages end up being silently dropped from the STT pipeline, breaking auto-transcription for Feishu users.

## Root cause
The Feishu adapter maps audio messages to `MessageType.AUDIO` via `_resolve_media_message_type()` and `_resolve_normalized_message_type()`. This was correct before the Telegram AUDIO/VOICE split, but now AUDIO means "file attachment" (no STT) while VOICE means "voice message" (goes through STT).

## Why this fix is minimal
Changes four call sites in `gateway/platforms/feishu.py` from `MessageType.AUDIO` to `MessageType.VOICE`:
- `_resolve_media_message_type()` — audio/* media type mapping
- `_resolve_normalized_message_type()` — preferred="audio" resolution
- `_should_batch_media_event()` — media batching check
- `_extract_message_content()` — text extraction candidate check

No changes to other platform adapters or the core STT pipeline.

## What I tested
- Updated `test_extract_audio_message_downloads_and_caches` to expect `VOICE` instead of `AUDIO`
- Added `test_audio_message_maps_to_voice_for_stt` as a regression test for #30822

## What I intentionally did not change
- Telegram AUDIO/VOICE handling
- Core STT pipeline logic
- Other platform adapters (Mattermost, WhatsApp, etc.)