### PR TITLE
feat(gateway): per-platform gateway_restart_notification_channel override

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -581,6 +581,24 @@ class PlatformConfig:
     # noise; keep True for back-channels where the operator wants them.
     gateway_restart_notification: bool = True
 
+    # Override target for restart/shutdown lifecycle notifications on this
+    # platform. When set, ALL lifecycle notifications on this platform
+    # (startup "online", post-restart "restarted", and shutdown drain pings —
+    # both the active-session and home-channel broadcasts) are routed to THIS
+    # single chat instead of the active-session sources and the platform home
+    # channel. Useful when you want operators in an ops channel (e.g.
+    # "#ops-alerts") to know about restarts but don't want end-user channels
+    # to receive lifecycle pings during active conversations.
+    #
+    # The value is a bare platform chat id. It is NOT split on ':' — platform
+    # ids can themselves contain colons (e.g. a Matrix room id like
+    # "!room:example.org"), so the whole string is used verbatim as the chat
+    # id, matching how ``home_channel.chat_id`` is treated. Thread/topic
+    # targeting is not encoded here; point this at a channel/room directly.
+    # Has no effect if ``gateway_restart_notification`` is False (which fully
+    # suppresses lifecycle pings on this platform).
+    gateway_restart_notification_channel: Optional[str] = None
+
     # Whether the gateway shows a "typing…" / "is thinking…" status indicator
     # while the agent processes a message on this platform. Default True
     # preserves prior behavior. Set False on platforms where the indicator is
@@ -615,6 +633,8 @@ class PlatformConfig:
         }
         if self.typing_status_text is not None:
             result["typing_status_text"] = self.typing_status_text
+        if self.gateway_restart_notification_channel:
+            result["gateway_restart_notification_channel"] = self.gateway_restart_notification_channel
         if self.token:
             result["token"] = self.token
         if self.api_key:
@@ -643,6 +663,13 @@ class PlatformConfig:
         if _grn is None:
             _grn = extra.get("gateway_restart_notification")
 
+        # gateway_restart_notification_channel mirrors the flag above: it may
+        # arrive top-level or bridged into extra by the shared-key loop in
+        # load_gateway_config(), so check both.
+        _grn_chan = data.get("gateway_restart_notification_channel")
+        if _grn_chan is None:
+            _grn_chan = extra.get("gateway_restart_notification_channel")
+
         # typing_indicator mirrors gateway_restart_notification: it may arrive
         # top-level or bridged into extra by the shared-key loop in
         # load_gateway_config(), so check both.
@@ -670,6 +697,7 @@ class PlatformConfig:
             home_channel=home_channel,
             reply_to_mode=data.get("reply_to_mode", "first"),
             gateway_restart_notification=_coerce_bool(_grn, True),
+            gateway_restart_notification_channel=_grn_chan if _grn_chan else None,
             typing_indicator=_coerce_bool(_typing, True),
             typing_status_text=_typing_text,
             channel_overrides=channel_overrides,
@@ -1546,6 +1574,8 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = channel_prompts
                 if "gateway_restart_notification" in platform_cfg:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
+                if "gateway_restart_notification_channel" in platform_cfg:
+                    bridged["gateway_restart_notification_channel"] = platform_cfg["gateway_restart_notification_channel"]
                 if "typing_indicator" in platform_cfg:
                     bridged["typing_indicator"] = platform_cfg["typing_indicator"]
                 if "typing_status_text" in platform_cfg:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6530,12 +6530,83 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception as e:
                 logger.debug("Failed interrupting agent during shutdown: %s", e)
 
