### PR TITLE
fix(tui): commit composer input bursts immediately

### DIFF
--- a/ui-tui/src/__tests__/textInputBurstInput.test.ts
+++ b/ui-tui/src/__tests__/textInputBurstInput.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { applyPrintableInsert } from '../components/textInput.js'
+import { applyPrintableInsert, shouldRouteMultiCharInputAsPaste } from '../components/textInput.js'
 
 describe('applyPrintableInsert', () => {
   it('applies non-bracketed multi-character bursts immediately', () => {
@@ -25,5 +25,16 @@ describe('applyPrintableInsert', () => {
   it('rejects control or escape-bearing input', () => {
     expect(applyPrintableInsert('abc', 3, '\x1b[200~pasted')).toBeNull()
     expect(applyPrintableInsert('abc', 3, '\t')).toBeNull()
+  })
+})
+
+describe('shouldRouteMultiCharInputAsPaste', () => {
+  it('keeps newline-bearing chunks on the paste path', () => {
+    expect(shouldRouteMultiCharInputAsPaste('hello\nworld')).toBe(true)
+    expect(shouldRouteMultiCharInputAsPaste('hello\r\nworld'.replace(/\r\n/g, '\n'))).toBe(true)
+  })
+
+  it('treats repeated printable key bursts as immediate input', () => {
+    expect(shouldRouteMultiCharInputAsPaste('xxxxx')).toBe(false)
   })
 })

--- a/ui-tui/src/__tests__/textInputBurstInput.test.ts
+++ b/ui-tui/src/__tests__/textInputBurstInput.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { applyPrintableInsert } from '../components/textInput.js'
+
+describe('applyPrintableInsert', () => {
+  it('applies non-bracketed multi-character bursts immediately', () => {
+    const burst = applyPrintableInsert('abc', 3, 'xxxxx')
+
+    const repeated = [...'xxxxx'].reduce(
+      (state, ch) => applyPrintableInsert(state.value, state.cursor, ch)!,
+      { cursor: 3, value: 'abc' }
+    )
+
+    expect(burst).toEqual({ cursor: 8, value: 'abcxxxxx' })
+    expect(burst).toEqual(repeated)
+  })
+
+  it('replaces the selected range for burst input', () => {
+    expect(applyPrintableInsert('abZZef', 4, 'cd', { end: 4, start: 2 })).toEqual({
+      cursor: 4,
+      value: 'abcdef'
+    })
+  })
+
+  it('rejects control or escape-bearing input', () => {
+    expect(applyPrintableInsert('abc', 3, '\x1b[200~pasted')).toBeNull()
+    expect(applyPrintableInsert('abc', 3, '\t')).toBeNull()
+  })
+})

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -34,6 +34,7 @@ const DIM_OFF = `${ESC}[22m`
 const FWD_DEL_RE = new RegExp(`${ESC}\\[3(?:[~$^]|;)`)
 const PRINTABLE = /^[ -~\u00a0-\uffff]+$/
 const BRACKET_PASTE = new RegExp(`${ESC}?\\[20[01]~`, 'g')
+const KEY_BURST_MS = 16
 const MULTI_CLICK_MS = 500
 
 const invert = (s: string) => INV + s + INV_OFF
@@ -89,6 +90,34 @@ function snapPos(s: string, p: number) {
   }
 
   return last
+}
+
+export interface TextInsertResult {
+  cursor: number
+  value: string
+}
+
+export function applyPrintableInsert(
+  value: string,
+  cursor: number,
+  text: string,
+  range?: { end: number; start: number } | null
+): null | TextInsertResult {
+  if (!PRINTABLE.test(text)) {
+    return null
+  }
+
+  if (range) {
+    return {
+      cursor: range.start + text.length,
+      value: value.slice(0, range.start) + text + value.slice(range.end)
+    }
+  }
+
+  return {
+    cursor: cursor + text.length,
+    value: value.slice(0, cursor) + text + value.slice(cursor)
+  }
 }
 
 function prevPos(s: string, p: number) {
@@ -308,6 +337,7 @@ export function supportsFastEchoTerminal(env: NodeJS.ProcessEnv = process.env): 
   // off by default in Termux mode; allow explicit opt-in for local debugging.
   if (isTermuxTuiMode(env)) {
     const override = String(env.HERMES_TUI_TERMUX_FAST_ECHO ?? '').trim().toLowerCase()
+
     if (override) {
       return /^(?:1|true|yes|on)$/i.test(override)
     }
@@ -400,10 +430,7 @@ export function TextInput({
   const selRef = useRef<null | { end: number; start: number }>(null)
   const vRef = useRef(value)
   const self = useRef(false)
-  const pasteBuf = useRef('')
-  const pasteEnd = useRef<null | number>(null)
-  const pasteTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const pastePos = useRef(0)
+  const keyBurstTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const editVersionRef = useRef(0)
   const parentChangeTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const pendingParentValue = useRef<string | null>(null)
@@ -536,8 +563,8 @@ export function TextInput({
 
   useEffect(
     () => () => {
-      if (pasteTimer.current) {
-        clearTimeout(pasteTimer.current)
+      if (keyBurstTimer.current) {
+        clearTimeout(keyBurstTimer.current)
       }
 
       if (parentChangeTimer.current) {
@@ -695,21 +722,26 @@ export function TextInput({
     return !!h
   }
 
-  const flushPaste = () => {
-    const text = pasteBuf.current
-    const at = pastePos.current
-    const end = pasteEnd.current ?? at
-    pasteBuf.current = ''
-    pasteEnd.current = null
-    pasteTimer.current = null
+  const flushKeyBurst = () => {
+    if (keyBurstTimer.current) {
+      clearTimeout(keyBurstTimer.current)
+      keyBurstTimer.current = null
+    }
 
-    if (!text) {
+    flushParentChange()
+  }
+
+  const scheduleKeyBurstCommit = (next: string, nextCur: number) => {
+    commit(next, nextCur, true, false, false)
+
+    if (keyBurstTimer.current) {
       return
     }
 
-    if (!emitPaste({ cursor: at, text, value: vRef.current }) && PRINTABLE.test(text)) {
-      commit(vRef.current.slice(0, at) + text + vRef.current.slice(end), at + text.length)
-    }
+    keyBurstTimer.current = setTimeout(() => {
+      keyBurstTimer.current = null
+      flushParentChange()
+    }, KEY_BURST_MS)
   }
 
   const clearSel = () => {
@@ -850,6 +882,8 @@ export function TextInput({
       // follow-up on #19835). The pass-through predicate is a no-op for
       // ordinary typing and plain paste when voice is unbound to 'v'.
       if (shouldPassThroughToGlobalHandler(inp, k, voiceRecordKey)) {
+        flushKeyBurst()
+
         return
       }
 
@@ -859,6 +893,8 @@ export function TextInput({
         eventRaw === '\x16' ||
         (isMac && isActionMod(k) && inp.toLowerCase() === 'v')
       ) {
+        flushKeyBurst()
+
         if (cbPaste.current) {
           return void emitPaste({ cursor: curRef.current, hotkey: true, text: '', value: vRef.current })
         }
@@ -875,6 +911,8 @@ export function TextInput({
       }
 
       if (isMac && isActionMod(k) && inp.toLowerCase() === 'c') {
+        flushKeyBurst()
+
         const range = selRange()
 
         if (range) {
@@ -887,6 +925,8 @@ export function TextInput({
       }
 
       if (k.upArrow || k.downArrow) {
+        flushKeyBurst()
+
         const next = lineNav(vRef.current, curRef.current, k.upArrow ? -1 : 1)
 
         if (next !== null) {
@@ -899,11 +939,11 @@ export function TextInput({
       }
 
       if (k.return) {
+        flushKeyBurst()
+
         if (k.shift || k.ctrl || (isMac ? isActionMod(k) : k.meta)) {
-          flushParentChange()
           commit(ins(vRef.current, curRef.current, '\n'), curRef.current + 1)
         } else {
-          flushParentChange()
           cbSubmit.current?.(vRef.current)
         }
 
@@ -921,6 +961,11 @@ export function TextInput({
       const actionDeleteWord = (mod && inp === 'w') || isMacActionFallback(k, inp, 'w')
       const range = selRange()
       const delFwd = k.delete || fwdDel.current
+      const isPrintableInput = (event.keypress.isPasted || inp.length > 0) && PRINTABLE.test(inp.replace(BRACKET_PASTE, ''))
+
+      if (!isPrintableInput) {
+        flushKeyBurst()
+      }
 
       if (mod && inp === 'z') {
         return swap(undo, redo)
@@ -1050,31 +1095,34 @@ export function TextInput({
         }
 
         if (text.length > 1 || text.includes('\n')) {
-          if (!pasteBuf.current) {
-            pastePos.current = range ? range.start : c
-            pasteEnd.current = range ? range.end : pastePos.current
+          const inserted = applyPrintableInsert(v, c, text, range)
+
+          if (!inserted) {
+            return
           }
 
-          pasteBuf.current += text
-
-          if (pasteTimer.current) {
-            clearTimeout(pasteTimer.current)
-          }
-
-          pasteTimer.current = setTimeout(flushPaste, 50)
+          v = inserted.value
+          c = inserted.cursor
+          scheduleKeyBurstCommit(v, c)
 
           return
         }
 
-        if (PRINTABLE.test(text)) {
+        {
+          const inserted = applyPrintableInsert(v, c, text, range)
+
+          if (!inserted) {
+            return
+          }
+
           if (range) {
-            v = v.slice(0, range.start) + text + v.slice(range.end)
-            c = range.start + text.length
+            v = inserted.value
+            c = inserted.cursor
           } else {
             const simpleAppend = canFastAppend(v, c, text)
 
-            v = v.slice(0, c) + text + v.slice(c)
-            c += text.length
+            v = inserted.value
+            c = inserted.cursor
 
             if (simpleAppend) {
               stdout!.write(text)
@@ -1091,8 +1139,6 @@ export function TextInput({
               return
             }
           }
-        } else {
-          return
         }
       } else {
         return
@@ -1125,11 +1171,13 @@ export function TextInput({
         if (e.button === 2) {
           e.stopImmediatePropagation?.()
           const decision = decideRightClickAction(vRef.current, selRange())
+
           if (decision.action === 'copy') {
             void writeClipboardText(decision.text)
 
             return
           }
+
           emitPaste({ cursor: curRef.current, hotkey: true, text: '', value: vRef.current })
 
           return
@@ -1222,10 +1270,12 @@ export function decideRightClickAction(
 ): RightClickDecision {
   if (range && range.end > range.start) {
     const text = value.slice(range.start, range.end)
+
     if (text) {
       return { action: 'copy', text }
     }
   }
+
   return { action: 'paste' }
 }
 

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -120,6 +120,8 @@ export function applyPrintableInsert(
   }
 }
 
+export const shouldRouteMultiCharInputAsPaste = (text: string): boolean => text.includes('\n')
+
 function prevPos(s: string, p: number) {
   const pos = snapPos(s, p)
   let prev = 0
@@ -1095,6 +1097,16 @@ export function TextInput({
         }
 
         if (text.length > 1 || text.includes('\n')) {
+          if (shouldRouteMultiCharInputAsPaste(text)) {
+            flushKeyBurst()
+
+            if (!emitPaste({ cursor: c, text, value: v })) {
+              commit(ins(v, c, text), c + text.length)
+            }
+
+            return
+          }
+
           const inserted = applyPrintableInsert(v, c, text, range)
 
           if (!inserted) {

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -34,7 +34,7 @@ const DIM_OFF = `${ESC}[22m`
 const FWD_DEL_RE = new RegExp(`${ESC}\\[3(?:[~$^]|;)`)
 const PRINTABLE = /^[ -~\u00a0-\uffff]+$/
 const BRACKET_PASTE = new RegExp(`${ESC}?\\[20[01]~`, 'g')
-const KEY_BURST_MS = 16
+const FRAME_BATCH_MS = 16
 const MULTI_CLICK_MS = 500
 
 const invert = (s: string) => INV + s + INV_OFF
@@ -602,7 +602,7 @@ export function TextInput({
       return
     }
 
-    parentChangeTimer.current = setTimeout(flushParentChange, 16)
+    parentChangeTimer.current = setTimeout(flushParentChange, FRAME_BATCH_MS)
   }
 
   const cancelLocalRender = () => {
@@ -620,7 +620,7 @@ export function TextInput({
     localRenderTimer.current = setTimeout(() => {
       localRenderTimer.current = null
       setCur(curRef.current)
-    }, 16)
+    }, FRAME_BATCH_MS)
   }
 
   const canFastEchoBase = () => supportsFastEchoTerminal() && focus && termFocus && !selected && !mask && !!stdout?.isTTY
@@ -743,7 +743,7 @@ export function TextInput({
     keyBurstTimer.current = setTimeout(() => {
       keyBurstTimer.current = null
       flushParentChange()
-    }, KEY_BURST_MS)
+    }, FRAME_BATCH_MS)
   }
 
   const clearSel = () => {


### PR DESCRIPTION
## Summary
- Salvages the non-bracketed multi-character composer burst fix from #30632.
- Replaces the delayed pseudo-paste buffer with immediate local composer updates plus a frame-sized parent-state flush.
- Adds focused regression coverage for immediate printable burst insertion, selected-range replacement, and escape/control rejection.

## Related
- Supersedes #30632.
- Supersedes #29051.

## Test plan
- `npm run build --prefix packages/hermes-ink`
- `npx vitest run --maxWorkers 4 --testTimeout 15000 src/__tests__/textInputBurstInput.test.ts src/__tests__/textInputFastEcho.test.ts src/__tests__/textInputCursorSourceOfTruth.test.ts src/__tests__/textInputWrap.test.ts src/__tests__/textInputLineNav.test.ts src/__tests__/cursorDriftRegression.test.ts`
- `npx eslint src/components/textInput.tsx src/__tests__/textInputBurstInput.test.ts` (0 errors; existing React compiler warning in `textInput.tsx` remains)
- `npm run build`
- `npm run type-check` currently fails on existing `packages/hermes-ink/src/utils/execFileNoThrow.ts` Node type errors unrelated to this PR.