### PR TITLE
test(fast-command): stub _load_gateway_runtime_config too

### DIFF
--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -148,6 +148,15 @@ async def test_run_agent_passes_priority_processing_to_gateway_agent(monkeypatch
     monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
     monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
     monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    # ``_load_service_tier`` was refactored to call ``_load_gateway_runtime_config``
+    # (which wraps ``_load_gateway_config`` plus env-expansion).  Since the test
+    # stubs ``_load_gateway_config`` to ``{}``, also stub the runtime wrapper
+    # directly so the priority routing assertions still exercise the live tier.
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_runtime_config",
+        lambda: {"agent": {"service_tier": "fast"}},
+    )
     monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
     monkeypatch.setattr(
         gateway_run,


### PR DESCRIPTION
## Summary
Fixes `test_run_agent_passes_priority_processing_to_gateway_agent` broken on main by PR 2362cc468.

That PR refactored `_load_service_tier` to read config via the new `_load_gateway_runtime_config` wrapper instead of opening `_hermes_home/config.yaml` directly. The test still only stubs the INNER `_load_gateway_config` to `{}`, so the wrapper sees an empty config and returns None — priority routing never kicks in.

```
FAILED tests/gateway/test_fast_command.py::test_run_agent_passes_priority_processing_to_gateway_agent
 - AssertionError: assert None == 'priority'
```

## Changes
Also stub `_load_gateway_runtime_config` to return `{'agent': {'service_tier': 'fast'}}` so the priority routing assertions actually exercise the live tier.

## Validation
- Reproduces on current main: 3 passed, 1 failed
- With fix: 4/4 passed via `scripts/run_tests.sh tests/gateway/test_fast_command.py`