### PR TITLE
Add Cursor SDK provider

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -289,7 +289,7 @@ def init_agent(
     agent.provider = provider_name or ""
     agent.acp_command = acp_command or command
     agent.acp_args = list(acp_args or args or [])
-    if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server"}:
+    if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "cursor_sdk", "codex_app_server"}:
         agent.api_mode = api_mode
     elif agent.provider == "openai-codex":
         agent.api_mode = "codex_responses"
@@ -320,7 +320,16 @@ def init_agent(
         # (bedrock-runtime.<region>.amazonaws.com).
         agent.api_mode = "bedrock_converse"
     else:
-        agent.api_mode = "chat_completions"
+        try:
+            from providers import get_provider_profile as _get_profile_for_mode
+
+            _profile = _get_profile_for_mode(agent.provider)
+        except Exception:
+            _profile = None
+        if _profile and _profile.api_mode and _profile.api_mode != "chat_completions":
+            agent.api_mode = _profile.api_mode
+        else:
+            agent.api_mode = "chat_completions"
 
     # Eagerly warm the transport cache so import errors surface at init,
     # not mid-conversation.  Also validates the api_mode is registered.
@@ -687,6 +696,20 @@ def init_agent(
         if not agent.quiet_mode:
             _gr_label = " + Guardrails" if agent._bedrock_guardrail_config else ""
             print(f"🤖 AI Agent initialized with model: {agent.model} (AWS Bedrock, {agent._bedrock_region}{_gr_label})")
+    elif agent.api_mode == "cursor_sdk":
+        agent.api_key = api_key or os.getenv("CURSOR_API_KEY", "")
+        agent.base_url = base_url or "cursor-sdk://local"
+        agent.client = None
+        agent._client_kwargs = {
+            "api_key": agent.api_key,
+            "base_url": agent.base_url,
+        }
+        if not agent.quiet_mode:
+            print(f"🤖 AI Agent initialized with model: {agent.model} (Cursor SDK)")
+            if isinstance(agent.api_key, str) and len(agent.api_key) > 12:
+                print(f"🔑 Using API key: {agent.api_key[:8]}...{agent.api_key[-4:]}")
+            else:
+                print("⚠️  Warning: CURSOR_API_KEY appears invalid or missing")
     else:
         if api_key and base_url:
             # Explicit credentials from CLI/gateway — construct directly.

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -181,6 +181,19 @@ def interruptible_api_call(agent, api_kwargs: dict):
                         invalidate_runtime_client(region)
                     raise
                 result["response"] = normalize_converse_response(raw_response)
+            elif agent.api_mode == "cursor_sdk":
+                from agent.cursor_sdk_adapter import create_cursor_sdk_response
+
+                result["response"] = create_cursor_sdk_response(
+                    api_key=api_kwargs.get("api_key") or getattr(agent, "api_key", ""),
+                    model=api_kwargs.get("model") or getattr(agent, "model", ""),
+                    messages=api_kwargs.get("messages") or [],
+                    cwd=api_kwargs.get("cwd") or os.getcwd(),
+                    runtime=api_kwargs.get("runtime"),
+                    timeout=api_kwargs.get("timeout"),
+                    stream=False,
+                    interrupt_check=lambda: agent._interrupt_requested,
+                )
             else:
                 request_client = _set_request_client(
                     agent._create_request_openai_client(
@@ -316,6 +329,18 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             max_tokens=agent.max_tokens or 4096,
             region=region,
             guardrail_config=guardrail,
+        )
+
+    if agent.api_mode == "cursor_sdk":
+        _cursor = agent._get_transport()
+        return _cursor.build_kwargs(
+            model=agent.model,
+            messages=api_messages,
+            tools=None,
+            api_key=getattr(agent, "api_key", ""),
+            cwd=os.getenv("CURSOR_SDK_CWD") or os.getcwd(),
+            runtime=os.getenv("CURSOR_SDK_RUNTIME", "local"),
+            timeout=agent._resolved_api_call_timeout(),
         )
 
     if agent.api_mode == "codex_responses":
@@ -1301,6 +1326,56 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             t.join(timeout=0.3)
             if agent._interrupt_requested:
                 raise InterruptedError("Agent interrupted during Bedrock API call")
+        if result["error"] is not None:
+            raise result["error"]
+        return result["response"]
+
+    if agent.api_mode == "cursor_sdk":
+        result = {"response": None, "error": None}
+        first_delta_fired = {"done": False}
+
+        def _fire_first():
+            if not first_delta_fired["done"] and on_first_delta:
+                first_delta_fired["done"] = True
+                try:
+                    on_first_delta()
+                except Exception:
+                    pass
+
+        def _cursor_call():
+            try:
+                from agent.cursor_sdk_adapter import create_cursor_sdk_response
+
+                def _on_delta(text: str) -> None:
+                    _fire_first()
+                    agent._fire_stream_delta(text)
+
+                def _on_reasoning(text: str) -> None:
+                    _fire_first()
+                    agent._fire_reasoning_delta(text)
+
+                result["response"] = create_cursor_sdk_response(
+                    api_key=api_kwargs.get("api_key") or getattr(agent, "api_key", ""),
+                    model=api_kwargs.get("model") or getattr(agent, "model", ""),
+                    messages=api_kwargs.get("messages") or [],
+                    cwd=api_kwargs.get("cwd") or os.getcwd(),
+                    runtime=api_kwargs.get("runtime"),
+                    timeout=api_kwargs.get("timeout"),
+                    stream=True,
+                    on_delta=_on_delta if agent._has_stream_consumers() else None,
+                    on_reasoning_delta=_on_reasoning if agent.reasoning_callback else None,
+                    on_status=lambda message: agent._touch_activity(message),
+                    interrupt_check=lambda: agent._interrupt_requested,
+                )
+            except Exception as e:
+                result["error"] = e
+
+        t = threading.Thread(target=_cursor_call, daemon=True)
+        t.start()
+        while t.is_alive():
+            t.join(timeout=0.3)
+            if agent._interrupt_requested:
+                raise InterruptedError("Agent interrupted during Cursor SDK call")
         if result["error"] is not None:
             raise result["error"]
         return result["response"]

--- a/agent/cursor_sdk_adapter.py
+++ b/agent/cursor_sdk_adapter.py
@@ -1,0 +1,289 @@
+"""Python adapter for Cursor's TypeScript SDK.
+
+Cursor currently publishes the official SDK as the Node package ``@cursor/sdk``.
+Hermes is Python-first, so this module shells out to a small Node bridge and
+normalizes the result to the OpenAI-like response shape expected by the agent
+loop.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Callable, Iterable
+
+
+class CursorSdkError(RuntimeError):
+    """Raised when the Cursor SDK bridge reports an error."""
+
+
+def _bridge_path() -> Path:
+    return Path(__file__).with_name("cursor_sdk_bridge.mjs")
+
+
+def _text_from_content(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                if isinstance(item.get("text"), str):
+                    parts.append(item["text"])
+                elif item.get("type") == "image_url":
+                    parts.append("[image omitted]")
+        return "\n".join(part for part in parts if part)
+    if isinstance(content, dict):
+        for key in ("text", "content"):
+            value = content.get(key)
+            if isinstance(value, str):
+                return value
+    return "" if content is None else str(content)
+
+
+def _messages_to_cursor_prompt(messages: Iterable[dict[str, Any]]) -> str:
+    """Flatten Hermes/OpenAI-style history into one Cursor SDK prompt."""
+    rendered: list[str] = [
+        "You are running as the Cursor SDK provider inside Hermes Agent.",
+        "Use the conversation transcript below as context and answer the latest user request.",
+        "Do not mention this transcript wrapper. Do not fabricate tool calls.",
+        "",
+        "Conversation:",
+    ]
+
+    for msg in messages or []:
+        if not isinstance(msg, dict):
+            continue
+        role = str(msg.get("role") or "user").strip() or "user"
+        content = _text_from_content(msg.get("content")).strip()
+        if not content:
+            continue
+        if role == "tool":
+            tool_name = str(msg.get("tool_name") or msg.get("name") or "tool")
+            rendered.append(f"Tool result ({tool_name}):\n{content}")
+        elif role == "assistant":
+            rendered.append(f"Assistant:\n{content}")
+        elif role in {"system", "developer"}:
+            rendered.append(f"System:\n{content}")
+        else:
+            rendered.append(f"User:\n{content}")
+
+    rendered.extend(
+        [
+            "",
+            "Respond now with the assistant's next message only.",
+        ]
+    )
+    return "\n\n".join(rendered)
+
+
+def _response_namespace(
+    *,
+    content: str,
+    model: str,
+    finish_reason: str = "stop",
+) -> SimpleNamespace:
+    message = SimpleNamespace(role="assistant", content=content, tool_calls=None)
+    choice = SimpleNamespace(index=0, message=message, finish_reason=finish_reason)
+    usage = SimpleNamespace(prompt_tokens=0, completion_tokens=0, total_tokens=0)
+    return SimpleNamespace(
+        id="cursor-sdk-response",
+        object="chat.completion",
+        model=model,
+        choices=[choice],
+        usage=usage,
+    )
+
+
+def _run_bridge(
+    payload: dict[str, Any],
+    *,
+    timeout: float | None = None,
+    on_delta: Callable[[str], None] | None = None,
+    on_reasoning_delta: Callable[[str], None] | None = None,
+    on_status: Callable[[str], None] | None = None,
+    interrupt_check: Callable[[], bool] | None = None,
+) -> dict[str, Any]:
+    bridge = _bridge_path()
+    if not bridge.exists():
+        raise CursorSdkError(f"Cursor SDK bridge not found: {bridge}")
+
+    cmd = [os.getenv("CURSOR_SDK_NODE", "node"), str(bridge)]
+    env = os.environ.copy()
+    hermes_home = env.get("HERMES_HOME")
+    if not hermes_home:
+        try:
+            from hermes_constants import get_hermes_home
+
+            hermes_home = str(get_hermes_home())
+        except Exception:
+            hermes_home = str(Path.home() / ".hermes")
+        env["HERMES_HOME"] = hermes_home
+
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        env=env,
+    )
+    assert proc.stdin is not None
+    assert proc.stdout is not None
+
+    proc.stdin.write(json.dumps(payload))
+    proc.stdin.close()
+
+    lines: "queue.Queue[str | None]" = queue.Queue()
+
+    def _read_stdout() -> None:
+        try:
+            for stdout_line in proc.stdout:
+                lines.put(stdout_line)
+        finally:
+            lines.put(None)
+
+    reader = threading.Thread(target=_read_stdout, daemon=True)
+    reader.start()
+
+    started = time.monotonic()
+    final: dict[str, Any] | None = None
+    errors: list[str] = []
+
+    while True:
+        if interrupt_check and interrupt_check():
+            proc.terminate()
+            raise InterruptedError("Agent interrupted during Cursor SDK call")
+        if timeout is not None and timeout > 0 and time.monotonic() - started > timeout:
+            proc.terminate()
+            raise TimeoutError(f"Cursor SDK call timed out after {int(timeout)}s")
+
+        try:
+            line = lines.get(timeout=0.1)
+        except queue.Empty:
+            if proc.poll() is not None:
+                try:
+                    line = lines.get_nowait()
+                except queue.Empty:
+                    break
+            else:
+                continue
+        if line is None:
+            continue
+
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        etype = event.get("type")
+        if etype == "delta":
+            text = event.get("text")
+            if isinstance(text, str) and text and on_delta:
+                on_delta(text)
+        elif etype == "reasoning_delta":
+            text = event.get("text")
+            if isinstance(text, str) and text and on_reasoning_delta:
+                on_reasoning_delta(text)
+        elif etype == "status":
+            message = event.get("message")
+            if isinstance(message, str) and message and on_status:
+                on_status(message)
+        elif etype == "final":
+            final = event
+        elif etype == "error":
+            message = str(event.get("message") or "Cursor SDK bridge failed")
+            code = event.get("code")
+            errors.append(f"{code}: {message}" if code else message)
+
+    stderr = ""
+    if proc.stderr is not None:
+        stderr = proc.stderr.read().strip()
+    returncode = proc.wait(timeout=2)
+    if returncode != 0:
+        detail = errors[-1] if errors else stderr or f"exit code {returncode}"
+        raise CursorSdkError(detail)
+    if errors and final is None:
+        raise CursorSdkError(errors[-1])
+    if final is None:
+        raise CursorSdkError(stderr or "Cursor SDK bridge exited without a final response")
+    return final
+
+
+def create_cursor_sdk_response(
+    *,
+    api_key: str,
+    model: str,
+    messages: list[dict[str, Any]],
+    cwd: str | None = None,
+    runtime: str | None = None,
+    timeout: float | None = None,
+    stream: bool = False,
+    on_delta: Callable[[str], None] | None = None,
+    on_reasoning_delta: Callable[[str], None] | None = None,
+    on_status: Callable[[str], None] | None = None,
+    interrupt_check: Callable[[], bool] | None = None,
+) -> SimpleNamespace:
+    prompt = _messages_to_cursor_prompt(messages)
+    payload = {
+        "operation": "prompt",
+        "apiKey": api_key,
+        "model": model,
+        "prompt": prompt,
+        "cwd": cwd or os.getcwd(),
+        "runtime": runtime or os.getenv("CURSOR_SDK_RUNTIME", "local"),
+        "stream": bool(stream),
+    }
+    final = _run_bridge(
+        payload,
+        timeout=timeout,
+        on_delta=on_delta,
+        on_reasoning_delta=on_reasoning_delta,
+        on_status=on_status,
+        interrupt_check=interrupt_check,
+    )
+    content = str(final.get("result") or final.get("text") or "")
+    status = str(final.get("status") or "finished").lower()
+    finish_reason = "stop" if status == "finished" else status
+    return _response_namespace(content=content, model=model, finish_reason=finish_reason)
+
+
+def list_cursor_models(*, api_key: str, timeout: float = 8.0) -> list[str]:
+    payload = {"operation": "models", "apiKey": api_key}
+    final = _run_bridge(payload, timeout=timeout)
+    models = final.get("models")
+    if not isinstance(models, list):
+        return []
+    ids: list[str] = []
+    for item in models:
+        if isinstance(item, str):
+            ids.append(item)
+        elif isinstance(item, dict) and isinstance(item.get("id"), str):
+            ids.append(item["id"])
+            for alias in item.get("aliases") or []:
+                if isinstance(alias, str):
+                    ids.append(alias)
+    return sorted(dict.fromkeys(ids))
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = argv or sys.argv[1:]
+    if argv and argv[0] == "--prompt-from-stdin":
+        data = json.load(sys.stdin)
+        response = create_cursor_sdk_response(**data)
+        print(response.choices[0].message.content)
+        return 0
+    raise SystemExit("usage: python -m agent.cursor_sdk_adapter --prompt-from-stdin")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent/cursor_sdk_bridge.mjs
+++ b/agent/cursor_sdk_bridge.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+
+import { createRequire } from "node:module";
+import { pathToFileURL } from "node:url";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { spawnSync } from "node:child_process";
+
+const DEFAULT_SDK_SPEC = "@cursor/sdk@1.0.13";
+
+function emit(event) {
+  process.stdout.write(`${JSON.stringify(event)}\n`);
+}
+
+function readStdinJson() {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => {
+      data += chunk;
+    });
+    process.stdin.on("end", () => {
+      try {
+        resolve(JSON.parse(data || "{}"));
+      } catch (error) {
+        reject(error);
+      }
+    });
+    process.stdin.on("error", reject);
+  });
+}
+
+function managedPackageDir() {
+  if (process.env.CURSOR_SDK_NODE_DIR) {
+    return process.env.CURSOR_SDK_NODE_DIR;
+  }
+  const hermesHome = process.env.HERMES_HOME || path.join(os.homedir(), ".hermes");
+  return path.join(hermesHome, "cursor-sdk-node");
+}
+
+function ensureManagedSdk() {
+  const dir = managedPackageDir();
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const pkgJson = path.join(dir, "package.json");
+  if (!fs.existsSync(pkgJson)) {
+    fs.writeFileSync(
+      pkgJson,
+      JSON.stringify({ private: true, dependencies: {} }, null, 2),
+      { mode: 0o600 },
+    );
+  }
+  const spec = process.env.CURSOR_SDK_PACKAGE_SPEC || DEFAULT_SDK_SPEC;
+  const result = spawnSync(
+    "npm",
+    ["install", "--silent", "--no-audit", "--no-fund", spec],
+    { cwd: dir, encoding: "utf8" },
+  );
+  if (result.status !== 0) {
+    const stderr = (result.stderr || result.stdout || "").trim();
+    throw new Error(`Failed to install ${spec}: ${stderr || `exit ${result.status}`}`);
+  }
+  return dir;
+}
+
+async function loadCursorSdk() {
+  const localRequire = createRequire(import.meta.url);
+  try {
+    return localRequire("@cursor/sdk");
+  } catch (_) {
+    let dir = managedPackageDir();
+    let managedRequire = createRequire(path.join(dir, "package.json"));
+    try {
+      return managedRequire("@cursor/sdk");
+    } catch (_) {
+      dir = ensureManagedSdk();
+      managedRequire = createRequire(path.join(dir, "package.json"));
+    }
+    try {
+      return managedRequire("@cursor/sdk");
+    } catch (error) {
+      const resolved = managedRequire.resolve("@cursor/sdk");
+      return import(pathToFileURL(resolved).href);
+    }
+  }
+}
+
+function modelSelection(model) {
+  const id = String(model || "").trim();
+  if (!id) {
+    throw new Error("Cursor SDK model id is required");
+  }
+  return { id };
+}
+
+function textFromAssistantMessage(message) {
+  const content = message?.message?.content;
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .filter((part) => part && part.type === "text" && typeof part.text === "string")
+    .map((part) => part.text)
+    .join("");
+}
+
+function deltaText(update) {
+  if (!update || typeof update !== "object") {
+    return "";
+  }
+  const type = String(update.type || update.kind || "");
+  if (!/(text|token).*delta|delta.*(text|token)/i.test(type)) {
+    return "";
+  }
+  for (const key of ["text", "delta", "token", "content"]) {
+    if (typeof update[key] === "string") {
+      return update[key];
+    }
+  }
+  return "";
+}
+
+function thinkingText(update) {
+  if (!update || typeof update !== "object") {
+    return "";
+  }
+  const type = String(update.type || update.kind || "");
+  if (!/thinking/i.test(type)) {
+    return "";
+  }
+  for (const key of ["text", "delta", "token", "content"]) {
+    if (typeof update[key] === "string") {
+      return update[key];
+    }
+  }
+  return "";
+}
+
+async function runPrompt(sdk, request) {
+  const { Agent } = sdk;
+  const apiKey = request.apiKey || process.env.CURSOR_API_KEY;
+  if (!apiKey) {
+    throw new Error("CURSOR_API_KEY is required for the Cursor SDK provider");
+  }
+
+  const options = {
+    apiKey,
+    model: modelSelection(request.model),
+    name: "Hermes Cursor SDK Provider",
+  };
+  const runtime = String(request.runtime || "local").toLowerCase();
+  if (runtime === "cloud") {
+    options.cloud = request.cloud || {};
+  } else {
+    options.local = { cwd: request.cwd || process.cwd() };
+  }
+
+  const agent = await Agent.create(options);
+  let streamedText = "";
+  try {
+    const run = await agent.send(String(request.prompt || ""), {
+      onDelta: ({ update }) => {
+        const text = deltaText(update);
+        if (text) {
+          streamedText += text;
+          emit({ type: "delta", text });
+        }
+        const thinking = thinkingText(update);
+        if (thinking) {
+          emit({ type: "reasoning_delta", text: thinking });
+        }
+      },
+    });
+
+    let assistantText = "";
+    try {
+      for await (const message of run.stream()) {
+        if (message?.type === "assistant") {
+          assistantText = textFromAssistantMessage(message) || assistantText;
+        } else if (message?.type === "thinking" && typeof message.text === "string") {
+          emit({ type: "reasoning_delta", text: message.text });
+        } else if (message?.type === "status" && typeof message.message === "string") {
+          emit({ type: "status", message: message.message, status: message.status });
+        }
+      }
+    } catch (error) {
+      emit({ type: "status", message: `Cursor SDK stream ended: ${error.message}` });
+    }
+
+    const result = await run.wait();
+    emit({
+      type: "final",
+      status: result.status,
+      result: result.result || assistantText || streamedText,
+      model: result.model || options.model,
+      runId: result.id,
+      agentId: run.agentId,
+      durationMs: result.durationMs,
+    });
+  } finally {
+    agent.close();
+  }
+}
+
+async function listModels(sdk, request) {
+  const { Cursor } = sdk;
+  const apiKey = request.apiKey || process.env.CURSOR_API_KEY;
+  if (!apiKey) {
+    throw new Error("CURSOR_API_KEY is required for Cursor model listing");
+  }
+  const models = await Cursor.models.list({ apiKey });
+  emit({ type: "final", models });
+}
+
+async function main() {
+  const request = await readStdinJson();
+  const sdk = await loadCursorSdk();
+  if (request.operation === "models") {
+    await listModels(sdk, request);
+  } else {
+    await runPrompt(sdk, request);
+  }
+}
+
+main().catch((error) => {
+  emit({
+    type: "error",
+    code: error?.code || error?.name || "CursorSdkBridgeError",
+    message: error?.message || String(error),
+  });
+  process.exitCode = 1;
+});

--- a/agent/transports/__init__.py
+++ b/agent/transports/__init__.py
@@ -66,3 +66,7 @@ def _discover_transports() -> None:
         import agent.transports.bedrock  # noqa: F401
     except ImportError:
         pass
+    try:
+        import agent.transports.cursor_sdk  # noqa: F401
+    except ImportError:
+        pass

--- a/agent/transports/cursor_sdk.py
+++ b/agent/transports/cursor_sdk.py
@@ -1,0 +1,76 @@
+"""Transport for the Cursor SDK provider."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent.transports.base import ProviderTransport
+from agent.transports.types import NormalizedResponse, Usage
+
+
+class CursorSdkTransport(ProviderTransport):
+    """Cursor SDK transport.
+
+    The actual provider call is made in ``agent.cursor_sdk_adapter`` through a
+    Node bridge to Cursor's official ``@cursor/sdk`` package. This transport
+    owns the request/response shape exposed to the Hermes loop.
+    """
+
+    @property
+    def api_mode(self) -> str:
+        return "cursor_sdk"
+
+    def convert_messages(self, messages: list[dict[str, Any]], **kwargs) -> list[dict[str, Any]]:
+        return messages
+
+    def convert_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        # Cursor SDK has its own agent tool harness. Hermes function schemas are
+        # not forwarded as OpenAI tool calls on this transport.
+        return []
+
+    def build_kwargs(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        **params: Any,
+    ) -> dict[str, Any]:
+        return {
+            "__cursor_sdk__": True,
+            "model": model,
+            "messages": self.convert_messages(messages),
+            "api_key": params.get("api_key") or "",
+            "cwd": params.get("cwd") or "",
+            "runtime": params.get("runtime") or "",
+            "timeout": params.get("timeout"),
+        }
+
+    def normalize_response(self, response: Any, **kwargs) -> NormalizedResponse:
+        choice = response.choices[0]
+        message = choice.message
+        usage = None
+        raw_usage = getattr(response, "usage", None)
+        if raw_usage is not None:
+            usage = Usage(
+                prompt_tokens=getattr(raw_usage, "prompt_tokens", 0) or 0,
+                completion_tokens=getattr(raw_usage, "completion_tokens", 0) or 0,
+                total_tokens=getattr(raw_usage, "total_tokens", 0) or 0,
+            )
+        return NormalizedResponse(
+            content=getattr(message, "content", "") or "",
+            tool_calls=None,
+            finish_reason=getattr(choice, "finish_reason", "stop") or "stop",
+            usage=usage,
+        )
+
+    def validate_response(self, response: Any) -> bool:
+        return bool(
+            response is not None
+            and getattr(response, "choices", None)
+            and getattr(response.choices[0], "message", None) is not None
+        )
+
+
+from agent.transports import register_transport  # noqa: E402
+
+register_transport("cursor_sdk", CursorSdkTransport)

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -242,6 +242,7 @@ _VALID_API_MODES = {
     "codex_responses",
     "anthropic_messages",
     "bedrock_converse",
+    "cursor_sdk",
     # Optional opt-in: hand the entire turn to a `codex app-server` subprocess
     # so terminal/file-ops/patching/sandboxing run inside Codex's own runtime
     # instead of Hermes' tool dispatch. Gated behind config key
@@ -389,15 +390,28 @@ def _resolve_runtime_from_pool_entry(
             # Refs #16878.
             from hermes_cli.models import opencode_model_api_mode
             api_mode = opencode_model_api_mode(provider, effective_model)
+        elif provider == "cursor-sdk":
+            api_mode = "cursor_sdk"
         elif configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
             api_mode = configured_mode
         else:
+            try:
+                from providers import get_provider_profile
+
+                _profile = get_provider_profile(provider)
+            except Exception:
+                _profile = None
+            if _profile and _profile.api_mode and _profile.api_mode != "chat_completions":
+                api_mode = _profile.api_mode
+            else:
+                _profile = None
             # Auto-detect Anthropic-compatible endpoints (/anthropic suffix,
             # Kimi /coding, api.openai.com → codex_responses, api.x.ai →
             # codex_responses).
-            detected = _detect_api_mode_for_url(base_url)
-            if detected:
-                api_mode = detected
+            if _profile is None:
+                detected = _detect_api_mode_for_url(base_url)
+                if detected:
+                    api_mode = detected
 
     # OpenCode base URLs end with /v1 for OpenAI-compatible models, but the
     # Anthropic SDK prepends its own /v1/messages to the base_url.  Strip the
@@ -1176,7 +1190,15 @@ def _resolve_explicit_runtime(
             api_mode = "codex_responses"
         else:
             configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
-            if configured_mode:
+            try:
+                from providers import get_provider_profile
+
+                _profile = get_provider_profile(provider)
+            except Exception:
+                _profile = None
+            if _profile and _profile.api_mode and _profile.api_mode != "chat_completions":
+                api_mode = _profile.api_mode
+            elif configured_mode:
                 api_mode = configured_mode
             else:
                 # Auto-detect from URL (Anthropic /anthropic suffix,
@@ -1632,15 +1654,24 @@ def resolve_runtime_provider(
                 from hermes_cli.models import opencode_model_api_mode
                 _effective = target_model or model_cfg.get("default", "")
                 api_mode = opencode_model_api_mode(provider, _effective)
-            elif configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
-                api_mode = configured_mode
             else:
-                # Auto-detect Anthropic-compatible endpoints by URL convention
-                # (e.g. https://api.minimax.io/anthropic, https://dashscope.../anthropic)
-                # plus api.openai.com → codex_responses and api.x.ai → codex_responses.
-                detected = _detect_api_mode_for_url(base_url)
-                if detected:
-                    api_mode = detected
+                try:
+                    from providers import get_provider_profile
+
+                    _profile = get_provider_profile(provider)
+                except Exception:
+                    _profile = None
+                if _profile and _profile.api_mode and _profile.api_mode != "chat_completions":
+                    api_mode = _profile.api_mode
+                elif configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
+                    api_mode = configured_mode
+                else:
+                    # Auto-detect Anthropic-compatible endpoints by URL convention
+                    # (e.g. https://api.minimax.io/anthropic, https://dashscope.../anthropic)
+                    # plus api.openai.com → codex_responses and api.x.ai → codex_responses.
+                    detected = _detect_api_mode_for_url(base_url)
+                    if detected:
+                        api_mode = detected
         # Strip trailing /v1 for OpenCode Anthropic models (see comment above).
         if api_mode == "anthropic_messages" and provider in {"opencode-zen", "opencode-go"}:
             base_url = re.sub(r"/v1/?$", "", base_url)

--- a/plugins/model-providers/cursor-sdk/__init__.py
+++ b/plugins/model-providers/cursor-sdk/__init__.py
@@ -1,0 +1,66 @@
+"""Cursor SDK provider profile."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+_CURSOR_FALLBACK_MODELS = (
+    "composer-latest",
+    "composer-2.5",
+    "composer-2",
+    "gpt-5.5",
+    "claude-opus-4.7",
+    "claude-sonnet-4.6",
+    "gemini-3.1-pro-preview",
+)
+
+
+class CursorSdkProfile(ProviderProfile):
+    """Cursor SDK uses @cursor/sdk through Hermes' cursor_sdk transport."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Return Cursor's live SDK model catalog when the Node SDK is available."""
+        if not api_key:
+            return None
+        try:
+            from agent.cursor_sdk_adapter import list_cursor_models
+
+            models = list_cursor_models(api_key=api_key, timeout=timeout)
+        except Exception:
+            return None
+        return models or None
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        **context: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        return {}, {}
+
+
+cursor_sdk = CursorSdkProfile(
+    name="cursor-sdk",
+    aliases=("cursor", "cursor_sdk"),
+    api_mode="cursor_sdk",
+    display_name="Cursor SDK",
+    description="Cursor agents through the official SDK",
+    signup_url="https://cursor.com/settings/api-keys",
+    env_vars=("CURSOR_API_KEY",),
+    base_url="cursor-sdk://local",
+    models_url="",
+    auth_type="api_key",
+    supports_health_check=False,
+    fallback_models=_CURSOR_FALLBACK_MODELS,
+)
+
+register_provider(cursor_sdk)

--- a/plugins/model-providers/cursor-sdk/plugin.yaml
+++ b/plugins/model-providers/cursor-sdk/plugin.yaml
@@ -1,0 +1,5 @@
+name: cursor-sdk-provider
+kind: model-provider
+version: 1.0.0
+description: Cursor SDK
+author: Nous Research

--- a/tests/plugins/model_providers/test_cursor_sdk_provider.py
+++ b/tests/plugins/model_providers/test_cursor_sdk_provider.py
@@ -1,0 +1,141 @@
+"""Cursor SDK provider integration tests."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+def test_cursor_sdk_profile_registered():
+    import model_tools  # noqa: F401
+    import providers
+
+    profile = providers.get_provider_profile("cursor")
+    assert profile is not None
+    assert profile.name == "cursor-sdk"
+    assert profile.api_mode == "cursor_sdk"
+    assert profile.env_vars == ("CURSOR_API_KEY",)
+    assert profile.supports_health_check is False
+    assert "composer-latest" in profile.fallback_models
+
+
+def test_cursor_sdk_transport_builds_kwargs():
+    from agent.transports.cursor_sdk import CursorSdkTransport
+
+    kwargs = CursorSdkTransport().build_kwargs(
+        model="composer-latest",
+        messages=[{"role": "user", "content": "ping"}],
+        api_key="test-key",
+        cwd="/tmp/project",
+        runtime="local",
+        timeout=12.5,
+    )
+
+    assert kwargs == {
+        "__cursor_sdk__": True,
+        "model": "composer-latest",
+        "messages": [{"role": "user", "content": "ping"}],
+        "api_key": "test-key",
+        "cwd": "/tmp/project",
+        "runtime": "local",
+        "timeout": 12.5,
+    }
+
+
+def test_cursor_sdk_transport_normalizes_response():
+    from agent.transports.cursor_sdk import CursorSdkTransport
+
+    response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                finish_reason="stop",
+                message=SimpleNamespace(content="hello", tool_calls=None),
+            )
+        ],
+        usage=SimpleNamespace(prompt_tokens=1, completion_tokens=2, total_tokens=3),
+    )
+
+    normalized = CursorSdkTransport().normalize_response(response)
+    assert normalized.content == "hello"
+    assert normalized.tool_calls is None
+    assert normalized.finish_reason == "stop"
+    assert normalized.usage.total_tokens == 3
+
+
+def test_cursor_sdk_adapter_uses_bridge_payload(monkeypatch, tmp_path):
+    from agent import cursor_sdk_adapter
+
+    captured = {}
+
+    def fake_bridge(payload, **kwargs):
+        captured["payload"] = payload
+        captured["kwargs"] = kwargs
+        if kwargs["on_delta"]:
+            kwargs["on_delta"]("he")
+            kwargs["on_delta"]("llo")
+        return {"type": "final", "status": "finished", "result": "hello"}
+
+    monkeypatch.setattr(cursor_sdk_adapter, "_run_bridge", fake_bridge)
+    deltas = []
+
+    response = cursor_sdk_adapter.create_cursor_sdk_response(
+        api_key="test-key",
+        model="composer-latest",
+        messages=[
+            {"role": "system", "content": "be concise"},
+            {"role": "user", "content": "ping"},
+        ],
+        cwd=str(tmp_path),
+        runtime="local",
+        timeout=9,
+        stream=True,
+        on_delta=deltas.append,
+    )
+
+    assert captured["payload"]["apiKey"] == "test-key"
+    assert captured["payload"]["model"] == "composer-latest"
+    assert captured["payload"]["cwd"] == str(tmp_path)
+    assert captured["payload"]["runtime"] == "local"
+    assert "System:" in captured["payload"]["prompt"]
+    assert "User:" in captured["payload"]["prompt"]
+    assert deltas == ["he", "llo"]
+    assert response.choices[0].message.content == "hello"
+
+
+def test_cursor_sdk_build_api_kwargs_path(monkeypatch, tmp_path):
+    from agent.chat_completion_helpers import build_api_kwargs
+    from agent.transports.cursor_sdk import CursorSdkTransport
+
+    monkeypatch.setenv("CURSOR_SDK_CWD", str(tmp_path))
+    agent = SimpleNamespace(
+        api_mode="cursor_sdk",
+        model="composer-latest",
+        tools=[{"type": "function", "function": {"name": "ignored"}}],
+        api_key="test-key",
+        _resolved_api_call_timeout=lambda: 30,
+        _get_transport=lambda: CursorSdkTransport(),
+    )
+
+    kwargs = build_api_kwargs(agent, [{"role": "user", "content": "ping"}])
+    assert kwargs["__cursor_sdk__"] is True
+    assert kwargs["model"] == "composer-latest"
+    assert kwargs["messages"] == [{"role": "user", "content": "ping"}]
+    assert kwargs["api_key"] == "test-key"
+    assert kwargs["cwd"] == str(tmp_path)
+
+
+def test_runtime_provider_routes_cursor_sdk_to_cursor_api_mode(monkeypatch):
+    import model_tools  # noqa: F401
+    from hermes_cli import runtime_provider
+
+    monkeypatch.setenv("CURSOR_API_KEY", "test-key")
+    monkeypatch.setattr(
+        runtime_provider,
+        "_get_model_config",
+        lambda: {"provider": "cursor-sdk", "default": "composer-latest"},
+    )
+
+    runtime = runtime_provider.resolve_runtime_provider(requested="cursor-sdk")
+    assert runtime["provider"] == "cursor-sdk"
+    assert runtime["api_mode"] == "cursor_sdk"
+    assert runtime["base_url"] == "cursor-sdk://local"
+    assert runtime["api_key"] == "test-key"


### PR DESCRIPTION
## Summary
- add a bundled `cursor-sdk` model provider profile
- add a `cursor_sdk` transport backed by Cursor's official `@cursor/sdk` package
- wire Cursor SDK routing through runtime provider resolution and agent dispatch
- add regression coverage for provider registration, runtime routing, request building, and response normalization

## Tests
- `scripts/run_tests.sh tests/plugins/model_providers/test_cursor_sdk_provider.py`
- `python3 -m py_compile agent/agent_init.py hermes_cli/runtime_provider.py agent/cursor_sdk_adapter.py agent/transports/cursor_sdk.py plugins/model-providers/cursor-sdk/__init__.py`
- `.venv/bin/ruff check agent/cursor_sdk_adapter.py agent/transports/cursor_sdk.py plugins/model-providers/cursor-sdk/__init__.py tests/plugins/model_providers/test_cursor_sdk_provider.py agent/chat_completion_helpers.py agent/agent_init.py hermes_cli/runtime_provider.py agent/transports/__init__.py`
- `node --check agent/cursor_sdk_bridge.mjs`
