### PR TITLE
fix: restore worker gh auth bridge

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -109,6 +109,58 @@ _IS_WINDOWS = sys.platform == "win32"
 DEFAULT_CLAIM_TTL_SECONDS = 15 * 60
 
 
+def _maybe_inject_gh_config_dir(env: dict[str, str]) -> None:
+    """Bridge GitHub CLI auth into worker sessions without widening XDG scope.
+
+    Kanban workers intentionally redirect subprocess ``HOME`` into
+    ``{HERMES_HOME}/home`` for profile isolation. That keeps git/ssh/npm/gh
+    configs from bleeding between profiles, but it also means ``gh`` no longer
+    sees the operator's existing login under ``~/.config/gh/hosts.yml``.
+
+    Instead of repointing all XDG lookups at the operator's real home, inject
+    only ``GH_CONFIG_DIR`` when the operator already has a real gh config on
+    disk and the worker env hasn't set an explicit override. This keeps the fix
+    bounded to GitHub auth / PR creation while leaving the rest of the profile
+    isolation intact.
+    """
+    if env.get("GH_CONFIG_DIR"):
+        return
+
+    xdg_config_home = (env.get("XDG_CONFIG_HOME") or "").strip()
+    if xdg_config_home:
+        gh_config_dir = Path(xdg_config_home) / "gh"
+        if gh_config_dir.is_dir():
+            env["GH_CONFIG_DIR"] = str(gh_config_dir)
+        return
+
+    real_home: Optional[str] = None
+    try:
+        import pwd
+
+        resolved = pwd.getpwuid(os.getuid()).pw_dir.strip()  # windows-footgun: ok — POSIX fallback inside try/except (pwd import fails on Windows)
+        if resolved:
+            real_home = resolved
+    except Exception:
+        pass
+
+    if not real_home and _IS_WINDOWS:
+        candidate = (env.get("USERPROFILE") or "").strip()
+        if candidate:
+            real_home = candidate
+        else:
+            drive = (env.get("HOMEDRIVE") or "").strip()
+            path = (env.get("HOMEPATH") or "").strip()
+            if drive and path:
+                real_home = f"{drive}{path}"
+
+    if not real_home:
+        return
+
+    gh_config_dir = Path(real_home) / ".config" / "gh"
+    if gh_config_dir.is_dir():
+        env["GH_CONFIG_DIR"] = str(gh_config_dir)
+
+
 def _resolve_claim_ttl_seconds(ttl_seconds: Optional[int] = None) -> int:
     """Return the effective claim TTL, honoring the kanban env override.
 
@@ -5311,6 +5363,7 @@ def _default_spawn(
         # This only happens in test fixtures where the isolated
         # HERMES_HOME never had profiles created.
         pass
+    _maybe_inject_gh_config_dir(env)
     if task.tenant:
         env["HERMES_TENANT"] = task.tenant
     env["HERMES_KANBAN_TASK"] = task.id

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1882,6 +1882,96 @@ class TestSharedBoardPaths:
         assert env["HERMES_KANBAN_TASK"] == "t_dispatch_env"
         assert env["HERMES_KANBAN_BRANCH"] == "wt/t_dispatch_env"
 
+    def test_dispatcher_spawn_injects_gh_config_dir_from_xdg_config_home(
+        self, tmp_path, monkeypatch
+    ):
+        default_home = tmp_path / ".hermes"
+        default_home.mkdir()
+        self._set_home(monkeypatch, tmp_path, default_home)
+        xdg_config_home = tmp_path / "xdg"
+        gh_config_dir = xdg_config_home / "gh"
+        gh_config_dir.mkdir(parents=True)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_config_home))
+        monkeypatch.delenv("GH_CONFIG_DIR", raising=False)
+
+        captured = {}
+
+        class _FakePopen:
+            def __init__(self, cmd, **kwargs):
+                captured["env"] = kwargs.get("env", {})
+                self.pid = 4242
+
+        monkeypatch.setattr("subprocess.Popen", _FakePopen)
+
+        task = kb.Task(
+            id="t_gh_xdg",
+            title="x",
+            body=None,
+            assignee="coder",
+            status="ready",
+            priority=0,
+            created_by=None,
+            created_at=0,
+            started_at=None,
+            completed_at=None,
+            workspace_kind="worktree",
+            workspace_path=str(tmp_path / "ws"),
+            claim_lock=None,
+            claim_expires=None,
+            tenant=None,
+            branch_name=None,
+        )
+        kb._default_spawn(task, str(tmp_path / "ws"))
+
+        assert captured["env"]["GH_CONFIG_DIR"] == str(gh_config_dir)
+
+    def test_dispatcher_spawn_injects_gh_config_dir_from_real_home_when_xdg_missing(
+        self, tmp_path, monkeypatch
+    ):
+        import pwd
+        from types import SimpleNamespace
+
+        default_home = tmp_path / ".hermes"
+        default_home.mkdir()
+        self._set_home(monkeypatch, tmp_path, default_home)
+        real_home = tmp_path / "real-home"
+        gh_config_dir = real_home / ".config" / "gh"
+        gh_config_dir.mkdir(parents=True)
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+        monkeypatch.delenv("GH_CONFIG_DIR", raising=False)
+        monkeypatch.setattr(pwd, "getpwuid", lambda _uid: SimpleNamespace(pw_dir=str(real_home)))
+
+        captured = {}
+
+        class _FakePopen:
+            def __init__(self, cmd, **kwargs):
+                captured["env"] = kwargs.get("env", {})
+                self.pid = 4242
+
+        monkeypatch.setattr("subprocess.Popen", _FakePopen)
+
+        task = kb.Task(
+            id="t_gh_pwd",
+            title="x",
+            body=None,
+            assignee="coder",
+            status="ready",
+            priority=0,
+            created_by=None,
+            created_at=0,
+            started_at=None,
+            completed_at=None,
+            workspace_kind="worktree",
+            workspace_path=str(tmp_path / "ws"),
+            claim_lock=None,
+            claim_expires=None,
+            tenant=None,
+            branch_name=None,
+        )
+        kb._default_spawn(task, str(tmp_path / "ws"))
+
+        assert captured["env"]["GH_CONFIG_DIR"] == str(gh_config_dir)
+
 
 # ---------------------------------------------------------------------------
 # latest_summary / latest_summaries — surface task_runs.summary handoffs


### PR DESCRIPTION
## Summary
- inject `GH_CONFIG_DIR` into kanban worker spawn env when a real GitHub CLI config exists
- keep profile-local `HOME` isolation intact instead of widening all XDG lookups back to the host
- add regression coverage for both `XDG_CONFIG_HOME` and real-home fallback resolution

## Root cause
Worker tool subprocesses intentionally run with `HOME={HERMES_HOME}/home` for profile isolation. In the failing worker session, both `XDG_CONFIG_HOME` and `GH_CONFIG_DIR` were absent, so `gh` looked under the isolated profile home and could not see the operator's real auth file at `/home/mordecai/.config/gh/hosts.yml`.

PM-side reproduction already showed that auth worked again when `gh` was run with the real config path. This patch makes the worker spawn bridge that path explicitly, but only for GitHub CLI.

## Verification
- `python -m pytest tests/hermes_cli/test_kanban_db.py -q -o addopts=''`
  - `161 passed in 8.36s`
- live worker-context auth check:
  - `HOME=/home/mordecai/.hermes/profiles/worker/home GH_CONFIG_DIR=/home/mordecai/.config/gh gh auth status`
  - authenticated successfully from the worker context while keeping isolated `HOME`

## Report
- `/home/mordecai/.hermes/control-center/reports/worker-github-pr-auth-regression-2026-05-23.md`
