### PR TITLE
feat: allow custom provider capability metadata

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -503,6 +503,7 @@ class ModelCapabilities:
     supports_tools: bool = True
     supports_vision: bool = False
     supports_reasoning: bool = False
+    supports_multimodal_tool_results: Optional[bool] = None
     context_window: int = 200000
     max_output_tokens: int = 8192
     model_family: str = ""
@@ -565,6 +566,11 @@ def get_model_capabilities(provider: str, model: str) -> Optional[ModelCapabilit
             supports_tools=bool(custom_meta.get("supports_tools", True)),
             supports_vision=bool(custom_meta.get("supports_vision", False)),
             supports_reasoning=bool(custom_meta.get("supports_reasoning", False)),
+            supports_multimodal_tool_results=(
+                custom_meta.get("supports_multimodal_tool_results")
+                if isinstance(custom_meta.get("supports_multimodal_tool_results"), bool)
+                else None
+            ),
             context_window=(
                 _coerce_positive_int(custom_meta.get("context_length") or custom_meta.get("context_window"))
                 or 200000

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -319,12 +319,109 @@ def fetch_models_dev(force_refresh: bool = False) -> Dict[str, Any]:
     return _models_dev_cache
 
 
+def _normalize_provider_label(provider: str) -> str:
+    return (provider or "").strip().lower()
+
+
+def _is_custom_provider_label(provider: str) -> bool:
+    normalized = _normalize_provider_label(provider)
+    return normalized == "custom" or normalized.startswith("custom:")
+
+
+def _custom_provider_name_from_label(provider: str) -> str:
+    normalized = _normalize_provider_label(provider)
+    if normalized.startswith("custom:"):
+        return normalized.split(":", 1)[1].strip()
+    return ""
+
+
+def _coerce_positive_int(value: Any) -> Optional[int]:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)) and value > 0:
+        return int(value)
+    if isinstance(value, str):
+        try:
+            parsed = int(value.strip())
+        except ValueError:
+            return None
+        return parsed if parsed > 0 else None
+    return None
+
+
+def _custom_provider_model_metadata(provider: str, model: str) -> Optional[Dict[str, Any]]:
+    """Return config-declared metadata for a local/custom provider model.
+
+    Custom OpenAI-compatible endpoints do not exist in models.dev, so users need
+    a config-level way to declare safe capabilities for local models such as
+    Qwen 3.6 27B/35B. Provider-level values act as defaults; per-model entries
+    under ``models:`` can override limits/capabilities for one served model.
+    """
+    if not _is_custom_provider_label(provider) or not model:
+        return None
+
+    try:
+        from hermes_cli.config import get_compatible_custom_providers, load_config
+    except Exception:
+        return None
+
+    try:
+        custom_providers = get_compatible_custom_providers(load_config())
+    except Exception:
+        return None
+
+    requested_name = _custom_provider_name_from_label(provider)
+    model_lower = model.strip().lower()
+
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+        entry_name = str(entry.get("name") or entry.get("provider_key") or "").strip().lower()
+        provider_key = str(entry.get("provider_key") or "").strip().lower()
+        if requested_name and requested_name not in {entry_name, provider_key}:
+            continue
+
+        entry_model = str(entry.get("model") or "").strip()
+        models = entry.get("models") if isinstance(entry.get("models"), dict) else {}
+        model_meta = None
+        if isinstance(models, dict):
+            for mid, meta in models.items():
+                if str(mid).strip().lower() == model_lower:
+                    model_meta = meta if isinstance(meta, dict) else {}
+                    break
+
+        if model_meta is None and entry_model and entry_model.lower() != model_lower:
+            # Bare ``custom`` can have several saved local providers.  Skip
+            # providers that explicitly serve another model unless this model
+            # is listed under the provider's ``models`` map.
+            continue
+
+        merged = dict(entry)
+        merged.pop("models", None)
+        if isinstance(model_meta, dict):
+            merged.update(model_meta)
+        return merged
+
+    return None
+
+
+def _custom_context_length(provider: str, model: str) -> Optional[int]:
+    meta = _custom_provider_model_metadata(provider, model)
+    if not meta:
+        return None
+    return _coerce_positive_int(meta.get("context_length") or meta.get("context_window"))
+
+
 def lookup_models_dev_context(provider: str, model: str) -> Optional[int]:
     """Look up context_length for a provider+model combo in models.dev.
 
     Returns the context window in tokens, or None if not found.
     Handles case-insensitive matching and filters out context=0 entries.
     """
+    custom_ctx = _custom_context_length(provider, model)
+    if custom_ctx:
+        return custom_ctx
+
     mdev_provider_id = PROVIDER_TO_MODELS_DEV.get(provider)
     if not mdev_provider_id:
         return None
