### PR TITLE
fix: validate model catalog schema version bounds

### DIFF
--- a/hermes_cli/model_catalog.py
+++ b/hermes_cli/model_catalog.py
@@ -144,7 +144,14 @@ def _validate_manifest(data: Any) -> bool:
     if not isinstance(data, dict):
         return False
     version = data.get("version")
-    if not isinstance(version, int) or version > SUPPORTED_SCHEMA_VERSION:
+    # Reject bool explicitly: ``isinstance(True, int)`` is True in Python, so
+    # without this check a manifest with ``version: true`` would slip through.
+    if (
+        not isinstance(version, int)
+        or isinstance(version, bool)
+        or version < 1
+        or version > SUPPORTED_SCHEMA_VERSION
+    ):
         # Future schema version we don't understand — refuse rather than
         # guess. Older schemas (version < 1) aren't supported either.
         return False

--- a/tests/hermes_cli/test_model_catalog.py
+++ b/tests/hermes_cli/test_model_catalog.py
@@ -75,6 +75,23 @@ class TestValidation:
         m["version"] = 999
         assert _validate_manifest(m) is False
 
+    def test_rejects_pre_v1_version(self, isolated_home):
+        from hermes_cli.model_catalog import _validate_manifest
+        m = _valid_manifest()
+        m["version"] = 0
+        assert _validate_manifest(m) is False
+        m["version"] = -1
+        assert _validate_manifest(m) is False
+
+    def test_rejects_bool_version(self, isolated_home):
+        # ``isinstance(True, int)`` is True in Python — explicit guard
+        # prevents a YAML manifest with ``version: true`` from slipping
+        # through and being treated as version 1.
+        from hermes_cli.model_catalog import _validate_manifest
+        m = _valid_manifest()
+        m["version"] = True
+        assert _validate_manifest(m) is False
+
     def test_rejects_missing_providers(self, isolated_home):
         from hermes_cli.model_catalog import _validate_manifest
         m = _valid_manifest()


### PR DESCRIPTION
## Summary
- reject model catalog manifests with schema versions below 1
- reject boolean schema versions explicitly (`bool` is an `int` subclass in Python)
- add regression tests for pre-v1 and boolean versions

## Test Plan
- `python -m pytest tests/hermes_cli/test_model_catalog.py::TestValidation -v -o 'addopts='`
- `python -m pytest tests/hermes_cli/test_model_catalog.py -q -o 'addopts='`
- `ruff check hermes_cli/model_catalog.py tests/hermes_cli/test_model_catalog.py`
