### PR TITLE
fix(security): salvage project-plugin RCE bypass fix from PR #29311 (GHSA-5qr3-c538-wm9j)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4047,6 +4047,43 @@ async def set_dashboard_theme(body: ThemeSetBody):
 # Dashboard plugin system
 # ---------------------------------------------------------------------------
 
+def _safe_plugin_api_relpath(api_field: Any, *, dashboard_dir: Path) -> Optional[str]:
+    """Validate the manifest's ``api`` field for the plugin loader.
+
+    The web server later imports this file as a Python module via
+    ``importlib.util.spec_from_file_location`` (arbitrary code
+    execution by design — that's how plugins extend the backend).
+    Pre-#29156 the field was used as-is, which meant:
+
+    * An absolute path swallowed the plugin's dashboard directory
+      entirely — ``Path('safe/dashboard') / '/tmp/evil.py'`` resolves
+      to ``/tmp/evil.py``, so any attacker-controlled manifest could
+      point the import at any Python file on disk (GHSA-5qr3-c538-wm9j).
+    * A ``../..`` traversal could climb out of the plugin into
+      neighbouring directories on the search path.
+
+    Return the original string when the resolved path stays under
+    ``dashboard_dir``; return ``None`` (with a warning logged at the
+    call site) otherwise so the plugin still loads its static JS/CSS
+    but its backend ``api`` is rejected.
+    """
+    if not isinstance(api_field, str) or not api_field.strip():
+        return None
+    candidate = Path(api_field)
+    if candidate.is_absolute():
+        return None
+    try:
+        resolved = (dashboard_dir / candidate).resolve()
+        base = dashboard_dir.resolve()
+    except (OSError, RuntimeError):
+        return None
+    try:
+        resolved.relative_to(base)
+    except ValueError:
+        return None
+    return api_field
+
+
 def _discover_dashboard_plugins() -> list:
     """Scan plugins/*/dashboard/manifest.json for dashboard extensions.
 
@@ -4113,6 +4150,23 @@ def _discover_dashboard_plugins() -> list:
                 slots: List[str] = []
                 if isinstance(slots_src, list):
                     slots = [s for s in slots_src if isinstance(s, str) and s]
+                # Validate ``api`` at discovery time so the value cached
+                # on the plugin entry is already safe to feed into the
+                # importer.  An attacker-controlled manifest can name
+                # any absolute path or ``..`` traversal here — the
+                # web server then imports that file as a Python module
+                # (RCE, GHSA-5qr3-c538-wm9j).
+                raw_api = data.get("api")
+                dashboard_dir = child / "dashboard"
+                safe_api = _safe_plugin_api_relpath(raw_api, dashboard_dir=dashboard_dir)
+                if raw_api and safe_api is None:
+                    _log.warning(
+                        "Plugin %s: refusing unsafe api path %r (must be a "
+                        "relative file inside the plugin's dashboard/ "
+                        "directory); backend routes from this plugin will "
+                        "not be mounted",
+                        name, raw_api,
+                    )
                 plugins.append({
                     "name": name,
                     "label": data.get("label", name),
@@ -4123,10 +4177,10 @@ def _discover_dashboard_plugins() -> list:
                     "slots": slots,
                     "entry": data.get("entry", "dist/index.js"),
                     "css": data.get("css"),
-                    "has_api": bool(data.get("api")),
+                    "has_api": bool(safe_api),
                     "source": source,
-                    "_dir": str(child / "dashboard"),
-                    "_api_file": data.get("api"),
+                    "_dir": str(dashboard_dir),
+                    "_api_file": safe_api,
                 })
             except Exception as exc:
                 _log.warning("Bad dashboard plugin manifest %s: %s", manifest_file, exc)
@@ -4481,12 +4535,42 @@ def _mount_plugin_api_routes():
     Each plugin's ``api`` field points to a Python file that must expose
     a ``router`` (FastAPI APIRouter).  Routes are mounted under
     ``/api/plugins/<name>/``.
+
+    Backend import is restricted to ``bundled`` and ``user`` sources.
+    Project plugins (``./.hermes/plugins/``) ship with the CWD and are
+    therefore attacker-controlled in any threat model where the user
+    opens a malicious repo; they can extend the dashboard UI via
+    static JS/CSS but their Python ``api`` file is never auto-imported
+    by the web server.  See GHSA-5qr3-c538-wm9j (#29156).
     """
     for plugin in _get_dashboard_plugins():
         api_file_name = plugin.get("_api_file")
         if not api_file_name:
             continue
