### PR TITLE
fix(gateway): require auth for interaction buttons

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -63,6 +63,49 @@ _slash_user_id: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
 )
 
 
+def _env_truthy(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"true", "1", "yes"}
+
+
+def _csv_env_values(*names: str) -> set[str]:
+    values: set[str] = set()
+    for name in names:
+        raw = os.getenv(name, "").strip()
+        if raw:
+            values.update(part.strip() for part in raw.split(",") if part.strip())
+    return values
+
+
+def _coerce_user_allowlist(raw: Any) -> set[str]:
+    if raw is None:
+        return set()
+    if isinstance(raw, (list, tuple, set, frozenset)):
+        items = raw
+    else:
+        items = str(raw).split(",")
+    return {str(uid).strip() for uid in items if str(uid).strip()}
+
+
+def _slack_interaction_user_authorized(
+    user_id: str,
+    extra: Optional[Dict[str, Any]] = None,
+) -> bool:
+    """Return whether a Slack button click may resolve gateway state."""
+    if _env_truthy("SLACK_ALLOW_ALL_USERS") or _env_truthy("GATEWAY_ALLOW_ALL_USERS"):
+        return True
+    if not user_id:
+        return False
+
+    allowed_ids = _csv_env_values("SLACK_ALLOWED_USERS")
+    if not allowed_ids and extra:
+        allowed_ids = _coerce_user_allowlist(extra.get("allow_from"))
+    allowed_ids.update(_csv_env_values("GATEWAY_ALLOWED_USERS"))
+
+    if not allowed_ids:
+        return False
+    return "*" in allowed_ids or user_id in allowed_ids
+
+
 @dataclass
 class _ThreadContextCache:
     """Cache entry for fetched thread context."""
@@ -2395,16 +2438,13 @@ class SlackAdapter(BasePlatformAdapter):
         user_name = body.get("user", {}).get("name", "unknown")
         user_id = body.get("user", {}).get("id", "")
 
-        # Authorization — reuse the exec-approval allowlist.
-        allowed_csv = os.getenv("SLACK_ALLOWED_USERS", "").strip()
-        if allowed_csv:
-            allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
-            if "*" not in allowed_ids and user_id not in allowed_ids:
-                logger.warning(
-                    "[Slack] Unauthorized slash-confirm click by %s (%s) — ignoring",
-                    user_name, user_id,
-                )
-                return
+        # Authorization — button clicks bypass normal message auth flow.
+        if not _slack_interaction_user_authorized(user_id, self.config.extra):
+            logger.warning(
+                "[Slack] Unauthorized slash-confirm click by %s (%s) — ignoring",
+                user_name, user_id or "missing-user-id",
+            )
+            return
 
         # Parse session_key|confirm_id back out
         if "|" not in value:
@@ -2493,18 +2533,15 @@ class SlackAdapter(BasePlatformAdapter):
         user_name = body.get("user", {}).get("name", "unknown")
         user_id = body.get("user", {}).get("id", "")
 
-        # Only authorized users may click approval buttons.  Button clicks
+        # Only authorized users may click approval buttons. Button clicks
         # bypass the normal message auth flow in gateway/run.py, so we must
         # check here as well.
