### PR TITLE
docs: surface Nous Portal on pages where it solves a real problem the page describes

### DIFF
--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -109,6 +109,16 @@ hermes config set     # Set individual config values
 hermes setup          # Or run the full setup wizard to configure everything at once
 ```
 
+:::tip Fastest path: Nous Portal
+One subscription covers 300+ models plus the [Tool Gateway](/docs/user-guide/features/tool-gateway) (web search, image generation, TTS, cloud browser). Skip the per-tool key juggling:
+
+```bash
+hermes setup --portal
+```
+
+That logs you in, sets Nous as your provider, and turns on the Tool Gateway in one command.
+:::
+
 ---
 
 ## Prerequisites

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -148,7 +148,7 @@ Even when using Nous Portal, Codex, or a custom endpoint, some tools (vision, we
 :::
 
 :::tip Nous Tool Gateway
-Paid Nous Portal subscribers also get access to the **[Tool Gateway](/docs/user-guide/features/tool-gateway)** — web search, image generation, TTS, and browser automation routed through your subscription. No extra API keys needed. It's offered automatically during `hermes model` setup, or enable it later with `hermes tools`.
+Paid Nous Portal subscribers also get access to the **[Tool Gateway](/docs/user-guide/features/tool-gateway)** — web search, image generation, TTS, and browser automation routed through your subscription. No extra API keys needed. On a fresh install, `hermes setup --portal` logs you in, sets Nous as your provider, and turns the gateway on in one command. Existing users can enable it from `hermes model` or per-tool from `hermes tools`. Inspect routing at any time with `hermes portal status`.
 :::
 
 ### Two Commands for Model Management
@@ -164,7 +164,12 @@ If you're trying to switch to a provider you haven't set up yet (e.g. you only h
 
 ### Nous Portal
 
-Subscription-based access to Hermes-4 models (`Hermes-4-70B`, `Hermes-4.3-36B`, `Hermes-4-405B`) via Nous Research's portal. Run `hermes model`, pick **Nous Portal**, sign in through the browser — Hermes stores a long-lived refresh token at `~/.hermes/auth.json`.
+Subscription-based access to Hermes-4 models (`Hermes-4-70B`, `Hermes-4.3-36B`, `Hermes-4-405B`) via Nous Research's portal. Two paths:
+
+- **Fresh install:** `hermes setup --portal` — runs OAuth, sets Nous as your provider, and offers the [Tool Gateway](/docs/user-guide/features/tool-gateway) in one command.
+- **Existing install:** `hermes model`, pick **Nous Portal**, sign in through the browser.
+
+Either path stores a long-lived refresh token at `~/.hermes/auth.json`. Check status with `hermes portal status`.
 
 The refresh token is also shared across profiles via a shared token store, so logging in on one profile carries over to the others.
 

--- a/website/docs/user-guide/configuring-models.md
+++ b/website/docs/user-guide/configuring-models.md
@@ -11,6 +11,10 @@ Hermes uses two kinds of model slots:
 
 This page covers configuring both from the dashboard. If you prefer config files or the CLI, jump to [Alternative methods](#alternative-methods) at the bottom.
 
+:::tip Fastest path: Nous Portal
+[Nous Portal](/docs/user-guide/features/tool-gateway) provides 300+ models under one subscription. On a fresh install, run `hermes setup --portal` to log in and set Nous as your provider in one command. Inspect what's wired up with `hermes portal status`.
+:::
+
 ## The Models page
 
 Open the dashboard and click **Models** in the sidebar. You get two sections:

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -10,6 +10,10 @@ The API server exposes hermes-agent as an OpenAI-compatible HTTP endpoint. Any f
 
 Your agent handles requests with its full toolset (terminal, file operations, web search, memory, skills) and returns the final response. When streaming, tool progress indicators appear inline so frontends can show what the agent is doing.
 
+:::tip One backend covers models + tools
+Hermes itself needs a configured provider and tool backends for the API server to be useful. A [Nous Portal](/docs/user-guide/features/tool-gateway) subscription handles both — 300+ models plus web/image/TTS/browser via the Tool Gateway. Run `hermes setup --portal` once before starting the API server and frontends like Open WebUI or LobeChat get a fully tool-equipped backend.
+:::
+
 ## Quick Start
 
 ### 1. Enable the API server

--- a/website/docs/user-guide/features/batch-processing.md
+++ b/website/docs/user-guide/features/batch-processing.md
@@ -34,6 +34,10 @@ python batch_runner.py \
 python batch_runner.py --list_distributions
 ```
 
