### PR TITLE
fix(dingtalk): finalize open streaming cards before disconnect

### DIFF
--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -358,6 +358,19 @@ class DingTalkAdapter(BasePlatformAdapter):
             await asyncio.gather(*self._bg_tasks, return_exceptions=True)
             self._bg_tasks.clear()
 
+        # Finalize any open streaming cards before the HTTP client closes so
+        # they don't stay stuck in streaming state on DingTalk's UI after
+        # a gateway restart.  _close_streaming_siblings handles its own
+        # per-card exceptions; the outer try is a safety net for token fetch.
+        for _chat_id in list(self._streaming_cards):
+            try:
+                await self._close_streaming_siblings(_chat_id)
+            except Exception as _exc:
+                logger.debug(
+                    "[%s] Failed to finalize streaming card on disconnect for %s: %s",
+                    self.name, _chat_id, _exc,
+                )
+
         if self._http_client:
             await self._http_client.aclose()
             self._http_client = None

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -407,6 +407,36 @@ class TestConnect:
         assert len(adapter._dedup._seen) == 0
         assert adapter._http_client is None
 
+    @pytest.mark.asyncio
+    async def test_disconnect_finalizes_open_streaming_cards(self):
+        """Streaming cards must be finalized before HTTP client closes."""
+        from unittest.mock import AsyncMock, patch
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._http_client = AsyncMock()
+        adapter._stream_task = None
+        adapter._streaming_cards = {
+            "chat-1": {"track-a": "last content"},
+            "chat-2": {"track-b": "other"},
+        }
+
+        close_calls = []
+
+        async def fake_close_siblings(chat_id):
+            # HTTP client must still be alive at call time.
+            assert adapter._http_client is not None, (
+                "HTTP client was already closed before card finalization"
+            )
+            close_calls.append(chat_id)
+            adapter._streaming_cards.pop(chat_id, None)
+
+        with patch.object(adapter, "_close_streaming_siblings", side_effect=fake_close_siblings):
+            await adapter.disconnect()
+
+        assert set(close_calls) == {"chat-1", "chat-2"}
+        assert adapter._streaming_cards == {}
+        assert adapter._http_client is None
+
 
 # ---------------------------------------------------------------------------
 # Platform enum


### PR DESCRIPTION
## Problem

AI Card "tool progress" cards created with `finalize=False` were permanently stuck
in streaming state on DingTalk's UI after a gateway restart or planned shutdown.

`disconnect()` called `self._streaming_cards.clear()` without first invoking
`_close_streaming_siblings()` for each open chat. After the adapter came back
online it had no record of those cards, so they were never finalized — users
saw an endless spinner on every tool-progress card from the previous session.

## Root cause

The ordering in `disconnect()` was:

```
1. cancel bg_tasks
2. close HTTP client   ← finalization impossible after this point
3. _streaming_cards.clear()
```

`_close_streaming_siblings()` requires the HTTP client to be alive (token fetch
+ card-update request), so moving the finalization after `aclose()` would not
work either.

## Fix

Add a finalization loop **before** `self._http_client.aclose()`:

```python
for _chat_id in list(self._streaming_cards):
    try:
        await self._close_streaming_siblings(_chat_id)
    except Exception as _exc:
        logger.debug(...)
```

`_close_streaming_siblings` already handles per-card exceptions gracefully
(inner try/except), so a single failing card does not block the rest.
`_streaming_cards.clear()` is kept as a safety net for any cards that could
not be finalized.

## Test

`TestConnect::test_disconnect_finalizes_open_streaming_cards` — seeds two open
streaming cards, asserts that `_close_streaming_siblings` is called for each
chat, and asserts the HTTP client is still alive at the time of each call.

## Checklist

- [x] Fix is in `gateway/platforms/dingtalk.py`
- [x] Regression test added in `tests/gateway/test_dingtalk.py`
- [x] All 68 DingTalk tests pass
- [x] No existing tests broken