@@ -462,6 +559,23 @@ def get_model_capabilities(provider: str, model: str) -> Optional[ModelCapabilit
       - limit.output  (int) → max_output_tokens
       - family     (str)   → model_family
     """
+    custom_meta = _custom_provider_model_metadata(provider, model)
+    if custom_meta is not None:
+        return ModelCapabilities(
+            supports_tools=bool(custom_meta.get("supports_tools", True)),
+            supports_vision=bool(custom_meta.get("supports_vision", False)),
+            supports_reasoning=bool(custom_meta.get("supports_reasoning", False)),
+            context_window=(
+                _coerce_positive_int(custom_meta.get("context_length") or custom_meta.get("context_window"))
+                or 200000
+            ),
+            max_output_tokens=(
+                _coerce_positive_int(custom_meta.get("max_output_tokens") or custom_meta.get("max_output"))
+                or 8192
+            ),
+            model_family=str(custom_meta.get("family") or custom_meta.get("model_family") or ""),
+        )
+
     models = _get_provider_models(provider)
     if models is None:
         return None

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -464,6 +464,8 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     if num_tools > 0:
         agent._apply_pending_steer_to_tool_results(messages, num_tools)
 
+    agent._append_pending_multimodal_user_messages(messages)
+
 
 
 def execute_tool_calls_sequential(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
@@ -902,6 +904,8 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     # applied to sequential execution as well.
     if num_tools_seq > 0:
         agent._apply_pending_steer_to_tool_results(messages, num_tools_seq)
+
+    agent._append_pending_multimodal_user_messages(messages)
 
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3107,7 +3107,8 @@ def _normalize_custom_provider_entry(
         "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
         "api_mode", "transport", "model", "default_model", "models",
         "context_length", "rate_limit_delay", "supports_tools", "supports_vision",
-        "supports_reasoning", "max_output_tokens", "max_output",
+        "supports_reasoning", "supports_multimodal_tool_results",
+        "max_output_tokens", "max_output",
         "request_timeout_seconds", "stale_timeout_seconds",
         "discover_models", "extra_body",
     }
@@ -3196,7 +3197,12 @@ def _normalize_custom_provider_entry(
     if isinstance(context_length, int) and context_length > 0:
         normalized["context_length"] = context_length
 
-    for bool_key in ("supports_tools", "supports_vision", "supports_reasoning"):
+    for bool_key in (
+        "supports_tools",
+        "supports_vision",
+        "supports_reasoning",
+        "supports_multimodal_tool_results",
+    ):
         value = entry.get(bool_key)
         if isinstance(value, bool):
             normalized[bool_key] = value

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3106,7 +3106,8 @@ def _normalize_custom_provider_entry(
     _KNOWN_KEYS = {
         "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
         "api_mode", "transport", "model", "default_model", "models",
-        "context_length", "rate_limit_delay",
+        "context_length", "rate_limit_delay", "supports_tools", "supports_vision",
+        "supports_reasoning", "max_output_tokens", "max_output",
         "request_timeout_seconds", "stale_timeout_seconds",
         "discover_models", "extra_body",
     }
@@ -3194,6 +3195,15 @@ def _normalize_custom_provider_entry(
     context_length = entry.get("context_length")
     if isinstance(context_length, int) and context_length > 0:
         normalized["context_length"] = context_length
+
+    for bool_key in ("supports_tools", "supports_vision", "supports_reasoning"):
+        value = entry.get(bool_key)
+        if isinstance(value, bool):
+            normalized[bool_key] = value
+
+    max_output_tokens = entry.get("max_output_tokens", entry.get("max_output"))
+    if isinstance(max_output_tokens, int) and max_output_tokens > 0:
+        normalized["max_output_tokens"] = max_output_tokens
 
     rate_limit_delay = entry.get("rate_limit_delay")
     if isinstance(rate_limit_delay, (int, float)) and rate_limit_delay >= 0:

--- a/run_agent.py
+++ b/run_agent.py
@@ -3382,6 +3382,62 @@ class AIAgent:
         except Exception:
             return False
 
+    def _model_supports_multimodal_tool_results(self) -> bool:
+        """Return True if the active provider accepts image parts in tool results."""
+        try:
+            from tools.vision_tools import _supports_media_in_tool_results
+            provider = (getattr(self, "provider", "") or "").strip()
+            model = (getattr(self, "model", "") or "").strip()
+            return bool(_supports_media_in_tool_results(provider, model))
+        except Exception:
+            return False
+
+    def _queue_multimodal_tool_result_user_message(self, tool_name: str, result: Any) -> None:
+        """Queue images from a multimodal tool result as a follow-up user message.
+
+        Some local/OpenAI-compatible runtimes accept ``image_url`` in normal
+        user messages but reject the same content inside ``role: tool``.  For
+        those providers, keep the required tool result text-only, then append a
+        normal user message containing the image parts so the model still sees
+        the pixels on its next turn.
+        """
+        content = result.get("content") if isinstance(result, dict) else None
+        if not isinstance(content, list) or not self._content_has_image_parts(content):
+            return
+
+        text = (
+            f"The {tool_name} tool returned image content. The tool result was "
+            "sent as text because this provider does not accept images in "
+            "role=tool messages. Use the attached image(s) below together with "
+            "the preceding tool result."
+        )
+        parts: List[Dict[str, Any]] = [{"type": "text", "text": text}]
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            if part.get("type") in {"image_url", "input_image"}:
+                parts.append(part)
+
+        if len(parts) <= 1:
+            return
+        pending = getattr(self, "_pending_multimodal_user_messages", None)
+        if not isinstance(pending, list):
+            pending = []
+            self._pending_multimodal_user_messages = pending
+        pending.append({"role": "user", "content": parts})
+
+    def _drain_pending_multimodal_user_messages(self) -> List[Dict[str, Any]]:
+        pending = getattr(self, "_pending_multimodal_user_messages", None)
+        if not isinstance(pending, list) or not pending:
+            return []
+        self._pending_multimodal_user_messages = []
+        return list(pending)
+
+    def _append_pending_multimodal_user_messages(self, messages: list) -> None:
+        if not isinstance(messages, list):
+            return
+        messages.extend(self._drain_pending_multimodal_user_messages())
+
     def _preprocess_anthropic_content(self, content: Any, role: str) -> Any:
         if not self._content_has_image_parts(content):
             return content
@@ -3539,6 +3595,14 @@ class AIAgent:
                     "content this session — sending text summary",
                     tool_name, key[0], key[1],
                 )
+                return _multimodal_text_summary(result)
+            if not self._model_supports_multimodal_tool_results():
+                logger.debug(
+                    "Tool %s: model %s/%s supports vision but not multimodal "
+                    "tool results — sending text summary plus follow-up user image",
+                    tool_name, key[0], key[1],
+                )
+                self._queue_multimodal_tool_result_user_message(tool_name, result)
                 return _multimodal_text_summary(result)
             return content
 

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -127,6 +127,29 @@ class TestDecideImageInputMode:
         with patch("agent.models_dev.fetch_models_dev", return_value=registry):
             assert decide_image_input_mode("xiaomi", "mimo-v2.5-pro", {}) == "text"
 
+    def test_auto_uses_native_for_configured_custom_vision_model(self):
+        """Local custom models can opt into native screenshot routing via config."""
+        from hermes_constants import get_hermes_home
+
+        config_path = get_hermes_home() / "config.yaml"
+        config_path.write_text(
+            "providers:\n"
+            "  qwen-local:\n"
+            "    name: qwen-local\n"
+            "    base_url: http://127.0.0.1:18089/v1\n"
+            "    supports_tools: true\n"
+            "    supports_vision: true\n"
+            "    context_length: 8192\n"
+            "    models:\n"
+            "      qwen36-35b-oq4-mtp:\n"
+            "        context_length: 32768\n"
+            "      qwen36-27b-oq4-mtp:\n"
+            "        context_length: 8192\n"
+        )
+
+        assert decide_image_input_mode("custom:qwen-local", "qwen36-35b-oq4-mtp", {}) == "native"
+        assert decide_image_input_mode("custom", "qwen36-27b-oq4-mtp", {}) == "native"
+
 
 # ─── _coerce_capability_bool ─────────────────────────────────────────────────
 

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -520,6 +520,37 @@ class TestGetModelCapabilities:
         assert caps.supports_vision is True
         assert caps.supports_multimodal_tool_results is False
 
+    def test_model_level_multimodal_tool_results_overrides_provider_default(self):
+        """Model-level supports_multimodal_tool_results must override the provider default."""
+        from hermes_constants import get_hermes_home
+
+        config_path = get_hermes_home() / "config.yaml"
+        config_path.write_text(
+            "providers:\n"
+            "  qwen-local:\n"
+            "    name: qwen-local\n"
+            "    base_url: http://127.0.0.1:1234/v1\n"
+            "    supports_tools: true\n"
+            "    supports_vision: true\n"
+            "    supports_multimodal_tool_results: true\n"
+            "    context_length: 65536\n"
+            "    models:\n"
+            "      qwen36-27b-vision:\n"
+            "        supports_multimodal_tool_results: false\n"
+            "      qwen36-35b-vision:\n"
+            "        context_length: 131072\n"
+        )
+
+        # Model with explicit override to false — must win over provider true
+        caps_disabled = get_model_capabilities("custom:qwen-local", "qwen36-27b-vision")
+        assert caps_disabled is not None
+        assert caps_disabled.supports_multimodal_tool_results is False
+
+        # Model without explicit override — must inherit provider true
+        caps_inherited = get_model_capabilities("custom:qwen-local", "qwen36-35b-vision")
+        assert caps_inherited is not None
+        assert caps_inherited.supports_multimodal_tool_results is True
+
     def test_custom_provider_context_lookup_uses_config_context_length(self):
         """Context lookup should use custom provider config before models.dev fallback."""
         from hermes_constants import get_hermes_home

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -415,3 +415,98 @@ class TestGetModelCapabilities:
         with patch("agent.models_dev.fetch_models_dev", return_value=CAPS_REGISTRY):
             caps = get_model_capabilities("anthropic", "nonexistent-model")
         assert caps is None
+
+    def test_custom_provider_capabilities_from_config_entry(self):
+        """Local/custom providers can declare tool and vision capabilities in config.yaml."""
+        from hermes_constants import get_hermes_home
+
+        config_path = get_hermes_home() / "config.yaml"
+        config_path.write_text(
+            "model:\n"
+            "  provider: custom:qwen-local\n"
+            "  default: qwen36-35b-oq4-mtp\n"
+            "providers:\n"
+            "  qwen-local:\n"
+            "    name: qwen-local\n"
+            "    base_url: http://127.0.0.1:18089/v1\n"
+            "    api_mode: chat_completions\n"
+            "    model: qwen36-35b-oq4-mtp\n"
+            "    supports_tools: true\n"
+            "    supports_vision: true\n"
+            "    context_length: 32768\n"
+        )
+
+        caps = get_model_capabilities("custom", "qwen36-35b-oq4-mtp")
+
+        assert caps is not None
+        assert caps.supports_tools is True
+        assert caps.supports_vision is True
+        assert caps.context_window == 32768
+
+    def test_named_custom_provider_capabilities_from_config_entry(self):
+        """Provider labels like custom:qwen-local use the same custom metadata."""
+        from hermes_constants import get_hermes_home
+
+        config_path = get_hermes_home() / "config.yaml"
+        config_path.write_text(
+            "providers:\n"
+            "  qwen-local:\n"
+            "    name: qwen-local\n"
+            "    base_url: http://127.0.0.1:18089/v1\n"
+            "    model: qwen36-35b-oq4-mtp\n"
+            "    supports_tools: true\n"
+            "    supports_vision: true\n"
+            "    context_length: 32768\n"
+        )
+
+        caps = get_model_capabilities("custom:qwen-local", "qwen36-35b-oq4-mtp")
+
+        assert caps is not None
+        assert caps.supports_vision is True
+        assert caps.context_window == 32768
+
+    def test_custom_provider_per_model_capability_overrides(self):
+        """One local custom provider can declare separate 35B and 27B model caps."""
+        from hermes_constants import get_hermes_home
+
+        config_path = get_hermes_home() / "config.yaml"
+        config_path.write_text(
+            "providers:\n"
+            "  qwen-local:\n"
+            "    name: qwen-local\n"
+            "    base_url: http://127.0.0.1:18089/v1\n"
+            "    supports_tools: true\n"
+            "    supports_vision: true\n"
+            "    context_length: 8192\n"
+            "    models:\n"
+            "      qwen36-35b-oq4-mtp:\n"
+            "        context_length: 32768\n"
+            "      qwen36-27b-oq4-mtp:\n"
+            "        context_length: 8192\n"
+        )
+
+        caps_35b = get_model_capabilities("custom", "qwen36-35b-oq4-mtp")
+        caps_27b = get_model_capabilities("custom", "qwen36-27b-oq4-mtp")
+
+        assert caps_35b is not None
+        assert caps_27b is not None
+        assert caps_35b.supports_vision is True
+        assert caps_27b.supports_vision is True
+        assert caps_35b.context_window == 32768
+        assert caps_27b.context_window == 8192
+
+    def test_custom_provider_context_lookup_uses_config_context_length(self):
+        """Context lookup should use custom provider config before models.dev fallback."""
+        from hermes_constants import get_hermes_home
+
+        config_path = get_hermes_home() / "config.yaml"
+        config_path.write_text(
+            "providers:\n"
+            "  qwen-local:\n"
+            "    name: qwen-local\n"
+            "    base_url: http://127.0.0.1:18089/v1\n"
+            "    model: qwen36-27b-oq4-mtp\n"
+            "    context_length: 8192\n"
+        )
+
+        assert lookup_models_dev_context("custom", "qwen36-27b-oq4-mtp") == 8192

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -495,6 +495,31 @@ class TestGetModelCapabilities:
         assert caps_35b.context_window == 32768
         assert caps_27b.context_window == 8192
 
+    def test_custom_provider_multimodal_tool_result_capability_from_config(self):
+        """Local providers can say they accept user images but reject tool-result images."""
+        from hermes_constants import get_hermes_home
+
+        config_path = get_hermes_home() / "config.yaml"
+        config_path.write_text(
+            "providers:\n"
+            "  qwen-local:\n"
+            "    name: qwen-local\n"
+            "    base_url: http://127.0.0.1:1234/v1\n"
+            "    supports_tools: true\n"
+            "    supports_vision: true\n"
+            "    supports_multimodal_tool_results: false\n"
+            "    context_length: 65536\n"
+            "    models:\n"
+            "      qwen36-27b-vision:\n"
+            "        supports_multimodal_tool_results: false\n"
+        )
+
+        caps = get_model_capabilities("custom:qwen-local", "qwen36-27b-vision")
+
+        assert caps is not None
+        assert caps.supports_vision is True
+        assert caps.supports_multimodal_tool_results is False
+
     def test_custom_provider_context_lookup_uses_config_context_length(self):
         """Context lookup should use custom provider config before models.dev fallback."""
         from hermes_constants import get_hermes_home

--- a/tests/run_agent/test_multimodal_tool_content_recovery.py
+++ b/tests/run_agent/test_multimodal_tool_content_recovery.py
@@ -255,6 +255,38 @@ class TestToolResultContentShortCircuit:
         )
         assert isinstance(out, list)
 
+    def test_non_vision_model_computer_use_returns_json_error(self, monkeypatch):
+        """Non-vision models must get a structured JSON error for computer_use
+        so the agent can surface actionable guidance (switch to vision model)."""
+        import json
+
+        agent = _make_agent(provider="openai", model="gpt-4o-mini")
+        monkeypatch.setattr(agent, "_model_supports_vision", lambda: False)
+        out = agent._tool_result_content_for_active_model(
+            "computer_use", self._multimodal_result()
+        )
+
+        # Must be a JSON string, not a plain text summary.
+        assert isinstance(out, str)
+        parsed = json.loads(out)
+        assert "error" in parsed
+        assert "text_summary" in parsed
+        assert "vision-capable model" in parsed["error"]
+
+    def test_non_vision_model_other_tool_returns_plain_summary(self, monkeypatch):
+        """Non-vision models for non-computer_use tools get a plain text summary,
+        not the JSON error wrapper (that's computer_use-specific)."""
+        agent = _make_agent(provider="openai", model="gpt-4o-mini")
+        monkeypatch.setattr(agent, "_model_supports_vision", lambda: False)
+        out = agent._tool_result_content_for_active_model(
+            "vision_analyze", self._multimodal_result()
+        )
+
+        # Plain text summary — not JSON, no "error" key.
+        assert isinstance(out, str)
+        assert "capture mode=som" in out
+        assert not out.startswith("{")
+
 
 # ─── Classifier ──────────────────────────────────────────────────────────────
 

--- a/tests/run_agent/test_multimodal_tool_content_recovery.py
+++ b/tests/run_agent/test_multimodal_tool_content_recovery.py
@@ -186,6 +186,7 @@ class TestToolResultContentShortCircuit:
         agent = _make_agent(provider="xiaomi", model="mimo-v2.5")
         agent._no_list_tool_content_models = set()  # explicit empty
         monkeypatch.setattr(agent, "_model_supports_vision", lambda: True)
+        monkeypatch.setattr(agent, "_model_supports_multimodal_tool_results", lambda: True)
         out = agent._tool_result_content_for_active_model(
             "computer_use", self._multimodal_result()
         )
@@ -205,6 +206,29 @@ class TestToolResultContentShortCircuit:
         assert "data:image" not in out
         assert "image_url" not in out
 
+    def test_declared_no_multimodal_tool_results_queues_user_image_followup(self, monkeypatch):
+        """Vision models behind LM Studio-like endpoints need tool text + user image."""
+        agent = _make_agent(provider="custom:qwen-local", model="qwen36-27b-vision")
+        agent._no_list_tool_content_models = set()
+        monkeypatch.setattr(agent, "_model_supports_vision", lambda: True)
+        monkeypatch.setattr(agent, "_model_supports_multimodal_tool_results", lambda: False)
+
+        out = agent._tool_result_content_for_active_model(
+            "computer_use", self._multimodal_result("BASE64PNG")
+        )
+
+        assert isinstance(out, str)
+        assert "capture mode=som" in out
+        assert "BASE64PNG" not in out
+        pending = agent._drain_pending_multimodal_user_messages()
+        assert len(pending) == 1
+        assert pending[0]["role"] == "user"
+        assert any(part.get("type") == "image_url" for part in pending[0]["content"])
+        assert any(
+            part.get("type") == "text" and "computer_use" in part.get("text", "")
+            for part in pending[0]["content"]
+        )
+
     def test_cache_miss_on_different_model(self, monkeypatch):
         """Cache is per (provider, model). A cached entry for mimo-v2.5
         must NOT affect a session running on a different model.
@@ -212,6 +236,7 @@ class TestToolResultContentShortCircuit:
         agent = _make_agent(provider="xiaomi", model="mimo-v2.5-pro")
         agent._no_list_tool_content_models = {("xiaomi", "mimo-v2.5")}
         monkeypatch.setattr(agent, "_model_supports_vision", lambda: True)
+        monkeypatch.setattr(agent, "_model_supports_multimodal_tool_results", lambda: True)
         out = agent._tool_result_content_for_active_model(
             "computer_use", self._multimodal_result()
         )
@@ -224,6 +249,7 @@ class TestToolResultContentShortCircuit:
         agent = _make_agent()
         # Deliberately do not assign _no_list_tool_content_models.
         monkeypatch.setattr(agent, "_model_supports_vision", lambda: True)
+        monkeypatch.setattr(agent, "_model_supports_multimodal_tool_results", lambda: True)
         out = agent._tool_result_content_for_active_model(
             "computer_use", self._multimodal_result()
         )

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -932,7 +932,8 @@ class TestRunAgentMultimodalHelpers:
             ],
         }
 
-        with patch.object(agent, "_model_supports_vision", return_value=True):
+        with patch.object(agent, "_model_supports_vision", return_value=True), \
+             patch.object(agent, "_model_supports_multimodal_tool_results", return_value=True):
             content = agent._tool_result_content_for_active_model("computer_use", result)
 
         assert content is result["content"]

--- a/tests/tools/test_computer_use_vision_routing.py
+++ b/tests/tools/test_computer_use_vision_routing.py
@@ -148,8 +148,8 @@ class TestRouteDecision:
                 "anthropic", "claude-opus-4-5", None
             ) is False
 
-    def test_provider_rejects_multimodal_tool_results_routes_to_aux(self):
-        """Some providers' tool-result messages won't carry images at all."""
+    def test_provider_rejects_multimodal_tool_results_keeps_native_for_followup_split(self):
+        """Vision-capable providers can split tool text from a follow-up user image."""
         from tools.computer_use import vision_routing
 
         with patch.object(vision_routing, "_lookup_supports_vision", return_value=True), \
@@ -158,10 +158,10 @@ class TestRouteDecision:
                           return_value=False):
             assert vision_routing.should_route_capture_to_aux_vision(
                 "some-aggregator", "some-vision-model", {}
-            ) is True
+            ) is False
 
-    def test_unknown_provider_capabilities_fail_closed(self):
-        """When tool-result lookup returns None, route to aux (safe default)."""
+    def test_unknown_provider_capabilities_with_vision_keep_native_for_followup_split(self):
+        """Known vision support is enough; run_agent can avoid role=tool images."""
         from tools.computer_use import vision_routing
 
         with patch.object(vision_routing, "_lookup_supports_vision", return_value=True), \
@@ -170,7 +170,7 @@ class TestRouteDecision:
                           return_value=None):
             assert vision_routing.should_route_capture_to_aux_vision(
                 "exotic-provider", "exotic-model", {}
-            ) is True
+            ) is False
 
     def test_unknown_vision_capability_fails_closed(self):
         """When models.dev has no entry, prefer aux over a likely 404."""

--- a/tools/computer_use/vision_routing.py
+++ b/tools/computer_use/vision_routing.py
@@ -138,12 +138,17 @@ def should_route_capture_to_aux_vision(
         return True
 
     accepts_tool_image = _provider_accepts_multimodal_tool_result(provider, model)
+    supports_vision = _lookup_supports_vision(provider, model)
+    if supports_vision is True:
+        # A vision-capable model behind a provider that rejects images inside
+        # role=tool messages can still receive the screenshot as a follow-up
+        # normal user image. Keep the multimodal envelope so run_agent can
+        # split it into text-only tool result + user image.
+        return False
+
     if accepts_tool_image is None or accepts_tool_image is False:
         return True
 
-    supports_vision = _lookup_supports_vision(provider, model)
-    if supports_vision is True:
-        return False
     return True
 
 

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -441,6 +441,18 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
     if not p:
         return False
 
+    # Config-declared custom/local providers can override this explicitly.
+    # Some OpenAI-compatible local runtimes accept image_url in normal user
+    # messages but reject image_url parts inside role=tool messages.
+    try:
+        from agent.models_dev import get_model_capabilities
+        caps = get_model_capabilities(provider, model)
+        declared = getattr(caps, "supports_multimodal_tool_results", None) if caps else None
+        if isinstance(declared, bool):
+            return declared
+    except Exception:
+        pass
+
     # Aggregators that route to multiple vendors — assume support since
     # users on these aggregators are typically using vision-capable
     # frontier models. Falling back to text would be a regression for

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -1,3 +1,6 @@
+import { execFile, spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+
 import { Box, type ScrollBoxHandle, stringWidth, Text } from '@hermes/ink'
 import { useStore } from '@nanostores/react'
 import { type ReactNode, type RefObject, useEffect, useMemo, useRef, useState } from 'react'
@@ -19,6 +22,8 @@ import type { Msg, Usage } from '../types.js'
 
 const FACE_TICK_MS = 2500
 const HEART_COLORS = ['#ff5fa2', '#ff4d6d']
+const CODEX_LIMITS_REFRESH_MS = 60_000
+const CODEX_LIMITS_TIMEOUT_MS = 8_000
 
 // Keep verb segment width stable so status-bar content to the right doesn't
 // jitter when the ticker rotates between short/long verbs.
@@ -241,6 +246,172 @@ function SessionDuration({ startedAt }: { startedAt: number }) {
   return fmtDuration(now - startedAt)
 }
 
+const CODEX_APP_BINARY = '/Applications/Codex.app/Contents/Resources/codex'
+
+function codexLimitsCommand() {
+  const configured = process.env.HERMES_CODEX_LIMITS_CMD?.trim()
+  return configured && existsSync(configured) ? configured : null
+}
+
+function windowName(minutes?: null | number) {
+  if (minutes === 300) {
+    return '5h'
+  }
+
+  if (minutes === 10080) {
+    return 'wk'
+  }
+
+  if (!minutes) {
+    return 'win'
+  }
+
+  if (minutes % 1440 === 0) {
+    return `${minutes / 1440}d`
+  }
+
+  if (minutes % 60 === 0) {
+    return `${minutes / 60}h`
+  }
+
+  return `${minutes}m`
+}
+
+function miniCodexLimitStatus(result: any) {
+  const byId = result?.rateLimitsByLimitId ?? {}
+  const snapshot = byId.codex ?? result?.rateLimits ?? Object.values(byId)[0]
+
+  if (!snapshot || typeof snapshot !== 'object') {
+    return ''
+  }
+
+  const pieces = ['primary', 'secondary'].flatMap(key => {
+    const window = snapshot[key]
+
+    if (!window || typeof window !== 'object') {
+      return []
+    }
+
+    const used = Number(window.usedPercent ?? 0)
+    const left = Math.max(0, Math.round(100 - used))
+    return [`${windowName(Number(window.windowDurationMins))} ${left}%`]
+  })
+
+  return pieces.length ? `Codex ${pieces.join(' ')}` : ''
+}
+
+function readCodexLimitsStatus(): Promise<string> {
+  const overrideCmd = codexLimitsCommand()
+
+  if (overrideCmd) {
+    return new Promise(resolve => {
+      execFile(overrideCmd, ['--mini'], { timeout: CODEX_LIMITS_TIMEOUT_MS }, (error, stdout) => {
+        resolve(error ? '' : stdout.trim().replace(/\s+/g, ' '))
+      })
+    })
+  }
+
+  if (!existsSync(CODEX_APP_BINARY)) {
+    return Promise.resolve('')
+  }
+
+  return new Promise(resolve => {
+    const child = spawn(CODEX_APP_BINARY, ['app-server', '--listen', 'stdio://'], {
+      stdio: ['pipe', 'pipe', 'ignore']
+    })
+    let output = ''
+    let done = false
+    const finish = (status = '') => {
+      if (done) {
+        return
+      }
+
+      done = true
+      clearTimeout(timer)
+      child.kill()
+      resolve(status)
+    }
+    const timer = setTimeout(() => finish(''), CODEX_LIMITS_TIMEOUT_MS)
+
+    child.stdout.setEncoding('utf8')
+    child.stdout.on('data', chunk => {
+      output += chunk
+      const lines = output.split('\n')
+      output = lines.pop() ?? ''
+
+      for (const line of lines) {
+        try {
+          const message = JSON.parse(line)
+
+          if (message?.id === 2) {
+            finish(message.error ? '' : miniCodexLimitStatus(message.result))
+            return
+          }
+        } catch {
+          // Ignore non-JSON notifications/noise from the local app-server.
+        }
+      }
+    })
+    child.on('error', () => finish(''))
+    child.on('close', () => finish(''))
+    child.stdin.write(
+      `${JSON.stringify({ id: 1, method: 'initialize', params: { clientInfo: { name: 'hermes-tui', version: '0.1' }, capabilities: { experimentalApi: true } } })}\n`
+    )
+    child.stdin.write(`${JSON.stringify({ id: 2, method: 'account/rateLimits/read', params: null })}\n`)
+  })
+}
+
+function codexLimitColor(label: string, t: Theme) {
+  const values = [...label.matchAll(/(\d+)%/g)].map(match => Number(match[1]))
+  const lowest = values.length ? Math.min(...values) : 100
+
+  if (lowest <= 10) {
+    return t.color.statusCritical
+  }
+
+  if (lowest <= 25) {
+    return t.color.statusBad
+  }
+
+  if (lowest <= 50) {
+    return t.color.statusWarn
+  }
+
+  return t.color.statusGood
+}
+
+function useCodexLimitsStatus() {
+  const [status, setStatus] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+
+    const refresh = () => {
+      readCodexLimitsStatus()
+        .then(nextStatus => {
+          if (!cancelled) {
+            setStatus(nextStatus)
+          }
+        })
+        .catch(() => {
+          if (!cancelled) {
+            setStatus('')
+          }
+        })
+    }
+
+    refresh()
+    const id = setInterval(refresh, CODEX_LIMITS_REFRESH_MS)
+
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [])
+
+  return status
+}
+
 const effortLabel = (effort?: string) => {
   const value = String(effort ?? '')
     .trim()
@@ -306,6 +477,8 @@ export function StatusRule({
 }: StatusRuleProps) {
   const pct = usage.context_percent
   const barColor = ctxBarColor(pct, t)
+  const codexLimitsStatus = useCodexLimitsStatus()
+  const codexLimitsColor = codexLimitsStatus ? codexLimitColor(codexLimitsStatus, t) : t.color.muted
 
   const ctxLabel = usage.context_max
     ? `${fmtK(usage.context_used ?? 0)}/${fmtK(usage.context_max)}`
@@ -340,6 +513,7 @@ export function StatusRule({
               <SessionDuration startedAt={sessionStartedAt} />
             </Text>
           ) : null}
+          {codexLimitsStatus ? <Text color={codexLimitsColor}> │ {codexLimitsStatus}</Text> : null}
           {typeof usage.compressions === 'number' && usage.compressions > 0 ? (
             <Text color={t.color.muted}>
               {' │ '}


### PR DESCRIPTION
## Summary
- Add config-backed capability metadata for custom/local providers.
- Allow custom providers to declare `supports_tools`, `supports_vision`, `supports_reasoning`, `context_length`, output-token limits, and `supports_multimodal_tool_results`.
- Support per-model capability/context overrides under a provider `models:` map.
- Use this metadata in model capability lookup, context lookup, native image routing, and multimodal tool-result handling so local OpenAI-compatible models can be configured as real visual tool-using agents.

## Why
Local/custom OpenAI-compatible providers are not listed in models.dev, so Hermes previously treated them as unknown for vision support. That blocked native screenshot routing for local models that can use tools and images, such as Qwen3.6 35B and Qwen3.6 27B running through a local endpoint.

A second compatibility issue showed up with LM Studio/Qwen: the runtime accepts `image_url` parts in normal user messages, but rejects image parts inside `role: "tool"` messages. This PR now supports that split explicitly:

1. send the required tool result as text-only, preserving the tool-call protocol;
2. append the screenshot/image as a follow-up normal user message when `supports_multimodal_tool_results: false`.

## Example config
```yaml
providers:
  qwen-local:
    name: qwen-local
    base_url: http://127.0.0.1:1234/v1
    api_mode: chat_completions
    supports_tools: true
    supports_vision: true
    supports_multimodal_tool_results: false
    context_length: 65536
    models:
      qwen36-35b-vision:
        context_length: 32768
      qwen36-27b-vision:
        context_length: 65536
        supports_multimodal_tool_results: false
```

## Test Plan
- [x] `uv run --with python-dotenv --with pyyaml --with requests python -m py_compile agent/models_dev.py hermes_cli/config.py run_agent.py agent/tool_executor.py tools/vision_tools.py tools/computer_use/vision_routing.py`
- [x] `uv run --with pytest --with python-dotenv --with pyyaml --with requests python -m pytest tests/agent/test_models_dev.py tests/agent/test_image_routing.py tests/run_agent/test_multimodal_tool_content_recovery.py tests/tools/test_computer_use_vision_routing.py tests/tools/test_computer_use.py -q -o 'addopts='`
- [x] Local result for the updated focused suite: `213 passed`.
- [x] Earlier focused capability/config suite passed after the first commit: `107 passed`.
- [x] Verified smoke resolution for configured Qwen3.6 35B and 27B: tools=true, vision=true, native image mode, expected context lengths.
- [x] Verified direct LM Studio/Qwen user-message vision reads image pixels.
- [x] Verified Hermes `--image` native user-image routing with the Qwen profile.

## Notes
- Existing providers that already support multimodal tool results keep their current behavior.
- The new split path is only used when the active model supports vision but the provider/model is declared or detected as not accepting multimodal tool-result images.
