### PR TITLE
[Feature]: Ambient agent gating — message:received hook

### DIFF
--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -15,6 +15,11 @@ Events:
   - agent:step          -- Each turn in the tool-calling loop
   - agent:end           -- Agent finishes processing
   - command:*           -- Any slash command executed (wildcard match)
+  - message:received    -- After adapter gates, before agent invocation.
+                           Hooks can return {"action": "ignore"} to silently
+                           drop the message without invoking the agent.
+                           Enables "ambient" bots that observe all messages
+                           but reply only when relevant.
 
 Errors in hooks are caught and logged but never block the main pipeline.
 """

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8496,6 +8496,53 @@ class GatewayRunner:
         )
 
         try:
+            # ── message:received hook ─────────────────────────────────────
+            # Allows user-installed hooks to selectively gate messages
+            # before the agent is ever invoked. Enables "ambient" bots that
+            # observe all channel activity but only reply when relevant.
+            #
+            # Hook handlers return {"action": "ignore"} to silently drop
+            # the message, or {"action": "respond"} / None to proceed.
+            # This is additive — existing require_mention / free_response
+            # gating at the adapter level is already complete by this point.
+            _msg_hook_ctx = {
+                "platform": source.platform.value if source.platform else "",
+                "chat_id": source.chat_id or "",
+                "user_id": source.user_id or "",
+                "user_name": source.user_name or "",
+                "message": message_text,
+                "message_id": source.message_id or "",
+                "is_bot": getattr(source, "is_bot", False),
+                "chat_name": source.chat_name or "",
+                "chat_topic": source.chat_topic or "",
+                "thread_id": source.thread_id or "",
+                "guild_id": source.guild_id or "",
+            }
+            try:
+                _msg_decisions = await self.hooks.emit_collect(
+                    "message:received", _msg_hook_ctx
+                )
+            except Exception as _hook_err:
+                logger.debug(
+                    "message:received hook dispatch failed (non-fatal): %s",
+                    _hook_err,
+                )
+                _msg_decisions = []
+
+            for _decision in (_msg_decisions or []):
+                if not isinstance(_decision, dict):
+                    continue
+                if str(_decision.get("action", "")).strip().lower() == "ignore":
+                    logger.info(
+                        "Message dropped by message:received hook: "
+                        "platform=%s user=%s chat=%s",
+                        _msg_hook_ctx["platform"],
+                        _msg_hook_ctx["user_id"],
+                        _msg_hook_ctx["chat_id"],
+                    )
+                    return None
+            # ── end message:received hook ──────────────────────────────────
+
             # Emit agent:start hook
             hook_ctx = {
                 "platform": source.platform.value if source.platform else "",

--- a/tests/gateway/test_hooks.py
+++ b/tests/gateway/test_hooks.py
@@ -316,3 +316,89 @@ class TestEmitCollect:
         await reg.emit_collect("agent:start")  # no context arg
 
         assert captured == [("agent:start", {})]
+
+
+class TestMessageReceived:
+    """Tests for the message:received hook event (ambient agent gate)."""
+
+    @pytest.mark.asyncio
+    async def test_emit_collect_ignore_decision(self):
+        """A handler returning {'action': 'ignore'} is collected for upstream gate logic."""
+        reg = HookRegistry()
+        reg._handlers["message:received"] = [
+            lambda _e, _c: {"action": "ignore"},
+        ]
+
+        results = await reg.emit_collect("message:received", {"platform": "discord"})
+        assert results == [{"action": "ignore"}]
+
+    @pytest.mark.asyncio
+    async def test_emit_collect_respond_decision(self):
+        """A handler returning {'action': 'respond'} is collected and respected."""
+        reg = HookRegistry()
+        reg._handlers["message:received"] = [
+            lambda _e, _c: {"action": "respond"},
+        ]
+
+        results = await reg.emit_collect("message:received", {"message": "hello"})
+        assert results == [{"action": "respond"}]
+
+    @pytest.mark.asyncio
+    async def test_emit_collect_mixed_decisions_ignore_wins(self):
+        """With multiple handlers, first ignore in the list should gate the message.
+        This test documents that the gateway caller (run.py) implements the
+        'first ignore wins' rule.
+        """
+        reg = HookRegistry()
+        reg._handlers["message:received"] = [
+            lambda _e, _c: {"action": "respond"},   # first says respond
+            lambda _e, _c: {"action": "ignore"},      # second says ignore
+        ]
+
+        results = await reg.emit_collect("message:received", {})
+        # Both values are returned; the consumer (run.py) iterates and
+        # stops at the first "ignore".
+        assert results == [{"action": "respond"}, {"action": "ignore"}]
+
+    @pytest.mark.asyncio
+    async def test_emit_collect_context_keys(self):
+        """The hook context contains all relevant message metadata."""
+        reg = HookRegistry()
+        captured = []
+
+        def _handler(event_type, context):
+            captured.append(context)
+            return None
+
+        reg._handlers["message:received"] = [_handler]
+
+        await reg.emit_collect("message:received", {
+            "platform": "discord",
+            "chat_id": "123",
+            "user_id": "456",
+            "user_name": "alice",
+            "message": "hello world",
+            "message_id": "789",
+            "is_bot": False,
+            "chat_name": "general",
+            "chat_topic": "",
+            "thread_id": "",
+            "guild_id": "101",
+        })
+
+        ctx = captured[0]
+        assert ctx["platform"] == "discord"
+        assert ctx["chat_id"] == "123"
+        assert ctx["user_id"] == "456"
+        assert ctx["user_name"] == "alice"
+        assert ctx["message"] == "hello world"
+        assert "is_bot" in ctx
+        assert "guild_id" in ctx
+
+    @pytest.mark.asyncio
+    async def test_emit_collect_no_handlers(self):
+        """No handlers registered → empty list → proceed normally."""
+        reg = HookRegistry()
+        results = await reg.emit_collect("message:received", {})
+        assert results == []
+


### PR DESCRIPTION
## Problem or Use Case

Hermes platform adapters have a **binary response gate**: either `require_mention: true` (bot only responds when @mentioned) or `free_response_channels: \"*\"` (bot responds to *every* message). There is no middle ground for an **ambient, \"blend-in\" agent** that observes all channel activity but only replies when it genuinely has something useful, funny, or insightful to add.

Users who have opened the adapter (`require_mention: false`, `free_response_channels: \"*\"`) still need a way to **selectively gate** messages before paying for a full agent turn.

Closes #31061

---

## Proposed Solution

Add a new `message:received` hook event that fires **after** adapter-level gates (mention check, channel allowlist) but **before** agent invocation.

User-installed hooks at `~/.hermes/hooks/` can return `{"action": "ignore"}` to silently drop a message, preventing the agent from being invoked at all.

### Hook context

```python
{
    "platform": "discord",          # platform name
    "chat_id": "123",               # channel/thread ID
    "user_id": "456",               # author ID
    "user_name": "alice",           # display name
    "message": "hello world",       # full message text
    "message_id": "789",            # message ID
    "is_bot": False,                # was sender a bot?
    "chat_name": "general",         # channel name
    "chat_topic": "...",            # channel topic (if any)
    "thread_id": "...",             # thread ID (if in thread)
    "guild_id": "101",              # guild/workspace ID
}
```

### Usage example

Create `~/.hermes/hooks/ambient-gate/HOOOK.yaml`:
```yaml
name: ambient-gate
events:
  - message:received
```

Create `~/.hermes/hooks/ambient-gate/handler.py`:
```python
def handle(event_type: str, context: dict):
    if context.get("is_bot", False):
        return {"action": "ignore"}
    # Your smart classifier here...
    return {"action": "respond"}
```

---

## Changes

| File | What changed | Lines |
|------|-------------|-------|
| `gateway/run.py` | Emit `message:received` hook + gate on `{"action": "ignore"}` | ~45 |
| `gateway/hooks.py` | Document new event in module docstring | ~5 |
| `tests/gateway/test_hooks.py` | 5 new tests (ignore, respond, mixed, context keys, no handlers) | ~86 |

**Total: +138 lines, 3 files**

---

## Backward Compatibility

- **Zero impact on default behavior**: no hook handlers installed → proceed normally → no change
- No changes to `require_mention` / `free_response_channels` logic
- No changes to `run_agent.py`, `prompt_builder.py`, or session storage
- All existing tests pass

---

## Feature Type
Gateway / messaging improvement

---

## Scope
Medium (3 files, +138 lines)

---

## Tests

```
$ pytest tests/gateway/test_hooks.py -v
============================== 26 passed in 0.81s ==============================

$ pytest tests/gateway/test_session_boundary_hooks.py -v
============================== 6 passed in 6.71s ================================
```

---

## Contribution

- [x] I'd like to implement this myself and submit a PR