### PR TITLE
feat(kanban): add human_review status + review/approve/reject tools and CLI

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4623,7 +4623,10 @@ class GatewayRunner:
             logger.warning("kanban notifier: kanban_db not importable; notifier disabled")
             return
 
-        TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out")
+        TERMINAL_KINDS = (
+            "completed", "blocked", "gave_up", "crashed", "timed_out",
+            "human_review_requested", "approved", "rejected",
+        )
         # Subscriptions are removed only when the task reaches a truly final
         # status (done / archived). We used to also unsub on any terminal
         # event kind (gave_up / crashed / timed_out / blocked), but that
@@ -4840,6 +4843,36 @@ class GatewayRunner:
                             msg = (
                                 f"⏱ {tag}Kanban {sub['task_id']} timed out "
                                 f"(max_runtime={limit}s); will retry"
+                            )
+                        elif kind == "human_review_requested":
+                            note = ""
+                            if ev.payload and ev.payload.get("reason"):
+                                note = (
+                                    f": {str(ev.payload['reason'])[:NOTIFY_BLOCKED_REASON_MAX]}"
+                                )
+                            msg = (
+                                f"⏳ {tag}Kanban {sub['task_id']} ready for "
+                                f"your review — {title}{note}"
+                            )
+                        elif kind == "approved":
+                            note = ""
+                            if ev.payload and ev.payload.get("reason"):
+                                note = (
+                                    f": {str(ev.payload['reason'])[:NOTIFY_BLOCKED_REASON_MAX]}"
+                                )
+                            msg = (
+                                f"✅ {tag}Kanban {sub['task_id']} approved "
+                                f"— {title}{note}"
+                            )
+                        elif kind == "rejected":
+                            note = ""
+                            if ev.payload and ev.payload.get("reason"):
+                                note = (
+                                    f"\n{str(ev.payload['reason'])[:NOTIFY_BLOCKED_REASON_MAX]}"
+                                )
+                            msg = (
+                                f"↩ {tag}Kanban {sub['task_id']} rejected "
+                                f"— back to ready{note}"
                             )
                         else:
                             continue

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -65,6 +65,29 @@ _AGENT_CACHE_MAX_SIZE = 128
 _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
+
+# Kanban terminal-event notification truncation caps. The kanban notifier
+# loop (see ``_kanban_notifier_watcher`` below) inlines snippets of the
+# worker's handoff / blocked-reason / error into a single chat message so
+# the human doesn't need to open the dashboard for routine pings. Each
+# cap is sized for the kind of payload it gates and the worst-case
+# platform message limit (Telegram: 4096 chars per message;
+# Discord/Slack: ~2000). Bump these here — they're intentionally
+# per-kind so a chatty ``done`` summary can't crowd out a critical
+# ``blocked`` reason and vice versa.
+#
+# ``blocked`` is the one users actually act on (it's a question waiting
+# for a human answer), so it gets the largest budget. ``done`` summaries
+# are the next-most-useful (they tell you whether the work landed and
+# what shipped). Error and timeout payloads are usually tracebacks /
+# stderr; we want enough to triage at a glance but not so much that the
+# message overflows. ``result`` is the legacy ``task.result`` field that
+# pre-dates structured run summaries — kept smaller because anything
+# new should be using ``summary`` instead.
+NOTIFY_BLOCKED_REASON_MAX = 1500
+NOTIFY_DONE_SUMMARY_MAX = 800
+NOTIFY_DONE_RESULT_LEGACY_MAX = 400
+NOTIFY_GAVE_UP_ERROR_MAX = 600
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
@@ -4777,10 +4800,14 @@ class GatewayRunner:
                             if ev.payload and ev.payload.get("summary"):
                                 payload_summary = str(ev.payload["summary"])
                             if payload_summary:
-                                h = payload_summary.strip().splitlines()[0][:200]
+                                h = payload_summary.strip().splitlines()[0][
+                                    :NOTIFY_DONE_SUMMARY_MAX
+                                ]
                                 handoff = f"\n{h}"
                             elif task and task.result:
