### PR TITLE
fix: clean Windows Hermes repair branch

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1056,6 +1056,7 @@ def run_conversation(
                 if agent.api_mode == "codex_responses":
                     api_kwargs = agent._get_transport().preflight_kwargs(api_kwargs, allow_stream=False)
 
+                _pre_results: list = []
                 try:
                     from hermes_cli.plugins import invoke_hook as _invoke_hook
                     request_messages = api_kwargs.get("messages")
@@ -1069,7 +1070,7 @@ def run_conversation(
                     # mutated by the agent loop, so a shallow copy is
                     # sufficient; a deepcopy would walk every tool result
                     # and base64 image on every API call.
-                    _invoke_hook(
+                    _pre_results = _invoke_hook(
                         "pre_api_request",
                         task_id=effective_task_id,
                         session_id=agent.session_id or "",
@@ -1091,11 +1092,30 @@ def run_conversation(
                 except Exception:
                     pass
 
+                # Allow plugins to override model/provider before the API call.
+                # Plugins inspect the request and return {"model": "...", "provider": "..."}.
+                # Only the first non-None override takes effect.
+                _model_overridden = False
+                for _result in _pre_results:
+                    if isinstance(_result, dict) and _result.get("model"):
+                        agent.model = _result["model"]
+                        if _result.get("provider"):
+                            agent.provider = _result["provider"]
+                        if _result.get("base_url"):
+                            agent.base_url = _result["base_url"]
+                        _model_overridden = True
+                        break
+                if _model_overridden:
+                    api_kwargs = agent._build_api_kwargs(api_messages)
+                    if agent._force_ascii_payload:
+                        _sanitize_structure_non_ascii(api_kwargs)
+                    if agent.api_mode == "codex_responses":
+                        api_kwargs = agent._get_transport().preflight_kwargs(api_kwargs, allow_stream=False)
+
                 if env_var_enabled("HERMES_DUMP_REQUESTS"):
                     agent._dump_api_request_debug(api_kwargs, reason="preflight")
 
-                # Always prefer the streaming path — even without stream
-                # consumers.  Streaming gives us fine-grained health
+                # Always prefer the streaming path
                 # checking (90s stale-stream detection, 60s read timeout)
                 # that the non-streaming path lacks.  Without this,
                 # subagents and other quiet-mode callers can hang

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -74,6 +74,84 @@ from utils import base_url_host_matches, env_var_enabled
 logger = logging.getLogger(__name__)
 
 
+def _apply_pre_api_route_override(agent: Any, override: dict[str, Any]) -> bool:
+    """Apply a pre_api_request model/provider override to full runtime state.
+
+    Hook routing must update more than ``agent.model``.  Provider/base URL
+    changes can alter credentials, api_mode, default headers, transport cache,
+    and the shared OpenAI/Anthropic client.  Reuse ``switch_model`` so the
+    next request is built and sent with a coherent runtime snapshot.
+    """
+    if not isinstance(override, dict) or not override.get("model"):
+        return False
+
+    new_model = str(override.get("model") or "").strip()
+    if not new_model:
+        return False
+    explicit_provider = str(override.get("provider") or "").strip()
+    requested_provider = explicit_provider or str(agent.provider or "").strip()
+    explicit_base_url = str(override.get("base_url") or "").strip() or None
+
+    runtime: dict[str, Any] = {}
+    if requested_provider or explicit_base_url:
+        try:
+            from hermes_cli.runtime_provider import resolve_runtime_provider
+            runtime = resolve_runtime_provider(
+                requested=requested_provider or None,
+                explicit_base_url=explicit_base_url,
+                target_model=new_model,
+            ) or {}
+        except Exception as exc:
+            logger.warning(
+                "pre_api_request route override runtime resolution failed; "
+                "falling back to current runtime for model-only overrides. "
+                "provider=%s base_url=%s model=%s error=%s",
+                requested_provider,
+                explicit_base_url,
+                new_model,
+                exc,
+            )
+            # If the hook explicitly changes provider or base_url, do not send
+            # the request with the previous provider's credentials/client.
+            # Model-only overrides can safely reuse the current runtime.
+            if explicit_provider or explicit_base_url:
+                return False
+
+    new_provider = str(runtime.get("provider") or requested_provider or agent.provider or "").strip()
+    if "base_url" in runtime:
+        new_base_url = str(runtime.get("base_url") or "").strip()
+    else:
+        new_base_url = str(explicit_base_url or agent.base_url or "").strip()
+    if "api_key" in runtime:
+        new_api_key = runtime.get("api_key") or ""
+    else:
+        new_api_key = getattr(agent, "api_key", "")
+    new_api_mode = str(runtime.get("api_mode") or getattr(agent, "api_mode", "") or "").strip()
+
+    # switch_model historically treats empty api_key/base_url as "keep the
+    # current value".  Route overrides need exact runtime semantics, including
+    # intentionally-empty keys for local/no-auth providers and intentionally
+    # empty base URLs for native SDK transports.  Pre-clear those fields so the
+    # helper cannot leak the previous provider's credentials or endpoint.
+    if "api_key" in runtime and not new_api_key:
+        agent.api_key = ""
+    if "base_url" in runtime and not new_base_url:
+        agent.base_url = ""
+
+    agent.switch_model(
+        new_model,
+        new_provider,
+        api_key=new_api_key,
+        base_url=new_base_url,
+        api_mode=new_api_mode,
+    )
+    try:
+        set_runtime_main(agent.provider or "", agent.model or "")
+    except Exception:
+        pass
+    return True
+
+
 def _ollama_context_limit_error(agent: Any, request_tokens: int) -> Optional[str]:
     """Return a user-facing error when Ollama is loaded with too little context."""
     if not getattr(agent, "tools", None):
@@ -1097,12 +1175,7 @@ def run_conversation(
                 # Only the first non-None override takes effect.
                 _model_overridden = False
                 for _result in _pre_results:
-                    if isinstance(_result, dict) and _result.get("model"):
-                        agent.model = _result["model"]
-                        if _result.get("provider"):
-                            agent.provider = _result["provider"]
-                        if _result.get("base_url"):
-                            agent.base_url = _result["base_url"]
+                    if _apply_pre_api_route_override(agent, _result):
                         _model_overridden = True
                         break
                 if _model_overridden:
@@ -4113,6 +4186,7 @@ def run_conversation(
         "messages": messages,
         "api_calls": api_call_count,
         "completed": completed,
+        "failed": failed,
         "turn_exit_reason": _turn_exit_reason,
         "failed": failed,
         "partial": False,  # True only when stopped due to invalid tool calls

--- a/agent/lsp/install.py
+++ b/agent/lsp/install.py
@@ -268,7 +268,14 @@ def _install_npm(
                         shutil.copy2(c, link)
                     except OSError:
                         return str(c)
-            return str(link if link.exists() else c)
+            # On Windows, returning the POSIX shell wrapper causes
+            # subprocess.Popen(..., shell=False) to raise WinError 193. Return
+            # the npm-generated .cmd shim when available; it is the native
+            # executable wrapper Windows can spawn directly.
+            if os.name == "nt" and c.suffix.lower() == ".cmd":
+                return str(link if link.exists() else c)
+            if os.name != "nt":
+                return str(link if link.exists() else c)
     logger.warning("[install] npm install for %s succeeded but bin %s not found", pkg, bin_name)
     return None
 

--- a/agent/lsp/servers.py
+++ b/agent/lsp/servers.py
@@ -226,6 +226,32 @@ def _root_or_workspace(file_path: str, workspace: str, markers: Sequence[str], e
 # ---------------------------------------------------------------------------
 
 
+def _windows_cmd_shim_for_npm_bin(bin_path: str) -> Optional[str]:
+    """Return a runnable .cmd shim for npm-installed shell wrappers on Windows.
+
+    ``npm install`` on Windows creates both POSIX shell wrappers and ``.cmd``
+    launchers under ``node_modules/.bin``.  Hermes may copy/symlink only the
+    POSIX wrapper into ``~/.hermes/lsp/bin``; spawning that file directly with
+    ``subprocess.Popen`` on Windows raises WinError 193.  Prefer the sibling
+    ``.cmd`` shim whenever the selected binary is a non-extension npm wrapper.
+    """
+    if os.name != "nt":
+        return None
+    root, ext = os.path.splitext(bin_path)
+    if ext.lower() in {".exe", ".cmd", ".bat", ".com"}:
+        return None
+    candidates = [root + ".cmd"]
+    if os.path.basename(os.path.dirname(bin_path)).lower() == "bin":
+        staging = os.path.dirname(os.path.dirname(bin_path))
+        candidates.append(
+            os.path.join(staging, "node_modules", ".bin", os.path.basename(bin_path) + ".cmd")
+        )
+    for candidate in candidates:
+        if os.path.exists(candidate):
+            return candidate
+    return None
+
+
 def _spawn_pyright(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     bin_path = _resolve_override(ctx, "pyright") or _which(
         "pyright-langserver", "pyright"
@@ -235,6 +261,9 @@ def _spawn_pyright(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
         bin_path = try_install("pyright", ctx.install_strategy)
         if bin_path is None:
             return None
+    cmd_shim = _windows_cmd_shim_for_npm_bin(bin_path)
+    if cmd_shim:
+        bin_path = cmd_shim
     # If we got the cli ``pyright``, the langserver is its sibling.
     base = os.path.basename(bin_path)
     if base in {"pyright", "pyright.exe"}:

--- a/agent/lsp/servers.py
+++ b/agent/lsp/servers.py
@@ -265,11 +265,12 @@ def _spawn_pyright(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     if cmd_shim:
         bin_path = cmd_shim
     # If we got the cli ``pyright``, the langserver is its sibling.
-    base = os.path.basename(bin_path)
-    if base in {"pyright", "pyright.exe"}:
+    base = os.path.basename(bin_path).lower()
+    if base in {"pyright", "pyright.exe", "pyright.cmd", "pyright.bat"}:
         sibling = os.path.join(os.path.dirname(bin_path), "pyright-langserver")
-        if os.path.exists(sibling):
-            bin_path = sibling
+        sibling_shim = _windows_cmd_shim_for_npm_bin(sibling) or sibling
+        if os.path.exists(sibling_shim):
+            bin_path = sibling_shim
     init: Dict[str, Any] = {}
     # Pick the project's venv interpreter if there is one — otherwise
     # pyright defaults to "python on PATH" which is rarely the venv.

--- a/cli.py
+++ b/cli.py
@@ -3071,7 +3071,10 @@ class HermesCLI:
         self.conversation_history: List[Dict[str, Any]] = []
         self.session_start = datetime.now()
         self._resumed = False
-        # Per-prompt elapsed timer — started at the beginning of each chat turn,
+        # Track whether user explicitly ran /_new (vs fresh CLI start) so
+        # auto-resume does not fire after /_new resets the session.
+        self._new_session_requested = False
+        # Per-prompt elapsed timer
         # frozen when the agent thread completes, displayed in the status bar.
         self._prompt_start_time: Optional[float] = None  # time.time() when turn started
         self._prompt_duration: float = 0.0  # frozen duration of last completed turn
@@ -5077,6 +5080,64 @@ class HermesCLI:
 
         return True
 
+    def _auto_resume_last_session(self):
+        """Silently pick up the most recent CLI session on fresh CLI start.
+
+        Called from run() when neither ``_resumed`` (manual --resume) nor
+        ``_new_session_requested`` (user ran /_new) is set.  Queries the
+        session DB for the newest 'cli' source session with messages, adopts
+        its session_id, loads its conversation history, and reactivates the
+        session so the new process continues it rather than creating a fork.
+        """
+        if self._session_db is None:
+            return
+        try:
+            results = self._session_db._conn.execute(
+                """
+                SELECT id, title, source, message_count
+                  FROM sessions
+                 WHERE source = 'cli'
+                   AND message_count > 0
+                   AND ended_at IS NOT NULL
+                 ORDER BY started_at DESC
+                 LIMIT 1
+                """,
+            ).fetchall()
+        except Exception:
+            return
+        if not results:
+            return
+        row = results[0]
+        prev_id, title, source, msg_count = row
+        # Adopt the old session_id so the new process continues it
+        self.session_id = prev_id
+        self._resumed = True
+        self._new_session_requested = True  # suppress double-fire if run() is called again
+        # Load history (mirrors _preload_resumed_session logic)
+        try:
+            restored = self._session_db.get_messages_as_conversation(prev_id)
+        except Exception:
+            restored = None
+        if restored:
+            restored = [m for m in restored if m.get("role") != "session_meta"]
+            self.conversation_history = restored
+        # Reactivate the session in the DB (clear ended_at/end_reason)
+        try:
+            self._session_db._conn.execute(
+                "UPDATE sessions SET ended_at = NULL, end_reason = NULL WHERE id = ?",
+                (prev_id,),
+            )
+            self._session_db._conn.commit()
+        except Exception:
+            pass
+        # Brief non-intrusive notice
+        title_part = f' "{title}"' if title else ''
+        accent = _accent_hex()
+        self._console_print(
+            f"[{accent}]↻ Resuming last session{title_part}: "
+            f"{msg_count} msgs · {prev_id}[/]"
+        )
+
     def _display_resumed_history(self):
         """Render a compact recap of previous conversation messages.
 
@@ -6282,6 +6343,7 @@ class HermesCLI:
         self.conversation_history = []
         self._pending_title = None
         self._resumed = False
+        self._new_session_requested = True  # suppress auto-resume for this session
 
         if self.agent:
             self.agent.session_id = self.session_id
@@ -12116,6 +12178,10 @@ class HermesCLI:
         if self._resumed:
             if self._preload_resumed_session():
                 self._display_resumed_history()
+        # Auto-resume: fresh CLI start (not /_new) → silently pick up where
+        # the previous session left off so context is never lost.
+        elif not self._new_session_requested:
+            self._auto_resume_last_session()
 
         try:
             from hermes_cli.skin_engine import get_active_skin

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1027,15 +1027,11 @@ def load_gateway_config() -> GatewayConfig:
                         group_allowed_chats = ",".join(str(v) for v in group_allowed_chats)
                     os.environ["TELEGRAM_GROUP_ALLOWED_CHATS"] = str(group_allowed_chats)
                 for _telegram_extra_key in ("guest_mode", "disable_link_previews", "observe_unmentioned_group_messages"):
+
                     if _telegram_extra_key in telegram_cfg:
-                        plat_data = platforms_data.setdefault(Platform.TELEGRAM.value, {})
-                        if not isinstance(plat_data, dict):
-                            plat_data = {}
-                            platforms_data[Platform.TELEGRAM.value] = plat_data
-                        extra = plat_data.setdefault("extra", {})
-                        if not isinstance(extra, dict):
-                            extra = {}
-                            plat_data["extra"] = extra
+                        _, extra = _ensure_platform_extra_dict(
+                            platforms_data, Platform.TELEGRAM.value
+                        )
                         extra[_telegram_extra_key] = telegram_cfg[_telegram_extra_key]
                 if _telegram_extra:
                     _plat_data, _plat_extra = _ensure_platform_extra_dict(
@@ -1829,16 +1825,47 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         discover_plugins()  # idempotent
         from gateway.platform_registry import platform_registry
         for entry in platform_registry.plugin_entries():
+            platform = Platform(entry.name)
+            pconfig = config.platforms.get(platform)
+            explicitly_enabled = bool(pconfig and pconfig.enabled)
+
             try:
-                if not entry.check_fn():
-                    continue
+                requirements_ok = bool(entry.check_fn())
             except Exception as e:
                 logger.debug("check_fn for %s raised: %s", entry.name, e)
                 continue
-            platform = Platform(entry.name)
+
+            plugin_configured = False
+            if pconfig is not None:
+                try:
+                    if entry.is_connected is not None:
+                        plugin_configured = bool(entry.is_connected(pconfig))
+                    elif entry.validate_config is not None:
+                        plugin_configured = bool(entry.validate_config(pconfig))
+                    else:
+                        plugin_configured = requirements_ok
+                except Exception as e:
+                    logger.debug("config check for %s raised: %s", entry.name, e)
+                    plugin_configured = False
+
+            # check_fn() only proves dependencies are importable (for some
+            # plugins that means a lazy-installed Python package), not that
+            # the platform has credentials.  Do not turn a top-level YAML
+            # tuning section such as ``discord.require_mention`` into an
+            # enabled gateway adapter unless either:
+            #   1. the plugin reports it is actually configured, or
+            #   2. the user explicitly enabled it in config.yaml.
+            if not requirements_ok or (not plugin_configured and not explicitly_enabled):
+                continue
+
             if platform not in config.platforms:
                 config.platforms[platform] = PlatformConfig()
-            config.platforms[platform].enabled = True
+
+            if plugin_configured:
+                config.platforms[platform].enabled = True
+            elif not explicitly_enabled:
+                continue
+
             # Seed extras from env if the plugin opted in.
             if entry.env_enablement_fn is not None:
                 try:

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -22,6 +22,19 @@ from utils import is_truthy_value
 logger = logging.getLogger(__name__)
 
 
+def _env_value(name: str, default: str = "") -> str:
+    """Read env with Hermes config fallback (.env / Windows registry)."""
+    value = os.getenv(name)
+    if value is not None and value != "":
+        return value
+    try:
+        from hermes_cli.config import get_env_value
+        value = get_env_value(name)
+    except Exception:
+        value = None
+    return value if value not in (None, "") else default
+
+
 def _coerce_bool(value: Any, default: bool = True) -> bool:
     """Coerce bool-ish config values, preserving a caller-provided default."""
     if value is None:
@@ -1571,8 +1584,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             )
 
     # Feishu / Lark
-    feishu_app_id = os.getenv("FEISHU_APP_ID")
-    feishu_app_secret = os.getenv("FEISHU_APP_SECRET")
+    feishu_app_id = _env_value("FEISHU_APP_ID")
+    feishu_app_secret = _env_value("FEISHU_APP_SECRET")
     if feishu_app_id and feishu_app_secret:
         if Platform.FEISHU not in config.platforms:
             config.platforms[Platform.FEISHU] = PlatformConfig()
@@ -1580,22 +1593,22 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         config.platforms[Platform.FEISHU].extra.update({
             "app_id": feishu_app_id,
             "app_secret": feishu_app_secret,
-            "domain": os.getenv("FEISHU_DOMAIN", "feishu"),
-            "connection_mode": os.getenv("FEISHU_CONNECTION_MODE", "websocket"),
+            "domain": _env_value("FEISHU_DOMAIN", "feishu"),
+            "connection_mode": _env_value("FEISHU_CONNECTION_MODE", "websocket"),
         })
-        feishu_encrypt_key = os.getenv("FEISHU_ENCRYPT_KEY", "")
+        feishu_encrypt_key = _env_value("FEISHU_ENCRYPT_KEY", "")
         if feishu_encrypt_key:
             config.platforms[Platform.FEISHU].extra["encrypt_key"] = feishu_encrypt_key
-        feishu_verification_token = os.getenv("FEISHU_VERIFICATION_TOKEN", "")
+        feishu_verification_token = _env_value("FEISHU_VERIFICATION_TOKEN", "")
         if feishu_verification_token:
             config.platforms[Platform.FEISHU].extra["verification_token"] = feishu_verification_token
-        feishu_home = os.getenv("FEISHU_HOME_CHANNEL")
+        feishu_home = _env_value("FEISHU_HOME_CHANNEL")
         if feishu_home:
             config.platforms[Platform.FEISHU].home_channel = HomeChannel(
                 platform=Platform.FEISHU,
                 chat_id=feishu_home,
-                name=os.getenv("FEISHU_HOME_CHANNEL_NAME", "Home"),
-                thread_id=os.getenv("FEISHU_HOME_CHANNEL_THREAD_ID") or None,
+                name=_env_value("FEISHU_HOME_CHANNEL_NAME", "Home"),
+                thread_id=_env_value("FEISHU_HOME_CHANNEL_THREAD_ID") or None,
             )
 
     # WeCom (Enterprise WeChat)

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -145,6 +145,19 @@ from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
+
+def _env_value(name: str, default: str = "") -> str:
+    """Read env with Hermes config fallback (.env / Windows registry)."""
+    value = os.getenv(name)
+    if value is not None and value != "":
+        return value
+    try:
+        from hermes_cli.config import get_env_value
+        value = get_env_value(name)
+    except Exception:
+        value = None
+    return value if value not in (None, "") else default
+
 # ---------------------------------------------------------------------------
 # Regex patterns
 # ---------------------------------------------------------------------------
@@ -1508,23 +1521,23 @@ class FeishuAdapter(BasePlatformAdapter):
             allow_bots = "none"
 
         return FeishuAdapterSettings(
-            app_id=str(extra.get("app_id") or os.getenv("FEISHU_APP_ID", "")).strip(),
-            app_secret=str(extra.get("app_secret") or os.getenv("FEISHU_APP_SECRET", "")).strip(),
-            domain_name=str(extra.get("domain") or os.getenv("FEISHU_DOMAIN", "feishu")).strip().lower(),
+            app_id=str(extra.get("app_id") or _env_value("FEISHU_APP_ID", "")).strip(),
+            app_secret=str(extra.get("app_secret") or _env_value("FEISHU_APP_SECRET", "")).strip(),
+            domain_name=str(extra.get("domain") or _env_value("FEISHU_DOMAIN", "feishu")).strip().lower(),
             connection_mode=str(
-                extra.get("connection_mode") or os.getenv("FEISHU_CONNECTION_MODE", "websocket")
+                extra.get("connection_mode") or _env_value("FEISHU_CONNECTION_MODE", "websocket")
             ).strip().lower(),
-            encrypt_key=os.getenv("FEISHU_ENCRYPT_KEY", "").strip(),
-            verification_token=os.getenv("FEISHU_VERIFICATION_TOKEN", "").strip(),
-            group_policy=os.getenv("FEISHU_GROUP_POLICY", "allowlist").strip().lower(),
+            encrypt_key=_env_value("FEISHU_ENCRYPT_KEY", "").strip(),
+            verification_token=_env_value("FEISHU_VERIFICATION_TOKEN", "").strip(),
+            group_policy=_env_value("FEISHU_GROUP_POLICY", "allowlist").strip().lower(),
             allowed_group_users=frozenset(
                 item.strip()
-                for item in os.getenv("FEISHU_ALLOWED_USERS", "").split(",")
+                for item in _env_value("FEISHU_ALLOWED_USERS", "").split(",")
                 if item.strip()
             ),
-            bot_open_id=os.getenv("FEISHU_BOT_OPEN_ID", "").strip(),
-            bot_user_id=os.getenv("FEISHU_BOT_USER_ID", "").strip(),
-            bot_name=os.getenv("FEISHU_BOT_NAME", "").strip(),
+            bot_open_id=_env_value("FEISHU_BOT_OPEN_ID", "").strip(),
+            bot_user_id=_env_value("FEISHU_BOT_USER_ID", "").strip(),
+            bot_name=_env_value("FEISHU_BOT_NAME", "").strip(),
             dedup_cache_size=max(
                 32,
                 int(os.getenv("HERMES_FEISHU_DEDUP_CACHE_SIZE", str(_DEFAULT_DEDUP_CACHE_SIZE))),
@@ -1565,7 +1578,7 @@ class FeishuAdapter(BasePlatformAdapter):
             group_rules=group_rules,
             allow_bots=allow_bots,
             require_mention=_to_boolean(
-                extra.get("require_mention", os.getenv("FEISHU_REQUIRE_MENTION", "true"))
+                extra.get("require_mention", _env_value("FEISHU_REQUIRE_MENTION", "true"))
             ),
         )
 

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -112,6 +112,8 @@ def _exec_schtasks(args: list[str]) -> tuple[int, str, str]:
             [schtasks, *args],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=_SCHTASKS_TIMEOUT_S,
             # CREATE_NO_WINDOW avoids a flashing console window when the CLI
             # is itself hosted in a TUI. See tools/browser_tool.py for the

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -517,6 +517,14 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             # Fall back to inline api_key when key_env is absent or unresolvable
             if not resolved_api_key:
                 resolved_api_key = str(entry.get("api_key", "") or "").strip()
+            # get_env_value also checks Hermes .env and Windows HKCU\Environment;
+            # os.getenv alone misses credentials loaded through Hermes config.
+            if not resolved_api_key and key_env:
+                try:
+                    from hermes_cli.config import get_env_value
+                    resolved_api_key = str(get_env_value(key_env) or "").strip()
+                except Exception:
+                    pass
 
             if requested_norm in {ep_name, name_norm, f"custom:{name_norm}"}:
                 # Found match by provider key

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -25,6 +25,8 @@ Session context:
 
 import logging
 import os
+import sys
+import time
 import threading
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
@@ -308,6 +310,7 @@ class _ManagedRotatingFileHandler(RotatingFileHandler):
     def __init__(self, *args, **kwargs):
         from hermes_cli.config import is_managed
         self._managed = is_managed()
+        self._rollover_suppressed_until = 0.0
         super().__init__(*args, **kwargs)
 
     def _chmod_if_managed(self):
@@ -323,7 +326,34 @@ class _ManagedRotatingFileHandler(RotatingFileHandler):
         return stream
 
     def doRollover(self):
-        super().doRollover()
+        now = time.time()
+        if os.name == "nt" and now < self._rollover_suppressed_until:
+            return
+        try:
+            super().doRollover()
+        except PermissionError:
+            # Windows refuses to rename a log file while another Hermes process
+            # still has it open (common with gateway + CLI/doctor sharing
+            # agent.log).  The stdlib handler writes a noisy "Logging error"
+            # traceback to stderr on every rollover attempt, which can drown out
+            # real diagnostics.  Degrade gracefully by reopening the current log
+            # in append mode and delaying the next rollover check; future
+            # short-lived commands can still log, and a later process can rotate
+            # once the file is no longer locked.
+            if os.name != "nt":
+                raise
+            if self.stream:
+                try:
+                    self.stream.close()
+                except OSError:
+                    pass
+                self.stream = None
+            self.stream = self._open()
+            self._rollover_suppressed_until = now + 3600
+            print(
+                f"Hermes logging: skipped locked log rollover for {self.baseFilename}",
+                file=sys.stderr,
+            )
         self._chmod_if_managed()
 
 

--- a/tests/agent/lsp/test_install_and_lint_fixes.py
+++ b/tests/agent/lsp/test_install_and_lint_fixes.py
@@ -275,5 +275,45 @@ def test_check_lint_returns_error_for_real_ts_type_errors(tmp_path):
     assert "TS2322" in lint.output
 
 
+# ---------------------------------------------------------------------------
+# Fix 4: Windows npm bins prefer .cmd shims, not POSIX shell wrappers
+# ---------------------------------------------------------------------------
+
+
+def test_windows_cmd_shim_for_npm_bin_prefers_sibling_cmd(tmp_path, monkeypatch):
+    """Windows cannot Popen npm's extensionless shell wrapper directly."""
+    from agent.lsp import servers
+
+    wrapper = tmp_path / "pyright-langserver"
+    wrapper.write_text("#!/bin/sh\n")
+    shim = tmp_path / "pyright-langserver.cmd"
+    shim.write_text("@echo off\n")
+
+    monkeypatch.setattr(servers.os, "name", "nt")
+
+    assert servers._windows_cmd_shim_for_npm_bin(str(wrapper)) == str(shim)
+
+
+def test_windows_cmd_shim_for_npm_bin_leaves_native_executables_alone(tmp_path, monkeypatch):
+    from agent.lsp import servers
+
+    exe = tmp_path / "pyright-langserver.exe"
+    exe.write_text("")
+    monkeypatch.setattr(servers.os, "name", "nt")
+
+    assert servers._windows_cmd_shim_for_npm_bin(str(exe)) is None
+
+
+def test_windows_cmd_shim_for_npm_bin_noop_on_posix(tmp_path, monkeypatch):
+    from agent.lsp import servers
+
+    wrapper = tmp_path / "pyright-langserver"
+    wrapper.write_text("#!/bin/sh\n")
+    (tmp_path / "pyright-langserver.cmd").write_text("@echo off\n")
+    monkeypatch.setattr(servers.os, "name", "posix")
+
+    assert servers._windows_cmd_shim_for_npm_bin(str(wrapper)) is None
+
+
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__, "-v"])

--- a/tests/agent/lsp/test_install_and_lint_fixes.py
+++ b/tests/agent/lsp/test_install_and_lint_fixes.py
@@ -315,5 +315,27 @@ def test_windows_cmd_shim_for_npm_bin_noop_on_posix(tmp_path, monkeypatch):
     assert servers._windows_cmd_shim_for_npm_bin(str(wrapper)) is None
 
 
+def test_spawn_pyright_cmd_uses_langserver_cmd_sibling(tmp_path, monkeypatch):
+    """If PATH resolves pyright.cmd, Windows must still spawn pyright-langserver.cmd."""
+    from agent.lsp import servers
+    from agent.lsp.servers import ServerContext
+
+    pyright_cmd = tmp_path / "pyright.cmd"
+    pyright_cmd.write_text("@echo off\n")
+    langserver_shell = tmp_path / "pyright-langserver"
+    langserver_shell.write_text("#!/bin/sh\n")
+    langserver_cmd = tmp_path / "pyright-langserver.cmd"
+    langserver_cmd.write_text("@echo off\n")
+
+    monkeypatch.setattr(servers.os, "name", "nt")
+    monkeypatch.setattr(servers, "_which", lambda *names: str(pyright_cmd))
+
+    spec = servers._spawn_pyright(str(tmp_path), ServerContext(workspace_root=str(tmp_path)))
+
+    assert spec is not None
+    assert spec.command[0] == str(langserver_cmd)
+    assert spec.command[1:] == ["--stdio"]
+
+
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__, "-v"])

--- a/tests/cli/test_cli_new_session.py
+++ b/tests/cli/test_cli_new_session.py
@@ -280,3 +280,41 @@ def test_new_session_with_duplicate_title_surfaces_error(capsys):
     captured = capsys.readouterr()
     assert "New session started: Dup" not in captured.out
     assert "New session started!" in captured.out
+
+
+
+def test_auto_resume_last_cli_session_adopts_previous_session(tmp_path):
+    cli = _make_cli()
+    cli._session_db = SessionDB(db_path=tmp_path / "state.db")
+    old_id = "20260523_120000_old"
+    cli._session_db.create_session(session_id=old_id, source="cli", model="gpt-5.5")
+    cli._session_db.append_message(old_id, role="user", content="continue this")
+    cli._session_db.end_session(old_id, end_reason="user_exit")
+    cli._console_print = MagicMock()
+
+    cli._auto_resume_last_session()
+
+    assert cli.session_id == old_id
+    assert cli._resumed is True
+    assert cli._new_session_requested is True
+    assert cli.conversation_history == [{"role": "user", "content": "continue this"}]
+    session = cli._session_db.get_session(old_id)
+    assert session["ended_at"] is None
+    assert session["end_reason"] is None
+
+
+def test_auto_resume_skips_empty_or_non_cli_sessions(tmp_path):
+    cli = _make_cli()
+    cli._session_db = SessionDB(db_path=tmp_path / "state.db")
+    original_id = cli.session_id
+    cli._session_db.create_session(session_id="empty_cli", source="cli", model="gpt-5.5")
+    cli._session_db.end_session("empty_cli", end_reason="user_exit")
+    cli._session_db.create_session(session_id="gateway_session", source="telegram", model="gpt-5.5")
+    cli._session_db.append_message("gateway_session", role="user", content="not cli")
+    cli._session_db.end_session("gateway_session", end_reason="user_exit")
+
+    cli._auto_resume_last_session()
+
+    assert cli.session_id == original_id
+    assert cli._resumed is False
+    assert cli.conversation_history == []

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -473,6 +473,54 @@ class TestLoadGatewayConfig:
             "C01ABC": "Code review mode",
         }
 
+    def test_plugin_tuning_section_without_credentials_does_not_enable_adapter(self, tmp_path, monkeypatch):
+        """A plugin's top-level YAML settings should not start its adapter
+        unless credentials/configuration are actually present.
+
+        Regression: discord.py being installed made the Discord plugin
+        check_fn() return True, so a harmless ``discord.require_mention``
+        config block enabled Discord without DISCORD_BOT_TOKEN and caused the
+        gateway to retry forever with "No bot token configured".
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "discord:\n"
+            "  require_mention: true\n"
+            "  free_response_channels: ''\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.DISCORD].enabled is False
+        assert Platform.DISCORD not in config.get_connected_platforms()
+
+    def test_explicitly_enabled_plugin_section_is_preserved_without_credentials(self, tmp_path, monkeypatch):
+        """If a user explicitly writes platforms.discord.enabled: true,
+        preserve that intent so startup can surface the adapter's own error.
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "platforms:\n"
+            "  discord:\n"
+            "    enabled: true\n"
+            "discord:\n"
+            "  require_mention: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.DISCORD].enabled is True
+
     def test_bridges_feishu_allow_bots_from_config_yaml_to_env(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -78,6 +78,58 @@ class TestConfigEnvOverrides(unittest.TestCase):
         self.assertIn(Platform.FEISHU, config.get_connected_platforms())
 
 
+class TestFeishuHermesEnvFallback(unittest.TestCase):
+    @patch.dict(os.environ, {"HOME": "C:/Users/Administrator", "HERMES_HOME": "C:/Users/Administrator/.hermes-test"}, clear=True)
+    def test_feishu_gateway_config_uses_get_env_value_fallback(self):
+        from gateway import config as gateway_config
+        from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+
+        values = {
+            "FEISHU_APP_ID": "cli_from_dotenv",
+            "FEISHU_APP_SECRET": "secret_from_dotenv",
+            "FEISHU_CONNECTION_MODE": "websocket",
+            "FEISHU_HOME_CHANNEL": "oc_from_dotenv",
+        }
+        with patch.object(gateway_config, "_env_value", side_effect=lambda name, default="": values.get(name, default)):
+            config = GatewayConfig()
+            _apply_env_overrides(config)
+
+        self.assertIn(Platform.FEISHU, config.platforms)
+        platform_config = config.platforms[Platform.FEISHU]
+        self.assertTrue(platform_config.enabled)
+        self.assertEqual(platform_config.extra["app_id"], "cli_from_dotenv")
+        self.assertEqual(platform_config.extra["app_secret"], "secret_from_dotenv")
+        self.assertEqual(platform_config.extra["connection_mode"], "websocket")
+        self.assertEqual(platform_config.home_channel.chat_id, "oc_from_dotenv")
+
+    @patch.dict(os.environ, {"HOME": "C:/Users/Administrator", "HERMES_HOME": "C:/Users/Administrator/.hermes-test"}, clear=True)
+    def test_feishu_adapter_settings_uses_get_env_value_fallback(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms import feishu as feishu_mod
+        from gateway.platforms.feishu import FeishuAdapter
+
+        values = {
+            "FEISHU_APP_ID": "cli_from_dotenv",
+            "FEISHU_APP_SECRET": "secret_from_dotenv",
+            "FEISHU_DOMAIN": "lark",
+            "FEISHU_CONNECTION_MODE": "webhook",
+            "FEISHU_ALLOWED_USERS": "ou_1, ou_2",
+            "FEISHU_BOT_OPEN_ID": "ou_bot",
+            "FEISHU_REQUIRE_MENTION": "false",
+        }
+        with patch.object(feishu_mod, "_env_value", side_effect=lambda name, default="": values.get(name, default)):
+            adapter = FeishuAdapter(PlatformConfig())
+            settings = adapter._settings
+
+        self.assertEqual(settings.app_id, "cli_from_dotenv")
+        self.assertEqual(settings.app_secret, "secret_from_dotenv")
+        self.assertEqual(settings.domain_name, "lark")
+        self.assertEqual(settings.connection_mode, "webhook")
+        self.assertEqual(settings.allowed_group_users, frozenset({"ou_1", "ou_2"}))
+        self.assertEqual(settings.bot_open_id, "ou_bot")
+        self.assertFalse(settings.require_mention)
+
+
 class TestFeishuMessageNormalization(unittest.TestCase):
     def test_normalize_merge_forward_preserves_summary_lines(self):
         from gateway.platforms.feishu import normalize_feishu_message

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -2701,3 +2701,31 @@ def test_host_derived_key_helper_basic_cases():
     for k in ("DEEPSEEK_API_KEY", "GROQ_API_KEY", "MISTRAL_API_KEY",
               "OPENAI_API_KEY", "OPENROUTER_API_KEY"):
         _os.environ.pop(k, None)
+
+def test_named_provider_key_env_uses_get_env_value_fallback(monkeypatch):
+    """New-style providers.* key_env can live in Hermes .env / Windows HKCU, not os.environ."""
+    monkeypatch.delenv("IEPOSE_API_KEY", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "iepose": {
+                    "name": "iepose",
+                    "base_url": "https://ai3456.iepose.cn/v1",
+                    "key_env": "IEPOSE_API_KEY",
+                    "default_model": "gpt-5.5",
+                    "api_mode": "chat_completions",
+                }
+            }
+        },
+    )
+    monkeypatch.setattr("hermes_cli.config.get_env_value", lambda name: "dotenv-token" if name == "IEPOSE_API_KEY" else "")
+
+    resolved = rp._get_named_custom_provider("iepose")
+
+    assert resolved is not None
+    assert resolved["api_key"] == "dotenv-token"
+    assert resolved["base_url"] == "https://ai3456.iepose.cn/v1"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["model"] == "gpt-5.5"

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2713,6 +2713,110 @@ class TestRunConversation:
         assert any(msg.get("role") == "user" and msg.get("content") == "search something" for msg in pre_request_calls[0]["request_messages"])
         assert all("usage" in c and "response" in c and "assistant_message" in c for c in post_request_calls)
 
+    def test_pre_api_request_model_override_switches_full_runtime(self, agent):
+        self._setup_agent(agent)
+        agent.model = "old-model"
+        agent.provider = "openrouter"
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent.api_key = "old-key"
+        agent.api_mode = "chat_completions"
+        agent._client_kwargs = {"api_key": "old-key", "base_url": agent.base_url}
+        response = _mock_response(content="Routed answer", finish_reason="stop")
+
+        api_calls = []
+
+        def _fake_api_call(api_kwargs):
+            api_calls.append(api_kwargs)
+            return response
+
+        def _fake_hook(name, **kwargs):
+            if name == "pre_api_request":
+                return [{
+                    "model": "new-model",
+                    "provider": "new-provider",
+                    "base_url": "https://new.example/v1",
+                }]
+            return []
+
+        with (
+            patch("hermes_cli.plugins.invoke_hook", side_effect=_fake_hook),
+            patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={
+                "provider": "new-provider",
+                "api_mode": "chat_completions",
+                "base_url": "https://new.example/v1",
+                "api_key": "new-key",
+                "source": "test",
+            }) as mock_resolve_runtime,
+            patch.object(agent, "_interruptible_api_call", side_effect=_fake_api_call),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_create_openai_client", return_value=MagicMock()),
+        ):
+            result = agent.run_conversation("route this")
+
+        assert result["final_response"] == "Routed answer"
+        mock_resolve_runtime.assert_called_once_with(
+            requested="new-provider",
+            explicit_base_url="https://new.example/v1",
+            target_model="new-model",
+        )
+        assert agent.model == "new-model"
+        assert agent.provider == "new-provider"
+        assert agent.base_url == "https://new.example/v1"
+        assert agent.api_key == "new-key"
+        assert agent.api_mode == "chat_completions"
+        assert agent._client_kwargs["api_key"] == "new-key"
+        assert agent._client_kwargs["base_url"] == "https://new.example/v1"
+        assert api_calls[0]["model"] == "new-model"
+
+    def test_pre_api_request_override_allows_empty_runtime_key_and_base_url(self, agent):
+        self._setup_agent(agent)
+        agent.model = "old-model"
+        agent.provider = "openrouter"
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent.api_key = "old-key"
+        agent.api_mode = "chat_completions"
+        agent._client_kwargs = {"api_key": "old-key", "base_url": agent.base_url}
+        response = _mock_response(content="Local answer", finish_reason="stop")
+
+        api_calls = []
+
+        def _fake_api_call(api_kwargs):
+            api_calls.append(api_kwargs)
+            return response
+
+        def _fake_hook(name, **kwargs):
+            if name == "pre_api_request":
+                return [{"model": "local-model", "provider": "local-noauth"}]
+            return []
+
+        with (
+            patch("hermes_cli.plugins.invoke_hook", side_effect=_fake_hook),
+            patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value={
+                "provider": "local-noauth",
+                "api_mode": "chat_completions",
+                "base_url": "",
+                "api_key": "",
+                "source": "test",
+            }),
+            patch.object(agent, "_interruptible_api_call", side_effect=_fake_api_call),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_create_openai_client", return_value=MagicMock()),
+        ):
+            result = agent.run_conversation("route local")
+
+        assert result["final_response"] == "Local answer"
+        assert agent.model == "local-model"
+        assert agent.provider == "local-noauth"
+        assert agent.base_url == ""
+        assert agent.api_key == ""
+        assert agent._client_kwargs["api_key"] == ""
+        assert agent._client_kwargs["base_url"] == ""
+        assert api_calls[0]["model"] == "local-model"
+
     def test_content_with_tool_calls_stays_silent_for_non_cli_quiet_mode(self, agent):
         self._setup_agent(agent)
         agent.platform = None

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -250,10 +250,6 @@ def _find_bash() -> str:
             if os.path.isfile(candidate):
                 return candidate
 
-    found = shutil.which("bash")
-    if found:
-        return found
-
     for candidate in (
         os.path.join(os.environ.get("ProgramFiles", r"C:\Program Files"), "Git", "bin", "bash.exe"),
         os.path.join(os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)"), "Git", "bin", "bash.exe"),
@@ -261,6 +257,10 @@ def _find_bash() -> str:
     ):
         if candidate and os.path.isfile(candidate):
             return candidate
+
+    found = shutil.which("bash")
+    if found:
+        return found
 
     raise RuntimeError(
         "Git Bash not found. Hermes Agent requires Git for Windows on Windows.\n"


### PR DESCRIPTION
## Summary
- Rebuilds the Windows Hermes repair work on top of current `origin/main` as a clean, linear branch.
- Keeps the focused fixes for Windows LSP npm shims, Feishu/env fallback, pre-api route override runtime switching, unconfigured gateway plugin suppression, CLI auto-resume, and Windows log rollover handling.
- Drops the noisy merge commit from the earlier local repair branch, reducing deletion-heavy scope drift.

## Why
The previous repair branch contained a merge commit that introduced large unrelated deletions in core files such as `cli.py`, `hermes_cli/gateway_windows.py`, and `hermes_cli/runtime_provider.py`. This branch recreates the intended fixes without that merge noise.

## Test Plan
- `python -m py_compile agent/conversation_loop.py agent/lsp/install.py agent/lsp/servers.py cli.py gateway/config.py gateway/platforms/feishu.py hermes_cli/gateway_windows.py hermes_cli/runtime_provider.py hermes_logging.py tools/environments/local.py`
- `python -m pytest tests/hermes_cli/test_gateway_windows.py::test_elevated_gateway_command_uses_pythonw_hidden_console tests/gateway/test_config.py tests/gateway/test_feishu.py::TestConfigEnvOverrides tests/agent/lsp/test_install_and_lint_fixes.py tests/run_agent/test_run_agent.py::TestRunConversation::test_pre_api_request_model_override_switches_full_runtime tests/run_agent/test_run_agent.py::TestRunConversation::test_pre_api_request_override_allows_empty_runtime_key_and_base_url -q -o addopts='' -n 0 --tb=short`
- Result: 72 passed, 2 third-party deprecation warnings.
- `git diff --check`
- Exact conflict-marker check for `^<<<<<<<` / `^>>>>>>>`

## Notes
Local git HTTPS push to GitHub was unreliable from this Windows host, so the fork branch was created with the GitHub REST Git Data API using equivalent commit contents. No force push was used.
