### PR TITLE
feat(kanban): opt-in HERMES_KANBAN_SYNCHRONOUS_MODE for synchronous=FULL durability hardening

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1181,7 +1181,36 @@ def connect(
             # See hermes_state._WAL_INCOMPAT_MARKERS for detection logic.
             from hermes_state import apply_wal_with_fallback
             apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
-            conn.execute("PRAGMA synchronous=NORMAL")
+            # Durability mode. Default `normal` preserves prior behavior
+            # (synchronous=NORMAL — COMMIT returns before WAL frames are
+            # durably on disk; fast, sufficient for single-writer setups).
+            #
+            # `full` enables synchronous=FULL + tighter wal_autocheckpoint
+            # for heartbeat-heavy concurrent-writer workloads (e.g. a
+            # dispatcher process + worker subprocesses both writing event
+            # rows and status updates). With NORMAL, those workloads can
+            # hit a "database disk image is malformed" race where the WAL
+            # header ends up inconsistent with main DB pages. FULL forces
+            # fsync() after every commit — slower writes but durable.
+            # The kanban workload is dispatch-bounded, not write-bounded,
+            # so the perf cost is bounded.
+            #
+            # wal_autocheckpoint=100 (vs default 1000) keeps the WAL small
+            # so the durability window stays short. Heartbeat-heavy review
+            # workloads (50+ events in 5 minutes) can otherwise grow the
+            # WAL to many MB before checkpoint, widening the window where
+            # a worker crash can leave the WAL irreparable.
+            #
+            # Opt in via env var so simpler deployments are not penalized.
+            # See issue #30896 for the repro pattern.
+            sync_mode = os.environ.get(
+                "HERMES_KANBAN_SYNCHRONOUS_MODE", "normal"
+            ).strip().lower()
+            if sync_mode == "full":
+                conn.execute("PRAGMA synchronous=FULL")
+                conn.execute("PRAGMA wal_autocheckpoint=100")
+            else:
+                conn.execute("PRAGMA synchronous=NORMAL")
             conn.execute("PRAGMA foreign_keys=ON")
             needs_init = resolved not in _INITIALIZED_PATHS
             if needs_init:


### PR DESCRIPTION
## Summary

Adds an opt-in env-var (`HERMES_KANBAN_SYNCHRONOUS_MODE=full`) that switches the kanban DB to `PRAGMA synchronous=FULL` + `PRAGMA wal_autocheckpoint=100` for deployments that hit the WAL/main-DB consistency race documented in #30896. **Default behavior unchanged** — when the env var is unset or set to anything other than `"full"`, the prior `synchronous=NORMAL` behavior is preserved.

## Why opt-in vs default-change (v2 of this PR)

The v1 of this PR changed the default for all deployments. @jsboige's review on the v1 thread suggested making it a config flag instead — that's exactly right for an upstream merge. Simpler single-writer deployments (the common case) shouldn't pay the fsync cost for a race they'll never hit. Operators who DO hit the race (heartbeat-heavy concurrent-writer workloads — multi-process dispatcher + worker subprocesses writing 50+ events in 5 minutes against the same DB) can opt in with one env var.

## What the env var does

```python
sync_mode = os.environ.get("HERMES_KANBAN_SYNCHRONOUS_MODE", "normal").strip().lower()
if sync_mode == "full":
    conn.execute("PRAGMA synchronous=FULL")
    conn.execute("PRAGMA wal_autocheckpoint=100")
else:
    conn.execute("PRAGMA synchronous=NORMAL")
```

- `HERMES_KANBAN_SYNCHRONOUS_MODE=full` → `synchronous=FULL` + `wal_autocheckpoint=100` (durable, slower)
- anything else or unset → `synchronous=NORMAL` (current behavior, fast)

## Why these two PRAGMAs

**`synchronous=FULL`**: with `NORMAL`, COMMIT returns before WAL frames are durably on disk. Under a multi-process workload where dispatcher + workers both write rows, a SIGKILL or power-loss-like race mid-WAL-write can leave the WAL header inconsistent with main DB pages — producing "database disk image is malformed" on subsequent reads. `FULL` forces fsync() after every commit. The perf cost is bounded because the kanban workload is dispatch-bounded, not write-bounded.

**`wal_autocheckpoint=100`** (down from default 1000): keeps the WAL small so the durability window stays short. Heartbeat-heavy review workloads can otherwise grow the WAL to many MB before checkpoint, widening the window where a worker crash can leave the WAL irreparable.

## Known limitation (filed at #31618)

Even with `synchronous=FULL`, corruption can still recur under SIGKILL-on-reclaim mid-WAL-write (cgroup memory pressure killing a worker between fsync calls). The fix-class in #30969 (leases + corruption detection) is the comprehensive answer for that failure mode. This PR closes the easier-to-hit POSIX-fsync race; the harder cgroup-SIGKILL race needs leases.

## Backwards compatibility

100%. Default behavior identical to current code. No schema changes, no migration, no startup cost change for the common case. Single new env-var check on `connect()`.

## Test plan

- Unit test the env-var parsing: unset → NORMAL, "full" → FULL+autocheckpoint, "normal" → NORMAL, "FULL" (uppercase) → FULL (case-insensitive), unknown value → NORMAL (safe default).
- Integration: run the repro from #30896 once with `HERMES_KANBAN_SYNCHRONOUS_MODE=full` (expect: no corruption); once without (expect: corruption reproduces, matching current behavior).

## Validation

Tested in production for 11 days with the v1 (default-change) shape. Confirmed the WAL-consistency race no longer fires under heartbeat-heavy load. Confirmed via #31618 that the harder SIGKILL-mid-fsync class still happens — but that's #30969's domain, not this PR's.

## Related

- Repro / root cause: #30896
- Insufficient-fix datapoint: #31618
- Comprehensive alternative: #30969
- Superseded v1 reviewer note: @jsboige's comment recommending the config-flag shape adopted here.