-                                r = task.result.strip().splitlines()[0][:160]
+                                r = task.result.strip().splitlines()[0][
+                                    :NOTIFY_DONE_RESULT_LEGACY_MAX
+                                ]
                                 handoff = f"\n{r}"
                             msg = (
                                 f"✔ {tag}Kanban {sub['task_id']} done"
@@ -4789,12 +4816,14 @@ class GatewayRunner:
                         elif kind == "blocked":
                             reason = ""
                             if ev.payload and ev.payload.get("reason"):
-                                reason = f": {str(ev.payload['reason'])[:160]}"
+                                reason = (
+                                    f": {str(ev.payload['reason'])[:NOTIFY_BLOCKED_REASON_MAX]}"
+                                )
                             msg = f"⏸ {tag}Kanban {sub['task_id']} blocked{reason}"
                         elif kind == "gave_up":
                             err = ""
                             if ev.payload and ev.payload.get("error"):
-                                err = f"\n{str(ev.payload['error'])[:200]}"
+                                err = f"\n{str(ev.payload['error'])[:NOTIFY_GAVE_UP_ERROR_MAX]}"
                             msg = (
                                 f"✖ {tag}Kanban {sub['task_id']} gave up "
                                 f"after repeated spawn failures{err}"

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -550,6 +550,47 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_unblock = sub.add_parser("unblock", help="Return one or more blocked/scheduled tasks to ready")
     p_unblock.add_argument("task_ids", nargs="+")
 
+    # --- review / human-review / approve / reject ---
+    p_review = sub.add_parser(
+        "review",
+        help="Move a running task to 'review' (worker→auto-review agent handoff)",
+    )
+    p_review.add_argument("task_id")
+    p_review.add_argument(
+        "reason", nargs="*",
+        help="Handoff note — typically the PR URL plus a one-line summary",
+    )
+
+    p_hreview = sub.add_parser(
+        "human-review",
+        help="Move a running or review task to 'human_review' (auto-review passed; awaits Sahil)",
+    )
+    p_hreview.add_argument("task_id")
+    p_hreview.add_argument(
+        "reason", nargs="*",
+        help="Human-facing handoff (PR URL, merged-commit hint, etc.)",
+    )
+
+    p_approve = sub.add_parser(
+        "approve",
+        help="Approve a human_review task (→ done)",
+    )
+    p_approve.add_argument("task_id")
+    p_approve.add_argument(
+        "--reason", default=None,
+        help="Optional approval note (audit-only)",
+    )
+
+    p_reject = sub.add_parser(
+        "reject",
+        help="Reject a review/human_review task (→ ready, with audit comment)",
+    )
+    p_reject.add_argument("task_id")
+    p_reject.add_argument(
+        "--reason", default=None,
+        help="Why the work was rejected — surfaced to the next worker via the comment thread",
+    )
+
     p_archive = sub.add_parser("archive", help="Archive one or more tasks")
     p_archive.add_argument("task_ids", nargs="*",
                            help="Task ids to archive (default mode)")
@@ -899,6 +940,10 @@ def kanban_command(args: argparse.Namespace) -> int:
         "block":    _cmd_block,
         "schedule": _cmd_schedule,
         "unblock":  _cmd_unblock,
+        "review":   _cmd_review,
+        "human-review": _cmd_human_review,
+        "approve":  _cmd_approve,
+        "reject":   _cmd_reject,
         "archive":  _cmd_archive,
         "tail":     _cmd_tail,
         "dispatch": _cmd_dispatch,
@@ -1953,6 +1998,96 @@ def _cmd_unblock(args: argparse.Namespace) -> int:
             else:
                 print(f"Unblocked {tid}")
     return 0 if not failed else 1
+
+
+def _cmd_review(args: argparse.Namespace) -> int:
+    reason = " ".join(args.reason).strip() if args.reason else None
+    author = _profile_author()
+    tid = args.task_id
+    with kb.connect() as conn:
+        if reason:
+            kb.add_comment(conn, tid, author, f"REVIEW: {reason}")
+        ok = kb.move_to_review(
+            conn,
+            tid,
+            reason=reason,
+            expected_run_id=_worker_run_id_for(tid),
+        )
+    if not ok:
+        print(
+            f"cannot move {tid} to review (not running/ready?)",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"Sent {tid} to review" + (f": {reason}" if reason else ""))
+    return 0
+
+
+def _cmd_human_review(args: argparse.Namespace) -> int:
+    reason = " ".join(args.reason).strip() if args.reason else None
+    author = _profile_author()
+    tid = args.task_id
+    with kb.connect() as conn:
+        if reason:
+            kb.add_comment(conn, tid, author, f"HUMAN-REVIEW: {reason}")
+        ok = kb.move_to_human_review(
+            conn,
+            tid,
+            reason=reason,
+            expected_run_id=_worker_run_id_for(tid),
+        )
+    if not ok:
+        print(
+            f"cannot move {tid} to human_review (not running/review?)",
+            file=sys.stderr,
+        )
+        return 1
+    print(
+        f"Sent {tid} to human_review"
+        + (f": {reason}" if reason else "")
+    )
+    return 0
+
+
+def _cmd_approve(args: argparse.Namespace) -> int:
+    reason = (args.reason or "").strip() or None
+    author = _profile_author()
+    tid = args.task_id
+    with kb.connect() as conn:
+        if reason:
+            kb.add_comment(conn, tid, author, f"APPROVED: {reason}")
+        ok = kb.approve_task(conn, tid, reason=reason)
+    if not ok:
+        print(
+            f"cannot approve {tid} (not in human_review?)",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"Approved {tid}" + (f": {reason}" if reason else ""))
+    return 0
+
+
+def _cmd_reject(args: argparse.Namespace) -> int:
+    reason = (args.reason or "").strip() or None
+    author = _profile_author()
+    tid = args.task_id
+    if not reason:
+        print(
+            "--reason is required for reject — the next worker needs context",
+            file=sys.stderr,
+        )
+        return 1
+    with kb.connect() as conn:
+        kb.add_comment(conn, tid, author, f"REJECTED: {reason}")
+        ok = kb.reject_task(conn, tid, reason=reason)
+    if not ok:
+        print(
+            f"cannot reject {tid} (not in review/human_review?)",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"Rejected {tid}: {reason}")
+    return 0
 
 
 def _cmd_archive(args: argparse.Namespace) -> int:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -94,7 +94,7 @@ _log = logging.getLogger(__name__)
 # Constants
 # ---------------------------------------------------------------------------
 
-VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"}
+VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "human_review", "done", "archived"}
 VALID_INITIAL_STATUSES = {"running", "blocked"}
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
@@ -3137,6 +3137,250 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
             {"status": new_status} if new_status != "ready" else None,
         )
         return True
