### PR TITLE
chore: sync local cleanup and guardrail fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ docs/superpowers/*
 .gitnexus
 .claude/
 CLAUDE.md
+
+# External nested research/worktree checkouts
+/tinker-atropos/

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 .venv/
 .vscode/
 .env
+.env.*
 .env.local
 .env.development.local
 .env.test.local
@@ -75,3 +76,6 @@ models-dev-upstream/
 hermes_cli/tui_dist/*
 hermes_cli/scripts/
 docs/superpowers/*
+.gitnexus
+.claude/
+CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1130,3 +1130,82 @@ not the specific names.
 
 Reviewers should reject new change-detector tests; authors should convert
 them into invariants before re-requesting review.
+
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **hermes-agent**. Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> If any GitNexus tool warns the index is stale, run `~/scripts/gitnexus-safe-analyze.sh /Users/kihwangkim/dev/hermes-agent` in terminal first. Never run bare `npx gitnexus analyze` from `~`; it can index the home tree and starve Hermes.
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## When Debugging
+
+1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
+2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
+3. `READ gitnexus://repo/hermes-agent/process/{processName}` — trace the full execution flow step by step
+4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
+
+## When Refactoring
+
+- **Renaming**: MUST use `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` first. Review the preview — graph edits are safe, text_search edits need manual review. Then run with `dry_run: false`.
+- **Extracting/Splitting**: MUST run `gitnexus_context({name: "target"})` to see all incoming/outgoing refs, then `gitnexus_impact({target: "target", direction: "upstream"})` to find all external callers before moving code.
+- After any refactor: run `gitnexus_detect_changes({scope: "all"})` to verify only expected files changed.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Tools Quick Reference
+
+| Tool | When to use | Command |
+|------|-------------|---------|
+| `query` | Find code by concept | `gitnexus_query({query: "auth validation"})` |
+| `context` | 360-degree view of one symbol | `gitnexus_context({name: "validateUser"})` |
+| `impact` | Blast radius before editing | `gitnexus_impact({target: "X", direction: "upstream"})` |
+| `detect_changes` | Pre-commit scope check | `gitnexus_detect_changes({scope: "staged"})` |
+| `rename` | Safe multi-file rename | `gitnexus_rename({symbol_name: "old", new_name: "new", dry_run: true})` |
+| `cypher` | Custom graph queries | `gitnexus_cypher({query: "MATCH ..."})` |
+
+## Impact Risk Levels
+
+| Depth | Meaning | Action |
+|-------|---------|--------|
+| d=1 | WILL BREAK — direct callers/importers | MUST update these |
+| d=2 | LIKELY AFFECTED — indirect deps | Should test |
+| d=3 | MAY NEED TESTING — transitive | Test if critical path |
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/hermes-agent/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/hermes-agent/clusters` | All functional areas |
+| `gitnexus://repo/hermes-agent/processes` | All execution flows |
+| `gitnexus://repo/hermes-agent/process/{name}` | Step-by-step execution trace |
+
+## Self-Check Before Finishing
+
+Before completing any code modification task, verify:
+1. `gitnexus_impact` was run for all modified symbols
+2. No HIGH/CRITICAL risk warnings were ignored
+3. `gitnexus_detect_changes()` confirms changes match expected scope
+4. All d=1 (WILL BREAK) dependents were updated
+
+## CLI
+
+- Re-index: `~/scripts/gitnexus-safe-analyze.sh /Users/kihwangkim/dev/hermes-agent`
+- Check freshness: `npx gitnexus status`
+- Generate docs: `npx gitnexus wiki`
+
+<!-- gitnexus:end -->

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -37,9 +37,20 @@ _EXCLUDED_DIRS = {
     ".git",             # nested git dirs (profiles shouldn't have these, but safety)
     "node_modules",     # js deps if website/ somehow leaks in
     "backups",          # prior auto-backups — don't nest backups exponentially
+    "state-snapshots",  # quick snapshots rotate separately; never nest them into full zips
+    ".gitnexus",        # generated code graph indexes — re-analyze instead
+    ".pytest_cache",    # test caches — regenerated locally
+    ".mypy_cache",      # type-checker caches — regenerated locally
+    ".ruff_cache",      # linter caches — regenerated locally
     "checkpoints",      # session-local trajectory caches — regenerated per-session,
                         # session-hash-keyed so they don't port to another machine anyway
 }
+
+# Directory prefixes to skip. Profile skill bundles can contain local virtualenvs
+# such as ``.venv-mlx-tts``; they are large and machine-specific.
+_EXCLUDED_DIR_PREFIXES = (
+    ".venv",
+)
 
 # File-name suffixes to skip
 _EXCLUDED_SUFFIXES = (
@@ -71,7 +82,7 @@ def _should_exclude(rel_path: Path) -> bool:
 
     # Any path component matches an excluded dir name
     for part in parts:
-        if part in _EXCLUDED_DIRS:
+        if part in _EXCLUDED_DIRS or part.startswith(_EXCLUDED_DIR_PREFIXES):
             return True
 
     name = rel_path.name
@@ -164,7 +175,7 @@ def run_backup(args) -> None:
         orig_dirnames = dirnames[:]
         dirnames[:] = [
             d for d in dirnames
-            if d not in _EXCLUDED_DIRS
+            if d not in _EXCLUDED_DIRS and not d.startswith(_EXCLUDED_DIR_PREFIXES)
         ]
         for removed in set(orig_dirnames) - set(dirnames):
             skipped_dirs.add(str(rel_dir / removed))
@@ -492,7 +503,10 @@ _QUICK_STATE_FILES = (
 )
 
 _QUICK_SNAPSHOTS_DIR = "state-snapshots"
-_QUICK_DEFAULT_KEEP = 20
+# Quick snapshots include state.db, which can grow into multi-GB FTS indexes on
+# gateway-heavy installs. Keep a short rollback window by default so pre-update
+# snapshots do not silently dominate HERMES_HOME disk usage.
+_QUICK_DEFAULT_KEEP = 3
 
 
 def _quick_snapshot_root(hermes_home: Optional[Path] = None) -> Path:
@@ -717,7 +731,10 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
         for dirpath, dirnames, filenames in os.walk(hermes_root, followlinks=False):
             dp = Path(dirpath)
             # Prune excluded directories in-place so os.walk doesn't descend
-            dirnames[:] = [d for d in dirnames if d not in _EXCLUDED_DIRS]
+            dirnames[:] = [
+                d for d in dirnames
+                if d not in _EXCLUDED_DIRS and not d.startswith(_EXCLUDED_DIR_PREFIXES)
+            ]
 
             for fname in filenames:
                 fpath = dp / fname

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -41,6 +41,7 @@ from _hermes_home import get_hermes_home
 HERMES_HOME = get_hermes_home()
 TOKEN_PATH = HERMES_HOME / "google_token.json"
 CLIENT_SECRET_PATH = HERMES_HOME / "google_client_secret.json"
+GWS_CREDENTIALS_PATH = HERMES_HOME / "google_gws_credentials.json"
 
 SCOPES = [
     "https://www.googleapis.com/auth/gmail.readonly",
@@ -86,9 +87,29 @@ def _gws_binary() -> str | None:
     return shutil.which("gws")
 
 
+def _ensure_gws_credentials_file() -> Path:
+    token = _normalize_authorized_user_payload(json.loads(TOKEN_PATH.read_text()))
+    payload = {
+        "client_id": token["client_id"],
+        "client_secret": token["client_secret"],
+        "refresh_token": token["refresh_token"],
+        "type": "authorized_user",
+    }
+    existing = None
+    if GWS_CREDENTIALS_PATH.exists():
+        try:
+            existing = json.loads(GWS_CREDENTIALS_PATH.read_text())
+        except Exception:
+            existing = None
+    if existing != payload:
+        GWS_CREDENTIALS_PATH.write_text(json.dumps(payload, indent=2))
+        GWS_CREDENTIALS_PATH.chmod(0o600)
+    return GWS_CREDENTIALS_PATH
+
+
 def _gws_env() -> dict[str, str]:
     env = os.environ.copy()
-    env["GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE"] = str(TOKEN_PATH)
+    env["GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE"] = str(_ensure_gws_credentials_file())
     return env
 
 
@@ -179,11 +200,20 @@ def get_credentials():
     _ensure_authenticated()
 
     from google.oauth2.credentials import Credentials
+    from google.auth.exceptions import RefreshError
     from google.auth.transport.requests import Request
 
     creds = Credentials.from_authorized_user_file(str(TOKEN_PATH), _stored_token_scopes())
     if creds.expired and creds.refresh_token:
-        creds.refresh(Request())
+        try:
+            creds.refresh(Request())
+        except RefreshError as exc:
+            print(f"Google OAuth refresh failed: {exc}", file=sys.stderr)
+            print("Re-run Google Workspace OAuth setup with a valid client secret.", file=sys.stderr)
+            print(f"  python {Path(__file__).parent / 'setup.py'} --client-secret /path/to/client_secret.json", file=sys.stderr)
+            print(f"  python {Path(__file__).parent / 'setup.py'} --auth-url", file=sys.stderr)
+            print(f"  python {Path(__file__).parent / 'setup.py'} --auth-code CODE_OR_REDIRECT_URL", file=sys.stderr)
+            sys.exit(1)
         TOKEN_PATH.write_text(
             json.dumps(
                 _normalize_authorized_user_payload(json.loads(creds.to_json())),

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -59,6 +59,22 @@ def _make_hermes_tree(root: Path) -> None:
     (root / "plugins").mkdir(exist_ok=True)
     (root / "plugins" / "__pycache__").mkdir()
     (root / "plugins" / "__pycache__" / "mod.cpython-312.pyc").write_bytes(b"\x00")
+    (root / "plugins" / ".pytest_cache").mkdir()
+    (root / "plugins" / ".pytest_cache" / "nodeids").write_text("[]")
+    (root / "plugins" / ".ruff_cache").mkdir()
+    (root / "plugins" / ".ruff_cache" / "cache").write_text("{}")
+    (root / "plugins" / ".mypy_cache").mkdir()
+    (root / "plugins" / ".mypy_cache" / "cache").write_text("{}")
+
+    # Generated indexes and local virtualenvs (should be EXCLUDED)
+    (root / "profiles" / "coder" / "skills").mkdir()
+    (root / "profiles" / "coder" / "skills" / ".gitnexus").mkdir()
+    (root / "profiles" / "coder" / "skills" / ".gitnexus" / "graph.kuzu").write_bytes(b"graph")
+    (root / "profiles" / "coder" / "skills" / ".venv-mlx-tts").mkdir()
+    (root / "profiles" / "coder" / "skills" / ".venv-mlx-tts" / "python").write_bytes(b"venv")
+    (root / "state-snapshots").mkdir()
+    (root / "state-snapshots" / "20260513-123559-pre-update").mkdir()
+    (root / "state-snapshots" / "20260513-123559-pre-update" / "state.db").write_bytes(b"snapshot")
 
     # PID files (should be EXCLUDED)
     (root / "gateway.pid").write_text("12345")
@@ -102,6 +118,16 @@ class TestShouldExclude:
         """backups/ is excluded so pre-update backups don't nest exponentially."""
         from hermes_cli.backup import _should_exclude
         assert _should_exclude(Path("backups/pre-update-2026-04-27-063400.zip"))
+
+    def test_excludes_generated_cache_dirs(self):
+        """Generated cache dirs are large, machine-specific, and safe to rebuild."""
+        from hermes_cli.backup import _should_exclude
+        assert _should_exclude(Path("state-snapshots/20260513-123559/state.db"))
+        assert _should_exclude(Path("profiles/coder/skills/.gitnexus/graph.kuzu"))
+        assert _should_exclude(Path("profiles/coder/skills/.venv-mlx-tts/bin/python"))
+        assert _should_exclude(Path("plugins/.pytest_cache/nodeids"))
+        assert _should_exclude(Path("plugins/.ruff_cache/cache"))
+        assert _should_exclude(Path("plugins/.mypy_cache/cache"))
 
     def test_excludes_sqlite_sidecars(self):
         """SQLite WAL/SHM/journal sidecars must not ship alongside the
@@ -218,6 +244,18 @@ class TestBackup:
             names = zf.namelist()
             pycache_files = [n for n in names if "__pycache__" in n]
             assert pycache_files == []
+            generated_cache_files = [
+                n for n in names
+                if (
+                    "state-snapshots/" in n
+                    or ".gitnexus/" in n
+                    or ".venv" in n
+                    or ".pytest_cache/" in n
+                    or ".ruff_cache/" in n
+                    or ".mypy_cache/" in n
+                )
+            ]
+            assert generated_cache_files == []
 
     def test_excludes_pid_files(self, tmp_path, monkeypatch):
         """Backup does NOT include PID files."""
@@ -1185,11 +1223,16 @@ class TestQuickSnapshot:
         assert len(snaps) <= _QUICK_DEFAULT_KEEP
 
     def test_manual_prune(self, hermes_home):
-        from hermes_cli.backup import create_quick_snapshot, prune_quick_snapshots, list_quick_snapshots
+        from hermes_cli.backup import (
+            _QUICK_DEFAULT_KEEP,
+            create_quick_snapshot,
+            prune_quick_snapshots,
+            list_quick_snapshots,
+        )
         for i in range(10):
             create_quick_snapshot(label=f"s{i}", hermes_home=hermes_home)
         deleted = prune_quick_snapshots(keep=3, hermes_home=hermes_home)
-        assert deleted == 7
+        assert deleted == max(_QUICK_DEFAULT_KEEP - 3, 0)
         assert len(list_quick_snapshots(hermes_home=hermes_home)) == 3
 
     def test_snapshot_includes_pairing_directories(self, hermes_home):
@@ -1311,6 +1354,10 @@ class TestPreUpdateBackup:
         assert not any(n.startswith("hermes-agent/") for n in names)
         # __pycache__ excluded
         assert not any("__pycache__" in n for n in names)
+        # Generated caches excluded
+        assert not any(n.startswith("state-snapshots/") for n in names)
+        assert not any(".gitnexus/" in n for n in names)
+        assert not any(".venv" in n for n in names)
         # pid files excluded
         assert "gateway.pid" not in names
 
@@ -1578,6 +1625,9 @@ class TestPreMigrationBackup:
         # Same exclusions as the shared helper
         assert not any(n.startswith("hermes-agent/") for n in names)
         assert not any("__pycache__" in n for n in names)
+        assert not any(n.startswith("state-snapshots/") for n in names)
+        assert not any(".gitnexus/" in n for n in names)
+        assert not any(".venv" in n for n in names)
         assert "gateway.pid" not in names
 
     def test_restorable_with_hermes_import(self, hermes_home, tmp_path):

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -50,8 +50,10 @@ def api_module(monkeypatch, tmp_path):
     # installed (CI).  Without this, calendar_list() falls through to the
     # Python SDK path which imports ``googleapiclient`` — not in deps.
     module._gws_binary = lambda: "/usr/bin/gws"
-    # Bypass authentication check — no real token file in CI.
+    # Bypass authentication check, but still provide the token material that
+    # the gws CLI credentials-file path now derives from.
     module._ensure_authenticated = lambda: None
+    _write_token(module.TOKEN_PATH)
     return module
 
 
@@ -263,6 +265,9 @@ def test_api_get_credentials_refresh_persists_authorized_user_type(api_module, m
     oauth2_module = types.ModuleType("google.oauth2")
     credentials_module = types.ModuleType("google.oauth2.credentials")
     credentials_module.Credentials = FakeCredentialsModule
+    auth_module = types.ModuleType("google.auth")
+    auth_exceptions_module = types.ModuleType("google.auth.exceptions")
+    setattr(auth_exceptions_module, "RefreshError", Exception)
     transport_module = types.ModuleType("google.auth.transport")
     requests_module = types.ModuleType("google.auth.transport.requests")
     requests_module.Request = lambda: object()
@@ -270,6 +275,8 @@ def test_api_get_credentials_refresh_persists_authorized_user_type(api_module, m
     monkeypatch.setitem(sys.modules, "google", google_module)
     monkeypatch.setitem(sys.modules, "google.oauth2", oauth2_module)
     monkeypatch.setitem(sys.modules, "google.oauth2.credentials", credentials_module)
+    monkeypatch.setitem(sys.modules, "google.auth", auth_module)
+    monkeypatch.setitem(sys.modules, "google.auth.exceptions", auth_exceptions_module)
     monkeypatch.setitem(sys.modules, "google.auth.transport", transport_module)
     monkeypatch.setitem(sys.modules, "google.auth.transport.requests", requests_module)
 

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -199,6 +199,25 @@ class TestUnifiedCronjobTool:
         assert listing["jobs"][0]["prompt_preview"] == ""
         assert listing["jobs"][0]["schedule"] == "every 60m"
 
+    def test_list_can_return_compact_agent_facing_records(self):
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check server status and produce a detailed incident report",
+                schedule="every 1h",
+                name="Server Check",
+            )
+        )
+        assert created["success"] is True
+
+        listing = json.loads(cronjob(action="list", include_details=False))
+
+        assert listing["success"] is True
+        assert listing["jobs"][0]["name"] == "Server Check"
+        assert listing["jobs"][0]["state"] == "scheduled"
+        assert "prompt_preview" not in listing["jobs"][0]
+        assert "script" not in listing["jobs"][0]
+
     def test_pause_and_resume(self):
         created = json.loads(cronjob(action="create", prompt="Check", schedule="every 1h"))
         job_id = created["job_id"]

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -330,6 +330,23 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
     return result
 
 
+def _format_job_summary(job: Dict[str, Any]) -> Dict[str, Any]:
+    """Compact job shape for agent-facing list output."""
+    job_id = str(job.get("id") or "unknown")
+    name = str(job.get("name") or job_id or "cron job")
+    return {
+        "job_id": job_id,
+        "name": name,
+        "schedule": job.get("schedule_display") or "?",
+        "repeat": _repeat_display(job),
+        "deliver": job.get("deliver", "local"),
+        "next_run_at": job.get("next_run_at"),
+        "last_status": job.get("last_status"),
+        "enabled": job.get("enabled", True),
+        "state": job.get("state", "scheduled" if job.get("enabled", True) else "paused"),
+    }
+
+
 def cronjob(
     action: str,
     job_id: Optional[str] = None,
@@ -351,6 +368,7 @@ def cronjob(
     workdir: Optional[str] = None,
     profile: Optional[str] = None,
     no_agent: Optional[bool] = None,
+    include_details: bool = True,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -437,7 +455,8 @@ def cronjob(
             )
 
         if normalized == "list":
-            jobs = [_format_job(job) for job in list_jobs(include_disabled=include_disabled)]
+            formatter = _format_job if include_details else _format_job_summary
+            jobs = [formatter(job) for job in list_jobs(include_disabled=include_disabled)]
             return json.dumps({"success": True, "count": len(jobs), "jobs": jobs}, indent=2)
 
         if not job_id:
@@ -620,6 +639,16 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "string",
                 "description": "One of: create, list, update, pause, resume, remove, run"
             },
+            "include_disabled": {
+                "type": "boolean",
+                "default": False,
+                "description": "For action='list': include disabled/paused jobs. Default false keeps the output focused on active jobs."
+            },
+            "include_details": {
+                "type": "boolean",
+                "default": False,
+                "description": "For action='list': include prompt previews, script paths, and advanced fields. Default false keeps tool output compact; set true only when those details are specifically needed."
+            },
             "job_id": {
                 "type": "string",
                 "description": "Required for update/pause/resume/remove/run"
@@ -755,7 +784,7 @@ registry.register(
         name=args.get("name"),
         repeat=args.get("repeat"),
         deliver=args.get("deliver"),
-        include_disabled=args.get("include_disabled", True),
+        include_disabled=args.get("include_disabled", False),
         skill=args.get("skill"),
         skills=args.get("skills"),
         model=_mo[1],
@@ -768,6 +797,7 @@ registry.register(
         workdir=args.get("workdir"),
         profile=args.get("profile"),
         no_agent=args.get("no_agent"),
+        include_details=args.get("include_details", False),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1139,6 +1139,16 @@ class MCPServerTask:
         from tools.registry import registry
 
         async with self._refresh_lock:
+            # A list_changed notification can arrive after the session has
+            # already been torn down (e.g. server crash, reconnect cycle).
+            # Skip cleanly instead of raising AttributeError on None.session.
+            if self.session is None:
+                logger.debug(
+                    "MCP server '%s': skipping tools refresh — session not initialized",
+                    self.name,
+                )
+                return
+
             # Capture old tool names for change diff
             old_tool_names = set(self._registered_tool_names)
 


### PR DESCRIPTION
## Summary
- Exclude generated local backup artifacts from repository state.
- Compact default cron job listings to reduce noisy output.
- Normalize Google Workspace/gws credential handling and add regression coverage.
- Skip MCP refresh after session teardown.
- Add GitNexus project guardrails and ignore nested research checkout artifacts.

## Verification
- `./venv/bin/python -m pytest tests/skills/test_google_workspace_api.py tests/hermes_cli/test_backup.py tests/tools/test_cronjob_tools.py tests/tools/test_mcp_tool.py tests/tools/test_mcp_tool_session_expired.py -q`
  - Result: `371 passed in 43.50s`
- PR state checked after push: open, mergeable.
- GitHub reports no PR checks on this branch.

## Notes
- Direct push to `NousResearch/hermes-agent` is not available for `sege66`; this PR is the safe upstreaming path from the fork.
- Copilot review request could not be submitted from this account/API path (`404 Not Found`), likely because the upstream repository or current permissions do not expose that reviewer request endpoint for this actor.
