### PR TITLE
fix(tui_gateway): replace deprecated utcfromtimestamp + pin UTC filename contract

### DIFF
--- a/tests/tui_gateway/test_spawn_tree_save.py
+++ b/tests/tui_gateway/test_spawn_tree_save.py
@@ -1,0 +1,64 @@
+"""Regression tests for spawn_tree.save filename timestamp handling."""
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def server():
+    with patch.dict(
+        "sys.modules",
+        {
+            "hermes_constants": MagicMock(
+                get_hermes_home=MagicMock(return_value="/tmp/hermes_test")
+            ),
+            "hermes_cli.env_loader": MagicMock(),
+            "hermes_cli.banner": MagicMock(),
+            "hermes_state": MagicMock(),
+        },
+    ):
+        import importlib
+
+        mod = importlib.import_module("tui_gateway.server")
+        yield mod
+        mod._sessions.clear()
+        mod._pending.clear()
+        mod._answers.clear()
+        mod._methods.clear()
+        importlib.reload(mod)
+
+
+def test_spawn_tree_save_filename_uses_utc(server, tmp_path, monkeypatch):
+    """spawn_tree.save must render its filename timestamp in UTC regardless
+    of the runner's local timezone.
+
+    Replacing the deprecated ``datetime.utcfromtimestamp()`` with a naive
+    ``datetime.fromtimestamp()`` (no ``tz=timezone.utc``) silently produces
+    different filenames in non-UTC environments. Pinning the UTC contract
+    here means that pseudo-fix would fail this test rather than diverging
+    silently across environments.
+    """
+    monkeypatch.setenv("TZ", "America/New_York")
+    if hasattr(time, "tzset"):
+        time.tzset()
+
+    monkeypatch.setattr(server, "_spawn_tree_session_dir", lambda sid: tmp_path)
+    monkeypatch.setattr(server, "_append_spawn_tree_index", lambda d, e: None)
+
+    handler = server._methods["spawn_tree.save"]
+    finished_at = 1700000000.0  # 2023-11-14T22:13:20Z (17:13:20 EST)
+    response = handler(
+        1,
+        {
+            "session_id": "test",
+            "subagents": [{"name": "a"}],
+            "finished_at": finished_at,
+        },
+    )
+
+    assert "result" in response, response
+    expected_filename = "20231114T221320.json"
+    assert response["result"]["path"].endswith("/" + expected_filename)
+    assert (tmp_path / expected_filename).exists()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2989,12 +2989,12 @@ def _(rid, params: dict) -> dict:
     if not isinstance(subagents, list) or not subagents:
         return _err(rid, 4000, "subagents list required")
 
-    from datetime import datetime
+    from datetime import datetime, timezone
 
     started_at = params.get("started_at")
     finished_at = params.get("finished_at") or time.time()
     label = str(params.get("label") or "")
-    ts = datetime.utcfromtimestamp(float(finished_at)).strftime("%Y%m%dT%H%M%S")
+    ts = datetime.fromtimestamp(float(finished_at), tz=timezone.utc).strftime("%Y%m%dT%H%M%S")
     fname = f"{ts}.json"
     d = _spawn_tree_session_dir(session_id or "default")
     path = d / fname


### PR DESCRIPTION
## What

Replaces `datetime.utcfromtimestamp()` with the timezone-aware `datetime.fromtimestamp(ts, tz=timezone.utc)` in the `spawn_tree.save` handler at `tui_gateway/server.py:2997`, and adds a regression test pinning the UTC filename contract.

## Why

Python 3.12 deprecated `datetime.utcfromtimestamp()` (PEP-recommended replacement). `pyproject.toml` pins `requires-python = ">=3.11"` and dev runs on 3.13 — so this site emits `DeprecationWarning` today and will break when the API is removed in a future Python release.

## Why narrow scope

Multiple open PRs already cover the `gateway/platforms/bluebubbles.py:383/439` occurrences (#29030, #23820, #25049, #29797, #30139). This PR is intentionally scoped to the **one site no other open PR's diff actually touches**:

- #29030's body claims to fix `tui_gateway/server.py` but the actual diff is bluebubbles-only.
- #30139's diff is bluebubbles + several other files but does not include `tui_gateway/server.py`.

## Test

`tests/tui_gateway/test_spawn_tree_save.py` is a new regression test that:

1. Forces `TZ=America/New_York` via `monkeypatch.setenv` + `time.tzset()`.
2. Calls `_methods["spawn_tree.save"]` directly with a known timestamp (`finished_at=1700000000.0` = `2023-11-14T22:13:20Z` / `17:13:20 EST`).
3. Asserts the resulting filename is `20231114T221320.json` (UTC), not `20231114T171320.json` (local).

This guards against the easy mis-fix of dropping `tz=timezone.utc` and using a naive `datetime.fromtimestamp()`, which would silently produce different filenames per runner timezone without any warning.

```
tests/tui_gateway/test_spawn_tree_save.py::test_spawn_tree_save_filename_uses_utc PASSED
```

All 85 `tests/tui_gateway/` tests pass.

## Out of scope

- `gateway/platforms/bluebubbles.py` — see PRs above.
- `optional-skills/blockchain/hyperliquid/scripts/hyperliquid_client.py` — third-party plugin, separate concern.