### PR TITLE
fix(skills_guard): match documented --force behavior; medium/low findings = safe (salvage of #3256)

### DIFF
--- a/tests/tools/test_skills_guard.py
+++ b/tests/tools/test_skills_guard.py
@@ -152,6 +152,31 @@ class TestShouldAllowInstall:
         )
         assert allowed is False
         assert "Blocked" in reason
+        # Error message MUST explain why --force didn't work, not invite a retry.
+        assert "does not override" in reason
+        assert "Use --force to override" not in reason
+
+    def test_force_does_not_override_dangerous_for_trusted_message(self):
+        f = [Finding("x", "critical", "c", "f", 1, "m", "d")]
+        allowed, reason = should_allow_install(
+            self._result("trusted", "dangerous", f), force=True
+        )
+        assert allowed is False
+        assert "does not override" in reason
+        assert "Use --force to override" not in reason
+
+    def test_non_dangerous_block_keeps_force_hint(self):
+        # When --force CAN override the block, the error message must still
+        # point to it. Use builtin trust + dangerous to land in the block
+        # branch without triggering the dangerous-specific message.
+        f = [Finding("x", "high", "network", "f", 1, "m", "d")]
+        # Construct a path where decision == block but verdict != dangerous.
+        # community + caution = block per current INSTALL_POLICY.
+        allowed, reason = should_allow_install(
+            self._result("community", "caution", f), force=False
+        )
+        assert allowed is False
+        assert "Use --force to override" in reason
 
     def test_force_does_not_override_dangerous_for_trusted(self):
         f = [Finding("x", "critical", "c", "f", 1, "m", "d")]

--- a/tests/tools/test_skills_guard.py
+++ b/tests/tools/test_skills_guard.py
@@ -84,13 +84,13 @@ class TestDetermineVerdict:
         f = Finding("x", "high", "network", "f.py", 1, "m", "d")
         assert _determine_verdict([f]) == "caution"
 
-    def test_medium_finding_caution(self):
+    def test_medium_finding_safe(self):
         f = Finding("x", "medium", "structural", "f.py", 1, "m", "d")
-        assert _determine_verdict([f]) == "caution"
+        assert _determine_verdict([f]) == "safe"
 
-    def test_low_finding_caution(self):
+    def test_low_finding_safe(self):
         f = Finding("x", "low", "obfuscation", "f.py", 1, "m", "d")
-        assert _determine_verdict([f]) == "caution"
+        assert _determine_verdict([f]) == "safe"
 
 
 # ---------------------------------------------------------------------------
@@ -145,21 +145,21 @@ class TestShouldAllowInstall:
         allowed, _ = should_allow_install(self._result("community", "dangerous", f), force=False)
         assert allowed is False
 
-    def test_force_overrides_dangerous_for_community(self):
+    def test_force_does_not_override_dangerous_for_community(self):
         f = [Finding("x", "critical", "c", "f", 1, "m", "d")]
         allowed, reason = should_allow_install(
             self._result("community", "dangerous", f), force=True
         )
-        assert allowed is True
-        assert "Force-installed" in reason
+        assert allowed is False
+        assert "Blocked" in reason
 
-    def test_force_overrides_dangerous_for_trusted(self):
+    def test_force_does_not_override_dangerous_for_trusted(self):
         f = [Finding("x", "critical", "c", "f", 1, "m", "d")]
         allowed, reason = should_allow_install(
             self._result("trusted", "dangerous", f), force=True
         )
