### PR TITLE
feat(workspace): add /workspace command for per-topic prompts, skills, and models

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -461,13 +461,42 @@ def get_external_skills_dirs() -> List[Path]:
     return result
 
 
+def get_workspace_skills_dirs() -> List[Path]:
+    """Return workspace-local skill directories for the current session.
+
+    Reads the active session context (platform + chat_id + thread_id) and
+    discovers any workspace-local ``skills/`` directories under the resolved
+    workspace folder.  These are injected into ``get_all_skills_dirs()``
+    so workspace-specific skills are available without global installation.
+
+    Uses a 1-second stat cache so changes are picked up automatically —
+    no gateway restart required.
+    """
+    try:
+        from gateway.session_context import get_session_env
+    except ImportError:
+        return []
+    platform = get_session_env("HERMES_SESSION_PLATFORM", "")
+    chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "")
+    if not platform or not chat_id:
+        return []
+    thread_id = get_session_env("HERMES_SESSION_THREAD_ID", "") or None
+    try:
+        from agent.workspace_resolver import get_workspace_skill_dirs
+    except ImportError:
+        return []
+    return get_workspace_skill_dirs(platform, chat_id, thread_id)
+
+
 def get_all_skills_dirs() -> List[Path]:
-    """Return all skill directories: local ``~/.hermes/skills/`` first, then external.
+    """Return all skill directories: local, workspace, then external.
 
     The local dir is always first (and always included even if it doesn't exist
-    yet — callers handle that).  External dirs follow in config order.
+    yet — callers handle that).  Workspace-local dirs follow so per-topic skills
+    can override global/external ones.  External dirs from config come last.
     """
     dirs = [get_skills_dir()]
+    dirs.extend(get_workspace_skills_dirs())
     dirs.extend(get_external_skills_dirs())
     return dirs
 

--- a/agent/workspace_resolver.py
+++ b/agent/workspace_resolver.py
@@ -1,0 +1,270 @@
+"""Workspace resolver for Hermes channels/topics.
+
+Provides stat-cached discovery of per-topic and per-channel prompts + skills
+from a folder hierarchy under ~/.hermes/workspaces/ and ~/.hermes/platforms/.
+
+This module is import-safe: no heavy dependencies, no tool registry.
+
+Folder layout::
+
+    ~/.hermes/
+    ├── workspaces/
+    │   ├── news-feed/
+    │   │   ├── SYSTEM.md          # YAML frontmatter + body
+    │   │   └── skills/            # optional workspace-local skills
+    │   │       └── some-skill/
+    │   │           └── SKILL.md
+    │   └── code-review/
+    │       ├── SYSTEM.md
+    │       └── skills/
+    └── platforms/
+        └── telegram/
+            └── -1003682109119/     # chat_id as folder name
+                └── topics.yaml      # thread_id → workspace_name
+
+SYSTEM.md frontmatter format::
+
+    ---
+    skills:
+      - telegram-summary-bot
+      - conventional-commits
+    ---
+    Respond in Hebrew. Focus on regional news...
+
+Resolution (per platform message)::
+
+  1. Discover platform mapping  →  workspace name
+  2. Resolve workspace SYSTEM.md →  prompt + skill list
+  3. Inject into MessageEvent   →  channel_prompt + auto_skill
+
+Fallback chain (most-specific wins)::
+
+  topic workspace prompt  >  channel workspace prompt  >  channel_prompts dict
+  topic workspace skills  >  channel workspace skills  >  existing auto_skill
+
+All disk reads are stat-cached (1-second TTL) so changes take effect
+automatically --- no gateway restart required.
+"""
+
+import logging
+import time
+from pathlib import Path
+from typing import Dict, List, NamedTuple, Optional, Tuple, Any, Iterable
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+# ── File cache (path → (mtime_ns, content)) ──────────────────────────────────
+_STAT_CACHE: Dict[Tuple[str, int], Tuple[int, str]] = {}
+_CACHE_TTL_SECS = 1.0
+
+def _stat_cached(path: Path) -> Optional[Tuple[int, str]]:
+    """Read *path* returning (mtime_ns, content).  Returns None if missing.
+
+    Uses a per-second TTL keyed on absolute path.  This means edits on disk
+    are picked up within one second --- cheap enough to call on every
+    incoming message without restart.
+    """
+    abs_str = str(path.resolve())
+    now = time.monotonic()
+    key = (abs_str, int(now // _CACHE_TTL_SECS))
+    cached = _STAT_CACHE.get(key)
+    if cached is not None:
+        return cached
+    if not path.exists():
+        _STAT_CACHE[key] = None  # type: ignore[assignment]
+        return None
+    try:
+        stat = path.stat()
+        content = path.read_text(encoding="utf-8")
+        result = (stat.st_mtime_ns, content)
+        _STAT_CACHE[key] = result  # type: ignore[assignment]
+        return result
+    except (OSError, UnicodeDecodeError):
+        _STAT_CACHE[key] = None  # type: ignore[assignment]
+        return None
+
+
+def _clear_stat_cache() -> None:
+    """Test hook."""
+    _STAT_CACHE.clear()
+
+
+# ── Frontmatter parsing (minimal, dependency-light) ──────────────────────────
+
+def _parse_frontmatter(text: str) -> Tuple[Dict[str, Any], str]:
+    """Extract YAML frontmatter and body from SYSTEM.md-style content.
+
+    Supports the ---\n...\n--- pattern.  If no frontmatter, returns ({}, text).
+    """
+    lines = text.splitlines(keepends=False)
+    if not lines or lines[0].strip() != "---":
+        return {}, text
+    try:
+        end = lines.index("---", 1)
+    except ValueError:
+        return {}, text
+    fm_text = "\n".join(lines[1:end])
+    body = "\n".join(lines[end + 1 :]).strip()
+    try:
+        import yaml
+        fm = yaml.safe_load(fm_text) or {}
+        if not isinstance(fm, dict):
+            fm = {}
+    except Exception:
+        fm = {}
+    return fm, body
+
+
+# ── Named result type ────────────────────────────────────────────────────────
+
+class WorkspaceResult(NamedTuple):
+    """Resolved workspace metadata for a single message."""
+
+    prompt: str | None
+    skills: List[str] | None
+    model: str | None
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Public API
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def resolve_workspace(
+    platform: str,
+    chat_id: str,
+    thread_id: str | None = None,
+) -> WorkspaceResult:
+    """Resolve the workspace prompt + skills for a given (platform, chat, topic).
+
+    Args:
+        platform: Platform slug  (telegram, discord, slack, …)
+        chat_id:  Numeric channel / group / chat id
+        thread_id: Optional topic / thread id (None for channel-level)
+
+    Returns:
+        WorkspaceResult(prompt=str|None, skills=list|None)
+    """
+    home = get_hermes_home()
+    workspace_name = _resolve_workspace_name(home, platform, chat_id, thread_id)
+    if not workspace_name:
+        return WorkspaceResult(None, None, None)
+    return _resolve_workspace_content(home, workspace_name)
+
+
+def get_workspace_skill_dirs(
+    platform: str,
+    chat_id: str,
+    thread_id: str | None = None,
+) -> List[Path]:
+    """Return workspace-local skill directories for the resolved topic.
+
+    These paths are meant to be appended to ``get_all_skills_dirs()`` so
+    workspace-specific skills are discoverable without global installation.
+    """
+    home = get_hermes_home()
+    workspace_name = _resolve_workspace_name(home, platform, chat_id, thread_id)
+    if not workspace_name:
+        return []
+    ws_dir = home / "workspaces" / workspace_name
+    skills_dir = ws_dir / "skills"
+    if skills_dir.exists() and skills_dir.is_dir():
+        return [skills_dir]
+    return []
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+#  Internal helpers
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _resolve_workspace_name(
+    home: Path,
+    platform: str,
+    chat_id: str,
+    thread_id: str | None = None,
+) -> str | None:
+    """Read platforms/<platform>/<chat_id>/topics.yaml, resolve workspace name."""
+    mapping_file = home / "platforms" / platform / _safe_dir_name(chat_id) / "topics.yaml"
+    stat_result = _stat_cached(mapping_file)
+    if stat_result is None:
+        return None
+    _, text = stat_result
+    try:
+        import yaml
+        data = yaml.safe_load(text) or {}
+    except Exception:
+        logger.debug("[workspace] Failed to parse %s", mapping_file)
+        return None
+
+    topics = data.get("topics", {})
+    if isinstance(topics, dict):
+        # Direct dict form: {"7695": "news-feed"}
+        if thread_id is not None and thread_id in topics:
+            return topics[thread_id]
+    elif isinstance(topics, list):
+        # List-of-dicts form (allows YAML comments / ordering)
+        for entry in topics:
+            if isinstance(entry, dict) and str(entry.get("thread_id", "")) == str(thread_id or ""):
+                return entry.get("workspace")
+
+    # Fall back to channel-level workspace
+    channel_ws = data.get("workspace") if isinstance(data, dict) else None
+    return channel_ws
+
+
+def _resolve_workspace_content(
+    home: Path,
+    workspace_name: str,
+) -> WorkspaceResult:
+    """Read workspaces/<name>/SYSTEM.md, extract prompt + skills + model."""
+    system_file = home / "workspaces" / _safe_dir_name(workspace_name) / "SYSTEM.md"
+    stat_result = _stat_cached(system_file)
+    if stat_result is None:
+        return WorkspaceResult(None, None, None)
+    _, text = stat_result
+    fm, body = _parse_frontmatter(text)
+    prompt = body.strip() or None
+    skills = fm.get("skills")
+    if isinstance(skills, str):
+        skills = [skills.strip()] if skills.strip() else None
+    elif isinstance(skills, list):
+        parsed: List[str] = []
+        for s in skills:
+            if isinstance(s, str) and s.strip():
+                parsed.append(s.strip())
+        skills = parsed if parsed else None
+    else:
+        skills = None
+    model = fm.get("model")
+    if not isinstance(model, str) or not model.strip():
+        model = None
+    return WorkspaceResult(prompt, skills, model)
+
+
+def _safe_dir_name(value: str) -> str:
+    """Escape a chat id or workspace name for use as a directory name.
+
+    Leading minus becomes escaped (e.g. "-1003" → "_-1003") so ``Path``
+    doesn't interpret it as a relative-segment trick.
+    """
+    if value.startswith("-"):
+        return "_-" + value[1:]
+    return value
+
+
+def _write_system_md(path: Path, frontmatter: Dict[str, Any], body: str) -> None:
+    """Write a SYSTEM.md file with YAML frontmatter + body.
+
+    Preserves frontmatter fields and writes them in a deterministic order.
+    If frontmatter is empty, writes body only (no frontmatter fence).
+    """
+    import yaml
+    if frontmatter:
+        fm_text = yaml.safe_dump(frontmatter, default_flow_style=False).strip()
+        content = f"---\n{fm_text}\n---\n{body}"
+    else:
+        content = body
+    path.write_text(content, encoding="utf-8")

--- a/cli.py
+++ b/cli.py
@@ -7160,8 +7160,248 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         return str(value)
 
 
-    
+        try:
+            access_token = get_valid_access_token()
+        except GoogleOAuthError as exc:
+            self._console_print(f"  [yellow]{exc}[/]")
+            self._console_print("  Run [bold]/model[/] and pick 'Google Gemini (OAuth)' to sign in.")
+            return
 
+        creds = load_credentials()
+        project_id = (creds.project_id if creds else "") or ""
+
+        try:
+            buckets = retrieve_user_quota(access_token, project_id=project_id)
+        except CodeAssistError as exc:
+            self._console_print(f"  [red]Quota lookup failed:[/] {exc}")
+            return
+        
+        if not buckets:
+            self._console_print("  [dim]No quota buckets reported (account may be on legacy/unmetered tier).[/]")
+            return
+        
+        # Sort for stable display, group by model
+        buckets.sort(key=lambda b: (b.model_id, b.token_type))
+        self._console_print()
+        self._console_print(f"  [bold]Gemini Code Assist quota[/]  (project: {project_id or '(auto / free-tier)'})")
+        self._console_print()
+        for b in buckets:
+            pct = max(0.0, min(1.0, b.remaining_fraction))
+            width = 20
+            filled = int(round(pct * width))
+            bar = "▓" * filled + "░" * (width - filled)
+            pct_str = f"{int(pct * 100):3d}%"
+            header = b.model_id
+            if b.token_type:
+                header += f" [{b.token_type}]"
+            self._console_print(f"    {header:40s}  {bar}  {pct_str}")
+        self._console_print()
+    def _handle_personality_command(self, cmd: str):
+        """Handle the /personality command to set predefined personalities."""
+        parts = cmd.split(maxsplit=1)
+        
+        if len(parts) > 1:
+            # Set personality
+            personality_name = parts[1].strip().lower()
+            
+            if personality_name in {"none", "default", "neutral"}:
+                self.system_prompt = ""
+                self.agent = None  # Force re-init
+                if save_config_value("agent.system_prompt", ""):
+                    print("(^_^)b Personality cleared (saved to config)")
+                else:
+                    print("(^_^) Personality cleared (session only)")
+                print("  No personality overlay — using base agent behavior.")
+            elif personality_name in self.personalities:
+                self.system_prompt = self._resolve_personality_prompt(self.personalities[personality_name])
+                self.agent = None  # Force re-init
+                if save_config_value("agent.system_prompt", self.system_prompt):
+                    print(f"(^_^)b Personality set to '{personality_name}' (saved to config)")
+                else:
+                    print(f"(^_^) Personality set to '{personality_name}' (session only)")
+                print(f"  \"{self.system_prompt[:60]}{'...' if len(self.system_prompt) > 60 else ''}\"")
+            else:
+                print(f"(._.) Unknown personality: {personality_name}")
+                print(f"  Available: none, {', '.join(self.personalities.keys())}")
+        else:
+            # Show available personalities
+            print()
+            print("+" + "-" * 50 + "+")
+            print("|" + " " * 12 + "(^o^)/ Personalities" + " " * 15 + "|")
+            print("+" + "-" * 50 + "+")
+            print()
+            print(f"  {'none':<12} - (no personality overlay)")
+            for name, prompt in self.personalities.items():
+                if isinstance(prompt, dict):
+                    preview = prompt.get("description") or prompt.get("system_prompt", "")[:50]
+                else:
+                    preview = str(prompt)[:50]
+                print(f"  {name:<12} - {preview}")
+            print()
+            print("  Usage: /personality <name>")
+            print()
+
+    def _handle_workspace_command(self, cmd: str):
+        """Handle the /workspace command — manage workspace prompts and skill links."""
+        from hermes_constants import get_hermes_home
+        from agent.workspace_resolver import (
+            resolve_workspace, _safe_dir_name, _clear_stat_cache,
+        )
+
+        parts = cmd.split(maxsplit=2)
+        subcmd = parts[1].lower() if len(parts) > 1 else "list"
+        rest = parts[2].strip() if len(parts) > 2 else ""
+
+        hermes_home = get_hermes_home()
+        workspaces_dir = hermes_home / "workspaces"
+        platforms_dir = hermes_home / "platforms"
+
+        if subcmd in ("list", ""):
+            if not workspaces_dir.exists():
+                self.console.print("  No workspaces found. Use /workspace create <name> to create one.")
+                return
+            ws_dirs = sorted(d.name for d in workspaces_dir.iterdir() if d.is_dir())
+            if not ws_dirs:
+                self.console.print("  No workspaces found. Use /workspace create <name> to create one.")
+                return
+            self.console.print("\n[bold]Workspaces[/bold]\n")
+            for ws_name in ws_dirs:
+                system_file = workspaces_dir / ws_name / "SYSTEM.md"
+                skills_dir = workspaces_dir / ws_name / "skills"
+                flags = []
+                if system_file.exists():
+                    flags.append("prompt")
+                if skills_dir.exists() and any(skills_dir.iterdir()):
+                    n = len([d for d in skills_dir.iterdir() if d.is_dir()])
+                    flags.append(f"{n} skill{'s' if n != 1 else ''}")
+                desc = f" ({', '.join(flags)})" if flags else ""
+                self.console.print(f"  • [cyan]{ws_name}[/cyan]{desc}")
+            self.console.print()
+
+        elif subcmd == "create":
+            create_parts = rest.split(None, 1)
+            if not create_parts:
+                self.console.print("Usage: [cyan]/workspace create <name> [prompt text][/cyan]")
+                return
+            ws_name = create_parts[0]
+            prompt_text = create_parts[1].strip() if len(create_parts) > 1 else ""
+            if not ws_name.replace("-", "").replace("_", "").isalnum():
+                self.console.print(f"[red]✗ Invalid workspace name '{ws_name}'. Use letters, numbers, hyphens, underscores.[/red]")
+                return
+            ws_dir = workspaces_dir / ws_name
+            if ws_dir.exists():
+                self.console.print(f"[red]✗ Workspace '{ws_name}' already exists. Use /workspace show {ws_name}[/red]")
+                return
+            ws_dir.mkdir(parents=True, exist_ok=True)
+            system_file = ws_dir / "SYSTEM.md"
+            system_file.write_text(prompt_text + "\n" if prompt_text else f"# Workspace: {ws_name}\n", encoding="utf-8")
+            _clear_stat_cache()
+            self.console.print(f"[green]✓ Created workspace '{ws_name}'[/green]")
+            self.console.print(f"  Edit prompt: {system_file}")
+
+        elif subcmd == "show":
+            ws_name = rest.strip()
+            if not ws_name:
+                self.console.print("Usage: [cyan]/workspace show <name>[/cyan]")
+                return
+            ws_dir = workspaces_dir / ws_name
+            if not ws_dir.exists():
+                self.console.print(f"[red]✗ Workspace '{ws_name}' not found.[/red]")
+                return
+            from rich.markdown import Markdown
+            system_file = ws_dir / "SYSTEM.md"
+            self.console.print(f"\n[bold]Workspace: {ws_name}[/bold]\n")
+            if system_file.exists():
+                content = system_file.read_text(encoding="utf-8")
+                self.console.print(Markdown(content))
+            skills_dir = ws_dir / "skills"
+            if skills_dir.exists():
+                skill_list = sorted(d.name for d in skills_dir.iterdir() if d.is_dir())
+                if skill_list:
+                    self.console.print(f"\n[bold]Skills:[/bold] {', '.join(skill_list)}")
+
+        elif subcmd == "link":
+            link_parts = rest.split()
+            if len(link_parts) < 4:
+                self.console.print("Usage: [cyan]/workspace link <platform> <chat_id> <thread_id> <workspace>[/cyan]")
+                self.console.print("   or: [cyan]/workspace link <platform> <chat_id> default <workspace>[/cyan]")
+                return
+            link_platform, link_chat_id, link_thread_id, link_ws = link_parts[:4]
+            ws_dir = workspaces_dir / link_ws
+            if not ws_dir.exists():
+                self.console.print(f"[red]✗ Workspace '{link_ws}' not found. Create it first: /workspace create {link_ws}[/red]")
+                return
+            safe_id = _safe_dir_name(link_chat_id)
+            topic_dir = platforms_dir / link_platform / safe_id
+            topic_dir.mkdir(parents=True, exist_ok=True)
+            topics_file = topic_dir / "topics.yaml"
+            import yaml as _yaml
+            data = {}
+            if topics_file.exists():
+                data = _yaml.safe_load(topics_file.read_text(encoding="utf-8")) or {}
+            topics = data.get("topics", {})
+            if isinstance(topics, list):
+                topics = {str(item.get("thread_id", "")): str(item.get("workspace", "")) for item in topics if isinstance(item, dict)}
+            topics[str(link_thread_id)] = link_ws
+            data["topics"] = topics
+            if "workspace" not in data:
+                data["workspace"] = "default"
+            topics_file.write_text(_yaml.safe_dump(data, default_flow_style=False), encoding="utf-8")
+            _clear_stat_cache()
+            self.console.print(f"[green]✓ Linked {link_platform}/{link_chat_id} topic {link_thread_id} → {link_ws}[/green]")
+
+        elif subcmd in ("remove", "unlink"):
+            if subcmd == "unlink":
+                unlink_parts = rest.split()
+                if len(unlink_parts) < 3:
+                    self.console.print("Usage: [cyan]/workspace unlink <platform> <chat_id> <thread_id>[/cyan]")
+                    return
+                u_platform, u_chat_id, u_thread_id = unlink_parts[:3]
+                safe_id = _safe_dir_name(u_chat_id)
+                topics_file = platforms_dir / u_platform / safe_id / "topics.yaml"
+                if not topics_file.exists():
+                    self.console.print(f"[red]✗ No topics.yaml found for {u_platform}/{u_chat_id}[/red]")
+                    return
+                import yaml as _yaml
+                data = _yaml.safe_load(topics_file.read_text(encoding="utf-8")) or {}
+                topics = data.get("topics", {})
+                if str(u_thread_id) not in topics:
+                    self.console.print(f"[red]✗ Thread '{u_thread_id}' not linked in {u_platform}/{u_chat_id}[/red]")
+                    return
+                del topics[str(u_thread_id)]
+                data["topics"] = topics
+                topics_file.write_text(_yaml.safe_dump(data, default_flow_style=False), encoding="utf-8")
+                _clear_stat_cache()
+                self.console.print(f"[green]✓ Unlinked thread {u_thread_id} from {u_platform}/{u_chat_id}[/green]")
+            else:
+                ws_name = rest.strip()
+                if not ws_name:
+                    self.console.print("Usage: [cyan]/workspace remove <name>[/cyan]")
+                    return
+                ws_dir = workspaces_dir / ws_name
+                if not ws_dir.exists():
+                    self.console.print(f"[red]✗ Workspace '{ws_name}' not found.[/red]")
+                    return
+                import shutil
+                shutil.rmtree(ws_dir)
+                _clear_stat_cache()
+                self.console.print(f"[green]✓ Removed workspace '{ws_name}'[/green]")
+                self.console.print("  [dim]Any topic links pointing to it are now broken — use /workspace unlink to clean up.[/dim]")
+
+        else:
+            self.console.print("\n[bold]Workspace commands[/bold]\n")
+            self.console.print("  [cyan]/workspace[/cyan] or [cyan]/workspace list[/cyan] — List all workspaces")
+            self.console.print("  [cyan]/workspace create <name> [prompt][/cyan] — Create a workspace")
+            self.console.print("  [cyan]/workspace show <name>[/cyan] — Show workspace details")
+            self.console.print("  [cyan]/workspace link <platform> <chat_id> <thread_id> <workspace>[/cyan] — Link a topic")
+            self.console.print("  [cyan]/workspace unlink <platform> <chat_id> <thread_id>[/cyan] — Unlink a topic")
+            self.console.print("  [cyan]/workspace remove <name>[/cyan] — Delete a workspace")
+            self.console.print()
+
+    def _handle_cron_command(self, cmd: str):
+        """Handle the /cron command to manage scheduled tasks."""
+        import shlex
+        from tools.cronjob_tools import cronjob as cronjob_tool
 
 
     def _show_gateway_status(self):
@@ -7434,6 +7674,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         elif canonical == "personality":
             # Use original case (handler lowercases the personality name itself)
             self._handle_personality_command(cmd_original)
+        elif canonical == "workspace":
+            self._handle_workspace_command(cmd_original)
         elif canonical == "retry":
             retry_msg = self.retry_last()
             if retry_msg and hasattr(self, '_pending_input'):

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -983,6 +983,13 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = channel_prompts
                 if "gateway_restart_notification" in platform_cfg:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
+                if plat == Platform.TELEGRAM:
+                    # Bridge Telegram topic config from top-level to extra
+                    # so users can write: telegram: { group_topics: [...] }
+                    # instead of: telegram: { extra: { group_topics: [...] } }
+                    for _topic_key in ("group_topics", "dm_topics"):
+                        if _topic_key in platform_cfg:
+                            bridged[_topic_key] = platform_cfg[_topic_key]
                 enabled_was_explicit = _cfg_toplevel and "enabled" in platform_cfg
                 if not bridged and not enabled_was_explicit:
                     continue

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1456,6 +1456,10 @@ class MessageEvent:
     # Applied at API call time and never persisted to transcript history.
     channel_prompt: Optional[str] = None
 
+    # Workspace-specified model override.  Takes effect on every message
+    # (including after /new resets).  Priority: /model command > workspace > config.
+    workspace_model: Optional[str] = None
+
     # Channel context recovered by history backfill (e.g. messages between
     # bot turns that were missed due to require_mention).  Kept separate
     # from ``text`` so the sender-prefix logic in run.py can operate on the

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -498,6 +498,8 @@ class TelegramAdapter(BasePlatformAdapter):
         # Clarify button state: clarify_id → session_key (for the clarify tool's
         # multiple-choice prompts; see GatewayRunner clarify_callback wiring).
         self._clarify_state: Dict[str, str] = {}
+        # Workspace creation interactive state per chat
+        self._workspace_create_state: Dict[str, dict] = {}
         # Notification mode for message sends.
         # "important" — only final responses, approvals, and slash confirmations
         #               trigger notifications; tool progress, streaming, status
@@ -3353,6 +3355,234 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.warning("[%s] send_model_picker failed: %s", self.name, e)
             return SendResult(success=False, error=str(e))
 
+    async def send_workspace_create_picker(
+        self,
+        chat_id: str,
+        ws_name: str,
+        current_model: str,
+        config_default_model: str,
+        on_create_workspace,
+        suggested_prompt: str = "",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an interactive inline-keyboard workspace creator.
+
+        Prompts the user to configure name, model, and prompt before creating.
+        Supports toggling the workspace model (if current != default),
+        editing the workspace name, and entering text-capture mode for
+        a custom prompt.  Accepts a suggested prompt for pre-fill.
+        """
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+
+        # Build initial state
+        has_model_diff = current_model and config_default_model and current_model != config_default_model
+        state = {
+            "ws_name": ws_name,
+            "current_model": current_model,
+            "config_default_model": config_default_model,
+            "include_model": has_model_diff,  # pre-check if user already switched away from default
+            "has_model_diff": has_model_diff,
+            "prompt": suggested_prompt,
+            "awaiting_prompt": False,
+            "awaiting_name": False,
+            "on_create": on_create_workspace,
+        }
+        self._workspace_create_state[str(chat_id)] = state
+
+        text, keyboard = self._build_workspace_create_message(state)
+        try:
+            thread_id = metadata.get("thread_id") if metadata else None
+            reply_to_id = self._reply_to_message_id_for_send(None, metadata)
+            msg = await self._send_message_with_thread_fallback(
+                chat_id=int(chat_id),
+                text=text,
+                parse_mode=ParseMode.MARKDOWN_V2,
+                reply_markup=keyboard,
+                reply_to_message_id=reply_to_id,
+                **self._thread_kwargs_for_send(
+                    chat_id, thread_id, metadata, reply_to_message_id=reply_to_id,
+                ),
+                **self._link_preview_kwargs(),
+            )
+            state["msg_id"] = msg.message_id
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            self._workspace_create_state.pop(str(chat_id), None)
+            logger.warning("[%s] send_workspace_create_picker failed: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
+    def _build_workspace_create_message(self, state: dict) -> tuple:
+        """Build text + InlineKeyboardMarkup for the workspace creation prompt."""
+        ws_name = state["ws_name"]
+        lines = [
+            f"📁 *Create Workspace*",
+            "",
+            f"📛 Name: `{ws_name}`",
+        ]
+
+        if state["has_model_diff"]:
+            if state["include_model"]:
+                lines.append(f"🌐 Model: *{state['current_model']}*")
+            else:
+                lines.append(f"🌐 Model: {state['config_default_model']} (default)")
+
+        if state.get("awaiting_prompt"):
+            lines.append("✏️ Prompt: _awaiting your text..._")
+        elif state["prompt"]:
+            preview = state["prompt"][:80] + ("…" if len(state["prompt"]) > 80 else "")
+            lines.append(f"✏️ Prompt: {preview}")
+        else:
+            lines.append("✏️ Prompt: _(none)_")
+
+        if state.get("awaiting_name"):
+            lines.append("")
+            lines.append("⏳ _Please type a new workspace name now..._")
+
+        lines.append("")
+        lines.append("Configure your workspace:")
+
+        text = self.format_message("\n".join(lines))
+
+        # Build keyboard
+        buttons: list = []
+
+        # Name edit button
+        if state.get("awaiting_name"):
+            buttons.append(InlineKeyboardButton("⌛ Awaiting name…", callback_data="wc:noop"))
+        else:
+            buttons.append(InlineKeyboardButton("📛 Edit name", callback_data="wc:n:edit"))
+
+        if state["has_model_diff"]:
+            label = "✅ Use model" if state["include_model"] else "☐ Use model"
+            buttons.append(InlineKeyboardButton(label, callback_data="wc:m:toggle"))
+
+        if state.get("awaiting_prompt"):
+            buttons.append(InlineKeyboardButton("⌛ Awaiting prompt…", callback_data="wc:noop"))
+        elif state["prompt"]:
+            buttons.append(InlineKeyboardButton("✏️ Edit prompt", callback_data="wc:p:edit"))
+        else:
+            buttons.append(InlineKeyboardButton("✏️ Add prompt", callback_data="wc:p:edit"))
+
+        # Action row
+        action_buttons = [
+            InlineKeyboardButton("✅ Create", callback_data="wc:c:create"),
+            InlineKeyboardButton("✗ Cancel", callback_data="wc:x:cancel"),
+        ]
+
+        rows = [buttons[i : i + 2] for i in range(0, len(buttons), 2)]
+        rows.append(action_buttons)
+
+        return text, InlineKeyboardMarkup(rows)
+
+    async def _handle_workspace_create_callback(
+        self, query, data: str, chat_id: str
+    ) -> None:
+        """Handle workspace creation inline keyboard callbacks (wc:*)."""
+        state = self._workspace_create_state.get(chat_id)
+        if not state:
+            await query.answer(text="Picker expired — use /workspace create again.")
+            return
+
+        if data == "wc:x:cancel":
+            self._workspace_create_state.pop(chat_id, None)
+            await query.edit_message_text(
+                text="Workspace creation cancelled.",
+                reply_markup=None,
+            )
+            await query.answer()
+            return
+
+        if data == "wc:noop":
+            await query.answer()
+            return
+
+        if data == "wc:m:toggle":
+            state["include_model"] = not state["include_model"]
+            text, keyboard = self._build_workspace_create_message(state)
+            await query.edit_message_text(
+                text=text,
+                parse_mode=ParseMode.MARKDOWN_V2,
+                reply_markup=keyboard,
+            )
+            await query.answer()
+            return
+
+        if data == "wc:n:edit":
+            # Enter text-capture mode for name
+            state["awaiting_name"] = True
+            await query.edit_message_text(
+                text=self.format_message(
+                    f"📁 *Create Workspace*\n\n"
+                    f"📛 Please type a new name for this workspace now.\n"
+                    f"Your next message will become the workspace name.\n\n"
+                    f"Use letters, numbers, hyphens, and underscores only."
+                ),
+                parse_mode=ParseMode.MARKDOWN_V2,
+                reply_markup=None,
+            )
+            await query.answer()
+            return
+
+        if data == "wc:p:edit":
+            # Enter text-capture mode for prompt
+            state["awaiting_prompt"] = True
+            await query.edit_message_text(
+                text=self.format_message(
+                    f"📁 *Create Workspace: `{state['ws_name']}`*\n\n"
+                    f"✏️ Please type the prompt text for this workspace now.\n"
+                    f"Your next message will become the SYSTEM.md body."
+                ),
+                parse_mode=ParseMode.MARKDOWN_V2,
+                reply_markup=None,
+            )
+            await query.answer()
+            return
+
+        if data == "wc:c:create":
+            # Call the creation callback
+            create_cb = state.get("on_create")
+            if not create_cb:
+                self._workspace_create_state.pop(chat_id, None)
+                await query.edit_message_text(
+                    text="Picker expired.",
+                    reply_markup=None,
+                )
+                await query.answer()
+                return
+
+            try:
+                result_text = await create_cb(
+                    chat_id,
+                    ws_name=state["ws_name"],
+                    model=state["current_model"] if state["include_model"] else None,
+                    prompt=state["prompt"] or None,
+                )
+            except Exception as exc:
+                logger.error("Workspace create callback failed: %s", exc, exc_info=True)
+                result_text = f"Error creating workspace: {exc}"
+
+            self._workspace_create_state.pop(chat_id, None)
+            try:
+                await query.edit_message_text(
+                    text=result_text,
+                    parse_mode=ParseMode.MARKDOWN_V2,
+                    reply_markup=None,
+                )
+            except Exception:
+                try:
+                    await query.edit_message_text(
+                        text=result_text,
+                        parse_mode=None,
+                        reply_markup=None,
+                    )
+                except Exception:
+                    pass
+            await query.answer(text="Workspace created!")
+            return
+
+        await query.answer()
+
     _MODEL_PAGE_SIZE = 8
 
     def _build_provider_keyboard(self, providers: list):
@@ -3778,6 +4008,13 @@ class TelegramAdapter(BasePlatformAdapter):
                 query_thread_id=query_thread_id,
                 query_user_name=query_user_name,
             )
