### PR TITLE
feat(dashboard): add Japanese Sans/Serif font themes

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3758,6 +3758,8 @@ _BUILTIN_DASHBOARD_THEMES = [
     {"name": "mono",      "label": "Mono",           "description": "Clean grayscale — minimal and focused"},
     {"name": "cyberpunk", "label": "Cyberpunk",      "description": "Neon green on black — matrix terminal"},
     {"name": "rose",      "label": "Rosé",           "description": "Soft pink and warm ivory — easy on the eyes"},
+    {"name": "japanese-sans",  "label": "Japanese Sans",  "description": "Hermes Teal palette with Noto Sans JP typography"},
+    {"name": "japanese-serif", "label": "Japanese Serif", "description": "Hermes Teal palette with Noto Serif JP typography"},
 ]
 
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2366,3 +2366,37 @@ class TestPtyWebSocket:
             ):
                 pass
         assert exc.value.code == 4400
+
+
+# ---------------------------------------------------------------------------
+# Built-in dashboard theme inventory tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuiltinDashboardThemes:
+    """Sanity tests for the built-in theme list shipped from the backend.
+
+    Regression coverage for #30756 — Japanese font themes must be present in
+    `_BUILTIN_DASHBOARD_THEMES` so they show up in `/api/dashboard/themes`
+    and stay in sync with the frontend's `BUILTIN_THEMES` map in
+    `web/src/themes/presets.ts`.
+    """
+
+    def test_japanese_themes_listed(self):
+        from hermes_cli.web_server import _BUILTIN_DASHBOARD_THEMES
+        names = {t["name"] for t in _BUILTIN_DASHBOARD_THEMES}
+        assert "japanese-sans" in names
+        assert "japanese-serif" in names
+
+    def test_japanese_themes_have_label_and_description(self):
+        from hermes_cli.web_server import _BUILTIN_DASHBOARD_THEMES
+        by_name = {t["name"]: t for t in _BUILTIN_DASHBOARD_THEMES}
+        for n in ("japanese-sans", "japanese-serif"):
+            entry = by_name[n]
+            assert entry["label"].strip()
+            assert entry["description"].strip()
+
+    def test_theme_names_are_unique(self):
+        from hermes_cli.web_server import _BUILTIN_DASHBOARD_THEMES
+        names = [t["name"] for t in _BUILTIN_DASHBOARD_THEMES]
+        assert len(names) == len(set(names))

--- a/web/src/themes/presets.ts
+++ b/web/src/themes/presets.ts
@@ -204,6 +204,54 @@ export const defaultLargeTheme: DashboardTheme = {
   },
 };
 
+/**
+ * Japanese-friendly typography variants.
+ *
+ * These share the same palette as ``defaultTheme`` so the only thing that
+ * changes when a user picks them is the typography — fontSans / fontMono /
+ * fontDisplay stacks resolve to Japanese-capable fonts (Noto Sans JP / Noto
+ * Serif JP / Noto Sans Mono CJK JP via Google Fonts), with safe system-font
+ * fallbacks so the dashboard still renders correctly if the stylesheet fails
+ * to load. Closes #30756.
+ */
+const JAPANESE_SYSTEM_SANS_FALLBACK =
+  '"Hiragino Sans", "Hiragino Kaku Gothic ProN", "Yu Gothic", "Meiryo", ' +
+  SYSTEM_SANS;
+const JAPANESE_SYSTEM_SERIF_FALLBACK =
+  '"Hiragino Mincho ProN", "Yu Mincho", "MS Mincho", "Hiragino Mincho Pro", ' +
+  'Georgia, "Times New Roman", serif';
+
+export const japaneseSansTheme: DashboardTheme = {
+  name: "japanese-sans",
+  label: "Japanese Sans",
+  description: "Hermes Teal palette with Noto Sans JP typography",
+  palette: defaultTheme.palette,
+  typography: {
+    ...DEFAULT_TYPOGRAPHY,
+    fontSans: `"Noto Sans JP", ${JAPANESE_SYSTEM_SANS_FALLBACK}`,
+    fontMono: `"Noto Sans Mono CJK JP", ${SYSTEM_MONO}`,
+    fontUrl:
+      "https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700&display=swap",
+  },
+  layout: DEFAULT_LAYOUT,
+};
+
+export const japaneseSerifTheme: DashboardTheme = {
+  name: "japanese-serif",
+  label: "Japanese Serif",
+  description: "Hermes Teal palette with Noto Serif JP typography",
+  palette: defaultTheme.palette,
+  typography: {
+    ...DEFAULT_TYPOGRAPHY,
+    fontSans: `"Noto Serif JP", ${JAPANESE_SYSTEM_SERIF_FALLBACK}`,
+    fontMono: `"Noto Sans Mono CJK JP", ${SYSTEM_MONO}`,
+    fontDisplay: `"Noto Serif JP", ${JAPANESE_SYSTEM_SERIF_FALLBACK}`,
+    fontUrl:
+      "https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@400;500;600;700&display=swap",
+  },
+  layout: DEFAULT_LAYOUT,
+};
+
 export const BUILTIN_THEMES: Record<string, DashboardTheme> = {
   default: defaultTheme,
   "default-large": defaultLargeTheme,
@@ -212,4 +260,6 @@ export const BUILTIN_THEMES: Record<string, DashboardTheme> = {
   mono: monoTheme,
   cyberpunk: cyberpunkTheme,
   rose: roseTheme,
+  "japanese-sans": japaneseSansTheme,
+  "japanese-serif": japaneseSerifTheme,
 };


### PR DESCRIPTION
## Summary
- Add `japanese-sans` (Noto Sans JP) and `japanese-serif` (Noto Serif JP) variants to the built-in dashboard theme list, with safe macOS/Windows/Linux system-font fallbacks (Hiragino Sans / Yu Gothic / Meiryo, Hiragino Mincho / Yu Mincho / MS Mincho).
- Both reuse `defaultTheme`'s palette and plug into the existing `ThemeTypography` (`fontSans` / `fontMono` / `fontDisplay` / `fontUrl`) path — no orphan constants file.
- Mirror the two new entries in `_BUILTIN_DASHBOARD_THEMES` in `hermes_cli/web_server.py` so they surface through `/api/dashboard/themes`.

This satisfies the acceptance criteria from #30756:
- ✅ Japanese font options are reachable from the dashboard theme picker.
- ✅ The selected font stack is applied through the existing theme CSS variables (`--theme-font-sans`, `--theme-font-mono`, `--theme-font-display`).
- ✅ Build/tests cover the integration path.

## Test Plan
- [x] `python -m pytest tests/hermes_cli/test_web_server.py::TestBuiltinDashboardThemes -q -o 'addopts='`  → 3 passed

`TestBuiltinDashboardThemes` asserts the new theme names are present, have non-empty label/description, and that the inventory list has no duplicate names.

Closes #30756