### PR TITLE
fix(gateway): unify media extension list between extract_media and extract_local_files

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -33,6 +33,32 @@ _AUDIO_EXTS = frozenset({'.ogg', '.opus', '.mp3', '.wav', '.m4a', '.flac'})
 _TELEGRAM_AUDIO_ATTACHMENT_EXTS = frozenset({'.mp3', '.m4a'})
 _TELEGRAM_VOICE_EXTS = frozenset({'.ogg', '.opus'})
 
+# Media file extensions recognized for native delivery.
+# Used by both extract_media() for explicit MEDIA: tags and
+# extract_local_files() for bare path detection.
+_MEDIA_EXTS = (
+    # Images (embed inline)
+    '.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.tiff', '.svg',
+    # Video (embed inline where supported)
+    '.mp4', '.mov', '.avi', '.mkv', '.webm',
+    # Audio (delivered as voice/audio where supported)
+    '.mp3', '.wav', '.ogg', '.m4a', '.flac',
+    # Documents (uploaded as file attachments)
+    '.pdf', '.docx', '.doc', '.odt', '.rtf', '.txt', '.md',
+    # Spreadsheets / data
+    '.xlsx', '.xls', '.ods', '.csv', '.tsv', '.json', '.xml', '.yaml', '.yml',
+    # Presentations
+    '.pptx', '.ppt', '.odp', '.key',
+    # Archives
+    '.zip', '.tar', '.gz', '.tgz', '.bz2', '.xz', '.7z', '.rar',
+    # Web / rendered output
+    '.html', '.htm',
+    # Mobile apps
+    '.apk', '.ipa',
+    # Ebooks
+    '.epub',
+)
+
 
 def _platform_name(platform) -> str:
     """Normalize a Platform enum / raw string into a lowercase name."""
@@ -2267,8 +2293,10 @@ class BasePlatformAdapter(ABC):
         
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
+        # Extension list comes from the module-level _MEDIA_EXTS constant.
+        ext_part = '|'.join(e.lstrip('.') for e in _MEDIA_EXTS)
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:''' + ext_part + r''')(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()
@@ -2310,25 +2338,7 @@ class BasePlatformAdapter(ABC):
             Tuple of (list of expanded file paths, cleaned text with the
             raw path strings removed).
         """
-        _LOCAL_MEDIA_EXTS = (
-            # Images (embed inline)
-            '.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.tiff', '.svg',
-            # Video (embed inline where supported)
-            '.mp4', '.mov', '.avi', '.mkv', '.webm',
-            # Audio (delivered as voice/audio where supported)
-            '.mp3', '.wav', '.ogg', '.m4a', '.flac',
-            # Documents (uploaded as file attachments)
-            '.pdf', '.docx', '.doc', '.odt', '.rtf', '.txt', '.md',
-            # Spreadsheets / data
-            '.xlsx', '.xls', '.ods', '.csv', '.tsv', '.json', '.xml', '.yaml', '.yml',
-            # Presentations
-            '.pptx', '.ppt', '.odp', '.key',
-            # Archives
-            '.zip', '.tar', '.gz', '.tgz', '.bz2', '.xz', '.7z', '.rar',
-            # Web / rendered output
-            '.html', '.htm',
-        )
-        ext_part = '|'.join(e.lstrip('.') for e in _LOCAL_MEDIA_EXTS)
+        ext_part = '|'.join(e.lstrip('.') for e in _MEDIA_EXTS)
 
         # (?<![/:\w.]) prevents matching inside URLs (e.g. https://…/img.png)
         #             and relative paths (./foo.png)

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -360,6 +360,38 @@ class TestExtractMedia:
         assert "[[audio_as_voice]]" not in cleaned
         assert "[[as_document]]" not in cleaned
 
+    def test_media_tag_recognizes_html_extension(self):
+        """HTML files should be matched by MEDIA: directive (#31137)."""
+        content = "MEDIA:/tmp/report.html"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [("/tmp/report.html", False)]
+        assert cleaned == ""
+
+    def test_media_tag_recognizes_md_extension(self):
+        """Markdown files should be matched by MEDIA: directive (#31137)."""
+        content = "MEDIA:/tmp/notes.md"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [("/tmp/notes.md", False)]
+
+    def test_media_tag_recognizes_json_extension(self):
+        """JSON files should be matched by MEDIA: directive (#31137)."""
+        content = "MEDIA:/tmp/data.json"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [("/tmp/data.json", False)]
+
+    def test_media_tag_recognizes_svg_extension(self):
+        """SVG files should be matched by MEDIA: directive (#31137)."""
+        content = "MEDIA:/tmp/diagram.svg"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [("/tmp/diagram.svg", False)]
+
+    def test_media_tag_recognizes_all_archive_extensions(self):
+        """All archive extensions from _MEDIA_EXTS should work."""
+        for ext in [".tar", ".gz", ".tgz", ".bz2", ".xz"]:
+            content = f"MEDIA:/tmp/archive{ext}"
+            media, _ = BasePlatformAdapter.extract_media(content)
+            assert len(media) == 1, f"Failed for {ext}"
+
 
 class TestMediaDeliveryPathValidation:
     def _patch_roots(self, monkeypatch, *roots):


### PR DESCRIPTION
The media_pattern regex in extract_media() had a hardcoded extension list that drifted from the _LOCAL_MEDIA_EXTS tuple in extract_local_files(). Extensions like .html, .md, .json, .svg, .tar, .gz were missing from the MEDIA: directive regex, causing silent data loss when agents emitted explicit MEDIA:/path/file.html tags.

Fix by extracting the extension list to a module-level _MEDIA_EXTS constant and using it in both places. The regex is now built dynamically from the same source of truth.

Fixes #31137

## Checklist
- [x] I have read the CONTRIBUTING.md guidelines
- [x] Code compiles without warnings
- [x] Tests pass locally
- [x] New tests added for the fix