### PR TITLE
fix(gateway): mark unconfigured platforms as non-retryable to stop reconnect loop (#31049)

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -509,6 +509,7 @@ class SlackAdapter(BasePlatformAdapter):
             logger.error(
                 "[Slack] slack-bolt not installed. Run: pip install slack-bolt",
             )
+            self._set_fatal_error("missing_dependency", "slack-bolt not installed", retryable=False)
             return False
 
         raw_token = self.config.token
@@ -516,9 +517,11 @@ class SlackAdapter(BasePlatformAdapter):
 
         if not raw_token:
             logger.error("[Slack] SLACK_BOT_TOKEN not set")
+            self._set_fatal_error("missing_credentials", "SLACK_BOT_TOKEN not set", retryable=False)
             return False
         if not app_token:
             logger.error("[Slack] SLACK_APP_TOKEN not set")
+            self._set_fatal_error("missing_credentials", "SLACK_APP_TOKEN not set", retryable=False)
             return False
 
         proxy_url = _resolve_slack_proxy_url()

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1337,10 +1337,12 @@ class TelegramAdapter(BasePlatformAdapter):
                 "[%s] python-telegram-bot not installed. Run: pip install python-telegram-bot",
                 self.name,
             )
+            self._set_fatal_error("missing_dependency", "python-telegram-bot not installed", retryable=False)
             return False
         
         if not self.config.token:
             logger.error("[%s] No bot token configured", self.name)
+            self._set_fatal_error("missing_credentials", "No bot token configured", retryable=False)
             return False
         
         try:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -599,6 +599,7 @@ class DiscordAdapter(BasePlatformAdapter):
         """Connect to Discord and start receiving events."""
         if not DISCORD_AVAILABLE:
             logger.error("[%s] discord.py not installed. Run: pip install discord.py", self.name)
+            self._set_fatal_error("missing_dependency", "discord.py not installed", retryable=False)
             return False
 
         # Load opus codec for voice channel support
@@ -627,6 +628,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
         if not self.config.token:
             logger.error("[%s] No bot token configured", self.name)
+            self._set_fatal_error("missing_credentials", "No bot token configured", retryable=False)
             return False
 
         try:

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -905,3 +905,34 @@ async def test_safe_sync_detects_contexts_drift():
     fake_http.edit_global_command.assert_not_awaited()
     fake_http.delete_global_command.assert_awaited_once_with(999, 77)
     fake_http.upsert_global_command.assert_awaited_once_with(999, desired)
+
+
+# ============================================================================
+# #31049: unconfigured platform skips reconnection (non-retryable fatal error)
+# ============================================================================
+
+class TestDiscordUnconfiguredNonRetryable:
+    """Verify that missing dependency/token sets a non-retryable fatal error
+    so the gateway does not queue the platform for background reconnection."""
+
+    def test_no_discord_lib_sets_non_retryable_fatal(self, monkeypatch):
+        """connect() with discord.py unavailable → non-retryable fatal error."""
+        _ensure_discord_mock()
+        adapter = DiscordAdapter(PlatformConfig(enabled=True, token="fake"))
+        # Simulate discord.py not installed
+        monkeypatch.setattr(discord_platform, "DISCORD_AVAILABLE", False)
+        result = asyncio.get_event_loop().run_until_complete(adapter.connect())
+        assert result is False
+        assert adapter.has_fatal_error is True
+        assert adapter.fatal_error_retryable is False
+        assert adapter.fatal_error_code == "missing_dependency"
+
+    def test_no_bot_token_sets_non_retryable_fatal(self, monkeypatch):
+        """connect() with empty token → non-retryable fatal error."""
+        _ensure_discord_mock()
+        adapter = DiscordAdapter(PlatformConfig(enabled=True, token=""))
+        result = asyncio.get_event_loop().run_until_complete(adapter.connect())
+        assert result is False
+        assert adapter.has_fatal_error is True
+        assert adapter.fatal_error_retryable is False
+        assert adapter.fatal_error_code == "missing_credentials"

