### PR TITLE
fix(cli): prefer module form when resolving Hermes from a Windows venv

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1479,13 +1479,31 @@ def _resolve_hermes_bin() -> Optional[list[str]]:
     """Resolve the Hermes update command as argv parts.
 
     Tries in order:
-    1. ``shutil.which("hermes")`` — standard PATH lookup
-    2. ``sys.executable -m hermes_cli.main`` — fallback when Hermes is running
+    1. Windows venv guard — when running from a venv on Windows, prefer the
+       interpreter-bound module form. A bare ``hermes`` lookup on a
+       restricted ``PATH`` (Scheduled Task, detached process) can resolve
+       to a *different* interpreter's ``hermes.exe`` (pip console-script
+       launcher) that cannot bootstrap the venv's editable install and
+       dies with ``ModuleNotFoundError: No module named 'hermes_cli'``.
+    2. ``shutil.which("hermes")`` — standard PATH lookup
+    3. ``sys.executable -m hermes_cli.main`` — fallback when Hermes is running
        from a venv/module invocation and the ``hermes`` shim is not on PATH
 
     Returns argv parts ready for quoting/joining, or ``None`` if neither works.
     """
     import shutil
+
+    if sys.platform == "win32" and (
+        os.environ.get("VIRTUAL_ENV")
+        or sys.prefix != getattr(sys, "base_prefix", sys.prefix)
+    ):
+        try:
+            import importlib.util
+
+            if importlib.util.find_spec("hermes_cli") is not None:
+                return [sys.executable, "-m", "hermes_cli.main"]
+        except Exception:
+            pass
 
     hermes_bin = shutil.which("hermes")
     if hermes_bin:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1475,6 +1475,25 @@ def _resolve_gateway_model(config: dict | None = None) -> str:
     return ""
 
 
+def _can_import_hermes_cli() -> bool:
+    """Return ``True`` when ``hermes_cli`` resolves under the current interpreter.
+
+    ``importlib.util.find_spec`` is the supported probe but it can raise
+    ``ImportError`` / ``ValueError`` when a malformed parent package shadows
+    ``hermes_cli`` on ``sys.path`` (rare but observed during partial editable
+    installs). A failed probe means we cannot safely spawn ``-m
+    hermes_cli.main`` from this interpreter, so the caller should fall back
+    to the PATH-based shim.
+    """
+    try:
+        import importlib.util
+
+        return importlib.util.find_spec("hermes_cli") is not None
+    except (ImportError, ValueError) as exc:
+        logger.debug("hermes_cli find_spec probe failed: %r", exc)
+        return False
+
+
 def _resolve_hermes_bin() -> Optional[list[str]]:
     """Resolve the Hermes update command as argv parts.
 
@@ -1493,29 +1512,22 @@ def _resolve_hermes_bin() -> Optional[list[str]]:
     """
     import shutil
 
