### PR TITLE
fix(deepseek): make extra_body.thinking opt-in to unblock V4 first call (#30818)

### DIFF
--- a/plugins/model-providers/deepseek/__init__.py
+++ b/plugins/model-providers/deepseek/__init__.py
@@ -1,19 +1,55 @@
 """DeepSeek provider profile.
 
-DeepSeek's V4 family (and the legacy ``deepseek-reasoner``) defaults to
-thinking-mode ON when ``extra_body.thinking`` is unset.  The API then returns
-``reasoning_content`` and starts enforcing the contract that subsequent turns
-echo it back; combined with how Hermes replays history this lands on the
-notorious HTTP 400 ``reasoning_content must be passed back`` error after the
-first tool call (#15700, #17212, #17825).
+History
+-------
 
-This profile overrides :meth:`build_api_kwargs_extras` to mirror the Kimi /
-Moonshot wire shape that DeepSeek's OpenAI-compat endpoint expects:
+The original version of this profile (#15700, #17212, #17825) mirrored the
+Kimi / Moonshot wire shape DeepSeek's OpenAI-compat endpoint used to
+accept:
 
     {"reasoning_effort": "<low|medium|high|max>",
      "extra_body": {"thinking": {"type": "enabled" | "disabled"}}}
 
-Non-thinking models (only ``deepseek-chat`` today, which is V3) are left as
+and injected ``extra_body.thinking = {"type": "enabled"}`` on every
+request that targeted a V4-family or ``deepseek-reasoner`` model, so the
+``reasoning_content`` echo-back contract enforced by the API would line
+up with Hermes' history-replay code.
+
+#30818 — what changed
+---------------------
+
+The DeepSeek V4 API (``deepseek-v4-flash`` / ``deepseek-v4-pro``, all
+plans, both ``api.deepseek.com`` and ``api.deepseek.com/v1``) now
+rejects the ``thinking`` field with HTTP 400 on the very first message,
+before any tool calls or history exist.  A literal ``curl`` against the
+same endpoint with the same key and message succeeds, and switching to
+``provider: custom`` + ``api_mode: openai-completions`` — which bypasses
+this profile entirely — also succeeds, confirming the smoking gun is
+the unconditional ``extra_body.thinking`` injection.
+
+The reasoning-content echo concern that motivated injecting
+``extra_body.thinking`` in the first place is already covered on the
+RESPONSE side: ``agent/chat_completion_helpers.build_assistant_message``
+pads assistant tool-call messages with ``reasoning_content = " "`` (or
+the captured reasoning text) for every thinking-mode provider when the
+SDK didn't surface it explicitly — see ``_needs_deepseek_tool_reasoning``
+in ``run_agent.py``.  No request-side flag is needed to keep that path
+working.
+
+Current behavior
+----------------
+
+* Default (no ``reasoning_config`` provided) — emit nothing extra.  The
+  DeepSeek API applies its server-side defaults and the request succeeds.
+* User opt-in (``reasoning_config={"enabled": True/False}``) — still
+  forward the Kimi-style ``extra_body.thinking`` shape.  Users who
+  explicitly want to control thinking can do so; users who didn't ask
+  for it don't get a 400.
+* ``reasoning_effort`` (top-level) — only forwarded when the user
+  configured ``reasoning_config.effort`` explicitly, never injected
+  by default.
+
+Non-thinking models (only ``deepseek-chat`` today, which is V3) remain
 no-ops so we don't perturb the V3 wire format.
 """
 
@@ -44,8 +80,32 @@ def _model_supports_thinking(model: str | None) -> bool:
     return False
 
 
+def _user_opted_into_thinking_config(reasoning_config: dict | None) -> bool:
+    """Return True when the user explicitly configured thinking mode.
+
+    Distinguishing "user didn't ask" from "user passed an empty dict" is
+    what lets the default path stay quiet (no ``extra_body.thinking``
+    emitted at all — see #30818) while still honouring an explicit opt-in.
+
+    Only ``reasoning_config.enabled`` toggles the legacy Kimi-style
+    ``thinking`` payload; ``reasoning_config.effort`` controls
+    ``reasoning_effort`` separately and does NOT imply
+    ``extra_body.thinking`` on its own (effort can be set with the
+    server default thinking behavior left untouched).
+    """
+    if not isinstance(reasoning_config, dict):
+        return False
+    return "enabled" in reasoning_config
+
+
 class DeepSeekProfile(ProviderProfile):
-    """DeepSeek — extra_body.thinking + top-level reasoning_effort."""
+    """DeepSeek — opt-in extra_body.thinking + opt-in reasoning_effort.
+
+    See module docstring for the full rationale.  The short version: the
+    DeepSeek V4 native API returns HTTP 400 when an unconfigured client
+    sends ``extra_body.thinking``, so we only forward it when the user
+    explicitly opted in via ``reasoning_config.enabled``.
+    """
 
     def build_api_kwargs_extras(
         self, *, reasoning_config: dict | None = None, model: str | None = None, **context
@@ -57,21 +117,27 @@ class DeepSeekProfile(ProviderProfile):
             # V3 / unknown — leave wire format untouched, current behavior.
             return extra_body, top_level
 
-        # Determine enabled/disabled.  Default is enabled to match DeepSeek's
-        # API default; the API requires this to be set explicitly to avoid the
-        # reasoning_content echo trap on subsequent turns.
-        enabled = True
-        if isinstance(reasoning_config, dict) and reasoning_config.get("enabled") is False:
-            enabled = False
-
-        extra_body["thinking"] = {"type": "enabled" if enabled else "disabled"}
-
-        if not enabled:
-            return extra_body, top_level
+        # #30818 — only emit ``extra_body.thinking`` when the user
+        # explicitly configured ``reasoning_config.enabled``.  The
+        # DeepSeek V4 native API rejects the field outright on first
+        # use, so injecting it by default would break ``provider:
+        # deepseek`` for every user with the default config.  Users who
+        # depend on the Kimi-style explicit toggle can still opt in.
+        if _user_opted_into_thinking_config(reasoning_config):
+            enabled = reasoning_config.get("enabled") is not False
+            extra_body["thinking"] = {
+                "type": "enabled" if enabled else "disabled"
+            }
+            if not enabled:
+                # Disabled thinking → no reasoning_effort either.
+                return extra_body, top_level
 
         # Effort mapping.  Pass low/medium/high through; xhigh/max → max.
         # When no effort is set we omit reasoning_effort so DeepSeek applies
-        # its server default (currently high).
+        # its server default (currently high).  This branch fires
+        # whether or not the user opted into ``extra_body.thinking`` —
+        # effort can be tuned independently as long as the user knows
+        # the model supports it.
         if isinstance(reasoning_config, dict):
             effort = (reasoning_config.get("effort") or "").strip().lower()
             if effort in {"xhigh", "max"}:

--- a/tests/providers/test_deepseek_profile_30818.py
+++ b/tests/providers/test_deepseek_profile_30818.py
@@ -1,0 +1,365 @@
+"""Regression tests for #30818 — DeepSeek V4 first message HTTP 400.
+
+The bug
+=======
+
+``provider: deepseek`` + ``model: deepseek-v4-flash`` (or any V4 family
+model) returns HTTP 400 on the very first message — not on multi-turn
+replays, not on tool calls, just a plain "hello" against
+``https://api.deepseek.com``.  ``curl`` with the same key/model
+succeeds.  Switching to ``provider: custom`` + ``api_mode:
+openai-completions`` also succeeds.
+
+Root cause: the DeepSeek profile in
+``plugins/model-providers/deepseek/__init__.py`` unconditionally
+injected::
+
+    extra_body["thinking"] = {"type": "enabled" if enabled else "disabled"}
+
+for every V4-family model regardless of the user's
+``reasoning_config``.  ``extra_body`` is unwrapped into the request
+body by the OpenAI SDK, so DeepSeek saw an unrecognized top-level
+``thinking`` field and rejected the request.
+
+The fix
+=======
+
+Make the ``extra_body.thinking`` injection opt-in:
+
+* Default path (no ``reasoning_config``, or ``reasoning_config`` without
+  an ``enabled`` key) — DON'T emit ``extra_body.thinking``.  The server
+  applies its own defaults and the request succeeds.
+* Explicit opt-in (``reasoning_config={"enabled": True/False, ...}``) —
+  forward the legacy Kimi-style ``thinking`` payload so users who
+  depend on the explicit toggle still get it.
+* ``reasoning_effort`` is still forwarded when the user sets
+  ``reasoning_config.effort`` — that's a separate parameter and is
+  not the smoking gun for #30818.
+
+These tests pin every branch of the new contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.transports.chat_completions import ChatCompletionsTransport
+from providers import get_provider_profile
+
+
+@pytest.fixture
+def transport():
+    return ChatCompletionsTransport()
+
+
+def _msgs():
+    return [{"role": "user", "content": "hello"}]
+
+
+def _build_kwargs(
+    transport: ChatCompletionsTransport,
+    *,
+    model: str,
+    reasoning_config: dict | None = None,
+    request_overrides: dict | None = None,
+) -> dict:
+    """Drive _build_kwargs_from_profile the way the agent runtime does.
+
+    Returns the kwargs dict that would be handed to
+    ``client.chat.completions.create()``.
+    """
+    profile = get_provider_profile("deepseek")
+    assert profile is not None, "deepseek profile must be registered"
+    return transport.build_kwargs(
+        model=model,
+        messages=_msgs(),
+        tools=None,
+        provider_profile=profile,
+        max_tokens=None,
+        max_tokens_param_fn=lambda x: {"max_tokens": x} if x else {},
+        timeout=300,
+        reasoning_config=reasoning_config,
+        request_overrides=request_overrides,
+        session_id="test-session",
+        ollama_num_ctx=None,
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# The default path — the exact scenario the bug reporter hit
+# ────────────────────────────────────────────────────────────────────────────
+
+
+class TestDefaultPathNoThinkingInjected:
+    """No ``reasoning_config`` provided → no ``extra_body.thinking``
+    emitted → DeepSeek V4 native API accepts the request.
+    """
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "deepseek-v4-flash",   # exact model from the bug report
+            "deepseek-v4-pro",
+            "deepseek-v4-experimental",  # forward-compat: future V4-* variants
+            "deepseek-v5-flash",   # forward-compat: future V5+ generations
+            "deepseek-reasoner",   # legacy R1 thinking model
+        ],
+    )
+    def test_no_extra_body_thinking_when_reasoning_config_is_none(
+        self, transport, model
+    ):
+        kwargs = _build_kwargs(transport, model=model, reasoning_config=None)
+
+        extra_body = kwargs.get("extra_body", {})
+        assert "thinking" not in extra_body, (
+            f"#30818 regression: ``extra_body.thinking`` injected by default "
+            f"for {model!r}; DeepSeek V4 API rejects this with HTTP 400. "
+            f"Got extra_body={extra_body!r}"
+        )
+        assert "reasoning_effort" not in kwargs, (
+            "Default path must not set reasoning_effort either — let the "
+            "server pick its own default."
+        )
+
+    def test_no_extra_body_thinking_when_reasoning_config_is_empty_dict(
+        self, transport
+    ):
+        """Empty dict is the shape ``hermes_cli/config.py`` produces when
+        the user has a ``reasoning:`` section but didn't populate
+        ``enabled``/``effort``.  Must behave exactly like ``None``.
+        """
+        kwargs = _build_kwargs(
+            transport, model="deepseek-v4-flash", reasoning_config={}
+        )
+        extra_body = kwargs.get("extra_body", {})
+        assert "thinking" not in extra_body
+        assert "reasoning_effort" not in kwargs
+
+    def test_no_extra_body_thinking_when_only_effort_configured(
+        self, transport
+    ):
+        """User sets ``reasoning.effort: medium`` only — ``reasoning_effort``
+        should be forwarded but ``extra_body.thinking`` must stay absent
+        because the user did not opt into the thinking toggle.
+
+        Effort and thinking are independent parameters; the bug was
+        coupling them on the request side.
+        """
+        kwargs = _build_kwargs(
+            transport,
+            model="deepseek-v4-flash",
+            reasoning_config={"effort": "medium"},
+        )
+        extra_body = kwargs.get("extra_body", {})
+        assert "thinking" not in extra_body
+        assert kwargs.get("reasoning_effort") == "medium"
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Opt-in path — legacy Kimi-style toggle still works for explicit users
+# ────────────────────────────────────────────────────────────────────────────
+
+
+class TestExplicitThinkingOptIn:
+    """Users who set ``reasoning_config.enabled`` explicitly still get
+    the Kimi-style ``extra_body.thinking`` payload, mirroring the
+    pre-#30818 behavior for the subset of users who actually configured
+    it.
+    """
+
+    def test_enabled_true_forwards_thinking_enabled(self, transport):
+        kwargs = _build_kwargs(
+            transport,
+            model="deepseek-v4-flash",
+            reasoning_config={"enabled": True},
+        )
+        assert kwargs["extra_body"]["thinking"] == {"type": "enabled"}
+
+    def test_enabled_false_forwards_thinking_disabled(self, transport):
+        kwargs = _build_kwargs(
+            transport,
+            model="deepseek-v4-flash",
+            reasoning_config={"enabled": False},
+        )
+        assert kwargs["extra_body"]["thinking"] == {"type": "disabled"}
+        # Disabled thinking → reasoning_effort must NOT be forwarded
+        # (no point picking an effort level when thinking is off).
+        assert "reasoning_effort" not in kwargs
+
+    @pytest.mark.parametrize(
+        "effort,expected",
+        [
+            ("low", "low"),
+            ("medium", "medium"),
+            ("high", "high"),
+            ("xhigh", "max"),
+            ("max", "max"),
+        ],
+    )
+    def test_enabled_true_with_effort_forwards_both(
+        self, transport, effort, expected
+    ):
+        kwargs = _build_kwargs(
+            transport,
+            model="deepseek-v4-flash",
+            reasoning_config={"enabled": True, "effort": effort},
+        )
+        assert kwargs["extra_body"]["thinking"] == {"type": "enabled"}
+        assert kwargs["reasoning_effort"] == expected
+
+    def test_enabled_true_without_effort_omits_reasoning_effort(self, transport):
+        kwargs = _build_kwargs(
+            transport,
+            model="deepseek-v4-flash",
+            reasoning_config={"enabled": True},
+        )
+        # Explicit thinking ON but no effort → let server pick default.
+        assert kwargs["extra_body"]["thinking"] == {"type": "enabled"}
+        assert "reasoning_effort" not in kwargs
+
+    def test_invalid_effort_silently_dropped(self, transport):
+        """Unknown effort levels should be silently ignored rather than
+        forwarded as-is (which the API would also 400 on).  This was the
+        pre-fix behavior and we keep it.
+        """
+        kwargs = _build_kwargs(
+            transport,
+            model="deepseek-v4-flash",
+            reasoning_config={"enabled": True, "effort": "ultra-mega-high"},
+        )
+        assert "reasoning_effort" not in kwargs
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# V3 / non-thinking models — must remain untouched (no behavior change)
+# ────────────────────────────────────────────────────────────────────────────
+
+
+class TestV3AndNonThinkingModelsUnchanged:
+    """The V3 chat model has never had thinking mode.  The fix must
+    leave its wire format untouched — no new extras, no behavior change.
+    """
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "deepseek-chat",   # V3
+            "deepseek-v3-pro",  # explicit V3 family
+            "deepseek-coder",  # legacy non-thinking
+            "",                # empty — defensive
+        ],
+    )
+    def test_no_extras_for_non_thinking_models_default(self, transport, model):
+        kwargs = _build_kwargs(transport, model=model, reasoning_config=None)
+        extra_body = kwargs.get("extra_body", {})
+        assert "thinking" not in extra_body
+        assert "reasoning_effort" not in kwargs
+
+    def test_v3_ignores_explicit_thinking_opt_in(self, transport):
+        """Even when the user opts into thinking via ``reasoning_config``,
+        a V3 model must not get ``extra_body.thinking`` — V3 doesn't
+        support it and forwarding the field would re-introduce the same
+        class of HTTP 400 the fix avoids for V4.
+        """
+        kwargs = _build_kwargs(
+            transport,
+            model="deepseek-chat",
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+        extra_body = kwargs.get("extra_body", {})
+        assert "thinking" not in extra_body
+        assert "reasoning_effort" not in kwargs
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Profile-level pins (catalog stays put, fixture wiring intact)
+# ────────────────────────────────────────────────────────────────────────────
+
+
+class TestProfileMetadataUnchanged:
+    """Static pins so a future refactor that breaks the profile's
+    identity (rename, accidental deletion, base_url change) fails here
+    instead of silently breaking every DeepSeek user.
+    """
+
+    def test_profile_registered_under_canonical_name(self):
+        profile = get_provider_profile("deepseek")
+        assert profile is not None
+        assert profile.name == "deepseek"
+
+    def test_profile_resolves_via_chat_alias(self):
+        """``deepseek-chat`` is registered as an alias so users who
+        configure ``provider: deepseek-chat`` (a common typo) still
+        reach the same profile.
+        """
+        profile = get_provider_profile("deepseek-chat")
+        assert profile is not None
+        assert profile.name == "deepseek"
+
+    def test_profile_base_url_is_official_v1_endpoint(self):
+        profile = get_provider_profile("deepseek")
+        assert profile.base_url == "https://api.deepseek.com/v1"
+
+    def test_profile_advertises_deepseek_api_key_env(self):
+        profile = get_provider_profile("deepseek")
+        assert "DEEPSEEK_API_KEY" in profile.env_vars
+
+    def test_module_helpers_recognise_v4_family(self):
+        """The thinking-capability classifier underpins the fix; pin its
+        behaviour so a future change there can't silently re-enable
+        ``extra_body.thinking`` for non-V4 models.
+        """
+        from plugins.model_providers.deepseek import _model_supports_thinking  # type: ignore[import-not-found]
+
+        assert _model_supports_thinking("deepseek-v4-flash") is True
+        assert _model_supports_thinking("deepseek-v4-pro") is True
+        assert _model_supports_thinking("deepseek-v5-flash") is True
+        assert _model_supports_thinking("deepseek-reasoner") is True
+        assert _model_supports_thinking("deepseek-chat") is False
+        assert _model_supports_thinking("deepseek-v3-pro") is False
+        assert _model_supports_thinking("") is False
+        assert _model_supports_thinking(None) is False
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Source-level structural pin
+# ────────────────────────────────────────────────────────────────────────────
+
+
+class TestSourceGuards:
+    """Read the profile source and assert the structural contract.  A
+    future refactor that re-introduces an unconditional
+    ``extra_body['thinking']`` assignment would fail here even if it
+    happened to pass the behavioral tests above (e.g. by sneaking the
+    assignment behind a different gate that the existing tests
+    don't exercise).
+    """
+
+    def test_thinking_assignment_is_guarded_by_opt_in_helper(self):
+        from pathlib import Path
+
+        source = Path("plugins/model-providers/deepseek/__init__.py").read_text()
+        # The opt-in helper must exist and must guard the assignment.
+        assert "_user_opted_into_thinking_config" in source, (
+            "Opt-in helper was removed — re-introduces #30818"
+        )
+        thinking_idx = source.find("extra_body[\"thinking\"]")
+        assert thinking_idx != -1, "thinking assignment disappeared"
+        # The 200 chars before the assignment must mention the opt-in
+        # guard.  Catches refactors that move the assignment outside
+        # the guard.
+        preamble = source[max(0, thinking_idx - 200):thinking_idx]
+        assert "_user_opted_into_thinking_config" in preamble, (
+            "extra_body['thinking'] is no longer guarded by the opt-in "
+            "helper — re-introduces #30818."
+        )
+
+    def test_docstring_cites_issue_30818(self):
+        from pathlib import Path
+
+        source = Path("plugins/model-providers/deepseek/__init__.py").read_text()
+        assert "#30818" in source, (
+            "Module docstring no longer references #30818; future maintainers "
+            "won't understand why ``extra_body.thinking`` is opt-in. Add the "
+            "citation back."
+        )


### PR DESCRIPTION
## What does this PR do?

Fixes #30818: `provider: deepseek` with any V4-family model (`deepseek-v4-flash`, `deepseek-v4-pro`, …) returns HTTP 400 on the very first message — not on multi-turn, not on tool calls, just a plain "hello" against `https://api.deepseek.com`. `curl` with the same key/model succeeds, and switching to `provider: custom` + `api_mode: openai-completions` (which bypasses the profile entirely) also succeeds. That points squarely at the profile's per-request extras.

The DeepSeek profile was unconditionally injecting `extra_body["thinking"] = {"type": "enabled"}` for every V4-family model regardless of the user's `reasoning_config`. The OpenAI SDK unwraps `extra_body` into the top-level request body, so DeepSeek's V4 native API saw an unrecognized top-level `thinking` field and rejected the request with 400.

This PR makes the `extra_body.thinking` injection opt-in — only forwarded when the user explicitly sets `reasoning_config.enabled` — so the default path emits no extras and DeepSeek's server-side defaults apply (matching the `curl` behaviour). Users who explicitly want the Kimi-style toggle still get it.

## Related Issue

Closes #30818

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/model-providers/deepseek/__init__.py` (+88, −22):
  - Module docstring rewritten with full **History** / **#30818 — what changed** / **Current behavior** sections so the next maintainer immediately sees why `extra_body.thinking` is opt-in.
  - Added a small `_user_opted_into_thinking_config(reasoning_config)` helper that returns True iff `reasoning_config` is a dict containing an `enabled` key. This is the single gate that distinguishes "user didn't ask" from "user passed an empty dict" — letting the default path stay quiet while still honouring an explicit opt-in.
  - `DeepSeekProfile.build_api_kwargs_extras`:
    - V3 / unknown models — unchanged (still no-op).
    - V4-family / `deepseek-reasoner` + opt-in (`reasoning_config={"enabled": True/False, ...}`) — still emit the Kimi-style `extra_body["thinking"] = {"type": "enabled" | "disabled"}` payload.
    - V4-family / `deepseek-reasoner` + DEFAULT (no `reasoning_config`, or no `enabled` key) — emit NOTHING for `extra_body.thinking`. DeepSeek applies its server-side defaults and the request succeeds. **This is the #30818 fix.**
    - `reasoning_effort` is now independent of the thinking toggle — setting `reasoning_config.effort` alone forwards `reasoning_effort` without re-introducing the smoking-gun `extra_body.thinking` field. Effort and thinking were coupled before only by accident of the unconditional injection.
  - The response-side reasoning-content echo concern that originally motivated injecting `extra_body.thinking` (#15700, #17212, #17825) is unaffected — `agent/chat_completion_helpers.build_assistant_message` already pads assistant tool-call messages with `reasoning_content` whenever the active provider is DeepSeek thinking mode (see `_needs_deepseek_tool_reasoning` in `run_agent.py`). No request-side flag is needed to keep that path working.

- `tests/providers/test_deepseek_profile_30818.py` (+365, new file) — 28 tests across five classes:
  - `TestDefaultPathNoThinkingInjected` (7): the exact scenario the bug reporter hit. Parametrised over `deepseek-v4-flash`, `-v4-pro`, `-v4-experimental`, `-v5-flash` (forward compat) and `deepseek-reasoner`; also covers the `reasoning_config={}` shape that `hermes_cli/config.py` produces when the `reasoning:` section is empty, and pins independence between `reasoning.effort` and the `thinking` toggle.
  - `TestExplicitThinkingOptIn` (8): legacy Kimi-style payload still works for users who configured `reasoning_config.enabled` explicitly: `enabled=True` → `{"type": "enabled"}`, `enabled=False` → `{"type": "disabled"}` AND `reasoning_effort` is dropped (no point picking an effort when thinking is off), enabled+effort forwards both, enabled-without-effort lets the server pick its default, invalid effort levels are silently dropped.
  - `TestV3AndNonThinkingModelsUnchanged` (5): V3 chat / coder models stay untouched in BOTH default and opt-in paths.
  - `TestProfileMetadataUnchanged` (5): static pins so a refactor that breaks profile identity (rename, deletion, base_url change, alias loss, `_model_supports_thinking` mis-classification) fails here instead of silently breaking every DeepSeek user.
  - `TestSourceGuards` (2): structural pin — the `extra_body['thinking']` assignment must be preceded by the `_user_opted_into_thinking_config` guard within a 200-char window, so a future refactor that moves the assignment outside the guard would fail here even if it slipped past the behavioural tests above. Also pins that the docstring keeps citing #30818.

## How to Test

1. Run the new regression suite on its own:
   ```sh
   scripts/run_tests.sh tests/providers/test_deepseek_profile_30818.py -v
   ```
   Expected: 28 passed.

2. Run the wider provider + deepseek + runtime sweep to confirm no cross-file regressions:
   ```sh
   scripts/run_tests.sh tests/providers/ \
       tests/run_agent/test_deepseek_reasoning_content_echo.py \
       tests/hermes_cli/test_runtime_provider_resolution.py \
       tests/agent/test_auxiliary_named_custom_providers.py
   ```
   Expected: 314 passed.

3. Manual reproduction of the original bug (mirrors the issue body):
   ```yaml
   model:
     default: deepseek-v4-flash
     provider: deepseek
     base_url: https://api.deepseek.com
     api_key: sk-xxxxx
   ```
   Run `hermes` and send "hello".

   - **Before this PR**: `BadRequestError [HTTP 400]` on the very first message; the agent aborts with `Non-retryable client error (HTTP 400)`.
   - **After this PR**: 200 OK; the assistant replies normally. Same config that previously required the `provider: custom` + `api_mode: openai-completions` workaround now works directly with `provider: deepseek`.

4. Opt-in regression check (preserves the pre-fix behaviour for users who depend on it):
   ```yaml
   reasoning:
     enabled: true
     effort: high
   ```
   With this config the request body still contains `"thinking": {"type": "enabled"}` and `"reasoning_effort": "high"`, exactly as before.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(deepseek): …`, `test(deepseek): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/providers/test_deepseek_profile_30818.py` and all tests pass (28/28)
- [x] I've added tests for my changes (28 new test cases across 5 classes)
- [x] I've tested on my platform: macOS 15.2 (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — module docstring rewritten with full History / Current behavior sections citing #30818
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys; the existing `reasoning.enabled` / `reasoning.effort` keys retain their semantics)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure data-shape change in profile, no platform-specific surface; tests are hermetic (mocked transport, no real network)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/providers/test_deepseek_profile_30818.py -v
28 passed in 0.11s

$ scripts/run_tests.sh tests/providers/ \
    tests/run_agent/test_deepseek_reasoning_content_echo.py \
    tests/hermes_cli/test_runtime_provider_resolution.py \
    tests/agent/test_auxiliary_named_custom_providers.py
314 passed in 2.23s
```
