### PR TITLE
fix(memory): refuse mutations when on-disk file changed since last read (#26045)

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -380,3 +380,99 @@ class TestExternalDriftGuard:
         # at the same snapshot. Different second is also fine.
         assert ".bak." in r1["drift_backup"]
         assert ".bak." in r2["drift_backup"]
+
+
+# =========================================================================
+# On-disk change guard (supplementary to drift guard — #26045)
+#
+# Even when the file is structurally valid (no drift), a concurrent
+# session or patch tool might have changed the on-disk content between
+# our read and write.  The replace/remove/add operations must refuse
+# when the file's content hash doesn't match what we saw at entry.
+# =========================================================================
+
+
+class TestOnDiskChangeGuard:
+    """Mutations must refuse when on-disk content changed since the last read."""
+
+    def test_replace_refuses_when_file_changed_between_read_and_write(self, store):
+        """The file was externally modified after our lock-acquire snapshot.
+
+        Simulate a concurrent write that changes the file between our
+        _snapshot_on_disk() call and the pre-flush verification.
+        """
+        store.add("memory", "Entry one.")
+        store.add("memory", "Entry two.")
+
+        import unittest.mock
+        with unittest.mock.patch.object(
+            MemoryStore, "_check_on_disk_unchanged", return_value=False
+        ):
+            result = store.replace("memory", "Entry one", "Entry one updated")
+
+        assert result["success"] is False
+        assert "modified on disk" in result["error"]
+        assert "26045" in result["error"]
+
+    def test_replace_succeeds_when_file_unchanged(self, store):
+        """Normal replace flow: file hasn't been touched externally."""
+        store.add("memory", "Original entry.")
+        result = store.replace("memory", "Original", "Updated entry.")
+
+        assert result["success"] is True
+        assert "Updated entry." in result["entries"]
+        assert "Original entry." not in result["entries"]
+
+    def test_remove_refuses_when_file_changed_between_read_and_write(self, store):
+        """Remove also guards against stale on-disk state."""
+        store.add("memory", "To be removed.")
+
+        import unittest.mock
+        with unittest.mock.patch.object(
+            MemoryStore, "_check_on_disk_unchanged", return_value=False
+        ):
+            result = store.remove("memory", "To be removed")
+
+        assert result["success"] is False
+        assert "modified on disk" in result["error"]
+
+    def test_add_refuses_when_file_changed_between_read_and_write(self, store):
+        """Add also guards against stale on-disk state."""
+        store.add("memory", "Existing entry.")
+
+        import unittest.mock
+        with unittest.mock.patch.object(
+            MemoryStore, "_check_on_disk_unchanged", return_value=False
+        ):
+            result = store.add("memory", "Another entry.")
+
+        assert result["success"] is False
+        assert "modified on disk" in result["error"]
+
+    def test_on_disk_guard_does_not_trigger_when_file_is_new(self, tmp_path, monkeypatch):
+        """First-ever add to a non-existent file should succeed (snapshot is None)."""
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        store = MemoryStore(memory_char_limit=500, user_char_limit=300)
+        store.load_from_disk()
+
+        result = store.add("memory", "First entry ever.")
+        assert result["success"] is True
+
+    def test_on_disk_guard_and_drift_guard_are_independent(self, store):
+        """Both guards coexist — drift is checked first, on-disk second.
+
+        If drift is detected, the on-disk guard is never reached.
+        If drift is clean but the file changed, on-disk guard fires.
+        """
+        store.add("memory", "Clean entry.")
+
+        # Simulate drift by appending content without § delimiters.
+        path = store._path_for("memory")
+        raw = path.read_text(encoding="utf-8")
+        # Content that makes one giant entry exceeding char_limit
+        path.write_text(raw + "\n\n" + "x" * 600, encoding="utf-8")
+
+        result = store.replace("memory", "Clean", "Replaced.")
+        # Drift guard should fire first
+        assert result["success"] is False
+        assert "drift_backup" in result

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -23,6 +23,7 @@ Design:
 - Frozen snapshot pattern: system prompt is stable, tool responses show live state
 """
 
+import hashlib
 import json
 import logging
 import os
@@ -216,6 +217,23 @@ class MemoryStore:
             return mem_dir / "USER.md"
         return mem_dir / "MEMORY.md"
 
+    @staticmethod
+    def _snapshot_on_disk(path: Path) -> Optional[str]:
+        """Return a content hash of the on-disk file, or None if it doesn't exist."""
+        if not path.exists():
+            return None
+        try:
+            raw = path.read_text(encoding="utf-8")
+            return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+        except (OSError, IOError):
+            return None
+
+    @staticmethod
+    def _check_on_disk_unchanged(path: Path, snapshot: Optional[str]) -> bool:
+        """Return True if the on-disk file content matches the snapshot hash."""
+        current = MemoryStore._snapshot_on_disk(path)
+        return current == snapshot
+
     def _reload_target(self, target: str) -> Optional[str]:
         """Re-read entries from disk into in-memory state.
 
@@ -273,13 +291,16 @@ class MemoryStore:
             return {"success": False, "error": scan_error}
 
         with self._file_lock(self._path_for(target)):
+            path = self._path_for(target)
+            pre_hash = self._snapshot_on_disk(path)
+
             # Re-read from disk under lock to pick up writes from other sessions.
             # If external drift was detected, the file was backed up to .bak.<ts>
             # — refuse the mutation so we don't clobber the un-roundtrippable
             # content the patch tool / shell append / sister session wrote.
             bak = self._reload_target(target)
             if bak:
-                return _drift_error(self._path_for(target), bak)
+                return _drift_error(path, bak)
 
             entries = self._entries_for(target)
             limit = self._char_limit(target)
@@ -307,6 +328,19 @@ class MemoryStore:
 
             entries.append(content)
             self._set_entries(target, entries)
+
+            # Refuse if the on-disk file changed since we read it.
+            if not self._check_on_disk_unchanged(path, pre_hash):
+                return {
+                    "success": False,
+                    "error": (
+                        f"Refusing to add to {path.name}: the file was modified "
+                        f"on disk since it was last read. Re-read the current state "
+                        f"and retry. This guard prevents overwriting concurrent "
+                        f"writes (issue #26045)."
+                    ),
+                }
+
             self.save_to_disk(target)
 
         return self._success_response(target, "Entry added.")
@@ -326,9 +360,12 @@ class MemoryStore:
             return {"success": False, "error": scan_error}
 
         with self._file_lock(self._path_for(target)):
+            path = self._path_for(target)
+            pre_hash = self._snapshot_on_disk(path)
+
             bak = self._reload_target(target)
             if bak:
-                return _drift_error(self._path_for(target), bak)
+                return _drift_error(path, bak)
 
             entries = self._entries_for(target)
             matches = [(i, e) for i, e in enumerate(entries) if old_text in e]
@@ -365,6 +402,21 @@ class MemoryStore:
                     ),
                 }
 
+            # Refuse if the on-disk file changed since we read it (e.g. a
+            # concurrent session or patch tool edit).  This is the same
+            # contract the patch tool enforces and would alone have prevented
+            # the original ~8KB data-loss incident (#26045).
+            if not self._check_on_disk_unchanged(path, pre_hash):
+                return {
+                    "success": False,
+                    "error": (
+                        f"Refusing to replace in {path.name}: the file was modified "
+                        f"on disk since it was last read. Re-read the current state "
+                        f"and retry. This guard prevents overwriting concurrent "
+                        f"writes (issue #26045)."
+                    ),
+                }
+
             entries[idx] = new_content
             self._set_entries(target, entries)
             self.save_to_disk(target)
@@ -378,9 +430,12 @@ class MemoryStore:
             return {"success": False, "error": "old_text cannot be empty."}
 
         with self._file_lock(self._path_for(target)):
+            path = self._path_for(target)
+            pre_hash = self._snapshot_on_disk(path)
+
             bak = self._reload_target(target)
             if bak:
-                return _drift_error(self._path_for(target), bak)
+                return _drift_error(path, bak)
 
             entries = self._entries_for(target)
             matches = [(i, e) for i, e in enumerate(entries) if old_text in e]
@@ -401,6 +456,19 @@ class MemoryStore:
                 # All identical -- safe to remove just the first
 
             idx = matches[0][0]
+
+            # Refuse if the on-disk file changed since we read it.
+            if not self._check_on_disk_unchanged(path, pre_hash):
+                return {
+                    "success": False,
+                    "error": (
+                        f"Refusing to remove from {path.name}: the file was modified "
+                        f"on disk since it was last read. Re-read the current state "
+                        f"and retry. This guard prevents overwriting concurrent "
+                        f"writes (issue #26045)."
+                    ),
+                }
+
             entries.pop(idx)
             self._set_entries(target, entries)
             self.save_to_disk(target)


### PR DESCRIPTION
## Summary

Follow-up to #26045 (commit 6855d17). The drift guard detects structurally un-roundtrippable content, but [jrhouston-trilogy recommended](https://github.com/NousResearch/hermes-agent/issues/26045#issuecomment-4475213900) an additional defense: refuse mutations when the on-disk file has changed since last read — the same contract the `patch` tool already enforces.

This alone would have prevented the original ~8KB data-loss incident.

## Changes

- **`tools/memory_tool.py`**: Added SHA-256 content-hash snapshot at lock acquisition. Before `save_to_disk()`, re-reads the file and refuses if the hash differs. Applied to all three mutation paths (`add`, `replace`, `remove`).
- **`tests/tools/test_memory_tool.py`**: 6 new tests in `TestOnDiskChangeGuard`

## Relationship to existing drift guard

Both defenses are active and independent:
1. **Drift guard** fires first — detects structurally un-roundtrippable content (missing delimiters, oversized entries)
2. **On-disk guard** fires second — detects any content change between read and write, even if structurally valid

## Test plan

```
pytest tests/tools/test_memory_tool.py -v   # 46 passed (40 existing + 6 new)
```

Refs #26045