### PR TITLE
fix(qqbot): raise RuntimeError in _read_events when WebSocket is closed

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -675,7 +675,7 @@ class QQAdapter(BasePlatformAdapter):
 
     async def _read_events(self) -> None:
         """Read WebSocket frames until connection closes."""
-        if not self._ws:
+        if not self._ws or self._ws.closed:
             raise RuntimeError("WebSocket not connected")
 
         while self._running and self._ws and not self._ws.closed:

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -2172,3 +2172,55 @@ class TestCloseCodeClassification:
         assert 4001 in fatal_codes
         assert 4915 in fatal_codes
 
+
+
+# ---------------------------------------------------------------------------
+# _read_events: closed WebSocket guard
+# ---------------------------------------------------------------------------
+
+class TestReadEventsClosedWebSocket:
+    """Verify _read_events raises on closed WebSocket (#31101)."""
+
+    def _make_adapter(self):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b"))
+
+    @pytest.mark.asyncio
+    async def test_raises_on_closed_websocket(self):
+        """_read_events should raise RuntimeError when WS is closed."""
+        adapter = self._make_adapter()
+
+        class FakeClosedWS:
+            closed = True
+
+        adapter._ws = FakeClosedWS()
+
+        with pytest.raises(RuntimeError, match="WebSocket not connected"):
+            await adapter._read_events()
+
+    @pytest.mark.asyncio
+    async def test_raises_on_none_websocket(self):
+        """_read_events should raise RuntimeError when WS is None."""
+        adapter = self._make_adapter()
+        adapter._ws = None
+
+        with pytest.raises(RuntimeError, match="WebSocket not connected"):
+            await adapter._read_events()
+
+    @pytest.mark.asyncio
+    async def test_enters_loop_when_ws_open(self):
+        """_read_events should enter the loop when WS is open and not closed."""
+        adapter = self._make_adapter()
+        adapter._running = False  # Stop immediately
+
+        class FakeOpenWS:
+            closed = False
+
+            async def receive(self):
+                # This should never be called because _running is False
+                pass
+
+        adapter._ws = FakeOpenWS()
+
+        # Should not raise - the while loop exits immediately because _running is False
+        await adapter._read_events()


### PR DESCRIPTION
When reconnect fails (e.g., _get_gateway_url() times out), the old closed WebSocket object was not None but had closed=True. The guard `if not self._ws` passed, but the while loop `while self._ws and not self._ws.closed` never executed, causing _read_events to return silently. This led to an infinite silent loop with no retry attempts.

Fix by checking both `not self._ws` and `self._ws.closed` in the guard.

Fixes #31101

## Checklist
- [x] I have read the CONTRIBUTING.md guidelines
- [x] Code compiles without warnings
- [x] Tests pass locally
- [x] New tests added for the fix