### PR TITLE
fix(auxiliary): treat Codex usage limits as quota exhaustion

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2294,6 +2294,7 @@ def _is_payment_error(exc: Exception) -> bool:
             "not available on the free tier",
             # Daily / monthly / weekly quota exhaustion keywords
             "quota exceeded", "quota_exceeded",
+            "usage_limit", "usage_limit_reached",
             "too many tokens per day", "daily limit",
             "tokens per day", "daily quota",
             "resource exhausted",  # Vertex AI / gRPC quota errors

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1291,6 +1291,16 @@ class TestIsPaymentError:
         exc.status_code = 429
         assert _is_payment_error(exc) is True
 
+    def test_429_usage_limit_reached_is_quota_exhaustion(self):
+        """Codex/ChatGPT usage-limit exhaustion should trigger provider fallback."""
+        exc = Exception(
+            "Error code: 429 - {'error': {'type': 'usage_limit_reached', "
+            "'message': 'The usage limit has been reached', "
+            "'plan_type': 'team', 'resets_in_seconds': 260790}}"
+        )
+        setattr(exc, "status_code", 429)
+        assert _is_payment_error(exc) is True
+
     def test_429_transient_rate_limit_not_quota(self):
         """Transient 429 rate limit without quota keywords is NOT a payment error."""
         exc = Exception("Rate limit exceeded. Retry after 10s.")


### PR DESCRIPTION
## Summary
- classify Codex/ChatGPT `usage_limit_reached` 429 responses as quota exhaustion in auxiliary-client payment/capacity detection
- ensures explicitly configured auxiliary tasks (e.g. vision using `openai-codex`) can use their configured `fallback_chain` instead of re-raising the 429
- adds a regression test for the Codex usage-limit error body

## Test Plan
- [x] `/Users/hermes/.hermes/hermes-agent/venv/bin/python -m pytest tests/agent/test_auxiliary_client.py::TestIsPaymentError -q -o addopts=''` → `14 passed`
- [!] `/Users/hermes/.hermes/hermes-agent/venv/bin/python -m pytest tests/agent/test_auxiliary_client.py -q -o addopts=''` currently hits a pre-existing timing-sensitive failure in `TestCodexAuxiliaryAdapterTimeout::test_enforces_total_timeout_while_stream_keeps_emitting_events`; this change only touches `_is_payment_error` keyword classification and its targeted tests pass.

## Notes
This fixes the case where Codex OAuth returns:

```text
HTTP 429: {'error': {'type': 'usage_limit_reached', 'message': 'The usage limit has been reached', ...}}
```

Before this patch `_is_rate_limit_error()` recognized it, but `_is_payment_error()` did not. Explicitly configured auxiliary providers only bypass the explicit-provider gate for capacity errors (`payment`/quota or connection), so configured fallback chains were skipped for this multi-day usage cap.