### PR TITLE
fix(gateway): bridge terminal.docker_extra_args to env for gateway sessions (#30415)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -827,6 +827,7 @@ if _config_path.exists():
                 "container_memory": "TERMINAL_CONTAINER_MEMORY",
                 "container_disk": "TERMINAL_CONTAINER_DISK",
                 "container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
+                "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
                 "docker_volumes": "TERMINAL_DOCKER_VOLUMES",
                 "docker_env": "TERMINAL_DOCKER_ENV",
                 "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",

--- a/tests/test_docker_extra_args_bridge.py
+++ b/tests/test_docker_extra_args_bridge.py
@@ -1,0 +1,15 @@
+"""Test that docker_extra_args is bridged from terminal config to gateway env."""
+from pathlib import Path
+
+
+class TestDockerExtraArgsGatewayBridge:
+    """Verify TERMINAL_DOCKER_EXTRA_ARGS mapping exists in the terminal env bridge."""
+
+    def test_docker_extra_args_key_exists_in_source(self):
+        """The docker_extra_args → TERMINAL_DOCKER_EXTRA_ARGS mapping must exist."""
+        gateway_run = Path(__file__).resolve().parents[1] / "gateway" / "run.py"
+        source = gateway_run.read_text()
+        assert '"docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS"' in source, (
+            "docker_extra_args must be mapped to TERMINAL_DOCKER_EXTRA_ARGS "
+            "in the terminal env bridge so gateway sessions inherit it from config"
+        )


### PR DESCRIPTION
## What does this PR do?

Fixes #30415 — adds the missing `docker_extra_args` entry to `gateway/run.py`'s `_terminal_env_map`, bridging the `terminal.docker_extra_args` config key to the `TERMINAL_DOCKER_EXTRA_ARGS` env var.

## Why is this needed?

`config.yaml`'s `terminal.docker_extra_args` is silently dropped when the gateway spawns per-session sandbox containers. Every other `terminal.docker_*` key in that block IS bridged, so users reasonably expect this one to be too. Net effect: sandbox containers spawn without documented extra args (bind mounts, devices, capabilities).

## Root cause

The `_terminal_env_map` in `gateway/run.py` omits `docker_extra_args`. The existing list/dict serialization logic (lines 482-485) already handles the encoding — only the map entry was missing.

## How to test

1. Set `terminal.docker_extra_args` in config.yaml
2. Run via gateway with docker backend
3. Verify the argument reaches the spawned container

Existing env-bridge test passes.

## Checklist
- [x] Bug fix (non-breaking change)
- [x] One logical change per PR
- [x] Follows codebase style
- [x] No new dependencies
- [x] CONTRIBUTING.md guidelines followed