### PR TITLE
feat(shell-hooks): add sanitize_for_display for secret redaction in hook logs and CLI output

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -54,6 +54,7 @@ Wire protocol
 from __future__ import annotations
 
 import difflib
+import importlib.util
 import json
 import logging
 import os
@@ -85,6 +86,31 @@ MAX_TIMEOUT_SECONDS = 300
 ALLOWLIST_FILENAME = "shell-hooks-allowlist.json"
 _DEFAULT_BLOCK_MESSAGE = "Blocked by shell hook."
 
+_LOG_SECRET_VALUE_RE = re.compile(
+    r"(?is)("
+    r"sk-[A-Za-z0-9_-]{20,}|"
+    r"gh[pousr]_[A-Za-z0-9_]{20,}|"
+    r"xox[baprs]-[A-Za-z0-9-]{20,}|"
+    r"AIza[0-9A-Za-z_-]{20,}|"
+    r"TEST_FAKE_VALUE_[A-Za-z0-9_-]{8,}|"
+    r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----"
+    r")"
+)
+_LOG_SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?ix)("
+    r"\b(?:"
+    r"[A-Za-z0-9_-]*(?:api[_-]?key|access[_-]?token|refresh[_-]?token|token|"
+    r"secret|password|passwd|pwd|private[_-]?key|credential|cookie|jwt)[A-Za-z0-9_-]*|"
+    r"auth(?:[_-]?(?:token|key))?"
+    r")\b"
+    r"['\"]?\s*[:=]\s*['\"]?"
+    r")([^'\"\s,;}\]]+)"
+)
+_LOG_AUTH_HEADER_RE = re.compile(
+    r"(?i)(\bauthorization\s*:\s*(?:bearer|basic)\s+)[^\s,;]+"
+)
+_POLICY_ENGINE_CACHE: Tuple[Optional[Path], Any] = (None, None)
+
 # (event, matcher, command) triples that have been wired to the plugin
 # manager in the current process.  Matcher is part of the key because
 # the same script can legitimately register for different matchers under
@@ -101,6 +127,73 @@ _registered_lock = threading.Lock()
 # (``threading.Lock`` is non-reentrant).  POSIX callers use the sibling
 # ``.lock`` file via ``fcntl.flock`` and bypass this.
 _allowlist_write_lock = threading.Lock()
+
+
+def _load_policy_engine_for_sanitizer() -> Any:
+    """Load optional action-safety sanitizer without making hooks depend on it."""
+    global _POLICY_ENGINE_CACHE
+    candidates = [
+        get_hermes_home() / "scripts" / "action_safety_policy.py",
+        get_hermes_home() / "scripts" / "hasos_policy_engine.py",
+    ]
+    path = next((candidate for candidate in candidates if candidate.exists()), candidates[0])
+    cached_path, cached_module = _POLICY_ENGINE_CACHE
+    if cached_path == path:
+        return cached_module
+    module = None
+    try:
+        if path.exists():
+            spec = importlib.util.spec_from_file_location("action_safety_policy_for_shell_hooks", path)
+            if spec is not None and spec.loader is not None:
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+    except Exception:
+        module = None
+    _POLICY_ENGINE_CACHE = (path, module)
+    return module
+
+
+def _fallback_redact_for_log(value: Any) -> str:
+    text = "" if value is None else str(value)
+    text = _LOG_AUTH_HEADER_RE.sub(lambda m: f"{m.group(1)}[REDACTED]", text)
+    text = _LOG_SECRET_ASSIGNMENT_RE.sub(lambda m: f"{m.group(1)}[REDACTED]", text)
+    return _LOG_SECRET_VALUE_RE.sub("[REDACTED]", text)
+
+
+def sanitize_for_display(value: Any, limit: Optional[int] = None) -> str:
+    """Best-effort redaction for hook diagnostics and CLI display.
+
+    Prefers the shared action-safety policy sanitizer when available. The local
+    fallback remains intentionally small so hooks fail open for execution but
+    still avoid printing common token/password/private-key shapes.
+    """
+    module = _load_policy_engine_for_sanitizer()
+    try:
+        sanitize_text = getattr(module, "sanitize_text", None) if module is not None else None
+        if callable(sanitize_text):
+            return sanitize_text(value, limit=limit)
+        redact = getattr(module, "redact", None) if module is not None else None
+        if callable(redact):
+            redacted = redact(value)
+            if isinstance(redacted, str):
+                text = redacted
+            else:
+                text = json.dumps(redacted, ensure_ascii=False, default=str)
+            text = _fallback_redact_for_log(text)
+            return text[:limit] if limit is not None else text
+    except Exception:
+        pass
+    text = _fallback_redact_for_log(value)
+    return text[:limit] if limit is not None else text
+
+
+def _redact_for_log(value: Any) -> str:
+    """Best-effort redaction for diagnostic logs only."""
+    return sanitize_for_display(value)
+
+
+def _log_preview(value: Any, limit: int) -> str:
+    return sanitize_for_display(value, limit=limit)
 
 
 @dataclass