--- a/tests/gateway/test_slack_connect.py
+++ b/tests/gateway/test_slack_connect.py
@@ -1,0 +1,70 @@
+"""Tests for Slack connect() non-retryable fatal error on missing credentials.
+
+When Slack has no bot token, no app token, or slack-bolt not installed,
+connect() must set a non-retryable fatal error so the gateway does not queue
+it for background reconnection (#31049).
+"""
+
+import asyncio
+import os
+import sys
+from unittest.mock import MagicMock
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_slack_mock():
+    if "slack_bolt" in sys.modules and hasattr(sys.modules.get("slack_bolt"), "__file__"):
+        return
+
+    slack_bolt = MagicMock()
+    slack_bolt.async_app.AsyncApp = MagicMock
+    slack_bolt.adapter.socket_mode.async_handler.AsyncSocketModeHandler = MagicMock
+    sys.modules.setdefault("slack_bolt", slack_bolt)
+    sys.modules.setdefault("slack_bolt.async_app", MagicMock())
+    sys.modules.setdefault("slack_bolt.adapter", MagicMock())
+    sys.modules.setdefault("slack_bolt.adapter.socket_mode", MagicMock())
+    sys.modules.setdefault("slack_bolt.adapter.socket_mode.async_handler", MagicMock())
+
+
+_ensure_slack_mock()
+
+import gateway.platforms.slack as slack_mod  # noqa: E402
+from gateway.platforms.slack import SlackAdapter  # noqa: E402
+
+
+class TestSlackUnconfiguredNonRetryable:
+    """Verify that missing dependency/tokens sets a non-retryable fatal error."""
+
+    def test_no_slack_bolt_sets_non_retryable_fatal(self, monkeypatch):
+        """connect() with slack-bolt unavailable → non-retryable fatal error."""
+        adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-fake"))
+        monkeypatch.setattr(slack_mod, "SLACK_AVAILABLE", False)
+        result = asyncio.get_event_loop().run_until_complete(adapter.connect())
+        assert result is False
+        assert adapter.has_fatal_error is True
+        assert adapter.fatal_error_retryable is False
+        assert adapter.fatal_error_code == "missing_dependency"
+
+    def test_no_bot_token_sets_non_retryable_fatal(self, monkeypatch):
+        """connect() with empty SLACK_BOT_TOKEN → non-retryable fatal error."""
+        monkeypatch.setattr(slack_mod, "SLACK_AVAILABLE", True)
+        adapter = SlackAdapter(PlatformConfig(enabled=True, token=""))
+        monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+        result = asyncio.get_event_loop().run_until_complete(adapter.connect())
+        assert result is False
+        assert adapter.has_fatal_error is True
+        assert adapter.fatal_error_retryable is False
+        assert adapter.fatal_error_code == "missing_credentials"
+
+    def test_no_app_token_sets_non_retryable_fatal(self, monkeypatch):
+        """connect() with SLACK_BOT_TOKEN set but SLACK_APP_TOKEN missing
+        → non-retryable fatal error."""
+        monkeypatch.setattr(slack_mod, "SLACK_AVAILABLE", True)
+        adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-fake"))
+        monkeypatch.delenv("SLACK_APP_TOKEN", raising=False)
+        result = asyncio.get_event_loop().run_until_complete(adapter.connect())
+        assert result is False
+        assert adapter.has_fatal_error is True
+        assert adapter.fatal_error_retryable is False
+        assert adapter.fatal_error_code == "missing_credentials"

--- a/tests/gateway/test_telegram_connect.py
+++ b/tests/gateway/test_telegram_connect.py
@@ -1,0 +1,57 @@
+"""Tests for Telegram connect() non-retryable fatal error on missing credentials.
+
+When Telegram has no bot token or no python-telegram-bot installed, connect()
+must set a non-retryable fatal error so the gateway does not queue it for
+background reconnection (#31049).
+"""
+
+import asyncio
+import sys
+from unittest.mock import MagicMock
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    telegram_mod = MagicMock()
+    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    telegram_mod.constants.ChatType.GROUP = "group"
+    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
+    telegram_mod.constants.ChatType.CHANNEL = "channel"
+    telegram_mod.constants.ChatType.PRIVATE = "private"
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, telegram_mod)
+
+
+_ensure_telegram_mock()
+
+import gateway.platforms.telegram as telegram_mod  # noqa: E402
+from gateway.platforms.telegram import TelegramAdapter  # noqa: E402
+
+
+class TestTelegramUnconfiguredNonRetryable:
+    """Verify that missing dependency/token sets a non-retryable fatal error."""
+
+    def test_no_telegram_lib_sets_non_retryable_fatal(self, monkeypatch):
+        """connect() with python-telegram-bot unavailable → non-retryable fatal error."""
+        adapter = TelegramAdapter(PlatformConfig(enabled=True, token="fake"))
+        monkeypatch.setattr(telegram_mod, "TELEGRAM_AVAILABLE", False)
+        result = asyncio.get_event_loop().run_until_complete(adapter.connect())
+        assert result is False
+        assert adapter.has_fatal_error is True
+        assert adapter.fatal_error_retryable is False
+        assert adapter.fatal_error_code == "missing_dependency"
+
+    def test_no_bot_token_sets_non_retryable_fatal(self, monkeypatch):
+        """connect() with empty token → non-retryable fatal error."""
+        adapter = TelegramAdapter(PlatformConfig(enabled=True, token=""))
+        result = asyncio.get_event_loop().run_until_complete(adapter.connect())
+        assert result is False
+        assert adapter.has_fatal_error is True
+        assert adapter.fatal_error_retryable is False
+        assert adapter.fatal_error_code == "missing_credentials"


### PR DESCRIPTION
## Problem

When a platform plugin (e.g. `hermes-discord`) is listed in `config.yaml` but has no credentials configured (no bot token), the gateway enters an infinite reconnect loop instead of skipping the platform silently.

Closes #31049

## Root Cause

Platform adapters (Discord, Telegram, Slack) return `False` from `connect()` when credentials are missing, but don't call `_set_fatal_error(retryable=False)`. The gateway's startup code treats a bare `False` return (no fatal error set) as a transient failure and queues the platform for background reconnection with growing backoff — even though missing credentials will never self-resolve.

## Fix

Call `_set_fatal_error(retryable=False)` before returning `False` in credential/dependency checks. The gateway already handles non-retryable fatal errors correctly — it logs the error and skips reconnection.

Affected platforms:
- Discord: missing `discord.py` or bot token
- Telegram: missing `python-telegram-bot` or bot token
- Slack: missing `slack-bolt`, `SLACK_BOT_TOKEN`, or `SLACK_APP_TOKEN`

No behavioral change for platforms that have valid credentials or encounter transient network errors.

## Changes

- `plugins/platforms/discord/adapter.py` — `_set_fatal_error` before `return False` for missing dependency/token
- `gateway/platforms/telegram.py` — `_set_fatal_error` before `return False` for missing dependency/token
- `gateway/platforms/slack.py` — `_set_fatal_error` before `return False` for missing dependency/tokens

## How to Test

```bash
# New regression tests
python -m pytest tests/gateway/test_discord_connect.py -k "no_token or no_discord_lib" -v
python -m pytest tests/gateway/test_telegram_connect.py -v
python -m pytest tests/gateway/test_slack_connect.py -v
```