### PR TITLE
feat(feishu): render markdown tables as native Card JSON 2.0 table cards

### DIFF
--- a/gateway/platforms/_feishu_card_table.py
+++ b/gateway/platforms/_feishu_card_table.py
@@ -1,0 +1,230 @@
+"""Markdown → Feishu Card JSON 2.0 table conversion (pure-stdlib helpers).
+
+Isolated module so the conversion logic can be unit-tested without loading
+the full ``gateway.platforms.feishu`` stack (which pulls in ``hermes_cli``,
+``lark_oapi``, websockets, aiohttp, etc.). The dispatch is wired up in
+``gateway.platforms.feishu._build_outbound_payload``.
+
+Why a dedicated module:
+
+- Feishu Card JSON 1.0 (used by ``send_exec_approval`` / ``send_update_prompt``)
+  has no ``tag: "table"`` component. Card JSON 2.0 introduces it (Lark V7.4+),
+  and the two schemas may be mixed across messages within the same chat —
+  each ``send_message`` payload is independent.
+- We invoke 2.0 only when the outbound content actually contains a markdown
+  table; everything else stays on the existing text / post / 1.0 card paths.
+- Keeping the helpers in their own module makes them trivially unit-testable
+  with the stdlib alone (``re``, ``json``, ``typing``).
+"""
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Dict, List, Tuple
+
+
+_MD_TABLE_SEPARATOR_RE = re.compile(r"^\s*\|[-|: ]+\|\s*$")
+
+
+def _split_md_table_row(row_line: str) -> List[str]:
+    """Split one markdown table row line into cell strings.
+
+    Strips the leading / trailing ``|`` and trims surrounding whitespace
+    on each cell.
+    """
+    stripped = row_line.strip()
+    if stripped.startswith("|"):
+        stripped = stripped[1:]
+    if stripped.endswith("|"):
+        stripped = stripped[:-1]
+    return [cell.strip() for cell in stripped.split("|")]
+
+
+def _split_content_at_tables(content: str) -> List[Tuple[str, str]]:
+    """Split content into alternating ('text', str) and ('table', str) segments.
+
+    A table starts at a pipe-row whose next line matches the separator
+    pattern ``^\\s*\\|[-|: ]+\\|\\s*$``. The table extends through every
+    following line that begins with ``|``. Non-table chunks (including
+    blank lines) are returned verbatim.
+    """
+    segments: List[Tuple[str, str]] = []
+    lines = content.splitlines(keepends=True)
+    n = len(lines)
+    i = 0
+    while i < n:
+        is_table_start = (
+            i + 1 < n
+            and lines[i].lstrip().startswith("|")
+            and lines[i].rstrip().endswith("|")
+            and _MD_TABLE_SEPARATOR_RE.match(lines[i + 1] or "")
+        )
+        if is_table_start:
+            j = i + 2
+            while j < n and lines[j].lstrip().startswith("|"):
+                j += 1
+            segments.append(("table", "".join(lines[i:j])))
+            i = j
+            continue
+        # Accumulate non-table lines until next table start or EOF.
+        j = i
+        while j < n:
+            if (
+                j + 1 < n
+                and lines[j].lstrip().startswith("|")
+                and lines[j].rstrip().endswith("|")
+                and _MD_TABLE_SEPARATOR_RE.match(lines[j + 1] or "")
+            ):
+                break
+            j += 1
+        segments.append(("text", "".join(lines[i:j])))
+        i = j
+    return segments
+
+
+def _parse_markdown_table_to_card_element(table_text: str) -> Dict[str, Any]:
+    """Parse a markdown table block into a Feishu Card JSON 2.0 table element.
+
+    First content row is treated as the header. Subsequent rows are data.
+    Columns use ``data_type: "markdown"`` so cell content can carry inline
+    formatting (bold / links / emoji ✅/❌ etc.) that scout-mcp commonly
+    emits. ``page_size: 10`` keeps long shortlists scrollable without
+    making the card huge.
+    """
+    rows_raw = [ln for ln in table_text.splitlines() if ln.strip().startswith("|")]
+    if len(rows_raw) < 2:
+        return {"tag": "markdown", "content": table_text}
+    header_cells = _split_md_table_row(rows_raw[0])
+    data_rows_raw = rows_raw[2:]  # rows_raw[1] is the |---| separator
+    columns: List[Dict[str, Any]] = []
+    for idx, cell in enumerate(header_cells):
+        col_name = f"col{idx + 1}"
+        columns.append(
+            {
+                "name": col_name,
+                "display_name": cell or col_name,
+                "data_type": "markdown",
+            }
+        )
+    rows: List[Dict[str, Any]] = []
+    for row_line in data_rows_raw:
+        cells = _split_md_table_row(row_line)
+        while len(cells) < len(columns):
+            cells.append("")
+        rows.append({columns[i]["name"]: cells[i] for i in range(len(columns))})
+    return {
+        "tag": "table",
+        "page_size": 10,
+        "columns": columns,
+        "rows": rows,
+    }
+
+
+def _build_card_with_table_payload(content: str) -> str:
+    """Build a Feishu interactive card (JSON 2.0) preserving markdown tables.
+
+    Splits ``content`` at each markdown table block: prose around the table
+    becomes ``tag: "markdown"`` element(s); each table becomes a native
+    ``tag: "table"`` element. Renders as sortable / paginated table UI on
+    Lark V7.4+ clients instead of the previously-broken md-table fallback
+    that produced blank messages.
+    """
+    segments = _split_content_at_tables(content)
+    elements: List[Dict[str, Any]] = []
+    for seg_kind, seg_text in segments:
+        if seg_kind == "table":
+            elements.append(_parse_markdown_table_to_card_element(seg_text))
+        elif seg_text.strip():
+            elements.append({"tag": "markdown", "content": seg_text})
+    if not elements:
+        elements = [{"tag": "markdown", "content": content}]
+    card: Dict[str, Any] = {
+        "schema": "2.0",
+        "config": {"wide_screen_mode": True},
+        "body": {"elements": elements},
+    }
+    return json.dumps(card, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# Self-check entry point — `python3 gateway/platforms/_feishu_card_table.py`
+# ---------------------------------------------------------------------------
+#
+# Runs a minimal end-to-end check using a real Scout / Feishu transcript
+# fragment (the 2026-05-21 office-furniture incident). Does NOT import the
+# full gateway package, so it works in a sparse checkout without hermes_cli
+# or lark_oapi installed.
+#
+# Run via:
+#     python3 gateway/platforms/_feishu_card_table.py
+#
+# Exits non-zero on any assertion failure; on success, dumps the produced
+# card JSON so a human can eyeball the structure before shipping.
+
+
+_SCOUT_FEISHU_FRAGMENT = (
+    "结果出来了,先做个初步筛选:\n"
+    "\n"
+    "| 关键词 | AMZ123排名 | 亚马逊竞品数 | 竞品<2000? |\n"
+    "|---|---|---|---|\n"
+    "| office desk | 2961 | **123,664** | ❌ |\n"
+    "| office chair | 201 | **62,794** | ❌ |\n"
+    "| ergonomic office chair | 3546 | **16,873** | ❌ |\n"
+    "| filing cabinet | 9120 | **18,600** | ❌ |\n"
+    "| office desk accessories | 3043 | **111,356** | ❌ |\n"
+    "| ✅ **criss cross office chair** | **7256** | **1,410** | ✅ |\n"
+    "\n"
+    "**主要发现:** 办公家具类目主词竞品数都 >1 万,符合 <2000 的就一个\n"
+)
+
+
+def _run_selfcheck() -> int:
+    raw = _build_card_with_table_payload(_SCOUT_FEISHU_FRAGMENT)
+    card = json.loads(raw)
+
+    # Structural assertions
+    assert card["schema"] == "2.0", f"expected schema 2.0, got {card['schema']!r}"
+    elements = card["body"]["elements"]
+    tags = [e["tag"] for e in elements]
+    assert tags == ["markdown", "table", "markdown"], f"unexpected element order: {tags}"
+
+    table = elements[1]
+    assert len(table["columns"]) == 4, f"expected 4 columns, got {len(table['columns'])}"
+    assert table["columns"][0]["display_name"] == "关键词"
+    assert len(table["rows"]) == 6, f"expected 6 rows, got {len(table['rows'])}"
+
+    last = table["rows"][5]
+    assert "criss cross office chair" in last["col1"], f"row 5 col1 wrong: {last['col1']!r}"
+    assert last["col4"] == "✅", f"row 5 col4 wrong: {last['col4']!r}"
+
+    # Dump for visual eyeballing
+    print("=" * 72)
+    print("SELF-CHECK: Scout / Feishu 2026-05-21 office-furniture transcript")
+    print("=" * 72)
+    print("Input markdown content:")
+    print("-" * 72)
+    print(_SCOUT_FEISHU_FRAGMENT)
+    print("-" * 72)
+    print("Output card JSON (msg_type=interactive payload):")
+    print("-" * 72)
+    print(json.dumps(card, ensure_ascii=False, indent=2))
+    print("-" * 72)
+    print(f"Element count: {len(elements)}")
+    for i, e in enumerate(elements):
+        if e["tag"] == "table":
+            print(
+                f"  [{i}] table: {len(e['columns'])} cols, {len(e['rows'])} rows, "
+                f"page_size={e['page_size']}"
+            )
+        else:
+            content_preview = e.get("content", "")[:60].replace("\n", " ")
+            print(f"  [{i}] {e['tag']}: {content_preview!r}")
+    print("=" * 72)
+    print("OK")
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(_run_selfcheck())

--- a/gateway/platforms/_feishu_card_table.py
+++ b/gateway/platforms/_feishu_card_table.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import json
 import re
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 
 _MD_TABLE_SEPARATOR_RE = re.compile(r"^\s*\|[-|: ]+\|\s*$")
@@ -120,7 +120,10 @@ def _parse_markdown_table_to_card_element(table_text: str) -> Dict[str, Any]:
     }
 
 
