### PR TITLE
fix(tui): clear TTS env var on voice off, and add TTS indicator to status bar

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5869,6 +5869,9 @@ def _(rid, params: dict) -> dict:
             except Exception as e:
                 logger.warning("voice: stop_continuous failed during toggle off: %s", e)
 
+            # Clear TTS so it can be toggled independently after voice is off.
+            os.environ["HERMES_VOICE_TTS"] = "0"
+
         return _ok(
             rid,
             {

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -216,6 +216,7 @@ export interface InputHandlerContext {
     setProcessing: StateSetter<boolean>
     setRecording: StateSetter<boolean>
     setVoiceEnabled: StateSetter<boolean>
+    setVoiceTts: StateSetter<boolean>
   }
   wheelStep: number
 }
@@ -254,6 +255,7 @@ export interface GatewayEventHandlerContext {
     setProcessing: StateSetter<boolean>
     setRecording: StateSetter<boolean>
     setVoiceEnabled: StateSetter<boolean>
+    setVoiceTts: StateSetter<boolean>
   }
 }
 
@@ -296,6 +298,7 @@ export interface SlashHandlerContext {
   voice: {
     setVoiceEnabled: StateSetter<boolean>
     setVoiceRecordKey: (v: ParsedVoiceRecordKey) => void
+    setVoiceTts: StateSetter<boolean>
   }
 }
 

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -232,6 +232,7 @@ export const sessionCommands: SlashCommand[] = [
       ctx.gateway.rpc<VoiceToggleResponse>('voice.toggle', { action }).then(
         ctx.guarded<VoiceToggleResponse>(r => {
           ctx.voice.setVoiceEnabled(!!r.enabled)
+          ctx.voice.setVoiceTts(!!r.tts)
 
           // Render the configured record key (config.yaml ``voice.record_key``)
           // instead of hardcoded "Ctrl+B" — the gateway response carries the

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -102,6 +102,7 @@ export function useMainApp(gw: GatewayClient) {
   const [stickyPrompt, setStickyPrompt] = useState('')
   const [catalog, setCatalog] = useState<null | SlashCatalog>(null)
   const [voiceEnabled, setVoiceEnabled] = useState(false)
+  const [voiceTts, setVoiceTts] = useState(false)
   const [voiceRecording, setVoiceRecording] = useState(false)
   const [voiceProcessing, setVoiceProcessing] = useState(false)
   const [voiceRecordKey, setVoiceRecordKey] = useState<ParsedVoiceRecordKey>(DEFAULT_VOICE_RECORD_KEY)
@@ -555,7 +556,8 @@ export function useMainApp(gw: GatewayClient) {
       recording: voiceRecording,
       setProcessing: setVoiceProcessing,
       setRecording: setVoiceRecording,
-      setVoiceEnabled
+      setVoiceEnabled,
+      setVoiceTts
     },
     wheelStep: WHEEL_SCROLL_STEP
   })
@@ -579,7 +581,8 @@ export function useMainApp(gw: GatewayClient) {
         voice: {
           setProcessing: setVoiceProcessing,
           setRecording: setVoiceRecording,
-          setVoiceEnabled
+          setVoiceEnabled,
+          setVoiceTts
         }
       }),
     [
@@ -827,7 +830,7 @@ export function useMainApp(gw: GatewayClient) {
       turnStartedAt: ui.sid ? turnStartedAt : null,
       // CLI parity: the classic prompt_toolkit status bar shows a red dot
       // on REC (cli.py:_get_voice_status_fragments line 2344).
-      voiceLabel: voiceRecording ? '● REC' : voiceProcessing ? '◉ STT' : `voice ${voiceEnabled ? 'on' : 'off'}`
+      voiceLabel: voiceRecording ? '● REC' : voiceProcessing ? '◉ STT' : `voice ${voiceEnabled ? 'on' : 'off'}${voiceTts ? ' [tts]' : ''}`
     }),
     [
       cwd,
@@ -839,7 +842,8 @@ export function useMainApp(gw: GatewayClient) {
       ui,
       voiceEnabled,
       voiceProcessing,
-      voiceRecording
+      voiceRecording,
+      voiceTts
     ]
   )
 


### PR DESCRIPTION
Closes #30986

## What

Two related TUI bugs fixed:

### Bug 1: `/voice off` leaves TTS stuck ON
In TUI mode, turning voice off did not clear `HERMES_VOICE_TTS`, making it impossible to disable TTS afterward (the tts toggle requires voice mode ON).

**Fix**: Clear `HERMES_VOICE_TTS` in the off branch of `tui_gateway/server.py`.

### Bug 2: Status bar missing TTS indicator
The TUI status bar only showed `voice on/off` with no indication of TTS state, even though the `voice.toggle` RPC already returns `tts: true/false`.

**Fix**: Add `voiceTts` state tracking to the frontend, sync from RPC response, display `[tts]` suffix in status bar.

## Changes
- `tui_gateway/server.py` (+3): clear `HERMES_VOICE_TTS` when voice is turned off
- `ui-tui/src/app/useMainApp.ts` (+8/-4): add `voiceTts` state, thread `setVoiceTts` through voice contexts, display `[tts]` in status bar
- `ui-tui/src/app/slash/commands/session.ts` (+1): sync `tts` from voice.toggle RPC response
- `ui-tui/src/app/interfaces.ts` (+3): add `setVoiceTts` to all voice context interfaces

## How to test
1. `hermes --tui`
2. `/voice on` → status bar shows `voice on`
3. `/voice tts` → status bar shows `voice on [tts]`
4. `/voice off` → status bar shows `voice off`, TTS state cleared
5. `/voice on` again → status bar shows `voice on` (no [tts])

## Infographic

![PR #30987 — TUI voice TTS fix](https://v3b.fal.media/files/b/0a9b6bdd/Y-iW7P2KaX5HBWDQLgAc6_OIL6KqDk.png)
