### PR TITLE
feat(doctor): report provider plugin source + overrides (#30922)

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1809,6 +1809,53 @@ def run_doctor(args):
     except Exception as e:
         check_warn("Could not check tool availability", f"({e})")
     
+    _section("Provider Plugins")
+    try:
+        from providers import (
+            get_provider_source,
+            list_provider_overrides,
+            list_providers,
+        )
+
+        _profiles = list_providers()
+        _overrides = list_provider_overrides()
+        _by_source: dict[str, list[str]] = {"bundled": [], "user": [], "legacy": []}
+        _unknown_source: list[str] = []
+        for _p in _profiles:
+            _src = get_provider_source(_p.name)
+            if _src in _by_source:
+                _by_source[_src].append(_p.name)
+            else:
+                _unknown_source.append(_p.name)
+
+        _bundled_n = len(_by_source["bundled"])
+        _user_n = len(_by_source["user"])
+        _legacy_n = len(_by_source["legacy"])
+        _detail_parts = [f"{_bundled_n} bundled"]
+        if _user_n:
+            _detail_parts.append(f"{_user_n} user")
+        if _legacy_n:
+            _detail_parts.append(f"{_legacy_n} legacy")
+        check_ok(
+            f"{len(_profiles)} provider profile(s) active",
+            f"({', '.join(_detail_parts)})",
+        )
+
+        if _overrides:
+            check_warn(
+                f"{len(_overrides)} provider(s) overridden by later-loaded plugin(s)"
+            )
+            for _name in sorted(_overrides):
+                _active = get_provider_source(_name) or "?"
+                _displaced = ", ".join(_overrides[_name])
+                check_info(f"{_name}: active={_active}, displaced={_displaced}")
+        elif _by_source["user"]:
+            check_info(
+                "User plugins (no overrides): " + ", ".join(sorted(_by_source["user"]))
+            )
+    except Exception as _e:
+        check_warn("Could not enumerate provider plugins", str(_e))
+
     _section("Skills Hub")
     hub_dir = HERMES_HOME / "skills" / ".hub"
     if hub_dir.exists():

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -42,7 +42,20 @@ logger = logging.getLogger(__name__)
 
 _REGISTRY: dict[str, ProviderProfile] = {}
 _ALIASES: dict[str, str] = {}
+# Canonical name -> source label ("bundled" | "user" | "legacy") for the
+# currently active profile. Populated during discovery so `hermes doctor`
+# can report where each active profile came from.
+_SOURCES: dict[str, str] = {}
+# Canonical name -> list of source labels that previously registered the same
+# name but were displaced. Only present for names that were overridden at
+# least once. Order is the order in which they were displaced.
+_OVERRIDES: dict[str, list[str]] = {}
 _discovered = False
+
+# Source label of the plugin currently being imported, set by
+# _import_plugin_dir / _discover_providers and read by register_provider so
+# the registrant doesn't have to know its own provenance.
+_CURRENT_SOURCE: str | None = None
 
 # Repo-root ``plugins/model-providers/`` — populated at discovery time.
 _BUNDLED_PLUGINS_DIR = (
@@ -57,9 +70,16 @@ def register_provider(profile: ProviderProfile) -> None:
     plugins under ``$HERMES_HOME/plugins/model-providers/`` can override
     bundled profiles without editing repo code.
     """
-    _REGISTRY[profile.name] = profile
+    name = profile.name
+    if _CURRENT_SOURCE is not None and name in _REGISTRY:
+        prev_source = _SOURCES.get(name)
+        if prev_source is not None and prev_source != _CURRENT_SOURCE:
+            _OVERRIDES.setdefault(name, []).append(prev_source)
+    _REGISTRY[name] = profile
+    if _CURRENT_SOURCE is not None:
+        _SOURCES[name] = _CURRENT_SOURCE
     for alias in profile.aliases:
-        _ALIASES[alias] = profile.name
+        _ALIASES[alias] = name
 
 
 def get_provider_profile(name: str) -> ProviderProfile | None:
@@ -88,6 +108,30 @@ def list_providers() -> list[ProviderProfile]:
     return result
 
 
+def get_provider_source(name: str) -> str | None:
+    """Return the source label of the active profile for ``name``.
+
+    Returns ``"bundled"``, ``"user"``, ``"legacy"``, or ``None`` if the
+    name is not registered. Accepts aliases.
+    """
+    if not _discovered:
+        _discover_providers()
+    canonical = _ALIASES.get(name, name)
+    return _SOURCES.get(canonical)
+
+
+def list_provider_overrides() -> dict[str, list[str]]:
+    """Return ``{canonical_name: [displaced_sources]}`` for overridden profiles.
+
+    Only includes profiles that were registered by more than one source
+    during discovery. The list contains the sources whose registrations
+    were displaced by the currently active one, in displacement order.
+    """
+    if not _discovered:
+        _discover_providers()
+    return {k: list(v) for k, v in _OVERRIDES.items()}
+
+
 def _user_plugins_dir() -> Path | None:
     """Return ``$HERMES_HOME/plugins/model-providers/`` if it exists."""
     try:
@@ -102,7 +146,9 @@ def _user_plugins_dir() -> Path | None:
 def _import_plugin_dir(plugin_dir: Path, source: str) -> None:
     """Import a single plugin directory so it self-registers.
 
-    ``source`` is "bundled" or "user", used only for log messages.
+    ``source`` is "bundled" or "user", used for log messages and stored on
+    each registered profile via the ``_CURRENT_SOURCE`` module-level
+    contextual variable that ``register_provider`` reads.
     """
     init_file = plugin_dir / "__init__.py"
     if not init_file.exists():
@@ -121,6 +167,8 @@ def _import_plugin_dir(plugin_dir: Path, source: str) -> None:
     if module_name in sys.modules:
         return  # already imported
 
+    global _CURRENT_SOURCE
+    _CURRENT_SOURCE = source
     try:
         spec = importlib.util.spec_from_file_location(
             module_name, init_file, submodule_search_locations=[str(plugin_dir)]
@@ -135,6 +183,8 @@ def _import_plugin_dir(plugin_dir: Path, source: str) -> None:
             "Failed to load %s provider plugin %s: %s", source, plugin_dir.name, exc
         )
         sys.modules.pop(module_name, None)
+    finally:
+        _CURRENT_SOURCE = None
 
 
 def _discover_providers() -> None:
@@ -148,7 +198,7 @@ def _discover_providers() -> None:
     Each step imports its plugins, which call ``register_provider()`` at
     module-level. Later steps win on name collision.
     """
-    global _discovered
+    global _discovered, _CURRENT_SOURCE
     if _discovered:
         return
     _discovered = True
@@ -181,11 +231,14 @@ def _discover_providers() -> None:
         for _importer, modname, _ispkg in pkgutil.iter_modules(_pkg.__path__):
             if modname.startswith("_") or modname == "base":
                 continue
+            _CURRENT_SOURCE = "legacy"
             try:
                 importlib.import_module(f"providers.{modname}")
             except ImportError as exc:
                 logger.warning(
                     "Failed to import legacy provider module %s: %s", modname, exc
                 )
+            finally:
+                _CURRENT_SOURCE = None
     except Exception:
-        pass
+        _CURRENT_SOURCE = None

--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -23,6 +23,8 @@ def _clear_provider_caches():
     import providers as _pkg
     _pkg._REGISTRY.clear()
     _pkg._ALIASES.clear()
+    _pkg._SOURCES.clear()
+    _pkg._OVERRIDES.clear()
     _pkg._discovered = False
     # Evict any cached plugin modules so the next import re-executes.
     for mod in list(sys.modules.keys()):
@@ -107,6 +109,85 @@ def test_user_plugin_overrides_bundled(tmp_path, monkeypatch):
 
     # Clean up: reset discovery state so other tests see the bundled version
     _clear_provider_caches()
+
+
+def test_bundled_profiles_report_source_bundled():
+    """Every bundled profile should be tagged with source='bundled'."""
+    _clear_provider_caches()
+    from providers import get_provider_source, list_providers
+
+    profiles = list_providers()
+    assert profiles, "Discovery returned no profiles"
+    # Sample across several built-ins; if any of these are missing the change
+    # has bigger problems than source tracking.
+    for required in ("gmi", "openrouter", "anthropic", "deepseek"):
+        assert get_provider_source(required) == "bundled", (
+            f"{required} expected source='bundled', got {get_provider_source(required)!r}"
+        )
+    # Aliases must resolve to the canonical profile's source.
+    from providers import get_provider_profile
+
+    for p in profiles:
+        for alias in p.aliases:
+            assert get_provider_source(alias) == get_provider_source(p.name), (
+                f"alias {alias!r} of {p.name!r} reports different source"
+            )
+            assert get_provider_profile(alias) is p
+
+
+def test_user_override_records_displaced_source(tmp_path, monkeypatch):
+    """A user plugin that overrides a bundled profile must update source +
+    record the displaced 'bundled' source in list_provider_overrides()."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    user_gmi = hermes_home / "plugins" / "model-providers" / "gmi"
+    user_gmi.mkdir(parents=True)
+    (user_gmi / "__init__.py").write_text(
+        "from providers import register_provider\n"
+        "from providers.base import ProviderProfile\n"
+        "register_provider(ProviderProfile(\n"
+        '    name="gmi",\n'
+        '    aliases=(),\n'
+        '    env_vars=("GMI_API_KEY",),\n'
+        '    base_url="https://user-override.example/v1",\n'
+        '    auth_type="api_key",\n'
+        "))\n"
+    )
+    (user_gmi / "plugin.yaml").write_text(
+        "name: gmi\nkind: model-provider\nversion: 0.0.1\n"
+    )
+
+    _clear_provider_caches()
+    from providers import (
+        get_provider_profile,
+        get_provider_source,
+        list_provider_overrides,
+    )
+
+    assert get_provider_source("gmi") == "user"
+    overrides = list_provider_overrides()
+    assert "gmi" in overrides, f"gmi missing from overrides: {overrides}"
+    assert overrides["gmi"] == ["bundled"]
+    # Returned mapping must be a defensive copy.
+    overrides["gmi"].append("tampered")
+    fresh = list_provider_overrides()
+    assert fresh["gmi"] == ["bundled"]
+    # Active profile is the user one.
+    profile = get_provider_profile("gmi")
+    assert profile is not None
+    assert profile.base_url == "https://user-override.example/v1"
+
+    _clear_provider_caches()
+
+
+def test_get_provider_source_unknown_returns_none():
+    """Unregistered names return None rather than raising."""
+    _clear_provider_caches()
+    from providers import get_provider_source
+
+    assert get_provider_source("definitely-not-a-real-provider-xyz") is None
 
 
 def test_general_plugin_manager_skips_model_provider_kind(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Make model-provider plugin overrides visible in `hermes doctor`. The plugin loader has always supported user plugins under `\$HERMES_HOME/plugins/model-providers/<name>/` overriding bundled ones via last-writer-wins, but nothing told the user whether their override was actually picked up — both `hermes doctor` and the setup wizard were silent on it. Closes #30922.

## Fix

- `providers/__init__.py`: track the source of every registration via a module-level `_CURRENT_SOURCE` variable set by `_import_plugin_dir` (during bundled/user discovery) and `_discover_providers` (legacy single-file path). `register_provider` stores it into `_SOURCES[name]`; on a name collision the displaced source is appended to `_OVERRIDES[name]`.
- New public helpers:
  - `get_provider_source(name)` → `"bundled" | "user" | "legacy" | None` (alias-aware).
  - `list_provider_overrides()` → `{canonical: [displaced_sources_in_order]}`, returning a defensive copy.
- `hermes_cli/doctor.py`: new **Provider Plugins** section (just before *Skills Hub*) that prints
  - `N provider profile(s) active (X bundled, Y user, Z legacy)` — `user` / `legacy` parts only appear when non-zero, and
  - a warning + per-name detail line for every override (`active=…, displaced=…`), or a single info line listing user plugins when there are none.

The section degrades to a single `check_warn` if discovery raises, so a broken plugin can't take down the whole doctor run.

## Test plan

- [x] `tests/providers/test_plugin_discovery.py::test_bundled_profiles_report_source_bundled` — every bundled profile is tagged `bundled`, and aliases resolve to the canonical profile's source.
- [x] `…::test_user_override_records_displaced_source` — a user plugin under a temp `HERMES_HOME` flips source to `user`, records `displaced=["bundled"]`, and the returned override mapping is a defensive copy.
- [x] `…::test_get_provider_source_unknown_returns_none` — unregistered names return `None` instead of raising.
- [x] Existing `test_user_plugin_overrides_bundled` and `test_all_34_profiles_register` still pass; `_clear_provider_caches` was updated to also clear the new `_SOURCES` / `_OVERRIDES` dicts.
- [x] Full `tests/providers/` + `tests/hermes_cli/test_doctor.py` suite: 156 passed; the single fail (`test_doctor_reports_vercel_backend_diagnostics`) reproduces on main with the same `ModuleNotFoundError: requests` and is unrelated.

Fixes #30922