### PR TITLE
test(kanban): allow tmp_path artifacts past media-delivery validator

### DIFF
--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -17,6 +17,11 @@ def kanban_home(tmp_path, monkeypatch):
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    # Allow the kanban notifier path-validator to upload artifacts the
+    # tests write under ``tmp_path``. Without this, every artifact-delivery
+    # test silently drops files because ``tmp_path`` isn't inside the
+    # default ``MEDIA_DELIVERY_SAFE_ROOTS`` cache dirs.
+    monkeypatch.setenv("HERMES_MEDIA_ALLOW_DIRS", str(tmp_path))
     kb.init_db()
     return home
 


### PR DESCRIPTION
## Summary
Fixes two tests broken on main by #41d2c758c ("Fix unsafe gateway media path delivery").

That PR tightened `validate_media_delivery_path` so artifacts must live inside `MEDIA_DELIVERY_SAFE_ROOTS` or a path operator-allowlisted via `HERMES_MEDIA_ALLOW_DIRS`. Two kanban-notifier tests put their PDFs/PNGs under pytest's `tmp_path`, which is correctly rejected — they started failing on main immediately after that merge:

```
FAILED tests/hermes_cli/test_kanban_notify.py::test_notifier_uploads_artifacts_on_completion
FAILED tests/hermes_cli/test_kanban_notify.py::test_notifier_artifact_delivery_skips_missing_files
```

The validator is correct — the tests were relying on the looser pre-fix behaviour.

## Changes
Add `monkeypatch.setenv("HERMES_MEDIA_ALLOW_DIRS", str(tmp_path))` to the `kanban_home` fixture so artifacts under `tmp_path` pass the validator. Same mechanism the operator-facing env var documents.

## Validation
`scripts/run_tests.sh tests/hermes_cli/test_kanban_notify.py` → 12/12 passed (was 10 passed, 2 failed on main).