### PR TITLE
fix(credential_pool): resolve op:// refs before seeding pool

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1759,7 +1759,13 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
     # changes to the .env file.
     def _get_env_prefer_dotenv(key: str) -> str:
         env_file = load_env()
-        val = env_file.get(key) or os.environ.get(key) or ""
+        val = env_file.get(key, "")
+        # Unresolved op:// references in .env are placeholders; the real
+        # secret was resolved into os.environ by _apply_external_secret_sources
+        # at startup. Falling back to os.environ here lets the resolved value win.
+        if val.startswith("op://"):
+            val = ""
+        val = val or os.environ.get(key) or ""
         return val.strip()
 
     # Honour user suppression — `hermes auth remove <provider> <N>` for an


### PR DESCRIPTION
## Summary

`_get_env_prefer_dotenv` in `agent/credential_pool.py` preferred the raw `.env` value over `os.environ`. When a provider's API key in `.env` was an unresolved `op://` 1Password reference, that literal string won over the resolved value that `_apply_external_secret_sources` had written into `os.environ` at startup.

Concretely, with `.env` containing:
```
OPENROUTER_API_KEY=op://Hermes/OpenRouter/credential
```
the OpenRouter pool ended up with `access_token="op://Hermes/OpenRouter/credential"`, every request to OpenRouter returned `HTTP 401: Missing Authentication header`, and the auxiliary client misclassified the 401 as a "payment / credit error" and marked the provider unhealthy, cascading to the configured fallback.

Same bug affects every other provider whose key is stored as an `op://` ref (anthropic, nous, etc.), since they all read through the same helper.

## Fix

Treat values starting with `op://` in `.env` as placeholders and fall through to `os.environ`, where `_apply_external_secret_sources` has already placed the resolved secret.

```python
def _get_env_prefer_dotenv(key: str) -> str:
    env_file = load_env()
    val = env_file.get(key, "")
    if val.startswith("op://"):
        val = ""
    val = val or os.environ.get(key) or ""
    return val.strip()
```

## Test plan

- [x] With `OPENROUTER_API_KEY=op://...` in `.env`, restart gateway, confirm pool entry has the resolved `sk-or-v1...` token (not the literal `op://...`).
- [x] Confirm OpenRouter calls no longer return 401.
- [x] One-shot prompt via `hermes -z` returns the model response end-to-end.
- [ ] Verify the same fix resolves `op://` refs for other providers in the same code path (Anthropic, Nous) — not directly tested in my setup but should follow from the shared helper.

## Notes

Stumbled on a couple of adjacent issues that aren't fixed here but are worth tracking separately:

1. **In-process-only 1Password cache.** `agent/secret_sources/onepassword.py:43` keeps resolved values in a module-level dict. Every fresh `hermes` CLI invocation re-resolves all `op://` refs, which trips the 1Password rate limit (`error resolving secret reference: ... rate limit exceeded`) when several commands run back-to-back. A persistent on-disk cache would help.
2. **Stale pool entries persist past the fix.** Existing `~/.hermes/auth.json` entries written before this fix keep their `access_token="op://..."` and aren't overwritten until the pool is otherwise refreshed. Users hitting this bug may need to clear the affected provider's `credential_pool` entry in `auth.json` once, or run a refresh.