### PR TITLE
Add subconscious observability and reduce conflict noise

### DIFF
--- a/plugins/memory/subconscious/__init__.py
+++ b/plugins/memory/subconscious/__init__.py
@@ -1,0 +1,216 @@
+"""Local structured subconscious memory provider for Hermes."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from agent.memory_provider import MemoryProvider
+from tools.registry import tool_error
+
+from .consolidate import run_consolidation
+from .store import LAYERS, SubconsciousStore
+
+_TOOL_SCHEMA = {
+    "name": "subconscious",
+    "description": (
+        "Local structured subconscious memory: status/search/hybrid_search/add/link/related/skill_candidates/consolidate/metrics/expire/conflicts "
+        "across working, episodic, semantic, and procedural layers. No network or API keys."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {"type": "string", "enum": ["status", "search", "hybrid_search", "add", "link", "related", "skill_candidates", "consolidate", "metrics", "expire", "conflicts"]},
+            "layer": {"type": "string", "enum": sorted(LAYERS)},
+            "query": {"type": "string"},
+            "content": {"type": "string"},
+            "tags": {"type": "array", "items": {"type": "string"}},
+            "limit": {"type": "integer"},
+            "topic_id": {"type": "string"},
+            "chat_id": {"type": "string"},
+            "platform": {"type": "string"},
+            "source_id": {"type": "integer"},
+            "target_id": {"type": "integer"},
+            "memory_id": {"type": "integer"},
+            "relation": {"type": "string"},
+            "weight": {"type": "number"},
+            "dry_run": {"type": "boolean"},
+        },
+        "required": ["action"],
+    },
+}
+
+
+class SubconsciousMemoryProvider(MemoryProvider):
+    def __init__(self) -> None:
+        self._store: SubconsciousStore | None = None
+        self._hermes_home = ""
+        self._session_id = ""
+        self._platform = ""
+        self._active = False
+
+    @property
+    def name(self) -> str:
+        return "subconscious"
+
+    def is_available(self) -> bool:
+        return True
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        self._session_id = session_id or ""
+        self._hermes_home = kwargs.get("hermes_home") or ""
+        if not self._hermes_home:
+            from hermes_constants import get_hermes_home
+            self._hermes_home = str(get_hermes_home())
+        self._platform = kwargs.get("platform") or ""
+        db_path = Path(self._hermes_home) / "subconscious" / "subconscious.db"
+        self._store = SubconsciousStore(db_path)
+        self._active = kwargs.get("agent_context", "primary") == "primary"
+
+    def system_prompt_block(self) -> str:
+        return (
+            "Subconscious memory provider is available: use it for local structured "
+            "recall/status across working, episodic, semantic, and procedural layers."
+        )
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if not self._store or not query.strip():
+            return ""
+        rows = self._store.hybrid_search(query, limit=6)
+        if not rows:
+            return ""
+        lines = ["## Subconscious Recall"]
+        for row in rows:
+            lines.append(f"- {row['layer']}: {row['summary'] or row['content']}")
+        return "\n".join(lines)
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        if not self._active or not self._store:
+            return
+        text = (user_content or "").strip()
+        if any(marker in text.lower() for marker in ("remember", "одобряю", "карт бланш", "do not", "don't", "always", "never")):
+            self._store.add_memory(
+                "working",
+                text[:1200],
+                summary=text[:220],
+                tags=["turn", "candidate"],
+                source="sync_turn",
+                session_id=session_id or self._session_id,
+                confidence=0.4,
+                metadata={"platform": self._platform},
+            )
+
+    def on_memory_write(self, action: str, target: str, content: str, metadata: Dict[str, Any] | None = None) -> None:
+        if not self._active or not self._store or action not in {"add", "replace"}:
+            return
+        layer = "procedural" if target == "memory" and any(k in content.lower() for k in ("workflow", "run ", "command", "skill")) else "semantic"
+        self._store.add_memory(
+            layer,
+            content,
+            summary=content[:220],
+            tags=["built-in-memory", target],
+            source="memory_tool",
+            session_id=(metadata or {}).get("session_id", self._session_id),
+            confidence=0.8,
+            metadata=metadata or {},
+        )
+
+    def on_pre_compress(self, messages: List[Dict[str, Any]]) -> str:
+        if not self._store:
+            return ""
+        rows = self._store.search("pending unresolved todo blocker next", layer="working", limit=5)
+        if not rows:
+            return ""
+        return "Subconscious working memory to preserve:\n" + "\n".join(f"- {r['summary'] or r['content']}" for r in rows)
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return [_TOOL_SCHEMA]
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
+        if tool_name != "subconscious":
+            return tool_error(f"Unknown subconscious tool: {tool_name}")
+        action = args.get("action")
+        try:
+            if action == "status":
+                return json.dumps({"success": True, **self._require_store().status()}, ensure_ascii=False)
+            if action == "search":
+                rows = self._require_store().search(
+                    args.get("query", ""),
+                    layer=args.get("layer"),
+                    limit=args.get("limit", 8),
+                    topic_id=args.get("topic_id"),
+                    chat_id=args.get("chat_id"),
+                    platform=args.get("platform"),
+                )
+                return json.dumps({"success": True, "results": rows}, ensure_ascii=False)
+            if action == "hybrid_search":
+                rows = self._require_store().hybrid_search(
+                    args.get("query", ""),
+                    layer=args.get("layer"),
+                    limit=args.get("limit", 8),
+                    topic_id=args.get("topic_id"),
+                    chat_id=args.get("chat_id"),
+                    platform=args.get("platform"),
+                )
+                return json.dumps({"success": True, "results": rows}, ensure_ascii=False)
+            if action == "add":
+                metadata = {
+                    key: args[key]
+                    for key in ("topic_id", "chat_id", "platform")
+                    if args.get(key) not in (None, "")
+                }
+                row_id = self._require_store().add_memory(
+                    args.get("layer") or "semantic",
+                    args.get("content") or "",
+                    tags=args.get("tags") or ["manual"],
+                    source="subconscious_tool",
+                    session_id=self._session_id,
+                    confidence=0.7,
+                    metadata=metadata,
+                )
+                return json.dumps({"success": True, "id": row_id}, ensure_ascii=False)
+            if action == "link":
+                edge_id = self._require_store().add_edge(
+                    int(args.get("source_id") or 0),
+                    int(args.get("target_id") or 0),
+                    relation=args.get("relation") or "related",
+                    weight=float(args.get("weight") or 0.5),
+                    source="subconscious_tool",
+                    metadata={"platform": self._platform},
+                )
+                return json.dumps({"success": True, "edge_id": edge_id}, ensure_ascii=False)
+            if action == "related":
+                rows = self._require_store().related(int(args.get("memory_id") or 0), limit=args.get("limit", 8))
+                return json.dumps({"success": True, "results": rows}, ensure_ascii=False)
+            if action == "skill_candidates":
+                rows = self._require_store().skill_candidates(limit=args.get("limit", 20))
+                return json.dumps({"success": True, "results": rows}, ensure_ascii=False)
+            if action == "consolidate":
+                result = run_consolidation(self._hermes_home, dry_run=bool(args.get("dry_run", False)))
+                return json.dumps(result, ensure_ascii=False)
+            if action == "metrics":
+                result = self._require_store().capture_metrics_snapshot()
+                return json.dumps({"success": True, **result}, ensure_ascii=False)
+            if action == "expire":
+                result = self._require_store().expire_stale_memories()
+                return json.dumps(result, ensure_ascii=False)
+            if action == "conflicts":
+                result = self._require_store().detect_conflicts()
+                return json.dumps(result, ensure_ascii=False)
+            return tool_error("action must be one of: status, search, hybrid_search, add, link, related, skill_candidates, consolidate, metrics, expire, conflicts")
+        except Exception as exc:
+            return tool_error(str(exc))
+
+    def _require_store(self) -> SubconsciousStore:
+        if not self._store:
+            raise RuntimeError("subconscious provider not initialized")
+        return self._store
+
+    def shutdown(self) -> None:
+        if self._store:
+            self._store.close()
+            self._store = None
+
+
+def register(ctx) -> None:
+    ctx.register_memory_provider(SubconsciousMemoryProvider())

--- a/plugins/memory/subconscious/consolidate.py
+++ b/plugins/memory/subconscious/consolidate.py
@@ -1,0 +1,162 @@
+"""Deterministic daily consolidation for the local subconscious provider."""
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .store import SubconsciousStore, default_ttl_days
+
+_DURABLE_HINTS = re.compile(
+    r"\b(prefers?|remember|do not|don't|always|never|uses?|project|topic|rule|protocol|workflow|approved|decision)\b",
+    re.IGNORECASE,
+)
+_PROCEDURAL_HINTS = re.compile(r"\b(run|command|workflow|steps?|procedure|skill|debug|test|deploy)\b", re.IGNORECASE)
+_NOISE_HINTS = re.compile(
+    r"("
+    r"^\s*[\{\[]|"
+    r'"(?:output|exit_code|tool_calls_made|success|error|job_id|targets)"\s*:|'
+    r"^\s*(?:#\s*)?Cron Job:|"
+    r"<persisted-output>|"
+    r"\[CONTEXT COMPACTION|"
+    r"Review the conversation above and update|"
+    r"Script path must be relative|"
+    r"📚\s*skill_view|💻\s*terminal|⏰\s*cronjob|"
+    r"/Users/xbr/.+\.(?:jsonl|sqlite3|py|md)"
+    r")",
+    re.IGNORECASE,
+)
+_MAX_ITEM_CHARS = 900
+
+
+def _state_db_path(hermes_home: str | Path) -> Path:
+    return Path(hermes_home).expanduser() / "state.db"
+
+
+def _iter_recent_messages(hermes_home: str | Path, limit: int = 120) -> list[dict[str, Any]]:
+    import sqlite3
+
+    db_path = _state_db_path(hermes_home)
+    if not db_path.exists():
+        return []
+    conn = sqlite3.connect(str(db_path), timeout=5.0)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            """
+            SELECT m.session_id, m.role, m.content, m.timestamp, s.title, s.source AS platform
+            FROM messages m
+            LEFT JOIN sessions s ON s.id = m.session_id
+            WHERE m.content IS NOT NULL AND TRIM(m.content) != ''
+            ORDER BY m.timestamp DESC, m.id DESC
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def _compact(text: str, max_chars: int = _MAX_ITEM_CHARS) -> str:
+    text = re.sub(r"\s+", " ", (text or "")).strip()
+    if len(text) <= max_chars:
+        return text
+    return text[: max_chars - 1].rstrip() + "…"
+
+
+def _is_noisy_message(msg: dict[str, Any], content: str) -> bool:
+    """Skip raw tool/system artifacts so reflection keeps human-useful memory."""
+    role = str(msg.get("role") or "").lower()
+    if role == "tool":
+        return True
+    return bool(_NOISE_HINTS.search(content or ""))
+
+
+def run_consolidation(
+    hermes_home: str | Path,
+    *,
+    db_path: str | Path | None = None,
+    run_key: str | None = None,
+    dry_run: bool = False,
+    message_limit: int = 120,
+) -> dict[str, Any]:
+    """Extract lightweight structured memories from recent session history.
+
+    This is intentionally deterministic and stdlib-only: no LLM calls, no network,
+    and safe for no-agent cron jobs.  It records candidates conservatively so a
+    human/agent can later refine them into built-in memory or skills.
+    """
+    hermes_home = Path(hermes_home).expanduser()
+    db_path = Path(db_path) if db_path else hermes_home / "subconscious" / "subconscious.db"
+    store = SubconsciousStore(db_path)
+    run_key = run_key or datetime.now(timezone.utc).strftime("daily-%Y-%m-%d")
+    stats = {"messages_scanned": 0, "working": 0, "episodic": 0, "semantic": 0, "procedural": 0, "dry_run": dry_run}
+
+    try:
+        if not dry_run and not store.begin_run(run_key):
+            stats["skipped"] = "already_ran"
+            return {"success": True, "status": "skipped", "run_key": run_key, "stats": stats}
+
+        messages = list(reversed(_iter_recent_messages(hermes_home, limit=message_limit)))
+        stats["messages_scanned"] = len(messages)
+        seen: set[tuple[str, str]] = set()
+
+        for msg in messages:
+            content = _compact(str(msg.get("content") or ""))
+            if not content:
+                continue
+            if _is_noisy_message(msg, content):
+                continue
+            session_id = str(msg.get("session_id") or "")
+            source = f"session:{session_id}" if session_id else "session"
+            lower = content.lower()
+
+            layer = None
+            tags = ["reflection"]
+            if any(k in lower for k in ("blocker", "pending", "todo", "next step", "unresolved", "жду", "нужно")):
+                layer = "working"
+                tags.append("open-loop")
+            elif _PROCEDURAL_HINTS.search(content):
+                layer = "procedural"
+                tags.append("workflow")
+            elif _DURABLE_HINTS.search(content):
+                layer = "semantic"
+                tags.append("fact-candidate")
+            elif msg.get("role") == "assistant" and len(content) > 120:
+                layer = "episodic"
+                tags.append("summary-candidate")
+
+            if not layer:
+                continue
+            key = (layer, content)
+            if key in seen:
+                continue
+            seen.add(key)
+            stats[layer] += 1
+            if not dry_run:
+                store.add_memory(
+                    layer,
+                    content,
+                    summary=_compact(content, 180),
+                    tags=tags,
+                    source=source,
+                    session_id=session_id,
+                    confidence=0.45 if layer in {"semantic", "procedural"} else 0.4,
+                    ttl_days=default_ttl_days(layer),
+                    metadata={"role": msg.get("role"), "platform": msg.get("platform"), "title": msg.get("title")},
+                )
+
+        if not dry_run:
+            stats["metrics"] = store.capture_metrics_snapshot()
+            stats["expire"] = store.expire_stale_memories()
+            stats["conflicts"] = store.detect_conflicts()
+            store.finish_run(run_key, status="completed", stats=stats)
+        return {"success": True, "status": "completed", "run_key": run_key, "stats": stats, "db_path": str(db_path)}
+    except Exception as exc:
+        if not dry_run:
+            store.finish_run(run_key, status="failed", stats=stats, error=str(exc))
+        return {"success": False, "status": "failed", "run_key": run_key, "stats": stats, "error": str(exc), "db_path": str(db_path)}
+    finally:
+        store.close()

