### PR TITLE
feat(tool-context): compact large tool results before replay

### DIFF
--- a/agent/tool_context_policy.py
+++ b/agent/tool_context_policy.py
@@ -1,0 +1,294 @@
+"""Compact tool results before they enter model context.
+
+This module keeps large tool outputs useful without letting raw HTML, logs, or
+file dumps dominate the next prompt. It is deliberately deterministic: no LLM
+summaries, no external storage, and only a small set of built-in tool classes.
+"""
+
+from __future__ import annotations
+
+import html
+import json
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_MAX_CHARS = 12_000
+_TERMINAL_MAX_CHARS = 12_000
+_FILE_MAX_CHARS = 16_000
+_WEB_MAX_CHARS = 8_000
+_JSON_MAX_CHARS = 12_000
+_HEAD_CHARS = 3_000
+_TAIL_CHARS = 2_000
+
+
+@dataclass(frozen=True)
+class ToolContextConfig:
+    enabled: bool = True
+    default_max_chars: int = _DEFAULT_MAX_CHARS
+    terminal_max_chars: int = _TERMINAL_MAX_CHARS
+    file_max_chars: int = _FILE_MAX_CHARS
+    web_max_chars: int = _WEB_MAX_CHARS
+    json_max_chars: int = _JSON_MAX_CHARS
+    head_chars: int = _HEAD_CHARS
+    tail_chars: int = _TAIL_CHARS
+
+
+def _coerce_int(value: Any, default: int, *, minimum: int = 1000) -> int:
+    try:
+        coerced = int(value)
+    except Exception:
+        return default
+    return max(minimum, coerced)
+
+
+def load_tool_context_config(config: Mapping[str, Any] | None = None) -> ToolContextConfig:
+    """Load tool-context config from a config dict or config.yaml."""
+    if config is None:
+        try:
+            from hermes_cli.config import load_config
+
+            config = load_config() or {}
+        except Exception:
+            config = {}
+
+    raw = config.get("tool_context") if isinstance(config, Mapping) else None
+    if not isinstance(raw, Mapping):
+        raw = {}
+
+    return ToolContextConfig(
+        enabled=bool(raw.get("enabled", True)),
+        default_max_chars=_coerce_int(raw.get("default_max_chars"), _DEFAULT_MAX_CHARS),
+        terminal_max_chars=_coerce_int(raw.get("terminal_max_chars"), _TERMINAL_MAX_CHARS),
+        file_max_chars=_coerce_int(raw.get("file_max_chars"), _FILE_MAX_CHARS),
+        web_max_chars=_coerce_int(raw.get("web_max_chars"), _WEB_MAX_CHARS),
+        json_max_chars=_coerce_int(raw.get("json_max_chars"), _JSON_MAX_CHARS),
+        head_chars=_coerce_int(raw.get("head_chars"), _HEAD_CHARS, minimum=200),
+        tail_chars=_coerce_int(raw.get("tail_chars"), _TAIL_CHARS, minimum=200),
+    )
+
+
+def _json_loads(value: str) -> Any | None:
+    try:
+        return json.loads(value)
+    except Exception:
+        return None
+
+
+def _json_dumps(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+
+
+def classify_tool(tool_name: str, args: Mapping[str, Any] | None = None, content: str = "") -> str:
+    name = (tool_name or "").lower()
+    if name in {"terminal", "process", "execute_code"}:
+        return "terminal"
+    if name in {"read_file", "search_files", "skill_view"}:
+        return "file"
+    if name.startswith("web_") or name in {"web_extract", "web_search", "browser"}:
+        return "web"
+    if _looks_like_html(content):
+        return "web"
+    if _json_loads(content) is not None:
+        return "json"
+    return "generic"
+
+
+def _max_chars_for(kind: str, cfg: ToolContextConfig) -> int:
+    if kind == "terminal":
+        return cfg.terminal_max_chars
+    if kind == "file":
+        return cfg.file_max_chars
+    if kind == "web":
+        return cfg.web_max_chars
+    if kind == "json":
+        return cfg.json_max_chars
+    return cfg.default_max_chars
+
+
+def _notice(tool_name: str, original_chars: int, kept_chars: int) -> str:
+    return (
+        f"[tool output compacted: tool={tool_name or 'unknown'} "
+        f"original_chars={original_chars} kept_chars={kept_chars}]"
+    )
+
+
+def _head_tail(text: str, max_chars: int, cfg: ToolContextConfig) -> str:
+    if len(text) <= max_chars:
+        return text
+    head = min(cfg.head_chars, max_chars // 2)
+    tail = min(cfg.tail_chars, max_chars - head - 200)
+    tail = max(200, tail)
+    omitted = len(text) - head - tail
+    return (
+        text[:head].rstrip()
+        + f"\n\n[... compacted: {omitted} chars omitted ...]\n\n"
+        + text[-tail:].lstrip()
+    )
+
+
+def _looks_like_html(text: str) -> bool:
+    sample = text[:4096].lower()
+    return "<html" in sample or "<!doctype html" in sample or ("<head" in sample and "<body" in sample)
+
+
+def _strip_html_noise(text: str) -> str:
+    text = re.sub(r"(?is)<(script|style|svg|noscript)\b.*?</\1>", " ", text)
+    text = re.sub(r"(?is)<!--.*?-->", " ", text)
+    return text
+
+
+def _tag_text(pattern: str, text: str, limit: int = 12) -> list[str]:
+    values = []
+    for match in re.finditer(pattern, text, flags=re.I | re.S):
+        value = re.sub(r"<[^>]+>", " ", match.group(1))
+        value = html.unescape(re.sub(r"\s+", " ", value)).strip()
+        if value and value not in values:
+            values.append(value)
+        if len(values) >= limit:
+            break
+    return values
+
+
+def _compact_html(tool_name: str, text: str, max_chars: int, cfg: ToolContextConfig) -> str:
+    original = len(text)
+    clean = _strip_html_noise(text)
+    title = _tag_text(r"<title[^>]*>(.*?)</title>", clean, limit=1)
+    meta = _tag_text(r'<meta[^>]+name=["\']description["\'][^>]+content=["\'](.*?)["\']', clean, limit=1)
+    headings = _tag_text(r"<h[1-3][^>]*>(.*?)</h[1-3]>", clean, limit=16)
+    body = re.sub(r"(?is)<[^>]+>", " ", clean)
+    body = html.unescape(re.sub(r"\s+", " ", body)).strip()
+
+    lines = [_notice(tool_name, original, max_chars)]
+    if title:
+        lines.append(f"Title: {title[0]}")
+    if meta:
+        lines.append(f"Description: {meta[0]}")
+    if headings:
+        lines.append("Headings:")
+        lines.extend(f"- {h}" for h in headings)
+    if body:
+        lines.append("Text preview:")
+        lines.append(_head_tail(body, max_chars=max_chars, cfg=cfg))
+    compacted = "\n".join(lines)
+    return compacted[:max_chars]
+
+
+def _error_lines(text: str, limit: int = 30) -> list[str]:
+    found = []
+    for line in text.splitlines():
+        low = line.lower()
+        if any(marker in low for marker in ("error", "exception", "failed", "warning", "traceback")):
+            found.append(line[:500])
+        if len(found) >= limit:
+            break
+    return found
+
+
+def _compact_terminal(tool_name: str, text: str, max_chars: int, cfg: ToolContextConfig) -> str:
+    errors = _error_lines(text)
+    body = _head_tail(text, max_chars=max_chars, cfg=cfg)
+    if not errors:
+        return f"{_notice(tool_name, len(text), max_chars)}\n{body}"[:max_chars]
+    prefix = [_notice(tool_name, len(text), max_chars), "Important lines:"]
+    prefix.extend(f"- {line}" for line in errors)
+    return ("\n".join(prefix) + "\n\nOutput preview:\n" + body)[:max_chars]
+
+
+def _compact_json_value(value: Any, tool_name: str, kind: str, max_chars: int, cfg: ToolContextConfig) -> str:
+    if isinstance(value, dict):
+        changed = False
+        result = dict(value)
+        for key, item in list(result.items()):
+            if not isinstance(item, str):
+                continue
+            item_kind = "web" if _looks_like_html(item) else kind
+            item_max = max(1000, max_chars - 1500)
+            if len(item) > item_max:
+                changed = True
+                if item_kind == "web":
+                    result[key] = _compact_html(tool_name, item, item_max, cfg)
+                elif kind == "terminal":
+                    result[key] = _compact_terminal(tool_name, item, item_max, cfg)
+                else:
+                    result[key] = _head_tail(item, item_max, cfg)
+        dumped = _json_dumps(result)
+        if len(dumped) <= max_chars:
+            if changed:
+                logger.info("tool_context compacted JSON fields for %s", tool_name)
+            return dumped
+
+        skeleton = {}
+        for key, item in value.items():
+            if isinstance(item, (str, int, float, bool)) or item is None:
+                skeleton[key] = item if not isinstance(item, str) else _head_tail(item, 1000, cfg)
+            elif isinstance(item, list):
+                skeleton[key] = f"[list len={len(item)}]"
+            elif isinstance(item, dict):
+                skeleton[key] = f"[object keys={list(item.keys())[:12]}]"
+            else:
+                skeleton[key] = f"[{type(item).__name__}]"
+        dumped = _json_dumps({
+            "_hermes_context_compacted": True,
+            "_original_chars": len(_json_dumps(value)),
+            "summary": skeleton,
+        })
+        if len(dumped) <= max_chars:
+            return dumped
+
+        fallback = {
+            "_hermes_context_compacted": True,
+            "_original_chars": len(_json_dumps(value)),
+            "keys": list(value.keys())[:50],
+            "preview": _head_tail(_json_dumps(value), max(1000, max_chars - 500), cfg),
+        }
+        dumped = _json_dumps(fallback)
+        if len(dumped) <= max_chars:
+            return dumped
+        fallback["preview"] = fallback["preview"][: max(200, max_chars - 800)]
+        return _json_dumps(fallback)
+
+    dumped = _json_dumps(value)
+    return _head_tail(dumped, max_chars, cfg)
+
+
+def compact_tool_result(
+    tool_name: str,
+    args: Mapping[str, Any] | None,
+    content: Any,
+    *,
+    config: Mapping[str, Any] | ToolContextConfig | None = None,
+) -> Any:
+    """Return the tool result content that should be sent back to the model."""
+    if not isinstance(content, str):
+        return content
+
+    cfg = config if isinstance(config, ToolContextConfig) else load_tool_context_config(config)
+    if not cfg.enabled:
+        return content
+
+    kind = classify_tool(tool_name, args, content)
+    max_chars = _max_chars_for(kind, cfg)
+    if len(content) <= max_chars:
+        return content
+
+    parsed = _json_loads(content)
+    if parsed is not None:
+        compacted = _compact_json_value(parsed, tool_name, kind, max_chars, cfg)
+    elif kind == "web":
+        compacted = _compact_html(tool_name, content, max_chars, cfg)
+    elif kind == "terminal":
+        compacted = _compact_terminal(tool_name, content, max_chars, cfg)
+    else:
+        compacted = f"{_notice(tool_name, len(content), max_chars)}\n{_head_tail(content, max_chars, cfg)}"
+        compacted = compacted[:max_chars]
+
+    if len(compacted) < len(content):
+        logger.info(
+            "tool_context compacted tool=%s kind=%s original_chars=%d context_chars=%d",
+            tool_name, kind, len(content), len(compacted),
+        )
+    return compacted

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -30,6 +30,7 @@ from agent.display import (
     _detect_tool_failure,
 )
 from agent.tool_guardrails import ToolGuardrailDecision
+from agent.tool_context_policy import compact_tool_result
 from agent.tool_dispatch_helpers import (
     _is_destructive_command,
     _is_multimodal_tool_result,
@@ -60,6 +61,38 @@ def _ra():
     """Lazy reference to ``run_agent`` so patches like ``run_agent._set_interrupt`` work."""
     import run_agent
     return run_agent
+
+
+def _context_content_for_model(
+    agent,
+    *,
+    tool_name: str,
+    tool_args: dict,
+    tool_call_id: str,
+    function_result: Any,
+    effective_task_id: str,
+) -> Any:
+    """Prepare a tool result for model context without changing UI callbacks."""
+    if _is_multimodal_tool_result(function_result):
+        subdir_hints = agent._subdirectory_hints.check_tool_call(tool_name, tool_args)
+        if subdir_hints:
+            _append_subdir_hint_to_multimodal(function_result, subdir_hints)
+        return agent._tool_result_content_for_active_model(tool_name, function_result)
+
+    context_result = maybe_persist_tool_result(
+        content=function_result,
+        tool_name=tool_name,
+        tool_use_id=tool_call_id,
+        env=get_active_env(effective_task_id),
+    )
+
+    context_result = compact_tool_result(tool_name, tool_args, context_result)
+
+    subdir_hints = agent._subdirectory_hints.check_tool_call(tool_name, tool_args)
+    if subdir_hints:
+        context_result += subdir_hints
+
+    return agent._tool_result_content_for_active_model(tool_name, context_result)
 
 
 def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
@@ -418,31 +451,16 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             except Exception as cb_err:
                 logging.debug(f"Tool complete callback error: {cb_err}")
 
-        function_result = maybe_persist_tool_result(
-            content=function_result,
+        # Keep callbacks/display on the raw tool result above; only compact
+        # the content that is appended back into model context.
+        _tool_content = _context_content_for_model(
+            agent,
             tool_name=name,
-            tool_use_id=tc.id,
-            env=get_active_env(effective_task_id),
-        ) if not _is_multimodal_tool_result(function_result) else function_result
-
-        subdir_hints = agent._subdirectory_hints.check_tool_call(name, args)
-        if subdir_hints:
-            if _is_multimodal_tool_result(function_result):
-                # Append the hint to the text summary part so the model
-                # still sees it; don't touch the image blocks.
-                _append_subdir_hint_to_multimodal(function_result, subdir_hints)
-            else:
-                function_result += subdir_hints
-
-        # Unwrap _multimodal dicts to an OpenAI-style content list so any
-        # vision-capable provider receives [{type:text},{type:image_url}]
-        # rather than a raw Python dict.  The Anthropic adapter already
-        # accepts content lists; vision-capable OpenAI-compatible servers
-        # (mlx-vlm, GPT-4o, …) accept image_url in tool messages natively.
-        # Text-only servers get a string-safe fallback here so a rejected
-        # image tool result never poisons canonical session history.
-        # String results pass through unchanged.
-        _tool_content = agent._tool_result_content_for_active_model(name, function_result)
+            tool_args=args,
+            tool_call_id=tc.id,
+            function_result=function_result,
+            effective_task_id=effective_task_id,
+        )
         messages.append(make_tool_result_message(name, _tool_content, tc.id))
 
         # ── Per-tool /steer drain ───────────────────────────────────
@@ -840,24 +858,16 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             except Exception as cb_err:
                 logging.debug(f"Tool complete callback error: {cb_err}")
 
-        function_result = maybe_persist_tool_result(
-            content=function_result,
+        # Keep callbacks/display on the raw tool result above; only compact
+        # the content that is appended back into model context.
+        _tool_content = _context_content_for_model(
+            agent,
             tool_name=function_name,
-            tool_use_id=tool_call.id,
-            env=get_active_env(effective_task_id),
-        ) if not _is_multimodal_tool_result(function_result) else function_result
-
-        # Discover subdirectory context files from tool arguments
-        subdir_hints = agent._subdirectory_hints.check_tool_call(function_name, function_args)
-        if subdir_hints:
-            if _is_multimodal_tool_result(function_result):
-                _append_subdir_hint_to_multimodal(function_result, subdir_hints)
-            else:
-                function_result += subdir_hints
-
-        # Unwrap _multimodal dicts to an OpenAI-style content list
-        # (see parallel path for rationale). String results pass through.
-        _tool_content = agent._tool_result_content_for_active_model(function_name, function_result)
+            tool_args=function_args,
+            tool_call_id=tool_call.id,
+            function_result=function_result,
+            effective_task_id=effective_task_id,
+        )
         messages.append(make_tool_result_message(function_name, _tool_content, tool_call.id))
 
         # ── Per-tool /steer drain ───────────────────────────────────

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -336,6 +336,23 @@ tool_loop_guardrails:
     idempotent_no_progress: 5
 
 # =============================================================================
+# Tool Context Compaction
+# =============================================================================
+# Keeps large tool results useful without letting raw HTML, logs, JSON payloads,
+# or file dumps dominate the next model prompt. Display/log output stays intact;
+# these limits apply to the tool-result message appended back into conversation
+# context for the next model call.
+tool_context:
+  enabled: true
+  default_max_chars: 12000
+  terminal_max_chars: 12000
+  file_max_chars: 16000
+  web_max_chars: 8000
+  json_max_chars: 12000
+  head_chars: 3000
+  tail_chars: 2000
+
+# =============================================================================
 # Context Compression (Auto-shrinks long conversations)
 # =============================================================================
 # When conversation approaches model's context limit, middle turns are

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -773,6 +773,21 @@ DEFAULT_CONFIG = {
         "max_line_length": 2000,
     },
 
+    # Tool-context compaction happens after a tool returns and before its
+    # result is appended back into the model conversation. It keeps TUI/log
+    # output intact while preventing large HTML, terminal, JSON, or file
+    # payloads from dominating the next prompt.
+    "tool_context": {
+        "enabled": True,
+        "default_max_chars": 12_000,
+        "terminal_max_chars": 12_000,
+        "file_max_chars": 16_000,
+        "web_max_chars": 8_000,
+        "json_max_chars": 12_000,
+        "head_chars": 3_000,
+        "tail_chars": 2_000,
+    },
+
     # Tool loop guardrails nudge models when they repeat failed or
     # non-progressing tool calls. Soft warnings are always-on by default;
     # hard stops are opt-in so interactive CLI/TUI sessions keep flowing.
@@ -3301,7 +3316,7 @@ _KNOWN_ROOT_KEYS = {
     "fallback_providers", "credential_pool_strategies", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
     "auxiliary", "custom_providers", "context", "memory", "gateway",
-    "sessions",
+    "sessions", "tool_context",
 }
 
 # Valid fields inside a custom_providers list entry

--- a/tests/agent/test_tool_context_policy.py
+++ b/tests/agent/test_tool_context_policy.py
@@ -1,0 +1,95 @@
+import json
+
+from agent.tool_context_policy import (
+    ToolContextConfig,
+    classify_tool,
+    compact_tool_result,
+)
+
+
+def test_small_output_is_unchanged():
+    content = "ok\nsmall output"
+    assert compact_tool_result("terminal", {"command": "echo ok"}, content) == content
+
+
+def test_html_output_is_compacted_to_page_signals():
+    html = """
+    <!doctype html>
+    <html>
+      <head>
+        <title>Example Page</title>
+        <meta name="description" content="Example description">
+        <style>body {{ color: red; }}</style>
+        <script>console.log("noise")</script>
+      </head>
+      <body>
+        <h1>Main Heading</h1>
+        <h2>Useful Section</h2>
+        <p>{body}</p>
+      </body>
+    </html>
+    """.format(body="useful text " * 3000)
+    result = compact_tool_result(
+        "web_extract",
+        {"url": "https://example.com"},
+        json.dumps({"output": html}),
+        config=ToolContextConfig(web_max_chars=4000, head_chars=1000, tail_chars=500),
+    )
+    assert len(result) <= 4000
+    assert "tool output compacted" in result
+    assert "Example Page" in result
+    assert "Main Heading" in result
+    assert "console.log" not in result
+
+
+def test_terminal_output_keeps_error_lines_and_tail():
+    output = "\n".join(
+        ["start"]
+        + [f"line {i}" for i in range(2000)]
+        + ["ERROR: build failed", "final line"]
+    )
+    result = compact_tool_result(
+        "terminal",
+        {"command": "npm test"},
+        json.dumps({"status": "error", "output": output, "exit_code": 1}),
+        config=ToolContextConfig(terminal_max_chars=3500, head_chars=800, tail_chars=700),
+    )
+    assert len(result) <= 3500
+    assert "ERROR: build failed" in result
+    assert "final line" in result
+    assert "tool output compacted" in result
+
+
+def test_large_json_skeleton_preserves_keys():
+    payload = {
+        "status": "success",
+        "items": [{"id": i, "value": "x" * 100} for i in range(1000)],
+        "summary": "done",
+    }
+    result = compact_tool_result(
+        "unknown_tool",
+        {},
+        json.dumps(payload),
+        config=ToolContextConfig(json_max_chars=2500, head_chars=500, tail_chars=500),
+    )
+    assert len(result) <= 2500
+    parsed = json.loads(result)
+    assert parsed["_hermes_context_compacted"] is True
+    assert parsed["summary"]["status"] == "success"
+    assert parsed["summary"]["items"].startswith("[list len=")
+
+
+def test_disabled_config_returns_original():
+    content = "x" * 20_000
+    result = compact_tool_result(
+        "terminal",
+        {},
+        content,
+        config=ToolContextConfig(enabled=False, terminal_max_chars=1000),
+    )
+    assert result == content
+
+
+def test_classify_html_by_content():
+    assert classify_tool("terminal", {}, "<html><body>hello</body></html>") == "terminal"
+    assert classify_tool("unknown", {}, "<html><body>hello</body></html>") == "web"

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -556,6 +556,28 @@ tool_output:
   max_lines: 500
 ```
 
+## Tool Context Compaction
+
+Tool output truncation limits control what individual tools return. Tool context compaction runs one step later: after a tool returns, before the result is appended back into the model conversation. It keeps display/log output intact while giving the next model call a compact, deterministic view of large terminal, file, web/HTML, JSON, and generic outputs.
+
+```yaml
+tool_context:
+  enabled: true
+  default_max_chars: 12000
+  terminal_max_chars: 12000
+  file_max_chars: 16000
+  web_max_chars: 8000
+  json_max_chars: 12000
+  head_chars: 3000
+  tail_chars: 2000
+```
+
+- **`enabled`** — Turns insertion-time tool context compaction on or off. Default `true`.
+- **`*_max_chars`** — Maximum characters retained in the tool result that is sent back to the model, by output class. HTML outputs are reduced to page signals such as title, description, headings, and text preview.
+- **`head_chars` / `tail_chars`** — Generic head/tail budgets used when a large result cannot be summarized by a structured rule.
+
+This is separate from context compression. Compression summarizes older conversation turns when the prompt approaches the model limit; tool context compaction prevents recent tool outputs from bloating the prompt in the first place.
+
 ## Global Toolset Disable
 
 To suppress specific toolsets across the CLI and every gateway platform in one


### PR DESCRIPTION
Fixes #415
Refs #513

## What does this PR do?

This PR adds insertion-time tool result compaction so large tool outputs are reduced before they are appended back into the model conversation. The goal is to keep recent tool calls useful without letting raw HTML, long terminal output, or large JSON/file payloads dominate the next prompt before normal context compression has a chance to run.

The approach is deterministic and cache-friendly: it compacts only the tool-result message being appended, leaves TUI/log callbacks on the raw tool result, and avoids LLM summaries or external vector storage.

## Related Issue

Fixes #415
Refs #513

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `agent/tool_context_policy.py` with deterministic compaction for terminal, file, web/HTML, JSON, and generic tool results.
- Route both sequential and concurrent tool execution through the same context-only compaction path before `make_tool_result_message()`.
- Keep display/log callbacks on the raw tool result so user-visible output is not reduced by this policy.
- Add `tool_context` defaults to `hermes_cli/config.py` and `cli-config.yaml.example`.
- Document tool context compaction in `website/docs/user-guide/configuration.md`.
- Add focused tests in `tests/agent/test_tool_context_policy.py`.

## How to Test

1. Run the focused regression suite:
   ```bash
   /Users/zhi/.hermes/hermes-agent/venv/bin/python -m pytest -q \
     tests/agent/test_tool_context_policy.py \
     tests/tools/test_tool_result_storage.py \
     tests/tools/test_budget_config.py \
     tests/agent/test_context_compressor.py
   ```
2. Compile the touched modules:
   ```bash
   /Users/zhi/.hermes/hermes-agent/venv/bin/python -m py_compile \
     agent/tool_context_policy.py \
     agent/tool_executor.py \
     hermes_cli/config.py
   ```
3. Local smoke test on macOS with a Chinese-language Hermes session and local llama.cpp backend: a real 57,701-character HTML/tool result compacted to an 823-character model-context result while preserving title, description, headings, and text preview.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, local llama.cpp backend, Chinese-language Hermes session

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Focused tests:

```text
158 passed in 17.16s
```
