### PR TITLE
test(acp): pin parse_model_input in slash-command tests to fix flake

### DIFF
--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -971,6 +971,18 @@ class TestSessionConfiguration:
             "hermes_cli.runtime_provider.resolve_runtime_provider",
             fake_resolve_runtime_provider,
         )
+        # Pin the parser so this test doesn't depend on live
+        # ``_KNOWN_PROVIDER_NAMES`` / ``_PROVIDER_ALIASES`` module state
+        # (sibling of the same hardening on
+        # ``test_model_switch_uses_requested_provider``).
+        monkeypatch.setattr(
+            "hermes_cli.models.parse_model_input",
+            lambda raw, current: ("anthropic", "claude-sonnet-4-6"),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.models.detect_provider_for_model",
+            lambda model, current: None,
+        )
         manager = SessionManager(db=SessionDB(tmp_path / "state.db"))
 
         with patch("run_agent.AIAgent", side_effect=fake_agent):
@@ -1542,6 +1554,20 @@ class TestSlashCommands:
         monkeypatch.setattr(
             "hermes_cli.runtime_provider.resolve_runtime_provider",
             fake_resolve_runtime_provider,
+        )
+        # Pin the model-string parser independently of the live
+        # ``_KNOWN_PROVIDER_NAMES`` / ``_PROVIDER_ALIASES`` module state.
+        # Otherwise any test in the same xdist worker that mutates those
+        # globals (e.g. registers a custom provider that shadows
+        # ``anthropic``) flakes this one — observed once in CI as
+        # ``'custom' == 'anthropic'``.
+        monkeypatch.setattr(
+            "hermes_cli.models.parse_model_input",
+            lambda raw, current: ("anthropic", "claude-sonnet-4-6"),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.models.detect_provider_for_model",
+            lambda model, current: None,
         )
         manager = SessionManager(db=SessionDB(tmp_path / "state.db"))
 


### PR DESCRIPTION
## Summary
Removes a global-catalog dependency that was making two ACP slash-command tests flake in CI.

Run 26326728502 / job 77505732299 hit `AssertionError: assert 'custom' == 'anthropic'` in `tests/acp/test_server.py::TestSlashCommands::test_model_switch_uses_requested_provider`. The test had only mocked `resolve_runtime_provider` + `load_config` + `AIAgent` — but `_resolve_model_selection` still went through the real `hermes_cli.models.parse_model_input` / `detect_provider_for_model`, which read `_KNOWN_PROVIDER_NAMES` / `_PROVIDER_ALIASES` module state. When something earlier in the same xdist worker mutated that catalog, the parser fell into the wrong branch and returned `custom`.

Per-file isolation in `scripts/run_tests.sh` means it's an in-file test ordering issue, but I couldn't reproduce the specific ordering locally.

## Changes
Both `test_set_session_model_accepts_provider_prefixed_choice` and `test_model_switch_uses_requested_provider` now also monkeypatch:
- `hermes_cli.models.parse_model_input` → `("anthropic", "claude-sonnet-4-6")`
- `hermes_cli.models.detect_provider_for_model` → `None`

This keeps the tests focused on what they were written to verify (the `requested_provider → runtime → AIAgent kwargs` plumbing) without leaning on shared module state that other tests can mutate.

## Validation
`scripts/run_tests.sh tests/acp/test_server.py` → 77/77 passed.