+
+
+def move_to_review(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    reason: Optional[str] = None,
+    expected_run_id: Optional[int] = None,
+) -> bool:
+    """Transition ``running -> review`` (worker-initiated handoff to the
+    auto-review agent).
+
+    Closes the worker's current run with ``outcome='review_requested'`` so the
+    review agent's lifecycle is tracked on its own run row when the dispatcher
+    claims this task next tick. ``reason`` is the human-facing PR URL / handoff
+    note carried on the closing run and the ``review_requested`` event payload.
+
+    Returns ``False`` when the task is missing or not in ``running``/``ready``
+    state. Atomic CAS: a concurrent ``complete_task`` / ``block_task`` will win
+    the race and this call returns ``False``.
+    """
+    with write_txn(conn):
+        if expected_run_id is None:
+            cur = conn.execute(
+                """
+                UPDATE tasks
+                   SET status        = 'review',
+                       claim_lock    = NULL,
+                       claim_expires = NULL,
+                       worker_pid    = NULL
+                 WHERE id = ?
+                   AND status IN ('running', 'ready')
+                """,
+                (task_id,),
+            )
+        else:
+            cur = conn.execute(
+                """
+                UPDATE tasks
+                   SET status        = 'review',
+                       claim_lock    = NULL,
+                       claim_expires = NULL,
+                       worker_pid    = NULL
+                 WHERE id = ?
+                   AND status IN ('running', 'ready')
+                   AND current_run_id = ?
+                """,
+                (task_id, int(expected_run_id)),
+            )
+        if cur.rowcount != 1:
+            return False
+        run_id = _end_run(
+            conn, task_id,
+            outcome="review_requested", status="review_requested",
+            summary=reason,
+        )
+        if run_id is None and reason:
+            run_id = _synthesize_ended_run(
+                conn, task_id,
+                outcome="review_requested",
+                summary=reason,
+            )
+        _append_event(
+            conn, task_id, "review_requested",
+            {"reason": reason} if reason else None,
+            run_id=run_id,
+        )
+        return True
+
+
+def move_to_human_review(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    reason: Optional[str] = None,
+    expected_run_id: Optional[int] = None,
+) -> bool:
+    """Transition ``running|review -> human_review`` (auto-review agent passed;
+    waiting on a human decision).
+
+    Called by the auto-review agent after it verifies the PR and merges. The
+    dispatcher does **not** auto-spawn anything for ``human_review`` — the
+    task parks until a human runs ``hermes kanban approve <id>`` /
+    ``reject <id>`` or the equivalent tools fire.
+
+    ``reason`` (e.g. the PR URL + one-line summary) is carried on the
+    ``human_review_requested`` event so gateway notifiers can render it to the
+    subscribed human directly without a second SQL round-trip.
+    """
+    with write_txn(conn):
+        if expected_run_id is None:
+            cur = conn.execute(
+                """
+                UPDATE tasks
+                   SET status        = 'human_review',
+                       claim_lock    = NULL,
+                       claim_expires = NULL,
+                       worker_pid    = NULL
+                 WHERE id = ?
+                   AND status IN ('running', 'review')
+                """,
+                (task_id,),
+            )
+        else:
+            cur = conn.execute(
+                """
+                UPDATE tasks
+                   SET status        = 'human_review',
+                       claim_lock    = NULL,
+                       claim_expires = NULL,
+                       worker_pid    = NULL
+                 WHERE id = ?
+                   AND status IN ('running', 'review')
+                   AND current_run_id = ?
+                """,
+                (task_id, int(expected_run_id)),
+            )
+        if cur.rowcount != 1:
+            return False
+        run_id = _end_run(
+            conn, task_id,
+            outcome="human_review_requested",
+            status="human_review_requested",
+            summary=reason,
+        )
+        if run_id is None and reason:
+            run_id = _synthesize_ended_run(
+                conn, task_id,
+                outcome="human_review_requested",
+                summary=reason,
+            )
+        _append_event(
+            conn, task_id, "human_review_requested",
+            {"reason": reason} if reason else None,
+            run_id=run_id,
+        )
+        return True
+
+
+def approve_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    reason: Optional[str] = None,
+) -> bool:
+    """Transition ``human_review -> done`` (human approval).
+
+    The closing audit event is ``approved`` (distinct from ``completed`` so
+    the dashboard / notifier can render a different glyph). Triggers the same
+    downstream effects as ``complete_task``: clears the failure counter,
+    recomputes ready for dependents, and cleans up the workspace.
+    """
+    now = int(time.time())
+    with write_txn(conn):
+        cur = conn.execute(
+            """
+            UPDATE tasks
+               SET status       = 'done',
+                   completed_at = ?,
+                   claim_lock   = NULL,
+                   claim_expires= NULL,
+                   worker_pid   = NULL
+             WHERE id = ?
+               AND status = 'human_review'
+            """,
+            (now, task_id),
+        )
+        if cur.rowcount != 1:
+            return False
+        run_id = _synthesize_ended_run(
+            conn, task_id,
+            outcome="approved",
+            summary=reason,
+        )
+        _append_event(
+            conn, task_id, "approved",
+            {"reason": reason} if reason else None,
+            run_id=run_id,
+        )
+    _clear_failure_counter(conn, task_id)
+    recompute_ready(conn)
+    _cleanup_workspace(conn, task_id)
+    return True
+
+
+def reject_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    reason: Optional[str] = None,
+) -> bool:
+    """Transition ``review|human_review -> running`` (rejection bounces the
+    work back to the original worker with an audit comment for the next run).
+
+    Used by both:
+
+    * the auto-review agent — when it finds the PR doesn't satisfy AC, it
+      calls this to bounce the task back so the original worker can iterate,
+    * the human reviewer — when they reject what landed in ``human_review``.
+
+    ``reason`` is captured both on the ``rejected`` event payload and as a
+    synthesized closing run summary so the next worker's ``kanban_show``
+    surfaces the rejection rationale via the normal prior-runs path.
+    """
+    now = int(time.time())
+    with write_txn(conn):
+        cur = conn.execute(
+            """
+            UPDATE tasks
+               SET status        = 'running',
+                   started_at    = COALESCE(started_at, ?),
+                   completed_at  = NULL,
+                   claim_lock    = NULL,
+                   claim_expires = NULL,
+                   worker_pid    = NULL
+             WHERE id = ?
+               AND status IN ('review', 'human_review')
+            """,
+            (now, task_id),
+        )
+        if cur.rowcount != 1:
+            return False
+        # Synthesize a closing run so prior attempt history captures the
+        # rejection rationale even though no worker was actively claimed.
+        # The next ready->running transition will open a fresh run.
+        run_id = _synthesize_ended_run(
+            conn, task_id,
+            outcome="rejected",
+            summary=reason,
+        )
+        # Flip status back to 'ready' so the dispatcher picks it up on the
+        # next tick: 'running' with no claim_lock would otherwise live in
+        # limbo until release_stale_claims swept it.
+        conn.execute(
+            "UPDATE tasks SET status = 'ready', current_run_id = NULL "
+            "WHERE id = ? AND status = 'running' AND claim_lock IS NULL",
+            (task_id,),
+        )
+        _append_event(
+            conn, task_id, "rejected",
+            {"reason": reason} if reason else None,
+            run_id=run_id,
+        )
+    return True
 
 
 def specify_triage_task(

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -234,3 +234,175 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
         f"deliveries (texts: {[d['text'] for d in adapter.sent]})"
     )
     assert "crashed" in adapter.sent[1]["text"].lower()
