### PR TITLE
fix(transport): strip internal bookkeeping fields before API calls

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -127,6 +127,10 @@ class ChatCompletionsTransport(ProviderTransport):
           ``Extra inputs are not permitted, field: 'messages[N].tool_name'``.
           Permissive providers (OpenRouter, MiniMax) silently ignore the
           field, which masked the bug for months.
+        - Internal bookkeeping fields: ``_empty_recovery_synthetic``,
+          ``_thinking_prefill``, ``_empty_terminal_sentinel`` — set by
+          conversation_loop.py for empty-response recovery and thinking-prefill
+          tracking. Strict providers reject these with HTTP 400.
         """
         needs_sanitize = False
         for msg in messages:
@@ -136,6 +140,9 @@ class ChatCompletionsTransport(ProviderTransport):
                 "codex_reasoning_items" in msg
                 or "codex_message_items" in msg
                 or "tool_name" in msg
+                or "_empty_recovery_synthetic" in msg
+                or "_thinking_prefill" in msg
+                or "_empty_terminal_sentinel" in msg
             ):
                 needs_sanitize = True
                 break
@@ -160,6 +167,9 @@ class ChatCompletionsTransport(ProviderTransport):
             msg.pop("codex_reasoning_items", None)
             msg.pop("codex_message_items", None)
             msg.pop("tool_name", None)
+            msg.pop("_empty_recovery_synthetic", None)
+            msg.pop("_thinking_prefill", None)
+            msg.pop("_empty_terminal_sentinel", None)
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):
                 for tc in tool_calls:


### PR DESCRIPTION
Strips internal bookkeeping fields from messages in ChatCompletionsTransport.convert_messages() before sending to strict providers.

Fixes #30959