### PR TITLE
fix(mcp): raise clear ImportError in _run_stdio when SDK unavailable

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1462,6 +1462,25 @@ class TestHTTPConfig:
 
         asyncio.run(_test())
 
+    def test_stdio_unavailable_raises_clear_import_error(self):
+        """Regression for #30904: when the SDK import block failed (mcp not
+        installed, or a build that doesn't expose StdioServerParameters at
+        the top level), `_run_stdio` must surface a clear ImportError rather
+        than letting the dangling `StdioServerParameters` reference raise a
+        confusing `NameError: name 'StdioServerParameters' is not defined`.
+        """
+        from tools.mcp_tool import MCPServerTask
+
+        server = MCPServerTask("local")
+        config = {"command": "python3", "args": ["/tmp/echo_mcp.py"]}
+
+        async def _test():
+            with patch("tools.mcp_tool._MCP_AVAILABLE", False):
+                with pytest.raises(ImportError, match="stdio transport"):
+                    await server._run_stdio(config)
+
+        asyncio.run(_test())
+
     def test_http_seeds_initial_protocol_header(self):
         from tools.mcp_tool import LATEST_PROTOCOL_VERSION, MCPServerTask
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1255,6 +1255,19 @@ class MCPServerTask:
 
     async def _run_stdio(self, config: dict):
         """Run the server using stdio transport."""
+        # Mirror the _run_http guard: if the SDK import block above failed
+        # (mcp not installed, or a non-standard build that doesn't re-export
+        # StdioServerParameters at top level), surface a clear ImportError
+        # here rather than letting StdioServerParameters dereference below
+        # raise a confusing NameError. See #30904.
+        if not _MCP_AVAILABLE:
+            raise ImportError(
+                f"MCP server '{self.name}' requires the 'mcp' Python SDK "
+                "for stdio transport, but it is not available (import of "
+                "'StdioServerParameters' from 'mcp' failed). Install or "
+                "repair the SDK with 'uv pip install \"mcp>=1.0\"'."
+            )
+
         command = config.get("command")
         args = config.get("args", [])
         user_env = config.get("env")


### PR DESCRIPTION
## What does this PR do?

When the `mcp` Python SDK isn't installed (or is installed but doesn't expose `StdioServerParameters` at its top level — some forks/older builds only ship it under `mcp.client.stdio`), the module-level `from mcp import ClientSession, StdioServerParameters` fails atomically. `_MCP_AVAILABLE` stays `False`, and none of `ClientSession` / `StdioServerParameters` / `stdio_client` are bound at module scope.

`_run_http` already guards against this on line [1339](https://github.com/NousResearch/hermes-agent/blob/main/tools/mcp_tool.py#L1339) with a clear `ImportError`. `_run_stdio` was missing the parallel guard, so `hermes mcp test <name>` surfaced the very confusing `NameError: name 'StdioServerParameters' is not defined` (reported in #30904) instead of the actionable \"install the mcp SDK\" message.

This PR mirrors the `_run_http` guard at the entry of `_run_stdio`. No other behavior changes.

> Audited siblings: `_run_http` already has the equivalent `_MCP_HTTP_AVAILABLE` guard; the SSE transport path uses a defaulted-`None` `sse_client` that returns a different shaped error; `_run_stdio` was the only entry point still missing the guard.

## Related Issue

Fixes #30904

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/mcp_tool.py` — at the top of `MCPServerTask._run_stdio`, raise `ImportError` with an install hint when `_MCP_AVAILABLE` is `False`, mirroring the existing `_run_http` guard.
- `tests/tools/test_mcp_tool.py` — add `test_stdio_unavailable_raises_clear_import_error` next to the existing `test_http_unavailable_raises`, asserting the new behavior.

## How to Test

1. Repro before the patch:
   \`\`\`bash
   uv run --with pytest --with pytest-asyncio --with pytest-timeout --with mcp \\
     python3 -m pytest tests/tools/test_mcp_tool.py::TestHTTPConfig::test_stdio_unavailable_raises_clear_import_error -v
   \`\`\`
   (Without the production guard, the test fails because `_run_stdio` proceeds to `StdioServerParameters(...)`.)
2. With this PR: same command passes.
3. Full file suite stays green:
   \`\`\`bash
   uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout --with mcp \\
     python3 -m pytest tests/tools/test_mcp_tool.py
   \`\`\`
   → 196 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (\`fix(scope):\`, \`feat(scope):\`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, \`docs/\`, docstrings) — or N/A (inline comment cites the issue and explains the mirror)
- [x] I've updated \`cli-config.yaml.example\` if I added/changed config keys — N/A
- [x] I've updated \`CONTRIBUTING.md\` or \`AGENTS.md\` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure error-message routing change, no platform-specific behavior)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before (user-facing message in #30904):

\`\`\`
$ hermes mcp test ax-status
  Testing 'ax-status'...
  Transport: stdio → python3
  Auth: none
  ✗ Connection failed (7061ms): name 'StdioServerParameters' is not defined
\`\`\`

After:

\`\`\`
$ hermes mcp test ax-status
  Testing 'ax-status'...
  Transport: stdio → python3
  Auth: none
  ✗ Connection failed (Xms): MCP server 'ax-status' requires the 'mcp' Python SDK
    for stdio transport, but it is not available (import of 'StdioServerParameters'
    from 'mcp' failed). Install or repair the SDK with 'uv pip install "mcp>=1.0"'.
\`\`\`