### PR TITLE
feat(approval): explicit self-PID descriptors for gateway patterns

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -336,19 +336,19 @@ DANGEROUS_PATTERNS = [
     # Gateway lifecycle protection: prevent the agent from killing its own
     # gateway process.  These commands trigger a gateway restart/stop that
     # terminates all running agents mid-work.
-    (r'\bhermes\s+gateway\s+(stop|restart)\b', "stop/restart hermes gateway (kills running agents)"),
-    (r'\bhermes\s+update\b', "hermes update (restarts gateway, kills running agents)"),
+    (r'\bhermes\s+gateway\s+(stop|restart)\b', "stop/restart hermes gateway — current session ends (kills running agents)"),
+    (r'\bhermes\s+update\b', "hermes update — restarts gateway, current session ends (kills running agents)"),
     # Gateway protection: never start gateway outside systemd management
     (r'gateway\s+run\b.*(&\s*$|&\s*;|\bdisown\b|\bsetsid\b)', "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')"),
     (r'\bnohup\b.*gateway\s+run\b', "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')"),
     # Self-termination protection: prevent agent from killing its own process
-    (r'\b(pkill|killall)\b.*\b(hermes|gateway|cli\.py)\b', "kill hermes/gateway process (self-termination)"),
+    (r'\b(pkill|killall)\b.*\b(hermes|gateway|cli\.py)\b', "kill hermes/gateway process — current session ends (self-termination)"),
     # Self-termination via kill + command substitution (pgrep/pidof).
     # The name-based pattern above catches `pkill hermes` but not
     # `kill -9 $(pgrep -f hermes)` because the substitution is opaque
     # to regex at detection time. Catch the structural pattern instead.
-    (r'\bkill\b.*\$\(\s*pgrep\b', "kill process via pgrep expansion (self-termination)"),
-    (r'\bkill\b.*`\s*pgrep\b', "kill process via backtick pgrep expansion (self-termination)"),
+    (r'\bkill\b.*\$\(\s*pgrep\b', "kill via pgrep — likely targets hermes/gateway PID, current session ends (self-termination)"),
+    (r'\bkill\b.*`\s*pgrep\b', "kill via backtick pgrep — likely targets hermes/gateway PID, current session ends (self-termination)"),
     # File copy/move/edit into sensitive system paths
     (r'\b(cp|mv|install)\b.*\s/etc/', "copy/move file into /etc/"),
     (rf'\b(cp|mv|install)\b.*\s["\']?{_PROJECT_SENSITIVE_WRITE_TARGET}["\']?{_COMMAND_TAIL}', "overwrite project env/config file"),


### PR DESCRIPTION
## Summary

Enriches 5 `DANGEROUS_PATTERNS` descriptions in `tools/approval.py` that
target the running hermes-agent gateway itself, surfacing the blast radius
("current session ends") at approval time rather than as a surprise after
the user clicks approve.

Patterns enriched:

- `hermes gateway stop|restart`
- `hermes update`
- `pkill|killall hermes|gateway|cli.py`
- `kill … \$(pgrep …)`
- `kill … \`pgrep …\``

The existing approval message template already wraps the description in
\`⚠️ This command is potentially dangerous (…)\`, so the consequence is now
visible inline at the moment of decision without any structural changes.

## Motivation

In a recent incident a user approved \`kill process via pgrep expansion
(self-termination)\` via Telegram without realizing the substitution
expanded to the gateway's own PID — the active session was terminated
mid-work. The pre-change descriptor doesn't make the consequence obvious
to a user scanning a yes/no prompt.

After the change the same prompt reads:

> kill via pgrep — likely targets hermes/gateway PID, current session ends (self-termination)

## Scope and non-scope

Scope: descriptor text only. 5 string changes, 5 LOC delta.

Non-scope:

- No \`DANGEROUS_PATTERNS\` schema changes (kept as 2-tuples).
- No runtime PID resolution (deliberately — would require evaluating
  pgrep/pidof substitutions inside the approval flow, with the security
  regressions that implies).
- No new approval modes or config keys.

## Behavioral note

Because \`pattern_key == description\` (see line 454), users with permanent
approvals saved against the previous descriptor strings will be re-prompted
once per affected pattern after upgrading. This is arguably desirable —
prior \`/approve always\` decisions were given without the new context.

## Test plan

- [x] \`python -m py_compile tools/approval.py\` clean
- [x] Gateway restart via systemd loads without errors (\`[hooks] Loaded\` + service active)
- [ ] Trigger one of the enriched patterns interactively to confirm the new wording lands in the approval message (deferred to reviewers; the description is plumbed through unchanged template)