### PR TITLE
feat(docker): add Windows Docker Desktop compatible compose file

### DIFF
--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -1,0 +1,38 @@
+#
+# docker-compose.windows.yml — Windows Docker Desktop compatible
+#
+# Differences from docker-compose.yml:
+#   - Removes `network_mode: host` (not supported on Docker Desktop for Windows)
+#   - Uses explicit port mappings instead
+#   - Uses Windows-style volume path for ~/.hermes
+#
+# Usage:
+#   docker compose -f docker-compose.windows.yml up -d
+#
+services:
+  gateway:
+    image: nousresearch/hermes-agent:latest
+    container_name: hermes
+    restart: unless-stopped
+    volumes:
+      - ${USERPROFILE}/.hermes:/opt/data
+    environment:
+      - HERMES_UID=10000
+      - HERMES_GID=10000
+    command: ["gateway", "run"]
+
+  dashboard:
+    image: nousresearch/hermes-agent:latest
+    container_name: hermes-dashboard
+    restart: unless-stopped
+    depends_on:
+      - gateway
+    volumes:
+      - ${USERPROFILE}/.hermes:/opt/data
+    environment:
+      - HERMES_UID=10000
+      - HERMES_GID=10000
+      - HERMES_DASHBOARD_HOST=0.0.0.0
+    ports:
+      - "127.0.0.1:9119:9119"
+    command: ["dashboard", "--host", "0.0.0.0", "--port", "9119", "--no-open", "--insecure"]


### PR DESCRIPTION
## What does this PR do?

Adds \docker-compose.windows.yml\ as a companion to the existing \docker-compose.yml\ for users running Docker Desktop on Windows.

Docker Desktop for Windows does not support \
etwork_mode: host\ (it is Linux-only). The existing \docker-compose.yml\ uses host networking, which silently fails on Windows — containers start but the gateway and dashboard cannot communicate as expected.

This file is a minimal, drop-in alternative that:
- Removes \
etwork_mode: host\ entirely
- Adds an explicit port mapping (\127.0.0.1:9119:9119\) for the dashboard
- Passes \--insecure\ to the dashboard command (required when binding to \