### PR TITLE
[security] fix(state): restrict sensitive store file permissions

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -30,6 +30,7 @@ import hmac
 import json
 import logging
 import os
+from pathlib import Path
 import socket as _socket
 import re
 import sqlite3
@@ -329,6 +330,23 @@ class ResponseStore:
     if the on-disk path is unavailable.
     """
 
+    @staticmethod
+    def _secure_file_mode(path: Optional[str]) -> None:
+        """Force owner-only permissions on the response store and SQLite sidecars."""
+        if not path or path == ":memory:":
+            return
+        for candidate in (Path(path), Path(f"{path}-wal"), Path(f"{path}-shm")):
+            try:
+                if candidate.exists():
+                    candidate.chmod(0o600)
+            except Exception:
+                logger.debug("Failed to restrict response store permissions for %s", candidate, exc_info=True)
+
+    def _commit(self) -> None:
+        """Commit and re-apply owner-only permissions to DB/sidecar files."""
+        self._conn.commit()
+        self._secure_file_mode(self._db_path)
+
     def __init__(self, max_size: int = MAX_STORED_RESPONSES, db_path: str = None):
         self._max_size = max_size
         if db_path is None:
@@ -337,16 +355,20 @@ class ResponseStore:
                 db_path = str(get_hermes_home() / "response_store.db")
             except Exception:
                 db_path = ":memory:"
+        self._db_path = db_path if db_path != ":memory:" else None
         try:
             self._conn = sqlite3.connect(db_path, check_same_thread=False)
+            self._secure_file_mode(self._db_path)
         except Exception:
             self._conn = sqlite3.connect(":memory:", check_same_thread=False)
+            self._db_path = None
         # Use shared WAL-fallback helper so response_store.db degrades
         # gracefully on NFS/SMB/FUSE-mounted HERMES_HOME (same filesystem
         # issue addressed for state.db/kanban.db — see
         # hermes_state._WAL_INCOMPAT_MARKERS).
         from hermes_state import apply_wal_with_fallback
         apply_wal_with_fallback(self._conn, db_label="response_store.db")
+        self._secure_file_mode(self._db_path)
         self._conn.execute(
             """CREATE TABLE IF NOT EXISTS responses (
                 response_id TEXT PRIMARY KEY,
@@ -360,7 +382,7 @@ class ResponseStore:
                 response_id TEXT NOT NULL
             )"""
         )
-        self._conn.commit()
+        self._commit()
 
     def get(self, response_id: str) -> Optional[Dict[str, Any]]:
         """Retrieve a stored response by ID (updates access time for LRU)."""
@@ -373,7 +395,7 @@ class ResponseStore:
             "UPDATE responses SET accessed_at = ? WHERE response_id = ?",
             (time.time(), response_id),
         )
-        self._conn.commit()
+        self._commit()
         return json.loads(row[0])
 
     def put(self, response_id: str, data: Dict[str, Any]) -> None:
@@ -405,7 +427,7 @@ class ResponseStore:
                     f"DELETE FROM responses WHERE response_id IN ({placeholders})",
                     evict_ids,
                 )
-        self._conn.commit()
+        self._commit()
 
     def delete(self, response_id: str) -> bool:
         """Remove a response from the store. Returns True if found and deleted."""
@@ -416,7 +438,7 @@ class ResponseStore:
         cursor = self._conn.execute(
             "DELETE FROM responses WHERE response_id = ?", (response_id,)
         )
-        self._conn.commit()
+        self._commit()
         return cursor.rowcount > 0
 
     def get_conversation(self, name: str) -> Optional[str]:
@@ -432,7 +454,7 @@ class ResponseStore:
             "INSERT OR REPLACE INTO conversations (name, response_id) VALUES (?, ?)",
             (name, response_id),
         )
-        self._conn.commit()
+        self._commit()
 
     def close(self) -> None:
         """Close the database connection."""

--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -11,8 +11,10 @@ hot-reloaded by the webhook adapter without a gateway restart.
 """
 
 import json
+import os
 import re
 import secrets
+import tempfile
 import time
 from pathlib import Path
 from typing import Dict
@@ -23,6 +25,7 @@ from hermes_cli.config import cfg_get
 
 
 _SUBSCRIPTIONS_FILENAME = "webhook_subscriptions.json"
