### PR TITLE
[security] fix(file-safety): deny reads of Google OAuth tokens

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -145,11 +145,11 @@ def get_read_block_error(path: str) -> Optional[str]:
         carrier.
       * Credential / secret stores under HERMES_HOME and the global Hermes
         root: ``auth.json``, ``auth.lock``, ``.anthropic_oauth.json``,
-        ``.env``, ``webhook_subscriptions.json``, and anything under
-        ``mcp-tokens/``. These hold plaintext provider keys, OAuth tokens,
-        and HMAC secrets that the agent never needs to read directly —
-        provider tools / gateway adapters consume them through internal
-        channels.
+        ``.env``, ``webhook_subscriptions.json``, ``auth/google_oauth.json``,
+        and anything under ``mcp-tokens/``. These hold plaintext provider keys,
+        OAuth tokens, and HMAC secrets that the agent never needs to read
+        directly — provider tools / gateway adapters consume them through
+        internal channels.
 
     **This is NOT a security boundary.** The terminal tool runs as the
     same OS user with shell access; the agent can still ``cat auth.json``
@@ -214,6 +214,7 @@ def get_read_block_error(path: str) -> Optional[str]:
         ".anthropic_oauth.json",
         ".env",
         "webhook_subscriptions.json",
+        os.path.join("auth", "google_oauth.json"),
     )
     for hd in hermes_dirs:
         for name in credential_file_names:

--- a/tests/agent/test_file_safety_credentials.py
+++ b/tests/agent/test_file_safety_credentials.py
@@ -66,6 +66,16 @@ def test_anthropic_oauth_json_blocked(fake_home):
     assert "credential store" in err
 
 
+def test_google_oauth_json_blocked(fake_home):
+    """Gemini OAuth tokens live under auth/google_oauth.json — blocked."""
+    from agent.file_safety import get_read_block_error
+
+    oauth = _create(fake_home, Path("auth") / "google_oauth.json")
+    err = get_read_block_error(str(oauth))
+    assert err is not None
+    assert "credential store" in err
+
+
 def test_arbitrary_hermes_home_file_not_blocked(fake_home):
     """Non-credential files inside HERMES_HOME stay readable."""
     from agent.file_safety import get_read_block_error
