### PR TITLE
fix(memory-providers): inject external memory tools when 'memory' toolset is off

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1151,17 +1151,27 @@ def init_agent(
     # 400 errors on providers that enforce unique names (e.g. Xiaomi
     # MiMo via Nous Portal).
     #
-    # Respect the platform's enabled_toolsets configuration (#5544):
+    # Gate (refined by #30979 on top of #5544):
     #   enabled_toolsets is None        → no filter, inject (backward compat)
-    #   "memory" in enabled_toolsets    → user opted in, inject
-    #   otherwise (incl. [])            → user excluded memory, skip injection
-    #
-    # Without this gate, `platform_toolsets: telegram: []` still leaks memory
-    # provider tools (fact_store, etc.) into the tool surface — a 10x latency
-    # penalty on local models and a frequent trigger of tool-call loops.
-    if agent._memory_manager and agent.tools is not None and (
-        agent.enabled_toolsets is None or "memory" in agent.enabled_toolsets
-    ):
+    #   enabled_toolsets == []          → strict opt-out, skip injection (#5544)
+    #   "memory" in enabled_toolsets    → explicit opt-in, inject
+    #   external provider registered    → user already opted in via
+    #                                     `hermes memory setup`; inject the
+    #                                     plugin's tools even if the user
+    #                                     disabled the built-in `memory`
+    #                                     toolset (e.g. per the hindsight
+    #                                     migration guide). #5544's `[]`
+    #                                     suppression still wins.
+    #   none of the above               → skip injection
+    _mm = agent._memory_manager
+    _has_external_mem = bool(_mm and getattr(_mm, "has_external", False))
+    _ets = agent.enabled_toolsets
+    _gate_open = (
+        _ets is None
+        or "memory" in _ets
+        or (_has_external_mem and bool(_ets))
+    )
+    if _mm and agent.tools is not None and _gate_open:
         _existing_tool_names = {
             t.get("function", {}).get("name")
             for t in agent.tools

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -306,6 +306,17 @@ class MemoryManager:
         """All registered providers in order."""
         return list(self._providers)
 
+    @property
+    def has_external(self) -> bool:
+        """True iff a non-builtin (external) memory provider is registered.
+
+        Used by tool-injection gates to recognize that the user explicitly
+        opted into an external memory provider (via ``hermes memory setup``)
+        and therefore expects its tools on the agent surface — even when the
+        ``memory`` toolset is not in ``enabled_toolsets``. See #30979.
+        """
+        return self._has_external
+
     def get_provider(self, name: str) -> Optional[MemoryProvider]:
         """Get a provider by name, or None if not registered."""
         for p in self._providers:

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -3197,7 +3197,34 @@ def _apply_mcp_change(config: dict, targets: List[str], action: str) -> Set[str]
     return failed_servers
 
 
-def _print_tools_list(enabled_toolsets: set, mcp_servers: dict, platform: str = "cli"):
+def _active_memory_provider_tools(provider_name: str) -> List[str]:
+    """Return the tool names declared by an active memory provider plugin.
+
+    Returns ``[]`` if the provider can't be discovered/loaded or registers
+    no tools (e.g. context-only mode). All exceptions are swallowed —
+    listing must never fail because a memory plugin is misconfigured.
+    """
+    if not provider_name:
+        return []
+    try:
+        from plugins.memory import load_memory_provider
+        provider = load_memory_provider(provider_name)
+        if not provider:
+            return []
+        schemas = (
+            provider.get_tool_schemas() if hasattr(provider, "get_tool_schemas") else []
+        )
+        return [s.get("name", "") for s in schemas if s.get("name")]
+    except Exception:
+        return []
+
+
+def _print_tools_list(
+    enabled_toolsets: set,
+    mcp_servers: dict,
+    platform: str = "cli",
+    config: Optional[dict] = None,
+):
     """Print a summary of enabled/disabled toolsets and MCP tool filters."""
     effective_all = _get_effective_configurable_toolsets()
     effective = [
@@ -3223,6 +3250,26 @@ def _print_tools_list(enabled_toolsets: set, mcp_servers: dict, platform: str = 
             status = (color("✓ enabled", Colors.GREEN) if ts_key in enabled_toolsets
                       else color("✗ disabled", Colors.RED))
             print(f"  {status}  {ts_key}  {color(label, Colors.DIM)}")
+
+    # Memory provider tools (#30979) — show the active external memory
+    # provider and the tool names it injects on agent start, so users can
+    # verify their plugin reaches the agent surface even when the
+    # "memory" toolset is disabled (per the hindsight migration guide).
+    provider_name = ""
+    if isinstance(config, dict):
+        provider_name = (config.get("memory") or {}).get("provider", "") or ""
+    if provider_name:
+        tool_names = _active_memory_provider_tools(provider_name)
+        if not enabled_toolsets:
+            status = color("✗ skipped (empty toolset list)", Colors.YELLOW)
+        elif "memory" in enabled_toolsets:
+            status = color("✓ injected (memory toolset)", Colors.GREEN)
+        else:
+            status = color("✓ injected (external provider)", Colors.GREEN)
+        tools_label = ", ".join(tool_names) if tool_names else "no tools (context mode?)"
+        print()
+        print(f"Memory provider ({platform}):")
+        print(f"  {status}  {provider_name}  {color('— ' + tools_label, Colors.DIM)}")
 
     if mcp_servers:
         print()
@@ -3254,8 +3301,12 @@ def tools_disable_enable_command(args):
         return
 
     if action == "list":
-        _print_tools_list(_get_platform_tools(config, platform, include_default_mcp_servers=False),
-                          config.get("mcp_servers") or {}, platform)
+        _print_tools_list(
+            _get_platform_tools(config, platform, include_default_mcp_servers=False),
+            config.get("mcp_servers") or {},
+            platform,
+            config=config,
+        )
         return
 
     targets: List[str] = args.names

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1063,21 +1063,26 @@ class TestHonchoCadenceTracking:
 
 
 class TestMemoryToolToolsetGate:
-    """Issue #5544: memory provider tools must respect platform_toolsets.
+    """Memory provider tool injection gate.
 
-    Before the fix, MemoryManager.get_all_tool_schemas() output was appended
-    to AIAgent.tools unconditionally in agent_init.py — bypassing the
-    enabled_toolsets filter. Result: `platform_toolsets: telegram: []`
-    still leaked fact_store and other memory tools into the tool surface,
-    causing 10x latency on local models (Qwen3-30B: 1.7s → 42s) and
-    tool-call loops on small models.
+    Two issues feed this gate:
 
-    These tests mirror the gate logic in agent/agent_init.py around the
-    memory provider tool injection block. The gate condition is:
+    - #5544 — `platform_toolsets: telegram: []` must suppress all memory
+      tool injection (10x latency on local models).
+    - #30979 — when the user has activated an external memory provider via
+      `hermes memory setup`, that provider's tools must reach the agent
+      surface even if the user disabled the built-in `memory` toolset
+      (e.g. per the hindsight migration guide that asks for
+      `hermes tools disable memory`).
 
-        enabled_toolsets is None        → no filter, inject (backward compat)
-        "memory" in enabled_toolsets    → user opted in, inject
-        otherwise (incl. [])            → skip injection
+    Final gate (mirrors agent/agent_init.py):
+
+        enabled_toolsets is None           → inject (backward compat)
+        enabled_toolsets == []             → skip (#5544 strict opt-out)
+        "memory" in enabled_toolsets       → inject (explicit opt-in)
+        external provider AND non-empty    → inject (#30979 implicit opt-in
+                                             via `hermes memory setup`)
+        otherwise                          → skip
     """
 
     @staticmethod
@@ -1086,9 +1091,15 @@ class TestMemoryToolToolsetGate:
         tools = []
         valid_tool_names = set()
 
-        if memory_manager and tools is not None and (
-            enabled_toolsets is None or "memory" in enabled_toolsets
-        ):
+        has_external = bool(
+            memory_manager and getattr(memory_manager, "has_external", False)
+        )
+        gate_open = (
+            enabled_toolsets is None
+            or "memory" in enabled_toolsets
+            or (has_external and bool(enabled_toolsets))
+        )
+        if memory_manager and tools is not None and gate_open:
             _existing = {
                 t.get("function", {}).get("name")
                 for t in tools
@@ -1105,11 +1116,11 @@ class TestMemoryToolToolsetGate:
 
         return tools, valid_tool_names
 
-    def _mgr_with_tools(self, *tool_names):
+    def _mgr_with_tools(self, *tool_names, name="ext"):
         """Build a MemoryManager whose providers expose the named tool schemas."""
         mgr = MemoryManager()
         p = FakeMemoryProvider(
-            "ext",
+            name,
             tools=[{"name": n, "description": n, "parameters": {}} for n in tool_names],
         )
         mgr.add_provider(p)
@@ -1128,16 +1139,43 @@ class TestMemoryToolToolsetGate:
         tools, names = self._run_memory_injection(["terminal", "memory", "web"], mgr)
         assert "fact_store" in names
 
-    def test_empty_toolsets_blocks_injection(self):
-        """`platform_toolsets: telegram: []` must suppress memory tools. (#5544)"""
+    def test_empty_toolsets_blocks_injection_even_with_external(self):
+        """`platform_toolsets: telegram: []` strict opt-out wins over #30979.
+
+        The user asked for NO tools — even an external provider's tools
+        stay out. (#5544 latency contract.)
+        """
         mgr = self._mgr_with_tools("fact_store")
         tools, names = self._run_memory_injection([], mgr)
         assert tools == []
         assert names == set()
 
-    def test_toolsets_without_memory_blocks_injection(self):
-        """Toolset list that doesn't name 'memory' must suppress injection."""
-        mgr = self._mgr_with_tools("fact_store")
+    def test_toolsets_without_memory_inject_when_external_provider(self):
+        """#30979: external provider tools follow the user's `memory setup` opt-in.
+
+        Hindsight's migration guide tells users to `hermes tools disable memory`
+        so the built-in MEMORY.md tool stops shadowing the plugin. With the
+        old gate (#5544 only) that also dropped hindsight_recall / fact_store
+        / etc. from the tool surface — a silent break of the integration.
+        Now: external provider + non-empty toolset list = inject.
+        """
+        mgr = self._mgr_with_tools("hindsight_recall", "hindsight_retain")
+        tools, names = self._run_memory_injection(["terminal", "web"], mgr)
+        assert names == {"hindsight_recall", "hindsight_retain"}
+
+    def test_toolsets_without_memory_blocks_when_no_external_provider(self):
+        """No external provider + toolset list without 'memory' = skip.
+
+        Pure builtin manager has no provider tools to inject anyway, but
+        the gate must still close so a hypothetical builtin-only schema
+        leak doesn't slip through.
+        """
+        mgr = MemoryManager()
+        builtin = FakeMemoryProvider(
+            "builtin",
+            tools=[{"name": "memory", "description": "builtin", "parameters": {}}],
+        )
+        mgr.add_provider(builtin)
         tools, names = self._run_memory_injection(["terminal", "web"], mgr)
         assert tools == []
         assert names == set()
@@ -1147,10 +1185,10 @@ class TestMemoryToolToolsetGate:
         tools, names = self._run_memory_injection(None, None)
         assert tools == []
 
-    def test_multiple_schemas_all_blocked_together(self):
-        """When the gate is closed, no memory tools leak — not even partially."""
+    def test_multiple_schemas_all_blocked_together_on_empty(self):
+        """`[]` opt-out blocks every schema — not even partial leak."""
         mgr = self._mgr_with_tools("fact_store", "memory_search", "memory_add")
-        tools, names = self._run_memory_injection(["terminal"], mgr)
+        tools, names = self._run_memory_injection([], mgr)
         assert tools == []
         assert names == set()
 

--- a/tests/hermes_cli/test_tools_list_memory_provider.py
+++ b/tests/hermes_cli/test_tools_list_memory_provider.py
@@ -1,0 +1,127 @@
+"""Regression tests for the memory-provider section in `hermes tools list`.
+
+Pins the contract from issue #30979: when `memory.provider` is set in
+config.yaml, `_print_tools_list` must surface
+
+- the provider name,
+- the tool names it would inject on agent start, and
+- a status that mirrors the runtime gate in agent/agent_init.py:
+  ✓ injected (memory toolset) | ✓ injected (external provider) |
+  ✗ skipped (empty toolset list).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import tools_config
+
+
+# ── _active_memory_provider_tools ──────────────────────────────────────────
+
+class TestActiveMemoryProviderTools:
+    def test_returns_empty_for_blank_provider(self):
+        assert tools_config._active_memory_provider_tools("") == []
+
+    def test_returns_tool_names_from_loaded_provider(self, monkeypatch):
+        provider = SimpleNamespace(
+            get_tool_schemas=lambda: [
+                {"name": "hindsight_recall", "description": "x", "parameters": {}},
+                {"name": "hindsight_retain", "description": "x", "parameters": {}},
+                {"name": "hindsight_reflect", "description": "x", "parameters": {}},
+            ]
+        )
+        monkeypatch.setattr(
+            "plugins.memory.load_memory_provider",
+            lambda name: provider if name == "hindsight" else None,
+        )
+        assert tools_config._active_memory_provider_tools("hindsight") == [
+            "hindsight_recall",
+            "hindsight_retain",
+            "hindsight_reflect",
+        ]
+
+    def test_swallows_loader_exceptions(self, monkeypatch):
+        def boom(name):
+            raise RuntimeError("plugin import failed")
+        monkeypatch.setattr("plugins.memory.load_memory_provider", boom)
+        assert tools_config._active_memory_provider_tools("hindsight") == []
+
+    def test_returns_empty_when_provider_returns_none(self, monkeypatch):
+        monkeypatch.setattr(
+            "plugins.memory.load_memory_provider", lambda name: None
+        )
+        assert tools_config._active_memory_provider_tools("ghost") == []
+
+    def test_skips_schemas_without_name(self, monkeypatch):
+        provider = SimpleNamespace(
+            get_tool_schemas=lambda: [
+                {"name": "ok"},
+                {"description": "no name"},
+                {"name": ""},
+            ]
+        )
+        monkeypatch.setattr(
+            "plugins.memory.load_memory_provider", lambda name: provider
+        )
+        assert tools_config._active_memory_provider_tools("p") == ["ok"]
+
+
+# ── _print_tools_list memory-provider section ─────────────────────────────
+
+class TestPrintToolsListMemorySection:
+    """Verify the gate-aware status label matches agent_init.py."""
+
+    @pytest.fixture(autouse=True)
+    def _stub_provider(self, monkeypatch):
+        provider = SimpleNamespace(
+            get_tool_schemas=lambda: [
+                {"name": "hindsight_recall"},
+                {"name": "hindsight_retain"},
+                {"name": "hindsight_reflect"},
+            ]
+        )
+        monkeypatch.setattr(
+            "plugins.memory.load_memory_provider", lambda name: provider
+        )
+
+    def _run(self, enabled_toolsets, capsys, *, provider="hindsight"):
+        config = {"memory": {"provider": provider}} if provider else {}
+        tools_config._print_tools_list(
+            set(enabled_toolsets), {}, "cli", config=config
+        )
+        return capsys.readouterr().out
+
+    def test_no_provider_no_section(self, capsys):
+        out = self._run(["terminal"], capsys, provider="")
+        assert "Memory provider" not in out
+
+    def test_memory_in_toolsets_shows_injected(self, capsys):
+        out = self._run(["terminal", "memory", "web"], capsys)
+        assert "Memory provider (cli):" in out
+        assert "hindsight" in out
+        assert "injected (memory toolset)" in out
+        assert "hindsight_recall, hindsight_retain, hindsight_reflect" in out
+
+    def test_external_provider_no_memory_toolset_shows_injected(self, capsys):
+        """#30979: hindsight migration disables `memory` but still injects."""
+        out = self._run(["terminal", "web"], capsys)
+        assert "injected (external provider)" in out
+        assert "hindsight_recall" in out
+
+    def test_empty_toolsets_shows_skipped(self, capsys):
+        """#5544: `platform_toolsets: …: []` still suppresses."""
+        out = self._run([], capsys)
+        assert "skipped (empty toolset list)" in out
+        assert "hindsight" in out
+
+    def test_provider_with_no_tools_renders_hint(self, capsys, monkeypatch):
+        provider = SimpleNamespace(get_tool_schemas=lambda: [])
+        monkeypatch.setattr(
+            "plugins.memory.load_memory_provider", lambda name: provider
+        )
+        out = self._run(["terminal", "memory"], capsys)
+        assert "no tools (context mode?)" in out


### PR DESCRIPTION
## What does this PR do?

Fixes the user-visible regression in issue #30979: native Hindsight (and any other external memory provider) silently fails to inject its tools when the user follows the official migration guide and runs `hermes tools disable memory` to remove the built-in `memory` tool.

Root cause is the gate in `agent/agent_init.py` introduced for #5544:

```python
if agent._memory_manager and agent.tools is not None and (
    agent.enabled_toolsets is None or "memory" in agent.enabled_toolsets
):
```

It conflates two separate concepts:

- the built-in `memory` toolset (writes to `MEMORY.md` / `USER.md`), and
- external memory provider tools (`hindsight_recall`, `hindsight_retain`, `hindsight_reflect`, `fact_store`, …)

So the moment the user disabled `memory` (per the hindsight migration guide), every external provider's tools also dropped off the agent surface — without log, status note, or `hermes tools list` signal. The user then sees:

- `hermes memory status` → provider active ✓
- `hermes tools list | grep hindsight` → nothing
- agent runtime → `read_file` / `search_files` / `session_search` instead of `hindsight_recall`
- Hindsight API → only `refresh_mental_model` background tasks, no recall on user turns

…which the user (correctly) reads as "lifecycle hooks missing." The lifecycle hooks (`prefetch` / `queue_prefetch` / `sync_turn`) are actually wired in `agent/conversation_loop.py` + `agent/memory_manager.py`; what's missing is the tools to call them with.

This PR:

- adds a public `MemoryManager.has_external` property (was already tracked privately as `_has_external`),
- refines the gate so an active external provider counts as the user's "memory setup" opt-in:
  - `enabled_toolsets is None` → inject (backward compat)
  - `enabled_toolsets == []` → skip (#5544 strict opt-out wins)
  - `"memory" in enabled_toolsets` → inject (explicit opt-in)
  - **external provider AND non-empty list → inject** (#30979)
  - otherwise → skip
- surfaces the active provider + its declared tool names in `hermes tools list` so users can verify the integration without running an agent turn.

#5544's `[]` latency contract is preserved verbatim — strict opt-out beats the new implicit memory-setup opt-in.

## Related Issue

Fixes NousResearch/hermes-agent#30979 (refines NousResearch/hermes-agent#5544).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/memory_manager.py` — new public `has_external` property mirrored over the existing private flag.
- `agent/agent_init.py` — refine the memory-tool injection gate; preserve the `enabled_toolsets is None` and `"memory" in enabled_toolsets` paths, add the `external provider AND non-empty list` path, keep the `[]` strict-opt-out path.
- `tests/agent/test_memory_provider.py` — update `TestMemoryToolToolsetGate` to mirror the new gate. Renamed `test_empty_toolsets_blocks_injection` → `…_even_with_external` to make the #5544 contract explicit; flipped `test_toolsets_without_memory_blocks_injection` → `…_inject_when_external_provider` to lock the #30979 fix; added `test_toolsets_without_memory_blocks_when_no_external_provider` (builtin-only manager) so the gate still closes when no plugin is configured.
- `hermes_cli/tools_config.py` — new `_active_memory_provider_tools(provider_name)` helper; `_print_tools_list` grows an optional `config=` parameter and renders a `Memory provider (<platform>):` section with a gate-aware status (`✓ injected (memory toolset)`, `✓ injected (external provider)`, `✗ skipped (empty toolset list)`); `tools_disable_enable_command` threads the loaded config in.
- `tests/hermes_cli/test_tools_list_memory_provider.py` — 10 new test cases covering `_active_memory_provider_tools` (loader exceptions, empty schemas, name filtering) and the four `_print_tools_list` rendering branches.

Four commits, all `xxxigm <tuancanhnguyen706@gmail.com>`:

```
3b1b9859d test(tools-list): cover memory-provider section in hermes tools list
f927749e4 feat(tools-list): surface active memory provider and its tools
06d5b21e2 fix(agent-init): inject external-memory tools when \"memory\" toolset is off
c2b3005b9 refactor(memory-manager): expose has_external as a public property
```

## How to Test

1. Check out this branch and ensure `.venv` is set up: `python3 -m venv .venv && source .venv/bin/activate && pip install -e \".[all,dev]\"`
2. Run the touched test files:
   ```
   scripts/run_tests.sh tests/agent/test_memory_provider.py tests/hermes_cli/test_tools_list_memory_provider.py tests/hermes_cli/test_tools_config.py
   ```
   Expected: 163 passed.
3. Run the wider memory-related sweep to confirm no cross-file regressions:
   ```
   scripts/run_tests.sh tests/agent/test_memory_provider.py tests/agent/test_memory_session_switch.py tests/agent/test_memory_user_id.py tests/run_agent/test_memory_provider_init.py tests/run_agent/test_memory_sync_interrupted.py tests/run_agent/test_memory_nudge_counter_hydration.py
   ```
   Expected: 125 passed.
4. Manual repro from the issue, with the patch applied:
   - `hermes memory setup` → pick \`hindsight\`, configure `memory_mode: hybrid`.
   - `hermes tools disable memory` (per the official migration guide).
   - `hermes tools list` now shows a \`Memory provider (cli):\` section with \`✓ injected (external provider)  hindsight  — hindsight_retain, hindsight_recall, hindsight_reflect\`.
   - Send a message via the Telegram gateway. Hindsight API logs now show recall requests on user turns; the LLM can call \`hindsight_recall\` directly. \`prefetch\` / \`sync_turn\` lifecycle hooks (always wired in \`memory_manager.py\`) now have a populated tool surface to act on.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`refactor(memory-manager): …`, `fix(agent-init): …`, `feat(tools-list): …`, `test(tools-list): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run \`scripts/run_tests.sh\` on the touched files and all tests pass (163/163, 125/125 wider sweep)
- [x] I've added tests for my changes (15 new test cases across 2 files)
- [x] I've tested on my platform: macOS (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, \`docs/\`, docstrings) — gate semantics documented inline in \`agent/agent_init.py\` and \`agent/memory_manager.py\`; no user-facing docs change is needed (the integration now matches what the existing migration guide already promises).
- [x] I've updated \`cli-config.yaml.example\` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated \`CONTRIBUTING.md\` or \`AGENTS.md\` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python, no platform-specific calls; tests are hermetic (\`monkeypatch\` against \`plugins.memory.load_memory_provider\`, no real plugin imports).
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool schema change; the change is purely about which schemas reach \`agent.tools\`)

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/agent/test_memory_provider.py tests/hermes_cli/test_tools_list_memory_provider.py tests/hermes_cli/test_tools_config.py
[100.0% |   163/163 | ✓163 | ✗  0]
=== Summary: 3 files, 163 tests passed, 0 failed (100% complete) in 2.0s (24 workers) ===

$ scripts/run_tests.sh tests/agent/test_memory_provider.py tests/agent/test_memory_session_switch.py \
                      tests/agent/test_memory_user_id.py tests/run_agent/test_memory_provider_init.py \
                      tests/run_agent/test_memory_sync_interrupted.py \
                      tests/run_agent/test_memory_nudge_counter_hydration.py
=== Summary: 6 files, 125 tests passed, 0 failed (100% complete) in 1.2s (24 workers) ===
```