-        allowed_csv = os.getenv("SLACK_ALLOWED_USERS", "").strip()
-        if allowed_csv:
-            allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
-            if "*" not in allowed_ids and user_id not in allowed_ids:
-                logger.warning(
-                    "[Slack] Unauthorized approval click by %s (%s) — ignoring",
-                    user_name, user_id,
-                )
-                return
+        if not _slack_interaction_user_authorized(user_id, self.config.extra):
+            logger.warning(
+                "[Slack] Unauthorized approval click by %s (%s) — ignoring",
+                user_name, user_id or "missing-user-id",
+            )
+            return
 
         # Map action_id to approval choice
         choice_map = {

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4933,34 +4933,35 @@ def _component_check_auth(
 ) -> bool:
     """Shared user-or-role OR semantics for component view button clicks.
 
-    Mirrors ``DiscordAdapter._is_allowed_user`` / the slash and on_message
-    gates so every Discord interaction surface honors the same trust
-    boundary. Component views (ExecApprovalView, SlashConfirmView,
-    UpdatePromptView, ModelPickerView) used to receive only
-    ``allowed_user_ids``: in role-only deployments
-    (DISCORD_ALLOWED_ROLES set, DISCORD_ALLOWED_USERS empty) the user
-    set was empty and the legacy "no allowlist = allow everyone" branch
-    let any guild member click the buttons -- approving exec commands,
-    cancelling slash confirmations, switching the model.
+    Mirrors the gateway's external-surface authorization model: component
+    button clicks must be explicitly authorized by a Discord user/role
+    allowlist, a global user allowlist, or an explicit allow-all flag.
 
     Behavior:
 
-      - both allowlists empty -> allow (preserves existing no-allowlist
-        deployments, no regression)
-      - user is in user allowlist -> allow
+      - DISCORD_ALLOW_ALL_USERS or GATEWAY_ALLOW_ALL_USERS -> allow
+      - user is in DISCORD_ALLOWED_USERS or GATEWAY_ALLOWED_USERS -> allow
       - role allowlist set + user has a role in it -> allow
       - role allowlist set + interaction.user has no resolvable
         ``roles`` attribute (e.g. DM context with a role policy active)
         -> reject (fail closed)
       - otherwise -> reject
     """
-    user_set = allowed_user_ids or set()
-    role_set = allowed_role_ids or set()
-    has_users = bool(user_set)
-    has_roles = bool(role_set)
-    if not has_users and not has_roles:
+    if os.getenv("DISCORD_ALLOW_ALL_USERS", "").strip().lower() in {"true", "1", "yes"}:
+        return True
+    if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").strip().lower() in {"true", "1", "yes"}:
         return True
 
+    user_set = {str(uid).strip() for uid in (allowed_user_ids or set()) if str(uid).strip()}
+    global_allowed = {
+        uid.strip()
+        for uid in os.getenv("GATEWAY_ALLOWED_USERS", "").split(",")
+        if uid.strip()
+    }
+    user_set.update(global_allowed)
+    role_set = set(allowed_role_ids or set())
+    has_users = bool(user_set)
+    has_roles = bool(role_set)
     user = getattr(interaction, "user", None)
     if user is None:
         return False
@@ -4970,7 +4971,7 @@ def _component_check_auth(
             uid = str(user.id)
         except AttributeError:
             uid = ""
-        if uid and uid in user_set:
+        if "*" in user_set or (uid and uid in user_set):
             return True
 
     if has_roles:

--- a/tests/gateway/test_discord_component_auth.py
+++ b/tests/gateway/test_discord_component_auth.py
@@ -1,15 +1,15 @@
-"""Security regression tests: Discord component views honor role allowlists.
+"""Security regression tests: Discord component views honor allowlists.
 
-The four interactive component views (ExecApprovalView, SlashConfirmView,
-UpdatePromptView, ModelPickerView) historically accepted only
+The interactive component views (ExecApprovalView, SlashConfirmView,
+UpdatePromptView, ModelPickerView, ClarifyChoiceView) historically accepted only
 ``allowed_user_ids``. Deployments that configure DISCORD_ALLOWED_ROLES
 without DISCORD_ALLOWED_USERS therefore had a wide-open component
 surface: any guild member who could see the prompt could approve exec
 commands, cancel slash confirmations, or switch the model -- even when
 the same user would be rejected at the slash and on_message gates.
 
-These tests pin the user-or-role OR semantics and the fail-closed
-behavior on missing role data so the parity cannot regress.
+These tests pin user/role/global allowlist semantics, explicit allow-all
+handling, and fail-closed behavior so the parity cannot regress.
 """
 
 from types import SimpleNamespace
@@ -19,6 +19,7 @@ import pytest
 # Trigger the shared discord mock from tests/gateway/conftest.py before
 # importing the production module.
 from plugins.platforms.discord.adapter import (  # noqa: E402
+    ClarifyChoiceView,
     ExecApprovalView,
     ModelPickerView,
     SlashConfirmView,
@@ -27,9 +28,19 @@ from plugins.platforms.discord.adapter import (  # noqa: E402
 )
 
 
+@pytest.fixture(autouse=True)
+def _clear_component_auth_env(monkeypatch):
+    for name in (
+        "DISCORD_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOWED_USERS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
 # ---------------------------------------------------------------------------
-# Direct helper coverage -- the four views all delegate to this helper, so
-# pinning the helper's contract pins all four call sites.
+# Direct helper coverage -- the views all delegate to this helper, so
+# pinning the helper's contract pins all call sites.
 # ---------------------------------------------------------------------------
 
 
@@ -49,16 +60,30 @@ def _interaction(user_id, role_ids=None, *, drop_user=False, drop_roles=False):
     return SimpleNamespace(user=SimpleNamespace(**user_kwargs))
 
 
-# ── back-compat: empty allowlists -> allow everyone ────────────────────────
+# ── no policy configured -> deny unless allow-all is explicit ──────────────
 
 
-def test_component_check_empty_allowlists_allows_everyone():
-    """SECURITY-CRITICAL backwards-compat: deployments without any
-    DISCORD_ALLOWED_* env vars set must continue to allow component
-    interactions from anyone (no regression for unconfigured setups)."""
+def test_component_check_empty_allowlists_rejects_by_default(monkeypatch):
+    """Button interactions must fail closed without an allowlist or allow-all."""
+    monkeypatch.delenv("DISCORD_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+    interaction = _interaction(11111)
+    assert _component_check_auth(interaction, set(), set()) is False
+    assert _component_check_auth(interaction, None, None) is False
+
+
+@pytest.mark.parametrize(
+    ("env_name", "env_value"),
+    [
+        ("DISCORD_ALLOW_ALL_USERS", "true"),
+        ("GATEWAY_ALLOW_ALL_USERS", "yes"),
+    ],
+)
+def test_component_check_explicit_allow_all_passes(monkeypatch, env_name, env_value):
+    monkeypatch.setenv(env_name, env_value)
     interaction = _interaction(11111)
     assert _component_check_auth(interaction, set(), set()) is True
-    assert _component_check_auth(interaction, None, None) is True
 
 
 # ── user allowlist ─────────────────────────────────────────────────────────
@@ -74,6 +99,23 @@ def test_component_check_user_not_in_user_allowlist_rejected():
     assert _component_check_auth(interaction, {"11111"}, set()) is False
 
 
+def test_component_check_user_in_global_allowlist_passes(monkeypatch):
+    monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "11111,22222")
+    interaction = _interaction(11111)
+    assert _component_check_auth(interaction, set(), set()) is True
+
+
+def test_component_check_global_allowlist_without_match_rejects(monkeypatch):
+    monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "22222")
+    interaction = _interaction(11111)
+    assert _component_check_auth(interaction, set(), set()) is False
+
+
+def test_component_check_wildcard_user_allowlist_passes():
+    interaction = _interaction(99999)
+    assert _component_check_auth(interaction, {"*"}, set()) is True
+
+
 # ── role allowlist OR semantics ────────────────────────────────────────────
 
 
@@ -85,6 +127,11 @@ def test_component_check_role_only_user_with_matching_role_passes():
     empty, ignoring the role allowlist."""
     interaction = _interaction(99999, role_ids=[42])
     assert _component_check_auth(interaction, set(), {42}) is True
+
+
+def test_component_check_accepts_role_allowlist_sequences():
+    interaction = _interaction(99999, role_ids=[42])
+    assert _component_check_auth(interaction, set(), [42]) is True
 
 
 def test_component_check_role_only_user_without_matching_role_rejected():
@@ -196,8 +243,19 @@ def test_model_picker_view_accepts_role_allowlist():
     assert view._check_auth(_interaction(99999, role_ids=[7])) is False
 
 
+def test_clarify_choice_view_accepts_role_allowlist():
+    view = ClarifyChoiceView(
+        choices=["one", "two"],
+        clarify_id="clarify-1",
+        allowed_user_ids=set(),
+        allowed_role_ids={42},
+    )
+    assert view._check_auth(_interaction(99999, role_ids=[42])) is True
+    assert view._check_auth(_interaction(99999, role_ids=[7])) is False
+
+
 # ---------------------------------------------------------------------------
-# Empty allowlists across views: legacy "allow everyone" must hold.
+# Empty allowlists across views: fail closed unless allow-all is explicit.
 # ---------------------------------------------------------------------------
 
 
@@ -207,14 +265,26 @@ def test_model_picker_view_accepts_role_allowlist():
         lambda: ExecApprovalView(session_key="s", allowed_user_ids=set()),
         lambda: SlashConfirmView(session_key="s", confirm_id="c", allowed_user_ids=set()),
         lambda: UpdatePromptView(session_key="s", allowed_user_ids=set()),
+        lambda: ClarifyChoiceView(
+            choices=["one"],
+            clarify_id="c",
+            allowed_user_ids=set(),
+        ),
     ],
 )
