### PR TITLE
security(skills): prevent prefix-match trust level bypass

### DIFF
--- a/tests/tools/test_skills_guard.py
+++ b/tests/tools/test_skills_guard.py
@@ -66,6 +66,28 @@ class TestResolveTrustLevel:
         assert _resolve_trust_level("random-user/my-skill") == "community"
         assert _resolve_trust_level("") == "community"
 
+    def test_prefix_attack_on_trusted_repo_rejected(self):
+        """Prefix-match attack should not grant trusted tier (#31141).
+
+        An attacker-controlled repo like 'openai/skills-evil' should NOT
+        match 'openai/skills' via startswith — only exact match or
+        sub-path (openai/skills/foo) should be trusted.
+        """
+        assert _resolve_trust_level("openai/skills-evil") == "community"
+        assert _resolve_trust_level("anthropics/skills-malicious") == "community"
+        assert _resolve_trust_level("huggingface/skills-attack") == "community"
+
+    def test_prefix_attack_on_official_rejected(self):
+        """The 'official' username should not match 'official-evil/repo'."""
+        assert _resolve_trust_level("official-evil/malware") == "community"
+        assert _resolve_trust_level("official-attacker/skill") == "community"
+
+    def test_subpath_of_trusted_repo_is_trusted(self):
+        """Legitimate sub-paths under trusted repos should still work."""
+        assert _resolve_trust_level("openai/skills/some-skill") == "trusted"
+        assert _resolve_trust_level("anthropics/skills/deep/nested/skill") == "trusted"
+        assert _resolve_trust_level("huggingface/skills/llm/finetune") == "trusted"
+
 
 # ---------------------------------------------------------------------------
 # _determine_verdict

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -918,11 +918,11 @@ def _resolve_trust_level(source: str) -> str:
     if normalized_source == "agent-created":
         return "agent-created"
     # Official optional skills shipped with the repo
-    if normalized_source.startswith("official/") or normalized_source == "official":
+    if normalized_source == "official" or normalized_source.startswith("official/"):
         return "builtin"
-    # Check if source matches any trusted repo
+    # Check if source matches any trusted repo (exact match or sub-path)
     for trusted in TRUSTED_REPOS:
-        if normalized_source.startswith(trusted) or normalized_source == trusted:
+        if normalized_source == trusted or normalized_source.startswith(trusted + "/"):
             return "trusted"
     return "community"
 


### PR DESCRIPTION
The trust level check in _resolve_trust_level used startswith() without ensuring the match was a proper path boundary. This allowed an attacker-controlled repo like `openai/skills-evil` to match `openai/skills` via startswith, granting trusted tier to untrusted skills.

Fix by checking exact match OR startswith with slash separator:
```
normalized_source == trusted or normalized_source.startswith(trusted + "/")
```

This ensures only the exact trusted repo or its sub-paths are trusted, not repos that share a common prefix string.

Fixes #31141

## Checklist
- [x] I have read the CONTRIBUTING.md guidelines
- [x] Code compiles without warnings
- [x] Tests pass locally
- [x] New tests added for the fix