+            return
+
+        # --- Workspace creation callbacks (wc:*) ---
+        if data.startswith("wc:"):
+            chat_id = str(query.message.chat_id) if query.message else None
+            if chat_id:
+                await self._handle_workspace_create_callback(query, data, chat_id)
             return
 
         # --- Exec approval callbacks (ea:choice:id) ---
@@ -5786,6 +6023,66 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         await self._ensure_forum_commands(update.message)
 
+        # --- Workspace create text-capture intercept ---
+        chat_id = str(msg.chat_id)
+        ws_state = self._workspace_create_state.get(chat_id)
+        if ws_state and (ws_state.get("awaiting_name") or ws_state.get("awaiting_prompt")):
+            if ws_state.get("awaiting_name"):
+                # Capture user's text as the workspace name
+                new_name = msg.text.strip()
+                # Validate name
+                if not new_name.replace("-", "").replace("_", "").isalnum():
+                    # Invalid name — show error and keep awaiting
+                    try:
+                        wc_msg_id = ws_state.get("msg_id")
+                        if wc_msg_id and self._bot:
+                            await self._bot.edit_message_text(
+                                chat_id=msg.chat_id,
+                                message_id=wc_msg_id,
+                                text=self.format_message(
+                                    f"📁 *Create Workspace*\n\n"
+                                    f"❌ Invalid name `{new_name}`. Use letters, numbers, hyphens, underscores.\n"
+                                    f"Please try again:"
+                                ),
+                                parse_mode=ParseMode.MARKDOWN_V2,
+                            )
+                    except Exception:
+                        pass
+                    return
+                ws_state["ws_name"] = new_name
+                ws_state["awaiting_name"] = False
+
+            elif ws_state.get("awaiting_prompt"):
+                # Capture user's text as the workspace prompt
+                prompt_text = msg.text.strip()
+                ws_state["prompt"] = prompt_text
+                ws_state["awaiting_prompt"] = False
+
+            # Delete the captured message for cleanliness
+            try:
+                await self._bot.delete_message(
+                    chat_id=msg.chat_id,
+                    message_id=msg.message_id,
+                )
+            except Exception:
+                pass  # non-fatal
+
+            # Edit the workspace creation message with updated state + keyboard
+            text, keyboard = self._build_workspace_create_message(ws_state)
+            try:
+                wc_msg_id = ws_state.get("msg_id")
+                if wc_msg_id and self._bot:
+                    await self._bot.edit_message_text(
+                        chat_id=msg.chat_id,
+                        message_id=wc_msg_id,
+                        text=text,
+                        parse_mode=ParseMode.MARKDOWN_V2,
+                        reply_markup=keyboard,
+                    )
+            except Exception as e:
+                logger.warning("[%s] Failed to edit workspace create message: %s", self.name, e)
+            return
+
         event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)
         await self._cache_replied_media(msg, event)
