### PR TITLE
fix(gateway): accept X-Hub-Signature header for Jira/Atlassian webhooks

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -634,7 +634,7 @@ class WebhookAdapter(BasePlatformAdapter):
     def _validate_signature(
         self, request: "web.Request", body: bytes, secret: str
     ) -> bool:
-        """Validate webhook signature (GitHub, GitLab, Svix, generic HMAC-SHA256)."""
+        """Validate webhook signature (GitHub, Jira, GitLab, Svix, generic HMAC-SHA256)."""
         def _header(name: str) -> str:
             return (
                 request.headers.get(name, "")
@@ -659,14 +659,16 @@ class WebhookAdapter(BasePlatformAdapter):
                 timestamp=svix_timestamp,
                 signature_header=svix_signature,
             )
-
         # GitHub: X-Hub-Signature-256 = sha256=<hex>
-        gh_sig = request.headers.get("X-Hub-Signature-256", "")
-        if gh_sig:
+        # Jira/Atlassian: X-Hub-Signature = sha256=<hex> (same format, no -256 suffix)
+        hub_sig = request.headers.get(
+            "X-Hub-Signature-256", ""
+        ) or request.headers.get("X-Hub-Signature", "")
+        if hub_sig:
             expected = "sha256=" + hmac.new(
                 secret.encode(), body, hashlib.sha256
             ).hexdigest()
-            return hmac.compare_digest(gh_sig, expected)
+            return hmac.compare_digest(hub_sig, expected)
 
         # GitLab: X-Gitlab-Token = <plain secret>
         gl_token = request.headers.get("X-Gitlab-Token", "")

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -89,8 +89,8 @@ def _mock_request(headers=None, body=b"", content_length=None, match_info=None):
     return req
 
 
-def _github_signature(body: bytes, secret: str) -> str:
-    """Compute X-Hub-Signature-256 for *body* using *secret*."""
+def _hmac_sha256_signature(body: bytes, secret: str) -> str:
+    """Compute HMAC-SHA256 signature (`sha256=<hex>`) for *body* using *secret*."""
     return "sha256=" + hmac.new(
         secret.encode(), body, hashlib.sha256
     ).hexdigest()
@@ -121,21 +121,38 @@ def _svix_signature(body: bytes, secret: str, msg_id: str, timestamp: str) -> st
 class TestValidateSignature:
     """Tests for WebhookAdapter._validate_signature."""
 
-    def test_validate_github_signature_valid(self):
+    def test_validate_hmac_sha256_signature_valid(self):
         """Valid X-Hub-Signature-256 is accepted."""
         adapter = _make_adapter()
         body = b'{"action": "opened"}'
         secret = "webhook-secret-42"
-        sig = _github_signature(body, secret)
+        sig = _hmac_sha256_signature(body, secret)
         req = _mock_request(headers={"X-Hub-Signature-256": sig})
         assert adapter._validate_signature(req, body, secret) is True
 
-    def test_validate_github_signature_invalid(self):
+    def test_validate_hmac_sha256_signature_invalid(self):
         """Wrong X-Hub-Signature-256 is rejected."""
         adapter = _make_adapter()
         body = b'{"action": "opened"}'
         secret = "webhook-secret-42"
         req = _mock_request(headers={"X-Hub-Signature-256": "sha256=deadbeef"})
+        assert adapter._validate_signature(req, body, secret) is False
+
+    def test_validate_jira_signature_valid(self):
+        """Valid X-Hub-Signature (Jira/Atlassian style, no -256 suffix) is accepted."""
+        adapter = _make_adapter()
+        body = b'{"webhookEvent": "jira:issue_updated"}'
+        secret = "jira-secret"
+        sig = _hmac_sha256_signature(body, secret)
+        req = _mock_request(headers={"X-Hub-Signature": sig})
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_validate_jira_signature_invalid(self):
+        """Wrong X-Hub-Signature (Jira style) is rejected."""
+        adapter = _make_adapter()
+        body = b'{"webhookEvent": "jira:issue_updated"}'
+        secret = "jira-secret"
+        req = _mock_request(headers={"X-Hub-Signature": "sha256=deadbeef"})
         assert adapter._validate_signature(req, body, secret) is False
 
     def test_validate_gitlab_token(self):

--- a/tests/gateway/test_webhook_integration.py
+++ b/tests/gateway/test_webhook_integration.py
@@ -47,8 +47,8 @@ def _create_app(adapter: WebhookAdapter) -> web.Application:
     return app
 
 
