### PR TITLE
fix(agent): guard xAI reasoning replay by provider

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -363,6 +363,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             session_id=getattr(agent, "session_id", None),
             max_tokens=agent.max_tokens,
             request_overrides=agent.request_overrides,
+            provider=agent.provider,
             is_github_responses=is_github_responses,
             is_codex_backend=is_codex_backend,
             is_xai_responses=is_xai_responses,

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -248,22 +248,28 @@ def _chat_messages_to_responses_input(
     messages: List[Dict[str, Any]],
     *,
     is_xai_responses: bool = False,
+    reasoning_provider: str | None = None,
 ) -> List[Dict[str, Any]]:
     """Convert internal chat-style messages to Responses input items.
 
-    ``is_xai_responses`` is kept for transport signature compatibility but
-    no longer suppresses encrypted reasoning replay.  Earlier (PR #26644,
+    ``is_xai_responses`` is kept for transport signature compatibility and
+    gates replay of legacy unknown-origin encrypted reasoning.  Earlier (PR #26644,
     May 2026) we believed xAI's OAuth/SuperGrok ``/v1/responses`` surface
     rejected replayed ``encrypted_content`` reasoning items minted by
     prior turns, and we stripped them.  That decision was wrong — xAI
     explicitly relies on Hermes threading encrypted reasoning back across
-    turns for cross-turn coherence (the whole point of their partnership
-    integration).  We now replay encrypted reasoning on every Responses
-    transport (xAI, native Codex, custom relays) and let xAI tell us
-    explicitly if a specific surface ever rejects a payload.
+    turns for cross-turn coherence.  Provider-tagged xAI reasoning is still
+    replayed, but legacy unknown-origin or cross-provider encrypted blobs are
+    filtered before xAI sees them because xAI cannot decrypt blobs minted by a
+    different provider/session chain.
     """
     items: List[Dict[str, Any]] = []
     seen_item_ids: set = set()
+    current_reasoning_provider = (
+        reasoning_provider.strip().lower()
+        if isinstance(reasoning_provider, str)
+        else ""
+    )
 
     for msg in messages:
         if not isinstance(msg, dict):
