### PR TITLE
fix(api-server): unblock /v1/chat/completions with narrow kwargs-collision fix

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -878,6 +878,15 @@ class APIServerAdapter(BasePlatformAdapter):
         from hermes_cli.tools_config import _get_platform_tools
 
         runtime_kwargs = _resolve_runtime_agent_kwargs()
+        # Defer to the server-side `config.yaml` model rather than letting
+        # the kwarg below collide with a `model` key already populated in
+        # `runtime_kwargs`. Without this pop, the explicit `model=model`
+        # on the `AIAgent(...)` constructor a few lines down raises
+        # `TypeError: AIAgent() got multiple values for keyword argument
+        # 'model'` and 500s every `POST /v1/chat/completions` regardless
+        # of payload. See #10773 for the per-request-model design; this is
+        # the narrow band-aid only.
+        runtime_kwargs.pop('model', None)
         reasoning_config = GatewayRunner._load_reasoning_config()
         model = _resolve_gateway_model()
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -305,6 +305,67 @@ class TestAdapterInit:
         assert isinstance(agent, FakeAgent)
         assert captured["reasoning_config"] == {"enabled": True, "effort": "xhigh"}
 
+    def test_create_agent_pops_colliding_model_from_runtime_kwargs(self, monkeypatch):
+        """Regression test for the model-kwarg collision:
+        `_resolve_runtime_agent_kwargs()` sources `model` from
+        `config.yaml`, so `runtime_kwargs` can carry a `model` key.
+        Before the fix, `AIAgent(model=model, **runtime_kwargs)` then raised
+        `TypeError: AIAgent() got multiple values for keyword argument
+        'model'` and every `POST /v1/chat/completions` returned HTTP 500.
+
+        After the fix, the colliding key is popped out of `runtime_kwargs`
+        before the constructor call, so the explicit `model=model` (from
+        `_resolve_gateway_model()`) wins unambiguously and the request
+        flows. See PR #31139 / issue #10773 for the broader per-request-
+        model design discussion this band-aid sits beneath.
+        """
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        # runtime_kwargs DOES carry a colliding `model` key — this is the
+        # exact shape that triggered the TypeError before the fix.
+        monkeypatch.setattr(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            lambda: {
+                "provider": "openai-codex",
+                "model": "model-from-runtime-kwargs-this-collides",
+            },
+        )
+        monkeypatch.setattr(
+            "gateway.run._resolve_gateway_model",
+            lambda: "model-from-gateway-resolver",
+        )
+        monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {})
+        monkeypatch.setattr(
+            "gateway.run.GatewayRunner._load_reasoning_config",
+            staticmethod(lambda: {}),
+        )
+        monkeypatch.setattr(
+            "gateway.run.GatewayRunner._load_fallback_model",
+            staticmethod(lambda: None),
+        )
+        monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: set())
+
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+
+        # This call would raise TypeError before the fix.
+        agent = adapter._create_agent(session_id="api-session")
+
+        assert isinstance(agent, FakeAgent)
+        # The explicit model=model kwarg (from _resolve_gateway_model) wins;
+        # the colliding runtime_kwargs.model was popped before the call.
+        assert captured["model"] == "model-from-gateway-resolver", (
+            "Explicit model=model kwarg must win; runtime_kwargs.model was the "
+            "colliding source that gets popped."
+        )
+        # provider should still come through from runtime_kwargs unaffected.
+        assert captured["provider"] == "openai-codex"
+
 
 # ---------------------------------------------------------------------------
 # Auth checking


### PR DESCRIPTION
## What changed and why

`gateway/platforms/api_server.py`'s `_create_agent()` builds `runtime_kwargs` via `_resolve_runtime_agent_kwargs()` (which sources `model` from `config.yaml` among other settings), then a few lines later constructs `AIAgent(model=model, **runtime_kwargs)`. The explicit `model=model` collides with the `model` key already populated in `runtime_kwargs`, raising:

```
TypeError: AIAgent() got multiple values for keyword argument 'model'
```

…before any request is ever served. The API server platform is therefore unusable for any OpenAI-compatible client — every `POST /v1/chat/completions` returns HTTP 500 with that exact error.

This PR adds one line — `runtime_kwargs.pop('model', None)` — right after `_resolve_runtime_agent_kwargs()` returns, so the explicit `model=model` kwarg below wins unambiguously. The request-level `model` field is ignored in favor of the server-side `config.yaml` value, which matches the current (broken-by-the-crash) implicit behavior.

**Strictly less scope than #25552 / #16403 / #18549 / #5862.** No per-request routing, no new config surface, no behavior change for anyone whose payload already matched the server-side model. Just unblocks the 500 while the broader per-request-model design at #10773 gets settled. When #10773's full design lands, this pop gets replaced by whatever per-request routing it specifies.

## How to test

Reproduction (any OS, hermes-agent v0.14.0):

```bash
# 1. Enable the API server
cat >> ~/.hermes/.env <<'ENV'
API_SERVER_ENABLED=true
API_SERVER_KEY=test-key
ENV

# 2. Start the gateway
hermes gateway

# 3. POST a chat completion request
curl -H 'Authorization: Bearer test-key' \
     -H 'Content-Type: application/json' \
     http://localhost:8642/v1/chat/completions \
     -d '{"model":"hermes-agent","messages":[{"role":"user","content":"ping"}]}'
```

**Before this PR:** HTTP 500 within ~50ms regardless of payload:

```json
{
  "error": {
    "message": "Internal server error: run_agent.AIAgent() got multiple values for keyword argument 'model'",
    "type": "server_error",
    "param": null,
    "code": null
  }
}
```

**After this PR:** HTTP 200 with a real OpenAI-shaped Chat Completion:

```json
{
  "id": "chatcmpl-f67cabfe3f6146b1a870ab6b5ac54",
  "object": "chat.completion",
  "created": 1779567828,
  "model": "hermes-agent",
  "choices": [{
    "index": 0,
    "message": {"role": "assistant", "content": "pong"},
    "finish_reason": "stop"
  }],
  "usage": {"prompt_tokens": 14816, "completion_tokens": 29, "total_tokens": 14845}
}
```

## What platforms

Tested on:

- **Windows 11 Pro (build 26200)**, hermes-agent v0.14.0, Python 3.11.15 via the bundled venv. Foundry broker hitting `/v1/chat/completions` through a Tailscale-mesh reverse proxy (Basic Auth at edge, Bearer auto-injected for `/v1/*` paths). Real agent invocation, real tool-calls, `finish_reason: stop`, 33-second end-to-end response.
- **Windows 11 Pro (build 26200)**, second independent machine, same hermes-agent version. Same Foundry-broker → API server path. Independent smoke confirmed `200` + matching response shape.

No Linux smoke from me personally — the kwargs collision is purely a Python-level constructor argument issue, not platform-specific, but flagging the gap for completeness.

## Related issues

- **#10773** — root issue: `feat(api-server): honor request-level model field for per-request model selection`. This PR is strictly less than what #10773 asks for; it just unblocks the crash so the broader design can land cleanly later.
- **#25552** — competing implementation (still OPEN, no merge). Larger surface area; this PR is the band-aid only.
- **#16403, #18549, #5862** — other competing implementations of #10773.
- **#24008** — closed as duplicate of #10773.
- **My comment on #10773** with this proposal: https://github.com/NousResearch/hermes-agent/pull/10773#issuecomment-4526474033

## AI usage disclosure

- **Provider:** Anthropic
- **Model:** Claude 4.7 (Sonnet, 1M context)
- **Mode:** Used to draft the patch (single-line code change + 8-line explanatory comment), this PR body, and to verify the anchor-based edit produced no collateral changes. Production smoke tests above were run by humans on real production machines (two separate Windows boxes), not by the model.