### PR TITLE
fix(cli): scope USER_OWNED_EXCLUDE to root in profile distribution copy

### DIFF
--- a/hermes_cli/profile_distribution.py
+++ b/hermes_cli/profile_distribution.py
@@ -573,11 +573,13 @@ def _copy_dist_payload(
         if entry.is_dir():
             if dest.exists():
                 shutil.rmtree(dest)
-            shutil.copytree(
-                entry,
-                dest,
-                ignore=lambda d, names: [n for n in names if n in USER_OWNED_EXCLUDE],
-            )
+            # ``USER_OWNED_EXCLUDE`` is root-scoped: the loop above already
+            # filters protected root entries. Filtering by basename at every
+            # descendant depth (the prior ``ignore=`` lambda) silently dropped
+            # distribution-owned nested paths that happened to share a name
+            # with a root-level protected entry, e.g.
+            # ``skills/<category>/hermes-agent/SKILL.md``.
+            shutil.copytree(entry, dest)
         else:
             shutil.copy2(entry, dest)
 

--- a/tests/hermes_cli/test_profile_distribution.py
+++ b/tests/hermes_cli/test_profile_distribution.py
@@ -604,3 +604,76 @@ class TestErrorSurfaces:
         staged = _make_staging_dir(profile_env, "bad", manifest=mf)
         with pytest.raises((ValueError, DistributionError)):
             plan_install(str(staged), tmp_path / "work")
+
+
+# ===========================================================================
+# USER_OWNED_EXCLUDE is root-scoped, not basename-at-all-depths
+# ===========================================================================
+
+
+class TestUserOwnedExcludeRootScope:
+    """Regression tests for https://github.com/NousResearch/hermes-agent/issues/31033.
+
+    ``USER_OWNED_EXCLUDE`` protects user-owned root entries on update; it must
+    not silently drop distribution-owned nested paths that happen to share a
+    basename with a root-level protected entry.
+    """
+
+    def test_nested_distribution_path_with_protected_basename_preserved(
+        self, profile_env
+    ):
+        """A distribution-owned ``skills/<category>/hermes-agent/SKILL.md`` must
+        land in the target profile even though ``hermes-agent`` is a root-level
+        protected basename.
+        """
+        staged = _make_staging_dir(profile_env, "src")
+        nested = staged / "skills" / "autonomous-ai-agents" / "hermes-agent"
+        nested.mkdir(parents=True, exist_ok=True)
+        (nested / "SKILL.md").write_text(
+            "---\nname: hermes-agent\ndescription: nested\n---\n# Nested\n"
+        )
+
+        plan = install_distribution(str(staged), name="nested-dist")
+
+        copied = (
+            plan.target_dir
+            / "skills"
+            / "autonomous-ai-agents"
+            / "hermes-agent"
+            / "SKILL.md"
+        )
+        assert copied.exists(), (
+            "Distribution-owned nested skill directory was dropped — "
+            "USER_OWNED_EXCLUDE is matching by basename at descendant depths "
+            "instead of root-scoped."
+        )
+        assert "Nested" in copied.read_text()
+
+    def test_root_protected_basename_still_excluded(self, profile_env):
+        """The fix must not weaken the root-scoped protection: a root-level
+        ``hermes-agent/`` directory in the staging payload must still be
+        skipped, even if it ships alongside a nested same-basename path.
+        """
+        staged = _make_staging_dir(profile_env, "src")
+        # Root-level user-owned marker (should NOT be copied)
+        (staged / "hermes-agent").mkdir(exist_ok=True)
+        (staged / "hermes-agent" / "marker.txt").write_text("root leaked")
+        # Nested distribution-owned same-basename path (should be copied)
+        nested = staged / "skills" / "autonomous-ai-agents" / "hermes-agent"
+        nested.mkdir(parents=True, exist_ok=True)
+        (nested / "SKILL.md").write_text(
+            "---\nname: hermes-agent\ndescription: nested\n---\n# Nested\n"
+        )
+
+        plan = install_distribution(str(staged), name="root-protected")
+
+        assert not (plan.target_dir / "hermes-agent").exists(), (
+            "Root-level hermes-agent/ leaked into the target profile."
+        )
+        assert (
+            plan.target_dir
+            / "skills"
+            / "autonomous-ai-agents"
+            / "hermes-agent"
+            / "SKILL.md"
+        ).exists(), "Nested distribution-owned hermes-agent/ was dropped."


### PR DESCRIPTION
## What does this PR do?

`hermes_cli/profile_distribution.py::_copy_dist_payload` filtered protected
basenames at every recursive depth via
`shutil.copytree(..., ignore=lambda d, names: [n for n in names if n in USER_OWNED_EXCLUDE])`.
The outer `for entry in staged.iterdir()` already drops root-level
user-owned entries (lines 545-549), so the inner lambda was redundant for
the protection use case but actively wrong for distribution-owned nested
paths that share a basename with a root-level protected entry — for
example `skills/<category>/hermes-agent/SKILL.md`. The nested skill
silently disappeared during `hermes profile install --force` /
`hermes profile update`.

Drop the per-depth `ignore=` argument. Root-scoped exclusion stays intact
via the existing outer-loop check at the top of `_copy_dist_payload`. The
sibling export path (`hermes_cli/profiles.py::_default_export_ignore`)
already implements the correct "root-only vs all-depth" split, so this
aligns the install/update path with the same intent.

## Related Issue

Fixes #31033

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/profile_distribution.py` — drop the `ignore=` lambda from the
  recursive `shutil.copytree` call inside `_copy_dist_payload`; comment
  documents the root-scoped intent.
- `tests/hermes_cli/test_profile_distribution.py` — add
  `TestUserOwnedExcludeRootScope` with two regression cases:
  - `test_nested_distribution_path_with_protected_basename_preserved` —
    proves `skills/<category>/hermes-agent/SKILL.md` lands in the target
    profile.
  - `test_root_protected_basename_still_excluded` — proves a root-level
    `hermes-agent/` in the staging payload is still skipped, so the fix
    does not weaken the root-scoped protection.

## How to Test

1. Build a staging payload that contains both
   `skills/autonomous-ai-agents/hermes-agent/SKILL.md` and a root-level
   `hermes-agent/` directory.
2. `uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout python3 -m pytest tests/hermes_cli/test_profile_distribution.py -v`
3. Expected: all 65 tests pass. Reverting the source change makes the two
   new tests fail with `Nested distribution-owned hermes-agent/ was dropped.`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior matches the docstring's stated intent
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure `pathlib`/`shutil` change, platform-neutral
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

- @alt-glitch confirmed on the issue that this is a distinct variant from
  @zccyman's open PR #25150 (additive-merge fix for destructive
  `rmtree`+`copytree` deletion of local skills). The two fixes are
  orthogonal: #25150 swaps the destructive copy for an additive walk but
  keeps the same `ignore=lambda d, names: ...` pattern, so the nested
  basename bug would survive that PR untouched. Whichever lands first,
  the other should rebase trivially — only the same `ignore=` argument
  needs to be removed from the new helper.
- Distinct from #25297 (closed; cron-exclusion concern).

> Audited siblings: `hermes_cli/profiles.py::_default_export_ignore`
> already implements the correct "root-only" split with an explicit
> `if Path(directory) == root_dir:` check. No widening needed in this
> PR; the export path is already correct and the install/update path
> now matches its intent.