### PR TITLE
feat(web): add web tool backend fallback chains

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -363,6 +363,11 @@ DEFAULT_CONFIG = {
         "backend": "",           # shared fallback — applies to both search and extract
         "search_backend": "",    # per-capability override for web_search (e.g. "searxng")
         "extract_backend": "",   # per-capability override for web_extract (e.g. "native")
+        "fallback_enabled": False,  # when true, retry web_search/web_extract through fallback_backends on quota/rate/API errors
+        "fallback_backends": {      # ordered fallback chains; omitted/empty uses sensible per-capability defaults
+            "search": [],
+            "extract": [],
+        },
         "extract_char_limit": 15000,  # per-page char budget for web_extract; larger pages truncate + store full text in cache/web
     },
 

--- a/tests/tools/test_web_tools_fallback_router.py
+++ b/tests/tools/test_web_tools_fallback_router.py
@@ -1,0 +1,139 @@
+import asyncio
+import json
+
+import pytest
+
+from agent.web_search_provider import WebSearchProvider
+
+
+class FakeProvider(WebSearchProvider):
+    def __init__(self, name, *, search_response=None, extract_response=None, raises=False, available=True):
+        self._name = name
+        self.search_response = search_response
+        self.extract_response = extract_response
+        self.raises = raises
+        self.available = available
+        self.search_calls = []
+        self.extract_calls = []
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def display_name(self):
+        return self._name
+
+    def is_available(self):
+        return self.available
+
+    def supports_search(self):
+        return self.search_response is not None or self.raises
+
+    def supports_extract(self):
+        return self.extract_response is not None or self.raises
+
+    def search(self, query, limit=5):
+        self.search_calls.append((query, limit))
+        if self.raises:
+            raise RuntimeError(f"{self._name} quota exceeded")
+        return self.search_response
+
+    def extract(self, urls, **kwargs):
+        self.extract_calls.append((list(urls), kwargs))
+        if self.raises:
+            raise RuntimeError(f"{self._name} quota exceeded")
+        return self.extract_response
+
+
+@pytest.fixture(autouse=True)
+def reset_registry_and_config(monkeypatch):
+    from agent import web_search_registry
+
+    web_search_registry._reset_for_tests()
+    monkeypatch.setattr("tools.web_tools._ensure_web_plugins_loaded", lambda: None)
+    yield
+    web_search_registry._reset_for_tests()
+
+
+def test_web_search_fallback_tries_firecrawl_when_tavily_errors(monkeypatch):
+    from agent.web_search_registry import register_provider
+    from tools import web_tools
+
+    tavily = FakeProvider("tavily", search_response={"success": False, "error": "quota exceeded"})
+    firecrawl = FakeProvider(
+        "firecrawl",
+        search_response={
+            "success": True,
+            "data": {"web": [{"title": "ok", "url": "https://example.com", "description": "fallback"}]},
+        },
+    )
+    register_provider(tavily)
+    register_provider(firecrawl)
+
+    monkeypatch.setattr(web_tools, "_is_backend_available", lambda backend: backend in {"tavily", "firecrawl"})
+    monkeypatch.setattr(web_tools, "_load_web_config", lambda: {
+        "search_backend": "tavily",
+        "fallback_enabled": True,
+        "fallback_backends": {"search": ["tavily", "firecrawl"]},
+    })
+
+    result = json.loads(web_tools.web_search_tool("credit limits", limit=3))
+
+    assert result["success"] is True
+    assert result["data"]["web"][0]["description"] == "fallback"
+    assert len(tavily.search_calls) == 1
+    assert len(firecrawl.search_calls) == 1
+
+
+def test_web_search_does_not_fallback_when_disabled(monkeypatch):
+    from agent.web_search_registry import register_provider
+    from tools import web_tools
+
+    tavily = FakeProvider("tavily", search_response={"success": False, "error": "quota exceeded"})
+    firecrawl = FakeProvider("firecrawl", search_response={"success": True, "data": {"web": []}})
+    register_provider(tavily)
+    register_provider(firecrawl)
+
+    monkeypatch.setattr(web_tools, "_is_backend_available", lambda backend: backend in {"tavily", "firecrawl"})
+    monkeypatch.setattr(web_tools, "_load_web_config", lambda: {
+        "search_backend": "tavily",
+        "fallback_enabled": False,
+        "fallback_backends": {"search": ["tavily", "firecrawl"]},
+    })
+
+    result = json.loads(web_tools.web_search_tool("credit limits", limit=3))
+
+    assert result["success"] is False
+    assert "quota" in result["error"]
+    assert len(tavily.search_calls) == 1
+    assert len(firecrawl.search_calls) == 0
+
+
+def test_web_extract_fallback_tries_firecrawl_when_tavily_results_all_error(monkeypatch):
+    from agent.web_search_registry import register_provider
+    from tools import web_tools
+
+    tavily = FakeProvider(
+        "tavily",
+        extract_response=[{"url": "https://example.com", "title": "", "content": "", "error": "quota exceeded"}],
+    )
+    firecrawl = FakeProvider(
+        "firecrawl",
+        extract_response=[{"url": "https://example.com", "title": "ok", "content": "fallback content"}],
+    )
+    register_provider(tavily)
+    register_provider(firecrawl)
+
+    monkeypatch.setattr(web_tools, "_is_backend_available", lambda backend: backend in {"tavily", "firecrawl"})
+    monkeypatch.setattr(web_tools, "_load_web_config", lambda: {
+        "extract_backend": "tavily",
+        "fallback_enabled": True,
+        "fallback_backends": {"extract": ["tavily", "firecrawl"]},
+    })
+
+    result = json.loads(asyncio.run(web_tools.web_extract_tool(["https://example.com"])))
+
+    assert result["results"][0]["content"] == "fallback content"
+    assert len(tavily.extract_calls) == 1
+    assert len(firecrawl.extract_calls) == 1

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -366,6 +366,132 @@ def _ddgs_package_importable() -> bool:
     except ImportError:
         return False
 