-def test_views_empty_allowlists_allow_everyone(view_factory):
+def test_views_empty_allowlists_reject_by_default(view_factory, monkeypatch):
+    monkeypatch.delenv("DISCORD_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
     view = view_factory()
-    assert view._check_auth(_interaction(99999)) is True
+    assert view._check_auth(_interaction(99999)) is False
 
 
-def test_model_picker_view_empty_allowlists_allow_everyone():
+def test_model_picker_view_empty_allowlists_reject_by_default(monkeypatch):
+    monkeypatch.delenv("DISCORD_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+
     async def _noop(*_a, **_k):
         return ""
 
@@ -227,4 +297,10 @@ def test_model_picker_view_empty_allowlists_allow_everyone():
         allowed_user_ids=set(),
     )
     assert view.allowed_role_ids == set()
+    assert view._check_auth(_interaction(99999)) is False
+
+
+def test_view_empty_allowlists_allow_with_explicit_allow_all(monkeypatch):
+    monkeypatch.setenv("DISCORD_ALLOW_ALL_USERS", "true")
+    view = ExecApprovalView(session_key="s", allowed_user_ids=set())
     assert view._check_auth(_interaction(99999)) is True

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -43,8 +43,19 @@ def _ensure_slack_mock():
 
 _ensure_slack_mock()
 
-from gateway.platforms.slack import SlackAdapter
+from gateway.platforms.slack import SlackAdapter, _slack_interaction_user_authorized
 from gateway.config import Platform, PlatformConfig
+
+
+@pytest.fixture(autouse=True)
+def _clear_slack_interaction_auth_env(monkeypatch):
+    for name in (
+        "SLACK_ALLOWED_USERS",
+        "GATEWAY_ALLOWED_USERS",
+        "SLACK_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+    ):
+        monkeypatch.delenv(name, raising=False)
 
 
 def _make_adapter():
@@ -57,6 +68,65 @@ def _make_adapter():
     adapter._team_bot_user_ids = {"T1": "U_BOT"}
     adapter._channel_team = {"C1": "T1"}
     return adapter
+
+
+# ===========================================================================
+# Slack interaction authorization
+# ===========================================================================
+
+
+class TestSlackInteractionAuthorization:
+    """Button clicks must follow the gateway's external-surface auth model."""
+
+    def test_no_allowlist_rejects_by_default(self, monkeypatch):
+        monkeypatch.delenv("SLACK_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("SLACK_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+
+        assert _slack_interaction_user_authorized("U123") is False
+
+    def test_platform_allowlist_permits_user(self, monkeypatch):
+        monkeypatch.setenv("SLACK_ALLOWED_USERS", "U123,U456")
+
+        assert _slack_interaction_user_authorized("U123") is True
+        assert _slack_interaction_user_authorized("U999") is False
+
+    def test_global_allowlist_permits_user(self, monkeypatch):
+        monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "U123")
+
+        assert _slack_interaction_user_authorized("U123") is True
+        assert _slack_interaction_user_authorized("U999") is False
+
+    def test_config_allow_from_permits_user(self, monkeypatch):
+        monkeypatch.delenv("SLACK_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+
+        assert _slack_interaction_user_authorized("U123", {"allow_from": ["U123"]}) is True
+        assert _slack_interaction_user_authorized("U999", {"allow_from": ["U123"]}) is False
+
+    def test_platform_env_allowlist_takes_precedence_over_config(self, monkeypatch):
+        monkeypatch.setenv("SLACK_ALLOWED_USERS", "U999")
+
+        assert _slack_interaction_user_authorized("U999", {"allow_from": ["U123"]}) is True
+        assert _slack_interaction_user_authorized("U123", {"allow_from": ["U123"]}) is False
+
+    @pytest.mark.parametrize(
+        ("env_name", "env_value"),
+        [
+            ("SLACK_ALLOW_ALL_USERS", "true"),
+            ("GATEWAY_ALLOW_ALL_USERS", "yes"),
+        ],
+    )
+    def test_explicit_allow_all_permits_user(self, monkeypatch, env_name, env_value):
+        monkeypatch.setenv(env_name, env_value)
+
+        assert _slack_interaction_user_authorized("U999") is True
+
+    def test_wildcard_allowlist_permits_user(self, monkeypatch):
+        monkeypatch.setenv("SLACK_ALLOWED_USERS", "*")
+
+        assert _slack_interaction_user_authorized("U999") is True
 
 
 # ===========================================================================
@@ -153,7 +223,8 @@ class TestSlackApprovalAction:
     """Test the approval button click handler."""
 
     @pytest.mark.asyncio
-    async def test_resolves_approval(self):
+    async def test_resolves_approval(self, monkeypatch):
+        monkeypatch.setenv("SLACK_ALLOWED_USERS", "U123")
         adapter = _make_adapter()
         adapter._approval_resolved["1234.5678"] = False
 
@@ -167,7 +238,7 @@ class TestSlackApprovalAction:
                 ],
             },
             "channel": {"id": "C1"},
-            "user": {"name": "norbert"},
+            "user": {"name": "norbert", "id": "U123"},
         }
         action = {
             "action_id": "hermes_approve_once",
@@ -189,7 +260,8 @@ class TestSlackApprovalAction:
         assert "Approved once by norbert" in update_kwargs["text"]
 
     @pytest.mark.asyncio
-    async def test_prevents_double_click(self):
+    async def test_prevents_double_click(self, monkeypatch):
+        monkeypatch.setenv("SLACK_ALLOWED_USERS", "U123")
         adapter = _make_adapter()
         adapter._approval_resolved["1234.5678"] = True  # Already resolved
 
@@ -197,7 +269,7 @@ class TestSlackApprovalAction:
         body = {
             "message": {"ts": "1234.5678", "blocks": []},
             "channel": {"id": "C1"},
-            "user": {"name": "norbert"},
+            "user": {"name": "norbert", "id": "U123"},
         }
         action = {
             "action_id": "hermes_approve_once",
@@ -212,7 +284,8 @@ class TestSlackApprovalAction:
         mock_resolve.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_deny_action(self):
+    async def test_deny_action(self, monkeypatch):
+        monkeypatch.setenv("SLACK_ALLOWED_USERS", "U123")
         adapter = _make_adapter()
         adapter._approval_resolved["1.2"] = False
 
@@ -222,7 +295,7 @@ class TestSlackApprovalAction:
                 {"type": "section", "text": {"type": "mrkdwn", "text": "cmd"}},
             ]},
             "channel": {"id": "C1"},
