### PR TITLE
fix(streaming): use finish_reason=length for partial stream stub

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2131,7 +2131,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 id="partial-stream-stub",
                 model=getattr(agent, "model", "unknown"),
                 choices=[SimpleNamespace(
-                    index=0, message=_stub_msg, finish_reason="stop",
+                    index=0, message=_stub_msg, finish_reason="length",
                 )],
                 usage=None,
             )


### PR DESCRIPTION
Partial stream stub responses returned finish_reason=stop which caused the agent loop to exit prematurely even when budget remained.

The model had not legitimately finished — the connection dropped mid-stream. Changing to finish_reason=length triggers the continuation path in conversation_loop.py, allowing the agent to retry or continue working on the goal.

Fixes #30963