### PR TITLE
feat(acp): emit durable tool-call timing metadata

### DIFF
--- a/acp_adapter/events.py
+++ b/acp_adapter/events.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import logging
 from collections import deque
+from datetime import datetime, timezone
 from typing import Any, Callable, Deque, Dict
 
 import acp
@@ -23,6 +24,17 @@ from .tools import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _duration_ms(duration: Any) -> int | None:
+    try:
+        return int(max(0.0, float(duration)) * 1000)
+    except (TypeError, ValueError):
+        return None
 
 
 def _json_loads_maybe_prefix(value: str) -> Any:
@@ -132,6 +144,45 @@ def make_tool_progress_cb(
     """
 
     def _tool_progress(event_type: str, name: str = None, preview: str = None, args: Any = None, **kwargs) -> None:
+        if event_type == "tool.completed":
+            queue = tool_call_ids.get(name or "")
+            if isinstance(queue, str):
+                queue = deque([queue])
+                tool_call_ids[name or ""] = queue
+            if not queue:
+                return
+            tc_id = queue[0]
+            meta = tool_call_meta.setdefault(tc_id, {})
+            hermes = dict(meta.get("hermes") or {})
+            duration_ms = _duration_ms(kwargs.get("duration"))
+            completed_at = (
+                kwargs.get("completed_at")
+                or kwargs.get("completedAt")
+                or _utc_now_iso()
+            )
+            response = kwargs.get("response") if "response" in kwargs else kwargs.get("result")
+            if response is not None and not isinstance(response, str):
+                response = str(response)
+            arguments = meta.get("args") if isinstance(meta.get("args"), dict) else {}
+            hermes.update(
+                {
+                    "call_id": tc_id,
+                    "tool_name": name,
+                    "arguments": arguments,
+                    "outcome": "failed" if kwargs.get("is_error") else "completed",
+                    "completed_at": completed_at,
+                    "completedAt": completed_at,
+                    "durationSource": "monotonic",
+                }
+            )
+            if response is not None:
+                hermes["response"] = response
+            if duration_ms is not None:
+                hermes["duration_ms"] = duration_ms
+                hermes["durationMs"] = duration_ms
+            meta["hermes"] = hermes
+            return
+
         # Only emit ACP ToolCallStart for tool.started; ignore other event types
         if event_type != "tool.started":
             return
@@ -143,7 +194,7 @@ def make_tool_progress_cb(
         if not isinstance(args, dict):
             args = {}
 
-        tc_id = make_tool_call_id()
+        tc_id = str(kwargs.get("tool_call_id") or "").strip() or make_tool_call_id()
         queue = tool_call_ids.get(name)
         if queue is None:
             queue = deque()
@@ -161,7 +212,17 @@ def make_tool_progress_cb(
                 snapshot = capture_local_edit_snapshot(name, args)
             except Exception:
                 logger.debug("Failed to capture ACP edit snapshot for %s", name, exc_info=True)
-        tool_call_meta[tc_id] = {"args": args, "snapshot": snapshot}
+        meta = {"args": args, "snapshot": snapshot}
+        started_at = kwargs.get("started_at") or kwargs.get("startedAt")
+        if started_at:
+            meta["hermes"] = {
+                "call_id": tc_id,
+                "tool_name": name,
+                "arguments": args,
+                "started_at": started_at,
+                "startedAt": started_at,
+            }
+        tool_call_meta[tc_id] = meta
 
         edit_diff = None
         if name in {"write_file", "patch"} and edit_approval_policy_getter is not None:
@@ -176,7 +237,10 @@ def make_tool_progress_cb(
             except Exception:
                 logger.debug("Failed to prepare auto-approved ACP edit diff for %s", name, exc_info=True)
 
-        update = build_tool_start(tc_id, name, args, edit_diff=edit_diff)
+        update_kwargs = {"edit_diff": edit_diff}
+        if "hermes" in meta:
+            update_kwargs["hermes_meta"] = meta["hermes"]
+        update = build_tool_start(tc_id, name, args, **update_kwargs)
         _send_update(conn, session_id, loop, update)
 
     return _tool_progress
@@ -241,12 +305,17 @@ def make_step_cb(
                 if tool_name and queue:
                     tc_id = queue.popleft()
                     meta = tool_call_meta.pop(tc_id, {})
+                    complete_kwargs = {
+                        "result": str(result) if result is not None else None,
+                        "function_args": function_args or meta.get("args"),
+                        "snapshot": meta.get("snapshot"),
+                    }
+                    if meta.get("hermes"):
+                        complete_kwargs["hermes_meta"] = meta["hermes"]
                     update = build_tool_complete(
                         tc_id,
                         tool_name,
-                        result=str(result) if result is not None else None,
-                        function_args=function_args or meta.get("args"),
-                        snapshot=meta.get("snapshot"),
+                        **complete_kwargs,
                     )
                     _send_update(conn, session_id, loop, update)
                     if tool_name == "todo":

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1052,12 +1052,17 @@ class HermesACPAgent(acp.Agent):
                     continue
                 result = message.get("content")
                 result_text = result if isinstance(result, str) else None
+                field_meta = message.get("_meta") if isinstance(message, dict) else None
+                hermes_meta = None
+                if isinstance(field_meta, dict) and isinstance(field_meta.get("hermes"), dict):
+                    hermes_meta = field_meta["hermes"]
                 if not await _send(
                     build_tool_complete(
                         tool_call_id,
                         tool_name,
                         result=result_text,
                         function_args=function_args,
+                        hermes_meta=hermes_meta,
                     )
                 ):
                     return

--- a/acp_adapter/tools.py
+++ b/acp_adapter/tools.py
@@ -184,6 +184,22 @@ def _text(content: str) -> Any:
     return acp.tool_content(acp.text_block(content))
 
 
+def _normalize_hermes_field_meta(hermes_meta: Any) -> dict | None:
+    """Wrap Hermes extension payloads for ACP's ``_meta`` field."""
+    if not hermes_meta:
+        return None
+    if isinstance(hermes_meta, dict) and isinstance(hermes_meta.get("hermes"), dict):
+        return hermes_meta
+    return {"hermes": hermes_meta}
+
+
+def _attach_hermes_field_meta(update: Any, hermes_meta: Any) -> Any:
+    field_meta = _normalize_hermes_field_meta(hermes_meta)
+    if field_meta is not None:
+        update.field_meta = field_meta
+    return update
+
+
 def _json_loads_maybe(value: Optional[str]) -> Any:
     if not isinstance(value, str):
         return value
@@ -1086,11 +1102,17 @@ def build_tool_start(
     arguments: Dict[str, Any],
     *,
     edit_diff: Any = None,
+    hermes_meta: Any = None,
 ) -> ToolCallStart:
     """Create a ToolCallStart event for the given hermes tool invocation."""
     kind = get_tool_kind(tool_name)
     title = build_tool_title(tool_name, arguments)
     locations = extract_locations(arguments)
+
+    def _start_tool_call(*args: Any, **kwargs: Any) -> ToolCallStart:
+        return _attach_hermes_field_meta(
+            acp.start_tool_call(*args, **kwargs), hermes_meta
+        )
 
     if tool_name == "patch":
         if edit_diff is not None:
@@ -1105,7 +1127,7 @@ def build_tool_start(
             mode = arguments.get("mode", "replace")
             path = arguments.get("path") or "patch input"
             content = [_text(f"Preparing {mode} edit for {path}. Approval prompt shows the diff.")]
-        return acp.start_tool_call(
+        return _start_tool_call(
             tool_call_id, title, kind=kind, content=content, locations=locations,
         )
 
@@ -1121,14 +1143,14 @@ def build_tool_start(
         else:
             path = arguments.get("path", "")
             content = [_text(f"Preparing write to {path}. Approval prompt shows the diff." if path else "Preparing file write. Approval prompt shows the diff.")]
-        return acp.start_tool_call(
+        return _start_tool_call(
             tool_call_id, title, kind=kind, content=content, locations=locations,
         )
 
     if tool_name == "terminal":
         command = arguments.get("command", "")
         content = [_text(f"$ {command}")]
-        return acp.start_tool_call(
+        return _start_tool_call(
             tool_call_id, title, kind=kind, content=content, locations=locations,
         )
 
@@ -1136,7 +1158,7 @@ def build_tool_start(
         # The title and location already identify the file. Sending a synthetic
         # "Reading ..." content block makes Zed render an unhelpful Output
         # section before the real file contents arrive on completion.
-        return acp.start_tool_call(
+        return _start_tool_call(
             tool_call_id, title, kind=kind, content=None, locations=locations,
         )
 
@@ -1146,7 +1168,7 @@ def build_tool_start(
         search_path = arguments.get("path")
         where = f" in {search_path}" if search_path else ""
         content = [_text(f"Searching for '{pattern}' ({target}){where}")]
-        return acp.start_tool_call(
+        return _start_tool_call(
             tool_call_id, title, kind=kind, content=content, locations=locations,
         )
 
@@ -1162,7 +1184,7 @@ def build_tool_start(
             content = [_text("\n".join(preview_lines))]
         else:
             content = [_text("Reading todo list")]
-        return acp.start_tool_call(
+        return _start_tool_call(
             tool_call_id, title, kind=kind, content=content, locations=locations,
         )
 
@@ -1170,7 +1192,7 @@ def build_tool_start(
         name = str(arguments.get("name") or "?").strip() or "?"
         file_path = str(arguments.get("file_path") or "SKILL.md").strip() or "SKILL.md"
         content = [_text(f"Loading skill '{name}' ({file_path})")]
-        return acp.start_tool_call(
+        return _start_tool_call(
             tool_call_id, title, kind=kind, content=content, locations=locations,
         )
 
@@ -1205,7 +1227,7 @@ def build_tool_start(
         else:
             content = [_text(f"Running skill_manage action '{action}' on skill '{name}' ({file_path})")]
 
-        return acp.start_tool_call(
+        return _start_tool_call(
             tool_call_id, title, kind=kind, content=content, locations=locations,
         )
 
@@ -1213,21 +1235,21 @@ def build_tool_start(
         code = str(arguments.get("code") or "").strip()
         preview = code[:1200] + (f"\n... ({len(code)} chars total, truncated)" if len(code) > 1200 else "")
         content = [_text(f"Running Python helper script:\n\n```python\n{preview}\n```" if preview else "Running Python helper script")]
-        return acp.start_tool_call(
+        return _start_tool_call(
             tool_call_id, title, kind=kind, content=content, locations=locations,
         )
 
     if tool_name == "web_search":
         query = str(arguments.get("query") or "").strip()
         content = [_text(f"Searching the web for: {query}" if query else "Searching the web")]
-        return acp.start_tool_call(
+        return _start_tool_call(
             tool_call_id, title, kind=kind, content=content, locations=locations,
         )
 
     if tool_name == "web_extract":
         # The title identifies the URL(s). Avoid a duplicate content block so
         # Zed renders this like read_file: compact start, concise completion.
-        return acp.start_tool_call(
+        return _start_tool_call(
             tool_call_id, title, kind=kind, content=None, locations=locations,
         )
 
@@ -1239,7 +1261,7 @@ def build_tool_start(
         if data_preview:
             text += "\nInput: " + _truncate_text(data_preview, limit=500)
         content = [_text(text)]
-        return acp.start_tool_call(
+        return _start_tool_call(
             tool_call_id, title, kind=kind, content=content, locations=locations,
         )
 
@@ -1258,14 +1280,14 @@ def build_tool_start(
         else:
             goal = str(arguments.get("goal") or "").strip()
             content = [_text("Delegating task" + (f":\n{_truncate_text(goal, limit=800)}" if goal else ""))]
-        return acp.start_tool_call(
+        return _start_tool_call(
             tool_call_id, title, kind=kind, content=content, locations=locations,
         )
 
     if tool_name == "session_search":
         query = str(arguments.get("query") or "").strip()
         content = [_text(f"Searching past sessions for: {query}" if query else "Loading recent sessions")]
-        return acp.start_tool_call(
+        return _start_tool_call(
             tool_call_id, title, kind=kind, content=content, locations=locations,
         )
 
@@ -1277,7 +1299,7 @@ def build_tool_start(
         if preview:
             text += "\nPreview: " + _truncate_text(preview, limit=500)
         content = [_text(text)]
-        return acp.start_tool_call(
+        return _start_tool_call(
             tool_call_id, title, kind=kind, content=content, locations=locations,
         )
 
@@ -1287,12 +1309,12 @@ def build_tool_start(
         except (TypeError, ValueError):
             args_text = str(arguments)
         content = [_text(_truncate_text(args_text, limit=1200))]
-        return acp.start_tool_call(
+        return _start_tool_call(
             tool_call_id, title, kind=kind, content=content, locations=locations,
         )
 
     if not arguments:
-        return acp.start_tool_call(
+        return _start_tool_call(
             tool_call_id, title, kind=kind, content=None, locations=locations, raw_input=None,
         )
 
@@ -1302,7 +1324,7 @@ def build_tool_start(
     except (TypeError, ValueError):
         args_text = str(arguments)
     content = [acp.tool_content(acp.text_block(args_text))]
-    return acp.start_tool_call(
+    return _start_tool_call(
         tool_call_id, title, kind=kind, content=content, locations=locations,
         raw_input=None if tool_name in _POLISHED_TOOLS else arguments,
     )
@@ -1318,6 +1340,7 @@ def build_tool_complete(
     result: Optional[str] = None,
     function_args: Optional[Dict[str, Any]] = None,
     snapshot: Any = None,
+    hermes_meta: Any = None,
 ) -> ToolCallProgress:
     """Create a ToolCallUpdate (progress) event for a completed tool call."""
     kind = get_tool_kind(tool_name)
@@ -1331,13 +1354,14 @@ def build_tool_complete(
             function_args=function_args,
             snapshot=snapshot,
         )
-    return acp.update_tool_call(
+    update = acp.update_tool_call(
         tool_call_id,
         kind=kind,
         status="failed" if _tool_result_failed(result, tool_name) else "completed",
         content=content,
         raw_output=None if tool_name in _POLISHED_TOOLS or _is_structured_json_result(result) else result,
     )
+    return _attach_hermes_field_meta(update, hermes_meta)
 
 
 # ---------------------------------------------------------------------------

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -317,17 +317,41 @@ def _trajectory_normalize_msg(msg: Dict[str, Any]) -> Dict[str, Any]:
     return msg
 
 
-def make_tool_result_message(name: str, content: Any, tool_call_id: str) -> dict:
+def _normalize_tool_field_meta(hermes_meta: Any) -> dict | None:
+    """Return an internal ``_meta`` dict for a tool message.
+
+    Callers usually pass the inner Hermes payload, but persistence/rewrite
+    paths may already have the full ``{"hermes": ...}`` wrapper.  Accept both
+    shapes so metadata can round-trip without every caller knowing the layer.
+    """
+    if not hermes_meta:
+        return None
+    if isinstance(hermes_meta, dict) and isinstance(hermes_meta.get("hermes"), dict):
+        return hermes_meta
+    return {"hermes": hermes_meta}
+
+
+def make_tool_result_message(
+    name: str,
+    content: Any,
+    tool_call_id: str,
+    *,
+    hermes_meta: Any = None,
+) -> dict:
     """Build a tool-result message dict with both the OpenAI-format ``name``
     field (required by the wire format and provider adapters) and the internal
     ``tool_name`` field (written to the session DB messages table)."""
-    return {
+    msg = {
         "role": "tool",
         "name": name,
         "tool_name": name,
         "content": content,
         "tool_call_id": tool_call_id,
     }
+    field_meta = _normalize_tool_field_meta(hermes_meta)
+    if field_meta is not None:
+        msg["_meta"] = field_meta
+    return msg
 
 
 __all__ = [

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -20,6 +20,7 @@ import os
 import random
 import threading
 import time
+from datetime import datetime, timezone
 from typing import Any, Optional
 
 from agent.display import (
@@ -54,6 +55,47 @@ logger = logging.getLogger(__name__)
 # Maximum number of concurrent worker threads for parallel tool execution.
 # Mirrors the constant in ``run_agent`` for tests/imports that look here.
 _MAX_TOOL_WORKERS = 8
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _duration_ms(duration: Any) -> int:
+    try:
+        return int(max(0.0, float(duration)) * 1000)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _build_hermes_tool_meta(
+    *,
+    call_id: str,
+    tool_name: str,
+    arguments: dict,
+    response: Any,
+    duration: float,
+    is_error: bool,
+    started_at: str | None = None,
+    completed_at: str | None = None,
+) -> dict:
+    completed = completed_at or _utc_now_iso()
+    meta = {
+        "call_id": call_id,
+        "tool_name": tool_name,
+        "arguments": arguments,
+        "outcome": "failed" if is_error else "completed",
+        "response": _multimodal_text_summary(response),
+        "duration_ms": _duration_ms(duration),
+        "durationMs": _duration_ms(duration),
+        "durationSource": "monotonic",
+        "completed_at": completed,
+        "completedAt": completed,
+    }
+    if started_at:
+        meta["started_at"] = started_at
+        meta["startedAt"] = started_at
+    return meta
 
 
 def _ra():
@@ -143,6 +185,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         parsed_calls.append((tool_call, function_name, function_args, block_result, blocked_by_guardrail))
 
     # ── Logging / callbacks ──────────────────────────────────────────
+    tool_started_at: dict[str, str] = {}
     tool_names_str = ", ".join(name for _, name, _, _, _ in parsed_calls)
     if not agent.quiet_mode:
         print(f"  ⚡ Concurrent: {num_tools} tool calls — {tool_names_str}")
@@ -161,7 +204,12 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         if agent.tool_progress_callback:
             try:
                 preview = _build_tool_preview(name, args)
-                agent.tool_progress_callback("tool.started", name, preview, args)
+                started_at = _utc_now_iso()
+                tool_started_at[tc.id] = started_at
+                agent.tool_progress_callback(
+                    "tool.started", name, preview, args,
+                    tool_call_id=tc.id, started_at=started_at,
+                )
             except Exception as cb_err:
                 logging.debug(f"Tool progress callback error: {cb_err}")
 
@@ -232,7 +280,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 _set_sudo_password_callback(_parent_sudo_cb)
             except Exception:
                 pass
-        start = time.time()
+        start = time.monotonic()
         try:
             result = agent._invoke_tool(
                 function_name,
@@ -245,7 +293,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         except Exception as tool_error:
             result = f"Error executing tool '{function_name}': {tool_error}"
             logger.error("_invoke_tool raised for %s: %s", function_name, tool_error, exc_info=True)
-        duration = time.time() - start
+        duration = time.monotonic() - start
         is_error, _ = _detect_tool_failure(function_name, result)
         if is_error:
             logger.info("tool %s failed (%.2fs): %s", function_name, duration, result[:200])
@@ -297,7 +345,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 # concurrent tool batches. Also check for user interrupts
                 # so we don't block indefinitely when the user sends /stop
                 # or a new message during concurrent tool execution.
-                _conc_start = time.time()
+                _conc_start = time.monotonic()
                 _interrupt_logged = False
                 while True:
                     done, not_done = concurrent.futures.wait(
@@ -326,7 +374,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                         concurrent.futures.wait(not_done, timeout=3.0)
                         break
 
-                    _conc_elapsed = int(time.time() - _conc_start)
+                    _conc_elapsed = int(time.monotonic() - _conc_start)
                     # Heartbeat every ~30s (6 × 5s poll intervals)
                     if _conc_elapsed > 0 and _conc_elapsed % 30 < 6:
                         _still_running = [
@@ -349,6 +397,10 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     for i, (tc, name, args, block_result, blocked_by_guardrail) in enumerate(parsed_calls):
         r = results[i]
         blocked = False
+        function_name = name
+        function_args = args
+        is_error = True
+        hermes_meta = None
         if r is None:
             # Tool was cancelled (interrupt) or thread didn't return
             if agent._interrupt_requested:
@@ -383,11 +435,22 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 except Exception as _ver_err:
                     logging.debug("file-mutation verifier record failed: %s", _ver_err)
 
+            hermes_meta = _build_hermes_tool_meta(
+                call_id=tc.id,
+                tool_name=function_name,
+                arguments=function_args,
+                response=function_result,
+                duration=tool_duration,
+                is_error=is_error,
+                started_at=tool_started_at.get(tc.id),
+            )
             if not blocked and agent.tool_progress_callback:
                 try:
                     agent.tool_progress_callback(
                         "tool.completed", function_name, None, None,
                         duration=tool_duration, is_error=is_error,
+                        completed_at=hermes_meta.get("completed_at"),
+                        response=hermes_meta.get("response"),
                     )
                 except Exception as cb_err:
                     logging.debug(f"Tool progress callback error: {cb_err}")
@@ -443,7 +506,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         # image tool result never poisons canonical session history.
         # String results pass through unchanged.
         _tool_content = agent._tool_result_content_for_active_model(name, function_result)
-        messages.append(make_tool_result_message(name, _tool_content, tc.id))
+        messages.append(make_tool_result_message(name, _tool_content, tc.id, hermes_meta=hermes_meta))
 
         # ── Per-tool /steer drain ───────────────────────────────────
         # Same as the sequential path: drain between each collected
@@ -547,10 +610,15 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             except Exception:
                 pass
 
+        started_at = None
         if not _execution_blocked and agent.tool_progress_callback:
             try:
                 preview = _build_tool_preview(function_name, function_args)
-                agent.tool_progress_callback("tool.started", function_name, preview, function_args)
+                started_at = _utc_now_iso()
+                agent.tool_progress_callback(
+                    "tool.started", function_name, preview, function_args,
+                    tool_call_id=tool_call.id, started_at=started_at,
+                )
             except Exception as cb_err:
                 logging.debug(f"Tool progress callback error: {cb_err}")
 
@@ -584,7 +652,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             except Exception:
                 pass  # never block tool execution
 
-        tool_start_time = time.time()
+        tool_start_time = time.monotonic()
 
         if _block_msg is not None:
             # Tool blocked by plugin policy — return error without executing.
@@ -602,7 +670,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 merge=function_args.get("merge", False),
                 store=agent._todo_store,
             )
-            tool_duration = time.time() - tool_start_time
+            tool_duration = time.monotonic() - tool_start_time
             if agent._should_emit_quiet_tool_messages():
                 agent._vprint(f"  {_get_cute_tool_message_impl('todo', function_args, tool_duration, result=function_result)}")
         elif function_name == "session_search":
@@ -623,7 +691,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     db=session_db,
                     current_session_id=agent.session_id,
                 )
-            tool_duration = time.time() - tool_start_time
+            tool_duration = time.monotonic() - tool_start_time
             if agent._should_emit_quiet_tool_messages():
                 agent._vprint(f"  {_get_cute_tool_message_impl('session_search', function_args, tool_duration, result=function_result)}")
         elif function_name == "memory":
@@ -650,7 +718,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     )
                 except Exception:
                     pass
-            tool_duration = time.time() - tool_start_time
+            tool_duration = time.monotonic() - tool_start_time
             if agent._should_emit_quiet_tool_messages():
                 agent._vprint(f"  {_get_cute_tool_message_impl('memory', function_args, tool_duration, result=function_result)}")
         elif function_name == "clarify":
@@ -660,7 +728,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 choices=function_args.get("choices"),
                 callback=agent.clarify_callback,
             )
-            tool_duration = time.time() - tool_start_time
+            tool_duration = time.monotonic() - tool_start_time
             if agent._should_emit_quiet_tool_messages():
                 agent._vprint(f"  {_get_cute_tool_message_impl('clarify', function_args, tool_duration, result=function_result)}")
         elif function_name == "delegate_task":
@@ -682,7 +750,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 _delegate_result = function_result
             finally:
                 agent._delegate_spinner = None
-                tool_duration = time.time() - tool_start_time
+                tool_duration = time.monotonic() - tool_start_time
                 cute_msg = _get_cute_tool_message_impl('delegate_task', function_args, tool_duration, result=_delegate_result)
                 if spinner:
                     spinner.stop(cute_msg)
@@ -705,7 +773,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 function_result = json.dumps({"error": f"Context engine tool '{function_name}' failed: {tool_error}"})
                 logger.error("context_engine.handle_tool_call raised for %s: %s", function_name, tool_error, exc_info=True)
             finally:
-                tool_duration = time.time() - tool_start_time
+                tool_duration = time.monotonic() - tool_start_time
                 cute_msg = _get_cute_tool_message_impl(function_name, function_args, tool_duration, result=_ce_result)
                 if spinner:
                     spinner.stop(cute_msg)
@@ -729,7 +797,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 function_result = json.dumps({"error": f"Memory tool '{function_name}' failed: {tool_error}"})
                 logger.error("memory_manager.handle_tool_call raised for %s: %s", function_name, tool_error, exc_info=True)
             finally:
-                tool_duration = time.time() - tool_start_time
+                tool_duration = time.monotonic() - tool_start_time
                 cute_msg = _get_cute_tool_message_impl(function_name, function_args, tool_duration, result=_mem_result)
                 if spinner:
                     spinner.stop(cute_msg)
@@ -757,7 +825,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 function_result = f"Error executing tool '{function_name}': {tool_error}"
                 logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)
             finally:
-                tool_duration = time.time() - tool_start_time
+                tool_duration = time.monotonic() - tool_start_time
                 cute_msg = _get_cute_tool_message_impl(function_name, function_args, tool_duration, result=_spinner_result)
                 if spinner:
                     spinner.stop(cute_msg)
@@ -775,7 +843,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             except Exception as tool_error:
                 function_result = f"Error executing tool '{function_name}': {tool_error}"
                 logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)
-            tool_duration = time.time() - tool_start_time
+            tool_duration = time.monotonic() - tool_start_time
 
         if isinstance(function_result, str):
             result_preview = function_result if agent.verbose_logging else (
@@ -817,11 +885,22 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             except Exception as _ver_err:
                 logging.debug("file-mutation verifier record failed: %s", _ver_err)
 
+        hermes_meta = _build_hermes_tool_meta(
+            call_id=tool_call.id,
+            tool_name=function_name,
+            arguments=function_args,
+            response=function_result,
+            duration=tool_duration,
+            is_error=_is_error_result,
+            started_at=started_at,
+        )
         if not _execution_blocked and agent.tool_progress_callback:
             try:
                 agent.tool_progress_callback(
                     "tool.completed", function_name, None, None,
                     duration=tool_duration, is_error=_is_error_result,
+                    completed_at=hermes_meta.get("completed_at"),
+                    response=hermes_meta.get("response"),
                 )
             except Exception as cb_err:
                 logging.debug(f"Tool progress callback error: {cb_err}")
@@ -858,7 +937,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # Unwrap _multimodal dicts to an OpenAI-style content list
         # (see parallel path for rationale). String results pass through.
         _tool_content = agent._tool_result_content_for_active_model(function_name, function_result)
-        messages.append(make_tool_result_message(function_name, _tool_content, tool_call.id))
+        messages.append(make_tool_result_message(function_name, _tool_content, tool_call.id, hermes_meta=hermes_meta))
 
         # ── Per-tool /steer drain ───────────────────────────────────
         # Drain pending steer BETWEEN individual tool calls so the

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -127,6 +127,7 @@ class ChatCompletionsTransport(ProviderTransport):
           ``Extra inputs are not permitted, field: 'messages[N].tool_name'``.
           Permissive providers (OpenRouter, MiniMax) silently ignore the
           field, which masked the bug for months.
+        - ``_meta`` internal extension payloads used by ACP/session replay.
         """
         needs_sanitize = False
         for msg in messages:
@@ -136,6 +137,7 @@ class ChatCompletionsTransport(ProviderTransport):
                 "codex_reasoning_items" in msg
                 or "codex_message_items" in msg
                 or "tool_name" in msg
+                or "_meta" in msg
             ):
                 needs_sanitize = True
                 break
@@ -160,6 +162,7 @@ class ChatCompletionsTransport(ProviderTransport):
             msg.pop("codex_reasoning_items", None)
             msg.pop("codex_message_items", None)
             msg.pop("tool_name", None)
+            msg.pop("_meta", None)
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):
                 for tc in tool_calls:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1278,6 +1278,7 @@ class SessionStore:
                         message.get("platform_message_id") or message.get("message_id")
                     ),
                     observed=bool(message.get("observed")),
+                    field_meta=message.get("_meta") or message.get("field_meta"),
                 )
             except Exception as e:
                 logger.debug("Session DB operation failed: %s", e)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -238,7 +238,8 @@ CREATE TABLE IF NOT EXISTS messages (
     codex_reasoning_items TEXT,
     codex_message_items TEXT,
     platform_message_id TEXT,
-    observed INTEGER DEFAULT 0
+    observed INTEGER DEFAULT 0,
+    field_meta TEXT
 );
 
 CREATE TABLE IF NOT EXISTS state_meta (
@@ -1462,6 +1463,7 @@ class SessionDB:
         codex_message_items: Any = None,
         platform_message_id: str = None,
         observed: bool = False,
+        field_meta: Any = None,
     ) -> int:
         """
         Append a message to a session. Returns the message row ID.
@@ -1489,6 +1491,7 @@ class SessionDB:
             if codex_message_items else None
         )
         tool_calls_json = json.dumps(tool_calls) if tool_calls else None
+        field_meta_json = json.dumps(field_meta) if field_meta else None
         # Multimodal content (list of parts) must be JSON-encoded: sqlite3
         # cannot bind list/dict parameters directly.
         stored_content = self._encode_content(content)
@@ -1503,8 +1506,8 @@ class SessionDB:
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   codex_message_items, platform_message_id, observed, field_meta)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -1522,6 +1525,7 @@ class SessionDB:
                     codex_message_items_json,
                     platform_message_id,
                     1 if observed else 0,
+                    field_meta_json,
                 ),
             )
             msg_id = cursor.lastrowid
@@ -1583,6 +1587,11 @@ class SessionDB:
                     json.dumps(codex_message_items) if codex_message_items else None
                 )
                 tool_calls_json = json.dumps(tool_calls) if tool_calls else None
+                field_meta = msg.get("_meta") or msg.get("field_meta")
+                field_meta_json = (
+                    field_meta if isinstance(field_meta, str)
+                    else json.dumps(field_meta) if field_meta else None
+                )
                 # Accept either `platform_message_id` (new explicit name) or
                 # `message_id` (yuanbao's existing convention on message dicts).
                 platform_msg_id = (
@@ -1593,8 +1602,8 @@ class SessionDB:
                     """INSERT INTO messages (session_id, role, content, tool_call_id,
                        tool_calls, tool_name, timestamp, token_count, finish_reason,
                        reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                       codex_message_items, platform_message_id, observed)
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                       codex_message_items, platform_message_id, observed, field_meta)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                     (
                         session_id,
                         role,
@@ -1612,6 +1621,7 @@ class SessionDB:
                         codex_message_items_json,
                         platform_msg_id,
                         1 if msg.get("observed") else 0,
+                        field_meta_json,
                     ),
                 )
                 total_messages += 1
@@ -1639,6 +1649,12 @@ class SessionDB:
         result = []
         for row in rows:
             msg = dict(row)
+            field_meta = msg.pop("field_meta", None)
+            if field_meta:
+                try:
+                    msg["_meta"] = json.loads(field_meta)
+                except (json.JSONDecodeError, TypeError):
+                    logger.warning("Failed to deserialize field_meta in get_messages, dropping it")
             if "content" in msg:
                 msg["content"] = self._decode_content(msg["content"])
             if msg.get("tool_calls"):
@@ -1929,7 +1945,7 @@ class SessionDB:
             rows = self._conn.execute(
                 "SELECT role, content, tool_call_id, tool_calls, tool_name, "
                 "finish_reason, reasoning, reasoning_content, reasoning_details, "
-                "codex_reasoning_items, codex_message_items, platform_message_id, observed "
+                "codex_reasoning_items, codex_message_items, platform_message_id, observed, field_meta "
                 f"FROM messages WHERE session_id IN ({placeholders}) ORDER BY id",
                 tuple(session_ids),
             ).fetchall()
@@ -1944,6 +1960,11 @@ class SessionDB:
                 msg["tool_call_id"] = row["tool_call_id"]
             if row["tool_name"]:
                 msg["tool_name"] = row["tool_name"]
+            if row["field_meta"]:
+                try:
+                    msg["_meta"] = json.loads(row["field_meta"])
+                except (json.JSONDecodeError, TypeError):
+                    logger.warning("Failed to deserialize field_meta in conversation replay, dropping it")
             if row["tool_calls"]:
                 try:
                     msg["tool_calls"] = json.loads(row["tool_calls"])

--- a/run_agent.py
+++ b/run_agent.py
@@ -1291,6 +1291,7 @@ class AIAgent:
                     reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
                     codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
                     codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
+                    field_meta=msg.get("_meta") or msg.get("field_meta"),
                 )
             self._last_flushed_db_idx = len(messages)
         except Exception as e:

--- a/tests/acp/test_events.py
+++ b/tests/acp/test_events.py
@@ -279,6 +279,41 @@ class TestStepCallback:
             snapshot="snap",
         )
 
+    def test_step_callback_passes_hermes_timing_metadata(self, mock_conn, event_loop_fixture):
+        from collections import deque
+
+        hermes_meta = {
+            "call_id": "tc-timed",
+            "tool_name": "terminal",
+            "arguments": {"command": "pwd"},
+            "outcome": "completed",
+            "duration_ms": 1234,
+            "durationMs": 1234,
+            "durationSource": "monotonic",
+        }
+        tool_call_ids = {"terminal": deque(["tc-timed"])}
+        tool_call_meta = {"tc-timed": {"args": {"command": "pwd"}, "snapshot": None, "hermes": hermes_meta}}
+        loop = event_loop_fixture
+
+        cb = make_step_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
+
+        with patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts, \
+             patch("acp_adapter.events.build_tool_complete") as mock_btc:
+            future = MagicMock(spec=Future)
+            future.result.return_value = None
+            mock_rcts.return_value = future
+
+            cb(1, [{"name": "terminal", "result": "ok"}])
+
+        mock_btc.assert_called_once_with(
+            "tc-timed",
+            "terminal",
+            result="ok",
+            function_args={"command": "pwd"},
+            snapshot=None,
+            hermes_meta=hermes_meta,
+        )
+
     def test_tool_progress_captures_snapshot_metadata(self, mock_conn, event_loop_fixture):
         tool_call_ids = {}
         tool_call_meta = {}
@@ -296,6 +331,40 @@ class TestStepCallback:
             "snapshot": "snapshot",
         }
         mock_send.assert_called_once()
+
+    def test_tool_progress_records_timing_metadata_for_completion(self, mock_conn, event_loop_fixture):
+        from collections import deque
+
+        tool_call_ids = {"terminal": deque(["tc-timed"])}
+        tool_call_meta = {
+            "tc-timed": {
+                "args": {"command": "pwd"},
+                "snapshot": None,
+                "hermes": {"startedAt": "2026-05-23T18:42:11.123Z"},
+            }
+        }
+        loop = event_loop_fixture
+
+        cb = make_tool_progress_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
+        cb(
+            "tool.completed",
+            "terminal",
+            None,
+            None,
+            duration=1.234,
+            is_error=False,
+            completed_at="2026-05-23T18:42:12.357Z",
+        )
+
+        hermes = tool_call_meta["tc-timed"]["hermes"]
+        assert hermes["call_id"] == "tc-timed"
+        assert hermes["tool_name"] == "terminal"
+        assert hermes["arguments"] == {"command": "pwd"}
+        assert hermes["outcome"] == "completed"
+        assert hermes["duration_ms"] == 1234
+        assert hermes["durationMs"] == 1234
+        assert hermes["durationSource"] == "monotonic"
+        assert hermes["completedAt"] == "2026-05-23T18:42:12.357Z"
 
     def test_todo_completion_emits_native_plan_update_after_tool_completion(self, mock_conn, event_loop_fixture):
         from collections import deque

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -425,6 +425,63 @@ class TestSessionOps:
         assert "cli.py:42" in tool_updates[1].content[0].content.text
 
     @pytest.mark.asyncio
+    async def test_load_session_replays_persisted_tool_timing_metadata(self, agent):
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        new_resp = await agent.new_session(cwd="/tmp")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        hermes_meta = {
+            "call_id": "call_terminal_1",
+            "tool_name": "terminal",
+            "arguments": {"command": "pwd"},
+            "outcome": "completed",
+            "response": "/tmp",
+            "duration_ms": 1234,
+            "durationMs": 1234,
+            "durationSource": "monotonic",
+            "startedAt": "2026-05-23T18:42:11.123Z",
+            "completedAt": "2026-05-23T18:42:12.357Z",
+        }
+        state.history = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_terminal_1",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": '{"command":"pwd"}'},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_terminal_1",
+                "tool_name": "terminal",
+                "content": "/tmp",
+                "_meta": {"hermes": hermes_meta},
+            },
+        ]
+
+        mock_conn.session_update.reset_mock()
+        resp = await agent.load_session(cwd="/tmp", session_id=new_resp.session_id)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        assert isinstance(resp, LoadSessionResponse)
+        tool_updates = [
+            call.kwargs["update"]
+            for call in mock_conn.session_update.await_args_list
+            if getattr(call.kwargs.get("update"), "session_update", None)
+            in {"tool_call", "tool_call_update"}
+        ]
+        assert len(tool_updates) == 2
+        assert isinstance(tool_updates[1], ToolCallProgress)
+        assert tool_updates[1].field_meta == {"hermes": hermes_meta}
+
+    @pytest.mark.asyncio
     async def test_load_session_replays_native_plan_for_persisted_todo_tool(self, agent):
         """Persisted todo tool results should rebuild Zed's native plan panel."""
         mock_conn = MagicMock(spec=acp.Client)

--- a/tests/acp/test_tools.py
+++ b/tests/acp/test_tools.py
@@ -147,6 +147,19 @@ class TestBuildToolTitle:
 
 
 class TestBuildToolStart:
+    def test_build_tool_start_attaches_hermes_started_metadata(self):
+        result = build_tool_start(
+            "tc-timed-start",
+            "terminal",
+            {"command": "pwd"},
+            hermes_meta={"startedAt": "2026-05-23T18:42:11.123Z"},
+        )
+
+        assert result.field_meta == {
+            "hermes": {"startedAt": "2026-05-23T18:42:11.123Z"}
+        }
+        assert result.model_dump(by_alias=True, exclude_none=True)["_meta"] == result.field_meta
+
     def test_build_tool_start_for_patch(self):
         """patch start should not duplicate the edit-approval diff."""
         args = {
@@ -300,6 +313,35 @@ class TestBuildToolStart:
 
 
 class TestBuildToolComplete:
+    def test_build_tool_complete_attaches_hermes_timing_metadata(self):
+        result = build_tool_complete(
+            "tc-timed-complete",
+            "terminal",
+            "ok",
+            function_args={"command": "pwd"},
+            hermes_meta={
+                "call_id": "tc-timed-complete",
+                "tool_name": "terminal",
+                "arguments": {"command": "pwd"},
+                "outcome": "completed",
+                "response": "ok",
+                "duration_ms": 1234,
+                "durationMs": 1234,
+                "durationSource": "monotonic",
+                "started_at": "2026-05-23T18:42:11.123Z",
+                "startedAt": "2026-05-23T18:42:11.123Z",
+                "completed_at": "2026-05-23T18:42:12.357Z",
+                "completedAt": "2026-05-23T18:42:12.357Z",
+            },
+        )
+
+        hermes = result.field_meta["hermes"]
+        assert hermes["durationMs"] == 1234
+        assert hermes["duration_ms"] == 1234
+        assert hermes["durationSource"] == "monotonic"
+        assert hermes["outcome"] == "completed"
+        assert result.model_dump(by_alias=True, exclude_none=True)["_meta"] == result.field_meta
+
     def test_build_tool_complete_for_terminal(self):
         """Completed terminal call should include output text."""
         result = build_tool_complete("tc-2", "terminal", "total 42\ndrwxr-xr-x 2 root root 4096 ...")

--- a/tests/hermes_cli/test_list_picker_providers.py
+++ b/tests/hermes_cli/test_list_picker_providers.py
@@ -19,6 +19,12 @@ import pytest
 from hermes_cli import model_switch
 
 
+@pytest.fixture(autouse=True)
+def _disable_live_api_model_fetch(monkeypatch):
+    """Keep picker passthrough tests independent of local model servers."""
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *a, **kw: [])
+
+
 def _make_provider(slug, name=None, models=None, *, is_current=False,
                    is_user_defined=False, source="built-in", api_url=None):
     """Build a dict shaped like ``list_authenticated_providers`` output."""

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -5,6 +5,8 @@ shared slash-command pipeline (`/model` in CLI/gateway/Telegram) historically
 only looked at `providers:`.
 """
 
+import pytest
+
 import hermes_cli.providers as providers_mod
 from hermes_cli.model_switch import list_authenticated_providers, switch_model
 from hermes_cli.providers import resolve_provider_full
@@ -16,6 +18,19 @@ _MOCK_VALIDATION = {
     "recognized": True,
     "message": None,
 }
+
+
+@pytest.fixture(autouse=True)
+def _disable_live_api_model_fetch(monkeypatch):
+    """Keep custom-provider picker tests hermetic by default.
+
+    Several tests use localhost/openai-compatible URLs to exercise config
+    grouping. If a developer happens to have a compatible server listening,
+    live ``/models`` discovery can replace the static fixture models and make
+    the assertions environment-dependent. Tests that explicitly cover live
+    discovery override this fixture with their own fake.
+    """
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *a, **kw: [])
 
 
 def test_list_authenticated_providers_includes_custom_providers(monkeypatch):

--- a/tests/run_agent/test_strict_api_validation.py
+++ b/tests/run_agent/test_strict_api_validation.py
@@ -93,6 +93,41 @@ class TestStrictApiValidation:
         assert tool_call["id"] == "call_123"
         assert tool_call["function"]["name"] == "terminal"
 
+    def test_api_kwargs_strip_internal_tool_meta_without_mutating_history(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "openrouter")
+        agent.api_mode = "chat_completions"
+        hermes_meta = {
+            "call_id": "call_123",
+            "tool_name": "terminal",
+            "duration_ms": 1234,
+            "durationSource": "monotonic",
+        }
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "Checking now.",
+                "tool_calls": [
+                    {
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": '{"command":"pwd"}'},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_123",
+                "content": "/tmp",
+                "_meta": {"hermes": hermes_meta},
+            },
+        ]
+
+        kwargs = agent._build_api_kwargs(messages)
+
+        assert "_meta" not in kwargs["messages"][2]
+        assert messages[2]["_meta"] == {"hermes": hermes_meta}
+
     def test_codex_preserves_fields_for_replay(self, monkeypatch):
         """Codex mode should preserve fields for Responses API replay."""
         agent = _make_agent(monkeypatch, "openrouter")

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -215,7 +215,10 @@ def test_config_enabled_hard_stop_concurrent_path_does_not_submit_blocked_calls_
     assert starts == [("c-allow", "web_search", allowed_args)]
     started_events = [event for event in progress_events if event[0] == "tool.started"]
     completed_events = [event for event in progress_events if event[0] == "tool.completed"]
-    assert started_events == [("tool.started", "web_search", allowed_args, {})]
+    assert len(started_events) == 1
+    assert started_events[0][1:3] == ("web_search", allowed_args)
+    assert started_events[0][3]["tool_call_id"] == "c-allow"
+    assert "started_at" in started_events[0][3]
     assert len(completed_events) == 1
     assert completed_events[0][1] == "web_search"
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -235,6 +235,30 @@ class TestMessageStorage:
         messages = db.get_messages("s1")
         assert messages[0]["tool_calls"] == tool_calls
 
+    def test_tool_message_meta_round_trip(self, db):
+        db.create_session(session_id="s1", source="cli")
+        hermes_meta = {
+            "call_id": "call_1",
+            "tool_name": "terminal",
+            "arguments": {"command": "pwd"},
+            "outcome": "completed",
+            "duration_ms": 1234,
+            "durationMs": 1234,
+            "durationSource": "monotonic",
+        }
+
+        db.append_message(
+            "s1",
+            role="tool",
+            content="/tmp",
+            tool_name="terminal",
+            tool_call_id="call_1",
+            field_meta={"hermes": hermes_meta},
+        )
+
+        messages = db.get_messages("s1")
+        assert messages[0]["_meta"] == {"hermes": hermes_meta}
+
     def test_multimodal_list_content_round_trip(self, db):
         """Multimodal ``content`` (list of parts) must survive the SQLite
         round-trip.  sqlite3 cannot bind Python lists directly, so the DB
@@ -305,6 +329,25 @@ class TestMessageStorage:
         msgs = db.get_messages("s1")
         tool_msg = next(m for m in msgs if m["role"] == "tool")
         assert tool_msg["tool_name"] == "web_search"
+
+    def test_replace_messages_persists_tool_meta(self, db):
+        from agent.tool_dispatch_helpers import make_tool_result_message
+
+        db.create_session(session_id="s1", source="cli")
+        hermes_meta = {
+            "call_id": "c1",
+            "tool_name": "terminal",
+            "duration_ms": 1234,
+            "durationSource": "monotonic",
+        }
+
+        db.replace_messages(
+            "s1",
+            [make_tool_result_message("terminal", "ok", "c1", hermes_meta={"hermes": hermes_meta})],
+        )
+
+        msgs = db.get_messages("s1")
+        assert msgs[0]["_meta"] == {"hermes": hermes_meta}
 
     def test_replace_messages_handles_multimodal_content(self, db):
         """`replace_messages` (used by /retry, /undo, /compress) must also


### PR DESCRIPTION
## What does this PR do?

This PR persists and emits Hermes tool-call timing metadata for ACP tool-call lifecycle updates so clients can render faithful durations for both live and replayed history.

Today, replayed ACP tool history is reconstructed and emitted back-to-back. Clients that measure duration from local receive time either show historical tools as nearly instantaneous or suppress replay durations entirely. This change makes Hermes the durable source of truth by storing per-tool metadata and threading it through ACP live emission and replay.

The metadata is additive and backwards-compatible:

- existing public ACP fields stay unchanged;
- timing is emitted under `_meta.hermes`;
- elapsed duration is measured from a monotonic clock;
- wall-clock timestamps are used only for display/debugging;
- provider-facing model payloads are sanitized so Hermes-internal `_meta` is not sent to LLM APIs.

## Related Issue

Fixes #31117

Related: #31076 is complementary session-level ACP provenance metadata under `_meta.hermes`; this PR is tool-call/message-level timing metadata and is not a dependency.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/tool_executor.py`
  - Capture tool start/completion timing around existing execution points.
  - Compute `duration_ms` from `time.monotonic()` and emit Hermes metadata through tool-progress callbacks.
- `agent/tool_dispatch_helpers.py`, `run_agent.py`
  - Preserve optional Hermes metadata on generated tool result messages so it can be persisted with the conversation.
- `acp_adapter/tools.py`, `acp_adapter/events.py`, `acp_adapter/server.py`
  - Accept and propagate `_meta.hermes` on ACP tool-call start/completion updates.
  - Reconstruct replayed tool updates with persisted metadata instead of client-local receive-time timing.
- `hermes_state.py`, `gateway/session.py`
  - Add durable message-level `field_meta` storage/readback for internal metadata such as `_meta.hermes`.
- `agent/transports/chat_completions.py`
  - Strip Hermes-internal `_meta` from strict/provider-facing model payloads while retaining it internally for persistence/replay.
- Tests:
  - Add ACP builder/event/replay coverage for timing metadata.
  - Add session persistence/readback coverage for `field_meta`.
  - Add strict API boundary coverage ensuring `_meta` is not sent to providers.
  - Update tool guardrail callback expectations for metadata-bearing `tool.started` events.
  - Add hermetic model-discovery stubs in model-picker tests to avoid ambient local `/models` service contamination during the full suite.

## How to Test

1. Focused ACP/session/provider-boundary tests:

   ```bash
   source /home/volt/.hermes/hermes-agent/venv/bin/activate
   scripts/run_tests.sh \
     tests/acp/test_tools.py \
     tests/acp/test_events.py \
     tests/acp/test_server.py \
     tests/test_hermes_state.py \
     tests/run_agent/test_strict_api_validation.py \
     tests/run_agent/test_tool_call_guardrail_runtime.py
   ```

2. Full test suite:

   ```bash
   source /home/volt/.hermes/hermes-agent/venv/bin/activate
   scripts/run_tests.sh
   ```

3. Cross-platform/format checks:

   ```bash
   git diff --check
   source /home/volt/.hermes/hermes-agent/venv/bin/activate
   python scripts/check-windows-footguns.py \
     acp_adapter/events.py \
     acp_adapter/server.py \
     acp_adapter/tools.py \
     agent/tool_dispatch_helpers.py \
     agent/tool_executor.py \
     agent/transports/chat_completions.py \
     gateway/session.py \
     hermes_state.py \
     run_agent.py \
     tests/acp/test_events.py \
     tests/acp/test_server.py \
     tests/acp/test_tools.py \
     tests/hermes_cli/test_list_picker_providers.py \
     tests/hermes_cli/test_model_switch_custom_providers.py \
     tests/run_agent/test_strict_api_validation.py \
     tests/run_agent/test_tool_call_guardrail_runtime.py \
     tests/test_hermes_state.py
   ```

Verified locally:

- `scripts/run_tests.sh` — 25,181 passed, 0 failed.
- Focused related subsets — 430 passed, 0 failed.
- Compatibility check with related PR #31076 applied in a temp worktree — 584 targeted tests passed, 0 failed.
- `git diff --check` — clean.
- `python scripts/check-windows-footguns.py <changed files>` — no Windows footguns found across 17 files.

No interactive ACP editor/client smoke test was run; coverage is via ACP adapter unit/replay tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — via the project-preferred `scripts/run_tests.sh` wrapper
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux / Linux 7.0.9, Python 3.11.15 via Hermes dev venv

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, metadata is covered by tests and issue/PR contract
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool schema exposed to the model changed

## Screenshots / Logs

N/A. This is protocol/session metadata; assertions are covered by ACP adapter and persistence tests.

## Reviewer Notes

- `_meta.hermes` mirrors the compatibility approach used by related ACP provenance work, but this PR is self-contained.
- `duration_ms` compatibility is preserved where existing code uses snake_case internally; ACP-facing metadata uses camelCase under `_meta.hermes`.
- Hermes TUI live tool progress is expected unchanged: `tui_gateway` keeps its own `duration_s` path today, callbacks tolerate the added kwargs, and persisted `_meta.hermes` can be consumed by TUI/replay views later if desired.
- The model-picker test fixture changes are test hermeticity only. If maintainers prefer an even narrower PR, they can be split out without changing the ACP timing implementation.
