### PR TITLE
fix(memory-setup): validate required schema fields, abort wizard if blank

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -52,6 +52,32 @@ def _prompt(label: str, default: str | None = None, secret: bool = False) -> str
     return val or (default or "")
 
 
+# Hard cap on re-prompt attempts; protects non-tty / piped-stdin runs from
+# spinning forever when stdin is exhausted.
+_REQUIRED_RETRIES = 2
+
+
+def _prompt_field(
+    field: dict, label: str, default: str | None = None, secret: bool = False
+) -> tuple[str, bool]:
+    """Prompt for a schema field; re-prompt blank input when ``required: True``.
+
+    Returns ``(value, aborted)``. ``aborted`` is True when the field is
+    required and stayed blank after all attempts — the caller should stop
+    the wizard without persisting partial state.
+    """
+    val = _prompt(label, default=default, secret=secret)
+    if val or not field.get("required"):
+        return val, False
+    for _ in range(_REQUIRED_RETRIES):
+        print(f"  ⚠ '{field.get('key', '')}' is required.")
+        val = _prompt(label, default=default, secret=secret)
+        if val:
+            return val, False
+    print(f"\n  Missing required field '{field.get('key', '')}'; setup aborted.\n")
+    return "", True
+
+
 # ---------------------------------------------------------------------------
 # Provider discovery
 # ---------------------------------------------------------------------------
@@ -324,7 +350,13 @@ def cmd_setup(args) -> None:
                 # Regular text prompt
                 current = provider_config.get(key)
                 effective_default = current or default
-                val = _prompt(desc, default=str(effective_default) if effective_default else None)
+                val, aborted = _prompt_field(
+                    field,
+                    desc,
+                    default=str(effective_default) if effective_default else None,
+                )
+                if aborted:
+                    return
                 if val:
                     provider_config[key] = val
                     # Also write to .env if this field has an env_var

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -337,13 +337,17 @@ def cmd_setup(args) -> None:
                 # Prompt for secret
                 existing = os.environ.get(env_var, "") if env_var else ""
                 if existing:
+                    # An existing value already satisfies "required"; blank
+                    # input intentionally keeps it.
                     masked = f"...{existing[-4:]}" if len(existing) > 4 else "set"
                     val = _prompt(f"{desc} (current: {masked}, blank to keep)", secret=True)
                 else:
                     hint = f"  Get yours at {url}" if url else ""
                     if hint:
                         print(hint)
-                    val = _prompt(desc, secret=True)
+                    val, aborted = _prompt_field(field, desc, secret=True)
+                    if aborted:
+                        return
                 if val and env_var:
                     env_writes[env_var] = val
             else:

