### PR TITLE
feat: surface fallback restore and subagent models

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1641,6 +1641,10 @@ def restore_primary_runtime(agent) -> bool:
             "Primary runtime restored for new turn: %s (%s)",
             agent.model, agent.provider,
         )
+        agent._emit_status(
+            f"✅ Fallback cleared — resuming with primary model: "
+            f"{agent.model} via {agent.provider}"
+        )
         return True
     except Exception as e:
         logger.warning("Failed to restore primary runtime: %s", e)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3452,8 +3452,9 @@ class TurnRunner:
         if not ctx.tool_progress_enabled:
             return
 
-        # Only act on tool.started events (ignore tool.completed, reasoning.available, etc.)
-        if event_type not in {"tool.started",}:
+        # Only act on visible progress events (ignore tool.completed,
+        # reasoning.available, etc.)
+        if event_type not in {"tool.started", "subagent.start"}:
             return
 
         # Never render a progress bubble for the clarify tool.  The
@@ -3482,6 +3483,35 @@ class TurnRunner:
                 return
         except Exception:
             pass
+
+        if event_type == "subagent.start":
+            subagent_label = "Subagent"
+            task_index = kwargs.get("task_index")
+            task_count = kwargs.get("task_count")
+            if (
+                isinstance(task_index, int)
+                and isinstance(task_count, int)
+                and task_count > 1
+            ):
+                subagent_label = f"Subagent {task_index + 1}/{task_count}"
+            dedup_key = (
+                "subagent.start",
+                kwargs.get("subagent_id"),
+                task_index,
+                preview,
+            )
+            if ctx.progress_mode == "new" and dedup_key == ctx.last_tool[0]:
+                return
+            ctx.last_tool[0] = dedup_key
+            model = (kwargs.get("model") or "").strip()
+            msg = f"🤖 {subagent_label}"
+            if preview:
+                msg += f": \"{preview}\""
+            if model:
+                msg += f"\nModel: `{model}`"
+            ctx.last_was_terminal_block[0] = False
+            ctx.progress_queue.put(msg)
+            return
 
         # "new" mode: only report when tool changes
         if ctx.progress_mode == "new" and tool_name == ctx.last_tool[0]:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4400,8 +4400,9 @@ class TurnRunner:
         if not ctx.tool_progress_enabled:
             return
 
-        # Only act on tool.started events (ignore tool.completed, reasoning.available, etc.)
-        if event_type not in {"tool.started",}:
+        # Only act on visible progress events (ignore tool.completed,
+        # reasoning.available, etc.)
+        if event_type not in {"tool.started", "subagent.start"}:
             return
 
         # Never render a progress bubble for the clarify tool.  The
@@ -4430,6 +4431,35 @@ class TurnRunner:
                 return
         except Exception:
             pass
+
+        if event_type == "subagent.start":
+            subagent_label = "Subagent"
+            task_index = kwargs.get("task_index")
+            task_count = kwargs.get("task_count")
+            if (
+                isinstance(task_index, int)
+                and isinstance(task_count, int)
+                and task_count > 1
+            ):
+                subagent_label = f"Subagent {task_index + 1}/{task_count}"
+            dedup_key = (
+                "subagent.start",
+                kwargs.get("subagent_id"),
+                task_index,
+                preview,
+            )
+            if ctx.progress_mode == "new" and dedup_key == ctx.last_tool[0]:
+                return
+            ctx.last_tool[0] = dedup_key
+            model = (kwargs.get("model") or "").strip()
+            msg = f"🤖 {subagent_label}"
+            if preview:
+                msg += f': "{preview}"'
+            if model:
+                msg += f"\nModel: `{model}`"
+            ctx.last_was_terminal_block[0] = False
+            ctx.progress_queue.put(msg)
+            return
 
         # "new" mode: only report when tool changes
         if ctx.progress_mode == "new" and tool_name == ctx.last_tool[0]:

--- a/run_agent.py
+++ b/run_agent.py
@@ -948,7 +948,7 @@ class AIAgent:
             self._vprint(f"{self.log_prefix}{message}", force=True)
         except Exception:
             pass
-        if self.status_callback:
+        if getattr(self, "status_callback", None):
             try:
                 self.status_callback("lifecycle", message)
             except Exception:

--- a/run_agent.py
+++ b/run_agent.py
@@ -999,7 +999,7 @@ class AIAgent:
             self._vprint(f"{self.log_prefix}{message}", force=True)
         except Exception:
             pass
-        if self.status_callback:
+        if getattr(self, "status_callback", None):
             try:
                 self.status_callback("lifecycle", message)
             except Exception:

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -331,6 +331,61 @@ class ThinkingAgent:
         }
 
 
