### PR TITLE
feat(google-workspace): add tasks list subcommand to google_api.py

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -286,6 +286,25 @@ $GAPI docs create --title "Draft" --body "First paragraph..."
 $GAPI docs append DOC_ID --text "Additional content to append"
 ```
 
+### Tasks
+
+```bash
+# List open tasks across all task lists (default 50 per list)
+$GAPI tasks list --max 50
+
+# Include completed tasks
+$GAPI tasks list --max 50 --show-completed
+
+# Include hidden tasks
+$GAPI tasks list --max 50 --show-hidden
+```
+
+Output: `[{title, list, status, due, notes}]` where `status` is `⬜` (open) or `✅`
+(completed) and `due` is `YYYY-MM-DD` (Tasks only stores the date part).
+
+For creating, updating, or completing tasks, call the Google Tasks API directly
+via `curl` — `google_api.py` exposes the `list` operation only.
+
 ## Output Format
 
 All commands return JSON. Parse with `jq` or read directly. Key fields:
@@ -307,6 +326,7 @@ All commands return JSON. Parse with `jq` or read directly. Key fields:
 - **Sheets create**: `{status: "created", spreadsheetId, title, spreadsheetUrl}`
 - **Docs create**: `{status: "created", documentId, title, url}`
 - **Docs append**: `{status: "appended", documentId, inserted_at, characters}`
+- **Tasks list**: `[{title, list, status, due, notes}]` (status `⬜`/`✅`, due `YYYY-MM-DD`)
 
 ## Rules
 

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -18,6 +18,7 @@ Usage:
   python google_api.py sheets update SHEET_ID RANGE --values '[[...]]'
   python google_api.py sheets append SHEET_ID RANGE --values '[[...]]'
   python google_api.py docs get DOC_ID
+  python google_api.py tasks list [--max 50] [--show-completed] [--show-hidden]
 """
 
 import argparse
@@ -51,6 +52,7 @@ SCOPES = [
     "https://www.googleapis.com/auth/contacts.readonly",
     "https://www.googleapis.com/auth/spreadsheets",
     "https://www.googleapis.com/auth/documents",
+    "https://www.googleapis.com/auth/tasks.readonly",
 ]
 
 
@@ -1043,6 +1045,73 @@ def _docs_insert_text(doc_id: str, text: str, index: int) -> None:
 
 
 # =========================================================================
+# Tasks
+# =========================================================================
+
+
+def _tasks_format_due(due: str) -> str:
+    """Google Tasks stores due as an RFC 3339 timestamp but only the date part is meaningful."""
+    if not due:
+        return ""
+    return due.split("T", 1)[0]
+
+
+def _tasks_list_via_gws(args):
+    lists = _run_gws(["tasks", "tasklists", "list"]).get("items", []) or []
+    items = []
+    for tl in lists:
+        result = _run_gws(
+            ["tasks", "tasks", "list"],
+            params={
+                "tasklist": tl["id"],
+                "maxResults": args.max,
+                "showCompleted": args.show_completed,
+                "showHidden": args.show_hidden,
+            },
+        )
+        for t in result.get("items", []) or []:
+            if not args.show_completed and t.get("status") == "completed":
+                continue
+            items.append({
+                "title": t.get("title", ""),
+                "list": tl.get("title", ""),
+                "status": "✅" if t.get("status") == "completed" else "⬜",
+                "due": _tasks_format_due(t.get("due", "")),
+                "notes": t.get("notes", "") or "",
+            })
+    return items
+
+
+def _tasks_list_via_python(args):
+    service = build_service("tasks", "v1")
+    lists = service.tasklists().list().execute().get("items", []) or []
+    items = []
+    for tl in lists:
+        result = service.tasks().list(
+            tasklist=tl["id"],
+            maxResults=args.max,
+            showCompleted=args.show_completed,
+            showHidden=args.show_hidden,
+        ).execute()
+        for t in result.get("items", []) or []:
+            if not args.show_completed and t.get("status") == "completed":
+                continue
+            items.append({
+                "title": t.get("title", ""),
+                "list": tl.get("title", ""),
+                "status": "✅" if t.get("status") == "completed" else "⬜",
+                "due": _tasks_format_due(t.get("due", "")),
+                "notes": t.get("notes", "") or "",
+            })
+    return items
+
+
+def tasks_list(args):
+    items = _tasks_list_via_gws(args) if _gws_binary() else _tasks_list_via_python(args)
+    print(json.dumps(items, indent=2, ensure_ascii=False))
+
+
+# =========================================================================
 # CLI parser
 # =========================================================================
 
@@ -1212,6 +1281,16 @@ def main():
     p.add_argument("doc_id")
     p.add_argument("--text", required=True, help="Text to append to the end of the document")
     p.set_defaults(func=docs_append)
+
+    # --- Tasks ---
+    tasks = sub.add_parser("tasks")
+    tasks_sub = tasks.add_subparsers(dest="action", required=True)
+
+    p = tasks_sub.add_parser("list")
+    p.add_argument("--max", type=int, default=50, help="Max tasks per task list (default 50)")
+    p.add_argument("--show-completed", action="store_true", help="Include completed tasks")
+    p.add_argument("--show-hidden", action="store_true", help="Include hidden tasks")
+    p.set_defaults(func=tasks_list)
 
     args = parser.parse_args()
     args.func(args)

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -51,6 +51,7 @@ SCOPES = [
     "https://www.googleapis.com/auth/contacts.readonly",
     "https://www.googleapis.com/auth/spreadsheets",
     "https://www.googleapis.com/auth/documents",
+    "https://www.googleapis.com/auth/tasks.readonly",
 ]
 
 REQUIRED_PACKAGES = ["google-api-python-client", "google-auth-oauthlib", "google-auth-httplib2"]

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -234,3 +234,87 @@ def test_api_get_credentials_refresh_persists_authorized_user_type(api_module, m
     assert isinstance(creds, FakeCredentials)
     assert saved["token"] == "ya29.refreshed"
     assert saved["type"] == "authorized_user"
+
+
+def _tasks_capture(captured):
+    """Side-effect factory: respond to tasklists/list and tasks/list gws calls."""
+
+    def run(cmd, **kwargs):
+        captured.setdefault("cmds", []).append(cmd)
+        if "tasklists" in cmd:
+            return MagicMock(returncode=0, stdout=json.dumps({
+                "items": [{"id": "list-1", "title": "My Tasks"}],
+            }), stderr="")
+        return MagicMock(returncode=0, stdout=json.dumps({
+            "items": [
+                {"title": "open task", "status": "needsAction",
+                 "due": "2026-06-01T00:00:00.000Z", "notes": "note"},
+                {"title": "done task", "status": "completed",
+                 "due": "2026-05-20T00:00:00.000Z", "notes": ""},
+            ],
+        }), stderr="")
+
+    return run
+
+
+def test_api_tasks_list_invokes_gws_with_correct_commands(api_module):
+    """tasks_list calls _run_gws for tasklists.list then tasks.list per list."""
+    captured = {}
+    args = api_module.argparse.Namespace(
+        max=50, show_completed=False, show_hidden=False, func=api_module.tasks_list,
+    )
+
+    with patch.object(api_module.subprocess, "run", side_effect=_tasks_capture(captured)):
+        api_module.tasks_list(args)
+
+    cmds = captured["cmds"]
+    assert len(cmds) == 2
+    # First call: list of task lists
+    assert cmds[0][0] == "/usr/bin/gws"
+    assert "tasks" in cmds[0] and "tasklists" in cmds[0] and "list" in cmds[0]
+    # Second call: tasks within the list, with showCompleted/showHidden flags
+    assert "tasks" in cmds[1] and "list" in cmds[1]
+    params_idx = cmds[1].index("--params")
+    params = json.loads(cmds[1][params_idx + 1])
+    assert params["tasklist"] == "list-1"
+    assert params["maxResults"] == 50
+    assert params["showCompleted"] is False
+    assert params["showHidden"] is False
+
+
+def test_api_tasks_list_formats_output_and_filters_completed(api_module, capsys):
+    """tasks_list emits the documented shape and drops completed items by default."""
+    captured = {}
+    args = api_module.argparse.Namespace(
+        max=50, show_completed=False, show_hidden=False, func=api_module.tasks_list,
+    )
+
+    with patch.object(api_module.subprocess, "run", side_effect=_tasks_capture(captured)):
+        api_module.tasks_list(args)
+
+    output = json.loads(capsys.readouterr().out)
+    assert output == [{
+        "title": "open task",
+        "list": "My Tasks",
+        "status": "⬜",
+        "due": "2026-06-01",
+        "notes": "note",
+    }]
+
+
+def test_api_tasks_list_includes_completed_when_requested(api_module, capsys):
+    """--show-completed passes the flag and keeps completed items in output."""
+    captured = {}
+    args = api_module.argparse.Namespace(
+        max=50, show_completed=True, show_hidden=False, func=api_module.tasks_list,
+    )
+
+    with patch.object(api_module.subprocess, "run", side_effect=_tasks_capture(captured)):
+        api_module.tasks_list(args)
+
+    params = json.loads(captured["cmds"][1][captured["cmds"][1].index("--params") + 1])
+    assert params["showCompleted"] is True
+
+    output = json.loads(capsys.readouterr().out)
+    statuses = sorted({row["status"] for row in output})
+    assert statuses == ["✅", "⬜"]


### PR DESCRIPTION
## Summary

Adds `python google_api.py tasks list [--max N] [--show-completed] [--show-hidden]` to the Google Workspace skill, returning `[{title, list, status, due, notes}]` aggregated across all of the user's task lists.

- `status` is `⬜` (open) or `✅` (completed)
- `due` is normalized to `YYYY-MM-DD` (Tasks only stores the date part of RFC 3339)
- Completed items are filtered out unless `--show-completed` is passed
- Both the gws-binary path and the google-api-python-client fallback are implemented, mirroring the existing pattern in this file
- Adds `https://www.googleapis.com/auth/tasks.readonly` to `SCOPES` in both `google_api.py` and `setup.py`

Read-only by design — the docstring and `SKILL.md` note that creating/updating tasks should call the Tasks API directly via curl. Happy to extend to `tasks create` in a follow-up if there's interest.

## Why

The Google Tasks API has a stable, narrow surface that's a natural fit for the same `_run_gws` / `build_service` pattern the rest of the file uses. Without a `tasks` subcommand, agents using this skill have to hand-roll OAuth-token-refresh + raw HTTP just to read task lists.

## Test plan

- [x] `pytest tests/skills/test_google_workspace_api.py` — 10/10 pass (3 new + 7 existing)
- [x] `pytest tests/skills/` — 175/175 pass
- [x] `ruff check` clean on all changed files
- [x] Manual run against a real account with `tasks.readonly` granted — returned tasks formatted as documented