+    def _lifecycle_override_target(self, platform: Platform) -> Optional[str]:
+        """Return this platform's configured lifecycle-override chat id, or None.
+
+        When set, every lifecycle notification (startup / post-restart /
+        shutdown) for the platform is routed to this single chat instead of
+        the active-session sources and the home channel. Honors
+        ``gateway_restart_notification=False`` (which suppresses lifecycle
+        pings entirely) and only applies to enabled platforms.
+        """
+        cfg = self.config.platforms.get(platform)
+        if cfg is None or not cfg.enabled:
+            return None
+        if not cfg.gateway_restart_notification:
+            return None
+        target = getattr(cfg, "gateway_restart_notification_channel", None)
+        return target or None
+
+    async def _send_lifecycle_override_notification(
+        self, platform: Platform, adapter: Any, msg: str,
+    ) -> bool:
+        """Deliver ONE lifecycle notification to a platform's override channel.
+
+        Returns True only when the adapter confirms delivery (SendResult is
+        not reported as ``success=False``). On any failure the caller should
+        fall back to the normal per-session / home-channel delivery rather
+        than silently claiming the notification landed.
+
+        The configured value is used verbatim as the chat id and is NOT split
+        on ':' — platform ids such as Matrix room ids ("!room:example.org")
+        contain colons and must survive intact. Thread/topic targeting is not
+        encoded in this string; the override points at a channel/room directly.
+        """
+        target = self._lifecycle_override_target(platform)
+        if not target or adapter is None:
+            return False
+        # No thread component: mirror the home-channel no-thread send path.
+        meta = _non_conversational_metadata(platform=platform)
+        try:
+            if meta:
+                result = await adapter.send(target, msg, metadata=meta)
+            else:
+                result = await adapter.send(target, msg)
+        except Exception as e:
+            logger.debug(
+                "Override lifecycle notification raised for %s: %s",
+                platform.value, e,
+            )
+            return False
+        if result is not None and getattr(result, "success", True) is False:
+            logger.warning(
+                "Override lifecycle notification to %s (%s) not delivered: %s",
+                platform.value, target,
+                getattr(result, "error", "send returned success=False"),
+            )
+            return False
+        logger.info(
+            "Lifecycle notification routed to override channel for %s: %s",
+            platform.value, target,
+        )
+        return True
+
     async def _notify_active_sessions_of_shutdown(self) -> None:
         """Send shutdown/restart notifications to active chats and home channels.
 
         Called at the very start of stop() — adapters are still connected so
         messages can be delivered. Best-effort: individual send failures are
         logged and swallowed so they never block the shutdown sequence.
+
+        Per-platform override: when a platform's
+        ``gateway_restart_notification_channel`` is set and the override send
+        succeeds, BOTH the per-session loop and the home-channel broadcast are
+        skipped FOR THAT PLATFORM and a single notification lands in the
+        override chat instead. Used to keep restart pings out of end-user
+        channels (where active sessions live during normal work) and route
+        them to an ops-only channel instead. If the override send fails
+        (SendResult.success is False), the platform falls back to the normal
+        per-session / home-channel delivery.
         """
         active = self._snapshot_running_agents()
         restart_source = self._restart_command_source if self._restart_requested else None
@@ -6548,6 +6619,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             else "Your current task will be interrupted."
         )
         msg = f"⚠️ Gateway {action} — {hint}"
+
+        # Per-platform override: if a platform has a configured lifecycle
+        # override channel, send ONE notification there and skip BOTH the
+        # per-session loop and the home-channel broadcast below for that
+        # platform. Delivery is confirmed via SendResult.success — a platform
+        # is only added to override_sent_platforms when the send actually
+        # landed, so a failed override send falls back to the normal
+        # per-session / home-channel delivery instead of silently dropping
+        # the notification.
+        override_sent_platforms: set[str] = set()
+        for platform, adapter in list(self.adapters.items()):
+            if await self._send_lifecycle_override_notification(platform, adapter, msg):
+                override_sent_platforms.add(platform.value)
 
         notified: set[tuple[str, str, Optional[str]]] = set()
         for session_key in active:
@@ -6600,6 +6684,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "Shutdown notification suppressed for active session: %s has gateway_restart_notification=false",
                         platform_str,
                     )
+                    continue
+
+                # If this platform has an override channel configured, the
+                # single override notification was already sent above — skip
+                # the per-session loop to avoid double-pinging.
+                if platform_str in override_sent_platforms:
                     continue
 
                 reply_to_message_id = getattr(source, "message_id", None) if source is not None else None
@@ -6679,6 +6769,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # ``RuntimeError: dictionary changed size during iteration`` —
         # observed in a user report during gateway shutdown.
         for platform, adapter in list(self.adapters.items()):
+            # A configured lifecycle override already received the single
+            # shutdown notification for this platform above — don't also
+            # broadcast to the home channel.
+            if platform.value in override_sent_platforms:
+                continue
+
             home = self.config.get_home_channel(platform)
             if not home or not home.chat_id:
                 continue
@@ -17031,6 +17127,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 return None
 
