### PR TITLE
fix(gateway): fail closed for email pairing

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6408,13 +6408,15 @@ class GatewayRunner:
         Resolution order:
         1. Explicit per-platform ``unauthorized_dm_behavior`` in config — always wins.
         2. Explicit global ``unauthorized_dm_behavior`` in config — wins when no per-platform.
-        3. When an allowlist (``PLATFORM_ALLOWED_USERS``,
+        3. Email defaults to ``"ignore"`` because email addresses are public,
+           spam-prone, and should not auto-pair unknown senders.
+        4. When an allowlist (``PLATFORM_ALLOWED_USERS``,
            ``PLATFORM_GROUP_ALLOWED_USERS`` / ``PLATFORM_GROUP_ALLOWED_CHATS``,
            or ``GATEWAY_ALLOWED_USERS``) is configured, default to ``"ignore"`` —
            the allowlist signals that the owner has deliberately restricted
            access; spamming unknown contacts with pairing codes is both noisy
            and a potential info-leak. (#9337)
-        4. No allowlist and no explicit config → ``"pair"`` (open-gateway default).
+        5. No allowlist and no explicit config → ``"pair"`` (open-gateway default).
         """
         config = getattr(self, "config", None)
 
@@ -6429,6 +6431,11 @@ class GatewayRunner:
         if config and hasattr(config, "unauthorized_dm_behavior"):
             if config.unauthorized_dm_behavior != "pair":  # non-default → explicit override
                 return config.unauthorized_dm_behavior
+
+        # Email addresses are public and routinely receive spam/catchall mail.
+        # Require an explicit per-platform opt-in before sending pairing codes.
+        if platform == Platform.EMAIL:
+            return "ignore"
 
         # No explicit override.  Fall back to allowlist-aware default:
         # if any allowlist is configured for this platform, silently drop

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -724,6 +724,56 @@ def test_explicit_pair_config_overrides_allowlist_default(monkeypatch):
     assert behavior == "pair"
 
 
+@pytest.mark.asyncio
+async def test_email_without_allowlist_ignores_unauthorized_dm(monkeypatch):
+    """Email is fail-closed by default because public addresses attract spam."""
+    _clear_auth_env(monkeypatch)
+
+    config = GatewayConfig(
+        platforms={Platform.EMAIL: PlatformConfig(enabled=True)},
+    )
+    runner, adapter = _make_runner(Platform.EMAIL, config)
+
+    result = await runner._handle_message(
+        _make_event(Platform.EMAIL, "stranger@example.com", "stranger@example.com")
+    )
+
+    assert result is None
+    runner.pairing_store.generate_code.assert_not_called()
+    adapter.send.assert_not_awaited()
+
+
+def test_get_unauthorized_dm_behavior_email_no_allowlist_returns_ignore(monkeypatch):
+    """Email should not send pairing codes to unknown senders by default."""
+    _clear_auth_env(monkeypatch)
+
+    config = GatewayConfig(
+        platforms={Platform.EMAIL: PlatformConfig(enabled=True)},
+    )
+    runner, _adapter = _make_runner(Platform.EMAIL, config)
+
+    behavior = runner._get_unauthorized_dm_behavior(Platform.EMAIL)
+    assert behavior == "ignore"
+
+
+def test_email_explicit_pair_config_overrides_fail_closed_default(monkeypatch):
+    """Operators can still opt email into pairing with explicit platform config."""
+    _clear_auth_env(monkeypatch)
+
+    config = GatewayConfig(
+        platforms={
+            Platform.EMAIL: PlatformConfig(
+                enabled=True,
+                extra={"unauthorized_dm_behavior": "pair"},
+            ),
+        },
+    )
+    runner, _adapter = _make_runner(Platform.EMAIL, config)
+
+    behavior = runner._get_unauthorized_dm_behavior(Platform.EMAIL)
+    assert behavior == "pair"
+
+
 def test_allowlist_authorized_user_returns_ignore_for_unauthorized(monkeypatch):
     """_get_unauthorized_dm_behavior returns 'ignore' when allowlist is set.
 


### PR DESCRIPTION
## What changed
- Make email unauthorized-DM handling fail closed by default.
- Keep explicit per-platform `unauthorized_dm_behavior: pair` as an opt-in escape hatch.
- Add regression tests proving unknown email senders are ignored and do not receive pairing codes.

## Why
Public email addresses and catchall aliases receive spam. The old default treated unknown email senders like private DM users and sent pairing-code replies, which caused Hermes to respond from the configured Gmail account to spam/catchall messages.

## Validation
- `.venv/bin/python -m pytest tests/gateway/test_unauthorized_dm_behavior.py -q`
- `33 passed`
