### PR TITLE
fix(test): allow tmp_path in kanban notify artifact delivery tests

### DIFF
--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -16,6 +16,9 @@ def kanban_home(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
+    # tmp_path must be in the media-delivery allow list so that artifact
+    # files created by tests pass validate_media_delivery_path().
+    monkeypatch.setenv("HERMES_MEDIA_ALLOW_DIRS", str(tmp_path))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb.init_db()
     return home


### PR DESCRIPTION
## Problem

Two tests in `test_kanban_notify.py` fail on current main:

- `test_notifier_uploads_artifacts_on_completion`
- `test_notifier_artifact_delivery_skips_missing_files`

Both assert that artifact files are uploaded, but get 0 uploads instead.

## Root Cause

Commit 41d2c758c ("Fix unsafe gateway media path delivery") added `validate_media_delivery_path()` which only allows files under hermes-managed cache dirs or `HERMES_MEDIA_ALLOW_DIRS`. The two tests create artifacts in `tmp_path`, which is outside those roots, so `filter_local_delivery_paths` silently drops them.

## Fix

Add `HERMES_MEDIA_ALLOW_DIRS=tmp_path` via monkeypatch in the `kanban_home` fixture so test-created files pass the safety check.

## How to Test

```bash
python -m pytest tests/hermes_cli/test_kanban_notify.py
```