### PR TITLE
feat(telegram): use choice text as clarify button labels

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4721,8 +4721,8 @@ class TelegramAdapter(BasePlatformAdapter):
             if choices:
                 # Render full option text in the message body so mobile
                 # users can read long choices that would be truncated in
-                # inline button labels.  Buttons keep short numeric labels
-                # (1, 2, …, Other) to avoid Telegram truncation.
+                # inline button labels.  Buttons show the choice text itself,
+                # truncated to 60 characters to stay within Telegram limits.
                 option_lines = "\n".join(
                     f"{i + 1}. {_html.escape(str(c))}"
                     for i, c in enumerate(choices)
@@ -4738,12 +4738,17 @@ class TelegramAdapter(BasePlatformAdapter):
 
             if choices:
                 # Telegram caps callback_data at 64 bytes; keep "cl:<id>:<idx>"
-                # short.
+                # short.  Button labels are capped at 60 characters so Telegram
+                # doesn't truncate them.
+                _MAX_LABEL = 60
                 rows = []
-                for idx in range(len(choices)):
+                for idx, choice in enumerate(choices):
+                    label = str(choice)
+                    if len(label) > _MAX_LABEL:
+                        label = label[: _MAX_LABEL - 1] + "…"
                     rows.append([
                         InlineKeyboardButton(
-                            str(idx + 1),
+                            label,
                             callback_data=f"cl:{clarify_id}:{idx}",
                         )
                     ])

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -78,11 +78,20 @@ class TestTelegramSendClarify:
         _clear_clarify_state()
 
     @pytest.mark.asyncio
-    async def test_multi_choice_renders_buttons_and_other(self):
+    async def test_multi_choice_renders_buttons_and_other(self, monkeypatch):
         adapter = _make_adapter()
         mock_msg = MagicMock()
         mock_msg.message_id = 100
         adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        buttons = []
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.InlineKeyboardButton",
+            lambda text, callback_data: buttons.append(text) or (text, callback_data),
+        )
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.InlineKeyboardMarkup", lambda rows: rows
+        )
 
         result = await adapter.send_clarify(
             chat_id="12345",
@@ -98,15 +107,13 @@ class TestTelegramSendClarify:
         kwargs = adapter._bot.send_message.call_args[1]
         assert kwargs["chat_id"] == 12345
         assert "Which option?" in kwargs["text"]
-        # Full option text rendered in the message body (not just buttons)
+        # Full option text still rendered in the message body (not just buttons)
         assert "1. alpha" in kwargs["text"]
         assert "2. beta" in kwargs["text"]
         assert "3. gamma" in kwargs["text"]
-        # InlineKeyboardMarkup with N+1 buttons (3 choices + Other)
-        markup = kwargs["reply_markup"]
-        assert markup is not None
-        # Mocked InlineKeyboardMarkup — just verify it was constructed
-        # with rows.  We check state instead of poking the mock structure.
+        # Buttons are labelled with the choice text itself, plus the Other button
+        assert buttons == ["alpha", "beta", "gamma", "✏️ Other (type answer)"]
+        assert kwargs["reply_markup"] is not None
         assert "cid1" in adapter._clarify_state
         assert adapter._clarify_state["cid1"] == "sk1"
 
@@ -146,13 +153,22 @@ class TestTelegramSendClarify:
         assert result.success is False
 
     @pytest.mark.asyncio
-    async def test_long_choice_rendered_in_body_not_truncated(self):
-        """Long choice text appears in full in the message body;
-        button labels stay short numeric (1, 2, …)."""
+    async def test_long_choice_label_truncated_body_full(self, monkeypatch):
+        """A long choice is truncated to 60 chars in its button label, but
+        appears in full in the message body so it stays readable."""
         adapter = _make_adapter()
         mock_msg = MagicMock()
         mock_msg.message_id = 102
         adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        buttons = []
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.InlineKeyboardButton",
+            lambda text, callback_data: buttons.append(text) or (text, callback_data),
+        )
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.InlineKeyboardMarkup", lambda rows: rows
+        )
 
         long_choice = "x" * 200
         result = await adapter.send_clarify(
@@ -166,9 +182,11 @@ class TestTelegramSendClarify:
         kwargs = adapter._bot.send_message.call_args[1]
         # The full long choice text appears in the message body
         assert long_choice in kwargs["text"]
-        # The button label should be short ("1"), not the long choice
-        # (we can't inspect mock button labels directly, but the send
-        # succeeded — old truncation code could raise on edge cases)
+        # The button label is clipped to 60 chars with an ellipsis
+        choice_label = buttons[0]
+        assert len(choice_label) == 60
+        assert choice_label.endswith("…")
+        assert choice_label.startswith("x")
 
     @pytest.mark.asyncio
     async def test_html_escapes_question(self):

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -1271,8 +1271,14 @@ When the agent calls the `clarify` tool — to ask which approach you prefer, ge
 
 > ❓ Which framework should I use for the dashboard?
 >
-> [1. Next.js] [2. Remix] [3. Astro]
+> 1. Next.js
+> 2. Remix
+> 3. Astro
+>
+> [Next.js] [Remix] [Astro]
 > [✏️ Other (type answer)]
+
+Each button is labelled with the choice text (truncated to 60 characters if long). The full numbered list stays in the message body so long choices remain readable even when a button label is clipped.
 
 Tap a button to answer, or tap **Other** to type a free-form response (the next message you send becomes the answer). Open-ended `clarify` calls (no preset choices) skip the buttons and just capture your next message.
 


### PR DESCRIPTION
## Problem

`clarify` prompts in Telegram render inline buttons with numeric labels
(`1`, `2`, `3`). Users must cross-reference the message body to map each
number to its meaning, which is slow on mobile.

## Solution

Label each inline button with its choice text (truncated to 60 characters to
stay within Telegram's limit). The full numbered choice list stays in the
message body, so long choices remain fully readable even when a button label
is clipped — preserving the #27497 accessibility contract.

### Changes

- `plugins/platforms/telegram/adapter.py` (`send_clarify`):
  - Button label is now the choice text, capped at 60 chars (ellipsis if truncated).
  - Full numbered choice list retained in the message body.
  - Callback data (`cl:<id>:<idx>`) unchanged — no change to dispatch logic.
- `tests/gateway/test_telegram_clarify_buttons.py`:
  - Assert buttons carry choice-text labels, the 60-char truncation, and that
    long choices stay full-length in the body.
- `website/docs/user-guide/messaging/telegram.md`:
  - Updated the clarify example to text-labeled buttons + the numbered body list.

## Verification

```bash
pytest tests/gateway/test_telegram_clarify_buttons.py
# 14 passed
```

Rebased on current `main`; ruff clean.

## Migration & maintainer decision

Rebased onto current `main`: the Telegram adapter has moved to
`plugins/platforms/telegram/adapter.py` (`560010547`), and the change is
transplanted there. #27497 (via `6fb57bc9`) intentionally introduced numeric
labels + a full body list to avoid mobile truncation of long labels; this PR
keeps that body list and only relabels the buttons, so it does not regress that
contract. Whether text labels are preferred over numeric is a UX call — happy to
close if maintainers prefer to keep numeric labels.

For reference vs. #29308 (also open): same label change, but that PR removes the
body list (long choices become readable nowhere) and adds no tests; this one
retains the body list and adds test + doc coverage.

_(Dropped an earlier erroneous `Fixes #25710` — unrelated issue.)_
