### PR TITLE
docs(providers): add explicit hook contract for ProviderProfile

### DIFF
--- a/website/docs/developer-guide/model-provider-plugin.md
+++ b/website/docs/developer-guide/model-provider-plugin.md
@@ -107,6 +107,12 @@ Full definition in `providers/base.py`. The most useful ones:
 
 ## Overridable hooks
 
+### Contract
+- All hooks are optional — you only need to override what your provider requires.
+- Default implementations in `ProviderProfile` are safe no-ops or pass-throughs.
+- Hooks are called with keyword arguments only where documented.
+- Return values must match the documented types (see examples below).
+
 Subclass `ProviderProfile` for non-trivial quirks:
 
 ```python


### PR DESCRIPTION
Closes #30923

## Summary
Added a short "Contract" subsection under "Overridable hooks" that makes the guarantees explicit:
- Hooks are optional
- Safe defaults exist
- Keyword-only where documented
- Return types must be respected

This addresses the missing contract that was the core of the issue.