-    if sys.platform == "win32" and (
-        os.environ.get("VIRTUAL_ENV")
-        or sys.prefix != getattr(sys, "base_prefix", sys.prefix)
+    if (
+        sys.platform == "win32"
+        and (
+            os.environ.get("VIRTUAL_ENV")
+            or sys.prefix != getattr(sys, "base_prefix", sys.prefix)
+        )
+        and _can_import_hermes_cli()
     ):
-        try:
-            import importlib.util
-
-            if importlib.util.find_spec("hermes_cli") is not None:
-                return [sys.executable, "-m", "hermes_cli.main"]
-        except Exception:
-            pass
+        return [sys.executable, "-m", "hermes_cli.main"]
 
     hermes_bin = shutil.which("hermes")
     if hermes_bin:
         return [hermes_bin]
 
-    try:
-        import importlib.util
-
-        if importlib.util.find_spec("hermes_cli") is not None:
-            return [sys.executable, "-m", "hermes_cli.main"]
-    except Exception:
-        pass
+    if _can_import_hermes_cli():
+        return [sys.executable, "-m", "hermes_cli.main"]
 
     return None
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6297,6 +6297,20 @@ def _hermes_path_argv(path: str) -> list[str]:
     return [_absolute_hermes_path(path)]
 
 
+def _running_in_venv() -> bool:
+    """Return true when the current interpreter is inside a virtualenv.
+
+    Checks both ``$VIRTUAL_ENV`` (set by venv/virtualenv activation) and the
+    ``sys.prefix != sys.base_prefix`` invariant — the latter catches venvs
+    that were never ``activate``d (Scheduled Tasks, launchd jobs, detached
+    processes that exec the venv's python directly).
+    """
+    if os.environ.get("VIRTUAL_ENV"):
+        return True
+    base_prefix = getattr(sys, "base_prefix", sys.prefix)
+    return sys.prefix != base_prefix
+
+
 def _resolve_hermes_argv() -> list[str]:
     """Resolve the ``hermes`` invocation as argv parts for ``Popen``.
 
@@ -6305,13 +6319,23 @@ def _resolve_hermes_argv() -> list[str]:
     1. ``$HERMES_BIN`` — explicit operator override. Path-like values are
        normalized to absolute paths; bare command names keep normal PATH
        semantics and never prefer a same-directory file before ``PATH``.
-    2. ``shutil.which("hermes")`` — the console-script shim, normalized to
+    2. Windows venv guard — when running from a venv on Windows with no
+       explicit override, prefer the interpreter-bound module form. A bare
+       ``hermes`` lookup on a Scheduled Task's restricted ``PATH`` can
+       resolve to a *different* interpreter's ``hermes.exe`` (e.g. the
+       system Python's console-script launcher). The pip-generated
+       ``.exe`` launcher cannot bootstrap the venv's editable install when
+       its ``__editable__`` ``.pth`` is not on the spawned interpreter's
+       ``sys.path``, so the worker dies with
+       ``ModuleNotFoundError: No module named 'hermes_cli'``. Using the
+       venv's ``sys.executable`` directly side-steps the launcher entirely.
+    3. ``shutil.which("hermes")`` — the console-script shim, normalized to
        an absolute path. On Windows, ``which`` can return a relative
        ``.\\hermes.CMD`` when the current directory is on ``PATH``; directly
        launching batch shims is also unsafe with task-derived argv. The
        dispatcher therefore falls back to the interpreter-bound module form
        for implicit ``.cmd`` / ``.bat`` shims.
-    3. ``sys.executable -m hermes_cli.main`` — fallback for setups where
+    4. ``sys.executable -m hermes_cli.main`` — fallback for setups where
        Hermes is launched from a venv and the ``hermes`` shim is not on
        the dispatcher's ``$PATH`` (cron, systemd ``User=`` services,
        launchd jobs, detached processes, etc.). Goes through the running
@@ -6330,6 +6354,9 @@ def _resolve_hermes_argv() -> list[str]:
         resolved_env_bin = _safe_which_no_cwd(env_bin)
         if resolved_env_bin:
             return _hermes_path_argv(resolved_env_bin)
+        return _module_hermes_argv()
+
+    if _IS_WINDOWS and _running_in_venv():
         return _module_hermes_argv()
 
     hermes_bin = _safe_which_no_cwd("hermes") if _IS_WINDOWS else shutil.which("hermes")

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6298,7 +6298,7 @@ def _hermes_path_argv(path: str) -> list[str]:
 
 
 def _running_in_venv() -> bool:
-    """Return true when the current interpreter is inside a virtualenv.
+    """Return ``True`` when the current interpreter is inside a virtualenv.
 
     Checks both ``$VIRTUAL_ENV`` (set by venv/virtualenv activation) and the
     ``sys.prefix != sys.base_prefix`` invariant — the latter catches venvs

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -185,6 +185,72 @@ class TestHandleUpdateCommand:
         assert result is None
 
     @pytest.mark.asyncio
+    async def test_resolve_hermes_bin_windows_venv_prefers_module_form(self, monkeypatch):
+        """Windows + venv bypasses the .exe shim to avoid the cross-interpreter trap.
+
+        Mirrors ``hermes_cli.kanban_db._resolve_hermes_argv`` (#30943). On a
+        Windows Scheduled Task with a restricted ``PATH``, ``shutil.which``
+        can resolve a *different* interpreter's ``hermes.exe`` launcher;
+        spawning it then dies with ``ModuleNotFoundError: hermes_cli`` because
+        the system interpreter has no ``__editable__`` ``.pth`` for the venv.
+        """
+        import sys
+        from gateway.run import _resolve_hermes_bin
+
+        monkeypatch.setenv("VIRTUAL_ENV", "C:\\venvs\\hermes")
+        monkeypatch.setattr(sys, "platform", "win32")
+        fake_spec = MagicMock()
+        with patch("shutil.which", return_value="C:\\Python312\\Scripts\\hermes.exe"), \
+             patch("importlib.util.find_spec", return_value=fake_spec):
+            result = _resolve_hermes_bin()
+
+        assert result == [sys.executable, "-m", "hermes_cli.main"]
+
+    @pytest.mark.asyncio
+    async def test_resolve_hermes_bin_windows_unactivated_venv_uses_sys_prefix(self, monkeypatch):
+        """``sys.prefix != sys.base_prefix`` catches unactivated Scheduled-Task venvs."""
+        import sys
+        from gateway.run import _resolve_hermes_bin
+
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(sys, "prefix", "C:\\venvs\\hermes")
+        monkeypatch.setattr(sys, "base_prefix", "C:\\Python312")
+        fake_spec = MagicMock()
+        with patch("shutil.which", return_value="C:\\Python312\\Scripts\\hermes.exe"), \
+             patch("importlib.util.find_spec", return_value=fake_spec):
+            result = _resolve_hermes_bin()
+
+        assert result == [sys.executable, "-m", "hermes_cli.main"]
+
+    @pytest.mark.asyncio
+    async def test_resolve_hermes_bin_windows_non_venv_still_uses_shim(self, monkeypatch):
+        """Outside a venv on Windows the shim is still preferred."""
+        import sys
+        from gateway.run import _resolve_hermes_bin
+
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(sys, "base_prefix", sys.prefix)
+        with patch("shutil.which", return_value="C:\\Python312\\Scripts\\hermes.exe"):
+            result = _resolve_hermes_bin()
+
+        assert result == ["C:\\Python312\\Scripts\\hermes.exe"]
+
+    @pytest.mark.asyncio
+    async def test_resolve_hermes_bin_posix_venv_still_uses_shim(self, monkeypatch):
+        """The venv guard is Windows-only — POSIX shims are not affected."""
+        import sys
+        from gateway.run import _resolve_hermes_bin
+
+        monkeypatch.setenv("VIRTUAL_ENV", "/home/u/venvs/hermes")
+        monkeypatch.setattr(sys, "platform", "linux")
+        with patch("shutil.which", return_value="/home/u/venvs/hermes/bin/hermes"):
+            result = _resolve_hermes_bin()
+
+        assert result == ["/home/u/venvs/hermes/bin/hermes"]
+
+    @pytest.mark.asyncio
     async def test_writes_pending_marker(self, tmp_path):
         """Writes .update_pending.json with correct platform and chat info."""
         runner = _make_runner()

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2726,6 +2726,93 @@ def test_resolve_hermes_argv_module_actually_runs():
     assert "Hermes Agent" in r.stdout, f"unexpected output: {r.stdout[:200]!r}"
 
 
+def test_resolve_hermes_argv_windows_venv_prefers_module_form(monkeypatch):
+    """Windows + venv resolves to the venv ``sys.executable`` module form.
+
+    Regression for #30943: under a Windows Scheduled Task with a restricted
+    ``PATH``, ``shutil.which("hermes")`` can resolve to the *system*
+    Python's ``hermes.exe`` console-script launcher instead of the venv's.
+    The system launcher then spawns the system interpreter, which has no
+    ``__editable__`` ``.pth`` for the venv's ``hermes_cli`` install, so the
+    worker dies with ``ModuleNotFoundError: No module named 'hermes_cli'``.
+    The venv guard avoids the launcher entirely by going straight through
+    the running ``sys.executable``.
+    """
+    import sys
+    import hermes_cli.kanban_db as kb
+
+    monkeypatch.delenv("HERMES_BIN", raising=False)
+    monkeypatch.setattr(kb, "_IS_WINDOWS", True)
+    monkeypatch.setenv("VIRTUAL_ENV", "C:\\venvs\\hermes")
+    monkeypatch.setattr(kb, "_safe_which_no_cwd", lambda name: "C:\\Python312\\Scripts\\hermes.exe")
+
+    assert kb._resolve_hermes_argv() == [sys.executable, "-m", "hermes_cli.main"]
+
+
+def test_resolve_hermes_argv_windows_unactivated_venv_prefers_module_form(monkeypatch):
+    """Detects an unactivated venv via ``sys.prefix != sys.base_prefix``.
+
+    Scheduled Tasks and detached processes routinely exec the venv's
+    ``python.exe`` directly without ``activate``, so ``$VIRTUAL_ENV`` is
+    not set. The ``sys.prefix`` check catches that path.
+    """
+    import sys
+    import hermes_cli.kanban_db as kb
+
+    monkeypatch.delenv("HERMES_BIN", raising=False)
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.setattr(kb, "_IS_WINDOWS", True)
+    monkeypatch.setattr(sys, "prefix", "C:\\venvs\\hermes")
+    monkeypatch.setattr(sys, "base_prefix", "C:\\Python312")
+    monkeypatch.setattr(kb, "_safe_which_no_cwd", lambda name: "C:\\Python312\\Scripts\\hermes.exe")
+
+    assert kb._resolve_hermes_argv() == [sys.executable, "-m", "hermes_cli.main"]
+
+
+def test_resolve_hermes_argv_windows_non_venv_still_uses_path_shim(monkeypatch, tmp_path):
+    """Outside a venv on Windows the shim is still preferred for familiar ``ps`` output."""
+    import sys
+    import hermes_cli.kanban_db as kb
+
+    shim = tmp_path / "Scripts" / "hermes.exe"
+    shim.parent.mkdir()
+    shim.write_text("", encoding="utf-8")
+    monkeypatch.delenv("HERMES_BIN", raising=False)
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.setattr(kb, "_IS_WINDOWS", True)
+    monkeypatch.setattr(sys, "base_prefix", sys.prefix)
+    monkeypatch.setattr(kb, "_safe_which_no_cwd", lambda name: str(shim))
+
+    assert kb._resolve_hermes_argv() == [str(shim)]
+
+
+def test_resolve_hermes_argv_posix_venv_still_uses_path_shim(monkeypatch):
+    """The venv guard is Windows-only — POSIX shims work correctly from a venv."""
+    import shutil
+    import hermes_cli.kanban_db as kb
+
+    monkeypatch.delenv("HERMES_BIN", raising=False)
+    monkeypatch.setenv("VIRTUAL_ENV", "/home/u/venvs/hermes")
+    monkeypatch.setattr(kb, "_IS_WINDOWS", False)
+    monkeypatch.setattr(shutil, "which", lambda name: "/home/u/venvs/hermes/bin/hermes")
+
+    assert kb._resolve_hermes_argv() == ["/home/u/venvs/hermes/bin/hermes"]
+
+
+def test_resolve_hermes_argv_windows_venv_explicit_hermes_bin_wins(monkeypatch, tmp_path):
+    """``HERMES_BIN`` is an explicit operator override and beats the venv guard."""
+    import hermes_cli.kanban_db as kb
+
+    shim = tmp_path / "bin" / "hermes.exe"
+    shim.parent.mkdir()
+    shim.write_text("", encoding="utf-8")
+    monkeypatch.setattr(kb, "_IS_WINDOWS", True)
+    monkeypatch.setenv("VIRTUAL_ENV", "C:\\venvs\\hermes")
+    monkeypatch.setenv("HERMES_BIN", str(shim))
+
+    assert kb._resolve_hermes_argv() == [str(shim)]
+
+
 # ---------------------------------------------------------------------------
 # task_age — guard against corrupt timestamp values
 #


### PR DESCRIPTION
## What does this PR do?

On Windows, when Hermes runs from a venv via a Scheduled Task with a restricted `PATH`, the kanban dispatcher's `_resolve_hermes_argv()` (and the gateway's parallel `_resolve_hermes_bin()`) can resolve a *different* interpreter's `hermes.exe` console-script launcher (e.g. the system Python's, leftover on PATH) instead of the venv's. Spawning that `.exe` then dies with `ModuleNotFoundError: No module named 'hermes_cli'` because the system interpreter has no `__editable__` `.pth` for the venv's editable install — the worker never starts, and the kanban task stays stuck in `running`.

Add a Windows-venv guard to both resolvers: when `_IS_WINDOWS` AND running from a venv (`$VIRTUAL_ENV` set OR `sys.prefix != sys.base_prefix`) AND `$HERMES_BIN` is not explicitly set, go straight through `sys.executable -m hermes_cli.main` so the venv's own interpreter is used directly and the pip launcher is bypassed entirely.

`$HERMES_BIN` still wins so operators can pin a specific shim. Non-Windows code paths and non-venv Windows code paths are unchanged.

> Mirrors `gateway.run._resolve_hermes_bin` precedence: `\$HERMES_BIN` > Windows-venv guard > `shutil.which(\"hermes\")` > `sys.executable -m hermes_cli.main`. Both resolvers get the same guard because both spawn detached `hermes` subprocesses that hit the same restricted-PATH Scheduled-Task / detached-process context.

> Audited siblings: confirmed there are exactly two `hermes` argv resolvers in the tree — `hermes_cli/kanban_db.py::_resolve_hermes_argv` (worker spawn) and `gateway/run.py::_resolve_hermes_bin` (detached `/restart`, `hermes update`). Both are patched. No other code paths spawn the `hermes` CLI as a subprocess.

## Related Issue

Fixes #30943

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- \`hermes_cli/kanban_db.py\` — add module-level \`_running_in_venv()\` helper; insert Windows-venv guard in \`_resolve_hermes_argv()\` between the \`HERMES_BIN\` branch and the \`shutil.which\` lookup; expand docstring with the new step #2.
- \`gateway/run.py\` — insert the equivalent Windows-venv guard inline in \`_resolve_hermes_bin()\` (kept inline because the function already inlines the \`importlib.util.find_spec\` fallback); update docstring.
- \`tests/hermes_cli/test_kanban_db.py\` — 5 new tests: Windows venv via \`\$VIRTUAL_ENV\`, Windows venv via \`sys.prefix\` divergence (unactivated), Windows non-venv still uses shim, POSIX venv still uses shim, \`HERMES_BIN\` override beats venv guard.
- \`tests/gateway/test_update_command.py\` — 4 new tests covering the same matrix for \`_resolve_hermes_bin\`.

## How to Test

\`\`\`
uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout python3 -m pytest tests/hermes_cli/test_kanban_db.py tests/gateway/test_update_command.py tests/gateway/test_restart_drain.py
\`\`\`

Expected: 9 new tests pass + 207 existing resolver / update / restart tests continue to pass (216 total).

Regression-guard: I verified the bug behavior by stashing only the production-code changes (keeping the new tests) — all 4 Windows-venv tests then fail with exactly the reported symptom (resolver returns the wrong \`.exe\` shim instead of falling through to \`sys.executable -m hermes_cli.main\`). With the production code restored, they pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (\`fix(scope):\`, \`feat(scope):\`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x (Windows behavior exercised via monkeypatched \`_IS_WINDOWS\` / \`sys.platform\` / \`sys.prefix\` / \`\$VIRTUAL_ENV\`)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, \`docs/\`, docstrings) — docstrings on both resolvers now describe the new precedence step
- [x] I've updated \`cli-config.yaml.example\` if I added/changed config keys — N/A
- [x] I've updated \`CONTRIBUTING.md\` or \`AGENTS.md\` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the guard is gated on \`_IS_WINDOWS\` / \`sys.platform == \"win32\"\` so POSIX behavior is unchanged
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

Adjacent prior work in this area:

- #28398 (merged, teknium1 salvage of #27483) — added \`_is_windows_batch_shim\` / \`_safe_which_no_cwd\` to avoid launching \`.cmd\`/\`.bat\` shims as argv[0] and to skip the \`.\`-on-PATH attack. **Orthogonal**: that fix handles the case where the *shape* of the resolved shim is unsafe; this PR handles the case where the *interpreter behind* the resolved \`.exe\` is wrong.
- #23222 (merged, teknium1 salvage of #23198) — established the \`sys.executable -m hermes_cli.main\` fallback when no shim is on PATH. This PR uses the same fallback but triggers it earlier on a more specific condition (Windows venv with \`HERMES_BIN\` unset).
- #24528 (closed, shanewas) — proposed an \`importlib.util.find_spec(\"hermes_cli\")\` check before returning the module form. Different concern (defensive import check vs. cross-interpreter avoidance); both could coexist but this PR doesn't depend on it.

## Screenshots / Logs

N/A — covered by the new regression tests. The user's reproduction in the issue body (\`hermes gateway\` via Scheduled Task in a venv, kanban worker spawn → \`ModuleNotFoundError: No module named 'hermes_cli'\`) is exercised by \`test_resolve_hermes_argv_windows_venv_prefers_module_form\` and \`test_resolve_hermes_argv_windows_unactivated_venv_prefers_module_form\`.