### PR TITLE
fix(cron,gateway): isolate gateway auth from cron profile-context env…

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -173,7 +173,12 @@ def _job_profile_context(job_id: str, profile: Optional[str]):
     env_snapshot = os.environ.copy()
 
     from hermes_cli.profiles import normalize_profile_name, resolve_profile_env
-    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+    from hermes_constants import (
+        clear_gateway_baseline_env,
+        reset_hermes_home_override,
+        set_gateway_baseline_env,
+        set_hermes_home_override,
+    )
 
     normalized_profile = normalize_profile_name(raw_profile)
     try:
@@ -189,6 +194,12 @@ def _job_profile_context(job_id: str, profile: Optional[str]):
 
     override_token = None
     try:
+        # Pin the gateway thread's auth env reads to the pre-mutation snapshot
+        # BEFORE we let cron mutate os.environ via load_dotenv(override=True)
+        # downstream. Without this, the gateway's asyncio thread sees the
+        # profile-B env mid-job and rejects profile-A users, generating
+        # unwanted pairing codes in feishu-pending.json (#31026).
+        set_gateway_baseline_env(env_snapshot)
         override_token = set_hermes_home_override(profile_home)
         _hermes_home = profile_home
         logger.info(
@@ -210,6 +221,14 @@ def _job_profile_context(job_id: str, profile: Optional[str]):
         for k, v in env_snapshot.items():
             if os.environ.get(k) != v:
                 os.environ[k] = v
+        # Clear the baseline AFTER restoring os.environ. If we cleared first,
+        # there'd be a window where gateway_getenv falls back to a still-
+        # mutated os.environ — the exact leak we are guarding against (#31026).
+        # With this order, gateway readers either (a) see the baseline while
+        # the env restore is in flight, or (b) see the restored live env after
+        # the baseline clears. Both states equal the snapshot, so the
+        # gateway's view is consistent throughout.
+        clear_gateway_baseline_env()
 
 
 def _resolve_origin(job: dict) -> Optional[dict]:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -665,7 +665,7 @@ _ensure_ssl_certs()
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # Resolve Hermes home directory (respects HERMES_HOME override)
-from hermes_constants import get_hermes_home
+from hermes_constants import gateway_getenv, get_hermes_home
 from utils import atomic_json_write, atomic_yaml_write, base_url_host_matches, is_truthy_value
 _hermes_home = get_hermes_home()
 
@@ -6209,7 +6209,10 @@ class GatewayRunner:
                 Platform.QQBOT: "QQ_GROUP_ALLOWED_USERS",
             }.get(source.platform, "")
             if chat_allowlist_env:
-                raw_chat_allowlist = os.getenv(chat_allowlist_env, "").strip()
+                # gateway_getenv (not os.getenv) so an in-process cron profile
+                # context mutating os.environ on another thread cannot flip
+                # the gateway's auth verdict mid-message (#31026).
+                raw_chat_allowlist = gateway_getenv(chat_allowlist_env, "").strip()
                 if raw_chat_allowlist:
                     allowed_group_ids = {
                         cid.strip()
@@ -6286,14 +6289,20 @@ class GatewayRunner:
             except Exception:
                 pass
 
+        # All env reads in this method use gateway_getenv (not os.getenv): the
+        # cron ticker runs as a background thread in this same process and
+        # may have mutated os.environ for a per-job profile context. Reading
+        # the live env here would flip the gateway's verdict on legitimate
+        # users mid-message (#31026).
+
         # Per-platform allow-all flag (e.g., DISCORD_ALLOW_ALL_USERS=true)
         platform_allow_all_var = platform_allow_all_map.get(source.platform, "")
-        if platform_allow_all_var and os.getenv(platform_allow_all_var, "").lower() in {"true", "1", "yes"}:
+        if platform_allow_all_var and gateway_getenv(platform_allow_all_var, "").lower() in {"true", "1", "yes"}:
             return True
 
         if getattr(source, "is_bot", False):
             allow_bots_var = platform_allow_bots_map.get(source.platform)
-            if allow_bots_var and os.getenv(allow_bots_var, "none").lower().strip() in {"mentions", "all"}:
+            if allow_bots_var and gateway_getenv(allow_bots_var, "none").lower().strip() in {"mentions", "all"}:
                 return True
 
         # Discord role-based access (DISCORD_ALLOWED_ROLES): the adapter's
@@ -6304,7 +6313,7 @@ class GatewayRunner:
         # (issue #7871).
         if (
             source.platform == Platform.DISCORD
-            and os.getenv("DISCORD_ALLOWED_ROLES", "").strip()
+            and gateway_getenv("DISCORD_ALLOWED_ROLES", "").strip()
         ):
             return True
 
@@ -6314,17 +6323,17 @@ class GatewayRunner:
             return True
 
         # Check platform-specific and global allowlists
-        platform_allowlist = os.getenv(platform_env_map.get(source.platform, ""), "").strip()
+        platform_allowlist = gateway_getenv(platform_env_map.get(source.platform, ""), "").strip()
         group_user_allowlist = ""
         group_chat_allowlist = ""
         if source.chat_type in {"group", "forum"}:
-            group_user_allowlist = os.getenv(platform_group_user_env_map.get(source.platform, ""), "").strip()
-            group_chat_allowlist = os.getenv(platform_group_chat_env_map.get(source.platform, ""), "").strip()
-        global_allowlist = os.getenv("GATEWAY_ALLOWED_USERS", "").strip()
+            group_user_allowlist = gateway_getenv(platform_group_user_env_map.get(source.platform, ""), "").strip()
+            group_chat_allowlist = gateway_getenv(platform_group_chat_env_map.get(source.platform, ""), "").strip()
+        global_allowlist = gateway_getenv("GATEWAY_ALLOWED_USERS", "").strip()
 
         if not platform_allowlist and not group_user_allowlist and not group_chat_allowlist and not global_allowlist:
             # No allowlists configured -- check global allow-all flag
-            return os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
+            return gateway_getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
 
         # Telegram can optionally authorize group traffic by chat ID.
         # Keep this separate from TELEGRAM_GROUP_ALLOWED_USERS, which gates
@@ -6459,13 +6468,15 @@ class GatewayRunner:
                 ),
                 Platform.QQBOT: ("QQ_GROUP_ALLOWED_USERS",),
             }
-            if os.getenv(platform_env_map.get(platform, ""), "").strip():
+            # gateway_getenv (not os.getenv) to stay isolated from the cron
+            # ticker's per-job profile-context env mutation (#31026).
+            if gateway_getenv(platform_env_map.get(platform, ""), "").strip():
                 return "ignore"
             for env_key in platform_group_env_map.get(platform, ()):
-                if os.getenv(env_key, "").strip():
+                if gateway_getenv(env_key, "").strip():
                     return "ignore"
 
-        if os.getenv("GATEWAY_ALLOWED_USERS", "").strip():
+        if gateway_getenv("GATEWAY_ALLOWED_USERS", "").strip():
             return "ignore"
 
         return "pair"

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -6,8 +6,10 @@ without risk of circular imports.
 
 import os
 import sysconfig
+import threading
 from contextvars import ContextVar, Token
 from pathlib import Path
+from typing import Dict, Mapping, Optional
 
 
 _profile_fallback_warned: bool = False
@@ -38,6 +40,66 @@ def get_hermes_home_override() -> str | None:
     if override is _UNSET or not override:
         return None
     return str(override)
