### PR TITLE
feat: add configurable typing indicator delay for messaging platforms

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -868,6 +868,8 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = channel_prompts
                 if "gateway_restart_notification" in platform_cfg:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
+                if "typing_indicator_delay" in platform_cfg:
+                    bridged["typing_indicator_delay"] = platform_cfg["typing_indicator_delay"]
                 enabled_was_explicit = "enabled" in platform_cfg
                 if not bridged and not enabled_was_explicit:
                     continue

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2293,6 +2293,25 @@ class BasePlatformAdapter(ABC):
         one of them succeeds within the 5s platform-side window, the bubble
         stays visible across provider stalls / upstream API timeouts.
         """
+        # Optional configurable delay before showing typing indicator.
+        # Set per-platform via ``typing_indicator_delay`` (seconds) in
+        # the platform config.  0 = immediate (default, prior behavior).
+        _delay = float(
+            getattr(getattr(self, "config", None), "extra", {}).get(
+                "typing_indicator_delay", 0
+            )
+        )
+        if _delay > 0:
+            if stop_event is not None:
+                try:
+                    await asyncio.wait_for(stop_event.wait(), timeout=_delay)
+                except asyncio.TimeoutError:
+                    pass  # delay elapsed, proceed to show typing
+                if stop_event.is_set():
+                    return
+            else:
+                await asyncio.sleep(_delay)
+
         # Bound each send_typing round-trip so the refresh cadence isn't
         # gated on network health.  Must stay below ``interval`` so a slow
         # call gets abandoned before the next scheduled tick.


### PR DESCRIPTION
## Summary

Adds a per-platform `typing_indicator_delay` config option (seconds) so users can suppress the typing bubble for fast responses.

## What it does

When a messaging platform is configured with `typing_indicator_delay: 3` (for example), the gateway waits 3 seconds before starting the typing indicator refresh loop. Quick responses (fast tool calls, simple replies, slash commands) finish before the delay elapses — no typing bubble at all. Longer operations still show typing after the delay so users know something is happening.

Default is 0, which preserves the existing behavior (typing indicator starts immediately).

## Changes

- **`gateway/platforms/base.py`** — `_keep_typing()` reads `typing_indicator_delay` from `self.config.extra` and sleeps before entering the refresh loop
- **`gateway/config.py`** — `load_gateway_config()` bridges the key from platform YAML sections into `PlatformConfig.extra`

## Usage

In `config.yaml`, under any platform section:

```yaml
telegram:
  typing_indicator_delay: 3   # wait 3s before showing typing
```

Setting to 0 (default) keeps the immediate typing indicator behavior.