### PR TITLE
chore(release): AUTHOR_MAP entry for egilewski (PR #30432)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1270,6 +1270,7 @@ AUTHOR_MAP = {
     "120500656+oooindefatigable@users.noreply.github.com": "ooovenenoso",
     "vanthinh6886@gmail.com": "vanthinh6886",  # PR #28018 salvage (yaml/flock/atomic write guards)
     "erik.engervall@gmail.com": "erikengervall",  # PR #28774 (firecrawl integration tag)
+    "egilewski@egilewski.com": "egilewski",  # PR #30432 (MEDIA path traversal fix, GHSA-jmf9-9729-7pp8)
 }
 
 


### PR DESCRIPTION
Maps `egilewski@egilewski.com` -> `egilewski` so the contributor's salvaged commit from PR #30432 (MEDIA path traversal fix) is credited correctly in release notes.

Trivial follow-up after merging the salvage.