### PR TITLE
fix(auxiliary): ensure provider aliases are consistently resolved for per-task auxiliary configuration

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -319,7 +319,30 @@ def _normalize_aux_provider(provider: Optional[str]) -> str:
             normalized = main_prov
         else:
             return "custom"
-    return _PROVIDER_ALIASES.get(normalized, normalized)
+    if normalized in _PROVIDER_ALIASES:
+        return _PROVIDER_ALIASES[normalized]
+    # Fall through to the shared CLI alias table so auxiliary.<task>.provider
+    # accepts the same aliases as `hermes model` (e.g. nvidia-nim → nvidia).
+    # Local table stays first: providers.py sometimes canonicalizes to
+    # models.dev ids (github-copilot) while aux/PROVIDER_REGISTRY still use
+    # Hermes ids (copilot). Only adopt a shared mapping when the registry
+    # already knows that canonical id.
+    try:
+        from hermes_cli.providers import normalize_provider
+
+        shared = normalize_provider(normalized)
+    except Exception:
+        return normalized
+    if shared == normalized:
+        return normalized
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY
+
+        if shared in PROVIDER_REGISTRY:
+            return shared
+    except Exception:
+        pass
+    return normalized
 
 
 # Sentinel: when returned by _fixed_temperature_for_model(), callers must

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -394,6 +394,21 @@ class TestNormalizeAuxProvider:
         assert _normalize_aux_provider("github-copilot-acp") == "copilot-acp"
         assert _normalize_aux_provider("copilot-acp-agent") == "copilot-acp"
 
+    def test_maps_nvidia_aliases_via_shared_provider_table(self):
+        """CLI aliases (hermes_cli.providers) must resolve for aux config too.
+
+        Regression for PR #31134: auxiliary.<task>.provider: nvidia-nim used to
+        miss PROVIDER_REGISTRY (canonical key is nvidia / NVIDIA_API_KEY).
+        """
+        for alias in ("nvidia-nim", "nim", "build-nvidia", "nemotron"):
+            assert _normalize_aux_provider(alias) == "nvidia"
+        assert _normalize_aux_provider("nvidia") == "nvidia"
+
+    def test_prefers_local_aux_ids_over_models_dev_canonical(self):
+        # providers.normalize_provider("github") → github-copilot (models.dev),
+        # but aux registry still keys on copilot. Local table must win.
+        assert _normalize_aux_provider("github") == "copilot"
+
 
 class TestReadCodexAccessToken:
     def test_valid_auth_store(self, tmp_path, monkeypatch):
@@ -5192,6 +5207,29 @@ class TestNvidiaBillingHeaders:
         call_kwargs = mock_openai.call_args[1]
         headers = call_kwargs["default_headers"]
         assert headers["X-BILLING-INVOKE-ORIGIN"] == "HermesAgent"
+
+    def test_resolve_provider_client_accepts_nvidia_nim_alias(self, monkeypatch):
+        """auxiliary.<task>.provider: nvidia-nim must use NVIDIA_API_KEY.
+
+        Behavior-level gate for #31134 / sweeper review: aliased aux config
+        must build a client through the canonical nvidia credentials path.
+        """
+        monkeypatch.setenv("NVIDIA_API_KEY", "nvidia-key")
+        monkeypatch.delenv("NVIDIA_BASE_URL", raising=False)
+        mock_openai = MagicMock()
+        mock_openai.return_value = MagicMock(name="nvidia-alias-client")
+
+        with patch("agent.auxiliary_client.OpenAI", mock_openai):
+            client, model = resolve_provider_client(
+                provider="nvidia-nim",
+                model="nvidia/test-model",
+            )
+
+        assert client is not None
+        assert model == "nvidia/test-model"
+        call_kwargs = mock_openai.call_args[1]
+        assert call_kwargs["api_key"] == "nvidia-key"
+        assert "integrate.api.nvidia.com" in call_kwargs["base_url"]
 
     def test_resolve_provider_client_local_nim_skips_billing_origin_header(self, monkeypatch):
         monkeypatch.setenv("NVIDIA_API_KEY", "nvidia-key")


### PR DESCRIPTION
## Summary

`auxiliary.<task>.provider` aliases such as `nvidia-nim` never hit `PROVIDER_REGISTRY` (canonical `nvidia` / `NVIDIA_API_KEY`) because `_normalize_aux_provider` only consulted a hand-maintained local table. CLI aliases already live in `hermes_cli.providers`.

**Fix (shared source, not another local pad):**
1. Keep the local `_PROVIDER_ALIASES` table first — aux/PROVIDER_REGISTRY still use Hermes ids (`copilot`) while `providers.normalize_provider` sometimes returns models.dev ids (`github-copilot`).
2. Fall through to `hermes_cli.providers.normalize_provider`.
3. Only adopt the shared canonical when it is already in `PROVIDER_REGISTRY`.

That covers `nvidia-nim` / `nim` / `build-nvidia` / `nemotron` (and future CLI aliases registered the same way) without duplicating the NVIDIA list by hand.

## Test plan

- [x] `pytest tests/agent/test_auxiliary_client.py::TestNormalizeAuxProvider tests/agent/test_auxiliary_client.py::TestNvidiaBillingHeaders` — all pass
- [x] Normalize: all four NVIDIA aliases → `nvidia`; local `github` → `copilot` still wins over models.dev
- [x] Behavior: `resolve_provider_client(provider=\"nvidia-nim\")` builds a client with `NVIDIA_API_KEY` against `integrate.api.nvidia.com`

## Notes

- Rebuilt on current `main` (prior May tip was ~7k commits behind; history rewritten on this head branch).
- Addresses sweeper review: full alias set via shared normalizer + behavior-level regression test.