### PR TITLE
fix(browser_tool.py): use AGENT_BROWSER_ARGS for sandbox bypass

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1802,7 +1802,8 @@ def _run_browser_command(
         # - Ubuntu 23.10+ / AppArmor systems: unprivileged user namespaces
         #   are restricted, causing Chromium to exit with "No usable sandbox"
         #   even for non-root users running under systemd or containers.
-        if "AGENT_BROWSER_CHROME_FLAGS" not in browser_env:
+        # agent-browser reads AGENT_BROWSER_ARGS (not _CHROME_FLAGS).
+        if "AGENT_BROWSER_ARGS" not in browser_env:
             _needs_sandbox_bypass = False
             if hasattr(os, "geteuid") and os.geteuid() == 0:
                 _needs_sandbox_bypass = True
@@ -1821,8 +1822,8 @@ def _run_browser_command(
                 except OSError:
                     pass
             if _needs_sandbox_bypass:
-                browser_env["AGENT_BROWSER_CHROME_FLAGS"] = (
-                    "--no-sandbox --disable-dev-shm-usage"
+                browser_env["AGENT_BROWSER_ARGS"] = (
+                    "--no-sandbox,--disable-dev-shm-usage"
                 )
 
         # Use temp files for stdout/stderr instead of pipes.


### PR DESCRIPTION
## Problem

The auto-detection logic that injects `--no-sandbox` on AppArmor-restricted systems (Ubuntu 23.10+) sets the wrong environment variable.

`agent-browser` v0.26.0 reads `AGENT_BROWSER_ARGS` (comma-separated), but Hermes was setting `AGENT_BROWSER_CHROME_FLAGS` which agent-browser ignores entirely.

## Impact

- Chromium crashes with **"No usable sandbox!"** on systems where `/proc/sys/kernel/apparmor_restrict_unprivileged_userns == 1`
- The auto-detection code runs correctly but silently fails because the wrong env var is passed

## Changes

- Rename env var: `AGENT_BROWSER_CHROME_FLAGS` → `AGENT_BROWSER_ARGS`
- Adjust flag format: space-separated → comma-separated
- Add inline comment documenting the agent-browser env var contract

## Verification

Tested on Ubuntu 24.04 with AppArmor userns restrictions enabled. Before fix: `browser_navigate` fails with sandbox error. After fix: succeeds and returns snapshot.

Fixes silent --no-sandbox bypass failure on AppArmor-restricted Linux.