-            "user": {"name": "alice"},
+            "user": {"name": "alice", "id": "U123"},
         }
         action = {"action_id": "hermes_deny", "value": "session-key"}
 
@@ -235,6 +308,102 @@ class TestSlackApprovalAction:
         mock_resolve.assert_called_once_with("session-key", "deny")
         update_kwargs = mock_client.chat_update.call_args[1]
         assert "Denied by alice" in update_kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_no_allowlist_rejects_approval_button(self, monkeypatch):
+        monkeypatch.delenv("SLACK_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("SLACK_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+
+        adapter = _make_adapter()
+        adapter._approval_resolved["1.2"] = False
+
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "1.2", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "eve", "id": "U999"},
+        }
+        action = {"action_id": "hermes_approve_once", "value": "session-key"}
+
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
+            await adapter._handle_approval_action(ack, body, action)
+
+        ack.assert_called_once()
+        mock_resolve.assert_not_called()
+        mock_client.chat_update.assert_not_called()
+        assert adapter._approval_resolved["1.2"] is False
+
+
+# ===========================================================================
+# _handle_slash_confirm_action — button click handler
+# ===========================================================================
+
+class TestSlackSlashConfirmAction:
+    """Test the slash-confirm button click handler authorization."""
+
+    @pytest.mark.asyncio
+    async def test_no_allowlist_rejects_slash_confirm_button(self):
+        adapter = _make_adapter()
+
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "3.4", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "eve", "id": "U999"},
+        }
+        action = {"action_id": "hermes_confirm_once", "value": "session-key|confirm-id"}
+
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        with patch("tools.slash_confirm.resolve", new_callable=AsyncMock) as mock_resolve:
+            await adapter._handle_slash_confirm_action(ack, body, action)
+
+        ack.assert_called_once()
+        mock_resolve.assert_not_called()
+        mock_client.chat_update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_allowed_user_resolves_slash_confirm_button(self, monkeypatch):
+        monkeypatch.setenv("SLACK_ALLOWED_USERS", "U123")
+        adapter = _make_adapter()
+
+        ack = AsyncMock()
+        body = {
+            "message": {
+                "ts": "3.5",
+                "blocks": [
+                    {
+                        "type": "section",
+                        "text": {"type": "mrkdwn", "text": "Confirm this action"},
+                    },
+                ],
+            },
+            "channel": {"id": "C1"},
+            "user": {"name": "alice", "id": "U123"},
+        }
+        action = {"action_id": "hermes_confirm_once", "value": "session-key|confirm-id"}
+
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+        mock_client.chat_postMessage = AsyncMock()
+
+        with patch(
+            "tools.slash_confirm.resolve",
+            new_callable=AsyncMock,
+            return_value="done",
+        ) as mock_resolve:
+            await adapter._handle_slash_confirm_action(ack, body, action)
+
+        ack.assert_called_once()
+        mock_resolve.assert_called_once_with("session-key", "confirm-id", "once")
+        mock_client.chat_update.assert_called_once()
+        mock_client.chat_postMessage.assert_called_once()
 
 
 # ===========================================================================


