### PR TITLE
fix: parse MEDIA paths with spaced filenames

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2268,7 +2268,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)[^\n]+?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -33,6 +33,15 @@ _AUDIO_EXTS = frozenset({'.ogg', '.opus', '.mp3', '.wav', '.m4a', '.flac'})
 _TELEGRAM_AUDIO_ATTACHMENT_EXTS = frozenset({'.mp3', '.m4a'})
 _TELEGRAM_VOICE_EXTS = frozenset({'.ogg', '.opus'})
 
+# Shared MEDIA:<path> directive matcher for extraction and streaming cleanup.
+# Supports optional whitespace after MEDIA:, quoted/backticked paths, and
+# unquoted absolute/home-relative paths with spaces up to a known media/document
+# extension. Keep this single pattern shared so streamed previews and final
+# attachment extraction never diverge.
+MEDIA_DIRECTIVE_RE = re.compile(
+    r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)[^\n]+?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
+)
+
 
 def _platform_name(platform) -> str:
     """Normalize a Platform enum / raw string into a lowercase name."""
@@ -2267,10 +2276,7 @@ class BasePlatformAdapter(ABC):
         
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
-        media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)[^\n]+?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
-        )
-        for match in media_pattern.finditer(content):
+        for match in MEDIA_DIRECTIVE_RE.finditer(content):
             path = match.group("path").strip()
             if len(path) >= 2 and path[0] == path[-1] and path[0] in "`\"'":
                 path = path[1:-1].strip()
@@ -2280,7 +2286,7 @@ class BasePlatformAdapter(ABC):
 
         # Remove MEDIA tags from content (including surrounding quote/backtick wrappers)
         if media:
-            cleaned = media_pattern.sub('', cleaned)
+            cleaned = MEDIA_DIRECTIVE_RE.sub('', cleaned)
             cleaned = re.sub(r'\n{3,}', '\n\n', cleaned).strip()
         
         return media, cleaned

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -642,7 +642,9 @@ class GatewayStreamConsumer:
     # Pattern to strip MEDIA:<path> tags (including optional surrounding quotes).
     # Matches the simple cleanup regex used by the non-streaming path in
     # gateway/platforms/base.py for post-processing.
-    _MEDIA_RE = re.compile(r'''[`"']?MEDIA:\s*\S+[`"']?''')
+    _MEDIA_RE = re.compile(
+        r'''[`"']?MEDIA:\s*(?:`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)[^\n]+?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
+    )
 
     @staticmethod
     def _clean_for_display(text: str) -> str:

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Optional
 
 from gateway.platforms.base import BasePlatformAdapter as _BasePlatformAdapter
-from gateway.platforms.base import _custom_unit_to_cp
+from gateway.platforms.base import MEDIA_DIRECTIVE_RE, _custom_unit_to_cp
 from gateway.config import (
     DEFAULT_STREAMING_EDIT_INTERVAL as _DEFAULT_STREAMING_EDIT_INTERVAL,
     DEFAULT_STREAMING_BUFFER_THRESHOLD as _DEFAULT_STREAMING_BUFFER_THRESHOLD,
@@ -640,11 +640,9 @@ class GatewayStreamConsumer:
             logger.error("Stream consumer error: %s", e)
 
     # Pattern to strip MEDIA:<path> tags (including optional surrounding quotes).
-    # Matches the simple cleanup regex used by the non-streaming path in
-    # gateway/platforms/base.py for post-processing.
-    _MEDIA_RE = re.compile(
-        r'''[`"']?MEDIA:\s*(?:`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)[^\n]+?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
-    )
+    # Shared with the final attachment extraction path so streamed previews and
+    # post-processing stay in sync.
+    _MEDIA_RE = MEDIA_DIRECTIVE_RE
 
     @staticmethod
     def _clean_for_display(text: str) -> str:

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -329,6 +329,22 @@ class TestExtractMedia:
         assert media == [("/tmp/Jane Doe/speech.flac", False)]
         assert cleaned == ""
 
+    def test_media_tag_supports_extension_after_space(self):
+        content = "MEDIA:/private/tmp/company-files-downloads/XM1307HE产品规格书V1.2 .docx"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [("/private/tmp/company-files-downloads/XM1307HE产品规格书V1.2 .docx", False)]
+        assert cleaned == ""
+
+    def test_media_tag_strips_extension_after_space_from_stream_display(self):
+        from gateway.stream_consumer import GatewayStreamConsumer
+
+        text = "已准备\nMEDIA:/private/tmp/company-files-downloads/XM1307HE产品规格书V1.2 .docx\n请查收"
+        cleaned = GatewayStreamConsumer._clean_for_display(text)
+        assert "MEDIA:" not in cleaned
+        assert "V1.2 .docx" not in cleaned
+        assert "已准备" in cleaned
+        assert "请查收" in cleaned
+
     def test_as_document_directive_stripped_from_cleaned_text(self):
         """[[as_document]] is a routing directive — strip it from
         user-visible text just like [[audio_as_voice]]. Callers detect the

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -8,6 +8,7 @@ import pytest
 from gateway.platforms.base import (
     BasePlatformAdapter,
     GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE,
+    MEDIA_DIRECTIVE_RE,
     MessageEvent,
     MessageType,
     safe_url_for_log,
@@ -334,6 +335,17 @@ class TestExtractMedia:
         media, cleaned = BasePlatformAdapter.extract_media(content)
         assert media == [("/private/tmp/company-files-downloads/XM1307HE产品规格书V1.2 .docx", False)]
         assert cleaned == ""
+
+    def test_media_tag_supports_unquoted_paths_with_multiple_spaces(self):
+        content = "MEDIA:/private/tmp/company files/downloads/my file name.docx"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [("/private/tmp/company files/downloads/my file name.docx", False)]
+        assert cleaned == ""
+
+    def test_stream_display_uses_shared_media_directive_pattern(self):
+        from gateway.stream_consumer import GatewayStreamConsumer
+
+        assert GatewayStreamConsumer._MEDIA_RE is MEDIA_DIRECTIVE_RE
 
     def test_media_tag_strips_extension_after_space_from_stream_display(self):
         from gateway.stream_consumer import GatewayStreamConsumer


### PR DESCRIPTION
## Summary
- Handle unquoted `MEDIA:` file paths that contain spaces before the file extension, e.g. `V1.2 .docx`
- Ensure streamed gateway display cleanup removes the full `MEDIA:` tag for those paths
- Add regression coverage for both media extraction and stream display cleanup

## Test Plan
- `python -m pytest -o 'addopts=' tests/gateway/test_platform_base.py -q`