### PR TITLE
feat(cron): add per-job reasoning effort

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -16,7 +16,7 @@ import re
 import uuid
 from datetime import datetime, timedelta
 from pathlib import Path
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, parse_reasoning_effort
 from typing import Optional, Dict, List, Any, Union
 
 logger = logging.getLogger(__name__)
@@ -152,6 +152,16 @@ def _normalize_job_record(job: Dict[str, Any]) -> Dict[str, Any]:
 
     profile = _coerce_job_text(normalized.get("profile")).strip()
     normalized["profile"] = profile or None
+
+    try:
+        normalized["reasoning_effort"] = _normalize_reasoning_effort(normalized.get("reasoning_effort"))
+    except ValueError as exc:
+        logger.warning(
+            "Job '%s': invalid reasoning_effort in stored record: %s",
+            normalized.get("id", "?"),
+            exc,
+        )
+        normalized["reasoning_effort"] = None
 
     return normalized
 
@@ -528,6 +538,18 @@ def _normalize_profile(profile: Optional[str]) -> Optional[str]:
     return normalized
 
 
+def _normalize_reasoning_effort(value: Any) -> Optional[str]:
+    """Normalize/validate an optional per-job reasoning effort override."""
+    text = str(value or "").strip().lower()
+    if not text:
+        return None
+    if parse_reasoning_effort(text) is None:
+        raise ValueError(
+            "reasoning_effort must be one of: none, minimal, low, medium, high, xhigh"
+        )
+    return text
+
+
 def create_job(
     prompt: Optional[str],
     schedule: str,
@@ -545,6 +567,7 @@ def create_job(
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
     profile: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
     no_agent: bool = False,
 ) -> Dict[str, Any]:
     """
@@ -629,6 +652,7 @@ def create_job(
     normalized_toolsets = normalized_toolsets or None
     normalized_workdir = _normalize_workdir(workdir)
     normalized_profile = _normalize_profile(profile)
+    normalized_reasoning_effort = _normalize_reasoning_effort(reasoning_effort)
     normalized_no_agent = bool(no_agent)
 
     # no_agent jobs are meaningless without a script — the script IS the job.
@@ -684,6 +708,7 @@ def create_job(
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
         "profile": normalized_profile,
+        "reasoning_effort": normalized_reasoning_effort,
     }
 
     jobs = load_jobs()
@@ -781,6 +806,11 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                 updates["profile"] = None
             else:
                 updates["profile"] = _normalize_profile(_profile)
+
+        # Validate / normalize per-job reasoning effort if present. Empty
+        # string/None clears the override and restores global fallback.
+        if "reasoning_effort" in updates:
+            updates["reasoning_effort"] = _normalize_reasoning_effort(updates.get("reasoning_effort"))
 
         updated = _apply_skill_fields({**job, **updates})
         schedule_changed = "schedule" in updates

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1498,10 +1498,19 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         except Exception:
             pass
 
-        # Reasoning config from config.yaml
+        # Reasoning config: per-job override falls back to config.yaml
         from hermes_constants import parse_reasoning_effort
-        effort = str(_cfg.get("agent", {}).get("reasoning_effort", "")).strip()
+        global_effort = str(_cfg.get("agent", {}).get("reasoning_effort", "")).strip()
+        job_effort = str(job.get("reasoning_effort") or "").strip()
+        effort = job_effort or global_effort
         reasoning_config = parse_reasoning_effort(effort)
+        if job_effort and reasoning_config is None:
+            logger.warning(
+                "Job '%s': invalid reasoning_effort %r; falling back to global agent.reasoning_effort",
+                job_id,
+                job_effort,
+            )
+            reasoning_config = parse_reasoning_effort(global_effort)
 
         # Prefill messages from env or config.yaml
         prefill_messages = None

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -101,6 +101,9 @@ def cron_list(show_all: bool = False):
         profile = job.get("profile")
         if profile:
             print(f"    Profile:   {profile}")
+        reasoning_effort = job.get("reasoning_effort")
+        if reasoning_effort is not None:
+            print(f"    Reasoning: {reasoning_effort}")
 
         # Execution history
         last_status = job.get("last_status")
@@ -178,6 +181,7 @@ def cron_create(args):
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
         profile=getattr(args, "profile", None),
+        reasoning_effort=getattr(args, "reasoning_effort", None),
         no_agent=getattr(args, "no_agent", False) or None,
     )
     if not result.get("success"):
@@ -197,6 +201,8 @@ def cron_create(args):
         print(f"  Workdir: {job_data['workdir']}")
     if job_data.get("profile"):
         print(f"  Profile: {job_data['profile']}")
+    if job_data.get("reasoning_effort") is not None:
+        print(f"  Reasoning: {job_data['reasoning_effort']}")
     print(f"  Next run: {result['next_run_at']}")
     return 0
 
@@ -231,6 +237,11 @@ def cron_edit(args):
             if skill not in final_skills:
                 final_skills.append(skill)
 
+    if getattr(args, "clear_reasoning_effort", False) and getattr(args, "reasoning_effort", None):
+        print(color("Cannot combine --reasoning-effort with --clear-reasoning-effort", Colors.RED))
+        return 1
+    reasoning_effort = "" if getattr(args, "clear_reasoning_effort", False) else getattr(args, "reasoning_effort", None)
+
     result = _cron_api(
         action="update",
         job_id=args.job_id,
@@ -243,6 +254,7 @@ def cron_edit(args):
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
         profile=getattr(args, "profile", None),
+        reasoning_effort=reasoning_effort,
         no_agent=getattr(args, "no_agent", None),
     )
     if not result.get("success"):
@@ -265,6 +277,8 @@ def cron_edit(args):
         print(f"  Workdir: {updated['workdir']}")
     if updated.get("profile"):
         print(f"  Profile: {updated['profile']}")
+    if updated.get("reasoning_effort") is not None:
+        print(f"  Reasoning: {updated['reasoning_effort']}")
     return 0
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11820,6 +11820,11 @@ def main():
         "--profile",
         help="Hermes profile name to run the job under. Use 'default' for the root profile. Named profiles must already exist. Omit to preserve the scheduler's existing profile.",
     )
+    cron_create.add_argument(
+        "--reasoning-effort",
+        choices=["none", "minimal", "low", "medium", "high", "xhigh"],
+        help="Optional per-job reasoning effort override. Omit to use global agent.reasoning_effort; 'none' explicitly disables reasoning for this job.",
+    )
 
     # cron edit
     cron_edit = cron_subparsers.add_parser(
@@ -11887,6 +11892,16 @@ def main():
     cron_edit.add_argument(
         "--profile",
         help="Hermes profile name to run the job under. Use 'default' for the root profile. Pass empty string to clear.",
+    )
+    cron_edit.add_argument(
+        "--reasoning-effort",
+        choices=["none", "minimal", "low", "medium", "high", "xhigh"],
+        help="Optional per-job reasoning effort override. Use 'none' to explicitly disable reasoning for this job.",
+    )
+    cron_edit.add_argument(
+        "--clear-reasoning-effort",
+        action="store_true",
+        help="Clear the per-job reasoning override and restore global agent.reasoning_effort fallback.",
     )
 
     # lifecycle actions

--- a/tests/cron/test_cron_reasoning_effort.py
+++ b/tests/cron/test_cron_reasoning_effort.py
@@ -1,0 +1,241 @@
+import sys
+import types
+
+import pytest
+
+from cron.jobs import create_job, get_job, list_jobs, save_jobs, update_job
+
+
+@pytest.fixture()
+def tmp_cron_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+    return tmp_path
+
+
+def test_create_stores_normalized_reasoning_effort(tmp_cron_dir):
+    job = create_job(prompt="Think lightly", schedule="30m", reasoning_effort=" low ")
+    assert job["reasoning_effort"] == "low"
+    assert get_job(job["id"])["reasoning_effort"] == "low"
+
+
+def test_create_stores_none_as_explicit_override(tmp_cron_dir):
+    job = create_job(prompt="No reasoning", schedule="30m", reasoning_effort="NONE")
+    assert job["reasoning_effort"] == "none"
+
+
+def test_create_invalid_reasoning_effort_raises(tmp_cron_dir):
+    with pytest.raises(ValueError, match="reasoning_effort must be one of"):
+        create_job(prompt="Bad", schedule="30m", reasoning_effort="turbo")
+
+
+def test_update_changes_preserves_and_clears_reasoning_effort(tmp_cron_dir):
+    job = create_job(prompt="Update me", schedule="30m", reasoning_effort="low")
+
+    updated = update_job(job["id"], {"reasoning_effort": "HIGH"})
+    assert updated["reasoning_effort"] == "high"
+
+    preserved = update_job(job["id"], {"name": "renamed"})
+    assert preserved["reasoning_effort"] == "high"
+
+    cleared = update_job(job["id"], {"reasoning_effort": ""})
+    assert cleared is not None
+    assert cleared["reasoning_effort"] is None
+
+    updated = update_job(job["id"], {"reasoning_effort": "none"})
+    assert updated["reasoning_effort"] == "none"
+
+    cleared = update_job(job["id"], {"reasoning_effort": None})
+    assert cleared["reasoning_effort"] is None
+
+
+def test_legacy_invalid_reasoning_effort_is_read_safe(tmp_cron_dir):
+    save_jobs([
+        {
+            "id": "abc123deadbe",
+            "name": "legacy",
+            "prompt": "legacy",
+            "schedule_display": "every 60m",
+            "schedule": {"kind": "interval", "minutes": 60, "display": "every 60m"},
+            "enabled": True,
+            "reasoning_effort": "turbo",
+        }
+    ])
+
+    jobs = list_jobs()
+    assert jobs[0]["reasoning_effort"] is None
+    assert get_job("abc123deadbe")["reasoning_effort"] is None
+
+
+@pytest.fixture()
+def scheduler_harness(tmp_path, monkeypatch):
+    """Patch heavy scheduler dependencies and capture AIAgent kwargs."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / ".env").write_text("", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    captured = {}
+
+    class FakeAIAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def run_conversation(self, prompt):
+            captured["prompt"] = prompt
+            return {"completed": True, "final_response": "ok"}
+
+        def get_activity_summary(self):
+            return {"seconds_since_activity": 0.0}
+
+    fake_run_agent = types.ModuleType("run_agent")
+    setattr(fake_run_agent, "AIAgent", FakeAIAgent)
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    fake_state = types.ModuleType("hermes_state")
+
+    class FakeSessionDB:
+        pass
+
+    setattr(fake_state, "SessionDB", FakeSessionDB)
+    monkeypatch.setitem(sys.modules, "hermes_state", fake_state)
+
+    fake_runtime_provider = types.ModuleType("hermes_cli.runtime_provider")
+    setattr(
+        fake_runtime_provider,
+        "resolve_runtime_provider",
+        lambda **kwargs: {
+            "provider": kwargs.get("requested") or "openai-codex",
+            "api_key": "[REDACTED]",
+            "base_url": None,
+            "api_mode": None,
+        },
+    )
+    setattr(fake_runtime_provider, "format_runtime_provider_error", lambda exc: str(exc))
+    monkeypatch.setitem(sys.modules, "hermes_cli.runtime_provider", fake_runtime_provider)
+
+    fake_auth = types.ModuleType("hermes_cli.auth")
+
+    class FakeAuthError(Exception):
+        pass
+
+    setattr(fake_auth, "AuthError", FakeAuthError)
+    monkeypatch.setitem(sys.modules, "hermes_cli.auth", fake_auth)
+
+    fake_dotenv = types.ModuleType("dotenv")
+    setattr(fake_dotenv, "load_dotenv", lambda *args, **kwargs: True)
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_mcp = types.ModuleType("tools.mcp_tool")
+    setattr(fake_mcp, "discover_mcp_tools", lambda: [])
+    monkeypatch.setitem(sys.modules, "tools.mcp_tool", fake_mcp)
+
+    return home, captured
+
+
+def _minimal_job(reasoning_effort=None):
+    job = {
+        "id": "abc123deadbe",
+        "name": "reasoning test",
+        "prompt": "Say ok",
+        "schedule": {"kind": "interval", "minutes": 60, "display": "every 60m"},
+        "schedule_display": "every 60m",
+        "enabled": True,
+        "deliver": "local",
+    }
+    if reasoning_effort is not None:
+        job["reasoning_effort"] = reasoning_effort
+    return job
+
+
+def test_scheduler_uses_job_reasoning_effort_over_global(scheduler_harness):
+    home, captured = scheduler_harness
+    (home / "config.yaml").write_text(
+        "model:\n  default: gpt-5.5\n  provider: openai-codex\nagent:\n  reasoning_effort: high\n",
+        encoding="utf-8",
+    )
+
+    from cron.scheduler import run_job
+
+    success, _doc, final_response, error = run_job(_minimal_job("low"))
+
+    assert success is True
+    assert final_response == "ok"
+    assert error is None
+    assert captured["reasoning_config"] == {"enabled": True, "effort": "low"}
+
+
+def test_scheduler_falls_back_to_global_reasoning_effort(scheduler_harness):
+    home, captured = scheduler_harness
+    (home / "config.yaml").write_text(
+        "model:\n  default: gpt-5.5\n  provider: openai-codex\nagent:\n  reasoning_effort: high\n",
+        encoding="utf-8",
+    )
+
+    from cron.scheduler import run_job
+
+    success, _doc, final_response, error = run_job(_minimal_job())
+
+    assert success is True
+    assert final_response == "ok"
+    assert error is None
+    assert captured["reasoning_config"] == {"enabled": True, "effort": "high"}
+
+
+def test_scheduler_none_disables_reasoning_instead_of_fallback(scheduler_harness):
+    home, captured = scheduler_harness
+    (home / "config.yaml").write_text(
+        "model:\n  default: gpt-5.5\n  provider: openai-codex\nagent:\n  reasoning_effort: high\n",
+        encoding="utf-8",
+    )
+
+    from cron.scheduler import run_job
+
+    success, _doc, final_response, error = run_job(_minimal_job("none"))
+
+    assert success is True
+    assert final_response == "ok"
+    assert error is None
+    assert captured["reasoning_config"] == {"enabled": False}
+
+
+def test_scheduler_invalid_hand_edited_value_falls_back_to_global(scheduler_harness):
+    home, captured = scheduler_harness
+    (home / "config.yaml").write_text(
+        "model:\n  default: gpt-5.5\n  provider: openai-codex\nagent:\n  reasoning_effort: medium\n",
+        encoding="utf-8",
+    )
+
+    from cron.scheduler import run_job
+
+    success, _doc, final_response, error = run_job(_minimal_job("turbo"))
+
+    assert success is True
+    assert final_response == "ok"
+    assert error is None
+    assert captured["reasoning_config"] == {"enabled": True, "effort": "medium"}
+
+
+def test_scheduler_no_agent_ignores_reasoning_and_never_constructs_agent(
+    scheduler_harness
+):
+    _home, captured = scheduler_harness
+    scripts_dir = _home / "scripts"
+    scripts_dir.mkdir()
+    script = scripts_dir / "silent.sh"
+    script.write_text("#!/bin/sh\n", encoding="utf-8")
+    script.chmod(0o755)
+
+    job = _minimal_job("high")
+    job["no_agent"] = True
+    job["script"] = "silent.sh"
+
+    from cron.scheduler import run_job, SILENT_MARKER
+
+    success, _doc, final_response, error = run_job(job)
+
+    assert success is True
+    assert final_response == SILENT_MARKER
+    assert error is None
+    assert "reasoning_config" not in captured

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -1,6 +1,8 @@
 """Tests for hermes_cli.cron command handling."""
 
 from argparse import Namespace
+import sys
+import types
 
 import pytest
 
@@ -111,3 +113,83 @@ class TestCronCommandLifecycle:
         assert jobs[0]["skills"] == ["blogwatcher", "maps"]
         assert jobs[0]["name"] == "Skill combo"
         assert jobs[0]["profile"] == "default"
+
+    def test_create_edit_clear_and_list_reasoning_effort(self, tmp_cron_dir, capsys, monkeypatch):
+        cron_command(
+            Namespace(
+                cron_command="create",
+                schedule="every 1h",
+                prompt="Check reasoning",
+                name="Reasoning job",
+                deliver=None,
+                repeat=None,
+                skill=None,
+                skills=None,
+                workdir=None,
+                profile=None,
+                no_agent=False,
+                reasoning_effort="low",
+            )
+        )
+        out = capsys.readouterr().out
+        assert "Reasoning: low" in out
+        job = list_jobs()[0]
+        assert job["reasoning_effort"] == "low"
+
+        cron_command(
+            Namespace(
+                cron_command="edit",
+                job_id=job["id"],
+                schedule=None,
+                prompt=None,
+                name=None,
+                deliver=None,
+                repeat=None,
+                skill=None,
+                skills=None,
+                add_skills=None,
+                remove_skills=None,
+                clear_skills=False,
+                script=None,
+                workdir=None,
+                profile=None,
+                no_agent=None,
+                reasoning_effort="high",
+                clear_reasoning_effort=False,
+            )
+        )
+        out = capsys.readouterr().out
+        assert "Reasoning: high" in out
+        assert get_job(job["id"])["reasoning_effort"] == "high"
+
+        fake_gateway = types.ModuleType("hermes_cli.gateway")
+        setattr(fake_gateway, "find_gateway_pids", lambda: [123])
+        monkeypatch.setitem(sys.modules, "hermes_cli.gateway", fake_gateway)
+
+        cron_command(Namespace(cron_command="list", all=False))
+        out = capsys.readouterr().out
+        assert "Reasoning: high" in out
+
+        cron_command(
+            Namespace(
+                cron_command="edit",
+                job_id=job["id"],
+                schedule=None,
+                prompt=None,
+                name=None,
+                deliver=None,
+                repeat=None,
+                skill=None,
+                skills=None,
+                add_skills=None,
+                remove_skills=None,
+                clear_skills=False,
+                script=None,
+                workdir=None,
+                profile=None,
+                no_agent=None,
+                reasoning_effort=None,
+                clear_reasoning_effort=True,
+            )
+        )
+        assert get_job(job["id"])["reasoning_effort"] is None

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -5,6 +5,7 @@ import pytest
 from pathlib import Path
 
 from tools.cronjob_tools import (
+    CRONJOB_SCHEMA,
     _scan_cron_prompt,
     check_cronjob_requirements,
     cronjob,
@@ -221,6 +222,46 @@ class TestUnifiedCronjobTool:
         assert updated["success"] is True
         assert updated["job"]["name"] == "New Name"
         assert updated["job"]["schedule"] == "every 120m"
+
+    def test_reasoning_effort_create_update_clear_and_schema(self):
+        created = json.loads(
+            cronjob(action="create", prompt="Check", schedule="every 1h", reasoning_effort="low")
+        )
+        assert created["success"] is True
+        assert created["job"]["reasoning_effort"] == "low"
+        job_id = created["job_id"]
+
+        updated = json.loads(cronjob(action="update", job_id=job_id, reasoning_effort="high"))
+        assert updated["success"] is True
+        assert updated["job"]["reasoning_effort"] == "high"
+
+        preserved = json.loads(cronjob(action="update", job_id=job_id, name="renamed"))
+        assert preserved["success"] is True
+        assert preserved["job"]["reasoning_effort"] == "high"
+
+        none_override = json.loads(cronjob(action="update", job_id=job_id, reasoning_effort="none"))
+        assert none_override["success"] is True
+        assert none_override["job"]["reasoning_effort"] == "none"
+
+        cleared = json.loads(cronjob(action="update", job_id=job_id, reasoning_effort=""))
+        assert cleared["success"] is True
+        assert "reasoning_effort" not in cleared["job"]
+
+        enum_values = CRONJOB_SCHEMA["parameters"]["properties"]["reasoning_effort"]["enum"]
+        assert enum_values == ["", "none", "minimal", "low", "medium", "high", "xhigh"]
+
+    def test_invalid_reasoning_effort_fails_without_writing(self):
+        created = json.loads(
+            cronjob(action="create", prompt="Check", schedule="every 1h", reasoning_effort="turbo")
+        )
+        assert created["success"] is False
+
+        listing = json.loads(cronjob(action="list"))
+        assert listing["count"] == 0
+
+        good = json.loads(cronjob(action="create", prompt="Check", schedule="every 1h"))
+        updated = json.loads(cronjob(action="update", job_id=good["job_id"], reasoning_effort="turbo"))
+        assert updated["success"] is False
 
     def test_update_runtime_overrides_can_set_and_clear(self):
         created = json.loads(

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -327,6 +327,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["workdir"] = job["workdir"]
     if job.get("profile"):
         result["profile"] = job["profile"]
+    if job.get("reasoning_effort") is not None:
+        result["reasoning_effort"] = job["reasoning_effort"]
     return result
 
 
@@ -350,6 +352,7 @@ def cronjob(
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
     profile: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
     no_agent: Optional[bool] = None,
     task_id: str = None,
 ) -> str:
@@ -417,6 +420,7 @@ def cronjob(
                 enabled_toolsets=enabled_toolsets or None,
                 workdir=_normalize_optional_job_value(workdir),
                 profile=_normalize_optional_job_value(profile),
+                reasoning_effort=_normalize_optional_job_value(reasoning_effort),
                 no_agent=_no_agent,
             )
             return json.dumps(
@@ -555,6 +559,9 @@ def cronjob(
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
                 updates["profile"] = _normalize_optional_job_value(profile) or None
+            if reasoning_effort is not None:
+                # Empty string clears the per-job override and restores global fallback.
+                updates["reasoning_effort"] = _normalize_optional_job_value(reasoning_effort) or None
             if no_agent is not None:
                 # Toggling no_agent on/off at update time. If flipping to True,
                 # we need a script to already exist on the job (or be part of
@@ -712,6 +719,11 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "string",
                 "description": "Optional Hermes profile name to run the job under. When set, the scheduler resolves that profile, applies a context-local Hermes home override, loads that profile's config/.env for the run, and bridges HERMES_HOME into subprocesses. Any temporary process-environment changes from profile .env loading are restored after the job exits. Use 'default' for the root Hermes profile. Named profiles must already exist. When unset (default), preserves the scheduler's existing profile. On update, pass an empty string to clear. Jobs with profile run sequentially (not parallel) to keep profile-scoped runtime state isolated."
             },
+            "reasoning_effort": {
+                "type": "string",
+                "enum": ["", "none", "minimal", "low", "medium", "high", "xhigh"],
+                "description": "Optional per-job reasoning/thinking effort override. If omitted or cleared, the job uses global agent.reasoning_effort. Pass 'none' to explicitly disable reasoning for this job; this is different from clearing, which restores global fallback. Ignored when no_agent=True; may be no-op for ACP runtimes. On update, pass empty string to clear."
+            },
         },
         "required": ["action"]
     }
@@ -767,6 +779,7 @@ registry.register(
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         profile=args.get("profile"),
+        reasoning_effort=args.get("reasoning_effort"),
         no_agent=args.get("no_agent"),
         task_id=kw.get("task_id"),
     ))(),

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -121,6 +121,40 @@ When `workdir` is set:
 Jobs with a `workdir` run sequentially on the scheduler tick, not in the parallel pool. This is deliberate — `TERMINAL_CWD` is process-global, so two workdir jobs running at the same time would corrupt each other's cwd. Workdir-less jobs still run in parallel as before.
 :::
 
+## Tuning reasoning effort per job
+
+By default, cron jobs use the same `agent.reasoning_effort` configured for normal Hermes sessions. For scheduled background work, that is not always the right trade-off: a routine feed digest or low-risk watchdog can usually run faster and cheaper with lighter reasoning than an interactive coding session.
+
+Set a per-job override with `--reasoning-effort`:
+
+```bash
+hermes cron create "0 3 * * *" \
+  "Summarize yesterday's low-priority feeds" \
+  --reasoning-effort low
+```
+
+The same option is available through the `cronjob` tool:
+
+```python
+cronjob(
+    action="create",
+    schedule="0 3 * * *",
+    prompt="Summarize yesterday's low-priority feeds",
+    reasoning_effort="low",
+)
+```
+
+Valid values are `none`, `minimal`, `low`, `medium`, `high`, and `xhigh`.
+
+Semantics:
+
+- omit the field to use global `agent.reasoning_effort`
+- set `none` to explicitly disable reasoning for that job
+- clear the override with `hermes cron edit <job_id> --clear-reasoning-effort`
+- `no_agent` script-only jobs ignore reasoning effort because they never create an agent or call a model
+
+This lets you keep a stronger global setting for interactive sessions while making recurring low-risk cron jobs less expensive in latency and token usage.
+
 ## Running cron jobs in a specific profile
 
 By default a cron job inherits whichever Hermes profile owned the gateway / CLI that created it. Pass `--profile <name>` (CLI) or `profile=` (cronjob tool) to re-target the job at a different profile — the scheduler resolves that profile's `HERMES_HOME`, temporarily switches into it for the duration of the run, loads its `.env` + `config.yaml`, and executes the job there:


### PR DESCRIPTION
## Summary

This adds an optional per-cron-job `reasoning_effort` override for scheduled Hermes jobs.

Cron jobs can now choose one of:

- `none`
- `minimal`
- `low`
- `medium`
- `high`
- `xhigh`

If a job does not set `reasoning_effort`, it keeps the existing behavior and falls back to global `agent.reasoning_effort` from `config.yaml`.

## Why

Scheduled jobs often have very different reasoning needs than interactive sessions:

- simple collectors, digests, and watchdogs usually do not need the same reasoning depth as active coding work;
- lower reasoning effort can make routine cron runs faster;
- lower reasoning effort can reduce token/reasoning-token usage for recurring background work;
- users can preserve a stronger global/default setting for interactive sessions while making low-risk scheduled jobs cheaper and less intrusive.

This is especially useful for overnight/off-peak cron workloads where many jobs run autonomously and should not burn the same model budget as deliberate interactive work.

## Behavior

- `create_job(..., reasoning_effort="low")` stores a normalized per-job override.
- `update_job(..., {"reasoning_effort": ""})` or `None` clears the override and restores global fallback.
- `reasoning_effort="none"` is an explicit override that disables reasoning for that job; it is not treated as clearing/fallback.
- invalid stored legacy values are read-safe and fall back to the global setting.
- `no_agent=True` script-only jobs still return before constructing `AIAgent`, so the field has no effect there.

## Interfaces

- `hermes cron create --reasoning-effort ...`
- `hermes cron edit --reasoning-effort ...`
- `hermes cron edit --clear-reasoning-effort`
- `cronjob` tool schema + create/update support
- `hermes cron list` / `cronjob list` display the override when present
- user docs updated in `website/docs/user-guide/features/cron.md`

## How to test

```bash
./venv/bin/python scripts/check-windows-footguns.py
scripts/run_tests.sh tests/cron/test_cron_reasoning_effort.py tests/hermes_cli/test_cron.py tests/tools/test_cronjob_tools.py -q
```

Result: `66 passed` under `scripts/run_tests.sh` hermetic env and no Windows footguns in the staged diff.

## Manual test

Verified with a real local cron run: a temporary job with `reasoning_effort="minimal"` produced a session row with:

```json
"reasoning_config": {
  "enabled": true,
  "effort": "minimal"
}
```

## Platforms tested

- Linux 6.12, Python from the repository venv.

This change is config plumbing and scheduler logic only; it does not add platform-specific filesystem, process-management, or shell behavior.
