### PR TITLE
feat: add Kagi web search provider plugin

### DIFF
--- a/agent/web_search_registry.py
+++ b/agent/web_search_registry.py
@@ -127,6 +127,7 @@ _LEGACY_PREFERENCE = (
     "searxng",
     "brave-free",
     "ddgs",
+    "kagi",
 )
 
 
@@ -148,7 +149,7 @@ def _resolve(configured: Optional[str], *, capability: str) -> Optional[WebSearc
 
     3. **Legacy preference walk, filtered by availability.** Walk the
        :data:`_LEGACY_PREFERENCE` order (firecrawl → parallel → tavily →
-       exa → searxng → brave-free → ddgs) looking for a provider whose
+       exa → searxng → brave-free → ddgs → kagi) looking for a provider whose
        ``supports_<capability>()`` is True AND whose ``is_available()`` is
        True. Matches the historic ``tools.web_tools._get_backend()``
        candidate order so users with credentials but no explicit config

--- a/plugins/web/kagi/__init__.py
+++ b/plugins/web/kagi/__init__.py
@@ -1,0 +1,15 @@
+"""Kagi web search plugin — bundled, auto-loaded.
+
+Uses the existing ``kagi_search.py`` script which scrapes Kagi's
+``/html/search`` endpoint via a session cookie.  Requires ``KAGI_SESSION``
+in ``~/.hermes/.env``.
+"""
+
+from __future__ import annotations
+
+from plugins.web.kagi.provider import KagiWebSearchProvider
+
+
+def register(ctx) -> None:
+    """Register the Kagi provider with the plugin context."""
+    ctx.register_web_search_provider(KagiWebSearchProvider())

--- a/plugins/web/kagi/__init__.py
+++ b/plugins/web/kagi/__init__.py
@@ -1,8 +1,8 @@
 """Kagi web search plugin — bundled, auto-loaded.
 
-Uses the existing ``kagi_search.py`` script which scrapes Kagi's
-``/html/search`` endpoint via a session cookie.  Requires ``KAGI_SESSION``
-in ``~/.hermes/.env``.
+Calls Kagi Search API v1 (POST /api/v1/search) and Extract API
+(POST /api/v1/extract) directly. Requires ``KAGI_API_KEY`` in
+``~/.hermes/.env``.
 """
 
 from __future__ import annotations

--- a/plugins/web/kagi/plugin.yaml
+++ b/plugins/web/kagi/plugin.yaml
@@ -1,0 +1,7 @@
+name: web-kagi
+version: 1.0.0
+description: "Kagi web search via session-cookie-backed /html/search endpoint. Set KAGI_SESSION in ~/.hermes/.env."
+author: iacore
+kind: backend
+provides_web_providers:
+  - kagi

--- a/plugins/web/kagi/plugin.yaml
+++ b/plugins/web/kagi/plugin.yaml
@@ -1,6 +1,6 @@
 name: web-kagi
-version: 1.0.0
-description: "Kagi web search via session-cookie-backed /html/search endpoint. Set KAGI_SESSION in ~/.hermes/.env."
+version: 2.0.0
+description: "Kagi web search + extract via API v1 (Bearer token). Set KAGI_API_KEY in ~/.hermes/.env."
 author: iacore
 kind: backend
 provides_web_providers:

--- a/plugins/web/kagi/provider.py
+++ b/plugins/web/kagi/provider.py
@@ -12,7 +12,7 @@ Configuration::
 
     # ~/.hermes/config.yaml
     web:
