### PR TITLE
feat(delegation): add inherit_memory opt-in so subagents read MEMORY.md

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -881,6 +881,10 @@ delegation:
                                               # The parent TUI owns stdin, so blocking would deadlock; non-interactive resolution is required.
                                               # Both choices emit a logger.warning audit line. Flip to true only for cron/batch pipelines.
   # inherit_mcp_toolsets: true                # When explicit child toolsets are narrowed, also keep the parent's MCP toolsets (default: true). Set false for strict intersection.
+  # inherit_memory: false                     # When true, subagents load the same MEMORY.md / USER.md the parent uses, so operating preferences
+                                              # (e.g. "prefer Composio over local IMAP gmail MCP", "use Camofox not Safari on captcha sites") are honored
+                                              # inside delegated tasks too.  Default false preserves the historical narrow-context behaviour where the
+                                              # subagent only sees the parent's explicit ``context`` argument.  See issue #30269.
   # model: "google/gemini-3-flash-preview"    # Override model for subagents (empty = inherit parent)
   # provider: "openrouter"                    # Override provider for subagents (empty = inherit parent)
   #                                           # Resolves full credentials (base_url, api_key) automatically.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1219,6 +1219,13 @@ DEFAULT_CONFIG = {
         # extras" without silently stripping MCP tools the parent already has.
         # Set to false for strict intersection.
         "inherit_mcp_toolsets": True,
+        # When True, subagents load the same MEMORY.md / USER.md the parent
+        # uses (i.e. AIAgent is instantiated with skip_memory=False) so the
+        # user's persistent operating preferences are honored inside
+        # delegated tasks too.  Default False preserves the historical narrow
+        # behaviour where the child only sees the parent's explicit
+        # ``context`` argument.  See issue #30269.
+        "inherit_memory": False,
         "max_iterations": 50,  # per-subagent iteration cap (each subagent gets its own budget,
                                # independent of the parent's max_iterations)
         "child_timeout_seconds": 600,  # wall-clock timeout for each child agent (floor 30s,

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1529,6 +1529,72 @@ class TestChildCredentialPoolResolution(unittest.TestCase):
             ["web", "browser"],
         )
 
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_build_child_agent_skip_memory_default_true(self, mock_cfg):
+        """Subagents skip MEMORY.md by default (issue #30269 baseline)."""
+        parent = _make_mock_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="Test default skip_memory",
+                context=None,
+                toolsets=["terminal"],
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        self.assertTrue(MockAgent.call_args[1]["skip_memory"])
+
+    @patch(
+        "tools.delegate_tool._load_config",
+        return_value={"inherit_memory": True},
+    )
+    def test_build_child_agent_inherit_memory_when_enabled(self, mock_cfg):
+        """delegation.inherit_memory=True flips skip_memory=False on child (issue #30269)."""
+        parent = _make_mock_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="Test inherit_memory opt-in",
+                context=None,
+                toolsets=["terminal"],
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        self.assertFalse(MockAgent.call_args[1]["skip_memory"])
+
+    @patch(
+        "tools.delegate_tool._load_config",
+        return_value={"inherit_memory": False},
+    )
+    def test_build_child_agent_inherit_memory_explicit_false(self, mock_cfg):
+        """Explicit delegation.inherit_memory=False preserves skip_memory=True."""
+        parent = _make_mock_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="Test inherit_memory explicit off",
+                context=None,
+                toolsets=["terminal"],
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        self.assertTrue(MockAgent.call_args[1]["skip_memory"])
+
 
 class TestChildCredentialLeasing(unittest.TestCase):
     def test_run_single_child_acquires_and_releases_lease(self):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -452,6 +452,23 @@ def _get_inherit_mcp_toolsets() -> bool:
     return is_truthy_value(cfg.get("inherit_mcp_toolsets"), default=True)
 
 
