### PR TITLE
fix(acp): support generic ACP backends beyond Copilot CLI

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1217,12 +1217,13 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     client_kwargs = dict(client_kwargs)
     _validate_proxy_env_urls()
     _validate_base_url(client_kwargs.get("base_url"))
-    if agent.provider == "copilot-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://copilot"):
+    if agent.provider == "copilot-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://"):
         from agent.copilot_acp_client import CopilotACPClient
 
         client = CopilotACPClient(**client_kwargs)
         _ra().logger.info(
-            "Copilot ACP client created (%s, shared=%s) %s",
+            "ACP client created via %s (%s, shared=%s) %s",
+            getattr(client, '_acp_command', 'acp'),
             reason,
             shared,
             agent._client_log_context(),

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -25,6 +25,7 @@ from agent.file_safety import get_read_block_error, is_write_denied
 from agent.redact import redact_sensitive_text
 
 ACP_MARKER_BASE_URL = "acp://copilot"
+ACP_MARKER_BASE_URL_GENERIC = "acp://generic"
 _DEFAULT_TIMEOUT_SECONDS = 900.0
 
 _TOOL_CALL_BLOCK_RE = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
@@ -55,13 +56,17 @@ def _is_gh_copilot_deprecation_message(stderr_text: str) -> bool:
 
 def _resolve_command() -> str:
     return (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
+        os.getenv("HERMES_ACP_COMMAND", "").strip()
+        or os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
         or os.getenv("COPILOT_CLI_PATH", "").strip()
         or "copilot"
     )
 
 
 def _resolve_args() -> list[str]:
+    if "HERMES_ACP_ARGS" in os.environ:
+        raw = os.environ["HERMES_ACP_ARGS"].strip()
+        return shlex.split(raw) if raw else []
     raw = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
     if not raw:
         return ["--acp", "--stdio"]
@@ -348,10 +353,18 @@ class CopilotACPClient:
         **_: Any,
     ):
         self.api_key = api_key or "copilot-acp"
-        self.base_url = base_url or ACP_MARKER_BASE_URL
+        self.base_url = base_url or (
+            ACP_MARKER_BASE_URL_GENERIC if (
+                (acp_command or command or "").strip() not in ("copilot", "", None)
+                and not (acp_command or command or "").strip().endswith("copilot")
+            ) else ACP_MARKER_BASE_URL
+        )
         self._default_headers = dict(default_headers or {})
         self._acp_command = acp_command or command or _resolve_command()
-        self._acp_args = list(acp_args or args or _resolve_args())
+        self._acp_args = list(
+            acp_args if acp_args is not None
+            else (args if args is not None else _resolve_args())
+        )
         self._acp_cwd = str(Path(acp_cwd or os.getcwd()).resolve())
         self.chat = _ACPChatNamespace(self)
         self.is_closed = False
@@ -436,9 +449,18 @@ class CopilotACPClient:
         )
 
     def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
+        executable = self._acp_command
+        try:
+            import shutil as _shutil
+            resolved = _shutil.which(executable)
+            if resolved:
+                executable = resolved
+        except Exception:
+            pass
+
         try:
             proc = subprocess.Popen(
-                [self._acp_command] + self._acp_args,
+                [executable] + self._acp_args,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -449,13 +471,13 @@ class CopilotACPClient:
             )
         except FileNotFoundError as exc:
             raise RuntimeError(
-                f"Could not start Copilot ACP command '{self._acp_command}'. "
-                "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH."
+                f"Could not start ACP command '{self._acp_command}'. "
+                "或设置 HERMES_ACP_COMMAND 环境变量指向正确的可执行文件。"
             ) from exc
 
         if proc.stdin is None or proc.stdout is None:
             proc.kill()
-            raise RuntimeError("Copilot ACP process did not expose stdin/stdout pipes.")
+            raise RuntimeError("ACP process did not expose stdin/stdout pipes.")
 
         self.is_closed = False
         with self._active_process_lock:
@@ -522,7 +544,7 @@ class CopilotACPClient:
                 if "error" in msg:
                     err = msg.get("error") or {}
                     raise RuntimeError(
-                        f"Copilot ACP {method} failed: {err.get('message') or err}"
+                        f"ACP {method} failed: {err.get('message') or err}"
                     )
                 return msg.get("result")
 
@@ -543,8 +565,8 @@ class CopilotACPClient:
                         "directly with a Copilot subscription token) via `hermes setup`.\n\n"
                         f"Original error:\n{stderr_text}"
                     )
-                raise RuntimeError(f"Copilot ACP process exited early: {stderr_text}")
-            raise TimeoutError(f"Timed out waiting for Copilot ACP response to {method}.")
+                raise RuntimeError(f"ACP process exited early: {stderr_text}")
+            raise TimeoutError(f"Timed out waiting for ACP response to {method}.")
 
         try:
             _request(
@@ -573,7 +595,7 @@ class CopilotACPClient:
             ) or {}
             session_id = str(session.get("sessionId") or "").strip()
             if not session_id:
-                raise RuntimeError("Copilot ACP did not return a sessionId.")
+                raise RuntimeError("ACP did not return a sessionId.")
 
             text_parts: list[str] = []
             reasoning_parts: list[str] = []

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1052,8 +1052,9 @@ def _build_child_agent(
         effective_acp_args = []
 
     if override_acp_command:
-        # If explicitly forcing an ACP transport override, the provider MUST be copilot-acp
-        # so run_agent.py initializes the CopilotACPClient.
+        # ACP transport override — route to the ACP client backend.
+        # "copilot-acp" is the internal provider marker that triggers
+        # CopilotACPClient creation (works for any ACP-compatible CLI).
         effective_provider = "copilot-acp"
         effective_api_mode = "chat_completions"
 


### PR DESCRIPTION
## What does this PR do?

Fixes the ACP client to support any ACP-compatible CLI backend, not just GitHub Copilot CLI.

Closes #31083

## Changes

- **agent/copilot_acp_client.py**: Add HERMES_ACP_COMMAND/ARGS env vars, shutil.which() executable resolution, is not None acp_args checks, generic error messages and base URL
- **agent/agent_runtime_helpers.py**: Accept acp:// prefix for transport routing
- **tools/delegate_tool.py**: Update copilot-acp marker comment

## Type of Change

- [x] Bug fix

## Test

1. npm install -g @agentclientprotocol/claude-agent-acp
2. HERMES_ACP_COMMAND=claude-agent-acp HERMES_ACP_ARGS=""
3. delegate_task(goal="hello", acp_command="claude-agent-acp", acp_args=[])

Tested on Windows 11. Backward compatible.