-        assert allowed is True
-        assert "Force-installed" in reason
+        assert allowed is False
+        assert "Blocked" in reason
 
     # -- agent-created policy --
 

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -661,7 +661,7 @@ def should_allow_install(result: ScanResult, force: bool = False) -> Tuple[bool,
     if decision == "allow":
         return True, f"Allowed ({result.trust_level} source, {result.verdict} verdict)"
 
-    if force:
+    if force and result.verdict != "dangerous":
         return True, (
             f"Force-installed despite {result.verdict} verdict "
             f"({len(result.findings)} findings)"
@@ -932,7 +932,8 @@ def _determine_verdict(findings: List[Finding]) -> str:
         return "dangerous"
     if has_high:
         return "caution"
-    return "caution"
+    # medium/low findings alone are informational, not blocking
+    return "safe"
 
 
 def _build_summary(name: str, source: str, trust: str, verdict: str, findings: List[Finding]) -> str:

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -661,7 +661,7 @@ def should_allow_install(result: ScanResult, force: bool = False) -> Tuple[bool,
     if decision == "allow":
         return True, f"Allowed ({result.trust_level} source, {result.verdict} verdict)"
 
-    if force and result.verdict != "dangerous":
+    if force and not (result.verdict == "dangerous" and result.trust_level in ("community", "trusted")):
         return True, (
             f"Force-installed despite {result.verdict} verdict "
             f"({len(result.findings)} findings)"

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -674,6 +674,13 @@ def should_allow_install(result: ScanResult, force: bool = False) -> Tuple[bool,
             f"{len(result.findings)} findings)"
         )
 
+    # Dangerous verdicts cannot be overridden by --force (community/trusted);
+    # other blocks can.
+    if result.verdict == "dangerous" and result.trust_level in ("community", "trusted"):
+        return False, (
+            f"Blocked ({result.trust_level} source + dangerous verdict, "
+            f"{len(result.findings)} findings). --force does not override a dangerous verdict."
+        )
     return False, (
         f"Blocked ({result.trust_level} source + {result.verdict} verdict, "
         f"{len(result.findings)} findings). Use --force to override."


### PR DESCRIPTION
Salvage of @sprmn24's PR #3256 (6,397 commits behind main, couldn't merge cleanly).

Closes two correctness bugs in `tools/skills_guard.py` where the implementation contradicted the public docs (`website/docs/user-guide/features/skills.md#security-scanning-and---force`).

## Bug 1 — `_determine_verdict()` never returned `safe` for medium/low findings

The fallback return at the end of `_determine_verdict()` was `"caution"` instead of `"safe"`. Any skill with only medium or low severity findings — `../../` path notation, unpinned `pip install`, string reversal — was classified as `caution`, which for community sources = blocked. Users had to use `--force` to install benign skills.

Fix: medium/low only → `safe`. Critical → `dangerous` and high → `caution` are unchanged.

## Bug 2 — `--force` overrode `dangerous` verdicts, contradicting docs

Docs explicitly state:
> `--force` does **not** override a `dangerous` scan verdict.

Code did the opposite — `should_allow_install()` had a bare `if force: return True` that bypassed verdict checks entirely. A user (or LLM) calling `--force` could install a skill flagged with critical findings: reverse shells, credential dumpers, etc.

Fix: `--force` is now skipped when verdict == `dangerous` and trust_level ∈ {community, trusted}. Caution/high blocks remain overridable as documented.

## Follow-up commit on top (one extra commit, ours)

The previous block-message ended in "Use `--force` to override" regardless of verdict — but after the Bug 2 fix, dangerous community/trusted skills can't be `--force`'d at all. The hint sent users in a retry loop. Replace it with a specific message: "`--force` does not override a dangerous verdict." Plus two regression tests covering the new message shape and one pinning the existing `--force` hint for non-dangerous blocks.

## Validation

`scripts/run_tests.sh tests/tools/test_skills_guard.py` — 57/57 passing (was 55; +2 new tests).

E2E verified: medium/low findings now return `safe`; `--force` on dangerous community/trusted is rejected with the new message; `--force` on caution blocks still works.

## Credit

Cherry-picked from PR #3256, @sprmn24's authorship preserved on the two contributor commits. Error-message hardening and additional tests are our follow-up commit.

Not a security advisory — Skills Guard is in-process heuristics per SECURITY.md §2.4, not a security boundary. This is a correctness fix: code now matches the documented behavior.