### PR TITLE
fix(qqbot): salvage 4 fixes from #27944 (intent, op 7/9, filename, SILK)

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -705,9 +705,8 @@ class QQAdapter(BasePlatformAdapter):
                 "token": f"QQBot {token}",
                 "intents": (1 << 25)
                            | (1 << 30)
-                           | (
-                                   1 << 12
-                           ),  # C2C_GROUP_AT_MESSAGES + PUBLIC_GUILD_MESSAGES + DIRECT_MESSAGE
+                           | (1 << 12)
+                           | (1 << 26),  # C2C_GROUP_AT_MESSAGES + PUBLIC_GUILD_MESSAGES + DIRECT_MESSAGE + INTERACTION
                 "shard": [0, 1],
                 "properties": {
                     "$os": "macOS",
@@ -1620,11 +1619,15 @@ class QQAdapter(BasePlatformAdapter):
                 except Exception as exc:
                     logger.debug("[%s] Failed to cache image: %s", self._log_tag, exc)
             else:
-                # Other attachments (video, file, etc.): record as text.
+                # Other attachments (video, file, etc.): download and record with path.
                 try:
                     cached_path = await self._download_and_cache(url, ct)
                     if cached_path:
-                        other_attachments.append(f"[Attachment: {filename or ct}]")
+                        name = filename or ct
+                        if ct.startswith("video/"):
+                            other_attachments.append(f"[video: {name} ({cached_path})]")
+                        else:
+                            other_attachments.append(f"[file: {name} ({cached_path})]")
                 except Exception as exc:
                     logger.debug("[%s] Failed to cache attachment: %s", self._log_tag, exc)
 

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1942,7 +1942,7 @@ class QQAdapter(BasePlatformAdapter):
     @staticmethod
     def _guess_ext_from_data(data: bytes) -> str:
         """Guess file extension from magic bytes."""
-        if data[:9] == b"#!SILK_V3" or data[:5] == b"#!SILK":
+        if data[:9] == b"#!SILK_V3" or data[:6] == b"#!SILK":
             return ".silk"
         if data[:2] == b"\x02!":
             return ".silk"
@@ -1962,7 +1962,7 @@ class QQAdapter(BasePlatformAdapter):
     @staticmethod
     def _looks_like_silk(data: bytes) -> bool:
         """Check if bytes look like a SILK audio file."""
-        return data[:4] == b"#!SILK" or data[:2] == b"\x02!" or data[:9] == b"#!SILK_V3"
+        return data[:6] == b"#!SILK" or data[:2] == b"\x02!" or data[:9] == b"#!SILK_V3"
 
     async def _convert_silk_to_wav(self, src_path: str, wav_path: str) -> Optional[str]:
         """Convert audio file to WAV using the pilk library.

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1654,7 +1654,7 @@ class QQAdapter(BasePlatformAdapter):
             elif ct.startswith("image/"):
                 # Image: download and cache locally.
                 try:
-                    cached_path = await self._download_and_cache(url, ct)
+                    cached_path = await self._download_and_cache(url, ct, filename)
                     if cached_path and os.path.isfile(cached_path):
                         image_urls.append(cached_path)
                         image_media_types.append(ct or "image/jpeg")
@@ -1669,7 +1669,7 @@ class QQAdapter(BasePlatformAdapter):
             else:
                 # Other attachments (video, file, etc.): download and record with path.
                 try:
-                    cached_path = await self._download_and_cache(url, ct)
+                    cached_path = await self._download_and_cache(url, ct, filename)
                     if cached_path:
                         name = filename or ct
                         if ct.startswith("video/"):
@@ -1687,8 +1687,14 @@ class QQAdapter(BasePlatformAdapter):
             "attachment_info": attachment_info,
         }
 
-    async def _download_and_cache(self, url: str, content_type: str) -> Optional[str]:
-        """Download a URL and cache it locally."""
+    async def _download_and_cache(
+            self, url: str, content_type: str, original_name: str = "",
+    ) -> Optional[str]:
+        """Download a URL and cache it locally.
+
+        :param original_name: Preferred filename from attachment metadata.
+            Falls back to the URL path basename if empty.
+        """
         from tools.url_safety import is_safe_url
 
         if not is_safe_url(url):
@@ -1719,7 +1725,11 @@ class QQAdapter(BasePlatformAdapter):
             # Convert to .wav using ffmpeg so STT engines can process it.
             return await self._convert_audio_to_wav(data, url)
         else:
-            filename = Path(urlparse(url).path).name or "qq_attachment"
+            filename = (
+                original_name
+                or Path(urlparse(url).path).name
+                or "qq_attachment"
+            )
             return cache_document_from_bytes(data, filename)
 
     @staticmethod

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -534,9 +534,30 @@ class QQAdapter(BasePlatformAdapter):
                 self._mark_transport_disconnected()
                 self._fail_pending("Connection closed")
 
-                # Stop reconnecting for fatal codes
-                if code in {4914, 4915}:
-                    desc = "offline/sandbox-only" if code == 4914 else "banned"
+                # Stop reconnecting for fatal codes (unrecoverable errors)
+                if code in {
+                        4001,  # Invalid opcode
+                        4002,  # Invalid payload
+                        4010,  # Invalid shard
+                        4011,  # Sharding required
+                        4012,  # Invalid API version
+                        4013,  # Invalid intent
+                        4014,  # Intent not authorized
+                        4914,  # Offline/sandbox-only
+                        4915,  # Banned
+                }:
+                    fatal_descriptions = {
+                        4001: "invalid opcode",
+                        4002: "invalid payload",
+                        4010: "invalid shard",
+                        4011: "sharding required",
+                        4012: "invalid API version",
+                        4013: "invalid intent",
+                        4014: "intent not authorized",
+                        4914: "offline/sandbox-only",
+                        4915: "banned",
+                    }
+                    desc = fatal_descriptions.get(code, f"fatal error (code={code})")
                     logger.error(
                         "[%s] Bot is %s. Check QQ Open Platform.", self._log_tag, desc
                     )
@@ -573,10 +594,11 @@ class QQAdapter(BasePlatformAdapter):
                     self._token_expires_at = 0.0
 
                 # Session invalid → clear session, will re-identify on next Hello
+                # Note: 4009 (connection timeout) is NOT included here — it is
+                # resumable per the QQ protocol and should preserve session state.
                 if code in {
                         4006,
                         4007,
-                        4009,
                         4900,
                         4901,
                         4902,
@@ -823,6 +845,32 @@ class QQAdapter(BasePlatformAdapter):
 
         # op 11 = Heartbeat ACK
         if op == 11:
+            return
+
+        # op 7 = Server Reconnect — server asks client to reconnect (e.g.
+        # load-balancing, maintenance).  Close the WS so _read_events raises
+        # and the outer loop triggers a reconnect with Resume.
+        if op == 7:
+            logger.info("[%s] Server requested reconnect (op 7)", self._log_tag)
+            if self._ws and not self._ws.closed:
+                self._create_task(self._ws.close())
+            return
+
+        # op 9 = Invalid Session — d=True means session is resumable,
+        # d=False means we must re-identify from scratch.
+        if op == 9:
+            resumable = bool(d) if d is not None else False
+            if not resumable:
+                logger.info(
+                    "[%s] Invalid session (op 9, not resumable), clearing session",
+                    self._log_tag,
+                )
+                self._session_id = None
+                self._last_seq = None
+            else:
+                logger.info("[%s] Invalid session (op 9, resumable)", self._log_tag)
+            if self._ws and not self._ws.closed:
+                self._create_task(self._ws.close())
             return
 
         logger.debug("[%s] Unknown op: %s", self._log_tag, op)

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1810,3 +1810,207 @@ class TestSendUpdatePrompt:
 
         adapter.send_with_keyboard = fake_swk  # type: ignore[assignment]
         await adapter.send_update_prompt(chat_id="u", prompt="ok?")
+
+
+# ---------------------------------------------------------------------------
+# _send_identify includes INTERACTION intent
+# ---------------------------------------------------------------------------
+
+class TestIdentifyIntents:
+    """Verify the WebSocket identify payload includes the INTERACTION intent bit."""
+
+    def _make_adapter(self):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b"))
+
+    @pytest.mark.asyncio
+    async def test_intents_include_interaction_bit(self):
+        adapter = self._make_adapter()
+
+        # Mock token retrieval and WebSocket
+        adapter._access_token = "fake_token"
+        adapter._token_expires_at = 9999999999.0
+
+        sent_payloads = []
+
+        class FakeWS:
+            closed = False
+
+            async def send_json(self, payload):
+                sent_payloads.append(payload)
+
+        adapter._ws = FakeWS()
+        await adapter._send_identify()
+
+        assert len(sent_payloads) == 1
+        intents = sent_payloads[0]["d"]["intents"]
+
+        # Verify all expected intent bits are present
+        assert intents & (1 << 25), "GROUP_MESSAGES (1<<25) missing"
+        assert intents & (1 << 30), "GUILD_AT_MESSAGE (1<<30) missing"
+        assert intents & (1 << 12), "DIRECT_MESSAGES (1<<12) missing"
+        assert intents & (1 << 26), "INTERACTION (1<<26) missing"
+
+
+# ---------------------------------------------------------------------------
+# _process_attachments: video/file path exposure
+# ---------------------------------------------------------------------------
+
+class TestProcessAttachmentsPathExposure:
+    """Verify that video and file attachments include the cached local path."""
+
+    def _make_adapter(self):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b"))
+
+    @pytest.mark.asyncio
+    async def test_video_attachment_includes_path(self):
+        adapter = self._make_adapter()
+
+        # Mock _download_and_cache to return a known path
+        async def fake_download(url, ct):
+            return "/tmp/cache/video_abc123.mp4"
+
+        adapter._download_and_cache = fake_download  # type: ignore[assignment]
+
+        attachments = [
+            {
+                "content_type": "video/mp4",
+                "url": "https://multimedia.nt.qq.com.cn/download/video123",
+                "filename": "my_video.mp4",
+            }
+        ]
+        result = await adapter._process_attachments(attachments)
+
+        assert result["image_urls"] == []
+        assert result["voice_transcripts"] == []
+        info = result["attachment_info"]
+        assert "[video:" in info
+        assert "my_video.mp4" in info
+        assert "/tmp/cache/video_abc123.mp4" in info
+
+    @pytest.mark.asyncio
+    async def test_file_attachment_includes_path(self):
+        adapter = self._make_adapter()
+
+        async def fake_download(url, ct):
+            return "/tmp/cache/doc_abc123_report.pdf"
+
+        adapter._download_and_cache = fake_download  # type: ignore[assignment]
+
+        attachments = [
+            {
+                "content_type": "application/pdf",
+                "url": "https://multimedia.nt.qq.com.cn/download/file456",
+                "filename": "report.pdf",
+            }
+        ]
+        result = await adapter._process_attachments(attachments)
+
+        info = result["attachment_info"]
+        assert "[file:" in info
+        assert "report.pdf" in info
+        assert "/tmp/cache/doc_abc123_report.pdf" in info
+
+    @pytest.mark.asyncio
+    async def test_video_without_filename_falls_back_to_content_type(self):
+        adapter = self._make_adapter()
+
+        async def fake_download(url, ct):
+            return "/tmp/cache/video_xyz.mp4"
+
+        adapter._download_and_cache = fake_download  # type: ignore[assignment]
+
+        attachments = [
+            {
+                "content_type": "video/mp4",
+                "url": "https://cdn.qq.com/vid",
+                "filename": "",
+            }
+        ]
+        result = await adapter._process_attachments(attachments)
+
+        info = result["attachment_info"]
+        assert "[video: video/mp4" in info
+        assert "/tmp/cache/video_xyz.mp4" in info
+
+    @pytest.mark.asyncio
+    async def test_download_failure_produces_no_attachment_info(self):
+        adapter = self._make_adapter()
+
+        async def fake_download(url, ct):
+            return None
+
+        adapter._download_and_cache = fake_download  # type: ignore[assignment]
+
+        attachments = [
+            {
+                "content_type": "video/mp4",
+                "url": "https://cdn.qq.com/vid",
+                "filename": "vid.mp4",
+            }
+        ]
+        result = await adapter._process_attachments(attachments)
+        assert result["attachment_info"] == ""
+
+    @pytest.mark.asyncio
+    async def test_quoted_video_includes_path_in_quote_block(self):
+        """Quoted video attachments should surface the cached path in the quote block."""
+        adapter = self._make_adapter()
+
+        async def fake_process(atts):
+            # Simulate the fixed _process_attachments for a video attachment.
+            return {
+                "image_urls": [],
+                "image_media_types": [],
+                "voice_transcripts": [],
+                "attachment_info": "[video: clip.mp4 (/tmp/cache/clip.mp4)]",
+            }
+
+        adapter._process_attachments = fake_process  # type: ignore[assignment]
+
+        d = {
+            "message_type": 103,
+            "msg_elements": [{
+                "content": "看看这个视频",
+                "attachments": [
+                    {"content_type": "video/mp4",
+                     "url": "https://qq-cdn/clip.mp4",
+                     "filename": "clip.mp4"}
+                ],
+            }],
+        }
+        out = await adapter._process_quoted_context(d)
+        assert "[Quoted message]:" in out["quote_block"]
+        assert "/tmp/cache/clip.mp4" in out["quote_block"]
+
+    @pytest.mark.asyncio
+    async def test_quoted_file_includes_path_in_quote_block(self):
+        """Quoted file attachments should surface the cached path in the quote block."""
+        adapter = self._make_adapter()
+
+        async def fake_process(atts):
+            return {
+                "image_urls": [],
+                "image_media_types": [],
+                "voice_transcripts": [],
+                "attachment_info": "[file: report.pdf (/tmp/cache/report.pdf)]",
+            }
+
+        adapter._process_attachments = fake_process  # type: ignore[assignment]
+
+        d = {
+            "message_type": 103,
+            "msg_elements": [{
+                "content": "",
+                "attachments": [
+                    {"content_type": "application/pdf",
+                     "url": "https://qq-cdn/report.pdf",
+                     "filename": "report.pdf"}
+                ],
+            }],
+        }
+        out = await adapter._process_quoted_context(d)
+        assert "[Quoted message]:" in out["quote_block"]
+        assert "/tmp/cache/report.pdf" in out["quote_block"]
+

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1868,7 +1868,7 @@ class TestProcessAttachmentsPathExposure:
         adapter = self._make_adapter()
 
         # Mock _download_and_cache to return a known path
-        async def fake_download(url, ct):
+        async def fake_download(url, ct, original_name=""):
             return "/tmp/cache/video_abc123.mp4"
 
         adapter._download_and_cache = fake_download  # type: ignore[assignment]
@@ -1893,7 +1893,7 @@ class TestProcessAttachmentsPathExposure:
     async def test_file_attachment_includes_path(self):
         adapter = self._make_adapter()
 
-        async def fake_download(url, ct):
+        async def fake_download(url, ct, original_name=""):
             return "/tmp/cache/doc_abc123_report.pdf"
 
         adapter._download_and_cache = fake_download  # type: ignore[assignment]
@@ -1916,7 +1916,7 @@ class TestProcessAttachmentsPathExposure:
     async def test_video_without_filename_falls_back_to_content_type(self):
         adapter = self._make_adapter()
 
-        async def fake_download(url, ct):
+        async def fake_download(url, ct, original_name=""):
             return "/tmp/cache/video_xyz.mp4"
 
         adapter._download_and_cache = fake_download  # type: ignore[assignment]
@@ -1938,7 +1938,7 @@ class TestProcessAttachmentsPathExposure:
     async def test_download_failure_produces_no_attachment_info(self):
         adapter = self._make_adapter()
 
-        async def fake_download(url, ct):
+        async def fake_download(url, ct, original_name=""):
             return None
 
         adapter._download_and_cache = fake_download  # type: ignore[assignment]

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -2014,3 +2014,161 @@ class TestProcessAttachmentsPathExposure:
         assert "[Quoted message]:" in out["quote_block"]
         assert "/tmp/cache/report.pdf" in out["quote_block"]
 
+
+# ---------------------------------------------------------------------------
+# WebSocket op 7 (Server Reconnect) and op 9 (Invalid Session)
+# ---------------------------------------------------------------------------
+
+class TestOp7ServerReconnect:
+    """Verify op 7 triggers WS close (which triggers reconnect in outer loop)."""
+
+    def _make_adapter(self):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b"))
+
+    def test_op7_closes_websocket(self):
+        adapter = self._make_adapter()
+        adapter._session_id = "sess_keep"
+        adapter._last_seq = 42
+
+        close_called = []
+
+        class FakeWS:
+            closed = False
+
+            async def close(self):
+                close_called.append(True)
+
+        adapter._ws = FakeWS()
+        adapter._dispatch_payload({"op": 7, "d": None})
+
+        # Session should be preserved for Resume
+        assert adapter._session_id == "sess_keep"
+        assert adapter._last_seq == 42
+        # close() should have been scheduled
+        assert len(close_called) == 0  # _create_task schedules, not immediate
+        # But the task was created — verify via asyncio
+
+    @pytest.mark.asyncio
+    async def test_op7_close_task_executes(self):
+        adapter = self._make_adapter()
+        close_called = []
+
+        class FakeWS:
+            closed = False
+
+            async def close(self):
+                close_called.append(True)
+                self.closed = True
+
+        adapter._ws = FakeWS()
+        adapter._dispatch_payload({"op": 7, "d": None})
+
+        # Let the event loop run the scheduled task
+        await asyncio.sleep(0)
+        assert close_called == [True]
+        # Session preserved
+        assert adapter._session_id is None  # was never set
+
+
+class TestOp9InvalidSession:
+    """Verify op 9 handles resumable vs non-resumable sessions."""
+
+    def _make_adapter(self):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b"))
+
+    def test_op9_not_resumable_clears_session(self):
+        adapter = self._make_adapter()
+        adapter._session_id = "sess_old"
+        adapter._last_seq = 99
+
+        class FakeWS:
+            closed = False
+
+            async def close(self):
+                self.closed = True
+
+        adapter._ws = FakeWS()
+        adapter._dispatch_payload({"op": 9, "d": False})
+
+        assert adapter._session_id is None
+        assert adapter._last_seq is None
+
+    def test_op9_resumable_preserves_session(self):
+        adapter = self._make_adapter()
+        adapter._session_id = "sess_keep"
+        adapter._last_seq = 99
+
+        class FakeWS:
+            closed = False
+
+            async def close(self):
+                self.closed = True
+
+        adapter._ws = FakeWS()
+        adapter._dispatch_payload({"op": 9, "d": True})
+
+        # Session should be preserved for Resume
+        assert adapter._session_id == "sess_keep"
+        assert adapter._last_seq == 99
+
+    @pytest.mark.asyncio
+    async def test_op9_non_resumable_triggers_ws_close(self):
+        adapter = self._make_adapter()
+        adapter._session_id = "s"
+        adapter._last_seq = 1
+        close_called = []
+
+        class FakeWS:
+            closed = False
+
+            async def close(self):
+                close_called.append(True)
+                self.closed = True
+
+        adapter._ws = FakeWS()
+        adapter._dispatch_payload({"op": 9, "d": False})
+        await asyncio.sleep(0)
+
+        assert close_called == [True]
+
+
+# ---------------------------------------------------------------------------
+# Close code classification
+# ---------------------------------------------------------------------------
+
+class TestCloseCodeClassification:
+    """Verify fatal close codes stop reconnecting and 4009 preserves session."""
+
+    def _make_adapter(self):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b"))
+
+    def test_4009_preserves_session(self):
+        """4009 (connection timeout) should NOT clear the session."""
+        adapter = self._make_adapter()
+        adapter._session_id = "sess_to_keep"
+        adapter._last_seq = 50
+
+        # The session-clearing codes set should NOT contain 4009.
+        # We verify the logic directly: dispatch a close-code event that
+        # exercises the session-clearing path (4006), then verify 4009 does not.
+        session_clear_codes = {
+            4006, 4007, 4900, 4901, 4902, 4903,
+            4904, 4905, 4906, 4907, 4908, 4909,
+            4910, 4911, 4912, 4913,
+        }
+        assert 4009 not in session_clear_codes
+
+    def test_fatal_codes_include_intent_errors(self):
+        """4013 (invalid intent) and 4014 (not authorized) should be fatal."""
+        fatal_codes = {4001, 4002, 4010, 4011, 4012, 4013, 4014, 4914, 4915}
+        # Verify these are all treated as fatal by checking the adapter's
+        # code path would call _set_fatal_error. We verify the set membership
+        # which is what the if-branch checks.
+        assert 4013 in fatal_codes
+        assert 4014 in fatal_codes
+        assert 4001 in fatal_codes
+        assert 4915 in fatal_codes
+


### PR DESCRIPTION
## Summary

Salvages 4 of 5 commits from #27944 (@WideLee, commits by walli@tencent.com) onto current main. Deferred the 5th commit — a ~255-line WS-thread architecture rewrite + media send support — for separate review with live testing.

## Changes (cherry-picked)

- **INTERACTION intent (`1 << 26`)** — `_send_identify()` was missing the INTERACTION bit, so QQ gateway never dispatched `INTERACTION_CREATE` and approval button clicks were silently lost.
- **Video/file path exposure** — `_process_attachments()` now formats non-image/voice attachments as `[video: name (path)]` / `[file: name (path)]` instead of opaque `[Attachment: name]`, so the LLM can reference local paths for send-back.
- **WS op 7 / op 9** — op 7 (Server Reconnect) closes the WS to trigger reconnect with Resume; op 9 (Invalid Session) checks `d` to pick Resume vs re-Identify. Both were previously ignored.
- **Close code classification** — 4009 (connection timeout) removed from session-clearing set (resumable per QQ protocol); 4001/4002/4010-4014 added to fatal set.
- **Original filename** — `_download_and_cache()` accepts `original_name`, prefers attachment metadata `filename` over the CDN URL hash basename.
- **SILK magic byte slice** — `data[:5]`/`data[:4]` → `data[:6]` so the 6-byte `b"#!SILK"` literal can actually match.

## Deferred (not included)

Commit `310cd3e3b` "dedicated WS thread + heartbeat restart + media send support" — moves WS lifecycle to a dedicated daemon thread with its own asyncio loop, switches `_token_lock` from `asyncio.Lock` to `threading.Lock`, adds sync httpx variants, dispatches inbound messages via `run_coroutine_threadsafe`. Substantial concurrency rewrite that supersedes #28167 (8199ec380, magic524's "keep QQBot reconnect loop alive" fix). Wants live gateway validation before merge.

## Validation

| | Result |
|---|---|
| `pytest tests/gateway/test_qqbot.py` | 158 passed |
| Authorship | walli (preserved via cherry-pick; in AUTHOR_MAP) |
| Conflicts | Auto-merged (no manual resolution needed) |

Original PR: #27944



## Infographic

![qqbot-salvage](https://v3b.fal.media/files/b/0a9b5852/e2qANOMe9wt4GD2Za_tY__euZzhjeZ.png)
