### PR TITLE
feat: adaptive titles and context refresh handoffs

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1519,10 +1519,10 @@ class HermesACPAgent(acp.Agent):
 
                 def _notify_title_update(_title: str) -> None:
                     if conn:
-                        loop.call_soon_threadsafe(
-                            asyncio.create_task,
-                            self._send_session_info_update(session_id),
-                        )
+                        def _schedule_session_info_update() -> None:
+                            asyncio.create_task(self._send_session_info_update(session_id))
+
+                        loop.call_soon_threadsafe(_schedule_session_info_update)
 
                 maybe_auto_title(
                     self.session_manager._get_db(),

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -450,6 +450,16 @@ def compress_context(
             f"accuracy may degrade. Consider /new to start fresh.",
             force=True,
         )
+        try:
+            from agent.session_handoff import maybe_prepare_context_refresh_handoff
+
+            maybe_prepare_context_refresh_handoff(
+                agent,
+                compressed,
+                reason=f"compression_count>={_cc}",
+            )
+        except Exception as _handoff_err:
+            logger.debug("context refresh handoff preparation failed: %s", _handoff_err)
 
     # Update token estimate after compaction so pressure calculations
     # use the post-compression count, not the stale pre-compression one.

--- a/agent/session_handoff.py
+++ b/agent/session_handoff.py
@@ -1,0 +1,231 @@
+"""Automatic context-refresh handoff helpers.
+
+This module writes a lightweight `/new` continuation handoff when a logical
+conversation has been compressed repeatedly. It is intentionally conservative:
+prepare a verified file and notify the caller; do not reset the session here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+_DEFAULT_CONTEXT_REFRESH_CONFIG: Dict[str, Any] = {
+    "enabled": True,
+    "handoff_after_compressions": 2,
+    "mode": "prepare_only",
+    "require_safe_turn_boundary": True,
+    "require_no_running_processes": True,
+    "write_session_handoff": True,
+    "write_project_handoff_when_detectable": True,
+    "include_sha256": True,
+    "max_handoff_lines": 250,
+    "handoff_base_dir": "",
+}
+
+
+@dataclass(frozen=True)
+class HandoffResult:
+    path: Path
+    session_id: str
+    line_count: int
+    byte_count: int
+    sha256: str
+    resume_prompt: str
+
+
+def _effective_config(agent: Any) -> Dict[str, Any]:
+    cfg = dict(_DEFAULT_CONTEXT_REFRESH_CONFIG)
+    try:
+        agent_cfg = getattr(agent, "context_refresh_config", None)
+        if agent_cfg is None:
+            from hermes_cli.config import load_config
+
+            agent_cfg = (load_config() or {}).get("context_refresh", {})
+        if isinstance(agent_cfg, dict):
+            cfg.update(agent_cfg)
+    except Exception:
+        pass
+    return cfg
+
+
+def _handoff_base_dir(cfg: Dict[str, Any]) -> Path:
+    configured = str(cfg.get("handoff_base_dir") or "").strip()
+    if configured:
+        return Path(configured).expanduser()
+    return Path.home() / "agent-artifacts"
+
+
+def _session_title(agent: Any, session_id: str) -> str:
+    try:
+        db = getattr(agent, "_session_db", None)
+        if db:
+            return db.get_session_title(session_id) or "untitled"
+    except Exception:
+        pass
+    return "untitled"
+
+
+def _message_excerpt(messages: list, max_messages: int = 8, max_chars: int = 3000) -> str:
+    parts: list[str] = []
+    for msg in (messages or [])[-max_messages:]:
+        role = msg.get("role") if isinstance(msg, dict) else None
+        if role not in {"user", "assistant"}:
+            continue
+        content = msg.get("content") or ""
+        if not isinstance(content, str):
+            content = str(content)
+        content = content.strip()
+        if content:
+            parts.append(f"- {role}: {content[:500]}")
+    excerpt = "\n".join(parts)
+    return excerpt[:max_chars] if excerpt else "- No compact excerpt available; rehydrate from session history."
+
+
+def _build_handoff_content(
+    *,
+    agent: Any,
+    messages: list,
+    session_id: str,
+    reason: str,
+    compression_count: int,
+    cfg: Dict[str, Any],
+) -> str:
+    title = _session_title(agent, session_id)
+    generated = time.strftime("%Y-%m-%d %H:%M:%S %z")
+    resume_prompt = _resume_prompt(session_id, _handoff_path(cfg, session_id))
+    excerpt = _message_excerpt(messages)
+    mode = cfg.get("mode", "prepare_only")
+
+    return f"""# Automatic Context Refresh Handoff
+
+Generated: {generated}
+Session ID: {session_id}
+Session title/topic: {title}
+Reason: {reason}
+Compression count: {compression_count}
+Mode: {mode}
+
+## Fresh /new Resume Prompt
+
+```text
+{resume_prompt}
+```
+
+## What This File Is
+
+This is an automatic prepare-only context refresh handoff created after repeated context compression. It preserves continuity for a fresh `/new` session. It does not prove that implementation, repo, GitHub, scheduler, runtime, publication, or audit state is complete.
+
+## Recent Conversation Excerpt
+
+{excerpt}
+
+## Current Known State
+
+- Local repo state: unverified; verify before action
+- GitHub push/publication state: unverified; verify before action
+- Tests/validators: unverified; verify before action
+- Runtime/scheduler/timer state: unverified; verify before action
+- External/live calls: unverified; verify before action
+- Finished-product status: unverified; verify before action
+
+## Next Valid Actions
+
+1. Start a fresh `/new` session if context drift is becoming a risk.
+2. Read this handoff first.
+3. Verify current source-of-truth state with tools before making claims or taking side effects.
+4. Continue from the user's latest explicit objective, not from stale compacted transcript requests.
+
+## What Not To Do Accidentally
+
+- Do not claim repo/GitHub/runtime/scheduler/publication/test status unless verified.
+- Do not treat this prepare-only handoff as proof the task is complete.
+- Do not auto-`/new` in the middle of a tool loop.
+- Do not overwrite manual session titles while resuming.
+"""
+
+
+def _handoff_path(cfg: Dict[str, Any], session_id: str) -> Path:
+    return _handoff_base_dir(cfg) / "session-handoffs" / session_id / "AFTER_SESSION_COMPRESSION_HANDOFF.md"
+
+
+def _resume_prompt(session_id: str, path: Path) -> str:
+    return f"Reference session {session_id}. Read {path} first, then continue from the Next Valid Actions section."
+
+
+def write_handoff_file(path: Path, content: str, session_id: str) -> HandoffResult:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    data = path.read_bytes()
+    line_count = content.count("\n") + (0 if content.endswith("\n") else 1)
+    return HandoffResult(
+        path=path,
+        session_id=session_id,
+        line_count=line_count,
+        byte_count=len(data),
+        sha256=hashlib.sha256(data).hexdigest(),
+        resume_prompt=_resume_prompt(session_id, path),
+    )
+
+
+def maybe_prepare_context_refresh_handoff(agent: Any, messages: list, reason: str) -> Optional[HandoffResult]:
+    """Prepare a session handoff when compression count reaches threshold.
+
+    Returns a HandoffResult when a new handoff is written, otherwise None.
+    """
+    cfg = _effective_config(agent)
+    if not cfg.get("enabled", True) or not cfg.get("write_session_handoff", True):
+        return None
+    if cfg.get("mode", "prepare_only") not in {"prepare_only", "auto_new"}:
+        return None
+
+    compressor = getattr(agent, "context_compressor", None)
+    compression_count = int(getattr(compressor, "compression_count", 0) or 0)
+    threshold = int(cfg.get("handoff_after_compressions") or 2)
+    if compression_count < threshold:
+        return None
+
+    prepared_for = int(getattr(agent, "_context_refresh_handoff_prepared_for_count", 0) or 0)
+    if prepared_for >= compression_count:
+        return None
+
+    session_id = getattr(agent, "session_id", None) or os.environ.get("HERMES_SESSION_ID") or "unknown-session"
+    path = _handoff_path(cfg, session_id)
+    content = _build_handoff_content(
+        agent=agent,
+        messages=messages,
+        session_id=session_id,
+        reason=reason,
+        compression_count=compression_count,
+        cfg=cfg,
+    )
+
+    result = write_handoff_file(path, content, session_id)
+    setattr(agent, "_context_refresh_handoff_prepared_for_count", compression_count)
+    setattr(
+        agent,
+        "_pending_context_refresh",
+        {
+            "handoff_path": str(result.path),
+            "session_id": session_id,
+            "reason": reason,
+            "compression_count": compression_count,
+            "sha256": result.sha256,
+            "mode": cfg.get("mode", "prepare_only"),
+        },
+    )
+
+    notify = getattr(agent, "_emit_warning", None)
+    if callable(notify):
+        notify(
+            "Context refresh handoff ready after "
+            f"{compression_count} compressions: {result.path} "
+            f"({result.line_count} lines, {result.byte_count} bytes, sha256 {result.sha256}). "
+            f"After /new: {result.resume_prompt}"
+        )
+    return result

--- a/agent/session_handoff.py
+++ b/agent/session_handoff.py
@@ -20,15 +20,15 @@ from typing import Any, Dict, Optional
 _DEFAULT_CONTEXT_REFRESH_CONFIG: Dict[str, Any] = {
     "enabled": True,
     "handoff_after_compressions": 2,
-    "mode": "auto_new",
+    "mode": "prepare_only",
     "auto_new_policy": "phase_boundary",
     "require_safe_turn_boundary": True,
     "require_no_running_processes": True,
     "write_session_handoff": True,
-    "write_project_handoff_when_detectable": True,
     "include_sha256": True,
     "max_handoff_lines": 250,
     "handoff_base_dir": "",
+    "auto_new_surfaces": ["cli", "gateway"],
 }
 
 
@@ -160,6 +160,31 @@ This is an automatic context refresh handoff created after repeated context comp
 """
 
 
+def _limit_handoff_lines(content: str, max_lines: int) -> str:
+    """Bound handoff length while preserving the action/safety sections."""
+    if max_lines <= 0:
+        return content
+    lines = content.splitlines()
+    if len(lines) <= max_lines:
+        return content
+
+    required_sections = ("## Next Valid Actions", "## What Not To Do Accidentally")
+    required_start = None
+    for idx, line in enumerate(lines):
+        if line in required_sections:
+            required_start = idx
+            break
+    if required_start is None:
+        return "\n".join(lines[:max_lines]) + "\n"
+
+    required = lines[required_start:]
+    head_budget = max_lines - len(required) - 1
+    if head_budget < 1:
+        return "\n".join(lines[:max_lines]) + "\n"
+    trimmed = lines[:head_budget] + ["..."] + required
+    return "\n".join(trimmed[:max_lines]) + "\n"
+
+
 def _handoff_path(cfg: Dict[str, Any], session_id: str) -> Path:
     return _handoff_base_dir(cfg) / "session-handoffs" / session_id / "AFTER_SESSION_COMPRESSION_HANDOFF.md"
 
@@ -250,6 +275,25 @@ def should_auto_new_after_context_refresh(
     mode = str(pending.get("mode") or cfg.get("mode") or "prepare_only")
     if mode != "auto_new":
         return ContextRefreshDecision(False, f"mode_is_{mode}", pending)
+
+    surface = str(
+        cfg.get("surface")
+        or getattr(agent, "context_refresh_surface", None)
+        or getattr(agent, "platform", None)
+        or "cli"
+    ).strip().lower()
+    supported = cfg.get("auto_new_surfaces", _DEFAULT_CONTEXT_REFRESH_CONFIG["auto_new_surfaces"])
+    if isinstance(supported, str):
+        supported_surfaces = {item.strip().lower() for item in supported.split(",") if item.strip()}
+    elif isinstance(supported, (list, tuple, set)):
+        supported_surfaces = {str(item).strip().lower() for item in supported if str(item).strip()}
+    else:
+        supported_surfaces = {"cli", "gateway"}
+    if surface and surface not in supported_surfaces:
+        return ContextRefreshDecision(False, f"unsupported_surface_{surface}", pending)
+
+    if cfg.get("require_safe_turn_boundary", True) and result is None:
+        return ContextRefreshDecision(False, "safe_turn_boundary_required", pending)
     if not _result_is_completed(result):
         return ContextRefreshDecision(False, "turn_not_completed", pending)
 
@@ -312,28 +356,29 @@ def maybe_prepare_context_refresh_handoff(agent: Any, messages: list, reason: st
         compression_count=compression_count,
         cfg=cfg,
     )
+    content = _limit_handoff_lines(content, int(cfg.get("max_handoff_lines") or 0))
 
     result = write_handoff_file(path, content, session_id)
+    include_sha256 = bool(cfg.get("include_sha256", True))
+    pending = {
+        "handoff_path": str(result.path),
+        "session_id": session_id,
+        "reason": reason,
+        "compression_count": compression_count,
+        "mode": cfg.get("mode", "prepare_only"),
+    }
+    if include_sha256:
+        pending["sha256"] = result.sha256
     setattr(agent, "_context_refresh_handoff_prepared_for_count", compression_count)
-    setattr(
-        agent,
-        "_pending_context_refresh",
-        {
-            "handoff_path": str(result.path),
-            "session_id": session_id,
-            "reason": reason,
-            "compression_count": compression_count,
-            "sha256": result.sha256,
-            "mode": cfg.get("mode", "prepare_only"),
-        },
-    )
+    setattr(agent, "_pending_context_refresh", pending)
 
     notify = getattr(agent, "_emit_warning", None)
     if callable(notify):
+        sha_part = f", sha256 {result.sha256}" if include_sha256 else ""
         notify(
             "Context refresh handoff ready after "
             f"{compression_count} compressions: {result.path} "
-            f"({result.line_count} lines, {result.byte_count} bytes, sha256 {result.sha256}). "
+            f"({result.line_count} lines, {result.byte_count} bytes{sha_part}). "
             f"After /new: {result.resume_prompt}"
         )
     return result

--- a/agent/session_handoff.py
+++ b/agent/session_handoff.py
@@ -1,14 +1,16 @@
 """Automatic context-refresh handoff helpers.
 
 This module writes a lightweight `/new` continuation handoff when a logical
-conversation has been compressed repeatedly. It is intentionally conservative:
-prepare a verified file and notify the caller; do not reset the session here.
+conversation has been compressed repeatedly. Reset/session-rotation is still
+owned by the CLI or gateway caller so it can happen only at a safe turn
+boundary, after the visible work for the current turn is complete.
 """
 
 from __future__ import annotations
 
 import hashlib
 import os
+import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -18,7 +20,8 @@ from typing import Any, Dict, Optional
 _DEFAULT_CONTEXT_REFRESH_CONFIG: Dict[str, Any] = {
     "enabled": True,
     "handoff_after_compressions": 2,
-    "mode": "prepare_only",
+    "mode": "auto_new",
+    "auto_new_policy": "phase_boundary",
     "require_safe_turn_boundary": True,
     "require_no_running_processes": True,
     "write_session_handoff": True,
@@ -37,6 +40,13 @@ class HandoffResult:
     byte_count: int
     sha256: str
     resume_prompt: str
+
+
+@dataclass(frozen=True)
+class ContextRefreshDecision:
+    should_auto_new: bool
+    reason: str
+    pending: Optional[Dict[str, Any]] = None
 
 
 def _effective_config(agent: Any) -> Dict[str, Any]:
@@ -119,7 +129,7 @@ Mode: {mode}
 
 ## What This File Is
 
-This is an automatic prepare-only context refresh handoff created after repeated context compression. It preserves continuity for a fresh `/new` session. It does not prove that implementation, repo, GitHub, scheduler, runtime, publication, or audit state is complete.
+This is an automatic context refresh handoff created after repeated context compression. It preserves continuity for a fresh `/new` session. In `auto_new` mode, Hermes may rotate automatically only after a safe completed phase boundary. It does not prove that implementation, repo, GitHub, scheduler, runtime, publication, or audit state is complete.
 
 ## Recent Conversation Excerpt
 
@@ -136,7 +146,7 @@ This is an automatic prepare-only context refresh handoff created after repeated
 
 ## Next Valid Actions
 
-1. Start a fresh `/new` session if context drift is becoming a risk.
+1. If this handoff was prepared in `auto_new` mode, allow automatic `/new` only after the current phase is complete and the next phase is about to begin.
 2. Read this handoff first.
 3. Verify current source-of-truth state with tools before making claims or taking side effects.
 4. Continue from the user's latest explicit objective, not from stale compacted transcript requests.
@@ -144,8 +154,8 @@ This is an automatic prepare-only context refresh handoff created after repeated
 ## What Not To Do Accidentally
 
 - Do not claim repo/GitHub/runtime/scheduler/publication/test status unless verified.
-- Do not treat this prepare-only handoff as proof the task is complete.
-- Do not auto-`/new` in the middle of a tool loop.
+- Do not treat this handoff as proof the task or phase is complete.
+- Do not auto-`/new` before a phase boundary or in the middle of a tool loop.
 - Do not overwrite manual session titles while resuming.
 """
 
@@ -156,6 +166,104 @@ def _handoff_path(cfg: Dict[str, Any], session_id: str) -> Path:
 
 def _resume_prompt(session_id: str, path: Path) -> str:
     return f"Reference session {session_id}. Read {path} first, then continue from the Next Valid Actions section."
+
+
+def build_context_refresh_resume_note(pending: Optional[Dict[str, Any]]) -> str:
+    """Build the one-shot note injected into the first turn of the new session."""
+    if not pending:
+        return ""
+    session_id = str(pending.get("session_id") or "")
+    handoff_path = str(pending.get("handoff_path") or "")
+    if not session_id or not handoff_path:
+        return ""
+    return (
+        "[Automatic context refresh: the previous session was safely rotated "
+        "after a completed phase. Before answering the user's new message, "
+        f"read {handoff_path} and use it to continue from session {session_id}.]"
+    )
+
+
+def _result_is_completed(result: Optional[Dict[str, Any]]) -> bool:
+    if result is None:
+        return True
+    if result.get("failed") or result.get("partial") or result.get("interrupted"):
+        return False
+    if result.get("completed") is False:
+        return False
+    return bool(result.get("final_response") or result.get("completed") is True)
+
+
+_PHASE_BOUNDARY_PATTERNS = (
+    re.compile(r"\bphase\s+(?:\d+|[a-z]+)\s+(?:is\s+)?(?:complete|completed|done|finished)\b", re.I),
+    re.compile(r"\b(?:complete|completed|done|finished)\s+(?:with\s+)?phase\s+(?:\d+|[a-z]+)\b", re.I),
+    re.compile(r"\bphase\s+(?:complete|completed|done|finished)\b", re.I),
+    re.compile(r"\bready\s+(?:to|for)\s+(?:begin|start|move\s+on\s+to|proceed\s+to)?\s*(?:the\s+)?next\s+phase\b", re.I),
+    re.compile(r"\bnext\s+phase\s+(?:can|will|should|is\s+ready\s+to)\b", re.I),
+)
+
+
+def _phase_boundary_detected(result: Optional[Dict[str, Any]]) -> bool:
+    if not result:
+        return False
+    if result.get("context_refresh_phase_boundary") is True or result.get("phase_complete") is True:
+        return True
+    text = result.get("final_response") or ""
+    if not isinstance(text, str):
+        text = str(text)
+    return any(pattern.search(text) for pattern in _PHASE_BOUNDARY_PATTERNS)
+
+
+def _has_running_background_processes(pending: Dict[str, Any], session_key: Optional[str]) -> bool:
+    try:
+        from tools.process_registry import process_registry
+
+        if session_key and process_registry.has_active_for_session(session_key):
+            return True
+        session_id = str(pending.get("session_id") or "")
+        if session_id and process_registry.has_active_processes(session_id):
+            return True
+    except Exception:
+        # Fail closed: if we cannot verify that no background process is tied to
+        # the old session, do not auto-reset it.
+        return True
+    return False
+
+
+def should_auto_new_after_context_refresh(
+    agent: Any,
+    result: Optional[Dict[str, Any]] = None,
+    *,
+    session_key: Optional[str] = None,
+) -> ContextRefreshDecision:
+    """Return whether a prepared context-refresh handoff should now rotate.
+
+    This is intentionally a *post-turn* decision helper. The compression hook
+    only prepares the handoff and sets ``agent._pending_context_refresh``; CLI
+    and gateway callers invoke this after the turn has completed and any queued
+    follow-up handling has drained.
+    """
+    pending = getattr(agent, "_pending_context_refresh", None)
+    if not isinstance(pending, dict):
+        return ContextRefreshDecision(False, "no_pending_context_refresh")
+
+    cfg = _effective_config(agent)
+    mode = str(pending.get("mode") or cfg.get("mode") or "prepare_only")
+    if mode != "auto_new":
+        return ContextRefreshDecision(False, f"mode_is_{mode}", pending)
+    if not _result_is_completed(result):
+        return ContextRefreshDecision(False, "turn_not_completed", pending)
+
+    policy = str(cfg.get("auto_new_policy") or "phase_boundary").strip().lower()
+    if policy in {"phase_boundary", "phase", "phase_complete"} and not _phase_boundary_detected(result):
+        return ContextRefreshDecision(False, "phase_boundary_not_detected", pending)
+    if policy in {"completed_turn", "turn_complete", "safe_turn_boundary"}:
+        boundary_reason = "safe_turn_boundary"
+    else:
+        boundary_reason = "phase_boundary"
+
+    if cfg.get("require_no_running_processes", True) and _has_running_background_processes(pending, session_key):
+        return ContextRefreshDecision(False, "running_background_processes", pending)
+    return ContextRefreshDecision(True, boundary_reason, pending)
 
 
 def write_handoff_file(path: Path, content: str, session_id: str) -> HandoffResult:

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -4,9 +4,11 @@ Runs asynchronously after the first response is delivered so it never
 adds latency to the user-facing reply.
 """
 
+import json
 import logging
 import threading
-from typing import Callable, Optional
+import time
+from typing import Any, Callable, Dict, Optional
 
 from agent.auxiliary_client import call_llm
 
@@ -25,13 +27,114 @@ _TITLE_PROMPT = (
     "Return ONLY the title text, nothing else. No quotes, no punctuation at the end, no prefixes."
 )
 
+_REFINE_TITLE_PROMPT = (
+    "Generate an improved short, descriptive title (3-7 words) for a conversation whose real "
+    "topic has become clearer after several turns. Prefer the actual current objective over the "
+    "initial vague request. Return ONLY the title text, nothing else. No quotes, no punctuation "
+    "at the end, no prefixes."
+)
+
+_TITLE_METADATA_KEY = "title_metadata"
+_AUTO_TITLE_SOURCES = {"auto_initial", "auto_refined"}
+_DEFAULT_TITLE_CONFIG = {
+    "enabled": True,
+    "initial_auto_title": True,
+    "adaptive_retitle": True,
+    "retitle_after_user_turns": 4,
+    "retitle_after_compression": True,
+    "retitle_auto_titles_only": True,
+    "lock_manual_titles": True,
+    "max_words": 7,
+}
+
+
+def _clean_title(title: str) -> Optional[str]:
+    """Normalize an LLM-produced title and enforce the legacy 80-char cap."""
+    title = (title or "").strip()
+    title = title.strip('"\'')
+    if title.lower().startswith("title:"):
+        title = title[6:].strip()
+    if len(title) > 80:
+        title = title[:77] + "..."
+    return title if title else None
+
+
+def _effective_title_config(title_config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Return merged session-title config without making config import mandatory."""
+    cfg = dict(_DEFAULT_TITLE_CONFIG)
+    if title_config is None:
+        try:
+            from hermes_cli.config import load_config
+
+            title_config = (load_config() or {}).get("session_titles", {})
+        except Exception:
+            title_config = {}
+    if isinstance(title_config, dict):
+        cfg.update(title_config)
+    return cfg
+
+
+def _conversation_excerpt(conversation_history: list, max_messages: int = 12, max_chars: int = 4000) -> str:
+    """Compact recent user/assistant context for adaptive retitling."""
+    parts = []
+    for msg in (conversation_history or [])[-max_messages:]:
+        role = msg.get("role")
+        if role not in {"user", "assistant"}:
+            continue
+        content = msg.get("content") or ""
+        if not isinstance(content, str):
+            content = str(content)
+        content = content.strip()
+        if not content:
+            continue
+        parts.append(f"{role.title()}: {content[:600]}")
+    excerpt = "\n\n".join(parts)
+    return excerpt[:max_chars]
+
+
+def _parse_model_config(raw: Any) -> Dict[str, Any]:
+    if isinstance(raw, dict):
+        return dict(raw)
+    if isinstance(raw, str) and raw.strip():
+        try:
+            parsed = json.loads(raw)
+            return parsed if isinstance(parsed, dict) else {}
+        except Exception:
+            return {}
+    return {}
+
+
+def _get_title_metadata(session_db, session_id: str) -> Dict[str, Any]:
+    try:
+        get_session = getattr(session_db, "get_session", None)
+        if get_session is None:
+            return {}
+        row = get_session(session_id)
+        if not row:
+            return {}
+        model_config = _parse_model_config(row.get("model_config"))
+        metadata = model_config.get(_TITLE_METADATA_KEY)
+        return dict(metadata) if isinstance(metadata, dict) else {}
+    except Exception:
+        return {}
+
+
+def _merge_title_metadata(session_db, session_id: str, metadata: Dict[str, Any]) -> None:
+    try:
+        merge = getattr(session_db, "merge_session_model_config", None)
+        if merge is None:
+            return
+        merge(session_id, {_TITLE_METADATA_KEY: metadata})
+    except Exception:
+        logger.debug("Failed to merge session title metadata", exc_info=True)
+
 
 def generate_title(
     user_message: str,
     assistant_response: str,
     timeout: float = 30.0,
     failure_callback: Optional[FailureCallback] = None,
-    main_runtime: dict = None,
+    main_runtime: Optional[dict] = None,
 ) -> Optional[str]:
     """Generate a session title from the first exchange.
 
@@ -62,15 +165,8 @@ def generate_title(
             timeout=timeout,
             main_runtime=main_runtime,
         )
-        title = (response.choices[0].message.content or "").strip()
-        # Clean up: remove quotes, trailing punctuation, prefixes like "Title: "
-        title = title.strip('"\'')
-        if title.lower().startswith("title:"):
-            title = title[6:].strip()
-        # Enforce reasonable length
-        if len(title) > 80:
-            title = title[:77] + "..."
-        return title if title else None
+        title = _clean_title(response.choices[0].message.content or "")
+        return title
     except Exception as e:
         # Log at WARNING so this shows up in agent.log without debug mode.
         # Full detail at debug level for operators who need the stack.
@@ -84,13 +180,54 @@ def generate_title(
         return None
 
 
+def generate_refined_title(
+    existing_title: str,
+    conversation_history: list,
+    timeout: float = 30.0,
+    failure_callback: Optional[FailureCallback] = None,
+    main_runtime: Optional[dict] = None,
+) -> Optional[str]:
+    """Generate a better title from later conversation context."""
+    excerpt = _conversation_excerpt(conversation_history)
+    if not excerpt:
+        return None
+
+    messages = [
+        {"role": "system", "content": _REFINE_TITLE_PROMPT},
+        {
+            "role": "user",
+            "content": f"Existing title: {existing_title or '(none)'}\n\nRecent conversation:\n{excerpt}",
+        },
+    ]
+
+    try:
+        response = call_llm(
+            task="title_generation",
+            messages=messages,
+            max_tokens=500,
+            temperature=0.3,
+            timeout=timeout,
+            main_runtime=main_runtime,
+        )
+        return _clean_title(response.choices[0].message.content or "")
+    except Exception as e:
+        logger.warning("Adaptive title refinement failed: %s", e)
+        logger.debug("Adaptive title refinement traceback", exc_info=True)
+        if failure_callback is not None:
+            try:
+                failure_callback("title refinement", e)
+            except Exception:
+                logger.debug("Title refinement failure_callback raised", exc_info=True)
+        return None
+
+
 def auto_title_session(
     session_db,
     session_id: str,
     user_message: str,
     assistant_response: str,
     failure_callback: Optional[FailureCallback] = None,
-    main_runtime: dict = None,
+    main_runtime: Optional[dict] = None,
     title_callback: Optional[TitleCallback] = None,
 ) -> None:
     """Generate and set a session title if one doesn't already exist.
@@ -120,6 +257,16 @@ def auto_title_session(
 
     try:
         session_db.set_session_title(session_id, title)
+        _merge_title_metadata(
+            session_db,
+            session_id,
+            {
+                "title_source": "auto_initial",
+                "title_locked": False,
+                "title_updated_at": time.time(),
+                "title_turn_count": 1,
+            },
+        )
         logger.debug("Auto-generated session title: %s", title)
         if title_callback is not None:
             try:
@@ -130,6 +277,123 @@ def auto_title_session(
         logger.debug("Failed to set auto-generated title: %s", e)
 
 
+def _refine_title_session_worker(
+    session_db,
+    session_id: str,
+    current_title: str,
+    conversation_history: list,
+    user_msg_count: int,
+    metadata: Dict[str, Any],
+    failure_callback: Optional[FailureCallback] = None,
+    main_runtime: Optional[dict] = None,
+    title_callback: Optional[TitleCallback] = None,
+) -> None:
+    title = generate_refined_title(
+        current_title,
+        conversation_history,
+        failure_callback=failure_callback,
+        main_runtime=main_runtime,
+    )
+    if not title or title == current_title:
+        return
+
+    try:
+        previous_title = current_title
+        session_db.set_session_title(session_id, title)
+        updated_metadata = dict(metadata)
+        updated_metadata.update(
+            {
+                "title_source": "auto_refined",
+                "title_locked": False,
+                "title_updated_at": time.time(),
+                "title_turn_count": user_msg_count,
+                "previous_title": previous_title,
+            }
+        )
+        _merge_title_metadata(session_db, session_id, updated_metadata)
+        logger.debug("Refined session title: %s", title)
+        if title_callback is not None:
+            try:
+                title_callback(title)
+            except Exception:
+                logger.debug("Adaptive title callback failed", exc_info=True)
+    except Exception as e:
+        logger.debug("Failed to set refined title: %s", e)
+
+
+def maybe_refine_title(
+    session_db,
+    session_id: str,
+    conversation_history: list,
+    failure_callback: Optional[FailureCallback] = None,
+    main_runtime: Optional[dict] = None,
+    title_callback: Optional[TitleCallback] = None,
+    title_config: Optional[Dict[str, Any]] = None,
+    run_in_background: bool = True,
+) -> None:
+    """Maybe re-evaluate an auto-generated title after the topic stabilizes.
+
+    The first implementation is intentionally conservative: it refines only
+    titles with auto provenance, never unknown/manual titles by default, and
+    only once after the configured user-turn threshold.
+    """
+    if not session_db or not session_id:
+        return
+
+    cfg = _effective_title_config(title_config)
+    if not cfg.get("enabled", True) or not cfg.get("adaptive_retitle", True):
+        return
+
+    user_msg_count = sum(1 for m in (conversation_history or []) if m.get("role") == "user")
+    threshold = int(cfg.get("retitle_after_user_turns") or 4)
+    if user_msg_count < threshold:
+        return
+
+    try:
+        current_title = session_db.get_session_title(session_id)
+    except Exception:
+        return
+    if not current_title:
+        return
+
+    metadata = _get_title_metadata(session_db, session_id)
+    if metadata.get("title_locked"):
+        return
+
+    source = metadata.get("title_source")
+    if cfg.get("retitle_auto_titles_only", True) and source not in _AUTO_TITLE_SOURCES:
+        return
+
+    if source == "auto_refined" and int(metadata.get("title_turn_count") or 0) >= threshold:
+        return
+
+    args = (
+        session_db,
+        session_id,
+        current_title,
+        conversation_history,
+        user_msg_count,
+        metadata,
+    )
+    kwargs = {
+        "failure_callback": failure_callback,
+        "main_runtime": main_runtime,
+        "title_callback": title_callback,
+    }
+    if not run_in_background:
+        _refine_title_session_worker(*args, **kwargs)
+        return
+
+    thread = threading.Thread(
+        target=_refine_title_session_worker,
+        args=args,
+        kwargs=kwargs,
+        daemon=True,
+        name="adaptive-title",
+    )
+    thread.start()
+
+
 def maybe_auto_title(
     session_db,
     session_id: str,
@@ -137,7 +401,7 @@ def maybe_auto_title(
     assistant_response: str,
     conversation_history: list,
     failure_callback: Optional[FailureCallback] = None,
-    main_runtime: dict = None,
+    main_runtime: Optional[dict] = None,
     title_callback: Optional[TitleCallback] = None,
 ) -> None:
     """Fire-and-forget title generation after the first exchange.
@@ -149,12 +413,27 @@ def maybe_auto_title(
     if not session_db or not session_id or not user_message or not assistant_response:
         return
 
+    cfg = _effective_title_config()
+    if not cfg.get("enabled", True):
+        return
+
     # Count user messages in history to detect first exchange.
     # conversation_history includes the exchange that just happened,
     # so for a first exchange we expect exactly 1 user message
     # (or 2 counting system). Be generous: generate on first 2 exchanges.
     user_msg_count = sum(1 for m in (conversation_history or []) if m.get("role") == "user")
     if user_msg_count > 2:
+        maybe_refine_title(
+            session_db,
+            session_id,
+            conversation_history,
+            failure_callback=failure_callback,
+            main_runtime=main_runtime,
+            title_callback=title_callback,
+            title_config=cfg,
+        )
+        return
+    if not cfg.get("initial_auto_title", True):
         return
 
     thread = threading.Thread(

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -129,6 +129,21 @@ def _merge_title_metadata(session_db, session_id: str, metadata: Dict[str, Any])
         logger.debug("Failed to merge session title metadata", exc_info=True)
 
 
+def mark_session_title_manual(session_db, session_id: str) -> None:
+    """Record that the current session title came from explicit user intent."""
+    if not session_db or not session_id:
+        return
+    metadata = _get_title_metadata(session_db, session_id)
+    metadata.update(
+        {
+            "title_source": "manual",
+            "title_locked": True,
+            "title_updated_at": time.time(),
+        }
+    )
+    _merge_title_metadata(session_db, session_id, metadata)
+
+
 def generate_title(
     user_message: str,
     assistant_response: str,

--- a/cli.py
+++ b/cli.py
@@ -6358,6 +6358,42 @@ class HermesCLI:
             else:
                 print("(^_^)v New session started!")
 
+    def _maybe_auto_new_after_context_refresh(
+        self,
+        result: Optional[dict],
+        *,
+        pending_message=None,
+        pending_steer=None,
+    ) -> bool:
+        """Rotate to a fresh session after a completed auto context-refresh turn."""
+        if pending_message or pending_steer or not self.agent:
+            return False
+        try:
+            from agent.session_handoff import (
+                build_context_refresh_resume_note,
+                should_auto_new_after_context_refresh,
+            )
+
+            decision = should_auto_new_after_context_refresh(self.agent, result)
+            if not decision.should_auto_new:
+                return False
+            pending = dict(decision.pending or {})
+            resume_note = build_context_refresh_resume_note(pending)
+            handoff_path = pending.get("handoff_path") or ""
+            old_session_id = self.session_id
+            self.new_session(silent=True)
+            if resume_note:
+                self._pending_context_refresh_note = resume_note
+            _cprint(
+                f"\n{_DIM}↻ Context refreshed automatically after a completed phase. "
+                f"Previous session: {old_session_id}. "
+                f"Handoff: {handoff_path}. The next turn will receive the handoff note.{_RST}"
+            )
+            return True
+        except Exception as exc:
+            logging.debug("auto context-refresh /new failed: %s", exc, exc_info=True)
+            return False
+
     def _handle_handoff_command(self, cmd_original: str) -> bool:
         """Handle ``/handoff <platform>`` — transfer this CLI session to a gateway platform.
 
@@ -11461,6 +11497,12 @@ class HermesCLI:
                 if _msn:
                     agent_message = _msn + "\n\n" + agent_message
                     self._pending_model_switch_note = None
+                # Prepend automatic context-refresh note so the first turn
+                # after an auto `/new` starts by reading the prepared handoff.
+                _crn = getattr(self, '_pending_context_refresh_note', None)
+                if _crn:
+                    agent_message = _crn + "\n\n" + agent_message
+                    self._pending_context_refresh_note = None
                 # Prepend pending /reload-skills note so the model sees which
                 # skills were added/removed before handling this turn. Same
                 # one-shot queue pattern as the model-switch note above.
@@ -11801,6 +11843,12 @@ class HermesCLI:
                 preview = _leftover_steer[:60] + ("..." if len(_leftover_steer) > 60 else "")
                 print(f"\n⏩ Delivering leftover /steer as next turn: '{preview}'")
                 self._pending_input.put(_leftover_steer)
+
+            self._maybe_auto_new_after_context_refresh(
+                result,
+                pending_message=pending_message,
+                pending_steer=_leftover_steer,
+            )
 
             return response
             

--- a/cli.py
+++ b/cli.py
@@ -4881,6 +4881,8 @@ class HermesCLI:
                     self.agent._ensure_db_session()
                     if self.agent._session_db_created:
                         self._session_db.set_session_title(self.session_id, self._pending_title)
+                        from agent.title_generator import mark_session_title_manual
+                        mark_session_title_manual(self._session_db, self.session_id)
                         _cprint(f"  Session title applied: {self._pending_title}")
                         self._pending_title = None
                     # else: row creation failed transiently — keep _pending_title for retry
@@ -6323,6 +6325,8 @@ class HermesCLI:
                     if sanitized:
                         try:
                             self._session_db.set_session_title(self.session_id, sanitized)
+                            from agent.title_generator import mark_session_title_manual
+                            mark_session_title_manual(self._session_db, self.session_id)
                             self._pending_title = None
                             title = sanitized
                         except ValueError as e:
@@ -8225,6 +8229,8 @@ class HermesCLI:
                             # Session exists in DB — set title directly
                             try:
                                 if self._session_db.set_session_title(self.session_id, new_title):
+                                    from agent.title_generator import mark_session_title_manual
+                                    mark_session_title_manual(self._session_db, self.session_id)
                                     _cprint(f"  Session title set: {new_title}")
                                 else:
                                     _cprint("  Session not found in database.")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8850,6 +8850,14 @@ class GatewayRunner:
             if self._should_send_voice_reply(event, response, agent_messages, already_sent=_already_sent):
                 await self._send_voice_reply(event, response)
 
+            response = await self._maybe_auto_new_after_context_refresh(
+                event,
+                agent_result,
+                response,
+                session_key,
+                session_entry,
+            )
+
             # If streaming already delivered the response, extract and
             # deliver any MEDIA: files before returning None.  Streaming
             # sends raw text chunks that include MEDIA: tags — the normal
@@ -9068,6 +9076,144 @@ class GatewayRunner:
             lines.append(f"◆ Endpoint: {base_url}")
 
         return "\n".join(lines)
+
+    async def _maybe_auto_new_after_context_refresh(
+        self,
+        event: MessageEvent,
+        agent_result: Dict[str, Any],
+        response: str,
+        session_key: str,
+        session_entry: Any,
+    ) -> str:
+        """Safely rotate a gateway session after completed work if requested."""
+        pending = agent_result.get("pending_context_refresh")
+        if not isinstance(pending, dict):
+            return response
+        try:
+            from types import SimpleNamespace
+            from agent.session_handoff import (
+                build_context_refresh_resume_note,
+                should_auto_new_after_context_refresh,
+            )
+
+            cfg = (_load_gateway_config() or {}).get("context_refresh", {})
+            probe_agent = SimpleNamespace(
+                _pending_context_refresh=pending,
+                context_refresh_config=cfg if isinstance(cfg, dict) else {},
+            )
+            decision = should_auto_new_after_context_refresh(
+                probe_agent,
+                agent_result,
+                session_key=session_key,
+            )
+            if not decision.should_auto_new:
+                logger.debug(
+                    "Context refresh auto-new skipped for %s: %s",
+                    session_key or "?",
+                    decision.reason,
+                )
+                return response
+
+            source = event.source
+            old_entry = self.session_store._entries.get(session_key)
+            old_session_id = str(
+                pending.get("session_id")
+                or getattr(old_entry, "session_id", None)
+                or getattr(session_entry, "session_id", "")
+            )
+
+            _cache_lock = getattr(self, "_agent_cache_lock", None)
+            if _cache_lock is not None:
+                with _cache_lock:
+                    cached = self._agent_cache.get(session_key)
+                    old_agent = cached[0] if isinstance(cached, tuple) else cached if cached else None
+                if old_agent is not None:
+                    self._cleanup_agent_resources(old_agent)
+            self._evict_cached_agent(session_key)
+
+            queued_events = getattr(self, "_queued_events", None)
+            if queued_events is not None:
+                queued_events.pop(session_key, None)
+
+            new_entry = self.session_store.reset_session(session_key)
+            if new_entry is None:
+                new_entry = self.session_store.get_or_create_session(source, force_new=True)
+
+            self._session_model_overrides.pop(session_key, None)
+            self._set_session_reasoning_override(session_key, None)
+            if hasattr(self, "_pending_model_notes"):
+                self._pending_model_notes.pop(session_key, None)
+            self._clear_session_boundary_security_state(session_key)
+
+            try:
+                from hermes_cli.plugins import invoke_hook as _invoke_hook
+                _invoke_hook(
+                    "on_session_finalize",
+                    session_id=old_session_id or None,
+                    platform=source.platform.value if source.platform else "",
+                )
+                _invoke_hook(
+                    "on_session_reset",
+                    session_id=getattr(new_entry, "session_id", None),
+                    platform=source.platform.value if source.platform else "",
+                )
+            except Exception:
+                pass
+
+            await self.hooks.emit("session:end", {
+                "platform": source.platform.value if source.platform else "",
+                "user_id": source.user_id,
+                "session_key": session_key,
+            })
+            await self.hooks.emit("session:reset", {
+                "platform": source.platform.value if source.platform else "",
+                "user_id": source.user_id,
+                "session_key": session_key,
+            })
+
+            if self._is_telegram_topic_lane(source) and new_entry is not None:
+                try:
+                    self._record_telegram_topic_binding(source, new_entry)
+                except Exception:
+                    logger.debug("Failed to rebind Telegram topic after auto context refresh", exc_info=True)
+
+            resume_note = build_context_refresh_resume_note(pending)
+            if resume_note:
+                notes = getattr(self, "_pending_context_refresh_notes", None)
+                if notes is None:
+                    notes = {}
+                    self._pending_context_refresh_notes = notes
+                notes[session_key] = resume_note
+
+            handoff_path = str(pending.get("handoff_path") or "")
+            notice = (
+                "↻ Context refreshed automatically after a completed phase. "
+                f"Previous session: `{old_session_id}`. "
+                f"Handoff: `{handoff_path}`. "
+                "Your next message will start fresh and receive the handoff note."
+            )
+            logger.info(
+                "Auto context refresh rotated session %s → %s using %s",
+                old_session_id,
+                getattr(new_entry, "session_id", ""),
+                handoff_path,
+            )
+            if agent_result.get("already_sent"):
+                adapter = self.adapters.get(source.platform)
+                if adapter:
+                    try:
+                        await adapter.send(
+                            source.chat_id,
+                            notice,
+                            metadata=self._thread_metadata_for_source(source, self._reply_anchor_for_event(event)),
+                        )
+                    except Exception:
+                        logger.debug("Auto context-refresh notice send failed", exc_info=True)
+                return response
+            return (response or "").rstrip() + "\n\n" + notice
+        except Exception:
+            logger.debug("Gateway auto context-refresh failed", exc_info=True)
+            return response
 
     async def _handle_reset_command(self, event: MessageEvent) -> Union[str, EphemeralReply]:
         """Handle /new or /reset command."""
@@ -16748,6 +16894,14 @@ class GatewayRunner:
                     + message
                 )
 
+            # Consume one-shot automatic context-refresh note generated by an
+            # auto `/new` after the previous completed turn.
+            _pending_cr_notes = getattr(self, "_pending_context_refresh_notes", None)
+            if _pending_cr_notes and session_key and session_key in _pending_cr_notes:
+                _crn = _pending_cr_notes.pop(session_key, None)
+                if _crn:
+                    message = _crn + "\n\n" + message
+
             # Consume one-shot /reload-skills note (if the user ran
             # /reload-skills since their last turn in this session). Same
             # queue pattern as CLI: prepend to the NEXT user message, then
@@ -16858,6 +17012,7 @@ class GatewayRunner:
                     "output_tokens": _output_toks,
                     "model": _resolved_model,
                     "context_length": _context_length,
+                    "pending_context_refresh": getattr(_agent, "_pending_context_refresh", None),
                 }
             
             # Scan tool results for MEDIA:<path> tags that need to be delivered
@@ -17019,6 +17174,7 @@ class GatewayRunner:
                 "model": _resolved_model,
                 "context_length": _context_length,
                 "session_id": effective_session_id,
+                "pending_context_refresh": getattr(agent, "_pending_context_refresh", None),
                 "response_previewed": result.get("response_previewed", False),
             }
         

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2507,7 +2507,8 @@ class GatewayRunner:
         """Total pending /queue items for a session — slot + overflow."""
         queued_events = getattr(self, "_queued_events", None) or {}
         depth = len(queued_events.get(session_key, []))
-        if adapter is not None and session_key in getattr(adapter, "_pending_messages", {}):
+        pending_messages = getattr(adapter, "_pending_messages", {}) if adapter is not None else {}
+        if isinstance(pending_messages, dict) and session_key in pending_messages:
             depth += 1
         return depth
 
@@ -9089,6 +9090,33 @@ class GatewayRunner:
         pending = agent_result.get("pending_context_refresh")
         if not isinstance(pending, dict):
             return response
+        adapter = self.adapters.get(event.source.platform) if getattr(event, "source", None) else None
+        if self._queue_depth(session_key, adapter=adapter) > 0:
+            logger.debug(
+                "Context refresh auto-new skipped for %s: queued_or_pending_events",
+                session_key or "?",
+            )
+            return response
+        queued_events = getattr(self, "_queued_events", None)
+        if queued_events and queued_events.get(session_key):
+            logger.debug(
+                "Context refresh auto-new skipped for %s: queued_events",
+                session_key or "?",
+            )
+            return response
+        goal_pending = getattr(self, "_goal_continuation_pending", None)
+        if goal_pending and session_key in goal_pending:
+            logger.debug(
+                "Context refresh auto-new skipped for %s: goal_continuation_pending",
+                session_key or "?",
+            )
+            return response
+        if self._goal_continuation_active_for_entry(session_entry):
+            logger.debug(
+                "Context refresh auto-new skipped for %s: goal_continuation_active",
+                session_key or "?",
+            )
+            return response
         try:
             from types import SimpleNamespace
             from agent.session_handoff import (
@@ -9099,7 +9127,10 @@ class GatewayRunner:
             cfg = (_load_gateway_config() or {}).get("context_refresh", {})
             probe_agent = SimpleNamespace(
                 _pending_context_refresh=pending,
-                context_refresh_config=cfg if isinstance(cfg, dict) else {},
+                context_refresh_config={
+                    **(cfg if isinstance(cfg, dict) else {}),
+                    "surface": "gateway",
+                },
             )
             decision = should_auto_new_after_context_refresh(
                 probe_agent,
@@ -9130,10 +9161,6 @@ class GatewayRunner:
                 if old_agent is not None:
                     self._cleanup_agent_resources(old_agent)
             self._evict_cached_agent(session_key)
-
-            queued_events = getattr(self, "_queued_events", None)
-            if queued_events is not None:
-                queued_events.pop(session_key, None)
 
             new_entry = self.session_store.reset_session(session_key)
             if new_entry is None:
@@ -9322,6 +9349,8 @@ class GatewayRunner:
             if sanitized:
                 try:
                     self._session_db.set_session_title(new_entry.session_id, sanitized)
+                    from agent.title_generator import mark_session_title_manual
+                    mark_session_title_manual(self._session_db, new_entry.session_id)
                     header = t("gateway.reset.header_titled", title=sanitized)
                 except ValueError as e:
                     _title_note = t("gateway.reset.title_error_untitled", error=str(e))
@@ -10901,6 +10930,24 @@ class GatewayRunner:
                 self._enqueue_fifo(_quick_key, cont_event, adapter)
         except Exception as exc:
             logger.debug("goal continuation: enqueue failed: %s", exc)
+
+    def _goal_continuation_active_for_entry(self, session_entry: Any) -> bool:
+        """Conservatively report whether a session has goal follow-up work."""
+        sid = getattr(session_entry, "session_id", None) or ""
+        if not sid:
+            return False
+        try:
+            from hermes_cli.goals import GoalManager
+        except Exception as exc:
+            logger.debug("goal continuation: goals module unavailable: %s", exc)
+            return False
+        try:
+            max_turns_fn = getattr(self, "_goal_max_turns_from_config", None)
+            max_turns = max_turns_fn() if callable(max_turns_fn) else None
+            return bool(GoalManager(session_id=sid, default_max_turns=max_turns).is_active())
+        except Exception as exc:
+            logger.debug("goal continuation active check failed: %s", exc)
+            return True
 
     async def _handle_undo_command(self, event: MessageEvent) -> str:
         """Handle /undo command - remove the last user/assistant exchange."""
@@ -12769,6 +12816,8 @@ class GatewayRunner:
             # Set the title
             try:
                 if self._session_db.set_session_title(session_id, sanitized):
+                    from agent.title_generator import mark_session_title_manual
+                    mark_session_title_manual(self._session_db, session_id)
                     return t("gateway.title.set_to", title=sanitized)
                 else:
                     return t("gateway.title.not_found")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -519,15 +519,15 @@ DEFAULT_CONFIG = {
     "context_refresh": {
         "enabled": True,
         "handoff_after_compressions": 2,
-        "mode": "auto_new",
+        "mode": "prepare_only",
         "auto_new_policy": "phase_boundary",
         "require_safe_turn_boundary": True,
         "require_no_running_processes": True,
         "write_session_handoff": True,
-        "write_project_handoff_when_detectable": True,
         "include_sha256": True,
         "max_handoff_lines": 250,
         "handoff_base_dir": "",
+        "auto_new_surfaces": ["cli", "gateway"],
     },
     "agent": {
         "max_turns": 90,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -516,6 +516,18 @@ DEFAULT_CONFIG = {
         "lock_manual_titles": True,
         "max_words": 7,
     },
+    "context_refresh": {
+        "enabled": True,
+        "handoff_after_compressions": 2,
+        "mode": "prepare_only",
+        "require_safe_turn_boundary": True,
+        "require_no_running_processes": True,
+        "write_session_handoff": True,
+        "write_project_handoff_when_detectable": True,
+        "include_sha256": True,
+        "max_handoff_lines": 250,
+        "handoff_base_dir": "",
+    },
     "agent": {
         "max_turns": 90,
         # Inactivity timeout for gateway agent execution (seconds).

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -519,7 +519,8 @@ DEFAULT_CONFIG = {
     "context_refresh": {
         "enabled": True,
         "handoff_after_compressions": 2,
-        "mode": "prepare_only",
+        "mode": "auto_new",
+        "auto_new_policy": "phase_boundary",
         "require_safe_turn_boundary": True,
         "require_no_running_processes": True,
         "write_session_handoff": True,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -506,6 +506,16 @@ DEFAULT_CONFIG = {
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
+    "session_titles": {
+        "enabled": True,
+        "initial_auto_title": True,
+        "adaptive_retitle": True,
+        "retitle_after_user_turns": 4,
+        "retitle_after_compression": True,
+        "retitle_auto_titles_only": True,
+        "lock_manual_titles": True,
+        "max_words": 7,
+    },
     "agent": {
         "max_turns": 90,
         # Inactivity timeout for gateway agent execution (seconds).

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -953,6 +953,40 @@ class SessionDB:
             row = cursor.fetchone()
         return dict(row) if row else None
 
+    def merge_session_model_config(self, session_id: str, patch: Dict[str, Any]) -> bool:
+        """Merge a JSON-object patch into a session's model_config sidecar.
+
+        Used for lightweight per-session metadata that does not justify a
+        schema migration. Returns True when the session exists and was updated.
+        """
+        if not isinstance(patch, dict):
+            raise ValueError("model_config patch must be a dict")
+
+        def _do(conn):
+            row = conn.execute(
+                "SELECT model_config FROM sessions WHERE id = ?", (session_id,)
+            ).fetchone()
+            if row is None:
+                return 0
+            current: Dict[str, Any] = {}
+            raw = row["model_config"] if isinstance(row, sqlite3.Row) else row[0]
+            if raw:
+                try:
+                    parsed = json.loads(raw)
+                    if isinstance(parsed, dict):
+                        current = parsed
+                except Exception:
+                    current = {}
+            current.update(patch)
+            cursor = conn.execute(
+                "UPDATE sessions SET model_config = ? WHERE id = ?",
+                (json.dumps(current), session_id),
+            )
+            return cursor.rowcount
+
+        rowcount = self._execute_write(_do)
+        return bool(rowcount)
+
     def resolve_session_id(self, session_id_or_prefix: str) -> Optional[str]:
         """Resolve an exact or uniquely prefixed session ID to the full ID.
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -559,6 +559,12 @@ class AIAgent:
         # Turn counter (added after reset_session_state was first written — #2635)
         self._user_turn_count = 0
 
+        # Context-refresh handoff state is session-scoped. If `/new` (manual or
+        # automatic) rotates the session, the freshly-started session should not
+        # inherit the old session's pending refresh marker.
+        self._pending_context_refresh = None
+        self._context_refresh_handoff_prepared_for_count = 0
+
         # Context engine reset (works for both built-in compressor and plugins)
         if hasattr(self, "context_compressor") and self.context_compressor:
             self.context_compressor.on_session_reset()

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1230,6 +1230,64 @@ class TestPrompt:
         assert callable(mock_title.call_args.kwargs["title_callback"])
 
     @pytest.mark.asyncio
+    async def test_title_callback_defers_session_info_coroutine_until_scheduled(self, agent, monkeypatch):
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        resp = await agent.new_session(cwd="/tmp")
+        state = agent.session_manager.get_session(resp.session_id)
+        state.agent.run_conversation = MagicMock(return_value={
+            "final_response": "Done.",
+            "messages": [
+                {"role": "user", "content": "fix zed titles"},
+                {"role": "assistant", "content": "Done."},
+            ],
+        })
+
+        loop = asyncio.get_running_loop()
+        scheduled = []
+
+        with patch("agent.title_generator.maybe_auto_title") as mock_title:
+            await agent.prompt(
+                session_id=resp.session_id,
+                prompt=[TextContentBlock(type="text", text="fix zed titles")],
+            )
+
+        def fake_call_soon_threadsafe(callback, *args):
+            # Current broken behavior creates the coroutine before scheduling it.
+            # Close any such coroutine so this RED test fails on the explicit
+            # assertion below instead of leaking a RuntimeWarning.
+            if args and hasattr(args[0], "close"):
+                args[0].close()
+            scheduled.append((callback, args))
+
+        monkeypatch.setattr(loop, "call_soon_threadsafe", fake_call_soon_threadsafe)
+
+        created = []
+
+        async def noop_send(_session_id):
+            return None
+
+        def fake_send_session_info_update(session_id):
+            created.append(session_id)
+            return noop_send(session_id)
+
+        monkeypatch.setattr(agent, "_send_session_info_update", fake_send_session_info_update)
+        callback = mock_title.call_args.kwargs["title_callback"]
+
+        callback("Fix Zed titles")
+
+        assert created == []
+        assert len(scheduled) == 1
+        scheduled_callback, scheduled_args = scheduled[0]
+        assert scheduled_args == ()
+
+        scheduled_callback()
+        await asyncio.sleep(0)
+        assert created == [resp.session_id]
+
+    @pytest.mark.asyncio
     async def test_prompt_sends_session_info_update_after_auto_title(self, agent):
         mock_conn = MagicMock(spec=acp.Client)
         mock_conn.session_update = AsyncMock()

--- a/tests/agent/test_session_handoff.py
+++ b/tests/agent/test_session_handoff.py
@@ -1,0 +1,77 @@
+"""Tests for automatic context-refresh handoff generation."""
+
+from types import SimpleNamespace
+
+from agent.session_handoff import maybe_prepare_context_refresh_handoff
+
+
+class FakeSessionDB:
+    def get_session_title(self, session_id):
+        return "Hermes Adaptive Titles"
+
+
+def make_agent(tmp_path, compression_count=2):
+    return SimpleNamespace(
+        session_id="sess-123",
+        _session_db=FakeSessionDB(),
+        context_compressor=SimpleNamespace(compression_count=compression_count),
+        context_refresh_config={
+            "enabled": True,
+            "handoff_after_compressions": 2,
+            "mode": "prepare_only",
+            "write_session_handoff": True,
+            "include_sha256": True,
+            "max_handoff_lines": 250,
+            "handoff_base_dir": str(tmp_path),
+        },
+        warnings=[],
+        _emit_warning=lambda msg: None,
+    )
+
+
+def test_prepares_handoff_at_configured_compression_threshold(tmp_path):
+    agent = make_agent(tmp_path, compression_count=2)
+    messages = [
+        {"role": "user", "content": "Implement adaptive session titles"},
+        {"role": "assistant", "content": "Implemented Phase 1"},
+    ]
+
+    result = maybe_prepare_context_refresh_handoff(agent, messages, reason="compression_count>=2")
+
+    assert result is not None
+    assert result.session_id == "sess-123"
+    assert result.path.exists()
+    assert result.path.name == "AFTER_SESSION_COMPRESSION_HANDOFF.md"
+    assert result.sha256
+    assert result.line_count > 0
+    assert "Reference session sess-123" in result.resume_prompt
+
+    content = result.path.read_text(encoding="utf-8")
+    assert "# Automatic Context Refresh Handoff" in content
+    assert "Session ID: sess-123" in content
+    assert "Reason: compression_count>=2" in content
+    assert "Hermes Adaptive Titles" in content
+    assert "Next Valid Actions" in content
+    assert "unverified; verify before action" in content
+
+    assert agent._pending_context_refresh["handoff_path"] == str(result.path)
+    assert agent._context_refresh_handoff_prepared_for_count == 2
+
+
+def test_skips_before_compression_threshold(tmp_path):
+    agent = make_agent(tmp_path, compression_count=1)
+
+    result = maybe_prepare_context_refresh_handoff(agent, [], reason="compression_count>=2")
+
+    assert result is None
+    assert not hasattr(agent, "_pending_context_refresh")
+
+
+def test_does_not_spam_duplicate_handoff_for_same_compression_count(tmp_path):
+    agent = make_agent(tmp_path, compression_count=2)
+
+    first = maybe_prepare_context_refresh_handoff(agent, [], reason="compression_count>=2")
+    second = maybe_prepare_context_refresh_handoff(agent, [], reason="compression_count>=2")
+
+    assert first is not None
+    assert second is None

--- a/tests/agent/test_session_handoff.py
+++ b/tests/agent/test_session_handoff.py
@@ -2,7 +2,11 @@
 
 from types import SimpleNamespace
 
-from agent.session_handoff import maybe_prepare_context_refresh_handoff
+from agent.session_handoff import (
+    build_context_refresh_resume_note,
+    maybe_prepare_context_refresh_handoff,
+    should_auto_new_after_context_refresh,
+)
 
 
 class FakeSessionDB:
@@ -10,7 +14,7 @@ class FakeSessionDB:
         return "Hermes Adaptive Titles"
 
 
-def make_agent(tmp_path, compression_count=2):
+def make_agent(tmp_path, compression_count=2, mode="prepare_only"):
     return SimpleNamespace(
         session_id="sess-123",
         _session_db=FakeSessionDB(),
@@ -18,11 +22,13 @@ def make_agent(tmp_path, compression_count=2):
         context_refresh_config={
             "enabled": True,
             "handoff_after_compressions": 2,
-            "mode": "prepare_only",
+            "mode": mode,
+            "auto_new_policy": "phase_boundary",
             "write_session_handoff": True,
             "include_sha256": True,
             "max_handoff_lines": 250,
             "handoff_base_dir": str(tmp_path),
+            "require_no_running_processes": False,
         },
         warnings=[],
         _emit_warning=lambda msg: None,
@@ -75,3 +81,56 @@ def test_does_not_spam_duplicate_handoff_for_same_compression_count(tmp_path):
 
     assert first is not None
     assert second is None
+
+
+def test_auto_new_decision_waits_for_completed_phase_boundary(tmp_path):
+    agent = make_agent(tmp_path, compression_count=2, mode="auto_new")
+    maybe_prepare_context_refresh_handoff(agent, [], reason="compression_count>=2")
+
+    interrupted = should_auto_new_after_context_refresh(
+        agent,
+        {"final_response": "stopping", "completed": False, "interrupted": True},
+    )
+    ordinary_completion = should_auto_new_after_context_refresh(
+        agent,
+        {"final_response": "done", "completed": True},
+    )
+    phase_complete = should_auto_new_after_context_refresh(
+        agent,
+        {
+            "final_response": "Phase 2 is complete. Next phase will begin with validation.",
+            "completed": True,
+        },
+    )
+
+    assert interrupted.should_auto_new is False
+    assert interrupted.reason == "turn_not_completed"
+    assert ordinary_completion.should_auto_new is False
+    assert ordinary_completion.reason == "phase_boundary_not_detected"
+    assert phase_complete.should_auto_new is True
+    assert phase_complete.reason == "phase_boundary"
+
+
+def test_prepare_only_mode_does_not_auto_new(tmp_path):
+    agent = make_agent(tmp_path, compression_count=2, mode="prepare_only")
+    maybe_prepare_context_refresh_handoff(agent, [], reason="compression_count>=2")
+
+    decision = should_auto_new_after_context_refresh(
+        agent,
+        {"final_response": "done", "completed": True},
+    )
+
+    assert decision.should_auto_new is False
+    assert decision.reason == "mode_is_prepare_only"
+
+
+def test_build_resume_note_for_new_session(tmp_path):
+    agent = make_agent(tmp_path, compression_count=2, mode="auto_new")
+    handoff = maybe_prepare_context_refresh_handoff(agent, [], reason="compression_count>=2")
+
+    note = build_context_refresh_resume_note(agent._pending_context_refresh)
+
+    assert handoff is not None
+    assert "Automatic context refresh" in note
+    assert "sess-123" in note
+    assert str(handoff.path) in note

--- a/tests/agent/test_session_handoff.py
+++ b/tests/agent/test_session_handoff.py
@@ -3,6 +3,7 @@
 from types import SimpleNamespace
 
 from agent.session_handoff import (
+    _DEFAULT_CONTEXT_REFRESH_CONFIG,
     build_context_refresh_resume_note,
     maybe_prepare_context_refresh_handoff,
     should_auto_new_after_context_refresh,
@@ -122,6 +123,117 @@ def test_prepare_only_mode_does_not_auto_new(tmp_path):
 
     assert decision.should_auto_new is False
     assert decision.reason == "mode_is_prepare_only"
+
+
+def test_default_context_refresh_mode_is_prepare_only(tmp_path):
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert _DEFAULT_CONTEXT_REFRESH_CONFIG["mode"] == "prepare_only"
+    assert DEFAULT_CONFIG["context_refresh"]["mode"] == "prepare_only"
+    agent = make_agent(tmp_path, compression_count=2, mode="auto_new")
+    agent.context_refresh_config.pop("mode")
+    maybe_prepare_context_refresh_handoff(agent, [], reason="compression_count>=2")
+
+    decision = should_auto_new_after_context_refresh(
+        agent,
+        {
+            "final_response": "Phase 2 is complete. Next phase will begin with validation.",
+            "completed": True,
+        },
+    )
+
+    assert agent._pending_context_refresh["mode"] == "prepare_only"
+    assert decision.should_auto_new is False
+    assert decision.reason == "mode_is_prepare_only"
+
+
+def test_auto_new_is_gated_to_supported_surfaces(tmp_path):
+    agent = make_agent(tmp_path, compression_count=2, mode="auto_new")
+    agent.platform = "tui"
+    maybe_prepare_context_refresh_handoff(agent, [], reason="compression_count>=2")
+
+    decision = should_auto_new_after_context_refresh(
+        agent,
+        {
+            "final_response": "Phase 2 is complete. Next phase will begin with validation.",
+            "completed": True,
+        },
+    )
+
+    assert decision.should_auto_new is False
+    assert decision.reason == "unsupported_surface_tui"
+
+    agent.platform = "acp"
+    decision = should_auto_new_after_context_refresh(
+        agent,
+        {
+            "final_response": "Phase 2 is complete. Next phase will begin with validation.",
+            "completed": True,
+        },
+    )
+    assert decision.should_auto_new is False
+    assert decision.reason == "unsupported_surface_acp"
+
+
+def test_safe_turn_boundary_config_is_consulted(tmp_path):
+    agent = make_agent(tmp_path, compression_count=2, mode="auto_new")
+    agent.context_refresh_config["require_safe_turn_boundary"] = True
+    maybe_prepare_context_refresh_handoff(agent, [], reason="compression_count>=2")
+
+    decision = should_auto_new_after_context_refresh(agent, None)
+
+    assert decision.should_auto_new is False
+    assert decision.reason == "safe_turn_boundary_required"
+
+    agent = make_agent(tmp_path / "unsafe-opt-out", compression_count=2, mode="auto_new")
+    agent.context_refresh_config["require_safe_turn_boundary"] = False
+    agent.context_refresh_config["auto_new_policy"] = "completed_turn"
+    maybe_prepare_context_refresh_handoff(agent, [], reason="compression_count>=2")
+
+    decision = should_auto_new_after_context_refresh(agent, None)
+
+    assert decision.should_auto_new is True
+    assert decision.reason == "safe_turn_boundary"
+
+
+def test_include_sha256_false_suppresses_pending_metadata_and_warning(tmp_path):
+    warnings = []
+    agent = make_agent(tmp_path, compression_count=2, mode="prepare_only")
+    agent.context_refresh_config["include_sha256"] = False
+    agent.warnings = warnings
+    agent._emit_warning = warnings.append
+
+    result = maybe_prepare_context_refresh_handoff(agent, [], reason="compression_count>=2")
+
+    assert result is not None
+    assert result.sha256
+    assert "sha256" not in agent._pending_context_refresh
+    assert warnings
+    assert result.sha256 not in warnings[0]
+
+
+def test_max_handoff_lines_bounds_written_file(tmp_path):
+    agent = make_agent(tmp_path, compression_count=2, mode="prepare_only")
+    agent.context_refresh_config["max_handoff_lines"] = 20
+    messages = [
+        {"role": "user", "content": f"message {idx}"}
+        for idx in range(40)
+    ]
+
+    result = maybe_prepare_context_refresh_handoff(agent, messages, reason="compression_count>=2")
+
+    assert result is not None
+    content = result.path.read_text(encoding="utf-8")
+    assert result.line_count <= 20
+    assert "## Next Valid Actions" in content
+    assert "## What Not To Do Accidentally" in content
+
+
+def test_project_handoff_knob_is_not_declared_until_supported():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert "write_project_handoff_when_detectable" not in _DEFAULT_CONTEXT_REFRESH_CONFIG
+    assert "write_project_handoff_when_detectable" not in DEFAULT_CONFIG["context_refresh"]
 
 
 def test_build_resume_note_for_new_session(tmp_path):

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -9,6 +9,7 @@ from agent.title_generator import (
     generate_title,
     generate_refined_title,
     auto_title_session,
+    mark_session_title_manual,
     maybe_auto_title,
     maybe_refine_title,
 )
@@ -238,6 +239,38 @@ class TestMaybeRefineTitle:
 
         gen.assert_not_called()
         assert db.set_titles == []
+
+    def test_manual_rename_after_auto_title_locks_against_refinement(self):
+        db = FakeTitleDB(
+            title="Initial Auto Title",
+            model_config={
+                "title_metadata": {
+                    "title_source": "auto_initial",
+                    "title_locked": False,
+                    "title_turn_count": 1,
+                }
+            },
+        )
+        db.set_session_title("sess-1", "User Manual Title")
+        mark_session_title_manual(db, "sess-1")
+
+        cfg = {
+            "enabled": True,
+            "adaptive_retitle": True,
+            "retitle_after_user_turns": 4,
+            "retitle_auto_titles_only": True,
+            "lock_manual_titles": True,
+        }
+        with patch("agent.title_generator.generate_refined_title") as gen:
+            maybe_refine_title(db, "sess-1", self._history(4), title_config=cfg, run_in_background=False)
+
+        gen.assert_not_called()
+        assert db.title == "User Manual Title"
+        metadata = db.model_config["title_metadata"]
+        assert metadata["title_source"] == "manual"
+        assert metadata["title_locked"] is True
+        assert metadata["title_turn_count"] == 1
+        assert "title_updated_at" in metadata
 
 
 class TestAutoTitleSession:

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -7,8 +7,10 @@ import pytest
 
 from agent.title_generator import (
     generate_title,
+    generate_refined_title,
     auto_title_session,
     maybe_auto_title,
+    maybe_refine_title,
 )
 
 
@@ -112,6 +114,130 @@ class TestGenerateTitle:
         # The user content in the messages should be truncated
         user_content = captured_kwargs["messages"][1]["content"]
         assert len(user_content) < 1100  # 500 + 500 + formatting
+
+
+class FakeTitleDB:
+    """Tiny session DB double for title provenance tests."""
+
+    def __init__(self, title=None, model_config=None):
+        self.title = title
+        self.model_config = model_config or {}
+        self.set_titles = []
+        self.merged_model_configs = []
+
+    def get_session_title(self, session_id):
+        return self.title
+
+    def set_session_title(self, session_id, title):
+        self.title = title
+        self.set_titles.append((session_id, title))
+        return True
+
+    def get_session(self, session_id):
+        return {"id": session_id, "title": self.title, "model_config": self.model_config}
+
+    def merge_session_model_config(self, session_id, patch):
+        self.model_config.update(patch)
+        self.merged_model_configs.append((session_id, patch))
+        return True
+
+
+class TestGenerateRefinedTitle:
+    """Unit tests for generating later, topic-aligned titles."""
+
+    def test_uses_conversation_context_and_existing_title(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Hermes Adaptive Session Titles"
+
+        history = [
+            {"role": "user", "content": "initial vague request"},
+            {"role": "assistant", "content": "sure"},
+            {"role": "user", "content": "now implement adaptive title refinement"},
+        ]
+
+        captured = {}
+
+        def mock_call_llm(**kwargs):
+            captured.update(kwargs)
+            return mock_response
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            title = generate_refined_title("Initial Help", history)
+
+        assert title == "Hermes Adaptive Session Titles"
+        user_content = captured["messages"][1]["content"]
+        assert "Existing title: Initial Help" in user_content
+        assert "adaptive title refinement" in user_content
+
+
+class TestMaybeRefineTitle:
+    """Tests for adaptive retitling policy and provenance guards."""
+
+    def _history(self, user_turns=4):
+        history = []
+        for i in range(user_turns):
+            history.append({"role": "user", "content": f"user topic turn {i}"})
+            history.append({"role": "assistant", "content": f"assistant answer {i}"})
+        return history
+
+    def test_refines_auto_title_after_configured_user_turns(self):
+        db = FakeTitleDB(
+            title="Initial Setup Help",
+            model_config={"title_metadata": {"title_source": "auto_initial", "title_turn_count": 1}},
+        )
+        cfg = {
+            "enabled": True,
+            "adaptive_retitle": True,
+            "retitle_after_user_turns": 4,
+            "retitle_auto_titles_only": True,
+            "lock_manual_titles": True,
+        }
+
+        with patch("agent.title_generator.generate_refined_title", return_value="Hermes Adaptive Titles"):
+            maybe_refine_title(db, "sess-1", self._history(4), title_config=cfg, run_in_background=False)
+
+        assert db.set_titles == [("sess-1", "Hermes Adaptive Titles")]
+        metadata = db.model_config["title_metadata"]
+        assert metadata["title_source"] == "auto_refined"
+        assert metadata["title_turn_count"] == 4
+        assert metadata["previous_title"] == "Initial Setup Help"
+
+    def test_does_not_overwrite_manual_or_unknown_title_by_default(self):
+        db = FakeTitleDB(title="User Chosen Title", model_config={})
+        cfg = {
+            "enabled": True,
+            "adaptive_retitle": True,
+            "retitle_after_user_turns": 4,
+            "retitle_auto_titles_only": True,
+            "lock_manual_titles": True,
+        }
+
+        with patch("agent.title_generator.generate_refined_title") as gen:
+            maybe_refine_title(db, "sess-1", self._history(4), title_config=cfg, run_in_background=False)
+
+        gen.assert_not_called()
+        assert db.set_titles == []
+        assert db.title == "User Chosen Title"
+
+    def test_does_not_refine_more_than_once_without_explicit_opt_in(self):
+        db = FakeTitleDB(
+            title="Already Refined Title",
+            model_config={"title_metadata": {"title_source": "auto_refined", "title_turn_count": 4}},
+        )
+        cfg = {
+            "enabled": True,
+            "adaptive_retitle": True,
+            "retitle_after_user_turns": 4,
+            "retitle_auto_titles_only": True,
+            "lock_manual_titles": True,
+        }
+
+        with patch("agent.title_generator.generate_refined_title") as gen:
+            maybe_refine_title(db, "sess-1", self._history(6), title_config=cfg, run_in_background=False)
+
+        gen.assert_not_called()
+        assert db.set_titles == []
 
 
 class TestAutoTitleSession:

--- a/tests/gateway/test_session_model_reset.py
+++ b/tests/gateway/test_session_model_reset.py
@@ -173,6 +173,142 @@ async def test_auto_context_refresh_skips_interrupted_turn(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_auto_context_refresh_skips_when_queue_has_events(monkeypatch):
+    from gateway.run import GatewayRunner
+
+    runner = _make_runner()
+    runner._evict_cached_agent = MagicMock()
+    runner._set_session_reasoning_override = MagicMock()
+    runner._clear_session_boundary_security_state = MagicMock()
+    runner._is_telegram_topic_lane = MagicMock(return_value=False)
+    session_key = build_session_key(_make_source())
+    queued = [_make_event("queued user message")]
+    runner._queued_events = {session_key: list(queued)}
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {
+            "context_refresh": {
+                "mode": "auto_new",
+                "auto_new_policy": "phase_boundary",
+                "require_no_running_processes": False,
+            }
+        },
+    )
+
+    response = await GatewayRunner._maybe_auto_new_after_context_refresh(
+        runner,
+        _make_event("hello"),
+        {
+            "final_response": "Phase 1 is complete. Next phase will begin with validation.",
+            "completed": True,
+            "pending_context_refresh": {
+                "mode": "auto_new",
+                "session_id": "sess-1",
+                "handoff_path": "/tmp/handoff.md",
+            },
+        },
+        "done",
+        session_key,
+        runner.session_store._entries[session_key],
+    )
+
+    runner.session_store.reset_session.assert_not_called()
+    assert runner._queued_events[session_key] == queued
+    assert response == "done"
+
+
+@pytest.mark.asyncio
+async def test_auto_context_refresh_skips_when_pending_slot_has_event(monkeypatch):
+    from gateway.run import GatewayRunner
+
+    runner = _make_runner()
+    runner._evict_cached_agent = MagicMock()
+    runner._set_session_reasoning_override = MagicMock()
+    runner._clear_session_boundary_security_state = MagicMock()
+    runner._is_telegram_topic_lane = MagicMock(return_value=False)
+    session_key = build_session_key(_make_source())
+    adapter = runner.adapters[Platform.TELEGRAM]
+    pending_event = _make_event("pending follow-up")
+    adapter._pending_messages = {session_key: pending_event}
+    runner._queued_events = {}
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {
+            "context_refresh": {
+                "mode": "auto_new",
+                "auto_new_policy": "phase_boundary",
+                "require_no_running_processes": False,
+            }
+        },
+    )
+
+    response = await GatewayRunner._maybe_auto_new_after_context_refresh(
+        runner,
+        _make_event("hello"),
+        {
+            "final_response": "Phase 1 is complete. Next phase will begin with validation.",
+            "completed": True,
+            "pending_context_refresh": {
+                "mode": "auto_new",
+                "session_id": "sess-1",
+                "handoff_path": "/tmp/handoff.md",
+            },
+        },
+        "done",
+        session_key,
+        runner.session_store._entries[session_key],
+    )
+
+    runner.session_store.reset_session.assert_not_called()
+    assert adapter._pending_messages[session_key] is pending_event
+    assert response == "done"
+
+
+@pytest.mark.asyncio
+async def test_auto_context_refresh_skips_when_goal_continuation_pending(monkeypatch):
+    from gateway.run import GatewayRunner
+
+    runner = _make_runner()
+    runner._evict_cached_agent = MagicMock()
+    runner._set_session_reasoning_override = MagicMock()
+    runner._clear_session_boundary_security_state = MagicMock()
+    runner._is_telegram_topic_lane = MagicMock(return_value=False)
+    runner._queued_events = {}
+    runner._goal_continuation_pending = {build_session_key(_make_source())}
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {
+            "context_refresh": {
+                "mode": "auto_new",
+                "auto_new_policy": "phase_boundary",
+                "require_no_running_processes": False,
+            }
+        },
+    )
+
+    session_key = build_session_key(_make_source())
+    response = await GatewayRunner._maybe_auto_new_after_context_refresh(
+        runner,
+        _make_event("hello"),
+        {
+            "final_response": "Phase 1 is complete. Next phase will begin with validation.",
+            "completed": True,
+            "pending_context_refresh": {
+                "mode": "auto_new",
+                "session_id": "sess-1",
+                "handoff_path": "/tmp/handoff.md",
+            },
+        },
+        "done",
+        session_key,
+        runner.session_store._entries[session_key],
+    )
+
+    runner.session_store.reset_session.assert_not_called()
+    assert response == "done"
+
+
+@pytest.mark.asyncio
 async def test_new_command_clears_session_model_override():
     """/new must remove the session-scoped model override for that session."""
     runner = _make_runner()

--- a/tests/gateway/test_session_model_reset.py
+++ b/tests/gateway/test_session_model_reset.py
@@ -67,6 +67,112 @@ def _make_runner():
 
 
 @pytest.mark.asyncio
+async def test_auto_context_refresh_rotates_after_completed_work(monkeypatch):
+    """Auto context refresh should run only after a completed agent turn."""
+    from gateway.run import GatewayRunner
+
+    runner = _make_runner()
+    runner._evict_cached_agent = MagicMock()
+    runner._cleanup_agent_resources = MagicMock()
+    runner._set_session_reasoning_override = MagicMock()
+    runner._clear_session_boundary_security_state = MagicMock()
+    runner._is_telegram_topic_lane = MagicMock(return_value=False)
+    runner._thread_metadata_for_source = MagicMock(return_value=None)
+    runner._reply_anchor_for_event = MagicMock(return_value="m1")
+    runner._queued_events = {}
+
+    session_key = build_session_key(_make_source())
+    old_entry = runner.session_store._entries[session_key]
+    new_entry = SessionEntry(
+        session_key=session_key,
+        session_id="sess-2",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner.session_store.reset_session.return_value = new_entry
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {
+            "context_refresh": {
+                "mode": "auto_new",
+                "auto_new_policy": "phase_boundary",
+                "require_no_running_processes": False,
+            }
+        },
+    )
+
+    response = await GatewayRunner._maybe_auto_new_after_context_refresh(
+        runner,
+        _make_event("hello"),
+        {
+            "final_response": "Phase 1 is complete. Next phase will begin with validation.",
+            "completed": True,
+            "pending_context_refresh": {
+                "mode": "auto_new",
+                "session_id": "sess-1",
+                "handoff_path": "/tmp/handoff.md",
+            },
+        },
+        "done",
+        session_key,
+        old_entry,
+    )
+
+    runner.session_store.reset_session.assert_called_once_with(session_key)
+    assert session_key in runner._pending_context_refresh_notes
+    assert "/tmp/handoff.md" in runner._pending_context_refresh_notes[session_key]
+    assert "Context refreshed automatically after a completed phase" in response
+    assert "sess-1" in response
+
+
+@pytest.mark.asyncio
+async def test_auto_context_refresh_skips_interrupted_turn(monkeypatch):
+    from gateway.run import GatewayRunner
+
+    runner = _make_runner()
+    runner._evict_cached_agent = MagicMock()
+    runner._set_session_reasoning_override = MagicMock()
+    runner._clear_session_boundary_security_state = MagicMock()
+    runner._is_telegram_topic_lane = MagicMock(return_value=False)
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {
+            "context_refresh": {
+                "mode": "auto_new",
+                "auto_new_policy": "phase_boundary",
+                "require_no_running_processes": False,
+            }
+        },
+    )
+    session_key = build_session_key(_make_source())
+    old_entry = runner.session_store._entries[session_key]
+
+    response = await GatewayRunner._maybe_auto_new_after_context_refresh(
+        runner,
+        _make_event("hello"),
+        {
+            "final_response": "interrupted",
+            "completed": False,
+            "interrupted": True,
+            "pending_context_refresh": {
+                "mode": "auto_new",
+                "session_id": "sess-1",
+                "handoff_path": "/tmp/handoff.md",
+            },
+        },
+        "interrupted",
+        session_key,
+        old_entry,
+    )
+
+    runner.session_store.reset_session.assert_not_called()
+    assert not hasattr(runner, "_pending_context_refresh_notes")
+    assert response == "interrupted"
+
+
+@pytest.mark.asyncio
 async def test_new_command_clears_session_model_override():
     """/new must remove the session-scoped model override for that session."""
     runner = _make_runner()

--- a/tests/gateway/test_title_command.py
+++ b/tests/gateway/test_title_command.py
@@ -5,6 +5,7 @@ across all gateway messenger platforms.
 """
 
 import os
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -69,6 +70,9 @@ class TestHandleTitleCommand:
 
         # Verify in DB
         assert db.get_session_title("test_session_123") == "My Research Project"
+        metadata = json.loads(db.get_session("test_session_123")["model_config"])["title_metadata"]
+        assert metadata["title_source"] == "manual"
+        assert metadata["title_locked"] is True
         db.close()
 
     @pytest.mark.asyncio
@@ -151,6 +155,9 @@ class TestHandleTitleCommand:
         result = await runner._handle_title_command(event)
         assert "helloworld" in result
         assert db.get_session_title("test_session_123") == "helloworld"
+        metadata = json.loads(db.get_session("test_session_123")["model_config"])["title_metadata"]
+        assert metadata["title_source"] == "manual"
+        assert metadata["title_locked"] is True
         db.close()
 
     @pytest.mark.asyncio
@@ -274,6 +281,10 @@ class TestResetCommandWithTitle:
         runner._session_db.set_session_title.assert_called_once_with(
             "sess-new", "Custom Name"
         )
+        runner._session_db.merge_session_model_config.assert_called_once()
+        patch_arg = runner._session_db.merge_session_model_config.call_args.args[1]
+        assert patch_arg["title_metadata"]["title_source"] == "manual"
+        assert patch_arg["title_metadata"]["title_locked"] is True
         # Header reflects the applied title
         assert "Custom Name" in str(result)
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1,5 +1,6 @@
 """Tests for hermes_state.py — SessionDB SQLite CRUD, FTS5 search, export."""
 
+import json
 import time
 import pytest
 from pathlib import Path
@@ -1416,8 +1417,22 @@ class TestSessionTitle:
         assert session["title"] == "Before End"
         assert session["ended_at"] is not None
 
+    def test_merge_session_model_config_preserves_existing_keys(self, db):
+        db.create_session(session_id="s1", source="cli", model_config={"cwd": "/tmp/work"})
+
+        assert db.merge_session_model_config("s1", {"title_metadata": {"title_source": "auto_initial"}}) is True
+
+        session = db.get_session("s1")
+        model_config = json.loads(session["model_config"])
+        assert model_config["cwd"] == "/tmp/work"
+        assert model_config["title_metadata"] == {"title_source": "auto_initial"}
+
+    def test_merge_session_model_config_returns_false_for_missing_session(self, db):
+        assert db.merge_session_model_config("missing", {"title_metadata": {}}) is False
+
 
 class TestSanitizeTitle:
+
     """Tests for SessionDB.sanitize_title() validation and cleaning."""
 
     def test_normal_title_unchanged(self):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -884,15 +884,20 @@ def test_session_title_clears_pending_after_persist(monkeypatch):
     class _FakeDB:
         def __init__(self):
             self.title = "old"
+            self.model_config = {}
 
         def get_session_title(self, _key):
             return self.title
 
         def get_session(self, _key):
-            return {"id": _key, "title": self.title}
+            return {"id": _key, "title": self.title, "model_config": self.model_config}
 
         def set_session_title(self, _key, title):
             self.title = title
+            return True
+
+        def merge_session_model_config(self, _key, patch):
+            self.model_config.update(patch)
             return True
 
     db = _FakeDB()
@@ -910,6 +915,9 @@ def test_session_title_clears_pending_after_persist(monkeypatch):
         assert resp["result"]["pending"] is False
         assert resp["result"]["title"] == "fresh"
         assert server._sessions["sid"]["pending_title"] is None
+        metadata = db.model_config["title_metadata"]
+        assert metadata["title_source"] == "manual"
+        assert metadata["title_locked"] is True
     finally:
         server._sessions.pop("sid", None)
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2479,6 +2479,8 @@ def _(rid, params: dict) -> dict:
             resolved_title = db.get_session_title(key) or ""
             if fallback:
                 if db.set_session_title(key, fallback):
+                    from agent.title_generator import mark_session_title_manual
+                    mark_session_title_manual(db, key)
                     session["pending_title"] = None
                     resolved_title = fallback
                 else:
@@ -2505,6 +2507,8 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 4021, "title required")
     try:
         if db.set_session_title(key, title):
+            from agent.title_generator import mark_session_title_manual
+            mark_session_title_manual(db, key)
             session["pending_title"] = None
             return _ok(rid, {"pending": False, "title": title})
         # rowcount == 0 can mean "same value" as well as "missing row".
@@ -3521,6 +3525,8 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     _session_key = session.get("session_key") or sid
                     try:
                         if _pdb.set_session_title(_session_key, _pending):
+                            from agent.title_generator import mark_session_title_manual
+                            mark_session_title_manual(_pdb, _session_key)
                             session["pending_title"] = None
                     except ValueError as exc:
                         # Invalid/duplicate title — non-retryable, drop it.


### PR DESCRIPTION
## Summary
- Refine auto-generated session titles after the topic settles while preserving manual/unknown titles by default
- Store title provenance metadata in session model_config
- Prepare a generic /new context-refresh handoff after repeated context compression
- Fix ACP title-update callback scheduling so session-info coroutine creation is deferred to the event loop

## Test Plan
- venv/bin/python -m pytest tests/agent/test_session_handoff.py tests/agent/test_title_generator.py tests/test_hermes_state.py::TestSessionTitle tests/gateway/test_title_command.py tests/acp/test_session.py tests/acp/test_server.py tests/cli/test_cli_new_session.py tests/hermes_cli/test_config.py tests/hermes_cli/test_aux_config.py -q -o 'addopts='
- venv/bin/python -m ruff check agent/session_handoff.py agent/conversation_compression.py agent/title_generator.py hermes_cli/config.py hermes_state.py acp_adapter/server.py tests/agent/test_session_handoff.py tests/agent/test_title_generator.py tests/test_hermes_state.py tests/acp/test_server.py
- git diff --check -- agent/session_handoff.py agent/conversation_compression.py agent/title_generator.py hermes_cli/config.py hermes_state.py acp_adapter/server.py tests/agent/test_session_handoff.py tests/agent/test_title_generator.py tests/test_hermes_state.py tests/acp/test_server.py