### PR TITLE
fix(credential_pool): per-model 429 rate limits to prevent 401-auth-pollution, with self-healing fallback cycle

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -822,7 +822,7 @@ def drop_thinking_only_and_merge_users(
 
 
 
-def restore_primary_runtime(agent) -> bool:
+def restore_primary_runtime(agent) -> Tuple[bool, float]:
     """Restore the primary runtime at the start of a new turn.
 
     In long-lived CLI sessions a single AIAgent instance spans multiple
@@ -832,6 +832,10 @@ def restore_primary_runtime(agent) -> bool:
 
     The gateway caches agents across messages (``_agent_cache`` in
     ``gateway/run.py``), so this restoration IS needed there too.
+
+    Returns (restored: bool, min_ttl: float).  *min_ttl* is the earliest
+    per-model rate-limit TTL across all pool entries for the primary model
+    (``time.monotonic()`` timestamp, or 0 when restored/not applicable).
     """
     if not agent._fallback_activated:
         # Reset the chain index even when no fallback was activated this
@@ -842,10 +846,32 @@ def restore_primary_runtime(agent) -> bool:
         # entirely, stranding the index and silently blocking all future
         # fallback attempts for the session.  Fixes #20465.
         agent._fallback_index = 0
-        return False
+        # Even with no active fallback, check per-model pool TTL so
+        # callers receive a useful min_ttl for sleep anchoring instead
+        # of 0 (which would cause tight-looping on the first turn when
+        # pool entries carry stale per-model rate limits from a previous
+        # session).
+        pool = getattr(agent, "_credential_pool", None)
+        if pool is not None:
+            model = agent.model or ""
+            pool_min_ttl = pool.rate_limit_min_ttl(model)
+            if pool_min_ttl is not None:
+                return False, pool_min_ttl
+        return False, 0
 
-    if getattr(agent, "_rate_limited_until", 0) > time.monotonic():
-        return False  # primary still in rate-limit cooldown, stay on fallback
+    # -- Check per-model pool TTL for the primary model --
+    pool = getattr(agent, "_credential_pool", None)
+    pool_min_ttl: Optional[float] = None
+    if pool is not None:
+        primary_model = (agent._primary_runtime or {}).get("model", "") or agent.model or ""
+        pool_min_ttl = pool.rate_limit_min_ttl(primary_model)
+    if pool_min_ttl is not None:
+        return False, pool_min_ttl
+
+    # Fall back to global rate-limit cooldown (set by _try_activate_fallback)
+    rl_until = getattr(agent, "_rate_limited_until", 0)
+    if rl_until > time.monotonic():
+        return False, rl_until
 
     rt = agent._primary_runtime
     try:
@@ -902,10 +928,10 @@ def restore_primary_runtime(agent) -> bool:
             "Primary runtime restored for new turn: %s (%s)",
             agent.model, agent.provider,
         )
-        return True
+        return True, 0
     except Exception as e:
         logging.warning("Failed to restore primary runtime: %s", e)
