### PR TITLE
Fix Telegram group command mention cleanup

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -4557,7 +4557,8 @@ class TelegramAdapter(BasePlatformAdapter):
         if not text or not self._bot or not getattr(self._bot, "username", None):
             return text
         username = re.escape(self._bot.username)
-        cleaned = re.sub(rf"(?i)@{username}\b[,:\-]*\s*", "", text).strip()
+        # In Telegram groups, keep the separator in /command@bot args.
+        cleaned = re.sub(rf"(?i)@{username}\b[,:\-]*\s*", " ", text).strip()
         return cleaned or text
 
     def _should_observe_unmentioned_group_message(self, message: Message) -> bool:

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -115,6 +115,13 @@ def _group_message(
     )
 
 
+def test_clean_bot_trigger_text_keeps_group_command_arg_separator():
+    adapter = _make_adapter(bot_username="ExampleHelper_bot")
+
+    assert adapter._clean_bot_trigger_text("/steer@ExampleHelper_bot hello") == "/steer hello"
+    assert adapter._clean_bot_trigger_text("/steer@OtherHelper_bot hello") == "/steer@OtherHelper_bot hello"
+
+
 def _dm_message(text="hello", *, from_user_id=111):
     return SimpleNamespace(
         message_id=43,


### PR DESCRIPTION
## Problem

Telegram group commands addressed to the current bot commonly use `/command@bot args`. The Telegram adapter stripped its own bot mention together with following whitespace, so the command and first argument were glued together before dispatch.

Example:

```text
/steer@ExampleHelper_bot hello -> /steerhello
```

That makes the gateway see `steerhello` instead of dispatching `/steer hello`.

## Fix

When cleaning this bot's Telegram trigger text, replace this bot's mention with one space instead of an empty string. This preserves the command/argument boundary while still removing only the current bot mention; mentions for other bots are left intact.

## Validation

- `python -m py_compile gateway/platforms/telegram.py tests/gateway/test_telegram_group_gating.py`
- `python -m pytest tests/gateway/test_telegram_group_gating.py -k 'clean_bot_trigger_text_keeps_group_command_arg_separator or observed_group_context_uses_shared_source' -q`