--- a/tests/hermes_cli/test_memory_setup_required.py
+++ b/tests/hermes_cli/test_memory_setup_required.py
@@ -1,0 +1,143 @@
+"""Regression tests for `hermes memory setup` required-field validation.
+
+Pins the contract from issue #30821: when a schema field is marked
+``required: True``, the wizard MUST NOT silently accept blank input and
+write ``memory.provider`` anyway.
+
+Covers:
+- `_prompt_field` behavior in isolation (default/required/non-required).
+- `cmd_setup` integration — the wizard aborts without persisting
+  ``memory.provider`` when the user keeps hitting Enter on a required
+  field with no default.
+"""
+
+from __future__ import annotations
+
+import io
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import memory_setup
+
+
+def _feed_stdin(monkeypatch, lines):
+    """Replace stdin with a StringIO of the given lines."""
+    monkeypatch.setattr(memory_setup.sys, "stdin", io.StringIO("\n".join(lines) + "\n"))
+
+
+# ── _prompt_field unit tests ───────────────────────────────────────────────
+
+class TestPromptField:
+    def test_returns_typed_value_for_optional_field(self, monkeypatch, capsys):
+        _feed_stdin(monkeypatch, ["my-value"])
+        val, aborted = memory_setup._prompt_field({"key": "x"}, "Label")
+        assert (val, aborted) == ("my-value", False)
+
+    def test_returns_blank_for_optional_blank_input(self, monkeypatch, capsys):
+        _feed_stdin(monkeypatch, [""])
+        val, aborted = memory_setup._prompt_field({"key": "x"}, "Label")
+        assert (val, aborted) == ("", False)
+
+    def test_required_blank_then_value_returns_value(self, monkeypatch, capsys):
+        _feed_stdin(monkeypatch, ["", "second-try"])
+        val, aborted = memory_setup._prompt_field(
+            {"key": "api_key", "required": True}, "API key"
+        )
+        assert (val, aborted) == ("second-try", False)
+        out = capsys.readouterr().out
+        assert "'api_key' is required" in out
+
+    def test_required_all_blank_aborts(self, monkeypatch, capsys):
+        _feed_stdin(monkeypatch, [""] * (memory_setup._REQUIRED_RETRIES + 1))
+        val, aborted = memory_setup._prompt_field(
+            {"key": "api_key", "required": True}, "API key"
+        )
+        assert (val, aborted) == ("", True)
+        out = capsys.readouterr().out
+        assert "Missing required field 'api_key'" in out
+        assert "setup aborted" in out
+
+    def test_required_with_default_accepts_blank(self, monkeypatch, capsys):
+        _feed_stdin(monkeypatch, [""])
+        val, aborted = memory_setup._prompt_field(
+            {"key": "base_url", "required": True}, "Base URL", default="https://x"
+        )
+        assert (val, aborted) == ("https://x", False)
+
+
+# ── cmd_setup integration ──────────────────────────────────────────────────
+
+class _FakeProvider:
+    """Minimal stand-in for a memory provider plugin."""
+
+    def __init__(self, schema):
+        self._schema = schema
+        self.saved = None
+
+    def get_config_schema(self):
+        return list(self._schema)
+
+    def save_config(self, cfg, hermes_home):
+        self.saved = (dict(cfg), hermes_home)
+
+
+@pytest.fixture
+def setup_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    (tmp_path / ".hermes").mkdir(parents=True, exist_ok=True)
+    state = {"loaded": {}, "saved": None}
+
+    def fake_load_config():
+        return state["loaded"]
+
+    def fake_save_config(c):
+        state["saved"] = dict(c)
+
+    monkeypatch.setattr("hermes_cli.config.load_config", fake_load_config)
+    monkeypatch.setattr("hermes_cli.config.save_config", fake_save_config)
+    monkeypatch.setattr(memory_setup, "_install_dependencies", lambda *_a, **_kw: None)
+    monkeypatch.setattr(memory_setup, "_curses_select", lambda *_a, **_kw: 0)
+    return state
+
+
+class TestCmdSetupRequired:
+    def test_blank_required_field_aborts_without_writing_provider(
+        self, setup_env, monkeypatch, capsys
+    ):
+        provider = _FakeProvider(
+            [{"key": "DB_PATH", "description": "path", "required": True}]
+        )
+        monkeypatch.setattr(
+            memory_setup,
+            "_get_available_providers",
+            lambda: [("fake", "local", provider)],
+        )
+        _feed_stdin(monkeypatch, [""] * (memory_setup._REQUIRED_RETRIES + 1))
+
+        memory_setup.cmd_setup(args=None)
+
+        assert setup_env["saved"] is None
+        assert provider.saved is None
+        out = capsys.readouterr().out
+        assert "Missing required field 'DB_PATH'" in out
+
+    def test_filled_required_field_writes_provider(
+        self, setup_env, monkeypatch, capsys
+    ):
+        provider = _FakeProvider(
+            [{"key": "DB_PATH", "description": "path", "required": True}]
+        )
+        monkeypatch.setattr(
+            memory_setup,
+            "_get_available_providers",
+            lambda: [("fake", "local", provider)],
+        )
+        _feed_stdin(monkeypatch, ["/tmp/db"])
+
+        memory_setup.cmd_setup(args=None)
+
+        assert setup_env["saved"] == {"memory": {"provider": "fake"}}
+        assert provider.saved is not None
+        saved_cfg, _ = provider.saved
+        assert saved_cfg == {"DB_PATH": "/tmp/db"}


### PR DESCRIPTION
## What does this PR do?