-        return False
+        return False, 0
 
 # Which error types indicate a transient transport failure worth
 # one more attempt with a rebuilt client / connection pool.

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -540,6 +540,7 @@ def recover_with_credential_pool(
     has_retried_429: bool,
     classified_reason: Optional[FailoverReason] = None,
     error_context: Optional[Dict[str, Any]] = None,
+    model_id: str = "",
 ) -> tuple[bool, bool]:
     """Attempt credential recovery via pool rotation.
 
@@ -570,7 +571,7 @@ def recover_with_credential_pool(
 
     if effective_reason == FailoverReason.billing:
         rotate_status = status_code if status_code is not None else 402
-        next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context)
+        next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context, model_id=model_id)
         if next_entry is not None:
             _ra().logger.info(
                 "Credential %s (billing) — rotated to pool entry %s",
@@ -593,7 +594,7 @@ def recover_with_credential_pool(
         if not has_retried_429 and not usage_limit_reached:
             return False, True
         rotate_status = status_code if status_code is not None else 429
-        next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context)
+        next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context, model_id=model_id)
         if next_entry is not None:
             _ra().logger.info(
                 "Credential %s (rate limit) — rotated to pool entry %s",
@@ -637,7 +638,7 @@ def recover_with_credential_pool(
         # Refresh failed — rotate to next credential instead of giving up.
         # The failed entry is already marked exhausted by try_refresh_current().
         rotate_status = status_code if status_code is not None else 401
-        next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context)
+        next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context, model_id=model_id)
         if next_entry is not None:
             _ra().logger.info(
                 "Credential %s (auth refresh failed) — rotated to pool entry %s",

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -510,7 +510,7 @@ def _to_openai_base_url(base_url: str) -> str:
     return url
 
 
-def _select_pool_entry(provider: str) -> Tuple[bool, Optional[Any]]:
+def _select_pool_entry(provider: str, model_id: str = "") -> Tuple[bool, Optional[Any]]:
     """Return (pool_exists_for_provider, selected_entry)."""
     try:
         pool = load_pool(provider)
@@ -520,7 +520,7 @@ def _select_pool_entry(provider: str) -> Tuple[bool, Optional[Any]]:
     if not pool or not pool.has_credentials():
         return False, None
     try:
-        return True, pool.select()
+        return True, pool.select(model_id=model_id)
     except Exception as exc:
         logger.debug("Auxiliary client: could not select pool entry for %s: %s", provider, exc)
         return True, None
@@ -2499,7 +2499,7 @@ def _recoverable_pool_provider(resolved_provider: str, client: Any) -> Optional[
     return None
 
 
-def _recover_provider_pool(provider: str, exc: Exception) -> bool:
+def _recover_provider_pool(provider: str, exc: Exception, model_id: str = "") -> bool:
     """Try same-provider credential-pool recovery for auxiliary calls."""
     normalized = _normalize_aux_provider(provider)
     try:
@@ -2521,6 +2521,7 @@ def _recover_provider_pool(provider: str, exc: Exception) -> bool:
         next_entry = pool.mark_exhausted_and_rotate(
             status_code=status_code if status_code is not None else 401,
             error_context=error_context,
+            model_id=model_id,
         )
         if next_entry is not None:
             _evict_cached_clients(normalized)
@@ -2532,6 +2533,7 @@ def _recover_provider_pool(provider: str, exc: Exception) -> bool:
         next_entry = pool.mark_exhausted_and_rotate(
             status_code=status_code if status_code is not None else fallback_status,
             error_context=error_context,
+            model_id=model_id,
         )
         if next_entry is not None:
             _evict_cached_clients(normalized)
@@ -4817,7 +4819,7 @@ def call_llm(
                     if not (_is_auth_error(retry_err) or _is_payment_error(retry_err) or _is_rate_limit_error(retry_err)):
                         raise
                     recovery_err = retry_err
-            if _recover_provider_pool(pool_provider, recovery_err):
+            if _recover_provider_pool(pool_provider, recovery_err, model_id=resolved_model or ""):
                 logger.info(
                     "Auxiliary %s: recovered %s via credential-pool rotation after %s",
                     task or "call", pool_provider, type(recovery_err).__name__,
@@ -5196,7 +5198,7 @@ async def async_call_llm(
                     if not (_is_auth_error(retry_err) or _is_payment_error(retry_err) or _is_rate_limit_error(retry_err)):
                         raise
                     recovery_err = retry_err
-            if _recover_provider_pool(pool_provider, recovery_err):
+            if _recover_provider_pool(pool_provider, recovery_err, model_id=resolved_model or ""):
                 logger.info(
                     "Auxiliary %s (async): recovered %s via credential-pool rotation after %s",
                     task or "call", pool_provider, type(recovery_err).__name__,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -685,13 +685,19 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
 
 
 
-def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool:
+def try_activate_fallback(agent, reason: "FailoverReason | None" = None, min_ttl: float = 0) -> bool:
     """Switch to the next fallback model/provider in the chain.
 
     Called when the current model is failing after retries.  Swaps the
     OpenAI client, model slug, and provider in-place so the retry loop
     can continue with the new backend.  Advances through the chain on
     each call; returns False when exhausted.