-def _build_card_with_table_payload(content: str) -> str:
+def _build_card_with_table_payload(
+    content: str,
+    sheet_url: Optional[str] = None,
+) -> str:
     """Build a Feishu interactive card (JSON 2.0) preserving markdown tables.
 
     Splits ``content`` at each markdown table block: prose around the table
@@ -128,22 +131,34 @@ def _build_card_with_table_payload(content: str) -> str:
     ``tag: "table"`` element. Renders as sortable / paginated table UI on
     Lark V7.4+ clients instead of the previously-broken md-table fallback
     that produced blank messages.
+
+    When ``sheet_url`` is supplied, a "Open in Lark Sheet" button (rendered
+    as a bold markdown link, schema-safe across Lark client versions) is
+    appended right after the **first** table. Multiple tables in one
+    message still get hints + raw source, but only the first table maps
+    to a Sheets-API-backed spreadsheet (single-message single-sheet to
+    keep the API call count predictable).
     """
     segments = _split_content_at_tables(content)
     elements: List[Dict[str, Any]] = []
+    table_index = 0
     for seg_kind, seg_text in segments:
         if seg_kind == "table":
             elements.append(_parse_markdown_table_to_card_element(seg_text))
-            # Native client UX hint: educate users about Feishu's built-in
-            # cell-copy gestures, plus the raw-markdown fallback they can
-            # long-press select. Lightweight zero-dependency enhancement —
-            # later iterations can replace this with a "Save to Sheet"
-            # button once OAuth scopes (sheets:spreadsheet) are granted.
-            elements.append(_build_table_hint_element())
-            # Append the raw markdown source itself so long-press select +
-            # copy works for the entire table at once on mobile clients
-            # that don't expose per-cell copy.
+            is_first_table = table_index == 0
+            attached_sheet = sheet_url if is_first_table else None
+            if attached_sheet:
+                # Visible CTA right after the table — markdown link is the
+                # most schema-portable button surface (no ``tag: "button"``
+                # field-name guessing across Card JSON v1 / v2).
+                elements.append(_build_sheet_open_element(attached_sheet))
+            # Hint text adapts to whether the sheet CTA is present.
+            elements.append(
+                _build_table_hint_element(has_sheet=bool(attached_sheet))
+            )
+            # Raw markdown source for long-press select + paste workflows.
             elements.append(_build_raw_source_disclosure(seg_text))
+            table_index += 1
         elif seg_text.strip():
             elements.append({"tag": "markdown", "content": seg_text})
     if not elements:
@@ -188,22 +203,44 @@ _SCOUT_FEISHU_FRAGMENT = (
 )
 
 
