### PR TITLE
ci(nix): auth api.github.com fetches to avoid transitive 401s

### DIFF
--- a/.github/actions/nix-setup/action.yml
+++ b/.github/actions/nix-setup/action.yml
@@ -11,6 +11,13 @@ runs:
   using: composite
   steps:
     - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+      with:
+        # Authenticate api.github.com tarball fetches so transitive flake inputs
+        # (e.g. nix-community/pyproject.nix pinned via uv2nix/build-system-pkgs)
+        # don't hit anonymous 401/rate-limit errors. GITHUB_TOKEN is auto-issued
+        # per workflow run and scoped read-only for fork PRs.
+        extra-conf: |
+          access-tokens = github.com=${{ github.token }}
     - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
       with:
         name: hermes-agent


### PR DESCRIPTION
## Summary
Nix workflow stops failing with 401 on transitive flake input fetches.

## Root cause
`flake.lock` pins `pyproject-nix` (singular, transitive) to `nix-community/pyproject.nix` via `uv2nix` and `build-system-pkgs`. CI's `nix flake check` fetches that tarball from `api.github.com` anonymously and intermittently gets 401-ed:

```
error: unable to download 'https://api.github.com/repos/nix-community/pyproject.nix/tarball/...': HTTP error 401
```

Our direct `pyproject-nix` input already points to the new `pyproject-nix/pyproject.nix` org, but the transitive pin still hits the old path.

## Changes
- `.github/actions/nix-setup/action.yml`: pass `access-tokens = github.com=${{ github.token }}` to the installer's `extra-conf`.

## Why this is safe
- `GITHUB_TOKEN` is auto-issued per workflow run, scoped to this repo, expires when the job ends.
- Already available to every step via `${{ github.token }}` — passing it to nix.conf adds no new exposure.
- Actions masks the value in logs automatically.
- Fork PRs get a read-only token; reads of public repos still work, so the fix applies to them too.
- DeterminateSystems' `nix-installer-action` documents `extra-conf` as the supported way to set this.

## Alternative considered
Forcing `uv2nix` / `build-system-pkgs` transitive `pyproject-nix` to follow our direct input via `inputs.X.inputs.pyproject-nix.follows = "pyproject-nix"`. Narrower fix but only patches this one transitive pin; the auth approach also covers any future input that hits api.github.com rate limits.

Flagging for nix-side review before merge.