+            # Route to the lifecycle override channel when configured — the
+            # "gateway restarted" ping goes there instead of the originating
+            # chat. Only skip the in-chat notify when the override actually
+            # delivered; otherwise fall through to the normal path.
+            if await self._send_lifecycle_override_notification(
+                platform,
+                adapter,
+                "♻ Gateway restarted successfully. Your session continues.",
+            ):
+                return None
+
             metadata = self._thread_metadata_for_target(
                 platform,
                 chat_id,
@@ -17085,6 +17192,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         message = "♻️ Gateway online — Hermes is back and ready."
 
         for platform, adapter in self.adapters.items():
+            # Route the "gateway online" ping to the lifecycle override
+            # channel when configured, instead of the home channel.
+            if await self._send_lifecycle_override_notification(
+                platform, adapter, message,
+            ):
+                continue
+
             home = self.config.get_home_channel(platform)
             if not home or not home.chat_id:
                 continue

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -120,6 +120,38 @@ class TestPlatformConfigRoundtrip:
     def test_typing_status_text_omitted_from_to_dict_when_unset(self):
         # None must not serialize — keeps existing config files byte-stable.
         assert "typing_status_text" not in PlatformConfig().to_dict()
+    def test_gateway_restart_notification_channel_defaults_none(self):
+        assert PlatformConfig().gateway_restart_notification_channel is None
+        assert PlatformConfig.from_dict({}).gateway_restart_notification_channel is None
+
+    def test_gateway_restart_notification_channel_roundtrip(self):
+        # Nested-platform-block shape: the key sits at the top level of the
+        # platform dict, exactly as ``platforms: telegram: {...}`` produces.
+        pc = PlatformConfig(enabled=True, gateway_restart_notification_channel="C0OPS999")
+        restored = PlatformConfig.from_dict(pc.to_dict())
+        assert restored.gateway_restart_notification_channel == "C0OPS999"
+
+    def test_gateway_restart_notification_channel_from_top_level_key(self):
+        restored = PlatformConfig.from_dict(
+            {"gateway_restart_notification_channel": "C0OPS999"}
+        )
+        assert restored.gateway_restart_notification_channel == "C0OPS999"
+
+    def test_gateway_restart_notification_channel_resolved_from_extra(self):
+        # The shared-key loop in load_gateway_config bridges the value into
+        # extra; from_dict must honor it there too (mirrors _grn fallback).
+        restored = PlatformConfig.from_dict(
+            {"extra": {"gateway_restart_notification_channel": "C0OPS999"}}
+        )
+        assert restored.gateway_restart_notification_channel == "C0OPS999"
+
+    def test_gateway_restart_notification_channel_matrix_room_id_preserved(self):
+        # A Matrix room id contains a ':' and must survive round-tripping
+        # verbatim — it is never parsed/split into chat_id + thread_id.
+        room = "!room123:example.org"
+        pc = PlatformConfig(enabled=True, gateway_restart_notification_channel=room)
+        restored = PlatformConfig.from_dict(pc.to_dict())
+        assert restored.gateway_restart_notification_channel == room
 
     def test_channel_overrides_roundtrip(self):
         pc = PlatformConfig(
@@ -1626,6 +1658,45 @@ class TestLoadGatewayConfig:
             "bridged into PlatformConfig.extra by the shared-key loop"
         )
         assert telegram.extra.get("require_mention") is False
+
+    def test_bridges_gateway_restart_notification_channel_top_level_key(self, tmp_path, monkeypatch):
+        """Top-level shared-key shape: ``telegram: gateway_restart_notification_channel``
+        is bridged into PlatformConfig and surfaces on the typed field."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "telegram:\n"
+            "  gateway_restart_notification_channel: \"C0OPS999\"\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        telegram = config.platforms[Platform.TELEGRAM]
+        assert telegram.gateway_restart_notification_channel == "C0OPS999"
+
+    def test_bridges_gateway_restart_notification_channel_nested_platforms(self, tmp_path, monkeypatch):
+        """Nested-platform-block shape: ``platforms: telegram:
+        gateway_restart_notification_channel`` reaches the typed field."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "platforms:\n"
+            "  telegram:\n"
+            "    gateway_restart_notification_channel: \"C0OPS999\"\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        telegram = config.platforms[Platform.TELEGRAM]
+        assert telegram.gateway_restart_notification_channel == "C0OPS999"
 
     def test_bridges_quoted_false_session_notify_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"

--- a/tests/gateway/test_restart_notification_channel_override.py
+++ b/tests/gateway/test_restart_notification_channel_override.py
@@ -1,0 +1,198 @@
+"""Per-platform lifecycle-override channel (PlatformConfig.gateway_restart_notification_channel).
+
+When a platform sets ``gateway_restart_notification_channel``, ALL lifecycle
+notifications for that platform — shutdown/restart drain (both the active-session
+pings and the home-channel broadcast), the post-restart "restarted" ping, and the
+startup "online" ping — are routed to that single chat instead of the active
+sessions and the home channel.
+
+These are behavioral tests against the real notification paths (not snapshots),
+mirroring the style in ``test_restart_drain.py`` / ``test_restart_notification.py``.
+"""
+
+import json
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import HomeChannel, Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from tests.gateway.restart_test_helpers import (
+    RestartTestAdapter,
+    make_restart_runner,
+    make_restart_source,
+)
+
+OVERRIDE_CHANNEL = "C0OPS999"
+
+
+class _MatrixLikeAdapter(RestartTestAdapter):
+    """Records sends exactly like RestartTestAdapter; used for a Matrix room id."""
+
+
+class _FailingOverrideAdapter(RestartTestAdapter):
+    """Returns success=False for the override target, success=True otherwise.
+
+    Lets us prove that a failed override send falls back to the normal
+    per-session / home-channel delivery instead of being silently claimed.
+    """
+
+    def __init__(self, failing_target: str):
+        super().__init__()
+        self._failing_target = failing_target
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent.append(content)
+        self.sent_calls.append((chat_id, content, metadata))
+        if chat_id == self._failing_target:
+            return SendResult(success=False, error="simulated override failure")
+        return SendResult(success=True, message_id="1")
+
+
+# ── shutdown: active-session ping routed to override ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_shutdown_active_session_routed_to_override_channel():
+    """With an override configured, an active session's shutdown ping lands
+    in the override channel ONLY — not the session's own chat."""
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification_channel = OVERRIDE_CHANNEL
+    session_key = "agent:main:telegram:dm:999"
+    runner._running_agents[session_key] = object()
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    targets = [c[0] for c in adapter.sent_calls]
+    assert targets == [OVERRIDE_CHANNEL], targets
+    assert "999" not in targets
+
+
+# ── shutdown: home-channel broadcast routed to override ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_shutdown_home_channel_routed_to_override_channel():
+    """With an override configured and no active sessions, the home-channel
+    shutdown broadcast is redirected to the override channel."""
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification_channel = OVERRIDE_CHANNEL
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    targets = [c[0] for c in adapter.sent_calls]
+    assert targets == [OVERRIDE_CHANNEL], targets
+    assert "home-42" not in targets
+
+
+# ── ask 1: success=False falls back, never silently claims delivery ──────
+
+
+@pytest.mark.asyncio
+async def test_override_send_failure_falls_back_to_active_session():
+    """If the override send returns success=False, the platform is NOT marked
+    delivered — the per-session ping still fires as a fallback."""
+    adapter = _FailingOverrideAdapter(failing_target=OVERRIDE_CHANNEL)
+    runner, adapter = make_restart_runner(adapter=adapter)
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification_channel = OVERRIDE_CHANNEL
+    session_key = "agent:main:telegram:dm:999"
+    runner._running_agents[session_key] = object()
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    targets = [c[0] for c in adapter.sent_calls]
+    # Override attempted (and failed), THEN the session chat received the
+    # fallback ping — the failure was not silently swallowed as "delivered".
+    assert OVERRIDE_CHANNEL in targets
+    assert "999" in targets
+
+
+# ── ask 4: Matrix room id is used verbatim, never split on ':' ───────────
+
+
+@pytest.mark.asyncio
+async def test_override_channel_matrix_room_id_not_split_on_colon():
+    """A Matrix-style room id ("!room123:example.org") must reach the adapter
+    intact — the override value is the whole chat id, never split on ':'."""
+    matrix_room = "!room123:example.org"
+    adapter = _MatrixLikeAdapter()
+    runner, _telegram = make_restart_runner()
+    runner.config.platforms[Platform.MATRIX] = PlatformConfig(
+        enabled=True,
+        token="***",
+        gateway_restart_notification_channel=matrix_room,
+    )
+    runner.adapters = {Platform.MATRIX: adapter}
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    targets = [c[0] for c in adapter.sent_calls]
+    assert targets == [matrix_room], targets
+
+
+# ── startup: "online" ping routed to override ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_startup_notification_routed_to_override_channel():
+    """The "gateway online" startup ping goes to the override channel instead
+    of the configured home channel when an override is set."""
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification_channel = OVERRIDE_CHANNEL
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+
+    await runner._send_home_channel_startup_notifications()
+
+    assert len(adapter.sent_calls) == 1
+    chat_id, content, _ = adapter.sent_calls[0]
+    assert chat_id == OVERRIDE_CHANNEL
+    assert "online" in content.lower()
+
+
+# ── restart: "restarted" ping routed to override ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_restart_notification_routed_to_override_channel(tmp_path, monkeypatch):
+    """The post-restart "gateway restarted" ping goes to the override channel
+    instead of the chat that ran /restart."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    (tmp_path / ".restart_notify.json").write_text(
+        json.dumps({"platform": "telegram", "chat_id": "42", "chat_type": "dm"})
+    )
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification_channel = OVERRIDE_CHANNEL
+
+    await runner._send_restart_notification()
+
+    targets = [c[0] for c in adapter.sent_calls]
+    assert targets == [OVERRIDE_CHANNEL], targets
+    assert "42" not in targets
+
+
+# ── suppression flag still wins over the override ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_override_suppressed_when_restart_notification_flag_false():
+    """gateway_restart_notification=False fully suppresses lifecycle pings,
+    even when an override channel is configured."""
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification = False
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification_channel = OVERRIDE_CHANNEL
+    session_key = "agent:main:telegram:dm:999"
+    runner._running_agents[session_key] = object()
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    assert adapter.sent_calls == []


### PR DESCRIPTION
## What this adds

An optional per-platform `gateway_restart_notification_channel`. When set, **all** lifecycle notifications for that platform are routed to that single chat instead of the active-session sources and the home channel — so operators can watch restarts in an ops channel (e.g. `#ops-alerts`) without pinging end-user channels during active conversations.

## Rework in response to review

Thanks for the detailed review — every point below is addressed. The branch was rebased onto current `main` first; several of the cited line numbers had moved and the kanban change had already landed, so I resolved against the current source and note the deltas inline.

### Review asks → changes

- [x] **Check `SendResult.success`, not just non-throw.** Override delivery now goes through a single helper `_send_lifecycle_override_notification()` that returns `True` only when the adapter does not report `success=False`. On failure it returns `False` and the caller falls back to the normal per-session / home-channel delivery — no more silently-claimed delivery. Mirrors the existing lifecycle `success=False` checks in `_notify_active_sessions_of_shutdown` / `_send_restart_notification`.
  Test: `test_override_send_failure_falls_back_to_active_session`.

- [x] **Cover ALL lifecycle paths.** The override now routes every lifecycle path (and only it, when a send succeeds):
  - shutdown active-session pings — `_notify_active_sessions_of_shutdown` (per-platform skip set)
  - shutdown home-channel broadcast — same function, second loop now also skips override platforms
  - post-restart "restarted" ping — `_send_restart_notification`
  - startup "online" ping — `_send_home_channel_startup_notifications`
  Tests: `test_shutdown_active_session_routed_to_override_channel`, `test_shutdown_home_channel_routed_to_override_channel`, `test_restart_notification_routed_to_override_channel`, `test_startup_notification_routed_to_override_channel`, plus `test_override_suppressed_when_restart_notification_flag_false` (the existing `gateway_restart_notification=False` suppression still wins).

- [x] **Wire the new field into the shared-key config bridge.** Added the `gateway_restart_notification_channel` bridge line next to `gateway_restart_notification` in the shared-key loop in `load_gateway_config()`, and the `from_dict` fallback reads it from `extra` too (mirrors `_grn` / `typing_indicator`).
  Tests (both shapes): `test_bridges_gateway_restart_notification_channel_top_level_key` (top-level shared key) and `test_bridges_gateway_restart_notification_channel_nested_platforms` (nested `platforms:` block), plus unit-level `from_dict` / `to_dict` roundtrip and `..._resolved_from_extra`.

- [x] **Platform-safe target encoding.** Dropped the `:`-split entirely. The configured value is used verbatim as the chat id, matching how `home_channel.chat_id` is treated, so a Matrix room id like `!room123:example.org` survives intact. Thread/topic targeting is not encoded into this single string precisely because platform ids can contain `:`; point the override at a channel/room directly.
  Tests: `test_override_channel_matrix_room_id_not_split_on_colon` (runtime path) and `test_gateway_restart_notification_channel_matrix_room_id_preserved` (config roundtrip).

- [x] **Drop the unrelated kanban PRAGMA change.** Removed from the diff entirely (it had already landed on `main` at `hermes_cli/kanban_db.py`). The PR is now single-purpose: `gateway/config.py`, `gateway/run.py`, and their tests only.

### Notes on cited line numbers

`main` moved since the review: `typing_indicator` / `channel_overrides` were added to `PlatformConfig` and the shutdown path now builds metadata via `_thread_metadata_for_target(...)` and already checks `SendResult.success`. I integrated with those rather than the older shapes, so the concrete line numbers differ from the review — the function names above are the stable anchors.

### Tests

`pytest tests/gateway/` for the touched areas: new override file 7 passed, new config cases 7 passed, full `test_config.py` + `test_restart_drain.py` + `test_restart_notification.py` + `test_gateway_shutdown.py` + `test_typing_indicator_toggle.py` + the new file = 186 passed, and the broader restart/startup/shutdown/lifecycle/drain/notification selection = 584 passed / 4 skipped, no regressions.