+
+def _web_fallback_enabled() -> bool:
+    """Return whether deterministic web-provider fallback is enabled."""
+    value = _load_web_config().get("fallback_enabled", False)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _configured_fallback_backends(capability: str, primary_backend: str) -> list[str]:
+    """Return the configured backend attempt order for search/extract.
+
+    ``web.fallback_backends`` may be either a list shared by all capabilities
+    or a dict with per-capability lists. The primary backend is always first,
+    and duplicates/empty names are removed while preserving order.
+    """
+    fallback_cfg = _load_web_config().get("fallback_backends")
+    configured: list[str] = []
+    if isinstance(fallback_cfg, dict):
+        raw = fallback_cfg.get(capability) or fallback_cfg.get("default") or []
+    else:
+        raw = fallback_cfg or []
+
+    if isinstance(raw, str):
+        raw_items = [part.strip() for part in raw.split(",")]
+    elif isinstance(raw, (list, tuple)):
+        raw_items = list(raw)
+    else:
+        raw_items = []
+
+    # Sensible defaults when the switch is enabled but the chain is omitted.
+    if not raw_items:
+        if capability == "search":
+            raw_items = [primary_backend, "firecrawl", "tavily", "ddgs"]
+        elif capability == "extract":
+            raw_items = [primary_backend, "firecrawl", "tavily", "exa", "parallel"]
+        else:
+            raw_items = [primary_backend]
+
+    seen: set[str] = set()
+    for name in [primary_backend, *raw_items]:
+        normalized = str(name or "").lower().strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        configured.append(normalized)
+    return configured
+
+
+def _web_provider_candidates(capability: str, primary_backend: str) -> list[Any]:
+    """Return provider instances to attempt for a web capability.
+
+    Provider candidates are registry-backed, so cold-start subprocesses and
+    delegated contexts must load web plugins before consulting the registry.
+    """
+    _ensure_web_plugins_loaded()
+    from agent.web_search_registry import (
+        get_active_extract_provider,
+        get_active_search_provider,
+        get_provider as _wsp_get_provider,
+    )
+
+    def capable(provider: Any) -> bool:
+        if provider is None:
+            return False
+        if capability == "search":
+            return bool(provider.supports_search())
+        if capability == "extract":
+            return bool(provider.supports_extract())
+        return False
+
+    provider = _wsp_get_provider(primary_backend) if primary_backend else None
+    if provider is None or not capable(provider):
+        provider = (
+            get_active_search_provider()
+            if capability == "search"
+            else get_active_extract_provider()
+        )
+    if provider is None:
+        return []
+
+    if not _web_fallback_enabled():
+        return [provider]
+
+    providers: list[Any] = []
+    seen: set[str] = set()
+    for name in _configured_fallback_backends(capability, provider.name):
+        candidate = _wsp_get_provider(name)
+        if candidate is None or not capable(candidate):
+            continue
+        try:
+            available = bool(candidate.is_available())
+        except Exception:
+            available = False
+        if not available:
+            continue
+        if candidate.name in seen:
+            continue
+        providers.append(candidate)
+        seen.add(candidate.name)
+
+    if provider.name not in seen:
+        providers.insert(0, provider)
+    return providers
+
+
+def _search_response_should_fallback(response_data: Dict[str, Any]) -> bool:
+    if not isinstance(response_data, dict):
+        return True
+    if response_data.get("success") is False or response_data.get("error"):
+        return True
+    web_results = response_data.get("data", {}).get("web") if isinstance(response_data.get("data"), dict) else None
+    return isinstance(web_results, list) and len(web_results) == 0
+
+
+def _extract_results_should_fallback(results: Any) -> bool:
+    if not isinstance(results, list) or not results:
+        return True
+    successes = [
+        item for item in results
+        if isinstance(item, dict) and not item.get("error") and (item.get("content") or item.get("raw_content"))
+    ]
+    return len(successes) == 0
+
 # ─── Firecrawl Client ────────────────────────────────────────────────────────
 
 # ─── Firecrawl Client ────────────────────────────────────────────────────────