@@ -149,6 +159,37 @@ def test_read_file_tool_blocks_relative_path_under_terminal_cwd(
     assert "credential store" in out["error"]
 
 
+def test_read_file_tool_blocks_nested_google_oauth_path(
+    fake_home, tmp_path, monkeypatch
+):
+    """The real read_file tool must not return Gemini OAuth token material."""
+    import json
+
+    import tools.file_tools as ft
+
+    oauth = _create(fake_home, Path("auth") / "google_oauth.json")
+    oauth.write_text(
+        json.dumps(
+            {
+                "refresh": "REFRESH_TOKEN_MARKER",
+                "access": "ACCESS_TOKEN_MARKER",
+                "email": "user@example.com",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        ft, "_get_live_tracking_cwd", lambda task_id="default": None
+    )
+
+    out = json.loads(ft.read_file_tool(str(oauth), task_id="google-oauth-test"))
+    assert "error" in out
+    assert "credential store" in out["error"]
+    assert "REFRESH_TOKEN_MARKER" not in json.dumps(out)
+    assert "ACCESS_TOKEN_MARKER" not in json.dumps(out)
+
+
 # ---------------------------------------------------------------------------
 # Widening: .env, webhook_subscriptions.json, mcp-tokens/
 # ---------------------------------------------------------------------------
@@ -222,11 +263,24 @@ def test_identically_named_files_outside_hermes_home_not_blocked(
             f"{rel} outside HERMES_HOME should NOT be blocked"
         )
 
+    google_oauth = project / "auth" / "google_oauth.json"
+    google_oauth.parent.mkdir()
+    google_oauth.write_text("not really a token", encoding="utf-8")
+    assert get_read_block_error(str(google_oauth)) is None
+
     tokens = project / "mcp-tokens"
     tokens.mkdir()
     tok_file = tokens / "token.json"
     tok_file.write_text("not really a token", encoding="utf-8")
     assert get_read_block_error(str(tok_file)) is None
+
+
+def test_non_secret_auth_subtree_file_not_blocked(fake_home):
+    """Only the known Google OAuth token path is blocked, not all auth/*."""
+    from agent.file_safety import get_read_block_error
+
+    note = _create(fake_home, Path("auth") / "notes.json")
+    assert get_read_block_error(str(note)) is None
 
 
 def test_config_yaml_not_blocked(fake_home):
@@ -267,6 +321,14 @@ def test_profile_mode_blocks_root_credentials(tmp_path, monkeypatch):
     root_env = root / ".env"
     root_env.write_text("x")
     assert "credential store" in (get_read_block_error(str(root_env)) or "")
+
+    # Root-level Google OAuth token store: blocked too
+    root_google_oauth = root / "auth" / "google_oauth.json"
+    root_google_oauth.parent.mkdir(parents=True, exist_ok=True)
+    root_google_oauth.write_text("x")
+    assert "credential store" in (
+        get_read_block_error(str(root_google_oauth)) or ""
+    )
 
     # Root-level mcp-tokens: blocked
     root_tok = root / "mcp-tokens" / "gh.json"


### PR DESCRIPTION
## Summary

This PR extends Hermes' credential-store read-deny list to cover the Gemini Google OAuth token file at `auth/google_oauth.json` under both the active `HERMES_HOME` and the global Hermes root.

Hermes already blocks direct `read_file` access to several credential stores (`auth.json`, `.env`, `.anthropic_oauth.json`, `webhook_subscriptions.json`, and `mcp-tokens/`). The Gemini OAuth flow stores refresh/access token material in `~/.hermes/auth/google_oauth.json`, but that nested token file was not included in the deny list.

## Security issues covered

| Issue | Impact | Severity |
| --- | --- | --- |
| `read_file` could read `auth/google_oauth.json` directly | Prompt/tool flows that reach `read_file` could retrieve Gemini OAuth refresh/access token material despite the credential-store deny policy | Low / defense-in-depth |

## Before this PR

- `agent/google_oauth.py` documented token storage at `~/.hermes/auth/google_oauth.json`.
- `agent/file_safety.py::get_read_block_error()` blocked several top-level credential stores and the `mcp-tokens/` subtree.
- `auth/google_oauth.json` was not recognized as a credential store.
- `tools.file_tools.read_file_tool()` could therefore return the nested Google OAuth token file content.

## After this PR

- `auth/google_oauth.json` is treated as a Hermes credential store under both:
  - the active `HERMES_HOME`; and
  - the global Hermes root used by profiles.
- `read_file` returns a credential-store denial instead of file content for that path.
- Unrelated project-local `auth/google_oauth.json` files outside Hermes state remain readable.
- Other files under `HERMES_HOME/auth/` are not blocked unless explicitly listed.

## Why this matters

The Google OAuth token file can contain refresh/access token material for Gemini provider authentication. Provider code consumes this credential store through internal channels; the agent's file-reading tool does not need direct access to it.

This patch keeps the existing credential-store hardening internally consistent and reduces the chance that indirect prompt injection or mistaken tool use exposes OAuth token material through `read_file`.

## How this differs from #30721

This PR is a narrow follow-up to the same defense-in-depth family as #30721.

#30721 added read-deny coverage for several credential stores, including `auth.json`, `.anthropic_oauth.json`, `.env`, `webhook_subscriptions.json`, and `mcp-tokens/`. It did not include the nested Gemini OAuth token file at `auth/google_oauth.json`.

This PR does not replace #30721 and does not change its threat-model framing. It only covers the omitted nested Google OAuth store.

## Attack flow

```text
Prompt/tool flow reaches read_file
  -> requests ~/.hermes/auth/google_oauth.json
  -> file_safety did not classify that nested path as a credential store
  -> read_file returned refresh/access token content
```

## Affected code

- `agent/file_safety.py`
  - `get_read_block_error()` credential-store deny list
- `tools/file_tools.py`
  - `read_file_tool()` already calls `get_read_block_error()` before reading
- `agent/google_oauth.py`
  - documents the token storage path and token fields

## Root cause

The credential read-deny list covered top-level Hermes credential files and `mcp-tokens/`, but omitted a credential-bearing nested OAuth store introduced under `auth/google_oauth.json`.

## CVSS assessment

- Issue: direct `read_file` access to Gemini OAuth token store
- CVSS v3.1: 3.1 Low
- Vector: `CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N`

Rationale: this is a local/tool-mediated defense-in-depth hardening gap, not a standalone remote exploit. The terminal tool remains a same-user bypass as documented by the existing read-deny policy. The practical risk is limited to flows where `read_file` is reachable and a model/tool policy expects credential-store reads to be denied.

## Safe reproduction steps

On a vulnerable checkout:

```bash
python3.11 - <<'PY'
import os, tempfile, json
from pathlib import Path
home = Path(tempfile.mkdtemp(prefix='hermes-google-oauth-read-poc-'))
os.environ['HERMES_HOME'] = str(home)
from tools.file_tools import read_file_tool
from agent.file_safety import get_read_block_error
secret_file = home / 'auth' / 'google_oauth.json'
secret_file.parent.mkdir(parents=True)
secret_file.write_text(json.dumps({
    'refresh': 'REFRESH_TOKEN_SECRET|project|managed',
    'access': 'ACCESS_TOKEN_SECRET',
    'email': 'victim@example.com',
}), encoding='utf-8')
print('block_error', get_read_block_error(str(secret_file)))
res = json.loads(read_file_tool(str(secret_file), task_id='poc-google-oauth'))
print('read_error', res.get('error'))
print('read_contains_refresh', 'REFRESH_TOKEN_SECRET' in res.get('content', ''))
print('read_contains_access', 'ACCESS_TOKEN_SECRET' in res.get('content', ''))
PY
```

## Expected vulnerable behavior

Before this PR, the vulnerable signal was:

```text
block_error None
read_error None
read_contains_refresh True
read_contains_access True
```

After this PR, the same path is denied and token markers are not returned.

## Changes in this PR

- Adds `auth/google_oauth.json` to the credential-store read-deny list.
- Updates the file-safety docstring to include the nested Google OAuth store.
- Adds tests for:
  - direct `get_read_block_error()` denial of `auth/google_oauth.json`;
  - the real `read_file_tool()` path not returning token marker content;
  - profile/global-root coverage;
  - unrelated project-local `auth/google_oauth.json` staying readable;
  - unrelated `HERMES_HOME/auth/*.json` files staying readable.

## Files changed

| File | What changed |
| --- | --- |
| `agent/file_safety.py` | Adds `auth/google_oauth.json` to credential-store read denial |
| `tests/agent/test_file_safety_credentials.py` | Adds positive and negative regression coverage for the nested token path |

## Maintainer impact

This is intentionally narrow. It does not block the entire `auth/` subtree, and it does not change write policy or terminal behavior. It only prevents direct `read_file` reads of the known Google OAuth credential file.

## Fix rationale

The existing policy already treats credential stores as internal implementation details consumed through provider/gateway code. `auth/google_oauth.json` has the same sensitivity profile as the already-denied OAuth/token stores, so it should be covered by the same file-safety check.

## Type of change

- [x] Security hardening
- [x] Bug fix
- [x] Tests
- [ ] Documentation-only change
- [ ] Breaking change

## Test plan

Commands run locally:

```bash
scripts/run_tests.sh tests/agent/test_file_safety_credentials.py
python3.11 -m compileall -q agent/file_safety.py tests/agent/test_file_safety_credentials.py
git diff --check
.venv/bin/ruff check agent/file_safety.py tests/agent/test_file_safety_credentials.py
```

Result:

```text
20 tests passed
All checks passed!
```

I also ran a safe post-fix proof harness with marker token values. The fixed behavior was:

```text
block_error_present True
read_error_present True
content_returned False
error_has_credential_store True
secret_leaked False
cleanup_exists False
```

## Disclosure notes

This PR is framed as defense-in-depth. It does not claim to create a hard same-user filesystem security boundary, because terminal/shell access can still read same-user files. It makes the existing `read_file` credential-store deny policy cover the Gemini Google OAuth token store consistently.
