### PR TITLE
fix(gateway): do not interrupt active runs for internal events

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3950,6 +3950,26 @@ class BasePlatformAdapter(ABC):
 
         # Check if there's already an active handler for this session
         if session_key in self._active_sessions:
+            # Internal synthetic events (background process completion/watch
+            # notifications) are routed through the normal adapter so they can
+            # reuse session context, but they are not live user input. Queue
+            # them for the next turn without setting the interrupt guard or
+            # invoking the busy-session handler, otherwise the gateway can emit
+            # a bogus "Interrupting current task" ack and abort user work.
+            if getattr(event, "internal", False):
+                logger.debug(
+                    "[%s] Queuing internal event for active session %s without interrupt",
+                    self.name,
+                    session_key,
+                )
+                merge_pending_message_event(
+                    self._pending_messages,
+                    session_key,
+                    event,
+                    merge_text=True,
+                )
+                return
+
             # Certain commands must bypass the active-session guard and be
             # dispatched directly to the gateway runner.  Without this, they
             # are queued as pending messages and either:

--- a/tests/gateway/test_active_session_text_merge.py
+++ b/tests/gateway/test_active_session_text_merge.py
@@ -47,6 +47,7 @@ def _make_event(
     user_id: str = "u1",
     user_name: str | None = None,
     thread_id: str | None = None,
+    internal: bool = False,
 ) -> MessageEvent:
     source = SessionSource(
         platform=Platform.TELEGRAM,
@@ -61,6 +62,7 @@ def _make_event(
         message_type=MessageType.TEXT,
         source=source,
         message_id=f"msg-{text[:8]}",
+        internal=internal,
     )
 
 
@@ -376,3 +378,32 @@ def test_busy_text_mode_respects_env_var_override(monkeypatch):
     adapter = _make_initialized_adapter()
     assert adapter._busy_text_mode == "interrupt"
     assert not adapter._is_queue_text_debounce_candidate(_make_event("test"))
+
+
+@pytest.mark.asyncio
+async def test_internal_followup_queues_without_interrupting_active_session():
+    """Synthetic process/watch events must not masquerade as live user input.
+
+    Background process notifications use ``MessageEvent.internal=True`` and may
+    arrive while the session they belong to is already processing a real user
+    turn. They should be queued for the next turn without setting the interrupt
+    guard; otherwise the gateway emits a bogus "Interrupting current task" ack
+    and aborts user work even though no user sent a new message.
+    """
+    adapter = _make_adapter()
+    first = _make_event("real user work")
+    session_key = build_session_key(first.source)
+
+    guard = asyncio.Event()
+    adapter._active_sessions[session_key] = guard
+    internal_event = _make_event(
+        '[IMPORTANT: Background process proc_x matched watch pattern "ready".]',
+        internal=True,
+    )
+
+    await adapter.handle_message(internal_event)
+
+    pending = adapter._pending_messages[session_key]
+    assert pending is internal_event
+    assert pending.internal is True
+    assert not guard.is_set(), "internal events must not interrupt the active user turn"


### PR DESCRIPTION
## Summary
- Prevent internal gateway follow-up events from interrupting an already active user session.
- Queue internal events for the next turn without setting the active-session interrupt guard or invoking the busy-session handler.
- Add a regression test covering internal follow-up queuing while a session is active.

## Why
Background/watch notifications and other gateway-internal events can be represented as `MessageEvent.internal=True`. When they arrive while a user session is active, they should not be treated like a new user message. The previous active-session guard path ignored the `internal` flag and could trigger the user-visible interrupt flow.

## Test Plan
- `python -m pytest tests/gateway/test_active_session_text_merge.py tests/gateway/test_internal_event_bypass_pairing.py tests/gateway/test_background_process_notifications.py tests/gateway/test_queue_consumption.py tests/gateway/test_session_split_brain_11016.py -q -o addopts=`
- `python -m py_compile gateway/platforms/base.py tests/gateway/test_active_session_text_merge.py`
- `git diff --check origin/main...HEAD`

## Notes
- User-origin follow-up messages still interrupt active sessions as before.
- This only changes handling for explicitly internal events.