@@ -671,29 +797,13 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         if is_interrupted():
             return tool_error("Interrupted", success=False)
 
-        # Dispatch through the web search registry. All 7 providers
-        # (brave-free, ddgs, searxng, exa, parallel, tavily, firecrawl)
-        # now live as plugins; the dispatcher is just a registry lookup +
-        # delegation. Sync only — every provider's search() is sync.
-        _ensure_web_plugins_loaded()
-        from agent.web_search_registry import (
-            get_active_search_provider,
-            get_provider as _wsp_get_provider,
-            _disabled_web_plugin_for,
-        )
+        # Dispatch through the web search registry. When web.fallback_enabled
+        # is true, walk the configured provider chain on quota/rate/API errors.
+        providers = _web_provider_candidates("search", _get_search_backend())
 
-        backend = _get_search_backend()
-        provider = _wsp_get_provider(backend) if backend else None
-        if provider is None or not provider.supports_search():
-            # Fall back to availability-walked active provider when the
-            # configured backend isn't a registered search provider (typo,
-            # uninstalled plugin, or capability mismatch).
-            provider = get_active_search_provider()
+        if not providers:
+            from agent.web_search_registry import _disabled_web_plugin_for
 
-        if provider is None:
-            # A bundled web plugin the user explicitly disabled looks
-            # identical to "no provider" here — point at the real cause
-            # (re-enable the plugin) rather than a generic setup hint.
             disabled_key = _disabled_web_plugin_for(capability="search")
             if disabled_key:
                 _vendor = disabled_key.split("/", 1)[-1]
@@ -715,11 +825,38 @@ def web_search_tool(query: str, limit: int = 5) -> str:
                     ),
                 }
         else:
-            logger.info(
-                "Web search via %s: '%s' (limit: %d)",
-                provider.name, query, limit,
-            )
-            response_data = provider.search(query, limit)
+            response_data = None
+            fallback_errors: list[str] = []
+            for idx, provider in enumerate(providers):
+                try:
+                    logger.info(
+                        "Web search via %s: '%s' (limit: %d)",
+                        provider.name, query, limit,
+                    )
+                    response_data = provider.search(query, limit)
+                except Exception as provider_exc:
+                    fallback_errors.append(f"{provider.name}: {provider_exc}")
+                    if idx < len(providers) - 1:
+                        logger.warning(
+                            "Web search provider %s failed; trying fallback %s",
+                            provider.name, providers[idx + 1].name,
+                        )
+                        continue
+                    raise
+
+                if _search_response_should_fallback(response_data) and idx < len(providers) - 1:
+                    fallback_errors.append(f"{provider.name}: {response_data.get('error') or 'empty results'}")
+                    logger.warning(
+                        "Web search provider %s returned fallback-worthy response; trying %s",
+                        provider.name, providers[idx + 1].name,
+                    )
+                    continue
+                break
+
+            if response_data is None:
+                response_data = {"success": False, "error": "No web search response returned"}
+            if isinstance(response_data, dict) and fallback_errors:
+                response_data.setdefault("fallback_attempts", fallback_errors)
 
         debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
         result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
@@ -859,108 +996,124 @@ async def web_extract_tool(
             # All seven providers (brave-free, ddgs, searxng, exa, parallel,
             # tavily, firecrawl) now live as plugins. The dispatcher is a
             # registry lookup + delegation. Some providers' extract() is
-            # async (parallel, firecrawl), others sync (exa, tavily) — we
-            # detect coroutine functions and await; sync functions run
-            # inline (the policy gate, SSRF re-check, etc. live inside the
-            # provider itself for the firecrawl per-URL loop).
+            # async (parallel, firecrawl), others sync (exa, tavily). When
+            # web.fallback_enabled is true, fall through the configured chain
+            # on quota/rate/API errors or all-error/empty extract results.
             _ensure_web_plugins_loaded()
             from agent.web_search_registry import (
-                get_active_extract_provider,
                 get_provider as _wsp_get_provider,
                 _disabled_web_plugin_for,
             )
 
-            provider = _wsp_get_provider(backend) if backend else None
-            if provider is None or not provider.supports_extract():
-                # When the configured name IS registered but doesn't support
-                # extract (search-only providers like brave-free / ddgs /
-                # searxng), surface that as a typed "search-only" error
-                # rather than silently switching backends. When the name
-                # isn't registered at all (typo / uninstalled plugin), fall
-                # through to the active-provider walk.
-                if provider is not None and not provider.supports_extract():
+            configured_provider = _wsp_get_provider(backend) if backend else None
+            if (
+                configured_provider is not None
+                and not configured_provider.supports_extract()
+                and not _web_fallback_enabled()
+            ):
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": (
+                            f"{configured_provider.display_name} is a search-only "
+                            "backend and cannot extract URL content. "
+                            "Set web.extract_backend to firecrawl, "
+                            "tavily, exa, or parallel."
+                        ),
+                    },
+                    ensure_ascii=False,
+                )
+
+            providers = _web_provider_candidates("extract", backend)
+            if not providers:
+                disabled_key = _disabled_web_plugin_for(capability="extract")
+                if disabled_key:
+                    _vendor = disabled_key.split("/", 1)[-1]
                     return json.dumps(
                         {
                             "success": False,
                             "error": (
-                                f"{provider.display_name} is a search-only "
-                                "backend and cannot extract URL content. "
-                                "Set web.extract_backend to firecrawl, "
-                                "tavily, exa, or parallel."
+                                f"web.extract_backend is set to '{_vendor}', "
+                                f"but its plugin ('{disabled_key}') is disabled "
+                                "in config. Re-enable it with "
+                                f"`hermes plugins enable {disabled_key}` "
+                                "(or remove it from plugins.disabled)."
                             ),
                         },
                         ensure_ascii=False,
                     )