### PR DESCRIPTION
## What does this PR do?

Aligns Slack Block Kit callbacks and Discord component button callbacks with the gateway external-surface authorization model.

Interactive button callbacks bypass the normal message dispatch authorization path, so they now require one of the configured authorization mechanisms before resolving gateway state:

- platform user/role allowlists
- `GATEWAY_ALLOWED_USERS`
- explicit allow-all flags

Slack also keeps compatibility with `allow_from` when no `SLACK_ALLOWED_USERS` env allowlist is configured.

## Related Issue

Related: #29627, #30742

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `gateway/platforms/slack.py`
  - Add shared Slack interaction authorization for button callbacks.
  - Apply it to approval and slash-confirm actions.
  - Honor `SLACK_ALLOWED_USERS`, `GATEWAY_ALLOWED_USERS`, `SLACK_ALLOW_ALL_USERS`, `GATEWAY_ALLOW_ALL_USERS`, and config `allow_from`.

- `plugins/platforms/discord/adapter.py`
  - Make component button auth fail closed when no allowlist or explicit allow-all is configured.
  - Honor `GATEWAY_ALLOWED_USERS`, wildcard user allowlists, and explicit allow-all flags.
  - Preserve Discord role allowlist behavior.

- `tests/gateway/test_discord_component_auth.py`
  - Add/adjust regression coverage for fail-closed defaults, global allowlists, explicit allow-all, wildcard users, and all Discord component views.

- `tests/gateway/test_slack_approval_buttons.py`
  - Add Slack interaction auth coverage.
  - Add regression coverage proving approval buttons do not resolve without an allowlist.

## How to Test

```bash
/private/tmp/hermes-agent-pr-venv/bin/python -m pytest -o addopts='' \
  tests/gateway/test_discord_component_auth.py \
  tests/gateway/test_slack_approval_buttons.py \
  -q
```

Result:

```text
59 passed, 4 warnings in 0.27s
```

The warnings are existing Slack `AsyncMock` runtime warnings from thread-context tests, not failures from this change.

```bash
/private/tmp/hermes-agent-pr-venv/bin/python -m ruff check \
  gateway/platforms/slack.py \
  plugins/platforms/discord/adapter.py \
  tests/gateway/test_discord_component_auth.py \
  tests/gateway/test_slack_approval_buttons.py
```

Result:

```text
All checks passed!
```

```bash
git diff --check
```

No output.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5, Python 3.13.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — pure env parsing and callback authorization checks
- [x] I've updated tool descriptions/schemas — N/A
