### PR TITLE
feat(gateway): add source-aware busy input rules

### DIFF
--- a/gateway/busy_input_policy.py
+++ b/gateway/busy_input_policy.py
@@ -1,0 +1,176 @@
+"""Source-aware busy-input policy for gateway sessions.
+
+The gateway's global ``display.busy_input_mode`` remains the safe default.
+This module lets operators add ordered, generic source rules without baking
+platform-specific workflows (Dispatch, worker lanes, etc.) into gateway/run.py.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Literal, Sequence
+
+BusyInputMode = Literal["interrupt", "queue", "steer"]
+_VALID_MODES: set[str] = {"interrupt", "queue", "steer"}
+
+
+def normalize_busy_input_mode(value: Any, *, default: BusyInputMode | None = None) -> BusyInputMode | None:
+    """Normalize a busy-input mode string, returning *default* for invalid values."""
+    mode = str(value or "").strip().lower()
+    if mode in _VALID_MODES:
+        return mode  # type: ignore[return-value]
+    return default
+
+
+def _string_list(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        text = value.strip()
+        return (text,) if text else ()
+    if isinstance(value, Iterable):
+        items: list[str] = []
+        for item in value:
+            text = str(item).strip()
+            if text:
+                items.append(text)
+        return tuple(items)
+    text = str(value).strip()
+    return (text,) if text else ()
+
+
+@dataclass(frozen=True)
+class BusyInputRule:
+    """One ordered source-aware override for a busy gateway session."""
+
+    mode: BusyInputMode
+    platform: str | None = None
+    is_bot: bool | None = None
+    user_ids: tuple[str, ...] = field(default_factory=tuple)
+    chat_ids: tuple[str, ...] = field(default_factory=tuple)
+    message_types: tuple[str, ...] = field(default_factory=tuple)
+    text_prefixes: tuple[str, ...] = field(default_factory=tuple)
+
+    @classmethod
+    def from_config(cls, raw: Any) -> "BusyInputRule | None":
+        if not isinstance(raw, dict):
+            return None
+        mode = normalize_busy_input_mode(raw.get("mode"))
+        if mode is None:
+            return None
+
+        platform = raw.get("platform")
+        platform_text = str(platform).strip().lower() if platform not in {None, ""} else None
+
+        raw_is_bot = raw.get("is_bot")
+        is_bot = raw_is_bot if isinstance(raw_is_bot, bool) else None
+
+        return cls(
+            mode=mode,
+            platform=platform_text,
+            is_bot=is_bot,
+            user_ids=_string_list(raw.get("user_ids")),
+            chat_ids=_string_list(raw.get("chat_ids")),
+            message_types=tuple(item.lower() for item in _string_list(raw.get("message_types"))),
+            text_prefixes=_string_list(raw.get("text_prefixes")),
+        )
+
+    def matches(self, event: Any) -> bool:
+        source = getattr(event, "source", None)
+        if source is None:
+            return False
+
+        if self.platform is not None and _platform_value(getattr(source, "platform", None)) != self.platform:
+            return False
+
+        if self.is_bot is not None and bool(getattr(source, "is_bot", False)) is not self.is_bot:
+            return False
+
+        if self.user_ids:
+            user_candidates = {
+                str(value)
+                for value in (
+                    getattr(source, "user_id", None),
+                    getattr(source, "user_id_alt", None),
+                )
+                if value not in {None, ""}
+            }
+            if not user_candidates.intersection(self.user_ids):
+                return False
+
+        if self.chat_ids:
+            chat_candidates = {
+                str(value)
+                for value in (
+                    getattr(source, "chat_id", None),
+                    getattr(source, "thread_id", None),
+                    getattr(source, "parent_chat_id", None),
+                    getattr(source, "chat_id_alt", None),
+                )
+                if value not in {None, ""}
+            }
+            if not chat_candidates.intersection(self.chat_ids):
+                return False
+
+        if self.message_types:
+            message_type = _message_type_value(getattr(event, "message_type", None))
+            if message_type not in self.message_types:
+                return False
+
+        if self.text_prefixes:
+            text = str(getattr(event, "text", "") or "")
+            if not any(text.startswith(prefix) for prefix in self.text_prefixes):
+                return False
+
+        return True
+
+
+def _platform_value(platform: Any) -> str | None:
+    value = getattr(platform, "value", platform)
+    if value in {None, ""}:
+        return None
+    return str(value).strip().lower()
+
+
+def _message_type_value(message_type: Any) -> str | None:
+    value = getattr(message_type, "value", message_type)
+    if value in {None, ""}:
+        return None
+    return str(value).strip().lower()
+
+
+def load_busy_input_rules(config: Any) -> list[BusyInputRule]:
+    """Load ordered ``display.busy_input_rules`` entries from config data."""
+    if not isinstance(config, dict):
+        return []
+    display = config.get("display")
+    if not isinstance(display, dict):
+        return []
+    raw_rules = display.get("busy_input_rules") or []
+    if not isinstance(raw_rules, Sequence) or isinstance(raw_rules, (str, bytes)):
+        return []
+
+    rules: list[BusyInputRule] = []
+    for raw_rule in raw_rules:
+        rule = BusyInputRule.from_config(raw_rule)
+        if rule is not None:
+            rules.append(rule)
+    return rules
+
+
+def resolve_busy_input_mode(
+    event: Any,
+    default_mode: Any,
+    rules: Sequence[BusyInputRule] | None = None,
+) -> BusyInputMode:
+    """Resolve the effective busy-input mode for *event*.
+
+    Rules are evaluated in order.  The first matching rule wins.  With no
+    matching rule, the normalized global default is returned; invalid defaults
+    fail safe to ``interrupt``.
+    """
+    fallback = normalize_busy_input_mode(default_mode, default="interrupt") or "interrupt"
+    for rule in rules or []:
+        if rule.matches(event):
+            return rule.mode
+    return fallback

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -927,6 +927,7 @@ from gateway.session import (
     build_session_key,
     is_shared_multi_user_session,
 )
+from gateway.busy_input_policy import load_busy_input_rules, resolve_busy_input_mode
 from gateway.delivery import DeliveryRouter
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -1551,6 +1552,7 @@ class GatewayRunner:
     # blow up on attribute access.
     _running_agents_ts: Dict[str, float] = {}
     _busy_input_mode: str = "interrupt"
+    _busy_input_rules: list = []
     _restart_drain_timeout: float = DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
     _exit_code: Optional[int] = None
     _draining: bool = False
@@ -1577,6 +1579,7 @@ class GatewayRunner:
         self._service_tier = self._load_service_tier()
         self._show_reasoning = self._load_show_reasoning()
         self._busy_input_mode = self._load_busy_input_mode()
+        self._busy_input_rules = self._load_busy_input_rules()
         self._restart_drain_timeout = self._load_restart_drain_timeout()
         self._provider_routing = self._load_provider_routing()
         self._fallback_model = self._load_fallback_model()
@@ -2824,6 +2827,19 @@ class GatewayRunner:
         return "interrupt"
 
     @staticmethod
+    def _load_busy_input_rules() -> list:
+        """Load ordered source-aware busy-input policy rules from config.yaml."""
+        return load_busy_input_rules(_load_gateway_runtime_config())
+
+    def _resolve_busy_input_mode(self, event: MessageEvent) -> str:
+        """Resolve effective busy-input mode for a busy-session event."""
+        return resolve_busy_input_mode(
+            event,
+            getattr(self, "_busy_input_mode", "interrupt"),
+            getattr(self, "_busy_input_rules", []),
+        )
+
+    @staticmethod
     def _load_restart_drain_timeout() -> float:
         """Load graceful gateway restart/stop drain timeout in seconds."""
         raw = os.getenv("HERMES_RESTART_DRAIN_TIMEOUT", "").strip()
@@ -2974,7 +2990,7 @@ class GatewayRunner:
         # queueing + interrupting.  If the agent isn't running yet
         # (sentinel) or lacks steer(), or the payload is empty, fall back
         # to queue semantics so nothing is lost.
-        effective_mode = self._busy_input_mode
+        effective_mode = self._resolve_busy_input_mode(event)
         steered = False
         if effective_mode == "steer":
             steer_text = (event.text or "").strip()
@@ -7106,11 +7122,12 @@ class GatewayRunner:
                     if self._queue_during_drain_enabled()
                     else f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
                 )
-            if self._busy_input_mode == "queue":
+            effective_mode = self._resolve_busy_input_mode(event)
+            if effective_mode == "queue":
                 logger.debug("PRIORITY queue follow-up for session %s", _quick_key)
                 self._queue_or_replace_pending_event(_quick_key, event)
                 return None
-            if self._busy_input_mode == "steer":
+            if effective_mode == "steer":
                 # Steer mode: inject text into the running agent mid-run via
                 # agent.steer().  Falls back to queue semantics if the payload
                 # is empty, the agent lacks steer(), or steer() rejects.

--- a/tests/gateway/test_busy_input_policy.py
+++ b/tests/gateway/test_busy_input_policy.py
@@ -1,0 +1,86 @@
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+from gateway.busy_input_policy import load_busy_input_rules, resolve_busy_input_mode
+
+
+def _event(
+    text="hello",
+    *,
+    platform=Platform.DISCORD,
+    user_id="human-1",
+    chat_id="deck-thread",
+    is_bot=False,
+    message_type=MessageType.TEXT,
+):
+    return MessageEvent(
+        text=text,
+        message_type=message_type,
+        source=SessionSource(
+            platform=platform,
+            chat_id=chat_id,
+            chat_type="thread",
+            user_id=user_id,
+            is_bot=is_bot,
+        ),
+    )
+
+
+def test_no_rules_preserves_global_default_mode():
+    assert resolve_busy_input_mode(_event(), "interrupt", []) == "interrupt"
+    assert resolve_busy_input_mode(_event(), "queue", []) == "queue"
+    assert resolve_busy_input_mode(_event(), "steer", []) == "steer"
+
+
+def test_bot_rule_can_queue_discord_messages_without_queuing_humans():
+    rules = load_busy_input_rules(
+        {
+            "display": {
+                "busy_input_rules": [
+                    {"platform": "discord", "is_bot": True, "mode": "queue"},
+                ]
+            }
+        }
+    )
+
+    assert resolve_busy_input_mode(_event(is_bot=True, user_id="dispatch-bot"), "interrupt", rules) == "queue"
+    assert resolve_busy_input_mode(_event(is_bot=False, user_id="operator"), "interrupt", rules) == "interrupt"
+
+
+def test_rules_are_generic_and_ordered_for_user_and_prefix_matches():
+    rules = load_busy_input_rules(
+        {
+            "display": {
+                "busy_input_rules": [
+                    {"platform": "discord", "user_ids": ["operator"], "mode": "steer"},
+                    {"platform": "discord", "text_prefixes": ["✅", "📊 **Status"], "mode": "queue"},
+                ]
+            }
+        }
+    )
+
+    assert resolve_busy_input_mode(_event("please redirect", user_id="operator"), "interrupt", rules) == "steer"
+    assert resolve_busy_input_mode(_event("✅ worker complete", user_id="dispatch-bot"), "interrupt", rules) == "queue"
+    assert resolve_busy_input_mode(_event("normal text", user_id="someone-else"), "interrupt", rules) == "interrupt"
+
+
+def test_rule_filters_cover_chat_ids_message_types_and_invalid_modes_are_ignored():
+    rules = load_busy_input_rules(
+        {
+            "display": {
+                "busy_input_rules": [
+                    {"platform": "discord", "chat_ids": ["other-thread"], "mode": "queue"},
+                    {"platform": "discord", "message_types": ["photo"], "mode": "queue"},
+                    {"platform": "discord", "is_bot": True, "mode": "bogus"},
+                ]
+            }
+        }
+    )
+
+    assert resolve_busy_input_mode(_event(chat_id="other-thread"), "interrupt", rules) == "queue"
+    assert resolve_busy_input_mode(_event(message_type=MessageType.PHOTO), "interrupt", rules) == "queue"
+    assert resolve_busy_input_mode(_event(is_bot=True), "interrupt", rules) == "interrupt"
+
+
+def test_default_mode_is_normalized_to_safe_interrupt():
+    assert resolve_busy_input_mode(_event(), "bogus", []) == "interrupt"

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -159,6 +159,61 @@ class TestBusySessionAck:
         agent.interrupt.assert_called_once_with("Are you working?")
 
     @pytest.mark.asyncio
+    async def test_source_rule_queues_bot_message_while_global_mode_interrupts(self):
+        """Source-aware rule can queue bot-authored busy messages without changing the global default."""
+        from gateway.busy_input_policy import load_busy_input_rules
+
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        runner._busy_input_rules = load_busy_input_rules(
+            {"display": {"busy_input_rules": [{"platform": "telegram", "is_bot": True, "mode": "queue"}]}}
+        )
+        adapter = _make_adapter()
+
+        event = _make_event(text="worker completion burst")
+        event.source.is_bot = True
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+
+        with patch("gateway.run.merge_pending_message_event") as mock_merge:
+            await runner._handle_active_session_busy_message(event, sk)
+
+        agent.interrupt.assert_not_called()
+        mock_merge.assert_called_once()
+        adapter._send_with_retry.assert_called_once()
+        call_kwargs = adapter._send_with_retry.call_args
+        content = call_kwargs.kwargs.get("content") or call_kwargs[1].get("content", "")
+        assert "Queued for the next turn" in content
+
+    @pytest.mark.asyncio
+    async def test_source_rule_leaves_human_message_interrupting(self):
+        """Bot queue rules must not weaken human/operator steering defaults."""
+        from gateway.busy_input_policy import load_busy_input_rules
+
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        runner._busy_input_rules = load_busy_input_rules(
+            {"display": {"busy_input_rules": [{"platform": "telegram", "is_bot": True, "mode": "queue"}]}}
+        )
+        adapter = _make_adapter()
+
+        event = _make_event(text="operator correction")
+        event.source.is_bot = False
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {"api_call_count": 1, "max_iterations": 5}
+        runner._running_agents[sk] = agent
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        agent.interrupt.assert_called_once_with("operator correction")
+
+    @pytest.mark.asyncio
     async def test_queue_mode_suppresses_interrupt_and_updates_ack(self):
         """When busy_input_mode is 'queue', message is queued WITHOUT interrupt."""
         runner, sentinel = _make_runner()

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -260,6 +260,25 @@ display:
   busy_input_mode: "steer"   # or "queue" or "interrupt" (default)
 ```
 
+Messaging gateways can also use ordered source rules to override the global mode for specific senders or message classes. The first matching rule wins; invalid rules are ignored. This is useful when human/operator messages should keep interrupting quickly, while bot-authored completion bursts should wait safely:
+
+```yaml
+display:
+  busy_input_mode: interrupt
+  busy_input_rules:
+    - platform: discord
+      is_bot: true
+      mode: queue
+    - platform: discord
+      user_ids: ["123456789"]
+      mode: steer
+    - platform: discord
+      text_prefixes: ["✅", "📊 **Status"]
+      mode: queue
+```
+
+Rule filters are generic: `platform`, `is_bot`, `user_ids`, `chat_ids`, `message_types`, and `text_prefixes`. Rule `mode` accepts `interrupt`, `queue`, or `steer`.
+
 `"queue"` mode is useful when you want to prepare follow-up messages without accidentally canceling in-flight work. `"steer"` mode is useful when you want to redirect the agent mid-task without interrupting — e.g. "actually, also check the tests" while it's still editing code. Unknown values fall back to `"interrupt"`.
 
 `"steer"` has two automatic fallbacks: if the agent hasn't started yet, or if images are attached, the message falls back to `"queue"` behavior so nothing is lost.

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -280,6 +280,25 @@ display:
   busy_ack_enabled: true   # set to false to suppress the ⚡/⏳/⏩ chat reply entirely
 ```
 
+For messaging gateways, `display.busy_input_rules` can override the global mode for specific sources. Rules are ordered and generic — no platform workflow is hardcoded:
+
+```yaml
+display:
+  busy_input_mode: interrupt
+  busy_input_rules:
+    - platform: discord
+      is_bot: true
+      mode: queue
+    - platform: discord
+      user_ids: ["123456789"]
+      mode: steer
+    - platform: discord
+      text_prefixes: ["✅", "📊 **Status"]
+      mode: queue
+```
+
+Supported rule filters: `platform`, `is_bot`, `user_ids`, `chat_ids`, `message_types`, and `text_prefixes`. Supported rule modes: `interrupt`, `queue`, and `steer`.
+
 The first time you message a busy agent on any platform, Hermes appends a one-line reminder to the busy-ack explaining the knob (`"💡 First-time tip — …"`). The reminder fires once per install — a flag under `onboarding.seen.busy_input_prompt` latches it. Delete that key to see the tip again.
 
 If you find the busy-ack noisy — especially with voice input or rapid-fire messages — set `display.busy_ack_enabled: false`. Your input is still queued/steered/interrupts as normal, only the chat reply is silenced.


### PR DESCRIPTION
## Summary

Adds deterministic, source-aware busy-input rules for gateway sessions. `display.busy_input_mode` remains the global fallback, while optional ordered `display.busy_input_rules` can override the busy behavior for matching message sources.

This lets operators keep normal human steering responsive while safely queueing known bot/system/worker-style message bursts, without changing the default behavior for existing Hermes users and without introducing LLM-based routing.

## Diff scope

- `gateway/busy_input_policy.py` — new focused policy module for parsing and resolving source-aware busy-input rules.
- `gateway/run.py` — minimal wiring to load rules and resolve the effective mode per incoming busy event.
- `tests/gateway/test_busy_input_policy.py` — focused unit tests for rule parsing/resolution and fallback behavior.
- `tests/gateway/test_busy_session_ack.py` — gateway behavior tests proving bot-source queue override while human messages still interrupt.
- `website/docs/user-guide/cli.md` and `website/docs/user-guide/messaging/index.md` — user docs for `display.busy_input_rules`.

## Behavior

Rules are ordered; first match wins. Supported filters:

- `platform`
- `is_bot`
- `user_ids`
- `chat_ids`
- `message_types`
- `text_prefixes`

Supported rule modes:

- `interrupt`
- `queue`
- `steer`

Example:

```yaml
display:
  busy_input_mode: interrupt
  busy_input_rules:
    - platform: discord
      is_bot: true
      mode: queue
    - platform: discord
      user_ids: ["123456789"]
      mode: steer
```

## Related context

- Refs #27017 — deterministic/config-based alternative to LLM-routed smart busy mode.
- Refs #26813 — preserves explicit `/stop` / `/interrupt` hard-control semantics.
- Refs #28503 — builds on the need for safe queue behavior during busy turns.
- Context: #27265 and #30091 show multi-agent/bot-authored gateway traffic is an active workflow.

Non-goal: this PR does **not** detect active `delegate_task` children and should not be treated as a fix for #30170. It provides a small, configurable primitive that complements broader busy-input work.

## Verification

Base:

```text
origin/main: cae7537359c0ba8fceedc0a6423a4d9f30972100
PR head:     50bb2187edc20c1d8e2678f08b9a675addd0720f
```

Focused gateway suite:

```bash
HOME=/Users/watson scripts/run_tests.sh \
  tests/gateway/test_busy_input_policy.py \
  tests/gateway/test_busy_session_ack.py \
  tests/gateway/test_busy_session_auth_bypass.py \
  tests/gateway/test_restart_drain.py \
  tests/gateway/test_runtime_config_env_expansion.py
```

Output:

```text
=== Summary: 5 files, 49 tests passed, 0 failed (100% complete) in 0.6s (20 workers) ===
```

Additional checks:

```bash
python3 -m py_compile gateway/busy_input_policy.py
git diff --check origin/main..HEAD
```

Output:

```text
py_compile_ok
diff_check_ok
```

## What was not tested

- Full repository test suite was not run locally for this branch.
- No live gateway instance was restarted.
- No production config was changed.
- No live Discord/Telegram/Slack message flow was exercised; coverage is via focused gateway/unit tests.