### PR TITLE
fix(security): use exact-or-subpath match for skills_guard trusted-repo tier

### DIFF
--- a/tests/tools/test_skills_guard.py
+++ b/tests/tools/test_skills_guard.py
@@ -66,6 +66,19 @@ class TestResolveTrustLevel:
         assert _resolve_trust_level("random-user/my-skill") == "community"
         assert _resolve_trust_level("") == "community"
 
+    def test_sibling_repo_sharing_trusted_repo_prefix_is_community(self):
+        # Regression for #31141: a sibling repo on the same org whose name
+        # shares a prefix with a trusted repo (e.g. ``openai/skills-evil`` vs
+        # ``openai/skills``) must NOT inherit the trusted tier via a bare
+        # ``startswith`` match. The trusted set is exact identifiers + their
+        # sub-paths only.
+        assert _resolve_trust_level("openai/skills-evil") == "community"
+        assert _resolve_trust_level("anthropics/skills-foo") == "community"
+        assert _resolve_trust_level("huggingface/skills-bar") == "community"
+        # Sub-paths under the attacker-controlled sibling repo must also stay
+        # community, not be re-promoted by deeper-path prefix overlap.
+        assert _resolve_trust_level("openai/skills-evil/some-skill") == "community"
+
 
 # ---------------------------------------------------------------------------
 # _determine_verdict

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -920,9 +920,14 @@ def _resolve_trust_level(source: str) -> str:
     # Official optional skills shipped with the repo
     if normalized_source.startswith("official/") or normalized_source == "official":
         return "builtin"
-    # Check if source matches any trusted repo
+    # Check if source matches any trusted repo. Match exact identifier or a
+    # sub-path under the repo (``trusted + "/"``) — never a bare ``startswith``
+    # of the repo name, which would also match sibling repos sharing the same
+    # owner-name prefix (e.g. ``openai/skills-evil`` for ``openai/skills``).
+    # Mirrors ``GitHubSource.trust_level_for()`` in skills_hub.py, which does
+    # exact set membership on the ``owner/repo`` split.
     for trusted in TRUSTED_REPOS:
-        if normalized_source.startswith(trusted) or normalized_source == trusted:
+        if normalized_source == trusted or normalized_source.startswith(trusted + "/"):
             return "trusted"
     return "community"
 


### PR DESCRIPTION
## What does this PR do?

`tools/skills_guard.py::_resolve_trust_level` resolved the `trusted` tier via `normalized_source.startswith(trusted)`. That bare prefix match silently extends the `trusted` tier to any sibling repo whose name *starts with* a trusted repo's name — e.g. `openai/skills-evil`, `anthropics/skills-foo`, `huggingface/skills-bar` all resolved to `trusted` and bypassed the install-time scan policy for that tier.

Replace `startswith(trusted)` with `normalized_source == trusted or normalized_source.startswith(trusted + "/")`. Legitimate sub-paths like `openai/skills/skill-creator` still resolve to `trusted`; sibling repos sharing the prefix no longer do.

Mirrors `GitHubSource.trust_level_for()` in `tools/skills_hub.py`, which already does exact set membership on the `owner/repo` split — this aligns the `skills_guard` policy resolver with the existing canonical hub pattern.

The reporter (#31141) noted a second escalation path via the `official/` builtin namespace (attacker-controlled GitHub username squatting on `official`). That one explicitly needs a maintainer decision (namespace reservation vs. policy change vs. moving builtin under an unsquatable path), so it's left out of this PR.

## Related Issue

Fixes #31141

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/skills_guard.py` — `_resolve_trust_level` now matches a trusted repo via exact identifier or `trusted + "/"` sub-path, never a bare `startswith(trusted)`.
- `tests/tools/test_skills_guard.py` — regression test covering all three trusted repos (`openai/skills`, `anthropics/skills`, `huggingface/skills`) plus one sub-path case to prevent re-introduction of the bare prefix check.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout python3 -m pytest tests/tools/test_skills_guard.py tests/tools/test_skills_hub.py -v`
2. Expected: 168 passed (58 in `test_skills_guard.py`, 110 in `test_skills_hub.py`).
3. Regression proof: reverting only the `tools/skills_guard.py` hunk turns the new `test_sibling_repo_sharing_trusted_repo_prefix_is_community` case red with `'trusted' == 'community'` AssertionError on `openai/skills-evil`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (one-line in-source comment added at the fix site)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python string comparison, no platform-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (internal trust resolver; no public-tool surface change)

## Screenshots / Logs

<!-- Optional. Not applicable to a string-comparison hardening fix. -->

> Audited siblings: `tools/skills_hub.py::GitHubSource.trust_level_for()` already implements the correct exact set membership; the other `trust_level_for` overrides in `skills_hub.py` (LocalSource, URLSource, WellKnownSource, GitHubAggregateSource) don't consult `TRUSTED_REPOS` directly. No widening needed.