### PR TITLE
gateway: add context guard for chat sessions

### DIFF
--- a/gateway/context_guard.py
+++ b/gateway/context_guard.py
@@ -1,0 +1,128 @@
+"""Gateway context guard helpers.
+
+The gateway can run for many turns on chat platforms.  If a session grows too
+large, the model/host may compact or fail before the user gets a clean handoff.
+These helpers resolve a small, opt-in policy that lets the gateway finish the
+current turn, then start the next turn on a fresh session once usage crosses a
+configured percentage of the context window.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class ContextGuardConfig:
+    """Resolved gateway context guard policy."""
+
+    enabled: bool = False
+    threshold: float = 0.60
+    auto_reset_next_turn: bool = True
+    append_notice: bool = True
+
+    @property
+    def threshold_percent(self) -> int:
+        return int(round(self.threshold * 100))
+
+
+def _truthy(value: Any, *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _as_float(value: Any, *, default: float) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    # Accept either fraction form (0.60) or percent form (60).
+    if parsed > 1:
+        parsed = parsed / 100.0
+    # Keep enough headroom to finish the current turn, but avoid silly values.
+    return max(0.10, min(parsed, 0.95))
+
+
+def resolve_context_guard_config(
+    user_config: Mapping[str, Any] | None,
+    platform_key: str,
+) -> ContextGuardConfig:
+    """Resolve ``gateway.context_guard`` with optional per-platform overrides.
+
+    Example config::
+
+        gateway:
+          context_guard:
+            enabled: true
+            threshold: 0.60
+            auto_reset_next_turn: true
+            platforms:
+              telegram:
+                enabled: true
+                threshold: 0.55
+    """
+
+    cfg = user_config or {}
+    gateway_cfg = cfg.get("gateway") if isinstance(cfg, Mapping) else {}
+    if not isinstance(gateway_cfg, Mapping):
+        gateway_cfg = {}
+
+    guard_cfg = gateway_cfg.get("context_guard")
+    if not isinstance(guard_cfg, Mapping):
+        # Backward/experimental top-level fallback, harmless if absent.
+        guard_cfg = cfg.get("context_guard") if isinstance(cfg, Mapping) else {}
+    if not isinstance(guard_cfg, Mapping):
+        guard_cfg = {}
+
+    merged: dict[str, Any] = dict(guard_cfg)
+    platforms = guard_cfg.get("platforms")
+    if isinstance(platforms, Mapping):
+        platform_override = platforms.get(platform_key)
+        if isinstance(platform_override, Mapping):
+            merged.update(platform_override)
+    merged.pop("platforms", None)
+
+    return ContextGuardConfig(
+        enabled=_truthy(merged.get("enabled"), default=False),
+        threshold=_as_float(merged.get("threshold"), default=0.60),
+        auto_reset_next_turn=_truthy(
+            merged.get("auto_reset_next_turn"), default=True
+        ),
+        append_notice=_truthy(merged.get("append_notice"), default=True),
+    )
+
+
+def should_guard_context(
+    *,
+    prompt_tokens: int,
+    context_length: int,
+    config: ContextGuardConfig,
+) -> bool:
+    """Return True when a completed turn should trigger a fresh next session."""
+
+    if not config.enabled or context_length <= 0 or prompt_tokens <= 0:
+        return False
+    return prompt_tokens >= int(context_length * config.threshold)
+
+
+def build_context_guard_notice(config: ContextGuardConfig) -> str:
+    """Short user-facing notice for chat platforms."""
+
+    pct = config.threshold_percent
+    if config.auto_reset_next_turn:
+        return (
+            f"\n\n🏴‍☠️ Context is past ~{pct}%. "
+            "I saved this turn and will start fresh on your next message."
+        )
+    return (
+        f"\n\n🏴‍☠️ Context is past ~{pct}%. "
+        "Best to start a fresh session soon."
+    )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8107,6 +8107,8 @@ class GatewayRunner:
 
         # Load conversation history from transcript
         history = self.session_store.load_transcript(session_entry.session_id)
+        _context_guard_after_turn = False
+        _context_guard_notice = ""
         
         # -----------------------------------------------------------------
         # Session hygiene: auto-compress pathologically large transcripts
@@ -8267,6 +8269,32 @@ class GatewayRunner:
                 # Threshold is configurable via
                 # compression.hygiene_hard_message_limit.
                 # (#2153)
+                try:
+                    from gateway.context_guard import (
+                        build_context_guard_notice,
+                        resolve_context_guard_config,
+                        should_guard_context,
+                    )
+
+                    _guard_cfg = resolve_context_guard_config(
+                        _hyg_data,
+                        _platform_config_key(source.platform),
+                    )
+                    if should_guard_context(
+                        prompt_tokens=_approx_tokens,
+                        context_length=_hyg_context_length,
+                        config=_guard_cfg,
+                    ):
+                        _context_guard_after_turn = bool(
+                            _guard_cfg.auto_reset_next_turn
+                        )
+                        if _guard_cfg.append_notice:
+                            _context_guard_notice = build_context_guard_notice(
+                                _guard_cfg
+                            )
+                except Exception as _guard_err:
+                    logger.debug("context guard check failed: %s", _guard_err)
+
                 _HARD_MSG_LIMIT = _hyg_hard_msg_limit
                 _needs_compress = (
                     _approx_tokens >= _compress_token_threshold
@@ -8845,6 +8873,24 @@ class GatewayRunner:
                 last_prompt_tokens=agent_result.get("last_prompt_tokens", 0),
             )
 
+            if (
+                _context_guard_after_turn
+                and not agent_failed_early
+                and not is_context_overflow_failure
+                and session_key
+            ):
+                try:
+                    self.session_store.suspend_session(session_key)
+                    self._evict_cached_agent(session_key)
+                    logger.info(
+                        "Context guard: marked session %s for fresh next turn",
+                        session_entry.session_id,
+                    )
+                    if _context_guard_notice and response:
+                        response = f"{response}{_context_guard_notice}"
+                except Exception as _guard_err:
+                    logger.debug("context guard suspend failed: %s", _guard_err)
+
             # Auto voice reply: send TTS audio before the text response
             _already_sent = bool(agent_result.get("already_sent"))
             if self._should_send_voice_reply(event, response, agent_messages, already_sent=_already_sent):
@@ -8883,6 +8929,17 @@ class GatewayRunner:
                             )
                     except Exception as _e:
                         logger.debug("trailing footer send failed: %s", _e)
+                if _context_guard_notice:
+                    try:
+                        _guard_adapter = self.adapters.get(source.platform)
+                        if _guard_adapter:
+                            await _guard_adapter.send(
+                                source.chat_id,
+                                _context_guard_notice.strip(),
+                                metadata=self._thread_metadata_for_source(source, self._reply_anchor_for_event(event)),
+                            )
+                    except Exception as _e:
+                        logger.debug("context guard notice send failed: %s", _e)
                 return None
 
             return response

--- a/tests/gateway/test_context_guard.py
+++ b/tests/gateway/test_context_guard.py
@@ -1,0 +1,71 @@
+from gateway.context_guard import (
+    ContextGuardConfig,
+    build_context_guard_notice,
+    resolve_context_guard_config,
+    should_guard_context,
+)
+
+
+def test_context_guard_defaults_off():
+    cfg = resolve_context_guard_config({}, "telegram")
+    assert cfg.enabled is False
+    assert cfg.threshold == 0.60
+    assert cfg.auto_reset_next_turn is True
+
+
+def test_context_guard_platform_override_wins():
+    cfg = resolve_context_guard_config(
+        {
+            "gateway": {
+                "context_guard": {
+                    "enabled": False,
+                    "threshold": 0.80,
+                    "platforms": {
+                        "telegram": {
+                            "enabled": True,
+                            "threshold": 55,
+                            "append_notice": False,
+                        }
+                    },
+                }
+            }
+        },
+        "telegram",
+    )
+    assert cfg.enabled is True
+    assert cfg.threshold == 0.55
+    assert cfg.append_notice is False
+
+
+def test_should_guard_context_uses_threshold():
+    cfg = ContextGuardConfig(enabled=True, threshold=0.60)
+    assert should_guard_context(
+        prompt_tokens=600,
+        context_length=1000,
+        config=cfg,
+    )
+    assert not should_guard_context(
+        prompt_tokens=599,
+        context_length=1000,
+        config=cfg,
+    )
+
+
+def test_should_guard_context_respects_disabled_and_missing_usage():
+    assert not should_guard_context(
+        prompt_tokens=900,
+        context_length=1000,
+        config=ContextGuardConfig(enabled=False),
+    )
+    assert not should_guard_context(
+        prompt_tokens=0,
+        context_length=1000,
+        config=ContextGuardConfig(enabled=True),
+    )
+
+
+def test_notice_is_short_and_mentions_fresh_next_message():
+    notice = build_context_guard_notice(ContextGuardConfig(enabled=True, threshold=0.55))
+    assert "55%" in notice
+    assert "next message" in notice
+    assert len(notice) < 180


### PR DESCRIPTION
## Summary
- Add an opt-in gateway context guard for long chat sessions
- When a platform session crosses the configured context threshold, finish the current turn, mark the session for a fresh next turn, and add a short notice
- Keep Telegram/other chat platforms from silently drifting into compaction/oversized-session loops

## Test plan
- `python -m pytest tests/gateway/test_context_guard.py tests/gateway/test_display_config.py -q`
- `python -m py_compile gateway/context_guard.py gateway/run.py`

## Local rollout
- Enabled `gateway.context_guard` for the Athena master Telegram profile at 60%
- Set Telegram display to quiet: tool progress off, streaming off, interim assistant messages off
