### PR TITLE
fix: strip internal underscore-prefixed fields from API message copies

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -818,8 +818,15 @@ def run_conversation(
             # Remove finish_reason - not accepted by strict APIs (e.g. Mistral)
             if "finish_reason" in api_msg:
                 api_msg.pop("finish_reason")
-            # Strip internal thinking-prefill marker
-            api_msg.pop("_thinking_prefill", None)
+            # Strip internal markers — underscore-prefixed fields are
+            # Hermes-internal tracking fields that must never reach the wire.
+            # Strict providers (Fireworks, Mistral, etc.) reject unknown keys
+            # in the messages array. This covers _thinking_prefill,
+            # _empty_recovery_synthetic, _empty_terminal_sentinel, and any
+            # future internal-only fields.
+            for _k in list(api_msg.keys()):
+                if _k.startswith("_"):
+                    api_msg.pop(_k, None)
             # Strip Codex Responses API fields (call_id, response_item_id) for
             # strict providers like Mistral, Fireworks, etc. that reject unknown fields.
             # Uses new dicts so the internal messages list retains the fields


### PR DESCRIPTION
Strict providers (Fireworks, Mistral, etc.) reject unknown keys in the
messages array with HTTP 400. The API-copy path (`api_msg = msg.copy()`)
already stripped `_thinking_prefill`, but `_empty_recovery_synthetic` and
`_empty_terminal_sentinel` were not being stripped, causing:

```
HTTP 400: 2 request validation errors: Extra inputs are not permitted,
field: 'messages[146]._empty_recovery_synthetic', value: True
```

Replace the one-off `_thinking_prefill` pop with a general loop that strips
all underscore-prefixed keys from the API message copy. This catches any
future internal-only fields automatically.

## Test plan

- `tests/run_agent/test_empty_response_recovery_persistence.py` — 3/3 pass
- `tests/run_agent/test_session_meta_filtering.py` — 4/4 pass
- `tests/run_agent/test_agent_guardrails.py` — 33/33 pass