### PR TITLE
security: redact identity content in remote management API responses

### DIFF
--- a/gateway/platforms/api_sanitiser.py
+++ b/gateway/platforms/api_sanitiser.py
@@ -1,0 +1,226 @@
+"""
+Response sanitiser for the Remote Management API (`/api/*`).
+
+The endpoints introduced in #23742 ship per-user identity content
+verbatim:
+
+* ``/api/memory`` returns ``user.content`` (the full USER.md
+  profile).
+* ``/api/sessions`` returns each row's ``system_prompt`` (the
+  persona + skills index + the SAME USER.md content embedded
+  inside, several KB per row).
+* ``/api/sessions/{id}/messages`` repeats the ``role: "system"``
+  content on every system message.
+
+Bearer-token auth is the only access gate. A leaked or stolen
+token exposes the user's identity profile in one request.
+
+This module is the hard redaction layer applied as a
+post-serialisation step on every response from the four affected
+handlers. It is **not** opt-out and not opt-in: the Remote
+Management surface is structural-only by policy.
+
+If a legitimate identity-read flow ever needs to be added (e.g. a
+desktop Persona-tab that wants to *render* USER.md content), it
+should arrive via a separate auth class (loopback token,
+SSH-tunnel-gated header, etc.) — not via re-loosening this filter.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Iterable, Tuple
+
+__all__ = [
+    "sanitize_value",
+    "sanitize_response",
+    "REDACTED",
+]
+
+# Sentinel string that replaces any leaked identity / secret value.
+# Tests assert against this literal — keep stable.
+REDACTED = "<redacted>"
+
+# Layer 1: field-name heuristic. Case-insensitive substring match
+# against the *key name*, not the value. When any of these
+# substrings appears in a key, the entire value is replaced with
+# the sentinel.
+_SECRET_FIELD_PATTERNS: Tuple[str, ...] = (
+    "api_key",
+    "apikey",
+    "token",
+    "secret",
+    "password",
+    "passwd",
+    "credential",
+    "bearer",
+    # Note: deliberately NOT including "auth" — the API server
+    # already ships `auth: {type: bearer, required: true}` in
+    # /v1/capabilities, and stripping that map would lie to clients
+    # about how auth works. The bearer-token value itself is in a
+    # field named "key" / "token" which the patterns above catch.
+)
+
+# Layer 2a: URL with embedded basic-auth credentials.
+# https://user:pass@host/path → https://<redacted>@host/path
+_URL_CRED_RE = re.compile(
+    r"(https?://)[^/\s@]+:[^/\s@]+@",
+    re.IGNORECASE,
+)
+
+# Layer 2b: Token-in-querystring patterns.
+# ?api_key=xxx&q=foo → ?api_key=<redacted>&q=foo
+_TOKEN_QS_RE = re.compile(
+    r"([?&](?:api_key|apikey|token|access_token|secret)=)[^&\s]+",
+    re.IGNORECASE,
+)
+
+# Layer 3: hard identity-field redaction. Applied at the
+# response-payload level after the structural pass.
+#
+# - Top-level fields whose VALUE is the identity content
+#   (replace the value with REDACTED, preserve siblings).
+_IDENTITY_FIELDS: Tuple[str, ...] = (
+    "system_prompt",
+)
+
+# - Nested object paths: dict[key1][key2] = REDACTED.
+#   Used for /api/memory which nests user content one level deep.
+_IDENTITY_OBJECT_PATHS: Tuple[Tuple[str, ...], ...] = (
+    ("user", "content"),
+)
+
+
+# ---------------------------------------------------------------------------
+# Field-name heuristic
+# ---------------------------------------------------------------------------
+
+
+def _looks_like_secret_field(name: str) -> bool:
+    """True when a key name suggests the value is a secret."""
+    n = name.lower()
+    return any(pattern in n for pattern in _SECRET_FIELD_PATTERNS)
+
+
+# ---------------------------------------------------------------------------
+# Structural pass — recursive walk
+# ---------------------------------------------------------------------------
+
+
+def sanitize_value(value: Any, _field: str = "") -> Any:
+    """Apply the structural filters to one value.
+
+    * Field-name secret detection → wholesale replacement.
+    * String content → URL-credential + querystring-token regex.
+    * Dicts/lists → recursive walk; field name carries down.
+
+    Does NOT touch identity-block fields here — that pass runs on
+    the full payload after the structural walk completes (see
+    :func:`sanitize_response`).
+    """
+    if _looks_like_secret_field(_field):
+        return REDACTED
+    if isinstance(value, str):
+        v = _URL_CRED_RE.sub(r"\1" + REDACTED + "@", value)
+        v = _TOKEN_QS_RE.sub(r"\1" + REDACTED, v)
+        return v
+    if isinstance(value, dict):
+        return {k: sanitize_value(v, k) for k, v in value.items()}
+    if isinstance(value, list):
+        return [sanitize_value(item) for item in value]
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Identity-block pass
+# ---------------------------------------------------------------------------
+
+
+def _redact_identity_fields_in_dict(d: Dict[str, Any]) -> None:
+    """In-place: replace any top-level identity field with REDACTED."""
+    for field in _IDENTITY_FIELDS:
+        if field in d:
+            d[field] = REDACTED
+
+
+def _redact_identity_object_paths_in_dict(d: Dict[str, Any]) -> None:
+    """In-place: walk known identity-object paths and redact the leaf."""
+    for path in _IDENTITY_OBJECT_PATHS:
+        node: Any = d
+        for segment in path[:-1]:
+            if not isinstance(node, dict) or segment not in node:
+                node = None
+                break
+            node = node[segment]
+        leaf_key = path[-1]
+        if isinstance(node, dict) and leaf_key in node:
+            node[leaf_key] = REDACTED
+
+
+def _walk_and_redact_identity(value: Any) -> Any:
+    """Recursively apply identity redaction to any dict found in the
+    response.  Sessions list responses nest the dict at
+    ``data["sessions"][n]``; we don't want to hardcode the nesting,
+    so we walk."""
+    if isinstance(value, dict):
+        # Also redact `role: system` message bodies — system-role
+        # messages carry the same identity content as
+        # ``system_prompt`` and travel in
+        # ``/api/sessions/{id}/messages``.
+        if value.get("role") == "system" and "content" in value:
+            value["content"] = REDACTED
+        _redact_identity_fields_in_dict(value)
+        _redact_identity_object_paths_in_dict(value)
+        for v in value.values():
+            _walk_and_redact_identity(v)
+    elif isinstance(value, list):
+        for item in value:
+            _walk_and_redact_identity(item)
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def sanitize_response(payload: Any) -> Any:
+    """Top-level sanitiser for a Remote Management API response.
+
+    Two passes:
+
+    1. Structural pass (:func:`sanitize_value`) — recursive walk;
+       replaces secrets by field name + scrubs URL credentials +
+       querystring tokens.
+    2. Identity pass — recursively walks the payload again and
+       redacts known identity fields (``system_prompt``,
+       ``user.content``, ``role: "system"`` message ``content``).
+
+    The two passes don't conflict: pass 1 doesn't touch the
+    identity fields (their names don't match the secret heuristic),
+    pass 2 doesn't touch structural data.
+
+    Returns a new sanitised value; the original payload is not
+    mutated. Safe to call on whatever shape Codex's handlers
+    return — dict, list, primitive.
+    """
+    structural = sanitize_value(payload)
+    # Identity pass mutates in-place on the new value returned by
+    # the structural pass (sanitize_value already produces fresh
+    # containers via dict/list comprehensions, so no shared state
+    # with the caller's input).
+    _walk_and_redact_identity(structural)
+    return structural
+
+
+def declared_policy() -> Dict[str, Any]:
+    """Policy summary for /v1/capabilities advertising.
+
+    Stays in this module so a future policy change only needs to
+    update one source of truth.
+    """
+    return {
+        "enabled": True,
+        "identity_blocks_redacted": True,
+        "opt_in_supported": False,
+    }

--- a/gateway/platforms/api_sanitiser.py
+++ b/gateway/platforms/api_sanitiser.py
@@ -61,6 +61,24 @@ _SECRET_FIELD_PATTERNS: Tuple[str, ...] = (
     # field named "key" / "token" which the patterns above catch.
 )
 
+# Allow-list for numeric *counters* whose key happens to contain
+# one of the secret substrings above. The classic case is
+# ``input_tokens`` / ``output_tokens`` / ``cache_read_tokens`` /
+# ``reasoning_tokens`` etc. — those are integer counts, not
+# credentials, and stripping them breaks any cost / usage display
+# downstream.
+#
+# Plural ``tokens`` is always a counter. Singular ``token`` stays
+# secret-by-default. Suffix forms like ``token_count`` /
+# ``tokenCount`` are also counters and explicitly allowed.
+_COUNTER_FIELD_RE = re.compile(
+    r"(?:^|_)tokens$"           # input_tokens, output_tokens, …
+    r"|^tokens$"                # bare "tokens"
+    r"|(?:^|_)token_count$"     # token_count, foo_token_count
+    r"|^tokencount$",           # camelCase form
+    re.IGNORECASE,
+)
+
 # Layer 2a: URL with embedded basic-auth credentials.
 # https://user:pass@host/path → https://<redacted>@host/path
 _URL_CRED_RE = re.compile(
@@ -97,8 +115,16 @@ _IDENTITY_OBJECT_PATHS: Tuple[Tuple[str, ...], ...] = (
 
 
 def _looks_like_secret_field(name: str) -> bool:
-    """True when a key name suggests the value is a secret."""
+    """True when a key name suggests the value is a secret.
+
+    Counter fields (``input_tokens``, ``tokenCount``, etc.) are
+    explicitly excluded — see ``_COUNTER_FIELD_RE``. They look like
+    they contain a secret substring but are integer counts that
+    must reach the client for cost / usage rendering.
+    """
     n = name.lower()
+    if _COUNTER_FIELD_RE.search(n):
+        return False
     return any(pattern in n for pattern in _SECRET_FIELD_PATTERNS)
 
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1117,6 +1117,8 @@ class APIServerAdapter(BasePlatformAdapter):
             logger.exception("GET /api/sessions failed")
             return _api_json_error(str(exc), status=500)
 
+        from gateway.platforms.api_sanitiser import sanitize_response
+
         normalized = []
         for item in sessions:
             row = dict(item)
@@ -1127,7 +1129,9 @@ class APIServerAdapter(BasePlatformAdapter):
             row["messageCount"] = row.get("message_count", 0)
             normalized.append(row)
         return web.json_response(
-            {"sessions": normalized, "total": total, "limit": limit, "offset": offset}
+            sanitize_response(
+                {"sessions": normalized, "total": total, "limit": limit, "offset": offset}
+            )
         )
 
     async def _handle_search_sessions(self, request: "web.Request") -> "web.Response":
@@ -1208,7 +1212,13 @@ class APIServerAdapter(BasePlatformAdapter):
             logger.exception("GET /api/sessions/%s/messages failed", session_id)
             return _api_json_error(str(exc), status=500)
 
-        return web.json_response({"session_id": resolved, "sessionId": resolved, "messages": messages})
+        from gateway.platforms.api_sanitiser import sanitize_response
+
+        return web.json_response(
+            sanitize_response(
+                {"session_id": resolved, "sessionId": resolved, "messages": messages}
+            )
+        )
 
     async def _handle_list_profiles(self, request: "web.Request") -> "web.Response":
         """GET /api/profiles — list Hermes profiles."""
@@ -1409,6 +1419,8 @@ class APIServerAdapter(BasePlatformAdapter):
         if auth_err:
             return auth_err
 
+        from gateway.platforms.api_sanitiser import declared_policy
+
         return web.json_response({
             "object": "hermes.api_server.capabilities",
             "platform": "hermes-agent",
@@ -1417,6 +1429,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "type": "bearer",
                 "required": bool(self._api_key),
             },
+            "sanitisation": declared_policy(),
             "runtime": {
                 "mode": "server_agent",
                 "tool_execution": "server",
@@ -2889,25 +2902,29 @@ class APIServerAdapter(BasePlatformAdapter):
                 }
             except Exception:
                 pass
+            from gateway.platforms.api_sanitiser import sanitize_response
+
             return web.json_response(
-                {
-                    "memory": {
-                        **memory_file,
-                        "entries": entries,
-                        "charCount": len(memory_file["content"]),
-                        "char_count": len(memory_file["content"]),
-                        "charLimit": MEMORY_CHAR_LIMIT,
-                        "char_limit": MEMORY_CHAR_LIMIT,
-                    },
-                    "user": {
-                        **user_file,
-                        "charCount": len(user_file["content"]),
-                        "char_count": len(user_file["content"]),
-                        "charLimit": USER_PROFILE_CHAR_LIMIT,
-                        "char_limit": USER_PROFILE_CHAR_LIMIT,
-                    },
-                    "stats": stats,
-                }
+                sanitize_response(
+                    {
+                        "memory": {
+                            **memory_file,
+                            "entries": entries,
+                            "charCount": len(memory_file["content"]),
+                            "char_count": len(memory_file["content"]),
+                            "charLimit": MEMORY_CHAR_LIMIT,
+                            "char_limit": MEMORY_CHAR_LIMIT,
+                        },
+                        "user": {
+                            **user_file,
+                            "charCount": len(user_file["content"]),
+                            "char_count": len(user_file["content"]),
+                            "charLimit": USER_PROFILE_CHAR_LIMIT,
+                            "char_limit": USER_PROFILE_CHAR_LIMIT,
+                        },
+                        "stats": stats,
+                    }
+                )
             )
         except (FileNotFoundError, ValueError) as exc:
             return _api_json_error(str(exc), status=400)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -15,6 +15,20 @@ Exposes an HTTP server with endpoints:
 - POST /v1/runs/{run_id}/stop       — interrupt a running agent
 - GET  /health                     — health check
 - GET  /health/detailed            — rich status for cross-container dashboard probing
+- GET  /api/sessions               — persisted session summaries
+- GET  /api/sessions/search        — full-text session search
+- GET  /api/sessions/{id}/messages — persisted session messages
+- GET  /api/profiles               — profile metadata
+- POST /api/profiles               — create profile
+- DELETE /api/profiles/{name}      — delete profile
+- POST /api/profiles/{name}/activate — set active profile
+- GET/PUT/POST /api/profiles/{name}/soul — read, write, reset persona
+- GET/POST/PUT/DELETE /api/memory  — read and edit memory/user profile files
+- GET/PUT /api/tools/toolsets      — list and update toolsets
+- GET /api/skills/installed        — installed skills
+- GET /api/skills/bundled          — bundled skills
+- GET /api/skills/content          — read a skill's SKILL.md
+- GET /api/gateway/status          — gateway runtime status
 
 Any OpenAI-compatible frontend (Open WebUI, LobeChat, LibreChat,
 AnythingLLM, NextChat, ChatBox, etc.) can connect to hermes-agent
@@ -35,6 +49,7 @@ import re
 import sqlite3
 import time
 import uuid
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 try:
@@ -575,6 +590,167 @@ except ImportError:
     _cron_trigger = None
 
 
+MEMORY_ENTRY_DELIMITER = "\n\u00a7\n"
+MEMORY_CHAR_LIMIT = 2200
+USER_PROFILE_CHAR_LIMIT = 1375
+
+
+def _api_json_error(message: str, status: int = 400) -> "web.Response":
+    return web.json_response({"error": message}, status=status)
+
+
+def _coerce_limit_offset(request: "web.Request", *, default_limit: int = 30) -> tuple[int, int]:
+    try:
+        limit = int(request.query.get("limit", default_limit))
+    except (TypeError, ValueError):
+        limit = default_limit
+    try:
+        offset = int(request.query.get("offset", 0))
+    except (TypeError, ValueError):
+        offset = 0
+    return max(1, min(limit, 200)), max(0, offset)
+
+
+def _csv_query_values(request: "web.Request", *names: str) -> list[str]:
+    values: list[str] = []
+    for name in names:
+        for raw in request.query.getall(name, []):
+            values.extend(part.strip() for part in raw.split(","))
+    return [value for value in values if value]
+
+
+def _session_source_filters(request: "web.Request") -> tuple[Optional[str], Optional[list[str]]]:
+    source = (request.query.get("source") or "").strip() or None
+    exclude_sources = _csv_query_values(request, "exclude_source", "exclude_sources")
+    return source, (exclude_sources or None)
+
+
+def _profile_dir_for_request(request: "web.Request") -> Path:
+    return _resolve_profile_dir(request.query.get("profile"))
+
+
+def _resolve_profile_dir(profile: Optional[str]) -> Path:
+    if not profile or profile == "current":
+        from hermes_constants import get_hermes_home
+
+        return get_hermes_home()
+
+    from hermes_cli import profiles as profiles_mod
+
+    name = profiles_mod.normalize_profile_name(profile)
+    profiles_mod.validate_profile_name(name)
+    if not profiles_mod.profile_exists(name):
+        raise FileNotFoundError(f"Profile '{name}' does not exist.")
+    return profiles_mod.get_profile_dir(name)
+
+
+def _read_text_file(path: Path) -> dict:
+    try:
+        st = path.stat()
+        return {
+            "content": path.read_text(encoding="utf-8"),
+            "exists": True,
+            "lastModified": int(st.st_mtime),
+            "last_modified": int(st.st_mtime),
+        }
+    except FileNotFoundError:
+        return {
+            "content": "",
+            "exists": False,
+            "lastModified": None,
+            "last_modified": None,
+        }
+
+
+def _parse_memory_entries(content: str) -> list[dict]:
+    if not content.strip():
+        return []
+    entries = []
+    for idx, entry in enumerate(content.split(MEMORY_ENTRY_DELIMITER)):
+        entry = entry.strip()
+        if entry:
+            entries.append({"index": idx, "content": entry})
+    return entries
+
+
+def _serialize_memory_entries(entries: list[dict]) -> str:
+    return MEMORY_ENTRY_DELIMITER.join(str(entry.get("content", "")).strip() for entry in entries)
+
+
+def _ensure_parent_and_write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _skill_frontmatter(content: str) -> tuple[str, str]:
+    name = ""
+    description = ""
+    if content.startswith("---"):
+        end = content.find("---", 3)
+        if end != -1:
+            frontmatter = content[3:end]
+            if match := re.search(r"^\s*name:\s*[\"']?([^\"'\n]+)[\"']?\s*$", frontmatter, re.M):
+                name = match.group(1).strip()
+            if match := re.search(r"^\s*description:\s*[\"']?([^\"'\n]+)[\"']?\s*$", frontmatter, re.M):
+                description = match.group(1).strip()
+    if not name:
+        if match := re.search(r"^#\s+(.+)$", content, re.M):
+            name = match.group(1).strip()
+    if not description:
+        for line in content.splitlines():
+            stripped = line.strip()
+            if stripped and not stripped.startswith(("#", "---")):
+                description = stripped[:160]
+                break
+    return name, description
+
+
+def _scan_skills(root: Path, *, source: str) -> list[dict]:
+    if not root.is_dir():
+        return []
+    skills: list[dict] = []
+    for skill_md in sorted(root.rglob("SKILL.md")):
+        if ".git" in skill_md.parts or ".hub" in skill_md.parts:
+            continue
+        try:
+            rel = skill_md.parent.relative_to(root)
+        except ValueError:
+            continue
+        parts = rel.parts
+        category = parts[0] if len(parts) > 1 else "local"
+        slug = parts[-1] if parts else skill_md.parent.name
+        try:
+            content = skill_md.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            content = ""
+        name, description = _skill_frontmatter(content[:4000])
+        skills.append(
+            {
+                "name": name or slug,
+                "slug": slug,
+                "category": category,
+                "description": description,
+                "source": source,
+                "path": str(skill_md.parent),
+            }
+        )
+    return skills
+
+
+def _path_within(path: Path, roots: list[Path]) -> bool:
+    try:
+        resolved = path.resolve()
+    except OSError:
+        return False
+    for root in roots:
+        try:
+            resolved.relative_to(root.resolve())
+            return True
+        except (OSError, ValueError):
+            continue
+    return False
+
+
 class APIServerAdapter(BasePlatformAdapter):
     """
     OpenAI-compatible HTTP API server adapter.
@@ -887,6 +1063,320 @@ class APIServerAdapter(BasePlatformAdapter):
             "pid": os.getpid(),
         })
 
