### PR TITLE
fix(bluebubbles): preserve URLs from markdown links when formatting for iMessage

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -674,6 +674,12 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         return info
 
     def format_message(self, content: str) -> str:
+        # iMessage detects and linkifies plain-text URLs natively, so the
+        # platform should not strip them. The shared strip_markdown drops
+        # `[text](url)` entirely (correct for SMS, wrong for iMessage), so
+        # first rewrite Markdown links to "text url" before stripping the
+        # rest of the markup.
+        content = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"\1 \2", content)
         return strip_markdown(content)
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`BlueBubblesAdapter.format_message` calls the shared `strip_markdown`, which deletes the URL portion of `[text](url)` and keeps only the anchor text. That's correct for SMS but wrong for iMessage, which natively detects and linkifies plain-text URLs.

## Symptom

The model writes:
```markdown
[Click here to unlock](https://vault.example/unlock?n=xxx)
```

The iMessage recipient receives:
```
Click here to unlock
```

No URL. Any flow that hands the user a URL — e.g. `mcp_vault_request_unlock` returning a click-through URL for browser-based authentication — silently breaks. The user sees an apparent invitation to click but nothing to click.

## Reproduce

1. Configure BlueBubbles adapter
2. Have the model respond with content containing a markdown link
3. Observe the outbound iMessage text — URL has been stripped

## Fix

Rewrite `[text](url)` → `text url` *before* calling `strip_markdown`, so the URL survives the markdown-stripping pass. iMessage renders the resulting plain-text URL as a clickable hyperlink automatically.

No behavior change for SMS / Feishu / Mattermost / other platforms that still call `strip_markdown` directly — those don't render hyperlinks anyway.

```diff
 def format_message(self, content: str) -> str:
+    # iMessage detects and linkifies plain-text URLs natively, so the
+    # platform should not strip them. The shared strip_markdown drops
+    # `[text](url)` entirely (correct for SMS, wrong for iMessage), so
+    # first rewrite Markdown links to "text url" before stripping the
+    # rest of the markup.
+    content = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"\1 \2", content)
     return strip_markdown(content)
```

## Test plan

- [x] Manual: send a vault unlock URL via WeChat→bot→iMessage; URL appears and is clickable
- [x] Regression: messages without markdown links unchanged
- [ ] Maintainer may want to add a unit test alongside existing `test_strip_markdown` helpers — happy to add if requested

🤖 Generated with [Claude Code](https://claude.com/claude-code)