### PR TITLE
Fix local browser launch with Playwright-managed Chromium

### DIFF
--- a/tests/tools/test_browser_playwright_executable.py
+++ b/tests/tools/test_browser_playwright_executable.py
@@ -1,0 +1,69 @@
+"""Regression tests for local browser executable discovery."""
+
+def _reset_browser_discovery(browser_tool):
+    browser_tool._cached_chromium_installed = None
+    browser_tool._cached_chromium_executable = None
+
+
+def test_playwright_chromium_cache_resolves_concrete_executable(tmp_path, monkeypatch):
+    from tools import browser_tool
+
+    home = tmp_path / "home"
+    chrome = home / ".cache" / "ms-playwright" / "chromium-1223" / "chrome-linux" / "chrome"
+    chrome.parent.mkdir(parents=True)
+    chrome.write_text("#!/bin/sh\n")
+
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("PLAYWRIGHT_BROWSERS_PATH", raising=False)
+    monkeypatch.delenv("AGENT_BROWSER_EXECUTABLE_PATH", raising=False)
+    monkeypatch.setattr(browser_tool.shutil, "which", lambda _name: None)
+    _reset_browser_discovery(browser_tool)
+
+    assert browser_tool._chromium_installed() is True
+    assert browser_tool._get_chromium_executable() == str(chrome)
+
+
+def test_playwright_headless_shell_cache_resolves_concrete_executable(tmp_path, monkeypatch):
+    from tools import browser_tool
+
+    cache = tmp_path / "ms-playwright"
+    headless = cache / "chromium_headless_shell-1223" / "chrome-linux" / "headless_shell"
+    headless.parent.mkdir(parents=True)
+    headless.write_text("#!/bin/sh\n")
+
+    monkeypatch.setenv("PLAYWRIGHT_BROWSERS_PATH", str(cache))
+    monkeypatch.delenv("AGENT_BROWSER_EXECUTABLE_PATH", raising=False)
+    monkeypatch.setattr(browser_tool.shutil, "which", lambda _name: None)
+    _reset_browser_discovery(browser_tool)
+
+    assert browser_tool._chromium_installed() is True
+    assert browser_tool._get_chromium_executable() == str(headless)
+
+
+def test_explicit_agent_browser_executable_path_is_respected(tmp_path, monkeypatch):
+    from tools import browser_tool
+
+    explicit = tmp_path / "custom-chrome"
+    explicit.write_text("#!/bin/sh\n")
+
+    monkeypatch.setenv("AGENT_BROWSER_EXECUTABLE_PATH", str(explicit))
+    monkeypatch.setattr(browser_tool.shutil, "which", lambda _name: None)
+    _reset_browser_discovery(browser_tool)
+
+    assert browser_tool._chromium_installed() is True
+    assert browser_tool._get_chromium_executable() == str(explicit)
+
+
+def test_cache_reset_clears_chromium_executable(monkeypatch):
+    from tools import browser_tool
+
+    browser_tool._cached_chromium_installed = True
+    browser_tool._cached_chromium_executable = "/tmp/chrome"
+
+    monkeypatch.setattr(browser_tool, "cleanup_browser", lambda _task_id: None)
+    monkeypatch.setattr(browser_tool, "_active_sessions", {})
+
+    browser_tool.cleanup_all_browsers()
+
+    assert browser_tool._cached_chromium_installed is None
+    assert browser_tool._cached_chromium_executable is None

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2006,6 +2006,15 @@ def _run_browser_command(
             idle_ms = str(BROWSER_SESSION_INACTIVITY_TIMEOUT * 1000)
             browser_env["AGENT_BROWSER_IDLE_TIMEOUT_MS"] = idle_ms
 
+        # agent-browser 0.27+ may not auto-discover Playwright's Chromium
+        # cache. When Hermes has already resolved a concrete executable, pass
+        # it explicitly so profile-scoped ms-playwright installs work at
+        # runtime, not just during requirements checks.
+        if "AGENT_BROWSER_EXECUTABLE_PATH" not in browser_env:
+            chromium_executable = _get_chromium_executable()
+            if chromium_executable:
+                browser_env["AGENT_BROWSER_EXECUTABLE_PATH"] = chromium_executable
+
         # Inject --no-sandbox when needed (issue #15765):
         # - Running as root: Chromium always refuses to start without it
         # - Ubuntu 23.10+ / AppArmor systems: unprivileged user namespaces
@@ -3470,7 +3479,7 @@ def cleanup_all_browsers() -> None:
     # Reset cached lookups so they are re-evaluated on next use.
     global _cached_agent_browser, _agent_browser_resolved
     global _cached_command_timeout, _command_timeout_resolved
-    global _cached_chromium_installed
+    global _cached_chromium_installed, _cached_chromium_executable
     global _cached_browser_engine, _browser_engine_resolved
     _cached_agent_browser = None
     _agent_browser_resolved = False
@@ -3478,6 +3487,7 @@ def cleanup_all_browsers() -> None:
     _cached_command_timeout = None
     _command_timeout_resolved = False
     _cached_chromium_installed = None
+    _cached_chromium_executable = None
     _cached_browser_engine = None
     _browser_engine_resolved = False
 
@@ -3488,6 +3498,7 @@ def cleanup_all_browsers() -> None:
 
 # Cache for Chromium discovery. Invalidated by _reset_browser_caches.
 _cached_chromium_installed: Optional[bool] = None
+_cached_chromium_executable: Optional[str] = None
 
 
 def _chromium_search_roots() -> List[str]:
@@ -3537,14 +3548,16 @@ def _chromium_installed() -> bool:
     the tool behind this check prevents advertising a capability that will
     fail at runtime.
     """
-    global _cached_chromium_installed
+    global _cached_chromium_installed, _cached_chromium_executable
     if _cached_chromium_installed is not None:
         return _cached_chromium_installed
 
     # 1. AGENT_BROWSER_EXECUTABLE_PATH — explicit user-configured browser
     ab_path = os.environ.get("AGENT_BROWSER_EXECUTABLE_PATH", "").strip()
     if ab_path:
-        if os.path.isfile(ab_path) or shutil.which(ab_path):
+        resolved = ab_path if os.path.isfile(ab_path) else shutil.which(ab_path)
+        if resolved:
+            _cached_chromium_executable = resolved
             _cached_chromium_installed = True
             return True
 
@@ -3556,6 +3569,7 @@ def _chromium_installed() -> bool:
         or shutil.which("chrome")
     )
     if system_chrome:
+        _cached_chromium_executable = system_chrome
         _cached_chromium_installed = True
         return True
 
@@ -3568,8 +3582,28 @@ def _chromium_installed() -> bool:
         except OSError:
             continue
         # Playwright names them ``chromium-<build>`` and
-        # ``chromium_headless_shell-<build>``; agent-browser accepts either.
+        # ``chromium_headless_shell-<build>``. agent-browser 0.27+ may not
+        # auto-discover those caches, so keep the concrete executable path and
+        # pass it through AGENT_BROWSER_EXECUTABLE_PATH at launch time.
         for entry in entries:
+            candidates: List[str] = []
+            if entry.startswith("chromium-"):
+                candidates.extend([
+                    os.path.join(root, entry, "chrome-linux", "chrome"),
+                    os.path.join(root, entry, "chrome-mac", "Chromium.app", "Contents", "MacOS", "Chromium"),
+                    os.path.join(root, entry, "chrome-win", "chrome.exe"),
+                ])
+            elif entry.startswith("chromium_headless_shell-"):
+                candidates.extend([
+                    os.path.join(root, entry, "chrome-linux", "headless_shell"),
+                    os.path.join(root, entry, "chrome-mac", "headless_shell"),
+                    os.path.join(root, entry, "chrome-win", "headless_shell.exe"),
+                ])
+            for candidate in candidates:
+                if os.path.isfile(candidate):
+                    _cached_chromium_executable = candidate
+                    _cached_chromium_installed = True
+                    return True
             if entry.startswith("chromium-") or entry.startswith(
                 "chromium_headless_shell-"
             ):
@@ -3577,7 +3611,19 @@ def _chromium_installed() -> bool:
                 return True
 
     _cached_chromium_installed = False
+    _cached_chromium_executable = None
     return False
+
+
+def _get_chromium_executable() -> Optional[str]:
+    """Return the concrete Chrome/Chromium executable discovered for local mode."""
+    global _cached_chromium_executable
+    if _cached_chromium_executable and os.path.isfile(_cached_chromium_executable):
+        return _cached_chromium_executable
+    _chromium_installed()
+    if _cached_chromium_executable and os.path.isfile(_cached_chromium_executable):
+        return _cached_chromium_executable
+    return None
 
 
 def _running_in_docker() -> bool:


### PR DESCRIPTION
## Summary
- resolve the concrete Chrome/Chromium executable when local browser discovery finds a Playwright-managed Chromium/headless-shell cache
- pass that executable to `agent-browser` via `AGENT_BROWSER_EXECUTABLE_PATH` unless the user already set one
- reset the executable cache during browser cleanup and add regression tests for Playwright cache discovery

## Why
`check_browser_requirements()` can currently pass when `~/.cache/ms-playwright/chromium-*` exists, but `agent-browser@0.27.x` may still fail real navigation with `Chrome not found` because it does not always auto-discover that Playwright cache. Passing the concrete executable path keeps the requirements check and runtime launch behavior aligned.

## Verification
- `python3 -m py_compile tools/browser_tool.py tests/tools/test_browser_playwright_executable.py`
- `python3 -m pytest tests/tools/test_browser_playwright_executable.py -q`
- `python3 -m ruff check tools/browser_tool.py tests/tools/test_browser_playwright_executable.py`
- Runtime smoke with `PYTHONPATH=/home/ubuntu/src/hermes-agent-upstream`, profile-scoped `HOME`, and actual `browser_navigate()` / `browser_snapshot()` using Playwright Chromium: passed