+_SUBSCRIPTIONS_FILE_MODE = 0o600
 
 
 def _hermes_home() -> Path:
@@ -48,12 +51,27 @@ def _load_subscriptions() -> Dict[str, dict]:
 def _save_subscriptions(subs: Dict[str, dict]) -> None:
     path = _subscriptions_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = path.with_suffix(".tmp")
-    tmp_path.write_text(
-        json.dumps(subs, indent=2, ensure_ascii=False),
-        encoding="utf-8",
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+        text=True,
     )
-    atomic_replace(tmp_path, path)
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(subs, fh, indent=2, ensure_ascii=False)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.chmod(tmp_path, _SUBSCRIPTIONS_FILE_MODE)
+        atomic_replace(tmp_path, path)
+        os.chmod(path, _SUBSCRIPTIONS_FILE_MODE)
+    except Exception:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
 
 
 def _get_webhook_config() -> dict:

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -14,6 +14,8 @@ Tests cover:
 
 import asyncio
 import json
+import os
+import stat
 import time
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -127,6 +129,43 @@ class TestResponseStore:
         assert store.get_conversation("chat-a") is None
         # resp_2 mapping should still be intact
         assert store.get_conversation("chat-b") == "resp_2"
+
+    def test_file_store_created_owner_only_under_permissive_umask(self, tmp_path):
+        db_path = tmp_path / "response_store.db"
+        store = None
+        old_umask = os.umask(0o022)
+        try:
+            store = ResponseStore(max_size=10, db_path=str(db_path))
+            store.put(
+                "resp_secret",
+                {
+                    "response": {"id": "resp_secret"},
+                    "conversation_history": [{"role": "tool", "content": "dummy-marker"}],
+                },
+            )
+        finally:
+            os.umask(old_umask)
+            if store is not None:
+                store.close()
+
+        assert stat.S_IMODE(db_path.stat().st_mode) == 0o600
+        assert b"dummy-marker" in db_path.read_bytes()
+        for sidecar in (db_path.with_name(db_path.name + "-wal"), db_path.with_name(db_path.name + "-shm")):
+            if sidecar.exists():
+                assert stat.S_IMODE(sidecar.stat().st_mode) == 0o600
+
+    def test_file_store_narrows_existing_broad_mode(self, tmp_path):
+        db_path = tmp_path / "response_store.db"
+        db_path.write_bytes(b"")
+        db_path.chmod(0o644)
+
+        store = ResponseStore(max_size=10, db_path=str(db_path))
+        try:
+            store.put("resp_1", {"output": "hello"})
+        finally:
+            store.close()
+
+        assert stat.S_IMODE(db_path.stat().st_mode) == 0o600
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_webhook_cli.py
+++ b/tests/hermes_cli/test_webhook_cli.py
@@ -3,6 +3,7 @@
 import json
 import os
 import pytest
+import stat
 from argparse import Namespace
 from pathlib import Path
 
@@ -144,6 +145,49 @@ class TestPersistence:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("broken{{{")
         assert _load_subscriptions() == {}
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits are platform-specific")
+    def test_save_creates_secret_file_owner_only_under_permissive_umask(self):
+        old_umask = os.umask(0o022)
+        try:
+            _save_subscriptions({"demo": {"secret": "TOPSECRET", "prompt": "x"}})
+        finally:
+            os.umask(old_umask)
+
+        path = _subscriptions_path()
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+        assert "TOPSECRET" in path.read_text(encoding="utf-8")
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits are platform-specific")
+    def test_save_preserves_owner_only_mode_on_update(self):
+        _save_subscriptions({"demo": {"secret": "FIRST", "prompt": "x"}})
+        path = _subscriptions_path()
+        path.chmod(0o600)
+
+        old_umask = os.umask(0o022)
+        try:
+            _save_subscriptions({"demo": {"secret": "SECOND", "prompt": "x"}})
+        finally:
+            os.umask(old_umask)
+
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+        assert "SECOND" in path.read_text(encoding="utf-8")
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits are platform-specific")
+    def test_save_narrows_existing_broad_secret_file_mode(self):
+        path = _subscriptions_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('{"demo":{"secret":"OLD"}}', encoding="utf-8")
+        path.chmod(0o644)
+
+        old_umask = os.umask(0o022)
+        try:
+            _save_subscriptions({"demo": {"secret": "NEWSECRET", "prompt": "x"}})
+        finally:
+            os.umask(old_umask)
+
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+        assert "NEWSECRET" in path.read_text(encoding="utf-8")
 
 
 class TestWebhookEnabledGate:


### PR DESCRIPTION
## Summary

This PR hardens two sensitive Hermes state stores so they are created and maintained as owner-only files instead of inheriting a permissive process umask.

- Restricts `webhook_subscriptions.json`, which stores dynamic webhook HMAC secrets, to `0600` on first creation and subsequent updates.
- Restricts `response_store.db`, which stores Responses API state including conversation history and tool outputs, to `0600` after SQLite creation/WAL setup and after commits that can create or touch SQLite sidecars.
- Narrows previously broad modes on existing state files when they are next rewritten/opened.
- Adds focused regression tests that force a permissive `022` umask and verify owner-only final modes.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Dynamic webhook HMAC secrets can be persisted with group/world-readable permissions | A same-host local user/process with access to the profile directory can read route HMAC secrets and forge authenticated webhook requests when the webhook listener is reachable. | Medium, deployment-dependent |
| Responses API state can be persisted with group/world-readable permissions | A same-host local user/process with access to the profile directory can read stored response objects, conversation history, tool calls/results, instructions, and session context from `response_store.db`. | Medium, deployment-dependent |

## Before this PR

- `hermes webhook subscribe` wrote `webhook_subscriptions.json` through a normal text-file write path, so the final file could inherit a permissive umask such as `022` and land as `0644`.
- `ResponseStore` used `sqlite3.connect(db_path)` for `response_store.db`; SQLite can create the database and sidecar files under the process umask.
- Existing files with broad modes were not narrowed by the affected writers.
- The existing tests covered functional persistence behavior but did not assert secure filesystem modes under a permissive umask.

## After this PR

- Webhook subscription saves use an owner-only temporary file and force the final `webhook_subscriptions.json` mode to `0600` after the atomic replace.
- `ResponseStore` forces owner-only permissions on `response_store.db` immediately after opening/creating it, after WAL setup/schema creation, and after commits that may create or touch SQLite sidecars.
- Existing broad modes are narrowed when the affected stores are saved/opened.
- Regression tests verify creation and narrowing behavior for both sensitive stores.

## Why this matters

Both files persist data that should be scoped to the Hermes profile owner. On shared hosts, multi-user workstations, shared profile mounts, or container volumes with multiple local principals, a default `0644` mode can expose secrets and conversation/tool-output history to unintended local readers.

This is a local sensitive-state disclosure and secret-exposure hardening issue, not a remote code execution bug.

## How this differs from related issue/PR

Related public work exists, but this PR is scoped to the two confirmed state-file permission issues and keeps the patch/test surface narrow.

- #24027 also addresses `response_store.db` file permissions, but it is a broader SQLite-permission PR that also touches holographic memory storage. This PR keeps the response-store fix with the webhook-secret permission fix, applies owner-only mode after WAL/schema setup and later commits, and adds focused `ResponseStore` umask/narrowing regressions.
- #23507 addresses encrypting `response_store.db` payloads at rest. Encryption and filesystem mode hardening are complementary: owner-only permissions still prevent same-host local readers from opening the database file in deployments where encryption is off, unavailable, or being migrated.
- This PR extends the existing webhook-subscription permission PR rather than opening a duplicate for `webhook_subscriptions.json`.

## Attack flow

```text
Hermes process starts with a permissive umask such as 022
    -> dynamic webhook subscription or Responses API state is persisted under the Hermes profile
        -> state file is created or left as group/world-readable
            -> another same-host local user/process reads the profile file
                -> webhook HMAC secrets or response/conversation/tool-output state is disclosed
```

## Affected code

| Issue | Files |
|-------|-------|
| Webhook subscription secret file permissions | `hermes_cli/webhook.py`, `tests/hermes_cli/test_webhook_cli.py` |
| Responses API state file permissions | `gateway/platforms/api_server.py`, `tests/gateway/test_api_server.py` |

## Root cause

Issue 1: webhook subscription secrets
- The subscription store persisted HMAC secrets with a normal text-file write path.
- File creation inherited the process umask instead of explicitly setting owner-only permissions for a secret-bearing state file.

