### PR TITLE
feat(browser): add cloud-to-cloud runtime fallback

### DIFF
--- a/tests/tools/test_browser_cloud_fallback.py
+++ b/tests/tools/test_browser_cloud_fallback.py
@@ -23,6 +23,34 @@ def _reset_session_state(monkeypatch):
 class TestCloudProviderRuntimeFallback:
     """Tests for _get_session_info cloud → local fallback."""
 
+    def test_cloud_failure_tries_configured_cloud_fallback_before_local(self, monkeypatch):
+        """When primary cloud provider fails, try configured secondary cloud before local."""
+        _reset_session_state(monkeypatch)
+
+        primary = Mock(name="browser-use")
+        primary.name = "browser-use"
+        primary.create_session.side_effect = RuntimeError("browser-use quota")
+        secondary = Mock(name="browserbase")
+        secondary.name = "browserbase"
+        secondary.create_session.return_value = {
+            "session_name": "browserbase-sess",
+            "bb_session_id": "bb_456",
+            "cdp_url": None,
+            "features": {"browserbase": True},
+        }
+        monkeypatch.setattr(browser_tool, "_get_cloud_provider", lambda: primary)
+        monkeypatch.setattr(browser_tool, "_get_runtime_cloud_fallback_providers", lambda _primary: [secondary])
+        monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: None)
+
+        session = browser_tool._get_session_info("task-cloud-chain")
+
+        assert session["session_name"] == "browserbase-sess"
+        assert session["fallback_from_cloud"] is True
+        assert session["fallback_provider"] == "browser-use"
+        assert session["fallback_to_provider"] == "browserbase"
+        primary.create_session.assert_called_once()
+        secondary.create_session.assert_called_once()
+
     def test_cloud_failure_falls_back_to_local(self, monkeypatch):
         """When cloud provider.create_session raises, fall back to local."""
         _reset_session_state(monkeypatch)

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -486,6 +486,86 @@ def _ensure_browser_plugins_loaded() -> None:
         logger.debug("Browser plugin discovery failed (non-fatal): %s", exc)
 
 
