### PR TITLE
fix(gateway-windows): atomic write for .cmd and startup launcher scripts

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -365,7 +365,9 @@ def _write_task_script() -> Path:
 
     content = _build_gateway_cmd_script(python_path, working_dir, hermes_home, profile_arg)
     script_path = get_task_script_path()
-    script_path.write_text(content, encoding="utf-8", newline="")
+    tmp = script_path.with_suffix(".tmp")
+    tmp.write_text(content, encoding="utf-8", newline="")
+    tmp.replace(script_path)
     return script_path
 
 
@@ -436,7 +438,9 @@ def _install_startup_entry(script_path: Path) -> Path:
     """Write the Startup-folder fallback launcher. Returns its path."""
     entry = get_startup_entry_path()
     entry.parent.mkdir(parents=True, exist_ok=True)
-    entry.write_text(_build_startup_launcher(script_path), encoding="utf-8", newline="")
+    tmp = entry.with_suffix(".tmp")
+    tmp.write_text(_build_startup_launcher(script_path), encoding="utf-8", newline="")
+    tmp.replace(entry)
     return entry
 
 


### PR DESCRIPTION
Salvages #30435 onto current main.

Windows scheduled-task `.cmd` and Startup-folder launcher now write via temp file + atomic rename, so a crash/kill mid-write can no longer leave a truncated script that silently fails on next login.

## Changes
- `hermes_cli/gateway_windows.py`: `_write_task_script()` and `_install_startup_entry()` switch from direct `write_text()` to `with_suffix('.tmp')` + `tmp.replace()`, matching the pattern already used in `hermes_cli/profiles.py`, `hermes_cli/webhook.py`, and several gateway adapters.

Authorship preserved via cherry-pick (@sprmn24).

Closes #30435


## Infographic

![atomic-write-windows-gateway](https://v3b.fal.media/files/b/0a9b5864/tljgKR1nW3FybyZM6k5mv_VdNQhlNV.png)