+:::tip Predictable cost at scale
+Batch runs spin up many concurrent agent sessions, each making model calls and tool calls. A [Nous Portal](/docs/user-guide/features/tool-gateway) subscription bundles model access plus web search, image gen, TTS, and cloud browsers under one bill — useful when you want stable cost-per-trajectory without juggling rate limits across five vendor accounts. Set up with `hermes setup --portal`, then point `--model` at a Nous model.
+:::
+
 ## Dataset Format
 
 The input dataset is a JSONL file (one JSON object per line). Each entry must have a `prompt` field:

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -49,7 +49,7 @@ Both `provider` and `model` are **required**. If either is missing, the fallback
 |----------|-------|-------------|
 | AI Gateway | `ai-gateway` | `AI_GATEWAY_API_KEY` |
 | OpenRouter | `openrouter` | `OPENROUTER_API_KEY` |
-| Nous Portal | `nous` | `hermes auth` (OAuth) |
+| Nous Portal | `nous` | `hermes setup --portal` (fresh) or `hermes auth add nous` (OAuth) |
 | OpenAI Codex | `openai-codex` | `hermes model` (ChatGPT OAuth) |
 | GitHub Copilot | `copilot` | `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN` |
 | GitHub Copilot ACP | `copilot-acp` | External process (editor integration) |

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -22,6 +22,10 @@ Before using voice features, make sure you have:
 The `~/.hermes/` directory and default `config.yaml` are created automatically the first time you run `hermes`. You only need to create `~/.hermes/.env` manually for API keys.
 :::
 
+:::tip Nous Portal covers both
+A paid [Nous Portal](/docs/user-guide/features/tool-gateway) subscription supplies the LLM (step 2) **and** OpenAI TTS via the Tool Gateway — no separate OpenAI key needed. On a fresh install, `hermes setup --portal` wires both up at once.
+:::
+
 ## Overview
 
 | Feature | Platform | Description |

--- a/website/docs/user-guide/windows-native.md
+++ b/website/docs/user-guide/windows-native.md
@@ -82,6 +82,10 @@ Top-to-bottom, in order:
 9. **Adds `%LOCALAPPDATA%\hermes\bin` to User PATH** — exposes the `hermes` command after you open a new terminal.
 10. **Runs `hermes setup`** — the normal first-run wizard (model, provider, toolsets). Skip with `-SkipSetup`.
 
+:::tip Skip provider hunting on Windows
+Native Windows is still early beta, and per-tool API key setup (Firecrawl, FAL, Browser Use, OpenAI TTS) is the highest-friction part of getting a useful agent. A [Nous Portal](/docs/user-guide/features/tool-gateway) subscription covers the model **and** all of those tools through one OAuth login. After the installer finishes, run `hermes setup --portal` to wire everything up.
+:::
+
 ## Feature matrix
 
 Everything except the dashboard's embedded terminal pane runs natively on Windows.


### PR DESCRIPTION
## Summary
Follow-up to #30869. Adds Portal mentions on user-facing pages that naturally call for an LLM + tool credentials but didn't previously acknowledge Portal as a one-stop option. One mention per page, concrete CLI commands only.

## Changes
| Page | What it adds |
|---|---|
| getting-started/installation.md | Tip after the 'after install' block — `hermes setup --portal` as the alternative to piecewise `hermes model` + `hermes tools`. |
| user-guide/configuring-models.md | Small tip near the top — the page is about provider/model choice and previously had zero Portal mention. |
| user-guide/features/voice-mode.md | Tip in Prerequisites — voice needs LLM + TTS, Portal covers both. |
| user-guide/features/batch-processing.md | Tip near Quick Start — Portal as a predictable-cost option for parallel agent runs that hit many APIs. |
| user-guide/features/api-server.md | Tip in the intro — backend needs models + tools, Portal gives a fully-equipped OpenAI-compatible endpoint. |
| user-guide/windows-native.md | Tip after install steps — early-beta Windows users skip per-tool key juggling. |
| integrations/providers.md | Updates existing Tool Gateway tip and the Nous Portal section to mention the new commands. |
| user-guide/features/fallback-providers.md | Nous row in the provider table lists `hermes setup --portal` as the fresh-install path. |

## Tone discipline
- One Portal mention per page (the Tool Gateway page is the only exception — its whole topic is Portal).
- Always solves a problem the page itself sets up (voice needs TTS, batch needs cost predictability, etc.).
- Concrete CLI commands (`hermes setup --portal`, `hermes portal status`), never just brand-name dropping.
- Pages where Portal isn't specifically advantageous (vision works with any vision-capable model, computer-use is macOS-only and bound to cua-driver, code-execution is about Python RPC) were left alone.

## Validation
- Each touched page renders correctly when scanned for code-fence and admonition balance.
- No sidebar changes needed.

## Companion
- Feature PR: #30860 — `hermes setup --portal` + `hermes portal` CLI
- First docs PR: #30869 — core docs touching the same surfaces