### PR TITLE
feat(gateway): make background review notifications configurable

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -940,6 +940,15 @@ display:
   #   false: Only send the final response
   interim_assistant_messages: true
 
+  # Gateway-only background review notifications.
+  # Controls user-facing post-turn notices such as memory/skill update summaries.
+  # This does not disable background review itself; it only suppresses the extra
+  # chat notification. Per-platform override:
+  # display.platforms.slack.background_review_notifications
+  #   true:  Send background review notifications after the main response (default)
+  #   false: Suppress those notification messages
+  background_review_notifications: true
+
   # What Enter does when Hermes is already busy (CLI and gateway platforms).
   #   interrupt: Interrupt the current run and redirect Hermes (default)
   #   queue:     Queue your message for the next turn

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -35,6 +35,10 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     "show_reasoning": False,
     "tool_preview_length": 0,
     "streaming": None,  # None = follow top-level streaming config
+    # User-facing summaries from background review, such as memory/skill update
+    # notices delivered after the main response. This controls notification
+    # delivery only; it does not disable the background review itself.
+    "background_review_notifications": True,
     # When true, delete tool-progress / "Still working..." / status bubbles
     # after the final response lands on platforms that support message
     # deletion (e.g. Telegram). Off by default — progress is still shown
@@ -190,7 +194,7 @@ def _normalise(setting: str, value: Any) -> Any:
         if value is True:
             return "all"
         return str(value).lower()
-    if setting in {"show_reasoning", "streaming"}:
+    if setting in {"show_reasoning", "streaming", "background_review_notifications"}:
         if isinstance(value, str):
             return value.lower() in {"true", "1", "yes", "on"}
         return bool(value)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16330,6 +16330,15 @@ class GatewayRunner:
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides") or {}
 
+            _background_review_notifications_enabled = bool(
+                resolve_display_setting(
+                    user_config,
+                    platform_key,
+                    "background_review_notifications",
+                    True,
+                )
+            )
+
             _bg_review_release = threading.Event()
             _bg_review_pending: list[str] = []
             _bg_review_pending_lock = threading.Lock()
@@ -16367,10 +16376,12 @@ class GatewayRunner:
                             return
                 _deliver_bg_review_message(message)
 
-            agent.background_review_callback = _bg_review_send
+            agent.background_review_callback = (
+                _bg_review_send if _background_review_notifications_enabled else None
+            )
             # Register the release hook on the adapter so base.py's finally
             # block can fire it after delivering the main response.
-            if _status_adapter and session_key:
+            if _background_review_notifications_enabled and _status_adapter and session_key:
                 if getattr(type(_status_adapter), "register_post_delivery_callback", None) is not None:
                     _status_adapter.register_post_delivery_callback(
                         session_key,

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -171,6 +171,22 @@ class TestYAMLNormalisation:
         config = {"display": {"platforms": {"slack": {"tool_progress": False}}}}
         assert resolve_display_setting(config, "slack", "tool_progress") == "off"
 
+    @pytest.mark.parametrize("raw", [False, "false", "off", "no", "0"])
+    def test_background_review_notifications_false_values(self, raw):
+        """Background review notification toggles use boolean normalisation."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {"display": {"background_review_notifications": raw}}
+        assert resolve_display_setting(config, "telegram", "background_review_notifications") is False
+
+    @pytest.mark.parametrize("raw", [True, "true", "on", "yes", "1"])
+    def test_background_review_notifications_true_values(self, raw):
+        """Background review notification toggles accept common true values."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {"display": {"background_review_notifications": raw}}
+        assert resolve_display_setting(config, "telegram", "background_review_notifications") is True
+
 
 # ---------------------------------------------------------------------------
 # Built-in platform defaults (tier system)
@@ -228,6 +244,29 @@ class TestPlatformDefaults:
         from gateway.display_config import resolve_display_setting
 
         assert resolve_display_setting({}, "telegram", "streaming") is None
+
+    def test_background_review_notifications_default_enabled(self):
+        """Background review notifications remain enabled unless configured off."""
+        from gateway.display_config import resolve_display_setting
+
+        assert resolve_display_setting({}, "telegram", "background_review_notifications") is True
+        assert resolve_display_setting({}, "slack", "background_review_notifications") is True
+
+    def test_background_review_notifications_platform_override(self):
+        """A platform override can disable only that platform's notifications."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "background_review_notifications": True,
+                "platforms": {
+                    "slack": {"background_review_notifications": False},
+                },
+            }
+        }
+
+        assert resolve_display_setting(config, "slack", "background_review_notifications") is False
+        assert resolve_display_setting(config, "telegram", "background_review_notifications") is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -972,6 +972,49 @@ async def test_run_agent_defers_background_review_notification_until_release(mon
 
     assert result["final_response"] == "done"
     assert adapter.sent == []
+    assert adapter._post_delivery_callbacks
+
+
+@pytest.mark.asyncio
+async def test_run_agent_can_suppress_background_review_notifications(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        BackgroundReviewAgent,
+        session_id="sess-bg-review-suppressed",
+        config_data={
+            "display": {
+                "background_review_notifications": False,
+                "interim_assistant_messages": True,
+            }
+        },
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.sent == []
+    assert adapter._post_delivery_callbacks == {}
+
+
+@pytest.mark.asyncio
+async def test_run_agent_platform_override_suppresses_background_review_notifications(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        BackgroundReviewAgent,
+        session_id="sess-bg-review-platform-suppressed",
+        config_data={
+            "display": {
+                "background_review_notifications": True,
+                "platforms": {
+                    "telegram": {"background_review_notifications": False},
+                },
+            }
+        },
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.sent == []
+    assert adapter._post_delivery_callbacks == {}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Adds `display.background_review_notifications` as a gateway display setting.
- Supports existing `display.platforms.<platform>.background_review_notifications` overrides.
- Suppresses only user-facing post-turn background review notification delivery when disabled.
- Leaves background review execution unchanged.
- Documents the setting in `cli-config.yaml.example`.

## Related issue

Fixes #30970. Related context: #18073, #4684, #20533, #20559.

## Type of change

- [x] Bug fix / behaviour control
- [x] Configuration
- [x] Tests
- [x] Documentation

## Changes

- `gateway/display_config.py`
  - Adds `background_review_notifications` defaulting to `true`.
  - Adds boolean normalisation for YAML/string values.
- `gateway/run.py`
  - Resolves the display setting per turn.
  - Sets `agent.background_review_callback` to `None` when disabled.
  - Avoids registering post-delivery callback machinery when disabled.
- `tests/gateway/test_display_config.py`
  - Adds resolver/default/normalisation/platform override coverage.
- `tests/gateway/test_run_progress_topics.py`
  - Adds runtime coverage for enabled vs disabled callback registration.
- `cli-config.yaml.example`
  - Documents the new setting and per-platform override shape.

## Test plan

```bash
python -m pytest tests/gateway/test_display_config.py tests/gateway/test_run_progress_topics.py -q -o 'addopts='
python -m py_compile gateway/display_config.py gateway/run.py
```

Both pass locally.

## Notes for reviewers

This PR deliberately does not add per-channel or chat-type display overrides. Those are related but broader design topics tracked separately in #20533 / #20559. This change is intentionally limited to controlling whether background review summaries are emitted as gateway messages.
