### PR TITLE
feat(kanban): add chat triage board routing

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1894,6 +1894,122 @@ def coerce_plaintext_gateway_command(event: "MessageEvent") -> None:
         return
 
 
+def _truthy_config_value(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on", "enabled"}:
+            return True
+        if normalized in {"0", "false", "no", "off", "disabled"}:
+            return False
+    return bool(value)
+
+
+def _kanban_chat_triage_config(extra: dict | None) -> dict | None:
+    raw = (extra or {}).get("kanban_chat_triage")
+    if raw is True:
+        return {"enabled": True}
+    if not isinstance(raw, dict):
+        return None
+    if not _truthy_config_value(raw.get("enabled"), False):
+        return None
+    return dict(raw)
+
+
+def _kanban_chat_triage_text(event: "MessageEvent", cfg: dict) -> str | None:
+    if (
+        event.source is None
+        or event.internal
+        or event.message_type != MessageType.TEXT
+        or event.is_command()
+    ):
+        return None
+    text = str(event.text or "").strip()
+    if not text:
+        return None
+    if _truthy_config_value(cfg.get("capture_all"), False):
+        return text
+    prefixes = cfg.get("trigger_prefixes", ("kanban:", "todo:"))
+    if isinstance(prefixes, str):
+        prefixes = [prefixes]
+    if not isinstance(prefixes, (list, tuple, set)):
+        return None
+    lowered = text.casefold()
+    for prefix in prefixes:
+        prefix_text = str(prefix or "").strip()
+        if prefix_text and lowered.startswith(prefix_text.casefold()):
+            return text[len(prefix_text):].strip() or text
+    return None
+
+
+def _kanban_chat_triage_source(event: "MessageEvent") -> dict:
+    source = event.source.to_dict() if event.source is not None else {}
+    if event.message_id and not source.get("message_id"):
+        source["message_id"] = str(event.message_id)
+    if event.reply_to_message_id:
+        source["reply_to_message_id"] = str(event.reply_to_message_id)
+    if event.platform_update_id is not None:
+        source["platform_update_id"] = event.platform_update_id
+    return source
+
+
+def _kanban_chat_triage_classification(
+    text: str,
+    event: "MessageEvent",
+    cfg: dict,
+) -> dict:
+    configured = cfg.get("classification") if isinstance(cfg.get("classification"), dict) else {}
+    classification = dict(configured)
+    classification.setdefault("intent", str(cfg.get("intent") or "task_request"))
+    classification.setdefault("category", str(cfg.get("category") or "general"))
+    classification.setdefault("confidence", 1.0)
+    if cfg.get("project_hint") and not classification.get("project_hint"):
+        classification["project_hint"] = str(cfg["project_hint"])
+    if cfg.get("assignee") and not classification.get("assignee"):
+        classification["assignee"] = str(cfg["assignee"])
+    if event.media_urls:
+        classification.setdefault(
+            "attachments",
+            [
+                {
+                    "type": event.media_types[idx] if idx < len(event.media_types) else "",
+                    "url": url,
+                }
+                for idx, url in enumerate(event.media_urls)
+            ],
+        )
+    if not classification.get("title"):
+        title = re.split(r"[.!?\n]", text, maxsplit=1)[0].strip()
+        if title:
+            classification["title"] = title
+    return classification
+
+
+def _kanban_chat_triage_context(event: "MessageEvent") -> dict:
+    context: dict[str, Any] = {}
+    if event.reply_to_text:
+        context["reply_to_text"] = event.reply_to_text
+    if event.reply_to_author_id:
+        context["reply_to_author_id"] = event.reply_to_author_id
+    if event.reply_to_author_name:
+        context["reply_to_author_name"] = event.reply_to_author_name
+    if event.channel_context:
+        context["channel_context"] = event.channel_context
+    metadata = {
+        k: v
+        for k, v in (event.metadata or {}).items()
+        if str(k).startswith("kanban_chat_triage_")
+    }
+    if metadata:
+        context["metadata"] = metadata
+    return context
+
+
 @dataclass
 class SendResult:
     """Result of sending a message."""
@@ -4673,6 +4789,53 @@ class BasePlatformAdapter(ABC):
 
         await self._drain_pending_after_session_command(session_key, command_guard)
 
+    async def _maybe_route_kanban_chat_triage(self, event: MessageEvent) -> bool:
+        cfg = _kanban_chat_triage_config(getattr(self.config, "extra", None))
+        if not cfg:
+            return False
+        triage_text = _kanban_chat_triage_text(event, cfg)
+        if triage_text is None:
+            return False
+
+        thread_meta = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
+        try:
+            from hermes_cli.kanban_chat_triage import route_chat_triage_task
+
+            result = await asyncio.to_thread(
+                route_chat_triage_task,
+                message_text=triage_text,
+                classification=_kanban_chat_triage_classification(
+                    triage_text,
+                    event,
+                    cfg,
+                ),
+                source=_kanban_chat_triage_source(event),
+                context=_kanban_chat_triage_context(event),
+                config=cfg,
+                board_override=cfg.get("board"),
+                created_by=f"gateway:{_platform_name(self.platform)}",
+            )
+            ack = str(result.get("ack") or "").strip()
+        except Exception as exc:
+            from hermes_cli.kanban_chat_triage import redact_chat_triage_text
+
+            ack = "Kanban triage failed: " + redact_chat_triage_text(str(exc))
+            logger.warning(
+                "[%s] Kanban chat triage failed: %s",
+                self.name,
+                ack,
+            )
+
+        if not _truthy_config_value(cfg.get("ack"), True):
+            return True
+        await self._send_with_retry(
+            chat_id=event.source.chat_id,
+            content=ack or "Queued for Kanban triage.",
+            reply_to=_reply_anchor_for_event(event),
+            metadata=_mark_notify_metadata(thread_meta),
+        )
+        return True
+
     async def handle_message(self, event: MessageEvent) -> None:
         """
         Process an incoming message.
@@ -4691,6 +4854,9 @@ class BasePlatformAdapter(ABC):
         # downstream delivery all agree on the same lane.
         # Offloaded: the sync hook must not block the loop.
         await asyncio.to_thread(self._apply_topic_recovery, event)
+
+        if await self._maybe_route_kanban_chat_triage(event):
+            return
 
         session_key = build_session_key(
             event.source,

--- a/hermes_cli/kanban_chat_triage.py
+++ b/hermes_cli/kanban_chat_triage.py
@@ -1,0 +1,536 @@
+"""Kanban-side chat triage routing helpers.
+
+This module is intentionally gateway-agnostic: platform adapters/classifiers can
+hand it normalized message metadata plus a deterministic classification, and it
+will resolve/create the right board, create exactly one triage task for the
+source message, and return the identifiers the gateway needs to acknowledge the
+queueing action.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+from hermes_cli import kanban_db as kb
+
+_ROUTING_VERSION = 1
+_MAX_TITLE = 80
+_GENERIC_PROJECT_NAMES = {
+    "bug",
+    "general",
+    "misc",
+    "stuff",
+    "task",
+    "tasks",
+    "thing",
+    "things",
+    "todo",
+    "work",
+}
+_SECRET_PATTERNS = (
+    re.compile(r"(?i)(api[_-]?key|token|password|secret|oauth[_-]?code)\s*[:=]\s*\S+"),
+    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----", re.S),
+)
+
+
+class ChatTriageError(RuntimeError):
+    """Actionable failure while resolving/creating a chat triage task."""
+
+
+@dataclass(frozen=True)
+class BoardDecision:
+    board_slug: str
+    source: str
+    created_board: bool = False
+    fallback_used: bool = False
+    reason: str = ""
+    unresolved_hint: Optional[str] = None
+
+
+def route_chat_triage_task(
+    *,
+    message_text: str,
+    classification: Mapping[str, Any],
+    source: Mapping[str, Any],
+    config: Optional[Mapping[str, Any]] = None,
+    context: Optional[Mapping[str, Any]] = None,
+    board_override: Optional[str] = None,
+    created_by: str = "chat-triage-router",
+) -> dict[str, Any]:
+    """Create or reuse a board and park the gateway message in triage.
+
+    Returns a stable dict containing ``board_id`` and ``task_id`` for gateway
+    acknowledgements. Duplicate deliveries of the same platform/chat/thread/
+    message id reuse the original task by passing an idempotency key through to
+    ``kanban_db.create_task``.
+    """
+
+    if not str(message_text or "").strip():
+        raise ChatTriageError("cannot create triage task: message_text is required")
+    cfg = dict(config or {})
+    src = {str(k): v for k, v in dict(source or {}).items() if v is not None}
+    cls = dict(classification or {})
+
+    decision = _resolve_or_create_board(
+        message_text=message_text,
+        classification=cls,
+        source=src,
+        config=cfg,
+        board_override=board_override,
+    )
+    assignee = _select_assignee(cls, cfg)
+    title = _derive_title(message_text, cls)
+    priority = _derive_priority(message_text, cls)
+    body = _build_task_body(
+        message_text=message_text,
+        classification=cls,
+        source=src,
+        context=dict(context or {}),
+        board_decision=decision,
+    )
+    idem = _idempotency_key(src, message_text)
+
+    try:
+        with kb.connect(board=decision.board_slug) as conn:
+            task_id = kb.create_task(
+                conn,
+                title=title,
+                body=body,
+                assignee=assignee,
+                created_by=created_by,
+                priority=priority,
+                triage=True,
+                idempotency_key=idem,
+            )
+            routing_metadata = _build_routing_metadata(
+                source=src,
+                message_text=message_text,
+                classification=cls,
+                board_decision=decision,
+                task_id=task_id,
+                assignee=assignee,
+                priority=priority,
+            )
+            _record_chat_routing_event(conn, task_id, routing_metadata)
+    except Exception as exc:  # pragma: no cover - exact sqlite details are platform-dependent
+        if isinstance(exc, ChatTriageError):
+            raise
+        raise ChatTriageError(
+            f"failed to create chat triage task on board {decision.board_slug!r}: {exc}"
+        ) from exc
+
+    ack = _format_ack(cfg, decision, task_id)
+    return {
+        "board_id": decision.board_slug,
+        "board_slug": decision.board_slug,
+        "task_id": task_id,
+        "created_board": decision.created_board,
+        "fallback_used": decision.fallback_used,
+        "ack": ack,
+        "chat_routing": routing_metadata,
+    }
+
+
+def _resolve_or_create_board(
+    *,
+    message_text: str,
+    classification: Mapping[str, Any],
+    source: Mapping[str, Any],
+    config: Mapping[str, Any],
+    board_override: Optional[str],
+) -> BoardDecision:
+    fallback = _safe_new_board_slug(config.get("fallback_board") or kb.DEFAULT_BOARD) or kb.DEFAULT_BOARD
+    candidate, decision_source, reason, explicit = _select_board_candidate(
+        message_text=message_text,
+        classification=classification,
+        config=config,
+        board_override=board_override,
+    )
+    candidate = candidate or fallback
+
+    try:
+        candidate_slug = _safe_new_board_slug(candidate)
+    except ValueError as exc:
+        raise ChatTriageError(f"invalid selected board {candidate!r}: {exc}") from exc
+    if not candidate_slug:
+        if candidate and str(candidate).strip() and str(candidate).strip().casefold() != fallback:
+            if not kb.board_exists(fallback):
+                if not bool(config.get("create_missing_boards", True)):
+                    raise ChatTriageError(
+                        f"fallback board {fallback!r} does not exist and create_missing_boards is false; "
+                        "create the fallback board or enable create_missing_boards"
+                    )
+                _create_board(fallback, classification={"category": "general"}, reason="missing fallback")
+                fallback_created = True
+            else:
+                fallback_created = False
+            return BoardDecision(
+                fallback,
+                "fallback",
+                created_board=fallback_created,
+                fallback_used=True,
+                reason=f"selected board hint {candidate!r} was generic or invalid",
+                unresolved_hint=str(candidate),
+            )
+        candidate_slug = fallback
+
+    if kb.board_exists(candidate_slug):
+        return BoardDecision(candidate_slug, decision_source, reason=reason)
+
+    if _may_create_board(
+        slug=candidate_slug,
+        explicit=explicit,
+        classification=classification,
+        config=config,
+        source=decision_source,
+    ):
+        _create_board(candidate_slug, classification=classification, reason=reason)
+        return BoardDecision(
+            candidate_slug,
+            decision_source,
+            created_board=True,
+            reason=f"created missing board {candidate_slug!r} ({reason})",
+        )
+
+    # Missing/uncertain selected board falls back, but do not silently create
+    # the fallback if config explicitly disabled board creation.
+    if not kb.board_exists(fallback):
+        if not bool(config.get("create_missing_boards", True)):
+            raise ChatTriageError(
+                f"fallback board {fallback!r} does not exist and create_missing_boards is false; "
+                "create the fallback board or enable create_missing_boards"
+            )
+        _create_board(fallback, classification={"category": "general"}, reason="missing fallback")
+        fallback_created = True
+    else:
+        fallback_created = False
+
+    return BoardDecision(
+        fallback,
+        "fallback",
+        created_board=fallback_created,
+        fallback_used=True,
+        reason=f"selected board {candidate_slug!r} missing or not allowed by policy",
+        unresolved_hint=candidate_slug,
+    )
+
+
+def _select_board_candidate(
+    *,
+    message_text: str,
+    classification: Mapping[str, Any],
+    config: Mapping[str, Any],
+    board_override: Optional[str],
+) -> tuple[Optional[str], str, str, bool]:
+    if board_override:
+        return str(board_override), "override", "explicit board override", True
+
+    text = message_text or ""
+    explicit = _explicit_board_or_project(text)
+    if explicit:
+        alias = _match_configured_board_alias(explicit.replace("-", " "), config)
+        if alias:
+            slug, matched = alias
+            return slug, "alias_match", f"explicit hint matched configured alias {matched!r}", True
+        return explicit, "explicit_project", f"explicit board/project hint {explicit!r}", True
+
+    project_hint = str(classification.get("project_hint") or "").strip()
+    explicit_hint = _explicit_board_or_project(project_hint)
+    if explicit_hint:
+        return explicit_hint, "explicit_project", f"explicit classifier project hint {explicit_hint!r}", True
+
+    alias = _match_configured_board_alias(project_hint or text, config)
+    if alias:
+        slug, matched = alias
+        return slug, "alias_match", f"matched configured alias {matched!r}", False
+
+    if project_hint:
+        return project_hint, "project_hint", f"classifier project_hint {project_hint!r}", False
+
+    category = str(classification.get("category") or "general").strip() or "general"
+    category_cfg = _mapping(config.get("categories")).get(category, {})
+    if isinstance(category_cfg, Mapping) and category_cfg.get("board"):
+        return str(category_cfg["board"]), "category_default", f"category {category!r} default board", False
+
+    return str(config.get("fallback_board") or kb.DEFAULT_BOARD), "fallback", "global fallback board", False
+
+
+def _explicit_board_or_project(text: str) -> Optional[str]:
+    if not text:
+        return None
+    patterns = (
+        r"\bboard\s*[:=]\s*([A-Za-z0-9][A-Za-z0-9_-]*)",
+        r"\bproject\s*[:=]\s*([^\n:;,.—–-]+)",
+        r"\bfor\s+([A-Za-z0-9][A-Za-z0-9 _-]{1,63}?)(?:\s*[:—-]|$)",
+    )
+    for pattern in patterns:
+        match = re.search(pattern, text, flags=re.I)
+        if match:
+            value = match.group(1).strip()
+            slug = _safe_new_board_slug(value)
+            if slug:
+                return slug
+    return None
+
+
+def _match_configured_board_alias(text: str, config: Mapping[str, Any]) -> Optional[tuple[str, str]]:
+    haystack = f" {str(text or '').casefold()} "
+    boards = _mapping(config.get("boards"))
+    matches: list[tuple[str, str]] = []
+    for raw_slug, raw_meta in boards.items():
+        try:
+            slug = kb._normalize_board_slug(str(raw_slug))
+        except ValueError:
+            continue
+        if not slug:
+            continue
+        aliases = [slug]
+        if isinstance(raw_meta, Mapping):
+            aliases.extend(str(a) for a in raw_meta.get("aliases") or [] if a)
+        for alias in aliases:
+            needle = f" {alias.casefold()} "
+            if needle in haystack:
+                matches.append((slug, alias))
+                break
+    if not matches:
+        return None
+    # Deterministic: prefer longest alias (most specific), then slug order.
+    matches.sort(key=lambda item: (-len(item[1]), item[0]))
+    return matches[0]
+
+
+def _may_create_board(
+    *,
+    slug: str,
+    explicit: bool,
+    classification: Mapping[str, Any],
+    config: Mapping[str, Any],
+    source: str,
+) -> bool:
+    if not bool(config.get("create_missing_boards", True)):
+        return False
+    if _is_generic_project_slug(slug):
+        return False
+    policy = str(config.get("board_create_policy") or "explicit_project_only")
+    if policy == "never":
+        return False
+    if policy == "always":
+        return True
+    confidence = _float(classification.get("confidence"), default=0.0)
+    if policy == "confident_project":
+        return confidence >= 0.85
+    if policy == "explicit_project_only":
+        return explicit or source == "override"
+    return False
+
+
+def _create_board(slug: str, *, classification: Mapping[str, Any], reason: str) -> None:
+    category = str(classification.get("category") or "general")
+    name = _display_name(slug)
+    description = (
+        "Auto-created by chat triage routing. Default Kanban statuses include "
+        f"triage; initial category={category}; reason={reason}."
+    )
+    try:
+        kb.create_board(slug, name=name, description=description)
+    except Exception as exc:
+        raise ChatTriageError(f"failed to create board {slug!r}: {exc}") from exc
+
+
+def _select_assignee(classification: Mapping[str, Any], config: Mapping[str, Any]) -> Optional[str]:
+    if classification.get("assignee"):
+        return str(classification["assignee"])
+    category = str(classification.get("category") or "general").strip() or "general"
+    category_cfg = _mapping(config.get("categories")).get(category, {})
+    if isinstance(category_cfg, Mapping) and category_cfg.get("assignee"):
+        return str(category_cfg["assignee"])
+    if config.get("triage_assignee"):
+        return str(config["triage_assignee"])
+    return None
+
+
+def _derive_title(message_text: str, classification: Mapping[str, Any]) -> str:
+    raw = str(classification.get("title") or classification.get("extracted_title") or "").strip()
+    if not raw:
+        raw = re.split(r"[.!?\n]", message_text.strip(), maxsplit=1)[0].strip()
+    raw = re.sub(r"\s+", " ", raw)
+    if len(raw) > _MAX_TITLE:
+        raw = raw[: _MAX_TITLE - 1].rstrip() + "…"
+    return raw or "Triage chat request"
+
+
+def _derive_priority(message_text: str, classification: Mapping[str, Any]) -> int:
+    urgency = str(classification.get("urgency") or "").casefold()
+    text = message_text.casefold()
+    if urgency in {"urgent", "high"} or any(w in text for w in ("urgent", "asap", "emergency")):
+        return 10
+    if urgency == "low" or any(w in text for w in ("someday", "backlog", "low priority")):
+        return -5
+    return 0
+
+
+def _build_task_body(
+    *,
+    message_text: str,
+    classification: Mapping[str, Any],
+    source: Mapping[str, Any],
+    context: Mapping[str, Any],
+    board_decision: BoardDecision,
+) -> str:
+    safe_text = _redact(message_text.strip())
+    lines = [
+        "Triage this request, assign the right specialist, and refine acceptance criteria before implementation.",
+        "",
+        "## Original message",
+        safe_text,
+        "",
+        "## Source",
+        _json_block(source),
+        "",
+        "## Classification",
+        _json_block(classification),
+        "",
+        "## Board decision",
+        _json_block(board_decision.__dict__),
+    ]
+    acceptance = classification.get("acceptance_criteria") or classification.get("criteria")
+    if acceptance:
+        lines.extend(["", "## Extracted acceptance criteria", _format_listish(acceptance)])
+    links = classification.get("links") or classification.get("link_urls")
+    if links:
+        lines.extend(["", "## Links", _format_listish(links)])
+    attachments = classification.get("attachments")
+    if attachments:
+        lines.extend(["", "## Attachments", _format_listish(attachments)])
+    if context:
+        lines.extend(["", "## Context", _json_block(context)])
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _build_routing_metadata(
+    *,
+    source: Mapping[str, Any],
+    message_text: str,
+    classification: Mapping[str, Any],
+    board_decision: BoardDecision,
+    task_id: str,
+    assignee: Optional[str],
+    priority: int,
+) -> dict[str, Any]:
+    return {
+        "routing_version": _ROUTING_VERSION,
+        "source": dict(source),
+        "message": {
+            "text_sha256": hashlib.sha256(message_text.encode("utf-8")).hexdigest(),
+            "text_excerpt": _redact(message_text.strip())[:280],
+            "attachment_count": _attachment_count(classification),
+            "link_urls": list(classification.get("link_urls") or classification.get("links") or []),
+        },
+        "classification": dict(classification),
+        "board_decision": dict(board_decision.__dict__),
+        "task_decision": {
+            "task_id": task_id,
+            "assignee": assignee,
+            "priority": priority,
+            "status": "triage",
+        },
+        "ack": {"sent": False, "format": None, "reply_message_id": None},
+        "bypass": {"bypassed": False, "rule": None},
+    }
+
+
+def _record_chat_routing_event(conn, task_id: str, routing_metadata: Mapping[str, Any]) -> None:
+    # Duplicate gateway deliveries reuse create_task(idempotency_key=...) and
+    # should not spam duplicate routing events either.
+    if any(event.kind == "chat_routing" for event in kb.list_events(conn, task_id)):
+        return
+    with kb.write_txn(conn):
+        kb._append_event(conn, task_id, "chat_routing", {"chat_routing": dict(routing_metadata)})
+
+
+def _format_ack(config: Mapping[str, Any], decision: BoardDecision, task_id: str) -> str:
+    template = str(config.get("ack_template") or "Queued for triage: board={board_slug} task={task_id}")
+    try:
+        ack = template.format(board_slug=decision.board_slug, board_id=decision.board_slug, task_id=task_id)
+    except Exception:
+        ack = f"Queued for triage: board={decision.board_slug} task={task_id}"
+    if decision.created_board and "created" not in ack.lower():
+        ack += " (created new board)"
+    elif decision.fallback_used and decision.unresolved_hint:
+        ack += f" (could not confidently match {decision.unresolved_hint})"
+    return ack
+
+
+def _idempotency_key(source: Mapping[str, Any], message_text: str) -> str:
+    identity_parts = [
+        source.get("platform"),
+        source.get("chat_id") or source.get("channel_id"),
+        source.get("thread_id"),
+        source.get("message_id"),
+    ]
+    if any(identity_parts):
+        raw = "|".join(str(p or "") for p in identity_parts)
+    else:
+        raw = "text|" + hashlib.sha256(message_text.encode("utf-8")).hexdigest()
+    return "chat-triage:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _safe_new_board_slug(value: Any) -> Optional[str]:
+    s = str(value or "").strip().casefold()
+    if not s:
+        return None
+    s = re.sub(r"[^a-z0-9]+", "-", s)
+    s = re.sub(r"-+", "-", s).strip("-")[:64].strip("-")
+    if not s or _is_generic_project_slug(s):
+        return None
+    return kb._normalize_board_slug(s)
+
+
+def _is_generic_project_slug(slug: str) -> bool:
+    return slug.casefold().strip("-_") in _GENERIC_PROJECT_NAMES
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _display_name(slug: str) -> str:
+    return " ".join(part.capitalize() for part in slug.replace("_", "-").split("-") if part)
+
+
+def _redact(text: str) -> str:
+    redacted = text
+    for pattern in _SECRET_PATTERNS:
+        redacted = pattern.sub(lambda m: f"{m.group(1) if m.groups() else 'secret'}=[REDACTED]", redacted)
+    return redacted
+
+
+def _json_block(value: Any) -> str:
+    return "```json\n" + json.dumps(value, indent=2, ensure_ascii=False, default=str) + "\n```"
+
+
+def _format_listish(value: Any) -> str:
+    if isinstance(value, (list, tuple, set)):
+        return "\n".join(f"- {item}" for item in value)
+    return str(value)
+
+
+def _attachment_count(classification: Mapping[str, Any]) -> int:
+    attachments = classification.get("attachments")
+    if isinstance(attachments, (list, tuple, set)):
+        return len(attachments)
+    try:
+        return int(classification.get("attachment_count") or 0)
+    except Exception:
+        return 0
+
+
+def _float(value: Any, *, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default

--- a/hermes_cli/kanban_chat_triage.py
+++ b/hermes_cli/kanban_chat_triage.py
@@ -15,6 +15,7 @@ import re
 from dataclasses import dataclass
 from typing import Any, Mapping, Optional
 
+from agent.redact import redact_sensitive_text
 from hermes_cli import kanban_db as kb
 
 _ROUTING_VERSION = 1
@@ -31,9 +32,12 @@ _GENERIC_PROJECT_NAMES = {
     "todo",
     "work",
 }
-_SECRET_PATTERNS = (
-    re.compile(r"(?i)(api[_-]?key|token|password|secret|oauth[_-]?code)\s*[:=]\s*\S+"),
-    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----", re.S),
+_EMBEDDED_SECRET_PATTERNS = (
+    (re.compile(r"sk-[A-Za-z0-9][A-Za-z0-9_-]{12,}"), "«redacted:sk-…»"),
+    (re.compile(r"gh[pousr]_[A-Za-z0-9_]{20,}"), "«redacted:gh…»"),
+    (re.compile(r"xox[baprs]-[A-Za-z0-9-]{20,}"), "«redacted:xox…»"),
+    (re.compile(r"hf_[A-Za-z0-9]{20,}"), "«redacted:hf_…»"),
+    (re.compile(r"glpat-[A-Za-z0-9_-]{20,}"), "«redacted:glpat-…»"),
 )
 
 
@@ -83,7 +87,8 @@ def route_chat_triage_task(
         board_override=board_override,
     )
     assignee = _select_assignee(cls, cfg)
-    title = _derive_title(message_text, cls)
+    assignee = _redact(assignee) if assignee is not None else None
+    title = _redact(_derive_title(message_text, cls))
     priority = _derive_priority(message_text, cls)
     body = _build_task_body(
         message_text=message_text,
@@ -116,7 +121,9 @@ def route_chat_triage_task(
                 priority=priority,
             )
             _record_chat_routing_event(conn, task_id, routing_metadata)
-    except Exception as exc:  # pragma: no cover - exact sqlite details are platform-dependent
+    except (
+        Exception
+    ) as exc:  # pragma: no cover - exact sqlite details are platform-dependent
         if isinstance(exc, ChatTriageError):
             raise
         raise ChatTriageError(
@@ -143,7 +150,10 @@ def _resolve_or_create_board(
     config: Mapping[str, Any],
     board_override: Optional[str],
 ) -> BoardDecision:
-    fallback = _safe_new_board_slug(config.get("fallback_board") or kb.DEFAULT_BOARD) or kb.DEFAULT_BOARD
+    fallback = (
+        _safe_new_board_slug(config.get("fallback_board") or kb.DEFAULT_BOARD)
+        or kb.DEFAULT_BOARD
+    )
     candidate, decision_source, reason, explicit = _select_board_candidate(
         message_text=message_text,
         classification=classification,
@@ -157,14 +167,22 @@ def _resolve_or_create_board(
     except ValueError as exc:
         raise ChatTriageError(f"invalid selected board {candidate!r}: {exc}") from exc
     if not candidate_slug:
-        if candidate and str(candidate).strip() and str(candidate).strip().casefold() != fallback:
+        if (
+            candidate
+            and str(candidate).strip()
+            and str(candidate).strip().casefold() != fallback
+        ):
             if not kb.board_exists(fallback):
                 if not bool(config.get("create_missing_boards", True)):
                     raise ChatTriageError(
                         f"fallback board {fallback!r} does not exist and create_missing_boards is false; "
                         "create the fallback board or enable create_missing_boards"
                     )
-                _create_board(fallback, classification={"category": "general"}, reason="missing fallback")
+                _create_board(
+                    fallback,
+                    classification={"category": "general"},
+                    reason="missing fallback",
+                )
                 fallback_created = True
             else:
                 fallback_created = False
@@ -204,7 +222,9 @@ def _resolve_or_create_board(
                 f"fallback board {fallback!r} does not exist and create_missing_boards is false; "
                 "create the fallback board or enable create_missing_boards"
             )
-        _create_board(fallback, classification={"category": "general"}, reason="missing fallback")
+        _create_board(
+            fallback, classification={"category": "general"}, reason="missing fallback"
+        )
         fallback_created = True
     else:
         fallback_created = False
@@ -235,13 +255,28 @@ def _select_board_candidate(
         alias = _match_configured_board_alias(explicit.replace("-", " "), config)
         if alias:
             slug, matched = alias
-            return slug, "alias_match", f"explicit hint matched configured alias {matched!r}", True
-        return explicit, "explicit_project", f"explicit board/project hint {explicit!r}", True
+            return (
+                slug,
+                "alias_match",
+                f"explicit hint matched configured alias {matched!r}",
+                True,
+            )
+        return (
+            explicit,
+            "explicit_project",
+            f"explicit board/project hint {explicit!r}",
+            True,
+        )
 
     project_hint = str(classification.get("project_hint") or "").strip()
     explicit_hint = _explicit_board_or_project(project_hint)
     if explicit_hint:
-        return explicit_hint, "explicit_project", f"explicit classifier project hint {explicit_hint!r}", True
+        return (
+            explicit_hint,
+            "explicit_project",
+            f"explicit classifier project hint {explicit_hint!r}",
+            True,
+        )
 
     alias = _match_configured_board_alias(project_hint or text, config)
     if alias:
@@ -249,14 +284,29 @@ def _select_board_candidate(
         return slug, "alias_match", f"matched configured alias {matched!r}", False
 
     if project_hint:
-        return project_hint, "project_hint", f"classifier project_hint {project_hint!r}", False
+        return (
+            project_hint,
+            "project_hint",
+            f"classifier project_hint {project_hint!r}",
+            False,
+        )
 
     category = str(classification.get("category") or "general").strip() or "general"
     category_cfg = _mapping(config.get("categories")).get(category, {})
     if isinstance(category_cfg, Mapping) and category_cfg.get("board"):
-        return str(category_cfg["board"]), "category_default", f"category {category!r} default board", False
+        return (
+            str(category_cfg["board"]),
+            "category_default",
+            f"category {category!r} default board",
+            False,
+        )
 
-    return str(config.get("fallback_board") or kb.DEFAULT_BOARD), "fallback", "global fallback board", False
+    return (
+        str(config.get("fallback_board") or kb.DEFAULT_BOARD),
+        "fallback",
+        "global fallback board",
+        False,
+    )
 
 
 def _explicit_board_or_project(text: str) -> Optional[str]:
@@ -277,7 +327,9 @@ def _explicit_board_or_project(text: str) -> Optional[str]:
     return None
 
 
-def _match_configured_board_alias(text: str, config: Mapping[str, Any]) -> Optional[tuple[str, str]]:
+def _match_configured_board_alias(
+    text: str, config: Mapping[str, Any]
+) -> Optional[tuple[str, str]]:
     haystack = f" {str(text or '').casefold()} "
     boards = _mapping(config.get("boards"))
     matches: list[tuple[str, str]] = []
@@ -329,11 +381,12 @@ def _may_create_board(
 
 
 def _create_board(slug: str, *, classification: Mapping[str, Any], reason: str) -> None:
-    category = str(classification.get("category") or "general")
+    category = _redact(str(classification.get("category") or "general"))
+    safe_reason = _redact(reason)
     name = _display_name(slug)
     description = (
         "Auto-created by chat triage routing. Default Kanban statuses include "
-        f"triage; initial category={category}; reason={reason}."
+        f"triage; initial category={category}; reason={safe_reason}."
     )
     try:
         kb.create_board(slug, name=name, description=description)
@@ -341,7 +394,9 @@ def _create_board(slug: str, *, classification: Mapping[str, Any], reason: str) 
         raise ChatTriageError(f"failed to create board {slug!r}: {exc}") from exc
 
 
-def _select_assignee(classification: Mapping[str, Any], config: Mapping[str, Any]) -> Optional[str]:
+def _select_assignee(
+    classification: Mapping[str, Any], config: Mapping[str, Any]
+) -> Optional[str]:
     if classification.get("assignee"):
         return str(classification["assignee"])
     category = str(classification.get("category") or "general").strip() or "general"
@@ -354,7 +409,9 @@ def _select_assignee(classification: Mapping[str, Any], config: Mapping[str, Any
 
 
 def _derive_title(message_text: str, classification: Mapping[str, Any]) -> str:
-    raw = str(classification.get("title") or classification.get("extracted_title") or "").strip()
+    raw = str(
+        classification.get("title") or classification.get("extracted_title") or ""
+    ).strip()
     if not raw:
         raw = re.split(r"[.!?\n]", message_text.strip(), maxsplit=1)[0].strip()
     raw = re.sub(r"\s+", " ", raw)
@@ -366,9 +423,13 @@ def _derive_title(message_text: str, classification: Mapping[str, Any]) -> str:
 def _derive_priority(message_text: str, classification: Mapping[str, Any]) -> int:
     urgency = str(classification.get("urgency") or "").casefold()
     text = message_text.casefold()
-    if urgency in {"urgent", "high"} or any(w in text for w in ("urgent", "asap", "emergency")):
+    if urgency in {"urgent", "high"} or any(
+        w in text for w in ("urgent", "asap", "emergency")
+    ):
         return 10
-    if urgency == "low" or any(w in text for w in ("someday", "backlog", "low priority")):
+    if urgency == "low" or any(
+        w in text for w in ("someday", "backlog", "low priority")
+    ):
         return -5
     return 0
 
@@ -382,6 +443,10 @@ def _build_task_body(
     board_decision: BoardDecision,
 ) -> str:
     safe_text = _redact(message_text.strip())
+    safe_source = _redact_value(source)
+    safe_classification = _redact_value(classification)
+    safe_context = _redact_value(context)
+    safe_board_decision = _redact_value(board_decision.__dict__)
     lines = [
         "Triage this request, assign the right specialist, and refine acceptance criteria before implementation.",
         "",
@@ -389,25 +454,35 @@ def _build_task_body(
         safe_text,
         "",
         "## Source",
-        _json_block(source),
+        _json_block(safe_source),
         "",
         "## Classification",
-        _json_block(classification),
+        _json_block(safe_classification),
         "",
         "## Board decision",
-        _json_block(board_decision.__dict__),
+        _json_block(safe_board_decision),
     ]
-    acceptance = classification.get("acceptance_criteria") or classification.get("criteria")
+    acceptance = classification.get("acceptance_criteria") or classification.get(
+        "criteria"
+    )
     if acceptance:
-        lines.extend(["", "## Extracted acceptance criteria", _format_listish(acceptance)])
+        lines.extend([
+            "",
+            "## Extracted acceptance criteria",
+            _format_listish(_redact_value(acceptance)),
+        ])
     links = classification.get("links") or classification.get("link_urls")
     if links:
-        lines.extend(["", "## Links", _format_listish(links)])
+        lines.extend(["", "## Links", _format_listish(_redact_value(links))])
     attachments = classification.get("attachments")
     if attachments:
-        lines.extend(["", "## Attachments", _format_listish(attachments)])
+        lines.extend([
+            "",
+            "## Attachments",
+            _format_listish(_redact_value(attachments)),
+        ])
     if context:
-        lines.extend(["", "## Context", _json_block(context)])
+        lines.extend(["", "## Context", _json_block(safe_context)])
     return "\n".join(lines).rstrip() + "\n"
 
 
@@ -421,14 +496,16 @@ def _build_routing_metadata(
     assignee: Optional[str],
     priority: int,
 ) -> dict[str, Any]:
-    return {
+    metadata = {
         "routing_version": _ROUTING_VERSION,
         "source": dict(source),
         "message": {
             "text_sha256": hashlib.sha256(message_text.encode("utf-8")).hexdigest(),
             "text_excerpt": _redact(message_text.strip())[:280],
             "attachment_count": _attachment_count(classification),
-            "link_urls": list(classification.get("link_urls") or classification.get("links") or []),
+            "link_urls": list(
+                classification.get("link_urls") or classification.get("links") or []
+            ),
         },
         "classification": dict(classification),
         "board_decision": dict(board_decision.__dict__),
@@ -441,41 +518,64 @@ def _build_routing_metadata(
         "ack": {"sent": False, "format": None, "reply_message_id": None},
         "bypass": {"bypassed": False, "rule": None},
     }
+    return _redact_value(metadata)
 
 
-def _record_chat_routing_event(conn, task_id: str, routing_metadata: Mapping[str, Any]) -> None:
+def _record_chat_routing_event(
+    conn, task_id: str, routing_metadata: Mapping[str, Any]
+) -> None:
     # Duplicate gateway deliveries reuse create_task(idempotency_key=...) and
     # should not spam duplicate routing events either.
     if any(event.kind == "chat_routing" for event in kb.list_events(conn, task_id)):
         return
     with kb.write_txn(conn):
-        kb._append_event(conn, task_id, "chat_routing", {"chat_routing": dict(routing_metadata)})
+        kb._append_event(
+            conn, task_id, "chat_routing", {"chat_routing": dict(routing_metadata)}
+        )
 
 
-def _format_ack(config: Mapping[str, Any], decision: BoardDecision, task_id: str) -> str:
-    template = str(config.get("ack_template") or "Queued for triage: board={board_slug} task={task_id}")
+def _format_ack(
+    config: Mapping[str, Any], decision: BoardDecision, task_id: str
+) -> str:
+    template = str(
+        config.get("ack_template")
+        or "Queued for triage: board={board_slug} task={task_id}"
+    )
     try:
-        ack = template.format(board_slug=decision.board_slug, board_id=decision.board_slug, task_id=task_id)
+        ack = template.format(
+            board_slug=decision.board_slug,
+            board_id=decision.board_slug,
+            task_id=task_id,
+        )
     except Exception:
         ack = f"Queued for triage: board={decision.board_slug} task={task_id}"
     if decision.created_board and "created" not in ack.lower():
         ack += " (created new board)"
     elif decision.fallback_used and decision.unresolved_hint:
         ack += f" (could not confidently match {decision.unresolved_hint})"
-    return ack
+    return _redact(ack)
 
 
 def _idempotency_key(source: Mapping[str, Any], message_text: str) -> str:
+    text_digest = hashlib.sha256(message_text.encode("utf-8")).hexdigest()
     identity_parts = [
         source.get("platform"),
         source.get("chat_id") or source.get("channel_id"),
         source.get("thread_id"),
-        source.get("message_id"),
     ]
-    if any(identity_parts):
-        raw = "|".join(str(p or "") for p in identity_parts)
+    message_id = source.get("message_id")
+    if message_id:
+        identity_parts.append(message_id)
+        raw = "source-message|" + "|".join(str(p or "") for p in identity_parts)
+    elif any(identity_parts):
+        raw = (
+            "source-content|"
+            + "|".join(str(p or "") for p in identity_parts)
+            + "|"
+            + text_digest
+        )
     else:
-        raw = "text|" + hashlib.sha256(message_text.encode("utf-8")).hexdigest()
+        raw = "text|" + text_digest
     return "chat-triage:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
 
@@ -499,18 +599,43 @@ def _mapping(value: Any) -> Mapping[str, Any]:
 
 
 def _display_name(slug: str) -> str:
-    return " ".join(part.capitalize() for part in slug.replace("_", "-").split("-") if part)
+    return " ".join(
+        part.capitalize() for part in slug.replace("_", "-").split("-") if part
+    )
 
 
 def _redact(text: str) -> str:
-    redacted = text
-    for pattern in _SECRET_PATTERNS:
-        redacted = pattern.sub(lambda m: f"{m.group(1) if m.groups() else 'secret'}=[REDACTED]", redacted)
+    redacted = redact_sensitive_text(str(text), force=True, file_read=True)
+    for pattern, replacement in _EMBEDDED_SECRET_PATTERNS:
+        redacted = pattern.sub(replacement, redacted)
     return redacted
 
 
+def redact_chat_triage_text(text: str) -> str:
+    """Redact chat-triage storage/ack text with the same forced policy."""
+    return _redact(text)
+
+
+def _redact_value(value: Any) -> Any:
+    if isinstance(value, str):
+        return _redact(value)
+    if isinstance(value, Mapping):
+        return {str(k): _redact_value(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_redact_value(v) for v in value]
+    if isinstance(value, tuple):
+        return [_redact_value(v) for v in value]
+    if isinstance(value, set):
+        return [_redact_value(v) for v in sorted(value, key=str)]
+    return value
+
+
 def _json_block(value: Any) -> str:
-    return "```json\n" + json.dumps(value, indent=2, ensure_ascii=False, default=str) + "\n```"
+    return (
+        "```json\n"
+        + json.dumps(value, indent=2, ensure_ascii=False, default=str)
+        + "\n```"
+    )
 
 
 def _format_listish(value: Any) -> str:

--- a/tests/gateway/test_kanban_chat_triage_gateway.py
+++ b/tests/gateway/test_kanban_chat_triage_gateway.py
@@ -1,0 +1,156 @@
+import asyncio
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, SendResult
+from gateway.session import SessionSource
+from hermes_cli import kanban_db as kb
+from tests.gateway.restart_test_helpers import RestartTestAdapter
+
+
+@pytest.fixture
+def fresh_home(tmp_path, monkeypatch):
+    home = tmp_path / "hermes_home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    for var in (
+        "HERMES_KANBAN_DB",
+        "HERMES_KANBAN_WORKSPACES_ROOT",
+        "HERMES_KANBAN_HOME",
+        "HERMES_KANBAN_BOARD",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    try:
+        import hermes_constants
+
+        hermes_constants._cached_default_hermes_root = None  # type: ignore[attr-defined]
+    except Exception:
+        pass
+    kb._INITIALIZED_PATHS.clear()
+    return home
+
+
+@pytest.fixture
+def inline_to_thread(monkeypatch):
+    async def run_inline(func, /, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr("gateway.platforms.base.asyncio.to_thread", run_inline)
+
+
+def _source(message_id: str | None = "m1") -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-100123",
+        chat_type="group",
+        user_id="u1",
+        user_name="Sean",
+        thread_id="17585",
+        message_id=message_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_configured_gateway_routes_triggered_message_to_kanban_without_agent(
+    fresh_home,
+    inline_to_thread,
+):
+    kb.create_board("inbox")
+    adapter = RestartTestAdapter()
+    adapter.config = PlatformConfig(
+        enabled=True,
+        token="***",
+        extra={
+            "kanban_chat_triage": {
+                "enabled": True,
+                "trigger_prefixes": ["todo:"],
+                "fallback_board": "inbox",
+                "create_missing_boards": False,
+            }
+        },
+    )
+    called = False
+    sent: list[str] = []
+
+    async def handler(_event):
+        nonlocal called
+        called = True
+        return "agent response"
+
+    async def send_ack(*, chat_id, content, reply_to=None, metadata=None):
+        sent.append(content)
+        return SendResult(success=True, message_id="ack1")
+
+    adapter.set_message_handler(handler)
+    adapter._send_with_retry = send_ack
+    event = MessageEvent(
+        text="todo: fix gateway triage handoff",
+        source=_source(),
+        message_id="m1",
+    )
+
+    await adapter.handle_message(event)
+    await asyncio.sleep(0)
+
+    assert called is False
+    assert sent and "Queued for triage: board=inbox task=" in sent[0]
+    assert adapter._active_sessions == {}
+    with kb.connect(board="inbox") as conn:
+        rows = conn.execute("SELECT title, status FROM tasks").fetchall()
+    assert [(row["title"], row["status"]) for row in rows] == [
+        ("fix gateway triage handoff", "triage")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_gateway_kanban_chat_triage_is_inert_without_matching_config(fresh_home):
+    kb.create_board("inbox")
+    adapter = RestartTestAdapter()
+    adapter.config = PlatformConfig(
+        enabled=True,
+        token="***",
+        extra={"kanban_chat_triage": {"enabled": True, "trigger_prefixes": ["todo:"]}},
+    )
+    routed = await adapter._maybe_route_kanban_chat_triage(
+        MessageEvent(text="ordinary chat", source=_source(), message_id="m1")
+    )
+
+    assert routed is False
+
+
+@pytest.mark.asyncio
+async def test_gateway_kanban_chat_triage_redacts_failure_reply(
+    fresh_home, inline_to_thread, caplog
+):
+    secret = "sk-abc1234567890supersecret"
+    adapter = RestartTestAdapter()
+    adapter.config = PlatformConfig(
+        enabled=True,
+        token="***",
+        extra={
+            "kanban_chat_triage": {
+                "enabled": True,
+                "trigger_prefixes": ["todo:"],
+                "fallback_board": f"inbox-{secret}",
+                "create_missing_boards": False,
+            }
+        },
+    )
+    sent: list[str] = []
+
+    async def send_ack(*, chat_id, content, reply_to=None, metadata=None):
+        sent.append(content)
+        return SendResult(success=True, message_id="ack1")
+
+    adapter._send_with_retry = send_ack
+    adapter.set_message_handler(lambda _event: "agent response")
+
+    await adapter.handle_message(
+        MessageEvent(text="todo: route this", source=_source(message_id=None))
+    )
+
+    assert sent
+    assert sent[0].startswith("Kanban triage failed:")
+    assert secret not in sent[0]
+    assert secret not in caplog.text

--- a/tests/hermes_cli/test_kanban_chat_triage.py
+++ b/tests/hermes_cli/test_kanban_chat_triage.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_WORKTREE = Path(__file__).resolve().parents[2]
+if str(_WORKTREE) not in sys.path:
+    sys.path.insert(0, str(_WORKTREE))
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.kanban_chat_triage import ChatTriageError, route_chat_triage_task
+
+
+@pytest.fixture
+def fresh_home(tmp_path, monkeypatch):
+    home = tmp_path / "hermes_home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    for var in (
+        "HERMES_KANBAN_DB",
+        "HERMES_KANBAN_WORKSPACES_ROOT",
+        "HERMES_KANBAN_HOME",
+        "HERMES_KANBAN_BOARD",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    try:
+        import hermes_constants
+        hermes_constants._cached_default_hermes_root = None  # type: ignore[attr-defined]
+    except Exception:
+        pass
+    kb._INITIALIZED_PATHS.clear()
+    return home
+
+
+def _config(**overrides):
+    config = {
+        "triage_assignee": "paul",
+        "fallback_board": "inbox",
+        "create_missing_boards": True,
+        "board_create_policy": "explicit_project_only",
+        "ack_template": "Queued for triage: board={board_slug} task={task_id}",
+        "boards": {
+            "hermes-agent": {"aliases": ["hermes", "hermes agent"], "default_category": "engineering"},
+            "inbox": {"aliases": ["inbox", "general"], "default_category": "general"},
+        },
+        "categories": {
+            "engineering": {"board": "hermes-agent", "assignee": "paul"},
+            "general": {"board": "inbox", "assignee": "paul"},
+        },
+    }
+    config.update(overrides)
+    return config
+
+
+def _source(message_id="m1"):
+    return {
+        "platform": "telegram",
+        "chat_id": "-100123",
+        "thread_id": "17585",
+        "message_id": message_id,
+        "user_id": "12345",
+        "user_display": "Sean",
+        "received_at": "2026-05-23T17:54:00Z",
+    }
+
+
+def _routing_event(board_slug, task_id):
+    with kb.connect(board=board_slug) as conn:
+        events = kb.list_events(conn, task_id)
+    event = next(e for e in events if e.kind == "chat_routing")
+    return event.payload
+
+
+def test_reuses_existing_board_by_alias_and_creates_triage_task(fresh_home):
+    kb.create_board("hermes-agent")
+    kb.create_board("inbox")
+
+    result = route_chat_triage_task(
+        message_text="Add this to kanban for Hermes Agent: fix gateway retries",
+        classification={
+            "intent": "task_request",
+            "category": "engineering",
+            "project_hint": "Hermes Agent",
+            "confidence": 0.91,
+            "title": "Fix gateway retries",
+        },
+        source=_source(),
+        config=_config(),
+    )
+
+    assert result["board_id"] == "hermes-agent"
+    assert result["created_board"] is False
+    assert result["ack"] == f"Queued for triage: board=hermes-agent task={result['task_id']}"
+    with kb.connect(board="hermes-agent") as conn:
+        task = kb.get_task(conn, result["task_id"])
+    assert task is not None
+    assert task.status == "triage"
+    assert task.assignee == "paul"
+    assert task.title == "Fix gateway retries"
+    assert "Original message" in (task.body or "")
+    payload = _routing_event("hermes-agent", result["task_id"])
+    assert payload["chat_routing"]["classification"]["category"] == "engineering"
+    assert payload["chat_routing"]["board_decision"]["source"] == "alias_match"
+
+
+def test_missing_explicit_project_board_is_created(fresh_home):
+    kb.create_board("inbox")
+
+    result = route_chat_triage_task(
+        message_text="project: New Launch Site — build landing page backlog",
+        classification={
+            "intent": "website_request",
+            "category": "website",
+            "project_hint": "New Launch Site",
+            "confidence": 0.88,
+            "title": "Build landing page backlog",
+        },
+        source=_source(),
+        config=_config(categories={"website": {"board": "barista-labs-website", "assignee": "paul"}}),
+    )
+
+    assert result["board_id"] == "new-launch-site"
+    assert result["created_board"] is True
+    assert kb.board_exists("new-launch-site")
+    with kb.connect(board="new-launch-site") as conn:
+        task = kb.get_task(conn, result["task_id"])
+    assert task is not None
+    assert task.status == "triage"
+
+
+def test_uncertain_missing_board_falls_back_without_creating_generic_board(fresh_home):
+    kb.create_board("inbox")
+
+    result = route_chat_triage_task(
+        message_text="We should fix the task thing someday",
+        classification={
+            "intent": "task_request",
+            "category": "general",
+            "project_hint": "task",
+            "confidence": 0.62,
+        },
+        source=_source(),
+        config=_config(),
+    )
+
+    assert result["board_id"] == "inbox"
+    assert result["fallback_used"] is True
+    assert not kb.board_exists("task")
+    with kb.connect(board="inbox") as conn:
+        task = kb.get_task(conn, result["task_id"])
+    assert task is not None
+    assert task.status == "triage"
+
+
+def test_duplicate_source_message_returns_original_task(fresh_home):
+    kb.create_board("hermes-agent")
+    kb.create_board("inbox")
+    kwargs = {
+        "message_text": "board:hermes-agent Add retry-safe gateway triage routing",
+        "classification": {
+            "intent": "task_request",
+            "category": "engineering",
+            "project_hint": "hermes-agent",
+            "confidence": 0.95,
+            "title": "Add retry-safe gateway triage routing",
+        },
+        "source": _source("dup1"),
+        "config": _config(),
+    }
+
+    first = route_chat_triage_task(**kwargs)
+    second = route_chat_triage_task(**kwargs)
+
+    assert second["task_id"] == first["task_id"]
+    with kb.connect(board="hermes-agent") as conn:
+        rows = conn.execute("SELECT id FROM tasks WHERE idempotency_key IS NOT NULL").fetchall()
+        routing_events = [e for e in kb.list_events(conn, first["task_id"]) if e.kind == "chat_routing"]
+    assert [row["id"] for row in rows] == [first["task_id"]]
+    assert len(routing_events) == 1
+
+
+def test_missing_fallback_board_without_create_permission_is_actionable(fresh_home):
+    with pytest.raises(ChatTriageError) as exc:
+        route_chat_triage_task(
+            message_text="track this",
+            classification={"intent": "task_request", "category": "general", "confidence": 0.9},
+            source=_source(),
+            config=_config(create_missing_boards=False),
+        )
+
+    assert "fallback board 'inbox' does not exist" in str(exc.value)
+    assert "create_missing_boards" in str(exc.value)

--- a/tests/hermes_cli/test_kanban_chat_triage.py
+++ b/tests/hermes_cli/test_kanban_chat_triage.py
@@ -28,6 +28,7 @@ def fresh_home(tmp_path, monkeypatch):
         monkeypatch.delenv(var, raising=False)
     try:
         import hermes_constants
+
         hermes_constants._cached_default_hermes_root = None  # type: ignore[attr-defined]
     except Exception:
         pass
@@ -43,7 +44,10 @@ def _config(**overrides):
         "board_create_policy": "explicit_project_only",
         "ack_template": "Queued for triage: board={board_slug} task={task_id}",
         "boards": {
-            "hermes-agent": {"aliases": ["hermes", "hermes agent"], "default_category": "engineering"},
+            "hermes-agent": {
+                "aliases": ["hermes", "hermes agent"],
+                "default_category": "engineering",
+            },
             "inbox": {"aliases": ["inbox", "general"], "default_category": "general"},
         },
         "categories": {
@@ -93,7 +97,10 @@ def test_reuses_existing_board_by_alias_and_creates_triage_task(fresh_home):
 
     assert result["board_id"] == "hermes-agent"
     assert result["created_board"] is False
-    assert result["ack"] == f"Queued for triage: board=hermes-agent task={result['task_id']}"
+    assert (
+        result["ack"]
+        == f"Queued for triage: board=hermes-agent task={result['task_id']}"
+    )
     with kb.connect(board="hermes-agent") as conn:
         task = kb.get_task(conn, result["task_id"])
     assert task is not None
@@ -119,7 +126,11 @@ def test_missing_explicit_project_board_is_created(fresh_home):
             "title": "Build landing page backlog",
         },
         source=_source(),
-        config=_config(categories={"website": {"board": "barista-labs-website", "assignee": "paul"}}),
+        config=_config(
+            categories={
+                "website": {"board": "barista-labs-website", "assignee": "paul"}
+            }
+        ),
     )
 
     assert result["board_id"] == "new-launch-site"
@@ -176,17 +187,100 @@ def test_duplicate_source_message_returns_original_task(fresh_home):
 
     assert second["task_id"] == first["task_id"]
     with kb.connect(board="hermes-agent") as conn:
-        rows = conn.execute("SELECT id FROM tasks WHERE idempotency_key IS NOT NULL").fetchall()
-        routing_events = [e for e in kb.list_events(conn, first["task_id"]) if e.kind == "chat_routing"]
+        rows = conn.execute(
+            "SELECT id FROM tasks WHERE idempotency_key IS NOT NULL"
+        ).fetchall()
+        routing_events = [
+            e
+            for e in kb.list_events(conn, first["task_id"])
+            if e.kind == "chat_routing"
+        ]
     assert [row["id"] for row in rows] == [first["task_id"]]
     assert len(routing_events) == 1
+
+
+def test_missing_message_id_idempotency_uses_content_hash(fresh_home):
+    kb.create_board("inbox")
+    source = _source(message_id=None)
+
+    first = route_chat_triage_task(
+        message_text="todo: first missing id message",
+        classification={
+            "intent": "task_request",
+            "category": "general",
+            "confidence": 0.9,
+        },
+        source=source,
+        config=_config(),
+    )
+    second = route_chat_triage_task(
+        message_text="todo: second missing id message",
+        classification={
+            "intent": "task_request",
+            "category": "general",
+            "confidence": 0.9,
+        },
+        source=source,
+        config=_config(),
+    )
+    retry = route_chat_triage_task(
+        message_text="todo: first missing id message",
+        classification={
+            "intent": "task_request",
+            "category": "general",
+            "confidence": 0.9,
+        },
+        source=source,
+        config=_config(),
+    )
+
+    assert first["task_id"] != second["task_id"]
+    assert retry["task_id"] == first["task_id"]
+
+
+def test_persisted_chat_triage_structures_are_force_redacted(fresh_home, monkeypatch):
+    monkeypatch.setenv("HERMES_REDACT_SECRETS", "false")
+    kb.create_board("inbox")
+    secret = "sk-abcdefghijklmnopqrstuvwxyz1234567890"
+
+    result = route_chat_triage_task(
+        message_text=f"todo: rotate leaked key {secret}",
+        classification={
+            "intent": "task_request",
+            "category": "general",
+            "title": f"rotate {secret}",
+            "assignee": f"owner-{secret}",
+            "project_hint": "inbox",
+            "confidence": 0.9,
+            "links": [f"https://example.test/?token={secret}"],
+            "acceptance_criteria": [f"remove {secret}"],
+        },
+        source={**_source("secret-1"), "user_display": f"Sean {secret}"},
+        context={"thread_summary": f"context {secret}"},
+        config=_config(),
+    )
+
+    with kb.connect(board="inbox") as conn:
+        task = kb.get_task(conn, result["task_id"])
+    payload = _routing_event("inbox", result["task_id"])
+    persisted = json.dumps(
+        {"task": task.__dict__, "event": payload},
+        ensure_ascii=False,
+        default=str,
+    )
+    assert secret not in persisted
+    assert "redacted" in persisted.lower()
 
 
 def test_missing_fallback_board_without_create_permission_is_actionable(fresh_home):
     with pytest.raises(ChatTriageError) as exc:
         route_chat_triage_task(
             message_text="track this",
-            classification={"intent": "task_request", "category": "general", "confidence": 0.9},
+            classification={
+                "intent": "task_request",
+                "category": "general",
+                "confidence": 0.9,
+            },
             source=_source(),
             config=_config(create_missing_boards=False),
         )

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -253,6 +253,32 @@ hermes kanban create "nightly ops review" \
     --json
 ```
 
+### Route prefixed chat messages into triage
+
+A messaging platform can opt into deterministic Kanban capture without sending
+the message through the agent loop. Configure the platform's `extra` block and
+choose explicit prefixes; matching messages become `triage` tasks and receive a
+short acknowledgement in the originating chat.
+
+```yaml
+# config.yaml
+platforms:
+  telegram:
+    extra:
+      kanban_chat_triage:
+        enabled: true
+        trigger_prefixes: ["todo:", "kanban:"]
+        fallback_board: inbox
+        create_missing_boards: false
+```
+
+This is disabled by default. Prefer explicit prefixes over `capture_all: true`,
+which diverts every ordinary text message on that platform away from the agent.
+With `create_missing_boards: false`, create the fallback board first. Source,
+classification, reply context, attachment metadata, and routing events are
+force-redacted before persistence; duplicate platform message IDs reuse the
+original task.
+
 ### Bulk CLI verbs
 
 All the lifecycle verbs accept multiple ids so you can clean up a batch


### PR DESCRIPTION
## Summary
- Adds a gateway-agnostic Kanban chat triage helper that deterministically resolves configured boards via override, explicit hints, aliases, category, and fallback.
- Creates missing boards when policy allows, ensuring default lanes include triage and new chat tasks land in the triage lane rather than active execution lanes.
- Persists redacted original message/context/source metadata/classification into triage tasks with deterministic idempotency keys and actionable `ChatTriageError` failures for gateway callers.

## Validation
- `python -m ruff check hermes_cli/kanban_chat_triage.py tests/hermes_cli/test_kanban_chat_triage.py`
- `python -m py_compile hermes_cli/kanban_chat_triage.py tests/hermes_cli/test_kanban_chat_triage.py`
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_chat_triage.py`
- `HERMES_TEST_WORKERS=1 scripts/run_tests.sh tests/hermes_cli/test_kanban_chat_triage.py tests/hermes_cli/test_kanban_boards.py tests/hermes_cli/test_kanban_db.py`

## Notes
- Rebased to current upstream main and cherry-picked only the Kanban-side helper/test commit; unrelated fork/docs changes are not included.
- Gateway/classifier hookup is intentionally left to downstream routing integration work.
