### PR TITLE
fix(nix): ship managed FAL backend in sealed package

### DIFF
--- a/nix/hermes-agent.nix
+++ b/nix/hermes-agent.nix
@@ -36,9 +36,14 @@
 }:
 let
   nodejs = nodejs_22;
+  # The sealed Nix runtime lives in the store, so first-use lazy installs
+  # cannot repair missing Python backends there. Ship the managed FAL
+  # backend in the default package so `hermes --tui` image generation works
+  # out of the box on the documented Nix install path.
+  nixRuntimeDependencyGroups = [ "fal" ];
   hermesVenv = callPackage ./python.nix {
     inherit uv2nix pyproject-nix pyproject-build-systems;
-    dependency-groups = [ "all" ] ++ extraDependencyGroups;
+    dependency-groups = [ "all" ] ++ nixRuntimeDependencyGroups ++ extraDependencyGroups;
   };
 
   hermesNpmLib = callPackage ./lib.nix {


### PR DESCRIPTION
## Summary
- include the `fal` dependency group in the default Nix sealed runtime
- avoid first-use lazy install attempts for image generation inside the immutable store python
- keep the fix Nix-specific instead of widening `[all]` for every install path

Closes #30931