### PR TITLE
fix(openviking): on_memory_write handles all actions + visible errors

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -31,6 +31,7 @@ import mimetypes
 import os
 import tempfile
 import threading
+import time
 import uuid
 import zipfile
 from pathlib import Path
@@ -638,26 +639,59 @@ class OpenVikingMemoryProvider(MemoryProvider):
         content: str,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
-        """Mirror built-in memory writes to OpenViking via content/write."""
-        if not self._client or action != "add" or not content:
+        """Mirror built-in memory writes to OpenViking via content/write.
+
+        Handles ``add`` and ``replace`` by writing to a fresh UUID-suffixed
+        URI (every call generates a new URI, so ``mode="create"`` cannot
+        collide).  ``remove`` is acknowledged at INFO and skipped — the
+        plugin does not persist a memory→URI mapping.
+
+        Transient write-lock errors (``INVALID_ARGUMENT: resource is
+        busy``) are retried once with a 200 ms backoff.  Final failures
+        surface at WARNING so silent mirror outages are detectable
+        without DEBUG logging.
+        """
+        if not self._client or not content:
+            return
+        if action == "remove":
+            logger.info(
+                "OpenViking mirror: 'remove' on target=%s skipped "
+                "(plugin does not track memory→URI mapping). "
+                "Stale entries may accumulate; consider periodic "
+                "viking_browse cleanup.",
+                target,
+            )
+            return
+        if action not in {"add", "replace"}:
             return
 
         subdir = _MEMORY_WRITE_TARGET_SUBDIR_MAP.get(target, _DEFAULT_MEMORY_SUBDIR)
         uri = self._build_memory_uri(subdir)
 
         def _write():
-            try:
-                client = _VikingClient(
-                    self._endpoint, self._api_key,
-                    account=self._account, user=self._user, agent=self._agent,
-                )
-                client.post("/api/v1/content/write", {
-                    "uri": uri,
-                    "content": content,
-                    "mode": "create",
-                })
-            except Exception as e:
-                logger.debug("OpenViking memory mirror failed: %s", e)
+            client = _VikingClient(
+                self._endpoint, self._api_key,
+                account=self._account, user=self._user, agent=self._agent,
+            )
+            payload = {"uri": uri, "content": content, "mode": "create"}
+            last_exc: Optional[BaseException] = None
+            for attempt in range(2):
+                try:
+                    client.post("/api/v1/content/write", payload)
+                    return
+                except RuntimeError as e:
+                    msg = str(e)
+                    # Retry only on transient write-lock conflicts
+                    if "INVALID_ARGUMENT" in msg and "busy" in msg and attempt == 0:
+                        time.sleep(0.2)
+                        last_exc = e
+                        continue
+                    last_exc = e
+                    break
+                except Exception as e:
+                    last_exc = e
+                    break
+            logger.warning("OpenViking memory mirror failed: %s", last_exc)
 
         t = threading.Thread(target=_write, daemon=True, name="openviking-memwrite")
         t.start()

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1,4 +1,5 @@
 import json
+import threading
 import zipfile
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -420,3 +421,136 @@ def test_viking_client_health_sends_auth_headers(monkeypatch):
     assert client.health() is True
     assert captured["url"] == "https://example.com/health"
     assert captured["headers"]["Authorization"] == "Bearer test-key"
