### PR TITLE
feat(gateway): render todo tool results as editable Telegram checklist (#31001)

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -822,6 +822,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 agent.tool_progress_callback(
                     "tool.completed", function_name, None, None,
                     duration=tool_duration, is_error=_is_error_result,
+                    result=function_result,
                 )
             except Exception as cb_err:
                 logging.debug(f"Tool progress callback error: {cb_err}")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -248,7 +248,8 @@ def _render_todo_checklist(result_str: str) -> str:
     for item in todos:
         content = (item.get("content") or "")[:80]
         status = _STATUS_MAP.get(item.get("status", "pending"), "[ ]")
-        lines.append(f"{status} {content}")
+        item_id = item.get("id", "")
+        lines.append(f"{status} {content} ({item_id})" if item_id else f"{status} {content}")
     return "\n".join(lines)
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -223,6 +223,35 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
     return redacted
 
 
+_STATUS_MAP = {
+    "pending": "[ ]",
+    "in_progress": "[>]",
+    "completed": "[x]",
+    "cancelled": "[-]",
+}
+
+
+def _render_todo_checklist(result_str: str) -> str:
+    """Parse a todo tool result and render a compact checklist.
+
+    Returns the checklist string, or an empty string on failure (caller
+    should handle the empty case gracefully).
+    """
+    try:
+        data = json.loads(result_str)
+    except (json.JSONDecodeError, TypeError):
+        return ""
+    todos = data.get("todos") if isinstance(data, dict) else None
+    if not todos:
+        return ""
+    lines = ["📋 Task List"]
+    for item in todos:
+        content = (item.get("content") or "")[:80]
+        status = _STATUS_MAP.get(item.get("status", "pending"), "[ ]")
+        lines.append(f"{status} {content}")
+    return "\n".join(lines)
+
+
 def _prepare_gateway_status_message(platform: Any, event_type: str, message: str) -> Optional[str]:
     """Filter/sanitize agent status callbacks before platform delivery."""
     text = str(message or "").strip()
@@ -15651,6 +15680,16 @@ class GatewayRunner:
                             mark_seen(_hermes_home / "config.yaml", TOOL_PROGRESS_FLAG)
                 except Exception as _hint_err:
                     logger.debug("tool-progress onboarding hint failed: %s", _hint_err)
+                return
+
+
+            # Todo checklist: on tool.completed, render todo results as an
+            # editable checklist in the progress message bubble.
+            if event_type == "tool.completed" and tool_name == "todo":
+                try:
+                    progress_queue.put(_render_todo_checklist(kwargs.get("result", "")))
+                except Exception:
+                    logger.debug("Failed to render todo checklist", exc_info=True)
                 return
 
 

--- a/tests/gateway/test_run_todo_progress.py
+++ b/tests/gateway/test_run_todo_progress.py
@@ -1,0 +1,79 @@
+"""Tests for Telegram todo checklist rendering in gateway progress messages.
+
+When the todo tool completes during a Telegram session, the gateway should
+render a compact editable checklist in the progress bubble. Subsequent todo
+calls edit the same message in-place.
+"""
+
+import json
+
+
+def _make_todo_result(todos):
+    """Build the JSON string that the todo tool returns for a given item list."""
+    pending = sum(1 for i in todos if i.get("status", "pending") == "pending")
+    in_progress = sum(1 for i in todos if i.get("status") == "in_progress")
+    completed = sum(1 for i in todos if i.get("status") == "completed")
+    cancelled = sum(1 for i in todos if i.get("status") == "cancelled")
+    return json.dumps({
+        "todos": todos,
+        "summary": {
+            "total": len(todos),
+            "pending": pending,
+            "in_progress": in_progress,
+            "completed": completed,
+            "cancelled": cancelled,
+        },
+    }, ensure_ascii=False)
+
+
+class TestRenderTodoChecklist:
+    """Unit tests for the _render_todo_checklist helper in gateway/run.py."""
+
+    def _render(self, result_str):
+        from gateway.run import _render_todo_checklist
+        return _render_todo_checklist(result_str)
+
+    def test_renders_checklist_from_todo_result(self):
+        """Should render a full checklist with all four status types."""
+        result = _make_todo_result([
+            {"id": "1", "content": "Set up CI/CD", "status": "pending"},
+            {"id": "2", "content": "Write tests", "status": "in_progress"},
+            {"id": "3", "content": "Deploy", "status": "completed"},
+            {"id": "4", "content": "Cancel this", "status": "cancelled"},
+        ])
+        checklist = self._render(result)
+        assert "📋 Task List" in checklist
+        assert "[ ] Set up CI/CD" in checklist
+        assert "[>] Write tests" in checklist
+        assert "[x] Deploy" in checklist
+        assert "[-] Cancel this" in checklist
+
+    def test_empty_todos_returns_empty_string(self):
+        """Empty todo list should return empty string (not crash)."""
+        result = _make_todo_result([])
+        assert self._render(result) == ""
+
+    def test_invalid_json_returns_empty_string(self):
+        """Invalid JSON result should return empty string (fail closed)."""
+        assert self._render("not valid json") == ""
+        assert self._render("") == ""
+        assert self._render(None) == ""
+
+    def test_truncates_long_content(self):
+        """Items longer than 80 chars should be truncated."""
+        long_content = "A" * 200
+        result = _make_todo_result([
+            {"id": "1", "content": long_content, "status": "pending"},
+        ])
+        checklist = self._render(result)
+        assert len(long_content) > 80
+        assert "A" * 80 in checklist
+        assert "A" * 81 not in checklist
+
+    def test_default_status_is_pending(self):
+        """Items without a status should render as pending."""
+        result = _make_todo_result([
+            {"id": "1", "content": "No status", "status": ""},
+        ])
+        checklist = self._render(result)
+        assert "[ ] No status" in checklist

--- a/tests/gateway/test_run_todo_progress.py
+++ b/tests/gateway/test_run_todo_progress.py
@@ -43,10 +43,10 @@ class TestRenderTodoChecklist:
         ])
         checklist = self._render(result)
         assert "📋 Task List" in checklist
