### PR TITLE
fix(bluebubbles): dedup inbound webhook events by message GUID

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -30,7 +30,7 @@ from gateway.platforms.base import (
     cache_audio_from_bytes,
     cache_document_from_bytes,
 )
-from gateway.platforms.helpers import strip_markdown
+from gateway.platforms.helpers import MessageDeduplicator, strip_markdown
 
 logger = logging.getLogger(__name__)
 
@@ -129,6 +129,12 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._private_api_enabled: Optional[bool] = None
         self._helper_connected: bool = False
         self._guid_cache: Dict[str, str] = {}
+        # Suppress duplicate inbound webhooks for the same message GUID.
+        # BlueBubbles fires both `new-message` and `updated-message` on
+        # delivered/read/edit echoes for the same message; without dedup the
+        # second event normalizes to a different chat key (chatIdentifier vs
+        # chatGuid) and spins up a parallel session for the same chat.
+        self._dedup = MessageDeduplicator()
 
     # ------------------------------------------------------------------
     # API helpers
@@ -822,6 +828,17 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             or record.get("is_from_me")
         )
         if is_from_me:
+            return web.Response(text="ok")
+
+        # Dedup by message GUID before any session-key derivation. Mirrors
+        # the pattern used by slack/dingtalk/wecom/weixin/mattermost/feishu
+        # via the same `MessageDeduplicator` helper.
+        msg_guid = self._value(
+            record.get("guid"),
+            record.get("messageGuid"),
+            record.get("id"),
+        )
+        if msg_guid and self._dedup.is_duplicate(msg_guid):
             return web.Response(text="ok")
 
         # Skip tapback reactions delivered as messages

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -134,7 +134,9 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         # delivered/read/edit echoes for the same message; without dedup the
         # second event normalizes to a different chat key (chatIdentifier vs
         # chatGuid) and spins up a parallel session for the same chat.
-        self._dedup = MessageDeduplicator()
+        # Explicit bounds: 2000 entries / 5 min TTL cap memory for
+        # long-running gateway processes.
+        self._dedup = MessageDeduplicator(max_size=2000, ttl_seconds=300)
 
     # ------------------------------------------------------------------
     # API helpers

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -698,3 +698,112 @@ class TestBlueBubblesWebhookRegistration:
             adapter._unregister_webhook()
         )
         assert ok is False
+
+
+class TestBlueBubblesInboundDedup:
+    """Regression coverage for #30708 — exact-GUID dedup across new-message
+    and updated-message webhook events for the same iMessage."""
+
+    @pytest.mark.asyncio
+    async def test_same_guid_new_then_updated_message_dedups(self, monkeypatch):
+        import asyncio
+        import json
+
+        adapter = _make_adapter(monkeypatch)
+        delivered = []
+
+        async def fake_handle_message(event):
+            delivered.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+
+        class _FakeRequest:
+            def __init__(self, payload, password):
+                self._payload = payload
+                self.query = {"password": password}
+                self.headers = {}
+
+            async def read(self):
+                return json.dumps(self._payload).encode("utf-8")
+
+        new_msg = {
+            "type": "new-message",
+            "data": {
+                "guid": "MESSAGE-GUID-1",
+                "text": "yes",
+                "handle": {"address": "+15551234567"},
+                "isFromMe": False,
+                "chatGuid": "any;-;+15551234567",
+                "chatIdentifier": "+15551234567",
+            },
+        }
+        # Same message GUID, updated-message without chatGuid. Pre-fix this
+        # was treated as a new message and normalized to a bare
+        # chatIdentifier session key, spinning up a parallel session.
+        upd_msg = {
+            "type": "updated-message",
+            "data": {
+                "guid": "MESSAGE-GUID-1",
+                "text": "yes",
+                "handle": {"address": "+15551234567"},
+                "isFromMe": False,
+                "chatIdentifier": "+15551234567",
+            },
+        }
+
+        r1 = await adapter._handle_webhook(_FakeRequest(new_msg, "secret"))
+        await asyncio.sleep(0)
+        r2 = await adapter._handle_webhook(_FakeRequest(upd_msg, "secret"))
+        await asyncio.sleep(0)
+
+        assert r1.status == 200
+        assert r2.status == 200
+        assert len(delivered) == 1, (
+            "duplicate inbound webhook for the same message GUID was not "
+            "suppressed; second event would have created a parallel session"
+        )
+        assert delivered[0].text == "yes"
+
+    @pytest.mark.asyncio
+    async def test_different_guids_both_delivered(self, monkeypatch):
+        """Two distinct iMessages must still both be delivered."""
+        import asyncio
+        import json
+
+        adapter = _make_adapter(monkeypatch)
+        delivered = []
+
+        async def fake_handle_message(event):
+            delivered.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+
+        class _FakeRequest:
+            def __init__(self, payload, password):
+                self._payload = payload
+                self.query = {"password": password}
+                self.headers = {}
+
+            async def read(self):
+                return json.dumps(self._payload).encode("utf-8")
+
+        def _msg(guid, text):
+            return {
+                "type": "new-message",
+                "data": {
+                    "guid": guid,
+                    "text": text,
+                    "handle": {"address": "+15551234567"},
+                    "isFromMe": False,
+                    "chatGuid": "any;-;+15551234567",
+                },
+            }
+
+        r1 = await adapter._handle_webhook(_FakeRequest(_msg("M1", "hi"), "secret"))
+        await asyncio.sleep(0)
+        r2 = await adapter._handle_webhook(_FakeRequest(_msg("M2", "there"), "secret"))
+        await asyncio.sleep(0)
+
+        assert r1.status == 200
+        assert r2.status == 200
+        assert [e.text for e in delivered] == ["hi", "there"]

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -700,6 +700,19 @@ class TestBlueBubblesWebhookRegistration:
         assert ok is False
 
 
