### PR TITLE
fix(openviking): on_memory_write handles replace/remove + visible errors (#31000)

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -31,6 +31,7 @@ import mimetypes
 import os
 import tempfile
 import threading
+import time
 import uuid
 import zipfile
 from pathlib import Path
@@ -638,26 +639,57 @@ class OpenVikingMemoryProvider(MemoryProvider):
         content: str,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
-        """Mirror built-in memory writes to OpenViking via content/write."""
-        if not self._client or action != "add" or not content:
+        """Mirror built-in memory writes to OpenViking via content/write.
+
+        Handles ``add`` and ``replace`` by writing the content under a
+        fresh UUID-suffixed URI in the target's subdirectory. Because
+        every write uses a new URI, OpenViking's ``mode="create"`` never
+        collides on the path; ``replace`` history accumulates as
+        additional snapshots in the knowledge base.
+
+        ``remove`` is acknowledged at INFO and skipped: this plugin does
+        not persist a memory-entry → viking-URI mapping, so it has no
+        way to locate the URI of the original entry to delete. Logging
+        at INFO keeps the gap visible without spamming.
+
+        Transient "resource is busy" errors from the server's concurrent
+        write lock are retried once with a short backoff. Final failures
+        surface at WARNING so silent mirror outages are detectable
+        without DEBUG logging (see #31000).
+        """
+        if not self._client or not content:
+            return
+        if action == "remove":
+            logger.info(
+                "OpenViking mirror: 'remove' on target=%s skipped "
+                "(plugin does not track memory→URI mapping)",
+                target,
+            )
+            return
+        if action not in {"add", "replace"}:
             return
 
         subdir = _MEMORY_WRITE_TARGET_SUBDIR_MAP.get(target, _DEFAULT_MEMORY_SUBDIR)
         uri = self._build_memory_uri(subdir)
 
         def _write():
-            try:
-                client = _VikingClient(
-                    self._endpoint, self._api_key,
-                    account=self._account, user=self._user, agent=self._agent,
-                )
-                client.post("/api/v1/content/write", {
-                    "uri": uri,
-                    "content": content,
-                    "mode": "create",
-                })
-            except Exception as e:
-                logger.debug("OpenViking memory mirror failed: %s", e)
+            client = _VikingClient(
+                self._endpoint, self._api_key,
+                account=self._account, user=self._user, agent=self._agent,
+            )
+            payload = {"uri": uri, "content": content, "mode": "create"}
+            last_exc: Optional[BaseException] = None
+            for attempt in range(2):
+                try:
+                    client.post("/api/v1/content/write", payload)
+                    return
+                except Exception as e:
+                    last_exc = e
+                    if "busy" in str(e).lower() and attempt == 0:
+                        time.sleep(0.2)
+                        continue
+                    break
+            logger.warning("OpenViking memory mirror failed: %s", last_exc)
 
         t = threading.Thread(target=_write, daemon=True, name="openviking-memwrite")
         t.start()

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1,4 +1,5 @@
 import json
+import threading
 import zipfile
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -399,6 +400,154 @@ def test_viking_client_headers_sent_with_real_tenant_values():
     headers = client._headers()
     assert headers["X-OpenViking-Account"] == "real-account"
     assert headers["X-OpenViking-User"] == "real-user"
+
+
+# on_memory_write — see #31000
+# ---------------------------------------------------------------------------
+
+
+def _build_mirror_provider(monkeypatch, *, post_side_effect=None):
+    """Return a provider wired to a recording fake _VikingClient.
+
+    The hook spawns a daemon thread that constructs a fresh _VikingClient,
+    so we patch the class symbol in the module rather than ``provider._client``.
+    Returns (provider, posts) where ``posts`` is a list of recorded
+    ``(path, payload)`` tuples populated as the background thread runs.
+    """
+    posts: list = []
+
+    class _FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def post(self, path, payload=None, **kwargs):
+            posts.append((path, payload))
+            if post_side_effect is not None:
+                result = post_side_effect(len(posts), payload)
+                if isinstance(result, BaseException):
+                    raise result
+                return result or {"result": {"written_bytes": len(payload.get("content", ""))}}
+            return {"result": {"written_bytes": len(payload.get("content", ""))}}
+
+    import plugins.memory.openviking as ov_mod
+
+    monkeypatch.setattr(ov_mod, "_VikingClient", _FakeClient)
+    provider = OpenVikingMemoryProvider()
+    # Mark client as initialized so the hook proceeds. The fake replaces the
+    # class the hook instantiates, so the value of provider._client is unused
+    # past the truthiness gate.
+    provider._client = MagicMock()
+    provider._endpoint = "http://127.0.0.1:1933"
+    provider._api_key = ""
+    provider._account = "default"
+    provider._user = "default"
+    provider._agent = "hermes"
+    return provider, posts
+
+
+def _join_mirror_threads():
+    """Wait for any openviking-memwrite threads to finish before asserting."""
+    for t in threading.enumerate():
+        if t.name == "openviking-memwrite":
+            t.join(timeout=2.0)
+
+
+def test_on_memory_write_add_writes_under_target_subdir(monkeypatch):
+    provider, posts = _build_mirror_provider(monkeypatch)
+
+    provider.on_memory_write("add", "user", "Jordan prefers concise commits")
+    _join_mirror_threads()
+
+    assert len(posts) == 1
+    path, payload = posts[0]
+    assert path == "/api/v1/content/write"
+    assert payload["content"] == "Jordan prefers concise commits"
+    assert payload["mode"] == "create"
+    # user → preferences subdir
+    assert "/memories/preferences/" in payload["uri"]
+
+
+def test_on_memory_write_replace_now_mirrors(monkeypatch):
+    """Regression for #31000 bug 1: 'replace' previously dropped silently."""
+    provider, posts = _build_mirror_provider(monkeypatch)
+
+    provider.on_memory_write("replace", "memory", "updated agent note")
+    _join_mirror_threads()
+
+    assert len(posts) == 1
+    _, payload = posts[0]
+    assert payload["content"] == "updated agent note"
+    # memory → patterns subdir
+    assert "/memories/patterns/" in payload["uri"]
+
+
+def test_on_memory_write_remove_skips_but_logs(monkeypatch, caplog):
+    """Regression for #31000 bug 1: 'remove' must not silently no-op."""
+    provider, posts = _build_mirror_provider(monkeypatch)
+
+    with caplog.at_level("INFO", logger="plugins.memory.openviking"):
+        provider.on_memory_write("remove", "user", "old fact")
+    _join_mirror_threads()
+
+    assert posts == []
+    assert any(
+        "remove" in r.message and "skipped" in r.message
+        for r in caplog.records
+    ), f"expected an INFO log for remove; got: {[r.message for r in caplog.records]}"
+
+
+def test_on_memory_write_unknown_action_skips(monkeypatch):
+    provider, posts = _build_mirror_provider(monkeypatch)
+
+    provider.on_memory_write("rebuild", "memory", "x")
+    _join_mirror_threads()
+
+    assert posts == []
+
+
+def test_on_memory_write_empty_content_skips(monkeypatch):
+    provider, posts = _build_mirror_provider(monkeypatch)
+
+    provider.on_memory_write("add", "user", "")
+    _join_mirror_threads()
+
+    assert posts == []
+
+
+def test_on_memory_write_retries_on_busy_error(monkeypatch):
+    """Regression for #31000 bug 2: transient busy errors get one retry."""
+
+    def _side_effect(call_no, _payload):
+        if call_no == 1:
+            return RuntimeError("INVALID_ARGUMENT: resource is busy and cannot be written now")
+        return {"result": {"written_bytes": 0}}
+
+    provider, posts = _build_mirror_provider(monkeypatch, post_side_effect=_side_effect)
+    monkeypatch.setattr("plugins.memory.openviking.time.sleep", lambda _s: None)
+
+    provider.on_memory_write("add", "user", "retry me")
+    _join_mirror_threads()
+
+    assert len(posts) == 2, "expected one retry after a 'busy' error"
+
+
+def test_on_memory_write_failure_logs_at_warning(monkeypatch, caplog):
+    """Regression for #31000 bug 3: failures must be visible at WARNING."""
+
+    def _always_fail(_call_no, _payload):
+        return RuntimeError("kaboom")
+
+    provider, _ = _build_mirror_provider(monkeypatch, post_side_effect=_always_fail)
+
+    with caplog.at_level("WARNING", logger="plugins.memory.openviking"):
+        provider.on_memory_write("add", "user", "needs visibility")
+    _join_mirror_threads()
+
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert any("OpenViking memory mirror failed" in r.message for r in warnings), (
+        f"expected a WARNING log for the final failure; got: "
+        f"{[(r.levelname, r.message) for r in caplog.records]}"
+    )
 
 
 def test_viking_client_health_sends_auth_headers(monkeypatch):


### PR DESCRIPTION
## Summary

The OpenViking memory mirror has three independent bugs that combine to silently lose data — every \`replace\` and \`remove\` from the built-in memory tool is dropped, transient server lock errors have no retry, and failures log at DEBUG so weeks of outages are invisible. This PR fixes all three. Closes #31000.

## Fix

\`plugins/memory/openviking/__init__.py\` — \`on_memory_write\`:

- **Bug 1 (action filter):** replace the \`action != \"add\"\` gate with explicit handling for \`add\`/\`replace\` (both write under a fresh UUID-suffixed URI — \`_build_memory_uri\` already produces a new path per call, so \`mode=\"create\"\` cannot collide; \`replace\` history accumulates as snapshots). \`remove\` is acknowledged at INFO with a one-line note that the plugin doesn't persist a memory→URI map to look up the original entry — better than the previous silent drop. Unknown actions and empty content still no-op.
- **Bug 2 (no retry on busy):** wrap the POST in a two-attempt loop that retries once with a 200 ms backoff when the error message contains \"busy\". Other errors break out immediately.
- **Bug 3 (invisible failures):** the final exception (after retry, if any) now logs at WARNING via \`logger.warning(\"OpenViking memory mirror failed: %s\", last_exc)\`, so a broken mirror is detectable at default log levels.

### Note on the issue's \"mode='upsert'\" diagnosis

The original report attributed \"resource is busy\" to URI collisions on re-add, but every call already generates a fresh \`uuid.uuid4().hex[:12]\` URI, so URIs cannot collide. The real cause is the server's concurrent write lock, so the fix is a brief retry rather than switching modes — which keeps us from depending on an upsert API that may not exist server-side. Result is the same observable behavior the reporter wanted.

## Test plan

7 new tests in \`tests/plugins/memory/test_openviking_provider.py\`:

- [x] \`test_on_memory_write_add_writes_under_target_subdir\` — \`add\`/\`user\` lands under \`/memories/preferences/\` with \`mode=\"create\"\`.
- [x] \`test_on_memory_write_replace_now_mirrors\` — regression for bug 1: \`replace\`/\`memory\` writes under \`/memories/patterns/\` (was silently dropped).
- [x] \`test_on_memory_write_remove_skips_but_logs\` — \`remove\` no longer silent; emits an INFO record explaining why.
- [x] \`test_on_memory_write_unknown_action_skips\` — defensive: unsupported actions no-op.
- [x] \`test_on_memory_write_empty_content_skips\` — empty content still no-op.
- [x] \`test_on_memory_write_retries_on_busy_error\` — regression for bug 2: one \"busy\" failure followed by success → two POSTs recorded.
- [x] \`test_on_memory_write_failure_logs_at_warning\` — regression for bug 3: terminal failure emits a WARNING record.

The hook spawns a daemon thread that constructs a fresh \`_VikingClient\`, so the test helper patches the module-level class symbol and joins the named \`openviking-memwrite\` thread before asserting.

Full suite: \`tests/plugins/memory/ + tests/openviking_plugin/ + tests/agent/test_memory_provider.py\` — 251 passed.

Fixes #31000