### PR TITLE
fix(gateway): drop pytest-tmpdir node resolutions from generated service templates

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2251,6 +2251,22 @@ def _hermes_home_for_target_user(target_home_dir: str) -> str:
         return str(current_hermes)
 
 
+def _looks_like_pytest_temp_path(path: str | Path) -> bool:
+    """Return True when ``path`` looks like a pytest tmpdir artifact.
+
+    Used to keep generated systemd/launchd service templates from baking in
+    stale `/tmp/pytest-of-.../hermes_test/...` paths that a previous test run
+    may have left behind on the developer's machine (e.g. via a
+    `~/.local/bin/node` symlink that still resolves into a pytest tempdir).
+    """
+    raw = str(path)
+    return (
+        "/pytest-of-" in raw
+        or "/hermes_test/" in raw
+        or raw.endswith("/hermes_test")
+    )
+
+
 def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:
     """Build PATH directory list for service units, excluding non-existent dirs."""
     if project_root is None:
@@ -2323,7 +2339,15 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
     resolved_node = shutil.which("node")
     if resolved_node:
         resolved_node_dir = str(Path(resolved_node).resolve().parent)
-        if resolved_node_dir not in path_entries:
+        # Skip stale pytest-tmpdir resolutions (e.g. ~/.local/bin/node
+        # symlinks left over from a prior test run) so the systemd unit
+        # never bakes in /tmp/pytest-of-.../hermes_test/node/bin — that
+        # also causes systemd_unit_is_current() to flap "outdated"
+        # forever on the next `hermes gateway status`. (#31074)
+        if (
+            resolved_node_dir not in path_entries
+            and not _looks_like_pytest_temp_path(resolved_node_dir)
+        ):
             path_entries.append(resolved_node_dir)
 
     common_bin_paths = [
@@ -3031,11 +3055,21 @@ def generate_launchd_plist() -> str:
     resolved_node = shutil.which("node")
     if resolved_node:
         resolved_node_dir = str(Path(resolved_node).resolve().parent)
-        if resolved_node_dir not in priority_dirs:
+        # Skip stale pytest-tmpdir resolutions so the launchd plist never
+        # bakes in /tmp/pytest-of-.../hermes_test/node/bin (#31074).
+        if (
+            resolved_node_dir not in priority_dirs
+            and not _looks_like_pytest_temp_path(resolved_node_dir)
+        ):
             priority_dirs.append(resolved_node_dir)
     sane_path = ":".join(
         dict.fromkeys(
-            priority_dirs + [p for p in os.environ.get("PATH", "").split(":") if p]
+            priority_dirs
+            + [
+                p
+                for p in os.environ.get("PATH", "").split(":")
+                if p and not _looks_like_pytest_temp_path(p)
+            ]
         )
     )
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2258,13 +2258,11 @@ def _looks_like_pytest_temp_path(path: str | Path) -> bool:
     stale `/tmp/pytest-of-.../hermes_test/...` paths that a previous test run
     may have left behind on the developer's machine (e.g. via a
     `~/.local/bin/node` symlink that still resolves into a pytest tempdir).