+class SubagentProgressAgent:
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.tool_progress_callback
+        if cb is not None:
+            cb(
+                "subagent.start",
+                preview="Audit the codebase",
+                model="claude-sonnet-4-6",
+                task_index=0,
+                task_count=1,
+            )
+            time.sleep(0.35)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class TwoSubagentProgressAgent:
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.tool_progress_callback
+        if cb is not None:
+            cb(
+                "subagent.start",
+                preview="Audit gateway progress",
+                model="claude-sonnet-4-6",
+                task_index=0,
+                task_count=2,
+                subagent_id="child-a",
+            )
+            cb(
+                "subagent.start",
+                preview="Audit fallback restore",
+                model="claude-sonnet-4-6",
+                task_index=1,
+                task_count=2,
+                subagent_id="child-b",
+            )
+            time.sleep(0.35)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class LongPreviewAgent:
     """Agent that emits a tool call with a very long preview string."""
     LONG_CMD = "cd /home/teknium/.hermes/hermes-agent/.worktrees/hermes-d8860339 && source .venv/bin/activate && python -m pytest tests/gateway/test_run_progress_topics.py -n0 -q"
@@ -478,6 +533,91 @@ def _make_runner(adapter):
         stt_enabled=False,
     )
     return runner
+
+
+@pytest.mark.asyncio
+async def test_run_agent_progress_shows_subagent_model(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = SubagentProgressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        thread_id="17585",
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-subagent",
+        session_key="agent:main:telegram:group:-1001:17585",
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.sent
+    assert "Subagent" in adapter.sent[0]["content"]
+    assert "Audit the codebase" in adapter.sent[0]["content"]
+    assert "claude-sonnet-4-6" in adapter.sent[0]["content"]
+    assert adapter.sent[0]["metadata"] == {"thread_id": "17585"}
+
+
+@pytest.mark.asyncio
+async def test_run_agent_progress_shows_each_subagent_in_new_mode(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "new")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = TwoSubagentProgressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        thread_id="17585",
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-subagent-new-mode",
+        session_key="agent:main:telegram:group:-1001:17585",
+    )
+
+    assert result["final_response"] == "done"
+    progress_text = "\n".join(
+        [call["content"] for call in adapter.sent]
+        + [call["content"] for call in adapter.edits]
+    )
+    assert progress_text.count("Subagent 1/2") >= 1
+    assert "Audit gateway progress" in progress_text
+    assert progress_text.count("Subagent 2/2") >= 1
+    assert "Audit fallback restore" in progress_text
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -245,6 +245,38 @@ class SubagentProgressAgent:
         }
 
 
+class TwoSubagentProgressAgent:
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.tool_progress_callback
+        if cb is not None:
+            cb(
+                "subagent.start",
+                preview="Audit gateway progress",
+                model="claude-sonnet-4-6",
+                task_index=0,
+                task_count=2,
+                subagent_id="child-a",
+            )
+            cb(
+                "subagent.start",
+                preview="Audit fallback restore",
+                model="claude-sonnet-4-6",
+                task_index=1,
+                task_count=2,
+                subagent_id="child-b",
+            )
+            time.sleep(0.35)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class LongPreviewAgent:
     """Agent that emits a tool call with a very long preview string."""
     LONG_CMD = "cd /home/teknium/.hermes/hermes-agent/.worktrees/hermes-d8860339 && source .venv/bin/activate && python -m pytest tests/gateway/test_run_progress_topics.py -n0 -q"
@@ -496,6 +528,50 @@ async def test_run_agent_progress_shows_subagent_model(monkeypatch, tmp_path):
     assert "Audit the codebase" in adapter.sent[0]["content"]
     assert "claude-sonnet-4-6" in adapter.sent[0]["content"]
     assert adapter.sent[0]["metadata"] == {"thread_id": "17585"}