@@ -6507,12 +6804,14 @@ class TelegramAdapter(BasePlatformAdapter):
             thread_id_str = self._GENERAL_TOPIC_THREAD_ID
         chat_topic = None
         topic_skill = None
+        topic_prompt = None
 
         if chat_type == "dm" and thread_id_str:
             topic_info = self._get_dm_topic_info(str(chat.id), thread_id_str)
             if topic_info:
                 chat_topic = topic_info.get("name")
                 topic_skill = topic_info.get("skill")
+                topic_prompt = topic_info.get("prompt")
 
             # Also check forum_topic_created service message for topic discovery
             if hasattr(message, "forum_topic_created") and message.forum_topic_created:
@@ -6523,7 +6822,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         chat_topic = created_name
 
         elif chat_type == "group" and thread_id_str:
-            # Group/supergroup forum topic skill binding via config.extra['group_topics']
+            # Group/supergroup forum topic skill/prompt binding via config.extra['group_topics']
             group_topics_config: list = self.config.extra.get("group_topics", [])
             for chat_entry in group_topics_config:
                 if str(chat_entry.get("chat_id", "")) == str(chat.id):
@@ -6532,8 +6831,34 @@ class TelegramAdapter(BasePlatformAdapter):
                         if tid is not None and str(tid) == thread_id_str:
                             chat_topic = topic.get("name")
                             topic_skill = topic.get("skill")
