### PR TITLE
feat: allow configurable Telegram command menu priority

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -545,12 +545,72 @@ need to survive the visible menu cap ahead of lower-priority built-ins.
 """
 
 
+def _configured_telegram_menu_priority() -> list[str]:
+    """Return user-configured Telegram menu priority command names.
+
+    Users can place custom plugin/skill commands ahead of the built-in priority
+    list with ``telegram.menu_priority`` in config.yaml. The value may be a YAML
+    list or a comma-separated string. Unknown commands are harmless: they are
+    ignored naturally when sorting because only commands present in the menu are
+    ranked.
+    """
+    try:
+        from hermes_cli.config import read_raw_config
+
+        cfg = read_raw_config()
+    except Exception:
+        return []
+
+    value: Any = None
+    telegram_cfg = cfg.get("telegram") if isinstance(cfg, dict) else None
+    if isinstance(telegram_cfg, dict):
+        value = telegram_cfg.get("menu_priority")
+
+    if value is None:
+        # Backward-compatible with early user docs/examples that nested
+        # Telegram settings under gateway.telegram. Hermes' canonical config
+        # keeps platform blocks at the top level, but accepting both shapes
+        # makes this knob forgiving.
+        gateway_cfg = cfg.get("gateway") if isinstance(cfg, dict) else None
+        if isinstance(gateway_cfg, dict):
+            nested_telegram = gateway_cfg.get("telegram")
+            if isinstance(nested_telegram, dict):
+                value = nested_telegram.get("menu_priority")
+
+    if isinstance(value, str):
+        raw_items = [item.strip() for item in value.split(",")]
+    elif isinstance(value, (list, tuple)):
+        raw_items = [str(item).strip() for item in value]
+    else:
+        return []
+
+    result: list[str] = []
+    seen: set[str] = set()
+    for item in raw_items:
+        name = _sanitize_telegram_name(item.lstrip("/"))
+        if name and name not in seen:
+            result.append(name)
+            seen.add(name)
+    return result
+
+
+def _telegram_menu_priority() -> list[str]:
+    """Return configured priority followed by built-in operational priority."""
+    configured = _configured_telegram_menu_priority()
+    seen = set(configured)
+    return configured + [
+        _sanitize_telegram_name(name)
+        for name in _TELEGRAM_MENU_PRIORITY
+        if _sanitize_telegram_name(name) not in seen
+    ]
+
+
 def _prioritize_telegram_menu_commands(
     commands: list[tuple[str, str]],
 ) -> list[tuple[str, str]]:
     priority = {
-        _sanitize_telegram_name(name): index
-        for index, name in enumerate(_TELEGRAM_MENU_PRIORITY)
+        name: index
+        for index, name in enumerate(_telegram_menu_priority())
     }
     return [
         command

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1397,6 +1397,10 @@ DEFAULT_CONFIG = {
         "reactions": False,            # Add 👀/✅/❌ reactions to messages during processing
         "channel_prompts": {},         # Per-chat/topic ephemeral system prompts (topics inherit from parent group)
         "allowed_chats": "",           # If set, bot ONLY responds in these group/supergroup chat IDs (whitelist)
+        # Optional command names to pin first in Telegram's capped BotCommand
+        # menu. Useful for custom plugin/skill shortcuts; unknown names are
+        # ignored. Example: ["help", "new", "my_plugin_command"].
+        "menu_priority": [],
     },
 
     # Mattermost platform settings (gateway mode)

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -975,6 +975,60 @@ class TestTelegramMenuCommands:
         ):
             assert name in names
 
+
+    def test_configured_menu_priority_can_pin_plugin_commands(self, tmp_path, monkeypatch):
+        """telegram.menu_priority lets custom commands survive the visible menu cap."""
+        from unittest.mock import patch
+        import hermes_cli.plugins as plugins_mod
+
+        plugin_dir = tmp_path / "plugins" / "shortcut-plugin"
+        plugin_dir.mkdir(parents=True, exist_ok=True)
+        (plugin_dir / "plugin.yaml").write_text(
+            "name: shortcut-plugin\nversion: 0.1.0\ndescription: Test shortcuts\n"
+        )
+        (plugin_dir / "__init__.py").write_text(
+            "def register(ctx):\n"
+            "    for name in ['specialists', 'research', 'edit', 'field', 'hdebug', 'review']:\n"
+            "        ctx.register_command(name, lambda args, name=name: name, description=f'{name} shortcut')\n"
+        )
+        (tmp_path / "config.yaml").write_text(
+            "plugins:\n"
+            "  enabled:\n"
+            "    - shortcut-plugin\n"
+            "telegram:\n"
+            "  menu_priority:\n"
+            "    - specialists\n"
+            "    - research\n"
+            "    - edit\n"
+            "    - field\n"
+            "    - hdebug\n"
+            "    - review\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        with patch.object(plugins_mod, "_plugin_manager", None):
+            menu, hidden = telegram_menu_commands(max_commands=6)
+
+        assert [name for name, _desc in menu] == [
+            "specialists",
+            "research",
+            "edit",
+            "field",
+            "hdebug",
+            "review",
+        ]
+        assert hidden > 0
+
+    def test_configured_menu_priority_accepts_comma_string_and_sanitizes(self, tmp_path, monkeypatch):
+        (tmp_path / "config.yaml").write_text(
+            "telegram:\n  menu_priority: '/Status, /new, status, debug'\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        menu, _hidden = telegram_menu_commands(max_commands=4)
+
+        assert [name for name, _desc in menu][:4] == ["status", "new", "debug", "help"]
+
     def test_includes_plugin_commands_via_lazy_discovery(self, tmp_path, monkeypatch):
         """Telegram menu generation should discover plugin slash commands on first access."""
         from unittest.mock import patch


### PR DESCRIPTION
## Summary

Telegram caps the visible BotCommand menu at a small number of entries. Users with custom plugin or skill slash commands have no way to ensure those commands appear before built-in commands in the capped menu.

This adds a `telegram.menu_priority` config key that lets users pin any command names to the top of the Telegram menu:

```yaml
telegram:
  menu_priority:
    - my_plugin
    - help
    - new
```

The configured list prepends to the existing built-in operational command priority, so users get their shortcuts first and the well-known operational commands still survive the cap. Unknown names are harmless — they are silently ignored.

## Changes

- `hermes_cli/commands.py`: adds `_configured_telegram_menu_priority()` (reads config) and `_telegram_menu_priority()` (merges configured + built-in); updates `_prioritize_telegram_menu_commands()` to use the merged priority
- `hermes_cli/config.py`: adds `telegram.menu_priority: []` to `DEFAULT_CONFIG` with a comment
- `tests/hermes_cli/test_commands.py`: two new tests — plugin commands can be pinned via config, and comma-string values are accepted and sanitized

## Test Plan

```bash
python -m pytest tests/hermes_cli/test_commands.py::TestTelegramMenuCommands::test_configured_menu_priority_can_pin_plugin_commands tests/hermes_cli/test_commands.py::TestTelegramMenuCommands::test_configured_menu_priority_accepts_comma_string_and_sanitizes tests/hermes_cli/test_commands.py::TestTelegramMenuCommands::test_operational_builtins_survive_thirty_command_cap -q -o 'addopts='
```

All 3 pass.