+
+
+@pytest.mark.asyncio
+async def test_run_agent_progress_shows_each_subagent_in_new_mode(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "new")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = TwoSubagentProgressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        thread_id="17585",
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-subagent-new-mode",
+        session_key="agent:main:telegram:group:-1001:17585",
+    )
+
+    assert result["final_response"] == "done"
+    progress_text = "\n".join(
+        [call["content"] for call in adapter.sent]
+        + [call["content"] for call in adapter.edits]
+    )
+    assert progress_text.count("Subagent 1/2") >= 1
+    assert "Audit gateway progress" in progress_text
+    assert progress_text.count("Subagent 2/2") >= 1
+    assert "Audit fallback restore" in progress_text
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -205,6 +205,7 @@ class ThinkingAgent:
     thinking_progress is enabled but tool_progress is off.
     """
 
+
     def __init__(self, **kwargs):
         self.tool_progress_callback = kwargs.get("tool_progress_callback")
         self.tools = []
@@ -213,6 +214,29 @@ class ThinkingAgent:
         cb = self.tool_progress_callback
         if cb is not None:
             cb("_thinking", "weighing the options here")
+            time.sleep(0.35)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class SubagentProgressAgent:
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.tool_progress_callback
+        if cb is not None:
+            cb(
+                "subagent.start",
+                preview="Audit the codebase",
+                model="claude-sonnet-4-6",
+                task_index=0,
+                task_count=1,
+            )
             time.sleep(0.35)
         return {
             "final_response": "done",
@@ -346,6 +370,174 @@ def _make_runner(adapter):
         stt_enabled=False,
     )
     return runner
+
+
+@pytest.mark.asyncio
+async def test_run_agent_progress_stays_in_originating_topic(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    import tools.terminal_tool  # noqa: F401 - register terminal emoji for this fake-agent test
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        thread_id="17585",
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-1",
+        session_key="agent:main:telegram:group:-1001:17585",
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.sent == [
+        {
+            "chat_id": "-1001",
+            "content": '💻 Running pwd',
+            "reply_to": None,
+            "metadata": {"thread_id": "17585"},
+        }
+    ]
+    assert adapter.edits
+    assert all(call["metadata"] == {"thread_id": "17585"} for call in adapter.typing)
+
+
+@pytest.mark.asyncio
+async def test_run_agent_progress_edits_keep_originating_topic_metadata(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = MetadataEditProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        thread_id="17585",
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-progress-edit-topic",
+        session_key="agent:main:telegram:group:-1001:17585",
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.edits
+    assert all(call["metadata"] == {"thread_id": "17585"} for call in adapter.edits)
+
+
+@pytest.mark.asyncio
+async def test_run_agent_progress_shows_subagent_model(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = SubagentProgressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        thread_id="17585",
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-subagent",
+        session_key="agent:main:telegram:group:-1001:17585",
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.sent
+    assert "Subagent" in adapter.sent[0]["content"]
+    assert "Audit the codebase" in adapter.sent[0]["content"]
+    assert "claude-sonnet-4-6" in adapter.sent[0]["content"]
+    assert adapter.sent[0]["metadata"] == {"thread_id": "17585"}
+
+
+@pytest.mark.asyncio
+async def test_run_agent_progress_does_not_use_event_message_id_for_telegram_dm(monkeypatch, tmp_path):
+    """Telegram DM progress must not reuse event message id as thread metadata."""
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = ProgressCaptureAdapter(platform=Platform.TELEGRAM)
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-2",
+        session_key="agent:main:telegram:dm:12345",
+        event_message_id="777",
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.sent
+    assert adapter.sent[0]["metadata"] is None
+    assert all(call["metadata"] is None for call in adapter.typing)
 
 
 @pytest.mark.asyncio

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -201,6 +201,30 @@ class TestRestorePrimaryRuntime:
 
         assert agent._use_prompt_caching == original_caching
 
+    def test_restore_emits_status_callback(self):
+        """When fallback is cleared, user-facing surfaces should be notified."""
+        agent = _make_agent(
+            fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+        )
+        status_events = []
+        agent.status_callback = lambda event_type, message: status_events.append((event_type, message))
+
+        mock_client = _mock_resolve()
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
+            agent._try_activate_fallback()
+        status_events.clear()
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            result = agent._restore_primary_runtime()
+
+        assert result is True
+        assert status_events == [
+            (
+                "lifecycle",
+                f"✅ Fallback cleared — resuming with primary model: {agent.model} via {agent.provider}",
+            )
+        ]
+
     def test_restore_skips_cross_provider_pool_entry(self):
         """Restore must not swap in a fallback provider credential for the primary runtime."""
 

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -180,6 +180,11 @@ class TestRestorePrimaryRuntime:
             "fallback anthropic/claude-sonnet-4 via openrouter is no longer active."
         ]
 
+    def test_emit_status_tolerates_minimal_agent_without_status_callback(self):
+        agent = object.__new__(AIAgent)
+
+        AIAgent._emit_status(agent, "restored")
+
     def test_does_not_label_temporary_model_restore_as_fallback_recovery(self):
         """`/model --once` reuses restore with no provider fallback lifecycle."""
         agent = _make_agent()


### PR DESCRIPTION
## Summary
- Emit a user-facing lifecycle status when a turn-scoped fallback restores back to the primary runtime.
- Render `subagent.start` progress events in gateway progress bubbles and include the effective subagent model when provided.
- Add regression coverage for primary restore status callbacks and Telegram topic-scoped subagent model progress.

## Tests
- `scripts/run_tests.sh tests/run_agent/test_primary_runtime_restore.py tests/gateway/test_run_progress_topics.py`
- `python -m py_compile agent/agent_runtime_helpers.py gateway/run.py tests/run_agent/test_primary_runtime_restore.py tests/gateway/test_run_progress_topics.py && git diff --check`

## Notes
- This is a small replacement for the fallback/subagent visibility pieces from the old broad #3984 branch.
- It does not change fallback selection, provider routing, or delegation model resolution.
