### PR TITLE
fix: ignore Telegram /start platform pings

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6842,6 +6842,13 @@ class GatewayRunner:
                 if _denied is not None:
                     return _denied
 
+            # Telegram sends /start for bot launches/deep-links. Treat it as a
+            # platform ping, not a user command: no help dump, no agent
+            # interrupt, no queued text.
+            if _cmd_def_inner and _cmd_def_inner.name == "start":
+                logger.info("Ignoring /start platform ping for active session %s", _quick_key)
+                return ""
+
             if _cmd_def_inner and _cmd_def_inner.name == "restart":
                 return await self._handle_restart_command(event)
 
@@ -7258,6 +7265,10 @@ class GatewayRunner:
         
         if canonical == "help":
             return await self._handle_help_command(event)
+
+        if canonical == "start":
+            logger.info("Ignoring /start platform ping for session %s", _quick_key)
+            return ""
 
         if canonical == "commands":
             return await self._handle_commands_command(event)

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -63,6 +63,8 @@ class CommandDef:
 
 COMMAND_REGISTRY: list[CommandDef] = [
     # Session
+    CommandDef("start", "Acknowledge platform start pings without a reply", "Session",
+               gateway_only=True),
     CommandDef("new", "Start a new session (fresh session ID + history)", "Session",
                aliases=("reset",), args_hint="[name]"),
     CommandDef("topic", "Enable or inspect Telegram DM topic sessions", "Session",

--- a/tests/gateway/test_gateway_command_help.py
+++ b/tests/gateway/test_gateway_command_help.py
@@ -26,6 +26,16 @@ def _make_runner():
     return object.__new__(GatewayRunner)
 
 
+def test_start_is_known_gateway_command():
+    """Telegram sends /start automatically; gateway should intercept it as a no-op."""
+    from hermes_cli.commands import GATEWAY_KNOWN_COMMANDS, resolve_command
+
+    cmd = resolve_command("start")
+    assert "start" in GATEWAY_KNOWN_COMMANDS
+    assert cmd is not None
+    assert cmd.name == "start"
+
+
 @pytest.mark.asyncio
 async def test_help_sanitizes_slash_command_mentions_for_telegram(monkeypatch):
     """Telegram help output must not expose invalid uppercase/hyphenated slashes."""

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -331,6 +331,42 @@ async def test_command_messages_do_not_leave_sentinel():
 
 
 @pytest.mark.asyncio
+async def test_start_command_is_noop_and_does_not_show_help():
+    """Telegram /start is a platform ping; it must not dump /help output."""
+    runner = _make_runner()
+    event = _make_event(text="/start")
+    session_key = build_session_key(event.source)
+
+    runner._handle_help_command = AsyncMock(return_value="Help text")
+
+    result = await runner._handle_message(event)
+
+    assert result == ""
+    runner._handle_help_command.assert_not_awaited()
+    assert session_key not in runner._running_agents
+
+
+@pytest.mark.asyncio
+async def test_start_command_is_noop_during_active_session():
+    """A mid-run /start must not interrupt the active agent or show commands."""
+    runner = _make_runner()
+    event = _make_event(text="/start")
+    session_key = build_session_key(event.source)
+
+    fake_agent = MagicMock()
+    fake_agent.get_activity_summary.return_value = {"seconds_since_activity": 0}
+    runner._running_agents[session_key] = fake_agent
+    runner._handle_help_command = AsyncMock(return_value="Help text")
+
+    result = await runner._handle_message(event)
+
+    assert result == ""
+    runner._handle_help_command.assert_not_awaited()
+    fake_agent.interrupt.assert_not_called()
+    assert session_key not in runner.adapters[Platform.TELEGRAM]._pending_messages
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("command_text", "handler_attr", "handler_result"),
     [


### PR DESCRIPTION
## Summary

Telegram automatically sends `/start` when a user opens or launches the bot. Hermes was treating this as a regular command, which could cause an unexpected help dump or interrupt an active agent session mid-run.

This fix registers `/start` as a known gateway-only command and makes it a silent no-op — no reply, no help, no agent interruption.

## Changes

- `hermes_cli/commands.py`: registers `start` as a `gateway_only` CommandDef so it is recognized and dispatchable without appearing in the CLI
- `gateway/run.py`: intercepts `/start` on both the running-agent fast-path and the cold-path, returning an empty string immediately
- `tests/gateway/test_gateway_command_help.py`: asserts `start` is in `GATEWAY_KNOWN_COMMANDS`
- `tests/gateway/test_session_race_guard.py`: two tests for cold-path and active-session no-op behavior

## Test Plan

```bash
python -m pytest tests/gateway/test_gateway_command_help.py::test_start_is_known_gateway_command tests/gateway/test_session_race_guard.py::test_start_command_is_noop_and_does_not_show_help tests/gateway/test_session_race_guard.py::test_start_command_is_noop_during_active_session -q -o 'addopts='
```

All 3 pass.