### PR TITLE
fix(tests): allowlist tmp_path for kanban_notify artifact delivery tests

### DIFF
--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -482,7 +482,7 @@ async def test_gateway_create_autosubscribes_on_explicit_board(kanban_home):
 
 
 @pytest.mark.asyncio
-async def test_notifier_uploads_artifacts_on_completion(kanban_home, tmp_path):
+async def test_notifier_uploads_artifacts_on_completion(kanban_home, tmp_path, monkeypatch):
     """When a completed event carries ``artifacts`` in its payload, the
     notifier uploads each file to the subscribed chat as a native
     attachment. Images batch through send_multiple_images; documents
@@ -493,6 +493,13 @@ async def test_notifier_uploads_artifacts_on_completion(kanban_home, tmp_path):
     from gateway.run import GatewayRunner
     from gateway.config import Platform
     from tools import kanban_tools as kt
+
+    # ``_deliver_kanban_artifacts`` routes candidates through
+    # ``BasePlatformAdapter.filter_local_delivery_paths``, which only accepts
+    # paths under ``MEDIA_DELIVERY_SAFE_ROOTS`` or roots explicitly allowlisted
+    # via ``HERMES_MEDIA_ALLOW_DIRS``. Test fixtures live under ``tmp_path``,
+    # so allowlist it for the duration of the test.
+    monkeypatch.setenv("HERMES_MEDIA_ALLOW_DIRS", str(tmp_path))
 
     # Materialize real files so os.path.isfile passes inside the helper.
     chart_path = tmp_path / "q3-revenue.png"
@@ -572,7 +579,7 @@ async def test_notifier_uploads_artifacts_on_completion(kanban_home, tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_notifier_artifact_delivery_skips_missing_files(kanban_home, tmp_path):
+async def test_notifier_artifact_delivery_skips_missing_files(kanban_home, tmp_path, monkeypatch):
     """Missing artifact paths are silently skipped — they may have been
     referenced by name only. The notifier must not crash and must still
     deliver any artifacts that do exist."""
@@ -580,6 +587,10 @@ async def test_notifier_artifact_delivery_skips_missing_files(kanban_home, tmp_p
     from gateway.run import GatewayRunner
     from gateway.config import Platform
     from tools import kanban_tools as kt
+
+    # Allow ``tmp_path`` through the media-delivery safety filter. See the
+    # companion test for the full explanation.
+    monkeypatch.setenv("HERMES_MEDIA_ALLOW_DIRS", str(tmp_path))
 
     real_pdf = tmp_path / "real.pdf"
     real_pdf.write_bytes(b"%PDF-fake")


### PR DESCRIPTION
## Summary
Restores test (6) to green on main — fixes two failures introduced by commit `41d2c758c` ("Fix unsafe gateway media path delivery").

That commit added `BasePlatformAdapter.filter_local_delivery_paths` inside `_deliver_kanban_artifacts`, which rejects paths outside `MEDIA_DELIVERY_SAFE_ROOTS`. The two artifact-delivery tests create fixtures under `pytest`'s `tmp_path`, which lives outside those roots — so under CI's hermetic HOME the filter silently dropped both fake PNG/PDF artifacts and the `images_uploaded` / `documents_uploaded` assertions failed.

Production behaviour is unchanged. This is a test-only fix.

## Changes
- `tests/hermes_cli/test_kanban_notify.py`: monkeypatch `HERMES_MEDIA_ALLOW_DIRS=str(tmp_path)` in both tests so the safety filter accepts the fixtures. Added explanatory comments pointing at the upstream wiring.

## Validation
```
HOME=/tmp/hermes-clean-ci python3 -m pytest tests/hermes_cli/test_kanban_notify.py -v
12 passed in 0.36s
```

Repro of the failure on `origin/main` (clean env): both
`test_notifier_uploads_artifacts_on_completion` and
`test_notifier_artifact_delivery_skips_missing_files` fail with
`WARNING gateway.platforms.base:base.py:2228 Skipping unsafe local file path outside allowed roots` followed by empty `images_uploaded` / `documents_uploaded`.