+class _FakeWebhookRequest:
+    """Stand-in for aiohttp's ``web.Request`` in inbound-webhook tests."""
+
+    def __init__(self, payload, password):
+        self._payload = payload
+        self.query = {"password": password}
+        self.headers = {}
+
+    async def read(self):
+        import json
+        return json.dumps(self._payload).encode("utf-8")
+
+
 class TestBlueBubblesInboundDedup:
     """Regression coverage for #30708 — exact-GUID dedup across new-message
     and updated-message webhook events for the same iMessage."""
@@ -707,24 +720,16 @@ class TestBlueBubblesInboundDedup:
     @pytest.mark.asyncio
     async def test_same_guid_new_then_updated_message_dedups(self, monkeypatch):
         import asyncio
-        import json
 
         adapter = _make_adapter(monkeypatch)
         delivered = []
+        delivered_event = asyncio.Event()
 
         async def fake_handle_message(event):
             delivered.append(event)
+            delivered_event.set()
 
         monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
-
-        class _FakeRequest:
-            def __init__(self, payload, password):
-                self._payload = payload
-                self.query = {"password": password}
-                self.headers = {}
-
-            async def read(self):
-                return json.dumps(self._payload).encode("utf-8")
 
         new_msg = {
             "type": "new-message",
@@ -751,10 +756,13 @@ class TestBlueBubblesInboundDedup:
             },
         }
 
-        r1 = await adapter._handle_webhook(_FakeRequest(new_msg, "secret"))
-        await asyncio.sleep(0)
-        r2 = await adapter._handle_webhook(_FakeRequest(upd_msg, "secret"))
-        await asyncio.sleep(0)
+        r1 = await adapter._handle_webhook(_FakeWebhookRequest(new_msg, "secret"))
+        await asyncio.wait_for(delivered_event.wait(), timeout=2.0)
+        r2 = await adapter._handle_webhook(_FakeWebhookRequest(upd_msg, "secret"))
+        # Drain any background tasks from the second request so a stray
+        # delivery would have a turn to fire before we assert dedup.
+        for _ in range(5):
+            await asyncio.sleep(0)
 
         assert r1.status == 200
         assert r2.status == 200
@@ -768,24 +776,17 @@ class TestBlueBubblesInboundDedup:
     async def test_different_guids_both_delivered(self, monkeypatch):
         """Two distinct iMessages must still both be delivered."""
         import asyncio
-        import json
 
         adapter = _make_adapter(monkeypatch)
         delivered = []
+        delivered_count = asyncio.Event()
 
         async def fake_handle_message(event):
             delivered.append(event)
+            if len(delivered) >= 2:
+                delivered_count.set()
 
         monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