+def _get_inherit_memory() -> bool:
+    """Whether subagents should load MEMORY.md / USER.md like the parent does.
+
+    Config key: ``delegation.inherit_memory`` (bool, default False).
+
+    Default is False to preserve the historical behavior where subagents
+    receive only the parent's explicit ``context`` argument and skip the
+    persistent memory file.  Setting it True flips ``skip_memory=False`` on
+    the child AIAgent so it reads the same MEMORY.md / USER.md that the
+    parent does, ensuring operating preferences (e.g. "prefer Composio
+    over local IMAP gmail MCP", "use Camofox not Safari on captcha-protected
+    sites") are honored inside delegated tasks too.  See issue #30269.
+    """
+    cfg = _load_config()
+    return is_truthy_value(cfg.get("inherit_memory"), default=False)
+
+
 def _is_mcp_toolset_name(name: str) -> bool:
     """Return True for canonical MCP toolsets and their registered aliases."""
     if not name:
@@ -1122,7 +1139,12 @@ def _build_child_agent(
         log_prefix=f"[subagent-{task_index}]",
         platform=parent_agent.platform,
         skip_context_files=True,
-        skip_memory=True,
+        # By default subagents skip MEMORY.md / USER.md to keep their context
+        # narrow and deterministic.  Operators can flip this with
+        # ``delegation.inherit_memory: true`` so children read the same
+        # persistent memory the parent does — see issue #30269 and
+        # ``_get_inherit_memory()`` for the rationale.
+        skip_memory=not _get_inherit_memory(),
         clarify_callback=None,
         thinking_callback=child_thinking_cb,
         session_db=getattr(parent_agent, "_session_db", None),


### PR DESCRIPTION
## Summary
Subagents spawned by `delegate_task` were instantiated with `skip_memory=True` (`tools/delegate_tool.py:1125`), so they never loaded the user's `MEMORY.md` / `USER.md`. The parent agent's persistent operating preferences — e.g. *"prefer Composio over local IMAP gmail MCP"*, *"use Camofox not Safari on captcha-protected sites"* — were silently dropped on delegation, causing children to pick the broken tool path the parent had explicitly remembered to avoid (the exact scenario in #30269).

This adds a new `delegation.inherit_memory` config flag (default `False`, byte-stable with the historical behaviour) that, when set to `True`, flips `skip_memory=False` on the child `AIAgent` so it reads the same memory files the parent does.

### Changes
- `tools/delegate_tool.py` — new `_get_inherit_memory()` helper (mirrors `_get_inherit_mcp_toolsets()`) + wires `skip_memory=not _get_inherit_memory()` in `_build_child_agent`.
- `hermes_cli/config.py` — schema default `inherit_memory: False` with documentation in the `delegation` block.
- `cli-config.yaml.example` — example documents the new key, its rationale, and the issue link.
- `tests/tools/test_delegate.py` — three regression tests in `TestChildCredentialPoolResolution`:
  - `test_build_child_agent_skip_memory_default_true` (baseline byte-stable behaviour)
  - `test_build_child_agent_inherit_memory_when_enabled`
  - `test_build_child_agent_inherit_memory_explicit_false`

### Why opt-in
Memory inheritance widens every subagent's context, which (a) costs prompt-cache prefix invalidation on memory edits and (b) can leak unrelated parent preferences into a focused worker. Keeping it off by default preserves the narrow-context guarantee delegate_task currently provides; users with memory-dependent preferences can flip it explicitly.

### Scope: CLI + gateway (single dispatch path)
`delegate_task` is a model-invoked tool registered via `tools/registry.py` and exposed to every `AIAgent` regardless of host (CLI, gateway, TUI gateway, `batch_runner`, cron). All child agents are constructed through the single `_build_child_agent()` in `tools/delegate_tool.py` — the same site this PR patches — so the `delegation.inherit_memory` flag flips `skip_memory` uniformly for gateway-resident parents and CLI parents alike. There is no separate gateway-side dispatcher to update.

## Test Plan
- [x] `python -m pytest tests/tools/test_delegate.py -k "inherit_memory or skip_memory_default" -q -o 'addopts='` → 3 passed
- [x] `python -m pytest tests/tools/test_delegate.py::TestChildCredentialPoolResolution -q -o 'addopts='` → 11 passed (existing 8 + 3 new)

Closes #30269