-_TABLE_HINT_CONTENT = (
+_TABLE_HINT_NO_SHEET = (
     "💡 **复制 / 下载提示** · 长按 cell 复制单元格 · "
     "长按下方原始数据可全选复制并粘贴到飞书表格 / Excel · "
-    "「保存到飞书表格」按钮 v3 上线中"
+    "「保存到飞书表格」按钮需 sheets:spreadsheet OAuth scope (v3 上线中)"
+)
+
+_TABLE_HINT_WITH_SHEET = (
+    "💡 长按 cell 复制单元格 · 长按下方原始数据全选复制 · "
+    "点击上方 📊 按钮在飞书表格中查看 / 编辑 / 分享 / 导出 CSV"
 )
 
 
-def _build_table_hint_element() -> Dict[str, Any]:
-    """Inline markdown hint educating users about native Feishu copy gestures.
+def _build_table_hint_element(has_sheet: bool = False) -> Dict[str, Any]:
+    """Inline markdown hint educating users about copy / download paths.
 
-    Lightweight zero-dependency enhancement: explains that Feishu desktop
-    + mobile clients already support long-press copy on table cells, and
-    points to the raw-markdown disclosure block that follows for full
-    table copy / paste workflows.
+    When the card carries a Lark Sheet CTA (``has_sheet=True``), the hint
+    points users to the button and drops the "v3 coming soon" caveat.
+    Otherwise it explains the long-press fallback and flags that the
+    Sheet button is pending OAuth scope provisioning.
     """
-    return {"tag": "markdown", "content": _TABLE_HINT_CONTENT}
+    content = _TABLE_HINT_WITH_SHEET if has_sheet else _TABLE_HINT_NO_SHEET
+    return {"tag": "markdown", "content": content}
+
+
+def _build_sheet_open_element(sheet_url: str) -> Dict[str, Any]:
+    """Render the "Open in Lark Sheet" CTA as a bold markdown link.
+
+    A markdown link works across both Card JSON 1.0 and 2.0 renderers
+    without depending on the ``tag: "button"`` field-name (which differs
+    between schema versions and Lark client builds). The cell rendering
+    is clickable on every Lark client + browser surface.
+    """
+    return {
+        "tag": "markdown",
+        "content": (
+            f"[**📊 在飞书表格中打开 · 编辑 · 分享 · 导出 CSV**]({sheet_url})"
+        ),
+    }
 
 
 def _build_raw_source_disclosure(table_text: str) -> Dict[str, Any]:
@@ -223,23 +260,34 @@ def _build_raw_source_disclosure(table_text: str) -> Dict[str, Any]:
 
 
 def _run_selfcheck() -> int:
+    # === Case A: no sheet_url — v2 layout (hint + raw source only) ===
     raw = _build_card_with_table_payload(_SCOUT_FEISHU_FRAGMENT)
     card = json.loads(raw)
-
-    # Structural assertions
     assert card["schema"] == "2.0", f"expected schema 2.0, got {card['schema']!r}"
     elements = card["body"]["elements"]
     tags = [e["tag"] for e in elements]
-    # Order: intro-markdown / table / hint-markdown / raw-source-markdown / footer-markdown
     assert tags == [
         "markdown", "table", "markdown", "markdown", "markdown"
-    ], f"unexpected element order: {tags}"
+    ], f"case A: unexpected element order: {tags}"
+    assert "长按 cell 复制单元格" in elements[2]["content"], "case A: hint missing copy text"
+    assert "v3 上线中" in elements[2]["content"], "case A: hint should flag v3 pending"
+    assert elements[3]["content"].startswith("```markdown"), "case A: raw-source missing fence"
+    assert "| 关键词 |" in elements[3]["content"], "case A: raw-source missing original table"
 
-    # Hint element must contain the copy-affordance educational text.
-    assert "长按 cell 复制单元格" in elements[2]["content"], "hint element missing copy text"
-    # Raw-source disclosure must be a fenced markdown block preserving pipes.
-    assert elements[3]["content"].startswith("```markdown"), "raw-source missing fence"
-    assert "| 关键词 |" in elements[3]["content"], "raw-source missing original table"
+    # === Case B: with sheet_url — v3 layout (CTA button + adjusted hint) ===
+    mock_url = "https://feishu.cn/sheets/shtcnMOCKTOKEN12345"
+    raw_b = _build_card_with_table_payload(_SCOUT_FEISHU_FRAGMENT, sheet_url=mock_url)
+    card_b = json.loads(raw_b)
+    elements_b = card_b["body"]["elements"]
+    tags_b = [e["tag"] for e in elements_b]
+    # Order: intro / table / sheet-cta / hint / raw-source / footer
+    assert tags_b == [
+        "markdown", "table", "markdown", "markdown", "markdown", "markdown"
+    ], f"case B: unexpected element order: {tags_b}"
+    assert mock_url in elements_b[2]["content"], "case B: sheet-cta missing URL"
+    assert "📊" in elements_b[2]["content"], "case B: sheet-cta missing button emoji"
+    assert "v3 上线中" not in elements_b[3]["content"], "case B: hint should drop v3-pending caveat"
+    assert "点击上方 📊 按钮" in elements_b[3]["content"], "case B: hint should reference CTA"
 
     table = elements[1]
     assert len(table["columns"]) == 4, f"expected 4 columns, got {len(table['columns'])}"

--- a/gateway/platforms/_feishu_card_table.py
+++ b/gateway/platforms/_feishu_card_table.py
@@ -123,6 +123,7 @@ def _parse_markdown_table_to_card_element(table_text: str) -> Dict[str, Any]:
 def _build_card_with_table_payload(
     content: str,
     sheet_url: Optional[str] = None,
+    bitable_url: Optional[str] = None,
 ) -> str:
     """Build a Feishu interactive card (JSON 2.0) preserving markdown tables.
 
@@ -132,12 +133,17 @@ def _build_card_with_table_payload(
     Lark V7.4+ clients instead of the previously-broken md-table fallback
     that produced blank messages.
 
-    When ``sheet_url`` is supplied, a "Open in Lark Sheet" button (rendered
-    as a bold markdown link, schema-safe across Lark client versions) is
-    appended right after the **first** table. Multiple tables in one
-    message still get hints + raw source, but only the first table maps
-    to a Sheets-API-backed spreadsheet (single-message single-sheet to
-    keep the API call count predictable).
+    Right after the **first** table, a single inline element renders the
+    storage CTAs as bold markdown links (schema-portable across Card JSON
+    v1 / v2). Two channels are supported:
+
+    - ``sheet_url`` — populated Lark Sheet for download / edit / share
+      (Lark Sheet has built-in CSV export = "本地下载")
+    - ``bitable_url`` — blank Lark Bitable app for downstream automation
+      / view / dashboard workflows ("保存到飞书多维表格")
+
+    Both ``None`` ⇒ no storage CTA element is emitted; the user still
+    gets the native table UI (long-press copy on cells works natively).
     """
     segments = _split_content_at_tables(content)
     elements: List[Dict[str, Any]] = []
@@ -145,19 +151,10 @@ def _build_card_with_table_payload(
     for seg_kind, seg_text in segments:
         if seg_kind == "table":
             elements.append(_parse_markdown_table_to_card_element(seg_text))
-            is_first_table = table_index == 0
-            attached_sheet = sheet_url if is_first_table else None
-            if attached_sheet:
-                # Visible CTA right after the table — markdown link is the
-                # most schema-portable button surface (no ``tag: "button"``
-                # field-name guessing across Card JSON v1 / v2).
-                elements.append(_build_sheet_open_element(attached_sheet))
-            # Hint text adapts to whether the sheet CTA is present.
-            elements.append(
-                _build_table_hint_element(has_sheet=bool(attached_sheet))
-            )
-            # Raw markdown source for long-press select + paste workflows.
-            elements.append(_build_raw_source_disclosure(seg_text))
+            if table_index == 0:
+                storage_el = _build_storage_links_element(sheet_url, bitable_url)
+                if storage_el is not None:
+                    elements.append(storage_el)
             table_index += 1
         elif seg_text.strip():
             elements.append({"tag": "markdown", "content": seg_text})
@@ -203,91 +200,80 @@ _SCOUT_FEISHU_FRAGMENT = (
 )
 
 
-_TABLE_HINT_NO_SHEET = (
-    "💡 **复制 / 下载提示** · 长按 cell 复制单元格 · "
-    "长按下方原始数据可全选复制并粘贴到飞书表格 / Excel · "
-    "「保存到飞书表格」按钮需 sheets:spreadsheet OAuth scope (v3 上线中)"
-)
+def _build_storage_links_element(
+    sheet_url: Optional[str],
+    bitable_url: Optional[str],
+) -> Optional[Dict[str, Any]]:
+    """Render the inline storage CTAs as bold markdown links.
 
-_TABLE_HINT_WITH_SHEET = (
-    "💡 长按 cell 复制单元格 · 长按下方原始数据全选复制 · "
-    "点击上方 📊 按钮在飞书表格中查看 / 编辑 / 分享 / 导出 CSV"
-)
+    Two complementary export channels:
 
+    - **Lark Sheet** (``sheet_url``): data is pre-populated; clients use
+      the in-sheet menu to export CSV / Excel locally ("本地下载") or
+      copy / share / edit collaboratively.
+    - **Lark Bitable** (``bitable_url``): blank base ready for views,
+      automations, and downstream pipelines ("保存到飞书多维表格 — 自己
+      组织的多维表格").
 
-def _build_table_hint_element(has_sheet: bool = False) -> Dict[str, Any]:
-    """Inline markdown hint educating users about copy / download paths.
-
-    When the card carries a Lark Sheet CTA (``has_sheet=True``), the hint
-    points users to the button and drops the "v3 coming soon" caveat.
-    Otherwise it explains the long-press fallback and flags that the
-    Sheet button is pending OAuth scope provisioning.
+    Markdown links are deliberately chosen over ``tag: "button"`` because
+    they are schema-portable across Card JSON v1 / v2 and every Lark
+    client build. Returns ``None`` when neither URL is available so the
+    caller can skip emitting an empty element.
     """
-    content = _TABLE_HINT_WITH_SHEET if has_sheet else _TABLE_HINT_NO_SHEET
-    return {"tag": "markdown", "content": content}
-
-
-def _build_sheet_open_element(sheet_url: str) -> Dict[str, Any]:
-    """Render the "Open in Lark Sheet" CTA as a bold markdown link.
-
-    A markdown link works across both Card JSON 1.0 and 2.0 renderers
-    without depending on the ``tag: "button"`` field-name (which differs
-    between schema versions and Lark client builds). The cell rendering
-    is clickable on every Lark client + browser surface.
-    """
-    return {
-        "tag": "markdown",
-        "content": (
-            f"[**📊 在飞书表格中打开 · 编辑 · 分享 · 导出 CSV**]({sheet_url})"
-        ),
-    }
-
-
-def _build_raw_source_disclosure(table_text: str) -> Dict[str, Any]:
-    """Re-emit the original markdown table inside a fenced code block.
-
-    Feishu cards render fenced ``markdown`` content as plain monospace,
-    so long-press select-all on this block lets users copy the table as
-    valid markdown to paste into Lark Sheets, Excel, or any md-capable
-    surface. This is the closest we can ship without a backend Sheets
-    API integration.
-    """
-    stripped = table_text.rstrip("\n")
-    return {
-        "tag": "markdown",
-        "content": f"```markdown\n{stripped}\n```",
-    }
+    parts: List[str] = []
+    if sheet_url:
+        parts.append(f"[**📥 下载 CSV · 编辑(飞书表格)**]({sheet_url})")
+    if bitable_url:
+        parts.append(f"[**📊 保存到多维表格**]({bitable_url})")
+    if not parts:
+        return None
+    return {"tag": "markdown", "content": "  ·  ".join(parts)}
 
 
 def _run_selfcheck() -> int:
-    # === Case A: no sheet_url — v2 layout (hint + raw source only) ===
+    # === Case A: no storage URLs — minimal card (intro / table / footer) ===
     raw = _build_card_with_table_payload(_SCOUT_FEISHU_FRAGMENT)
     card = json.loads(raw)
     assert card["schema"] == "2.0", f"expected schema 2.0, got {card['schema']!r}"
     elements = card["body"]["elements"]
     tags = [e["tag"] for e in elements]
     assert tags == [
-        "markdown", "table", "markdown", "markdown", "markdown"
+        "markdown", "table", "markdown"
     ], f"case A: unexpected element order: {tags}"
-    assert "长按 cell 复制单元格" in elements[2]["content"], "case A: hint missing copy text"
-    assert "v3 上线中" in elements[2]["content"], "case A: hint should flag v3 pending"
-    assert elements[3]["content"].startswith("```markdown"), "case A: raw-source missing fence"
-    assert "| 关键词 |" in elements[3]["content"], "case A: raw-source missing original table"
+    # No raw-markdown disclosure block in the output anymore.
+    for el in elements:
+        assert not el.get("content", "").startswith("```markdown"), (
+            "case A: raw-source disclosure must be gone in v4"
+        )
 
-    # === Case B: with sheet_url — v3 layout (CTA button + adjusted hint) ===
-    mock_url = "https://feishu.cn/sheets/shtcnMOCKTOKEN12345"
-    raw_b = _build_card_with_table_payload(_SCOUT_FEISHU_FRAGMENT, sheet_url=mock_url)
+    # === Case B: sheet_url only — single CTA link ===
+    mock_sheet = "https://feishu.cn/sheets/shtcnMOCKTOKEN12345"
+    raw_b = _build_card_with_table_payload(_SCOUT_FEISHU_FRAGMENT, sheet_url=mock_sheet)
     card_b = json.loads(raw_b)
     elements_b = card_b["body"]["elements"]
     tags_b = [e["tag"] for e in elements_b]
-    # Order: intro / table / sheet-cta / hint / raw-source / footer
+    # Order: intro / table / storage-links / footer
     assert tags_b == [
-        "markdown", "table", "markdown", "markdown", "markdown", "markdown"
+        "markdown", "table", "markdown", "markdown"
     ], f"case B: unexpected element order: {tags_b}"
-    assert mock_url in elements_b[2]["content"], "case B: sheet-cta missing URL"
-    assert "📊" in elements_b[2]["content"], "case B: sheet-cta missing button emoji"
-    assert "v3 上线中" not in elements_b[3]["content"], "case B: hint should drop v3-pending caveat"
-    assert "点击上方 📊 按钮" in elements_b[3]["content"], "case B: hint should reference CTA"
+    assert mock_sheet in elements_b[2]["content"], "case B: sheet URL missing"
+    assert "📥 下载 CSV" in elements_b[2]["content"], "case B: missing CSV button label"
+    assert "多维表格" not in elements_b[2]["content"], "case B: bitable label should be absent"
+
+    # === Case C: both sheet_url and bitable_url — twin CTA links ===
+    mock_bitable = "https://feishu.cn/base/bascnMOCKTOKEN67890"
+    raw_c = _build_card_with_table_payload(
+        _SCOUT_FEISHU_FRAGMENT, sheet_url=mock_sheet, bitable_url=mock_bitable
+    )
+    card_c = json.loads(raw_c)
+    elements_c = card_c["body"]["elements"]
+    storage = elements_c[2]["content"]
+    assert mock_sheet in storage and mock_bitable in storage, (
+        "case C: both URLs must appear in the storage CTA element"
+    )
+    assert "📥 下载 CSV" in storage and "📊 保存到多维表格" in storage, (
+        "case C: both button labels must appear"
+    )
 
     table = elements[1]
     assert len(table["columns"]) == 4, f"expected 4 columns, got {len(table['columns'])}"

--- a/gateway/platforms/_feishu_card_table.py
+++ b/gateway/platforms/_feishu_card_table.py
@@ -134,6 +134,16 @@ def _build_card_with_table_payload(content: str) -> str:
     for seg_kind, seg_text in segments:
         if seg_kind == "table":
             elements.append(_parse_markdown_table_to_card_element(seg_text))
+            # Native client UX hint: educate users about Feishu's built-in
+            # cell-copy gestures, plus the raw-markdown fallback they can
+            # long-press select. Lightweight zero-dependency enhancement —
+            # later iterations can replace this with a "Save to Sheet"
+            # button once OAuth scopes (sheets:spreadsheet) are granted.
+            elements.append(_build_table_hint_element())
+            # Append the raw markdown source itself so long-press select +
+            # copy works for the entire table at once on mobile clients
+            # that don't expose per-cell copy.
+            elements.append(_build_raw_source_disclosure(seg_text))
         elif seg_text.strip():
             elements.append({"tag": "markdown", "content": seg_text})
     if not elements:
@@ -178,6 +188,40 @@ _SCOUT_FEISHU_FRAGMENT = (
 )
 
 
+_TABLE_HINT_CONTENT = (
+    "💡 **复制 / 下载提示** · 长按 cell 复制单元格 · "
+    "长按下方原始数据可全选复制并粘贴到飞书表格 / Excel · "
+    "「保存到飞书表格」按钮 v3 上线中"
+)
+
+
+def _build_table_hint_element() -> Dict[str, Any]:
+    """Inline markdown hint educating users about native Feishu copy gestures.
+
+    Lightweight zero-dependency enhancement: explains that Feishu desktop
+    + mobile clients already support long-press copy on table cells, and
+    points to the raw-markdown disclosure block that follows for full
+    table copy / paste workflows.
+    """
+    return {"tag": "markdown", "content": _TABLE_HINT_CONTENT}
+
+
+def _build_raw_source_disclosure(table_text: str) -> Dict[str, Any]:
+    """Re-emit the original markdown table inside a fenced code block.
+
+    Feishu cards render fenced ``markdown`` content as plain monospace,
+    so long-press select-all on this block lets users copy the table as
+    valid markdown to paste into Lark Sheets, Excel, or any md-capable
+    surface. This is the closest we can ship without a backend Sheets
+    API integration.
+    """
+    stripped = table_text.rstrip("\n")
+    return {
+        "tag": "markdown",
+        "content": f"```markdown\n{stripped}\n```",
+    }
+
+
 def _run_selfcheck() -> int:
     raw = _build_card_with_table_payload(_SCOUT_FEISHU_FRAGMENT)
     card = json.loads(raw)
@@ -186,7 +230,16 @@ def _run_selfcheck() -> int:
     assert card["schema"] == "2.0", f"expected schema 2.0, got {card['schema']!r}"
     elements = card["body"]["elements"]
     tags = [e["tag"] for e in elements]
-    assert tags == ["markdown", "table", "markdown"], f"unexpected element order: {tags}"
+    # Order: intro-markdown / table / hint-markdown / raw-source-markdown / footer-markdown
+    assert tags == [
+        "markdown", "table", "markdown", "markdown", "markdown"
+    ], f"unexpected element order: {tags}"
+
+    # Hint element must contain the copy-affordance educational text.
+    assert "长按 cell 复制单元格" in elements[2]["content"], "hint element missing copy text"
+    # Raw-source disclosure must be a fenced markdown block preserving pipes.
+    assert elements[3]["content"].startswith("```markdown"), "raw-source missing fence"
+    assert "| 关键词 |" in elements[3]["content"], "raw-source missing original table"
 
     table = elements[1]
     assert len(table["columns"]) == 4, f"expected 4 columns, got {len(table['columns'])}"

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -4270,13 +4270,13 @@ class FeishuAdapter(BasePlatformAdapter):
         if not headers or not data_rows:
             return None
 
-        try:
-            app_id = self._client.config.app_id
-            app_secret = self._client.config.app_secret
-            base_url = getattr(self._client.config, "domain", None) or "https://open.feishu.cn"
-        except AttributeError as exc:
-            logger.warning("[Feishu] sheet create: cannot read credentials: %s", exc)
-            return None
+        # Bot credentials live on the adapter instance (set in connect()
+        # from FEISHU_APP_ID / FEISHU_APP_SECRET), not on the lark_oapi
+        # Client object — Client has no ``.config`` attribute on this SDK
+        # build.
+        app_id = self._app_id
+        app_secret = self._app_secret
+        base_url = "https://open.feishu.cn"
         if not app_id or not app_secret:
             logger.warning("[Feishu] sheet create: app_id or app_secret missing")
             return None

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -607,6 +607,12 @@ def _build_markdown_post_rows(content: str) -> List[List[Dict[str, str]]]:
     return rows or [[{"tag": "md", "text": content}]]
 
 
+# Card JSON 2.0 table builders live in a sibling module so they can be
+# unit-tested without loading the full feishu adapter stack (which pulls in
+# hermes_cli, lark_oapi, websockets, aiohttp). See _feishu_card_table.py.
+from gateway.platforms._feishu_card_table import _build_card_with_table_payload  # noqa: E402
+
+
 def parse_feishu_post_payload(
     payload: Any,
     *,
@@ -4222,12 +4228,14 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
+        # Markdown tables: route through Card JSON 2.0 interactive card with
+        # native ``tag: "table"`` component (Lark V7.4+). Previously this path
+        # forced plain text because post-type 'md' elements render tables as
+        # blank — the native card path produces sortable / paginated UI that
+        # matches the experience Doubao etc. ship in their own apps.
+        # See ``_build_card_with_table_payload`` for the conversion details.
         if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
+            return "interactive", _build_card_with_table_payload(content)
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1777,7 +1777,14 @@ class FeishuAdapter(BasePlatformAdapter):
 
         try:
             for chunk in chunks:
-                msg_type, payload = self._build_outbound_payload(chunk)
+                # If this chunk carries a markdown table, asynchronously create
+                # a Lark Sheet so the card can include an "Open in Sheet" CTA.
+                # Failure (network / OAuth / quota) returns ``None`` and we
+                # fall back to the no-CTA card — never blocks the send.
+                sheet_url: Optional[str] = None
+                if _MARKDOWN_TABLE_RE.search(chunk):
+                    sheet_url = await self._create_lark_sheet_from_first_table(chunk)
+                msg_type, payload = self._build_outbound_payload(chunk, sheet_url=sheet_url)
                 try:
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
@@ -4227,15 +4234,142 @@ class FeishuAdapter(BasePlatformAdapter):
     # Outbound payload construction and send pipeline
     # =========================================================================
 
-    def _build_outbound_payload(self, content: str) -> tuple[str, str]:
+    async def _create_lark_sheet_from_first_table(self, content: str) -> Optional[str]:
+        """Parse the first markdown table from ``content``, create a Lark
+        spreadsheet, populate it with the table data, and return the sheet
+        URL. Returns ``None`` on any failure — callers fall back to the
+        no-button card layout. All failures are logged but never raised.
+
+        Requires the bot to have these OAuth scopes:
+        - ``sheets:spreadsheet`` (create + write)
+        - ``drive:drive`` (place the new file in cloud space)
+        """
+        from gateway.platforms._feishu_card_table import (
+            _split_content_at_tables,
+            _split_md_table_row,
+        )
+        table_text: Optional[str] = None
+        for kind, seg in _split_content_at_tables(content):
+            if kind == "table":
+                table_text = seg
+                break
+        if not table_text:
+            return None
+        raw_lines = [ln for ln in table_text.splitlines() if ln.strip().startswith("|")]
+        if len(raw_lines) < 2:
+            return None
+
+        def _strip_inline_md(s: str) -> str:
+            return re.sub(r"\*\*(.+?)\*\*", r"\1", s).strip()
+
+        headers = [_strip_inline_md(h) for h in _split_md_table_row(raw_lines[0])]
+        data_rows = [
+            [_strip_inline_md(c) for c in _split_md_table_row(ln)]
+            for ln in raw_lines[2:]
+        ]
+        if not headers or not data_rows:
+            return None
+
+        try:
+            app_id = self._client.config.app_id
+            app_secret = self._client.config.app_secret
+            base_url = getattr(self._client.config, "domain", None) or "https://open.feishu.cn"
+        except AttributeError as exc:
+            logger.warning("[Feishu] sheet create: cannot read credentials: %s", exc)
+            return None
+        if not app_id or not app_secret:
+            logger.warning("[Feishu] sheet create: app_id or app_secret missing")
+            return None
+
+        try:
+            async with httpx.AsyncClient(timeout=15.0) as http:
+                tok_resp = await http.post(
+                    f"{base_url}/open-apis/auth/v3/tenant_access_token/internal",
+                    json={"app_id": app_id, "app_secret": app_secret},
+                )
+                tok_data = tok_resp.json()
+                if tok_data.get("code") != 0:
+                    logger.warning("[Feishu] sheet create: token fetch failed: %s", tok_data)
+                    return None
+                token = tok_data["tenant_access_token"]
+                api_headers = {
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": "application/json; charset=utf-8",
+                }
+
+                title = f"Scout 表格 {datetime.utcnow().strftime('%Y-%m-%d %H:%M UTC')}"
+                create_resp = await http.post(
+                    f"{base_url}/open-apis/sheets/v3/spreadsheets",
+                    json={"title": title},
+                    headers=api_headers,
+                )
+                create_data = create_resp.json()
+                if create_data.get("code") != 0:
+                    logger.warning("[Feishu] sheet create v3 failed: %s", create_data)
+                    return None
+                sheet_info = create_data["data"]["spreadsheet"]
+                sst_token = sheet_info["spreadsheet_token"]
+                sheet_url = sheet_info.get("url") or f"https://feishu.cn/sheets/{sst_token}"
+
+                meta_resp = await http.get(
+                    f"{base_url}/open-apis/sheets/v3/spreadsheets/{sst_token}/sheets/query",
+                    headers=api_headers,
+                )
+                meta_data = meta_resp.json()
+                if meta_data.get("code") != 0 or not meta_data.get("data", {}).get("sheets"):
+                    logger.warning(
+                        "[Feishu] sheet meta query failed; returning blank-sheet URL: %s",
+                        meta_data,
+                    )
+                    return sheet_url
+                sheet_id = meta_data["data"]["sheets"][0]["sheet_id"]
+
+                all_rows = [headers] + data_rows
+                n_rows = len(all_rows)
+                n_cols = max(len(r) for r in all_rows)
+                all_rows = [r + [""] * (n_cols - len(r)) for r in all_rows]
+
+                def _col_letter(idx: int) -> str:
+                    if idx < 26:
+                        return chr(ord("A") + idx)
+                    return chr(ord("A") + idx // 26 - 1) + chr(ord("A") + idx % 26)
+
+                end_col = _col_letter(n_cols - 1)
+                range_str = f"{sheet_id}!A1:{end_col}{n_rows}"
+                append_resp = await http.post(
+                    f"{base_url}/open-apis/sheets/v2/spreadsheets/{sst_token}/values_append",
+                    json={"valueRange": {"range": range_str, "values": all_rows}},
+                    headers=api_headers,
+                )
+                append_data = append_resp.json()
+                if append_data.get("code") != 0:
+                    logger.warning("[Feishu] sheet values_append failed: %s", append_data)
+                else:
+                    logger.info(
+                        "[Feishu] sheet populated: token=%s rows=%d cols=%d",
+                        sst_token, n_rows, n_cols,
+                    )
+                return sheet_url
+        except Exception as exc:
+            logger.warning("[Feishu] sheet create exception: %s", exc, exc_info=True)
+            return None
+
+    def _build_outbound_payload(
+        self,
+        content: str,
+        sheet_url: Optional[str] = None,
+    ) -> tuple[str, str]:
         # Markdown tables: route through Card JSON 2.0 interactive card with
         # native ``tag: "table"`` component (Lark V7.4+). Previously this path
         # forced plain text because post-type 'md' elements render tables as
         # blank — the native card path produces sortable / paginated UI that
         # matches the experience Doubao etc. ship in their own apps.
+        # ``sheet_url`` (when provided by an async caller via
+        # ``_create_lark_sheet_from_first_table``) decorates the card with a
+        # "Open in Lark Sheet" CTA pointing at the populated spreadsheet.
         # See ``_build_card_with_table_payload`` for the conversion details.
         if _MARKDOWN_TABLE_RE.search(content):
-            return "interactive", _build_card_with_table_payload(content)
+            return "interactive", _build_card_with_table_payload(content, sheet_url=sheet_url)
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}

--- a/tests/gateway/platforms/test_feishu_card_table.py
+++ b/tests/gateway/platforms/test_feishu_card_table.py
@@ -1,0 +1,225 @@
+"""Markdown table → Feishu Card JSON 2.0 outbound conversion tests.
+
+Validates the new dispatch in ``_build_outbound_payload``: when the LLM
+emits a markdown table, the adapter must send a native ``tag: "table"``
+interactive card (Lark V7.4+) instead of the prior plain-text fallback
+that lost all alignment.
+
+Also doubles as a self-check script — when run directly via
+``python tests/gateway/platforms/test_feishu_card_table.py`` it prints
+the full card JSON produced from a real-world Scout / Feishu transcript
+fragment so a human can eyeball the structure before shipping.
+"""
+from __future__ import annotations
+
+import json
+
+from gateway.platforms._feishu_card_table import (
+    _build_card_with_table_payload,
+    _parse_markdown_table_to_card_element,
+    _split_content_at_tables,
+    _split_md_table_row,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper-level unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_split_md_table_row_strips_pipes_and_whitespace():
+    row = "| office desk | 2961 | **123,664** | ❌ |"
+    assert _split_md_table_row(row) == ["office desk", "2961", "**123,664**", "❌"]
+
+
+def test_split_md_table_row_keeps_empty_cells():
+    row = "| a |   | c |"
+    assert _split_md_table_row(row) == ["a", "", "c"]
+
+
+def test_split_content_at_tables_pure_text_yields_single_text_segment():
+    content = "Hello world\nLine two"
+    segs = _split_content_at_tables(content)
+    assert len(segs) == 1
+    assert segs[0][0] == "text"
+    assert "Hello world" in segs[0][1]
+
+
+def test_split_content_at_tables_isolates_table_block():
+    content = (
+        "Intro paragraph before the table.\n"
+        "\n"
+        "| col1 | col2 |\n"
+        "|------|------|\n"
+        "| a    | b    |\n"
+        "| c    | d    |\n"
+        "\n"
+        "Footer line after the table.\n"
+    )
+    segs = _split_content_at_tables(content)
+    kinds = [k for k, _ in segs]
+    assert kinds == ["text", "table", "text"]
+    assert "Intro paragraph" in segs[0][1]
+    assert segs[1][1].count("\n") >= 3  # header + sep + 2 data rows
+    assert "Footer line" in segs[2][1]
+
+
+def test_parse_markdown_table_to_card_element_builds_columns_and_rows():
+    table = (
+        "| 关键词 | SERP 数 |\n"
+        "|---|---|\n"
+        "| office desk | 2961 |\n"
+        "| office chair | 201 |\n"
+    )
+    elem = _parse_markdown_table_to_card_element(table)
+    assert elem["tag"] == "table"
+    assert elem["columns"] == [
+        {"name": "col1", "display_name": "关键词", "data_type": "markdown"},
+        {"name": "col2", "display_name": "SERP 数", "data_type": "markdown"},
+    ]
+    assert elem["rows"] == [
+        {"col1": "office desk", "col2": "2961"},
+        {"col1": "office chair", "col2": "201"},
+    ]
+    assert elem["page_size"] == 10
+
+
+def test_parse_markdown_table_handles_ragged_rows_by_padding():
+    table = (
+        "| a | b | c |\n"
+        "|---|---|---|\n"
+        "| 1 | 2 |\n"  # missing third cell
+    )
+    elem = _parse_markdown_table_to_card_element(table)
+    assert elem["rows"] == [{"col1": "1", "col2": "2", "col3": ""}]
+
+
+def test_parse_markdown_table_degrades_when_no_data_rows():
+    table = "| only header |\n|------|\n"
+    elem = _parse_markdown_table_to_card_element(table)
+    assert elem["tag"] == "table"
+    assert elem["rows"] == []
+
+
+# ---------------------------------------------------------------------------
+# Top-level payload build tests
+# ---------------------------------------------------------------------------
+
+
+def test_build_card_with_table_payload_emits_schema_2_envelope():
+    content = "| h1 | h2 |\n|---|---|\n| a | b |\n"
+    raw = _build_card_with_table_payload(content)
+    card = json.loads(raw)
+    assert card["schema"] == "2.0"
+    assert card["config"] == {"wide_screen_mode": True}
+    assert isinstance(card["body"]["elements"], list)
+    assert card["body"]["elements"][0]["tag"] == "table"
+
+
+def test_build_card_with_table_payload_mixes_markdown_and_table_in_order():
+    content = (
+        "**主要发现:** 办公家具大词都 >1万\n"
+        "\n"
+        "| 关键词 | SERP | 状态 |\n"
+        "|---|---|---|\n"
+        "| desk | 41284 | ❌ |\n"
+        "| chair | 980 | ✅ |\n"
+        "\n"
+        "Next: 用 ✅ 词跑下一阶段\n"
+    )
+    raw = _build_card_with_table_payload(content)
+    card = json.loads(raw)
+    elements = card["body"]["elements"]
+    tags = [e["tag"] for e in elements]
+    assert tags == ["markdown", "table", "markdown"]
+    assert "主要发现" in elements[0]["content"]
+    assert elements[1]["rows"][1] == {"col1": "chair", "col2": "980", "col3": "✅"}
+    assert "Next" in elements[2]["content"]
+
+
+def test_build_card_with_table_payload_pure_table_no_prose():
+    content = "| h1 | h2 |\n|---|---|\n| a | b |\n"
+    raw = _build_card_with_table_payload(content)
+    card = json.loads(raw)
+    tags = [e["tag"] for e in card["body"]["elements"]]
+    assert tags == ["table"]
+
+
+# ---------------------------------------------------------------------------
+# Real-world regression: the 2026-05-21 Scout / Feishu office-furniture
+# incident transcript fragment. This must produce a card whose table rows
+# preserve the ❌ / ✅ status markers and the SERP integers as cell strings.
+# ---------------------------------------------------------------------------
+
+
+_SCOUT_FEISHU_FRAGMENT = (
+    "结果出来了,先做个初步筛选:\n"
+    "\n"
+    "| 关键词 | AMZ123排名 | 亚马逊竞品数 | 竞品<2000? |\n"
+    "|---|---|---|---|\n"
+    "| office desk | 2961 | **123,664** | ❌ |\n"
+    "| office chair | 201 | **62,794** | ❌ |\n"
+    "| ergonomic office chair | 3546 | **16,873** | ❌ |\n"
+    "| filing cabinet | 9120 | **18,600** | ❌ |\n"
+    "| office desk accessories | 3043 | **111,356** | ❌ |\n"
+    "| ✅ **criss cross office chair** | **7256** | **1,410** | ✅ |\n"
+    "\n"
+    "**主要发现:** 办公家具类目主词竞品数都 >1 万,符合 <2000 的就一个\n"
+)
+
+
+def test_scout_feishu_office_furniture_fragment_round_trip():
+    raw = _build_card_with_table_payload(_SCOUT_FEISHU_FRAGMENT)
+    card = json.loads(raw)
+    elements = card["body"]["elements"]
+    tags = [e["tag"] for e in elements]
+    assert tags == ["markdown", "table", "markdown"]
+    table = elements[1]
+    assert len(table["columns"]) == 4
+    assert table["columns"][0]["display_name"] == "关键词"
+    assert len(table["rows"]) == 6
+    # The last row must preserve ✅ marker and bold markdown:
+    last = table["rows"][5]
+    assert "criss cross office chair" in last["col1"]
+    assert last["col4"] == "✅"
+
+
+# ---------------------------------------------------------------------------
+# Self-check entry point — `python test_feishu_card_table.py`
+# Prints the full card JSON produced from the real Scout transcript so a
+# human can eyeball the structure (columns, rows, ✅/❌, markdown spans)
+# before merging the PR.
+# ---------------------------------------------------------------------------
+
+
+def _self_check() -> None:
+    raw = _build_card_with_table_payload(_SCOUT_FEISHU_FRAGMENT)
+    card = json.loads(raw)
+    print("=" * 72)
+    print("SELF-CHECK: Scout / Feishu 2026-05-21 office-furniture transcript")
+    print("=" * 72)
+    print("Input markdown content:")
+    print("-" * 72)
+    print(_SCOUT_FEISHU_FRAGMENT)
+    print("-" * 72)
+    print("Output card JSON (msg_type=interactive payload):")
+    print("-" * 72)
+    print(json.dumps(card, ensure_ascii=False, indent=2))
+    print("-" * 72)
+    elements = card["body"]["elements"]
+    print(f"Element count: {len(elements)}")
+    for i, e in enumerate(elements):
+        if e["tag"] == "table":
+            print(
+                f"  [{i}] table: {len(e['columns'])} cols, {len(e['rows'])} rows, "
+                f"page_size={e['page_size']}"
+            )
+        else:
+            content_preview = e.get("content", "")[:60].replace("\n", " ")
+            print(f"  [{i}] {e['tag']}: {content_preview!r}")
+    print("=" * 72)
+    print("OK")
+
+
+if __name__ == "__main__":
+    _self_check()

--- a/tests/gateway/platforms/test_feishu_card_table.py
+++ b/tests/gateway/platforms/test_feishu_card_table.py
@@ -131,10 +131,14 @@ def test_build_card_with_table_payload_mixes_markdown_and_table_in_order():
     card = json.loads(raw)
     elements = card["body"]["elements"]
     tags = [e["tag"] for e in elements]
-    assert tags == ["markdown", "table", "markdown"]
+    # Order: intro / table / hint / raw-source / footer
+    assert tags == ["markdown", "table", "markdown", "markdown", "markdown"]
     assert "主要发现" in elements[0]["content"]
     assert elements[1]["rows"][1] == {"col1": "chair", "col2": "980", "col3": "✅"}
-    assert "Next" in elements[2]["content"]
+    # Hint and raw-source disclosure live at indices 2 and 3.
+    assert "长按 cell 复制单元格" in elements[2]["content"]
+    assert elements[3]["content"].startswith("```markdown")
+    assert "Next" in elements[4]["content"]
 
 
 def test_build_card_with_table_payload_pure_table_no_prose():
@@ -142,7 +146,8 @@ def test_build_card_with_table_payload_pure_table_no_prose():
     raw = _build_card_with_table_payload(content)
     card = json.loads(raw)
     tags = [e["tag"] for e in card["body"]["elements"]]
-    assert tags == ["table"]
+    # A bare table still emits the hint and raw-source disclosure after it.
+    assert tags == ["table", "markdown", "markdown"]
 
 
 # ---------------------------------------------------------------------------
@@ -173,7 +178,8 @@ def test_scout_feishu_office_furniture_fragment_round_trip():
     card = json.loads(raw)
     elements = card["body"]["elements"]
     tags = [e["tag"] for e in elements]
-    assert tags == ["markdown", "table", "markdown"]
+    # Order: intro / table / hint / raw-source / footer
+    assert tags == ["markdown", "table", "markdown", "markdown", "markdown"]
     table = elements[1]
     assert len(table["columns"]) == 4
     assert table["columns"][0]["display_name"] == "关键词"
@@ -182,6 +188,9 @@ def test_scout_feishu_office_furniture_fragment_round_trip():
     last = table["rows"][5]
     assert "criss cross office chair" in last["col1"]
     assert last["col4"] == "✅"
+    # Hint educates users; raw-source preserves the full markdown table.
+    assert "长按 cell 复制单元格" in elements[2]["content"]
+    assert "criss cross office chair" in elements[3]["content"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes the user-facing gap in #9978 for the table sub-case: when the agent emits a markdown table, the Feishu adapter currently force-routes to msg_type=text because post-type 'md' elements don't render tables. On the client this surfaces as ASCII-pipe walls that don't even align on mobile.

This change detects markdown tables (existing `_MARKDOWN_TABLE_RE`) and routes them through a Card JSON 2.0 interactive payload with the native `tag: "table"` component (Lark V7.4+):

- Prose around the table is preserved as `tag: "markdown"` element(s).
- Each table becomes a sortable / paginated `tag: "table"` element.
- Column display names come from the markdown header row; cells use `data_type: "markdown"` so existing bold / link / ✅ / ❌ formatting carries through.
- `page_size: 10` keeps long shortlists scrollable.
- Card JSON 1.0 paths (`send_exec_approval`, `send_update_prompt`) are untouched — schemas may be mixed across messages within one chat.

Helpers live in a dedicated `_feishu_card_table.py` module so they can be unit-tested without loading the full feishu adapter stack (which pulls in hermes_cli / lark_oapi / websockets / aiohttp). The module also doubles as a standalone self-check entry point.

Self-check:

    python3 gateway/platforms/_feishu_card_table.py

Uses a real 2026-05-21 Feishu transcript fragment (Chinese header, bold cells, ✅ / ❌ markers, leading + trailing prose) and dumps the produced card JSON for visual inspection + asserts on schema / element order / row preservation.

Unit tests in `tests/gateway/platforms/test_feishu_card_table.py` cover: row splitting, segment detection, table-to-element conversion, ragged-row padding, header-only edge case, schema 2.0 envelope, mixed text+table+text ordering, pure-table-no-prose, and the office-furniture regression fragment.

Refs: #9978, #1788

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