+
+    *min_ttl* is the earliest per-model rate-limit TTL for the primary
+    model (from ``restore_primary_runtime``).  When the entire chain is
+    exhausted with no usable entry, the function sleeps until this TTL
+    expires before returning False — so the caller can retry without
+    tight-looping.
 
     Uses the centralized provider router (resolve_provider_client) for
     auth resolution and client construction — no duplicated provider→key
@@ -707,6 +713,18 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         if (not fallback_already_active) or (primary_provider and current_provider == primary_provider):
             agent._rate_limited_until = time.monotonic() + 60
     if agent._fallback_index >= len(agent._fallback_chain):
+        # Chain exhausted — if primary model has a pending rate-limit TTL,
+        # wait for it before returning so the caller can retry with the
+        # primary instead of bailing out entirely.
+        if min_ttl > 0:
+            now = time.monotonic()
+            if min_ttl > now:
+                wait = min_ttl - now
+                logging.info(
+                    "Fallback chain exhausted; waiting %.0fs for primary TTL to expire",
+                    wait,
+                )
+                time.sleep(wait)
         return False
 
     fb = agent._fallback_chain[agent._fallback_index]

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2427,10 +2427,26 @@ def run_conversation(
                         agent._credential_pool,
                         provider=agent.provider,
                         base_url=getattr(agent, "base_url", None),
+                        model_id=agent.model,
                     )
                     if not pool_may_recover:
                         agent._emit_status("⚠️ Rate limited — switching to fallback provider...")
