### PR TITLE
fix(agent): use atomic_json_write for request debug dumps instead of bare write_text

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1064,10 +1064,7 @@ def dump_api_request_debug(
 
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
         dump_file = agent.logs_dir / f"request_dump_{agent.session_id}_{timestamp}.json"
-        dump_file.write_text(
-            json.dumps(dump_payload, ensure_ascii=False, indent=2, default=str),
-            encoding="utf-8",
-        )
+        atomic_json_write(dump_file, dump_payload, default=str)
 
         agent._vprint(f"{agent.log_prefix}🧾 Request debug dump written to: {dump_file}")
 


### PR DESCRIPTION
## Summary
Crash mid-write no longer corrupts the API request debug dump — the file post-mortem analysis most depends on.

## Changes
- `agent/agent_runtime_helpers.py`: `dump_file.write_text(json.dumps(...))` → `atomic_json_write(dump_file, dump_payload, default=str)` (import was already there, unused)

## Validation
| | Before | After |
|---|---|---|
| Mid-write crash | partial file | previous file intact via temp+fsync+rename |
| Payload with datetime/custom objects | serialized via `default=str` | preserved via `default=str` forwarded through `**dump_kwargs` |

`default=str` is load-bearing: `body` is a deepcopy of `api_kwargs` and routinely holds datetime / httpx Response / custom objects. Without it the inner try raises TypeError and the whole dump is silently dropped — strictly worse than the partial-write being fixed.

E2E verified: real-world payload with datetime + custom class serializes correctly, no leftover temp files.

Salvage of #30602 (@sprmn24). Cherry-picked their commit onto current main, added `default=str` to preserve original serialization behavior.



## Infographic

![atomic-debug-dumps](https://v3b.fal.media/files/b/0a9b5865/nge1cuSUPq8ylOY9p3881_YawYGyVO.png)