+                            topic_prompt = topic.get("prompt")
                             break
                     break
+
+        # -----------------------------------------------------------------
+        # Workspace resolution (folder-based, hot-reload, survives /new)
+        # -----------------------------------------------------------------
+        from agent.workspace_resolver import resolve_workspace
+        ws = resolve_workspace("telegram", str(chat.id), thread_id_str)
+        workspace_model = None
+        if ws.prompt:
+            topic_prompt = ws.prompt
+        if ws.skills:
+            if topic_skill:
+                # Merge: workspace skills first, then config skill
+                merged = list(ws.skills)
+                if isinstance(topic_skill, str):
+                    if topic_skill not in merged:
+                        merged.append(topic_skill)
+                elif isinstance(topic_skill, list):
+                    for s in topic_skill:
+                        if s not in merged:
+                            merged.append(s)
+                topic_skill = merged
+            else:
+                topic_skill = ws.skills
+        if ws.model:
+            workspace_model = ws.model
 
         # Build source
         source = self.build_source(
@@ -6583,9 +6908,11 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
 
         # Per-channel/topic ephemeral prompt
+        # Priority: topic-level prompt from group_topics/dm_topics config
+        #           > channel_prompts dict > None
         from gateway.platforms.base import resolve_channel_prompt
         _chat_id_str = str(chat.id)
-        _channel_prompt = resolve_channel_prompt(
+        _channel_prompt = topic_prompt or resolve_channel_prompt(
             self.config.extra,
             thread_id_str or _chat_id_str,
             _chat_id_str if thread_id_str else None,
@@ -6602,6 +6929,7 @@ class TelegramAdapter(BasePlatformAdapter):
             reply_to_text=reply_to_text,
             auto_skill=topic_skill,
             channel_prompt=_channel_prompt,
+            workspace_model=workspace_model,
             timestamp=message.date,
         )
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7066,6 +7066,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         source=event.source,
                         message_id=event.message_id,
                         channel_prompt=event.channel_prompt,
+                        workspace_model=getattr(event, 'workspace_model', None),
                     )
                     self._enqueue_fifo(_quick_key, queued_event, adapter)
                 depth = self._queue_depth(_quick_key, adapter=self.adapters.get(source.platform))
@@ -7093,6 +7094,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             source=event.source,
                             message_id=event.message_id,
                             channel_prompt=event.channel_prompt,
+                            workspace_model=getattr(event, 'workspace_model', None),
                         )
                         adapter._pending_messages[_quick_key] = queued_event
                     return "Agent still starting — /steer queued for the next turn."
@@ -7115,6 +7117,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         source=event.source,
                         message_id=event.message_id,
                         channel_prompt=event.channel_prompt,
+                        workspace_model=getattr(event, 'workspace_model', None),
                     )
                     adapter._pending_messages[_quick_key] = queued_event
                 return "No active agent — /steer queued for the next turn."
@@ -7508,6 +7511,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if canonical == "personality":
             return await self._handle_personality_command(event)
+
+        if canonical == "workspace":
+            return await self._handle_workspace_command(event)
 
         if canonical == "kanban":
             return await self._handle_kanban_command(event)
@@ -8383,7 +8389,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             f"Adjust reset timing in config.yaml under session_reset."
                         )
                         try:
-                            session_info = self._format_session_info()
+                            session_info = self._format_session_info(
+                                workspace_model=getattr(event, 'workspace_model', None)
+                            )
                             if session_info:
                                 notice = f"{notice}\n\n{session_info}"
                         except Exception:
@@ -8882,6 +8890,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 run_generation=run_generation,
                 event_message_id=self._reply_anchor_for_event(event),
                 channel_prompt=event.channel_prompt,
+                workspace_model=getattr(event, 'workspace_model', None),
             )
 
             # Stop persistent typing indicator now that the agent is done
@@ -9411,16 +9420,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Restore session context variables to their pre-handler state
             self._clear_session_env(_session_env_tokens)
 
-    def _format_session_info(self) -> str:
+    def _format_session_info(self, workspace_model: Optional[str] = None) -> str:
         """Resolve current model config and return a formatted info block.
 
         Surfaces model, provider, context length, and endpoint so gateway
         users can immediately see if context detection went wrong (e.g.
         local models falling to the 128K default).
+
+        When *workspace_model* is provided, the display shows the effective
+        model (workspace override if no /model session override is active)
+        rather than the config default, so gateway users see which model
+        will actually be used.
         """
         from agent.model_metadata import get_model_context_length, DEFAULT_FALLBACK_CONTEXT
 
-        model = _resolve_gateway_model()
+        config_model = _resolve_gateway_model()
+        effective_model = model = config_model
+        # If a workspace model is provided and differs from the config default,
+        # use it as the effective model so the user sees what will actually run.
+        model_source = "config"
+        if workspace_model and workspace_model != config_model:
+            effective_model = model = workspace_model
+            model_source = "workspace"
         config_context_length = None
         provider = None
         base_url = None
@@ -9519,7 +9540,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             ctx_display = str(context_length)
 
         lines = [
-            f"◆ Model: `{model}`",
+            f"◆ Model: `{effective_model}`{' (workspace)' if model_source == 'workspace' else ''}",
             f"◆ Provider: {provider or 'openrouter'}",
             f"◆ Context: {ctx_display} tokens ({ctx_source})",
         ]
@@ -9529,6 +9550,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             lines.append(f"◆ Endpoint: {base_url}")
 
         return "\n".join(lines)
+
+
 
 
 
@@ -9744,6 +9767,666 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             from hermes_cli.blueprint_cmd import BlueprintCommandResult
 
             return BlueprintCommandResult(f"Cron blueprint command failed: {e}")
