### PR TITLE
fix(gateway): match extract_media extension list to extract_local_files

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2267,8 +2267,11 @@ class BasePlatformAdapter(ABC):
         
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
+        # NOTE: Keep this extension list in sync with `_LOCAL_MEDIA_EXTS` in
+        # `extract_local_files` below. Mismatches cause MEDIA: directives to be
+        # silently dropped while bare-path detection (or vice versa) still works.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|bmp|tiff|svg|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|tar|gz|tgz|bz2|xz|rar|7z|docx?|odt|rtf|xlsx?|ods|pptx?|odp|key|txt|md|csv|tsv|json|xml|yaml|yml|html|htm|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -794,3 +794,39 @@ class TestProxyKwargsForAiohttp:
             sess_kw, req_kw = proxy_kwargs_for_aiohttp("http://proxy:8080")
             assert sess_kw == {}
             assert req_kw == {"proxy": "http://proxy:8080"}
+
+
+class TestExtractMediaExtensionCoverage:
+    """Regression: MEDIA: directive extension list must cover every extension
+    that ``extract_local_files`` accepts. A mismatch causes MEDIA tags for
+    common artifact types (e.g. ``.html`` exports) to be silently dropped —
+    ``send_message`` reports success while the document never ships.
+    """
+
+    @pytest.mark.parametrize("ext", [
+        # Originally-missing extensions that triggered the regression
+        "html", "htm", "md", "svg", "bmp", "tiff",
+        "json", "xml", "yaml", "yml", "tsv",
+        "ods", "odp", "odt", "rtf", "key",
+        "tar", "gz", "tgz", "bz2", "xz",
+        # Extensions that were already covered — keep matching
+        "png", "jpg", "jpeg", "gif", "webp",
+        "mp4", "mov", "mkv", "webm",
+        "mp3", "wav", "ogg", "m4a", "flac",
+        "pdf", "docx", "xlsx", "pptx", "txt", "csv", "zip", "7z",
+    ])
+    def test_media_tag_extracted_for_extension(self, ext):
+        text = f"Here you go MEDIA:/tmp/report.{ext} done"
+        media, cleaned = BasePlatformAdapter.extract_media(text)
+        assert media == [(f"/tmp/report.{ext}", False)], (
+            f"MEDIA: directive for .{ext} was silently dropped — extension"
+            f" missing from extract_media regex"
+        )
+        assert f"/tmp/report.{ext}" not in cleaned
+
+    def test_media_tag_html_real_world_path(self):
+        """Specific case that produced the user-visible bug."""
+        text = "MEDIA:/root/.hermes/media_cache/00-Visual-Report.html"
+        media, cleaned = BasePlatformAdapter.extract_media(text)
+        assert media == [("/root/.hermes/media_cache/00-Visual-Report.html", False)]
+        assert cleaned == ""


### PR DESCRIPTION
## Summary

`gateway/platforms/base.py` had two file-extension whitelists that drifted out of sync:

- `extract_media()` parses explicit `MEDIA:<path>` directives.
- `extract_local_files()` finds bare local paths in response text.

`extract_local_files`'s `_LOCAL_MEDIA_EXTS` includes `.html`, `.htm`, `.md`, `.svg`, `.bmp`, `.tiff`, `.json`, `.xml`, `.yaml`, `.yml`, `.tsv`, `.ods`, `.odp`, `.odt`, `.rtf`, `.key`, `.tar`, `.gz`, `.tgz`, `.bz2`, `.xz`. The regex inside `extract_media` did not. A `MEDIA:/abs/path/file.html` directive was silently dropped — the parent `send_message` tool still reported `success: true` because the text portion shipped fine.

Closes #31137.

## Changes

- `gateway/platforms/base.py` (+4): extension list in the `extract_media` regex is now a superset of `_LOCAL_MEDIA_EXTS`. Added a `NOTE` comment binding the two together so future drift is caught in review.
- `tests/gateway/test_platform_base.py` (+36): `TestExtractMediaExtensionCoverage` — 43-case parametrized regression test covering every previously-missing extension + every previously-working one, plus the literal user-reported failure path (`MEDIA:/root/.hermes/media_cache/00-Visual-Report.html`).

## Validation

|  | Before | After |
|---|---|---|
| `MEDIA:/tmp/report.html` | regex no match → dropped silently | matched → file delivered |
| `MEDIA:/tmp/notes.md` | dropped | delivered |
| `MEDIA:/tmp/icon.svg` | dropped | delivered |
| `MEDIA:/tmp/data.json` | dropped | delivered |
| `MEDIA:/tmp/foo.mp3`, `.pdf`, `.docx`, etc. | delivered | delivered (unchanged) |
| `send_message` success reporting on dropped files | `success: true` (misleading) | `success: true` and file actually ships |

Targeted suite:
```
pytest tests/gateway/test_platform_base.py::TestExtractMediaExtensionCoverage -q
............................................                             [100%]
44 passed in 0.50s
```

Broader media-related suite (no regressions):
```
pytest tests/gateway/test_platform_base.py tests/gateway/test_media_extraction.py \
       tests/gateway/test_tts_media_routing.py tests/gateway/test_send_image_file.py \
       tests/tools/test_send_message_tool.py -q
294 passed, 2 skipped in 4.56s
```

Tested manually on Telegram (Ubuntu, Python 3.11, gateway under user systemd unit) — same path that produced the silent drop now ships the document natively.

## Why

This is a top-priority class of bug per [CONTRIBUTING.md](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#contribution-priorities): silent data loss (file attachments dropped without warning) affecting every messaging platform that goes through `BasePlatformAdapter.extract_media`. The fix surface is tiny and well-tested.
