### PR TITLE
feat: add BMAD Symphony plugin

### DIFF
--- a/plugins/bmad_symphony/__init__.py
+++ b/plugins/bmad_symphony/__init__.py
@@ -1,0 +1,92 @@
+"""BMad/Symphony plugin — deep planning + isolated implementation runs.
+
+This plugin combines:
+- a planning/intake layer (BMad)
+- a Symphony execution brief / worker fan-out layer
+- a proof-of-work gate that keeps handoffs honest
+- a plugin-local skill that teaches the agent when to use the workflow
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+from . import core
+from . import cli as workflow_cli
+from . import tools as workflow_tools
+
+logger = logging.getLogger(__name__)
+
+
+def _skill_path() -> Path:
+    return Path(__file__).resolve().parent / "skill" / "SKILL.md"
+
+
+def _session_injection(*, messages: Any = None, conversation_history: Any = None, user_message: Any = None, **_: Any) -> Optional[str]:
+    if not core.wants_injection(
+        messages=messages,
+        conversation_history=conversation_history,
+        user_message=user_message,
+    ):
+        return None
+    return core.build_injection()
+
+
+def _session_end(*_: Any, **__: Any) -> None:
+    try:
+        core.record_event("session_end", "BMad/Symphony session ended")
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("bmad-symphony session_end hook failed: %s", exc)
+
+
+def register(ctx) -> None:
+    """Register tools, hooks, CLI commands, slash commands, and the plugin skill."""
+    workflow_tools.register_toolset(ctx)
+
+    ctx.register_hook("pre_llm_call", _session_injection)
+    ctx.register_hook("on_session_end", _session_end)
+
+    ctx.register_cli_command(
+        name="bmad-symphony",
+        help="BMad planning + Symphony implementation runs",
+        setup_fn=workflow_cli.register_cli,
+        handler_fn=lambda args: workflow_cli.dispatch_namespace(
+            args,
+            dispatcher=ctx.dispatch_tool,
+            emit="print",
+        )[0],
+        description=(
+            "Create a BMad intake, turn it into a story, fan out Symphony "
+            "workers, and evaluate proof-of-work before handoff."
+        ),
+    )
+
+    ctx.register_command(
+        "bmad-symphony",
+        handler=lambda raw_args: workflow_cli.handle_slash(
+            raw_args,
+            dispatcher=ctx.dispatch_tool,
+        ),
+        description=(
+            "BMad/Symphony workflow: /bmad-symphony plan|story|run|proof|status|reset"
+        ),
+        args_hint="plan|story|run|proof|status|reset",
+    )
+
+    ctx.register_command(
+        "bmad",
+        handler=lambda raw_args: workflow_cli.handle_slash(
+            raw_args,
+            dispatcher=ctx.dispatch_tool,
+        ),
+        description="Shortcut alias for /bmad-symphony.",
+        args_hint="plan|story|run|proof|status|reset",
+    )
+
+    ctx.register_skill(
+        name="workflow",
+        path=_skill_path(),
+        description="Deep BMad/Symphony workflow playbook for planning, implementation, and proof.",
+    )

--- a/plugins/bmad_symphony/cli.py
+++ b/plugins/bmad_symphony/cli.py
@@ -1,0 +1,202 @@
+"""CLI and slash-command wiring for the BMad/Symphony plugin."""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+from typing import Any, Callable, Optional, Tuple
+
+from . import core
+
+
+class _Parser(argparse.ArgumentParser):
+    def error(self, message: str):  # type: ignore[override]
+        raise ValueError(message)
+
+
+def _add_common_fields(parser: argparse.ArgumentParser, *, include_goal: bool = True) -> None:
+    if include_goal:
+        parser.add_argument("--goal", default="", help="Goal or initiative to operate on")
+    parser.add_argument("--context", default="", help="Additional context, constraints, or background")
+
+
+def register_cli(subparser: argparse.ArgumentParser) -> None:
+    """Build the ``hermes bmad-symphony`` argparse tree."""
+    subs = subparser.add_subparsers(dest="bmad_symphony_command")
+
+    plan_p = subs.add_parser("plan", help="Create a BMad intake and planning brief")
+    _add_common_fields(plan_p)
+    plan_p.add_argument("--constraints", action="append", default=[], help="Constraint or priority; may be repeated")
+    plan_p.add_argument("--repo-scope", default="", help="Optional repository/module scope")
+    plan_p.add_argument("--audience", default="agent", help="Audience for the brief (agent, reviewer, user)")
+
+    story_p = subs.add_parser("story", help="Turn the intake into a story with acceptance criteria")
+    _add_common_fields(story_p)
+    story_p.add_argument("--acceptance", action="append", default=[], help="Acceptance criterion; may be repeated")
+    story_p.add_argument("--out-of-scope", action="append", default=[], help="Out-of-scope item; may be repeated")
+    story_p.add_argument("--note", action="append", default=[], help="Implementation note; may be repeated")
+
+    run_p = subs.add_parser("run", help="Prepare or dispatch a Symphony execution run")
+    _add_common_fields(run_p)
+    run_p.add_argument("--work-item", action="append", default=[], help="Work item goal; may be repeated")
+    run_p.add_argument("--parallelism", type=int, default=3, help="Number of worker tasks to prepare")
+    run_p.add_argument("--toolset", action="append", default=[], help="Toolset to grant workers; may be repeated")
+    run_p.add_argument("--auto-dispatch", action="store_true", help="Dispatch a delegate_task payload immediately")
+
+    proof_p = subs.add_parser("proof", help="Evaluate proof-of-work and merge readiness")
+    _add_common_fields(proof_p)
+    proof_p.add_argument("--evidence", action="append", default=[], help="Evidence item or summary; may be repeated")
+    proof_p.add_argument("--criteria", action="append", default=[], help="Proof criterion; may be repeated")
+    proof_p.add_argument("--test", action="append", default=[], help="Test / validation step; may be repeated")
+    proof_p.add_argument("--file", action="append", default=[], help="File changed / artifact; may be repeated")
+    proof_p.add_argument("--notes", default="", help="Reviewer notes or risk notes")
+
+    subs.add_parser("status", help="Show the current BMad/Symphony state")
+    subs.add_parser("reset", help="Clear the current BMad/Symphony state")
+
+    subparser.set_defaults(func=handle_cli)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = _Parser(prog="hermes bmad-symphony", add_help=True)
+    register_cli(parser)
+    return parser
+
+
+def _coerce_work_items(args: argparse.Namespace) -> list[str]:
+    items = list(getattr(args, "work_item", []) or [])
+    return [item for item in items if isinstance(item, str) and item.strip()]
+
+
+def _emit(message: str, emit: str) -> str:
+    if emit == "print":
+        print(message)
+    return message
+
+
+def dispatch_namespace(
+    args: argparse.Namespace,
+    *,
+    dispatcher: Optional[Callable[[str, dict], Any]] = None,
+    emit: str = "print",
+) -> Tuple[int, str]:
+    sub = getattr(args, "bmad_symphony_command", None)
+    if not sub:
+        return 2, _emit("usage: hermes bmad-symphony {plan,story,run,proof,status,reset}", emit)
+
+    if sub == "plan":
+        plan = core.build_intake(
+            goal=args.goal,
+            context=args.context,
+            constraints=args.constraints,
+            repo_scope=args.repo_scope,
+            audience=args.audience,
+        )
+        state = core.update_state(
+            mode="plan",
+            goal=args.goal,
+            context=args.context,
+            intake=plan,
+            active=True,
+            event="bmad_symphony_plan",
+            summary=plan["next_action"],
+        )
+        return 0, _emit(core.format_intake(plan) + "\n\n" + core.format_state(state), emit)
+
+    if sub == "story":
+        story = core.build_story(
+            goal=args.goal or core.current_goal(),
+            context=args.context,
+            acceptance=args.acceptance,
+            out_of_scope=args.out_of_scope,
+            implementation_notes=args.note,
+        )
+        state = core.update_state(
+            mode="story",
+            goal=args.goal or core.current_goal(),
+            context=args.context,
+            story=story,
+            active=True,
+            event="bmad_symphony_story",
+            summary="Story captured with acceptance criteria",
+        )
+        return 0, _emit(core.format_story(story) + "\n\n" + core.format_state(state), emit)
+
+    if sub == "run":
+        run = core.build_run_plan(
+            goal=args.goal or core.current_goal(),
+            context=args.context,
+            work_items=_coerce_work_items(args),
+            parallelism=args.parallelism,
+            toolsets=args.toolset,
+            auto_dispatch=args.auto_dispatch,
+        )
+        state = core.update_state(
+            mode="run",
+            goal=args.goal or core.current_goal(),
+            context=args.context,
+            run=run,
+            active=True,
+            event="bmad_symphony_run",
+            summary=f"Prepared {len(run['tasks'])} worker task(s)",
+        )
+        message = core.format_run_plan(run)
+        if args.auto_dispatch and dispatcher is not None:
+            dispatched = dispatcher("delegate_task", run["recommended_delegate_payload"])
+            message += "\n\nDelegate result:\n" + str(dispatched)
+        message += "\n\n" + core.format_state(state)
+        return 0, _emit(message, emit)
+
+    if sub == "proof":
+        proof = core.evaluate_proof(
+            goal=args.goal or core.current_goal(),
+            evidence=args.evidence,
+            criteria=args.criteria,
+            tests=args.test,
+            files_changed=args.file,
+            notes=args.notes,
+        )
+        state = core.update_state(
+            mode="proof",
+            goal=args.goal or core.current_goal(),
+            proof=proof,
+            active=proof["status"] != "pass",
+            event="bmad_symphony_proof",
+            summary=f"Proof gate evaluated: {proof['status']}",
+        )
+        return 0, _emit(core.format_proof(proof) + "\n\n" + core.format_state(state), emit)
+
+    if sub == "status":
+        return 0, _emit(core.format_state(), emit)
+
+    if sub == "reset":
+        state = core.clear_state()
+        return 0, _emit("BMad/Symphony state reset.\n\n" + core.format_state(state), emit)
+
+    return 2, _emit(f"unknown subcommand: {sub}", emit)
+
+
+def handle_cli(args: argparse.Namespace) -> int:
+    code, _ = dispatch_namespace(args, dispatcher=None, emit="print")
+    return code
+
+
+def parse_slash(raw_args: str) -> argparse.Namespace:
+    parser = build_parser()
+    argv = shlex.split(raw_args or "")
+    if not argv:
+        raise ValueError("No arguments provided")
+    return parser.parse_args(argv)
+
+
+def handle_slash(raw_args: str, *, dispatcher: Optional[Callable[[str, dict], Any]] = None) -> str:
+    parser = build_parser()
+    argv = shlex.split(raw_args or "")
+    if not argv:
+        return "usage: /bmad-symphony {plan,story,run,proof,status,reset}"
+    try:
+        args = parser.parse_args(argv)
+    except Exception as exc:
+        return f"{exc}\n\nusage: /bmad-symphony {{plan,story,run,proof,status,reset}}"
+    _, message = dispatch_namespace(args, dispatcher=dispatcher, emit="text")
+    return message

--- a/plugins/bmad_symphony/core.py
+++ b/plugins/bmad_symphony/core.py
@@ -1,0 +1,628 @@
+"""Core BMad/Symphony workflow helpers.
+
+This module keeps the plugin thin: state persistence, plan/story/run/proof
+builders, and human-readable formatting all live here so the CLI, slash
+command, tools, and hooks share one implementation path.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+try:
+    from hermes_constants import get_hermes_home
+except Exception:  # pragma: no cover - defensive fallback for tests/import order
+    def get_hermes_home() -> Path:  # type: ignore[no-redef]
+        return (Path.home() / ".hermes").resolve()
+
+PLUGIN_NAME = "bmad-symphony"
+STATE_VERSION = 1
+HISTORY_LIMIT = 25
+BMAD_SOURCE_URL = "https://docs.bmad-method.org/llms-full.txt"
+
+DEFAULT_TOOLSETS = ["terminal", "file", "delegation", "search", "web", "todo"]
+
+BMAD_SOURCE_DERIVATION = {
+    "source": BMAD_SOURCE_URL,
+    "rule": (
+        "BMAD-specific guidance is derived from the extracted BMAD documentation "
+        "artifact and user-provided context. Symphony/delegation is a Hermes "
+        "execution wrapper, not a BMAD source concept."
+    ),
+    "reference_file": "plugins/bmad_symphony/source/bmad_llms_extract.md",
+}
+
+BMAD_PHASES = [
+    "Analysis — optional brainstorming, research, product brief, or PRFAQ",
+    "Planning — required requirements via PRD or spec",
+    "Solutioning — architecture and technical work breakdown",
+    "Implementation — build epic by epic, story by story",
+]
+
+BMAD_TRACKS = [
+    "Quick Flow — bug fixes, simple features, clear scope; tech-spec only",
+    "BMad Method — products, platforms, complex features; PRD + Architecture + UX",
+    "Enterprise — compliance or multi-tenant systems; PRD + Architecture + Security + DevOps",
+]
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def state_dir() -> Path:
+    return get_hermes_home() / "plugins" / PLUGIN_NAME
+
+
+def state_file() -> Path:
+    return state_dir() / "state.json"
+
+
+def _default_state() -> Dict[str, Any]:
+    return {
+        "version": STATE_VERSION,
+        "active": False,
+        "mode": "idle",
+        "current_goal": "",
+        "context": "",
+        "intake": {},
+        "story": {},
+        "run": {},
+        "proof": {},
+        "history": [],
+        "updated_at": now_iso(),
+    }
+
+
+def load_state() -> Dict[str, Any]:
+    path = state_file()
+    if not path.exists():
+        return _default_state()
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return _default_state()
+    if not isinstance(raw, dict):
+        return _default_state()
+    base = _default_state()
+    base.update(raw)
+    base.setdefault("history", [])
+    return base
+
+
+def save_state(state: Dict[str, Any]) -> None:
+    path = state_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = dict(state)
+    payload["updated_at"] = now_iso()
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def clear_state() -> Dict[str, Any]:
+    state = _default_state()
+    save_state(state)
+    return state
+
+
+def _truncate(text: str, limit: int = 280) -> str:
+    text = " ".join((text or "").split())
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "…"
+
+
+def _split_lines(text: str) -> List[str]:
+    lines = []
+    for raw in (text or "").splitlines():
+        line = raw.strip(" -\t")
+        if line:
+            lines.append(line)
+    return lines
+
+
+def _coerce_list(value: Any) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return _split_lines(value)
+    if isinstance(value, Iterable):
+        items = []
+        for item in value:
+            if item is None:
+                continue
+            text = str(item).strip()
+            if text:
+                items.append(text)
+        return items
+    return []
+
+
+def _history_entry(event: str, summary: str, **data: Any) -> Dict[str, Any]:
+    entry: Dict[str, Any] = {
+        "ts": now_iso(),
+        "event": event,
+        "summary": summary,
+    }
+    if data:
+        entry["data"] = data
+    return entry
+
+
+def _append_history(state: Dict[str, Any], event: str, summary: str, **data: Any) -> Dict[str, Any]:
+    history = list(state.get("history", []))
+    history.append(_history_entry(event, summary, **data))
+    state["history"] = history[-HISTORY_LIMIT:]
+    return state
+
+
+def update_state(
+    *,
+    mode: str,
+    goal: str = "",
+    context: str = "",
+    intake: Optional[Dict[str, Any]] = None,
+    story: Optional[Dict[str, Any]] = None,
+    run: Optional[Dict[str, Any]] = None,
+    proof: Optional[Dict[str, Any]] = None,
+    active: Optional[bool] = None,
+    event: str = "update",
+    summary: str = "state updated",
+    extra: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    state = load_state()
+    state["mode"] = mode
+    if goal:
+        state["current_goal"] = goal
+    if context:
+        state["context"] = context
+    if intake is not None:
+        state["intake"] = intake
+    if story is not None:
+        state["story"] = story
+    if run is not None:
+        state["run"] = run
+    if proof is not None:
+        state["proof"] = proof
+    if active is not None:
+        state["active"] = active
+    if extra:
+        state.update(extra)
+    _append_history(state, event, summary, goal=goal or state.get("current_goal", ""), mode=mode)
+    save_state(state)
+    return state
+
+
+def record_event(event: str, summary: str, **data: Any) -> Dict[str, Any]:
+    state = load_state()
+    _append_history(state, event, summary, **data)
+    save_state(state)
+    return state
+
+
+def current_goal(state: Optional[Dict[str, Any]] = None) -> str:
+    source = state if state is not None else load_state()
+    return str(source.get("current_goal", "") or "").strip()
+
+
+def _goal_title(goal: str) -> str:
+    words = [w for w in _truncate(goal, 80).replace("/", " ").split() if w]
+    if not words:
+        return "BMad / Symphony initiative"
+    return " ".join(words[:8]).strip(" ,.")
+
+
+def _collect_acceptance(goal: str, context: str = "", acceptance: Any = None) -> List[str]:
+    items = _coerce_list(acceptance)
+    if items:
+        return items
+    collected = [
+        f"The requested outcome for '{_truncate(goal, 90)}' is delivered end-to-end.",
+        "The implementation is covered by proof-of-work: tests, checks, or reproducible validation.",
+        "The final handoff includes any caveats, follow-ups, or rollback notes.",
+    ]
+    if context:
+        collected.append("The solution respects the provided context and constraints.")
+    return collected
+
+
+def build_intake(
+    *,
+    goal: str,
+    context: str = "",
+    constraints: Any = None,
+    repo_scope: str = "",
+    audience: str = "agent",
+) -> Dict[str, Any]:
+    goal = (goal or "").strip()
+    context = (context or "").strip()
+    constraints_list = _coerce_list(constraints)
+    scope = repo_scope.strip()
+    parallel_axes = _coerce_list(constraints if isinstance(constraints, (list, tuple)) else [])
+    if not parallel_axes and context:
+        parallel_axes = _split_lines(context)[:3]
+
+    deliverables = [
+        "A BMad track recommendation: Quick Flow, BMad Method, or Enterprise.",
+        "A phase-aware next workflow recommendation grounded in the BMAD phase model.",
+        "A list of expected BMAD artifacts for the selected track and phase.",
+    ]
+
+    if scope:
+        deliverables.append(f"Scope is limited to: {scope}.")
+
+    assumptions = [
+        "Start with bmad-help whenever the next BMAD workflow is uncertain.",
+        "Use a fresh chat for each BMAD workflow to avoid context-limit and contamination issues.",
+    ]
+    if context:
+        assumptions.append("User-provided context is treated as the source of truth for constraints and preferences.")
+
+    risks = [
+        "Choosing a track by story count alone can be misleading; BMAD says to choose by planning need.",
+        "Skipping planning/solutioning artifacts can leave implementation stories under-specified.",
+    ]
+
+    return {
+        "title": _goal_title(goal),
+        "goal": goal,
+        "context": context,
+        "audience": audience,
+        "scope": scope,
+        "deliverables": deliverables,
+        "assumptions": assumptions,
+        "constraints": constraints_list,
+        "parallel_axes": parallel_axes,
+        "risks": risks,
+        "source_derivation": BMAD_SOURCE_DERIVATION,
+        "bmad_phases": BMAD_PHASES,
+        "planning_tracks": BMAD_TRACKS,
+        "recommended_flow": [
+            "Install/select BMad Method if not already installed",
+            "Run bmad-help to detect current artifacts and next workflow",
+            "Use the appropriate phase workflow in a fresh chat",
+            "For implementation, use sprint planning then create-story/dev-story/code-review per story",
+        ],
+        "expected_artifacts": [
+            "_bmad/ for agents, workflows, tasks, and configuration",
+            "_bmad-output/ for generated artifacts",
+            "PRD/addendum/decision-log for BMad Method and Enterprise planning",
+            "Architecture document before epics and stories for BMad Method and Enterprise",
+            "sprint-status.yaml before story implementation",
+        ],
+        "next_action": "Run bmad-help, then choose the next BMAD workflow from the extracted source model.",
+    }
+
+
+def build_story(
+    *,
+    goal: str,
+    context: str = "",
+    acceptance: Any = None,
+    out_of_scope: Any = None,
+    implementation_notes: Any = None,
+) -> Dict[str, Any]:
+    goal = (goal or "").strip()
+    acceptance_list = _collect_acceptance(goal, context=context, acceptance=acceptance)
+    out_of_scope_list = _coerce_list(out_of_scope) or [
+        "Skipping the BMAD phase/workflow sequence without an explicit reason",
+        "Adding BMAD process claims that are not present in the extracted source model",
+    ]
+    notes_list = _coerce_list(implementation_notes) or [
+        "Use a fresh chat for each BMAD workflow.",
+        "For implementation, follow the BMAD story cycle: bmad-create-story, bmad-dev-story, bmad-code-review.",
+    ]
+
+    return {
+        "title": _goal_title(goal),
+        "user_story": f"As a user, I want {_truncate(goal, 120)} so that the requested outcome is achieved.",
+        "goal": goal,
+        "context": context.strip(),
+        "source_derivation": BMAD_SOURCE_DERIVATION,
+        "acceptance_criteria": acceptance_list,
+        "out_of_scope": out_of_scope_list,
+        "implementation_notes": notes_list,
+        "bmad_phase_model": BMAD_PHASES,
+        "bmad_story_cycle": [
+            "bmad-create-story — create story file from epic",
+            "bmad-dev-story — implement the story",
+            "bmad-code-review — quality validation (recommended)",
+        ],
+    }
+
+
+def _default_worker_tasks(goal: str, parallelism: int) -> List[Dict[str, Any]]:
+    parallelism = max(1, parallelism)
+    templates = [
+        "Derive the current BMAD phase, planning track, and next workflow from the extracted source model for: {goal}",
+        "Inspect project artifacts (_bmad/, _bmad-output/, PRD, architecture, epics/stories, sprint-status.yaml) for: {goal}",
+        "Prepare the next BMAD workflow handoff using only extracted-source BMAD terms for: {goal}",
+        "Verify the handoff cites source-derived BMAD workflows and separates Hermes execution details from BMAD claims for: {goal}",
+    ]
+    tasks: List[Dict[str, Any]] = []
+    for idx in range(parallelism):
+        tasks.append({"goal": templates[idx % len(templates)].format(goal=_truncate(goal, 110))})
+    return tasks
+
+
+def build_run_plan(
+    *,
+    goal: str,
+    context: str = "",
+    work_items: Any = None,
+    parallelism: int = 3,
+    toolsets: Any = None,
+    auto_dispatch: bool = False,
+) -> Dict[str, Any]:
+    goal = (goal or "").strip()
+    context = (context or "").strip()
+    tasks = []
+    if isinstance(work_items, Sequence) and not isinstance(work_items, (str, bytes)):
+        for item in work_items:
+            if isinstance(item, dict):
+                task_goal = str(item.get("goal", "")).strip()
+                if not task_goal:
+                    continue
+                tasks.append({
+                    "goal": task_goal,
+                    "context": str(item.get("context", "")).strip(),
+                    "toolsets": _coerce_list(item.get("toolsets")) or DEFAULT_TOOLSETS,
+                })
+            else:
+                text = str(item).strip()
+                if text:
+                    tasks.append({"goal": text, "toolsets": DEFAULT_TOOLSETS})
+    if not tasks:
+        tasks = _default_worker_tasks(goal, parallelism)
+        for task in tasks:
+            task["toolsets"] = _coerce_list(toolsets) or DEFAULT_TOOLSETS
+
+    recommended_delegate_payload = {
+        "role": "orchestrator" if len(tasks) > 1 else "leaf",
+        "context": context,
+        "toolsets": _coerce_list(toolsets) or DEFAULT_TOOLSETS,
+    }
+    if len(tasks) > 1:
+        recommended_delegate_payload["tasks"] = tasks
+    else:
+        recommended_delegate_payload["goal"] = goal
+
+    return {
+        "goal": goal,
+        "context": context,
+        "parallelism": max(1, parallelism),
+        "source_derivation": BMAD_SOURCE_DERIVATION,
+        "mode": "batch" if len(tasks) > 1 else "single",
+        "proof_gate": [
+            "BMAD-specific statements cite the extracted source model or user-provided context.",
+            "Hermes/Symphony delegation details are labeled as execution wrapper behavior, not BMAD doctrine.",
+            "The next recommended workflow matches the current phase/artifact state.",
+        ],
+        "tasks": tasks,
+        "auto_dispatch": bool(auto_dispatch),
+        "recommended_delegate_payload": recommended_delegate_payload,
+    }
+
+
+def evaluate_proof(
+    *,
+    goal: str,
+    evidence: Any = None,
+    criteria: Any = None,
+    tests: Any = None,
+    files_changed: Any = None,
+    notes: str = "",
+) -> Dict[str, Any]:
+    evidence_text = "\n".join(_coerce_list(evidence)) or str(evidence or "").strip()
+    criteria_list = _collect_acceptance(goal, acceptance=criteria)
+    tests_list = _coerce_list(tests)
+    files_list = _coerce_list(files_changed)
+    note_text = (notes or "").strip()
+
+    score = 0
+    if evidence_text:
+        score += 1
+    if tests_list:
+        score += 1
+    if files_list:
+        score += 1
+    if any(token in evidence_text.lower() for token in ("pass", "passed", "green", "verified", "done")):
+        score += 1
+    if note_text:
+        score += 1
+
+    missing = []
+    if not evidence_text:
+        missing.append("evidence")
+    if not tests_list:
+        missing.append("tests or checks")
+    if not files_list:
+        missing.append("files changed or touched artifacts")
+
+    status = "pass" if score >= 4 and not missing else "needs_more_work"
+    return {
+        "goal": goal,
+        "status": status,
+        "score": score,
+        "criteria": criteria_list,
+        "source_derivation": BMAD_SOURCE_DERIVATION,
+        "tests": tests_list,
+        "files_changed": files_list,
+        "evidence": evidence_text,
+        "missing": missing,
+        "next_steps": [
+            "Add the missing proof if any",
+            "Run the smallest useful validation again",
+            "Summarize what can be reviewed safely",
+        ],
+    }
+
+
+def summarize_state(state: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    source = state if state is not None else load_state()
+    return {
+        "version": source.get("version", STATE_VERSION),
+        "active": bool(source.get("active", False)),
+        "mode": source.get("mode", "idle"),
+        "current_goal": source.get("current_goal", ""),
+        "context": source.get("context", ""),
+        "intake": source.get("intake", {}),
+        "story": source.get("story", {}),
+        "run": source.get("run", {}),
+        "proof": source.get("proof", {}),
+        "history": source.get("history", []),
+        "updated_at": source.get("updated_at", ""),
+    }
+
+
+def format_bullets(items: Sequence[str], indent: str = "- ") -> str:
+    return "\n".join(f"{indent}{item}" for item in items)
+
+
+def format_intake(plan: Dict[str, Any]) -> str:
+    lines = [f"BMad intake: {plan.get('title', 'initiative')}"]
+    if plan.get("goal"):
+        lines.append(f"Goal: {plan['goal']}")
+    if plan.get("context"):
+        lines.append(f"Context: {plan['context']}")
+    if plan.get("scope"):
+        lines.append(f"Scope: {plan['scope']}")
+    lines.append("")
+    lines.append("Deliverables:")
+    lines.append(format_bullets(plan.get("deliverables", []), indent="  - "))
+    lines.append("")
+    lines.append("Assumptions:")
+    lines.append(format_bullets(plan.get("assumptions", []), indent="  - "))
+    lines.append("")
+    lines.append("Risks:")
+    lines.append(format_bullets(plan.get("risks", []), indent="  - "))
+    lines.append("")
+    lines.append("Next action: " + str(plan.get("next_action", "")))
+    return "\n".join(lines).strip()
+
+
+def format_story(story: Dict[str, Any]) -> str:
+    lines = [f"Story: {story.get('title', 'initiative')}"]
+    if story.get("user_story"):
+        lines.append(story["user_story"])
+    lines.extend(["", "Acceptance criteria:"])
+    lines.append(format_bullets(story.get("acceptance_criteria", []), indent="  - "))
+    lines.extend(["", "Out of scope:"])
+    lines.append(format_bullets(story.get("out_of_scope", []), indent="  - "))
+    lines.extend(["", "Implementation notes:"])
+    lines.append(format_bullets(story.get("implementation_notes", []), indent="  - "))
+    lines.extend(["", "Proof requirements:"])
+    lines.append(format_bullets(story.get("proof_requirements", []), indent="  - "))
+    return "\n".join(lines).strip()
+
+
+def format_run_plan(run: Dict[str, Any]) -> str:
+    lines = [f"Symphony run plan for: {run.get('goal', '') or 'current initiative'}"]
+    if run.get("context"):
+        lines.append(f"Context: {run['context']}")
+    lines.extend(["", f"Parallelism: {run.get('parallelism', 1)}", "", "Worker tasks:"])
+    for idx, task in enumerate(run.get("tasks", []), start=1):
+        lines.append(f"  {idx}. {task.get('goal', '')}")
+        toolsets = task.get("toolsets") or []
+        if toolsets:
+            lines.append(f"     toolsets: {', '.join(toolsets)}")
+        task_context = task.get("context", "")
+        if task_context:
+            lines.append(f"     context: {task_context}")
+    lines.extend(["", "Proof gate:"])
+    lines.append(format_bullets(run.get("proof_gate", []), indent="  - "))
+    return "\n".join(lines).strip()
+
+
+def format_proof(proof: Dict[str, Any]) -> str:
+    lines = [f"Proof gate: {proof.get('status', 'unknown')}"]
+    lines.append(f"Score: {proof.get('score', 0)}")
+    if proof.get("goal"):
+        lines.append(f"Goal: {proof['goal']}")
+    lines.extend(["", "Criteria:"])
+    lines.append(format_bullets(proof.get("criteria", []), indent="  - "))
+    lines.extend(["", "Tests:"])
+    lines.append(format_bullets(proof.get("tests", []), indent="  - "))
+    lines.extend(["", "Files changed:"])
+    lines.append(format_bullets(proof.get("files_changed", []), indent="  - "))
+    if proof.get("missing"):
+        lines.extend(["", "Missing:"])
+        lines.append(format_bullets(proof.get("missing", []), indent="  - "))
+    if proof.get("evidence"):
+        lines.extend(["", "Evidence:", proof["evidence"]])
+    return "\n".join(lines).strip()
+
+
+def format_state(state: Optional[Dict[str, Any]] = None) -> str:
+    snapshot = summarize_state(state)
+    lines = ["BMad/Symphony state"]
+    lines.append(f"Mode: {snapshot['mode']}  Active: {snapshot['active']}")
+    if snapshot.get("current_goal"):
+        lines.append(f"Current goal: {snapshot['current_goal']}")
+    if snapshot.get("context"):
+        lines.append(f"Context: {snapshot['context']}")
+    if snapshot.get("intake"):
+        lines.extend(["", format_intake(snapshot["intake"])])
+    if snapshot.get("story"):
+        lines.extend(["", format_story(snapshot["story"])])
+    if snapshot.get("run"):
+        lines.extend(["", format_run_plan(snapshot["run"])])
+    if snapshot.get("proof"):
+        lines.extend(["", format_proof(snapshot["proof"])])
+    if snapshot.get("history"):
+        lines.extend(["", "Recent history:"])
+        for entry in snapshot["history"][-5:]:
+            lines.append(f"  - {entry.get('ts', '')} {entry.get('event', '')}: {entry.get('summary', '')}")
+    return "\n".join(lines).strip()
+
+
+def key_phrase(text: str) -> str:
+    return " ".join((text or "").lower().split())
+
+
+def wants_injection(*, messages: Any = None, conversation_history: Any = None, user_message: Any = None) -> bool:
+    haystacks: List[str] = []
+
+    def add(obj: Any) -> None:
+        if obj is None:
+            return
+        if isinstance(obj, str):
+            haystacks.append(obj)
+            return
+        if isinstance(obj, dict):
+            for key in ("content", "text", "message"):
+                value = obj.get(key)
+                if isinstance(value, str) and value:
+                    haystacks.append(value)
+            return
+        if isinstance(obj, Iterable):
+            for item in obj:
+                add(item)
+
+    add(user_message)
+    add(messages)
+    add(conversation_history)
+    combined = key_phrase("\n".join(haystacks))
+    if not combined:
+        return False
+    return any(token in combined for token in ("bmad", "symphony", "proof gate", "proof-of-work", "proof of work", "launch plan", "implementation run"))
+
+
+def build_injection(state: Optional[Dict[str, Any]] = None) -> str:
+    snapshot = summarize_state(state)
+    lines = [
+        "BMad/Symphony mode:",
+        "1. Intake before build.",
+        "2. Create a story with acceptance criteria.",
+        "3. Spawn isolated Symphony workers for implementation and verification.",
+        "4. Require proof-of-work before handoff.",
+    ]
+    if snapshot.get("current_goal"):
+        lines.append(f"Current goal: {snapshot['current_goal']}")
+    if snapshot.get("intake"):
+        lines.append(f"Intake: {snapshot['intake'].get('title', '')}")
+    if snapshot.get("proof") and snapshot["proof"].get("missing"):
+        lines.append("Outstanding proof: " + ", ".join(snapshot["proof"]["missing"]))
+    return "\n".join(lines)

--- a/plugins/bmad_symphony/plugin.yaml
+++ b/plugins/bmad_symphony/plugin.yaml
@@ -1,0 +1,18 @@
+name: bmad-symphony
+version: 1.1.0
+description: "Source-grounded BMAD workflow plugin: derive BMAD guidance from the extracted docs model, with optional Hermes/Symphony delegation kept separate."
+author: NousResearch
+kind: standalone
+platforms:
+  - linux
+  - macos
+provides_tools:
+  - bmad_intake
+  - bmad_story
+  - symphony_run
+  - bmad_proof
+  - bmad_status
+  - bmad_reset
+provides_hooks:
+  - pre_llm_call
+  - on_session_end

--- a/plugins/bmad_symphony/skill/SKILL.md
+++ b/plugins/bmad_symphony/skill/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: bmad-symphony-workflow
+description: Source-grounded BMAD workflow helper for Hermes. Use extracted BMAD docs to choose the next BMAD phase/workflow, then optionally use Hermes delegation as an execution wrapper.
+version: 1.1.0
+author: NousResearch
+license: MIT
+platforms:
+  - linux
+  - macos
+metadata:
+  hermes:
+    category: autonomous-ai-agents
+    tags:
+      - bmad
+      - source-grounded
+      - planning
+      - implementation
+    related_skills:
+      - hermes-agent:skills
+      - autonomous-ai-agents:plan
+---
+
+# BMAD workflow for Hermes
+
+This skill is the playbook for the Hermes BMAD plugin.
+
+## Grounding rule
+
+All BMAD-specific information must be derived from the extracted BMAD source model:
+
+- Source: `https://docs.bmad-method.org/llms-full.txt`
+- Local extract: `plugins/bmad_symphony/source/bmad_llms_extract.md`
+
+Do not invent BMAD phases, artifacts, commands, quality gates, or agent roles. If a fact is not in the extracted source model or explicitly provided by the user, label it as an assumption or omit it.
+
+Hermes/Symphony delegation is a Hermes execution wrapper. It is not a BMAD source concept and must be described separately from BMAD guidance.
+
+## Source-derived BMAD model
+
+BMAD organizes development into four phases:
+
+1. Analysis — optional brainstorming, research, product brief, or PRFAQ.
+2. Planning — required requirements via PRD or spec.
+3. Solutioning — architecture and technical work breakdown.
+4. Implementation — build epic by epic, story by story.
+
+Planning tracks:
+
+- Quick Flow — bug fixes, simple features, clear scope; tech-spec only.
+- BMad Method — products, platforms, complex features; PRD + Architecture + UX.
+- Enterprise — compliance or multi-tenant systems; PRD + Architecture + Security + DevOps.
+
+Track story counts are guidance, not definitions. Choose based on planning needs.
+
+## Required default behavior
+
+1. Start with `bmad-help` whenever the next workflow is uncertain.
+2. Use a fresh chat for each BMAD workflow.
+3. If BMAD is not installed, install from the project directory with `npx bmad-method install` and select the BMad Method module.
+4. Use `_bmad/` for agents/workflows/tasks/configuration and `_bmad-output/` for generated artifacts.
+5. Optionally capture technical preferences and rules in `_bmad-output/project-context.md` or generate it after architecture with `bmad-generate-project-context`.
+
+## Phase workflows
+
+### Analysis, optional
+
+- `bmad-brainstorming` — guided ideation.
+- `bmad-market-research`, `bmad-domain-research`, `bmad-technical-research` — research.
+- `bmad-product-brief` — foundation document when the concept is clear.
+- `bmad-prfaq` — Working Backwards stress test.
+
+### Planning, required
+
+For BMad Method and Enterprise:
+
+- Run `bmad-prd` in a fresh chat.
+- Outputs: `prd.md`, `addendum.md`, `decision-log.md`.
+- Intents: Create, Update, Validate.
+
+For Quick Flow:
+
+- Run `bmad-quick-dev`; it handles planning and implementation in a single workflow.
+
+For UI projects:
+
+- Optionally invoke `bmad-agent-ux-designer` and run `bmad-ux` after creating the PRD.
+
+### Solutioning
+
+Create architecture:
+
+1. Invoke `bmad-agent-architect` in a fresh chat.
+2. Run `bmad-create-architecture`.
+3. Produce the architecture document with technical decisions.
+
+Create epics and stories:
+
+1. Invoke `bmad-agent-pm` in a fresh chat.
+2. Run `bmad-create-epics-and-stories`.
+3. Use both PRD and Architecture to create technically-informed stories.
+
+Implementation readiness check, highly recommended:
+
+1. Invoke `bmad-agent-architect` in a fresh chat.
+2. Run `bmad-check-implementation-readiness`.
+3. Validate cohesion across planning documents.
+
+### Implementation
+
+Initialize sprint planning:
+
+- Invoke `bmad-agent-dev` and run `bmad-sprint-planning`.
+- Output: `sprint-status.yaml`.
+
+For each story, repeat with fresh chats:
+
+1. `bmad-create-story` — create story file from epic.
+2. `bmad-dev-story` — implement the story.
+3. `bmad-code-review` — quality validation, recommended.
+
+After completing all stories in an epic:
+
+- Invoke `bmad-agent-dev` and run `bmad-retrospective`.
+
+## Hermes plugin tools
+
+- `bmad_intake` — create a source-grounded BMAD track/phase/workflow recommendation.
+- `bmad_story` — shape the next BMAD handoff/story while preserving the source-derivation rule.
+- `symphony_run` — prepare optional Hermes delegation tasks; always separate wrapper behavior from BMAD claims.
+- `bmad_proof` — check that the handoff/implementation is grounded in extracted BMAD source facts and user-provided context.
+- `bmad_status` — inspect saved workflow state.
+- `bmad_reset` — clear saved workflow state.
+
+## Pitfalls
+
+- Do not present Symphony/delegation as part of BMAD.
+- Do not add generic agile or AI-agent guidance unless it is present in the extracted source or provided by the user.
+- Do not choose a BMAD track purely by story-count guidance.
+- Do not skip fresh chats between BMAD workflows.

--- a/plugins/bmad_symphony/source/bmad_llms_extract.md
+++ b/plugins/bmad_symphony/source/bmad_llms_extract.md
@@ -1,0 +1,122 @@
+# BMAD source extract
+
+Source: https://docs.bmad-method.org/llms-full.txt
+Fetched: 2026-05-23
+
+This file is the grounding reference for the Hermes BMAD plugin. BMAD-specific terminology and workflow guidance must be derived from this extract or from user-provided context. Do not add new BMAD claims from general knowledge.
+
+## Core workflow model
+
+BMAD organizes development into four phases:
+
+1. Analysis — brainstorming, research, product brief, PRFAQ; optional.
+2. Planning — requirements via PRD or spec; required.
+3. Solutioning — architecture and technical work breakdown.
+4. Implementation — build epic by epic, story by story.
+
+## Planning tracks
+
+- Quick Flow — bug fixes, simple features, clear scope, about 1–15 stories; creates a tech spec only.
+- BMad Method — products, platforms, complex features, about 10–50+ stories; creates PRD + Architecture + UX.
+- Enterprise — compliance, multi-tenant systems, about 30+ stories; creates PRD + Architecture + Security + DevOps.
+
+Story counts are guidance, not definitions. Choose the track based on planning needs.
+
+## Install and first step
+
+Install from a project directory:
+
+```bash
+npx bmad-method install
+```
+
+Prerelease channel:
+
+```bash
+npx bmad-method@next install
+```
+
+When prompted, select the BMad Method module.
+
+The installer creates:
+
+- `_bmad/` — agents, workflows, tasks, and configuration.
+- `_bmad-output/` — generated artifacts.
+
+After install, run:
+
+```text
+bmad-help
+```
+
+BMad-Help detects completed artifacts and recommends the next workflow. Start with `bmad-help` whenever unsure.
+
+## Fresh-chat rule
+
+Use a fresh chat for each workflow to prevent context limitations and contamination.
+
+## Optional project context
+
+Project conventions can be captured in `_bmad-output/project-context.md`, created manually or generated after architecture with:
+
+```text
+bmad-generate-project-context
+```
+
+## Phase 1 — Analysis workflows
+
+- `bmad-brainstorming` — guided ideation.
+- `bmad-market-research` / `bmad-domain-research` / `bmad-technical-research` — market, domain, and technical research.
+- `bmad-product-brief` — foundation document when the concept is clear.
+- `bmad-prfaq` — Working Backwards challenge to stress-test and forge the product concept.
+
+## Phase 2 — Planning workflows
+
+For BMad Method and Enterprise tracks:
+
+- Run `bmad-prd` in a new chat.
+- Output: `prd.md`, `addendum.md`, `decision-log.md`.
+- Intents: Create, Update, Validate.
+
+For Quick Flow:
+
+- Run `bmad-quick-dev`; it handles planning and implementation in a single workflow.
+
+If the project has a UI, optionally invoke `bmad-agent-ux-designer` and run `bmad-ux` after creating the PRD.
+
+## Phase 3 — Solutioning workflows
+
+Create architecture:
+
+1. Invoke `bmad-agent-architect` in a new chat.
+2. Run `bmad-create-architecture`.
+3. Output: architecture document with technical decisions.
+
+Create epics and stories:
+
+1. Invoke `bmad-agent-pm` in a new chat.
+2. Run `bmad-create-epics-and-stories`.
+3. The workflow uses both PRD and Architecture to create technically-informed stories.
+
+Implementation readiness check is highly recommended:
+
+1. Invoke `bmad-agent-architect` in a new chat.
+2. Run `bmad-check-implementation-readiness`.
+3. Validates cohesion across planning documents.
+
+## Phase 4 — Implementation workflow
+
+Initialize sprint planning:
+
+- Invoke `bmad-agent-dev` and run `bmad-sprint-planning`.
+- Output: `sprint-status.yaml`.
+
+Build cycle for each story, with fresh chats:
+
+1. DEV / `bmad-create-story` — create story file from epic.
+2. DEV / `bmad-dev-story` — implement the story.
+3. DEV / `bmad-code-review` — quality validation; recommended.
+
+After completing all stories in an epic:
+
+- Invoke `bmad-agent-dev` and run `bmad-retrospective`.

--- a/plugins/bmad_symphony/tools.py
+++ b/plugins/bmad_symphony/tools.py
@@ -1,0 +1,229 @@
+"""Tool handlers for the BMad/Symphony plugin."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable, Dict, Optional
+
+from . import core
+
+
+def _json(data: Dict[str, Any]) -> str:
+    return json.dumps(data, indent=2, ensure_ascii=False)
+
+
+def _maybe_dispatch_delegate(
+    ctx: Any,
+    payload: Dict[str, Any],
+) -> Optional[Any]:
+    if ctx is None:
+        return None
+    dispatcher = getattr(ctx, "dispatch_tool", None)
+    if not callable(dispatcher):
+        return None
+    try:
+        return dispatcher("delegate_task", payload)
+    except Exception:
+        return None
+
+
+def build_tool_handlers(ctx: Any) -> Dict[str, Callable[..., str]]:
+    """Return closure-based tool handlers bound to an optional plugin context."""
+
+    def bmad_intake(*, goal: str, context: str = "", constraints: Any = None, repo_scope: str = "", audience: str = "agent", **_: Any) -> str:
+        plan = core.build_intake(
+            goal=goal,
+            context=context,
+            constraints=constraints,
+            repo_scope=repo_scope,
+            audience=audience,
+        )
+        state = core.update_state(
+            mode="plan",
+            goal=goal,
+            context=context,
+            intake=plan,
+            active=True,
+            event="bmad_intake",
+            summary=plan["next_action"],
+        )
+        return _json({"plan": plan, "state": core.summarize_state(state)})
+
+    def bmad_story(*, goal: str = "", context: str = "", acceptance: Any = None, out_of_scope: Any = None, implementation_notes: Any = None, **_: Any) -> str:
+        current = goal or core.current_goal()
+        story = core.build_story(
+            goal=current,
+            context=context,
+            acceptance=acceptance,
+            out_of_scope=out_of_scope,
+            implementation_notes=implementation_notes,
+        )
+        state = core.update_state(
+            mode="story",
+            goal=current,
+            context=context,
+            story=story,
+            active=True,
+            event="bmad_story",
+            summary="Story captured with acceptance criteria",
+        )
+        return _json({"story": story, "state": core.summarize_state(state)})
+
+    def symphony_run(
+        *,
+        goal: str = "",
+        context: str = "",
+        work_items: Any = None,
+        parallelism: int = 3,
+        toolsets: Any = None,
+        auto_dispatch: bool = False,
+        **_: Any,
+    ) -> str:
+        current = goal or core.current_goal()
+        run = core.build_run_plan(
+            goal=current,
+            context=context,
+            work_items=work_items,
+            parallelism=parallelism,
+            toolsets=toolsets,
+            auto_dispatch=auto_dispatch,
+        )
+        state = core.update_state(
+            mode="run",
+            goal=current,
+            context=context,
+            run=run,
+            active=True,
+            event="symphony_run",
+            summary=f"Prepared {len(run['tasks'])} Symphony worker task(s)",
+        )
+        dispatched = None
+        if auto_dispatch:
+            dispatched = _maybe_dispatch_delegate(ctx, run["recommended_delegate_payload"])
+        result = {"run": run, "state": core.summarize_state(state)}
+        if dispatched is not None:
+            result["delegate_result"] = dispatched
+        return _json(result)
+
+    def bmad_proof(
+        *,
+        goal: str = "",
+        evidence: Any = None,
+        criteria: Any = None,
+        tests: Any = None,
+        files_changed: Any = None,
+        notes: str = "",
+        **_: Any,
+    ) -> str:
+        current = goal or core.current_goal()
+        proof = core.evaluate_proof(
+            goal=current,
+            evidence=evidence,
+            criteria=criteria,
+            tests=tests,
+            files_changed=files_changed,
+            notes=notes,
+        )
+        state = core.update_state(
+            mode="proof",
+            goal=current,
+            proof=proof,
+            active=proof["status"] != "pass",
+            event="bmad_proof",
+            summary=f"Proof gate evaluated: {proof['status']}",
+        )
+        return _json({"proof": proof, "state": core.summarize_state(state)})
+
+    def bmad_status(**_: Any) -> str:
+        return _json(core.summarize_state())
+
+    def bmad_reset(**_: Any) -> str:
+        state = core.clear_state()
+        return _json({"status": "reset", "state": core.summarize_state(state)})
+
+    return {
+        "bmad_intake": bmad_intake,
+        "bmad_story": bmad_story,
+        "symphony_run": symphony_run,
+        "bmad_proof": bmad_proof,
+        "bmad_status": bmad_status,
+        "bmad_reset": bmad_reset,
+    }
+
+
+def register_toolset(ctx: Any) -> None:
+    handlers = build_tool_handlers(ctx)
+    schemas: Dict[str, Dict[str, Any]] = {
+        "bmad_intake": {
+            "type": "object",
+            "properties": {
+                "goal": {"type": "string", "description": "The requested outcome or project goal."},
+                "context": {"type": "string", "description": "Constraints, repo context, or background."},
+                "constraints": {"type": ["array", "string"], "description": "Optional constraints or priorities."},
+                "repo_scope": {"type": "string", "description": "Optional repository / module scope."},
+                "audience": {"type": "string", "description": "Who the plan is for (agent, reviewer, user)."},
+            },
+            "required": ["goal"],
+        },
+        "bmad_story": {
+            "type": "object",
+            "properties": {
+                "goal": {"type": "string"},
+                "context": {"type": "string"},
+                "acceptance": {"type": ["array", "string"]},
+                "out_of_scope": {"type": ["array", "string"]},
+                "implementation_notes": {"type": ["array", "string"]},
+            },
+            "required": [],
+        },
+        "symphony_run": {
+            "type": "object",
+            "properties": {
+                "goal": {"type": "string"},
+                "context": {"type": "string"},
+                "work_items": {"type": ["array", "string"]},
+                "parallelism": {"type": "integer", "minimum": 1},
+                "toolsets": {"type": ["array", "string"]},
+                "auto_dispatch": {"type": "boolean"},
+            },
+            "required": [],
+        },
+        "bmad_proof": {
+            "type": "object",
+            "properties": {
+                "goal": {"type": "string"},
+                "evidence": {"type": ["array", "string"]},
+                "criteria": {"type": ["array", "string"]},
+                "tests": {"type": ["array", "string"]},
+                "files_changed": {"type": ["array", "string"]},
+                "notes": {"type": "string"},
+            },
+            "required": [],
+        },
+        "bmad_status": {"type": "object", "properties": {}, "required": []},
+        "bmad_reset": {"type": "object", "properties": {}, "required": []},
+    }
+
+    for name, handler in handlers.items():
+        ctx.register_tool(
+            name=name,
+            toolset="bmad_symphony",
+            schema=schemas[name],
+            handler=lambda args, _handler=handler, **kwargs: _handler(**(args or {})),
+            description={
+                "bmad_intake": "Create a source-grounded BMAD track/phase/workflow intake.",
+                "bmad_story": "Turn the intake into a source-grounded BMAD handoff or story.",
+                "symphony_run": "Build or dispatch optional Hermes delegation while separating wrapper behavior from BMAD claims.",
+                "bmad_proof": "Evaluate whether BMAD guidance is derived from the extracted source model and user context.",
+                "bmad_status": "Summarize the current BMAD/Hermes-wrapper state.",
+                "bmad_reset": "Clear the active workflow state.",
+            }[name],
+            emoji={
+                "bmad_intake": "🧭",
+                "bmad_story": "📘",
+                "symphony_run": "🎼",
+                "bmad_proof": "✅",
+                "bmad_status": "📊",
+                "bmad_reset": "🧹",
+            }[name],
+        )

--- a/tests/plugins/test_bmad_symphony.py
+++ b/tests/plugins/test_bmad_symphony.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from plugins.bmad_symphony import cli as workflow_cli
+from plugins.bmad_symphony import core
+from plugins.bmad_symphony import register
+
+
+class DummyCtx:
+    def __init__(self) -> None:
+        self.tools = []
+        self.hooks = []
+        self.cli_commands = []
+        self.commands = []
+        self.skills = []
+        self.dispatched = []
+
+    def register_tool(self, **kwargs):
+        self.tools.append(kwargs)
+
+    def register_hook(self, name, handler):
+        self.hooks.append((name, handler))
+
+    def register_cli_command(self, **kwargs):
+        self.cli_commands.append(kwargs)
+
+    def register_command(self, name, handler, **kwargs):
+        self.commands.append((name, handler, kwargs))
+
+    def register_skill(self, **kwargs):
+        self.skills.append(kwargs)
+
+    def dispatch_tool(self, name, payload):
+        self.dispatched.append((name, payload))
+        return {"tool": name, "payload": payload}
+
+
+@pytest.fixture()
+def temp_home(tmp_path, monkeypatch):
+    monkeypatch.setattr(core, "get_hermes_home", lambda: tmp_path)
+    return tmp_path
+
+
+def test_register_exposes_deep_surfaces(temp_home):
+    ctx = DummyCtx()
+    register(ctx)
+
+    tool_names = {tool["name"] for tool in ctx.tools}
+    assert tool_names == {
+        "bmad_intake",
+        "bmad_story",
+        "symphony_run",
+        "bmad_proof",
+        "bmad_status",
+        "bmad_reset",
+    }
+
+    assert [name for name, _ in ctx.hooks] == ["pre_llm_call", "on_session_end"]
+    assert {cmd["name"] for cmd in ctx.cli_commands} == {"bmad-symphony"}
+    assert {name for name, _, _ in ctx.commands} == {"bmad-symphony", "bmad"}
+    assert len(ctx.skills) == 1
+    assert ctx.skills[0]["path"].name == "SKILL.md"
+
+
+def test_plugin_manager_discovers_enabled_bmad_symphony(temp_home, monkeypatch):
+    from hermes_cli import plugins as plugin_module
+
+    monkeypatch.setattr(plugin_module, "_get_enabled_plugins", lambda: {"bmad-symphony"})
+    manager = plugin_module.PluginManager()
+    manager.discover_and_load(force=True)
+
+    record = [item for item in manager.list_plugins() if item["name"] == "bmad-symphony"][0]
+    assert record["enabled"] is True
+    assert record["tools"] == 6
+    assert record["hooks"] == 2
+    assert record["commands"] == 2
+    assert "bmad-symphony:workflow" in manager._plugin_skills
+
+    from tools.registry import registry
+    payload = registry.dispatch("bmad_intake", {"goal": "ship bmad plugin", "context": "test"})
+    assert "ship bmad plugin" in payload
+    assert "state" in payload
+
+
+def test_plan_story_run_and_proof_flow_persists_state(temp_home):
+    intake = core.build_intake(goal="ship a dashboard export", context="keep it small", constraints=["no new deps"])
+    assert "dashboard export" in intake["goal"]
+    state = core.update_state(mode="plan", goal=intake["goal"], intake=intake, active=True)
+    assert core.state_file().exists()
+    assert core.load_state()["current_goal"] == "ship a dashboard export"
+
+    story = core.build_story(goal=intake["goal"], acceptance=["Export is generated", "Tests pass"])
+    assert "acceptance_criteria" in story
+
+    run = core.build_run_plan(goal=intake["goal"], parallelism=2)
+    assert len(run["tasks"]) == 2
+    assert run["recommended_delegate_payload"]["toolsets"]
+
+    proof = core.evaluate_proof(
+        goal=intake["goal"],
+        evidence=["tests passed", "diff reviewed"],
+        tests=["pytest"],
+        files_changed=["src/export.py"],
+    )
+    assert proof["status"] == "pass"
+
+    state = core.update_state(mode="proof", goal=intake["goal"], proof=proof, active=False)
+    snapshot = core.summarize_state(state)
+    assert snapshot["proof"]["status"] == "pass"
+
+
+def test_pre_llm_injection_only_when_relevant(temp_home):
+    register_ctx = DummyCtx()
+    register(register_ctx)
+    hook = dict(register_ctx.hooks)["pre_llm_call"]
+    assert hook(user_message={"content": "hello"}) is None
+    injected = hook(user_message={"content": "We should use BMad for this"})
+    assert injected and "BMad/Symphony mode" in injected
+
+
+def test_cli_and_slash_handlers_can_dispatch(temp_home):
+    ctx = DummyCtx()
+    register(ctx)
+
+    cli_handler = ctx.cli_commands[0]["handler_fn"]
+    args = workflow_cli.build_parser().parse_args(["plan", "--goal", "fix the export pipeline"])
+    assert cli_handler(args) == 0
+
+    slash_handler = {name: handler for name, handler, _ in ctx.commands}["bmad"]
+    text = slash_handler('plan --goal "fix the export pipeline"')
+    assert "BMad intake" in text
+    assert "Current goal" in text
+    assert not ctx.dispatched
+
+
+def test_auto_dispatch_uses_delegate_tool(temp_home):
+    ctx = DummyCtx()
+    register(ctx)
+    tool_handler = {tool["name"]: tool["handler"] for tool in ctx.tools}["symphony_run"]
+    out = tool_handler({"goal": "fix the export pipeline", "auto_dispatch": True, "parallelism": 2})
+    assert "delegate_result" in out
+    assert ctx.dispatched[0][0] == "delegate_task"

--- a/website/docs/user-guide/features/built-in-plugins.md
+++ b/website/docs/user-guide/features/built-in-plugins.md
@@ -56,6 +56,7 @@ The repo ships these bundled plugins under `plugins/`. All are opt-in — enable
 | Plugin | Kind | Purpose |
 |---|---|---|
 | `disk-cleanup` | hooks + slash command | Auto-track ephemeral files and clean them on session end |
+| `bmad-symphony` | hooks + tools + CLI + slash command | BMad intake, Symphony worker fan-out, and proof-of-work gates |
 | `observability/langfuse` | hooks | Trace turns / LLM calls / tools to [Langfuse](https://langfuse.com) |
 | `spotify` | backend (7 tools) | Native Spotify playback, queue, search, playlists, albums, library |
 | `google_meet` | standalone | Join Meet calls, live-caption transcription, optional realtime duplex audio |
@@ -114,6 +115,34 @@ Auto-tracks and removes ephemeral files created during sessions — test scripts
 **Enabling:** `hermes plugins enable disk-cleanup` (or check the box in `hermes plugins`).
 
 **Disabling again:** `hermes plugins disable disk-cleanup`.
+
+### bmad-symphony
+
+Deep planning + implementation workflow for agentic work.
+
+**What it adds:**
+
+- `bmad_intake` — capture the goal, scope, assumptions, risks, and recommended next action
+- `bmad_story` — turn the intake into a reviewable story with acceptance criteria
+- `symphony_run` — generate or dispatch an isolated worker fan-out plan
+- `bmad_proof` — evaluate proof-of-work before merge or handoff
+- `bmad_status` / `bmad_reset` — inspect or reset the workflow state
+- `/bmad` and `/bmad-symphony` — in-session slash commands for the same workflow
+- `hermes bmad-symphony ...` — CLI entry point for humans and automation
+
+**Integration:**
+
+| Surface | Behaviour |
+|---|---|
+| `pre_llm_call` | Injects a compact reminder when the turn is clearly about BMad / Symphony work, or when an active workflow state exists. |
+| `on_session_end` | Records a terminal event in the plugin state log so the workflow history survives across turns. |
+| `register_skill` | Exposes a plugin-local skill (`bmad-symphony:workflow`) so the agent can load the playbook on demand. |
+
+**State** — saved at `$HERMES_HOME/plugins/bmad-symphony/state.json` so the plugin can remember the active goal, story, run, proof gate, and recent history.
+
+**Enabling:** `hermes plugins enable bmad-symphony`.
+
+**Disabling again:** `hermes plugins disable bmad-symphony`.
 
 ### observability/langfuse
 


### PR DESCRIPTION
## Summary
- Add bundled bmad-symphony plugin with BMAD intake, story, run, proof, status, and reset workflows
- Register tools, hooks, CLI command, slash commands, and plugin-local workflow skill
- Document the plugin in bundled plugin docs and add focused plugin tests

## Test Plan
- python -m pytest tests/plugins/test_bmad_symphony.py tests/hermes_cli/test_plugin_cli_registration.py tests/test_plugin_skills.py -q -o 'addopts='