### PR TITLE
feat: add compact SilverBullet workflow context

### DIFF
--- a/agent/silverbullet_context.py
+++ b/agent/silverbullet_context.py
@@ -1,0 +1,260 @@
+"""Compact SilverBullet workflow context for the system prompt."""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+
+DEFAULT_SPACE_PATH = "/srv/seedbox/config/silverbullet/space"
+INDEX_PAGES = ("_activity.md", "_ops.md", "_projects.md", "_review.md")
+ENTRYPOINT_DIRS = ("Services", "Projects")
+MAX_SOURCE_CHARS = 12_000
+MAX_LINES_PER_INDEX = 8
+
+
+def build_silverbullet_context_prompt(config: Optional[Mapping[str, Any]] = None) -> str:
+    """Build a small, session-stable SilverBullet context block.
+
+    Returns an empty string when disabled, missing, or unreadable. The output is
+    capped by ``max_chars`` and deliberately avoids injecting full project,
+    service, or daily-note pages.
+    """
+    if config is None:
+        try:
+            from hermes_cli.config import load_config_readonly
+            config = load_config_readonly()
+        except Exception:
+            return ""
+
+    context_cfg = _silverbullet_context_config(config)
+    if not _as_bool(context_cfg.get("enabled"), default=False):
+        return ""
+
+    space = _resolve_space_path(context_cfg)
+    if not space or not space.is_dir():
+        return ""
+
+    max_chars = _as_int(context_cfg.get("max_chars"), default=2000, minimum=80)
+    parts = [
+        "# SilverBullet Workflow Context",
+        (
+            "Use SilverBullet as active workflow context for durable plans, "
+            "operations notes, reviews, and project state; keep prompt context "
+            "compact and update the relevant page when workflow state should persist."
+        ),
+        _entrypoints_block(space),
+    ]
+
+    if _as_bool(context_cfg.get("include_activity"), default=True):
+        activity = _index_page_block(space, "_activity.md")
+        if activity:
+            parts.append(activity)
+
+    if _as_bool(context_cfg.get("include_indexes"), default=True):
+        for rel in INDEX_PAGES[1:]:
+            block = _index_page_block(space, rel)
+            if block:
+                parts.append(block)
+
+    recent_daily_notes = _as_int(context_cfg.get("recent_daily_notes"), default=1, minimum=0)
+    if recent_daily_notes > 0:
+        carry = _carry_forward_block(space)
+        if carry:
+            parts.append(carry)
+
+    return _truncate("\n\n".join(part for part in parts if part), max_chars)
+
+
+def _silverbullet_context_config(config: Mapping[str, Any]) -> Mapping[str, Any]:
+    silverbullet = config.get("silverbullet")
+    if not isinstance(silverbullet, Mapping):
+        return {}
+    context = silverbullet.get("context")
+    return context if isinstance(context, Mapping) else {}
+
+
+def _resolve_space_path(context_cfg: Mapping[str, Any]) -> Optional[Path]:
+    raw = context_cfg.get("space_path") or os.getenv("SILVERBULLET_SPACE") or DEFAULT_SPACE_PATH
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    return Path(os.path.expandvars(os.path.expanduser(raw))).resolve()
+
+
+def _entrypoints_block(_space: Path) -> str:
+    entries = [f"- `{rel}`" for rel in (*INDEX_PAGES, *ENTRYPOINT_DIRS)]
+    return "Entrypoints:\n" + "\n".join(entries)
+
+
+def _index_page_block(space: Path, rel: str) -> str:
+    path = space / rel
+    text = _read_text(path)
+    if not text:
+        return ""
+    lines = _extract_bullet_or_link_lines(text, limit=MAX_LINES_PER_INDEX)
+    if not lines:
+        return ""
+    return f"## `{rel}`\n" + "\n".join(lines)
+
+
+def _extract_bullet_or_link_lines(text: str, *, limit: int) -> list[str]:
+    lines: list[str] = []
+    in_fence = False
+    for raw_line in text.splitlines():
+        if _is_fence_line(raw_line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        line = _clean_line(raw_line)
+        if not line:
+            continue
+        if _is_bullet(line) or _has_markdown_link(line):
+            lines.append(_ensure_bullet(line))
+            if len(lines) >= limit:
+                break
+    return lines
+
+
+def _carry_forward_block(space: Path) -> str:
+    daily_note = _find_latest_daily_note(space)
+    if daily_note is None:
+        return ""
+    text = _read_text(daily_note)
+    if not text:
+        return ""
+    carry = _extract_carry_forward(text, limit=8)
+    if not carry:
+        return ""
+    rel = daily_note.relative_to(space).as_posix()
+    return f"## Carry Forward from `{rel}`\n" + "\n".join(carry)
+
+
+def _find_latest_daily_note(space: Path) -> Optional[Path]:
+    candidates: list[tuple[str, float, Path]] = []
+    for path in space.rglob("*.md"):
+        if not path.is_file():
+            continue
+        rel_parts = path.relative_to(space).parts
+        if rel_parts and rel_parts[0] in ENTRYPOINT_DIRS:
+            continue
+        date_key = _date_key(path)
+        if date_key:
+            try:
+                mtime = path.stat().st_mtime
+            except OSError:
+                mtime = 0.0
+            candidates.append((date_key, mtime, path))
+    if not candidates:
+        return None
+    candidates.sort(key=lambda item: (item[0], item[1], item[2].as_posix()), reverse=True)
+    return candidates[0][2]
+
+
+def _date_key(path: Path) -> str:
+    rel = path.as_posix()
+    match = re.search(r"(20\d{2})[-_/](\d{2})[-_/](\d{2})", rel)
+    if match:
+        return "".join(match.groups())
+    match = re.search(r"(20\d{2})(\d{2})(\d{2})", rel)
+    return "".join(match.groups()) if match else ""
+
+
+def _extract_carry_forward(text: str, *, limit: int) -> list[str]:
+    lines = text.splitlines()
+    start = None
+    for idx, line in enumerate(lines):
+        if re.match(r"^\s{0,3}#{1,6}\s+carry\s+forward\b", line, re.IGNORECASE):
+            start = idx + 1
+            break
+    if start is None:
+        return []
+
+    extracted: list[str] = []
+    in_fence = False
+    for raw_line in lines[start:]:
+        if _is_fence_line(raw_line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        if re.match(r"^\s{0,3}#{1,6}\s+", raw_line):
+            break
+        line = _clean_line(raw_line)
+        if not line:
+            continue
+        if _is_bullet(line) or _has_markdown_link(line):
+            extracted.append(_ensure_bullet(line))
+        else:
+            extracted.append(f"- {line}")
+        if len(extracted) >= limit:
+            break
+    return extracted
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")[:MAX_SOURCE_CHARS]
+    except OSError:
+        return ""
+
+
+def _clean_line(line: str) -> str:
+    return re.sub(r"\s+", " ", line.strip())
+
+
+def _is_bullet(line: str) -> bool:
+    return bool(re.match(r"^([-*+]|\d+[.)])\s+", line))
+
+
+def _has_markdown_link(line: str) -> bool:
+    return "[[" in line or bool(re.search(r"\[[^\]]+\]\([^)]+\)", line))
+
+
+def _is_fence_line(line: str) -> bool:
+    return bool(re.match(r"^\s{0,3}(```|~~~)", line))
+
+
+def _ensure_bullet(line: str) -> str:
+    if _is_bullet(line):
+        return line
+    return f"- {line}"
+
+
+def _truncate(text: str, max_chars: int) -> str:
+    if len(text) <= max_chars:
+        return text
+    marker = "\n\n[SilverBullet context truncated to configured max_chars.]"
+    if max_chars <= len(marker):
+        return marker[:max_chars]
+    cutoff = max_chars - len(marker)
+    prefix = text[:cutoff].rstrip()
+    line_cutoff = prefix.rfind("\n")
+    if line_cutoff > 0:
+        prefix = prefix[:line_cutoff].rstrip()
+    return prefix + marker
+
+
+def _as_bool(value: Any, *, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def _as_int(value: Any, *, default: int, minimum: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = default
+    return max(minimum, parsed)
+
+
+__all__ = ["build_silverbullet_context_prompt"]

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -14,7 +14,8 @@ Three tiers are joined with ``\\n\\n``:
   enforcement guidance + per-model operational guidance, skills prompt,
   alibaba model-name workaround, environment hints, platform hints.
 * ``context``  — caller-supplied ``system_message`` plus context files
-  (AGENTS.md / .cursorrules / etc.) discovered under ``TERMINAL_CWD``.
+  (AGENTS.md / .cursorrules / etc.) discovered under ``TERMINAL_CWD``
+  and optional compact workflow context such as SilverBullet.
 * ``volatile`` — memory snapshot, USER.md profile, external memory
   provider block, timestamp/session/model/provider line.
 
@@ -236,6 +237,10 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             cwd=_context_cwd, skip_soul=_soul_loaded)
         if context_files_prompt:
             context_parts.append(context_files_prompt)
+
+    silverbullet_context_prompt = _r.build_silverbullet_context_prompt()
+    if silverbullet_context_prompt:
+        context_parts.append(silverbullet_context_prompt)
 
     # ── Volatile tier (changes per session/turn — never cached) ───
     volatile_parts: List[str] = []

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -100,10 +100,10 @@ class ResponsesApiTransport(ProviderTransport):
                 payload_messages,
                 is_xai_responses=is_xai_responses,
             ),
-            "tools": response_tools,
             "store": False,
         }
         if response_tools:
+            kwargs["tools"] = response_tools
             kwargs["tool_choice"] = "auto"
             kwargs["parallel_tool_calls"] = True
 

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2202,13 +2202,20 @@ class SlackAdapter(BasePlatformAdapter):
             self.config.extra, channel_id, None,
         )
 