Issue 2: Responses API state
- SQLite database creation inherited the process umask.
- Permission narrowing was not applied consistently after SQLite setup and later commits that can create or touch sidecar files.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| `webhook_subscriptions.json` local secret disclosure | 5.5 Medium | `CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N` |
| `response_store.db` local state disclosure | 5.5 Medium | `CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N` |

Rationale:
- The attacker condition is local same-host/profile-volume read access, not unauthenticated remote access.
- Confidentiality impact is high for the affected files because they can contain webhook HMAC secrets or full conversation/tool-output state.
- Integrity and availability impact are not required for the core disclosure claim.

## Safe reproduction steps

### 1. Webhook subscription store
1. Run a dynamic subscription save path with `umask(0o022)`.
2. Persist a subscription containing a dummy HMAC secret.
3. Observe that vulnerable code can leave `webhook_subscriptions.json` as group/world-readable, while this PR leaves it as `0600`.

### 2. Responses API state store
1. Run `ResponseStore(db_path=...)` with `umask(0o022)`.
2. Store a dummy response object containing a marker in `conversation_history`.
3. Observe that vulnerable code can create `response_store.db` as group/world-readable with the marker present, while this PR leaves the database and any SQLite sidecars as `0600`.

## Expected vulnerable behavior

- `webhook_subscriptions.json` can be created with mode `0644` while containing route HMAC secrets.
- `response_store.db` can be created with mode `0644` while containing stored response and conversation/tool-output state.
- Existing broad modes may remain broad if the stores are later updated without explicit permission narrowing.

## Changes in this PR

- Writes webhook subscriptions through an owner-only temporary file.
- Applies `chmod(0o600)` to the final webhook subscription file after atomic replacement.
- Adds `ResponseStore` permission hardening for the database and SQLite `-wal` / `-shm` sidecars.
- Re-applies response-store permissions after commits that can create/touch SQLite files.
- Adds permissive-umask tests for first creation and broad-mode narrowing.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Webhook secret store | `hermes_cli/webhook.py` | Owner-only temp-file write and final mode narrowing for `webhook_subscriptions.json`. |
| Webhook tests | `tests/hermes_cli/test_webhook_cli.py` | Regression tests for owner-only creation, update, and narrowing from broad modes. |
| Responses API store | `gateway/platforms/api_server.py` | Owner-only mode enforcement for `response_store.db` and SQLite sidecars after open/WAL/schema/commit. |
| Responses API tests | `tests/gateway/test_api_server.py` | Regression tests for owner-only creation under `022` umask and narrowing an existing broad DB mode. |

## Maintainer impact

- Narrow patch limited to sensitive state-file creation/update behavior and focused tests.
- No webhook routing semantics, HMAC validation semantics, Responses API request/response behavior, or stored data schema changes are intended.
- Existing readable files are narrowed opportunistically when the affected store is saved/opened.
- Normal single-user installs should see no behavior change other than stricter local file modes.

## Fix rationale

- Sensitive state should not depend on the operator's ambient umask for confidentiality.
- Owner-only permissions match the expected privacy boundary for profile-local Hermes secrets and conversation state.
- Reapplying permissions after SQLite commits accounts for sidecar files that may be created after the initial `sqlite3.connect()` call.
- Focused umask tests lock in the exact failure mode without requiring a full gateway runtime.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Focused `ResponseStore` tests passed.
- [x] Webhook subscription CLI tests passed.
- [x] Touched Python files compile.
- [x] Diff whitespace check passed.
- [ ] Full repository suite was not run locally; the PR CI should cover the broader matrix.

Executed with:
- `python -m pytest tests/gateway/test_api_server.py -k 'ResponseStore' -q -o 'addopts='`
- `python -m pytest tests/hermes_cli/test_webhook_cli.py -q -o 'addopts='`
- `python -m py_compile gateway/platforms/api_server.py hermes_cli/webhook.py tests/gateway/test_api_server.py tests/hermes_cli/test_webhook_cli.py`
- `git diff --check`

## Disclosure notes

- This PR is bounded to local filesystem mode hardening for two sensitive Hermes state stores.
- It does not claim unauthenticated remote access to these files.
- It does not change webhook HMAC verification, Responses API state semantics, or database encryption behavior.
- No production endpoints, real secrets, or private local paths are needed for the regression tests.
