### PR TITLE
fix: add missing Path import to subprocess stress test

### DIFF
--- a/tests/stress/test_subprocess_e2e.py
+++ b/tests/stress/test_subprocess_e2e.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 import tempfile
 import time
+from pathlib import Path
 
 WT = str(Path(__file__).resolve().parents[2])
 FAKE_WORKER = str(Path(__file__).parent / "_fake_worker.py")


### PR DESCRIPTION
## Summary
- Restore the missing `Path` import in `tests/stress/test_subprocess_e2e.py`.

## Verification
- `python -m py_compile tests/stress/test_subprocess_e2e.py` ✅
- `python tests/stress/test_subprocess_e2e.py` still hits an environment/runtime failure before task dispatch in this checkout, so I left the change scoped to the import fix.

## Notes
- Branch: `fix/subprocess-e2e-path-import`
- Pushed to fork: `let-value/hermes-agent`