--- a/plugins/memory/subconscious/plugin.yaml
+++ b/plugins/memory/subconscious/plugin.yaml
@@ -1,0 +1,7 @@
+name: subconscious
+version: 0.1.0
+description: "Local structured subconscious memory — working/episodic/semantic/procedural layers with deterministic daily reflection."
+hooks:
+  - on_memory_write
+  - on_pre_compress
+  - on_session_end

--- a/plugins/memory/subconscious/store.py
+++ b/plugins/memory/subconscious/store.py
@@ -15,6 +15,60 @@ from pathlib import Path
 from typing import Any, Iterable
 
 LAYERS = {"working", "episodic", "semantic", "procedural"}
+_CONFLICT_MIN_CONFIDENCE = 0.5
+_CONFLICT_EXCLUDED_TAGS = {"hygiene:noisy", "soft-decayed"}
+_CONFLICT_INCLUDE_TAGS = {"conflict:include", "promoted", "policy:promoted"}
+_CONFLICT_TYPES = {
+    "must_vs_must_not",
+    "always_vs_never",
+    "should_vs_should_not",
+    "requires_vs_prohibits",
+    "allowed_vs_blocked",
+    "executes_vs_coordinates_only",
+    "implements_vs_delegates",
+}
+_CONFLICT_STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "are",
+    "as",
+    "be",
+    "but",
+    "by",
+    "for",
+    "from",
+    "if",
+    "in",
+    "into",
+    "is",
+    "it",
+    "not",
+    "of",
+    "on",
+    "or",
+    "the",
+    "then",
+    "this",
+    "to",
+    "unless",
+    "until",
+    "with",
+    "must",
+    "should",
+    "always",
+    "never",
+    "requires",
+    "prohibits",
+    "allowed",
+    "blocked",
+    "executes",
+    "coordinates",
+    "only",
+    "implements",
+    "delegates",
+}
+_NEGATIVE_ACTION_TOKENS = {"avoid", "defer", "exclude", "ignore", "omit", "skip", "wait"}
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS memories (
@@ -148,6 +202,55 @@ def _recency_score(value: str | None) -> float:
         parsed = parsed.replace(tzinfo=timezone.utc)
     age_days = max(0.0, (datetime.now(timezone.utc) - parsed.astimezone(timezone.utc)).total_seconds() / 86400.0)
     return 1.0 / (1.0 + age_days / 14.0)
+
+
+def _load_json(value: str | None) -> dict[str, Any]:
+    try:
+        loaded = json.loads(value or "{}")
+    except (TypeError, json.JSONDecodeError):
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _split_tags(tags: str | None) -> set[str]:
+    return {tag.strip().lower() for tag in (tags or "").split(",") if tag.strip()}
+
+
+def _tokens(text: str) -> set[str]:
+    values = re.findall(r"[\w:-]+", (text or "").lower(), flags=re.UNICODE)
+    return {value for value in values if len(value) > 2 and value not in _CONFLICT_STOPWORDS}
+
+
+def _looks_like_tool_artifact(content: str) -> bool:
+    stripped = (content or "").strip()
+    if not stripped or stripped[0] not in "{[":
+        return False
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        return False
+    if isinstance(parsed, dict):
+        tool_keys = {"success", "error", "current_entries", "target", "entries", "result"}
+        if tool_keys.intersection(parsed):
+            return True
+        inner = parsed.get("content")
+        return isinstance(inner, str) and inner.lstrip().startswith(("{", "["))
+    return isinstance(parsed, list)
+
+
+def _conflict_phrase_tokens(content: str, phrase: str) -> set[str]:
+    match = re.search(rf"\b{re.escape(phrase)}\b", content.lower())
+    if not match:
+        return set()
+    tail = content[match.end():]
+    tail = re.split(r"[.;\n]", tail, maxsplit=1)[0]
+    return _tokens(" ".join(re.findall(r"[\w:-]+", tail, flags=re.UNICODE)[:14]))
+
+
+def _overlap_ratio(left: set[str], right: set[str]) -> float:
+    if not left or not right:
+        return 0.0
+    return len(left & right) / float(min(len(left), len(right)))
 
 
 def default_ttl_days(layer: str) -> int | None:
@@ -548,7 +651,7 @@ class SubconsciousStore:
         return {"success": True, "expired_count": len(expired_ids), "expired_ids": expired_ids}
 
     def detect_conflicts(self) -> dict[str, Any]:
-        """Find simple contradictory semantic/procedural memories."""
+        """Find contradictory semantic/procedural memories with basic subject gating."""
         negation_pairs = {
             "must": "must not",
             "always": "never",
@@ -563,7 +666,7 @@ class SubconsciousStore:
                 dict(row)
                 for row in self._conn.execute(
                     """
-                    SELECT id, layer, content, confidence
+                    SELECT id, layer, content, summary, tags, confidence, metadata_json
                     FROM memories
                     WHERE layer IN ('semantic', 'procedural')
                     ORDER BY layer, confidence DESC, id ASC
@@ -571,17 +674,46 @@ class SubconsciousStore:
                 ).fetchall()
             ]
 
-        indexed: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+        skipped_count = 0
+        eligible_rows: list[dict[str, Any]] = []
         for row in rows:
+            tags = _split_tags(str(row.get("tags") or ""))
+            metadata = _load_json(str(row.get("metadata_json") or "{}"))
+            row["_tags"] = tags
+            row["_metadata"] = metadata
+            row["_scope_tokens"] = _tokens(" ".join(
+                str(metadata.get(key) or "") for key in ("platform", "chat_id", "topic_id")
+            ))
+            row["_subject_tokens"] = _tokens(" ".join(
+                str(row.get(key) or "") for key in ("content", "summary", "tags")
+            ))
+            promoted = bool(tags.intersection(_CONFLICT_INCLUDE_TAGS) or metadata.get("conflict_detection") == "include")
+            if not promoted and (
+                float(row.get("confidence") or 0.0) < _CONFLICT_MIN_CONFIDENCE
+                or tags.intersection(_CONFLICT_EXCLUDED_TAGS)
+                or _looks_like_tool_artifact(str(row.get("content") or ""))
+            ):
+                skipped_count += 1
+                continue
+            eligible_rows.append(row)
+
+        indexed: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+        for row in eligible_rows:
             content = str(row.get("content") or "").lower()
             for positive, negative in negation_pairs.items():
                 if re.search(rf"\b{re.escape(negative)}\b", content):
-                    indexed.setdefault((row["layer"], positive, "negative"), []).append(row)
+                    entry = {**row, "_conflict_tokens": _conflict_phrase_tokens(content, negative)}
+                    indexed.setdefault((row["layer"], positive, "negative"), []).append(entry)
                 elif re.search(rf"\b{re.escape(positive)}\b", content):
-                    indexed.setdefault((row["layer"], positive, "positive"), []).append(row)
+                    phrase_tokens = _conflict_phrase_tokens(content, positive)
+                    if phrase_tokens.intersection(_NEGATIVE_ACTION_TOKENS):
+                        continue
+                    entry = {**row, "_conflict_tokens": phrase_tokens}
+                    indexed.setdefault((row["layer"], positive, "positive"), []).append(entry)
 
         candidates: list[dict[str, Any]] = []
         seen_pairs: set[tuple[int, int, str]] = set()
+        rejected_by_gate = 0
         for layer in ("semantic", "procedural"):
             for positive, negative in negation_pairs.items():
                 positives = indexed.get((layer, positive, "positive"), [])
@@ -593,6 +725,18 @@ class SubconsciousStore:
                         key = (first_id, second_id, conflict_type)
                         if first_id == second_id or key in seen_pairs:
                             continue
+                        same_scope = bool(pos_row.get("_scope_tokens") and pos_row.get("_scope_tokens") & neg_row.get("_scope_tokens"))
+                        phrase_overlap = _overlap_ratio(
+                            pos_row.get("_conflict_tokens") or set(),
+                            neg_row.get("_conflict_tokens") or set(),
+                        )
+                        subject_overlap = _overlap_ratio(
+                            pos_row.get("_subject_tokens") or set(),
+                            neg_row.get("_subject_tokens") or set(),
+                        )
+                        if phrase_overlap < 0.5 and subject_overlap < 0.55:
+                            rejected_by_gate += 1
+                            continue
                         seen_pairs.add(key)
                         confidence = max(float(pos_row.get("confidence") or 0.0), float(neg_row.get("confidence") or 0.0))
                         candidates.append({
@@ -600,9 +744,14 @@ class SubconsciousStore:
                             "memory_id_2": second_id,
                             "conflict_type": conflict_type,
                             "severity": "high" if confidence >= 0.7 else "medium",
+                            "phrase_overlap": round(phrase_overlap, 4),
+                            "subject_overlap": round(subject_overlap, 4),
+                            "same_scope": same_scope,
                         })
 
         inserted = 0
+        stale_resolved = 0
+        candidate_keys = {(c["memory_id_1"], c["memory_id_2"], c["conflict_type"]) for c in candidates}
         ts = now_iso()
         with self._lock:
             for conflict in candidates:
@@ -622,15 +771,37 @@ class SubconsciousStore:
                     ),
                 )
                 inserted += int(cur.rowcount > 0)
+            existing = self._conn.execute(
+                "SELECT id, memory_id_1, memory_id_2, conflict_type FROM detected_conflicts WHERE resolved = 0"
+            ).fetchall()
+            for row in existing:
+                key = (int(row["memory_id_1"]), int(row["memory_id_2"]), str(row["conflict_type"]))
+                if str(row["conflict_type"]) in _CONFLICT_TYPES and key not in candidate_keys:
+                    cur = self._conn.execute("UPDATE detected_conflicts SET resolved = 1 WHERE id = ?", (row["id"],))
+                    stale_resolved += int(cur.rowcount > 0)
             unresolved_count = int(self._conn.execute(
                 "SELECT COUNT(*) AS n FROM detected_conflicts WHERE resolved = 0"
             ).fetchone()["n"])
             self._conn.commit()
+        hub_counts: dict[int, int] = {}
+        for conflict in candidates:
+            hub_counts[conflict["memory_id_1"]] = hub_counts.get(conflict["memory_id_1"], 0) + 1
+            hub_counts[conflict["memory_id_2"]] = hub_counts.get(conflict["memory_id_2"], 0) + 1
+        hubs = [
+            {"memory_id": memory_id, "conflict_count": count}
+            for memory_id, count in sorted(hub_counts.items(), key=lambda item: (-item[1], item[0]))[:10]
+            if count > 1
+        ]
         return {
             "success": True,
             "detected_count": len(candidates),
             "new_conflict_count": inserted,
             "conflict_count": unresolved_count,
+            "eligible_memory_count": len(eligible_rows),
+            "skipped_memory_count": skipped_count,
+            "rejected_by_gate_count": rejected_by_gate,
+            "stale_resolved_count": stale_resolved,
+            "hubs": hubs,
             "conflicts": candidates,
         }
 

--- a/plugins/memory/subconscious/store.py
+++ b/plugins/memory/subconscious/store.py
@@ -1,0 +1,681 @@
+"""Local structured subconscious memory store for Hermes.
+
+SQLite-only, profile-scoped, no external credentials.  The store keeps four
+cognitive layers: working, episodic, semantic, and procedural.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import threading
+from datetime import datetime, timezone
+from hashlib import sha256
+from pathlib import Path
+from typing import Any, Iterable
+
+LAYERS = {"working", "episodic", "semantic", "procedural"}
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS memories (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    layer TEXT NOT NULL CHECK(layer IN ('working','episodic','semantic','procedural')),
+    content TEXT NOT NULL,
+    summary TEXT DEFAULT '',
+    tags TEXT DEFAULT '',
+    source TEXT DEFAULT '',
+    session_id TEXT DEFAULT '',
+    confidence REAL DEFAULT 0.6,
+    ttl_days INTEGER,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    last_seen_at TEXT NOT NULL,
+    metadata_json TEXT DEFAULT '{}',
+    normalized_hash TEXT DEFAULT '',
+    UNIQUE(layer, content, source, session_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_subconscious_layer ON memories(layer);
+CREATE INDEX IF NOT EXISTS idx_subconscious_updated ON memories(updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_subconscious_session ON memories(session_id);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
+    content, summary, tags, content='memories', content_rowid='id'
+);
+
+CREATE TRIGGER IF NOT EXISTS memories_ai AFTER INSERT ON memories BEGIN
+    INSERT INTO memories_fts(rowid, content, summary, tags)
+    VALUES (new.id, new.content, new.summary, new.tags);
+END;
+CREATE TRIGGER IF NOT EXISTS memories_ad AFTER DELETE ON memories BEGIN
+    INSERT INTO memories_fts(memories_fts, rowid, content, summary, tags)
+    VALUES ('delete', old.id, old.content, old.summary, old.tags);
+END;
+CREATE TRIGGER IF NOT EXISTS memories_au AFTER UPDATE ON memories BEGIN
+    INSERT INTO memories_fts(memories_fts, rowid, content, summary, tags)
+    VALUES ('delete', old.id, old.content, old.summary, old.tags);
+    INSERT INTO memories_fts(rowid, content, summary, tags)
+    VALUES (new.id, new.content, new.summary, new.tags);
+END;
+
+CREATE TABLE IF NOT EXISTS consolidation_runs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_key TEXT NOT NULL UNIQUE,
+    status TEXT NOT NULL,
+    started_at TEXT NOT NULL,
+    finished_at TEXT,
+    stats_json TEXT DEFAULT '{}',
+    error TEXT DEFAULT ''
+);
+
+CREATE TABLE IF NOT EXISTS memory_edges (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_memory_id INTEGER NOT NULL,
+    target_memory_id INTEGER NOT NULL,
+    relation TEXT NOT NULL DEFAULT 'related',
+    weight REAL DEFAULT 0.5,
+    source TEXT DEFAULT '',
+    created_at TEXT NOT NULL,
+    metadata_json TEXT DEFAULT '{}',
+    UNIQUE(source_memory_id, target_memory_id, relation),
+    FOREIGN KEY(source_memory_id) REFERENCES memories(id) ON DELETE CASCADE,
+    FOREIGN KEY(target_memory_id) REFERENCES memories(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_subconscious_edges_source ON memory_edges(source_memory_id);
+CREATE INDEX IF NOT EXISTS idx_subconscious_edges_target ON memory_edges(target_memory_id);
+CREATE INDEX IF NOT EXISTS idx_subconscious_edges_relation ON memory_edges(relation);
+
+CREATE TABLE IF NOT EXISTS metrics_snapshots (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    snapshot_date TEXT NOT NULL UNIQUE,
+    total_memories INTEGER DEFAULT 0,
+    working_count INTEGER DEFAULT 0,
+    episodic_count INTEGER DEFAULT 0,
+    semantic_count INTEGER DEFAULT 0,
+    procedural_count INTEGER DEFAULT 0,
+    edge_count INTEGER DEFAULT 0,
+    duplicate_groups INTEGER DEFAULT 0,
+    avg_confidence REAL DEFAULT 0.0,
+    recall_precision_at_5 REAL DEFAULT 0.0,
+    stale_memory_count INTEGER DEFAULT 0,
+    conflict_count INTEGER DEFAULT 0,
+    autonomy_violations INTEGER DEFAULT 0,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS detected_conflicts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    memory_id_1 INTEGER NOT NULL,
+    memory_id_2 INTEGER NOT NULL,
+    conflict_type TEXT NOT NULL,
+    severity TEXT NOT NULL CHECK(severity IN ('low','medium','high')),
+    detected_at TEXT NOT NULL,
+    resolved BOOLEAN DEFAULT 0,
+    UNIQUE(memory_id_1, memory_id_2, conflict_type),
+    FOREIGN KEY(memory_id_1) REFERENCES memories(id) ON DELETE CASCADE,
+    FOREIGN KEY(memory_id_2) REFERENCES memories(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_conflicts_resolved ON detected_conflicts(resolved);
+"""
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _normalize_text(text: str) -> str:
+    return re.sub(r"\s+", " ", (text or "").strip().lower())
+
+
+def _normalized_hash(layer: str, content: str, metadata: dict[str, Any] | None) -> str:
+    scope = ""
+    if metadata:
+        scope = "|".join(str(metadata.get(key) or "") for key in ("platform", "chat_id", "topic_id"))
+    value = f"{layer}|{scope}|{_normalize_text(content)}"
+    return sha256(value.encode("utf-8")).hexdigest()
+
+
+def _recency_score(value: str | None) -> float:
+    if not value:
+        return 0.0
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return 0.0
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    age_days = max(0.0, (datetime.now(timezone.utc) - parsed.astimezone(timezone.utc)).total_seconds() / 86400.0)
+    return 1.0 / (1.0 + age_days / 14.0)
+
+
+def default_ttl_days(layer: str) -> int | None:
+    if layer == "working":
+        return 7
+    if layer == "procedural":
+        return 90
+    return None
+
+
+class SubconsciousStore:
+    def __init__(self, db_path: str | Path):
+        self.db_path = Path(db_path).expanduser()
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.RLock()
+        self._conn = sqlite3.connect(str(self.db_path), check_same_thread=False, timeout=10.0)
+        self._conn.row_factory = sqlite3.Row
+        self._init_db()
+
+    def _init_db(self) -> None:
+        from hermes_state import apply_wal_with_fallback
+        apply_wal_with_fallback(self._conn, db_label="subconscious.db")
+        with self._lock:
+            self._conn.execute("PRAGMA foreign_keys=ON")
+            self._conn.executescript(_SCHEMA)
+            self._ensure_column("memories", "normalized_hash", "TEXT DEFAULT ''")
+            self._conn.execute("CREATE INDEX IF NOT EXISTS idx_subconscious_norm ON memories(layer, normalized_hash)")
+            self._conn.commit()
+
+    def _ensure_column(self, table: str, column: str, definition: str) -> None:
+        cols = {row["name"] for row in self._conn.execute(f"PRAGMA table_info({table})").fetchall()}
+        if column not in cols:
+            self._conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {definition}")
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()
+
+    def add_memory(
+        self,
+        layer: str,
+        content: str,
+        *,
+        summary: str = "",
+        tags: Iterable[str] | str = "",
+        source: str = "",
+        session_id: str = "",
+        confidence: float = 0.6,
+        ttl_days: int | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> int:
+        layer = layer.strip().lower()
+        if layer not in LAYERS:
+            raise ValueError(f"unknown layer: {layer}")
+        content = (content or "").strip()
+        if not content:
+            raise ValueError("content must not be empty")
+        if not isinstance(tags, str):
+            tags = ",".join(t.strip() for t in tags if str(t).strip())
+        if ttl_days is None:
+            ttl_days = default_ttl_days(layer)
+        ts = now_iso()
+        metadata_json = json.dumps(metadata or {}, ensure_ascii=False, sort_keys=True)
+        norm_hash = _normalized_hash(layer, content, metadata or {})
+        with self._lock:
+            duplicate = self._conn.execute(
+                "SELECT id, confidence FROM memories WHERE layer=? AND normalized_hash=? ORDER BY confidence DESC, updated_at DESC LIMIT 1",
+                (layer, norm_hash),
+            ).fetchone()
+            if duplicate:
+                new_conf = min(1.0, max(float(duplicate["confidence"]), confidence) + 0.02)
+                self._conn.execute(
+                    "UPDATE memories SET last_seen_at=?, updated_at=?, confidence=? WHERE id=?",
+                    (ts, ts, new_conf, duplicate["id"]),
+                )
+                self._conn.commit()
+                return int(duplicate["id"])
+            try:
+                cur = self._conn.execute(
+                    """
+                    INSERT INTO memories
+                    (layer, content, summary, tags, source, session_id, confidence, ttl_days,
+                     created_at, updated_at, last_seen_at, metadata_json, normalized_hash)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (layer, content, summary, tags, source, session_id, confidence, ttl_days,
+                     ts, ts, ts, metadata_json, norm_hash),
+                )
+                self._conn.commit()
+                return int(cur.lastrowid)
+            except sqlite3.IntegrityError:
+                row = self._conn.execute(
+                    "SELECT id, confidence FROM memories WHERE layer=? AND content=? AND source=? AND session_id=?",
+                    (layer, content, source, session_id),
+                ).fetchone()
+                new_conf = min(1.0, max(float(row["confidence"]), confidence) + 0.02)
+                self._conn.execute(
+                    "UPDATE memories SET last_seen_at=?, updated_at=?, confidence=? WHERE id=?",
+                    (ts, ts, new_conf, row["id"]),
+                )
+                self._conn.commit()
+                return int(row["id"])
+
+    def search(
+        self,
+        query: str,
+        *,
+        layer: str | None = None,
+        limit: int = 8,
+        topic_id: str | None = None,
+        chat_id: str | None = None,
+        platform: str | None = None,
+    ) -> list[dict[str, Any]]:
+        query = (query or "").strip()
+        limit_value = 8 if limit is None else limit
+        limit = max(1, min(int(limit_value), 25))
+        fetch_limit = limit if not any((topic_id, chat_id, platform)) else min(limit * 5, 100)
+        params: list[Any] = []
+        where = ""
+        if layer:
+            layer = layer.strip().lower()
+            if layer not in LAYERS:
+                raise ValueError(f"unknown layer: {layer}")
+            where = "WHERE m.layer = ?"
+            params.append(layer)
+        with self._lock:
+            if query:
+                # FTS MATCH is brittle for punctuation-heavy chat text; fall back to LIKE if needed.
+                like = f"%{query}%"
+                rows = self._conn.execute(
+                    f"""
+                    SELECT m.* FROM memories m
+                    {where + (' AND' if where else 'WHERE')} (m.content LIKE ? OR m.summary LIKE ? OR m.tags LIKE ?)
+                    ORDER BY m.confidence DESC, m.updated_at DESC LIMIT ?
+                    """,
+                    (*params, like, like, like, fetch_limit),
+                ).fetchall()
+                if not rows:
+                    tokens = [token for token in query.replace('"', " ").split() if len(token) > 2][:6]
+                    if tokens:
+                        token_clause = " OR ".join(["m.content LIKE ? OR m.summary LIKE ? OR m.tags LIKE ?" for _ in tokens])
+                        token_params: list[Any] = []
+                        for token in tokens:
+                            token_like = f"%{token}%"
+                            token_params.extend([token_like, token_like, token_like])
+                        rows = self._conn.execute(
+                            f"""
+                            SELECT m.* FROM memories m
+                            {where + (' AND' if where else 'WHERE')} ({token_clause})
+                            ORDER BY m.confidence DESC, m.updated_at DESC LIMIT ?
+                            """,
+                            (*params, *token_params, fetch_limit),
+                        ).fetchall()
+            else:
+                rows = self._conn.execute(
+                    f"SELECT m.* FROM memories m {where} ORDER BY m.updated_at DESC LIMIT ?",
+                    (*params, fetch_limit),
+                ).fetchall()
+        filtered = [self._score_row(dict(r), topic_id=topic_id, graph_weight=0.0) for r in rows if self._matches_scope(dict(r), topic_id=topic_id, chat_id=chat_id, platform=platform)]
+        filtered.sort(key=lambda row: row["score"], reverse=True)
+        return filtered[:limit]
+
+    def _score_row(self, row: dict[str, Any], *, topic_id: str | None = None, graph_weight: float = 0.0) -> dict[str, Any]:
+        confidence = float(row.get("confidence") or 0.0)
+        recency = _recency_score(str(row.get("last_seen_at") or row.get("updated_at") or ""))
+        try:
+            metadata = json.loads(row.get("metadata_json") or "{}")
+        except (TypeError, json.JSONDecodeError):
+            metadata = {}
+        topic_boost = 0.15 if topic_id is not None and str(metadata.get("topic_id") or "") == str(topic_id) else 0.0
+        ttl_days = row.get("ttl_days")
+        decay = 1.0
+        if ttl_days:
+            try:
+                created = datetime.fromisoformat(str(row.get("created_at") or "").replace("Z", "+00:00"))
+                if created.tzinfo is None:
+                    created = created.replace(tzinfo=timezone.utc)
+                age_days = max(0.0, (datetime.now(timezone.utc) - created.astimezone(timezone.utc)).total_seconds() / 86400.0)
+                decay = max(0.05, 1.0 - age_days / max(float(ttl_days), 1.0))
+            except (TypeError, ValueError):
+                decay = 1.0
+        score = (confidence * 0.55 + recency * 0.20 + graph_weight * 0.20 + topic_boost) * decay
+        row["score"] = round(score, 6)
+        row["decay"] = round(decay, 6)
+        return row
+
+    def _matches_scope(
+        self,
+        row: dict[str, Any],
+        *,
+        topic_id: str | None = None,
+        chat_id: str | None = None,
+        platform: str | None = None,
+    ) -> bool:
+        if not any((topic_id, chat_id, platform)):
+            return True
+        try:
+            metadata = json.loads(row.get("metadata_json") or "{}")
+        except (TypeError, json.JSONDecodeError):
+            metadata = {}
+        if topic_id is not None and str(metadata.get("topic_id") or row.get("topic_id") or "") != str(topic_id):
+            return False
+        if chat_id is not None and str(metadata.get("chat_id") or "") != str(chat_id):
+            return False
+        if platform is not None and str(metadata.get("platform") or "") != str(platform):
+            return False
+        return True
+
+    def add_edge(
+        self,
+        source_memory_id: int,
+        target_memory_id: int,
+        *,
+        relation: str = "related",
+        weight: float = 0.5,
+        source: str = "",
+        metadata: dict[str, Any] | None = None,
+    ) -> int:
+        relation = (relation or "related").strip().lower()
+        if not relation:
+            raise ValueError("relation must not be empty")
+        ts = now_iso()
+        metadata_json = json.dumps(metadata or {}, ensure_ascii=False, sort_keys=True)
+        with self._lock:
+            cur = self._conn.execute(
+                """
+                INSERT INTO memory_edges
+                (source_memory_id, target_memory_id, relation, weight, source, created_at, metadata_json)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(source_memory_id, target_memory_id, relation)
+                DO UPDATE SET weight=excluded.weight, source=excluded.source, metadata_json=excluded.metadata_json
+                """,
+                (int(source_memory_id), int(target_memory_id), relation, float(weight), source, ts, metadata_json),
+            )
+            self._conn.commit()
+            if cur.lastrowid:
+                return int(cur.lastrowid)
+            row = self._conn.execute(
+                "SELECT id FROM memory_edges WHERE source_memory_id=? AND target_memory_id=? AND relation=?",
+                (int(source_memory_id), int(target_memory_id), relation),
+            ).fetchone()
+            return int(row["id"])
+
+    def related(self, memory_id: int, *, limit: int = 8) -> list[dict[str, Any]]:
+        limit = max(1, min(int(limit or 8), 25))
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT e.relation, e.weight, e.source AS edge_source, e.metadata_json AS edge_metadata_json, m.*
+                FROM memory_edges e
+                JOIN memories m ON m.id = CASE
+                    WHEN e.source_memory_id = ? THEN e.target_memory_id
+                    ELSE e.source_memory_id
+                END
+                WHERE e.source_memory_id = ? OR e.target_memory_id = ?
+                ORDER BY e.weight DESC, m.confidence DESC, m.updated_at DESC
+                LIMIT ?
+                """,
+                (int(memory_id), int(memory_id), int(memory_id), limit),
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+    def hybrid_search(
+        self,
+        query: str,
+        *,
+        layer: str | None = None,
+        limit: int = 8,
+        topic_id: str | None = None,
+        chat_id: str | None = None,
+        platform: str | None = None,
+    ) -> list[dict[str, Any]]:
+        direct = self.search(query, layer=layer, limit=limit, topic_id=topic_id, chat_id=chat_id, platform=platform)
+        seen = {int(row["id"]) for row in direct}
+        results = [{**row, "retrieval": "direct"} for row in direct]
+        for row in direct:
+            for related in self.related(int(row["id"]), limit=limit):
+                related_id = int(related["id"])
+                if related_id in seen:
+                    continue
+                if not self._matches_scope(related, topic_id=topic_id, chat_id=chat_id, platform=platform):
+                    continue
+                seen.add(related_id)
+                results.append({**self._score_row(related, topic_id=topic_id, graph_weight=float(related.get("weight") or 0.0)), "retrieval": "graph"})
+                if len(results) >= limit:
+                    results.sort(key=lambda item: item["score"], reverse=True)
+                    return results[:limit]
+        results.sort(key=lambda item: item["score"], reverse=True)
+        return results[:limit]
+
+    def skill_candidates(self, *, limit: int = 20) -> list[dict[str, Any]]:
+        limit = max(1, min(int(limit or 20), 50))
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT m.* FROM memories m
+                WHERE m.layer IN ('procedural','semantic')
+                  AND (m.tags LIKE '%workflow%' OR m.tags LIKE '%procedural%' OR m.tags LIKE '%skill%' OR m.content LIKE '%Run %' OR m.content LIKE '%command%' OR m.content LIKE '%implementation%')
+                ORDER BY m.confidence DESC, m.last_seen_at DESC, m.updated_at DESC
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+        return [self._score_row(dict(r)) for r in rows]
+
+    def counts(self) -> dict[str, int]:
+        with self._lock:
+            rows = self._conn.execute("SELECT layer, COUNT(*) AS n FROM memories GROUP BY layer").fetchall()
+        counts = {layer: 0 for layer in sorted(LAYERS)}
+        counts.update({r["layer"]: int(r["n"]) for r in rows})
+        return counts
+
+    def capture_metrics_snapshot(self) -> dict[str, Any]:
+        """Capture a daily observability snapshot for the local memory store."""
+        ts = now_iso()
+        snapshot_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        with self._lock:
+            counts = self.counts()
+            total = sum(counts.values())
+            edge_count = int(self._conn.execute("SELECT COUNT(*) AS n FROM memory_edges").fetchone()["n"])
+            duplicate_groups = int(self._conn.execute(
+                "SELECT COUNT(*) AS n FROM (SELECT normalized_hash FROM memories WHERE normalized_hash != '' GROUP BY layer, normalized_hash HAVING COUNT(*) > 1)"
+            ).fetchone()["n"])
+            avg_row = self._conn.execute("SELECT AVG(confidence) AS avg_confidence FROM memories").fetchone()
+            avg_confidence = float(avg_row["avg_confidence"] or 0.0)
+            stale_memory_count = int(self._conn.execute(
+                """
+                SELECT COUNT(*) AS n FROM memories
+                WHERE ttl_days IS NOT NULL
+                  AND julianday('now') - julianday(created_at) > ttl_days
+                """
+            ).fetchone()["n"])
+            conflict_count = int(self._conn.execute(
+                "SELECT COUNT(*) AS n FROM detected_conflicts WHERE resolved = 0"
+            ).fetchone()["n"])
+            self._conn.execute(
+                """
+                INSERT INTO metrics_snapshots
+                (snapshot_date, total_memories, working_count, episodic_count, semantic_count, procedural_count,
+                 edge_count, duplicate_groups, avg_confidence, stale_memory_count, conflict_count, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(snapshot_date) DO UPDATE SET
+                    total_memories=excluded.total_memories,
+                    working_count=excluded.working_count,
+                    episodic_count=excluded.episodic_count,
+                    semantic_count=excluded.semantic_count,
+                    procedural_count=excluded.procedural_count,
+                    edge_count=excluded.edge_count,
+                    duplicate_groups=excluded.duplicate_groups,
+                    avg_confidence=excluded.avg_confidence,
+                    stale_memory_count=excluded.stale_memory_count,
+                    conflict_count=excluded.conflict_count,
+                    created_at=excluded.created_at
+                """,
+                (
+                    snapshot_date,
+                    total,
+                    counts["working"],
+                    counts["episodic"],
+                    counts["semantic"],
+                    counts["procedural"],
+                    edge_count,
+                    duplicate_groups,
+                    avg_confidence,
+                    stale_memory_count,
+                    conflict_count,
+                    ts,
+                ),
+            )
+            self._conn.commit()
+        return {
+            "date": snapshot_date,
+            "total_memories": total,
+            "counts": counts,
+            "edge_count": edge_count,
+            "duplicate_groups": duplicate_groups,
+            "avg_confidence": avg_confidence,
+            "stale_memory_count": stale_memory_count,
+            "conflict_count": conflict_count,
+        }
+
+    def expire_stale_memories(self) -> dict[str, Any]:
+        """Delete memories that have exceeded their TTL."""
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT id FROM memories
+                WHERE ttl_days IS NOT NULL
+                  AND julianday('now') - julianday(created_at) > ttl_days
+                """
+            ).fetchall()
+            expired_ids = [int(row["id"]) for row in rows]
+            if not expired_ids:
+                return {"success": True, "expired_count": 0, "expired_ids": []}
+            placeholders = ",".join("?" for _ in expired_ids)
+            self._conn.execute(f"DELETE FROM memories WHERE id IN ({placeholders})", expired_ids)
+            self._conn.commit()
+        return {"success": True, "expired_count": len(expired_ids), "expired_ids": expired_ids}
+
+    def detect_conflicts(self) -> dict[str, Any]:
+        """Find simple contradictory semantic/procedural memories."""
+        negation_pairs = {
+            "must": "must not",
+            "always": "never",
+            "should": "should not",
+            "requires": "prohibits",
+            "allowed": "blocked",
+            "executes": "coordinates only",
+            "implements": "delegates",
+        }
+        with self._lock:
+            rows = [
+                dict(row)
+                for row in self._conn.execute(
+                    """
+                    SELECT id, layer, content, confidence
+                    FROM memories
+                    WHERE layer IN ('semantic', 'procedural')
+                    ORDER BY layer, confidence DESC, id ASC
+                    """
+                ).fetchall()
+            ]
+
+        indexed: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+        for row in rows:
+            content = str(row.get("content") or "").lower()
+            for positive, negative in negation_pairs.items():
+                if re.search(rf"\b{re.escape(negative)}\b", content):
+                    indexed.setdefault((row["layer"], positive, "negative"), []).append(row)
+                elif re.search(rf"\b{re.escape(positive)}\b", content):
+                    indexed.setdefault((row["layer"], positive, "positive"), []).append(row)
+
+        candidates: list[dict[str, Any]] = []
+        seen_pairs: set[tuple[int, int, str]] = set()
+        for layer in ("semantic", "procedural"):
+            for positive, negative in negation_pairs.items():
+                positives = indexed.get((layer, positive, "positive"), [])
+                negatives = indexed.get((layer, positive, "negative"), [])
+                for pos_row in positives:
+                    for neg_row in negatives:
+                        first_id, second_id = sorted((int(pos_row["id"]), int(neg_row["id"])))
+                        conflict_type = f"{positive}_vs_{negative.replace(' ', '_')}"
+                        key = (first_id, second_id, conflict_type)
+                        if first_id == second_id or key in seen_pairs:
+                            continue
+                        seen_pairs.add(key)
+                        confidence = max(float(pos_row.get("confidence") or 0.0), float(neg_row.get("confidence") or 0.0))
+                        candidates.append({
+                            "memory_id_1": first_id,
+                            "memory_id_2": second_id,
+                            "conflict_type": conflict_type,
+                            "severity": "high" if confidence >= 0.7 else "medium",
+                        })
+
+        inserted = 0
+        ts = now_iso()
+        with self._lock:
+            for conflict in candidates:
+                cur = self._conn.execute(
+                    """
+                    INSERT INTO detected_conflicts
+                    (memory_id_1, memory_id_2, conflict_type, severity, detected_at)
+                    VALUES (?, ?, ?, ?, ?)
+                    ON CONFLICT(memory_id_1, memory_id_2, conflict_type) DO NOTHING
+                    """,
+                    (
+                        conflict["memory_id_1"],
+                        conflict["memory_id_2"],
+                        conflict["conflict_type"],
+                        conflict["severity"],
+                        ts,
+                    ),
+                )
+                inserted += int(cur.rowcount > 0)
+            unresolved_count = int(self._conn.execute(
+                "SELECT COUNT(*) AS n FROM detected_conflicts WHERE resolved = 0"
+            ).fetchone()["n"])
+            self._conn.commit()
+        return {
+            "success": True,
+            "detected_count": len(candidates),
+            "new_conflict_count": inserted,
+            "conflict_count": unresolved_count,
+            "conflicts": candidates,
+        }
+
+    def begin_run(self, run_key: str) -> bool:
+        ts = now_iso()
+        with self._lock:
+            try:
+                self._conn.execute(
+                    "INSERT INTO consolidation_runs(run_key, status, started_at) VALUES (?, 'running', ?)",
+                    (run_key, ts),
+                )
+                self._conn.commit()
+                return True
+            except sqlite3.IntegrityError:
+                return False
+
+    def finish_run(self, run_key: str, *, status: str, stats: dict[str, Any] | None = None, error: str = "") -> None:
+        with self._lock:
+            self._conn.execute(
+                "UPDATE consolidation_runs SET status=?, finished_at=?, stats_json=?, error=? WHERE run_key=?",
+                (status, now_iso(), json.dumps(stats or {}, ensure_ascii=False, sort_keys=True), error, run_key),
+            )
+            self._conn.commit()
+
+    def last_run(self) -> dict[str, Any] | None:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM consolidation_runs ORDER BY started_at DESC, id DESC LIMIT 1"
+            ).fetchone()
+        return dict(row) if row else None
+
+    def status(self) -> dict[str, Any]:
+        with self._lock:
+            edge_count = int(self._conn.execute("SELECT COUNT(*) AS n FROM memory_edges").fetchone()["n"])
+            duplicate_count = int(self._conn.execute(
+                "SELECT COUNT(*) AS n FROM (SELECT normalized_hash FROM memories WHERE normalized_hash != '' GROUP BY layer, normalized_hash HAVING COUNT(*) > 1)"
+            ).fetchone()["n"])
+            conflict_count = int(self._conn.execute(
+                "SELECT COUNT(*) AS n FROM detected_conflicts WHERE resolved = 0"
+            ).fetchone()["n"])
+        return {
+            "db_path": str(self.db_path),
+            "counts": self.counts(),
+            "edge_count": edge_count,
+            "duplicate_groups": duplicate_count,
+            "conflict_count": conflict_count,
+            "last_run": self.last_run(),
+        }

--- a/tests/plugins/memory/test_subconscious_provider.py
+++ b/tests/plugins/memory/test_subconscious_provider.py
@@ -1,0 +1,205 @@
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from plugins.memory import discover_memory_providers, load_memory_provider
+from plugins.memory.subconscious.consolidate import run_consolidation
+from plugins.memory.subconscious.store import SubconsciousStore
+
+
+def test_subconscious_provider_discovered_and_available():
+    providers = {name: available for name, _desc, available in discover_memory_providers()}
+    assert providers.get("subconscious") is True
+    provider = load_memory_provider("subconscious")
+    assert provider is not None
+    assert provider.name == "subconscious"
+    assert provider.is_available()
+
+
+def test_store_layers_search_counts_and_status(tmp_path):
+    store = SubconsciousStore(tmp_path / "subconscious.db")
+    try:
+        fact_id = store.add_memory(
+            "semantic",
+            "Mikhail prefers concise reports",
+            tags=["user", "preference"],
+            metadata={"platform": "telegram", "chat_id": "-1003772186616", "topic_id": "1347"},
+        )
+        proc_id = store.add_memory(
+            "procedural",
+            "Run pytest before reporting implementation complete",
+            tags="tests",
+            metadata={"platform": "telegram", "chat_id": "-1003772186616", "topic_id": "1347"},
+        )
+        store.add_edge(fact_id, proc_id, relation="supports", weight=0.9, source="test")
+        assert store.counts()["semantic"] == 1
+        assert store.counts()["procedural"] == 1
+        results = store.search("Mikhail", limit=5)
+        assert len(results) == 1
+        assert results[0]["layer"] == "semantic"
+        duplicate_id = store.add_memory(
+            "semantic",
+            "  Mikhail   prefers concise reports  ",
+            tags=["user", "preference"],
+            metadata={"platform": "telegram", "chat_id": "-1003772186616", "topic_id": "1347"},
+        )
+        assert duplicate_id == fact_id
+        assert store.counts()["semantic"] == 1
+        scoped = store.search("Mikhail", topic_id="1347", platform="telegram", limit=5)
+        assert len(scoped) == 1
+        assert store.search("Mikhail", topic_id="642", limit=5) == []
+        hybrid = store.hybrid_search("Mikhail", topic_id="1347", limit=5)
+        assert {row["retrieval"] for row in hybrid} == {"direct", "graph"}
+        assert any(row.get("relation") == "supports" for row in hybrid)
+        assert all("score" in row for row in hybrid)
+        candidates = store.skill_candidates()
+        assert candidates[0]["layer"] == "procedural"
+        status = store.status()
+        assert Path(status["db_path"]).exists()
+        assert status["edge_count"] == 1
+        assert status["duplicate_groups"] == 0
+    finally:
+        store.close()
+
+
+def test_store_metrics_expire_and_conflict_detection(tmp_path):
+    store = SubconsciousStore(tmp_path / "subconscious.db")
+    try:
+        working_id = store.add_memory("working", "Pending follow-up should expire", tags=["open-loop"])
+        procedural_id = store.add_memory("procedural", "Run old cleanup workflow", tags=["workflow"])
+        semantic_id = store.add_memory("semantic", "Bud must use decision preflight", confidence=0.8)
+        semantic_conflict_id = store.add_memory("semantic", "Bud must not use decision preflight", confidence=0.75)
+
+        rows = store._conn.execute(
+            "SELECT id, ttl_days FROM memories WHERE id IN (?, ?, ?)",
+            (working_id, procedural_id, semantic_id),
+        ).fetchall()
+        ttl_by_id = {int(row["id"]): row["ttl_days"] for row in rows}
+        assert ttl_by_id[working_id] == 7
+        assert ttl_by_id[procedural_id] == 90
+        assert ttl_by_id[semantic_id] is None
+
+        old = (datetime.now(timezone.utc) - timedelta(days=120)).isoformat(timespec="seconds")
+        store._conn.execute(
+            "UPDATE memories SET created_at=?, updated_at=?, last_seen_at=? WHERE id IN (?, ?)",
+            (old, old, old, working_id, procedural_id),
+        )
+        store._conn.commit()
+
+        metrics = store.capture_metrics_snapshot()
+        assert metrics["stale_memory_count"] == 2
+        assert metrics["total_memories"] == 4
+
+        expired = store.expire_stale_memories()
+        assert expired["expired_count"] == 2
+        assert set(expired["expired_ids"]) == {working_id, procedural_id}
+
+        conflicts = store.detect_conflicts()
+        assert conflicts["new_conflict_count"] == 1
+        assert conflicts["conflict_count"] == 1
+        assert conflicts["conflicts"][0]["memory_id_1"] == semantic_id
+        assert conflicts["conflicts"][0]["memory_id_2"] == semantic_conflict_id
+        assert store.status()["conflict_count"] == 1
+    finally:
+        store.close()
+
+
+def test_provider_tool_status_add_search_and_memory_write(tmp_path):
+    provider = load_memory_provider("subconscious")
+    assert provider is not None
+    provider.initialize("session-1", hermes_home=str(tmp_path), platform="test", agent_context="primary")
+    try:
+        add_result = json.loads(provider.handle_tool_call("subconscious", {
+            "action": "add",
+            "layer": "semantic",
+            "content": "Agentic Stack uses Hermes as coordinator",
+            "tags": ["agentic-stack"],
+            "topic_id": "1347",
+            "chat_id": "-1003772186616",
+            "platform": "telegram",
+        }))
+        assert add_result["success"] is True
+        proc_result = json.loads(provider.handle_tool_call("subconscious", {
+            "action": "add",
+            "layer": "procedural",
+            "content": "Bud executes implementation after Hermes approval",
+            "tags": ["agentic-stack"],
+            "topic_id": "1347",
+            "chat_id": "-1003772186616",
+            "platform": "telegram",
+        }))
+        assert proc_result["success"] is True
+        link_result = json.loads(provider.handle_tool_call("subconscious", {
+            "action": "link",
+            "source_id": add_result["id"],
+            "target_id": proc_result["id"],
+            "relation": "delegates_to",
+            "weight": 0.8,
+        }))
+        assert link_result["success"] is True
+
+        search_result = json.loads(provider.handle_tool_call("subconscious", {
+            "action": "search",
+            "query": "coordinator",
+            "topic_id": "1347",
+        }))
+        assert search_result["success"] is True
+        assert search_result["results"][0]["layer"] == "semantic"
+        hybrid_result = json.loads(provider.handle_tool_call("subconscious", {
+            "action": "hybrid_search",
+            "query": "coordinator",
+            "topic_id": "1347",
+        }))
+        assert hybrid_result["success"] is True
+        assert {row["retrieval"] for row in hybrid_result["results"]} == {"direct", "graph"}
+        related_result = json.loads(provider.handle_tool_call("subconscious", {
+            "action": "related",
+            "memory_id": add_result["id"],
+        }))
+        assert related_result["success"] is True
+        assert related_result["results"][0]["relation"] == "delegates_to"
+        skill_candidates = json.loads(provider.handle_tool_call("subconscious", {
+            "action": "skill_candidates",
+        }))
+        assert skill_candidates["success"] is True
+        assert skill_candidates["results"]
+
+        provider.on_memory_write("add", "user", "User prefers concise reports", metadata={"session_id": "s2"})
+        status_result = json.loads(provider.handle_tool_call("subconscious", {"action": "status"}))
+        assert status_result["success"] is True
+        assert status_result["counts"]["semantic"] >= 2
+
+        provider.handle_tool_call("subconscious", {
+            "action": "add",
+            "layer": "semantic",
+            "content": "Hermes always coordinates review",
+        })
+        provider.handle_tool_call("subconscious", {
+            "action": "add",
+            "layer": "semantic",
+            "content": "Hermes never coordinates review",
+        })
+        conflict_result = json.loads(provider.handle_tool_call("subconscious", {"action": "conflicts"}))
+        assert conflict_result["success"] is True
+        assert conflict_result["conflict_count"] >= 1
+        metrics_result = json.loads(provider.handle_tool_call("subconscious", {"action": "metrics"}))
+        assert metrics_result["success"] is True
+        assert metrics_result["conflict_count"] >= 1
+        expire_result = json.loads(provider.handle_tool_call("subconscious", {"action": "expire"}))
+        assert expire_result["success"] is True
+    finally:
+        provider.shutdown()
+
+
+def test_consolidation_is_deterministic_without_state_db(tmp_path):
+    result = run_consolidation(tmp_path, run_key="test-run")
+    assert result["success"] is True
+    assert result["status"] == "completed"
+    assert result["stats"]["messages_scanned"] == 0
+    assert result["stats"]["metrics"]["total_memories"] == 0
+    assert result["stats"]["expire"]["expired_count"] == 0
+    assert result["stats"]["conflicts"]["conflict_count"] == 0
+
+    second = run_consolidation(tmp_path, run_key="test-run")
+    assert second["success"] is True
+    assert second["status"] == "skipped"

--- a/tests/plugins/memory/test_subconscious_provider.py
+++ b/tests/plugins/memory/test_subconscious_provider.py
@@ -69,6 +69,24 @@ def test_store_metrics_expire_and_conflict_detection(tmp_path):
         procedural_id = store.add_memory("procedural", "Run old cleanup workflow", tags=["workflow"])
         semantic_id = store.add_memory("semantic", "Bud must use decision preflight", confidence=0.8)
         semantic_conflict_id = store.add_memory("semantic", "Bud must not use decision preflight", confidence=0.75)
+        should_id = store.add_memory("semantic", "Hermes should coordinate with Bud after approval", confidence=0.8)
+        should_noise_id = store.add_memory("semantic", "Routine reports should not mention Hindsight unless relevant", confidence=0.8)
+        store.add_memory(
+            "semantic",
+            '{"success": false, "error": "Bud must not use decision preflight"}',
+            tags=["hygiene:noisy"],
+            confidence=0.9,
+        )
+        store.add_memory("semantic", "Bud must not use decision preflight in a noisy draft", confidence=0.4)
+        store._conn.execute(
+            """
+            INSERT INTO detected_conflicts
+            (memory_id_1, memory_id_2, conflict_type, severity, detected_at)
+            VALUES (?, ?, 'should_vs_should_not', 'high', ?)
+            """,
+            (should_id, should_noise_id, datetime.now(timezone.utc).isoformat(timespec="seconds")),
+        )
+        store._conn.commit()
 
         rows = store._conn.execute(
             "SELECT id, ttl_days FROM memories WHERE id IN (?, ?, ?)",
@@ -88,7 +106,7 @@ def test_store_metrics_expire_and_conflict_detection(tmp_path):
 
         metrics = store.capture_metrics_snapshot()
         assert metrics["stale_memory_count"] == 2
-        assert metrics["total_memories"] == 4
+        assert metrics["total_memories"] == 8
 
         expired = store.expire_stale_memories()
         assert expired["expired_count"] == 2
@@ -97,6 +115,9 @@ def test_store_metrics_expire_and_conflict_detection(tmp_path):
         conflicts = store.detect_conflicts()
         assert conflicts["new_conflict_count"] == 1
         assert conflicts["conflict_count"] == 1
+        assert conflicts["skipped_memory_count"] == 2
+        assert conflicts["rejected_by_gate_count"] == 1
+        assert conflicts["stale_resolved_count"] == 1
         assert conflicts["conflicts"][0]["memory_id_1"] == semantic_id
         assert conflicts["conflicts"][0]["memory_id_2"] == semantic_conflict_id
         assert store.status()["conflict_count"] == 1


### PR DESCRIPTION
## Summary

- add local subconscious observability/hygiene primitives: metrics snapshots, TTL expiry, and detected conflict storage
- add conflict detection tool/status integration for the subconscious memory provider
- harden conflict detection against lexical cross-product noise by filtering noisy/low-confidence/tool-artifact memories and requiring phrase/subject overlap before inserting conflicts
- reconcile stale detector-owned unresolved rows when a later detector run no longer considers them valid candidates

## Problem

A local Hermes Subconscious inventory found 109 unresolved "conflicts" that were almost entirely detector noise:

- 47 `must_vs_must_not`
- 62 `should_vs_should_not`

The old detector paired broad policy memories by lexical markers such as `must` and `must not` without enough subject/topic similarity, producing cross-product hubs. JSON/tool result artifacts and low-confidence noisy memories were also eligible.

## Solution

The detector now:

- skips memories tagged `hygiene:noisy` or `soft-decayed`
- skips confidence < 0.5 unless explicitly promoted
- skips JSON/tool result artifacts unless explicitly promoted
- ignores positive `must/should` statements whose phrase tail is actually a negative action like `omit`, `avoid`, `skip`, or `wait`
- requires lexical contradiction plus stronger phrase/subject overlap
- returns diagnostic counters: skipped, rejected_by_gate, stale_resolved, hubs
- marks previously inserted detector-owned rows resolved when a later run no longer detects them

## Local Verification

- Clean-copy DB rerun: 109 unresolved -> 0 unresolved
- Live local DB reconciliation: 109 unresolved -> 0 unresolved, `stale_resolved=109`
- Backup before reconciliation: `/Users/xbr/.agentic-stack/subconscious/backups/subconscious-before-detector-patch-20260523-165645.db`
- `.venv/bin/pytest tests/plugins/memory/test_subconscious_provider.py -n 0`: 5 passed
- `.venv/bin/pytest tests/plugins/memory -n 0`: 166 passed
- `uvx ruff check plugins/memory/subconscious/store.py tests/plugins/memory/test_subconscious_provider.py`: passed

## Notes

This is still heuristic conflict detection, not semantic reasoning. The intent is to suppress known false positives and leave high-quality candidate conflicts for manual review instead of flooding reports with lexical noise.
