### PR TITLE
fix: remove disk i/o error from WAL incompatibility markers

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -54,7 +54,16 @@ SCHEMA_VERSION = 13
 _WAL_INCOMPAT_MARKERS = (
     "locking protocol",       # SQLITE_PROTOCOL on NFS/SMB
     "not authorized",         # Some FUSE mounts block WAL pragma outright
-    "disk i/o error",         # Flaky network FS during WAL setup
+    # NOTE: "disk i/o error" deliberately NOT included.
+    # A disk I/O error is not a signal of WAL incompatibility — it signals
+    # genuine storage failure (failing SSD, FS corruption, etc.).  Falling
+    # back to DELETE journal mode and continuing to write to a malfunctioning
+    # disk compounds the damage: DELETE writes directly to the main DB file,
+    # where a partial write can corrupt B-tree pages beyond recovery.
+    # WAL mode is safer during I/O errors because writes land in the WAL
+    # sidecar first.  The correct response to disk I/O errors is to fail
+    # fast and let the caller (kanban dispatcher, session DB, etc.) retry
+    # or alert — not to silently switch to a more fragile journal mode.
 )
 
 # Last SessionDB() init error, per-process.  Surfaced in /resume and


### PR DESCRIPTION
## Summary

`_WAL_INCOMPAT_MARKERS` in `hermes_state.py` incorrectly included `"disk i/o error"` as a signal that WAL journal mode is unsupported on the filesystem. A disk I/O error is **not** a WAL incompatibility — it signals genuine storage failure.

## What Went Wrong

When the SQLite kanban DB experienced a transient disk I/O error on 2026-05-23, `apply_wal_with_fallback()` interpreted it as "WAL unsupported, fall back to DELETE journal mode." The DELETE fallback then continued writing directly to the main DB file during I/O errors, causing a partial write that corrupted a B-tree page pointer:

- `task_links` table B-tree page 62 referenced nonexistent page 289
- 161 of 166 parent-child link records were destroyed
- Recovery via `.recover` could not salvage the corrupted table data

## The Fix

Remove `"disk i/o error"` from `_WAL_INCOMPAT_MARKERS`. When a genuine disk I/O error occurs during WAL setup, the code now re-raises the exception (fail-fast) instead of silently switching to a more fragile journal mode. WAL is safer during I/O errors because writes land in the WAL sidecar first, rather than directly mutating B-tree pages.

## Impact

- **Before**: Disk I/O error → fall back to DELETE → continued writes on failing disk → data corruption
- **After**: Disk I/O error → raise → caller (kanban dispatcher / session DB) retries or alerts → no silent data corruption

## Verification

The fix has been running locally with `hermes gateway restart` and the kanban DB remains healthy (integrity check passes). A backup cron with pre-backup integrity check was also added to prevent undetected corruption from propagating to backups.

Closes #1