+
+
+def _create_blocked_subscription(reason: str):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="needs human input", assignee="worker")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        kb._append_event(conn, tid, kind="blocked", payload={"reason": reason})
+        return tid
+    finally:
+        conn.close()
+
+
+def _create_gave_up_subscription(error: str):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="dead worker", assignee="worker")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        kb._append_event(conn, tid, kind="gave_up", payload={"error": error})
+        return tid
+    finally:
+        conn.close()
+
+
+def test_blocked_reason_carries_full_actionable_context(tmp_path, monkeypatch):
+    """Blocked reasons must survive up to NOTIFY_BLOCKED_REASON_MAX chars.
+
+    Regression for the 160-char truncation that made blocked notifications
+    routinely unactionable — users couldn't see the question without
+    opening the dashboard. Caller-supplied 800-char reason must land in
+    the chat message intact.
+    """
+    from gateway.run import NOTIFY_BLOCKED_REASON_MAX
+
+    db_path = tmp_path / "blocked-cap.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    reason = (
+        "Rate limit key choice needs a human call. "
+        "Option A: IP from Cloudflare headers — simple, but NAT-unsafe "
+        "(false positives for users behind shared egress). "
+        "Option B: user_id — requires auth, skips anonymous endpoints "
+        "(login, signup, forgot-password). "
+        "Option C: hybrid — IP for anonymous endpoints, user_id for "
+        "authenticated, with a per-IP burst budget to soften shared-NAT "
+        "false-positives. Each option has a different blast radius and a "
+        "different impl cost; I need a decision before wiring anything in."
+    )
+    assert 160 < len(reason) <= NOTIFY_BLOCKED_REASON_MAX
+    _create_blocked_subscription(reason)
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    text = adapter.sent[0]["text"]
+    # Full reason should be present — every distinctive substring lands.
+    assert "Cloudflare headers" in text
+    assert "forgot-password" in text
+    assert "blast radius" in text
+
+
+def test_blocked_reason_is_truncated_at_documented_cap(tmp_path, monkeypatch):
+    """A reason longer than the cap is truncated at NOTIFY_BLOCKED_REASON_MAX."""
+    from gateway.run import NOTIFY_BLOCKED_REASON_MAX
+
+    db_path = tmp_path / "blocked-overflow.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    reason = "x" * (NOTIFY_BLOCKED_REASON_MAX + 500)
+    _create_blocked_subscription(reason)
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    text = adapter.sent[0]["text"]
+    # The reason substring (xs) is capped; assert exact cap length.
+    x_run = text.count("x")
+    assert x_run == NOTIFY_BLOCKED_REASON_MAX
+
+
+def test_done_summary_carries_extended_handoff(tmp_path, monkeypatch):
+    """Done summaries support up to NOTIFY_DONE_SUMMARY_MAX chars (first line)."""
+    from gateway.run import NOTIFY_DONE_SUMMARY_MAX
+
+    db_path = tmp_path / "done-cap.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    summary = (
+        "shipped token-bucket rate limiter on /api/* — keyed primarily on "
+        "user_id with IP fallback for anonymous endpoints; per-IP burst "
+        "budget of 60 rpm to soften shared-NAT false positives; 14/14 "
+        "tests pass including a NAT-collision regression and a "
+        "Cloudflare-header-stripping test; redis-backed counters with "
+        "60s TTL; metrics emitted to statsd under rate_limit.{hit,miss}."
+    )
+    assert 200 < len(summary) <= NOTIFY_DONE_SUMMARY_MAX
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="rate limit", assignee="worker")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        kb.complete_task(conn, tid, summary=summary)
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    text = adapter.sent[0]["text"]
+    assert "token-bucket" in text
+    assert "rate_limit.{hit,miss}" in text
+
+
+def test_gave_up_error_carries_extended_traceback_snippet(tmp_path, monkeypatch):
+    """gave_up errors carry up to NOTIFY_GAVE_UP_ERROR_MAX chars."""
+    from gateway.run import NOTIFY_GAVE_UP_ERROR_MAX
+
+    db_path = tmp_path / "gaveup-cap.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    err = (
+        "spawn_failed after 5 attempts: profile 'worker' missing "
+        "HERMES_ANTHROPIC_API_KEY in profile env; subprocess exited 2 "
+        "with stderr 'authentication failed: no credentials configured'. "
+        "Check ~/.hermes/profiles/worker/.env or set the key in the "
+        "global ~/.hermes/.env. See logs at ~/.hermes/logs/agent.log "
+        "around 2026-05-23T14:30:00Z for the full traceback."
+    )
+    assert 200 < len(err) <= NOTIFY_GAVE_UP_ERROR_MAX
+    _create_gave_up_subscription(err)
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    text = adapter.sent[0]["text"]
+    assert "HERMES_ANTHROPIC_API_KEY" in text
+    assert "agent.log" in text
+
+
+def test_notification_caps_are_ordered_so_blocked_wins(tmp_path, monkeypatch):
+    """Sanity-check the cap budget: blocked > done > error > legacy result.
+
+    The whole point of per-kind caps (rather than one shared limit) is
+    that ``blocked`` — the one users actually answer — should never lose
+    budget to a chatty ``done`` summary. Pin the ordering so future
+    tuning can't accidentally invert it.
+    """
+    from gateway.run import (
+        NOTIFY_BLOCKED_REASON_MAX,
+        NOTIFY_DONE_RESULT_LEGACY_MAX,
+        NOTIFY_DONE_SUMMARY_MAX,
+        NOTIFY_GAVE_UP_ERROR_MAX,
+    )
+
+    assert NOTIFY_BLOCKED_REASON_MAX > NOTIFY_DONE_SUMMARY_MAX
+    assert NOTIFY_DONE_SUMMARY_MAX > NOTIFY_GAVE_UP_ERROR_MAX
+    assert NOTIFY_GAVE_UP_ERROR_MAX > NOTIFY_DONE_RESULT_LEGACY_MAX
+    # Stay under Discord/Slack's ~2000-char single-message ceiling so
+    # even the largest cap fits in one chat message on the tightest
+    # platform we currently target.
+    assert NOTIFY_BLOCKED_REASON_MAX < 2000

