### PR TITLE
fix: unblock app tools PR CI

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -129,6 +129,7 @@ from agent.prompt_builder import (
     MEMORY_GUIDANCE, SESSION_SEARCH_GUIDANCE, SKILLS_GUIDANCE,
     HERMES_AGENT_HELP_GUIDANCE,
     KANBAN_GUIDANCE,
+    build_app_tools_prompt,
     build_nous_subscription_prompt,
 )
 from agent.model_metadata import (

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -123,7 +123,7 @@ class TestFirecrawlClientConfig:
                     _get_firecrawl_client()
                     mock_fc.assert_called_once_with(
                         api_key="nous-token",
-                        api_url="https://firecrawl-gateway.localhost:3009",
+                        api_url="https://127.0.0.1:3009",
                     )
 
     def test_default_gateway_domain_targets_nous_production_origin(self):

--- a/tools/environments/managed_modal.py
+++ b/tools/environments/managed_modal.py
@@ -60,8 +60,9 @@ class ManagedModalEnvironment(BaseModalExecutionEnvironment):
         if gateway is None:
             raise ValueError("Managed Modal requires a configured tool gateway and Nous user token")
 
-        self._gateway_origin = gateway.resolved_origin.rstrip("/")
-        self._gateway_host_header = gateway.gateway_host_header
+        gateway_origin = getattr(gateway, "resolved_origin", None) or gateway.gateway_origin
+        self._gateway_origin = gateway_origin.rstrip("/")
+        self._gateway_host_header = getattr(gateway, "gateway_host_header", None)
         self._nous_user_token = gateway.nous_user_token
         self._task_id = task_id
         self._persistent = persistent_filesystem


### PR DESCRIPTION
## Summary
- re-export `build_app_tools_prompt` through `run_agent` so system-prompt tests and patch contracts keep working
- make managed Modal tolerate gateway fakes without `resolved_origin` / `gateway_host_header`
- update the Firecrawl explicit localhost gateway test for the managed gateway's 127.0.0.1 rewrite

## Test Plan
- `python -m pytest tests/run_agent/test_compression_boundary_hook.py tests/tools/test_managed_modal_environment.py tests/tools/test_kanban_tools.py::test_kanban_guidance_not_in_normal_prompt tests/tools/test_kanban_tools.py::test_kanban_guidance_in_worker_prompt tests/tools/test_web_tools_config.py::TestFirecrawlClientConfig::test_explicit_firecrawl_gateway_url_takes_precedence tests/run_agent/test_run_agent.py tests/cron/test_codex_execution_paths.py -q -o 'addopts='` → 354 passed

This targets #31047's feature branch directly so it can be merged/cherry-picked before the app_tools PR lands.