-                        if agent._try_activate_fallback(reason=classified.reason):
+                        restored, min_ttl = agent._restore_primary_runtime()
+                        if restored:
+                            retry_count = 0
+                            compression_attempts = 0
+                            primary_recovery_attempted = False
+                            continue
+                        if agent._try_activate_fallback(reason=classified.reason, min_ttl=min_ttl):
+                            retry_count = 0
+                            compression_attempts = 0
+                            primary_recovery_attempted = False
+                            continue
+                        # Both fallback chain and primary are rate-limited —
+                        # try_activate_fallback already slept until min_ttl,
+                        # so the primary should now be recoverable.
+                        restored, _ = agent._restore_primary_runtime()
+                        if restored:
                             retry_count = 0
                             compression_attempts = 0
                             primary_recovery_attempted = False

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -203,9 +203,9 @@ def _is_manual_source(source: str) -> bool:
 def _model_rate_limited_until(entry: PooledCredential, model_id: str) -> Optional[float]:
     """Return the TTL end timestamp for this model, or None if not rate-limited.
 
-Uses ``time.monotonic()`` so callers that compare against the same clock
-get consistent per-model TTL windows regardless of wall-clock adjustments.
-"""
+    Uses ``time.monotonic()`` so callers that compare against the same clock
+    get consistent per-model TTL windows regardless of wall-clock adjustments.
+    """
     if model_id in entry.rate_limited:
         ts = entry.rate_limited[model_id][0]
         if time.monotonic() < ts:
@@ -1281,6 +1281,20 @@ class CredentialPool:
             return current
         available = self._available_entries()
         return available[0] if available else None
+
+    def rate_limit_min_ttl(self, model_id: str) -> Optional[float]:
+        """Return the earliest per-model rate-limit TTL across all entries.
+
+        Returns a ``time.monotonic()`` timestamp, or None if no entry is
+        rate-limited for *model_id*.
+        """
+        now = time.monotonic()
+        min_ttl: Optional[float] = None
+        for entry in self._entries:
+            ts = _model_rate_limited_until(entry, model_id)
+            if ts is not None and ts > now:
+                min_ttl = min(min_ttl, ts) if min_ttl is not None else ts
+        return min_ttl
 
     def mark_rate_limited(
         self,

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -9,7 +9,7 @@ import threading
 import time
 import uuid
 import re
-from dataclasses import dataclass, fields, replace
+from dataclasses import dataclass, field, fields, replace
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Set, Tuple
 
@@ -114,6 +114,8 @@ class PooledCredential:
     agent_key: Optional[str] = None
     agent_key_expires_at: Optional[str] = None
     request_count: int = 0
+    # Per-model rate limit tracking (429 only). Keys: model_id -> [reset_timestamp, consecutive_count].
+    rate_limited: Dict[str, list] = field(default_factory=dict)
     extra: Dict[str, Any] = None  # type: ignore[assignment]
 
     def __post_init__(self):
@@ -161,6 +163,8 @@ class PooledCredential:
         for k, v in self.extra.items():
             if v is not None:
                 result[k] = v
+        if self.rate_limited:
+            result["rate_limited"] = self.rate_limited
         return result
 
     @property
@@ -194,6 +198,19 @@ def _next_priority(entries: List[PooledCredential]) -> int:
 def _is_manual_source(source: str) -> bool:
     normalized = (source or "").strip().lower()
     return normalized == SOURCE_MANUAL or normalized.startswith(f"{SOURCE_MANUAL}:")
+
+
+def _model_rate_limited_until(entry: PooledCredential, model_id: str) -> Optional[float]:
+    """Return the TTL end timestamp for this model, or None if not rate-limited.
+
+Uses ``time.monotonic()`` so callers that compare against the same clock
+get consistent per-model TTL windows regardless of wall-clock adjustments.
+"""
+    if model_id in entry.rate_limited:
+        ts = entry.rate_limited[model_id][0]
+        if time.monotonic() < ts:
+            return ts
+    return None
 
 
 def _exhausted_ttl(error_code: Optional[int]) -> int:
@@ -1131,11 +1148,11 @@ class CredentialPool:
             return False
         return False
 
-    def select(self) -> Optional[PooledCredential]:
+    def select(self, model_id: str = "") -> Optional[PooledCredential]:
         with self._lock:
-            return self._select_unlocked()
+            return self._select_unlocked(model_id=model_id if model_id else None)
 
-    def _available_entries(self, *, clear_expired: bool = False, refresh: bool = False) -> List[PooledCredential]:
+    def _available_entries(self, *, model_id: str = None, clear_expired: bool = False, refresh: bool = False) -> List[PooledCredential]:
         """Return entries not currently in exhaustion cooldown.
 
         When *clear_expired* is True, entries whose cooldown has elapsed are
@@ -1206,6 +1223,15 @@ class CredentialPool:
                     self._replace_entry(entry, cleared)
                     entry = cleared
                     cleared_any = True
+            if model_id is not None:
+                rl_until = _model_rate_limited_until(entry, model_id)
+                if rl_until is not None:
+                    continue
+                if clear_expired and model_id in entry.rate_limited:
+                    cleared = replace(entry, rate_limited={k: v for k, v in entry.rate_limited.items() if k != model_id})
+                    self._replace_entry(entry, cleared)
+                    entry = cleared
+                    cleared_any = True
             if refresh and self._entry_needs_refresh(entry):
                 refreshed = self._refresh_entry(entry, force=False)
                 if refreshed is None:
@@ -1216,8 +1242,8 @@ class CredentialPool:
             self._persist()
         return available
 
-    def _select_unlocked(self) -> Optional[PooledCredential]:
-        available = self._available_entries(clear_expired=True, refresh=True)
+    def _select_unlocked(self, model_id: str = None) -> Optional[PooledCredential]:
+        available = self._available_entries(model_id=model_id, clear_expired=True, refresh=True)
         if not available:
             self._current_id = None
             logger.info("credential pool: no available entries (all exhausted or empty)")
@@ -1256,24 +1282,62 @@ class CredentialPool:
         available = self._available_entries()
         return available[0] if available else None
 