+
+    Requires ``/pytest-of-`` to appear in the path so a legitimate user
+    directory called ``hermes_test`` is not mistaken for a pytest leftover.
     """
-    raw = str(path)
-    return (
-        "/pytest-of-" in raw
-        or "/hermes_test/" in raw
-        or raw.endswith("/hermes_test")
-    )
+    return "/pytest-of-" in str(path)
 
 
 def _build_service_path_dirs(project_root: Path | None = None) -> list[str]:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1716,6 +1716,25 @@ class TestProfileArg:
         assert "/pytest-of-" not in path_value
         assert "/hermes_test/" not in path_value
 
+    def test_launchd_plist_keeps_user_dir_named_hermes_test(self, tmp_path, monkeypatch):
+        # A real user directory called ``hermes_test`` (no ``pytest-of-`` ancestor)
+        # must NOT be filtered out as a pytest tmpdir artifact. (#31074)
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: hermes_home)
+        monkeypatch.setenv(
+            "PATH",
+            "/Users/alice/code/hermes_test/scripts:/usr/local/bin:/usr/bin",
+        )
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: None)
+
+        path_value = self._launchd_path_value(gateway_cli.generate_launchd_plist())
+
+        assert "/Users/alice/code/hermes_test/scripts" in path_value
+        assert "/pytest-of-" not in path_value
+
     def test_launchd_plist_path_uses_real_user_home_not_profile_home(self, tmp_path, monkeypatch):
         profile_dir = tmp_path / ".hermes" / "profiles" / "orcha"
         profile_dir.mkdir(parents=True)

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -339,6 +339,33 @@ class TestGeneratedSystemdUnits:
 
         assert "/home/test/.nvm/versions/node/v24.14.0/bin" in unit
 
+    def test_user_unit_skips_pytest_temp_resolved_node_directory(self, monkeypatch):
+        # A ``~/.local/bin/node`` symlink can outlive the pytest tmpdir it
+        # originally pointed at. ``shutil.which("node")`` then resolves into
+        # ``/tmp/pytest-of-.../hermes_test/node/bin/node`` and the generated
+        # unit would otherwise persist that ephemeral path, causing
+        # ``hermes gateway status`` to flap "outdated" forever and the
+        # refresh path to refuse to write the polluted unit. (#31074)
+        monkeypatch.setattr(
+            gateway_cli.shutil,
+            "which",
+            lambda cmd: "/tmp/pytest-of-alice/pytest-42/test_x/hermes_test/node/bin/node"
+            if cmd == "node"
+            else None,
+        )
+
+        unit = gateway_cli.generate_systemd_unit(system=False)
+
+        # Scope the assertion to the PATH= line — HERMES_HOME under the test
+        # conftest legitimately sits inside the per-test pytest tmpdir.
+        import re
+
+        path_match = re.search(r'Environment="PATH=([^"]*)"', unit)
+        assert path_match is not None, "PATH environment missing from unit"
+        path_value = path_match.group(1)
+        assert "/pytest-of-" not in path_value
+        assert "/hermes_test/" not in path_value
+
     def test_user_unit_includes_wsl_windows_interop_paths(self, monkeypatch):
         monkeypatch.setattr(gateway_cli, "is_wsl", lambda: True)
         monkeypatch.setenv(
@@ -1628,6 +1655,66 @@ class TestProfileArg:
         plist = gateway_cli.generate_launchd_plist()
         assert "<string>--profile</string>" in plist
         assert "<string>mybot</string>" in plist
+
+    @staticmethod
+    def _launchd_path_value(plist: str) -> str:
+        # Extract just the PATH <string>…</string> payload so assertions can
+        # focus on the generated PATH and ignore HERMES_HOME/log paths, which
+        # legitimately sit under the test's tmp_path sandbox.
+        import re
+
+        match = re.search(
+            r"<key>PATH</key>\s*<string>(.*?)</string>",
+            plist,
+            flags=re.S,
+        )
+        assert match is not None, "PATH key missing from generated plist"
+        return match.group(1)
+
+    def test_launchd_plist_skips_pytest_temp_resolved_node_directory(self, tmp_path, monkeypatch):
+        # Same root cause as the systemd variant: a stale node symlink that
+        # resolves into a pytest tmpdir would otherwise leak into the
+        # installed plist's PATH. (#31074)
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: hermes_home)
+        monkeypatch.setenv("PATH", "/usr/local/bin:/usr/bin")
+        monkeypatch.setattr(
+            gateway_cli.shutil,
+            "which",
+            lambda cmd: "/tmp/pytest-of-alice/pytest-42/test_x/hermes_test/node/bin/node"
+            if cmd == "node"
+            else None,
+        )
+
+        path_value = self._launchd_path_value(gateway_cli.generate_launchd_plist())
+
+        assert "/pytest-of-" not in path_value
+        assert "/hermes_test/" not in path_value
+
+    def test_launchd_plist_omits_pytest_temp_entries_from_shell_path(self, tmp_path, monkeypatch):
+        # The launchd plist captures the invoking shell's PATH so user-installed
+        # tools (nvm, Homebrew, etc.) stay reachable under launchd. If that PATH
+        # contains a pytest-leftover entry it should not be baked in. (#31074)
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: hermes_home)
+        monkeypatch.setenv(
+            "PATH",
+            "/usr/local/bin:/tmp/pytest-of-alice/pytest-7/test_y/hermes_test/node/bin:/usr/bin",
+        )
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: None)
+
+        path_value = self._launchd_path_value(gateway_cli.generate_launchd_plist())
+
+        assert "/usr/local/bin" in path_value
+        assert "/usr/bin" in path_value
+        assert "/pytest-of-" not in path_value
+        assert "/hermes_test/" not in path_value
 
     def test_launchd_plist_path_uses_real_user_home_not_profile_home(self, tmp_path, monkeypatch):
         profile_dir = tmp_path / ".hermes" / "profiles" / "orcha"


### PR DESCRIPTION
## What does this PR do?

When ``shutil.which(\"node\")`` resolves to a leftover pytest tmpdir (e.g. a
``~/.local/bin/node`` symlink that still points at
``/tmp/pytest-of-.../hermes_test/node/bin/node`` from a prior test run),
``generate_systemd_unit()`` and ``generate_launchd_plist()`` would otherwise
bake that ephemeral path into the installed service template's PATH.

For the systemd path that has two visible symptoms:

- ``systemd_unit_is_current()`` keeps reporting \"outdated\" forever because
  the freshly generated unit differs from the installed one (the tmpdir
  segment changes across runs), so ``hermes gateway status`` flaps.
- The existing safety belt in ``refresh_systemd_unit_if_needed()`` silently
  refuses to write the polluted unit, leaving the user-scope refresh path
  permanently broken with no actionable output.

For the launchd path the comparison normalizer ignores PATH so it doesn't
flap, but the polluted PATH still gets baked into the installed plist on
first install and any refresh.

The fix adds a small ``_looks_like_pytest_temp_path()`` helper (mirrors the
existing inline detector in ``refresh_systemd_unit_if_needed()``) and uses
it to skip the resolved-node-directory append in both generators, plus
filters pytest-tmpdir entries out of the shell PATH that the launchd plist
captures.

## Related Issue

Fixes #31074

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- ``hermes_cli/gateway.py`` — new ``_looks_like_pytest_temp_path()`` helper,
  used to skip stale pytest-tmpdir entries in ``generate_systemd_unit()``,
  the resolved-node branch of ``generate_launchd_plist()``, and the
  shell-PATH capture of ``generate_launchd_plist()``.
- ``tests/hermes_cli/test_gateway_service.py`` — three regression tests:
  ``test_user_unit_skips_pytest_temp_resolved_node_directory`` (the issue's
  named test), ``test_launchd_plist_skips_pytest_temp_resolved_node_directory``,
  ``test_launchd_plist_omits_pytest_temp_entries_from_shell_path``. The
  launchd tests scope the assertion to the PATH= value via a small regex
  helper so the per-test conftest's sandboxed HERMES_HOME (which legitimately
  sits under ``tmp_path``) doesn't trip the assertion.

## How to Test

1. Reproduce locally:
   ``ln -sfn /tmp/pytest-of-user/pytest-42/test_x/hermes_test/node/bin/node ~/.local/bin/node``
   then ``hermes gateway status`` — before the fix this reports the unit as
   outdated, and ``refresh_systemd_unit_if_needed()`` silently no-ops.
2. ``uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout python3 -m pytest tests/hermes_cli/test_gateway_service.py -v -k 'pytest_temp or skips_pytest or omits_pytest'``
3. Expected: 3 passed.

> Regression guard: with the production patch reverted but the new tests
> kept, all three new tests fail with the expected ``/pytest-of-`` /
> ``/hermes_test/`` content in the generated PATH. Reapplying the patch
> makes them pass. The 6 pre-existing failures elsewhere in
> ``test_gateway_service.py`` reproduce on clean ``origin/main`` (macOS
> baseline — Linux-only systemd code paths) and are unrelated to this PR.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (\`fix(scope):\`, \`feat(scope):\`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, \`docs/\`, docstrings) — or N/A
- [x] I've updated \`cli-config.yaml.example\` if I added/changed config keys — or N/A
- [x] I've updated \`CONTRIBUTING.md\` or \`AGENTS.md\` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Sibling code paths

> Audited siblings: ``_build_wsl_interop_paths()`` (line 2032) resolves
> ``powershell.exe``/``cmd.exe``/``explorer.exe``/``wsl.exe`` via
> ``shutil.which`` but those land under ``/mnt/c/WINDOWS/...`` and aren't
> a plausible pytest-tmpdir target. The existing inline detector in
> ``refresh_systemd_unit_if_needed()`` (line 2308) is text-level (matches
> rendered unit content) rather than path-level, so the new helper is
> intentionally separate — happy to fold the inline check into the helper
> in a follow-up if preferred. No widening needed for this PR.

## Screenshots / Logs

<!-- N/A — the symptom is invisible until it bakes into the installed unit. -->