### PR TITLE
fix(cli): enforce correct user config target path in save_config_value

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2751,11 +2751,13 @@ def _parse_skills_argument(skills: str | list[str] | tuple[str, ...] | None) -> 
 
 def save_config_value(key_path: str, value: any) -> bool:
     """
-    Save a value to the active config file at the specified key path.
-    
-    Respects the same lookup order as load_cli_config():
-    1. ~/.hermes/config.yaml (user config - preferred, used if it exists)
-    2. ./cli-config.yaml (project config - fallback)
+    Save a value to the user config file at the specified key path.
+
+    Persistent CLI settings always belong in ``~/.hermes/config.yaml`` so the
+    rest of Hermes (gateway, doctor, subcommands) can see the same source of
+    truth. If the CLI is currently reading a project-local ``cli-config.yaml``
+    fallback because the user config does not exist yet, bootstrap the new user
+    config from that fallback before applying the update.
     
     Args:
         key_path: Dot-separated path like "agent.system_prompt"
@@ -2764,14 +2766,16 @@ def save_config_value(key_path: str, value: any) -> bool:
     Returns:
         True if successful, False otherwise
     """
-    # Use the same precedence as load_cli_config: user config first, then project config
     user_config_path = _hermes_home / 'config.yaml'
     project_config_path = Path(__file__).parent / 'cli-config.yaml'
-    config_path = user_config_path if user_config_path.exists() else project_config_path
+    config_path = user_config_path
     
     try:
         # Ensure parent directory exists (for ~/.hermes/config.yaml on first use)
         config_path.parent.mkdir(parents=True, exist_ok=True)
+
+        if not config_path.exists() and project_config_path.exists():
+            shutil.copyfile(project_config_path, config_path)
         
         # Save back atomically while preserving comments, ordering, quotes, and
         # readable Unicode in user-edited config.yaml.
@@ -2786,7 +2790,7 @@ def save_config_value(key_path: str, value: any) -> bool:
         
         return True
     except Exception as e:
-        logger.error("Failed to save config: %s", e)
+        logger.error("Failed to save config to %s: %s", config_path, e)
         return False
 
 

--- a/tests/cli/test_cli_save_config_value.py
+++ b/tests/cli/test_cli_save_config_value.py
@@ -132,3 +132,39 @@ class TestSaveConfigValueAtomic:
 
         assert result is False
         assert config_env.read_text() == original_content
+
+    def test_bootstraps_user_config_from_project_fallback(self, tmp_path, monkeypatch):
+        """First-run writes must create ~/.hermes/config.yaml, not mutate cli-config.yaml."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        repo_dir = tmp_path / "repo"
+        repo_dir.mkdir()
+        project_config = repo_dir / "cli-config.yaml"
+        project_config.write_text(
+            "model:\n"
+            "  provider: openrouter\n"
+            "display:\n"
+            "  skin: default\n",
+            encoding="utf-8",
+        )
+
+        import cli as cli_mod
+
+        monkeypatch.setattr(cli_mod, "_hermes_home", hermes_home)
+        monkeypatch.setattr(cli_mod, "__file__", str(repo_dir / "cli.py"))
+
+        assert not (hermes_home / "config.yaml").exists()
+
+        result = cli_mod.save_config_value("display.skin", "mono")
+
+        user_config = hermes_home / "config.yaml"
+        assert result is True
+        assert user_config.exists()
+        assert yaml.safe_load(user_config.read_text(encoding="utf-8")) == {
+            "model": {"provider": "openrouter"},
+            "display": {"skin": "mono"},
+        }
+        assert yaml.safe_load(project_config.read_text(encoding="utf-8")) == {
+            "model": {"provider": "openrouter"},
+            "display": {"skin": "default"},
+        }


### PR DESCRIPTION
## What does this PR do?

Fixes a config persistence bug in the interactive CLI when `~/.hermes/config.yaml` does not exist yet.

Before this change, `load_cli_config()` could fall back to the repo-local `cli-config.yaml`, and `save_config_value()` used that same fallback when persisting settings. That meant commands like `/model --global` and `/skin` could write to `cli-config.yaml` instead of creating/updating `~/.hermes/config.yaml`. The rest of Hermes, especially the gateway, does not treat `cli-config.yaml` as the authoritative user config source, so the saved settings were not reliably visible outside the interactive CLI.

This PR makes CLI persistence always target `~/.hermes/config.yaml`. On first write, if the CLI is currently reading a project-local `cli-config.yaml` fallback, it bootstraps the new user config from that file before applying the update. This preserves first-run behavior while restoring a single source of truth for persisted settings.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Updated `save_config_value()` in `cli.py` to always persist CLI settings to `~/.hermes/config.yaml`
- Added first-run bootstrap behavior: if `~/.hermes/config.yaml` does not exist but repo-local `cli-config.yaml` does, copy that fallback into the user config before applying the mutation
- Improved the save failure log message to include the target config path
- Added a regression test in `tests/cli/test_cli_save_config_value.py` covering the missing-user-config / project-fallback case and asserting that `cli-config.yaml` is left unchanged

## How to Test

1. Ensure `~/.hermes/config.yaml` does not exist, and create a repo-local `cli-config.yaml` with a setting such as `display.skin: default`
2. Trigger a persistent CLI write, for example via `/skin mono` or `/model <name> --global`
3. Verify that Hermes creates/updates `~/.hermes/config.yaml`, preserves the fallback config content as the base, and does not modify the repo-local `cli-config.yaml`

Additional regression coverage:
1. Run `pytest tests/cli/test_cli_save_config_value.py -q`
2. Confirm the suite passes
3. Confirm the new test covers first-run persistence into `~/.hermes/config.yaml`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
pytest tests/cli/test_cli_save_config_value.py -q
.........                                                                [100%]
9 passed in 4.28s