### PR TITLE
fix(cli): prevent temp directory leak on ZIP update failure

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6932,8 +6932,8 @@ def _update_via_zip(args):
     )
 
     print("→ Downloading latest version...")
+    tmp_dir = tempfile.mkdtemp(prefix="hermes-update-")
     try:
-        tmp_dir = tempfile.mkdtemp(prefix="hermes-update-")
         zip_path = os.path.join(tmp_dir, f"hermes-agent-{branch}.zip")
         urlretrieve(zip_url, zip_path)
 
@@ -6980,12 +6980,11 @@ def _update_via_zip(args):
 
         print(f"✓ Updated {update_count} items from ZIP")
 
-        # Cleanup
-        shutil.rmtree(tmp_dir, ignore_errors=True)
-
     except Exception as e:
         print(f"✗ ZIP update failed: {e}")
         sys.exit(1)
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
 
     # Clear stale bytecode after ZIP extraction
     removed = _clear_bytecode_cache(PROJECT_ROOT)


### PR DESCRIPTION
## What does this PR do?

The ZIP update path in `_update_from_zip()` creates a temp directory via `mkdtemp` but only cleans it up on the success path. Any exception during download, extraction, or file copying jumps to the `except` block which calls `sys.exit(1)` — the `shutil.rmtree` on line 6984 is never reached, leaving the temp directory and all its contents on disk indefinitely.

Moved temp directory creation outside the `try` block and placed cleanup in a `finally` block so it always runs, even when the update fails.

## Related Issue

No existing issue — found during code audit.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py`: move `shutil.rmtree` into a `finally` block so `tmp_dir` is always cleaned up

## How to Test

1. Simulate a failure during ZIP update: unplug network mid-download, or corrupt the ZIP, or trigger any exception between `mkdtemp` and the old cleanup call
2. Run `hermes update`
3. Verify that `/tmp/hermes-update-*` directories are cleaned up even after failure
4. Verify that successful updates still work as before (no regression)

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've tested on my platform: macOS

## Infographic

![pr-31104-temp-dir-leak-fix](https://v3b.fal.media/files/b/0a9b6bbe/Z9rumY0jsMZRpyocHnDxC_nedkdS5U.png)