+    def mark_rate_limited(
+        self,
+        entry: PooledCredential,
+        model_id: str,
+        status_code: int,
+        error_context: Optional[Dict[str, Any]] = None,
+    ) -> PooledCredential:
+        """Mark per-model rate limit (429 only). Does NOT set STATUS_EXHAUSTED.
+        TTL escalates on consecutive 429s: 5min -> 10min -> 15min (capped)."""
+        now = time.monotonic()
+        existing = entry.rate_limited.get(model_id)
+        if existing and existing[0] > now:
+            consecutive = existing[1] + 1
+        else:
+            consecutive = 1
+        config = _load_config_safe() or {}
+        strategies = config.get("credential_pool_strategies", {}) or {}
+        first_ttl = strategies.get("rate_limit_ttl_first_seconds", 300)
+        step_ttl = strategies.get("rate_limit_ttl_step_seconds", 300)
+        max_ttl = strategies.get("rate_limit_ttl_max_seconds", 1800)
+        ttl = min(first_ttl + step_ttl * (consecutive - 1), max_ttl)
+        reset_at = now + ttl
+        normalized_error = _normalize_error_context(error_context)
+        updated = replace(
+            entry,
+            rate_limited={**entry.rate_limited, model_id: [reset_at, consecutive]},
+            last_error_code=status_code,
+            last_error_reason=normalized_error.get("reason"),
+            last_error_message=normalized_error.get("message"),
+            last_error_reset_at=reset_at,
+            extra=entry.extra,
+        )
+        self._replace_entry(entry, updated)
+        self._persist()
+        return updated
+
     def mark_exhausted_and_rotate(
         self,
         *,
         status_code: Optional[int],
         error_context: Optional[Dict[str, Any]] = None,
+        model_id: str = "",
     ) -> Optional[PooledCredential]:
         with self._lock:
             entry = self.current() or self._select_unlocked()
             if entry is None:
                 return None
             _label = entry.label or entry.id[:8]
-            logger.info(
-                "credential pool: marking %s exhausted (status=%s), rotating",
-                _label, status_code,
-            )
-            self._mark_exhausted(entry, status_code, error_context)
+            if status_code == 429 and model_id:
+                logger.info("credential pool: marking %s rate-limited (model=%s, status=%s), rotating", _label, model_id, status_code)
+                self.mark_rate_limited(entry, model_id, status_code, error_context)
+            else:
+                logger.info("credential pool: marking %s exhausted (status=%s), rotating", _label, status_code)
+                self._mark_exhausted(entry, status_code, error_context)
             self._current_id = None
-            next_entry = self._select_unlocked()
+            next_entry = self._select_unlocked(model_id=model_id if status_code == 429 and model_id else None)
             if next_entry:
                 _next_label = next_entry.label or next_entry.id[:8]
                 logger.info("credential pool: rotated to %s", _next_label)

--- a/run_agent.py
+++ b/run_agent.py
@@ -2859,7 +2859,7 @@ class AIAgent:
     ) -> tuple[bool, bool]:
         """Forwarder — see ``agent.agent_runtime_helpers.recover_with_credential_pool``."""
         from agent.agent_runtime_helpers import recover_with_credential_pool
-        return recover_with_credential_pool(self, status_code=status_code, has_retried_429=has_retried_429, classified_reason=classified_reason, error_context=error_context)
+        return recover_with_credential_pool(self, status_code=status_code, has_retried_429=has_retried_429, classified_reason=classified_reason, error_context=error_context, model_id=self.model or "")
 
     def _credential_pool_may_recover_rate_limit(self) -> bool:
         """Whether a rate-limit retry should wait for same-provider credentials."""

--- a/run_agent.py
+++ b/run_agent.py
@@ -51,7 +51,7 @@ import threading
 from types import SimpleNamespace
 import urllib.request
 import uuid
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Tuple
 from urllib.parse import urlparse, parse_qs, urlunparse
 # NOTE: `from openai import OpenAI` is deliberately NOT at module top — the
 # SDK pulls ~240 ms of imports. We expose `OpenAI` as a thin proxy object
