### PR TITLE
fix(telegram): preserve observed group slash commands

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -4631,6 +4631,12 @@ class TelegramAdapter(BasePlatformAdapter):
         shared_source = self._telegram_group_observe_shared_source(event.source)
         observe_prompt = self._telegram_group_observe_channel_prompt()
         channel_prompt = f"{event.channel_prompt}\n\n{observe_prompt}" if event.channel_prompt else observe_prompt
+        if event.message_type == MessageType.COMMAND:
+            return dataclasses.replace(
+                event,
+                source=shared_source,
+                channel_prompt=channel_prompt,
+            )
         return dataclasses.replace(
             event,
             text=self._telegram_group_observe_attributed_text(event),

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -313,6 +313,40 @@ def test_observed_group_context_replays_normally_without_telegram_prompt():
     assert agent_history == [{"role": "user", "content": "[Alice|111]\nside chatter"}]
 
 
+def test_observed_group_context_preserves_slash_command_text_for_dispatch():
+    from gateway.platforms.base import MessageEvent, MessageType, Platform, SessionSource
+
+    adapter = _make_adapter(
+        require_mention=True,
+        allowed_chats=["-100"],
+        group_allowed_chats=["-100"],
+        observe_unmentioned_group_messages=True,
+    )
+    event = MessageEvent(
+        text="/new@hermes_bot",
+        message_type=MessageType.COMMAND,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-100",
+            user_id="111",
+            user_name="Alice",
+            chat_type="group",
+            thread_id="7",
+        ),
+        raw_message=_group_message(
+            "/new@hermes_bot",
+            entities=[_bot_command_entity("/new@hermes_bot", "/new@hermes_bot")],
+        ),
+    )
+
+    attributed = adapter._apply_telegram_group_observe_attribution(event)
+
+    assert attributed.text == "/new@hermes_bot"
+    assert attributed.get_command() == "new"
+    assert attributed.source.user_id is None
+    assert "observed Telegram group context" in attributed.channel_prompt
+
+
 def test_unmentioned_group_observe_requires_chat_allowlist_for_shared_context():
     async def _run():
         adapter = _make_adapter(


### PR DESCRIPTION
## Summary
- preserve Telegram slash-command text when observed group context attribution is applied
- keep shared observed-context routing/prompt behavior for command events
- add regression coverage for `/new@bot` dispatch with `require_mention` and observed group context enabled

## Why
With `telegram.require_mention: true` and `telegram.observe_unmentioned_group_messages: true`, addressed commands such as `/new@bot` pass the mention gate but were then rewritten with the observed-context speaker prefix. That made the dispatcher see text that no longer started with `/`, so the command could fall through to the agent instead of the gateway command handler.

## Tests
- `git diff --check origin/main..HEAD`
- `uv tool run ruff check .`
- `/home/dev/hermes/venv/bin/python scripts/check-windows-footguns.py --all`
- `/home/dev/hermes/venv/bin/python -m pytest tests/gateway/test_telegram_group_gating.py tests/test_hermes_state.py -q`