-      backend: "kagi"
+      search_backend: kagi
 """
 
 from __future__ import annotations

--- a/plugins/web/kagi/provider.py
+++ b/plugins/web/kagi/provider.py
@@ -1,0 +1,130 @@
+"""Kagi web search provider.
+
+Uses the existing ``kagi_search.py`` script which scrapes Kagi's
+``/html/search`` endpoint via a session cookie.  Because Kagi's Search
+API is still in closed beta, this provider shells out to the script
+rather than calling the API directly.
+
+Configuration::
+
+    # ~/.hermes/.env
+    KAGI_SESSION=<session_cookie>
+
+    # ~/.hermes/config.yaml
+    web:
+      backend: "kagi"
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+from pathlib import Path
+from typing import Any, Dict
+
+from agent.web_search_provider import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+_SCRIPT = Path(os.path.expanduser(
+    "~/.hermes/skills/research/kagi-search/scripts/kagi_search.py"
+))
+
+
+def _has_kagi_session() -> bool:
+    """Return True when KAGI_SESSION is available (env var or .env file)."""
+    env_path = Path(os.path.expanduser("~/.hermes/.env"))
+    try:
+        for line in env_path.read_text().splitlines():
+            if line.startswith("KAGI_SESSION=") and line.split("=", 1)[1].strip():
+                return True
+    except (OSError, FileNotFoundError):
+        pass
+    return bool(os.getenv("KAGI_SESSION", "").strip())
+
+
+class KagiWebSearchProvider(WebSearchProvider):
+    """Search via Kagi's session-cookie-backed /html/search endpoint.
+
+    Delegates to ``kagi_search.py --json`` which handles cookie loading
+    and HTML parsing.  Only search is supported — there is no extract
+    or crawl capability.
+    """
+
+    @property
+    def name(self) -> str:
+        return "kagi"
+
+    @property
+    def display_name(self) -> str:
+        return "Kagi"
+
+    def is_available(self) -> bool:
+        return _has_kagi_session() and _SCRIPT.exists()
+
+    def supports_search(self) -> bool:
+        return True
+
+    def supports_extract(self) -> bool:
+        return False
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        if not self.is_available():
+            return {
+                "success": False,
+                "error": "KAGI_SESSION not found or kagi_search.py missing",
+            }
+
+        try:
+            result = subprocess.run(
+                ["python3", str(_SCRIPT), "--json", "--limit", str(limit), query],
+                capture_output=True, text=True, timeout=30,
+            )
+        except subprocess.TimeoutExpired:
+            return {"success": False, "error": "Kagi search timed out (30s)"}
+        except Exception as exc:
+            return {"success": False, "error": f"Kagi search failed: {exc}"}
+
+        if result.returncode != 0:
+            return {
+                "success": False,
+                "error": f"kagi_search.py exited {result.returncode}: {result.stderr.strip()}",
+            }
+
+        try:
+            data = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            return {"success": False, "error": "Could not parse Kagi response"}
+
+        results = data.get("results", [])[:limit]
+        web_results = [
+            {
+                "title": r.get("title", ""),
+                "url": r.get("url", ""),
+                "description": r.get("snippet", ""),
+                "position": i + 1,
+            }
+            for i, r in enumerate(results)
+        ]
+
+        logger.info(
+            "Kagi search '%s': %d results (limit %d)",
+            query, len(web_results), limit,
+        )
+        return {"success": True, "data": {"web": web_results}}
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Kagi",
+            "badge": "free · session cookie · search only",
+            "tag": "Search via Kagi session cookie — set KAGI_SESSION in ~/.hermes/.env",
+            "env_vars": [
+                {
+                    "key": "KAGI_SESSION",
+                    "prompt": "Kagi session cookie",
+                    "url": "https://kagi.com",
+                },
+            ],
+        }

--- a/plugins/web/kagi/provider.py
+++ b/plugins/web/kagi/provider.py
@@ -1,57 +1,59 @@
-"""Kagi web search provider.
+"""Kagi web search + extract provider via API v1.
 
-Uses the existing ``kagi_search.py`` script which scrapes Kagi's
-``/html/search`` endpoint via a session cookie.  Because Kagi's Search
-API is still in closed beta, this provider shells out to the script
-rather than calling the API directly.
+Calls Kagi Search API (POST /api/v1/search) and Extract API
+(POST /api/v1/extract) directly — no script dependency.
 
 Configuration::
 
     # ~/.hermes/.env
-    KAGI_SESSION=<session_cookie>
+    KAGI_API_KEY=<api_key>
 
     # ~/.hermes/config.yaml
     web:
       search_backend: kagi