+        # Command dispatch depends on MessageEvent.text being the exact slash
+        # command string. Slack may include rich-text blocks, unfurls, files,
+        # or thread reply metadata alongside the text; those are useful for LLM
+        # turns but must not become /model args or other command payload.
+        if msg_type == MessageType.COMMAND:
+            text = original_text
+
         # Extract reply context if this message is a thread reply.
         # Mirrors the Telegram/Discord implementations so that gateway.run
         # can inject a `[Replying to: "..."]` prefix when the parent is not
         # already in the session history. Uses the thread-context cache when
         # available to avoid redundant conversations.replies calls.
         reply_to_text = None
-        if thread_ts and thread_ts != ts:
+        if msg_type != MessageType.COMMAND and thread_ts and thread_ts != ts:
             try:
                 reply_to_text = await self._fetch_thread_parent_text(
                     channel_id=channel_id,

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -1806,17 +1806,18 @@ class SlackAdapter(BasePlatformAdapter):
         # gateway dispatcher) handles it like a normal slash command.  Only
         # rewrite when the first token resolves to a known gateway command
         # so casual messages like "!nice work" pass through unchanged.
-        if original_text.startswith("!"):
+        bang_candidate = original_text.lstrip()
+        if bang_candidate.startswith("!"):
             try:
                 from hermes_cli.commands import is_gateway_known_command
-                first_token = original_text[1:].split(maxsplit=1)[0]
+                first_token = bang_candidate[1:].split(maxsplit=1)[0]
                 # Strip "@suffix" the same way get_command() does, so
                 # forms like ``!stop@hermes`` still resolve.
                 cmd_name = first_token.split("@", 1)[0].lower()
                 if cmd_name and "/" not in cmd_name and is_gateway_known_command(cmd_name):
-                    original_text = "/" + original_text[1:]
+                    original_text = "/" + bang_candidate[1:]
             except Exception:  # pragma: no cover - defensive
-                pass
+                logger.warning("[Slack] Failed to rewrite bang-prefixed command", exc_info=True)
 
         text = original_text
 

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -1820,6 +1820,7 @@ class SlackAdapter(BasePlatformAdapter):
                 logger.warning("[Slack] Failed to rewrite bang-prefixed command", exc_info=True)
 
         text = original_text
+        msg_type = MessageType.COMMAND if original_text.startswith("/") else MessageType.TEXT
 
         # Extract quoted/forwarded content from Slack blocks.
         # Slack's modern composer embeds forwarded messages in the ``blocks``
@@ -2011,10 +2012,17 @@ class SlackAdapter(BasePlatformAdapter):
 
         # When entering a thread for the first time (no existing session),
         # fetch thread context so the agent understands the conversation.
-        if is_thread_reply and not self._has_active_session_for_thread(
-            channel_id=channel_id,
-            thread_ts=event_thread_ts,
-            user_id=user_id,
+        # Commands intentionally skip fetched context: gateway command parsing
+        # expects event.text to start with "/", and commands do not need LLM
+        # conversation context to dispatch.
+        if (
+            msg_type != MessageType.COMMAND
+            and is_thread_reply
+            and not self._has_active_session_for_thread(
+                channel_id=channel_id,
+                thread_ts=event_thread_ts,
+                user_id=user_id,
+            )
         ):
             thread_context = await self._fetch_thread_context(
                 channel_id=channel_id,
@@ -2024,11 +2032,6 @@ class SlackAdapter(BasePlatformAdapter):
             )
             if thread_context:
                 text = thread_context + text
-
-        # Determine message type
-        msg_type = MessageType.TEXT
-        if (original_text or "").startswith("/"):
-            msg_type = MessageType.COMMAND
 
         # Handle file attachments
         media_urls = []

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -669,6 +669,19 @@ DEFAULT_CONFIG = {
         "persistent_shell": True,
     },
 
+    # Optional SilverBullet workflow context. Disabled by default so upstream
+    # installs do not inject local notes unless explicitly configured.
+    "silverbullet": {
+        "context": {
+            "enabled": False,
+            "space_path": None,
+            "max_chars": 2000,
+            "include_activity": True,
+            "include_indexes": True,
+            "recent_daily_notes": 1,
+        },
+    },
+
     "web": {
         "backend": "",           # shared fallback — applies to both search and extract
         "search_backend": "",    # per-capability override for web_search (e.g. "searxng")
@@ -3301,7 +3314,7 @@ _KNOWN_ROOT_KEYS = {
     "fallback_providers", "credential_pool_strategies", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
     "auxiliary", "custom_providers", "context", "memory", "gateway",
-    "sessions",
+    "sessions", "silverbullet",
 }
 
 # Valid fields inside a custom_providers list entry

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -307,7 +307,7 @@ def _resolve_runtime_from_pool_entry(
     api_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
     api_mode = "chat_completions"
     if provider == "openai-codex":
-        api_mode = "codex_responses"
+        api_mode = model_cfg.get("api_mode", "codex_responses")
         base_url = base_url or DEFAULT_CODEX_BASE_URL
     elif provider == "xai-oauth":
         api_mode = "codex_responses"

--- a/run_agent.py
+++ b/run_agent.py
@@ -143,6 +143,7 @@ from agent.context_compressor import ContextCompressor
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE
+from agent.silverbullet_context import build_silverbullet_context_prompt
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from agent.codex_responses_adapter import (
     _derive_responses_function_call_id as _codex_derive_responses_function_call_id,

--- a/tests/agent/test_silverbullet_context.py
+++ b/tests/agent/test_silverbullet_context.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from agent.silverbullet_context import build_silverbullet_context_prompt, _truncate
+
+
+def _cfg(space, **overrides):
+    context = {
+        "enabled": True,
+        "space_path": str(space) if space is not None else None,
+        "max_chars": 2000,
+        "include_activity": True,
+        "include_indexes": True,
+        "recent_daily_notes": 1,
+    }
+    context.update(overrides)
+    return {"silverbullet": {"context": context}}
+
+
+def test_disabled_returns_empty(tmp_path):
+    cfg = _cfg(tmp_path, enabled=False)
+
+    assert build_silverbullet_context_prompt(cfg) == ""
+
+
+def test_missing_space_returns_empty(tmp_path):
+    cfg = _cfg(tmp_path / "missing")
+
+    assert build_silverbullet_context_prompt(cfg) == ""
+
+
+def test_enabled_temp_space_includes_entrypoints_and_bullets(tmp_path):
+    (tmp_path / "Services").mkdir()
+    (tmp_path / "Projects").mkdir()
+    (tmp_path / "_activity.md").write_text(
+        "# Activity\n\n- [[Projects/Hermes]] tighten workflow context\nPlain paragraph ignored\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "_ops.md").write_text(
+        "- Rotate backups\n[Runbook](Services/Backups.md)\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "_projects.md").write_text(
+        "- Hermes: SilverBullet prompt integration\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "_review.md").write_text(
+        "- Review open PRs weekly\n",
+        encoding="utf-8",
+    )
+    daily_dir = tmp_path / "Daily Notes"
+    daily_dir.mkdir()
+    (daily_dir / "2026-05-22.md").write_text(
+        "# Daily\n\nLarge note body that should not be injected.\n\n"
+        "## Carry Forward\n"
+        "- Keep SilverBullet compact\n"
+        "- [[Projects/Hermes]] follow-up\n"
+        "## Later\n"
+        "- Not included\n",
+        encoding="utf-8",
+    )
+
+    block = build_silverbullet_context_prompt(_cfg(tmp_path))
+
+    assert "# SilverBullet Workflow Context" in block
+    assert "`_activity.md`" in block
+    assert "`Services`" in block
+    assert "- [[Projects/Hermes]] tighten workflow context" in block
+    assert "- [Runbook](Services/Backups.md)" in block
+    assert "## Carry Forward from `Daily Notes/2026-05-22.md`" in block
+    assert "- Keep SilverBullet compact" in block
+    assert "Large note body" not in block
+    assert "Not included" not in block
+
+
+def test_env_space_fallback_used_before_default(tmp_path, monkeypatch):
+    monkeypatch.setenv("SILVERBULLET_SPACE", str(tmp_path))
+    (tmp_path / "_activity.md").write_text("- Env fallback note\n", encoding="utf-8")
+
+    block = build_silverbullet_context_prompt(_cfg(None))
+
+    assert "- Env fallback note" in block
+
+
+def test_activity_ignores_bullets_inside_fenced_code(tmp_path):
+    (tmp_path / "_activity.md").write_text(
+        "# Activity\n\n"
+        "```markdown\n"
+        "- [ ] Short next action\n"
+        "- [[Projects/Template]] example link\n"
+        "```\n\n"
+        "- [[Projects/Hermes]] real next action\n",
+        encoding="utf-8",
+    )
+
+    block = build_silverbullet_context_prompt(_cfg(tmp_path))
+
+    assert "- [[Projects/Hermes]] real next action" in block
+    assert "- [ ] Short next action" not in block
+    assert "Projects/Template" not in block
+
+
+def test_max_chars_truncates_with_marker(tmp_path):
+    (tmp_path / "_activity.md").write_text(
+        "\n".join(f"- Item {idx} {'x' * 40}" for idx in range(20)),
+        encoding="utf-8",
+    )
+
+    block = build_silverbullet_context_prompt(_cfg(tmp_path, max_chars=260))
+
+    assert len(block) <= 260
+    assert "SilverBullet context truncated" in block
+
+
+def test_truncate_prefers_line_boundary_before_marker():
+    marker = "\n\n[SilverBullet context truncated to configured max_chars.]"
+    text = "Intro\n\n## Complete Heading\n- complete line\n## Next Heading\n- later " + ("x" * 100)
+    max_chars = len(marker) + len("Intro\n\n## Complete Heading\n- complete line\n## Next")
+
+    block = _truncate(text, max_chars)
+
+    assert block.endswith(marker)
+    assert "- complete line" in block
+    assert "## Next" not in block
+    assert len(block) <= max_chars
+
+
+def test_system_prompt_includes_silverbullet_block_when_enabled(monkeypatch):
+    from agent import system_prompt
+
+    fake_run_agent = SimpleNamespace(
+        load_soul_md=lambda: "",
+        build_nous_subscription_prompt=lambda _tools: "",
+        build_environment_hints=lambda: "",
+        build_context_files_prompt=lambda cwd=None, skip_soul=False: "PROJECT CONTEXT",
+        build_skills_system_prompt=lambda **_kwargs: "",
+        get_toolset_for_tool=lambda _tool: None,
+        build_silverbullet_context_prompt=lambda: "SILVERBULLET BLOCK",
+    )
+    monkeypatch.setattr(system_prompt, "_ra", lambda: fake_run_agent)
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    agent = SimpleNamespace(
+        load_soul_identity=False,
+        skip_context_files=False,
+        valid_tool_names=[],
+        _kanban_worker_guidance=None,
+        provider="",
+        model="",
+        platform="",
+        _tool_use_enforcement="auto",
+        _memory_store=None,
+        _memory_enabled=False,
+        _user_profile_enabled=False,
+        _memory_manager=None,
+        pass_session_id=False,
+        session_id="",
+    )
+
+    parts = system_prompt.build_system_prompt_parts(agent)
+
+    assert "PROJECT CONTEXT" in parts["context"]
+    assert "SILVERBULLET BLOCK" in parts["context"]
+    assert parts["context"].index("PROJECT CONTEXT") < parts["context"].index("SILVERBULLET BLOCK")

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -760,6 +760,29 @@ class TestBangPrefixCommands:
         assert msg_event.source.thread_id == "1111111111.000001"
 
     @pytest.mark.asyncio
+    async def test_bang_command_thread_without_session_skips_context_prefix(self, adapter):
+        """Fetched thread context must not hide the leading slash command."""
+        evt = self._make_event(
+            "!status",
+            thread_ts="1111111111.000001",
+            channel_type="im",
+            channel="D123",
+        )
+        adapter._fetch_thread_context = AsyncMock(
+            return_value='[Thread context from earlier messages]\n'
+        )
+
+        await adapter._handle_slack_message(evt)
+
+        adapter._fetch_thread_context.assert_not_awaited()
+        adapter.handle_message.assert_called_once()
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text.startswith("/status")
+        assert not msg_event.text.startswith("[Thread context")
+        assert msg_event.message_type == MessageType.COMMAND
+        assert msg_event.source.thread_id == "1111111111.000001"
+
+    @pytest.mark.asyncio
     async def test_bang_command_with_leading_newline_tab_works_inside_thread(self, adapter):
         """Leading newline/tab before ``!stop`` still dispatches in threads."""
         evt = self._make_event("\n\t!stop", thread_ts="1111111111.000001")

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -783,6 +783,40 @@ class TestBangPrefixCommands:
         assert msg_event.source.thread_id == "1111111111.000001"
 
     @pytest.mark.asyncio
+    async def test_bang_model_command_ignores_slack_blocks_and_reply_context(self, adapter):
+        """Slack block/reply metadata must not become /model arguments."""
+        evt = self._make_event(
+            "!model glm-5.1",
+            thread_ts="1111111111.000001",
+            channel_type="im",
+            channel="D123",
+        )
+        evt["blocks"] = [
+            {
+                "type": "rich_text",
+                "elements": [
+                    {
+                        "type": "rich_text_section",
+                        "elements": [
+                            {"type": "text", "text": "!model glm-5.1"},
+                            {"type": "text", "text": " extra block text"},
+                        ],
+                    }
+                ],
+            }
+        ]
+        adapter._fetch_thread_parent_text = AsyncMock(return_value="parent text")
+
+        await adapter._handle_slack_message(evt)
+
+        adapter._fetch_thread_parent_text.assert_not_awaited()
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "/model glm-5.1"
+        assert msg_event.get_command_args() == "glm-5.1"
+        assert msg_event.reply_to_text is None
+        assert msg_event.message_type == MessageType.COMMAND
+
+    @pytest.mark.asyncio
     async def test_bang_command_with_leading_newline_tab_works_inside_thread(self, adapter):
         """Leading newline/tab before ``!stop`` still dispatches in threads."""
         evt = self._make_event("\n\t!stop", thread_ts="1111111111.000001")

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -738,6 +738,15 @@ class TestBangPrefixCommands:
         assert msg_event.message_type == MessageType.COMMAND
 
     @pytest.mark.asyncio
+    async def test_bang_command_with_leading_space_is_rewritten(self, adapter):
+        """Leading whitespace before ``!model`` still dispatches."""
+        await adapter._handle_slack_message(self._make_event(" !model gpt-5.5"))
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text.startswith("/model gpt-5.5")
+        assert msg_event.message_type == MessageType.COMMAND
+
+    @pytest.mark.asyncio
     async def test_bang_works_inside_thread(self, adapter):
         """The whole point: ``!stop`` inside a thread reply dispatches."""
         evt = self._make_event("!stop", thread_ts="1111111111.000001")
@@ -748,6 +757,17 @@ class TestBangPrefixCommands:
         assert msg_event.message_type == MessageType.COMMAND
         # thread_id is preserved on the source so the reply lands in the
         # same thread.
+        assert msg_event.source.thread_id == "1111111111.000001"
+
+    @pytest.mark.asyncio
+    async def test_bang_command_with_leading_newline_tab_works_inside_thread(self, adapter):
+        """Leading newline/tab before ``!stop`` still dispatches in threads."""
+        evt = self._make_event("\n\t!stop", thread_ts="1111111111.000001")
+        await adapter._handle_slack_message(evt)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text.startswith("/stop")
+        assert msg_event.message_type == MessageType.COMMAND
         assert msg_event.source.thread_id == "1111111111.000001"
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add configurable, compact SilverBullet workflow context generation from a filesystem-backed notes space
- Inject the capped context block into the session context tier after project context files
- Add config defaults under `silverbullet.context`, disabled by default upstream
- Add tests for disabled/missing spaces, entrypoint extraction, fenced-code filtering, truncation, env fallback, and system prompt wiring

## Test Plan
- `./venv/bin/python -m pytest tests/agent/test_silverbullet_context.py tests/agent/test_prompt_builder.py tests/hermes_cli/test_config_validation.py tests/hermes_cli/test_config.py -q -o 'addopts='`
