### PR TITLE
fix(deepseek): map low/medium reasoning_effort to high per API spec

### DIFF
--- a/plugins/model-providers/deepseek/__init__.py
+++ b/plugins/model-providers/deepseek/__init__.py
@@ -69,7 +69,8 @@ class DeepSeekProfile(ProviderProfile):
         if not enabled:
             return extra_body, top_level
 
-        # Effort mapping.  Pass low/medium/high through; xhigh/max → max.
+        # Effort mapping. DeepSeek only accepts "high" and "max" for reasoning_effort.
+        # Per docs: "low and medium are mapped to high, and xhigh is mapped to max".
         # When no effort is set we omit reasoning_effort so DeepSeek applies
         # its server default (currently high).
         if isinstance(reasoning_config, dict):
@@ -77,7 +78,8 @@ class DeepSeekProfile(ProviderProfile):
             if effort in {"xhigh", "max"}:
                 top_level["reasoning_effort"] = "max"
             elif effort in {"low", "medium", "high"}:
-                top_level["reasoning_effort"] = effort
+                # low/medium → high (per DeepSeek API compatibility)
+                top_level["reasoning_effort"] = "high"
 
         return extra_body, top_level
 

--- a/tests/plugins/model_providers/test_deepseek_profile.py
+++ b/tests/plugins/model_providers/test_deepseek_profile.py
@@ -53,12 +53,15 @@ class TestDeepSeekThinkingWireShape:
         assert top_level == {"reasoning_effort": "high"}
 
     @pytest.mark.parametrize("effort", ["low", "medium", "high"])
-    def test_standard_efforts_pass_through(self, deepseek_profile, effort):
+    def test_standard_efforts_normalize_to_high(self, deepseek_profile, effort):
+        """DeepSeek API only accepts 'high' and 'max' for reasoning_effort.
+        Per docs: 'low and medium are mapped to high'.
+        """
         _, top_level = deepseek_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": effort},
             model="deepseek-v4-pro",
         )
-        assert top_level == {"reasoning_effort": effort}
+        assert top_level == {"reasoning_effort": "high"}
 
     @pytest.mark.parametrize("effort", ["xhigh", "max", "MAX", "  Max  "])
     def test_xhigh_and_max_normalize_to_max(self, deepseek_profile, effort):


### PR DESCRIPTION
## Summary

Fixes HTTP 400 errors when using `deepseek-v4-flash` with `provider: deepseek` by mapping `low`/`medium` reasoning_effort values to `high` per DeepSeek API specification.

## Root Cause

DeepSeek V4 API only accepts `"high"` and `"max"` for the `reasoning_effort` parameter. Hermes was passing `"low"` and `"medium"` directly, causing validation errors.

Per DeepSeek docs:
> In thinking mode, for compatibility, `low` and `medium` are mapped to `high`, and `xhigh` is mapped to `max`

## Changes

- `plugins/model-providers/deepseek/__init__.py`: Map `low`/`medium`/`high` → `"high"`
- Updated tests to reflect the normalization

## Test Plan

- [x] All 29 DeepSeek profile tests pass
- [x] Manual verification against DeepSeek API docs

Fixes #30818