@@ -237,7 +237,7 @@ def _routermint_headers() -> dict:
 
 
 def _pool_may_recover_from_rate_limit(
-    pool, *, provider: str | None = None, base_url: str | None = None
+    pool, *, provider: str | None = None, base_url: str | None = None, model_id: str | None = None
 ) -> bool:
     """Decide whether to wait for credential-pool rotation instead of falling back.
 
@@ -255,6 +255,9 @@ def _pool_may_recover_from_rate_limit(
     throttles — even a multi-entry pool shares the same quota window, so
     rotation won't recover.  Skip straight to the fallback for those (#13636).
 
+    When *model_id* is given, also checks per-model rate-limit state: if every
+    pool entry is rate-limited for that model, rotation cannot recover.
+
     In those cases we must fall back to the configured ``fallback_model``
     instead.  Returns True only when rotation has somewhere to go.
 
@@ -267,6 +270,8 @@ def _pool_may_recover_from_rate_limit(
     # CloudCode / Gemini CLI quotas are account-wide — all pool entries share
     # the same throttle window, so rotation can't recover.  Prefer fallback.
     if provider == "google-gemini-cli" or str(base_url or "").startswith("cloudcode-pa://"):
+        return False
+    if model_id and not pool._available_entries(model_id=model_id):
         return False
     return len(pool.entries()) > 1
 
@@ -3085,14 +3090,14 @@ class AIAgent:
         from agent.chat_completion_helpers import interruptible_streaming_api_call
         return interruptible_streaming_api_call(self, api_kwargs, on_first_delta=on_first_delta)
 
-    def _try_activate_fallback(self, reason: "FailoverReason | None" = None) -> bool:
+    def _try_activate_fallback(self, reason: "FailoverReason | None" = None, min_ttl: float = 0) -> bool:
         """Forwarder — see ``agent.chat_completion_helpers.try_activate_fallback``."""
         from agent.chat_completion_helpers import try_activate_fallback
-        return try_activate_fallback(self, reason)
+        return try_activate_fallback(self, reason, min_ttl=min_ttl)
 
     # ── Per-turn primary restoration ─────────────────────────────────────
 
-    def _restore_primary_runtime(self) -> bool:
+    def _restore_primary_runtime(self) -> Tuple[bool, float]:
         """Forwarder — see ``agent.agent_runtime_helpers.restore_primary_runtime``."""
         from agent.agent_runtime_helpers import restore_primary_runtime
         return restore_primary_runtime(self)

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -121,7 +121,7 @@ class TestRestorePrimaryRuntime:
     def test_noop_when_not_fallback(self):
         agent = _make_agent()
         assert agent._fallback_activated is False
-        assert agent._restore_primary_runtime() is False
+        restored, _ = agent._restore_primary_runtime(); assert not restored
 
     def test_resets_index_when_fallback_not_activated(self):
         """Regression for #20465: failed activation leaves _fallback_index advanced
@@ -140,7 +140,7 @@ class TestRestorePrimaryRuntime:
 
         # _restore_primary_runtime must reset the index so the next turn can retry
         result = agent._restore_primary_runtime()
-        assert result is False  # still no-op (primary was never left)
+        assert result[0] is False  # still no-op (primary was never left)
         assert agent._fallback_index == 0  # chain available again
 
     def test_restores_model_and_provider(self):
@@ -163,7 +163,7 @@ class TestRestorePrimaryRuntime:
         with patch("run_agent.OpenAI", return_value=MagicMock()):
             result = agent._restore_primary_runtime()
 
-        assert result is True
+        assert result[0] is True
         assert agent._fallback_activated is False
         assert agent.model == original_model
         assert agent.provider == original_provider
@@ -231,7 +231,7 @@ class TestRestorePrimaryRuntime:
         with patch("run_agent.OpenAI", side_effect=Exception("connection refused")):
             result = agent._restore_primary_runtime()
 
-        assert result is False
+        assert result[0] is False  # still not restored
 
 
 # =============================================================================
@@ -460,7 +460,7 @@ class TestRestoreInRunConversation:
 
         # Turn 2: restore primary
         with patch("run_agent.OpenAI", return_value=MagicMock()):
