### PR TITLE
fix(agent): log warning when fallback model normalization fails instead of silently swallowing

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -776,8 +776,11 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             from hermes_cli.model_normalize import normalize_model_for_provider
 
             fb_model = normalize_model_for_provider(fb_model, fb_provider)
-        except Exception:
-            pass
+        except Exception as _norm_err:
+            logger.warning(
+                "Could not normalize fallback model %r for provider %r: %s",
+                fb_model, fb_provider, _norm_err,
+            )
 
         # Determine api_mode from provider / base URL / model
         fb_api_mode = "chat_completions"


### PR DESCRIPTION
Salvage of #30439 by @sprmn24 onto current main.

## Summary
Replace bare `except Exception: pass` around `normalize_model_for_provider()` in the fallback-activation path with a `logger.warning(model, provider, err)` — so when fallback normalization fails for strict-identifier providers (Anthropic canonical names, Bedrock ARNs, regional variants), the failure is diagnosable instead of silent.

## Changes
- `agent/chat_completion_helpers.py:779` — bare `except Exception: pass` → `logger.warning(...)`. `logger` already exists at module scope (line 64). Behavior preserved (still swallows + continues with raw model); only adds a log line.

## Validation
- `py_compile` clean
- Diff is exactly the contributor's 5/-2

Closes #30439. Authorship preserved via rebase-merge.

## Infographic

![silent-fallback-fix](https://v3b.fal.media/files/b/0a9b5838/fuNFaXFHkQIX-ZtcBh0qF_WSRbUFpJ.png)
