### PR TITLE
fix(webhook): enforce INSECURE_NO_AUTH safety rail on dynamic route reloads

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -326,6 +326,17 @@ class WebhookAdapter(BasePlatformAdapter):
                         _INSECURE_NO_AUTH,
                     )
                     continue
+                if (
+                    effective_secret == _INSECURE_NO_AUTH
+                    and not _is_loopback_host(self._host)
+                ):
+                    logger.warning(
+                        "[webhook] Dynamic route '%s' skipped: INSECURE_NO_AUTH "
+                        "is only allowed on loopback hosts. Current host: '%s'.",
+                        k,
+                        self._host,
+                    )
+                    continue
                 new_dynamic[k] = v
             self._dynamic_routes = new_dynamic
             self._routes = {**self._dynamic_routes, **self._static_routes}

--- a/tests/gateway/test_webhook_dynamic_routes.py
+++ b/tests/gateway/test_webhook_dynamic_routes.py
@@ -138,9 +138,19 @@ class TestDynamicRouteSecretValidation:
         (tmp_path / _DYNAMIC_ROUTES_FILENAME).write_text(
             json.dumps({"test": {"secret": _INSECURE_NO_AUTH, "prompt": "p"}})
         )
-        adapter = _make_adapter()
+        adapter = _make_adapter(extra={"host": "127.0.0.1"})
         adapter._reload_dynamic_routes()
         assert "test" in adapter._routes
+
+    def test_insecure_no_auth_rejected_on_non_loopback_bind(self, tmp_path):
+        # Dynamic INSECURE_NO_AUTH routes are only valid on loopback hosts.
+        (tmp_path / _DYNAMIC_ROUTES_FILENAME).write_text(
+            json.dumps({"pub": {"secret": _INSECURE_NO_AUTH, "prompt": "p"}})
+        )
+        adapter = _make_adapter(extra={"host": "0.0.0.0"})
+        adapter._reload_dynamic_routes()
+        assert "pub" not in adapter._routes
+        assert "pub" not in adapter._dynamic_routes
 
     def test_warning_logged_on_skip(self, tmp_path, caplog):
         import logging


### PR DESCRIPTION
Salvage of #30429 by @Zyrixtrex onto current main.

Closes the hot-reload gap where dynamic routes from `dynamic_subscriptions.json` could ship `INSECURE_NO_AUTH` on a non-loopback host, bypassing the startup safety rail in `connect()`. `_reload_dynamic_routes()` now applies the same loopback check and skips offending routes with a warning.

## Validation
- tests/gateway/test_webhook_dynamic_routes.py: 13/13 pass

Original PR: #30429


## Infographic

![webhook-insecure-no-auth-dyn-route-rail](https://v3b.fal.media/files/b/0a9b5897/rO5kc8vwBHgof2sPNePay_qdHQvFsm.png)