-
-        class _FakeRequest:
-            def __init__(self, payload, password):
-                self._payload = payload
-                self.query = {"password": password}
-                self.headers = {}
-
-            async def read(self):
-                return json.dumps(self._payload).encode("utf-8")
 
         def _msg(guid, text):
             return {
@@ -799,10 +800,9 @@ class TestBlueBubblesInboundDedup:
                 },
             }
 
-        r1 = await adapter._handle_webhook(_FakeRequest(_msg("M1", "hi"), "secret"))
-        await asyncio.sleep(0)
-        r2 = await adapter._handle_webhook(_FakeRequest(_msg("M2", "there"), "secret"))
-        await asyncio.sleep(0)
+        r1 = await adapter._handle_webhook(_FakeWebhookRequest(_msg("M1", "hi"), "secret"))
+        r2 = await adapter._handle_webhook(_FakeWebhookRequest(_msg("M2", "there"), "secret"))
+        await asyncio.wait_for(delivered_count.wait(), timeout=2.0)
 
         assert r1.status == 200
         assert r2.status == 200


### PR DESCRIPTION
## What does this PR do?

BlueBubbles fires both `new-message` and `updated-message` for the same iMessage (the second on delivered/read/edit echoes). The adapter currently has no inbound dedup — unlike slack / dingtalk / wecom / weixin / mattermost / feishu, all of which use the shared `MessageDeduplicator` helper. As a result the same inbound message is processed twice, and because the two payloads carry the chat reference differently (`new-message` includes `chatGuid`, `updated-message` typically omits it and falls back to `chatIdentifier`), the gateway derives two distinct session keys (`any;-;<addr>` vs bare `<addr>`) and spins up two parallel sessions for one chat — producing interleaved/duplicate replies and, e.g., two "Session reset" confirmations for a single `/new`.

Fix: wire in the shared `MessageDeduplicator` at the top of `_handle_webhook`, keyed by the message GUID resolved with the same priority already used for `MessageEvent.message_id` (`guid` → `messageGuid` → `id`). The dedup runs *before* session-key derivation, so both the double-processing and the dual-session symptoms disappear without changing the event subscription — `updated-message` still flows through for the edits/retractions work tracked in #8513.

This is intentionally **scoped to the exact-GUID echo case from #30708**. The complementary text-then-attachment two-event coalescing described in #30989 is orthogonal (different GUIDs, requires a debounce-and-merge step modeled on Telegram's media-group handling) and is intentionally left out of this PR.

## Related Issue

Fixes #30708

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/bluebubbles.py` — import `MessageDeduplicator` alongside `strip_markdown`, instantiate `self._dedup = MessageDeduplicator()` in `__init__`, and call `self._dedup.is_duplicate(msg_guid)` near the top of `_handle_webhook` (after the `is_from_me` guard, before any chat-key derivation). The GUID is resolved with the same priority list already used for `MessageEvent.message_id`.
- `tests/gateway/test_bluebubbles.py` — new `TestBlueBubblesInboundDedup` class:
  - `test_same_guid_new_then_updated_message_dedups` — drives the exact `new-message` → `updated-message` sequence from the issue and asserts `handle_message` is called once, not twice. Pre-fix this test fails with two delivered events whose `source.chat_id` is `any;-;+15551234567` and `+15551234567` respectively (the two parallel sessions the issue describes).
  - `test_different_guids_both_delivered` — negative case proving distinct GUIDs still both reach `handle_message`.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout --with aiohttp python3 -m pytest tests/gateway/test_bluebubbles.py -v`
2. All 51 tests pass (49 pre-existing + 2 new).
3. Regression check: temporarily revert the production change and rerun the two new tests — `test_same_guid_new_then_updated_message_dedups` fails with `assert 2 == 1` and a diff showing the two distinct `source.chat_id` values from the issue body.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(bluebubbles): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal adapter wiring; no user-facing surface or config key changes)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (server-side adapter; runs wherever the gateway runs)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Salvage-with-widening

> Audited siblings: `slack.py`, `dingtalk.py`, `wecom.py`, `weixin.py`, `mattermost.py`, and `feishu.py` already use `MessageDeduplicator` (the helper docstring lists exactly this set as the adapters it consolidated). `bluebubbles.py` was the only inbound-message adapter missing the wiring. No widening needed.