### PR TITLE
fix(skills): add display_text to skills_list to stop gateway-side truncation

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -357,6 +357,63 @@ class TestSkillsList:
         assert result["categories"] == ["linked"]
         assert result["skills"][0]["name"] == "knowledge-brain"
 
+    def test_display_text_groups_by_category_and_lists_all(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "alpha", category="devops")
+            _make_skill(tmp_path, "beta", category="mlops")
+            _make_skill(tmp_path, "gamma")  # uncategorized
+            raw = skills_list()
+        result = json.loads(raw)
+        display = result["display_text"]
+        # All names appear — no truncation
+        assert "alpha" in display
+        assert "beta" in display
+        assert "gamma" in display
+        # Grouped by category header (convention: bare "uncategorized", no parens —
+        # matches hermes_cli/skills_config.py).
+        assert "## devops" in display
+        assert "## mlops" in display
+        assert "## uncategorized" in display
+        # Each skill rendered with description
+        assert "Description for alpha" in display
+        # Header reports total count
+        assert "Available skills (3 total)" in display
+        # Hint redirects model away from truncating
+        assert "do not truncate" in result["hint"].lower()
+
+    def test_display_text_empty_when_filter_empty(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "alpha", category="devops")
+            raw = skills_list(category="nonexistent")
+        result = json.loads(raw)
+        assert result["count"] == 0
+        assert result["display_text"] == "No skills to show."
+
+    def test_display_text_collapses_multiline_description(self, tmp_path):
+        # Descriptions with embedded newlines must render on one bullet line —
+        # otherwise the markdown list breaks visibly in WeChat/Telegram.
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = tmp_path / "weird"
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: weird\ndescription: |\n  line one\n  line two\n---\n\nBody.\n"
+            )
+            raw = skills_list()
+        result = json.loads(raw)
+        display = result["display_text"]
+        assert "line one line two" in display
+        # Must not appear as two separate lines (which would break the bullet).
+        assert "line one\nline two" not in display
+
+    def test_early_return_branches_include_display_text(self, tmp_path):
+        # Empty skills dir branch — display_text + hint must be present so the
+        # gateway response shape is stable.
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            raw = skills_list()
+        result = json.loads(raw)
+        assert "display_text" in result
+        assert "hint" in result
+
 
 # ---------------------------------------------------------------------------
 # skill_view

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -672,6 +672,43 @@ def _load_category_description(category_dir: Path) -> Optional[str]:
         return None
 
 