-            assert agent._restore_primary_runtime() is True
+            restored, _ = agent._restore_primary_runtime(); assert restored
 
         assert agent._fallback_activated is False
         assert agent._fallback_index == 0
@@ -490,7 +490,7 @@ class TestRateLimitCooldown:
         agent._rate_limited_until = time.monotonic() + 60
 
         result = agent._restore_primary_runtime()
-        assert result is False
+        assert result[0] is False
         assert agent._fallback_activated is True  # still on fallback
 
     def test_restore_allowed_after_cooldown_expires(self):
@@ -510,7 +510,7 @@ class TestRateLimitCooldown:
         with patch("run_agent.OpenAI", return_value=MagicMock()):
             result = agent._restore_primary_runtime()
 
-        assert result is True
+        assert result[0] is True
         assert agent._fallback_activated is False
 
     def test_cooldown_set_on_rate_limit_reason(self):


### PR DESCRIPTION
## What does this PR do?
Previously, a 429 on any model would mark the entire credential as globally exhausted (STATUS_EXHAUSTED), making it unavailable for all models — when the pool had no remaining entries, other models on the same provider would fail with 401 for lack of available credentials. This PR scopes 429 rate limits per-model via per-model TTL tracking, so a rate-limit on model-A leaves the same credential available for model-B. Additionally, when all pool entries are per-model rate-limited, the retry/fallback loop now self-heals: restore_primary_runtime reads the pool TTL as a sleep anchor for try_activate_fallback, so the loop waits for TTL expiry instead of bail-out or tight-looping.

Additionally, when all credential pool entries are per-model rate-limited, the retry/fallback loop now self-heals:
`restore_primary_runtime` reads the pool TTL and passes it to `try_activate_fallback` as a sleep anchor, so the loop waits for TTL expiry instead of bail-out or tight-looping.

## Related Issue
Fixes #8283 (429 on one model exhausts credential globally, causing 401 for other models on the same provider)

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made
- `agent/credential_pool.py` — Add `rate_limited` field to `PooledCredential`; add `mark_rate_limited()` with TTL escalation (5→10→15→30min); add `rate_limit_min_ttl()` for unified per-model TTL query; scope `select`/`_available_entries`/`mark_exhausted_and_rotate` by `model_id`; use `time.monotonic()` for consistent TTL comparison
- `agent/agent_runtime_helpers.py` — `restore_primary_runtime` returns `(bool, float)` with per-model pool TTL as sleep anchor; check per-model TTL even when `_fallback_activated=False`
- `agent/chat_completion_helpers.py` — `try_activate_fallback` accepts `min_ttl` parameter; sleeps until primary model TTL expires when fallback chain is exhausted
- `agent/conversation_loop.py` — Coordinate restore→fallback→restore cycle; pass `model_id` to
`_pool_may_recover_from_rate_limit`
- `agent/auxiliary_client.py` — Pass `model_id` through pool selection and recovery
- `run_agent.py` — Updated forwarder signatures for new return types and parameters
- `tests/run_agent/test_primary_runtime_restore.py` — Updated tests for new return types

## How to Test
1. Configure multiple credentials for a provider in `config.yaml` under `credential_pool_strategies`
2. Trigger 429 rate limits on one model and verify other models on the same credential still work
3. Exhaust all credentials with per-model 429 and verify the agent sleeps until TTL expiry instead of bail-out
4. `pytest tests/agent/test_credential_pool.py tests/run_agent/test_provider_fallback.py
tests/run_agent/test_primary_runtime_restore.py tests/agent/test_gemini_fast_fallback.py`

## Checklist
### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(credential_pool):`, `feat(conversation_loop):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest` and all tests pass (113 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 22.04.1

### Documentation & Housekeeping
- [x] I've updated relevant documentation — credential-pools.md (per-model rate limit docs + TTL config)
- [ ] I've updated `cli-config.yaml.example` — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [ ] I've considered cross-platform impact — N/A (pure Python, no OS-specific code)
- [ ] I've updated tool descriptions/schemas — N/A (no tool changes)
