### PR TITLE
feat(prompt-builder): make CONTEXT_FILE_MAX_CHARS configurable via env var

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -830,7 +830,23 @@ def build_environment_hints() -> str:
     return "\n\n".join(hints)
 
 
-CONTEXT_FILE_MAX_CHARS = 20_000
+def _read_context_file_max_chars() -> int:
+    """Configurable context-file truncation limit.
+
+    Set HERMES_CONTEXT_FILE_MAX_CHARS to a positive integer to raise the
+    default 20_000-char cap (helpful for very large SOUL.md / per-profile
+    config files where the default head/tail truncation can silently drop
+    constraints). Invalid or unset values fall back to 20_000.
+    """
+    raw = os.getenv("HERMES_CONTEXT_FILE_MAX_CHARS", "").strip()
+    if raw.isdigit():
+        v = int(raw)
+        if v > 0:
+            return v
+    return 20_000
+
+
+CONTEXT_FILE_MAX_CHARS = _read_context_file_max_chars()
 CONTEXT_TRUNCATE_HEAD_RATIO = 0.7
 CONTEXT_TRUNCATE_TAIL_RATIO = 0.2
 


### PR DESCRIPTION
## What does this PR do?

Make `CONTEXT_FILE_MAX_CHARS` in `agent/prompt_builder.py` configurable via the `HERMES_CONTEXT_FILE_MAX_CHARS` env var, instead of being hard-coded to `20_000`. Default remains `20_000` — current behavior unchanged for users who don't set the variable.

## Related Issue

None filed. Happy to file a tracking issue first if maintainers prefer.

## Motivation

Users who maintain large SOUL.md / per-profile config files hit the 20_000-char limit, and the existing `head 70% / tail 20%` truncation silently drops the middle without surfacing a warning. In a SOUL.md that has grown to ~36k chars with extended Hard Constraints and Behavioral Defaults, the middle-of-file constraints disappear from agent context — which is hard to debug without reading the prompt_builder source.

This PR is the minimum knob that closes the gap: raise the limit when you know you need it; default behavior is identical for users who don't care.

A more sophisticated fix (a warning when truncation actually happens, or per-file frontmatter overrides) is out of scope here.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/prompt_builder.py`: replace the hard-coded `CONTEXT_FILE_MAX_CHARS = 20_000` with a `_read_context_file_max_chars()` helper that reads `HERMES_CONTEXT_FILE_MAX_CHARS` and falls back to `20_000` on unset / invalid / non-positive values. `import os` is already present module-level.

## How to Test

```python
import os
# Test 1: unset → default 20_000 (current behavior)
os.environ.pop("HERMES_CONTEXT_FILE_MAX_CHARS", None)
# CONTEXT_FILE_MAX_CHARS evaluates to 20000

# Test 2: positive int → that value
os.environ["HERMES_CONTEXT_FILE_MAX_CHARS"] = "50000"
# CONTEXT_FILE_MAX_CHARS evaluates to 50000

# Test 3: garbage value → 20_000 fallback
os.environ["HERMES_CONTEXT_FILE_MAX_CHARS"] = "garbage"
# CONTEXT_FILE_MAX_CHARS evaluates to 20000

# Test 4: zero / negative → 20_000 fallback
os.environ["HERMES_CONTEXT_FILE_MAX_CHARS"] = "0"
# CONTEXT_FILE_MAX_CHARS evaluates to 20000
```

All four behaviors verified locally on macOS 15.4 against the patched file.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs — no duplicates
- [x] My PR contains **only** changes related to this feature
- [ ] I've run `pytest tests/ -q` — not run for this PR (small refactor of one module-level constant; behavior verified via direct unit checks shown above). Maintainers can re-run CI as appropriate.
- [ ] I've added tests for my changes — not added (4-case env-var read with validated allowlist; happy to add a small unit test if maintainers want one).
- [x] I've tested on my platform: macOS 15.4 (Darwin 25.4.0)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — N/A (env vars are usually documented via README or a settings reference; happy to add a note wherever maintainers prefer).
- [ ] I've updated `cli-config.yaml.example` — N/A (env var, not config key).
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A.
- [x] Cross-platform impact considered — env vars work identically on Windows/macOS/Linux.
- [x] Tool descriptions/schemas — N/A.