--- a/tests/gateway/test_kanban_notifier_human_review.py
+++ b/tests/gateway/test_kanban_notifier_human_review.py
@@ -1,0 +1,128 @@
+"""Tests for the gateway kanban notifier's human_review event path.
+
+Pins the new event-kind rendering added alongside the ``human_review`` status:
+
+* ``human_review_requested`` — fires the ⏳ "ready for your review" message.
+* ``approved`` — fires the ✅ "approved" message.
+* ``rejected`` — fires the ↩ "rejected — back to ready" message.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+from hermes_cli import kanban_db as kb
+
+
+class RecordingAdapter:
+    def __init__(self):
+        self.sent: list[dict] = []
+
+    async def send(self, chat_id, text, metadata=None):
+        self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
+
+
+async def _run_one_notifier_tick(monkeypatch, runner):
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(delay):
+        if delay == 5:
+            return None
+        runner._running = False
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    await runner._kanban_notifier_watcher(interval=1)
+
+
+def _make_runner(adapter):
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._kanban_sub_fail_counts = {}
+    return runner
+
+
+def _setup_subscribed_task():
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="human-review-flow", assignee="worker")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        task = kb.claim_task(conn, tid)
+        assert task is not None
+        return tid
+    finally:
+        conn.close()
+
+
+def test_notifier_renders_human_review_requested(tmp_path, monkeypatch):
+    db_path = tmp_path / "human-review.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    tid = _setup_subscribed_task()
+    conn = kb.connect()
+    try:
+        ok = kb.move_to_human_review(
+            conn, tid, reason="PR https://example.com/pr/42 merged; please approve",
+        )
+        assert ok
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    text = adapter.sent[0]["text"]
+    assert "⏳" in text
+    assert tid in text
+    assert "PR https://example.com/pr/42" in text
+
+
+def test_notifier_renders_approved(tmp_path, monkeypatch):
+    db_path = tmp_path / "approved.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    tid = _setup_subscribed_task()
+    conn = kb.connect()
+    try:
+        assert kb.move_to_human_review(conn, tid, reason="ready")
+        assert kb.approve_task(conn, tid, reason="LGTM")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    # Two messages expected: human_review_requested then approved.
+    kinds_seen = " | ".join(m["text"] for m in adapter.sent)
+    assert "✅" in kinds_seen
+    assert "approved" in kinds_seen.lower()
+    assert tid in kinds_seen
+
+
+def test_notifier_renders_rejected(tmp_path, monkeypatch):
+    db_path = tmp_path / "rejected.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    tid = _setup_subscribed_task()
+    conn = kb.connect()
+    try:
+        assert kb.move_to_human_review(conn, tid, reason="ready")
+        assert kb.reject_task(conn, tid, reason="needs tests for edge case")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    text_all = " | ".join(m["text"] for m in adapter.sent)
+    assert "↩" in text_all
+    assert "rejected" in text_all.lower()
+    assert "needs tests" in text_all

--- a/tests/hermes_cli/test_kanban_human_review.py
+++ b/tests/hermes_cli/test_kanban_human_review.py
@@ -1,0 +1,166 @@
+"""Tests for the human_review status and review/approve/reject transitions.
+
+Cover the four new ``kanban_db`` helpers (``move_to_review``,
+``move_to_human_review``, ``approve_task``, ``reject_task``) and the
+dispatcher's hands-off behavior for ``human_review`` tasks.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _claim(conn, tid):
+    task = kb.claim_task(conn, tid)
+    assert task is not None, "claim_task must succeed in fixture path"
+    return task
+
+
+def test_human_review_is_a_valid_status(kanban_home):
+    assert "human_review" in kb.VALID_STATUSES
+
+
+def test_move_to_review_running_to_review(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="x", assignee="worker")
+        _claim(conn, tid)
+        ok = kb.move_to_review(conn, tid, reason="PR opened at https://example/pr/1")
+        assert ok
+        t = kb.get_task(conn, tid)
+        assert t.status == "review"
+        events = [e.kind for e in kb.list_events(conn, tid)]
+        assert "review_requested" in events
+
+
+def test_move_to_review_rejects_blocked_task(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="x", assignee="worker")
+        _claim(conn, tid)
+        kb.block_task(conn, tid, reason="stuck")
+        assert kb.move_to_review(conn, tid, reason="too late") is False
+
+
+def test_move_to_human_review_review_to_human_review(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="x", assignee="worker")
+        _claim(conn, tid)
+        kb.move_to_review(conn, tid, reason="PR opened")
+        # Claim as review agent, then escalate to human_review.
+        _ = kb.claim_review_task(conn, tid)
+        ok = kb.move_to_human_review(
+            conn, tid, reason="PR merged; awaiting Sahil",
+        )
+        assert ok
+        t = kb.get_task(conn, tid)
+        assert t.status == "human_review"
+        events = [e.kind for e in kb.list_events(conn, tid)]
+        assert "human_review_requested" in events
+
+
+def test_move_to_human_review_rejects_blocked(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="x", assignee="worker")
+        _claim(conn, tid)
+        kb.block_task(conn, tid, reason="stuck")
+        assert kb.move_to_human_review(conn, tid, reason="x") is False
+
+
+def test_approve_task_human_review_to_done(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="x", assignee="worker")
+        _claim(conn, tid)
+        kb.move_to_human_review(conn, tid, reason="ready")
+        ok = kb.approve_task(conn, tid, reason="LGTM")
+        assert ok
+        t = kb.get_task(conn, tid)
+        assert t.status == "done"
+        assert t.completed_at is not None
+        events = [e.kind for e in kb.list_events(conn, tid)]
+        assert "approved" in events
+
+
+def test_approve_task_rejects_non_human_review(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="x", assignee="worker")
+        _claim(conn, tid)
+        # Still running — approve_task must refuse.
+        assert kb.approve_task(conn, tid, reason="nope") is False
+        # And on review — also refuse.
+        kb.move_to_review(conn, tid, reason="pr")
+        assert kb.approve_task(conn, tid, reason="nope") is False
+
+
+def test_reject_task_human_review_to_ready(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="x", assignee="worker")
+        _claim(conn, tid)
+        kb.move_to_human_review(conn, tid, reason="ready")
+        ok = kb.reject_task(conn, tid, reason="needs tests")
+        assert ok
+        t = kb.get_task(conn, tid)
+        assert t.status == "ready"
+        assert t.completed_at is None
+        events = [e.kind for e in kb.list_events(conn, tid)]
+        assert "rejected" in events
+
+
+def test_reject_task_review_to_ready(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="x", assignee="worker")
+        _claim(conn, tid)
+        kb.move_to_review(conn, tid, reason="pr")
+        ok = kb.reject_task(conn, tid, reason="AC not met")
+        assert ok
+        t = kb.get_task(conn, tid)
+        assert t.status == "ready"
+
+
+def test_reject_task_rejects_running(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="x", assignee="worker")
+        _claim(conn, tid)
+        assert kb.reject_task(conn, tid, reason="bad") is False
+
+
+def test_dispatch_skips_human_review_tasks(kanban_home):
+    """The dispatcher must NOT spawn anything for human_review."""
+    spawned: list = []
+
+    def fake_spawn(claimed, workspace, board=None):
+        spawned.append((claimed.id, claimed.status))
+        return 12345
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="x", assignee="worker")
+        _claim(conn, tid)
+        kb.move_to_human_review(conn, tid, reason="awaiting human")
+        result = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+    assert spawned == [], "dispatcher must skip human_review tasks"
+    # Nothing should have been spawned for our task in any bucket.
+    spawned_ids = [row[0] for row in result.spawned]
+    assert tid not in spawned_ids
+
+
+def test_approve_cas_atomic(kanban_home):
+    """Approve must be idempotent: a second call after success is a no-op."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="x", assignee="worker")
+        _claim(conn, tid)
+        kb.move_to_human_review(conn, tid, reason="ready")
+        assert kb.approve_task(conn, tid, reason="ok") is True
+        # Second call — task is already done; CAS row count == 0, returns False.
+        assert kb.approve_task(conn, tid, reason="ok") is False

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -748,6 +748,140 @@ def _handle_unblock(args: dict, **kw) -> str:
         return tool_error(f"kanban_unblock: {e}")
 
 
+def _handle_review(args: dict, **kw) -> str:
+    """Transition the worker's task to 'review' (auto-review agent handoff)."""
+    tid = _default_task_id(args.get("task_id"))
+    if not tid:
+        return tool_error(
+            "task_id is required (or set HERMES_KANBAN_TASK in the env)"
+        )
+    ownership_err = _enforce_worker_task_ownership(tid)
+    if ownership_err:
+        return ownership_err
+    reason = args.get("reason")
+    if not reason or not str(reason).strip():
+        return tool_error(
+            "reason is required — pass the PR URL plus a one-line summary"
+        )
+    board = args.get("board")
+    try:
+        kb, conn = _connect(board=board)
+        try:
+            ok = kb.move_to_review(
+                conn, tid,
+                reason=reason,
+                expected_run_id=_worker_run_id(tid),
+            )
+            if not ok:
+                return tool_error(
+                    f"could not move {tid} to review (unknown id or "
+                    f"not in running/ready)"
+                )
+            return _ok(task_id=tid, status="review")
+        finally:
+            conn.close()
+    except ValueError as e:
+        return tool_error(f"kanban_review: {e}")
+    except Exception as e:
+        logger.exception("kanban_review failed")
+        return tool_error(f"kanban_review: {e}")
+
+
+def _handle_human_review(args: dict, **kw) -> str:
+    """Transition a task to 'human_review' (auto-review agent passed)."""
+    tid = _default_task_id(args.get("task_id"))
+    if not tid:
+        return tool_error(
+            "task_id is required (or set HERMES_KANBAN_TASK in the env)"
+        )
+    ownership_err = _enforce_worker_task_ownership(tid)
+    if ownership_err:
+        return ownership_err
+    reason = args.get("reason")
+    if not reason or not str(reason).strip():
+        return tool_error(
+            "reason is required — pass the PR URL / merged-commit hint for the human"
+        )
+    board = args.get("board")
+    try:
+        kb, conn = _connect(board=board)
+        try:
+            ok = kb.move_to_human_review(
+                conn, tid,
+                reason=reason,
+                expected_run_id=_worker_run_id(tid),
+            )
+            if not ok:
+                return tool_error(
+                    f"could not move {tid} to human_review (unknown id or "
+                    f"not in running/review)"
+                )
+            return _ok(task_id=tid, status="human_review")
+        finally:
+            conn.close()
+    except ValueError as e:
+        return tool_error(f"kanban_human_review: {e}")
+    except Exception as e:
+        logger.exception("kanban_human_review failed")
+        return tool_error(f"kanban_human_review: {e}")
+
+
+def _handle_approve(args: dict, **kw) -> str:
+    """Approve a human_review task (-> done)."""
+    tid = args.get("task_id")
+    if not tid:
+        return tool_error("task_id is required")
+    reason = args.get("reason")
+    board = args.get("board")
+    try:
+        kb, conn = _connect(board=board)
+        try:
+            ok = kb.approve_task(conn, str(tid), reason=reason)
+            if not ok:
+                return tool_error(
+                    f"could not approve {tid} (not in human_review or unknown)"
+                )
+            return _ok(task_id=str(tid), status="done")
+        finally:
+            conn.close()
+    except ValueError as e:
+        return tool_error(f"kanban_approve: {e}")
+    except Exception as e:
+        logger.exception("kanban_approve failed")
+        return tool_error(f"kanban_approve: {e}")
+
+
+def _handle_reject(args: dict, **kw) -> str:
+    """Reject a review / human_review task (-> ready, with audit comment)."""
+    tid = args.get("task_id")
+    if not tid:
+        return tool_error("task_id is required")
+    reason = args.get("reason")
+    if not reason or not str(reason).strip():
+        return tool_error(
+            "reason is required — the next worker needs to know what to fix"
+        )
+    board = args.get("board")
+    try:
+        kb, conn = _connect(board=board)
+        try:
+            author = os.environ.get("HERMES_PROFILE") or "worker"
+            kb.add_comment(conn, str(tid), author, f"REJECTED: {reason}")
+            ok = kb.reject_task(conn, str(tid), reason=reason)
+            if not ok:
+                return tool_error(
+                    f"could not reject {tid} (not in review/human_review)"
+                )
+            return _ok(task_id=str(tid), status="ready")
+        finally:
+            conn.close()
+    except ValueError as e:
+        return tool_error(f"kanban_reject: {e}")
+    except Exception as e:
+        logger.exception("kanban_reject failed")
+        return tool_error(f"kanban_reject: {e}")
+
+
 def _handle_link(args: dict, **kw) -> str:
     """Add a parent→child dependency edge after the fact."""
     parent_id = args.get("parent_id")