+_DISPLAY_HINT = (
+    "Show display_text verbatim when the user asks to see or list skills "
+    "— do not truncate or summarize. "
+    "Use skill_view(name) to load full content of a specific skill."
+)
+
+
+def _format_skills_display(skills: List[Dict[str, Any]]) -> str:
+    """Render the skill list as markdown grouped by category.
+
+    The model can echo this verbatim instead of summarizing/truncating the
+    raw ``skills`` array when the user asks to see all installed skills.
+    """
+    if not skills:
+        return "No skills to show."
+
+    by_category: Dict[str, List[Dict[str, Any]]] = {}
+    for s in skills:
+        cat = s.get("category") or "uncategorized"
+        by_category.setdefault(cat, []).append(s)
+
+    lines: List[str] = [f"Available skills ({len(skills)} total):", ""]
+    for cat in sorted(by_category):
+        lines.append(f"## {cat}")
+        for s in by_category[cat]:
+            # Collapse any internal whitespace (incl. newlines) so multi-line
+            # YAML descriptions don't break the markdown bullet rendering.
+            desc = " ".join((s.get("description") or "").split())
+            if desc:
+                lines.append(f"- **{s['name']}** — {desc}")
+            else:
+                lines.append(f"- **{s['name']}**")
+        lines.append("")
+    lines.append("Use `skill_view(name)` to load full content of a specific skill.")
+    return "\n".join(lines)
+
+
 def skills_list(category: str = None, task_id: str = None) -> str:
     """
     List all available skills (progressive disclosure tier 1 - minimal metadata).
@@ -694,6 +731,8 @@ def skills_list(category: str = None, task_id: str = None) -> str:
                     "success": True,
                     "skills": [],
                     "categories": [],
+                    "display_text": "No skills to show.",
+                    "hint": _DISPLAY_HINT,
                     "message": f"No skills found. Skills directory created at {display_hermes_home()}/skills/",
                 },
                 ensure_ascii=False,
@@ -708,6 +747,8 @@ def skills_list(category: str = None, task_id: str = None) -> str:
                     "success": True,
                     "skills": [],
                     "categories": [],
+                    "display_text": "No skills to show.",
+                    "hint": _DISPLAY_HINT,
                     "message": "No skills found in skills/ directory.",
                 },
                 ensure_ascii=False,
@@ -731,7 +772,8 @@ def skills_list(category: str = None, task_id: str = None) -> str:
                 "skills": all_skills,
                 "categories": categories,
                 "count": len(all_skills),
-                "hint": "Use skill_view(name) to see full content, tags, and linked files",
+                "display_text": _format_skills_display(all_skills),
+                "hint": _DISPLAY_HINT,
             },
             ensure_ascii=False,
         )
@@ -1490,7 +1532,12 @@ if __name__ == "__main__":
 
 SKILLS_LIST_SCHEMA = {
     "name": "skills_list",
-    "description": "List available skills (name + description). Use skill_view(name) to load full content.",
+    "description": (
+        "List available skills. The response includes display_text — a pre-formatted "
+        "markdown listing grouped by category — that you should echo verbatim when the "
+        "user asks to see or list skills, instead of summarizing or truncating. "
+        "Use skill_view(name) to load full content of a specific skill."
+    ),
     "parameters": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
## Summary

`tools.skills_tool.skills_list` currently returns a `skills: [...]` array with one entry per skill. On the gateway path, the model receives a strong "keep responses concise" system prompt, so when the user asks "what skills do you have?" the model echoes only the first ~10 of the 60+ skills as a numbered list and stops. The rest are silently dropped.

Adding a pre-formatted, grouped-by-category Markdown listing in a new `display_text` field — together with a `hint` instructing the model to relay it verbatim — restores complete visibility without changing the existing `skills:` array (so existing callers are unaffected).

## Symptom

User asks (e.g. via the gateway / iMessage / Telegram): "list your skills" or "你都会什么".

Model returns:
```
Here are my skills:
1. skill-a
2. skill-b
... (truncated, with no notion of how many more there are)
```

Even though `skills_list` returned 60+ entries.

## Root cause

`skills_list` returns the skills as data, leaving rendering to the model. The gateway's "be concise" prompt biases the model toward summarizing rather than dumping. Cap is roughly model-dependent (8–12 items in our testing).

## Fix

Add two new fields to the `skills_list` response:

- `display_text` — a Markdown listing, grouped by category, with descriptions, suitable for pasting straight into chat. Header reports the total count.
- `hint` — instructs the model: do not truncate; relay verbatim.

The schema is updated so the model is told these fields exist and what to do with them. Existing callers that already consume `skills:` continue to work unchanged.

## Test plan

- [x] Added `test_display_text_groups_by_category_and_lists_all` — verifies all skills appear, grouped by category header, with descriptions, and that the count + anti-truncation hint are present.
- [x] Added `test_display_text_empty_when_filter_empty` — verifies the empty-filter case renders correctly.
- [x] Added `test_display_text_collapses_multiline_description` — verifies multi-line descriptions render as a single bullet line.
- [x] Existing tests unchanged and passing.
- [x] Manual: hit `/skills` from a WeChat / iMessage gateway session; bot now sends the full grouped listing.

## Notes

- Doesn't change the `skills:` array shape, so any caller that parses it programmatically (CLI, dashboard, etc.) is unaffected.
- Cherry-picked off latest upstream/main; one trivial conflict (a sibling test added independently in upstream) resolved by keeping both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)