### PR TITLE
fix(kanban): prefer module workers in windows venv

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5299,13 +5299,17 @@ def _resolve_hermes_argv() -> list[str]:
     1. ``$HERMES_BIN`` — explicit operator override. Path-like values are
        normalized to absolute paths; bare command names keep normal PATH
        semantics and never prefer a same-directory file before ``PATH``.
-    2. ``shutil.which("hermes")`` — the console-script shim, normalized to
+    2. On Windows inside a virtualenv, use ``sys.executable -m hermes_cli.main``
+       up front. pip's ``console_script`` launcher can resolve against the
+       wrong interpreter when PATH is restricted, which breaks editable
+       installs for spawned workers.
+    3. ``shutil.which("hermes")`` — the console-script shim, normalized to
        an absolute path. On Windows, ``which`` can return a relative
        ``.\\hermes.CMD`` when the current directory is on ``PATH``; directly
        launching batch shims is also unsafe with task-derived argv. The
        dispatcher therefore falls back to the interpreter-bound module form
        for implicit ``.cmd`` / ``.bat`` shims.
-    3. ``sys.executable -m hermes_cli.main`` — fallback for setups where
+    4. ``sys.executable -m hermes_cli.main`` — fallback for setups where
        Hermes is launched from a venv and the ``hermes`` shim is not on
        the dispatcher's ``$PATH`` (cron, systemd ``User=`` services,
        launchd jobs, detached processes, etc.). Goes through the running
@@ -5324,6 +5328,11 @@ def _resolve_hermes_argv() -> list[str]:
         resolved_env_bin = _safe_which_no_cwd(env_bin)
         if resolved_env_bin:
             return _hermes_path_argv(resolved_env_bin)
+        return _module_hermes_argv()
+
+    if _IS_WINDOWS and (
+        sys.prefix != sys.base_prefix or os.environ.get("VIRTUAL_ENV")
+    ):
         return _module_hermes_argv()
 
     hermes_bin = _safe_which_no_cwd("hermes") if _IS_WINDOWS else shutil.which("hermes")

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2172,6 +2172,8 @@ def test_resolve_hermes_argv_prefers_path_shim(monkeypatch):
     import hermes_cli.kanban_db as kb
 
     monkeypatch.delenv("HERMES_BIN", raising=False)
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.setattr(kb, "_IS_WINDOWS", False)
     monkeypatch.setattr(shutil, "which", lambda name: "/usr/local/bin/hermes")
     argv = kb._resolve_hermes_argv()
     assert argv == ["/usr/local/bin/hermes"]
@@ -2200,6 +2202,36 @@ def test_resolve_hermes_argv_avoids_implicit_windows_batch_shim(monkeypatch, tmp
     monkeypatch.setenv("PATH", str(bin_dir))
     monkeypatch.setenv("PATHEXT", ".CMD")
     monkeypatch.setattr(kb, "_IS_WINDOWS", True)
+
+    assert kb._resolve_hermes_argv() == [sys.executable, "-m", "hermes_cli.main"]
+
+
+def test_resolve_hermes_argv_windows_venv_prefers_module_form(monkeypatch):
+    """Windows workers spawned from a venv should not trust a PATH shim."""
+    import sys
+    import hermes_cli.kanban_db as kb
+
+    monkeypatch.delenv("HERMES_BIN", raising=False)
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.setattr(kb, "_IS_WINDOWS", True)
+    monkeypatch.setattr(kb, "_safe_which_no_cwd", lambda name: "C:\\Python312\\Scripts\\hermes.exe")
+    monkeypatch.setattr(sys, "prefix", "C:\\venvs\\hermes")
+    monkeypatch.setattr(sys, "base_prefix", "C:\\Python312")
+
+    assert kb._resolve_hermes_argv() == [sys.executable, "-m", "hermes_cli.main"]
+
+
+def test_resolve_hermes_argv_windows_virtual_env_var_prefers_module_form(monkeypatch):
+    """`VIRTUAL_ENV` alone should trigger the safer Windows module form."""
+    import sys
+    import hermes_cli.kanban_db as kb
+
+    monkeypatch.delenv("HERMES_BIN", raising=False)
+    monkeypatch.setenv("VIRTUAL_ENV", "C:\\venvs\\hermes")
+    monkeypatch.setattr(kb, "_IS_WINDOWS", True)
+    monkeypatch.setattr(kb, "_safe_which_no_cwd", lambda name: "C:\\Python312\\Scripts\\hermes.exe")
+    monkeypatch.setattr(sys, "prefix", "C:\\Python312")
+    monkeypatch.setattr(sys, "base_prefix", "C:\\Python312")
 
     assert kb._resolve_hermes_argv() == [sys.executable, "-m", "hermes_cli.main"]
 


### PR DESCRIPTION
Fixes #30943

## Summary
- prefer `sys.executable -m hermes_cli.main` for kanban worker spawns on Windows when the dispatcher is already running inside a virtualenv
- keep the existing PATH-shim behavior for non-Windows and non-venv cases
- add regression tests for both `sys.prefix`-based and `VIRTUAL_ENV`-only virtualenv detection

## Testing
- `python3 -m py_compile hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py`
- `uv run --with pytest-timeout pytest tests/hermes_cli/test_kanban_db.py -k 'resolve_hermes_argv'`\n- `git diff --check`