@@ -285,16 +291,38 @@ def _chat_messages_to_responses_input(
                 content_text = str(content) if content is not None else ""
 
             if role == "assistant":
-                # Replay encrypted reasoning items from previous turns
-                # so the API can maintain coherent reasoning chains.
-                # This applies to every Responses transport including
-                # xAI — see _chat_messages_to_responses_input docstring
-                # for the May 2026 reversal of the earlier xAI gate.
+                # Replay encrypted reasoning items from previous turns so the
+                # API can maintain coherent reasoning chains. Provider tags are
+                # local metadata used only to avoid cross-provider replay.
                 codex_reasoning = msg.get("codex_reasoning_items")
                 has_codex_reasoning = False
                 if isinstance(codex_reasoning, list):
                     for ri in codex_reasoning:
                         if isinstance(ri, dict) and ri.get("encrypted_content"):
+                            item_provider = ri.get("source_provider") or ri.get("provider")
+                            item_provider_norm = (
+                                item_provider.strip().lower()
+                                if isinstance(item_provider, str)
+                                else ""
+                            )
+                            # Legacy rows predate provider tagging. Do not send
+                            # unknown-origin encrypted blobs to xAI, because a
+                            # blob minted by Codex/OpenAI cannot be decrypted by
+                            # Grok after a provider switch within one session.
+                            if is_xai_responses and not item_provider_norm:
+                                continue
+                            if (
+                                current_reasoning_provider
+                                and item_provider_norm
+                                and item_provider_norm != current_reasoning_provider
+                            ):
+                                continue
+                            if (
+                                is_xai_responses
+                                and not current_reasoning_provider
+                                and item_provider_norm not in {"xai", "xai-oauth"}
+                            ):
+                                continue
                             item_id = ri.get("id")
                             if item_id and item_id in seen_item_ids:
                                 continue
@@ -302,7 +330,11 @@ def _chat_messages_to_responses_input(
                             # Responses API cannot look up items by ID and
                             # returns 404.  The encrypted_content blob is
                             # self-contained for reasoning chain continuity.
-                            replay_item = {k: v for k, v in ri.items() if k != "id"}
+                            replay_item = {
+                                k: v
+                                for k, v in ri.items()
+                                if k not in {"id", "provider", "source_provider"}
+                            }
                             items.append(replay_item)
                             if item_id:
                                 seen_item_ids.add(item_id)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1429,6 +1429,10 @@ def run_conversation(
                         _trunc_result = _trunc_transport.normalize_response(
                             response, strip_tool_prefix=agent._is_anthropic_oauth
                         )
+                    elif agent.api_mode == "codex_responses":
+                        _trunc_result = _trunc_transport.normalize_response(
+                            response, provider=agent.provider
+                        )
                     else:
                         _trunc_result = _trunc_transport.normalize_response(response)
                     _trunc_msg = _trunc_result
@@ -3020,6 +3024,8 @@ def run_conversation(
             _normalize_kwargs = {}
             if agent.api_mode == "anthropic_messages":
                 _normalize_kwargs["strip_tool_prefix"] = agent._is_anthropic_oauth
+            elif agent.api_mode == "codex_responses":
+                _normalize_kwargs["provider"] = agent.provider
             normalized = _transport.normalize_response(response, **_normalize_kwargs)
             assistant_message = normalized
             finish_reason = normalized.finish_reason

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -27,6 +27,7 @@ class ResponsesApiTransport(ProviderTransport):
         return _chat_messages_to_responses_input(
             messages,
             is_xai_responses=bool(kwargs.get("is_xai_responses")),
+            reasoning_provider=kwargs.get("provider"),
         )
 
     def convert_tools(self, tools: List[Dict[str, Any]]) -> Any:
@@ -99,6 +100,7 @@ class ResponsesApiTransport(ProviderTransport):
             "input": _chat_messages_to_responses_input(
                 payload_messages,
                 is_xai_responses=is_xai_responses,
+                reasoning_provider=params.get("provider"),
             ),
             "tools": response_tools,
             "store": False,
@@ -200,6 +202,7 @@ class ResponsesApiTransport(ProviderTransport):
 
         # _normalize_codex_response returns (SimpleNamespace, finish_reason_str)
         msg, finish_reason = _normalize_codex_response(response)
+        provider = kwargs.get("provider")
 
         tool_calls = None
         if msg and msg.tool_calls:
@@ -220,7 +223,18 @@ class ResponsesApiTransport(ProviderTransport):
         # Extract reasoning items for provider_data
         provider_data = {}
         if msg and hasattr(msg, "codex_reasoning_items") and msg.codex_reasoning_items:
-            provider_data["codex_reasoning_items"] = msg.codex_reasoning_items
+            if isinstance(provider, str) and provider.strip():
+                tagged_items = []
+                for item in msg.codex_reasoning_items:
+                    if isinstance(item, dict):
+                        tagged = dict(item)
+                        tagged.setdefault("source_provider", provider.strip().lower())
+                        tagged_items.append(tagged)
+                    else:
+                        tagged_items.append(item)
+                provider_data["codex_reasoning_items"] = tagged_items
+            else:
+                provider_data["codex_reasoning_items"] = msg.codex_reasoning_items
         if msg and hasattr(msg, "codex_message_items") and msg.codex_message_items:
             provider_data["codex_message_items"] = msg.codex_message_items
         if msg and hasattr(msg, "reasoning_details") and msg.reasoning_details:

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -428,6 +428,40 @@ class TestCodexNormalizeResponse:
             }
         ]
 
+    def test_reasoning_items_tagged_with_source_provider(self, transport):
+        """Provider tags are local metadata used to prevent cross-provider replay."""
+        r = SimpleNamespace(
+            output=[
+                SimpleNamespace(
+                    type="reasoning",
+                    id="rs_abc",
+                    encrypted_content="enc_blob",
+                    summary=[],
+                    status="completed",
+                ),
+                SimpleNamespace(
+                    type="message",
+                    role="assistant",
+                    content=[SimpleNamespace(type="output_text", text="Hello world")],
+                    status="completed",
+                ),
+            ],
+            status="completed",
+            incomplete_details=None,
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5,
+                                  input_tokens_details=None, output_tokens_details=None),
+        )
+        nr = transport.normalize_response(r, provider="xai-oauth")
+        assert nr.codex_reasoning_items == [
+            {
+                "type": "reasoning",
+                "encrypted_content": "enc_blob",
+                "id": "rs_abc",
+                "summary": [],
+                "source_provider": "xai-oauth",
+            }
+        ]
+
     def test_tool_call_response(self, transport):
         """Normalize a Codex response with tool calls."""
         r = SimpleNamespace(

--- a/tests/run_agent/test_codex_xai_oauth_recovery.py
+++ b/tests/run_agent/test_codex_xai_oauth_recovery.py
@@ -289,18 +289,19 @@ def test_classify_api_error_stream_event_unrelated_not_reclassified():
 # ---------------------------------------------------------------------------
 
 
-def _assistant_msg_with_encrypted_reasoning(text="hi from grok", encrypted="enc_blob"):
+def _assistant_msg_with_encrypted_reasoning(text="hi from grok", encrypted="enc_blob", provider=None):
+    reasoning_item = {
+        "type": "reasoning",
+        "id": "rs_xai_001",
+        "encrypted_content": encrypted,
+        "summary": [],
+    }
+    if provider:
+        reasoning_item["source_provider"] = provider
     return {
         "role": "assistant",
         "content": text,
-        "codex_reasoning_items": [
-            {
-                "type": "reasoning",
-                "id": "rs_xai_001",
-                "encrypted_content": encrypted,
-                "summary": [],
-            }
-        ],
+        "codex_reasoning_items": [reasoning_item],
     }
 
 
@@ -333,17 +334,23 @@ def test_codex_reasoning_replay_includes_encrypted_content_for_xai():
 
     msgs = [
         {"role": "user", "content": "hi"},
-        _assistant_msg_with_encrypted_reasoning(),
+        _assistant_msg_with_encrypted_reasoning(provider="xai-oauth"),
         {"role": "user", "content": "what's your name?"},
     ]
 
-    items = _chat_messages_to_responses_input(msgs, is_xai_responses=True)
+    items = _chat_messages_to_responses_input(
+        msgs,
+        is_xai_responses=True,
+        reasoning_provider="xai-oauth",
+    )
     reasoning = [it for it in items if it.get("type") == "reasoning"]
     assert len(reasoning) == 1, (
         "xAI must receive replayed reasoning items — see docstring for the "
         "May 2026 reversal of the earlier suppression gate."
     )
     assert reasoning[0]["encrypted_content"] == "enc_blob"
+    assert "source_provider" not in reasoning[0]
+    assert "provider" not in reasoning[0]
 
     # And the assistant's visible text must still be present alongside it.
     assistant_items = [
@@ -351,6 +358,62 @@ def test_codex_reasoning_replay_includes_encrypted_content_for_xai():
         if it.get("role") == "assistant" or it.get("type") == "message"
     ]
     assert assistant_items, "assistant message must still be present"
+
+
+def test_codex_reasoning_replay_skips_unknown_origin_items_for_xai():
+    """Do not send legacy untagged encrypted blobs to xAI after provider switches."""
+    from agent.codex_responses_adapter import _chat_messages_to_responses_input
+
+    msgs = [
+        {"role": "user", "content": "hi"},
+        _assistant_msg_with_encrypted_reasoning(),
+        {"role": "user", "content": "continue"},
+    ]
+
+    items = _chat_messages_to_responses_input(
+        msgs,
+        is_xai_responses=True,
+        reasoning_provider="xai-oauth",
+    )
+    reasoning = [it for it in items if it.get("type") == "reasoning"]
+    assert reasoning == []
+
+
+def test_codex_reasoning_replay_skips_cross_provider_items_for_xai():
+    """Codex/OpenAI encrypted blobs are not decryptable by xAI."""
+    from agent.codex_responses_adapter import _chat_messages_to_responses_input
+
+    msgs = [
+        {"role": "user", "content": "hi"},
+        _assistant_msg_with_encrypted_reasoning(provider="openai-codex"),
+        {"role": "user", "content": "continue"},
+    ]
+
+    items = _chat_messages_to_responses_input(
+        msgs,
+        is_xai_responses=True,
+        reasoning_provider="xai-oauth",
+    )
+    reasoning = [it for it in items if it.get("type") == "reasoning"]
+    assert reasoning == []
+
+
+def test_codex_reasoning_replay_skips_cross_provider_items_for_xai_without_current_provider():
+    """If the endpoint is xAI but the current provider name is unavailable, stay conservative."""
+    from agent.codex_responses_adapter import _chat_messages_to_responses_input
+
+    msgs = [
+        {"role": "user", "content": "hi"},
+        _assistant_msg_with_encrypted_reasoning(provider="openai-codex"),
+        {"role": "user", "content": "continue"},
+    ]
+
+    items = _chat_messages_to_responses_input(
+        msgs,
+        is_xai_responses=True,
+    )
+    reasoning = [it for it in items if it.get("type") == "reasoning"]
+    assert reasoning == []
 
 
 def test_codex_transport_xai_request_includes_encrypted_content():
@@ -386,18 +449,21 @@ def test_codex_transport_xai_replays_reasoning_in_input():
         messages=[
             {"role": "system", "content": "sys"},
             {"role": "user", "content": "hi"},
-            _assistant_msg_with_encrypted_reasoning(text="hi from grok"),
+            _assistant_msg_with_encrypted_reasoning(text="hi from grok", provider="xai-oauth"),
             {"role": "user", "content": "what's your name?"},
         ],
         tools=None,
         instructions="sys",
         reasoning_config={"enabled": True, "effort": "medium"},
         is_xai_responses=True,
+        provider="xai-oauth",
     )
     input_items = kwargs["input"]
     reasoning_items = [it for it in input_items if it.get("type") == "reasoning"]
     assert len(reasoning_items) == 1
     assert reasoning_items[0]["encrypted_content"] == "enc_blob"
+    assert "source_provider" not in reasoning_items[0]
+    assert "provider" not in reasoning_items[0]
 
 
 def test_codex_transport_native_codex_still_replays_reasoning_in_input():


### PR DESCRIPTION
## Summary

- tag Codex Responses encrypted reasoning items with the source provider that produced them
- skip unknown-origin or cross-provider encrypted reasoning blobs when building xAI Responses input
- strip local provider metadata before sending reasoning items back to any Responses API
- keep xAI-to-xAI encrypted reasoning replay intact and add regression coverage for provider switches

## Root cause

Hermes can resume a session after switching providers and replay previously persisted `codex_reasoning_items`. Those items contain opaque `encrypted_content` blobs. xAI can only decrypt blobs minted by the compatible xAI Responses chain, so legacy untagged or OpenAI/Codex-origin blobs can trigger HTTP 400: `Could not decrypt the provided encrypted_content`.

## How to test

- Reproduce by resuming a Codex/OpenAI-origin session after switching the active model provider to `xai-oauth`; before this change, the next xAI Responses request can include prior-provider encrypted reasoning and fail with HTTP 400.
- Verify the fix by running the xAI OAuth and Codex transport regression files through the repo test wrapper:
- `scripts/run_tests.sh tests/run_agent/test_codex_xai_oauth_recovery.py tests/agent/transports/test_codex_transport.py`

## Platforms tested

- Linux, Python 3.11

## Validation

- `scripts/run_tests.sh tests/run_agent/test_codex_xai_oauth_recovery.py tests/agent/transports/test_codex_transport.py` -> `80 tests passed, 0 failed`
- `/usr/local/lib/hermes-agent/venv/bin/python scripts/check-windows-footguns.py --diff upstream/main` -> `No Windows footguns found (5 file(s) scanned)`