+
+
+# ─── Gateway-baseline env snapshot ────────────────────────────────────────────
+#
+# The cron ticker runs as a background thread inside the gateway process and
+# may mutate ``os.environ`` for the duration of a per-job profile context
+# (see ``cron.scheduler._job_profile_context``). While that mutation is live,
+# the gateway's asyncio thread is still processing inbound messages and would
+# otherwise read the wrong profile's allowlist/auth env vars, rejecting
+# legitimate users and triggering an unwanted pairing flow (#31026).
+#
+# The cron context manager publishes a pre-mutation snapshot via
+# ``set_gateway_baseline_env`` and clears it on exit. Gateway auth code reads
+# env through ``gateway_getenv`` so its decisions stay pinned to the
+# gateway-process baseline regardless of what cron is doing on another thread.
+_baseline_env_lock = threading.RLock()
+_gateway_baseline_env: Optional[Dict[str, str]] = None
+
+
+def set_gateway_baseline_env(snapshot: Mapping[str, str]) -> None:
+    """Expose a pre-cron-context os.environ snapshot to the gateway thread.
+
+    Called by ``cron.scheduler._job_profile_context`` before it mutates
+    ``os.environ`` for a per-job profile. While this snapshot is set,
+    ``gateway_getenv`` reads from it instead of the live (cron-mutated)
+    environment, so the gateway's auth decisions remain isolated from
+    the cron job's profile context.
+    """
+    global _gateway_baseline_env
+    with _baseline_env_lock:
+        _gateway_baseline_env = dict(snapshot)
+
+
+def clear_gateway_baseline_env() -> None:
+    """Clear the gateway-baseline env snapshot.
+
+    Called by ``cron.scheduler._job_profile_context`` on exit, before it
+    restores ``os.environ``, so subsequent ``gateway_getenv`` reads fall
+    back to the (now-restored) live environment.
+    """
+    global _gateway_baseline_env
+    with _baseline_env_lock:
+        _gateway_baseline_env = None
+
+
+def gateway_getenv(key: str, default: str = "") -> str:
+    """Read an env var as the gateway thread should see it.
+
+    When a cron profile context has published a baseline snapshot (because
+    it is currently mutating ``os.environ`` on another thread), return the
+    snapshot's value. Otherwise fall back to ``os.getenv``.
+
+    Used by the gateway's auth path to keep user authorization decisions
+    immune to cron's per-job env mutations (#31026).
+    """
+    with _baseline_env_lock:
+        snapshot = _gateway_baseline_env
+    if snapshot is not None:
+        return snapshot.get(key, default)
+    return os.getenv(key, default)
 
 
 def get_hermes_home() -> Path:

--- a/tests/cron/test_cron_profile.py
+++ b/tests/cron/test_cron_profile.py
@@ -354,6 +354,70 @@ class TestRunJobProfileContext:
         assert observed["hermes_home_during_init"] == str(root)
         assert os.environ["HERMES_HOME"] == str(root)
 
+    def test_gateway_baseline_env_is_isolated_during_profile_run(
+        self, isolated_cron_profile_home, monkeypatch
+    ):
+        """Regression for #31026.
+
+        While a per-job profile context is active, the cron thread mutates
+        ``os.environ`` (so the cron job's agent reads profile B's values),
+        but ``gateway_getenv`` on the same process must keep returning the
+        gateway thread's pre-context (profile A) values. Otherwise the
+        gateway's auth path flips its verdict on legitimate users mid-job
+        and emits unwanted pairing codes.
+        """
+        import dotenv
+        import cron.scheduler as sched
+        from hermes_constants import gateway_getenv
+
+        _root, profile_home = isolated_cron_profile_home
+        observed: dict = {}
+        self._install_agent_stubs(monkeypatch, observed)
+
+        # Profile A (the gateway thread's baseline) has alice authorized.
+        monkeypatch.setenv("FEISHU_ALLOWED_USERS", "alice")
+        # Sanity-check the precondition.
+        assert gateway_getenv("FEISHU_ALLOWED_USERS") == "alice"
+
+        def fake_load_dotenv(path, *_a, **_kw):
+            # Simulate the profile's .env switching the allowlist to bob.
+            observed.setdefault("dotenv_paths", []).append(str(path))
+            os.environ["FEISHU_ALLOWED_USERS"] = "bob"
+            return True
+
+        monkeypatch.setattr(dotenv, "load_dotenv", fake_load_dotenv)
+
+        # Capture both views from inside the running cron job.
+        fake_mod = __import__("sys").modules["run_agent"]
+        original_run = fake_mod.AIAgent.run_conversation
+
+        def capture_run(self, *_a, **_kw):
+            observed["os_env_during_run"] = os.environ.get("FEISHU_ALLOWED_USERS")
+            observed["gateway_view_during_run"] = gateway_getenv("FEISHU_ALLOWED_USERS")
+            return original_run(self, *_a, **_kw)
+
+        monkeypatch.setattr(fake_mod.AIAgent, "run_conversation", capture_run)
+
+        job = {
+            "id": "iso",
+            "name": "profile-isolation-job",
+            "profile": "support",
+            "schedule_display": "manual",
+        }
+
+        success, _output, _response, error = sched.run_job(job)
+
+        assert success is True, error
+        # The cron job sees the mutated env (intentional — its agent must
+        # use profile B's credentials).
+        assert observed["os_env_during_run"] == "bob"
+        # The gateway thread's auth path stays pinned to the baseline.
+        assert observed["gateway_view_during_run"] == "alice"
+        # After the context exits the env is restored and the snapshot is
+        # cleared, so gateway_getenv reads live env again.
+        assert os.environ["FEISHU_ALLOWED_USERS"] == "alice"
+        assert gateway_getenv("FEISHU_ALLOWED_USERS") == "alice"
+
     def test_run_job_falls_back_on_missing_runtime_profile(
         self, isolated_cron_profile_home, monkeypatch
     ):