@@ -1192,6 +1326,119 @@ KANBAN_UNBLOCK_SCHEMA = {
     },
 }
 
+KANBAN_REVIEW_SCHEMA = {
+    "name": "kanban_review",
+    "description": (
+        "Move your current running task to 'review' so the auto-review "
+        "agent picks it up. Use this immediately after opening a PR for "
+        "the task's deliverable. ``reason`` should be the PR URL plus a "
+        "one-line summary so the review agent and human-in-the-loop "
+        "have everything they need without reading the whole thread."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "task_id": {
+                "type": "string",
+                "description": _DESC_TASK_ID_DEFAULT,
+            },
+            "reason": {
+                "type": "string",
+                "description": (
+                    "PR URL plus a one-line summary of what's ready for "
+                    "review. Surfaced on the review_requested event and "
+                    "carried in the closing-run summary."
+                ),
+            },
+            "board": _board_schema_prop(),
+        },
+        "required": ["reason"],
+    },
+}
+
+KANBAN_HUMAN_REVIEW_SCHEMA = {
+    "name": "kanban_human_review",
+    "description": (
+        "Move a task into 'human_review' (auto-review agent has finished "
+        "verifying / merging and the task now waits on a human "
+        "approve/reject decision). The dispatcher does NOT auto-spawn "
+        "anything for human_review — the task parks until somebody "
+        "runs kanban_approve / kanban_reject or the equivalent CLI."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "task_id": {
+                "type": "string",
+                "description": _DESC_TASK_ID_DEFAULT,
+            },
+            "reason": {
+                "type": "string",
+                "description": (
+                    "Human-facing handoff (merged PR URL, summary of "
+                    "what changed). Surfaced verbatim to the gateway "
+                    "notifier so the human sees it inline."
+                ),
+            },
+            "board": _board_schema_prop(),
+        },
+        "required": ["reason"],
+    },
+}
+
+KANBAN_APPROVE_SCHEMA = {
+    "name": "kanban_approve",
+    "description": (
+        "Approve a task currently in 'human_review' (-> done). Use this "
+        "when you (or the dispatched reviewer) judge the work meets the "
+        "task's acceptance criteria."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "task_id": {
+                "type": "string",
+                "description": "Task id to approve. Must currently be in human_review.",
+            },
+            "reason": {
+                "type": "string",
+                "description": "Optional approval note (audit-only).",
+            },
+            "board": _board_schema_prop(),
+        },
+        "required": ["task_id"],
+    },
+}
+
+KANBAN_REJECT_SCHEMA = {
+    "name": "kanban_reject",
+    "description": (
+        "Reject a task currently in 'review' or 'human_review'. Bounces "
+        "the task back to 'ready' with a durable comment so the next "
+        "worker run sees the rejection rationale via the normal "
+        "kanban_show prior-runs path."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "task_id": {
+                "type": "string",
+                "description": "Task id to reject. Must currently be in review or human_review.",
+            },
+            "reason": {
+                "type": "string",
+                "description": (
+                    "What needs to change before this can land. The "
+                    "next worker sees this in their context — be "
+                    "specific and actionable."
+                ),
+            },
+            "board": _board_schema_prop(),
+        },
+        "required": ["task_id", "reason"],
+    },
+}
+
 KANBAN_LINK_SCHEMA = {
     "name": "kanban_link",
     "description": (
@@ -1294,4 +1541,40 @@ registry.register(
     handler=_handle_link,
     check_fn=_check_kanban_mode,
     emoji="🔗",
+)
+
+registry.register(
+    name="kanban_review",
+    toolset="kanban",
+    schema=KANBAN_REVIEW_SCHEMA,
+    handler=_handle_review,
+    check_fn=_check_kanban_mode,
+    emoji="🔎",
+)
+
+registry.register(
+    name="kanban_human_review",
+    toolset="kanban",
+    schema=KANBAN_HUMAN_REVIEW_SCHEMA,
+    handler=_handle_human_review,
+    check_fn=_check_kanban_mode,
+    emoji="⏳",
+)
+
+registry.register(
+    name="kanban_approve",
+    toolset="kanban",
+    schema=KANBAN_APPROVE_SCHEMA,
+    handler=_handle_approve,
+    check_fn=_check_kanban_mode,
+    emoji="✅",
+)
+
+registry.register(
+    name="kanban_reject",
+    toolset="kanban",
+    schema=KANBAN_REJECT_SCHEMA,
+    handler=_handle_reject,
+    check_fn=_check_kanban_mode,
+    emoji="↩",
 )


### PR DESCRIPTION
## What

Differentiates **automated review** (existing `review` status — dispatcher auto-spawns the `sdlc-review` agent) from **human review** (new `human_review` status — parked, waits for the human reviewer to approve / reject).

Also surfaces a CLI + tool API for **manual** transitions, so a worker can request review itself after opening a PR.

```
running ─► review ──[agent passes; merges PR]──► human_review ──[approve]──► done
                                                              ──[reject]───► ready
        ─► review ──[agent rejects]────────────────────────────────────────► ready
```

## Changes

**`hermes_cli/kanban_db.py`**
- `human_review` added to `VALID_STATUSES`.
- New atomic CAS helpers: `move_to_review`, `move_to_human_review`, `approve_task`, `reject_task`. Each writes a dedicated audit event (`review_requested` / `human_review_requested` / `approved` / `rejected`) so the notifier and dashboard can render different glyphs per kind.
- `approve_task` clears the failure counter, recomputes ready for dependents, and cleans up the workspace (mirrors `complete_task`).
- `reject_task` flips status back to `ready` (not stuck `running` without a claim) and synthesises a closing run so the rejection rationale surfaces via the normal prior-runs path on the next worker's `kanban_show`.
- `dispatch_once` skips `human_review` tasks: no auto-spawn. The gateway notifier path is the only thing that fires for them.

**`hermes_cli/kanban.py` (CLI)**
- New subcommands: `hermes kanban review`, `human-review`, `approve`, `reject`. Pattern matches the existing `block` / `unblock` / `complete` subcommands.

**`tools/kanban_tools.py` (worker tool surface)**
- `kanban_review`, `kanban_human_review`, `kanban_approve`, `kanban_reject`. Mirror the `kanban_block` / `kanban_complete` shape. Worker-ownership enforced on the worker-initiated transitions.

**`gateway/run.py` (notifier)**
- `TERMINAL_KINDS` extended with the three new event kinds.
- Renders ⏳ for `human_review_requested`, ✅ for `approved`, ↩ for `rejected`. All capped at `NOTIFY_BLOCKED_REASON_MAX` (1500 chars), consistent with the blocked-reason path.

## Tests

- `tests/hermes_cli/test_kanban_human_review.py` — 12 tests covering: status validity, each transition (success + rejection from wrong source status), CAS atomicity (approve_task is idempotent on the second call), and the dispatcher's hands-off behavior for `human_review`.
- `tests/gateway/test_kanban_notifier_human_review.py` — 3 tests pinning the glyph + content of each new notifier message.

All 174 kanban + notifier tests pass locally. Ruff clean on all touched files.

## Out of scope

- The `sdlc-review` skill itself (already proposed in a separate config repo PR).
- Updating orchestrator / worker / engineering-process skills to teach them the new flow (separate task).
