### PR TITLE
fix(opencode): send explicit User-Agent for OpenCode Zen/Go WAF

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1208,6 +1208,10 @@ def init_agent(
                 client_kwargs["default_headers"] = {
                     "User-Agent": "claude-code/0.1.0",
                 }
+            elif base_url_host_matches(effective_base, "opencode.ai"):
+                from agent.auxiliary_client import build_opencode_headers
+
+                client_kwargs["default_headers"] = build_opencode_headers()
             elif base_url_host_matches(effective_base, "portal.qwen.ai"):
                 client_kwargs["default_headers"] = _ra()._qwen_portal_headers()
             elif base_url_host_matches(effective_base, "chatgpt.com"):

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1083,6 +1083,20 @@ _AI_GATEWAY_HEADERS = {
     "User-Agent": f"HermesAgent/{_HERMES_VERSION}",
 }
 
+
+def build_opencode_headers() -> dict:
+    """Return the User-Agent OpenCode Zen/Go's WAF requires (#15575).
+
+    opencode.ai fronts both ``/zen/v1`` and ``/zen/go/v1`` with a WAF that
+    rejects the OpenAI SDK's default ``OpenAI/Python x.y.z`` User-Agent with a
+    401 even when the API key is valid.  Sending an explicit client UA clears
+    it.  Every opencode.ai client construction path must go through this
+    helper — the WAF applies equally to the initial client, to clients rebuilt
+    on a model switch, and to auxiliary/async clients.
+    """
+    return {"User-Agent": f"hermes-agent/{_HERMES_VERSION}"}
+
+
 # Nous Portal extra_body for product attribution.
 # Callers should pass this as extra_body in chat.completions.create()
 # when the auxiliary client is backed by Nous Portal.
@@ -2531,6 +2545,8 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
             extra = {}
             if base_url_host_matches(base_url, "api.kimi.com"):
                 extra["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
+            elif base_url_host_matches(base_url, "opencode.ai"):
+                extra["default_headers"] = build_opencode_headers()
             elif base_url_host_matches(base_url, "githubcopilot.com"):
                 from hermes_cli.models import copilot_default_headers
 
@@ -2571,6 +2587,8 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
         extra = {}
         if base_url_host_matches(base_url, "api.kimi.com"):
             extra["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
+        elif base_url_host_matches(base_url, "opencode.ai"):
+            extra["default_headers"] = build_opencode_headers()
         elif base_url_host_matches(base_url, "githubcopilot.com"):
             from hermes_cli.models import copilot_default_headers
 
@@ -5841,6 +5859,8 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
         )
     elif base_url_host_matches(sync_base_url, "api.kimi.com"):
         async_kwargs["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
+    elif base_url_host_matches(sync_base_url, "opencode.ai"):
+        async_kwargs["default_headers"] = build_opencode_headers()
     elif base_url_host_matches(sync_base_url, "integrate.api.nvidia.com"):
         async_kwargs["default_headers"] = build_nvidia_nim_headers(sync_base_url)
     elif base_url_host_matches(sync_base_url, "x.ai"):
@@ -6495,6 +6515,8 @@ def resolve_provider_client(
         headers = {}
         if base_url_host_matches(base_url, "api.kimi.com"):
             headers["User-Agent"] = "claude-code/0.1.0"
+        elif base_url_host_matches(base_url, "opencode.ai"):
+            headers.update(build_opencode_headers())
         elif base_url_host_matches(base_url, "githubcopilot.com"):
             from hermes_cli.copilot_auth import copilot_request_headers
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -5920,6 +5920,7 @@ class AIAgent:
         from agent.auxiliary_client import (
             _AI_GATEWAY_HEADERS,
             build_nvidia_nim_headers,
+            build_opencode_headers,
             build_or_headers,
         )
 
@@ -5937,6 +5938,8 @@ class AIAgent:
             self._client_kwargs["default_headers"] = copilot_default_headers()
         elif base_url_host_matches(base_url, "api.kimi.com"):
             self._client_kwargs["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
+        elif base_url_host_matches(base_url, "opencode.ai"):
+            self._client_kwargs["default_headers"] = build_opencode_headers()
         elif base_url_host_matches(base_url, "portal.qwen.ai"):
             self._client_kwargs["default_headers"] = _qwen_portal_headers()
         elif base_url_host_matches(base_url, "chatgpt.com"):

--- a/tests/run_agent/test_opencode_zen_integration.py
+++ b/tests/run_agent/test_opencode_zen_integration.py
@@ -1,0 +1,156 @@
+"""Tests for the OpenCode Zen/Go WAF User-Agent fix (#15575).
+
+opencode.ai fronts both ``/zen/v1`` and ``/zen/go/v1`` with a WAF that returns
+a bare 401 (empty body) for requests carrying the OpenAI SDK's default
+User-Agent, even when the API key is valid.  Hermes must send an explicit UA
+on *every* client construction path, because the WAF does not care which of
+them built the request:
+
+- initial construction (``AIAgent.__init__``)
+- client rebuild after a model/base-url switch
+  (``_apply_client_headers_for_base_url``)
+- auxiliary and async clients (``agent.auxiliary_client``)
+
+Zen speaks the OpenAI-compatible wire for every model it proxies, Gemini
+included, so none of these paths may divert to Gemini's native client.
+"""
+from unittest.mock import MagicMock, patch
+
+from agent.auxiliary_client import build_opencode_headers
+from run_agent import AIAgent
+
+ZEN_BASE = "https://opencode.ai/zen/v1"
+GO_BASE = "https://opencode.ai/zen/go/v1"
+OTHER_BASE = "https://api.example.com/v1"
+
+
+def _make_agent(base_url, model):
+    return AIAgent(
+        api_key="sk-test",
+        base_url=base_url,
+        model=model,
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The shared helper
+# ---------------------------------------------------------------------------
+
+def test_helper_returns_identifiable_user_agent():
+    """The helper must yield a non-empty, hermes-identifying UA."""
+    headers = build_opencode_headers()
+    assert set(headers) == {"User-Agent"}
+    ua = headers["User-Agent"]
+    assert ua.startswith("hermes-agent/")
+    assert ua != "hermes-agent/"  # a version is actually interpolated
+
+
+def test_helper_returns_a_fresh_dict_each_call():
+    """Callers mutate the returned dict; it must not be shared state."""
+    first = build_opencode_headers()
+    first["X-Scratch"] = "1"
+    assert "X-Scratch" not in build_opencode_headers()
+
+
+# ---------------------------------------------------------------------------
+# Path 1: initial client construction
+# ---------------------------------------------------------------------------
+
+@patch("run_agent.OpenAI")
+def test_user_agent_injected_for_zen(mock_openai):
+    """Requests to opencode.ai/zen must carry a User-Agent header."""
+    mock_openai.return_value = MagicMock()
+    _make_agent(ZEN_BASE, "kimi-k2.5")
+    headers = mock_openai.call_args.kwargs.get("default_headers", {})
+    assert headers.get("User-Agent", "").startswith("hermes-agent"), (
+        f"User-Agent missing or wrong for {ZEN_BASE}: {headers!r}"
+    )
+
+
+@patch("run_agent.OpenAI")
+def test_user_agent_injected_for_go(mock_openai):
+    """Same User-Agent requirement for the opencode.ai/zen/go endpoint."""
+    mock_openai.return_value = MagicMock()
+    _make_agent(GO_BASE, "glm-5")
+    headers = mock_openai.call_args.kwargs.get("default_headers", {})
+    assert headers.get("User-Agent", "").startswith("hermes-agent"), (
+        f"User-Agent missing or wrong for {GO_BASE}: {headers!r}"
+    )
+
+
+@patch("run_agent.OpenAI")
+def test_user_agent_not_injected_for_other_hosts(mock_openai):
+    """The opencode-specific User-Agent must not leak to other hosts."""
+    mock_openai.return_value = MagicMock()
+    _make_agent(OTHER_BASE, "some-model")
+    headers = mock_openai.call_args.kwargs.get("default_headers", {})
+    assert not headers.get("User-Agent", "").startswith("hermes-agent")
+
+
+# ---------------------------------------------------------------------------
+# Path 2: client rebuild (model / base-url switch mid-session)
+# ---------------------------------------------------------------------------
+
+@patch("run_agent.OpenAI")
+def test_user_agent_survives_client_rebuild(mock_openai):
+    """A rebuild onto an opencode.ai base URL must re-apply the UA.
+
+    Regression guard: the original fix only covered __init__, so switching
+    models mid-session rebuilt the client without the header and the WAF
+    started 401ing again.
+    """
+    mock_openai.return_value = MagicMock()
+    agent = _make_agent(OTHER_BASE, "some-model")
+
+    agent._apply_client_headers_for_base_url(ZEN_BASE)
+
+    headers = agent._client_kwargs.get("default_headers", {})
+    assert headers.get("User-Agent", "").startswith("hermes-agent"), (
+        f"User-Agent lost on rebuild onto {ZEN_BASE}: {headers!r}"
+    )
+
+
+@patch("run_agent.OpenAI")
+def test_rebuild_away_from_opencode_drops_the_user_agent(mock_openai):
+    """Rebuilding onto another host must not keep the opencode UA."""
+    mock_openai.return_value = MagicMock()
+    agent = _make_agent(ZEN_BASE, "kimi-k2.5")
+
+    agent._apply_client_headers_for_base_url(OTHER_BASE)
+
+    headers = agent._client_kwargs.get("default_headers") or {}
+    assert not headers.get("User-Agent", "").startswith("hermes-agent")
+
+
+# ---------------------------------------------------------------------------
+# Zen is OpenAI-compatible for every model, Gemini included
+# ---------------------------------------------------------------------------
+
+@patch("run_agent.OpenAI")
+def test_gemini_model_on_zen_stays_on_openai_compatible_client(mock_openai):
+    """gemini-* on opencode.ai must NOT divert to Gemini's native client.
+
+    ``is_native_gemini_base_url`` only recognises
+    generativelanguage.googleapis.com; Zen proxies Gemini over its own
+    OpenAI-compatible /v1/chat/completions route, so the native wire would
+    POST generateContent payloads at an endpoint that cannot parse them.
+    """
+    from agent.gemini_native_adapter import GeminiNativeClient
+
+    mock_openai.return_value = MagicMock()
+    agent = _make_agent(ZEN_BASE, "gemini-3-flash")
+
+    assert not isinstance(agent.client, GeminiNativeClient)
+    assert mock_openai.called, "gemini-* on Zen should build a normal OpenAI client"
+
+
+@patch("run_agent.OpenAI")
+def test_gemini_model_on_zen_still_gets_the_user_agent(mock_openai):
+    """The WAF applies to Gemini traffic on Zen too."""
+    mock_openai.return_value = MagicMock()
+    _make_agent(ZEN_BASE, "gemini-3-flash")
+    headers = mock_openai.call_args.kwargs.get("default_headers", {})
+    assert headers.get("User-Agent", "").startswith("hermes-agent")


### PR DESCRIPTION
## What does this PR do?

Adds User-Agent header handling for OpenCode Zen/Go backends that sit behind a WAF returning 401 for unrecognised User-Agents. The header is applied on every client construction path, including rebuilds on model switch.

## Related Issue

Fixes #15575

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- agent/auxiliary_client.py: add build_opencode_headers() — single source of the
  User-Agent: hermes-agent/<version> header — and apply it in the API-key provider
  path (pool and non-pool), the async client, and resolve_provider_client
- agent/agent_init.py: apply the header in the explicit-credentials client path
- run_agent.py: apply the header in _apply_client_headers_for_base_url, so a
  model switch that rebuilds the client does not drop it
- tests/run_agent/test_opencode_zen_integration.py: cover the helper, both
  endpoints, non-leakage to other hosts, and the rebuild path in both directions


## How to Test

Configure Hermes with provider: custom, base_url: https://opencode.ai/zen/v1 and a valid OpenCode Zen API key
Run a request with a non-Gemini model (e.g. kimi-k2.5) — should succeed without a bare 401
Switch models mid-session (e.g. /model) and issue another request — should still
succeed, confirming the rebuilt client keeps the header

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before fix - bare 401, empty response body (WAF rejection before reaching the app):

`AuthenticationError [HTTP 401] - response_text: ""`

After WAF fix — 401 reaches the app with a real error body, confirming the key and routing are now the issue to address:

`Error from provider (GCP): Request had invalid authentication credentials`

(That GCP error is specific to gemini-* over Zen and is out of scope for this PR;
it's tracked separately. Non-Gemini models e.g. kimi-k2.5 succeed after the WAF fix.)