-                provider = get_active_extract_provider()
-                if provider is None:
-                    # If the configured backend is a bundled web plugin the
-                    # user explicitly disabled, the backend is set correctly
-                    # and the real fix is to re-enable the plugin — say so
-                    # instead of telling them to set web.extract_backend
-                    # (which they already did). #40190 follow-up.
-                    disabled_key = _disabled_web_plugin_for(capability="extract")
-                    if disabled_key:
-                        _vendor = disabled_key.split("/", 1)[-1]
-                        return json.dumps(
-                            {
-                                "success": False,
-                                "error": (
-                                    f"web.extract_backend is set to '{_vendor}', "
-                                    f"but its plugin ('{disabled_key}') is disabled "
-                                    "in config. Re-enable it with "
-                                    f"`hermes plugins enable {disabled_key}` "
-                                    "(or remove it from plugins.disabled)."
-                                ),
-                            },
-                            ensure_ascii=False,
-                        )
-                    return json.dumps(
-                        {
-                            "success": False,
-                            "error": (
-                                "No web extract provider configured. "
-                                "Set web.extract_backend to firecrawl, "
-                                "tavily, exa, or parallel."
-                            ),
-                        },
-                        ensure_ascii=False,
-                    )
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": (
+                            "No web extract provider configured. "
+                            "Set web.extract_backend to firecrawl, "
+                            "tavily, exa, or parallel."
+                        ),
+                    },
+                    ensure_ascii=False,
+                )
 
-            logger.info(
-                "Web extract via %s: %d URL(s)", provider.name, len(safe_urls)
-            )
-
-            # Async-or-sync dispatch: parallel + firecrawl have async
-            # extract(); exa + tavily are sync.
             import inspect