+      extract_backend: kagi
 """
 
 from __future__ import annotations
 
-import json
 import logging
 import os
-import subprocess
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
+
+import requests
 
 from agent.web_search_provider import WebSearchProvider
 
 logger = logging.getLogger(__name__)
 
-_SCRIPT = Path(os.path.expanduser(
-    "~/.hermes/skills/research/kagi-search/scripts/kagi_search.py"
-))
+_SEARCH_URL = "https://kagi.com/api/v1/search"
+_EXTRACT_URL = "https://kagi.com/api/v1/extract"
 
 
-def _has_kagi_session() -> bool:
-    """Return True when KAGI_SESSION is available (env var or .env file)."""
+def _load_api_key() -> str | None:
+    """Return KAGI_API_KEY from env or ~/.hermes/.env, or None."""
+    env_val = os.environ.get("KAGI_API_KEY")
+    if env_val:
+        return env_val
     env_path = Path(os.path.expanduser("~/.hermes/.env"))
     try:
         for line in env_path.read_text().splitlines():
-            if line.startswith("KAGI_SESSION=") and line.split("=", 1)[1].strip():
-                return True
+            if line.startswith("KAGI_API_KEY="):
+                val = line.strip().split("=", 1)[1]
+                if val:
+                    return val
     except (OSError, FileNotFoundError):
         pass
-    return bool(os.getenv("KAGI_SESSION", "").strip())
+    return None
+
+
+def _has_kagi_api_key() -> bool:
+    return _load_api_key() is not None
 
 
 class KagiWebSearchProvider(WebSearchProvider):
-    """Search via Kagi's session-cookie-backed /html/search endpoint.
-
-    Delegates to ``kagi_search.py --json`` which handles cookie loading
-    and HTML parsing.  Only search is supported — there is no extract
-    or crawl capability.
-    """
+    """Search + extract via Kagi API v1 (Bearer token auth)."""
 
     @property
     def name(self) -> str:
@@ -62,69 +64,143 @@ class KagiWebSearchProvider(WebSearchProvider):
         return "Kagi"
 
     def is_available(self) -> bool:
-        return _has_kagi_session() and _SCRIPT.exists()
+        return _has_kagi_api_key()
 
     def supports_search(self) -> bool:
         return True
 
     def supports_extract(self) -> bool:
-        return False
+        return True
+
+    # -- search ---------------------------------------------------------------
 
     def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
-        if not self.is_available():
-            return {
-                "success": False,
-                "error": "KAGI_SESSION not found or kagi_search.py missing",
-            }
+        api_key = _load_api_key()
+        if not api_key:
+            return {"success": False, "error": "KAGI_API_KEY not found in env or ~/.hermes/.env"}
+
+        payload: Dict[str, Any] = {"query": query}
+        if limit:
+            payload["limit"] = limit
 
         try:
-            result = subprocess.run(
-                ["python3", str(_SCRIPT), "--json", "--limit", str(limit), query],
-                capture_output=True, text=True, timeout=30,
+            resp = requests.post(
+                _SEARCH_URL,
+                json=payload,
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "User-Agent": "Hermes-KagiBot/2.0",
+                },
+                timeout=30,
             )
-        except subprocess.TimeoutExpired:
+            resp.raise_for_status()
+            data = resp.json()
+        except requests.Timeout:
             return {"success": False, "error": "Kagi search timed out (30s)"}
-        except Exception as exc:
+        except requests.RequestException as exc:
             return {"success": False, "error": f"Kagi search failed: {exc}"}
 
-        if result.returncode != 0:
-            return {
-                "success": False,
-                "error": f"kagi_search.py exited {result.returncode}: {result.stderr.strip()}",
-            }
-
-        try:
-            data = json.loads(result.stdout)
-        except json.JSONDecodeError:
-            return {"success": False, "error": "Could not parse Kagi response"}
-
-        results = data.get("results", [])[:limit]
+        items = data.get("data", {}).get("search", [])[:limit]
         web_results = [
             {
-                "title": r.get("title", ""),
-                "url": r.get("url", ""),
-                "description": r.get("snippet", ""),
+                "title": item.get("title", ""),
+                "url": item.get("url", ""),
+                "description": (item.get("snippet") or "").replace("\n", " "),
                 "position": i + 1,
             }
-            for i, r in enumerate(results)
+            for i, item in enumerate(items)
         ]
 
-        logger.info(
-            "Kagi search '%s': %d results (limit %d)",
-            query, len(web_results), limit,
-        )
+        logger.info("Kagi search '%s': %d results (limit %d)", query, len(web_results), limit)
         return {"success": True, "data": {"web": web_results}}
+
+    # -- extract --------------------------------------------------------------
+
+    def extract(self, urls: List[str], **kwargs: Any) -> Any:
+        api_key = _load_api_key()
+        if not api_key:
+            return {"success": False, "error": "KAGI_API_KEY not found in env or ~/.hermes/.env"}
+
+        if len(urls) > 10:
+            urls = urls[:10]
+            logger.warning("Kagi Extract API supports max 10 URLs, truncating")
+
+        timeout = kwargs.pop("timeout", None)
+        payload: Dict[str, Any] = {
+            "pages": [{"url": u} for u in urls],
+            "format": "json",
+        }
+        if timeout:
+            payload["timeout"] = timeout
+
+        try:
+            resp = requests.post(
+                _EXTRACT_URL,
+                json=payload,
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "User-Agent": "Hermes-KagiBot/2.0",
+                },
+                timeout=60,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except requests.Timeout:
+            return {"success": False, "error": "Kagi extract timed out (60s)"}
+        except requests.RequestException as exc:
+            return {"success": False, "error": f"Kagi extract failed: {exc}"}
+
+        results = []
+        for page in data.get("data", []):
+            url = page.get("url", "")
+            markdown = page.get("markdown")
+            error = page.get("error")
+
+            if error:
+                results.append({
+                    "url": url,
+                    "title": "",
+                    "content": "",
+                    "raw_content": "",
+                    "error": error,
+                })
+            elif markdown:
+                # Use first heading as title, fallback to URL
+                title = ""
+                for line in markdown.splitlines():
+                    if line.startswith("# "):
+                        title = line[2:].strip()
+                        break
+                results.append({
+                    "url": url,
+                    "title": title or url,
+                    "content": markdown,
+                    "raw_content": markdown,
+                })
+            else:
+                results.append({
+                    "url": url,
+                    "title": "",
+                    "content": "",
+                    "raw_content": "",
+                    "error": "no content",
+                })
+
+        logger.info("Kagi extract: %d URLs, %d results", len(urls), len(results))
+        return results
+
+    # -- setup schema ---------------------------------------------------------
 
     def get_setup_schema(self) -> Dict[str, Any]:
         return {
             "name": "Kagi",
-            "badge": "free · session cookie · search only",
-            "tag": "Search via Kagi session cookie — set KAGI_SESSION in ~/.hermes/.env",
+            "badge": "paid · API v1 · search + extract",
+            "tag": "Search and extract via Kagi API v1 — set KAGI_API_KEY in ~/.hermes/.env",
             "env_vars": [
                 {
-                    "key": "KAGI_SESSION",
-                    "prompt": "Kagi session cookie",
-                    "url": "https://kagi.com",
+                    "key": "KAGI_API_KEY",
+                    "prompt": "Kagi API key",
+                    "url": "https://kagi.com/settings?p=api",
                 },
             ],
         }

--- a/plugins/web/kagi/provider.py
+++ b/plugins/web/kagi/provider.py
@@ -126,9 +126,10 @@ class KagiWebSearchProvider(WebSearchProvider):
             logger.warning("Kagi Extract API supports max 10 URLs, truncating")
 
         timeout = kwargs.pop("timeout", None)
+        fmt = kwargs.pop("format", "json") or "json"
         payload: Dict[str, Any] = {
             "pages": [{"url": u} for u in urls],
-            "format": "json",
+            "format": fmt,
         }
         if timeout:
             payload["timeout"] = timeout
@@ -144,7 +145,15 @@ class KagiWebSearchProvider(WebSearchProvider):
                 timeout=60,
             )
             resp.raise_for_status()
-            data = resp.json()
+            if fmt == "markdown":
+                # Single-URL markdown returns raw text, not JSON.
+                data = (
+                    {"data": [{"url": urls[0], "markdown": resp.text}]}
+                    if len(urls) == 1
+                    else resp.json()
+                )
+            else:
+                data = resp.json()
         except requests.Timeout:
             return {"success": False, "error": "Kagi extract timed out (60s)"}
         except requests.RequestException as exc:

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -149,7 +149,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}:
+    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "kagi", "xai"}:
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -168,6 +168,7 @@ def _get_backend() -> str:
         ("searxng", _has_env("SEARXNG_URL")),
         ("brave-free", _has_env("BRAVE_SEARCH_API_KEY")),
         ("ddgs", _ddgs_package_importable()),
+        ("kagi", _has_env("KAGI_SESSION")),
     )
     for backend, available in backend_candidates:
         if available:
@@ -230,6 +231,8 @@ def _is_backend_available(backend: str) -> bool:
         return _has_env("BRAVE_SEARCH_API_KEY")
     if backend == "ddgs":
         return _ddgs_package_importable()
+    if backend == "kagi":
+        return _has_env("KAGI_SESSION")
     if backend == "xai":
         # Cheap probe — env var OR auth.json has OAuth tokens. Must not
         # call resolve_xai_http_credentials() here because the OAuth path

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -168,7 +168,7 @@ def _get_backend() -> str:
         ("searxng", _has_env("SEARXNG_URL")),
         ("brave-free", _has_env("BRAVE_SEARCH_API_KEY")),
         ("ddgs", _ddgs_package_importable()),
-        ("kagi", _has_env("KAGI_SESSION")),
+        ("kagi", _has_env("KAGI_API_KEY")),
     )
     for backend, available in backend_candidates:
         if available:
@@ -232,7 +232,7 @@ def _is_backend_available(backend: str) -> bool:
     if backend == "ddgs":
         return _ddgs_package_importable()
     if backend == "kagi":
-        return _has_env("KAGI_SESSION")
+        return _has_env("KAGI_API_KEY")
     if backend == "xai":
         # Cheap probe — env var OR auth.json has OAuth tokens. Must not
         # call resolve_xai_http_credentials() here because the OAuth path


### PR DESCRIPTION
## What does this PR do?

This plugins adds Kagi search to Hermes Agent.

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- plugins/web/kagi/: provider that shells out to kagi_search.py script using KAGI_SESSION cookie auth, following the plugin registry pattern (WebSearchProvider ABC from agent/web_search_provider)
- tools/web_tools.py: add kagi to backend lists and availability check

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. `hermes config set web.search_backend kagi`
2. Ask Hermes to do a web search.


## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

For tests, the test runner seems broken.
```
❯ uv run pytest tests/
ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
pytest: error: unrecognized arguments: --timeout=30 --timeout-method=signal
```

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

