### PR TITLE
fix(tui): right-click copies active transcript selection

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/app-mouse.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/app-mouse.test.ts
@@ -12,6 +12,7 @@ const makeApp = () => {
     lastHoverRow: -1,
     mouseCaptureTarget: undefined,
     props: {
+      getSelectedText: vi.fn(() => 'selected text'),
       onCopySelectionNoClear: vi.fn(async () => 'selected text'),
       onHoverAt: vi.fn(),
       onMouseDownAt: vi.fn(),
@@ -50,6 +51,20 @@ describe('handleMouseEvent right-click selection behavior', () => {
 
     expect(app.props.onCopySelectionNoClear).toHaveBeenCalledOnce()
     expect(app.props.onMouseDownAt).toHaveBeenCalledWith(2, 0, 2)
+  })
+
+  it('does not paste when highlighted selection text is empty', async () => {
+    const app = makeApp()
+    app.props.getSelectedText.mockReturnValue('')
+
+    startSelection(app.props.selection, 0, 0)
+    updateSelection(app.props.selection, 4, 0)
+
+    handleMouseEvent(app, { action: 'press', button: 2, col: 3, kind: 'mouse', row: 1 })
+    await Promise.resolve()
+
+    expect(app.props.onCopySelectionNoClear).not.toHaveBeenCalled()
+    expect(app.props.onMouseDownAt).not.toHaveBeenCalled()
   })
 
   it('does not repeatedly copy or paste during right-button motion events over a selection', () => {

--- a/ui-tui/packages/hermes-ink/src/ink/app-mouse.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/app-mouse.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { handleMouseEvent } from './components/App.js'
+import { createSelectionState, startSelection, updateSelection } from './selection.js'
+
+const makeApp = () => {
+  const selection = createSelectionState()
+
+  return {
+    clickCount: 1,
+    lastHoverCol: -1,
+    lastHoverRow: -1,
+    mouseCaptureTarget: undefined,
+    props: {
+      onCopySelectionNoClear: vi.fn(async () => 'selected text'),
+      onHoverAt: vi.fn(),
+      onMouseDownAt: vi.fn(),
+      onMouseDragAt: vi.fn(),
+      onMouseUpAt: vi.fn(),
+      onSelectionChange: vi.fn(),
+      selection
+    }
+  } as any
+}
+
+describe('handleMouseEvent right-click selection behavior', () => {
+  it('copies an active selection instead of dispatching right-click paste handlers', () => {
+    const app = makeApp()
+
+    startSelection(app.props.selection, 0, 0)
+    updateSelection(app.props.selection, 4, 0)
+
+    handleMouseEvent(app, { action: 'press', button: 2, col: 3, kind: 'mouse', row: 1 })
+
+    expect(app.props.onCopySelectionNoClear).toHaveBeenCalledOnce()
+    expect(app.props.onMouseDownAt).not.toHaveBeenCalled()
+    expect(app.clickCount).toBe(0)
+  })
+
+  it('still dispatches right-click handlers when no text is selected', () => {
+    const app = makeApp()
+
+    handleMouseEvent(app, { action: 'press', button: 2, col: 3, kind: 'mouse', row: 1 })
+
+    expect(app.props.onCopySelectionNoClear).not.toHaveBeenCalled()
+    expect(app.props.onMouseDownAt).toHaveBeenCalledWith(2, 0, 2)
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/ink/app-mouse.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/app-mouse.test.ts
@@ -24,17 +24,32 @@ const makeApp = () => {
 }
 
 describe('handleMouseEvent right-click selection behavior', () => {
-  it('copies an active selection instead of dispatching right-click paste handlers', () => {
+  it('copies an active selection instead of dispatching right-click paste handlers', async () => {
     const app = makeApp()
 
     startSelection(app.props.selection, 0, 0)
     updateSelection(app.props.selection, 4, 0)
 
     handleMouseEvent(app, { action: 'press', button: 2, col: 3, kind: 'mouse', row: 1 })
+    await Promise.resolve()
 
     expect(app.props.onCopySelectionNoClear).toHaveBeenCalledOnce()
     expect(app.props.onMouseDownAt).not.toHaveBeenCalled()
     expect(app.clickCount).toBe(0)
+  })
+
+  it('falls back to right-click handlers when selection copy has no clipboard path', async () => {
+    const app = makeApp()
+    app.props.onCopySelectionNoClear.mockResolvedValue('')
+
+    startSelection(app.props.selection, 0, 0)
+    updateSelection(app.props.selection, 4, 0)
+
+    handleMouseEvent(app, { action: 'press', button: 2, col: 3, kind: 'mouse', row: 1 })
+    await Promise.resolve()
+
+    expect(app.props.onCopySelectionNoClear).toHaveBeenCalledOnce()
+    expect(app.props.onMouseDownAt).toHaveBeenCalledWith(2, 0, 2)
   })
 
   it('still dispatches right-click handlers when no text is selected', () => {

--- a/ui-tui/packages/hermes-ink/src/ink/app-mouse.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/app-mouse.test.ts
@@ -52,6 +52,18 @@ describe('handleMouseEvent right-click selection behavior', () => {
     expect(app.props.onMouseDownAt).toHaveBeenCalledWith(2, 0, 2)
   })
 
+  it('does not repeatedly copy or paste during right-button motion events over a selection', () => {
+    const app = makeApp()
+
+    startSelection(app.props.selection, 0, 0)
+    updateSelection(app.props.selection, 4, 0)
+
+    handleMouseEvent(app, { action: 'press', button: 0x20 | 2, col: 3, kind: 'mouse', row: 1 })
+
+    expect(app.props.onCopySelectionNoClear).not.toHaveBeenCalled()
+    expect(app.props.onMouseDownAt).not.toHaveBeenCalled()
+  })
+
   it('still dispatches right-click handlers when no text is selected', () => {
     const app = makeApp()
 

--- a/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
@@ -76,6 +76,9 @@ type Props = {
   // DOM elements. Called for mode-1003 motion events with no button held.
   // No-op outside fullscreen (Ink.dispatchHover gates on altScreenActive).
   readonly onHoverAt: (col: number, row: number) => void
+  // Copy the active fullscreen text selection without clearing the highlight.
+  // Used for terminal-native right-click-copy behaviour.
+  readonly onCopySelectionNoClear: () => Promise<string>
   // Look up the OSC 8 hyperlink at (col, row) synchronously at click
   // time. Returns the URL or undefined. The browser-open is deferred by
   // MULTI_CLICK_TIMEOUT_MS so double-click can cancel it.
@@ -631,6 +634,13 @@ export function handleMouseEvent(app: App, m: ParsedMouse): void {
     if (baseButton !== 0) {
       // Non-left press breaks the multi-click chain.
       app.clickCount = 0
+
+      if (baseButton === 2 && hasSelection(sel)) {
+        void app.props.onCopySelectionNoClear()
+
+        return
+      }
+
       app.props.onMouseDownAt(col, row, baseButton)
 
       return

--- a/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
@@ -79,6 +79,7 @@ type Props = {
   // Copy the active fullscreen text selection without clearing the highlight.
   // Used for terminal-native right-click-copy behaviour.
   readonly onCopySelectionNoClear: () => Promise<string>
+  readonly getSelectedText: () => string
   // Look up the OSC 8 hyperlink at (col, row) synchronously at click
   // time. Returns the URL or undefined. The browser-open is deferred by
   // MULTI_CLICK_TIMEOUT_MS so double-click can cancel it.
@@ -637,6 +638,10 @@ export function handleMouseEvent(app: App, m: ParsedMouse): void {
 
       if (baseButton === 2 && hasSelection(sel)) {
         if ((m.button & 0x20) !== 0) {
+          return
+        }
+
+        if (!app.props.getSelectedText()) {
           return
         }
 

--- a/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
@@ -636,7 +636,14 @@ export function handleMouseEvent(app: App, m: ParsedMouse): void {
       app.clickCount = 0
 
       if (baseButton === 2 && hasSelection(sel)) {
-        void app.props.onCopySelectionNoClear()
+        void app.props
+          .onCopySelectionNoClear()
+          .then(text => {
+            if (!text) {
+              app.props.onMouseDownAt(col, row, baseButton)
+            }
+          })
+          .catch(() => app.props.onMouseDownAt(col, row, baseButton))
 
         return
       }

--- a/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
@@ -636,6 +636,10 @@ export function handleMouseEvent(app: App, m: ParsedMouse): void {
       app.clickCount = 0
 
       if (baseButton === 2 && hasSelection(sel)) {
+        if ((m.button & 0x20) !== 0) {
+          return
+        }
+
         void app.props
           .onCopySelectionNoClear()
           .then(text => {

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -1492,7 +1492,7 @@ export default class Ink {
       return ''
     }
 
-    const text = getSelectedText(this.selection, this.frontFrame.screen)
+    const text = this.getTextSelectionText()
 
     if (text) {
       try {
@@ -1512,6 +1512,10 @@ export default class Ink {
     }
 
     return ''
+  }
+
+  getTextSelectionText(): string {
+    return hasSelection(this.selection) ? getSelectedText(this.selection, this.frontFrame.screen) : ''
   }
 
   /**
@@ -2332,6 +2336,7 @@ export default class Ink {
         dispatchKeyboardEvent={this.dispatchKeyboardEvent}
         exitOnCtrlC={this.options.exitOnCtrlC}
         getHyperlinkAt={this.getHyperlinkAt}
+        getSelectedText={this.getTextSelectionText}
         onClickAt={this.dispatchClick}
         onCopySelectionNoClear={this.copySelectionNoClear}
         onCursorAdvance={this.noteExternalCursorAdvance}

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -2333,6 +2333,7 @@ export default class Ink {
         exitOnCtrlC={this.options.exitOnCtrlC}
         getHyperlinkAt={this.getHyperlinkAt}
         onClickAt={this.dispatchClick}
+        onCopySelectionNoClear={this.copySelectionNoClear}
         onCursorAdvance={this.noteExternalCursorAdvance}
         onCursorDeclaration={this.setCursorDeclaration}
         onExit={this.unmount}


### PR DESCRIPTION
## Summary
- Make right-click copy active fullscreen transcript selections through the existing selection clipboard path.
- Preserve prior right-click paste behavior when no text is selected.
- Add focused Ink mouse tests for selected vs unselected right-click presses.

## Context
Prior PR #23439 fixed right-click copy for composer-local selections. This covers the broader fullscreen transcript selection path.

## Test plan
- `npm run build --prefix packages/hermes-ink`
- `npx vitest run --maxWorkers 4 --testTimeout 15000 packages/hermes-ink/src/ink/app-mouse.test.ts src/__tests__/textInputRightClick.test.ts`
- `npx eslint packages/hermes-ink/src/ink/components/App.tsx packages/hermes-ink/src/ink/ink.tsx packages/hermes-ink/src/ink/app-mouse.test.ts`
- `npm run build`