-            if inspect.iscoroutinefunction(provider.extract):
-                results = await provider.extract(safe_urls, format=format)
-            else:
-                # Run sync extract() in a thread so we don't block the
-                # event loop on network I/O.
-                results = await asyncio.to_thread(
-                    provider.extract, safe_urls, format=format
+            provider_results = []
+            fallback_errors: list[str] = []
+            for idx, provider in enumerate(providers):
+                logger.info(
+                    "Web extract via %s: %d URL(s)", provider.name, len(safe_urls)
                 )
+                try:
+                    if inspect.iscoroutinefunction(provider.extract):
+                        candidate_results = await provider.extract(safe_urls, format=format)
+                    else:
+                        candidate_results = await asyncio.to_thread(
+                            provider.extract, safe_urls, format=format
+                        )
+                except Exception as provider_exc:
+                    fallback_errors.append(f"{provider.name}: {provider_exc}")
+                    if idx < len(providers) - 1:
+                        logger.warning(
+                            "Web extract provider %s failed; trying fallback %s",
+                            provider.name, providers[idx + 1].name,
+                        )
+                        continue
+                    raise
 
-        # Reconstruct the original input order across invalid, blocked, and
-        # provider-processed entries. Providers are expected to preserve the
-        # order of the safe URL list they receive.
-        if invalid_urls or ssrf_blocked:
-            safe_results = {
-                index: (
-                    results[position]
-                    if position < len(results)
-                    else {
-                        "url": safe_urls[position],
-                        "title": "",
-                        "content": "",
-                        "error": "Extract backend returned no result for this URL",
-                    }
-                )
-                for position, index in enumerate(safe_indices)
-            }
-            by_index = {**safe_results, **ssrf_blocked, **invalid_urls}
-            results = [by_index[index] for index in range(len(urls))]
+                if _extract_results_should_fallback(candidate_results) and idx < len(providers) - 1:
+                    fallback_errors.append(f"{provider.name}: empty/all-error results")
+                    logger.warning(
+                        "Web extract provider %s returned fallback-worthy results; trying %s",
+                        provider.name, providers[idx + 1].name,
+                    )
+                    continue
+                provider_results = candidate_results
+                break
+
+            if fallback_errors and isinstance(provider_results, list):
+                for item in provider_results:
+                    if isinstance(item, dict):
+                        item.setdefault("fallback_attempts", fallback_errors)
+
+            # Reconstruct the original input order across invalid, blocked, and
+            # provider-processed entries. Providers are expected to preserve the
+            # order of the safe URL list they receive.
+            if invalid_urls or ssrf_blocked:
+                safe_results = {
+                    index: (
+                        provider_results[position]
+                        if position < len(provider_results)
+                        else {
+                            "url": safe_urls[position],
+                            "title": "",
+                            "content": "",
+                            "error": "Extract backend returned no result for this URL",
+                        }
+                    )
+                    for position, index in enumerate(safe_indices)
+                }
+                by_index = {**safe_results, **ssrf_blocked, **invalid_urls}
+                results = [by_index[index] for index in range(len(urls))]
+            else:
+                results = provider_results
 
         response = {"results": results}
         

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2017,6 +2017,12 @@ web:
   # Or use per-capability keys to mix providers (e.g. free search + paid extract):
   search_backend: "searxng"
   extract_backend: "firecrawl"
+
+  # Optional deterministic fallback chains for transient quota/rate/API failures:
+  fallback_enabled: false
+  fallback_backends:
+    search: ["searxng", "tavily", "ddgs"]
+    extract: ["firecrawl", "tavily", "exa", "parallel"]
 ```
 
 | Backend | Env Var | Search | Extract |
@@ -2028,6 +2034,8 @@ web:
 | **Exa** | `EXA_API_KEY` | ✔ | ✔ |
 
 **Backend selection:** If `web.backend` is not set, the backend is auto-detected from available API keys. If only `SEARXNG_URL` is set, SearXNG is used. If only `EXA_API_KEY` is set, Exa is used. If only `TAVILY_API_KEY` is set, Tavily is used. If only `PARALLEL_API_KEY` is set, Parallel is used. Otherwise Firecrawl is the default.
+
+**Fallback chains:** Set `web.fallback_enabled: true` to retry `web_search` / `web_extract` with additional providers when the primary backend returns a quota/rate/API error or an empty/all-error result. `web.fallback_backends` may be a shared list or a per-capability map with `search` and `extract` lists. The configured primary backend is always tried first, and search-only providers still produce the explicit "search-only backend" diagnostic for `web_extract` when fallback is disabled.
 
 **SearXNG** is a free, self-hosted, privacy-respecting metasearch engine that queries 70+ search engines. No API key needed — just set `SEARXNG_URL` to your instance (e.g., `http://localhost:8080`). SearXNG is search-only; `web_extract` requires a separate extract provider (set `web.extract_backend`). See the [Web Search setup guide](/user-guide/features/web-search) for Docker setup instructions.
 

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -342,6 +342,23 @@ web:
 
 When per-capability keys are empty, both fall through to `web.backend`. When `web.backend` is also empty, the backend is auto-detected from whichever API key/URL is present.
 
+### Provider fallback chains
+
+Hermes can retry a secondary web provider automatically when the primary returns quota/rate/API errors or empty/all-error results:
+
+```yaml
+# ~/.hermes/config.yaml
+web:
+  search_backend: "searxng"
+  extract_backend: "firecrawl"
+  fallback_enabled: true
+  fallback_backends:
+    search: ["searxng", "tavily", "ddgs"]
+    extract: ["firecrawl", "tavily", "exa", "parallel"]
+```
+
+`fallback_backends` may also be a single shared list. Hermes always attempts the configured primary backend first, removes duplicates, skips unavailable or capability-mismatched providers, and records failed attempts in `fallback_attempts` on the returned JSON. If fallback is disabled, explicit capability errors remain strict — for example, `web.extract_backend: "searxng"` still returns the search-only backend diagnostic instead of silently switching providers.
+
 **Priority order (per capability):**
 1. `web.search_backend` / `web.extract_backend` (explicit per-capability)
 2. `web.backend` (shared fallback)


### PR DESCRIPTION
## Summary
- Add opt-in deterministic fallback chains for **web tool backends** (`web_search` / `web_extract`), not LLM providers
- Support `web.fallback_enabled` plus `web.fallback_backends` as either shared or per-capability chains
- Retry fallback-capable web backends on provider exceptions, error responses, or empty/all-error results
- Add focused unit coverage for enabled/disabled fallback behavior

## Relationship to existing fallback docs
Hermes already supports:
- main LLM fallback via `fallback_model` / `fallback_providers`
- auxiliary model fallback for tasks such as `auxiliary.web_extract`

This PR targets a different layer: the **web tool's search/extract backend provider** (Tavily/Firecrawl/Exa/Parallel/etc.) before any auxiliary LLM summarization happens.

## Test plan
- `python -m pytest tests/tools/test_web_tools_fallback_router.py -q -o 'addopts='`
