### PR TITLE
fix(gateway): clear zombie agent slot when session_reset races credential pool exhaustion

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7632,18 +7632,30 @@ class GatewayRunner:
                 logger.debug("goal continuation hook failed: %s", _goal_exc)
             return _agent_result
         finally:
-            # If _run_agent replaced the sentinel with a real agent and
-            # then cleaned it up, this is a no-op.  If we exited early
-            # (exception, command fallthrough, etc.) the sentinel must
-            # not linger or the session would be permanently locked out.
-            if self._running_agents.get(_quick_key) is _AGENT_PENDING_SENTINEL:
-                self._release_running_agent_state(_quick_key)
-            else:
-                # Agent path already cleaned _running_agents; make sure
-                # the paired metadata dicts are gone too.
-                self._running_agents_ts.pop(_quick_key, None)
-                if hasattr(self, "_busy_ack_ts"):
-                    self._busy_ack_ts.pop(_quick_key, None)
+            # Unconditional release — covers all exit paths:
+            #
+            # (a) Normal path: _run_agent completed and already called
+            #     _release_running_agent_state(key, run_generation=N).
+            #     _release_running_agent_state is idempotent (pop on absent
+            #     key is harmless), so this is a safe no-op.
+            #
+            # (b) Early exit (exception, command fallthrough): the sentinel
+            #     is still in the slot; this clears it so the session isn't
+            #     permanently locked.
+            #
+            # (c) Zombie race (#28686): session_reset bumps the run
+            #     generation (N → N+1) while gen-N's _run_agent finally
+            #     runs. The generation guard in _release_running_agent_state
+            #     returns False, leaving the dead gen-N agent in the slot.
+            #     The outer finally's old sentinel-check was also False (slot
+            #     holds a real agent, not the sentinel), so it fell into the
+            #     else-branch which popped _running_agents_ts and _busy_ack_ts
+            #     but NOT _running_agents[key]. Every subsequent message to
+            #     the session hit the "agent busy" guard and was silently
+            #     dropped. The unconditional call here — without a
+            #     run_generation guard — always clears the slot, regardless
+            #     of which generation the slot currently holds.
+            self._release_running_agent_state(_quick_key)
 
     async def _prepare_inbound_message_text(
         self,
@@ -9094,6 +9106,15 @@ class GatewayRunner:
         # Get existing session key
         session_key = self._session_key_for_source(source)
         self._invalidate_session_run_generation(session_key, reason="session_reset")
+        # Evict the stale agent slot immediately after bumping the generation.
+        # Without this, if the in-flight run's _release_running_agent_state
+        # was blocked by the generation guard (old gen != new gen), the slot
+        # retains the dead agent and the outer _process_message_or_command
+        # finally may also leave it in place — creating a zombie that silently
+        # drops all subsequent messages (#28686).  _release_running_agent_state
+        # is idempotent, so calling it here and again in the agent's own
+        # finally is safe.
+        self._release_running_agent_state(session_key)
 
         # Snapshot the old entry so on_session_finalize can report the
         # expiring session id before reset_session() rotates it.


### PR DESCRIPTION
Fixes #28686

## Problem

A Telegram thread (or any gateway session) permanently stops receiving
messages after two events coincide:

1. A skill that fires `session_reset` (e.g. `/cc`, `/new`) arrives while
   an agent turn is in flight for that thread.
2. The credential pool is simultaneously exhausted (e.g. a 402 from the
   upstream LLM drains the last slot).

The affected session becomes a zombie: the gateway believes an agent is
still running, so every subsequent inbound message is silently discarded
as "agent busy". Other sessions are unaffected. The only recovery was a
full gateway restart.

## Root cause - two-stage race

The zombie is created by the interaction of two independent code paths:

**Stage 1 - generation guard blocks the inner cleanup.**
`session_reset` calls `_invalidate_session_run_generation`, bumping gen
N to N+1. When gen-N's `_run_agent` finally block runs, it calls
`_release_running_agent_state(key, run_generation=N)`. The generation
guard sees N != N+1 and returns `False` - slot NOT cleared.

**Stage 2 - outer finally misses the zombie.**
`_process_message_or_command`'s outer finally checked
`_running_agents.get(key) is _AGENT_PENDING_SENTINEL`. That's `False`
(the slot holds a dead gen-N real agent, not the sentinel), so it fell
into the `else` branch, which popped `_running_agents_ts` and
`_busy_ack_ts` but NOT `_running_agents[key]`.

Result: the dead agent stays in the slot. The stale-eviction path can't
rescue it either because `_running_agents_ts.get(key)` returns `0`
(already popped), so the eviction condition is never true. Every new
message hits `if _quick_key in self._running_agents` - True - and is
silently queued/dropped forever.

## Fix

**Fix 1 - `_process_message_or_command` outer finally (`gateway/run.py`)**

Replace the sentinel-conditional cleanup with an unconditional
`_release_running_agent_state` call. `_release_running_agent_state` is
already idempotent (pop on absent key is harmless), so this is safe on
all exit paths:

- Normal completion: inner cleanup already ran, this is a no-op.
- Early exit / exception: sentinel still in slot, this clears it.
- Zombie race: dead gen-N agent in slot, this clears it unconditionally
  (no run_generation guard at the outer frame level).

**Fix 2 - `_handle_reset_command` (`gateway/run.py`)**

After `_invalidate_session_run_generation`, explicitly call
`_release_running_agent_state` without a generation guard. This evicts
the stale slot immediately at reset time, before the in-flight run's
finally even executes. Both fixes together ensure the slot is always
cleared by whichever path runs first.

## What this does NOT change

- No behaviour change for the normal (non-racing) path - the unconditional
  call in the outer finally is a no-op when the inner cleanup already ran.
- Sessions using systemd restart or the `--replace` flag are unaffected.
- No change to the generation-guard logic in `_release_running_agent_state`
  itself - the guard still protects newer runs from being clobbered by
  older ones during their own unwind.

## Test plan

Reproduce the zombie
./scripts/run_tests.sh tests/gateway/test_session_reset_race.py -q -k "zombie or session_reset"
Verify normal session cleanup still works
./scripts/run_tests.sh tests/gateway/test_running_agents.py -q -k "release or sentinel or cleanup"

Verified manually: after applying, sending `/cc` mid-turn no longer
leaves the thread in a zombie state. Subsequent messages are processed
normally without a gateway restart.