--- a/tests/gateway/test_profile_cron_no_pairing_leak.py
+++ b/tests/gateway/test_profile_cron_no_pairing_leak.py
@@ -1,0 +1,187 @@
+"""Regression test for #31026 — cron profile switching must not leak Feishu
+pairing state across profiles.
+
+The cron ticker runs as a background thread in the gateway process. When a
+job has ``profile: <other_profile>`` set, ``_job_profile_context`` mutates
+``os.environ`` (via ``load_dotenv(..., override=True)``) so the cron job's
+agent sees that profile's API keys and config.
+
+Before the fix, the gateway's auth path read those env vars directly via
+``os.getenv`` per-message, so users authorized in the source profile got
+rejected mid-cron and the unauthorized-DM-pair flow wrote pending pairing
+codes to ``feishu-pending.json`` for them.
+
+After the fix, ``_is_user_authorized`` and ``_get_unauthorized_dm_behavior``
+read through ``gateway_getenv`` which consults the pre-context baseline
+snapshot published by ``_job_profile_context``, so the gateway's verdict
+stays pinned to profile A's config regardless of cron-thread mutations.
+"""
+
+from __future__ import annotations
+
+import os
+import types
+from pathlib import Path
+
+import pytest
+
+from gateway.pairing import PairingStore
+from gateway.session import Platform, SessionSource
+from hermes_constants import (
+    clear_gateway_baseline_env,
+    gateway_getenv,
+    set_gateway_baseline_env,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_baseline():
+    clear_gateway_baseline_env()
+    yield
+    clear_gateway_baseline_env()
+
+
+def _build_test_runner(pairing_dir: Path) -> types.SimpleNamespace:
+    """Construct the minimum runner-shaped object the auth path needs.
+
+    GatewayRunner has heavy dependencies for full construction; the auth
+    methods only touch ``self.pairing_store`` and (via getattr) ``self.config``.
+    We bind the unbound methods onto a SimpleNamespace for direct invocation.
+    """
+    from gateway.run import GatewayRunner
+
+    # Module-level constant captured at import time — repoint at the test dir.
+    import gateway.pairing as pairing_mod
+    pairing_mod.PAIRING_DIR = pairing_dir
+    pairing_dir.mkdir(parents=True, exist_ok=True)
+
+    runner = types.SimpleNamespace()
+    runner.config = None
+    runner.pairing_store = PairingStore()
+    runner._is_user_authorized = GatewayRunner._is_user_authorized.__get__(runner)
+    runner._get_unauthorized_dm_behavior = GatewayRunner._get_unauthorized_dm_behavior.__get__(runner)
+    return runner
+
+
+def test_user_stays_authorized_during_cron_profile_context(tmp_path, monkeypatch):
+    """Profile A's user remains authorized even while os.environ is mutated."""
+    runner = _build_test_runner(tmp_path / "pairing")
+
+    # Profile A's gateway baseline: alice is authorized.
+    monkeypatch.setenv("FEISHU_ALLOWED_USERS", "alice")
+    monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+
+    # Snapshot the pre-context env (mirrors what _job_profile_context does).
+    set_gateway_baseline_env(dict(os.environ))
+
+    # Now simulate the cron job's load_dotenv(override=True) for profile B:
+    # B has NO feishu allowlist — alice is not in profile B's allowed users.
+    os.environ.pop("FEISHU_ALLOWED_USERS", None)
+
+    # Sanity: live env now lacks alice's entry.
+    assert os.environ.get("FEISHU_ALLOWED_USERS") is None
+    # The gateway baseline still authorizes alice.
+    assert gateway_getenv("FEISHU_ALLOWED_USERS") == "alice"
+
+    alice = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="dm-alice",
+        chat_type="dm",
+        user_id="alice",
+        user_name="Alice",
+    )
+
+    assert runner._is_user_authorized(alice) is True, (
+        "Profile A's user must remain authorized while cron has mutated env "
+        "for profile B (#31026)"
+    )
+
+
+def test_unauthorized_dm_behavior_stays_ignore_during_cron_profile_context(
+    tmp_path, monkeypatch
+):
+    """`_get_unauthorized_dm_behavior` must keep returning 'ignore' for profile
+    A (which has an allowlist) even while cron has cleared the env for profile
+    B. Before the fix this returned 'pair' mid-cron and triggered the
+    feishu-pending.json write."""
+    runner = _build_test_runner(tmp_path / "pairing")
+
+    monkeypatch.setenv("FEISHU_ALLOWED_USERS", "alice")
+    monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+
+    set_gateway_baseline_env(dict(os.environ))
+
+    # Cron mutates env to profile B's (empty allowlist).
+    os.environ.pop("FEISHU_ALLOWED_USERS", None)
+
+    assert runner._get_unauthorized_dm_behavior(Platform.FEISHU) == "ignore", (
+        "Gateway must stay in 'ignore' mode for profile A; otherwise the "
+        "unauthorized-DM-pair flow runs and contaminates feishu-pending.json "
+        "(#31026)"
+    )
+
+
+def test_after_baseline_cleared_gateway_reads_live_env(tmp_path, monkeypatch):
+    """Sanity: when the cron context exits and the baseline is cleared, the
+    gateway resumes reading the live env."""
+    runner = _build_test_runner(tmp_path / "pairing")
+
+    monkeypatch.setenv("FEISHU_ALLOWED_USERS", "alice")
+    monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+    set_gateway_baseline_env(dict(os.environ))
+
+    # Cron mutates...
+    os.environ.pop("FEISHU_ALLOWED_USERS", None)
+    # ...and cron exits: baseline clears, env restored (we simulate restore here).
+    clear_gateway_baseline_env()
+    os.environ["FEISHU_ALLOWED_USERS"] = "alice"
+
+    alice = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="dm-alice",
+        chat_type="dm",
+        user_id="alice",
+        user_name="Alice",
+    )
+    assert runner._is_user_authorized(alice) is True
+
+
+def test_no_pending_pairing_entry_written_during_profile_cron(tmp_path, monkeypatch):
+    """End-to-end regression: simulate the exact scenario from the issue.
+
+    Profile A authorizes alice. While a cron profile context for B is active
+    (env mutated), a message from alice is processed. With the fix the
+    authorization succeeds and the unauthorized-DM-pair flow does NOT run, so
+    ``feishu-pending.json`` is not created.
+    """
+    pairing_dir = tmp_path / "pairing"
+    runner = _build_test_runner(pairing_dir)
+
+    monkeypatch.setenv("FEISHU_ALLOWED_USERS", "alice")
+    monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+
+    # Enter the cron profile context.
+    set_gateway_baseline_env(dict(os.environ))
+    os.environ.pop("FEISHU_ALLOWED_USERS", None)
+
+    alice = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="dm-alice",
+        chat_type="dm",
+        user_id="alice",
+        user_name="Alice",
+    )
+
+    # Authorization succeeds → caller never enters the pair-code path that
+    # would write feishu-pending.json (see gateway/run.py:6586).
+    assert runner._is_user_authorized(alice) is True
+
+    pending_file = pairing_dir / "feishu-pending.json"
+    assert not pending_file.exists(), (
+        f"feishu-pending.json was created at {pending_file} — the cron "
+        "profile-context leak still leaks (#31026)"
+    )
+
+    clear_gateway_baseline_env()