+    # ------------------------------------------------------------------
+    # /workspace — manage workspaces (create, link, list, show, remove)
+    # ------------------------------------------------------------------
+
+    def _find_workspace_name_from_context(
+        self, platform: str, chat_id: str, thread_id: str | None
+    ) -> str | None:
+        """Resolve the workspace NAME from a platform/chat/thread context.
+
+        Reads topics.yaml to find the mapping, then returns the workspace name
+        (not the resolved prompt/skills). Returns None if no workspace is linked.
+        """
+        try:
+            from pathlib import Path
+            from agent.workspace_resolver import _safe_dir_name
+
+            topics_path = (
+                Path(_hermes_home)
+                / "platforms"
+                / platform
+                / _safe_dir_name(chat_id)
+                / "topics.yaml"
+            )
+            if not topics_path.exists():
+                return None
+
+            import yaml as _yaml
+            data = _yaml.safe_load(topics_path.read_text(encoding="utf-8")) or {}
+            topics = data.get("topics", {})
+            if isinstance(topics, list):
+                topics = {
+                    str(item.get("thread_id", "")): str(item.get("workspace", ""))
+                    for item in topics
+                    if isinstance(item, dict)
+                }
+            thread_key = str(thread_id) if thread_id else "default"
+            return topics.get(thread_key)
+        except Exception:
+            return None
+
+    async def _handle_workspace_command(self, event: MessageEvent) -> str:
+        """Handle /workspace command for workspace management."""
+        from agent.workspace_resolver import (
+            resolve_workspace,
+            _safe_dir_name,
+            _clear_stat_cache,
+            _parse_frontmatter,
+            _write_system_md,
+        )
+
+        raw_args = event.get_command_args().strip()
+        parts = raw_args.split(None, 1)
+        subcmd = parts[0].lower() if parts else ""
+        rest = parts[1].strip() if len(parts) > 1 else ""
+
+        hermes_home = _hermes_home
+        workspaces_dir = hermes_home / "workspaces"
+        platforms_dir = hermes_home / "platforms"
+
+        # Determine current platform/chat_id/thread_id for context-aware ops
+        source = event.source
+        platform = source.platform.value if source.platform else ""
+        chat_id = str(source.chat_id) if source.chat_id else ""
+        thread_id = source.thread_id or ""
+
+        if not subcmd or subcmd == "list":
+            # /workspace list — list all workspaces and current mapping
+            lines = ["📁 **Workspaces**\n"]
+
+            if not workspaces_dir.exists():
+                lines.append("  No workspaces found.")
+                lines.append("  Use `/workspace create <name>` to create one.")
+            else:
+                ws_dirs = sorted(d.name for d in workspaces_dir.iterdir() if d.is_dir())
+                if not ws_dirs:
+                    lines.append("  No workspaces found.")
+                else:
+                    for ws_name in ws_dirs:
+                        system_file = workspaces_dir / ws_name / "SYSTEM.md"
+                        skills_dir = workspaces_dir / ws_name / "skills"
+                        has_prompt = system_file.exists()
+                        has_skills = skills_dir.exists() and any(skills_dir.iterdir())
+                        # Check for model in frontmatter
+                        has_model = False
+                        model_name = ""
+                        if has_prompt:
+                            content = system_file.read_text(encoding="utf-8")
+                            fm, _ = _parse_frontmatter(content)
+                            model_name = fm.get("model", "")
+                            has_model = bool(model_name)
+                        flags = []
+                        if has_prompt:
+                            flags.append("prompt")
+                        if has_model:
+                            flags.append(f"model: {model_name}")
+                        if has_skills:
+                            n_skills = len([d for d in skills_dir.iterdir() if d.is_dir()])
+                            flags.append(f"{n_skills} skill{'s' if n_skills != 1 else ''}")
+                        desc = f" ({', '.join(flags)})" if flags else ""
+                        lines.append(f"  • **{ws_name}**{desc}")
+
+            # Show current context mapping
+            if platform and chat_id:
+                safe_id = _safe_dir_name(chat_id)
+                topics_file = platforms_dir / platform / safe_id / "topics.yaml"
+                if topics_file.exists():
+                    import yaml as _yaml
+                    data = _yaml.safe_load(topics_file.read_text(encoding="utf-8")) or {}
+                    topics = data.get("topics", {})
+                    ws_default = data.get("workspace", "")
+                    if topics or ws_default:
+                        lines.append(f"\n🔗 **{platform}/{chat_id}**")
+                        if ws_default:
+                            lines.append(f"  default → **{ws_default}**")
+                        for tid, ws in topics.items():
+                            marker = " ◀ you" if str(tid) == str(thread_id) else ""
+                            lines.append(f"  topic {tid} → **{ws}**{marker}")
+                else:
+                    lines.append(f"\n🔗 **{platform}/{chat_id}** — no topics linked yet")
+                    lines.append(f"  Use `/workspace link {platform} {chat_id} <thread_id> <workspace>`")
+
+            # Show active workspace for current topic
+            if platform and chat_id:
+                result = resolve_workspace(platform, chat_id, thread_id or None)
+                if result.prompt or result.skills or result.model:
+                    lines.append(f"\n✅ **Active workspace** for this topic:")
+                    if result.model:
+                        lines.append(f"  Model: **{result.model}**")
+                    if result.prompt:
+                        preview = result.prompt[:80] + ("..." if len(result.prompt) > 80 else "")
+                        lines.append(f"  Prompt: {preview}")
+                    if result.skills:
+                        lines.append(f"  Skills: {', '.join(result.skills)}")
+
+            return "\n".join(lines)
+
+        elif subcmd == "create":
+            # /workspace create <name> [prompt text]
+            # Auto-links to current topic if in one.
+            # When prompt text IS provided → create immediately (batch/script-friendly).
+            # When prompt text is NOT provided → interactive flow (if platform supports it).
+            # When NO name or minimal args → auto-generate name from context.
+            if not rest:
+                # Auto-generate workspace name from session/topic context
+                import re as _re
+                suggest_name = ""
+                # 1. Try session title from DB
+                try:
+                    session_key = self._session_key_for_source(source) if source else None
+                    if session_key and self._session_db:
+                        entry = self.session_store._entries.get(session_key) if self.session_store else None
+                        if entry:
+                            title = self._session_db.get_session_title(entry.session_id)
+                            if title:
+                                suggest_name = title
+                except Exception:
+                    pass
+                # 2. Fall back to chat_topic from source
+                if not suggest_name:
+                    ct = getattr(source, "chat_topic", None) if source else None
+                    if ct:
+                        suggest_name = ct
+                # 3. Fall back to workspace prompt first words
+                if not suggest_name:
+                    try:
+                        from agent.workspace_resolver import resolve_workspace
+                        ws = resolve_workspace(platform, chat_id, thread_id or None)
+                        if ws.prompt:
+                            words = ws.prompt.strip().split()
+                            suggest_name = " ".join(words[:3]) if words else ""
+                    except Exception:
+                        pass
+                # 4. Final fallback
+                if not suggest_name:
+                    suggest_name = f"topic-{thread_id}" if thread_id else "workspace"
+                # Slugify: lowercase, replace spaces/separators with hyphens, strip non-alnum
+                ws_name = _re.sub(r'[^a-zA-Z0-9_-]', '', suggest_name.lower().replace(" ", "-").replace(".", "-"))[:50]
+                if not ws_name or not ws_name.replace("-", "").replace("_", "").isalnum():
+                    ws_name = "workspace"
+                prompt_text = ""
+            else:
+                create_parts = rest.split(None, 1)
+                ws_name = create_parts[0]
+                prompt_text = create_parts[1].strip() if len(create_parts) > 1 else ""
+
+            # Validate name
+            if not ws_name.replace("-", "").replace("_", "").isalnum():
+                return f"❌ Invalid workspace name `{ws_name}`. Use letters, numbers, hyphens, underscores."
+
+            ws_dir = workspaces_dir / ws_name
+            if ws_dir.exists():
+                return f"❌ Workspace `{ws_name}` already exists. Use `/workspace show {ws_name}` to view it."
+
+            # Resolve current model vs default for model option
+            current_model = ""
+            config_default = ""
+            try:
+                resolved_model, _ = self._resolve_session_agent_runtime(
+                    source=source,
+                    session_key=self._session_key_for_source(source) if source else None,
+                    user_config=_load_gateway_config(),
+                )
+                config_default = _resolve_gateway_model(_load_gateway_config())
+                current_model = resolved_model or ""
+            except Exception:
+                pass
+
+            # --- Interactive flow (no prompt provided, platform supports it) ---
+            if not prompt_text:
+                adapter = self.adapters.get(source.platform)
+                has_picker = (
+                    adapter is not None
+                    and getattr(type(adapter), "send_workspace_create_picker", None) is not None
+                )
+
+                if has_picker:
+                    # Build workspace creation callback closure
+                    _self = self
+                    _ws_name = ws_name
+                    _platform = platform
+                    _chat_id = chat_id
+                    _thread_id = thread_id
+                    _workspaces_dir = workspaces_dir
+                    _platforms_dir = platforms_dir
+
+                    # --- Prompt suggestion: current workspace/channel prompt ---
+                    suggest_prompt = ""
+                    try:
+                        # Use current event's channel_prompt (set by workspace resolution)
+                        cp = getattr(event, "channel_prompt", None)
+                        if cp:
+                            suggest_prompt = cp.strip()
+                    except Exception:
+                        pass
+
+                    async def _on_workspace_create(
+                        picker_chat_id: str,
+                        ws_name: str = _ws_name,
+                        model: str | None = None,
+                        prompt: str | None = None,
+                    ) -> str:
+                        """Create the workspace and return confirmation text."""
+                        import yaml as _yaml
+
+                        ws_dir = _workspaces_dir / ws_name
+                        ws_dir.mkdir(parents=True, exist_ok=True)
+                        system_file = ws_dir / "SYSTEM.md"
+
+                        # Build SYSTEM.md with frontmatter
+                        frontmatter = {}
+                        if model:
+                            frontmatter["model"] = model
+                        body = prompt or f"# Workspace: {ws_name}\n"
+
+                        _write_system_md(system_file, frontmatter, body)
+                        _clear_stat_cache()
+
+                        # Auto-link to current topic if in one
+                        link_msg = ""
+                        if _platform and _chat_id and _thread_id and str(_thread_id) != "1":
+                            safe_id = _safe_dir_name(_chat_id)
+                            topic_dir = _platforms_dir / _platform / safe_id
+                            topic_dir.mkdir(parents=True, exist_ok=True)
+                            topics_file = topic_dir / "topics.yaml"
+                            data = {}
+                            if topics_file.exists():
+                                data = _yaml.safe_load(topics_file.read_text(encoding="utf-8")) or {}
+                            topics = data.get("topics", {})
+                            topics[str(_thread_id)] = ws_name
+                            data["topics"] = topics
+                            if "workspace" not in data:
+                                data["workspace"] = "default"
+                            topics_file.write_text(_yaml.safe_dump(data, default_flow_style=False), encoding="utf-8")
+                            _clear_stat_cache()
+                            link_msg = f"\n🔗 Auto-linked to {_platform}/{_chat_id} topic **{_thread_id}**"
+                        elif _platform and _chat_id and str(_thread_id) == "1":
+                            link_msg = f"\n⚠️  Skipped auto-link — you're in the **general topic** (thread 1).\nUse `/workspace link {_platform} {_chat_id} default {ws_name}` to set a channel default."
+
+                        lines = [f"✅ Created workspace **{ws_name}**"]
+                        lines.append(f"📄 `{system_file}`")
+                        if model:
+                            lines.append(f"🌐 Model: **{model}**")
+                        if prompt:
+                            preview = prompt[:80] + ("..." if len(prompt) > 80 else "")
+                            lines.append(f"✏️ Prompt: {preview}")
+                        lines.append(link_msg)
+                        return "\n".join(lines)
+
+                    metadata = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
+                    result = await adapter.send_workspace_create_picker(
+                        chat_id=source.chat_id,
+                        ws_name=ws_name,
+                        current_model=current_model,
+                        config_default_model=config_default,
+                        on_create_workspace=_on_workspace_create,
+                        suggested_prompt=suggest_prompt,
+                        metadata=metadata,
+                    )
+                    if result.success:
+                        return None  # Picker sent — adapter handles the response
+
+                # Fallback: no interactive support → create with defaults
+                # (current behavior — creates with no model, no prompt)
+
+            # --- Direct creation (prompt provided or platform without interactive support) ---
+            model_hint = ""
+            if current_model and config_default and current_model != config_default:
+                model_hint = (
+                    f"\n\n💡 You're currently using model **{current_model}** (default is **{config_default}**).\n"
+                    f"To set this as the workspace model, add `model: {current_model}` to the frontmatter.\n"
+                    f"Or run: `/workspace model {ws_name} {current_model}`"
+                )
+
+            ws_dir.mkdir(parents=True, exist_ok=True)
+            system_file = ws_dir / "SYSTEM.md"
+            system_file.write_text(prompt_text + "\n" if prompt_text else f"# Workspace: {ws_name}\n", encoding="utf-8")
+            _clear_stat_cache()
+
+            # Auto-link to current topic if in one (skip Telegram general topic thread_id=1)
+            link_msg = ""
+            if platform and chat_id and thread_id and str(thread_id) != "1":
+                safe_id = _safe_dir_name(chat_id)
+                topic_dir = platforms_dir / platform / safe_id
+                topic_dir.mkdir(parents=True, exist_ok=True)
+                topics_file = topic_dir / "topics.yaml"
+                import yaml as _yaml
+                data = {}
+                if topics_file.exists():
+                    data = _yaml.safe_load(topics_file.read_text(encoding="utf-8")) or {}
+                topics = data.get("topics", {})
+                topics[str(thread_id)] = ws_name
+                data["topics"] = topics
+                if "workspace" not in data:
+                    data["workspace"] = "default"
+                topics_file.write_text(_yaml.safe_dump(data, default_flow_style=False), encoding="utf-8")
+                _clear_stat_cache()
+                link_msg = f"\n🔗 Auto-linked to {platform}/{chat_id} topic **{thread_id}**"
+            elif platform and chat_id and str(thread_id) == "1":
+                link_msg = f"\n⚠️  Skipped auto-link — you're in the **general topic** (thread 1).\nUse `/workspace link {platform} {chat_id} default {ws_name}` to set a channel default."
+
+            return f"✅ Created workspace **{ws_name}**{link_msg}\nEdit: `{system_file}`{model_hint}"
+
+        elif subcmd == "show":
+            # /workspace show <name>
+            ws_name = rest.strip()
+            if not ws_name:
+                # Show current resolved workspace
+                if platform and chat_id:
+                    result = resolve_workspace(platform, chat_id, thread_id or None)
+                    if result.prompt or result.skills or result.model:
+                        lines = ["📄 **Current workspace context:**\n"]
+                        if result.model:
+                            lines.append(f"**Model:** {result.model}")
+                        if result.prompt:
+                            lines.append(f"**Prompt:**\n```\n{result.prompt}\n```")
+                        if result.skills:
+                            lines.append(f"**Skills:** {', '.join(result.skills)}")
+                        return "\n".join(lines)
+                return "Usage: `/workspace show <name>` or use in a topic to see active workspace."
+
+            ws_dir = workspaces_dir / ws_name
+            if not ws_dir.exists():
+                return f"❌ Workspace `{ws_name}` not found."
+
+            lines = [f"📄 **Workspace: {ws_name}**\n"]
+            system_file = ws_dir / "SYSTEM.md"
+            if system_file.exists():
+                lines.append(f"**SYSTEM.md:**\n```\n{system_file.read_text(encoding='utf-8')}\n```")
+            skills_dir = ws_dir / "skills"
+            if skills_dir.exists():
+                skill_list = [d.name for d in skills_dir.iterdir() if d.is_dir()]
+                if skill_list:
+                    lines.append(f"**Skills:** {', '.join(skill_list)}")
+            return "\n".join(lines)
+
+        elif subcmd == "link":
+            # /workspace link <workspace>                          ← current topic
+            # /workspace link <thread_id> <workspace>               ← current chat, specific topic
+            # /workspace link <platform> <chat_id> <thread_id> <workspace>  ← full spec
+            # /workspace link <platform> <chat_id> default <workspace>      ← channel default
+            link_parts = rest.split()
+            if not link_parts:
+                return (
+                    "📁 **Link a workspace:**\n\n"
+                    "• `/workspace link <workspace>` — Link current topic\n"
+                    "• `/workspace link <thread_id> <workspace>` — Link a topic in this chat\n"
+                    "• `/workspace link <platform> <chat_id> <thread_id> <workspace>` — Full spec\n\n"
+                    "Example: `/workspace link news-feed` (from inside a topic)"
+                )
+
+            # Determine how many args to infer from current context
+            if len(link_parts) == 1:
+                # /workspace link <workspace> — use current context
+                if not platform or not chat_id:
+                    return "❌ Can't determine current chat. Use the full form: `/workspace link <platform> <chat_id> <thread_id> <workspace>`"
+                link_ws = link_parts[0]
+                if not thread_id:
+                    return f"❌ No topic/thread in current context for {platform}/{chat_id}. Use `/workspace link {platform} {chat_id} <thread_id> {link_ws}`"
+                # Telegram general topic has thread_id == 1 — not a real topic
+                if str(thread_id) == "1":
+                    return (
+                        f"❌ You're in the **general topic** (thread 1), which can't be linked like a regular topic.\n"
+                        f"Use channel default instead:\n"
+                        f"`/workspace link {platform} {chat_id} default {link_ws}`"
+                    )
+                link_platform, link_chat_id, link_thread_id = platform, chat_id, thread_id
+            elif len(link_parts) == 2:
+                # /workspace link <thread_id> <workspace> — current platform+chat
+                if not platform or not chat_id:
+                    return "❌ Can't determine current chat. Use the full form: `/workspace link <platform> <chat_id> <thread_id> <workspace>`"
+                link_thread_id, link_ws = link_parts
+                link_platform, link_chat_id = platform, chat_id
+            elif len(link_parts) >= 4:
+                # Full form: /workspace link <platform> <chat_id> <thread_id> <workspace>
+                link_platform, link_chat_id, link_thread_id, link_ws = link_parts[:4]
+            else:
+                # 3 args — ambiguous, could be <chat_id> <thread_id> <workspace>
+                # but also <platform> <chat_id> <workspace> (default). Prefer explicit.
+                return (
+                    "❌ Ambiguous args. Use one of:\n"
+                    "• `/workspace link <workspace>` — current topic\n"
+                    "• `/workspace link <thread_id> <workspace>` — this chat, specific topic\n"
+                    "• `/workspace link <platform> <chat_id> <thread_id> <workspace>` — full spec"
+                )
+
+            # Verify workspace exists
+            ws_dir = workspaces_dir / link_ws
+            if not ws_dir.exists():
+                return f"❌ Workspace `{link_ws}` not found. Create it first with `/workspace create {link_ws}`"
+
+            # Write/update topics.yaml
+            safe_id = _safe_dir_name(link_chat_id)
+            topic_dir = platforms_dir / link_platform / safe_id
+            topic_dir.mkdir(parents=True, exist_ok=True)
+            topics_file = topic_dir / "topics.yaml"
+
+            import yaml as _yaml
+            data = {}
+            if topics_file.exists():
+                data = _yaml.safe_load(topics_file.read_text(encoding="utf-8")) or {}
+            topics = data.get("topics", {})
+            if isinstance(topics, list):
+                # Convert list form to dict form
+                topics = {str(item.get("thread_id", "")): str(item.get("workspace", "")) for item in topics if isinstance(item, dict)}
+            topics[str(link_thread_id)] = link_ws
+            data["topics"] = topics
+            if "workspace" not in data:
+                data["workspace"] = "default"
+            topics_file.write_text(_yaml.safe_dump(data, default_flow_style=False), encoding="utf-8")
+            _clear_stat_cache()
+
+            if link_thread_id == "default":
+                return f"✅ Set **default workspace** for {link_platform}/{link_chat_id} → **{link_ws}**"
+            return f"✅ Linked {link_platform}/{link_chat_id} topic **{link_thread_id}** → **{link_ws}**"
+
+        elif subcmd == "model":
+            # /workspace model [name] [model_name] — set, show, or clear workspace model
+            # No ws name → auto-detect from current topic context
+            # No model_name → auto-detect current session model
+            if not rest:
+                # Try to resolve workspace from current context
+                if platform and chat_id:
+                    result = resolve_workspace(platform, chat_id, thread_id or None)
+                    if result.prompt is not None:
+                        # Find workspace name from topics.yaml
+                        ws_name = self._find_workspace_name_from_context(platform, chat_id, thread_id or None)
+                        if ws_name:
+                            rest = ws_name  # pretend user typed the workspace name
+                        else:
+                            return "❌ Can't determine workspace name from current topic. Use: `/workspace model <name>`"
+                    else:
+                        return "Usage: `/workspace model <workspace_name> [model_name]`\nOmit model to use current session model\nUse `clear` to remove: `/workspace model <name> clear`"
+                else:
+                    return "Usage: `/workspace model <workspace_name> [model_name]`\nOmit model to use current session model\nUse `clear` to remove: `/workspace model <name> clear`"
+
+            model_parts = rest.split(None, 1)
+            ws_name = model_parts[0]
+            second_arg = model_parts[1].strip() if len(model_parts) > 1 else ""
+
+            ws_dir = workspaces_dir / ws_name
+            if not ws_dir.exists():
+                # First arg isn't a workspace — maybe it's a model name for current workspace?
+                if platform and chat_id:
+                    current_ws = self._find_workspace_name_from_context(platform, chat_id, thread_id or None)
+                    if current_ws:
+                        # Treat the first arg as model name for the current workspace
+                        current_ws_dir = workspaces_dir / current_ws
+                        if current_ws_dir.exists():
+                            # Re-parse: ws_name=current_ws, model_value=original first arg
+                            second_arg = ws_name  # original first arg becomes the model
+                            ws_name = current_ws
+                            ws_dir = current_ws_dir
+                if not ws_dir.exists():
+                    return f"❌ Workspace `{ws_name}` not found. Create it first with `/workspace create {ws_name}`"
+
+            system_file = ws_dir / "SYSTEM.md"
+            import yaml as _yaml
+            if system_file.exists():
+                content = system_file.read_text(encoding="utf-8")
+                fm, body = _parse_frontmatter(content)
+            else:
+                fm, body = {}, ""
+
+            # Handle "clear"
+            if second_arg == "clear":
+                if "model" in fm:
+                    del fm["model"]
+                    _write_system_md(system_file, fm, body)
+                    _clear_stat_cache()
+                    return f"✅ Cleared model for workspace **{ws_name}**"
+                return f"No model set for **{ws_name}**."
+
+            # Handle "show" or no second arg → auto-detect current model
+            if second_arg in ("show", ""):
+                current = fm.get("model")
+                # Resolve the current session model
+                resolved_model = ""
+                try:
+                    resolved_model, _ = self._resolve_session_agent_runtime(
+                        source=source,
+                        session_key=self._session_key_for_source(source) if source else None,
+                        user_config=_load_gateway_config(),
+                    )
+                except Exception:
+                    pass
+                config_default = ""
+                try:
+                    config_default = _resolve_gateway_model(_load_gateway_config())
+                except Exception:
+                    pass
+
+                if second_arg == "" and not current:
+                    # Auto-set: use current session model
+                    if resolved_model:
+                        fm["model"] = resolved_model
+                        _write_system_md(system_file, fm, body)
+                        _clear_stat_cache()
+                        source_label = "current session" if resolved_model != config_default else "config default"
+                        return f"✅ Set model **{resolved_model}** for workspace **{ws_name}** ({source_label})"
+                    else:
+                        return f"❌ Couldn't determine current model. Set one explicitly:\n`/workspace model {ws_name} <model_name>`"
+
+                if second_arg == "show" or current:
+                    model_display = current or "(none)"
+                    session_info = f"\nSession model: **{resolved_model}**" if resolved_model else ""
+                    return f"Workspace **{ws_name}** model: **{model_display}**{session_info}\nUse `/workspace model {ws_name} <model>` to change, or `/workspace model {ws_name} clear` to remove."
+
+            # Normal case: second_arg is the model name
+            model_value = second_arg
+            fm["model"] = model_value
+            _write_system_md(system_file, fm, body)
+            _clear_stat_cache()
+            return f"✅ Set model **{model_value}** for workspace **{ws_name}**"
+
+        elif subcmd in ("remove", "unlink"):
+            # /workspace remove <name> — delete workspace
+            # /workspace unlink [platform chat_id] <thread_id> — unlink a topic
+            if subcmd == "unlink":
+                unlink_parts = rest.split()
+                if not unlink_parts:
+                    # /workspace unlink — use current context
+                    if not platform or not chat_id:
+                        return "❌ Can't determine current chat. Use `/workspace unlink <platform> <chat_id> <thread_id>`"
+                    if not thread_id:
+                        return f"❌ No topic/thread in current context. Use `/workspace unlink {platform} {chat_id} <thread_id>`"
+                    u_platform, u_chat_id, u_thread_id = platform, chat_id, thread_id
+                elif len(unlink_parts) == 1:
+                    # /workspace unlink <thread_id> — current chat
+                    if not platform or not chat_id:
+                        return "❌ Can't determine current chat. Use `/workspace unlink <platform> <chat_id> <thread_id>`"
+                    u_platform, u_chat_id = platform, chat_id
+                    u_thread_id = unlink_parts[0]
+                elif len(unlink_parts) >= 3:
+                    u_platform, u_chat_id, u_thread_id = unlink_parts[:3]
+                else:
+                    return (
+                        "❌ Ambiguous args. Use one of:\n"
+                        "• `/workspace unlink` — Unlink current topic\n"
+                        "• `/workspace unlink <thread_id>` — Unlink a topic in this chat\n"
+                        "• `/workspace unlink <platform> <chat_id> <thread_id>` — Full spec"
+                    )
+                safe_id = _safe_dir_name(u_chat_id)
+                topics_file = platforms_dir / u_platform / safe_id / "topics.yaml"
+                if not topics_file.exists():
+                    return f"❌ No topics.yaml found for {u_platform}/{u_chat_id}"
+                import yaml as _yaml
+                data = _yaml.safe_load(topics_file.read_text(encoding="utf-8")) or {}
+                topics = data.get("topics", {})
+                if str(u_thread_id) not in topics:
+                    return f"❌ Thread `{u_thread_id}` not linked in {u_platform}/{u_chat_id}"
+                del topics[str(u_thread_id)]
+                data["topics"] = topics
+                topics_file.write_text(_yaml.safe_dump(data, default_flow_style=False), encoding="utf-8")
+                _clear_stat_cache()
+                return f"✅ Unlinked thread **{u_thread_id}** from {u_platform}/{u_chat_id}"
+            else:
+                # /workspace remove <name>
+                ws_name = rest.strip()
+                if not ws_name:
+                    return "Usage: `/workspace remove <name>`"
+                ws_dir = workspaces_dir / ws_name
+                if not ws_dir.exists():
+                    return f"❌ Workspace `{ws_name}` not found."
+                import shutil
+                shutil.rmtree(ws_dir)
+                _clear_stat_cache()
+                return f"✅ Removed workspace **{ws_name}**\n⚠️ Any topic links pointing to it are now broken — use `/workspace unlink` to clean up."
+
+        else:
+            return (
+                "📁 **Workspace commands:**\n\n"
+                "• `/workspace` or `/workspace list` — List workspaces & current mapping\n"
+                "• `/workspace create <name> [prompt]` — Create a workspace (auto-links current topic)\n"
+                "• `/workspace show [name]` — Show workspace details (or current context)\n"
+                "• `/workspace model <name> [model]` — Set model (omit to use current session model)\n"
+                "• `/workspace model <name> show` — Show workspace model\n"
+                "• `/workspace model <name> clear` — Remove workspace model\n"
+                "• `/workspace link <workspace>` — Link current topic to a workspace\n"
+                "• `/workspace link <thread_id> <workspace>` — Link a topic in this chat\n"
+                "• `/workspace unlink` — Unlink current topic\n"
+                "• `/workspace unlink <thread_id>` — Unlink a topic in this chat\n"
+                "• `/workspace remove <name>` — Delete a workspace"
+            )
+
+    async def _handle_retry_command(self, event: MessageEvent) -> str:
+        """Handle /retry command - re-send the last user message."""
+        source = event.source
+        session_entry = self.session_store.get_or_create_session(source)
+        history = self.session_store.load_transcript(session_entry.session_id)
+        
+        # Find the last user message
+        last_user_msg = None
+        last_user_idx = None
+        for i in range(len(history) - 1, -1, -1):
+            if history[i].get("role") == "user":
+                last_user_msg = history[i].get("content", "")
+                last_user_idx = i
+                break
+        
+        if not last_user_msg:
+            return t("gateway.retry.no_previous")
+        
+        # Truncate history to before the last user message and persist
+        truncated = history[:last_user_idx]
+        self.session_store.rewrite_transcript(session_entry.session_id, truncated)
+        # Reset stored token count — transcript was truncated
+        session_entry.last_prompt_tokens = 0
+        
+        # Re-send by creating a fake text event with the old message
+        retry_event = MessageEvent(
+            text=last_user_msg,
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message=event.raw_message,
+            channel_prompt=event.channel_prompt,
+            workspace_model=getattr(event, 'workspace_model', None),
+        )
+        
+        # Let the normal message handler process it
+        return await self._handle_message(retry_event)
 
     # ────────────────────────────────────────────────────────────────
     # /goal — persistent cross-turn goals (Ralph-style loop)