-        assert "[ ] Set up CI/CD" in checklist
-        assert "[>] Write tests" in checklist
-        assert "[x] Deploy" in checklist
-        assert "[-] Cancel this" in checklist
+        assert "[ ] Set up CI/CD (1)" in checklist
+        assert "[>] Write tests (2)" in checklist
+        assert "[x] Deploy (3)" in checklist
+        assert "[-] Cancel this (4)" in checklist
 
     def test_empty_todos_returns_empty_string(self):
         """Empty todo list should return empty string (not crash)."""


### PR DESCRIPTION
## What does this PR do?

When the agent calls `todo` in a Telegram session, renders a compact editable checklist (`[ ] pending`, `[>] in_progress`, `[x] completed`, `[-] cancelled`) in the running progress bubble. Subsequent `todo` calls edit the same message in-place using the existing progress message infrastructure (send-first-then-edit with flood control).

## Related Issue

Closes #31001

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- **`agent/tool_executor.py`**: Added `result=function_result` kwarg to the `tool.completed` progress callback so downstream handlers can inspect tool output.
- **`gateway/run.py`**: Added `_render_todo_checklist()` helper (module-level, ~20 lines) that parses the todo tool's JSON `{todos, summary}` and renders a compact checklist. Added handler in the progress callback that intercepts `tool.completed` for `todo` and puts the checklist into the progress queue.
- **`tests/gateway/test_run_todo_progress.py`**: 5 unit tests for the renderer: full checklist with all 4 status types, empty list, invalid JSON, content truncation at 80 chars, default status fallback.

## How to Test

1. Run the new tests: `python -m pytest tests/gateway/test_run_todo_progress.py -v`
2. Run existing gateway tests for regression: `python -m pytest tests/gateway/test_run_cleanup_progress.py tests/gateway/test_display_config.py -q`
3. (Dogfood) Run gateway connected to Telegram, trigger multi-step todo calls, verify checklist appears and updates in-place.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `pytest tests/gateway/test_run_todo_progress.py -q` and all tests pass (5/5)
- [x] I've run `pytest tests/gateway/test_run_cleanup_progress.py tests/gateway/test_display_config.py tests/tools/test_todo_tool.py -q` and all pass (145)
- [x] I've added tests for my changes (5 test cases)
- [x] I've tested on: Ubuntu 24.04

### Documentation & Housekeeping

- [x] N/A — No documentation, config, or cross-platform changes needed