+
+
+# ── on_memory_write mirroring tests (see #31000) ──────────────────────────
+
+
+def _patch_viking_client_and_build_provider(monkeypatch, *, post_side_effect=None):
+    """Set up a provider with a fake _VikingClient that records ``(path, payload)``.
+
+    ``threading.Thread`` is patched to run targets synchronously so callers
+    can assert on ``posts`` without worrying about background threads.
+
+    Returns ``(provider, posts)``.
+    """
+    posts: list = []
+
+    class _SyncThread:
+        """Drop-in that calls target() inline instead of starting a thread."""
+        def __init__(self, target, daemon=False, name=""):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    monkeypatch.setattr(threading, "Thread", _SyncThread)
+
+    class _FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def post(self, path, payload=None, **kwargs):
+            posts.append((path, payload))
+            if callable(post_side_effect):
+                result = post_side_effect(len(posts), payload)
+                if isinstance(result, BaseException):
+                    raise result
+            return {"status": "ok"}
+
+    monkeypatch.setattr(
+        "plugins.memory.openviking._VikingClient", _FakeClient
+    )
+    provider = OpenVikingMemoryProvider()
+    provider._endpoint = "http://test"
+    provider._api_key = ""
+    provider._account = "test"
+    provider._user = "test"
+    provider._agent = "hermes"
+    provider._client = _FakeClient()
+    provider._session_id = "test-session"
+    return provider, posts
+
+
+def test_on_memory_write_add_mirrors(monkeypatch):
+    provider, posts = _patch_viking_client_and_build_provider(monkeypatch)
+    provider.on_memory_write("add", "memory", "add-test-content")
+    assert len(posts) == 1
+    path, payload = posts[0]
+    assert path == "/api/v1/content/write"
+    assert payload["content"] == "add-test-content"
+    assert payload["mode"] == "create"
+    assert "memories/patterns/" in payload["uri"]
+
+
+def test_on_memory_write_replace_mirrors(monkeypatch):
+    provider, posts = _patch_viking_client_and_build_provider(monkeypatch)
+    provider.on_memory_write("replace", "memory", "replace-content")
+    assert len(posts) == 1
+    assert posts[0][1]["content"] == "replace-content"
+
+
+def test_on_memory_write_remove_skipped(monkeypatch, caplog):
+    import logging
+    caplog.set_level(logging.INFO)
+    provider, posts = _patch_viking_client_and_build_provider(monkeypatch)
+    provider.on_memory_write("remove", "memory", "gone")
+    assert len(posts) == 0
+    assert "remove" in caplog.text.lower()
+    assert "skipped" in caplog.text.lower()
+
+
+def test_on_memory_write_empty_content_skipped(monkeypatch):
+    provider, posts = _patch_viking_client_and_build_provider(monkeypatch)
+    provider.on_memory_write("add", "memory", "")
+    assert len(posts) == 0
+
+
+def test_on_memory_write_no_client_skipped(monkeypatch):
+    provider = OpenVikingMemoryProvider()
+    provider._client = None
+    provider.on_memory_write("add", "memory", "irrelevant")
+    # No crash → pass
+
+
+def test_on_memory_write_busy_retry_then_success(monkeypatch):
+    call_count = 0
+
+    def failing_then_ok(n, _payload):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError("INVALID_ARGUMENT: resource is busy")
+        return None
+
+    provider, posts = _patch_viking_client_and_build_provider(
+        monkeypatch, post_side_effect=failing_then_ok
+    )
+    provider.on_memory_write("add", "memory", "retry-me")
+    # Two calls: first fails (busy), second succeeds
+    assert len(posts) == 2
+    assert posts[1][1]["content"] == "retry-me"
+
+
+def test_on_memory_write_non_busy_error_no_retry(monkeypatch, caplog):
+    def raise_other(_n, _payload):
+        raise RuntimeError("INTERNAL: something else broke")
+
+    provider, posts = _patch_viking_client_and_build_provider(
+        monkeypatch, post_side_effect=raise_other
+    )
+    provider.on_memory_write("add", "memory", "fail")
+    assert len(posts) == 1
+    assert "something else broke" in caplog.text
+
+
+def test_on_memory_write_network_exception_logs_warning(monkeypatch, caplog):
+    def raise_network(_n, _payload):
+        raise ConnectionError("refused")
+
+    provider, posts = _patch_viking_client_and_build_provider(
+        monkeypatch, post_side_effect=raise_network
+    )
+    provider.on_memory_write("add", "memory", "net-fail")
+    assert len(posts) == 1
+    assert "refused" in caplog.text


### PR DESCRIPTION
## What

Fixes three bugs in `plugins/memory/openviking/__init__.py` `on_memory_write` (reported in #31000):

- **add/replace/remove all handled**. Previously only `add` was mirrored; `replace` and `remove` were silently dropped. Now `add`/`replace` write to fresh UUID URIs, `remove` is acknowledged at INFO with a cleanup reminder.
- **Transient write-lock errors retried**. The OpenViking server returns `INVALID_ARGUMENT: resource is busy` under concurrent writes. Now retried once with 200ms backoff. Only `RuntimeError` exceptions carrying the specific error code are retried — unexpected errors (network, timeout) fail immediately.
- **Failure visibility**. Final-failure log bumped from `debug` to `WARNING` so users can detect mirror outages.

## Differences from #31006

This is an independent implementation that improves on #31006 in two ways:

1. **Stricter retry guard**: catches `RuntimeError` specifically, then checks for both `"INVALID_ARGUMENT"` and `"busy"` in the message string — not a broad `except Exception` with a substring match on any exception.

2. **Remove log includes cleanup hint**: stale entries from `remove` operations will accumulate in Viking over time; the log now suggests periodic `viking_browse` cleanup.

## Testing

Manual verification on local OpenViking server: add, replace, and remove memories all produce the correct log output. Retry path triggered via concurrent write test.

Closes #31000