-        api_path = Path(plugin["_dir"]) / api_file_name
+        if plugin.get("source") == "project":
+            _log.warning(
+                "Plugin %s: ignoring backend api=%s (project plugins may "
+                "not auto-import Python code; move the plugin to "
+                "~/.hermes/plugins/ if you trust it)",
+                plugin["name"], api_file_name,
+            )
+            continue
+        dashboard_dir = Path(plugin["_dir"])
+        api_path = dashboard_dir / api_file_name
+        try:
+            resolved_api = api_path.resolve()
+            resolved_base = dashboard_dir.resolve()
+            resolved_api.relative_to(resolved_base)
+        except (OSError, RuntimeError, ValueError):
+            # Discovery already filters this, but re-check here in case
+            # ``_dir`` was tampered with after caching or a future caller
+            # bypasses the validator.  Defence in depth keeps the import
+            # primitive contained even if the upstream check regresses.
+            _log.warning(
+                "Plugin %s: refusing to import api file outside its "
+                "dashboard directory (%s)", plugin["name"], api_path,
+            )
+            continue
         if not api_path.exists():
             _log.warning("Plugin %s declares api=%s but file not found", plugin["name"], api_file_name)
             continue

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -48,6 +48,7 @@ from hermes_cli.config import (
     redact_key,
 )
 from gateway.status import get_running_pid, read_runtime_status
+from utils import env_var_enabled
 
 try:
     from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
@@ -4064,7 +4065,16 @@ def _discover_dashboard_plugins() -> list:
         (bundled_root / "memory", "bundled"),
         (bundled_root, "bundled"),
     ]
-    if os.environ.get("HERMES_ENABLE_PROJECT_PLUGINS"):
+    # GHSA-5qr3-c538-wm9j (#29156): the previous ``os.environ.get(...)``
+    # check treated *any* non-empty string as truthy, so ``=0``, ``=false``,
+    # and ``=no`` — all of which the agent loader and operators correctly
+    # read as "disabled" — silently *enabled* the untrusted project source
+    # in the web server.  Combined with the absolute-path RCE primitive on
+    # the manifest's ``api`` field (now patched below), this turned the
+    # opt-in into a sticky always-on switch.  Use the shared truthy
+    # semantics (``1`` / ``true`` / ``yes`` / ``on``) so the gate matches
+    # ``hermes_cli/plugins.py`` and the documented user contract.
+    if env_var_enabled("HERMES_ENABLE_PROJECT_PLUGINS"):
         search_dirs.append((Path.cwd() / ".hermes" / "plugins", "project"))
 
     for plugins_root, source in search_dirs:

--- a/tests/hermes_cli/test_project_plugin_rce_bypass.py
+++ b/tests/hermes_cli/test_project_plugin_rce_bypass.py
@@ -1,0 +1,361 @@
+"""Regression coverage for GHSA-5qr3-c538-wm9j (#29156) — Remote Code
+Execution via the ``HERMES_ENABLE_PROJECT_PLUGINS`` bypass in the web
+server's dashboard plugin loader.
+
+Two primitives combined into the original advisory chain:
+
+1. ``hermes_cli.web_server._discover_dashboard_plugins`` opted into
+   the untrusted ``./.hermes/plugins/`` source via
+   ``os.environ.get("HERMES_ENABLE_PROJECT_PLUGINS")`` — truthy for
+   any non-empty string, so ``=0`` / ``=false`` / ``=no`` (all of
+   which the agent loader treats as off, and which operators set to
+   *disable* project plugins) silently *enabled* the source.
+2. ``hermes_cli.web_server._mount_plugin_api_routes`` then imported
+   each plugin's manifest ``api`` field as a Python module via
+   ``importlib.util.spec_from_file_location``.  The field was used
+   raw, with no path-traversal check, so a single manifest line
+   ``{"api": "/tmp/payload.py"}`` was enough to redirect the
+   importer at any Python file on disk (``Path('safe') / '/abs'``
+   resolves to ``/abs`` in Python).
+
+These tests pin each layer of the new defence:
+
+* Truthy env semantics now match the agent loader.
+* ``_safe_plugin_api_relpath`` rejects absolute paths, ``..``
+  traversal, and non-string / empty values.
+* ``_mount_plugin_api_routes`` re-validates at import time and
+  refuses project-source plugins outright.
+* End-to-end the original PoC manifest no longer triggers
+  ``importlib`` for ``/tmp/payload.py``.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import web_server
+
+
+@pytest.fixture(autouse=True)
+def _reset_plugin_cache(monkeypatch):
+    """The plugin scanner caches its result per-process.  Bust the
+    cache before *and* after each test so leakage between tests can't
+    mask a regression — and so the production cache the import-time
+    ``_mount_plugin_api_routes()`` populated doesn't bleed in."""
+    web_server._dashboard_plugins_cache = None
+    yield
+    web_server._dashboard_plugins_cache = None
+
+
+def _write_plugin_manifest(root: Path, name: str, manifest: dict) -> Path:
+    """Drop a manifest under ``root/<name>/dashboard/manifest.json`` and
+    return the dashboard dir path."""
+    dashboard_dir = root / name / "dashboard"
+    dashboard_dir.mkdir(parents=True)
+    (dashboard_dir / "manifest.json").write_text(json.dumps(manifest))
+    return dashboard_dir
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 — HERMES_ENABLE_PROJECT_PLUGINS env gate uses truthy semantics.
+# ---------------------------------------------------------------------------
+
+
+class TestProjectPluginsEnvGate:
+    """Project plugins must only be discovered when the env var is set
+    to a documented truthy value.  Pre-#29156 any non-empty string —
+    including ``0`` / ``false`` / ``no`` — silently enabled the source."""
+
+    @pytest.fixture
+    def project_plugin(self, tmp_path, monkeypatch):
+        """Plant a project-source plugin under CWD's ``.hermes/plugins``
+        and isolate the user-plugins dir to an empty tmp tree."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        (tmp_path / "home").mkdir()
+        cwd = tmp_path / "evil-repo"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        _write_plugin_manifest(
+            cwd / ".hermes" / "plugins",
+            "evil",
+            {
+                "name": "evil",
+                "label": "Evil",
+                "entry": "dist/index.js",
+            },
+        )
+        return cwd
+
+    @pytest.mark.parametrize("value", ["", "0", "false", "FALSE", "no", "off", "False"])
+    def test_falsy_values_keep_project_plugins_disabled(
+        self, project_plugin, monkeypatch, value
+    ):
+        if value == "":
+            monkeypatch.delenv("HERMES_ENABLE_PROJECT_PLUGINS", raising=False)
+        else:
+            monkeypatch.setenv("HERMES_ENABLE_PROJECT_PLUGINS", value)
+
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        names = {p["name"] for p in plugins}
+        assert "evil" not in names, (
+            f"HERMES_ENABLE_PROJECT_PLUGINS={value!r} must NOT enable the "
+            "project source — that's the GHSA-5qr3-c538-wm9j env bypass."
+        )
+
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on", "YES"])
+    def test_truthy_values_enable_project_plugins(
+        self, project_plugin, monkeypatch, value
+    ):
+        monkeypatch.setenv("HERMES_ENABLE_PROJECT_PLUGINS", value)
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        evil = next((p for p in plugins if p["name"] == "evil"), None)
+        assert evil is not None
+        assert evil["source"] == "project"
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — _safe_plugin_api_relpath rejects path-traversal payloads.
+# ---------------------------------------------------------------------------
+
+
+class TestApiPathSanitizer:
+    """Unit-level coverage for the new ``_safe_plugin_api_relpath``
+    helper.  Anything that escapes the plugin's dashboard directory
+    must come back as ``None``."""
+
+    def _dashboard_dir(self, tmp_path):
+        d = tmp_path / "plug" / "dashboard"
+        d.mkdir(parents=True)
+        return d
+
+    def test_simple_relative_path_accepted(self, tmp_path):
+        d = self._dashboard_dir(tmp_path)
+        (d / "api.py").write_text("router = None\n")
+        assert web_server._safe_plugin_api_relpath("api.py", dashboard_dir=d) == "api.py"
+
+    def test_nested_relative_path_accepted(self, tmp_path):
+        d = self._dashboard_dir(tmp_path)
+        (d / "backend").mkdir()
+        (d / "backend" / "routes.py").write_text("router = None\n")
+        out = web_server._safe_plugin_api_relpath(
+            "backend/routes.py", dashboard_dir=d
+        )
+        assert out == "backend/routes.py"
+
+    @pytest.mark.parametrize("payload", [
+        "/etc/passwd",
+        "/tmp/payload.py",
+        "/usr/bin/python",
+        # NT-style absolute on POSIX is a relative path — covered by traversal below.
+    ])
+    def test_absolute_path_rejected(self, tmp_path, payload):
+        d = self._dashboard_dir(tmp_path)
+        assert web_server._safe_plugin_api_relpath(payload, dashboard_dir=d) is None
+
+    @pytest.mark.parametrize("payload", [
+        "../../../etc/passwd",
+        "../neighbour/api.py",
+        "../../../../tmp/evil.py",
+        "subdir/../../../../etc/passwd",
+    ])
+    def test_traversal_rejected(self, tmp_path, payload):
+        d = self._dashboard_dir(tmp_path)
+        assert web_server._safe_plugin_api_relpath(payload, dashboard_dir=d) is None
+
+    @pytest.mark.parametrize("payload", [None, "", "   ", 42, [], {}])
+    def test_non_string_or_empty_rejected(self, tmp_path, payload):
+        d = self._dashboard_dir(tmp_path)
+        assert web_server._safe_plugin_api_relpath(payload, dashboard_dir=d) is None
+
+
+# ---------------------------------------------------------------------------
+# Layer 3 — _discover_dashboard_plugins scrubs ``_api_file`` early.
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoveryScrubsApiField:
+    """The cached plugin entry must NEVER carry an unsanitised api path.
+    A regression here would re-arm the RCE for any caller that uses
+    ``plugin['_api_file']`` directly."""
+
+    @pytest.fixture
+    def user_plugin_factory(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("HERMES_ENABLE_PROJECT_PLUGINS", raising=False)
+
+        def _make(name: str, manifest: dict) -> None:
+            _write_plugin_manifest(tmp_path / "plugins", name, manifest)
+
+        return _make
+
+    def test_absolute_api_path_in_manifest_is_scrubbed(self, user_plugin_factory):
+        user_plugin_factory("evil", {
+            "name": "evil",
+            "label": "Evil",
+            "api": "/tmp/payload.py",
+            "entry": "dist/index.js",
+        })
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        evil = next(p for p in plugins if p["name"] == "evil")
+        assert evil["_api_file"] is None
+        assert evil["has_api"] is False
+
+    def test_traversal_api_path_in_manifest_is_scrubbed(self, user_plugin_factory):
+        user_plugin_factory("traverse", {
+            "name": "traverse",
+            "label": "Traverse",
+            "api": "../../../../tmp/evil.py",
+            "entry": "dist/index.js",
+        })
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        entry = next(p for p in plugins if p["name"] == "traverse")
+        assert entry["_api_file"] is None
+        assert entry["has_api"] is False
+
+    def test_safe_api_path_survives(self, user_plugin_factory, tmp_path):
+        user_plugin_factory("safe", {
+            "name": "safe",
+            "label": "Safe",
+            "api": "api.py",
+            "entry": "dist/index.js",
+        })
+        # Make the api file actually exist so a downstream mount could
+        # in principle proceed — we're only testing the discovery scrub.
+        (tmp_path / "plugins" / "safe" / "dashboard" / "api.py").write_text(
+            "router = None\n"
+        )
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        entry = next(p for p in plugins if p["name"] == "safe")
+        assert entry["_api_file"] == "api.py"
+        assert entry["has_api"] is True
+
+
+# ---------------------------------------------------------------------------
+# Layer 4 — _mount_plugin_api_routes refuses project-source + traversal.
+# ---------------------------------------------------------------------------
+
+
+class TestMountApiRoutesRefusesUntrusted:
+    """The mount routine is the actual ``importlib`` call site — these
+    tests poke synthetic plugin entries directly into the cache and
+    assert the importer is *not* invoked."""
+
+    def _payload_plugin(self, tmp_path, *, source: str, api_file: str = "api.py"):
+        dash = tmp_path / "plug" / "dashboard"
+        dash.mkdir(parents=True)
+        # Write a benign router file; the test asserts it's NOT imported
+        # regardless of whether it exists, since the source/path checks
+        # short-circuit before the importer runs.
+        (dash / "api.py").write_text(
+            "from fastapi import APIRouter\nrouter = APIRouter()\n"
+        )
+        return {
+            "name": "synthetic",
+            "label": "Synthetic",
+            "tab": {"path": "/synthetic", "position": "end"},
+            "slots": [],
+            "entry": "dist/index.js",
+            "css": None,
+            "has_api": True,
+            "source": source,
+            "_dir": str(dash),
+            "_api_file": api_file,
+        }
+
+    def test_project_source_api_is_not_imported(self, tmp_path):
+        plugin = self._payload_plugin(tmp_path, source="project")
+        web_server._dashboard_plugins_cache = [plugin]
+        with patch("importlib.util.spec_from_file_location") as spec:
+            web_server._mount_plugin_api_routes()
+        assert spec.call_count == 0, (
+            "project-source plugin's api file was imported — "
+            "GHSA-5qr3-c538-wm9j defence-in-depth regression"
+        )
+
+    def test_bundled_source_api_imports_normally(self, tmp_path):
+        plugin = self._payload_plugin(tmp_path, source="bundled")
+        web_server._dashboard_plugins_cache = [plugin]
+        with patch("importlib.util.spec_from_file_location") as spec:
+            spec.return_value = None  # loader is None -> early continue, safe
+            web_server._mount_plugin_api_routes()
+        assert spec.call_count == 1
+        # First positional arg after module_name is the resolved api path.
+        called_path = Path(spec.call_args.args[1])
+        assert called_path.name == "api.py"
+        assert called_path.is_absolute()
+
+    def test_traversal_api_caught_at_mount_time(self, tmp_path):
+        """Defence-in-depth: if discovery is bypassed (e.g. cache
+        tampering), mount-time validation still refuses to import a
+        file outside the dashboard dir."""
+        plugin = self._payload_plugin(tmp_path, source="user",
+                                       api_file="../../../tmp/evil.py")
+        web_server._dashboard_plugins_cache = [plugin]
+        with patch("importlib.util.spec_from_file_location") as spec:
+            web_server._mount_plugin_api_routes()
+        assert spec.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Layer 5 — End-to-end: the original PoC manifest no longer triggers RCE.
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEndPocBlocked:
+    """Reproduces the original advisory PoC shape: untrusted CWD with a
+    manifest pointing ``api`` at an attacker-chosen Python file, with
+    ``HERMES_ENABLE_PROJECT_PLUGINS=0`` (so the operator believed the
+    project source was disabled).  Post-fix, the importer must never
+    be invoked for the payload path, regardless of how the bypass is
+    framed (``=0`` truthy-string bypass, absolute path bypass,
+    project-source bypass)."""
+
+    def test_full_chain_blocked(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        (tmp_path / "home").mkdir()
+        cwd = tmp_path / "evil-repo"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        # The original bypass: operator sets the var to a "disabled"
+        # string the web server pre-fix treated as enabled.
+        monkeypatch.setenv("HERMES_ENABLE_PROJECT_PLUGINS", "0")
+        # Payload: absolute path inside a manifest dropped in CWD.
+        payload_py = tmp_path / "payload.py"
+        payload_py.write_text("OWNED = True\n")
+        _write_plugin_manifest(
+            cwd / ".hermes" / "plugins",
+            "evil",
+            {
+                "name": "evil",
+                "label": "Evil",
+                "api": str(payload_py),
+                "entry": "dist/index.js",
+            },
+        )
+
+        with patch("importlib.util.spec_from_file_location") as spec:
+            plugins = web_server._get_dashboard_plugins(force_rescan=True)
+            web_server._mount_plugin_api_routes()
+
+        # The project source must stay disabled because ``0`` is no
+        # longer truthy.  Even if the operator *had* opted in, the
+        # absolute-path api would be scrubbed at discovery, and even
+        # if discovery missed it the project-source guard in mount
+        # would refuse the import.
+        assert "evil" not in {p["name"] for p in plugins}
+        # Bundled plugins shipped with the repo may legitimately have
+        # ``api`` files and so ``spec_from_file_location`` can fire for
+        # those — the regression is specifically that the *payload*
+        # path / *evil* module are never targeted.
+        for call in spec.call_args_list:
+            module_name = call.args[0]
+            target = Path(call.args[1])
+            assert module_name != "hermes_dashboard_plugin_evil"
+            assert target != payload_py
+            assert "evil-repo" not in target.parts
+        assert "hermes_dashboard_plugin_evil" not in sys.modules

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -542,7 +542,7 @@ Advanced per-platform knobs for throttling the outbound message batcher. Most us
 | `HERMES_AGENT_NOTIFY_INTERVAL` | Gateway: interval in seconds between progress notifications on long-running agent turns. |
 | `HERMES_CHECKPOINT_TIMEOUT` | Timeout for filesystem checkpoint creation in seconds (default: `30`). |
 | `HERMES_EXEC_ASK` | Enable execution approval prompts in gateway mode (`true`/`false`) |
-| `HERMES_ENABLE_PROJECT_PLUGINS` | Enable auto-discovery of repo-local plugins from `./.hermes/plugins/` (`true`/`false`, default: `false`) |
+| `HERMES_ENABLE_PROJECT_PLUGINS` | Enable auto-discovery of repo-local plugins from `./.hermes/plugins/` for both the agent loader and the dashboard web server. Accepts the standard truthy set: `1` / `true` / `yes` / `on` (case-insensitive). Everything else — including `0`, `false`, `no`, `off`, and the empty string — is treated as **disabled** (default). Note: as of GHSA-5qr3-c538-wm9j (#29156) the dashboard web server refuses to auto-import a project plugin's Python `api` file even when this var is enabled — project plugins may extend the UI via static JS/CSS but their backend routes are only loaded when moved under `~/.hermes/plugins/`. |
 | `HERMES_PLUGINS_DEBUG` | `1`/`true` to surface verbose plugin-discovery logs on stderr — directories scanned, manifests parsed, skip reasons, and full tracebacks on parse or `register()` failure. Aimed at plugin authors. |
 | `HERMES_BACKGROUND_NOTIFICATIONS` | Background process notification mode in gateway: `all` (default), `result`, `error`, `off` |
 | `HERMES_EPHEMERAL_SYSTEM_PROMPT` | Ephemeral system prompt injected at API-call time (never persisted to sessions) |


### PR DESCRIPTION
Salvage of PR #29311 from @xxxigm onto current main (the original branch was 665 commits behind and could not merge cleanly).

Closes the project-plugin RCE chain in `hermes_cli/web_server.py` (advisory GHSA-5qr3-c538-wm9j, tracked publicly as #29156).

## What was wrong

Two primitives chained together:

1. **Truthy-string env gate.** `_discover_dashboard_plugins()` opted into the untrusted `./.hermes/plugins/` source via `if os.environ.get("HERMES_ENABLE_PROJECT_PLUGINS"):` — truthy for *any* non-empty string. Setting the var to `0`, `false`, `no`, or `off` (every documented "disabled" form, and what the agent loader at `hermes_cli/plugins.py` correctly reads as off via `env_var_enabled()`) silently *enabled* the project source in the web server.

2. **Absolute-path RCE in the manifest `api` field.** `_mount_plugin_api_routes()` then imported each plugin's `api` field as a Python module via `importlib.util.spec_from_file_location`. The field was used raw with no traversal check — and because `Path('safe/dashboard') / '/tmp/payload.py'` resolves to `/tmp/payload.py` in Python, a single manifest line `{"api": "/tmp/payload.py"}` was enough to redirect the importer at any Python file on disk.

## What changed

- `_discover_dashboard_plugins()` now uses the shared `utils.env_var_enabled()` — same semantics as the agent loader.
- New `_safe_plugin_api_relpath()` validator rejects absolute paths, `..` traversal, and non-string `api` values at discovery time.
- `_mount_plugin_api_routes()` refuses project-source plugins outright. Project plugins can still ship UI (static JS/CSS) but their backend Python is never auto-imported by the dashboard web server.
- 361-line regression suite (`tests/hermes_cli/test_project_plugin_rce_bypass.py`) covering all four layers + end-to-end PoC.
- `HERMES_ENABLE_PROJECT_PLUGINS` doc string updated to call out the contract.

## Validation

`scripts/run_tests.sh tests/hermes_cli/test_project_plugin_rce_bypass.py` — 35/35 passing.

E2E (separate from the test file) verified against current main:
- All falsy env values (`false`/`0`/`no`/`off`/`FALSE`) → project plugins disabled (was: silently enabled)
- All truthy env values (`1`/`true`/`yes`/`on`) → enabled (unchanged)
- `api` field with absolute path → BLOCKED
- `api` field with `../../../..` traversal → BLOCKED
- Legitimate `api: api.py` / `api: backend/routes.py` → ACCEPTED
- Full PoC chain (malicious cwd + `=0` opt-out) → evil plugin not discovered

## Credit

Cherry-picked from PR #29311. All four commits preserve @xxxigm's authorship.

Fixes #29156