-def _github_signature(body: bytes, secret: str) -> str:
-    """Compute X-Hub-Signature-256 for *body* using *secret*."""
+def _hmac_sha256_signature(body: bytes, secret: str) -> str:
+    """Compute HMAC-SHA256 signature (`sha256=<hex>`) for *body* using *secret*."""
     return "sha256=" + hmac.new(
         secret.encode(), body, hashlib.sha256
     ).hexdigest()
@@ -111,7 +111,7 @@ class TestGitHubPRWebhook:
 
         app = _create_app(adapter)
         body = json.dumps(GITHUB_PR_PAYLOAD).encode()
-        sig = _github_signature(body, secret)
+        sig = _hmac_sha256_signature(body, secret)
 
         async with TestClient(TestServer(app)) as cli:
             resp = await cli.post(

--- a/tests/gateway/test_webhook_signature_rate_limit.py
+++ b/tests/gateway/test_webhook_signature_rate_limit.py
@@ -46,8 +46,8 @@ def _create_app(adapter: WebhookAdapter) -> web.Application:
     return app
 
 
-def _github_signature(body: bytes, secret: str) -> str:
-    """Compute X-Hub-Signature-256 for *body* using *secret*."""
+def _hmac_sha256_signature(body: bytes, secret: str) -> str:
+    """Compute HMAC-SHA256 signature (`sha256=<hex>`) for *body* using *secret*."""
     return "sha256=" + hmac.new(
         secret.encode(), body, hashlib.sha256
     ).hexdigest()
@@ -116,7 +116,7 @@ class TestSignatureBeforeRateLimit:
             # consumed the rate limit bucket.
             # AFTER FIX: Bad requests don't touch rate limiting, so valid
             # request succeeds.
-            valid_sig = _github_signature(body, secret)
+            valid_sig = _hmac_sha256_signature(body, secret)
             resp = await cli.post(
                 f"/webhooks/{route_name}",
                 data=body,
@@ -168,7 +168,7 @@ class TestSignatureBeforeRateLimit:
         async with TestClient(TestServer(app)) as cli:
             # Send 'rate_limit' valid requests — all should succeed
             for i in range(rate_limit):
-                valid_sig = _github_signature(body, secret)
+                valid_sig = _hmac_sha256_signature(body, secret)
                 resp = await cli.post(
                     f"/webhooks/{route_name}",
                     data=body,
@@ -182,7 +182,7 @@ class TestSignatureBeforeRateLimit:
                 assert resp.status == 202
 
             # The next valid request SHOULD be rate-limited
-            valid_sig = _github_signature(body, secret)
+            valid_sig = _hmac_sha256_signature(body, secret)
             resp = await cli.post(
                 f"/webhooks/{route_name}",
                 data=body,
@@ -228,7 +228,7 @@ class TestSignatureBeforeRateLimit:
         async with TestClient(TestServer(app)) as cli:
             # Send 2 valid requests (should succeed)
             for i in range(2):
-                valid_sig = _github_signature(body, secret)
+                valid_sig = _hmac_sha256_signature(body, secret)
                 resp = await cli.post(
                     f"/webhooks/{route_name}",
                     data=body,
@@ -256,7 +256,7 @@ class TestSignatureBeforeRateLimit:
                 assert resp.status == 401
 
             # One more valid request should STILL succeed (only 2 consumed)
-            valid_sig = _github_signature(body, secret)
+            valid_sig = _hmac_sha256_signature(body, secret)
             resp = await cli.post(
                 f"/webhooks/{route_name}",
                 data=body,
@@ -273,7 +273,7 @@ class TestSignatureBeforeRateLimit:
             )
 
             # The 4th valid request should be rate-limited (2 + 2 = 4 = limit)
-            valid_sig = _github_signature(body, secret)
+            valid_sig = _hmac_sha256_signature(body, secret)
             resp = await cli.post(
                 f"/webhooks/{route_name}",
                 data=body,

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -225,6 +225,49 @@ platforms:
 
 ---
 
+## Jira Webhook Setup {#jira-webhook-setup}
+
+Jira webhooks authenticate via HMAC-SHA256 using the `X-Hub-Signature` header, with the signature value prefixed by `sha256=`.
+
+### 1. Create the webhook in Jira
+
+1. Go to **Jira Settings** → **System** → **WebHooks** (under "Advanced")
+2. Click **Create a WebHook**
+3. Fill in:
+   - **Name:** e.g. "Hermes Issue Triage"
+   - **URL:** `http://your-server:8644/webhooks/jira-issues`
+   - **Secret:** the same value you'll set as `secret` in your route config
+4. Under **Events**, check the events you want to trigger on (e.g. `jira:issue_created`, `jira:issue_updated`, `comment_created`)
+5. Click **Create**
+
+### 2. Add the route config
+
+```yaml
+platforms:
+  webhook:
+    enabled: true
+    extra:
+      routes:
+        jira-issues:
+          secret: "your-jira-webhook-secret"
+          prompt: |
+            A Jira event was received:
+            Event: {webhookEvent}
+            Issue: {issue.key} — {issue.fields.summary}
+            Reporter: {user.displayName}
+
+            Take appropriate action based on the event type and issue content.
+          deliver: "slack"
+          deliver_extra:
+            chat_id: "C07ABCDEFGH"   # Slack channel ID
+```
+
+### 3. Test it
+
+Create an issue in your Jira project and watch for the agent's follow-up in your Slack channel.
+
+---
+
 ## Delivery Options {#delivery-options}
 
 The `deliver` field controls where the agent's response goes after processing the webhook event.
@@ -386,6 +429,7 @@ The webhook adapter includes multiple layers of security:
 The adapter validates incoming webhook signatures using the appropriate method for each source:
 
 - **GitHub**: `X-Hub-Signature-256` header — HMAC-SHA256 hex digest prefixed with `sha256=`
+- **Jira**: `X-Hub-Signature` header — HMAC-SHA256 hex digest prefixed with `sha256=`
 - **GitLab**: `X-Gitlab-Token` header — plain secret string match
 - **Generic**: `X-Webhook-Signature` header — raw HMAC-SHA256 hex digest
 


### PR DESCRIPTION
## What does this PR do?

Hermes only checks `X-Hub-Signature-256` (the GitHub header name) when validating webhook signatures. Jira/Atlassian sends the identical `sha256=<hex>` HMAC-SHA256 format under the header `X-Hub-Signature` (no `-256` suffix). Because Hermes doesn't recognize this header, all Jira webhooks are rejected with `[webhook] Invalid signature for route ...`.

This fix falls back to `X-Hub-Signature` when `X-Hub-Signature-256` is absent. Both headers share the same signing scheme, so no additional logic is needed.

The [webhook documentation](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/webhooks) already lists JIRA as a supported source, but it has never worked due to this header name mismatch.

## Related Issue

Fixes # (no existing issue — this PR documents and fixes a misalignment between the advertised Jira webhook support and the actual implementation)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/webhook.py` — fall back to `X-Hub-Signature` after `X-Hub-Signature-256` in `_validate_signature()`; rename `gh_sig` → `hub_sig`; update docstring to list all four signature schemes
- `tests/gateway/test_webhook_adapter.py` — add `test_validate_jira_signature_valid` and `test_validate_jira_signature_invalid`; rename `_github_signature` → `_hmac_sha256_signature` helper and update test method names
- `tests/gateway/test_webhook_integration.py` — rename `_github_signature` → `_hmac_sha256_signature` helper
- `tests/gateway/test_webhook_signature_rate_limit.py` — rename `_github_signature` → `_hmac_sha256_signature` helper
- website/docs/user-guide/messaging/webhooks.md — add Jira to the HMAC signature validation table; add a new Jira Webhook Setup section with instructions, route config example, and testing steps

## How to Test

1. Configure a Jira webhook with a secret and point it at `http://<hermes-host>:8644/webhooks/jira-issue`
2. Add a `jira-issue` route to `config.yaml` under `platforms.webhook.extra.routes` with the matching secret
3. Trigger an issue update in Jira (e.g., transition an issue's status)
4. **Before (broken):** gateway logs `[webhook] Invalid signature for route jira-issue` and returns HTTP 401
5. **After (fixed):** webhook is accepted, payload is processed, and response is delivered to the configured target

Or run the unit tests:
```bash
pytest tests/gateway/test_webhook_adapter.py::TestValidateSignature -v -k "jira"
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Kubernetes on Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation — added Jira signature scheme to the security table and a new Jira Webhook Setup section in webhooks.md
- [x] I've updated `cli-config.yaml.example` — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — or N/A
- [x] I've considered cross-platform impact — or N/A
- [x] I've updated tool descriptions/schemas — or N/A

## Screenshots / Logs

**Before (broken):**
```
WARNING gateway.platforms.webhook: [webhook] Invalid signature for route jira-issue
WARNING gateway.platforms.webhook: [webhook] Invalid signature for route jira-issue
```

**After (fixed):**
Webhook accepted, payload delivered to Slack. No `Invalid signature` warnings.