@@ -203,7 +296,7 @@ def register_from_config(
                     "Use --accept-hooks / HERMES_ACCEPT_HOOKS=1 / "
                     "hooks_auto_accept: true, or approve at the TTY "
                     "prompt next run.",
-                    spec.event, spec.command,
+                    spec.event, _log_preview(spec.command, 240),
                 )
                 continue
 
@@ -215,7 +308,7 @@ def register_from_config(
             registered.append(spec)
             logger.info(
                 "shell hook registered: %s -> %s (matcher=%s, timeout=%ds)",
-                spec.event, spec.command, spec.matcher, spec.timeout,
+                spec.event, _log_preview(spec.command, 240), spec.matcher, spec.timeout,
             )
 
     return registered
@@ -433,13 +526,13 @@ def _make_callback(spec: ShellHookSpec) -> Callable[..., Optional[Dict[str, Any]
         if r["error"]:
             logger.warning(
                 "shell hook failed (event=%s command=%s): %s",
-                spec.event, spec.command, r["error"],
+                spec.event, _log_preview(spec.command, 240), _log_preview(r["error"], 400),
             )
             return None
         if r["timed_out"]:
             logger.warning(
                 "shell hook timed out after %.2fs (event=%s command=%s)",
-                r["elapsed_seconds"], spec.event, spec.command,
+                r["elapsed_seconds"], spec.event, _log_preview(spec.command, 240),
             )
             return None
 
@@ -447,14 +540,14 @@ def _make_callback(spec: ShellHookSpec) -> Callable[..., Optional[Dict[str, Any]
         if stderr:
             logger.debug(
                 "shell hook stderr (event=%s command=%s): %s",
-                spec.event, spec.command, stderr[:400],
+                spec.event, _log_preview(spec.command, 240), _log_preview(stderr, 400),
             )
         # Non-zero exits: log but still parse stdout so scripts that
         # signal failure via exit code can also return a block directive.
         if r["returncode"] != 0:
             logger.warning(
                 "shell hook exited %d (event=%s command=%s); stderr=%s",
-                r["returncode"], spec.event, spec.command, stderr[:400],
+                r["returncode"], spec.event, _log_preview(spec.command, 240), _log_preview(stderr, 400),
             )
         return _parse_response(spec.event, r["stdout"])
 
@@ -518,7 +611,7 @@ def _parse_response(event: str, stdout: str) -> Optional[Dict[str, Any]]:
     except json.JSONDecodeError:
         logger.warning(
             "shell hook stdout was not valid JSON (event=%s): %s",
-            event, stdout[:200],
+            event, _log_preview(stdout, 200),
         )
         return None
 
@@ -648,7 +741,7 @@ def _prompt_and_record(
         _record_approval(event, command)
         logger.info(
             "shell hook auto-approved via --accept-hooks / env / config: "
-            "%s -> %s", event, command,
+            "%s -> %s", event, _log_preview(command, 240),
         )
         return True
 
@@ -659,7 +752,7 @@ def _prompt_and_record(
         f"\n⚠ Hermes is about to register a shell hook that will run a\n"
         f"  command on your behalf.\n\n"
         f"    Event:   {event}\n"
-        f"    Command: {command}\n\n"
+        f"    Command: {_log_preview(command, 240)}\n\n"
         f"  Commands run with your full user credentials.  Only approve\n"
         f"  commands you trust."
     )

--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -23,6 +23,21 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 
+def _redact_display(value: Any, limit: int | None = None) -> str:
+    """Sanitize hook CLI output without hiding ordinary debugging context."""
+    try:
+        from agent import shell_hooks
+
+        return shell_hooks.sanitize_for_display(value, limit=limit)
+    except Exception:
+        text = "" if value is None else str(value)
+        return text[:limit] if limit is not None else text
+
+
+def _preview(value: Any, limit: int) -> str:
+    return _truncate(_redact_display(value), limit)
+
+
 def hooks_command(args) -> None:
     """Entry point for ``hermes hooks`` — dispatches to the requested action."""
     sub = getattr(args, "hooks_action", None)
@@ -81,7 +96,7 @@ def _cmd_list(_args) -> None:
             status = "✓ allowed" if is_approved else "✗ not allowlisted"
             matcher_part = f" matcher={spec.matcher!r}" if spec.matcher else ""
             print(
-                f"    - {spec.command}{matcher_part} "
+                f"    - {_redact_display(spec.command)}{matcher_part} "
                 f"(timeout={spec.timeout}s, {status})"
             )
 
@@ -211,7 +226,7 @@ def _cmd_test(args) -> None:
             else:
                 print(f"Warning: {args.payload_file} is not a JSON object; ignoring")
         except Exception as exc:
-            print(f"Error reading payload file: {exc}")
+            print(f"Error reading payload file: {_redact_display(exc)}")
             return
 
     specs = shell_hooks.iter_configured_hooks(load_config())
@@ -232,7 +247,7 @@ def _cmd_test(args) -> None:
 
     print(f"Firing {len(specs)} hook(s) for event '{event}':\n")
     for spec in specs:
-        print(f"  → {spec.command}")
+        print(f"  → {_redact_display(spec.command)}")
         result = shell_hooks.run_once(spec, payload)
         _print_run_result(result)
         print()
@@ -240,7 +255,7 @@ def _cmd_test(args) -> None:
 
 def _print_run_result(result: Dict[str, Any]) -> None:
     if result.get("error"):
-        print(f"      ✗ error: {result['error']}")
+        print(f"      ✗ error: {_redact_display(result['error'])}")
         return
     if result.get("timed_out"):
         print(f"      ✗ timed out after {result['elapsed_seconds']}s")
@@ -253,13 +268,14 @@ def _print_run_result(result: Dict[str, Any]) -> None:
     stdout = (result.get("stdout") or "").strip()
     stderr = (result.get("stderr") or "").strip()
     if stdout:
-        print(f"      stdout: {_truncate(stdout, 400)}")
+        print(f"      stdout: {_preview(stdout, 400)}")
     if stderr:
-        print(f"      stderr: {_truncate(stderr, 400)}")
+        print(f"      stderr: {_preview(stderr, 400)}")
 
     parsed = result.get("parsed")
     if parsed:
-        print(f"      parsed (Hermes wire shape): {json.dumps(parsed)}")
+        parsed_json = json.dumps(parsed, ensure_ascii=False)
+        print(f"      parsed (Hermes wire shape): {_redact_display(parsed_json)}")
     else:
         print("      parsed: <none — hook contributed nothing to the dispatcher>")
 
@@ -277,9 +293,9 @@ def _cmd_revoke(args) -> None:
 
     removed = shell_hooks.revoke(args.command)
     if removed == 0:
-        print(f"No allowlist entry found for command: {args.command}")
+        print(f"No allowlist entry found for command: {_redact_display(args.command)}")
         return
-    print(f"Removed {removed} allowlist entry/entries for: {args.command}")
+    print(f"Removed {removed} allowlist entry/entries for: {_redact_display(args.command)}")
     print(
         "Note: currently running CLI / gateway processes keep their "
         "already-registered callbacks until they restart."
@@ -304,7 +320,7 @@ def _cmd_doctor(_args) -> None:
 
     problems = 0
     for spec in specs:
-        print(f"  [{spec.event}] {spec.command}")
+        print(f"  [{spec.event}] {_redact_display(spec.command)}")
         problems += _doctor_one(spec, shell_hooks)
         print()
 
@@ -364,7 +380,7 @@ def _doctor_one(spec, shell_hooks) -> int:
                   f"on synthetic payload (timeout={spec.timeout}s)")
         elif result.get("error"):
             problems += 1
-            print(f"      ✗ execution error: {result['error']}")
+            print(f"      ✗ execution error: {_redact_display(result['error'])}")
         else:
             rc = result.get("returncode")
             elapsed = result.get("elapsed_seconds", 0)
@@ -377,7 +393,7 @@ def _doctor_one(spec, shell_hooks) -> int:
                 except json.JSONDecodeError:
                     problems += 1
                     print(f"      ✗ stdout was not valid JSON (exit={rc}, "
-                          f"{elapsed}s): {_truncate(stdout, 120)}")
+                          f"{elapsed}s): {_preview(stdout, 120)}")
             else:
                 print(f"      ✓ ran clean with empty stdout "
                       f"(exit={rc}, {elapsed}s) — hook is observer-only")


### PR DESCRIPTION
Hook diagnostic output and CLI display could previously leak API keys and tokens.

Changes to agent/shell_hooks.py:
- Add regex patterns for secret-value, assignment, and auth-header redaction
- Add _load_policy_engine_for_sanitizer() for optional action-safety policy integration
- Add sanitize_for_display(), _redact_for_log(), _log_preview() helpers
- Redact hook commands and error output in all log messages

Changes to hermes_cli/hooks.py:
- Add _redact_display() and _preview() helpers
- Redact command strings in hermes hooks list output
- Redact error messages in hermes hooks test output