### PR TITLE
feat(gateway): add human tool progress mode

### DIFF
--- a/gateway/human_progress.py
+++ b/gateway/human_progress.py
@@ -1,0 +1,96 @@
+"""Human-readable gateway progress labels.
+
+This module deliberately avoids exposing raw tool names, command strings,
+arguments, paths, JSON payloads, or other implementation details.  It is used
+by chat platforms that want a concise activity feed for humans rather than a
+developer-oriented tool trace.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+_GENERIC_PROGRESS = "Продолжаю работу над задачей."
+
+_TOOL_MESSAGES: dict[str, str] = {
+    "browser_back": "Возвращаюсь к предыдущей странице.",
+    "browser_click": "Выбираю нужный элемент на странице.",
+    "browser_console": "Проверяю состояние страницы.",
+    "browser_get_images": "Смотрю изображения на странице.",
+    "browser_navigate": "Открываю нужную страницу.",
+    "browser_press": "Взаимодействую со страницей.",
+    "browser_scroll": "Просматриваю страницу дальше.",
+    "browser_snapshot": "Проверяю содержимое страницы.",
+    "browser_type": "Заполняю поле на странице.",
+    "browser_vision": "Разбираю, что видно на странице.",
+    "clarify": "Уточняю недостающие детали.",
+    "cronjob": "Обновляю расписание задачи.",
+    "delegate_task": "Передаю часть работы отдельному агенту.",
+    "execute_code": "Проверяю гипотезу в изолированном коде.",
+    "image_generate": "Готовлю изображение по описанию.",
+    "memory": "Сохраняю важную долгосрочную настройку.",
+    "patch": "Вношу точечное изменение.",
+    "process": "Проверяю фоновый процесс.",
+    "read_file": "Изучаю найденный файл.",
+    "search_files": "Ищу релевантные места в проекте.",
+    "send_message": "Отправляю сообщение адресату.",
+    "session_search": "Ищу подходящий контекст в прошлых сессиях.",
+    "skill_manage": "Обновляю сохранённый рабочий навык.",
+    "skill_view": "Подгружаю нужный рабочий навык.",
+    "skills_list": "Проверяю доступные рабочие навыки.",
+    "terminal": "Проверяю это в рабочем окружении.",
+    "todo": "Обновляю план работы.",
+    "vision_analyze": "Анализирую изображение.",
+    "write_file": "Записываю подготовленные изменения.",
+}
+
+_TERMINAL_HINTS: tuple[tuple[str, str], ...] = (
+    ("pytest", "Запускаю проверку тестами."),
+    ("unittest", "Запускаю проверку тестами."),
+    ("npm test", "Запускаю проверку тестами."),
+    ("pnpm test", "Запускаю проверку тестами."),
+    ("yarn test", "Запускаю проверку тестами."),
+    ("ruff", "Проверяю качество Python-кода."),
+    ("mypy", "Проверяю типы Python-кода."),
+    ("eslint", "Проверяю качество JavaScript-кода."),
+    ("tsc", "Проверяю типы TypeScript-кода."),
+    ("git status", "Проверяю состояние изменений."),
+    ("git diff", "Смотрю, что изменилось."),
+    ("git log", "Смотрю историю изменений."),
+    ("git branch", "Проверяю текущую ветку."),
+    ("git fetch", "Обновляю сведения из репозитория."),
+    ("git push", "Отправляю изменения в репозиторий."),
+    ("git commit", "Фиксирую подготовленные изменения."),
+    ("docker", "Проверяю контейнерное окружение."),
+    ("systemctl", "Проверяю состояние системного сервиса."),
+)
+
+_SEARCH_TARGET_MESSAGES: dict[str, str] = {
+    "files": "Ищу подходящие файлы в проекте.",
+    "content": "Ищу совпадения внутри файлов.",
+}
+
+
+def human_tool_progress_message(tool_name: str | None, args: Mapping[str, Any] | None = None) -> str:
+    """Return a concise human-readable progress message for a tool call.
+
+    The returned text must be safe for end-user chat surfaces: no raw tool
+    arguments, shell commands, file paths, URLs, JSON, or internal function
+    names.  The message describes intent at a high level only.
+    """
+    name = (tool_name or "").strip()
+    data: Mapping[str, Any] = args if isinstance(args, Mapping) else {}
+
+    if name == "terminal":
+        command = str(data.get("command") or "").lower()
+        for needle, message in _TERMINAL_HINTS:
+            if needle in command:
+                return message
+        return _TOOL_MESSAGES[name]
+
+    if name == "search_files":
+        target = str(data.get("target") or "content").lower()
+        return _SEARCH_TARGET_MESSAGES.get(target, _TOOL_MESSAGES[name])
+
+    return _TOOL_MESSAGES.get(name, _GENERIC_PROGRESS)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15702,6 +15702,14 @@ class GatewayRunner:
                 return
             last_tool[0] = tool_name
             
+            # Human mode: show intent, not implementation details.  This avoids
+            # leaking raw tool names, command strings, paths, JSON payloads, or
+            # other developer-oriented arguments into chat surfaces.
+            if progress_mode == "human":
+                from gateway.human_progress import human_tool_progress_message
+                progress_queue.put(human_tool_progress_message(tool_name, args))
+                return
+
             # Build progress message with primary argument preview
             from agent.display import get_tool_emoji
             emoji = get_tool_emoji(tool_name, default="⚙️")

--- a/tests/gateway/test_human_progress.py
+++ b/tests/gateway/test_human_progress.py
@@ -1,0 +1,44 @@
+from gateway.display_config import resolve_display_setting
+from gateway.human_progress import human_tool_progress_message
+
+
+def test_human_tool_progress_hides_terminal_command_details():
+    msg = human_tool_progress_message(
+        "terminal",
+        {"command": "python -m pytest tests/gateway/test_run.py -q"},
+    )
+
+    assert msg == "Запускаю проверку тестами."
+    assert "pytest" not in msg
+    assert "tests/gateway" not in msg
+    assert "terminal" not in msg
+
+
+def test_human_tool_progress_hides_search_arguments():
+    msg = human_tool_progress_message(
+        "search_files",
+        {"pattern": "SECRET_PATTERN", "path": "/tmp/project", "target": "content"},
+    )
+
+    assert msg == "Ищу совпадения внутри файлов."
+    assert "SECRET_PATTERN" not in msg
+    assert "/tmp/project" not in msg
+    assert "search_files" not in msg
+
+
+def test_human_tool_progress_uses_generic_message_for_unknown_tools():
+    msg = human_tool_progress_message(
+        "custom_internal_tool",
+        {"token": "do-not-leak", "command": "rm -rf /tmp/example"},
+    )
+
+    assert msg == "Продолжаю работу над задачей."
+    assert "custom_internal_tool" not in msg
+    assert "do-not-leak" not in msg
+    assert "rm -rf" not in msg
+
+
+def test_display_config_accepts_human_tool_progress_mode():
+    cfg = {"display": {"platforms": {"telegram": {"tool_progress": "human"}}}}
+
+    assert resolve_display_setting(cfg, "telegram", "tool_progress") == "human"


### PR DESCRIPTION
## What

Adds a `human` value for `display.tool_progress` (per-platform). In this mode the gateway emits concise, human-readable progress messages describing *intent* instead of the developer-oriented tool trace (raw tool names, command strings, arguments, file paths, URLs, or JSON payloads).

## Why

Chat surfaces (Telegram, etc.) often want a clean activity feed for end users rather than a tool-by-tool developer trace. The existing modes (`off`/`new`/`all`/`verbose`) all expose implementation details.

## How

- New `gateway/human_progress.py`: `human_tool_progress_message(tool_name, args)` maps tool calls to high-level messages, with a safe generic fallback for unknown tools and special handling for `terminal`/`search_files` so command strings and search arguments are never leaked.
- `gateway/run.py`: when `progress_mode == "human"`, emit the human message and skip the detailed trace.
- `resolve_display_setting` already passes the value through unchanged, so `display.platforms.<platform>.tool_progress: human` just works — no config-schema change needed.

## Tests

`tests/gateway/test_human_progress.py` (4 tests): asserts terminal command details, search arguments, unknown-tool args, and secret-looking values are never exposed, and that the config resolves the new mode. All pass locally.

## Notes

- The progress strings are currently Russian; happy to move them to i18n / English if preferred.
