### PR TITLE
feat: support EXA_BASE_URL env var for custom Exa API endpoint

### DIFF
--- a/plugins/web/exa/provider.py
+++ b/plugins/web/exa/provider.py
@@ -12,9 +12,10 @@ Config keys this provider responds to::
       extract_backend: "exa"     # explicit per-capability
       backend: "exa"             # shared fallback for both
 
-Env var::
+Env vars::
 
     EXA_API_KEY=...    # https://exa.ai (paid tier; free trial available)
+    EXA_BASE_URL=...   # optional override of https://api.exa.ai
 
 The previous in-tree implementation lived at
 ``tools.web_tools._exa_search`` / ``_exa_extract``; this file is the
@@ -69,7 +70,11 @@ def _get_exa_client() -> Any:
 
     from exa_py import Exa  # noqa: WPS433 — deliberately lazy
 
-    client = Exa(api_key=api_key)
+    base_url = os.getenv("EXA_BASE_URL", "").strip()
+    kwargs = {"api_key": api_key}
+    if base_url:
+        kwargs["base_url"] = base_url
+    client = Exa(**kwargs)
     client.headers["x-exa-integration"] = "hermes-agent"
     _wt._exa_client = client
     return client
@@ -207,6 +212,11 @@ class ExaWebSearchProvider(WebSearchProvider):
                     "key": "EXA_API_KEY",
                     "prompt": "Exa API key",
                     "url": "https://exa.ai",
+                },
+                {
+                    "key": "EXA_BASE_URL",
+                    "prompt": "Exa API base URL (optional, default https://api.exa.ai)",
+                    "url": "",
                 },
             ],
         }


### PR DESCRIPTION
## Summary

The `exa-py` SDK already accepts a `base_url` parameter in its constructor (defaults to `https://api.exa.ai`), but the Hermes Exa provider was not passing it through. This PR adds `EXA_BASE_URL` env var support so users can route Exa calls through a self-hosted proxy or alternative endpoint.

## Changes

- **`plugins/web/exa/provider.py`**: Read `EXA_BASE_URL` env var and pass it to `Exa(api_key=..., base_url=...)` when set. No behavior change when the var is unset.
- Updated module docstring and `get_setup_schema()` to document the new env var (visible in `hermes tools` setup UI).
- Fixed minor docstring typo: "Env var::" → "Env vars::"

## Compatibility

Fully backward compatible — when `EXA_BASE_URL` is unset, the SDK defaults to `https://api.exa.ai` as before.

## Testing

All 6 existing Exa tests pass (tested locally):

```
tests/plugins/web/test_web_search_provider_plugins.py::TestBundledPluginsRegister::test_capability_flags_match_spec[exa-True-True-False] PASSED
tests/plugins/web/test_web_search_provider_plugins.py::TestBundledPluginsRegister::test_each_plugin_has_name_and_display_name[exa] PASSED
tests/plugins/web/test_web_search_provider_plugins.py::TestBundledPluginsRegister::test_each_plugin_has_setup_schema[exa] PASSED
tests/plugins/web/test_web_search_provider_plugins.py::TestIsAvailable::test_exa_requires_api_key PASSED
tests/plugins/web/test_web_search_provider_plugins.py::TestAsyncExtractDispatch::test_exa_extract_is_sync PASSED
tests/plugins/web/test_web_search_provider_plugins.py::TestErrorResponseShapes::test_exa_returns_error_dict_when_unconfigured PASSED
```
