### PR TITLE
fix: support GitHub webhook body mention metadata

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -662,9 +662,14 @@ class WebhookAdapter(BasePlatformAdapter):
 
         def _resolve(match: re.Match) -> str:
             key = match.group(1)
-            # Special token: dump the entire payload as JSON
+            # Special tokens expose webhook metadata/payload not otherwise
+            # available through dot-notation payload lookup.
             if key == "__raw__":
                 return json.dumps(payload, indent=2)[:4000]
+            if key == "__event__":
+                return event_type
+            if key == "__route__":
+                return route_name
             value: Any = payload
             for part in key.split("."):
                 if isinstance(value, dict):
@@ -724,26 +729,32 @@ class WebhookAdapter(BasePlatformAdapter):
     async def _deliver_github_comment(
         self, content: str, delivery: dict
     ) -> SendResult:
-        """Post agent response as a GitHub PR/issue comment via ``gh`` CLI."""
+        """Post agent response as a GitHub issue/PR conversation comment.
+
+        GitHub pull requests are issues under the hood, and ``gh issue
+        comment`` works for both issue comments and PR conversation comments.
+        Accept the newer ``issue_number`` key while keeping ``pr_number`` as a
+        backwards-compatible alias for existing webhook routes.
+        """
         extra = delivery.get("deliver_extra", {})
         repo = extra.get("repo", "")
-        pr_number = extra.get("pr_number", "")
+        issue_number = extra.get("issue_number") or extra.get("pr_number", "")
 
-        if not repo or not pr_number:
+        if not repo or not issue_number:
             logger.error(
-                "[webhook] github_comment delivery missing repo or pr_number"
+                "[webhook] github_comment delivery missing repo or issue_number"
             )
             return SendResult(
-                success=False, error="Missing repo or pr_number"
+                success=False, error="Missing repo or issue_number"
             )
 
         try:
             result = subprocess.run(
                 [
                     "gh",
-                    "pr",
+                    "issue",
                     "comment",
-                    str(pr_number),
+                    str(issue_number),
                     "--repo",
                     repo,
                     "--body",
@@ -755,12 +766,12 @@ class WebhookAdapter(BasePlatformAdapter):
             )
             if result.returncode == 0:
                 logger.info(
-                    "[webhook] Posted comment on %s#%s", repo, pr_number
+                    "[webhook] Posted comment on %s#%s", repo, issue_number
                 )
                 return SendResult(success=True)
             else:
                 logger.error(
-                    "[webhook] gh pr comment failed: %s", result.stderr
+                    "[webhook] gh issue comment failed: %s", result.stderr
                 )
                 return SendResult(success=False, error=result.stderr)
         except FileNotFoundError:

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -211,6 +211,17 @@ class TestRenderPrompt:
         assert "my-route" in result
         assert "key" in result
 
+    def test_render_prompt_event_and_route_tokens(self):
+        """Special tokens expose webhook metadata not present in payload."""
+        adapter = _make_adapter()
+        result = adapter._render_prompt(
+            "event={__event__} route={__route__} action={action}",
+            {"action": "opened"},
+            "issues",
+            "github-comments",
+        )
+        assert result == "event=issues route=github-comments action=opened"
+
 
 # ===================================================================
 # Delivery extra rendering

--- a/tests/gateway/test_webhook_integration.py
+++ b/tests/gateway/test_webhook_integration.py
@@ -273,7 +273,12 @@ class TestGitHubCommentDelivery:
     @pytest.mark.asyncio
     async def test_github_comment_delivery(self):
         """When deliver='github_comment', the adapter invokes
-        ``gh pr comment`` via subprocess.run (mocked)."""
+        ``gh issue comment`` via subprocess.run (mocked).
+
+        ``gh issue comment`` works for both issues and PR conversation
+        threads, so webhook routes can use either issue_number or the legacy
+        pr_number deliver_extra key.
+        """
         routes = {
             "pr-bot": {
                 "secret": _INSECURE_NO_AUTH,
@@ -326,7 +331,7 @@ class TestGitHubCommentDelivery:
         assert result.success is True
         mock_run.assert_called_once_with(
             [
-                "gh", "pr", "comment", "42",
+                "gh", "issue", "comment", "42",
                 "--repo", "org/repo",
                 "--body", "LGTM! The code looks great.",
             ],


### PR DESCRIPTION
## Summary
- Add {__event__} and {__route__} webhook prompt tokens so GitHub body mention prompts can distinguish issue, issue_comment, and pull_request events
- Use gh issue comment for GitHub comment delivery so one delivery path works for both issues and PR conversations
- Update webhook tests for event/route token rendering and issue-based comment delivery

## Test Plan
- python -m pytest tests/gateway/test_webhook_adapter.py tests/gateway/test_webhook_integration.py tests/gateway/test_webhook_deliver_only.py tests/hermes_cli/test_webhook_cli.py -q