+def _browser_fallback_enabled() -> bool:
+    """Return whether cloud-browser provider-to-provider fallback is enabled."""
+    try:
+        from hermes_cli.config import read_raw_config
+        cfg = read_raw_config()
+        browser_cfg = cfg.get("browser", {}) if isinstance(cfg, dict) else {}
+        value = browser_cfg.get("fallback_enabled", False) if isinstance(browser_cfg, dict) else False
+    except Exception:
+        value = False
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _browser_provider_label(provider: Any) -> str:
+    """Return a stable provider label for fallback metadata/logging."""
+    name = getattr(provider, "name", None)
+    if isinstance(name, str) and name.strip():
+        return name.strip()
+    try:
+        display = provider.provider_name()
+        if isinstance(display, str) and display.strip():
+            return display.strip()
+    except Exception:
+        pass
+    return type(provider).__name__
+
+
+def _configured_browser_fallback_provider_names(primary_name: str) -> list[str]:
+    """Return configured browser cloud fallback names, primary excluded."""
+    try:
+        from hermes_cli.config import read_raw_config
+        cfg = read_raw_config()
+        browser_cfg = cfg.get("browser", {}) if isinstance(cfg, dict) else {}
+        raw = browser_cfg.get("fallback_providers", []) if isinstance(browser_cfg, dict) else []
+    except Exception:
+        raw = []
+
+    if isinstance(raw, str):
+        raw_items = [part.strip() for part in raw.split(",")]
+    elif isinstance(raw, (list, tuple)):
+        raw_items = list(raw)
+    else:
+        raw_items = []
+    if not raw_items:
+        raw_items = ["browser-use", "browserbase"]
+
+    primary_norm = normalize_browser_cloud_provider(primary_name) or primary_name
+    names: list[str] = []
+    seen: set[str] = {primary_norm}
+    for item in raw_items:
+        normalized = normalize_browser_cloud_provider(item)
+        if not normalized or normalized in seen or normalized == "local":
+            continue
+        seen.add(normalized)
+        names.append(normalized)
+    return names
+
+
+def _get_runtime_cloud_fallback_providers(primary: CloudBrowserProvider) -> list[CloudBrowserProvider]:
+    """Return secondary cloud providers to try after the primary fails at runtime."""
+    if not _browser_fallback_enabled():
+        return []
+    _ensure_browser_plugins_loaded()
+    providers: list[CloudBrowserProvider] = []
+    for name in _configured_browser_fallback_provider_names(_browser_provider_label(primary)):
+        candidate = _registry_get_browser_provider(name)
+        if candidate is None:
+            continue
+        try:
+            available = bool(candidate.is_available())
+        except Exception:
+            available = False
+        if available:
+            providers.append(candidate)
+    return providers
+
+
 def _get_cloud_provider() -> Optional[CloudBrowserProvider]:
     """Return the configured cloud browser provider, or None for local mode.
 
@@ -1707,26 +1787,59 @@ def _get_session_info(task_id: Optional[str] = None) -> Dict[str, str]:
                     session_info = dict(session_info)
                     session_info["cdp_url"] = _resolve_cdp_override(str(session_info["cdp_url"]))
             except Exception as e:
-                provider_name = type(provider).__name__
-                logger.warning(
-                    "Cloud provider %s failed (%s); attempting fallback to local "
-                    "Chromium for task %s",
-                    provider_name, e, task_id,
-                    exc_info=True,
-                )
-                try:
-                    session_info = _create_local_session(task_id)
-                except Exception as local_error:
-                    raise RuntimeError(
-                        f"Cloud provider {provider_name} failed ({e}) and local "
-                        f"fallback also failed ({local_error})"
-                    ) from e
-                # Mark session as degraded for observability
-                if isinstance(session_info, dict):
-                    session_info = dict(session_info)
-                    session_info["fallback_from_cloud"] = True
-                    session_info["fallback_reason"] = str(e)
-                    session_info["fallback_provider"] = provider_name
+                provider_name = _browser_provider_label(provider)
+                fallback_errors = [f"{provider_name}: {e}"]
+                session_info = None
+                for fallback_provider in _get_runtime_cloud_fallback_providers(provider):
+                    fallback_name = _browser_provider_label(fallback_provider)
+                    try:
+                        logger.warning(
+                            "Cloud provider %s failed (%s); trying cloud fallback %s for task %s",
+                            provider_name, e, fallback_name, task_id,
+                            exc_info=True,
+                        )
+                        candidate = fallback_provider.create_session(task_id)
+                        if not candidate or not isinstance(candidate, dict):
+                            raise ValueError(f"Cloud fallback returned invalid session: {candidate!r}")
+                        if candidate.get("cdp_url"):
+                            candidate = dict(candidate)
+                            candidate["cdp_url"] = _resolve_cdp_override(str(candidate["cdp_url"]))
+                        session_info = dict(candidate)
+                        session_info["fallback_from_cloud"] = True
+                        session_info["fallback_reason"] = str(e)
+                        session_info["fallback_provider"] = provider_name
+                        session_info["fallback_to_provider"] = fallback_name
+                        break
+                    except Exception as fallback_error:
+                        fallback_errors.append(f"{fallback_name}: {fallback_error}")
+                        logger.warning(
+                            "Cloud fallback provider %s failed (%s); continuing fallback chain for task %s",
+                            fallback_name, fallback_error, task_id,
+                            exc_info=True,
+                        )
+
+                if session_info is None:
+                    logger.warning(
+                        "Cloud provider %s failed (%s); attempting fallback to local "
+                        "Chromium for task %s",
+                        provider_name, e, task_id,
+                        exc_info=True,
+                    )
+                    try:
+                        session_info = _create_local_session(task_id)
+                    except Exception as local_error:
+                        raise RuntimeError(
+                            f"Cloud provider {provider_name} failed ({e}); cloud fallback errors "
+                            f"{fallback_errors}; local fallback also failed ({local_error})"
+                        ) from e
+                    # Mark session as degraded for observability
+                    if isinstance(session_info, dict):
+                        session_info = dict(session_info)
+                        session_info["fallback_from_cloud"] = True
+                        session_info["fallback_reason"] = str(e)
+                        session_info["fallback_provider"] = provider_name
+                        if len(fallback_errors) > 1:
+                            session_info["cloud_fallback_errors"] = fallback_errors
 
     with _cleanup_lock:
         # Double-check: another thread may have created a session while we


### PR DESCRIPTION
## Summary
- Add runtime fallback from the primary browser cloud provider to configured secondary cloud providers before falling back to local Chromium
- Preserve existing behavior when no fallback providers are configured
- Annotate fallback session metadata for observability/debugging

## Relationship to existing fallback docs
Hermes already supports **LLM provider fallback** (`fallback_model` / `fallback_providers`) and existing browser cloud → local fallback. This PR is narrower: it adds **browser cloud provider → browser cloud provider** fallback before the existing local Chromium fallback path.

## Test plan
- `python -m pytest tests/tools/test_browser_cloud_fallback.py -q -o 'addopts='`
