### PR TITLE
fix(doctor): recognize self-hosted Mem0 without API key

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1906,14 +1906,18 @@ def run_doctor(args):
             from plugins.memory.mem0 import _load_config as _load_mem0_config
             mem0_cfg = _load_mem0_config()
             mem0_key = mem0_cfg.get("api_key", "")
+            mem0_host = mem0_cfg.get("host", "")
             if mem0_key:
                 check_ok("Mem0 API key configured")
+                check_info(f"user_id={mem0_cfg.get('user_id', '?')}  agent_id={mem0_cfg.get('agent_id', '?')}")
+            elif mem0_host:
+                check_ok(f"Mem0 self-hosted mode ({mem0_host})")
                 check_info(f"user_id={mem0_cfg.get('user_id', '?')}  agent_id={mem0_cfg.get('agent_id', '?')}")
             else:
                 _fail_and_issue(
                     "Mem0 API key not set",
-                    "(set MEM0_API_KEY in .env or run hermes memory setup)",
-                    "Mem0 is set as memory provider but API key is missing",
+                    "(set MEM0_API_KEY in .env or run 'hermes memory setup')",
+                    "Mem0 is set as memory provider but neither API key nor self-hosted URL is configured",
                     issues,
                 )
         except ImportError:


### PR DESCRIPTION
## Summary

`hermes doctor` reports a false-positive "Mem0 API key not set" when using a self-hosted Mem0 instance without a cloud API key.

The plugin's `is_available()` correctly accepts either `api_key` (cloud) or `host` (self-hosted), but the doctor check only validated `api_key`.

**Fix:** Added `host` fallback check — if `api_key` is empty but `host` is set, reports "Mem0 self-hosted mode" instead of failing.

## Changes

```python
# Before
if mem0_key:
    check_ok("Mem0 API key configured")
else:
    _fail("Mem0 API key not set")

# After
if mem0_key:
    check_ok("Mem0 API key configured")
elif mem0_host:
    check_ok(f"Mem0 self-hosted mode ({mem0_host})")
else:
    _fail("Mem0 API key not set")
```

## Test Plan

- [x] `hermes doctor` with self-hosted Mem0 (host in mem0.json, no api_key) → shows ✅
- [x] `hermes doctor` with cloud Mem0 (api_key set) → still shows ✅
- [x] `hermes doctor` with neither → still shows proper error