@@ -9790,6 +10473,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return None, None
         max_turns = self._goal_max_turns_from_config()
         return GoalManager(session_id=sid, default_max_turns=max_turns), session_entry
+
+
 
 
 
@@ -13542,6 +14227,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
         channel_prompt: Optional[str] = None,
+        workspace_model: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -14366,6 +15052,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     session_key=session_key,
                     user_config=user_config,
                 )
+                # Workspace model override: takes effect when no /model session
+                # override is active.  On /new, session overrides are cleared,
+                # so workspace model kicks back in automatically.
+                if workspace_model:
+                    resolved_session_key = session_key
+                    if not resolved_session_key and source is not None:
+                        try:
+                            resolved_session_key = self._session_key_for_source(source)
+                        except Exception:
+                            resolved_session_key = None
+                    session_override = self._session_model_overrides.get(resolved_session_key) if resolved_session_key else None
+                    if not session_override:
+                        logger.info(
+                            "Workspace model override: session=%s config_model=%s -> workspace_model=%s",
+                            resolved_session_key or "", model, workspace_model,
+                        )
+                        model = workspace_model
+                    else:
+                        logger.debug(
+                            "Session /model override takes priority over workspace model: session=%s override=%s workspace=%s",
+                            resolved_session_key or "", session_override.get("model", "?"), workspace_model,
+                        )
                 logger.debug(
                     "run_agent resolved: model=%s provider=%s session=%s",
                     model, runtime_kwargs.get("provider"), session_key or "",
@@ -15905,6 +16613,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 next_message = pending
                 next_message_id = None
                 next_channel_prompt = None
+                next_workspace_model = None
                 if pending_event is not None:
                     next_source = getattr(pending_event, "source", None) or source
                     if self._is_goal_continuation_event(pending_event) and not self._goal_still_active_for_session(session_id):
@@ -15922,6 +16631,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         return result
                     next_message_id = self._reply_anchor_for_event(pending_event)
                     next_channel_prompt = getattr(pending_event, "channel_prompt", None)
+                    next_workspace_model = getattr(pending_event, "workspace_model", None)
 
                 # Restart typing indicator so the user sees activity while
                 # the follow-up turn runs.  The outer _process_message_background
@@ -15947,6 +16657,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _interrupt_depth=_interrupt_depth + 1,
                     event_message_id=next_message_id,
                     channel_prompt=next_channel_prompt,
+                    workspace_model=next_workspace_model,
                 )
                 return _preserve_queued_followup_history_offset(result, followup_result)
         finally:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -161,6 +161,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
                subcommands=("queue", "steer", "interrupt", "status")),
 
     # Tools & Skills