--- a/tests/test_gateway_baseline_env.py
+++ b/tests/test_gateway_baseline_env.py
@@ -1,0 +1,145 @@
+"""Tests for the gateway-baseline-env snapshot mechanism (#31026).
+
+The cron ticker runs as a background thread inside the gateway process and
+mutates ``os.environ`` while a per-job profile context is active. The
+gateway's asyncio thread keeps handling messages during that window and
+must NOT see the cron-mutated values when making auth decisions, or it
+will reject legitimate users and trigger an unwanted pairing flow.
+
+The fix is a thread-safe snapshot published by cron's profile-context
+manager that ``gateway_getenv`` consults in preference to ``os.environ``.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+
+import pytest
+
+from hermes_constants import (
+    clear_gateway_baseline_env,
+    gateway_getenv,
+    set_gateway_baseline_env,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_snapshot():
+    """Ensure each test starts and ends with no baseline snapshot active."""
+    clear_gateway_baseline_env()
+    yield
+    clear_gateway_baseline_env()
+
+
+def test_gateway_getenv_falls_back_to_live_env_when_no_snapshot(monkeypatch):
+    monkeypatch.setenv("ISSUE_31026_KEY", "live-value")
+    assert gateway_getenv("ISSUE_31026_KEY") == "live-value"
+    assert gateway_getenv("ISSUE_31026_MISSING", "fallback") == "fallback"
+
+
+def test_baseline_snapshot_shadows_live_env_during_cron_mutation(monkeypatch):
+    monkeypatch.setenv("FEISHU_ALLOWED_USERS", "alice")
+    set_gateway_baseline_env(dict(os.environ))
+
+    # Simulate cron's load_dotenv(override=True) for a different profile.
+    monkeypatch.setenv("FEISHU_ALLOWED_USERS", "bob")
+
+    # Live env reflects the cron-thread mutation, but the gateway thread's
+    # accessor returns the pre-mutation baseline.
+    assert os.environ["FEISHU_ALLOWED_USERS"] == "bob"
+    assert gateway_getenv("FEISHU_ALLOWED_USERS") == "alice"
+
+
+def test_baseline_clear_restores_live_env_reads(monkeypatch):
+    monkeypatch.setenv("FEISHU_ALLOWED_USERS", "alice")
+    set_gateway_baseline_env(dict(os.environ))
+    monkeypatch.setenv("FEISHU_ALLOWED_USERS", "bob")
+    assert gateway_getenv("FEISHU_ALLOWED_USERS") == "alice"
+
+    clear_gateway_baseline_env()
+    # With no snapshot, gateway_getenv reads the live env (whatever it is now).
+    assert gateway_getenv("FEISHU_ALLOWED_USERS") == "bob"
+
+
+def test_baseline_default_returned_for_missing_key():
+    set_gateway_baseline_env({"OTHER_KEY": "x"})
+    assert gateway_getenv("MISSING_KEY", "default-val") == "default-val"
+    # Key present in snapshot but empty string still returns the snapshot value.
+    set_gateway_baseline_env({"MISSING_KEY": ""})
+    assert gateway_getenv("MISSING_KEY", "default-val") == ""
+
+
+def test_baseline_is_copied_not_aliased():
+    """Mutating the dict we passed in must not affect later gateway reads."""
+    snapshot = {"K": "v1"}
+    set_gateway_baseline_env(snapshot)
+    snapshot["K"] = "v2"  # mutate caller-owned dict
+    assert gateway_getenv("K") == "v1"
+
+
+def test_concurrent_reads_during_env_mutation_see_baseline(monkeypatch):
+    """Simulate the actual bug scenario.
+
+    Thread A (cron) sets a baseline, mutates os.environ for many iterations,
+    then clears the baseline. Thread B (gateway) keeps reading
+    ``gateway_getenv`` and must always see the baseline value while the
+    snapshot is set.
+    """
+    monkeypatch.setenv("FEISHU_ALLOWED_USERS", "alice")
+    stop = threading.Event()
+    observed: list[str] = []
+    reader_done = threading.Event()
+
+    def reader() -> None:
+        while not stop.is_set():
+            observed.append(gateway_getenv("FEISHU_ALLOWED_USERS", ""))
+            time.sleep(0)
+        reader_done.set()
+
+    def mutator() -> None:
+        set_gateway_baseline_env({"FEISHU_ALLOWED_USERS": "alice"})
+        try:
+            for i in range(200):
+                os.environ["FEISHU_ALLOWED_USERS"] = f"bob-{i}"
+                time.sleep(0)
+        finally:
+            clear_gateway_baseline_env()
+
+    r = threading.Thread(target=reader)
+    m = threading.Thread(target=mutator)
+    r.start()
+    m.start()
+    m.join(timeout=5)
+    stop.set()
+    r.join(timeout=5)
+    assert reader_done.is_set(), "reader thread did not exit"
+
+    # While the baseline was set, every observation taken during the mutation
+    # window must equal the baseline. After clear, observations can be any
+    # of the mutated values — but we are only enforcing the during-window
+    # invariant which the bug reported.
+    #
+    # Easier check: at least some observations happened, and none of them
+    # equal a "bob-*" value while the baseline was set. Since we can't
+    # distinguish per-observation easily, we assert the stronger property
+    # that the FIRST few observations (taken before the snapshot was
+    # cleared) are all "alice".
+    #
+    # The mutator clears the baseline only at the end, so all observations
+    # before the clear must be "alice".
+    leaked = [v for v in observed if v.startswith("bob-")]
+    # The reader may continue briefly after the mutator joins; values seen
+    # after clear can be "bob-*". To assert no leak DURING the window we
+    # confirm that "alice" was observed AT LEAST once and that the count of
+    # leaked "bob-*" observations is bounded by the gap between mutator
+    # finishing and the reader being stopped — which should be very small.
+    assert "alice" in observed, "reader never saw the baseline value"
+    # The reader spins until stop is set after mutator joins, so the only
+    # bob-* observations should be from the tail (post-clear). Their count
+    # is small in practice.
+    assert leaked == [] or all(v.startswith("bob-") for v in observed[-len(leaked):]), (
+        "saw a leaked 'bob-*' value while the baseline snapshot was supposed "
+        "to be active"
+    )


### PR DESCRIPTION
… mutation (#31026)

The cron ticker runs as a background thread inside the gateway process. When a job has `profile:` set, `_job_profile_context` mutates `os.environ` (via `load_dotenv(..., override=True)`) so the cron job's agent sees the target profile's API keys. The gateway's asyncio thread keeps handling inbound messages on the side and reads the same env vars per-message for auth (`_is_user_authorized`, `_get_unauthorized_dm_behavior`). During the cron window those reads return the WRONG profile's allowlist, so legitimate users get rejected mid-job and the unauthorized-DM-pair flow writes pending pairing codes into the source profile's `feishu-pending.json` for them.

This commit adds a thread-safe gateway-baseline env snapshot in `hermes_constants.py`. `_job_profile_context` publishes the pre-mutation snapshot via `set_gateway_baseline_env` before entering the profile context and clears it AFTER restoring `os.environ` on exit. The gateway's auth path reads through `gateway_getenv` so its decisions stay pinned to the gateway-process baseline regardless of what cron is doing on another thread. Cron-side semantics are unchanged — the cron job's agent still reads profile B's env via `os.environ`.

Tests:
- `tests/test_gateway_baseline_env.py` — 6 unit tests including a concurrent-mutation regression for the cross-thread race.
- `tests/cron/test_cron_profile.py::test_gateway_baseline_env_is_isolated_during_profile_run` — drives the full `run_job` path and asserts the gateway view stays at baseline while os.environ reflects profile B's values.
- `tests/gateway/test_profile_cron_no_pairing_leak.py` — 4 integration tests that invoke `GatewayRunner._is_user_authorized` / `_get_unauthorized_dm_behavior` under a simulated profile context and assert no `feishu-pending.json` is written.

All 3 of the integration tests fail at HEAD without the gateway/run.py edits — exactly matching the bug reported in #31026 — and pass with the fix.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

