### PR TITLE
feat(agent,cli): add cursor-acp provider via ACP

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -355,8 +355,8 @@ def init_agent(
     if (
         api_mode is None
         and agent.api_mode == "chat_completions"
-        and agent.provider != "copilot-acp"
-        and not str(agent.base_url or "").lower().startswith("acp://copilot")
+        and agent.provider not in {"copilot-acp", "cursor-acp"}
+        and not str(agent.base_url or "").lower().startswith("acp://")
         and not str(agent.base_url or "").lower().startswith("acp+tcp://")
         and not agent._is_azure_openai_url()
         and (
@@ -709,7 +709,7 @@ def init_agent(
                 client_kwargs = {"api_key": api_key, "base_url": base_url}
             if _provider_timeout is not None:
                 client_kwargs["timeout"] = _provider_timeout
-            if agent.provider == "copilot-acp":
+            if agent.provider in {"copilot-acp", "cursor-acp"}:
                 client_kwargs["command"] = agent.acp_command
                 client_kwargs["args"] = agent.acp_args
             effective_base = base_url

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1212,6 +1212,17 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
             agent._client_log_context(),
         )
         return client
+    if agent.provider == "cursor-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://cursor"):
+        from agent.cursor_acp_client import CursorACPClient
+
+        client = CursorACPClient(**client_kwargs)
+        _ra().logger.info(
+            "Cursor ACP client created (%s, shared=%s) %s",
+            reason,
+            shared,
+            agent._client_log_context(),
+        )
+        return client
     if agent.provider == "google-gemini-cli" or str(client_kwargs.get("base_url", "")).startswith("cloudcode-pa://"):
         from agent.gemini_cloudcode_adapter import GeminiCloudCodeClient
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3623,6 +3623,36 @@ def resolve_provider_client(
             logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                     else (client, final_model))
+
+        if provider == "cursor-acp":
+            api_key = str(creds.get("api_key", "")).strip()
+            base_url = str(creds.get("base_url", "")).strip()
+            command = str(creds.get("command", "")).strip() or None
+            args = list(creds.get("args") or [])
+            if not final_model:
+                logger.warning(
+                    "resolve_provider_client: cursor-acp requested but no model "
+                    "was provided or configured"
+                )
+                return None, None
+            if not api_key or not base_url:
+                logger.warning(
+                    "resolve_provider_client: cursor-acp requested but external "
+                    "process credentials are incomplete"
+                )
+                return None, None
+            from agent.cursor_acp_client import CursorACPClient
+
+            client = CursorACPClient(
+                api_key=api_key,
+                base_url=base_url,
+                command=command,
+                args=args,
+            )
+            logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
+            return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                    else (client, final_model))
+
         logger.warning("resolve_provider_client: external-process provider %s not "
                        "directly supported", provider)
         return None, None

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3648,6 +3648,7 @@ def resolve_provider_client(
                 base_url=base_url,
                 command=command,
                 args=args,
+                acp_model=final_model,
             )
             logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1119,13 +1119,11 @@ def run_conversation(
                 # session instead of re-failing every retry.
                 if getattr(agent, "_disable_streaming", False):
                     _use_streaming = False
-                # CopilotACPClient communicates via subprocess stdio and
-                # returns a plain SimpleNamespace — not an iterable
-                # stream.  Mirror the ACP exclusion used for Responses
-                # API upgrade (lines ~1083-1085).
+                # CopilotACPClient and CursorACPClient communicate via subprocess stdio
+                # and return a plain SimpleNamespace — not an iterable stream.
                 elif (
-                    agent.provider == "copilot-acp"
-                    or str(agent.base_url or "").lower().startswith("acp://copilot")
+                    agent.provider in {"copilot-acp", "cursor-acp"}
+                    or str(agent.base_url or "").lower().startswith("acp://")
                     or str(agent.base_url or "").lower().startswith("acp+tcp://")
                 ):
                     _use_streaming = False

--- a/agent/cursor_acp_client.py
+++ b/agent/cursor_acp_client.py
@@ -45,6 +45,18 @@ def _resolve_command() -> str:
     )
 
 
+def _split_command(command: str) -> list[str]:
+    """Split a Cursor ACP command override into argv.
+
+    This keeps the default path simple (``agent`` + args) while allowing the
+    same env-var shape used by other external-process providers, for example
+    ``CURSOR_ACP_COMMAND=\"/opt/cursor/bin/agent\"`` or a wrapper command with
+    fixed leading arguments.
+    """
+    parts = shlex.split((command or "").strip())
+    return parts or ["agent"]
+
+
 def _normalize_cursor_model(model: str | None) -> str | None:
     """Return the model id expected by Cursor's `agent --model` flag.
 
@@ -370,6 +382,7 @@ class CursorACPClient:
         self.base_url = base_url or ACP_MARKER_BASE_URL
         self._default_headers = dict(default_headers or {})
         self._acp_command = acp_command or command or _resolve_command()
+        self._acp_command_argv = _split_command(self._acp_command)
         if acp_args or args:
             self._acp_args = list(acp_args or args or [])
         else:
@@ -463,7 +476,7 @@ class CursorACPClient:
     def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
         try:
             proc = subprocess.Popen(
-                [self._acp_command] + self._acp_args,
+                self._acp_command_argv + self._acp_args,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -475,7 +488,8 @@ class CursorACPClient:
         except FileNotFoundError as exc:
             raise RuntimeError(
                 f"Could not start Cursor ACP command '{self._acp_command}'. "
-                "Install Cursor CLI (npm install -g @cursor/agent) or set CURSOR_ACP_COMMAND/CURSOR_CLI_PATH."
+                "Install Cursor Agent CLI (`curl https://cursor.com/install -fsS | bash`), "
+                "run `agent login`, or set CURSOR_ACP_COMMAND/CURSOR_CLI_PATH."
             ) from exc
 
         if proc.stdin is None or proc.stdout is None:
@@ -585,7 +599,7 @@ class CursorACPClient:
             )
             if auth_result and not auth_result.get("success", True):
                 raise RuntimeError(
-                    "Cursor ACP authentication failed. Run 'cursor login' first."
+                    "Cursor ACP authentication failed. Run 'agent login' first."
                 )
 
             # Step 3: Create session

--- a/agent/cursor_acp_client.py
+++ b/agent/cursor_acp_client.py
@@ -45,10 +45,28 @@ def _resolve_command() -> str:
     )
 
 
+def _normalize_cursor_model(model: str | None) -> str | None:
+    """Return the model id expected by Cursor's `agent --model` flag.
+
+    Hermes exposes Cursor ACP models with a provider prefix (for example
+    ``cursor/composer-2.5``) so they behave like other provider/model ids in
+    config. Cursor Agent's CLI expects the bare Cursor model id (for example
+    ``composer-2.5``). Keep this conversion at the ACP boundary so config stays
+    provider-qualified while the subprocess receives the exact Cursor id.
+    """
+    raw = (model or "").strip()
+    if not raw:
+        return None
+    if raw.startswith("cursor/"):
+        raw = raw.split("/", 1)[1].strip()
+    if raw in {"default", "cursor-acp"}:
+        return None
+    return raw or None
+
+
 def _resolve_model() -> str | None:
     """Return the Cursor model to request via --model, or None for account default."""
-    raw = os.getenv("CURSOR_ACP_MODEL", "").strip()
-    return raw or None
+    return _normalize_cursor_model(os.getenv("CURSOR_ACP_MODEL", ""))
 
 
 def _resolve_args() -> list[str]:
@@ -356,10 +374,12 @@ class CursorACPClient:
             self._acp_args = list(acp_args or args or [])
         else:
             self._acp_args = _resolve_args()
-            # Allow per-instance model override
-            explicit_model = (acp_model or model or "").strip()
-            if explicit_model and self._acp_args == ["acp"]:
-                self._acp_args = ["--model", explicit_model, "acp"]
+        # Allow per-instance model override whenever the caller did not provide
+        # a fully custom command line. Auth discovery returns ["acp"], and the
+        # configured Hermes model must still become Cursor's --model flag.
+        explicit_model = _normalize_cursor_model(acp_model or model)
+        if explicit_model and self._acp_args == ["acp"]:
+            self._acp_args = ["--model", explicit_model, "acp"]
         self._acp_cwd = str(Path(acp_cwd or os.getcwd()).resolve())
         self.chat = _ACPChatNamespace(self)
         self.is_closed = False

--- a/agent/cursor_acp_client.py
+++ b/agent/cursor_acp_client.py
@@ -1,0 +1,683 @@
+"""OpenAI-compatible shim that forwards Hermes requests to `agent acp`.
+
+This adapter lets Hermes treat the Cursor ACP server as a chat-style
+backend. Each request starts a short-lived ACP session, sends the formatted
+conversation as a single prompt, collects text chunks, and converts the result
+back into the minimal shape Hermes expects from an OpenAI client.
+
+Cursor ACP protocol: JSON-RPC 2.0 over stdio via `agent acp` subprocess.
+Auth: pre-authenticate with `agent login` (browser flow) or set CURSOR_API_KEY.
+For Composer 2.5 access, use `agent login` (browser/subscription auth).
+
+Model selection: pass `--model` via `CURSOR_ACP_MODEL` env var or `acp_model`
+param. If unset, ACP uses the account default model.
+
+Based on agent/copilot_acp_client.py from Hermes Agent.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import re
+import shlex
+import subprocess
+import threading
+import time
+from collections import deque
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+ACP_MARKER_BASE_URL = "acp://cursor"
+_DEFAULT_TIMEOUT_SECONDS = 900.0
+
+_TOOL_CALL_BLOCK_RE = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
+_TOOL_CALL_JSON_RE = re.compile(r"\{\s*\"id\"\s*:\s*\"[^\"]+\"\s*,\s*\"type\"\s*:\s*\"function\"\s*,\s*\"function\"\s*:\s*\{.*?\}\s*\}", re.DOTALL)
+
+
+def _resolve_command() -> str:
+    return (
+        os.getenv("CURSOR_ACP_COMMAND", "").strip()
+        or os.getenv("CURSOR_CLI_PATH", "").strip()
+        or "agent"
+    )
+
+
+def _resolve_model() -> str | None:
+    """Return the Cursor model to request via --model, or None for account default."""
+    raw = os.getenv("CURSOR_ACP_MODEL", "").strip()
+    return raw or None
+
+
+def _resolve_args() -> list[str]:
+    raw = os.getenv("CURSOR_ACP_ARGS", "").strip()
+    if raw:
+        return shlex.split(raw)
+    args: list[str] = []
+    model = _resolve_model()
+    if model:
+        args.extend(["--model", model])
+    args.append("acp")
+    return args
+
+
+def _resolve_home_dir() -> str:
+    """Return a stable HOME for child ACP processes."""
+
+    try:
+        from hermes_constants import get_subprocess_home
+
+        profile_home = get_subprocess_home()
+        if profile_home:
+            return profile_home
+    except Exception:
+        pass
+
+    home = os.environ.get("HOME", "").strip()
+    if home:
+        return home
+
+    expanded = os.path.expanduser("~")
+    if expanded and expanded != "~":
+        return expanded
+
+    try:
+        import pwd
+
+        resolved = pwd.getpwuid(os.getuid()).pw_dir.strip()
+        if resolved:
+            return resolved
+    except Exception:
+        pass
+
+    return "/tmp"
+
+
+def _build_subprocess_env() -> dict[str, str]:
+    env = os.environ.copy()
+    env["HOME"] = _resolve_home_dir()
+    return env
+
+
+def _jsonrpc_error(message_id: Any, code: int, message: str) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": message_id,
+        "error": {
+            "code": code,
+            "message": message,
+        },
+    }
+
+
+def _permission_allow_once(message_id: Any) -> dict[str, Any]:
+    """Respond to session/request_permission with allow-once.
+
+    Cursor ACP valid responses per official docs:
+    - allow-once
+    - allow-always
+    - reject-once
+    """
+    return {
+        "jsonrpc": "2.0",
+        "id": message_id,
+        "result": {
+            "outcome": {
+                "outcome": "selected",
+                "optionId": "allow-once",
+            }
+        },
+    }
+
+
+def _format_messages_as_prompt(
+    messages: list[dict[str, Any]],
+    model: str | None = None,
+    tools: list[dict[str, Any]] | None = None,
+    tool_choice: Any = None,
+) -> str:
+    sections: list[str] = [
+        "You are being used as the active ACP agent backend for Hermes.",
+        "Use ACP capabilities to complete tasks.",
+        "IMPORTANT: If you take an action with a tool, you MUST output tool calls using <tool_call>{...}</tool_call> blocks with JSON exactly in OpenAI function-call shape.",
+        "If no tool is needed, answer normally.",
+    ]
+    if model:
+        sections.append(f"Hermes requested model hint: {model}")
+
+    if isinstance(tools, list) and tools:
+        tool_specs: list[dict[str, Any]] = []
+        for t in tools:
+            if not isinstance(t, dict):
+                continue
+            fn = t.get("function") or {}
+            if not isinstance(fn, dict):
+                continue
+            name = fn.get("name")
+            if not isinstance(name, str) or not name.strip():
+                continue
+            tool_specs.append(
+                {
+                    "name": name.strip(),
+                    "description": fn.get("description", ""),
+                    "parameters": fn.get("parameters", {}),
+                }
+            )
+        if tool_specs:
+            sections.append(
+                "Available tools (OpenAI function schema). "
+                "When using a tool, emit ONLY <tool_call>{...}</tool_call> with one JSON object "
+                "containing id/type/function{name,arguments}. arguments must be a JSON string.\n"
+                + json.dumps(tool_specs, ensure_ascii=False)
+            )
+
+    if tool_choice is not None:
+        sections.append(f"Tool choice hint: {json.dumps(tool_choice, ensure_ascii=False)}")
+
+    transcript: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = str(message.get("role") or "unknown").strip().lower()
+        if role == "tool":
+            role = "tool"
+        elif role not in {"system", "user", "assistant"}:
+            role = "context"
+
+        content = message.get("content")
+        rendered = _render_message_content(content)
+        if not rendered:
+            continue
+
+        label = {
+            "system": "System",
+            "user": "User",
+            "assistant": "Assistant",
+            "tool": "Tool",
+            "context": "Context",
+        }.get(role, role.title())
+        transcript.append(f"{label}:\n{rendered}")
+
+    if transcript:
+        sections.append("Conversation transcript:\n\n" + "\n\n".join(transcript))
+
+    sections.append("Continue the conversation from the latest user request.")
+    return "\n\n".join(section.strip() for section in sections if section and section.strip())
+
+
+def _render_message_content(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, dict):
+        if "text" in content:
+            return str(content.get("text") or "").strip()
+        if "content" in content and isinstance(content.get("content"), str):
+            return str(content.get("content") or "").strip()
+        return json.dumps(content, ensure_ascii=True)
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str) and text.strip():
+                    parts.append(text.strip())
+        return "\n".join(parts).strip()
+    return str(content).strip()
+
+
+def _extract_tool_calls_from_text(text: str) -> tuple[list[SimpleNamespace], str]:
+    if not isinstance(text, str) or not text.strip():
+        return [], ""
+
+    extracted: list[SimpleNamespace] = []
+    consumed_spans: list[tuple[int, int]] = []
+
+    def _try_add_tool_call(raw_json: str) -> None:
+        try:
+            obj = json.loads(raw_json)
+        except Exception:
+            return
+        if not isinstance(obj, dict):
+            return
+        fn = obj.get("function")
+        if not isinstance(fn, dict):
+            return
+        fn_name = fn.get("name")
+        if not isinstance(fn_name, str) or not fn_name.strip():
+            return
+        fn_args = fn.get("arguments", "{}")
+        if not isinstance(fn_args, str):
+            fn_args = json.dumps(fn_args, ensure_ascii=False)
+        call_id = obj.get("id")
+        if not isinstance(call_id, str) or not call_id.strip():
+            call_id = f"acp_call_{len(extracted)+1}"
+
+        extracted.append(
+            SimpleNamespace(
+                id=call_id,
+                call_id=call_id,
+                response_item_id=None,
+                type="function",
+                function=SimpleNamespace(name=fn_name.strip(), arguments=fn_args),
+            )
+        )
+
+    for m in _TOOL_CALL_BLOCK_RE.finditer(text):
+        raw = m.group(1)
+        _try_add_tool_call(raw)
+        consumed_spans.append((m.start(), m.end()))
+
+    # Only try bare-JSON fallback when no XML blocks were found.
+    if not extracted:
+        for m in _TOOL_CALL_JSON_RE.finditer(text):
+            raw = m.group(0)
+            _try_add_tool_call(raw)
+            consumed_spans.append((m.start(), m.end()))
+
+    if not consumed_spans:
+        return extracted, text.strip()
+
+    consumed_spans.sort()
+    merged: list[tuple[int, int]] = []
+    for start, end in consumed_spans:
+        if not merged or start > merged[-1][1]:
+            merged.append((start, end))
+        else:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+
+    parts: list[str] = []
+    cursor = 0
+    for start, end in merged:
+        if cursor < start:
+            parts.append(text[cursor:start])
+        cursor = max(cursor, end)
+    if cursor < len(text):
+        parts.append(text[cursor:])
+
+    cleaned = "\n".join(p.strip() for p in parts if p and p.strip()).strip()
+    return extracted, cleaned
+
+
+def _ensure_path_within_cwd(path_text: str, cwd: str) -> Path:
+    candidate = Path(path_text)
+    if not candidate.is_absolute():
+        raise PermissionError("ACP file-system paths must be absolute.")
+    resolved = candidate.resolve()
+    root = Path(cwd).resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise PermissionError(f"Path '{resolved}' is outside the session cwd '{root}'.") from exc
+    return resolved
+
+
+class _ACPChatCompletions:
+    def __init__(self, client: "CursorACPClient"):
+        self._client = client
+
+    def create(self, **kwargs: Any) -> Any:
+        return self._client._create_chat_completion(**kwargs)
+
+
+class _ACPChatNamespace:
+    def __init__(self, client: "CursorACPClient"):
+        self.completions = _ACPChatCompletions(client)
+
+
+class CursorACPClient:
+    """Minimal OpenAI-client-compatible facade for Cursor ACP."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        default_headers: dict[str, str] | None = None,
+        acp_command: str | None = None,
+        acp_args: list[str] | None = None,
+        acp_cwd: str | None = None,
+        acp_model: str | None = None,
+        command: str | None = None,
+        args: list[str] | None = None,
+        model: str | None = None,
+        **_: Any,
+    ):
+        self.api_key = api_key or "cursor-acp"
+        self.base_url = base_url or ACP_MARKER_BASE_URL
+        self._default_headers = dict(default_headers or {})
+        self._acp_command = acp_command or command or _resolve_command()
+        if acp_args or args:
+            self._acp_args = list(acp_args or args or [])
+        else:
+            self._acp_args = _resolve_args()
+            # Allow per-instance model override
+            explicit_model = (acp_model or model or "").strip()
+            if explicit_model and self._acp_args == ["acp"]:
+                self._acp_args = ["--model", explicit_model, "acp"]
+        self._acp_cwd = str(Path(acp_cwd or os.getcwd()).resolve())
+        self.chat = _ACPChatNamespace(self)
+        self.is_closed = False
+        self._active_process: subprocess.Popen[str] | None = None
+        self._active_process_lock = threading.Lock()
+
+    def close(self) -> None:
+        proc: subprocess.Popen[str] | None
+        with self._active_process_lock:
+            proc = self._active_process
+            self._active_process = None
+        self.is_closed = True
+        if proc is None:
+            return
+        try:
+            proc.terminate()
+            proc.wait(timeout=2)
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+
+    def _create_chat_completion(
+        self,
+        *,
+        model: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        timeout: float | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: Any = None,
+        **_: Any,
+    ) -> Any:
+        prompt_text = _format_messages_as_prompt(
+            messages or [],
+            model=model,
+            tools=tools,
+            tool_choice=tool_choice,
+        )
+        # Normalise timeout: run_agent.py may pass an httpx.Timeout object
+        if timeout is None:
+            _effective_timeout = _DEFAULT_TIMEOUT_SECONDS
+        elif isinstance(timeout, (int, float)):
+            _effective_timeout = float(timeout)
+        else:
+            _candidates = [
+                getattr(timeout, attr, None)
+                for attr in ("read", "write", "connect", "pool", "timeout")
+            ]
+            _numeric = [float(v) for v in _candidates if isinstance(v, (int, float))]
+            _effective_timeout = max(_numeric) if _numeric else _DEFAULT_TIMEOUT_SECONDS
+
+        response_text, reasoning_text = self._run_prompt(
+            prompt_text,
+            timeout_seconds=_effective_timeout,
+        )
+
+        tool_calls, cleaned_text = _extract_tool_calls_from_text(response_text)
+
+        usage = SimpleNamespace(
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+        )
+        assistant_message = SimpleNamespace(
+            content=cleaned_text,
+            tool_calls=tool_calls,
+            reasoning=reasoning_text or None,
+            reasoning_content=reasoning_text or None,
+            reasoning_details=None,
+        )
+        finish_reason = "tool_calls" if tool_calls else "stop"
+        choice = SimpleNamespace(message=assistant_message, finish_reason=finish_reason)
+        return SimpleNamespace(
+            choices=[choice],
+            usage=usage,
+            model=model or "cursor-acp",
+        )
+
+    def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
+        try:
+            proc = subprocess.Popen(
+                [self._acp_command] + self._acp_args,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                bufsize=1,
+                cwd=self._acp_cwd,
+                env=_build_subprocess_env(),
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"Could not start Cursor ACP command '{self._acp_command}'. "
+                "Install Cursor CLI (npm install -g @cursor/agent) or set CURSOR_ACP_COMMAND/CURSOR_CLI_PATH."
+            ) from exc
+
+        if proc.stdin is None or proc.stdout is None:
+            proc.kill()
+            raise RuntimeError("Cursor ACP process did not expose stdin/stdout pipes.")
+
+        self.is_closed = False
+        with self._active_process_lock:
+            self._active_process = proc
+
+        inbox: queue.Queue[dict[str, Any]] = queue.Queue()
+        stderr_tail: deque[str] = deque(maxlen=40)
+
+        def _stdout_reader() -> None:
+            if proc.stdout is None:
+                return
+            for line in proc.stdout:
+                try:
+                    inbox.put(json.loads(line))
+                except Exception:
+                    inbox.put({"raw": line.rstrip("\n")})
+
+        def _stderr_reader() -> None:
+            if proc.stderr is None:
+                return
+            for line in proc.stderr:
+                stderr_tail.append(line.rstrip("\n"))
+
+        out_thread = threading.Thread(target=_stdout_reader, daemon=True)
+        err_thread = threading.Thread(target=_stderr_reader, daemon=True)
+        out_thread.start()
+        err_thread.start()
+
+        next_id = 0
+
+        def _request(method: str, params: dict[str, Any], *, text_parts: list[str] | None = None, reasoning_parts: list[str] | None = None) -> Any:
+            nonlocal next_id
+            next_id += 1
+            request_id = next_id
+            payload = {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "method": method,
+                "params": params,
+            }
+            proc.stdin.write(json.dumps(payload) + "\n")
+            proc.stdin.flush()
+
+            deadline = time.monotonic() + timeout_seconds
+            while time.monotonic() < deadline:
+                if proc.poll() is not None:
+                    break
+                try:
+                    msg = inbox.get(timeout=0.1)
+                except queue.Empty:
+                    continue
+
+                if self._handle_server_message(
+                    msg,
+                    process=proc,
+                    cwd=self._acp_cwd,
+                    text_parts=text_parts,
+                    reasoning_parts=reasoning_parts,
+                ):
+                    continue
+
+                if msg.get("id") != request_id:
+                    continue
+                if "error" in msg:
+                    err = msg.get("error") or {}
+                    raise RuntimeError(
+                        f"Cursor ACP {method} failed: {err.get('message') or err}"
+                    )
+                return msg.get("result")
+
+            stderr_text = "\n".join(stderr_tail).strip()
+            if proc.poll() is not None and stderr_text:
+                raise RuntimeError(f"Cursor ACP process exited early: {stderr_text}")
+            raise TimeoutError(f"Timed out waiting for Cursor ACP response to {method}.")
+
+        try:
+            # Step 1: Initialize
+            _request(
+                "initialize",
+                {
+                    "protocolVersion": 1,
+                    "clientCapabilities": {
+                        "fs": {
+                            "readTextFile": True,
+                            "writeTextFile": True,
+                        }
+                    },
+                    "clientInfo": {
+                        "name": "hermes-agent",
+                        "title": "Hermes Agent",
+                        "version": "0.0.0",
+                    },
+                },
+            )
+
+            # Step 2: Authenticate (Cursor requires this)
+            auth_result = _request(
+                "authenticate",
+                {
+                    "methodId": "cursor_login",
+                },
+            )
+            if auth_result and not auth_result.get("success", True):
+                raise RuntimeError(
+                    "Cursor ACP authentication failed. Run 'cursor login' first."
+                )
+
+            # Step 3: Create session
+            session = _request(
+                "session/new",
+                {
+                    "cwd": self._acp_cwd,
+                    "mcpServers": [],
+                },
+            ) or {}
+            session_id = str(session.get("sessionId") or "").strip()
+            if not session_id:
+                raise RuntimeError("Cursor ACP did not return a sessionId.")
+
+            # Step 4: Send prompt and collect response
+            text_parts: list[str] = []
+            reasoning_parts: list[str] = []
+            _request(
+                "session/prompt",
+                {
+                    "sessionId": session_id,
+                    "prompt": [
+                        {
+                            "type": "text",
+                            "text": prompt_text,
+                        }
+                    ],
+                },
+                text_parts=text_parts,
+                reasoning_parts=reasoning_parts,
+            )
+            return "".join(text_parts), "".join(reasoning_parts)
+        finally:
+            self.close()
+
+    def _handle_server_message(
+        self,
+        msg: dict[str, Any],
+        *,
+        process: subprocess.Popen[str],
+        cwd: str,
+        text_parts: list[str] | None,
+        reasoning_parts: list[str] | None,
+    ) -> bool:
+        method = msg.get("method")
+        if not isinstance(method, str):
+            return False
+
+        if method == "session/update":
+            params = msg.get("params") or {}
+            update = params.get("update") or {}
+            kind = str(update.get("sessionUpdate") or "").strip()
+            content = update.get("content") or {}
+            chunk_text = ""
+            if isinstance(content, dict):
+                chunk_text = str(content.get("text") or "")
+            if kind == "agent_message_chunk" and chunk_text and text_parts is not None:
+                text_parts.append(chunk_text)
+            elif kind == "agent_thought_chunk" and chunk_text and reasoning_parts is not None:
+                reasoning_parts.append(chunk_text)
+            return True
+
+        if process.stdin is None:
+            return True
+
+        message_id = msg.get("id")
+        params = msg.get("params") or {}
+
+        if method == "session/request_permission":
+            response = _permission_allow_once(message_id)
+        elif method == "fs/read_text_file":
+            try:
+                path = _ensure_path_within_cwd(str(params.get("path") or ""), cwd)
+                try:
+                    content = path.read_text()
+                except FileNotFoundError:
+                    content = ""
+                line = params.get("line")
+                limit = params.get("limit")
+                if isinstance(line, int) and line > 1:
+                    lines = content.splitlines(keepends=True)
+                    start = line - 1
+                    end = start + limit if isinstance(limit, int) and limit > 0 else None
+                    content = "".join(lines[start:end])
+                response = {
+                    "jsonrpc": "2.0",
+                    "id": message_id,
+                    "result": {
+                        "content": content,
+                    },
+                }
+            except Exception as exc:
+                response = _jsonrpc_error(message_id, -32602, str(exc))
+        elif method == "fs/write_text_file":
+            try:
+                path = _ensure_path_within_cwd(str(params.get("path") or ""), cwd)
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(str(params.get("content") or ""))
+                response = {
+                    "jsonrpc": "2.0",
+                    "id": message_id,
+                    "result": None,
+                }
+            except Exception as exc:
+                response = _jsonrpc_error(message_id, -32602, str(exc))
+        else:
+            response = _jsonrpc_error(
+                message_id,
+                -32601,
+                f"ACP client method '{method}' is not supported by Hermes yet.",
+            )
+
+        process.stdin.write(json.dumps(response) + "\n")
+        process.stdin.flush()
+        return True

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -45,7 +45,7 @@ def _resolve_requests_verify() -> bool | str:
 # Only these are stripped — Ollama-style "model:tag" colons (e.g. "qwen3.5:27b")
 # are preserved so the full model name reaches cache lookups and server queries.
 _PROVIDER_PREFIXES: frozenset[str] = frozenset({
-    "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
+    "openrouter", "nous", "openai-codex", "copilot", "copilot-acp", "cursor-acp", "cursor",
     "gemini", "ollama-cloud", "zai", "kimi-coding", "kimi-coding-cn", "stepfun", "minimax", "minimax-oauth", "minimax-cn", "anthropic", "deepseek",
     "opencode-zen", "opencode-go", "ai-gateway", "kilocode", "alibaba", "novita",
     "qwen-oauth",
@@ -1615,7 +1615,7 @@ def get_model_context_length(
     # This catches account-specific models (e.g. claude-opus-4.6-1m) that
     # don't exist in models.dev. For models that ARE in models.dev, this
     # returns the provider-enforced limit which is what users can actually use.
-    if effective_provider in {"copilot", "copilot-acp", "github-copilot"}:
+    if effective_provider in {"copilot", "copilot-acp", "cursor-acp", "github-copilot"}:
         try:
             from hermes_cli.models import get_copilot_model_context
             ctx = get_copilot_model_context(model, api_key=api_key)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -237,6 +237,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    "cursor-acp": ProviderConfig(
+        id="cursor-acp",
+        name="Cursor ACP",
+        auth_type="external_process",
+        inference_base_url="acp://cursor",
+        base_url_env_var="CURSOR_ACP_BASE_URL",
+    ),
     "gemini": ProviderConfig(
         id="gemini",
         name="Google AI Studio",
@@ -1420,6 +1427,7 @@ def resolve_provider(
         "github": "copilot", "github-copilot": "copilot",
         "github-models": "copilot", "github-model": "copilot",
         "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
+        "cursor": "cursor-acp", "cursor-agent": "cursor-acp",
         "aigateway": "ai-gateway", "vercel": "ai-gateway", "vercel-ai-gateway": "ai-gateway",
         "opencode": "opencode-zen", "zen": "opencode-zen",
         "qwen-portal": "qwen-oauth", "qwen-cli": "qwen-oauth", "qwen-oauth": "qwen-oauth", "google-gemini-cli": "google-gemini-cli", "gemini-cli": "google-gemini-cli", "gemini-oauth": "google-gemini-cli",
@@ -5668,16 +5676,24 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     if not pconfig or pconfig.auth_type != "external_process":
         return {"configured": False}
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
-    base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
-    if not base_url:
-        base_url = pconfig.inference_base_url
+    # Use generic credential resolver (works for copilot-acp and cursor-acp)
+    try:
+        creds = resolve_external_process_provider_credentials(provider_id)
+        command = creds.get("command", "")
+        args = list(creds.get("args") or [])
+        base_url = str(creds.get("base_url", "")).strip()
+    except Exception:
+        # Fallback to legacy copilot-acp defaults
+        command = (
+            os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
+            or os.getenv("COPILOT_CLI_PATH", "").strip()
+            or "copilot"
+        )
+        raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
+        args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+        base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
+        if not base_url:
+            base_url = pconfig.inference_base_url
 
     resolved_command = shutil.which(command) if command else None
     return {
@@ -5711,7 +5727,7 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return get_gemini_oauth_auth_status()
     if target == "minimax-oauth":
         return get_minimax_oauth_auth_status()
-    if target == "copilot-acp":
+    if target == "copilot-acp" or target == "cursor-acp":
         return get_external_process_provider_status(target)
     if target == "azure-foundry":
         return _get_azure_foundry_auth_status()
@@ -5853,6 +5869,7 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
 
 def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str, Any]:
     """Resolve runtime details for local subprocess-backed providers."""
+    import shutil
     pconfig = PROVIDER_REGISTRY.get(provider_id)
     if not pconfig or pconfig.auth_type != "external_process":
         raise AuthError(
@@ -5865,6 +5882,33 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
     if not base_url:
         base_url = pconfig.inference_base_url
 
+    if provider_id == "cursor-acp":
+        command = (
+            os.getenv("CURSOR_ACP_COMMAND", "").strip()
+            or os.getenv("CURSOR_CLI_PATH", "").strip()
+            or "agent"
+        )
+        raw_args = os.getenv("CURSOR_ACP_ARGS", "").strip()
+        args = shlex.split(raw_args) if raw_args else ["acp"]
+        resolved_command = shutil.which(command) if command else None
+        if not resolved_command and not base_url.startswith("acp+tcp://"):
+            raise AuthError(
+                f"Could not find the Cursor CLI command '{command}'. "
+                "Install Cursor CLI (curl https://cursor.com/install -fsS | bash) "
+                "or set CURSOR_ACP_COMMAND/CURSOR_CLI_PATH.",
+                provider=provider_id,
+                code="missing_cursor_cli",
+            )
+        return {
+            "provider": provider_id,
+            "api_key": "cursor-acp",
+            "base_url": base_url.rstrip("/"),
+            "command": resolved_command or command,
+            "args": args,
+            "source": "process",
+        }
+
+    # Default: copilot-acp (backward compatible)
     command = (
         os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
         or os.getenv("COPILOT_CLI_PATH", "").strip()

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1343,10 +1343,19 @@ def list_authenticated_providers(
                     has_creds = True
             except Exception as exc:
                 logger.debug("Anthropic external creds check failed: %s", exc)
+        # External-process providers (cursor-acp, copilot-acp) — check CLI availability
+        if not has_creds and overlay.auth_type == "external_process":
+            try:
+                from hermes_cli.auth import get_external_process_provider_status
+                ext_status = get_external_process_provider_status(hermes_slug)
+                if ext_status.get("configured") or ext_status.get("logged_in"):
+                    has_creds = True
+            except Exception as exc:
+                logger.debug("External process provider check failed for %s: %s", hermes_slug, exc)
         if not has_creds:
             continue
 
-        if hermes_slug in {"openai-codex", "copilot", "copilot-acp"}:
+        if hermes_slug in {"openai-codex", "copilot", "copilot-acp", "cursor-acp"}:
             # Use live OAuth-backed discovery so the gateway /model picker
             # matches what the user's authenticated Codex/Copilot backend
             # actually serves — including ChatGPT-Pro-only Codex slugs

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -204,6 +204,12 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "cursor-acp": [
+        "cursor/composer-2.5",
+        "cursor/composer-2",
+        "cursor/default",
+        "cursor-acp",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",
@@ -935,6 +941,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("nvidia",         "NVIDIA NIM",               "NVIDIA NIM (Nemotron models — build.nvidia.com or local NIM)"),
     ProviderEntry("copilot",        "GitHub Copilot",           "GitHub Copilot (uses GITHUB_TOKEN or gh auth token)"),
     ProviderEntry("copilot-acp",    "GitHub Copilot ACP",       "GitHub Copilot ACP (spawns `copilot --acp --stdio`)"),
+    ProviderEntry("cursor-acp",     "Cursor ACP",               "Cursor ACP (spawns `agent acp` — requires Cursor Individual/Pro subscription)"),
     ProviderEntry("huggingface",    "Hugging Face",             "Hugging Face Inference Providers (20+ open models)"),
     ProviderEntry("gemini",         "Google AI Studio",         "Google AI Studio (Gemini models — native Gemini API)"),
     ProviderEntry("google-gemini-cli", "Google Gemini (OAuth)",   "Google Gemini via OAuth + Code Assist (free tier supported; no API key needed)"),
@@ -994,6 +1001,8 @@ _PROVIDER_ALIASES = {
     "github-model": "copilot",
     "github-copilot-acp": "copilot-acp",
     "copilot-acp-agent": "copilot-acp",
+    "cursor": "cursor-acp",
+    "cursor-agent": "cursor-acp",
     "google": "gemini",
     "google-gemini": "gemini",
     "google-ai-studio": "gemini",
@@ -2184,6 +2193,8 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
         return get_codex_model_ids(access_token=access_token)
     if normalized == "xai-oauth":
         return list(_PROVIDER_MODELS.get("xai-oauth", _PROVIDER_MODELS.get("xai", [])))
+    if normalized == "cursor-acp":
+        return list(_PROVIDER_MODELS.get("cursor-acp", []))
     if normalized in {"copilot", "copilot-acp"}:
         try:
             live = _fetch_github_models(_resolve_copilot_catalog_api_key())

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -90,6 +90,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="acp://copilot",
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    "cursor-acp": HermesOverlay(
+        transport="codex_responses",
+        auth_type="external_process",
+        base_url_override="acp://cursor",
+        base_url_env_var="CURSOR_ACP_BASE_URL",
+    ),
     "github-copilot": HermesOverlay(
         transport="openai_chat",
         extra_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN"),
@@ -284,6 +290,8 @@ ALIASES: Dict[str, str] = {
     "copilot": "github-copilot",
     "github": "github-copilot",
     "github-copilot-acp": "copilot-acp",
+    "cursor": "cursor-acp",
+    "cursor-agent": "cursor-acp",
 
     # vercel (models.dev ID for AI Gateway)
     "ai-gateway": "vercel",
@@ -373,7 +381,8 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "nous": "Nous Portal",
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
-    "stepfun": "StepFun Step Plan",
+    "cursor-acp": "Cursor ACP",
+    "huggingface": "Hugging Face",
     "xiaomi": "Xiaomi MiMo",
     "gmi": "GMI Cloud",
     "tencent-tokenhub": "Tencent TokenHub",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1460,6 +1460,18 @@ def resolve_runtime_provider(
             "source": creds.get("source", "process"),
             "requested_provider": requested_provider,
         }
+    if provider == "cursor-acp":
+        creds = resolve_external_process_provider_credentials(provider)
+        return {
+            "provider": "cursor-acp",
+            "api_mode": "chat_completions",
+            "base_url": creds.get("base_url", "").rstrip("/") or "acp://cursor",
+            "api_key": creds.get("api_key", ""),
+            "command": creds.get("command", ""),
+            "args": list(creds.get("args") or []),
+            "source": creds.get("source", "process"),
+            "requested_provider": requested_provider,
+        }
 
     # Anthropic (native Messages API)
     if provider == "anthropic":

--- a/tests/hermes_cli/test_cursor_acp_provider.py
+++ b/tests/hermes_cli/test_cursor_acp_provider.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import patch
 
+from agent.cursor_acp_client import CursorACPClient, _normalize_cursor_model
 from hermes_cli import runtime_provider as rp
 from hermes_cli.model_switch import list_authenticated_providers
 from hermes_cli.models import provider_model_ids
@@ -16,6 +17,23 @@ def test_cursor_acp_model_catalog_contains_composer_models():
         "cursor/default",
         "cursor-acp",
     ]
+
+
+def test_cursor_acp_normalizes_provider_prefixed_model_for_agent_cli():
+    assert _normalize_cursor_model("cursor/composer-2.5") == "composer-2.5"
+    assert _normalize_cursor_model("composer-2.5") == "composer-2.5"
+    assert _normalize_cursor_model("cursor/default") is None
+    assert _normalize_cursor_model("cursor-acp") is None
+
+
+def test_cursor_acp_client_passes_configured_model_to_agent_cli():
+    client = CursorACPClient(
+        command="agent",
+        args=["acp"],
+        acp_model="cursor/composer-2.5",
+    )
+
+    assert client._acp_args == ["--model", "composer-2.5", "acp"]
 
 
 def test_cursor_alias_resolves_to_cursor_acp(monkeypatch):

--- a/tests/hermes_cli/test_cursor_acp_provider.py
+++ b/tests/hermes_cli/test_cursor_acp_provider.py
@@ -1,0 +1,69 @@
+"""Tests for Cursor ACP provider registration and runtime resolution."""
+
+from unittest.mock import patch
+
+from hermes_cli import runtime_provider as rp
+from hermes_cli.model_switch import list_authenticated_providers
+from hermes_cli.models import provider_model_ids
+
+
+def test_cursor_acp_model_catalog_contains_composer_models():
+    models = provider_model_ids("cursor-acp")
+
+    assert models == [
+        "cursor/composer-2.5",
+        "cursor/composer-2",
+        "cursor/default",
+        "cursor-acp",
+    ]
+
+
+def test_cursor_alias_resolves_to_cursor_acp(monkeypatch):
+    monkeypatch.setattr(rp.auth_mod, "_load_auth_store", lambda: {})
+    assert rp.resolve_provider("cursor") == "cursor-acp"
+    assert rp.resolve_provider("cursor-agent") == "cursor-acp"
+
+
+def test_resolve_runtime_provider_cursor_acp(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "cursor-acp")
+    monkeypatch.setattr(
+        rp,
+        "resolve_external_process_provider_credentials",
+        lambda provider: {
+            "provider": provider,
+            "api_key": "cursor-acp",
+            "base_url": "acp://cursor",
+            "command": "/usr/local/bin/agent",
+            "args": ["acp"],
+            "source": "process",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="cursor-acp")
+
+    assert resolved["provider"] == "cursor-acp"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["base_url"] == "acp://cursor"
+    assert resolved["api_key"] == "cursor-acp"
+    assert resolved["command"] == "/usr/local/bin/agent"
+    assert resolved["args"] == ["acp"]
+    assert resolved["source"] == "process"
+    assert resolved["requested_provider"] == "cursor-acp"
+
+
+def test_cursor_acp_picker_shows_static_catalog_when_cli_available():
+    with patch("agent.models_dev.fetch_models_dev", return_value={}), \
+         patch("hermes_cli.auth.get_external_process_provider_status", return_value={"configured": True}), \
+         patch("shutil.which", return_value="/usr/local/bin/agent"):
+        providers = list_authenticated_providers(current_provider="openrouter", max_models=50)
+
+    cursor = next((p for p in providers if p["slug"] == "cursor-acp"), None)
+
+    assert cursor is not None
+    assert cursor["models"] == [
+        "cursor/composer-2.5",
+        "cursor/composer-2",
+        "cursor/default",
+        "cursor-acp",
+    ]
+    assert cursor["total_models"] == 4

--- a/tests/hermes_cli/test_cursor_acp_provider.py
+++ b/tests/hermes_cli/test_cursor_acp_provider.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch
 
-from agent.cursor_acp_client import CursorACPClient, _normalize_cursor_model
+from agent.cursor_acp_client import CursorACPClient, _normalize_cursor_model, _split_command
 from hermes_cli import runtime_provider as rp
 from hermes_cli.model_switch import list_authenticated_providers
 from hermes_cli.models import provider_model_ids
@@ -33,6 +33,23 @@ def test_cursor_acp_client_passes_configured_model_to_agent_cli():
         acp_model="cursor/composer-2.5",
     )
 
+    assert client._acp_args == ["--model", "composer-2.5", "acp"]
+
+
+def test_cursor_acp_command_override_supports_wrapper_args():
+    assert _split_command('/opt/cursor/bin/agent --profile work') == [
+        "/opt/cursor/bin/agent",
+        "--profile",
+        "work",
+    ]
+
+    client = CursorACPClient(
+        command='/opt/cursor/bin/agent --profile work',
+        args=["acp"],
+        acp_model="cursor/composer-2.5",
+    )
+
+    assert client._acp_command_argv == ["/opt/cursor/bin/agent", "--profile", "work"]
     assert client._acp_args == ["--model", "composer-2.5", "acp"]
 
 

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -18,6 +18,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **OpenAI Codex** | `hermes model` (ChatGPT OAuth, uses Codex models) |
 | **GitHub Copilot** | `hermes model` (OAuth device code flow, `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `gh auth token`) |
 | **GitHub Copilot ACP** | `hermes model` (spawns local `copilot --acp --stdio`) |
+| **Cursor ACP** | `hermes model` (spawns local Cursor Agent CLI via `agent acp`; supports subscription auth after `agent login`) |
 | **Anthropic** | `hermes model` (Claude Max + extra usage credits via OAuth; also supports Anthropic API key or manual setup-token — see note below) |
 | **OpenRouter** | `OPENROUTER_API_KEY` in `~/.hermes/.env` |
 | **NovitaAI** | `NOVITA_API_KEY` in `~/.hermes/.env` (provider: `novita`, 200+ models, Model API, Agent Sandbox, GPU Cloud) |
@@ -266,7 +267,35 @@ hermes chat --provider copilot-acp --model copilot-acp
 # Requires the GitHub Copilot CLI in PATH and an existing `copilot login` session
 ```
 
+**`cursor-acp` — Cursor Agent Client Protocol backend**. Spawns Cursor's local Agent CLI as an ACP subprocess:
+
+```bash
+# Install Cursor Agent CLI, then authenticate with the browser/subscription flow.
+curl https://cursor.com/install -fsS | bash
+agent login
+
+# Run Composer through Hermes. The Hermes model id keeps the provider prefix,
+# and the ACP subprocess receives Cursor's bare model id (`composer-2.5`).
+hermes chat --provider cursor-acp --model cursor/composer-2.5 -q "Say hello from Cursor ACP"
+```
+
+Use this provider when you want Cursor Composer as the active Hermes backend. The separate Cursor SDK tool integrations are better for delegated coding-agent tasks; `cursor-acp` is the provider-selection path that keeps Hermes' normal session, memory, and message routing in charge.
+
 **Permanent config:**
+```yaml
+model:
+  provider: "cursor-acp"
+  default: "cursor/composer-2.5"
+```
+
+| Environment variable | Description |
+|---------------------|-------------|
+| `CURSOR_ACP_COMMAND` | Override the Cursor Agent binary path (default: `agent`) |
+| `CURSOR_CLI_PATH` | Legacy/alternate override for the Cursor Agent binary path |
+| `CURSOR_ACP_MODEL` | Override the Cursor model sent to `agent --model`; accepts `composer-2.5` or `cursor/composer-2.5` |
+| `CURSOR_ACP_ARGS` | Override ACP args entirely; when set, Hermes does not add `--model` automatically |
+
+**Copilot permanent config:**
 ```yaml
 model:
   provider: "copilot"


### PR DESCRIPTION
## Summary

Adds **Cursor ACP** as a native Hermes model provider using Cursor's Agent Client Protocol (`agent acp`). This follows the existing external-process provider pattern used by `copilot-acp`, but targets Cursor's CLI instead of GitHub Copilot.

This lets users use Cursor Composer, including `cursor/composer-2.5`, directly as a Hermes backend after `agent login`, without a separate Cursor API key.

## Why

Cursor Composer is not exposed through a normal chat-completions API. The supported local integration surface is the Cursor CLI ACP server:

- Cursor ACP docs: https://cursor.com/docs/cli/acp
- Cursor auth docs: https://cursor.com/docs/cli/reference/authentication

This complements #30641, which adds Cursor as a delegated tool through the Cursor SDK. This PR is for the other use case: selecting Cursor as the active Hermes provider in the model picker.

## Changes

- Add `agent/cursor_acp_client.py`, an OpenAI-compatible shim around `agent acp`.
- Register `cursor-acp` in provider metadata, aliases, auth status, and runtime resolution.
- Add Cursor model catalog entries:
  - `cursor/composer-2.5`
  - `cursor/composer-2`
  - `cursor/default`
  - `cursor-acp`
- Wire `cursor-acp` into agent client creation and auxiliary client resolution.
- Treat `cursor-acp` as an external-process provider in `/model` discovery.
- Disable normal streaming for `cursor-acp` because ACP handles its own subprocess stream.
- Add regression tests for model catalog, aliases, runtime resolution, and model picker visibility.

## How to test

Prerequisites:

```bash
curl https://cursor.com/install -fsS | bash
agent login
```

Then:

```bash
hermes chat --provider cursor-acp --model cursor/composer-2.5 -q "Say hello from Cursor ACP"
```

Or use `/model` and select **Cursor ACP**.

## Validation

Local validation on macOS:

```bash
python -m py_compile \
  agent/cursor_acp_client.py \
  agent/agent_runtime_helpers.py \
  agent/auxiliary_client.py \
  hermes_cli/auth.py \
  hermes_cli/providers.py \
  hermes_cli/runtime_provider.py \
  hermes_cli/models.py \
  hermes_cli/model_switch.py

python -m pytest \
  tests/hermes_cli/test_cursor_acp_provider.py \
  tests/hermes_cli/test_runtime_provider_resolution.py \
  tests/hermes_cli/test_copilot_in_model_list.py \
  -q
```

Result:

```text
134 passed
```

Manual smoke test performed on macOS 26.4.1 with Cursor CLI `agent v2026.05.20-2b5dd59` and Cursor Individual subscription. `cursor/composer-2.5` responded successfully through Hermes.

## Platform tested

- macOS 26.4.1
- Python 3.11
- Cursor CLI ACP via `agent acp`

## Related

- #30641: Cursor SDK tool integration, complementary to this provider
- #30640: Cursor SDK RFC