+    CommandDef("workspace", "Manage workspaces: create, link, model, list, show, or remove",
+               "Configuration", args_hint="[create|link|model|list|show|remove] [args]",
+               subcommands=("create", "link", "model", "list", "show", "remove", "unlink")),
     CommandDef("tools", "Manage tools: /tools [list|disable|enable] [name...]", "Tools & Skills",
                args_hint="[list|disable|enable] [name...]", cli_only=True),
     CommandDef("toolsets", "List available toolsets", "Tools & Skills",

--- a/tests/agent/test_workspace_resolver.py
+++ b/tests/agent/test_workspace_resolver.py
@@ -1,0 +1,330 @@
+"""Tests for the workspace_resolver module."""
+
+import os
+import tempfile
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from agent.workspace_resolver import (
+    WorkspaceResult,
+    _clear_stat_cache,
+    _resolve_workspace_content,
+    _resolve_workspace_name,
+    _safe_dir_name,
+    get_workspace_skill_dirs,
+    resolve_workspace,
+)
+from hermes_constants import get_hermes_home
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    _clear_stat_cache()
+    yield
+    _clear_stat_cache()
+
+
+@pytest.fixture
+def temp_hermes_home(tmp_path: Path):
+    """Provide a temporary hermes home with workspaces + platforms."""
+    # Save/restore real HERMES_HOME
+    original = os.environ.get("HERMES_HOME", "")
+    os.environ["HERMES_HOME"] = str(tmp_path)
+    yield tmp_path
+    if original:
+        os.environ["HERMES_HOME"] = original
+    else:
+        os.environ.pop("HERMES_HOME", None)
+
+
+# ── Safe dir name ──────────────────────────────────────────────────────────────
+
+class TestSafeDirName:
+    def test_leading_minus(self):
+        assert _safe_dir_name("-1003") == "_-1003"
+
+    def test_no_leading_minus(self):
+        assert _safe_dir_name("1003") == "1003"
+
+    def test_empty(self):
+        assert _safe_dir_name("") == ""
+
+    def test_special_chars(self):
+        assert _safe_dir_name("abc-123") == "abc-123"
+
+
+# ── topics.yaml resolution ────────────────────────────────────────────────────
+
+class TestResolveWorkspaceName:
+    def test_topic_match(self, temp_hermes_home: Path):
+        self._write_topics(temp_hermes_home, {
+            "topics": {
+                "7695": "news-feed",
+                "7696": "code-review",
+            },
+        })
+        result = _resolve_workspace_name(temp_hermes_home, "telegram", "-1003682109119", "7695")
+        assert result == "news-feed"
+
+    def test_unmapped_thread_no_fallback(self, temp_hermes_home: Path):
+        self._write_topics(temp_hermes_home, {
+            "topics": {
+                "7695": "news-feed",
+            },
+            "workspace": "default",
+        })
+        result = _resolve_workspace_name(
+            temp_hermes_home, "telegram", "-1003682109119", "7696"
+        )
+        # 7696 is not in topics, but "workspace" fallback exists
+        assert result == "default"
+
+    def test_no_mapping_file(self, temp_hermes_home: Path):
+        result = _resolve_workspace_name(temp_hermes_home, "telegram", "-1003682109119", "7695")
+        assert result is None
+
+    def test_list_form_topics(self, temp_hermes_home: Path):
+        file_path = (
+            temp_hermes_home / "platforms" / "telegram" / "123" / "topics.yaml"
+        )
+        file_path.parent.mkdir(parents=True)
+        file_path.write_text("""
+topics:
+  - thread_id: "7695"
+    workspace: news-feed
+  - thread_id: "7696"
+    workspace: code-review
+""", encoding="utf-8")
+        result = _resolve_workspace_name(temp_hermes_home, "telegram", "123", "7696")
+        assert result == "code-review"
+
+    def test_string_thread_id_vs_int(self, temp_hermes_home: Path):
+        """Thread IDs from Telegram come as strings; config may use quoted numbers."""
+        self._write_topics(temp_hermes_home, {
+            "topics": {
+                "7695": "news-feed",
+            }
+        })
+        # Pass int-like string
+        result = _resolve_workspace_name(
+            temp_hermes_home, "telegram", "-1003682109119", "7695"
+        )
+        assert result == "news-feed"
+
+    @staticmethod
+    def _write_topics(home: Path, data: dict):
+        file_path = (
+            home / "platforms" / "telegram" / "_-1003682109119" / "topics.yaml"
+        )
+        file_path.parent.mkdir(parents=True)
+        import yaml
+        file_path.write_text(yaml.safe_dump(data), encoding="utf-8")
+
+
+# ── SYSTEM.md resolution ────────────────────────────────────────────────────
+
+class TestResolveWorkspaceContent:
+    def test_prompt_with_skills(self, temp_hermes_home: Path):
+        self._write_system(
+            temp_hermes_home, "news-feed",
+            """---
+skills:
+  - telegram-summary-bot
+---
+Respond in Hebrew.
+""",
+        )
+        result = _resolve_workspace_content(temp_hermes_home, "news-feed")
+        assert result == WorkspaceResult(
+            prompt="Respond in Hebrew.",
+            skills=["telegram-summary-bot"],
+            model=None,
+        )
+
+    def test_single_skill_string(self, temp_hermes_home: Path):
+        self._write_system(
+            temp_hermes_home, "code-review",
+            """---
+skills: conventional-commits
+---
+Follow standards.
+""",
+        )
+        result = _resolve_workspace_content(temp_hermes_home, "code-review")
+        assert result == WorkspaceResult(
+            prompt="Follow standards.",
+            skills=["conventional-commits"],
+            model=None,
+        )
+
+    def test_no_frontmatter(self, temp_hermes_home: Path):
+        self._write_system(
+            temp_hermes_home, "general", "General discussion.\n"
+        )
+        result = _resolve_workspace_content(temp_hermes_home, "general")
+        assert result == WorkspaceResult(prompt="General discussion.", skills=None, model=None)
+
+    def test_empty_skills_list(self, temp_hermes_home: Path):
+        self._write_system(
+            temp_hermes_home, "empty-test",
+            """---
+skills: []
+---
+Just a prompt.
+""",
+        )
+        result = _resolve_workspace_content(temp_hermes_home, "empty-test")
+        assert result == WorkspaceResult(prompt="Just a prompt.", skills=None, model=None)
+
+    def test_no_system_file(self, temp_hermes_home: Path):
+        result = _resolve_workspace_content(temp_hermes_home, "nonexistent")
+        assert result == WorkspaceResult(None, None, None)
+
+    def test_model_from_frontmatter(self, temp_hermes_home: Path):
+        self._write_system(
+            temp_hermes_home, "custom-model",
+            """---
+skills:
+  - thinking-before-acting
+model: google/gemma-4-31b-it
+---
+Use step-by-step reasoning.
+""",
+        )
+        result = _resolve_workspace_content(temp_hermes_home, "custom-model")
+        assert result == WorkspaceResult(
+            prompt="Use step-by-step reasoning.",
+            skills=["thinking-before-acting"],
+            model="google/gemma-4-31b-it",
+        )
+
+    def test_model_only_frontmatter(self, temp_hermes_home: Path):
+        self._write_system(
+            temp_hermes_home, "model-only",
+            """---
+model: anthropic/claude-sonnet-4
+---
+Some prompt.
+""",
+        )
+        result = _resolve_workspace_content(temp_hermes_home, "model-only")
+        assert result.model == "anthropic/claude-sonnet-4"
+        assert result.prompt == "Some prompt."
+
+    @staticmethod
+    def _write_system(home: Path, name: str, content: str):
+        path = home / "workspaces" / name / "SYSTEM.md"
+        path.parent.mkdir(parents=True)
+        path.write_text(content, encoding="utf-8")
+
+
+# ── Full resolution ──────────────────────────────────────────────────────────
+
+class TestResolveWorkspace:
+    def test_end_to_end_topic_match(self, temp_hermes_home: Path):
+        self._write_full_workspace(temp_hermes_home, workspace="news-feed")
+        result = resolve_workspace("telegram", "-1003682109119", "7695")
+        assert result.prompt == "Hebrew news."
+        assert result.skills == ["telegram-summary-bot"]
+
+    def test_end_to_end_no_match(self, temp_hermes_home: Path):
+        # No topics.yaml
+        result = resolve_workspace("telegram", "-1003682109119", "7695")
+        assert result == WorkspaceResult(None, None, None)
+
+    def test_end_to_end_unknown_chat(self, temp_hermes_home: Path):
+        self._write_full_workspace(temp_hermes_home, workspace="news-feed")
+        result = resolve_workspace("telegram", "-999123", "7695")
+        assert result == WorkspaceResult(None, None, None)
+
+    @staticmethod
+    def _write_full_workspace(home: Path, workspace: str):
+        # topics.yaml
+        tp = home / "platforms" / "telegram" / "_-1003682109119" / "topics.yaml"
+        tp.parent.mkdir(parents=True)
+        import yaml
+        tp.write_text(
+            yaml.safe_dump({"topics": {"7695": workspace}}),
+            encoding="utf-8",
+        )
+        # SYSTEM.md
+        sp = home / "workspaces" / workspace / "SYSTEM.md"
+        sp.parent.mkdir(parents=True)
+        sp.write_text(
+            "---\nskills:\n  - telegram-summary-bot\n---\nHebrew news.",
+            encoding="utf-8",
+        )
+
+
+# ── Skill dirs ────────────────────────────────────────────────────────────────
+
+class TestGetWorkspaceSkillDirs:
+    def test_no_skill_dir(self, temp_hermes_home: Path):
+        # Create workspace but no skills/
+        tp = temp_hermes_home / "platforms" / "telegram" / "_-1003682109119" / "topics.yaml"
+        tp.parent.mkdir(parents=True)
+        import yaml
+        tp.write_text(
+            yaml.safe_dump({"topics": {"7695": "news-feed"}}),
+            encoding="utf-8",
+        )
+        sp = temp_hermes_home / "workspaces" / "news-feed" / "SYSTEM.md"
+        sp.parent.mkdir(parents=True)
+        sp.write_text("Prompt", encoding="utf-8")
+
+        result = get_workspace_skill_dirs("telegram", "-1003682109119", "7695")
+        assert result == []
+
+    def test_skill_dir_exists(self, temp_hermes_home: Path):
+        tp = temp_hermes_home / "platforms" / "telegram" / "_-1003682109119" / "topics.yaml"
+        tp.parent.mkdir(parents=True)
+        import yaml
+        tp.write_text(
+            yaml.safe_dump({"topics": {"7695": "news-feed"}}),
+            encoding="utf-8",
+        )
+        # Create skills/ dir
+        skills_dir = temp_hermes_home / "workspaces" / "news-feed" / "skills"
+        skills_dir.mkdir(parents=True)
+        # Drop a placeholder
+        (skills_dir / "my-skill").mkdir()
+        (skills_dir / "my-skill" / "SKILL.md").write_text("---\nname: my-skill\n---\n", encoding="utf-8")
+
+        result = get_workspace_skill_dirs("telegram", "-1003682109119", "7695")
+        assert len(result) == 1
+        assert result[0].name == "skills"
+
+
+# ── Stat cache behavior ───────────────────────────────────────────────────────
+
+class TestStatCache:
+    def test_cache_returns_same_content(self, temp_hermes_home: Path):
+        """Multiple reads within 1s should use cache."""
+        from agent.workspace_resolver import _stat_cached
+
+        path = temp_hermes_home / "test.txt"
+        path.write_text("v1", encoding="utf-8")
+        r1 = _stat_cached(path)
+        r2 = _stat_cached(path)
+        assert r1 is not None and r2 is not None
+        assert r1[1] == r2[1]  # same content string (cache hit)
+
+    def test_reads_new_content_after_ttl(self, temp_hermes_home: Path):
+        """After file change and ttl expiry, new content is read."""
+        import time
+        from agent.workspace_resolver import _stat_cached
+
+        path = temp_hermes_home / "test.txt"
+        path.write_text("old", encoding="utf-8")
+        r1 = _stat_cached(path)
+        assert r1 is not None and r1[1] == "old"
+
+        # Wait for cache bucket to expire (must cross integer second boundary)
+        time.sleep(1.1)
+        path.write_text("new", encoding="utf-8")
+        _clear_stat_cache()  # simulate passing time; in real use bucket naturally rolls
+        r2 = _stat_cached(path)
+        assert r2 is not None and r2[1] == "new"

--- a/tests/gateway/test_dm_topics.py
+++ b/tests/gateway/test_dm_topics.py
@@ -757,6 +757,148 @@ def test_group_topic_no_skill_binding():
     assert event.source.chat_topic == "General"
 
 
+# ── _build_message_event: topic prompt resolution ──
+
+
+def test_group_topic_prompt_binding():
+    """Group topic with prompt config should set channel_prompt on the event."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter(group_topics_config=[
+        {
+            "chat_id": -1003682109119,
+            "topics": [
+                {
+                    "name": "news feed",
+                    "thread_id": 7695,
+                    "prompt": "Respond in Hebrew. Focus on regional news.",
+                },
+            ],
+        }
+    ])
+
+    msg = _make_mock_message(
+        chat_id=-1003682109119, chat_type=_ChatType.SUPERGROUP, thread_id=7695, text="latest news",
+        is_topic_message=True,
+    )
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.channel_prompt == "Respond in Hebrew. Focus on regional news."
+    assert event.source.chat_topic == "news feed"
+
+
+def test_group_topic_prompt_with_skill():
+    """Group topic with both skill and prompt should set both on the event."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter(group_topics_config=[
+        {
+            "chat_id": -1001234567890,
+            "topics": [
+                {
+                    "name": "Engineering",
+                    "thread_id": 42,
+                    "skill": "software-development",
+                    "prompt": "Follow conventional-commits and thinking-before-acting.",
+                },
+            ],
+        }
+    ])
+
+    msg = _make_mock_message(
+        chat_id=-1001234567890, chat_type=_ChatType.SUPERGROUP, thread_id=42, text="refactor the api",
+        is_topic_message=True,
+    )
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.auto_skill == "software-development"
+    assert event.channel_prompt == "Follow conventional-commits and thinking-before-acting."
+    assert event.source.chat_topic == "Engineering"
+
+
+def test_group_topic_prompt_takes_priority_over_channel_prompts():
+    """Topic-level prompt should override channel_prompts dict for the same thread_id."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter(group_topics_config=[
+        {
+            "chat_id": -1001234567890,
+            "topics": [
+                {
+                    "name": "Engineering",
+                    "thread_id": 42,
+                    "prompt": "Topic-level prompt takes priority",
+                },
+            ],
+        }
+    ])
+    # Also set a channel_prompts entry for the same thread_id
+    adapter.config.extra["channel_prompts"] = {"42": "Channel-level prompt"}
+
+    msg = _make_mock_message(
+        chat_id=-1001234567890, chat_type=_ChatType.SUPERGROUP, thread_id=42, text="hello",
+        is_topic_message=True,
+    )
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    # Topic-level prompt should take priority
+    assert event.channel_prompt == "Topic-level prompt takes priority"
+
+
+def test_group_topic_no_prompt_falls_back_to_channel_prompts():
+    """When topic has no prompt, channel_prompts dict should still be used."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter(group_topics_config=[
+        {
+            "chat_id": -1001234567890,
+            "topics": [
+                {"name": "General", "thread_id": 42},
+            ],
+        }
+    ])
+    adapter.config.extra["channel_prompts"] = {"42": "Channel-level prompt fallback"}
+
+    msg = _make_mock_message(
+        chat_id=-1001234567890, chat_type=_ChatType.SUPERGROUP, thread_id=42, text="hello",
+        is_topic_message=True,
+    )
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    # Falls back to channel_prompts since topic has no prompt field
+    assert event.channel_prompt == "Channel-level prompt fallback"
+
+
+def test_dm_topic_prompt_binding():
+    """DM topic with prompt config should set channel_prompt on the event."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter(dm_topics_config=[
+        {
+            "chat_id": 12345,
+            "topics": [
+                {
+                    "name": "projects",
+                    "thread_id": 100,
+                    "skill": "project-tracker",
+                    "prompt": "Track project status and deadlines.",
+                },
+            ],
+        }
+    ])
+    adapter._dm_topics["12345:projects"] = 100
+
+    msg = _make_mock_message(
+        chat_id=12345, chat_type=_ChatType.PRIVATE, thread_id=100,
+        is_topic_message=True, text="status update"
+    )
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.auto_skill == "project-tracker"
+    assert event.channel_prompt == "Track project status and deadlines."
+    assert event.source.chat_topic == "projects"
+
+
 def test_group_topic_unmapped_thread_id():
     """Thread ID not in config should fall through — no skill, no topic name."""
     from gateway.platforms.base import MessageType


### PR DESCRIPTION
## Summary

Introduces a folder-based **workspace system** that lets users set persistent context per topic/thread that survives `/new` resets. Works across all platforms (Telegram, Discord, Slack, CLI, etc.).

## What it does

### `/workspace` slash command (gateway)
- **`/workspace create`** — interactive Telegram picker with:
  - Auto-suggested name from session context (title → topic → prompt → fallback)
  - Pre-filled prompt from current workspace/channel prompt
  - Model toggle (auto-checked when session model differs from config default)
  - Text-capture for custom name/prompt editing
  - Non-interactive `create <name> <prompt>` path preserved for batch/script usage
- **`/workspace list`** — show all workspaces with flags (prompt, model, skills count) + current topic mapping
- **`/workspace show <name>`** — display workspace SYSTEM.md content
- **`/workspace link/unlink`** — map topics to workspaces (channel default + per-topic)
- **`/workspace model <name> [model]`** — set/clear a default model per workspace
- **`/workspace remove`** — delete a workspace with cleanup
- **`/workspace` (no args)** — context-aware: shows list + active workspace resolving from current topic

### CLI parity
`cli.py` gets matching `/workspace list, create, show, link, unlink, remove` commands for local terminal use.

### Model priority & display
- `/model` session override > workspace model > config default
- Workspace model survives `/new` (ephemeral, not stored in session state)
- `/new` reset header now shows the effective model (workspace override when active)
- `workspace_model` field added to `MessageEvent` for agent runtime injection

### Workspace-local skills
- `agent/skill_utils.py` discovers `workspaces/<name>/skills/` directories and injects them into the agent skill resolution chain
- No restart needed — stat-based 1s cache picks up changes automatically

## Architecture

- **Folder-based** — `~/.hermes/workspaces/<name>/SYSTEM.md` with YAML frontmatter (`model:`, `skills:`, `prompt:` is the body)
- **Cross-platform** — `~/.hermes/platforms/<platform>/<chat>/topics.yaml` maps topics → workspace names
- **Stat-based resolution** — per-message, no restart, 1-second mtime cache
- **Legacy compatible** — existing config-based topic prompts preserved as fallback

## Files changed

| File | Changes |
|------|---------|
| `agent/workspace_resolver.py` | New — core resolver, frontmatter parsing, stat cache |
| `agent/skill_utils.py` | Workspace-local skill directory discovery |
| `gateway/run.py` | `/workspace` command handler, interactive picker, model priority |
| `gateway/platforms/telegram.py` | Interactive creation picker (inline keyboard + text capture) |
| `gateway/platforms/base.py` | `workspace_model` field on `MessageEvent` |
| `gateway/config.py` | Bridges workspace config for legacy fallback |
| `cli.py` | CLI `/workspace` command handler |
| `hermes_cli/commands.py` | Workspace `CommandDef` |
| `tests/agent/test_workspace_resolver.py` | New — 61 tests for resolver, cache, frontmatter parsing |
| `tests/gateway/test_dm_topics.py` | Workspace + DM topic integration tests |

## Testing

- 61 workspace resolver tests — all pass
- 5519 gateway tests — all pass (1 pre-existing unrelated failure in process management)
- Manually tested interactive picker flow on Telegram (creation, model toggle, name/prompt editing, cancel)