### PR TITLE
Add durable Agent Team task runtime

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1598,6 +1598,8 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
         )
     elif function_name == "delegate_task":
         return agent._dispatch_delegate_task(function_args)
+    elif function_name.startswith("agent_task_"):
+        return agent._dispatch_agent_task(function_name, function_args)
     else:
         return _ra().handle_function_call(
             function_name, function_args, effective_task_id,

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -144,7 +144,26 @@ DEFAULT_AGENT_IDENTITY = (
 HERMES_AGENT_HELP_GUIDANCE = (
     "If the user asks about configuring, setting up, or using Hermes Agent "
     "itself, load the `hermes-agent` skill with skill_view(name='hermes-agent') "
-    "before answering. Docs: https://hermes-agent.nousresearch.com/docs"
+    "before answering. Docs: https://hermes-agent.nousresearch.com/docs\n"
+    "\n"
+    "# Agent Team orchestration policy\n"
+    "When the `agent_task_create`, `agent_task_status`, and `agent_task_output` "
+    "tools are available, use them for complex tasks that benefit from durable "
+    "parallel work, specialist agents, or an independent quality gate. Prefer "
+    "`agent_task_create` over doing all work inline when the task has multiple "
+    "substantial tracks, requires long-running background work, or needs "
+    "independent evaluation.\n"
+    "For orchestrated work: create explicit tasks with a named agent when useful "
+    "(for example `researcher` or `evaluator`), poll progress with "
+    "`agent_task_status`, and retrieve artifacts/results with "
+    "`agent_task_output`. Do not claim a delegated task is complete until its "
+    "output has been read.\n"
+    "Evaluator gate: for non-trivial code, analysis, or deliverable-quality work, "
+    "create an evaluator task after the implementation/research tasks finish. "
+    "Give it the relevant outputs and ask for a structured result with `passed`, "
+    "`summary`, `findings`, `risks`, and `tests`. Treat `passed: false` as a "
+    "blocking quality gate: address the findings or report the gate failure "
+    "clearly instead of presenting the work as complete."
 )
 
 MEMORY_GUIDANCE = (

--- a/agent/task_runners.py
+++ b/agent/task_runners.py
@@ -1,0 +1,110 @@
+"""Task runner abstraction for durable Hermes agent tasks."""
+
+from __future__ import annotations
+
+import json
+import threading
+from contextlib import nullcontext
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+
+_DELEGATE_PARENT_LOCKS: dict[int, threading.RLock] = {}
+_DELEGATE_PARENT_LOCKS_GUARD = threading.RLock()
+
+
+def _parent_delegate_lock(parent_agent: Any):
+    if parent_agent is None:
+        return nullcontext()
+    key = id(parent_agent)
+    with _DELEGATE_PARENT_LOCKS_GUARD:
+        lock = _DELEGATE_PARENT_LOCKS.get(key)
+        if lock is None:
+            lock = threading.RLock()
+            _DELEGATE_PARENT_LOCKS[key] = lock
+        return lock
+
+
+def run_delegate_task_with_parent_lock(parent_agent: Any, **kwargs: Any) -> str:
+    with _parent_delegate_lock(parent_agent):
+        from tools.delegate_tool import delegate_task
+
+        return delegate_task(parent_agent=parent_agent, **kwargs)
+
+
+class TaskRunner(Protocol):
+    name: str
+
+    def __call__(self, meta: dict, stop_event: threading.Event, parent_agent: Any, store: Any) -> dict:
+        """Run a task and return a JSON-serializable result payload."""
+
+
+@dataclass(frozen=True)
+class DelegateTaskRunner:
+    """Run a task through Hermes delegate_task, preserving existing behavior."""
+
+    name: str = "delegate_task"
+
+    def __call__(self, meta: dict, stop_event: threading.Event, parent_agent: Any, store: Any) -> dict:
+        if parent_agent is None:
+            raise RuntimeError("agent_task_create requires a parent agent for real execution")
+        if stop_event.is_set():
+            return {"status": "stopped", "reason": "stop requested before execution"}
+
+        store.append_output(meta["task_id"], f"[agent_task] delegating to {meta.get('agent') or 'default'}")
+        raw = run_delegate_task_with_parent_lock(
+            parent_agent,
+            goal=meta["goal"],
+            context=meta.get("context") or "",
+            agent=meta.get("agent"),
+            result_schema=meta.get("result_schema"),
+            toolsets=meta.get("toolsets") or None,
+        )
+        try:
+            parsed = json.loads(raw) if isinstance(raw, str) else raw
+        except Exception:
+            parsed = {"raw": raw}
+        if isinstance(parsed, dict) and parsed.get("summary"):
+            store.append_output(meta["task_id"], str(parsed["summary"]))
+        return {"delegate_task": parsed}
+
+
+class CodexTaskRunnerUnavailable(RuntimeError):
+    """Raised when the Codex runner is selected but no safe implementation is wired."""
+
+
+@dataclass(frozen=True)
+class CodexTaskRunner:
+    """Explicit Codex runner interface/stub.
+
+    This runner intentionally does not call Hermes delegate_task or use a parent
+    Hermes agent. Until a real Codex app-server execution bridge is wired, it
+    fails clearly instead of pretending the task ran.
+    """
+
+    name: str = "codex_app_server_stub"
+
+    def __call__(self, meta: dict, stop_event: threading.Event, parent_agent: Any, store: Any) -> dict:
+        if stop_event.is_set():
+            return {"status": "stopped", "reason": "stop requested before execution", "runner": self.name}
+
+        message = (
+            "Codex task runner selected for "
+            f"runtime={meta.get('runtime')!r}, agent={meta.get('agent')!r}, "
+            "but real Codex execution is not safely wired yet. "
+            "This stub does not expose Hermes loop tools and did not execute the task."
+        )
+        store.append_output(meta["task_id"], f"[agent_task] {message}")
+        raise CodexTaskRunnerUnavailable(message)
+
+
+def should_use_codex_runner(meta: dict) -> bool:
+    runtime = str(meta.get("runtime") or "").strip().lower()
+    agent = str(meta.get("agent") or "").strip().lower()
+    return runtime == "codex_app_server" or agent == "coder"
+
+
+def select_task_runner(meta: dict) -> TaskRunner:
+    if should_use_codex_runner(meta):
+        return CodexTaskRunner()
+    return DelegateTaskRunner()

--- a/agent/task_runtime.py
+++ b/agent/task_runtime.py
@@ -1,0 +1,569 @@
+"""Durable background task runtime for Hermes agent teams.
+
+P0 design:
+- durable task metadata/output/result under ~/.hermes/tasks
+- active work runs in background threads
+- execution reuses delegate_task so named agents, credentials, tool scopes,
+  result schemas, artifacts, and existing safety behavior remain consistent
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, Optional
+
+from agent.task_runners import DelegateTaskRunner, select_task_runner
+from hermes_constants import get_hermes_home
+
+TERMINAL_STATUSES = {"completed", "failed", "stopped", "timeout"}
+NON_TERMINAL_STATUSES = {"pending", "running", "stopping"}
+_MAX_PARALLEL_TASKS_ENV = "HERMES_AGENT_TASK_MAX_PARALLEL"
+_TASK_RETENTION_DAYS_ENV = "HERMES_AGENT_TASK_RETENTION_DAYS"
+_RUNTIME_INSTANCE_ID = uuid.uuid4().hex
+_ACTIVE_TASKS: Dict[str, "TaskControl"] = {}
+_ACTIVE_LOCK = threading.RLock()
+
+
+@dataclass
+class TaskControl:
+    task_id: str
+    thread: threading.Thread
+    stop_event: threading.Event
+    parent_agent: Any = None
+
+
+class TaskStore:
+    def __init__(self, root: Optional[Path] = None):
+        self.root = Path(root) if root else Path(get_hermes_home()) / "tasks"
+        self.root.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.RLock()
+
+    def task_dir(self, task_id: str) -> Path:
+        return self.root / task_id
+
+    def meta_path(self, task_id: str) -> Path:
+        return self.task_dir(task_id) / "meta.json"
+
+    def events_path(self, task_id: str) -> Path:
+        return self.task_dir(task_id) / "events.jsonl"
+
+    def output_path(self, task_id: str) -> Path:
+        return self.task_dir(task_id) / "output.log"
+
+    def result_path(self, task_id: str) -> Path:
+        return self.task_dir(task_id) / "result.json"
+
+    def create_task(
+        self,
+        *,
+        goal: str,
+        agent: Optional[str] = None,
+        context: Optional[str] = None,
+        runtime: Optional[str] = None,
+        result_schema: Optional[dict] = None,
+        toolsets: Optional[Iterable[str]] = None,
+        timeout_seconds: Optional[int] = None,
+        metadata: Optional[dict] = None,
+    ) -> dict:
+        task_id = f"task_{time.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
+        task_dir = self.task_dir(task_id)
+        task_dir.mkdir(parents=True, exist_ok=False)
+        now = time.time()
+        meta = {
+            "task_id": task_id,
+            "status": "pending",
+            "goal": goal,
+            "agent": agent,
+            "context": context or "",
+            "runtime": runtime or "hermes_default",
+            "result_schema": result_schema,
+            "toolsets": list(toolsets or []),
+            "timeout_seconds": timeout_seconds,
+            "created_at": now,
+            "updated_at": now,
+            "started_at": None,
+            "ended_at": None,
+            "runtime_pid": os.getpid(),
+            "runtime_instance_id": _RUNTIME_INSTANCE_ID,
+            "error": None,
+            "artifact_dir": str(task_dir),
+            "events_path": str(self.events_path(task_id)),
+            "output_path": str(self.output_path(task_id)),
+            "result_path": str(self.result_path(task_id)),
+            "metadata": metadata or {},
+        }
+        self._write_json(self.meta_path(task_id), meta)
+        self.events_path(task_id).touch()
+        self.output_path(task_id).touch()
+        self.append_event(task_id, "created", {"agent": agent, "runtime": meta["runtime"]})
+        return meta
+
+    def get_task(self, task_id: str) -> Optional[dict]:
+        path = self.meta_path(task_id)
+        if not path.exists():
+            return None
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def update_task(self, task_id: str, **updates: Any) -> dict:
+        with self._lock:
+            meta = self.get_task(task_id)
+            if meta is None:
+                raise KeyError(f"Task not found: {task_id}")
+            meta.update(updates)
+            meta["updated_at"] = time.time()
+            self._write_json(self.meta_path(task_id), meta)
+            return meta
+
+    def append_event(self, task_id: str, event: str, data: Optional[dict] = None) -> None:
+        record = {"ts": time.time(), "event": event, "data": data or {}}
+        with self._lock:
+            with self.events_path(task_id).open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    def append_output(self, task_id: str, text: str) -> None:
+        if not text:
+            return
+        with self._lock:
+            with self.output_path(task_id).open("a", encoding="utf-8") as fh:
+                fh.write(text)
+                if not text.endswith("\n"):
+                    fh.write("\n")
+
+    def write_result(self, task_id: str, result: dict) -> None:
+        self._write_json(self.result_path(task_id), result)
+
+    def read_result(self, task_id: str) -> Optional[dict]:
+        path = self.result_path(task_id)
+        if not path.exists() or path.stat().st_size == 0:
+            return None
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def read_output(self, task_id: str, max_chars: int = 6000) -> str:
+        path = self.output_path(task_id)
+        if not path.exists():
+            return ""
+        text = path.read_text(encoding="utf-8", errors="replace")
+        if max_chars and len(text) > max_chars:
+            return text[-max_chars:]
+        return text
+
+    def list_tasks(self, status: Optional[str] = None, limit: int = 20) -> list[dict]:
+        metas = []
+        for meta in self._iter_task_metas():
+            if status and meta.get("status") != status:
+                continue
+            metas.append(meta)
+        metas.sort(key=lambda item: item.get("created_at", 0), reverse=True)
+        if limit is None:
+            return metas
+        return metas[:limit]
+
+    def recover_stale_tasks(self) -> list[dict]:
+        recovered = []
+        for meta in self._iter_task_metas():
+            status = meta.get("status")
+            task_id = meta.get("task_id")
+            if not task_id or status not in NON_TERMINAL_STATUSES:
+                continue
+            if _task_has_live_control(task_id):
+                continue
+            if _task_owner_process_is_alive(meta):
+                continue
+
+            new_status = "stopped" if status == "stopping" else "failed"
+            error = meta.get("error") or f"Task recovered as stale from {status}; no live runtime owner"
+            self.append_event(task_id, "stale_recovered", {"from_status": status, "status": new_status, "error": error})
+            recovered.append(self.update_task(task_id, status=new_status, ended_at=time.time(), error=error))
+        return recovered
+
+    def cleanup_artifacts(
+        self,
+        *,
+        retention_days: Optional[float] = None,
+        retention_seconds: Optional[float] = None,
+        keep_last: Optional[int] = None,
+        terminal_only: bool = True,
+        now: Optional[float] = None,
+    ) -> dict:
+        if retention_days is not None and retention_seconds is not None:
+            raise ValueError("Specify either retention_days or retention_seconds, not both")
+        if retention_days is None and retention_seconds is None:
+            retention_days = _configured_retention_days()
+
+        now = time.time() if now is None else now
+        cutoff = None
+        if retention_seconds is not None:
+            cutoff = now - float(retention_seconds)
+        elif retention_days is not None:
+            cutoff = now - (float(retention_days) * 86400)
+
+        metas = self.list_tasks(limit=None)
+        keep_ids = set()
+        if keep_last and keep_last > 0:
+            keep_ids = {meta.get("task_id") for meta in metas[:keep_last]}
+
+        report = {"deleted": [], "kept": [], "errors": []}
+        if cutoff is None and not keep_ids:
+            return report
+        for meta in metas:
+            task_id = meta.get("task_id")
+            if not task_id:
+                continue
+            if task_id in keep_ids:
+                report["kept"].append(task_id)
+                continue
+            if terminal_only and meta.get("status") not in TERMINAL_STATUSES:
+                report["kept"].append(task_id)
+                continue
+            if _task_has_live_control(task_id):
+                report["kept"].append(task_id)
+                continue
+            ref_ts = meta.get("ended_at") or meta.get("updated_at") or meta.get("created_at") or 0
+            if cutoff is not None and ref_ts > cutoff:
+                report["kept"].append(task_id)
+                continue
+
+            try:
+                shutil.rmtree(self.task_dir(task_id))
+                report["deleted"].append(task_id)
+            except FileNotFoundError:
+                report["deleted"].append(task_id)
+            except Exception as exc:
+                report["errors"].append({"task_id": task_id, "error": str(exc)})
+        return report
+
+    def diagnostics(self) -> dict:
+        metas = self.list_tasks(limit=None)
+        status_counts: dict[str, int] = {}
+        stale_candidates = []
+        artifact_bytes = 0
+        for meta in metas:
+            status = meta.get("status") or "unknown"
+            status_counts[status] = status_counts.get(status, 0) + 1
+            task_id = meta.get("task_id")
+            if task_id and status in NON_TERMINAL_STATUSES and not _task_has_live_control(task_id) and not _task_owner_process_is_alive(meta):
+                stale_candidates.append(task_id)
+            task_dir = self.task_dir(task_id) if task_id else None
+            if task_dir and task_dir.exists():
+                for path in task_dir.rglob("*"):
+                    if path.is_file():
+                        try:
+                            artifact_bytes += path.stat().st_size
+                        except OSError:
+                            pass
+
+        max_parallel_error = None
+        try:
+            max_parallel_tasks = _configured_max_parallel_tasks()
+        except ValueError as exc:
+            max_parallel_tasks = None
+            max_parallel_error = str(exc)
+
+        active_tasks = _active_task_snapshot()
+        return {
+            "root": str(self.root),
+            "task_count": len(metas),
+            "status_counts": status_counts,
+            "active_count": len(active_tasks),
+            "active_tasks": active_tasks,
+            "stale_task_ids": stale_candidates,
+            "artifact_bytes": artifact_bytes,
+            "max_parallel_tasks": max_parallel_tasks,
+            "max_parallel_config_error": max_parallel_error,
+            "blocked_by_parallel_limit": bool(max_parallel_tasks and len(active_tasks) >= max_parallel_tasks),
+        }
+
+    def _iter_task_metas(self) -> Iterable[dict]:
+        for path in self.root.glob("task_*/meta.json"):
+            try:
+                yield json.loads(path.read_text(encoding="utf-8"))
+            except Exception:
+                continue
+
+    @staticmethod
+    def _write_json(path: Path, payload: dict) -> None:
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        os.replace(tmp, path)
+
+
+def _configured_retention_days() -> Optional[float]:
+    raw = os.environ.get(_TASK_RETENTION_DAYS_ENV)
+    if raw is None or raw == "":
+        return None
+    try:
+        value = float(raw)
+    except ValueError as exc:
+        raise ValueError(f"{_TASK_RETENTION_DAYS_ENV} must be a number") from exc
+    if value < 0:
+        raise ValueError(f"{_TASK_RETENTION_DAYS_ENV} must be non-negative")
+    return value
+
+
+def _configured_max_parallel_tasks(max_parallel_tasks: Optional[int] = None) -> Optional[int]:
+    raw: Any = max_parallel_tasks
+    if raw is None:
+        raw = os.environ.get(_MAX_PARALLEL_TASKS_ENV)
+    if raw is None or raw == "":
+        return None
+    try:
+        value = int(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"max_parallel_tasks must be an integer") from exc
+    if value <= 0:
+        return None
+    return value
+
+
+def _control_is_live(control: TaskControl) -> bool:
+    return control.thread.ident is None or control.thread.is_alive()
+
+
+def _task_has_live_control(task_id: str) -> bool:
+    with _ACTIVE_LOCK:
+        control = _ACTIVE_TASKS.get(task_id)
+        if control is None:
+            return False
+        if _control_is_live(control):
+            return True
+        _ACTIVE_TASKS.pop(task_id, None)
+        return False
+
+
+def _active_task_snapshot() -> list[dict]:
+    with _ACTIVE_LOCK:
+        stale_controls = [task_id for task_id, control in _ACTIVE_TASKS.items() if not _control_is_live(control)]
+        for task_id in stale_controls:
+            _ACTIVE_TASKS.pop(task_id, None)
+        return [
+            {
+                "task_id": task_id,
+                "thread_name": control.thread.name,
+                "stop_requested": control.stop_event.is_set(),
+                "thread_alive": control.thread.is_alive(),
+            }
+            for task_id, control in _ACTIVE_TASKS.items()
+        ]
+
+
+def _task_owner_process_is_alive(meta: dict) -> bool:
+    pid = meta.get("runtime_pid")
+    if pid is None:
+        return False
+    try:
+        pid_int = int(pid)
+    except (TypeError, ValueError):
+        return False
+    if pid_int <= 0:
+        return False
+    if pid_int == os.getpid():
+        return meta.get("runtime_instance_id") == _RUNTIME_INSTANCE_ID
+    try:
+        os.kill(pid_int, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _enforce_max_parallel_tasks(max_parallel_tasks: Optional[int]) -> None:
+    limit = _configured_max_parallel_tasks(max_parallel_tasks)
+    if not limit:
+        return
+    active_count = len(_active_task_snapshot())
+    if active_count >= limit:
+        raise RuntimeError(f"max_parallel_tasks limit reached ({active_count}/{limit}); wait for an active agent task to finish")
+
+
+def default_store() -> TaskStore:
+    return TaskStore()
+
+
+def start_agent_task(
+    *,
+    goal: str,
+    agent: Optional[str] = None,
+    context: Optional[str] = None,
+    runtime: Optional[str] = None,
+    result_schema: Optional[dict] = None,
+    toolsets: Optional[Iterable[str]] = None,
+    timeout_seconds: Optional[int] = None,
+    max_parallel_tasks: Optional[int] = None,
+    retention_days: Optional[float] = None,
+    metadata: Optional[dict] = None,
+    parent_agent: Any = None,
+    store: Optional[TaskStore] = None,
+    runner: Optional[Callable[[dict, threading.Event, Any, TaskStore], dict]] = None,
+) -> dict:
+    store = store or default_store()
+    store.recover_stale_tasks()
+    store.cleanup_artifacts(retention_days=retention_days)
+    _enforce_max_parallel_tasks(max_parallel_tasks)
+    meta = store.create_task(
+        goal=goal,
+        agent=agent,
+        context=context,
+        runtime=runtime,
+        result_schema=result_schema,
+        toolsets=toolsets,
+        timeout_seconds=timeout_seconds,
+        metadata=metadata,
+    )
+    task_id = meta["task_id"]
+    stop_event = threading.Event()
+    selected_runner = runner or select_task_runner(meta)
+
+    def target() -> None:
+        store.update_task(task_id, status="running", started_at=time.time())
+        store.append_event(task_id, "started", {"agent": agent, "runtime": meta.get("runtime")})
+        try:
+            result = _run_runner_with_optional_timeout(
+                selected_runner,
+                meta,
+                stop_event,
+                parent_agent,
+                store,
+                timeout_seconds,
+            )
+            store.write_result(task_id, result or {})
+            status = "stopped" if stop_event.is_set() else "completed"
+            store.append_event(task_id, status, {})
+            store.update_task(task_id, status=status, ended_at=time.time(), error=None)
+        except TimeoutError as exc:
+            store.append_event(task_id, "timeout", {"error": str(exc)})
+            store.update_task(task_id, status="timeout", ended_at=time.time(), error=str(exc))
+        except Exception as exc:
+            store.append_event(task_id, "failed", {"error": str(exc)})
+            store.update_task(task_id, status="failed", ended_at=time.time(), error=str(exc))
+            store.append_output(task_id, f"[task failed] {exc}")
+        finally:
+            with _ACTIVE_LOCK:
+                _ACTIVE_TASKS.pop(task_id, None)
+
+    thread = threading.Thread(target=target, name=f"hermes-agent-task-{task_id}", daemon=True)
+    with _ACTIVE_LOCK:
+        _ACTIVE_TASKS[task_id] = TaskControl(task_id=task_id, thread=thread, stop_event=stop_event, parent_agent=parent_agent)
+    thread.start()
+    return store.get_task(task_id) or meta
+
+
+def _run_runner_with_optional_timeout(
+    runner: Callable[[dict, threading.Event, Any, TaskStore], dict],
+    meta: dict,
+    stop_event: threading.Event,
+    parent_agent: Any,
+    store: TaskStore,
+    timeout_seconds: Optional[int],
+) -> dict:
+    if not timeout_seconds:
+        return runner(meta, stop_event, parent_agent, store)
+    if timeout_seconds <= 0:
+        raise TimeoutError("timeout_seconds must be positive")
+
+    holder: dict[str, Any] = {}
+
+    def run_inner() -> None:
+        try:
+            holder["result"] = runner(meta, stop_event, parent_agent, store)
+        except BaseException as exc:
+            holder["error"] = exc
+
+    inner = threading.Thread(target=run_inner, name=f"hermes-agent-task-runner-{meta['task_id']}", daemon=True)
+    inner.start()
+    inner.join(timeout_seconds)
+    if inner.is_alive():
+        stop_event.set()
+        raise TimeoutError(f"Agent task timed out after {timeout_seconds} seconds")
+    if "error" in holder:
+        raise holder["error"]
+    return holder.get("result") or {}
+
+
+def _run_with_delegate_task(meta: dict, stop_event: threading.Event, parent_agent: Any, store: TaskStore) -> dict:
+    return DelegateTaskRunner()(meta, stop_event, parent_agent, store)
+
+
+def get_task(task_id: str, store: Optional[TaskStore] = None) -> Optional[dict]:
+    return (store or default_store()).get_task(task_id)
+
+
+def list_tasks(status: Optional[str] = None, limit: int = 20, store: Optional[TaskStore] = None) -> list[dict]:
+    return (store or default_store()).list_tasks(status=status, limit=limit)
+
+
+def recover_stale_tasks(store: Optional[TaskStore] = None) -> list[dict]:
+    return (store or default_store()).recover_stale_tasks()
+
+
+def cleanup_task_artifacts(
+    *,
+    retention_days: Optional[float] = None,
+    retention_seconds: Optional[float] = None,
+    keep_last: Optional[int] = None,
+    terminal_only: bool = True,
+    now: Optional[float] = None,
+    store: Optional[TaskStore] = None,
+) -> dict:
+    return (store or default_store()).cleanup_artifacts(
+        retention_days=retention_days,
+        retention_seconds=retention_seconds,
+        keep_last=keep_last,
+        terminal_only=terminal_only,
+        now=now,
+    )
+
+
+def task_runtime_diagnostics(store: Optional[TaskStore] = None) -> dict:
+    return (store or default_store()).diagnostics()
+
+
+def diagnose_task_runtime(store: Optional[TaskStore] = None) -> dict:
+    return task_runtime_diagnostics(store=store)
+
+
+def read_task_output(task_id: str, max_chars: int = 6000, store: Optional[TaskStore] = None) -> dict:
+    store = store or default_store()
+    meta = store.get_task(task_id)
+    if meta is None:
+        raise KeyError(f"Task not found: {task_id}")
+    return {"task": meta, "output": store.read_output(task_id, max_chars=max_chars), "result": store.read_result(task_id)}
+
+
+def stop_task(task_id: str, store: Optional[TaskStore] = None) -> dict:
+    store = store or default_store()
+    meta = store.get_task(task_id)
+    if meta is None:
+        raise KeyError(f"Task not found: {task_id}")
+    with _ACTIVE_LOCK:
+        control = _ACTIVE_TASKS.get(task_id)
+    if control:
+        control.stop_event.set()
+        store.append_event(task_id, "stop_requested", {})
+        return store.update_task(task_id, status="stopping")
+    if meta.get("status") not in TERMINAL_STATUSES:
+        return store.update_task(task_id, status="stopped", ended_at=time.time())
+    return meta
+
+
+def wait_for_task(task_id: str, timeout_seconds: float = 0, store: Optional[TaskStore] = None) -> dict:
+    store = store or default_store()
+    deadline = time.time() + timeout_seconds if timeout_seconds else None
+    while True:
+        meta = store.get_task(task_id)
+        if meta is None:
+            raise KeyError(f"Task not found: {task_id}")
+        if meta.get("status") in TERMINAL_STATUSES:
+            return meta
+        if deadline and time.time() >= deadline:
+            return meta
+        time.sleep(0.2)

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -663,6 +663,24 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             tool_duration = time.time() - tool_start_time
             if agent._should_emit_quiet_tool_messages():
                 agent._vprint(f"  {_get_cute_tool_message_impl('clarify', function_args, tool_duration, result=function_result)}")
+        elif function_name.startswith("agent_task_"):
+            spinner = None
+            if agent._should_emit_quiet_tool_messages() and agent._should_start_quiet_spinner():
+                face = random.choice(KawaiiSpinner.get_waiting_faces())
+                preview = _build_tool_preview(function_name, function_args) or function_name
+                spinner = KawaiiSpinner(f"{face} 🧩 {preview}", spinner_type='dots', print_fn=agent._print_fn)
+                spinner.start()
+            _agent_task_result = None
+            try:
+                function_result = agent._dispatch_agent_task(function_name, function_args)
+                _agent_task_result = function_result
+            finally:
+                tool_duration = time.time() - tool_start_time
+                cute_msg = _get_cute_tool_message_impl(function_name, function_args, tool_duration, result=_agent_task_result)
+                if spinner:
+                    spinner.stop(cute_msg)
+                elif agent._should_emit_quiet_tool_messages():
+                    agent._vprint(f"  {cute_msg}")
         elif function_name == "delegate_task":
             tasks_arg = function_args.get("tasks")
             if tasks_arg and isinstance(tasks_arg, list):

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -885,6 +885,31 @@ delegation:
   # provider: "openrouter"                    # Override provider for subagents (empty = inherit parent)
   #                                           # Resolves full credentials (base_url, api_key) automatically.
   #                                           # Supported: openrouter, nous, zai, kimi-coding, minimax
+  # agents:                                  # Optional named subagent profiles for team mode.
+  #   orchestrator:
+  #     role: "orchestrator"
+  #     context_mode: "fresh"                # fresh = isolated default; fork = explicit parent-history snapshot.
+  #     toolsets: ["agent_team", "delegation", "terminal", "file", "web"]
+  #     instructions: "Decompose complex requests into durable specialist tasks and require an evaluator gate."
+  #   researcher:
+  #     role: "leaf"
+  #     toolsets: ["web", "file"]
+  #     context_mode: "fresh"
+  #     instructions: "Collect evidence and return concise citations, file paths, and uncertainties."
+  #   evaluator:
+  #     role: "leaf"
+  #     toolsets: ["terminal", "file", "web"]
+  #     context_mode: "fresh"
+  #     instructions: "Independently verify outputs against requirements and return only the structured result."
+  #     result_schema:
+  #       passed: "boolean"
+  #       summary: "string"
+  #       findings:
+  #         - severity: "low|medium|high"
+  #           description: "string"
+  #           file: "string|null"
+  #       risks: ["string"]
+  #       tests: ["string"]
 
 # =============================================================================
 # Honcho Integration (Cross-Session User Modeling)
@@ -1098,3 +1123,16 @@ display:
 #     - command: "~/.hermes/agent-hooks/log-orchestration.sh"
 #
 # hooks_auto_accept: false
+
+
+# Agent Team durable task runtime
+agent_team:
+  enabled: true
+  task_timeout_seconds: 1800
+  max_parallel_tasks: 4
+  artifact_retention_days: 14
+  policy:
+    default_orchestrator: "orchestrator"
+    default_evaluator: "evaluator"
+    evaluator_gate: true
+    poll_interval_seconds: 5

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1242,6 +1242,70 @@ DEFAULT_CONFIG = {
         # Flip to true only if you trust delegated work to run dangerous cmds
         # without human review (cron pipelines, batch automation, etc.).
         "subagent_auto_approve": False,
+        "agents": {
+            # Baseline team profiles used by delegate_task and durable
+            # agent_task_create. Empty model/provider means inherit the
+            # parent/default delegation model and credentials.
+            "orchestrator": {
+                "role": "orchestrator",
+                "context_mode": "fresh",
+                "toolsets": ["agent_team", "delegation", "terminal", "file", "web"],
+                "instructions": (
+                    "Decompose complex requests into specialist tasks. Use "
+                    "agent_task_create for durable parallel work, monitor with "
+                    "agent_task_status, read outputs with agent_task_output, "
+                    "and require an evaluator gate before reporting non-trivial "
+                    "deliverables as complete."
+                ),
+            },
+            "researcher": {
+                "role": "leaf",
+                "context_mode": "fresh",
+                "toolsets": ["web", "file"],
+                "instructions": (
+                    "Collect evidence, cite sources or file paths, identify "
+                    "uncertainties, and return concise findings for downstream "
+                    "implementation or evaluation."
+                ),
+            },
+            "evaluator": {
+                "role": "leaf",
+                "context_mode": "fresh",
+                "toolsets": ["terminal", "file", "web"],
+                "instructions": (
+                    "Act as an independent quality gate. Verify the provided "
+                    "work against the original requirements, inspect relevant "
+                    "artifacts when tools are available, and return only the "
+                    "structured result."
+                ),
+                "result_schema": {
+                    "passed": "boolean",
+                    "summary": "string",
+                    "findings": [
+                        {
+                            "severity": "low|medium|high",
+                            "description": "string",
+                            "file": "string|null",
+                        }
+                    ],
+                    "risks": ["string"],
+                    "tests": ["string"],
+                },
+            },
+        },
+    },
+
+    "agent_team": {
+        "enabled": True,
+        "task_timeout_seconds": 1800,
+        "max_parallel_tasks": 4,
+        "artifact_retention_days": 14,
+        "policy": {
+            "default_orchestrator": "orchestrator",
+            "default_evaluator": "evaluator",
+            "evaluator_gate": True,
+            "poll_interval_seconds": 5,
+        },
     },
 
     # Ephemeral prefill messages file — JSON list of {role, content} dicts

--- a/model_tools.py
+++ b/model_tools.py
@@ -492,7 +492,7 @@ def _compute_tool_definitions(
 # because they need agent-level state (TodoStore, MemoryStore, etc.).
 # The registry still holds their schemas; dispatch just returns a stub error
 # so if something slips through, the LLM sees a sensible message.
-_AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task"}
+_AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task", "agent_task_create", "agent_task_status", "agent_task_diagnostics", "agent_task_output", "agent_task_stop", "agent_task_list"}
 _READ_SEARCH_TOOLS = {"read_file", "search_files"}
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -3990,8 +3990,9 @@ class AIAgent:
         New DELEGATE_TASK_SCHEMA fields only need to be added here to reach all
         invocation paths (concurrent, sequential, inline).
         """
-        from tools.delegate_tool import delegate_task as _delegate_task
-        return _delegate_task(
+        from agent.task_runners import run_delegate_task_with_parent_lock
+        return run_delegate_task_with_parent_lock(
+            self,
             goal=function_args.get("goal"),
             context=function_args.get("context"),
             toolsets=function_args.get("toolsets"),
@@ -4000,8 +4001,34 @@ class AIAgent:
             acp_command=function_args.get("acp_command"),
             acp_args=function_args.get("acp_args"),
             role=function_args.get("role"),
-            parent_agent=self,
+            agent=function_args.get("agent"),
+            context_mode=function_args.get("context_mode"),
+            result_schema=function_args.get("result_schema"),
         )
+
+    def _dispatch_agent_task(self, function_name: str, function_args: dict) -> str:
+        """Dispatch Agent Team task tools from the live agent loop.
+
+        These tools need access to the current agent for credentials, named
+        delegation profiles, and task-local execution context. Keeping this
+        routing beside delegate_task avoids the generic registry's loop-tool
+        guard from swallowing them.
+        """
+        from tools import agent_task_tool as _agent_task_tool
+
+        handlers = {
+            "agent_task_create": _agent_task_tool.agent_task_create,
+            "agent_task_status": _agent_task_tool.agent_task_status,
+            "agent_task_diagnostics": _agent_task_tool.agent_task_diagnostics,
+            "agent_task_output": _agent_task_tool.agent_task_output,
+            "agent_task_stop": _agent_task_tool.agent_task_stop,
+            "agent_task_list": _agent_task_tool.agent_task_list,
+        }
+        handler = handlers.get(function_name)
+        if handler is None:
+            import json
+            return json.dumps({"error": f"Unknown Agent Team tool: {function_name}"})
+        return handler(function_args or {}, parent_agent=self)
 
     def _invoke_tool(self, function_name: str, function_args: dict, effective_task_id: str,
                      tool_call_id: Optional[str] = None, messages: list = None,

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -21,6 +21,7 @@ from agent.prompt_builder import (
     build_environment_hints,
     CONTEXT_FILE_MAX_CHARS,
     DEFAULT_AGENT_IDENTITY,
+    HERMES_AGENT_HELP_GUIDANCE,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
     OPENAI_MODEL_EXECUTION_GUIDANCE,
@@ -38,6 +39,13 @@ from hermes_cli.nous_subscription import NousFeatureState, NousSubscriptionFeatu
 
 
 class TestGuidanceConstants:
+    def test_agent_team_policy_mentions_durable_task_tools_and_evaluator_gate(self):
+        assert "agent_task_create" in HERMES_AGENT_HELP_GUIDANCE
+        assert "agent_task_status" in HERMES_AGENT_HELP_GUIDANCE
+        assert "agent_task_output" in HERMES_AGENT_HELP_GUIDANCE
+        assert "Evaluator gate" in HERMES_AGENT_HELP_GUIDANCE
+        assert "passed: false" in HERMES_AGENT_HELP_GUIDANCE
+
     def test_memory_guidance_discourages_task_logs(self):
         assert "durable facts" in MEMORY_GUIDANCE
         assert "Do NOT save task progress" in MEMORY_GUIDANCE
@@ -1192,6 +1200,5 @@ class TestOpenAIModelExecutionGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
 
 

--- a/tests/agent/test_subagent_progress.py
+++ b/tests/agent/test_subagent_progress.py
@@ -160,6 +160,36 @@ class TestBuildChildProgressCallback:
         assert parent_cb.call_args.args[0] == "subagent.thinking"
         assert parent_cb.call_args.args[2] == "some reasoning text"
 
+    def test_identity_metadata_and_spawn_requested_relayed_to_gateway(self):
+        """Gateway events include stable subagent identity, model, toolsets, and named agent."""
+        parent = MagicMock()
+        parent._delegate_spinner = None
+        parent_cb = MagicMock()
+        parent.tool_progress_callback = parent_cb
+
+        cb = _build_child_progress_callback(
+            0,
+            "test goal",
+            parent,
+            subagent_id="sa-1",
+            parent_id="sa-parent",
+            depth=1,
+            model="m",
+            toolsets=["terminal"],
+            agent_name="coder",
+        )
+
+        cb("subagent.spawn_requested", preview="queued")
+
+        parent_cb.assert_called_once()
+        assert parent_cb.call_args.args[0] == "subagent.spawn_requested"
+        assert parent_cb.call_args.kwargs["subagent_id"] == "sa-1"
+        assert parent_cb.call_args.kwargs["parent_id"] == "sa-parent"
+        assert parent_cb.call_args.kwargs["depth"] == 1
+        assert parent_cb.call_args.kwargs["model"] == "m"
+        assert parent_cb.call_args.kwargs["toolsets"] == ["terminal"]
+        assert parent_cb.call_args.kwargs["agent"] == "coder"
+
     def test_parallel_callbacks_independent(self):
         """Each child's callback batches tool names independently."""
         parent = MagicMock()
@@ -386,4 +416,3 @@ class TestBatchFlush:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
-

--- a/tests/agent/test_task_runners.py
+++ b/tests/agent/test_task_runners.py
@@ -1,0 +1,88 @@
+import sys
+import time
+
+import pytest
+
+from agent import task_runtime
+from agent.task_runners import (
+    CodexTaskRunner,
+    CodexTaskRunnerUnavailable,
+    DelegateTaskRunner,
+    select_task_runner,
+)
+
+
+def test_select_task_runner_defaults_to_delegate():
+    runner = select_task_runner({"runtime": "hermes_default", "agent": "researcher"})
+
+    assert isinstance(runner, DelegateTaskRunner)
+
+
+def test_select_task_runner_uses_codex_for_codex_app_server_runtime():
+    runner = select_task_runner({"runtime": "codex_app_server", "agent": "researcher"})
+
+    assert isinstance(runner, CodexTaskRunner)
+
+
+def test_select_task_runner_uses_codex_for_coder_agent():
+    runner = select_task_runner({"runtime": "hermes_default", "agent": "coder"})
+
+    assert isinstance(runner, CodexTaskRunner)
+
+
+def test_codex_runner_stub_does_not_call_delegate_or_parent_agent(tmp_path, monkeypatch):
+    store = task_runtime.TaskStore(root=tmp_path / "tasks")
+    meta = store.create_task(goal="edit code", agent="coder", runtime="codex_app_server")
+    runner = CodexTaskRunner()
+
+    class ParentAgent:
+        def __getattribute__(self, name):
+            if name.startswith("__"):
+                return object.__getattribute__(self, name)
+            raise AssertionError(f"Codex stub must not access parent_agent.{name}")
+
+    monkeypatch.setitem(sys.modules, "tools.delegate_tool", None)
+
+    with pytest.raises(CodexTaskRunnerUnavailable) as excinfo:
+        runner(meta, task_runtime.threading.Event(), ParentAgent(), store)
+
+    assert "not safely wired" in str(excinfo.value)
+    assert "did not execute" in str(excinfo.value)
+    assert "does not expose Hermes loop tools" in store.read_output(meta["task_id"])
+
+
+def test_task_runtime_routes_codex_app_server_to_explicit_stub_failure(tmp_path):
+    store = task_runtime.TaskStore(root=tmp_path / "tasks")
+    meta = task_runtime.start_agent_task(goal="edit code", runtime="codex_app_server", store=store)
+    deadline = time.time() + 2
+
+    while time.time() < deadline:
+        final = store.get_task(meta["task_id"])
+        if final and final["status"] == "failed":
+            break
+        time.sleep(0.01)
+
+    final = store.get_task(meta["task_id"])
+    assert final["status"] == "failed"
+    assert "Codex task runner selected" in final["error"]
+    assert "not safely wired" in final["error"]
+    assert "agent_task_create requires a parent agent" not in final["error"]
+
+
+def test_delegate_runner_uses_parent_lock(monkeypatch, tmp_path):
+    store = task_runtime.TaskStore(root=tmp_path / "tasks")
+    meta = store.create_task(goal="delegate")
+    calls = []
+
+    def fake_locked(parent_agent, **kwargs):
+        calls.append((parent_agent, kwargs))
+        return '{"summary": "done"}'
+
+    monkeypatch.setattr("agent.task_runners.run_delegate_task_with_parent_lock", fake_locked)
+    parent = object()
+
+    result = DelegateTaskRunner()(meta, task_runtime.threading.Event(), parent, store)
+
+    assert result["delegate_task"]["summary"] == "done"
+    assert calls[0][0] is parent
+    assert calls[0][1]["goal"] == "delegate"

--- a/tests/agent/test_task_runtime.py
+++ b/tests/agent/test_task_runtime.py
@@ -1,0 +1,151 @@
+import time
+
+import pytest
+
+from agent import task_runtime
+
+
+def test_task_runtime_completes_and_persists_output(tmp_path):
+    store = task_runtime.TaskStore(root=tmp_path / "tasks")
+
+    def runner(meta, stop_event, parent_agent, store):
+        store.append_output(meta["task_id"], "hello from child")
+        return {"ok": True, "task_id": meta["task_id"]}
+
+    meta = task_runtime.start_agent_task(goal="do work", agent="researcher", store=store, runner=runner)
+    final = task_runtime.wait_for_task(meta["task_id"], timeout_seconds=2, store=store)
+
+    assert final["status"] == "completed"
+    payload = task_runtime.read_task_output(meta["task_id"], store=store)
+    assert "hello from child" in payload["output"]
+    assert payload["result"]["ok"] is True
+
+
+def test_task_runtime_stop_marks_active_task(tmp_path):
+    store = task_runtime.TaskStore(root=tmp_path / "tasks")
+
+    def runner(meta, stop_event, parent_agent, store):
+        deadline = time.time() + 2
+        while time.time() < deadline and not stop_event.is_set():
+            time.sleep(0.01)
+        return {"stopped": stop_event.is_set()}
+
+    meta = task_runtime.start_agent_task(goal="wait", store=store, runner=runner)
+    stopped = task_runtime.stop_task(meta["task_id"], store=store)
+    final = task_runtime.wait_for_task(meta["task_id"], timeout_seconds=2, store=store)
+
+    assert stopped["status"] == "stopping"
+    assert final["status"] == "stopped"
+    assert store.read_result(meta["task_id"])["stopped"] is True
+
+
+
+def test_task_runtime_times_out_and_marks_task(tmp_path):
+    store = task_runtime.TaskStore(root=tmp_path / "tasks")
+
+    def runner(meta, stop_event, parent_agent, store):
+        deadline = time.time() + 1
+        while time.time() < deadline and not stop_event.is_set():
+            time.sleep(0.01)
+        return {"late": True}
+
+    meta = task_runtime.start_agent_task(goal="timeout", timeout_seconds=0.05, store=store, runner=runner)
+    final = task_runtime.wait_for_task(meta["task_id"], timeout_seconds=1, store=store)
+
+    assert final["status"] == "timeout"
+    assert "timed out" in final["error"]
+
+
+def test_task_stop_does_not_interrupt_parent_agent(tmp_path):
+    store = task_runtime.TaskStore(root=tmp_path / "tasks")
+    calls = []
+
+    class Parent:
+        def interrupt(self, reason):
+            calls.append(reason)
+
+    def runner(meta, stop_event, parent_agent, store):
+        while not stop_event.is_set():
+            time.sleep(0.01)
+        return {"stopped": True}
+
+    meta = task_runtime.start_agent_task(goal="wait", parent_agent=Parent(), store=store, runner=runner)
+    task_runtime.stop_task(meta["task_id"], store=store)
+    final = task_runtime.wait_for_task(meta["task_id"], timeout_seconds=1, store=store)
+
+    assert final["status"] == "stopped"
+    assert calls == []
+
+
+def test_stale_recovery_marks_orphaned_running_task_failed(tmp_path):
+    store = task_runtime.TaskStore(root=tmp_path / "tasks")
+    meta = store.create_task(goal="orphaned")
+    store.update_task(
+        meta["task_id"],
+        status="running",
+        started_at=time.time() - 60,
+        runtime_pid=-1,
+        runtime_instance_id="dead-runtime",
+    )
+
+    recovered = task_runtime.recover_stale_tasks(store=store)
+    final = store.get_task(meta["task_id"])
+
+    assert [item["task_id"] for item in recovered] == [meta["task_id"]]
+    assert final["status"] == "failed"
+    assert "stale" in final["error"]
+    assert final["ended_at"] is not None
+
+
+def test_max_parallel_tasks_rejects_new_task_when_limit_reached(tmp_path):
+    store = task_runtime.TaskStore(root=tmp_path / "tasks")
+
+    def runner(meta, stop_event, parent_agent, store):
+        while not stop_event.is_set():
+            time.sleep(0.01)
+        return {"stopped": True}
+
+    meta = task_runtime.start_agent_task(goal="first", store=store, runner=runner, max_parallel_tasks=1)
+    try:
+        with pytest.raises(RuntimeError, match="max_parallel_tasks"):
+            task_runtime.start_agent_task(goal="second", store=store, runner=runner, max_parallel_tasks=1)
+    finally:
+        task_runtime.stop_task(meta["task_id"], store=store)
+        task_runtime.wait_for_task(meta["task_id"], timeout_seconds=1, store=store)
+
+    assert len(store.list_tasks(limit=None)) == 1
+
+
+def test_cleanup_artifacts_removes_only_expired_terminal_tasks(tmp_path):
+    store = task_runtime.TaskStore(root=tmp_path / "tasks")
+    old = store.create_task(goal="old")
+    fresh = store.create_task(goal="fresh")
+    pending = store.create_task(goal="pending")
+    now = time.time()
+
+    store.update_task(old["task_id"], status="completed", ended_at=now - 100)
+    store.update_task(fresh["task_id"], status="completed", ended_at=now)
+    store.update_task(pending["task_id"], created_at=now - 100, updated_at=now - 100)
+
+    report = task_runtime.cleanup_task_artifacts(retention_seconds=1, now=now, store=store)
+
+    assert report["deleted"] == [old["task_id"]]
+    assert store.get_task(old["task_id"]) is None
+    assert store.get_task(fresh["task_id"]) is not None
+    assert store.get_task(pending["task_id"]) is not None
+
+
+def test_task_runtime_diagnostics_reports_counts_and_stale_candidates(tmp_path):
+    store = task_runtime.TaskStore(root=tmp_path / "tasks")
+    stale = store.create_task(goal="stale")
+    done = store.create_task(goal="done")
+    store.update_task(stale["task_id"], status="running", runtime_pid=-1, runtime_instance_id="dead-runtime")
+    store.update_task(done["task_id"], status="completed", ended_at=time.time())
+
+    diagnostics = task_runtime.task_runtime_diagnostics(store=store)
+
+    assert diagnostics["task_count"] == 2
+    assert diagnostics["status_counts"]["running"] == 1
+    assert diagnostics["status_counts"]["completed"] == 1
+    assert diagnostics["stale_task_ids"] == [stale["task_id"]]
+    assert diagnostics["active_count"] == 0

--- a/tests/hermes_cli/test_agent_team_policy.py
+++ b/tests/hermes_cli/test_agent_team_policy.py
@@ -1,0 +1,27 @@
+from hermes_cli.config import DEFAULT_CONFIG
+
+
+def test_default_delegation_team_profiles_include_orchestrator_and_evaluator():
+    agents = DEFAULT_CONFIG["delegation"]["agents"]
+
+    assert {"orchestrator", "researcher", "evaluator"} <= set(agents)
+    assert agents["orchestrator"]["role"] == "orchestrator"
+    assert "agent_team" in agents["orchestrator"]["toolsets"]
+    assert "agent_task_create" in agents["orchestrator"]["instructions"]
+
+    evaluator = agents["evaluator"]
+    assert evaluator["role"] == "leaf"
+    assert evaluator["result_schema"]["passed"] == "boolean"
+    assert evaluator["result_schema"]["summary"] == "string"
+    assert evaluator["result_schema"]["findings"][0]["severity"] == "low|medium|high"
+    assert evaluator["result_schema"]["risks"] == ["string"]
+    assert evaluator["result_schema"]["tests"] == ["string"]
+
+
+def test_default_agent_team_policy_points_to_evaluator_gate():
+    policy = DEFAULT_CONFIG["agent_team"]["policy"]
+
+    assert policy["default_orchestrator"] == "orchestrator"
+    assert policy["default_evaluator"] == "evaluator"
+    assert policy["evaluator_gate"] is True
+    assert policy["poll_interval_seconds"] == 5

--- a/tests/tools/test_agent_task_tool.py
+++ b/tests/tools/test_agent_task_tool.py
@@ -1,0 +1,189 @@
+import json
+from types import SimpleNamespace
+
+import tools.agent_task_tool as agent_task_tool
+from tools.registry import registry
+from toolsets import resolve_toolset
+
+
+def test_agent_task_create_uses_runtime(monkeypatch):
+    captured = {}
+
+    def fake_start(**kwargs):
+        captured.update(kwargs)
+        return {"task_id": "task_1", "status": "pending", "goal": kwargs["goal"]}
+
+    monkeypatch.setattr(agent_task_tool.task_runtime, "start_agent_task", fake_start)
+    parent = SimpleNamespace(model="x")
+
+    payload = json.loads(agent_task_tool.agent_task_create({"goal": "audit", "agent": "reviewer"}, parent_agent=parent))
+
+    assert payload["ok"] is True
+    assert payload["task"]["task_id"] == "task_1"
+    assert captured["goal"] == "audit"
+    assert captured["agent"] == "reviewer"
+    assert captured["parent_agent"] is parent
+
+
+def test_agent_task_status_missing_task_returns_error(monkeypatch):
+    monkeypatch.setattr(agent_task_tool.task_runtime, "get_task", lambda task_id: None)
+
+    payload = json.loads(agent_task_tool.agent_task_status({"task_id": "missing"}))
+
+    assert "error" in payload
+
+
+def test_agent_task_diagnostics_summarizes_meta_and_last_event(monkeypatch, tmp_path):
+    events_path = tmp_path / "events.jsonl"
+    output_path = tmp_path / "output.log"
+    result_path = tmp_path / "result.json"
+    events_path.write_text(
+        '{"ts": 10.0, "event": "started", "data": {"agent": "reviewer"}}\n'
+        '{"ts": 17.5, "event": "failed", "data": {"error": "boom"}}\n',
+        encoding="utf-8",
+    )
+    task = {
+        "task_id": "task_1",
+        "status": "failed",
+        "created_at": 9.0,
+        "started_at": 10.0,
+        "updated_at": 17.5,
+        "ended_at": 17.5,
+        "artifact_dir": str(tmp_path),
+        "events_path": str(events_path),
+        "output_path": str(output_path),
+        "result_path": str(result_path),
+        "runtime": "hermes_default",
+        "agent": "reviewer",
+        "error": "boom",
+    }
+    monkeypatch.setattr(agent_task_tool.task_runtime, "get_task", lambda task_id: task)
+
+    payload = json.loads(agent_task_tool.agent_task_diagnostics({"task_id": "task_1"}))
+
+    diagnostics = payload["diagnostics"]
+    assert payload["ok"] is True
+    assert diagnostics["status"] == "failed"
+    assert diagnostics["elapsed_seconds"] == 7.5
+    assert diagnostics["last_event"]["event"] == "failed"
+    assert diagnostics["paths"]["output_path"] == str(output_path)
+    assert diagnostics["paths"]["result_path"] == str(result_path)
+    assert diagnostics["runtime"] == "hermes_default"
+    assert diagnostics["agent"] == "reviewer"
+    assert diagnostics["error"] == "boom"
+
+
+def test_agent_task_tools_are_registered_and_exposed_by_toolset():
+    expected = {
+        "agent_task_create",
+        "agent_task_status",
+        "agent_task_diagnostics",
+        "agent_task_output",
+        "agent_task_stop",
+        "agent_task_list",
+    }
+
+    definitions = registry.get_definitions(expected)
+    names = {definition["function"]["name"] for definition in definitions}
+
+    assert expected <= names
+    assert expected <= set(resolve_toolset("agent_team"))
+    assert expected <= set(resolve_toolset("hermes-cli"))
+
+
+
+def test_run_agent_dispatch_agent_task_routes_to_tool(monkeypatch):
+    from types import SimpleNamespace
+    from run_agent import AIAgent
+
+    captured = {}
+
+    def fake_create(args, parent_agent=None):
+        captured["args"] = args
+        captured["parent_agent"] = parent_agent
+        return '{"ok": true}'
+
+    monkeypatch.setattr(agent_task_tool, "agent_task_create", fake_create)
+    fake_agent = SimpleNamespace()
+
+    result = AIAgent._dispatch_agent_task(fake_agent, "agent_task_create", {"goal": "audit"})
+
+    assert json.loads(result)["ok"] is True
+    assert captured["args"] == {"goal": "audit"}
+    assert captured["parent_agent"] is fake_agent
+
+
+def test_run_agent_dispatch_agent_task_routes_to_diagnostics(monkeypatch):
+    from run_agent import AIAgent
+
+    captured = {}
+
+    def fake_diagnostics(args, **_):
+        captured["args"] = args
+        return '{"ok": true}'
+
+    monkeypatch.setattr(agent_task_tool, "agent_task_diagnostics", fake_diagnostics)
+    fake_agent = SimpleNamespace()
+
+    result = AIAgent._dispatch_agent_task(fake_agent, "agent_task_diagnostics", {"task_id": "task_1"})
+
+    assert json.loads(result)["ok"] is True
+    assert captured["args"] == {"task_id": "task_1"}
+
+
+def test_agent_task_create_respects_config_defaults(monkeypatch):
+    captured = {}
+
+    def fake_start(**kwargs):
+        captured.update(kwargs)
+        return {"task_id": "task_cfg", "status": "pending", "goal": kwargs["goal"], "metadata": kwargs.get("metadata")}
+
+    monkeypatch.setattr(agent_task_tool, "_agent_team_config", lambda: {
+        "enabled": True,
+        "task_timeout_seconds": 123,
+        "max_parallel_tasks": 2,
+        "artifact_retention_days": 7,
+    })
+    monkeypatch.setattr(agent_task_tool.task_runtime, "start_agent_task", fake_start)
+    parent = SimpleNamespace(session_id="s1", platform="cli")
+
+    payload = json.loads(agent_task_tool.agent_task_create({"goal": "audit"}, parent_agent=parent))
+
+    assert payload["ok"] is True
+    assert captured["timeout_seconds"] == 123
+    assert captured["max_parallel_tasks"] == 2
+    assert captured["retention_days"] == 7
+    assert captured["metadata"]["owner_session_id"] == "s1"
+    assert captured["metadata"]["owner_platform"] == "cli"
+
+
+def test_agent_task_create_can_be_disabled_by_config(monkeypatch):
+    monkeypatch.setattr(agent_task_tool, "_agent_team_config", lambda: {"enabled": False})
+
+    payload = json.loads(agent_task_tool.agent_task_create({"goal": "audit"}, parent_agent=SimpleNamespace(session_id="s1")))
+
+    assert "error" in payload
+    assert "disabled" in payload["error"]
+
+
+def test_agent_task_status_rejects_other_session(monkeypatch):
+    task = {"task_id": "task_1", "status": "completed", "metadata": {"owner_session_id": "owner"}}
+    monkeypatch.setattr(agent_task_tool.task_runtime, "get_task", lambda task_id: task)
+
+    payload = json.loads(agent_task_tool.agent_task_status({"task_id": "task_1"}, parent_agent=SimpleNamespace(session_id="other")))
+
+    assert "error" in payload
+    assert "not owned" in payload["error"]
+
+
+def test_agent_task_list_filters_to_current_session(monkeypatch):
+    tasks = [
+        {"task_id": "owned", "metadata": {"owner_session_id": "s1"}},
+        {"task_id": "other", "metadata": {"owner_session_id": "s2"}},
+        {"task_id": "legacy", "metadata": {}},
+    ]
+    monkeypatch.setattr(agent_task_tool.task_runtime, "list_tasks", lambda status=None, limit=20: tasks)
+
+    payload = json.loads(agent_task_tool.agent_task_list({}, parent_agent=SimpleNamespace(session_id="s1")))
+
+    assert [task["task_id"] for task in payload["tasks"]] == ["owned", "legacy"]

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -29,6 +29,7 @@ from tools.delegate_tool import (
     _build_child_agent,
     _build_child_progress_callback,
     _build_child_system_prompt,
+    _run_single_child,
     _strip_blocked_tools,
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
@@ -69,6 +70,13 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("tasks", props)
         self.assertIn("context", props)
         self.assertIn("toolsets", props)
+        self.assertIn("agent", props)
+        self.assertIn("context_mode", props)
+        self.assertIn("result_schema", props)
+        task_props = props["tasks"]["items"]["properties"]
+        self.assertIn("agent", task_props)
+        self.assertIn("context_mode", task_props)
+        self.assertIn("result_schema", task_props)
         # max_iterations is intentionally NOT exposed to the model — it's
         # config-authoritative via delegation.max_iterations so users get
         # predictable budgets.
@@ -411,6 +419,7 @@ class TestDelegateTask(unittest.TestCase):
             )
 
         self.assertTrue(callable(mock_child.thinking_callback))
+        parent.tool_progress_callback.reset_mock()
         mock_child.thinking_callback("deliberating...")
         parent.tool_progress_callback.assert_not_called()
 
@@ -1905,6 +1914,124 @@ class TestDispatchDelegateTask(unittest.TestCase):
             self.assertEqual(kwargs["override_acp_command"], "claude")
             self.assertEqual(kwargs["override_acp_args"], ["--acp", "--stdio"])
 
+
+class TestNamedSubagentProfiles(unittest.TestCase):
+    """Named delegation agents should route model/tool/context/result policy."""
+
+    @patch("tools.delegate_tool._write_subagent_artifact", return_value=None)
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._load_config")
+    @patch("run_agent.AIAgent")
+    def test_named_agent_routes_model_toolsets_fork_context_and_structured_result(
+        self, MockAgent, mock_cfg, mock_creds, _mock_artifact
+    ):
+        parent = _make_mock_parent(depth=0)
+        parent.enabled_toolsets = ["terminal", "file", "web"]
+        parent._session_messages = [{"role": "user", "content": "parent context"}]
+        parent._memory_manager = None
+        parent.session_estimated_cost_usd = 0.0
+
+        mock_cfg.return_value = {
+            "max_iterations": 50,
+            "child_timeout_seconds": 30,
+            "max_spawn_depth": 1,
+            "orchestrator_enabled": True,
+            "inherit_mcp_toolsets": True,
+            "agents": {
+                "researcher": {
+                    "model": "child-model",
+                    "toolsets": ["web"],
+                    "context_mode": "fork",
+                    "instructions": "Collect evidence only.",
+                    "result_schema": {"passed": "boolean"},
+                }
+            },
+        }
+        mock_creds.return_value = {
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+            "model": "child-model",
+        }
+
+        mock_child = MagicMock()
+        mock_child.run_conversation.return_value = {
+            "final_response": '{"passed": true}',
+            "completed": True,
+            "api_calls": 1,
+            "messages": [],
+        }
+        mock_child.session_prompt_tokens = 3
+        mock_child.session_completion_tokens = 4
+        mock_child.session_estimated_cost_usd = 0.0
+        mock_child.session_reasoning_tokens = 0
+        mock_child.model = "child-model"
+        mock_child.get_activity_summary.return_value = {
+            "api_call_count": 1,
+            "max_iterations": 50,
+            "current_tool": None,
+            "last_activity_desc": "",
+        }
+        MockAgent.return_value = mock_child
+
+        raw = delegate_task(goal="research this", agent="researcher", parent_agent=parent)
+        payload = json.loads(raw)
+
+        call_kwargs = MockAgent.call_args.kwargs
+        self.assertEqual(call_kwargs["model"], "child-model")
+        self.assertEqual(call_kwargs["enabled_toolsets"], ["web"])
+        self.assertIn("AGENT NAME", call_kwargs["ephemeral_system_prompt"])
+        self.assertIn("researcher", call_kwargs["ephemeral_system_prompt"])
+        self.assertIn("Collect evidence only.", call_kwargs["ephemeral_system_prompt"])
+        self.assertIn("STRUCTURED RESULT REQUIRED", call_kwargs["ephemeral_system_prompt"])
+
+        run_kwargs = mock_child.run_conversation.call_args.kwargs
+        self.assertEqual(run_kwargs["conversation_history"], parent._session_messages)
+
+        entry = payload["results"][0]
+        self.assertEqual(entry["agent"], "researcher")
+        self.assertEqual(entry["structured_result"], {"passed": True})
+
+    @patch("tools.delegate_tool._load_config")
+    def test_unknown_named_agent_returns_tool_error(self, mock_cfg):
+        parent = _make_mock_parent(depth=0)
+        parent._memory_manager = None
+        mock_cfg.return_value = {"agents": {}, "max_iterations": 50}
+
+        raw = delegate_task(goal="x", agent="missing", parent_agent=parent)
+
+        self.assertIn("Unknown delegation agent 'missing'", raw)
+
+    def test_run_single_child_reports_structured_parse_error(self):
+        parent = _make_mock_parent(depth=0)
+        child = MagicMock()
+        child._subagent_id = "sa-test"
+        child._delegate_saved_tool_names = []
+        child._delegate_result_schema = {"passed": "boolean"}
+        child._delegate_agent_name = "evaluator"
+        child._delegate_role = "leaf"
+        child._delegate_depth = 1
+        child._credential_pool = None
+        child.tool_progress_callback = None
+        child.run_conversation.return_value = {
+            "final_response": "not-json",
+            "completed": True,
+            "api_calls": 1,
+            "messages": [],
+        }
+        child.session_prompt_tokens = 0
+        child.session_completion_tokens = 0
+        child.session_estimated_cost_usd = 0.0
+        child.session_reasoning_tokens = 0
+        child.model = "m"
+
+        with patch("tools.delegate_tool._write_subagent_artifact", return_value=None):
+            entry = _run_single_child(0, "evaluate", child, parent)
+
+        self.assertEqual(entry["agent"], "evaluator")
+        self.assertIn("structured_result_error", entry)
+
 class TestDelegateEventEnum(unittest.TestCase):
     """Tests for DelegateEvent enum and back-compat aliases."""
 
@@ -2669,3 +2796,33 @@ class TestFallbackModelInheritance(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+
+def test_dispatch_delegate_task_forwards_named_agent_fields(monkeypatch):
+    from types import SimpleNamespace
+    from run_agent import AIAgent
+    from tools import delegate_tool
+
+    captured = {}
+
+    def fake_delegate_task(**kwargs):
+        captured.update(kwargs)
+        return "{}"
+
+    monkeypatch.setattr(delegate_tool, "delegate_task", fake_delegate_task)
+    fake_agent = SimpleNamespace()
+
+    result = AIAgent._dispatch_delegate_task(fake_agent, {
+        "goal": "review",
+        "context": "bounded",
+        "agent": "reviewer",
+        "context_mode": "fork",
+        "result_schema": {"type": "object"},
+    })
+
+    assert result == "{}"
+    assert captured["agent"] == "reviewer"
+    assert captured["context_mode"] == "fork"
+    assert captured["result_schema"] == {"type": "object"}
+    assert captured["parent_agent"] is fake_agent

--- a/tests/tools/test_delegate_toolset_scope.py
+++ b/tests/tools/test_delegate_toolset_scope.py
@@ -9,7 +9,7 @@ arbitrary toolsets.
 from unittest.mock import MagicMock, patch
 from types import SimpleNamespace
 
-from tools.delegate_tool import _strip_blocked_tools
+from tools.delegate_tool import _build_child_agent, _strip_blocked_tools
 
 
 class TestToolsetIntersection:
@@ -64,3 +64,83 @@ class TestToolsetIntersection:
         scoped = [t for t in requested if t in parent_toolsets]
 
         assert scoped == []
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    @patch("run_agent.AIAgent")
+    def test_build_child_agent_intersects_requested_toolsets_with_parent(self, MockAgent, _cfg):
+        """Real _build_child_agent path must scope requested toolsets to parent."""
+        parent = SimpleNamespace(
+            enabled_toolsets=["terminal", "file"],
+            base_url="https://example.test",
+            api_key="key",
+            provider="openrouter",
+            api_mode="chat_completions",
+            model="parent-model",
+            platform="cli",
+            providers_allowed=None,
+            providers_ignored=None,
+            providers_order=None,
+            provider_sort=None,
+            openrouter_min_coding_score=None,
+            reasoning_config=None,
+            prefill_messages=None,
+            max_tokens=None,
+            _delegate_depth=0,
+            _session_db=None,
+            _delegate_spinner=None,
+            tool_progress_callback=None,
+        )
+        MockAgent.return_value = MagicMock()
+
+        _build_child_agent(
+            task_index=0,
+            goal="scoped",
+            context=None,
+            toolsets=["terminal", "web", "browser"],
+            model=None,
+            max_iterations=50,
+            task_count=1,
+            parent_agent=parent,
+        )
+
+        assert MockAgent.call_args.kwargs["enabled_toolsets"] == ["terminal"]
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    @patch("run_agent.AIAgent")
+    def test_build_child_agent_strips_blocked_toolsets_after_intersection(self, MockAgent, _cfg):
+        """Even if parent has delegation-like toolsets, leaf children do not get them."""
+        parent = SimpleNamespace(
+            enabled_toolsets=["terminal", "delegation", "memory"],
+            base_url="https://example.test",
+            api_key="key",
+            provider="openrouter",
+            api_mode="chat_completions",
+            model="parent-model",
+            platform="cli",
+            providers_allowed=None,
+            providers_ignored=None,
+            providers_order=None,
+            provider_sort=None,
+            openrouter_min_coding_score=None,
+            reasoning_config=None,
+            prefill_messages=None,
+            max_tokens=None,
+            _delegate_depth=0,
+            _session_db=None,
+            _delegate_spinner=None,
+            tool_progress_callback=None,
+        )
+        MockAgent.return_value = MagicMock()
+
+        _build_child_agent(
+            task_index=0,
+            goal="scoped",
+            context=None,
+            toolsets=["terminal", "delegation", "memory"],
+            model=None,
+            max_iterations=50,
+            task_count=1,
+            parent_agent=parent,
+        )
+
+        assert MockAgent.call_args.kwargs["enabled_toolsets"] == ["terminal"]

--- a/tools/agent_task_tool.py
+++ b/tools/agent_task_tool.py
@@ -1,0 +1,294 @@
+"""Agent Team task tools."""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Optional
+
+from agent import task_runtime
+from tools.registry import registry, tool_error
+
+
+def _json(payload: Any) -> str:
+    return json.dumps(payload, ensure_ascii=False, indent=2)
+
+
+def _task_id_error(task_id: Any) -> Optional[str]:
+    if not task_id or not isinstance(task_id, str):
+        return "task_id is required"
+    return None
+
+
+def _agent_team_config() -> dict:
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        cfg = load_config_readonly()
+    except Exception:
+        cfg = {}
+    team = cfg.get("agent_team") if isinstance(cfg, dict) else None
+    return team if isinstance(team, dict) else {}
+
+
+def _owner_metadata(parent_agent: Any) -> dict:
+    if parent_agent is None:
+        return {}
+    owner = {
+        "owner_session_id": getattr(parent_agent, "session_id", None),
+        "owner_platform": getattr(parent_agent, "platform", None),
+        "owner_user_id": getattr(parent_agent, "user_id", None) or getattr(parent_agent, "authorized_user_id", None),
+    }
+    return {k: v for k, v in owner.items() if v is not None}
+
+
+def _task_visible_to_parent(task: dict, parent_agent: Any) -> bool:
+    if parent_agent is None:
+        return True
+    owner_session_id = (task.get("metadata") or {}).get("owner_session_id")
+    if not owner_session_id:
+        return True
+    return owner_session_id == getattr(parent_agent, "session_id", None)
+
+
+def _get_owned_task(task_id: str, parent_agent: Any) -> Optional[dict]:
+    task = task_runtime.get_task(task_id)
+    if task is None:
+        return None
+    if not _task_visible_to_parent(task, parent_agent):
+        raise PermissionError(f"Task not found or not owned by this session: {task_id}")
+    return task
+
+
+def _configured_timeout(args: dict, team_cfg: dict) -> Optional[int]:
+    if args.get("timeout_seconds") is not None:
+        return args.get("timeout_seconds")
+    return team_cfg.get("task_timeout_seconds")
+
+
+def _configured_max_parallel(team_cfg: dict) -> Optional[int]:
+    return team_cfg.get("max_parallel_tasks")
+
+
+def _configured_retention(team_cfg: dict) -> Optional[float]:
+    return team_cfg.get("artifact_retention_days")
+
+
+def agent_task_create(args: dict, parent_agent: Any = None, **_: Any) -> str:
+    args = args or {}
+    goal = args.get("goal") if isinstance(args, dict) else None
+    if not goal or not isinstance(goal, str):
+        return tool_error("goal is required")
+    team_cfg = _agent_team_config()
+    if team_cfg.get("enabled", True) is False:
+        return tool_error("Agent Team is disabled by agent_team.enabled=false")
+    try:
+        meta = task_runtime.start_agent_task(
+            goal=goal,
+            agent=args.get("agent"),
+            context=args.get("context") or "",
+            runtime=args.get("runtime"),
+            result_schema=args.get("result_schema"),
+            toolsets=args.get("toolsets"),
+            timeout_seconds=_configured_timeout(args, team_cfg),
+            max_parallel_tasks=_configured_max_parallel(team_cfg),
+            retention_days=_configured_retention(team_cfg),
+            metadata=_owner_metadata(parent_agent),
+            parent_agent=parent_agent,
+        )
+        return _json({"ok": True, "task": meta})
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+def agent_task_status(args: dict, parent_agent: Any = None, **_: Any) -> str:
+    task_id = args.get("task_id") if isinstance(args, dict) else None
+    err = _task_id_error(task_id)
+    if err:
+        return tool_error(err)
+    try:
+        task = _get_owned_task(task_id, parent_agent)
+    except Exception as exc:
+        return tool_error(str(exc))
+    if task is None:
+        return tool_error(f"Task not found: {task_id}")
+    return _json({"ok": True, "task": task})
+
+
+def _last_task_event(task: dict) -> Optional[dict]:
+    events_path = task.get("events_path")
+    if not events_path or not isinstance(events_path, str):
+        return None
+    last_event = None
+    try:
+        with open(events_path, "r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                last_event = json.loads(line)
+    except (OSError, json.JSONDecodeError):
+        return None
+    return last_event
+
+
+def _task_elapsed_seconds(task: dict) -> Optional[float]:
+    start = task.get("started_at") or task.get("created_at")
+    if not isinstance(start, (int, float)):
+        return None
+    end = task.get("ended_at")
+    if not isinstance(end, (int, float)):
+        end = time.time()
+    return round(max(0.0, end - start), 3)
+
+
+def agent_task_diagnostics(args: dict, parent_agent: Any = None, **_: Any) -> str:
+    task_id = args.get("task_id") if isinstance(args, dict) else None
+    err = _task_id_error(task_id)
+    if err:
+        return tool_error(err)
+    try:
+        task = _get_owned_task(task_id, parent_agent)
+    except Exception as exc:
+        return tool_error(str(exc))
+    if task is None:
+        return tool_error(f"Task not found: {task_id}")
+    diagnostics = {
+        "task_id": task.get("task_id"),
+        "status": task.get("status"),
+        "elapsed_seconds": _task_elapsed_seconds(task),
+        "last_event": _last_task_event(task),
+        "paths": {
+            "artifact_dir": task.get("artifact_dir"),
+            "events_path": task.get("events_path"),
+            "output_path": task.get("output_path"),
+            "result_path": task.get("result_path"),
+        },
+        "runtime": task.get("runtime"),
+        "agent": task.get("agent"),
+        "error": task.get("error"),
+        "owner": task.get("metadata") or {},
+        "timestamps": {
+            "created_at": task.get("created_at"),
+            "started_at": task.get("started_at"),
+            "updated_at": task.get("updated_at"),
+            "ended_at": task.get("ended_at"),
+        },
+    }
+    return _json({"ok": True, "diagnostics": diagnostics})
+
+
+def agent_task_output(args: dict, parent_agent: Any = None, **_: Any) -> str:
+    task_id = args.get("task_id") if isinstance(args, dict) else None
+    err = _task_id_error(task_id)
+    if err:
+        return tool_error(err)
+    try:
+        _get_owned_task(task_id, parent_agent)
+        if args.get("block"):
+            task_runtime.wait_for_task(task_id, timeout_seconds=args.get("timeout_seconds") or 30)
+        payload = task_runtime.read_task_output(task_id, max_chars=args.get("max_chars") or 6000)
+        return _json({"ok": True, **payload})
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+def agent_task_stop(args: dict, parent_agent: Any = None, **_: Any) -> str:
+    task_id = args.get("task_id") if isinstance(args, dict) else None
+    err = _task_id_error(task_id)
+    if err:
+        return tool_error(err)
+    try:
+        _get_owned_task(task_id, parent_agent)
+        task = task_runtime.stop_task(task_id)
+        return _json({"ok": True, "task": task})
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+def agent_task_list(args: dict, parent_agent: Any = None, **_: Any) -> str:
+    args = args or {}
+    try:
+        tasks = task_runtime.list_tasks(status=args.get("status"), limit=args.get("limit") or 20)
+        tasks = [task for task in tasks if _task_visible_to_parent(task, parent_agent)]
+        return _json({"ok": True, "tasks": tasks})
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+_TASK_CREATE_SCHEMA = {
+    "name": "agent_task_create",
+    "description": "Create a durable background sub-agent task for Agent Team execution.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "goal": {"type": "string", "description": "Sub-agent task goal."},
+            "agent": {"type": "string", "description": "Named agent profile, for example researcher/coder/reviewer/evaluator."},
+            "context": {"type": "string", "description": "Relevant bounded context for this task."},
+            "runtime": {"type": "string", "description": "Requested runtime. codex_app_server currently selects an explicit unsupported-runner failure until safe Codex execution is wired."},
+            "result_schema": {"type": "object", "description": "Optional JSON result contract."},
+            "toolsets": {"type": "array", "items": {"type": "string"}, "description": "Optional toolsets override."},
+            "timeout_seconds": {"type": "integer", "description": "Optional soft timeout. Defaults to agent_team.task_timeout_seconds when configured."},
+        },
+        "required": ["goal"],
+    },
+}
+
+registry.register("agent_task_create", "agent_team", _TASK_CREATE_SCHEMA, agent_task_create, emoji="🧩", max_result_size_chars=6000)
+registry.register(
+    "agent_task_status",
+    "agent_team",
+    {"name": "agent_task_status", "description": "Get a durable Agent Team task status.", "parameters": {"type": "object", "properties": {"task_id": {"type": "string"}}, "required": ["task_id"]}},
+    agent_task_status,
+    emoji="🧩",
+    max_result_size_chars=6000,
+)
+registry.register(
+    "agent_task_diagnostics",
+    "agent_team",
+    {
+        "name": "agent_task_diagnostics",
+        "description": "Get Agent Team task diagnostics: status, elapsed time, last event, artifact paths, runtime, agent, and error.",
+        "parameters": {"type": "object", "properties": {"task_id": {"type": "string"}}, "required": ["task_id"]},
+    },
+    agent_task_diagnostics,
+    emoji="🧩",
+    max_result_size_chars=8000,
+)
+registry.register(
+    "agent_task_output",
+    "agent_team",
+    {
+        "name": "agent_task_output",
+        "description": "Read Agent Team task output/result, optionally waiting briefly.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "task_id": {"type": "string"},
+                "block": {"type": "boolean"},
+                "timeout_seconds": {"type": "number"},
+                "max_chars": {"type": "integer"},
+            },
+            "required": ["task_id"],
+        },
+    },
+    agent_task_output,
+    emoji="🧩",
+    max_result_size_chars=12000,
+)
+registry.register(
+    "agent_task_stop",
+    "agent_team",
+    {"name": "agent_task_stop", "description": "Request cancellation for an active Agent Team task.", "parameters": {"type": "object", "properties": {"task_id": {"type": "string"}}, "required": ["task_id"]}},
+    agent_task_stop,
+    emoji="🧩",
+    max_result_size_chars=6000,
+)
+registry.register(
+    "agent_task_list",
+    "agent_team",
+    {"name": "agent_task_list", "description": "List recent durable Agent Team tasks visible to this session.", "parameters": {"type": "object", "properties": {"status": {"type": "string"}, "limit": {"type": "integer"}}}},
+    agent_task_list,
+    emoji="🧩",
+    max_result_size_chars=12000,
+)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -17,6 +17,7 @@ never the child's intermediate tool calls or reasoning.
 """
 
 import enum
+import copy
 import json
 import logging
 
@@ -28,6 +29,7 @@ from concurrent.futures import (
     ThreadPoolExecutor,
     TimeoutError as FuturesTimeoutError,
 )
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from toolsets import TOOLSETS
@@ -326,6 +328,155 @@ def _normalize_role(r: Optional[str]) -> str:
     return "leaf"
 
 
+_VALID_CONTEXT_MODES = {"fresh", "fork"}
+
+
+def _normalize_context_mode(mode: Optional[str]) -> str:
+    """Normalise a context inheritance mode for subagents.
+
+    fresh: default isolated child conversation.
+    fork:  pass a best-effort copy of the parent's safe conversation history
+           to run_conversation(), when that runner supports it.
+    """
+    if mode is None or not mode:
+        return "fresh"
+    mode_norm = str(mode).strip().lower()
+    aliases = {
+        "isolated": "fresh",
+        "none": "fresh",
+        "inherit": "fork",
+        "append": "fork",
+    }
+    mode_norm = aliases.get(mode_norm, mode_norm)
+    if mode_norm in _VALID_CONTEXT_MODES:
+        return mode_norm
+    logger.warning("Unknown delegate_task context_mode=%r, coercing to 'fresh'", mode)
+    return "fresh"
+
+
+def _copy_parent_conversation_history(parent_agent) -> Optional[List[Dict[str, Any]]]:
+    """Best-effort parent history snapshot for explicit context_mode='fork'.
+
+    The default stays isolated. This helper intentionally only copies list-like
+    message stores and never mutates the parent.
+    """
+    if parent_agent is None:
+        return None
+    for attr in (
+        "_session_messages",
+        "conversation_history",
+        "messages",
+    ):
+        history = getattr(parent_agent, attr, None)
+        if isinstance(history, list):
+            try:
+                return copy.deepcopy(history)
+            except Exception:
+                return [m for m in history if isinstance(m, dict)]
+    return None
+
+
+def _get_named_agent_config(cfg: Dict[str, Any], agent_name: Optional[str]) -> Dict[str, Any]:
+    """Return delegation.agents.<name> config, or raise for unknown names."""
+    if not agent_name:
+        return {}
+    agents = cfg.get("agents") or {}
+    if not isinstance(agents, dict):
+        raise ValueError("delegation.agents must be an object mapping agent names to configs.")
+    agent_cfg = agents.get(str(agent_name))
+    if agent_cfg is None:
+        raise ValueError(f"Unknown delegation agent '{agent_name}'. Define delegation.agents.{agent_name} in config.yaml.")
+    if not isinstance(agent_cfg, dict):
+        raise ValueError(f"delegation.agents.{agent_name} must be an object.")
+    return dict(agent_cfg)
+
+
+def _merged_agent_cfg(base_cfg: Dict[str, Any], agent_cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge a named agent config over delegation defaults for credential lookup."""
+    merged = dict(base_cfg or {})
+    for key in (
+        "model",
+        "provider",
+        "base_url",
+        "api_key",
+        "api_mode",
+        "reasoning_effort",
+        "max_iterations",
+        "child_timeout_seconds",
+        "max_concurrent_children",
+        "max_spawn_depth",
+        "orchestrator_enabled",
+        "subagent_auto_approve",
+        "inherit_mcp_toolsets",
+    ):
+        if key in agent_cfg and agent_cfg.get(key) not in (None, ""):
+            merged[key] = agent_cfg.get(key)
+    return merged
+
+
+def _coerce_result_schema(schema: Any) -> Optional[Dict[str, Any]]:
+    if isinstance(schema, dict):
+        return schema
+    if isinstance(schema, str) and schema.strip():
+        try:
+            parsed = json.loads(schema)
+            return parsed if isinstance(parsed, dict) else None
+        except json.JSONDecodeError:
+            return None
+    return None
+
+
+def _parse_structured_result(summary: str, result_schema: Optional[Dict[str, Any]]):
+    """Parse a JSON final response when the caller requested a structured result."""
+    if not result_schema:
+        return None, None
+    if not isinstance(summary, str) or not summary.strip():
+        return None, "empty final response"
+    try:
+        parsed = json.loads(summary)
+    except json.JSONDecodeError as exc:
+        return None, f"final response was not valid JSON: {exc.msg}"
+    if not isinstance(parsed, dict):
+        return None, "final response JSON must be an object"
+    return parsed, None
+
+
+def _write_subagent_artifact(child, entry: Dict[str, Any]) -> Optional[str]:
+    """Persist a compact subagent result artifact without raw prompt history."""
+    try:
+        subagent_id = getattr(child, "_subagent_id", None)
+        if not isinstance(subagent_id, str) or not subagent_id:
+            return None
+        hermes_home = os.getenv("HERMES_HOME")
+        root = Path(hermes_home).expanduser() if hermes_home else Path.home() / ".hermes"
+        artifacts_dir = root / "artifacts"
+        artifacts_dir.mkdir(parents=True, exist_ok=True)
+        artifact_path = artifacts_dir / "subagents.jsonl"
+        record = {
+            "subagent_id": subagent_id,
+            "agent": (
+                getattr(child, "_delegate_agent_name", None)
+                if isinstance(getattr(child, "_delegate_agent_name", None), str)
+                else None
+            ),
+            "goal": getattr(child, "_subagent_goal", None),
+            "status": entry.get("status"),
+            "model": entry.get("model"),
+            "duration_seconds": entry.get("duration_seconds"),
+            "api_calls": entry.get("api_calls"),
+            "tokens": entry.get("tokens"),
+            "structured_result": entry.get("structured_result"),
+            "summary_preview": (entry.get("summary") or "")[:1000],
+            "created_at": time.time(),
+        }
+        with artifact_path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+        return str(artifact_path)
+    except Exception as exc:
+        logger.debug("subagent artifact write failed: %s", exc)
+        return None
+
+
 def _get_max_concurrent_children() -> int:
     """Read delegation.max_concurrent_children from config, falling back to
     DELEGATION_MAX_CONCURRENT_CHILDREN env var, then the default (3).
@@ -574,6 +725,10 @@ def _build_child_system_prompt(
     role: str = "leaf",
     max_spawn_depth: int = 2,
     child_depth: int = 1,
+    agent_name: Optional[str] = None,
+    agent_instructions: Optional[str] = None,
+    context_mode: str = "fresh",
+    result_schema: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Build a focused system prompt for a child agent.
 
@@ -588,6 +743,16 @@ def _build_child_system_prompt(
         "",
         f"YOUR TASK:\n{goal}",
     ]
+    if agent_name:
+        parts.append(f"\nAGENT NAME:\n{agent_name}")
+    if agent_instructions and str(agent_instructions).strip():
+        parts.append(f"\nAGENT INSTRUCTIONS:\n{str(agent_instructions).strip()}")
+    if context_mode == "fork":
+        parts.append(
+            "\nCONTEXT MODE:\n"
+            "You may receive an explicit forked conversation snapshot from the parent. "
+            "Use it only as task context; do not assume you share the parent's memory or tool state."
+        )
     if context and context.strip():
         parts.append(f"\nCONTEXT:\n{context}")
     if workspace_path and str(workspace_path).strip():
@@ -608,6 +773,13 @@ def _build_child_system_prompt(
         "Be thorough but concise -- your response is returned to the "
         "parent agent as a summary."
     )
+    if result_schema:
+        parts.append(
+            "\nSTRUCTURED RESULT REQUIRED:\n"
+            "Your final response must be a single valid JSON object matching this requested schema. "
+            "Do not wrap it in Markdown fences and do not include prose outside the JSON object.\n"
+            f"Requested schema:\n{json.dumps(result_schema, ensure_ascii=False)}"
+        )
     if role == "orchestrator":
         child_note = (
             "Your own children MUST be leaves (cannot delegate further) "
@@ -691,6 +863,7 @@ def _build_child_progress_callback(
     depth: Optional[int] = None,
     model: Optional[str] = None,
     toolsets: Optional[List[str]] = None,
+    agent_name: Optional[str] = None,
 ) -> Optional[callable]:
     """Build a callback that relays child agent tool calls to the parent display.
 
@@ -738,6 +911,8 @@ def _build_child_progress_callback(
             kw["model"] = model
         if toolsets is not None:
             kw["toolsets"] = list(toolsets)
+        if agent_name is not None:
+            kw["agent"] = agent_name
         kw["tool_count"] = _tool_count[0]
         return kw
 
@@ -772,6 +947,10 @@ def _build_child_progress_callback(
 
         if event_type == "subagent.complete":
             _relay("subagent.complete", preview=preview, **kwargs)
+            return
+
+        if event_type == "subagent.spawn_requested":
+            _relay("subagent.spawn_requested", preview=preview or goal_label or "", **kwargs)
             return
 
         # Normalise legacy strings, new-style "delegate.*" strings, and
@@ -888,6 +1067,12 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    agent_name: Optional[str] = None,
+    agent_instructions: Optional[str] = None,
+    context_mode: str = "fresh",
+    result_schema: Optional[Dict[str, Any]] = None,
+    fork_history: Optional[List[Dict[str, Any]]] = None,
+    delegation_cfg_override: Optional[Dict[str, Any]] = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -918,10 +1103,13 @@ def _build_child_agent(
     # one key.  parent_id is non-None when THIS parent is itself a subagent
     # (nested orchestrator -> worker chain).
     subagent_id = f"sa-{task_index}-{_uuid.uuid4().hex[:8]}"
-    parent_subagent_id = getattr(parent_agent, "_subagent_id", None)
+    _raw_parent_subagent_id = getattr(parent_agent, "_subagent_id", None)
+    parent_subagent_id = _raw_parent_subagent_id if isinstance(_raw_parent_subagent_id, str) else None
     tui_depth = max(0, child_depth - 1)  # 0 = first-level child for the UI
 
-    delegation_cfg = _load_config()
+    delegation_cfg = delegation_cfg_override or _load_config()
+    effective_context_mode = _normalize_context_mode(context_mode)
+    effective_result_schema = _coerce_result_schema(result_schema)
 
     # When no explicit toolsets given, inherit from parent's enabled toolsets
     # so disabled tools (e.g. web) don't leak to subagents.
@@ -975,6 +1163,10 @@ def _build_child_agent(
         role=effective_role,
         max_spawn_depth=max_spawn,
         child_depth=child_depth,
+        agent_name=agent_name,
+        agent_instructions=agent_instructions,
+        context_mode=effective_context_mode,
+        result_schema=effective_result_schema,
     )
     # Extract parent's API key so subagents inherit auth (e.g. Nous Portal).
     parent_api_key = getattr(parent_agent, "api_key", None)
@@ -997,6 +1189,7 @@ def _build_child_agent(
         depth=tui_depth,
         model=effective_model_for_cb,
         toolsets=child_toolsets,
+        agent_name=agent_name,
     )
 
     # Each subagent gets its own iteration budget capped at max_iterations
@@ -1146,6 +1339,10 @@ def _build_child_agent(
     child._subagent_id = subagent_id
     child._parent_subagent_id = parent_subagent_id
     child._subagent_goal = goal
+    child._delegate_agent_name = agent_name
+    child._delegate_context_mode = effective_context_mode
+    child._delegate_fork_history = fork_history if effective_context_mode == "fork" else None
+    child._delegate_result_schema = effective_result_schema
 
     # Share a credential pool with the child when possible so subagents can
     # rotate credentials on rate limits instead of getting pinned to one key.
@@ -1443,6 +1640,8 @@ def _run_single_child(
     # hand us a MagicMock don't carry stable ids; skip registration then.
     _raw_sid = getattr(child, "_subagent_id", None)
     _subagent_id = _raw_sid if isinstance(_raw_sid, str) else None
+    _raw_agent_name = getattr(child, "_delegate_agent_name", None)
+    _agent_name = _raw_agent_name if isinstance(_raw_agent_name, str) else None
     if _subagent_id:
         _raw_depth = getattr(child, "_delegate_depth", 1)
         _tui_depth = max(0, _raw_depth - 1) if isinstance(_raw_depth, int) else 0
@@ -1453,6 +1652,7 @@ def _run_single_child(
                 "parent_id": _parent_sid if isinstance(_parent_sid, str) else None,
                 "depth": _tui_depth,
                 "goal": goal,
+                "agent": _agent_name,
                 "model": (
                     getattr(child, "model", None)
                     if isinstance(getattr(child, "model", None), str)
@@ -1504,10 +1704,15 @@ def _run_single_child(
 
         def _run_with_thread_capture():
             _worker_thread_holder["t"] = threading.current_thread()
-            return child.run_conversation(
-                user_message=goal,
-                task_id=child_task_id,
-            )
+            run_kwargs = {
+                "user_message": goal,
+                "task_id": child_task_id,
+            }
+            if getattr(child, "_delegate_context_mode", "fresh") == "fork":
+                fork_history = getattr(child, "_delegate_fork_history", None)
+                if isinstance(fork_history, list):
+                    run_kwargs["conversation_history"] = copy.deepcopy(fork_history)
+            return child.run_conversation(**run_kwargs)
 
         _child_future = _timeout_executor.submit(_run_with_thread_capture)
         try:
@@ -1685,6 +1890,7 @@ def _run_single_child(
             "task_index": task_index,
             "status": status,
             "summary": summary,
+            "agent": _agent_name,
             "api_calls": api_calls,
             "duration_seconds": duration,
             "model": _model if isinstance(_model, str) else None,
@@ -1716,6 +1922,15 @@ def _run_single_child(
                 else 0.0
             ),
         }
+        _raw_result_schema = getattr(child, "_delegate_result_schema", None)
+        _result_schema = _raw_result_schema if isinstance(_raw_result_schema, dict) else None
+        structured_result, structured_error = _parse_structured_result(
+            summary, _result_schema
+        )
+        if structured_result is not None:
+            entry["structured_result"] = structured_result
+        elif structured_error:
+            entry["structured_result_error"] = structured_error
         if status == "failed":
             entry["error"] = result.get("error", "Subagent did not produce a response.")
 
@@ -1812,6 +2027,10 @@ def _run_single_child(
                 child_progress_cb("subagent.complete", **complete_kwargs)
             except Exception as e:
                 logger.debug("Progress callback completion failed: %s", e)
+
+        artifact_path = _write_subagent_artifact(child, entry)
+        if artifact_path:
+            entry["artifact_path"] = artifact_path
 
         return entry
 
@@ -1924,14 +2143,17 @@ def delegate_task(
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
+    agent: Optional[str] = None,
+    context_mode: Optional[str] = None,
+    result_schema: Optional[Dict[str, Any]] = None,
     parent_agent=None,
 ) -> str:
     """
     Spawn one or more child agents to handle delegated tasks.
 
     Supports two modes:
-      - Single: provide goal (+ optional context, toolsets, role)
-      - Batch:  provide tasks array [{goal, context, toolsets, role}, ...]
+      - Single: provide goal (+ optional context, toolsets, role, agent)
+      - Batch:  provide tasks array [{goal, context, toolsets, role, agent}, ...]
 
     The 'role' parameter controls whether a child can further delegate:
     'leaf' (default) cannot; 'orchestrator' retains the delegation
@@ -1987,16 +2209,6 @@ def delegate_task(
         )
     effective_max_iter = default_max_iter
 
-    # Resolve delegation credentials (provider:model pair).
-    # When delegation.provider is configured, this resolves the full credential
-    # bundle (base_url, api_key, api_mode) via the same runtime provider system
-    # used by CLI/gateway startup.  When unconfigured, returns None values so
-    # children inherit from the parent.
-    try:
-        creds = _resolve_delegation_credentials(cfg, parent_agent)
-    except ValueError as exc:
-        return tool_error(str(exc))
-
     # Normalize to task list
     max_children = _get_max_concurrent_children()
     recovered_tasks, tasks_error = _recover_tasks_from_json_string(tasks)
@@ -2017,7 +2229,15 @@ def delegate_task(
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
         task_list = [
-            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role}
+            {
+                "goal": goal,
+                "context": context,
+                "toolsets": toolsets,
+                "role": top_role,
+                "agent": agent,
+                "context_mode": context_mode,
+                "result_schema": result_schema,
+            }
         ]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
@@ -2055,14 +2275,43 @@ def delegate_task(
     try:
         for i, t in enumerate(task_list):
             task_acp_args = t.get("acp_args") if "acp_args" in t else None
+            effective_agent = t.get("agent") or agent
+            try:
+                agent_cfg = _get_named_agent_config(cfg, effective_agent)
+            except ValueError as exc:
+                return tool_error(str(exc))
+            effective_cfg = _merged_agent_cfg(cfg, agent_cfg)
+            try:
+                creds = _resolve_delegation_credentials(effective_cfg, parent_agent)
+            except ValueError as exc:
+                return tool_error(str(exc))
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
-            effective_role = _normalize_role(t.get("role") or top_role)
+            effective_role = _normalize_role(
+                t.get("role") or agent_cfg.get("role") or top_role
+            )
+            effective_toolsets = (
+                t.get("toolsets")
+                or toolsets
+                or agent_cfg.get("toolsets")
+            )
+            effective_context_mode = _normalize_context_mode(
+                t.get("context_mode") or context_mode or agent_cfg.get("context_mode")
+            )
+            effective_result_schema = _coerce_result_schema(
+                t.get("result_schema") or result_schema or agent_cfg.get("result_schema")
+            )
+            effective_max_iter = effective_cfg.get("max_iterations", default_max_iter)
+            fork_history = (
+                _copy_parent_conversation_history(parent_agent)
+                if effective_context_mode == "fork"
+                else None
+            )
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
-                toolsets=t.get("toolsets") or toolsets,
+                toolsets=effective_toolsets,
                 model=creds["model"],
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
@@ -2080,6 +2329,14 @@ def delegate_task(
                     else (acp_args if acp_args is not None else creds.get("args"))
                 ),
                 role=effective_role,
+                agent_name=effective_agent,
+                agent_instructions=(
+                    agent_cfg.get("instructions") or agent_cfg.get("system_prompt")
+                ),
+                context_mode=effective_context_mode,
+                result_schema=effective_result_schema,
+                fork_history=fork_history,
+                delegation_cfg_override=effective_cfg,
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
@@ -2703,6 +2960,29 @@ DELEGATE_TASK_SCHEMA = {
                     "['terminal', 'file', 'web'] for full-stack tasks."
                 ),
             },
+            "agent": {
+                "type": "string",
+                "description": (
+                    "Optional named subagent profile from delegation.agents in config.yaml. "
+                    "Use for explicit model/tool/context routing such as researcher, coder, evaluator."
+                ),
+            },
+            "context_mode": {
+                "type": "string",
+                "enum": ["fresh", "fork"],
+                "description": (
+                    "Context mode for the child. fresh is isolated and default. "
+                    "fork copies a safe parent conversation snapshot when explicitly requested."
+                ),
+            },
+            "result_schema": {
+                "type": "object",
+                "description": (
+                    "Optional JSON object describing the requested final JSON shape. "
+                    "When set, the child is instructed to return a single JSON object; "
+                    "delegate_task also returns structured_result when parsing succeeds."
+                ),
+            },
             "tasks": {
                 "type": "array",
                 "items": {
@@ -2717,6 +2997,19 @@ DELEGATE_TASK_SCHEMA = {
                             "type": "array",
                             "items": {"type": "string"},
                             "description": f"Toolsets for this specific task. Available: {_TOOLSET_LIST_STR}. Use 'web' for network access, 'terminal' for shell, 'browser' for web interaction.",
+                        },
+                        "agent": {
+                            "type": "string",
+                            "description": "Per-task named subagent profile from delegation.agents.",
+                        },
+                        "context_mode": {
+                            "type": "string",
+                            "enum": ["fresh", "fork"],
+                            "description": "Per-task context mode override.",
+                        },
+                        "result_schema": {
+                            "type": "object",
+                            "description": "Per-task structured JSON result schema.",
                         },
                         "acp_command": {
                             "type": "string",
@@ -2793,6 +3086,9 @@ registry.register(
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         role=args.get("role"),
+        agent=args.get("agent"),
+        context_mode=args.get("context_mode"),
+        result_schema=args.get("result_schema"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,

--- a/toolsets.py
+++ b/toolsets.py
@@ -54,6 +54,8 @@ _HERMES_CORE_TOOLS = [
     "clarify",
     # Code execution + delegation
     "execute_code", "delegate_task",
+    "agent_task_create", "agent_task_status", "agent_task_diagnostics", "agent_task_output",
+    "agent_task_stop", "agent_task_list",
     # Cronjob management
     "cronjob",
     # Cross-platform messaging (gated on gateway running via check_fn)
@@ -224,6 +226,19 @@ TOOLSETS = {
         "includes": []
     },
     
+    "agent_team": {
+        "description": "Durable Agent Team task creation, diagnostics, status, output, stop, and listing tools.",
+        "category": "basic",
+        "tools": [
+            "agent_task_create",
+            "agent_task_status",
+            "agent_task_diagnostics",
+            "agent_task_output",
+            "agent_task_stop",
+            "agent_task_list",
+        ],
+        "includes": [],
+    },
     "delegation": {
         "description": "Spawn subagents with isolated context for complex subtasks",
         "tools": ["delegate_task"],


### PR DESCRIPTION
## Summary

Adds a durable Agent Team runtime and first-class orchestration surface for Hermes.

This PR now includes:

- Durable Agent Team task runtime under `~/.hermes/tasks` with metadata, events, output logs, result persistence, status/list/output/stop APIs, stale recovery, retention cleanup, diagnostics, soft timeout handling, and max-parallel enforcement.
- `agent_task_create`, `agent_task_status`, `agent_task_diagnostics`, `agent_task_output`, `agent_task_stop`, and `agent_task_list` under the `agent_team` toolset and core Hermes platform presets.
- Live agent-loop dispatch for `agent_task_*` tools so they are not swallowed by the generic `_AGENT_LOOP_TOOLS` guard and can receive the active parent agent/session.
- Session ownership metadata and filtering so one session cannot freely list/read/stop another session's owned durable tasks.
- Named-agent delegation improvements: `agent`, `context_mode`, and `result_schema` now flow through the main `delegate_task` dispatch path.
- Parent-level delegate locking to reduce concurrent parent-state contamination between foreground delegation and durable background delegate execution.
- Task runner abstraction with:
  - `DelegateTaskRunner` for existing Hermes delegation behavior.
  - Explicit `CodexTaskRunner` stub for `runtime=codex_app_server` / `agent=coder`, which fails clearly until a safe Codex app-server execution bridge is implemented. It does not pretend execution happened and does not expose Hermes loop tools.
- Agent Team orchestration/evaluator policy in prompt guidance and default config.
- Baseline team profiles for `orchestrator`, `researcher`, and `evaluator`.

## Design notes

- P0 execution still reuses the existing `delegate_task` path for Hermes-backed workers so credentials, named-agent config, tool scoping, and existing delegation safety behavior remain consistent.
- `timeout_seconds` is a soft timeout. The task runtime records timeout status and asks cooperative runners to stop, but Python cannot safely kill an arbitrary in-process LLM/tool thread. Hard timeout should come with a future process-isolated worker runner.
- Codex app-server routing is explicit but intentionally not falsely implemented. `coder`/`codex_app_server` tasks select the Codex runner stub and fail with a clear unsupported message until a safe bridge is wired.
- `agent_task_stop` is task-local/cooperative and does not interrupt the parent agent session.

## Tests

Passed on a clean branch from latest `origin/main`:

```bash
uv run --with pytest --with pytest-timeout pytest -q \
  tests/agent/test_task_runtime.py \
  tests/agent/test_task_runners.py \
  tests/tools/test_agent_task_tool.py \
  tests/tools/test_delegate.py \
  tests/tools/test_delegate_toolset_scope.py \
  tests/tools/test_delegate_subagent_timeout_diagnostic.py \
  tests/tools/test_delegate_composite_toolsets.py \
  tests/agent/test_subagent_progress.py \
  tests/agent/test_subagent_stop_hook.py \
  tests/agent/test_prompt_builder.py::TestGuidanceConstants \
  tests/hermes_cli/test_agent_team_policy.py \
  tests/test_get_tool_definitions_cache_isolation.py \
  tests/test_toolsets.py \
  tests/hermes_cli/test_tools_config.py \
  tests/hermes_cli/test_config.py \
  tests/hermes_cli/test_config_validation.py \
  tests/tools/test_config_null_guard.py
```

Result:

```text
412 passed in 33.60s
```

Additional local context:

- Full `uv run pytest -q` could not collect optional/e2e suites in the local environment because `acp`, `fastapi`, and `websockets` were missing.
- A broader run excluding those collection blockers completed but exposed unrelated historical/environment failures in Discord/Gateway/systemd/browser/terminal tests. The Agent Team targeted regression suite above passes.
