### PR TITLE
fix(providers): warn on duplicate model provider name/alias registration

### DIFF
--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -57,9 +57,23 @@ def register_provider(profile: ProviderProfile) -> None:
     plugins under ``$HERMES_HOME/plugins/model-providers/`` can override
     bundled profiles without editing repo code.
     """
-    _REGISTRY[profile.name] = profile
+    if profile.name in _REGISTRY:
+        logger.warning(
+            "Provider '%s' is being re-registered (last writer wins). "
+            "This usually means a user plugin is overriding a bundled one.",
+            profile.name,
+        )
     for alias in profile.aliases:
+        if alias in _ALIASES:
+            logger.warning(
+                "Alias '%s' is being re-registered to provider '%s' (was '%s').",
+                alias,
+                profile.name,
+                _ALIASES[alias],
+            )
         _ALIASES[alias] = profile.name
+
+    _REGISTRY[profile.name] = profile
 
 
 def get_provider_profile(name: str) -> ProviderProfile | None:

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -63,6 +63,15 @@ def register_provider(profile: ProviderProfile) -> None:
             "This usually means a user plugin is overriding a bundled one.",
             profile.name,
         )
+    if profile.name in _ALIASES:
+        logger.warning(
+            "Provider name '%s' conflicts with an existing alias for provider '%s' "
+            "(last writer wins).",
+            profile.name,
+            _ALIASES[profile.name],
+        )
+        del _ALIASES[profile.name]
+
     for alias in profile.aliases:
         if alias in _ALIASES:
             logger.warning(
@@ -70,6 +79,13 @@ def register_provider(profile: ProviderProfile) -> None:
                 alias,
                 profile.name,
                 _ALIASES[alias],
+            )
+        if alias in _REGISTRY:
+            logger.warning(
+                "Alias '%s' for provider '%s' conflicts with an existing provider name "
+                "(last writer wins for lookups).",
+                alias,
+                profile.name,
             )
         _ALIASES[alias] = profile.name
 

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -1,7 +1,26 @@
 """Tests for the provider module registry and profiles."""
 
-from providers import get_provider_profile, _REGISTRY
+import pytest
+import providers
+from providers import get_provider_profile, _ALIASES, _REGISTRY, register_provider
 from providers.base import ProviderProfile, OMIT_TEMPERATURE
+
+
+@pytest.fixture()
+def provider_registry_snapshot():
+    """Restore provider registry globals after tests that mutate registration state."""
+    registry = dict(_REGISTRY)
+    aliases = dict(_ALIASES)
+    discovered = providers._discovered
+    providers._discovered = True
+    try:
+        yield
+    finally:
+        _REGISTRY.clear()
+        _REGISTRY.update(registry)
+        _ALIASES.clear()
+        _ALIASES.update(aliases)
+        providers._discovered = discovered
 
 
 class TestRegistry:
@@ -21,6 +40,57 @@ class TestRegistry:
 
     def test_unknown_provider_returns_none(self):
         assert get_provider_profile("nonexistent-provider") is None
+
+    def test_duplicate_name_warns(self, caplog, provider_registry_snapshot):
+        existing = ProviderProfile(name="existing")
+        replacement = ProviderProfile(name="existing", base_url="https://new.example")
+        _REGISTRY[existing.name] = existing
+
+        with caplog.at_level("WARNING", logger="providers"):
+            register_provider(replacement)
+
+        assert "Provider 'existing' is being re-registered" in caplog.text
+        assert get_provider_profile("existing") is replacement
+
+    def test_duplicate_alias_warns(self, caplog, provider_registry_snapshot):
+        existing = ProviderProfile(name="existing")
+        replacement = ProviderProfile(name="replacement", aliases=("shared",))
+        _REGISTRY[existing.name] = existing
+        _ALIASES["shared"] = existing.name
+
+        with caplog.at_level("WARNING", logger="providers"):
+            register_provider(replacement)
+
+        assert "Alias 'shared' is being re-registered" in caplog.text
+        assert get_provider_profile("shared") is replacement
+
+    def test_provider_name_matching_existing_alias_warns_and_wins(
+        self, caplog, provider_registry_snapshot
+    ):
+        existing = ProviderProfile(name="existing")
+        replacement = ProviderProfile(name="alias-name")
+        _REGISTRY[existing.name] = existing
+        _ALIASES["alias-name"] = existing.name
+
+        with caplog.at_level("WARNING", logger="providers"):
+            register_provider(replacement)
+
+        assert "Provider name 'alias-name' conflicts with an existing alias" in caplog.text
+        assert "alias-name" not in _ALIASES
+        assert get_provider_profile("alias-name") is replacement
+
+    def test_alias_matching_existing_provider_name_warns_and_redirects_lookup(
+        self, caplog, provider_registry_snapshot
+    ):
+        existing = ProviderProfile(name="existing")
+        replacement = ProviderProfile(name="replacement", aliases=("existing",))
+        _REGISTRY[existing.name] = existing
+
+        with caplog.at_level("WARNING", logger="providers"):
+            register_provider(replacement)
+
+        assert "Alias 'existing' for provider 'replacement' conflicts" in caplog.text
+        assert get_provider_profile("existing") is replacement
 
     def test_all_providers_have_name(self):
         get_provider_profile("nvidia")  # trigger discovery


### PR DESCRIPTION
Closes #30921

## Summary
`register_provider()` now emits warnings when provider registration would overwrite or mask an existing provider name or alias. This makes user plugin overrides and lookup-affecting collisions visible instead of silently changing provider resolution.

## Changes
- Warn when a canonical provider name is re-registered
- Warn when an alias is re-registered
- Warn when a canonical provider name conflicts with an existing alias
- Warn when an alias conflicts with an existing canonical provider name
- Preserve last-writer-wins behavior
- Remove stale alias mappings when a new canonical provider name would otherwise stay masked by an older alias
- Add isolated `caplog` coverage for warning paths and final lookup behavior

## Test plan
- `python -m pytest tests/providers/test_provider_profiles.py -q -o 'addopts='`
- `python -m ruff check providers/__init__.py tests/providers/test_provider_profiles.py`