Fixes the `hermes memory setup` wizard so it no longer silently accepts blank input on schema fields marked `required: True`. Per issue #30821, the wizard at `hermes_cli/memory_setup.py:323-332` (Hermes Agent v0.14.0) collected the value, hit `if val:` (skipped on empty), and still wrote `memory.provider` to `config.yaml` — the provider then failed at first use with no "this field is required" feedback to the user.

This PR:

- Adds a small `_prompt_field(field, label, ...)` helper that re-prompts blank input up to `_REQUIRED_RETRIES` (=2) extra times when `field["required"]` is `True`, and then aborts cleanly with `Missing required field '<key>'; setup aborted.` — without writing `memory.provider`.
- Routes the **non-secret regular text branch** through `_prompt_field`.
- Routes the **secret branch's no-existing-env-var path** through `_prompt_field` too (the symmetric bug — empty input was silently dropped). The "blank to keep" path stays untouched because the existing env value already satisfies `required: True`.
- The helper has a hard retry cap so non-tty / piped-stdin runs (CI, scripts) can't spin forever when stdin is exhausted.

## Related Issue

Fixes NousResearch/hermes-agent#30821.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/memory_setup.py`
  - New `_prompt_field` helper + `_REQUIRED_RETRIES` cap (~20 lines).
  - Non-secret text branch in `cmd_setup` calls `_prompt_field` and `return`s early on abort.
  - Secret branch's no-existing-env-var path mirrored to `_prompt_field` with the same abort semantics.
  - The `existing` (`blank to keep`) secret path is left alone — existing values already satisfy `required: True`.
- `tests/hermes_cli/test_memory_setup_required.py` — 7 new test cases:
  - `TestPromptField` — 5 cases: optional blank, optional value, required blank-then-value, required all-blank aborts, required-with-default accepts blank.
  - `TestCmdSetupRequired` — 2 integration cases: blank required field aborts the wizard without writing `memory.provider`; filled required field writes `memory.provider` and the provider's native config.

Three commits, all `xxxigm <tuancanhnguyen706@gmail.com>`:

```
667817ed6 test(memory-setup): cover required-field validation paths
de2e37d99 fix(memory-setup): apply required-field validation to secret prompts
8ee8ec622 fix(memory-setup): re-prompt blank required fields, abort if still empty
```

## How to Test

1. Check out this branch and ensure `.venv` is set up: `python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[all,dev]"`
2. Run the new tests on their own:
   ```
   scripts/run_tests.sh tests/hermes_cli/test_memory_setup_required.py
   ```
   Expected: 7 passed.
3. Run alongside the existing memory-setup-adjacent suite to confirm no cross-file regressions:
   ```
   scripts/run_tests.sh tests/hermes_cli/test_memory_setup_required.py tests/hermes_cli/test_memory_reset.py
   ```
   Expected: 16 passed.
4. Manual repro from the issue, with the patch applied:
   - `hermes memory setup`, pick a provider whose schema has a `required: True` field with no `default`.
   - Press Enter on that prompt. The wizard now prints `⚠ '<key>' is required.` and re-prompts; after `_REQUIRED_RETRIES` more blanks it prints `Missing required field '<key>'; setup aborted.` and exits without writing `memory.provider`.
   - `hermes memory status` confirms no provider was activated.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(memory-setup): …`, `test(memory-setup): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/hermes_cli/test_memory_setup_required.py` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the new helper is documented in its own docstring; no user-facing docs change is needed since the wizard's contract (per `required: True`) already implied this behavior.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — fix uses only `sys.stdin` / `print`, same primitives the wizard already used; tests are hermetic (`StringIO` stdin, `tmp_path`, `monkeypatch`).
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool schema change)

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/hermes_cli/test_memory_setup_required.py
[100.0% |     7/7 | ✓7 | ✗0] ✓ tests/hermes_cli/test_memory_setup_required.py (7✓, 0.3s)
=== Summary: 1 files, 7 tests passed, 0 failed (100% complete) in 0.3s (24 workers) ===

$ scripts/run_tests.sh tests/hermes_cli/test_memory_setup_required.py tests/hermes_cli/test_memory_reset.py
[100.0% |    16/16 | ✓16 | ✗ 0]
=== Summary: 2 files, 16 tests passed, 0 failed (100% complete) in 0.4s (24 workers) ===
```