+    async def _handle_gateway_status(self, request: "web.Request") -> "web.Response":
+        """GET /api/gateway/status — return persisted gateway runtime status."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        from gateway.status import read_runtime_status
+
+        runtime = read_runtime_status() or {}
+        return web.json_response(
+            {
+                "ok": True,
+                "running": True,
+                "pid": os.getpid(),
+                "gateway_state": runtime.get("gateway_state"),
+                "platforms": runtime.get("platforms", {}),
+                "active_agents": runtime.get("active_agents", 0),
+                "exit_reason": runtime.get("exit_reason"),
+                "updated_at": runtime.get("updated_at"),
+            }
+        )
+
+    async def _handle_list_sessions(self, request: "web.Request") -> "web.Response":
+        """GET /api/sessions — list persisted session summaries."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        limit, offset = _coerce_limit_offset(request)
+        source, exclude_sources = _session_source_filters(request)
+        try:
+            from hermes_state import SessionDB
+
+            db_path = _profile_dir_for_request(request) / "state.db"
+            if not db_path.exists():
+                return web.json_response(
+                    {"sessions": [], "total": 0, "limit": limit, "offset": offset}
+                )
+            db = SessionDB(db_path)
+            try:
+                sessions = db.list_sessions_rich(
+                    source=source,
+                    exclude_sources=exclude_sources,
+                    limit=limit,
+                    offset=offset,
+                    order_by_last_active=True,
+                )
+                total = db.session_count(source=source) if not exclude_sources else len(sessions)
+            finally:
+                db.close()
+        except Exception as exc:
+            logger.exception("GET /api/sessions failed")
+            return _api_json_error(str(exc), status=500)
+
+        normalized = []
+        for item in sessions:
+            row = dict(item)
+            row.setdefault("preview", row.get("preview") or "")
+            row.setdefault("title", row.get("title"))
+            row["startedAt"] = row.get("started_at")
+            row["endedAt"] = row.get("ended_at")
+            row["messageCount"] = row.get("message_count", 0)
+            normalized.append(row)
+        return web.json_response(
+            {"sessions": normalized, "total": total, "limit": limit, "offset": offset}
+        )
+
+    async def _handle_search_sessions(self, request: "web.Request") -> "web.Response":
+        """GET /api/sessions/search?q=... — search persisted messages."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        query = (request.query.get("q") or "").strip()
+        if not query:
+            return web.json_response({"results": []})
+        try:
+            limit = max(1, min(int(request.query.get("limit", 20)), 100))
+        except (TypeError, ValueError):
+            limit = 20
+
+        try:
+            from hermes_state import SessionDB
+
+            db_path = _profile_dir_for_request(request) / "state.db"
+            if not db_path.exists():
+                return web.json_response({"results": []})
+            db = SessionDB(db_path)
+            try:
+                source, exclude_sources = _session_source_filters(request)
+                matches = db.search_messages(
+                    query=query,
+                    source_filter=[source] if source else None,
+                    exclude_sources=exclude_sources,
+                    limit=limit,
+                )
+            finally:
+                db.close()
+        except Exception as exc:
+            logger.exception("GET /api/sessions/search failed")
+            return _api_json_error(str(exc), status=500)
+
+        seen: dict[str, dict] = {}
+        for match in matches:
+            sid = match.get("session_id")
+            if not sid or sid in seen:
+                continue
+            seen[sid] = {
+                "session_id": sid,
+                "sessionId": sid,
+                "title": match.get("title"),
+                "snippet": match.get("snippet", ""),
+                "role": match.get("role"),
+                "source": match.get("source"),
+                "model": match.get("model"),
+                "started_at": match.get("session_started"),
+                "startedAt": match.get("session_started"),
+            }
+        return web.json_response({"results": list(seen.values())})
+
+    async def _handle_session_messages(self, request: "web.Request") -> "web.Response":
+        """GET /api/sessions/{session_id}/messages — fetch persisted messages."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        session_id = request.match_info["session_id"]
+        try:
+            from hermes_state import SessionDB
+
+            db_path = _profile_dir_for_request(request) / "state.db"
+            if not db_path.exists():
+                return _api_json_error("Session not found", status=404)
+            db = SessionDB(db_path)
+            try:
+                resolved = db.resolve_session_id(session_id)
+                if not resolved:
+                    return _api_json_error("Session not found", status=404)
+                messages = db.get_messages(resolved)
+            finally:
+                db.close()
+        except Exception as exc:
+            logger.exception("GET /api/sessions/%s/messages failed", session_id)
+            return _api_json_error(str(exc), status=500)
+
+        return web.json_response({"session_id": resolved, "sessionId": resolved, "messages": messages})
+
+    async def _handle_list_profiles(self, request: "web.Request") -> "web.Response":
+        """GET /api/profiles — list Hermes profiles."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            from hermes_cli import profiles as profiles_mod
+
+            active = profiles_mod.get_active_profile_name()
+            items = []
+            for profile in profiles_mod.list_profiles():
+                has_soul = (Path(profile.path) / "SOUL.md").exists()
+                item = {
+                    "name": profile.name,
+                    "path": str(profile.path),
+                    "is_default": profile.is_default,
+                    "isDefault": profile.is_default,
+                    "is_active": profile.name == active,
+                    "isActive": profile.name == active,
+                    "model": profile.model or "",
+                    "provider": profile.provider or "",
+                    "has_env": profile.has_env,
+                    "hasEnv": profile.has_env,
+                    "has_soul": has_soul,
+                    "hasSoul": has_soul,
+                    "skill_count": profile.skill_count,
+                    "skillCount": profile.skill_count,
+                    "gateway_running": profile.gateway_running,
+                    "gatewayRunning": profile.gateway_running,
+                }
+                items.append(item)
+            return web.json_response({"profiles": items, "active": active})
+        except Exception as exc:
+            logger.exception("GET /api/profiles failed")
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_create_profile(self, request: "web.Request") -> "web.Response":
+        """POST /api/profiles — create a Hermes profile."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            body = await request.json()
+        except Exception:
+            return _api_json_error("Invalid JSON in request body", status=400)
+        name = str(body.get("name") or "").strip()
+        clone = bool(body.get("clone") or body.get("clone_from_default"))
+        no_skills = bool(body.get("no_skills"))
+        if not name:
+            return _api_json_error("Profile name is required", status=400)
+
+        try:
+            from hermes_cli import profiles as profiles_mod
+
+            path = profiles_mod.create_profile(
+                name=name,
+                clone_from="default" if clone else None,
+                clone_config=clone,
+                no_skills=no_skills,
+            )
+            if not clone:
+                profiles_mod.seed_profile_skills(path, quiet=True)
+            if not profiles_mod.check_alias_collision(name):
+                profiles_mod.create_wrapper_script(name)
+            return web.json_response({"ok": True, "name": name, "path": str(path)})
+        except (ValueError, FileExistsError, FileNotFoundError) as exc:
+            return _api_json_error(str(exc), status=400)
+        except Exception as exc:
+            logger.exception("POST /api/profiles failed")
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_delete_profile(self, request: "web.Request") -> "web.Response":
+        """DELETE /api/profiles/{name} — delete a Hermes profile."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        name = request.match_info["name"]
+        try:
+            from hermes_cli import profiles as profiles_mod
+
+            path = profiles_mod.delete_profile(name, yes=True)
+            return web.json_response({"ok": True, "path": str(path)})
+        except FileNotFoundError as exc:
+            return _api_json_error(str(exc), status=404)
+        except ValueError as exc:
+            return _api_json_error(str(exc), status=400)
+        except Exception as exc:
+            logger.exception("DELETE /api/profiles/%s failed", name)
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_activate_profile(self, request: "web.Request") -> "web.Response":
+        """POST /api/profiles/{name}/activate — set the active profile."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        name = request.match_info["name"]
+        try:
+            from hermes_cli import profiles as profiles_mod
+
+            profiles_mod.set_active_profile(name)
+            return web.json_response({"ok": True, "active": profiles_mod.get_active_profile_name()})
+        except (ValueError, FileNotFoundError) as exc:
+            return _api_json_error(str(exc), status=400)
+        except Exception as exc:
+            logger.exception("POST /api/profiles/%s/activate failed", name)
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_get_soul(self, request: "web.Request") -> "web.Response":
+        """GET /api/profiles/{name}/soul — read persona/SOUL.md."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            profile_dir = _resolve_profile_dir(request.match_info["name"])
+            return web.json_response(_read_text_file(profile_dir / "SOUL.md"))
+        except FileNotFoundError as exc:
+            return _api_json_error(str(exc), status=404)
+        except ValueError as exc:
+            return _api_json_error(str(exc), status=400)
+
+    async def _handle_write_soul(self, request: "web.Request") -> "web.Response":
+        """PUT /api/profiles/{name}/soul — write persona/SOUL.md."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            body = await request.json()
+        except Exception:
+            return _api_json_error("Invalid JSON in request body", status=400)
+        try:
+            profile_dir = _resolve_profile_dir(request.match_info["name"])
+            _ensure_parent_and_write(profile_dir / "SOUL.md", str(body.get("content") or ""))
+            return web.json_response({"ok": True})
+        except FileNotFoundError as exc:
+            return _api_json_error(str(exc), status=404)
+        except ValueError as exc:
+            return _api_json_error(str(exc), status=400)
+        except Exception as exc:
+            logger.exception("PUT /api/profiles/%s/soul failed", request.match_info["name"])
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_reset_soul(self, request: "web.Request") -> "web.Response":
+        """POST /api/profiles/{name}/soul/reset — reset persona/SOUL.md."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            from hermes_cli.default_soul import DEFAULT_SOUL_MD
+
+            profile_dir = _resolve_profile_dir(request.match_info["name"])
+            _ensure_parent_and_write(profile_dir / "SOUL.md", DEFAULT_SOUL_MD)
+            return web.json_response({"ok": True, "content": DEFAULT_SOUL_MD})
+        except FileNotFoundError as exc:
+            return _api_json_error(str(exc), status=404)
+        except ValueError as exc:
+            return _api_json_error(str(exc), status=400)
+        except Exception as exc:
+            logger.exception("POST /api/profiles/%s/soul/reset failed", request.match_info["name"])
+            return _api_json_error(str(exc), status=500)
+
     async def _handle_models(self, request: "web.Request") -> "web.Response":
         """GET /v1/models — return hermes-agent as an available model."""
         auth_err = self._check_auth(request)
@@ -949,6 +1439,13 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_approval_response": True,
                 "tool_progress_events": True,
                 "approval_events": True,
+                "remote_sessions": True,
+                "remote_profiles": True,
+                "remote_memory": True,
+                "remote_persona": True,
+                "remote_skills": True,
+                "remote_toolsets": True,
+                "remote_gateway_status": True,
                 "session_continuity_header": "X-Hermes-Session-Id",
                 "session_key_header": "X-Hermes-Session-Key",
                 "cors": bool(self._cors_origins),
@@ -964,6 +1461,23 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_events": {"method": "GET", "path": "/v1/runs/{run_id}/events"},
                 "run_approval": {"method": "POST", "path": "/v1/runs/{run_id}/approval"},
                 "run_stop": {"method": "POST", "path": "/v1/runs/{run_id}/stop"},
+                "gateway_status": {"method": "GET", "path": "/api/gateway/status"},
+                "sessions": {"method": "GET", "path": "/api/sessions"},
+                "session_search": {"method": "GET", "path": "/api/sessions/search"},
+                "session_messages": {"method": "GET", "path": "/api/sessions/{session_id}/messages"},
+                "profiles": {"method": "GET", "path": "/api/profiles"},
+                "profile_create": {"method": "POST", "path": "/api/profiles"},
+                "profile_delete": {"method": "DELETE", "path": "/api/profiles/{name}"},
+                "profile_activate": {"method": "POST", "path": "/api/profiles/{name}/activate"},
+                "profile_soul": {"method": "GET/PUT", "path": "/api/profiles/{name}/soul"},
+                "profile_soul_reset": {"method": "POST", "path": "/api/profiles/{name}/soul/reset"},
+                "memory": {"method": "GET", "path": "/api/memory"},
+                "memory_entries": {"method": "POST/PUT/DELETE", "path": "/api/memory/entries"},
+                "memory_user": {"method": "PUT", "path": "/api/memory/user"},
+                "toolsets": {"method": "GET/PUT", "path": "/api/tools/toolsets"},
+                "installed_skills": {"method": "GET", "path": "/api/skills/installed"},
+                "bundled_skills": {"method": "GET", "path": "/api/skills/bundled"},
+                "skill_content": {"method": "GET", "path": "/api/skills/content"},
             },
         })
 
@@ -2344,6 +2858,286 @@ class APIServerAdapter(BasePlatformAdapter):
             "deleted": True,
         })
 
+    async def _handle_read_memory(self, request: "web.Request") -> "web.Response":
+        """GET /api/memory — read MEMORY.md and USER.md for a profile."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            profile_dir = _profile_dir_for_request(request)
+            memory_file = _read_text_file(profile_dir / "memories" / "MEMORY.md")
+            user_file = _read_text_file(profile_dir / "memories" / "USER.md")
+            entries = _parse_memory_entries(memory_file["content"])
+            stats = {"totalSessions": 0, "totalMessages": 0, "total_sessions": 0, "total_messages": 0}
+            try:
+                db_path = profile_dir / "state.db"
+                if db_path.exists():
+                    with sqlite3.connect(str(db_path)) as conn:
+                        row = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()
+                        total_sessions = int(row[0]) if row else 0
+                        row = conn.execute("SELECT COUNT(*) FROM messages").fetchone()
+                        total_messages = int(row[0]) if row else 0
+                else:
+                    total_sessions = 0
+                    total_messages = 0
+                stats = {
+                    "totalSessions": total_sessions,
+                    "totalMessages": total_messages,
+                    "total_sessions": total_sessions,
+                    "total_messages": total_messages,
+                }
+            except Exception:
+                pass
+            return web.json_response(
+                {
+                    "memory": {
+                        **memory_file,
+                        "entries": entries,
+                        "charCount": len(memory_file["content"]),
+                        "char_count": len(memory_file["content"]),
+                        "charLimit": MEMORY_CHAR_LIMIT,
+                        "char_limit": MEMORY_CHAR_LIMIT,
+                    },
+                    "user": {
+                        **user_file,
+                        "charCount": len(user_file["content"]),
+                        "char_count": len(user_file["content"]),
+                        "charLimit": USER_PROFILE_CHAR_LIMIT,
+                        "char_limit": USER_PROFILE_CHAR_LIMIT,
+                    },
+                    "stats": stats,
+                }
+            )
+        except (FileNotFoundError, ValueError) as exc:
+            return _api_json_error(str(exc), status=400)
+        except Exception as exc:
+            logger.exception("GET /api/memory failed")
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_add_memory_entry(self, request: "web.Request") -> "web.Response":
+        """POST /api/memory/entries — append a memory entry."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            body = await request.json()
+        except Exception:
+            return _api_json_error("Invalid JSON in request body", status=400)
+        try:
+            profile_dir = _profile_dir_for_request(request)
+            path = profile_dir / "memories" / "MEMORY.md"
+            existing = _read_text_file(path)
+            entries = _parse_memory_entries(existing["content"])
+            entries.append({"index": len(entries), "content": str(body.get("content") or "").strip()})
+            content = _serialize_memory_entries(entries)
+            if len(content) > MEMORY_CHAR_LIMIT:
+                return _api_json_error(
+                    f"Would exceed memory limit ({len(content)}/{MEMORY_CHAR_LIMIT} chars)",
+                    status=400,
+                )
+            _ensure_parent_and_write(path, content)
+            return web.json_response({"ok": True})
+        except Exception as exc:
+            logger.exception("POST /api/memory/entries failed")
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_update_memory_entry(self, request: "web.Request") -> "web.Response":
+        """PUT /api/memory/entries/{index} — update a memory entry."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            body = await request.json()
+            index = int(request.match_info["index"])
+        except Exception:
+            return _api_json_error("Invalid request", status=400)
+        try:
+            profile_dir = _profile_dir_for_request(request)
+            path = profile_dir / "memories" / "MEMORY.md"
+            entries = _parse_memory_entries(_read_text_file(path)["content"])
+            if index < 0 or index >= len(entries):
+                return _api_json_error("Entry not found", status=404)
+            entries[index]["content"] = str(body.get("content") or "").strip()
+            content = _serialize_memory_entries(entries)
+            if len(content) > MEMORY_CHAR_LIMIT:
+                return _api_json_error(
+                    f"Would exceed memory limit ({len(content)}/{MEMORY_CHAR_LIMIT} chars)",
+                    status=400,
+                )
+            _ensure_parent_and_write(path, content)
+            return web.json_response({"ok": True})
+        except Exception as exc:
+            logger.exception("PUT /api/memory/entries/%s failed", request.match_info.get("index"))
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_delete_memory_entry(self, request: "web.Request") -> "web.Response":
+        """DELETE /api/memory/entries/{index} — remove a memory entry."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            index = int(request.match_info["index"])
+        except Exception:
+            return _api_json_error("Invalid entry index", status=400)
+        try:
+            profile_dir = _profile_dir_for_request(request)
+            path = profile_dir / "memories" / "MEMORY.md"
+            entries = _parse_memory_entries(_read_text_file(path)["content"])
+            if index < 0 or index >= len(entries):
+                return _api_json_error("Entry not found", status=404)
+            entries.pop(index)
+            _ensure_parent_and_write(path, _serialize_memory_entries(entries))
+            return web.json_response({"ok": True})
+        except Exception as exc:
+            logger.exception("DELETE /api/memory/entries/%s failed", request.match_info.get("index"))
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_write_user_profile(self, request: "web.Request") -> "web.Response":
+        """PUT /api/memory/user — write USER.md."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            body = await request.json()
+        except Exception:
+            return _api_json_error("Invalid JSON in request body", status=400)
+        content = str(body.get("content") or "")
+        if len(content) > USER_PROFILE_CHAR_LIMIT:
+            return _api_json_error(
+                f"Exceeds limit ({len(content)}/{USER_PROFILE_CHAR_LIMIT} chars)",
+                status=400,
+            )
+        try:
+            profile_dir = _profile_dir_for_request(request)
+            _ensure_parent_and_write(profile_dir / "memories" / "USER.md", content)
+            return web.json_response({"ok": True})
+        except Exception as exc:
+            logger.exception("PUT /api/memory/user failed")
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_list_toolsets(self, request: "web.Request") -> "web.Response":
+        """GET /api/tools/toolsets — list configurable toolsets."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        platform = request.query.get("platform") or "api_server"
+        try:
+            from hermes_cli.config import load_config
+            from hermes_cli.tools_config import (
+                _get_effective_configurable_toolsets,
+                _get_platform_tools,
+                _toolset_has_keys,
+            )
+            from toolsets import resolve_toolset
+
+            config = load_config()
+            enabled = _get_platform_tools(config, platform, include_default_mcp_servers=False)
+            toolsets = []
+            for key, label, description in _get_effective_configurable_toolsets():
+                try:
+                    tools = sorted(set(resolve_toolset(key)))
+                except Exception:
+                    tools = []
+                is_enabled = key in enabled
+                toolsets.append(
+                    {
+                        "key": key,
+                        "name": key,
+                        "label": label,
+                        "description": description,
+                        "enabled": is_enabled,
+                        "available": is_enabled,
+                        "configured": _toolset_has_keys(key, config),
+                        "tools": tools,
+                    }
+                )
+            return web.json_response({"toolsets": toolsets, "platform": platform})
+        except Exception as exc:
+            logger.exception("GET /api/tools/toolsets failed")
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_set_toolset(self, request: "web.Request") -> "web.Response":
+        """PUT /api/tools/toolsets/{key} — enable or disable a toolset."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            body = await request.json()
+        except Exception:
+            return _api_json_error("Invalid JSON in request body", status=400)
+        key = request.match_info["key"]
+        platform = request.query.get("platform") or "api_server"
+        enabled = bool(body.get("enabled"))
+        try:
+            from hermes_cli.config import load_config, save_config
+            from hermes_cli.tools_config import _apply_toolset_change
+
+            config = load_config()
+            _apply_toolset_change(config, platform, [key], "enable" if enabled else "disable")
+            save_config(config)
+            return web.json_response({"ok": True, "key": key, "enabled": enabled, "platform": platform})
+        except Exception as exc:
+            logger.exception("PUT /api/tools/toolsets/%s failed", key)
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_installed_skills(self, request: "web.Request") -> "web.Response":
+        """GET /api/skills/installed — list installed skills."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            profile_dir = _profile_dir_for_request(request)
+            return web.json_response({"skills": _scan_skills(profile_dir / "skills", source="installed")})
+        except Exception as exc:
+            logger.exception("GET /api/skills/installed failed")
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_bundled_skills(self, request: "web.Request") -> "web.Response":
+        """GET /api/skills/bundled — list bundled skills from the repo."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        root = Path(__file__).resolve().parents[2] / "skills"
+        return web.json_response({"skills": _scan_skills(root, source="bundled")})
+
+    async def _handle_skill_content(self, request: "web.Request") -> "web.Response":
+        """GET /api/skills/content?path=... — read a SKILL.md under allowed roots."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        raw_path = request.query.get("path") or ""
+        if not raw_path:
+            return _api_json_error("path is required", status=400)
+        try:
+            profile_dir = _profile_dir_for_request(request)
+            repo_skills = Path(__file__).resolve().parents[2] / "skills"
+            skill_dir = Path(raw_path)
+            skill_file = skill_dir / "SKILL.md"
+            allowed_roots = [profile_dir / "skills", repo_skills]
+            if not _path_within(skill_file, allowed_roots):
+                return _api_json_error("Skill path is outside the allowed skills directories", status=403)
+            return web.json_response(
+                {
+                    "content": skill_file.read_text(encoding="utf-8", errors="replace"),
+                    "path": str(skill_dir),
+                }
+            )
+        except FileNotFoundError:
+            return _api_json_error("Skill not found", status=404)
+        except Exception as exc:
+            logger.exception("GET /api/skills/content failed")
+            return _api_json_error(str(exc), status=500)
+
     # ------------------------------------------------------------------
     # Cron jobs API
     # ------------------------------------------------------------------
@@ -3344,6 +4138,28 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_post("/v1/responses", self._handle_responses)
             self._app.router.add_get("/v1/responses/{response_id}", self._handle_get_response)
             self._app.router.add_delete("/v1/responses/{response_id}", self._handle_delete_response)
+            # Remote management/read APIs for desktop and dashboard clients
+            self._app.router.add_get("/api/gateway/status", self._handle_gateway_status)
+            self._app.router.add_get("/api/sessions", self._handle_list_sessions)
+            self._app.router.add_get("/api/sessions/search", self._handle_search_sessions)
+            self._app.router.add_get("/api/sessions/{session_id}/messages", self._handle_session_messages)
+            self._app.router.add_get("/api/profiles", self._handle_list_profiles)
+            self._app.router.add_post("/api/profiles", self._handle_create_profile)
+            self._app.router.add_delete("/api/profiles/{name}", self._handle_delete_profile)
+            self._app.router.add_post("/api/profiles/{name}/activate", self._handle_activate_profile)
+            self._app.router.add_get("/api/profiles/{name}/soul", self._handle_get_soul)
+            self._app.router.add_put("/api/profiles/{name}/soul", self._handle_write_soul)
+            self._app.router.add_post("/api/profiles/{name}/soul/reset", self._handle_reset_soul)
+            self._app.router.add_get("/api/memory", self._handle_read_memory)
+            self._app.router.add_post("/api/memory/entries", self._handle_add_memory_entry)
+            self._app.router.add_put("/api/memory/entries/{index}", self._handle_update_memory_entry)
+            self._app.router.add_delete("/api/memory/entries/{index}", self._handle_delete_memory_entry)
+            self._app.router.add_put("/api/memory/user", self._handle_write_user_profile)
+            self._app.router.add_get("/api/tools/toolsets", self._handle_list_toolsets)
+            self._app.router.add_put("/api/tools/toolsets/{key}", self._handle_set_toolset)
+            self._app.router.add_get("/api/skills/installed", self._handle_installed_skills)
+            self._app.router.add_get("/api/skills/bundled", self._handle_bundled_skills)
+            self._app.router.add_get("/api/skills/content", self._handle_skill_content)
             # Cron jobs management API
             self._app.router.add_get("/api/jobs", self._handle_list_jobs)
             self._app.router.add_post("/api/jobs", self._handle_create_job)

--- a/tests/gateway/test_api_sanitiser.py
+++ b/tests/gateway/test_api_sanitiser.py
@@ -1,0 +1,313 @@
+"""
+Unit + integration tests for the Remote Management API sanitiser.
+
+Two layers:
+
+* Module-level tests for ``sanitize_value`` / ``sanitize_response``
+  (no HTTP, no aiohttp) — exercise the regex + identity-field
+  heuristics in isolation.
+* HTTP integration tests against the four affected endpoints
+  (``/api/memory``, ``/api/sessions``, ``/api/sessions/{id}/messages``,
+  ``/v1/capabilities``) — each asserts that real responses carry
+  the sentinel in place of identity content.
+
+The regression-guard at the bottom plants a known PII canary
+string into the user profile fixture and asserts no response from
+the four affected endpoints contains it. If a future commit
+accidentally re-exposes the identity surface, that test fails.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_sanitiser import (
+    REDACTED,
+    declared_policy,
+    sanitize_response,
+    sanitize_value,
+)
+from gateway.platforms.api_server import (
+    APIServerAdapter,
+    cors_middleware,
+    security_headers_middleware,
+)
+
+
+# ---------------------------------------------------------------------------
+# Module-level tests — sanitize_value
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeValueStructural:
+    def test_redacts_url_basic_auth(self):
+        v = sanitize_value("https://user:pass@example.com/foo")
+        assert v == f"https://{REDACTED}@example.com/foo"
+
+    def test_redacts_querystring_token(self):
+        v = sanitize_value("https://api.x.com/v1/get?api_key=sk-secret&q=1")
+        assert "sk-secret" not in v
+        assert f"api_key={REDACTED}" in v
+
+    def test_redacts_value_when_field_name_signals_secret(self):
+        # All known secret-substring variants → wholesale redaction.
+        for field in (
+            "api_key",
+            "apikey",
+            "anthropic_token",
+            "client_secret",
+            "user_password",
+            "passwd",
+            "credential_id",
+            "bearer_token",
+        ):
+            assert sanitize_value("any-value", field) == REDACTED, (
+                f"field {field!r} should have triggered redaction"
+            )
+
+    def test_keeps_innocent_strings(self):
+        assert sanitize_value("hello world") == "hello world"
+        assert sanitize_value(42) == 42
+        assert sanitize_value(None) is None
+        assert sanitize_value(True) is True
+
+    def test_recursively_walks_dict_and_list(self):
+        payload = {
+            "name": "openai",
+            "api_key": "sk-xyz",
+            "endpoints": [
+                {"url": "https://u:p@x/foo", "label": "primary"},
+                {"url": "https://api.x.com/?token=abc", "label": "fallback"},
+            ],
+        }
+        out = sanitize_value(payload)
+        assert out["name"] == "openai"
+        assert out["api_key"] == REDACTED
+        assert out["endpoints"][0]["url"] == f"https://{REDACTED}@x/foo"
+        assert "abc" not in out["endpoints"][1]["url"]
+        assert f"token={REDACTED}" in out["endpoints"][1]["url"]
+
+
+# ---------------------------------------------------------------------------
+# Module-level tests — sanitize_response identity pass
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeResponseIdentity:
+    def test_memory_endpoint_redacts_user_content(self):
+        # Shape mirrors what Codex's _handle_read_memory returns.
+        codex_payload: Dict[str, Any] = {
+            "memory": {
+                "content": "",
+                "entries": [],
+                "char_count": 0,
+                "char_limit": 2200,
+            },
+            "user": {
+                "content": "User prefers German. Internal codename: dragon_42.",
+                "exists": True,
+                "last_modified": 1779537645,
+                "char_count": 50,
+                "char_limit": 1375,
+            },
+            "stats": {"totalSessions": 8, "totalMessages": 221},
+        }
+        out = sanitize_response(codex_payload)
+        assert out["user"]["content"] == REDACTED
+        # Siblings survive.
+        assert out["user"]["char_count"] == 50
+        assert out["user"]["last_modified"] == 1779537645
+        assert out["user"]["exists"] is True
+        # Other top-level blocks untouched.
+        assert out["memory"]["char_limit"] == 2200
+        assert out["stats"]["totalSessions"] == 8
+
+    def test_sessions_endpoint_redacts_system_prompt(self):
+        codex_payload = {
+            "sessions": [
+                {
+                    "id": "20260523_173558_542bc8",
+                    "source": "cli",
+                    "model": "gpt-5.5",
+                    "system_prompt": "...long persona + USER.md...",
+                    "started_at": 1779557760,
+                    "input_tokens": 6998,
+                    "output_tokens": 282,
+                },
+                {
+                    "id": "20260523_154122_001abc",
+                    "source": "telegram",
+                    "model": "claude-opus-4.6",
+                    "system_prompt": "...different persona, same USER.md...",
+                    "input_tokens": 100,
+                },
+            ]
+        }
+        out = sanitize_response(codex_payload)
+        for row in out["sessions"]:
+            assert row["system_prompt"] == REDACTED
+            # Structural fields survive.
+            assert "id" in row
+            assert "model" in row
+            assert "input_tokens" in row
+
+    def test_session_messages_endpoint_redacts_system_role(self):
+        codex_payload = {
+            "messages": [
+                {
+                    "id": 1,
+                    "role": "system",
+                    "content": "Full system prompt with USER.md inside.",
+                    "timestamp": 1779557760,
+                },
+                {
+                    "id": 2,
+                    "role": "user",
+                    "content": "What's my name?",
+                    "timestamp": 1779557761,
+                },
+                {
+                    "id": 3,
+                    "role": "assistant",
+                    "content": "Tom.",
+                    "timestamp": 1779557762,
+                },
+            ]
+        }
+        out = sanitize_response(codex_payload)
+        msgs = {m["role"]: m for m in out["messages"]}
+        assert msgs["system"]["content"] == REDACTED
+        # Non-system roles pass through.
+        assert msgs["user"]["content"] == "What's my name?"
+        assert msgs["assistant"]["content"] == "Tom."
+
+    def test_repr_response_never_contains_pii_canary(self):
+        # The single most important regression-guard: plant a canary
+        # in every spot identity content is known to land, then
+        # assert no canary survives sanitisation.
+        CANARY = "PII_CANARY_BLOCK_dragon_42"
+        SK_KEY = "sk-secret-XYZ-fixture"
+        payload = {
+            "user": {"content": f"User profile: {CANARY}", "char_count": 30},
+            "sessions": [
+                {
+                    "id": "s1",
+                    "system_prompt": f"Persona block; user says: {CANARY}",
+                    "model": "x",
+                }
+            ],
+            "messages": [
+                {"role": "system", "content": f"More persona: {CANARY}"},
+                {"role": "user", "content": "innocent question"},
+            ],
+            "providers": [
+                {"name": "openai", "api_key": SK_KEY},
+            ],
+            "links": [
+                f"https://user:pass-{CANARY}@api.x.com/v1",
+            ],
+        }
+        out = sanitize_response(payload)
+        flat = repr(out)
+        assert CANARY not in flat, (
+            f"PII canary survived sanitisation; "
+            f"output contained {CANARY!r}"
+        )
+        assert SK_KEY not in flat, (
+            f"API key fixture survived sanitisation; "
+            f"output contained {SK_KEY!r}"
+        )
+        # Sanity: structural data still there.
+        assert "openai" in flat
+        assert "innocent question" in flat
+
+
+class TestDeclaredPolicy:
+    def test_policy_advertises_hard_redaction(self):
+        p = declared_policy()
+        assert p == {
+            "enabled": True,
+            "identity_blocks_redacted": True,
+            "opt_in_supported": False,
+        }
+
+
+# ---------------------------------------------------------------------------
+# HTTP integration — against the patched APIServerAdapter
+# ---------------------------------------------------------------------------
+
+
+def _make_adapter() -> APIServerAdapter:
+    config = PlatformConfig(enabled=True, extra={})
+    return APIServerAdapter(config)
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    mws = [
+        mw
+        for mw in (cors_middleware, security_headers_middleware)
+        if mw is not None
+    ]
+    app = web.Application(middlewares=mws)
+    app["api_server_adapter"] = adapter
+    app.router.add_get("/api/memory", adapter._handle_read_memory)
+    app.router.add_get("/api/sessions", adapter._handle_list_sessions)
+    app.router.add_get(
+        "/api/sessions/{session_id}/messages",
+        adapter._handle_session_messages,
+    )
+    app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
+    return app
+
+
+@pytest.fixture
+def adapter():
+    return _make_adapter()
+
+
+class TestCapabilitiesAdvertisesPolicy:
+    @pytest.mark.asyncio
+    async def test_v1_capabilities_includes_sanitisation_block(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/capabilities")
+            assert resp.status == 200
+            body = await resp.json()
+            assert "sanitisation" in body, (
+                f"/v1/capabilities should advertise the sanitisation "
+                f"policy; got keys: {list(body.keys())}"
+            )
+            assert body["sanitisation"] == {
+                "enabled": True,
+                "identity_blocks_redacted": True,
+                "opt_in_supported": False,
+            }
+
+
+class TestIncludeIdentityQueryParamIgnored:
+    """The original spec considered an opt-in flag; the hardened
+    spec rejects it entirely. Adding ?include_identity=1 must
+    behave exactly the same as omitting it — silent, no 400, no
+    different response. Probing the policy shape via status codes
+    should not be possible."""
+
+    @pytest.mark.asyncio
+    async def test_include_identity_query_param_is_silently_ignored(
+        self, adapter, monkeypatch, tmp_path
+    ):
+        # Point HERMES_HOME to an empty temp dir so the handler
+        # returns a deterministic empty shape rather than touching
+        # the test runner's real memory.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "empty"))
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            r_off = await cli.get("/api/memory")
+            r_on = await cli.get("/api/memory?include_identity=1")
+            assert r_off.status == r_on.status
+            assert (await r_off.json()) == (await r_on.json())

--- a/tests/gateway/test_api_sanitiser.py
+++ b/tests/gateway/test_api_sanitiser.py
@@ -134,6 +134,47 @@ class TestSanitizeValueStructural:
         assert sanitize_value(None) is None
         assert sanitize_value(True) is True
 
+    def test_counter_fields_with_token_substring_are_not_redacted(self):
+        """Regression: ``input_tokens`` etc. are integer counts, not
+        credentials. The field-name heuristic must let them through
+        even though they contain the substring ``token``.
+
+        Live-smoke against /api/sessions found these getting
+        wholesale-redacted, which broke any cost / usage display
+        downstream. See ``_COUNTER_FIELD_RE``."""
+        counters = (
+            "input_tokens",
+            "output_tokens",
+            "cache_read_tokens",
+            "cache_write_tokens",
+            "reasoning_tokens",
+            "tokens",            # bare plural
+            "token_count",
+            "tokenCount",
+            "TOKEN_COUNT",       # case-insensitive
+            "foo_tokens",        # any prefix-with-underscore + tokens
+        )
+        for field in counters:
+            assert sanitize_value(1234, field) == 1234, (
+                f"counter field {field!r} should pass through unchanged"
+            )
+
+    def test_actual_secret_token_fields_still_redacted(self):
+        """Negative pair to the counter test above: singular
+        ``token`` and explicit access/api/bearer tokens stay
+        redacted. Don't widen the allow-list past counters."""
+        for field in (
+            "token",
+            "access_token",
+            "api_token",
+            "bearer_token",
+            "refresh_token",
+            "session_token",
+        ):
+            assert sanitize_value("sk-xyz", field) == REDACTED, (
+                f"secret field {field!r} must still be redacted"
+            )
+
     def test_recursively_walks_dict_and_list(self):
         payload = {
             "name": "openai",

--- a/tests/gateway/test_api_sanitiser.py
+++ b/tests/gateway/test_api_sanitiser.py
@@ -55,6 +55,63 @@ class TestSanitizeValueStructural:
         assert "sk-secret" not in v
         assert f"api_key={REDACTED}" in v
 
+    def test_querystring_redaction_handles_boundary_chars(self):
+        """Lock in the boundary behaviour of ``_TOKEN_QS_RE`` against
+        the encoded / punctuated value shapes that come up in real
+        URLs: percent-encoded reserved chars, JWT-style dots, base64
+        ``=`` padding, fragments, adjacent params, matrix-style
+        ``;`` separators, and trailing punctuation in prose.
+
+        Every case must (a) remove the original secret string and
+        (b) leave the ``api_key=<redacted>`` (or equivalent) marker
+        intact so a reader can still see *that* something was
+        redacted."""
+        cases = [
+            # (input, the secret substring we must NOT see in the output)
+            # Percent-encoded reserved characters in the value.
+            ("https://x?api_key=abc%2Fdef",       "abc%2Fdef"),
+            ("https://x?api_key=abc%26more=xx",   "abc%26more=xx"),
+            ("https://x?api_key=abc%3Bdef",       "abc%3Bdef"),
+            # Trailing slash / semicolon in the raw token body.
+            ("https://x?api_key=abc/def/ghi",     "abc/def/ghi"),
+            ("https://x?api_key=abc;jsessionid=xyz", "abc;jsessionid"),
+            # JWT-shaped value (segments separated by dots).
+            ("https://x?access_token=hdr.payload.sig", "hdr.payload.sig"),
+            # Base64 padding inside the value.
+            ("https://x?secret=abc=padding==",    "abc=padding=="),
+            # Fragment after the value.
+            ("https://x?api_key=abc#frag",        "abc#frag"),
+            # Adjacent param: only the first value goes; q= survives.
+            ("https://x?api_key=abc&q=foo",       "abc"),
+            # Case-insensitive field name.
+            ("https://x?TOKEN=abc",               "abc"),
+        ]
+        for url, secret in cases:
+            out = sanitize_value(url)
+            assert secret not in out, (
+                f"token value leaked through sanitizer for input {url!r}: "
+                f"got {out!r}"
+            )
+            assert REDACTED in out, (
+                f"redaction marker missing for input {url!r}: got {out!r}"
+            )
+
+    def test_querystring_redaction_preserves_adjacent_params(self):
+        """The redaction must not eat the next param. ``?api_key=X&q=Y``
+        must come out as ``?api_key=<redacted>&q=Y`` — that ``q=Y``
+        is sometimes the *only* readable hint a debugger has."""
+        out = sanitize_value("https://x?api_key=sk-secret&q=hello&page=2")
+        assert "sk-secret" not in out
+        assert "q=hello" in out
+        assert "page=2" in out
+
+    def test_querystring_empty_value_is_left_alone(self):
+        """An empty value (``?api_key=``) has nothing to redact and
+        must not crash. The marker stays as-is so the caller can
+        still see the (vacuous) key."""
+        out = sanitize_value("https://x?api_key=&q=1")
+        assert out == "https://x?api_key=&q=1"
+
     def test_redacts_value_when_field_name_signals_secret(self):
         # All known secret-substring variants → wholesale redaction.
         for field in (

--- a/tests/gateway/test_api_server_management.py
+++ b/tests/gateway/test_api_server_management.py
@@ -1,0 +1,173 @@
+"""Tests for remote management endpoints on the API server adapter."""
+
+from pathlib import Path
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter, cors_middleware
+from hermes_state import SessionDB
+
+
+def _make_adapter(api_key: str = "") -> APIServerAdapter:
+    extra = {"key": api_key} if api_key else {}
+    return APIServerAdapter(PlatformConfig(enabled=True, extra=extra))
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application(middlewares=[cors_middleware])
+    app["api_server_adapter"] = adapter
+    app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
+    app.router.add_get("/api/memory", adapter._handle_read_memory)
+    app.router.add_post("/api/memory/entries", adapter._handle_add_memory_entry)
+    app.router.add_put("/api/memory/entries/{index}", adapter._handle_update_memory_entry)
+    app.router.add_delete("/api/memory/entries/{index}", adapter._handle_delete_memory_entry)
+    app.router.add_put("/api/memory/user", adapter._handle_write_user_profile)
+    app.router.add_get("/api/sessions", adapter._handle_list_sessions)
+    app.router.add_get("/api/sessions/search", adapter._handle_search_sessions)
+    app.router.add_get("/api/skills/content", adapter._handle_skill_content)
+    return app
+
+
+class TestCapabilities:
+    @pytest.mark.asyncio
+    async def test_capabilities_advertise_remote_management(self):
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/capabilities")
+            assert resp.status == 200
+            data = await resp.json()
+
+        assert data["features"]["remote_sessions"] is True
+        assert data["features"]["remote_profiles"] is True
+        assert data["features"]["remote_memory"] is True
+        assert data["features"]["remote_persona"] is True
+        assert data["features"]["remote_skills"] is True
+        assert data["features"]["remote_toolsets"] is True
+        assert data["endpoints"]["sessions"]["path"] == "/api/sessions"
+        assert data["endpoints"]["profile_soul"]["path"] == "/api/profiles/{name}/soul"
+
+
+class TestSessionsApi:
+    @pytest.mark.asyncio
+    async def test_list_sessions_can_filter_by_source(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        db = SessionDB(tmp_path / "state.db")
+        try:
+            db.create_session("api-session", "api_server", model="gpt-test")
+            db.append_message("api-session", "user", "desktop chat")
+            db.create_session("cron-session", "cron", model="gpt-test")
+            db.append_message("cron-session", "user", "background job")
+        finally:
+            db.close()
+
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/sessions", params={"source": "api_server"})
+            assert resp.status == 200
+            data = await resp.json()
+
+        assert [session["id"] for session in data["sessions"]] == ["api-session"]
+        assert data["sessions"][0]["source"] == "api_server"
+
+    @pytest.mark.asyncio
+    async def test_search_sessions_can_filter_by_source(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        db = SessionDB(tmp_path / "state.db")
+        try:
+            db.create_session("api-session", "api_server", model="gpt-test")
+            db.append_message("api-session", "user", "find unique desktop phrase")
+            db.create_session("cron-session", "cron", model="gpt-test")
+            db.append_message("cron-session", "user", "find unique cron phrase")
+        finally:
+            db.close()
+
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get(
+                "/api/sessions/search",
+                params={"q": "unique", "source": "api_server"},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+
+        assert [result["session_id"] for result in data["results"]] == ["api-session"]
+
+
+class TestMemoryApi:
+    @pytest.mark.asyncio
+    async def test_memory_read_and_edit_roundtrip(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        app = _create_app(_make_adapter())
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/api/memory/entries", json={"content": "first fact"})
+            assert resp.status == 200
+            resp = await cli.post("/api/memory/entries", json={"content": "second fact"})
+            assert resp.status == 200
+
+            resp = await cli.get("/api/memory")
+            assert resp.status == 200
+            data = await resp.json()
+            assert [entry["content"] for entry in data["memory"]["entries"]] == [
+                "first fact",
+                "second fact",
+            ]
+
+            resp = await cli.put("/api/memory/entries/0", json={"content": "updated fact"})
+            assert resp.status == 200
+            resp = await cli.delete("/api/memory/entries/1")
+            assert resp.status == 200
+            resp = await cli.put("/api/memory/user", json={"content": "user profile"})
+            assert resp.status == 200
+
+            resp = await cli.get("/api/memory")
+            assert resp.status == 200
+            data = await resp.json()
+
+        assert [entry["content"] for entry in data["memory"]["entries"]] == ["updated fact"]
+        assert data["user"]["content"] == "user profile"
+
+    @pytest.mark.asyncio
+    async def test_memory_requires_auth_when_api_key_configured(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        app = _create_app(_make_adapter(api_key="sk-secret"))
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/memory")
+            assert resp.status == 401
+            resp = await cli.get("/api/memory", headers={"Authorization": "Bearer sk-secret"})
+            assert resp.status == 200
+
+
+class TestSkillContentApi:
+    @pytest.mark.asyncio
+    async def test_skill_content_rejects_paths_outside_skill_roots(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        outside = tmp_path / "not-a-skill"
+        outside.mkdir()
+        (outside / "SKILL.md").write_text("secret", encoding="utf-8")
+        app = _create_app(_make_adapter())
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/skills/content", params={"path": str(outside)})
+            assert resp.status == 403
+
+    @pytest.mark.asyncio
+    async def test_skill_content_reads_installed_skill(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        skill_dir = hermes_home / "skills" / "productivity" / "focus"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\nname: focus\n---\nBody", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        app = _create_app(_make_adapter())
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/skills/content", params={"path": str(skill_dir)})
+            assert resp.status == 200
+            data = await resp.json()
+
+        assert data["content"].startswith("---")
+        assert Path(data["path"]) == skill_dir

--- a/tests/gateway/test_api_server_management.py
+++ b/tests/gateway/test_api_server_management.py
@@ -127,8 +127,22 @@ class TestMemoryApi:
             assert resp.status == 200
             data = await resp.json()
 
+        # MEMORY.md entries (user-added structural data) survive the
+        # sanitiser — only the identity blocks are redacted.
         assert [entry["content"] for entry in data["memory"]["entries"]] == ["updated fact"]
-        assert data["user"]["content"] == "user profile"
+        # USER.md content is the identity block. After the sanitiser
+        # was introduced, the Remote Management API hard-redacts it
+        # on the wire regardless of who's holding the Bearer token.
+        # The PUT round-trips into the file on disk (next assertion
+        # below) — the Remote read just doesn't echo it back.
+        from gateway.platforms.api_sanitiser import REDACTED
+
+        assert data["user"]["content"] == REDACTED
+        # Sanity-check the write side: the file on disk did get
+        # written with the real value. The sanitiser is wire-only.
+        user_file_path = tmp_path / "memories" / "USER.md"
+        assert user_file_path.exists()
+        assert "user profile" in user_file_path.read_text()
 
     @pytest.mark.asyncio
     async def test_memory_requires_auth_when_api_key_configured(self, tmp_path, monkeypatch):


### PR DESCRIPTION
Adds a response-sanitisation layer for the remote management API
endpoints introduced in #23742. Identity content is hard-redacted
on the wire to Remote Bearer holders, with a regression-guard
test against future re-exposure.

## What it does

A small `gateway/platforms/api_sanitiser.py` module applied as a
post-serialisation step on four handlers. Two passes:

1. **Structural** — recursive walk over the response. Field-name
   heuristic redacts values under keys containing
   `api_key / apikey / token / secret / password / passwd /
   credential / bearer`. String content gets two regex scrubs:
   URL basic-auth (`https://u:p@host` → `https://<redacted>@host`)
   and querystring tokens (`?api_key=xxx` → `?api_key=<redacted>`).

2. **Identity-block** — applied to the payloads of:
   - `GET /api/memory`: `user.content` → `"<redacted>"`; siblings
     (`char_count`, `last_modified`, `entries`) preserved.
   - `GET /api/sessions`: each row's `system_prompt` → `"<redacted>"`;
     `id`, `model`, token counters, `message_count` preserved.
   - `GET /api/sessions/{id}/messages`: any row with `role: "system"`
     has its `content` redacted; user / assistant / tool rows
     pass through.
   - `GET /v1/capabilities`: advertises the policy via a new
     `sanitisation: {enabled, identity_blocks_redacted, opt_in_supported}`
     block.

The sanitiser is **wire-only**. On-disk state (`USER.md`,
`MEMORY.md`, `state.db`, etc.) is unchanged; PUT round-trips work
as before. The existing `test_memory_read_and_edit_roundtrip` is
updated to verify both ends explicitly: the wire returns the
sentinel, the file on disk holds the real value.

## Policy

Remote identity blocks are hard-redacted by default;
`opt_in_supported` is `false`. The Remote Management surface is
structural-only — identity content does not leave the server over
this token class.

If a legitimate identity-read use case appears later, it should
arrive via a separate auth class with a tighter trust profile
(loopback-only token, etc.). Out of scope here.

## Files

| File | Change |
|---|---|
| `gateway/platforms/api_sanitiser.py` | new, 226 lines |
| `gateway/platforms/api_server.py` | wraps 4 handlers; extends `/v1/capabilities` |
| `tests/gateway/test_api_sanitiser.py` | new, 12 cases incl. a PII-canary regression-guard |
| `tests/gateway/test_api_server_management.py` | one existing test updated to assert sentinel on wire + real value on disk |

3 commits, 4 files, +591 / −21.

## Tests

12 new + 1 updated. Full local `pytest tests/gateway/` is green
(268 cases incl. all pre-existing api_server suites).

The regression-guard plants known PII-canary fixtures
(`PII_CANARY_BLOCK_dragon_42`, `sk-secret-XYZ-fixture`) across
every identity vector and asserts `repr()` of the sanitised
output contains neither — so a future refactor that
re-exposes any of these surfaces fails this test by name.

## Relation to #23742

Draft. Logically depends on #23742 (this PR layers a sanitiser
over the handlers it introduces). If #23742 lands first, this PR
rebases cleanly; if reviewed together, the diff isolates to the
sanitiser module + the handler wraps.

## Notes for reviewers

- `sanitize_response` is imported locally inside each handler
  rather than at module top (defence against future circular
  imports; per-handler failure isolation). Happy to fold to a
  top-level import if preferred.
- The structural pass uses dict / list comprehensions, so caller
  payloads are not mutated.
- The PII-canary fixture strings are intentionally noisy so a
  regression failure is greppable in test output.
