### PR TITLE
feat(memory): add wiki include seam

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -53,8 +53,12 @@ _TAPBACK_REMOVED = {
     3003: "laugh", 3004: "emphasize", 3005: "question",
 }
 
-# Webhook event types that carry user messages
-_MESSAGE_EVENTS = {"new-message", "message", "updated-message"}
+# Webhook event types that carry user messages.
+# Do not consume BlueBubbles "updated-message" events here: those are edit/update
+# notifications for the same message GUID and can double-trigger auto replies when
+# the server registration includes both new-message and updated-message.
+_MESSAGE_EVENTS = {"new-message", "message"}
+_MAX_RECENT_MESSAGE_IDS = 512
 
 # Log redaction patterns
 _PHONE_RE = re.compile(r"\+?\d{7,15}")
@@ -129,6 +133,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._private_api_enabled: Optional[bool] = None
         self._helper_connected: bool = False
         self._guid_cache: Dict[str, str] = {}
+        self._recent_message_ids: Dict[str, None] = {}
 
     # ------------------------------------------------------------------
     # API helpers
@@ -221,10 +226,16 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
     @property
     def _webhook_url(self) -> str:
-        """Compute the external webhook URL for BlueBubbles registration."""
+        """Compute the external webhook URL for BlueBubbles registration.
+
+        Preserve the configured loopback host literally. BlueBubbles stores the
+        callback URL as an exact string, so normalizing ``127.0.0.1`` to
+        ``localhost`` creates a second registration instead of reusing the
+        existing one on machines configured with the numeric loopback address.
+        """
         host = self.webhook_host
-        if host in {"0.0.0.0", "127.0.0.1", "localhost", "::"}:
-            host = "localhost"
+        if host in {"0.0.0.0", "::"}:
+            host = DEFAULT_WEBHOOK_HOST
         return f"http://{host}:{self.webhook_port}{self.webhook_path}"
 
     @property
@@ -264,18 +275,44 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             return False
 
         webhook_url = self._webhook_register_url
+        desired_events = ["new-message"]
 
-        # Crash resilience — reuse an existing registration if present
+        # Crash resilience — reuse a clean existing registration if present.
+        # If a stale registration still includes updated-message, replace it so a
+        # clean restart cannot reintroduce duplicate auto-replies.
         existing = await self._find_registered_webhooks(webhook_url)
         if existing:
-            logger.info(
-                "[bluebubbles] webhook already registered: %s", webhook_url
-            )
-            return True
+            clean = [wh for wh in existing if wh.get("events") == desired_events]
+            stale = [wh for wh in existing if wh.get("events") != desired_events]
+            if stale:
+                for wh in stale:
+                    wh_id = wh.get("id")
+                    if wh_id:
+                        try:
+                            res = await self.client.delete(
+                                self._api_url(f"/api/v1/webhook/{wh_id}")
+                            )
+                            res.raise_for_status()
+                        except Exception as exc:
+                            logger.warning(
+                                "[bluebubbles] failed to remove stale webhook %s: %s",
+                                wh_id,
+                                exc,
+                            )
+                            return False
+                logger.info(
+                    "[bluebubbles] removed stale webhook registrations for: %s",
+                    webhook_url,
+                )
+            if clean:
+                logger.info(
+                    "[bluebubbles] webhook already registered: %s", webhook_url
+                )
+                return True
 
         payload = {
             "url": webhook_url,
-            "events": ["new-message", "updated-message"],
+            "events": desired_events,
         }
 
         try:
@@ -765,6 +802,24 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 return candidate.strip()
         return None
 
+    def _mark_message_seen(self, message_id: Optional[str]) -> bool:
+        """Return True if this inbound message GUID was already processed.
+
+        BlueBubbles can emit both ``new-message`` and ``updated-message`` for the
+        same GUID if a stale/manual registration includes update events. The code
+        registers only ``new-message``, but this bounded in-memory dedupe protects
+        existing bad registrations and duplicate delivery retries.
+        """
+        if not message_id:
+            return False
+        if message_id in self._recent_message_ids:
+            return True
+        self._recent_message_ids[message_id] = None
+        if len(self._recent_message_ids) > _MAX_RECENT_MESSAGE_IDS:
+            oldest = next(iter(self._recent_message_ids))
+            self._recent_message_ids.pop(oldest, None)
+        return False
+
     async def _handle_webhook(self, request):
         from aiohttp import web
 
@@ -798,7 +853,9 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             return web.json_response({"error": "invalid payload"}, status=400)
 
         event_type = self._value(payload.get("type"), payload.get("event")) or ""
-        # Only process message events; silently acknowledge everything else
+        # Only process message events; silently acknowledge everything else.
+        # In particular, acknowledge but do not consume updated-message events;
+        # processing them causes duplicate auto-replies for the same message GUID.
         if event_type and event_type not in _MESSAGE_EVENTS:
             return web.Response(text="ok")
 
@@ -898,6 +955,15 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if not sender or not (chat_guid or chat_identifier) or not text:
             return web.json_response({"error": "missing message fields"}, status=400)
 
+        message_id = self._value(
+            record.get("guid"),
+            record.get("messageGuid"),
+            record.get("id"),
+        )
+        if self._mark_message_seen(message_id):
+            logger.debug("[bluebubbles] duplicate message ignored: %s", _redact(message_id))
+            return web.Response(text="ok")
+
         session_chat_id = chat_guid or chat_identifier
         is_group = bool(record.get("isGroup")) or (";+;" in (chat_guid or ""))
         source = self.build_source(
@@ -913,11 +979,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             message_type=msg_type,
             source=source,
             raw_message=payload,
-            message_id=self._value(
-                record.get("guid"),
-                record.get("messageGuid"),
-                record.get("id"),
-            ),
+            message_id=message_id,
             reply_to_message_id=self._value(
                 record.get("threadOriginatorGuid"),
                 record.get("associatedMessageGuid"),

--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
+import shutil
 import signal
 import subprocess
 import sys
@@ -194,6 +196,59 @@ def snapshot_shutdown_context(received_signal: Any = None) -> Dict[str, Any]:
     return ctx
 
 
+def _build_async_diagnostic_script(signal_name: str, pid: int, platform: str) -> str:
+    """Build the detached shell diagnostic script for the current platform.
+
+    Keep this platform-aware: Linux has ``/proc``, ``ps auxf --sort`` and
+    often ``dmesg -T``/``journalctl``; macOS has none of those, but does have
+    ``ps -axo``, ``vm_stat``/``sysctl`` and unified logs via ``log show``.
+    The script is best-effort and every heavyweight probe is allowed to fail.
+    """
+    quoted_signal = shlex.quote(str(signal_name))
+    header = (
+        f"echo '=== shutdown diagnostic @ '{quoted_signal}' ==='; "
+        "echo '--- date ---'; date -u +%Y-%m-%dT%H:%M:%SZ; "
+    )
+
+    if platform == "darwin":
+        return header + (
+            "echo '--- ps (top 60 by cpu) ---'; "
+            "ps -arcwwwxo pid,ppid,%cpu,%mem,stat,etime,command 2>/dev/null | head -60 "
+            "|| ps aux 2>/dev/null | head -60 || true; "
+            "echo '--- process ancestry/self snapshot ---'; "
+            f"ps -o pid,ppid,stat,etime,command -p {pid} 2>/dev/null || true; "
+            f"ps -o pid,ppid,stat,etime,command -p $(ps -o ppid= -p {pid} 2>/dev/null | tr -d ' ') 2>/dev/null || true; "
+            "echo '--- load average ---'; "
+            "sysctl -n vm.loadavg 2>/dev/null || uptime 2>/dev/null || true; "
+            "echo '--- vm_stat ---'; vm_stat 2>/dev/null | head -40 || true; "
+            "echo '--- memory pressure ---'; memory_pressure -Q 2>/dev/null || true; "
+            "echo '--- recent macOS log (launchd/termination/kill, last 5m) ---'; "
+            "log show --last 5m --style compact --predicate "
+            "'process == \"launchd\" OR eventMessage CONTAINS[c] \"kill\" OR eventMessage CONTAINS[c] \"SIGTERM\" OR eventMessage CONTAINS[c] \"terminated\" OR eventMessage CONTAINS[c] \"exited\"' "
+            "2>/dev/null | tail -40 || true; "
+            "echo '=== end ==='"
+        )
+
+    if platform.startswith("linux"):
+        return header + (
+            "echo '--- ps auxf (top 60 by cpu) ---'; "
+            "ps auxf --sort=-pcpu 2>/dev/null | head -60 || ps aux 2>/dev/null | head -60 || true; "
+            "echo '--- pstree of self ---'; "
+            f"pstree -plau {pid} 2>/dev/null | head -40 || true; "
+            "echo '--- /proc/loadavg ---'; "
+            "cat /proc/loadavg 2>/dev/null || true; "
+            "echo '--- recent dmesg/journal (oom/killed) ---'; "
+            "dmesg -T 2>/dev/null | tail -20 || journalctl --user -n 20 --no-pager 2>/dev/null | tail -20 || true; "
+            "echo '=== end ==='"
+        )
+
+    return header + (
+        "echo '--- ps snapshot ---'; ps aux 2>/dev/null | head -60 || true; "
+        "echo '--- load average ---'; uptime 2>/dev/null || true; "
+        "echo '=== end ==='"
+    )
+
+
 def spawn_async_diagnostic(
     log_path: Path,
     signal_name: str,
@@ -203,9 +258,10 @@ def spawn_async_diagnostic(
     """Fire-and-forget ``ps``-style snapshot written to ``log_path``.
 
     Runs as a detached subprocess so it can't block the asyncio event loop
-    or compete with platform teardown.  The subprocess uses its own
-    ``timeout`` so a wedged ``ps`` still self-cleans within
-    ``timeout_seconds``.
+    or compete with platform teardown.  When GNU ``timeout`` is available we
+    use it; otherwise a tiny bash watchdog kills the child script after
+    ``timeout_seconds``.  This matters on macOS, where ``timeout`` is not a
+    default system command.
 
     Returns the subprocess PID on success, ``None`` on failure.  Never
     raises.
@@ -226,19 +282,7 @@ def spawn_async_diagnostic(
     if sys.platform == "win32":
         return None
 
-    script = (
-        f"echo '=== shutdown diagnostic @ {signal_name} ==='; "
-        "echo '--- date ---'; date -u +%Y-%m-%dT%H:%M:%SZ; "
-        "echo '--- ps auxf (top 60 by cpu) ---'; "
-        "ps auxf --sort=-pcpu 2>/dev/null | head -60; "
-        "echo '--- pstree of self ---'; "
-        f"pstree -plau {os.getpid()} 2>/dev/null | head -40 || true; "
-        "echo '--- /proc/loadavg ---'; "
-        "cat /proc/loadavg 2>/dev/null || true; "
-        "echo '--- recent dmesg (oom/killed) ---'; "
-        "dmesg -T 2>/dev/null | tail -20 || journalctl --user -n 20 --no-pager 2>/dev/null | tail -20 || true; "
-        "echo '=== end ==='"
-    )
+    script = _build_async_diagnostic_script(signal_name, os.getpid(), sys.platform)
 
     try:
         # Open the log file in append mode and let the subprocess inherit.
@@ -254,8 +298,26 @@ def spawn_async_diagnostic(
         # would also reap us anyway, but defense in depth).  Without
         # start_new_session, a SIGKILL on our cgroup takes the diag down
         # before it can flush.
+        command = ["bash", "-c", script]
+        timeout_bin = shutil.which("timeout")
+        if timeout_bin:
+            command = [timeout_bin, f"{timeout_seconds:.0f}", *command]
+        else:
+            command = [
+                "bash",
+                "-c",
+                (
+                    "bash -c \"$1\" & child=$!; "
+                    "(sleep \"$2\"; kill \"$child\" 2>/dev/null) & killer=$!; "
+                    "wait \"$child\"; status=$?; "
+                    "kill \"$killer\" 2>/dev/null || true; exit $status"
+                ),
+                "hermes-shutdown-diag-watchdog",
+                script,
+                f"{timeout_seconds:.0f}",
+            ]
         proc = subprocess.Popen(
-            ["timeout", f"{timeout_seconds:.0f}", "bash", "-c", script],
+            command,
             stdout=fd,
             stderr=subprocess.STDOUT,
             stdin=subprocess.DEVNULL,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1200,6 +1200,18 @@ DEFAULT_CONFIG = {
         "provider": "",
     },
 
+    # Memory Seam read-only include families. Default-off; the first slice is a
+    # least-sensitive Atlas wiki family that reads only explicit sanitized file
+    # descriptors when memory_seam.wiki.enabled is true and the toolset is enabled.
+    "memory_seam": {
+        "wiki": {
+            "enabled": False,
+            "allowed_roots": [],
+            "max_bytes": 131072,
+            "allowlist": [],
+        },
+    },
+
     # Subagent delegation — override the provider:model used by delegate_task
     # so child agents can run on a different (cheaper/faster) provider and model.
     # Uses the same runtime provider resolution as CLI/gateway startup, so all
@@ -3269,7 +3281,7 @@ _KNOWN_ROOT_KEYS = {
     "_config_version", "model", "providers", "fallback_model",
     "fallback_providers", "credential_pool_strategies", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
-    "auxiliary", "custom_providers", "context", "memory", "gateway",
+    "auxiliary", "custom_providers", "context", "memory", "memory_seam", "gateway",
     "sessions",
 }
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2852,11 +2852,8 @@ def generate_launchd_plist() -> str:
     <true/>
     
     <key>KeepAlive</key>
-    <dict>
-        <key>SuccessfulExit</key>
-        <false/>
-    </dict>
-    
+    <true/>
+
     <key>StandardOutPath</key>
     <string>{log_dir}/gateway.log</string>
     

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -208,8 +208,8 @@ def _graceful_restart_via_sigusr1(pid: int, drain_timeout: float) -> bool:
     SIGUSR1 is wired in gateway/run.py to ``request_restart(via_service=True)``
     which drains in-flight agent runs (up to ``agent.restart_drain_timeout``
     seconds), then exits with code 75.  Both systemd (``Restart=always``
-    + ``RestartForceExitStatus=75``) and launchd (``KeepAlive.SuccessfulExit
-    = false``) relaunch the process after the graceful exit.
+    + ``RestartForceExitStatus=75``) and launchd (unconditional
+    ``KeepAlive``) relaunch the process after the graceful exit.
 
     This is the drain-aware alternative to ``systemctl restart`` / ``SIGTERM``,
     which SIGKILL in-flight agents after a short timeout.
@@ -2969,7 +2969,8 @@ def launchd_stop():
         pass
     # bootout unloads the service definition so KeepAlive doesn't respawn
     # the process.  A plain `kill SIGTERM` only signals the process — launchd
-    # immediately restarts it because KeepAlive.SuccessfulExit = false.
+    # immediately restarts it because the gateway plist uses unconditional
+    # KeepAlive for always-on messaging surfaces.
     # `hermes gateway start` re-bootstraps when it detects the job is unloaded.
     try:
         subprocess.run(["launchctl", "bootout", target], check=True, timeout=90)

--- a/scripts/hermes-gateway
+++ b/scripts/hermes-gateway
@@ -56,6 +56,18 @@ def get_launchd_plist_path() -> Path:
     """Get the path for the launchd plist file (macOS)."""
     return Path.home() / "Library" / "LaunchAgents" / f"ai.hermes.gateway.plist"
 
+def get_launchd_label() -> str:
+    """Get the launchd label for the legacy standalone helper."""
+    return "ai.hermes.gateway"
+
+def get_launchd_domain() -> str:
+    """Get the per-user launchd domain."""
+    return f"gui/{os.getuid()}"
+
+def get_launchd_target() -> str:
+    """Get the fully-qualified launchd service target."""
+    return f"{get_launchd_domain()}/{get_launchd_label()}"
+
 def get_python_path() -> str:
     """Get the path to the Python interpreter."""
     # Prefer the venv if it exists
@@ -196,10 +208,7 @@ def generate_launchd_plist() -> str:
     <true/>
     
     <key>KeepAlive</key>
-    <dict>
-        <key>SuccessfulExit</key>
-        <false/>
-    </dict>
+    <true/>
     
     <key>StandardOutPath</key>
     <string>{log_dir}/gateway.log</string>
@@ -228,8 +237,12 @@ def install_launchd():
     print(f"Installing launchd service to: {plist_path}")
     plist_path.write_text(generate_launchd_plist())
     
-    # Load the service
-    subprocess.run(["launchctl", "load", str(plist_path)], check=True)
+    # Load the service in the current user's launchd domain.  The helper's
+    # plist uses unconditional KeepAlive, so control paths must use
+    # bootstrap/bootout instead of deprecated load/unload or plain stop.
+    subprocess.run(["launchctl", "bootout", get_launchd_target()], check=False)
+    subprocess.run(["launchctl", "bootstrap", get_launchd_domain(), str(plist_path)], check=True)
+    subprocess.run(["launchctl", "kickstart", get_launchd_target()], check=True)
     
     print(f"✓ Service installed and loaded")
     print(f"")
@@ -244,8 +257,9 @@ def uninstall_launchd():
     """Uninstall the launchd service (macOS)."""
     plist_path = get_launchd_plist_path()
     
-    # Unload first
-    subprocess.run(["launchctl", "unload", str(plist_path)], check=False)
+    # Unload first.  bootout prevents KeepAlive from immediately respawning
+    # the service after an intentional uninstall.
+    subprocess.run(["launchctl", "bootout", get_launchd_target()], check=False)
     
     # Remove the plist file
     if plist_path.exists():
@@ -256,22 +270,30 @@ def uninstall_launchd():
 
 def launchd_status():
     """Show launchd service status."""
-    subprocess.run(["launchctl", "list", "ai.hermes.gateway"])
+    subprocess.run(["launchctl", "list", get_launchd_label()])
 
 def launchd_start():
     """Start the launchd service."""
-    subprocess.run(["launchctl", "start", "ai.hermes.gateway"], check=True)
+    plist_path = get_launchd_plist_path()
+    plist_path.parent.mkdir(parents=True, exist_ok=True)
+    plist_path.write_text(generate_launchd_plist())
+    # If the job is already loaded, bootstrap returns non-zero; kickstart is
+    # still the correct start action.  If it is not loaded, bootstrap loads the
+    # freshly generated plist first.
+    subprocess.run(["launchctl", "bootstrap", get_launchd_domain(), str(plist_path)], check=False)
+    subprocess.run(["launchctl", "kickstart", get_launchd_target()], check=True)
     print(f"✓ Service started")
 
 def launchd_stop():
     """Stop the launchd service."""
-    subprocess.run(["launchctl", "stop", "ai.hermes.gateway"], check=True)
+    # bootout unloads the job so unconditional KeepAlive cannot respawn it.
+    subprocess.run(["launchctl", "bootout", get_launchd_target()], check=True)
     print(f"✓ Service stopped")
 
 def launchd_restart():
     """Restart the launchd service."""
-    launchd_stop()
-    launchd_start()
+    subprocess.run(["launchctl", "kickstart", "-k", get_launchd_target()], check=True)
+    print(f"✓ Service restarted")
 
 
 # =============================================================================

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -1,4 +1,6 @@
 """Tests for the BlueBubbles iMessage gateway adapter."""
+from typing import Any, cast
+
 import pytest
 
 from gateway.config import Platform, PlatformConfig
@@ -121,6 +123,35 @@ class TestBlueBubblesHelpers:
     def test_init_preserves_leading_slash(self, monkeypatch):
         adapter = _make_adapter(monkeypatch, webhook_path="/my-hook")
         assert adapter.webhook_path == "/my-hook"
+
+    def test_webhook_url_preserves_numeric_loopback_host(self, monkeypatch):
+        adapter = _make_adapter(
+            monkeypatch,
+            webhook_host="127.0.0.1",
+            webhook_port=8645,
+            webhook_path="/hermes-bluebubbles-webhook",
+        )
+
+        assert adapter._webhook_url == "http://127.0.0.1:8645/hermes-bluebubbles-webhook"
+
+    def test_webhook_url_maps_unspecified_host_to_numeric_loopback(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, webhook_host="0.0.0.0")
+
+        assert adapter._webhook_url.startswith("http://127.0.0.1:")
+
+    def test_message_events_do_not_include_updated_message(self, monkeypatch):
+        from gateway.platforms.bluebubbles import _MESSAGE_EVENTS
+
+        assert "new-message" in _MESSAGE_EVENTS
+        assert "updated-message" not in _MESSAGE_EVENTS
+
+    def test_message_guid_dedupe_marks_repeated_guid(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+
+        assert adapter._mark_message_seen("message-guid-1") is False
+        assert adapter._mark_message_seen("message-guid-1") is True
+        assert adapter._mark_message_seen("message-guid-2") is False
+        assert adapter._mark_message_seen(None) is False
 
     def test_server_url_normalized(self, monkeypatch):
         adapter = _make_adapter(monkeypatch, server_url="http://localhost:1234/")
@@ -423,19 +454,27 @@ class TestBlueBubblesAttachmentDownload:
 
 
 class TestBlueBubblesWebhookUrl:
-    """_webhook_url property normalises local hosts to 'localhost'."""
+    """_webhook_url property preserves exact callback identity where possible."""
 
     def test_default_host(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
-        # Default webhook_host is 0.0.0.0 → normalized to localhost
-        assert "localhost" in adapter._webhook_url
+        # Default webhook_host is 0.0.0.0 → externally reachable loopback URL.
+        assert adapter._webhook_url.startswith("http://127.0.0.1:")
         assert str(adapter.webhook_port) in adapter._webhook_url
         assert adapter.webhook_path in adapter._webhook_url
 
-    @pytest.mark.parametrize("host", ["0.0.0.0", "127.0.0.1", "localhost", "::"])
-    def test_local_hosts_normalized(self, monkeypatch, host):
+    @pytest.mark.parametrize(
+        ("host", "expected"),
+        [
+            ("0.0.0.0", "127.0.0.1"),
+            ("::", "127.0.0.1"),
+            ("127.0.0.1", "127.0.0.1"),
+            ("localhost", "localhost"),
+        ],
+    )
+    def test_local_hosts_preserve_or_map_to_stable_loopback(self, monkeypatch, host, expected):
         adapter = _make_adapter(monkeypatch, webhook_host=host)
-        assert adapter._webhook_url.startswith("http://localhost:")
+        assert adapter._webhook_url.startswith(f"http://{expected}:")
 
     def test_custom_host_preserved(self, monkeypatch):
         adapter = _make_adapter(monkeypatch, webhook_host="192.168.1.50")
@@ -561,6 +600,28 @@ class TestBlueBubblesWebhookRegistration:
         )
         assert ok is True
 
+    def test_register_fresh_uses_new_message_only(self, monkeypatch):
+        """Webhook registration must not subscribe to updated-message events."""
+        import asyncio
+        adapter = _make_adapter(monkeypatch)
+        adapter.client = self._mock_client(get_response={"status": 200, "data": []})
+        posted_payload = None
+
+        async def tracking_post(path, payload):
+            nonlocal posted_payload
+            posted_payload = payload
+            return {"status": 200, "data": {"id": 42}}
+
+        adapter._api_post = tracking_post
+
+        ok = asyncio.get_event_loop().run_until_complete(
+            adapter._register_webhook()
+        )
+
+        assert ok is True
+        assert posted_payload is not None
+        assert posted_payload["events"] == ["new-message"]
+
     def test_register_accepts_201(self, monkeypatch):
         """BB might return 201 Created — must still succeed."""
         import asyncio
@@ -599,6 +660,95 @@ class TestBlueBubblesWebhookRegistration:
         )
         assert ok is True
         assert not post_called, "Should reuse existing, not POST again"
+
+    def test_register_replaces_existing_updated_message_subscription(self, monkeypatch):
+        """Stale registrations with updated-message are removed and recreated."""
+        import asyncio
+        adapter = _make_adapter(monkeypatch)
+        url = adapter._webhook_register_url
+        deleted_urls = []
+        posted_payload = None
+
+        class Client:
+            async def get(self, *args, **kwargs):
+                class R:
+                    status_code = 200
+                    def raise_for_status(self):
+                        pass
+                    def json(self):
+                        return {"status": 200, "data": [
+                            {"id": 8, "url": url, "events": ["new-message", "updated-message"]},
+                        ]}
+                return R()
+
+            async def delete(self, *args, **kwargs):
+                deleted_urls.append(args[0] if args else "")
+                class R:
+                    status_code = 200
+                    def raise_for_status(self):
+                        pass
+                return R()
+
+        adapter.client = cast(Any, Client())
+
+        async def tracking_post(path, payload):
+            nonlocal posted_payload
+            posted_payload = payload
+            return {"status": 200, "data": {"id": 9}}
+        adapter._api_post = tracking_post
+
+        ok = asyncio.get_event_loop().run_until_complete(
+            adapter._register_webhook()
+        )
+        assert ok is True
+        assert any("/api/v1/webhook/8" in url for url in deleted_urls)
+        assert posted_payload is not None
+        assert posted_payload["events"] == ["new-message"]
+
+    def test_register_removes_stale_duplicate_but_reuses_clean_existing(self, monkeypatch):
+        """If both clean and stale duplicates exist, delete stale without adding another clean one."""
+        import asyncio
+        adapter = _make_adapter(monkeypatch)
+        url = adapter._webhook_register_url
+        deleted_urls = []
+        post_called = False
+
+        class Client:
+            async def get(self, *args, **kwargs):
+                class R:
+                    status_code = 200
+                    def raise_for_status(self):
+                        pass
+                    def json(self):
+                        return {"status": 200, "data": [
+                            {"id": 8, "url": url, "events": ["new-message", "updated-message"]},
+                            {"id": 9, "url": url, "events": ["new-message"]},
+                        ]}
+                return R()
+
+            async def delete(self, *args, **kwargs):
+                deleted_urls.append(args[0] if args else "")
+                class R:
+                    status_code = 200
+                    def raise_for_status(self):
+                        pass
+                return R()
+
+        adapter.client = cast(Any, Client())
+
+        async def tracking_post(path, payload):
+            nonlocal post_called
+            post_called = True
+            return {"status": 200, "data": {"id": 10}}
+        adapter._api_post = tracking_post
+
+        ok = asyncio.get_event_loop().run_until_complete(
+            adapter._register_webhook()
+        )
+        assert ok is True
+        assert any("/api/v1/webhook/8" in url for url in deleted_urls)
+        assert not any("/api/v1/webhook/9" in url for url in deleted_urls)
+        assert not post_called
 
     def test_register_returns_false_without_client(self, monkeypatch):
         import asyncio

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -151,6 +151,49 @@ class TestFormatters:
 # ---------------------------------------------------------------------------
 
 class TestSpawnAsyncDiagnostic:
+    def test_macos_diagnostic_script_uses_native_probes(self):
+        script = sf._build_async_diagnostic_script("SIGTERM", 12345, "darwin")
+
+        assert "vm_stat" in script
+        assert "sysctl -n vm.loadavg" in script
+        assert "log show --last 5m" in script
+        assert "/proc/loadavg" not in script
+        assert "dmesg -T" not in script
+        assert "ps auxf --sort" not in script
+
+    def test_linux_diagnostic_script_keeps_linux_probes(self):
+        script = sf._build_async_diagnostic_script("SIGTERM", 12345, "linux")
+
+        assert "/proc/loadavg" in script
+        assert "dmesg -T" in script
+        assert "ps auxf --sort" in script
+        assert "vm_stat" not in script
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only diagnostic")
+    def test_spawns_without_gnu_timeout_when_unavailable(
+        self, tmp_path, monkeypatch
+    ):
+        log_path = tmp_path / "diag.log"
+        captured = {}
+
+        class FakePopen:
+            pid = 4242
+
+            def __init__(self, command, **kwargs):
+                captured["command"] = command
+                captured["kwargs"] = kwargs
+
+        monkeypatch.setattr(sf.shutil, "which", lambda name: None)
+        monkeypatch.setattr(sf.subprocess, "Popen", FakePopen)
+
+        pid = sf.spawn_async_diagnostic(log_path, "SIGTERM", timeout_seconds=3.0)
+
+        assert pid == 4242
+        assert captured["command"][:2] == ["bash", "-c"]
+        assert captured["command"][3] == "hermes-shutdown-diag-watchdog"
+        assert captured["command"][-1] == "3"
+        assert "sleep \"$2\"; kill \"$child\"" in captured["command"][2]
+
     @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only diagnostic")
     def test_spawns_subprocess_and_writes_output(self, tmp_path):
         log_path = tmp_path / "diag.log"

--- a/tests/scripts/test_hermes_gateway_helper.py
+++ b/tests/scripts/test_hermes_gateway_helper.py
@@ -1,0 +1,124 @@
+"""Regression tests for the legacy scripts/hermes-gateway helper.
+
+The main `hermes gateway ...` CLI is implemented in hermes_cli.gateway, but this
+standalone helper is still shipped as an install/control entrypoint. Keep its
+launchd policy aligned with the canonical gateway service so it cannot regress
+macOS gateway reliability.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import plistlib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+HELPER_PATH = ROOT / "scripts" / "hermes-gateway"
+
+
+def load_helper():
+    loader = importlib.machinery.SourceFileLoader("hermes_gateway_helper", str(HELPER_PATH))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+def test_launchd_plist_uses_unconditional_keepalive():
+    helper = load_helper()
+
+    plist_text = helper.generate_launchd_plist()
+    plist = plistlib.loads(plist_text.encode("utf-8"))
+
+    assert plist["KeepAlive"] is True
+    assert "SuccessfulExit" not in plist_text
+
+
+def test_launchd_stop_uses_bootout_so_keepalive_does_not_respawn(monkeypatch):
+    helper = load_helper()
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        class Result:
+            returncode = 0
+        return Result()
+
+    monkeypatch.setattr(helper.subprocess, "run", fake_run)
+
+    helper.launchd_stop()
+
+    assert calls == [["launchctl", "bootout", f"gui/{helper.os.getuid()}/ai.hermes.gateway"]]
+
+
+def test_launchd_install_bootouts_then_bootstraps_current_plist(monkeypatch, tmp_path):
+    helper = load_helper()
+    calls: list[list[str]] = []
+    plist_path = tmp_path / "ai.hermes.gateway.plist"
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        class Result:
+            returncode = 0
+        return Result()
+
+    monkeypatch.setattr(helper, "get_launchd_plist_path", lambda: plist_path)
+    monkeypatch.setattr(helper.subprocess, "run", fake_run)
+
+    helper.install_launchd()
+
+    target = f"gui/{helper.os.getuid()}/ai.hermes.gateway"
+    assert plistlib.loads(plist_path.read_bytes())["KeepAlive"] is True
+    assert calls == [
+        ["launchctl", "bootout", target],
+        ["launchctl", "bootstrap", f"gui/{helper.os.getuid()}", str(plist_path)],
+        ["launchctl", "kickstart", target],
+    ]
+
+
+def test_launchd_uninstall_bootouts_before_removing_plist(monkeypatch, tmp_path):
+    helper = load_helper()
+    calls: list[list[str]] = []
+    plist_path = tmp_path / "ai.hermes.gateway.plist"
+    plist_path.write_text("stale")
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        class Result:
+            returncode = 0
+        return Result()
+
+    monkeypatch.setattr(helper, "get_launchd_plist_path", lambda: plist_path)
+    monkeypatch.setattr(helper.subprocess, "run", fake_run)
+
+    helper.uninstall_launchd()
+
+    assert not plist_path.exists()
+    assert calls == [["launchctl", "bootout", f"gui/{helper.os.getuid()}/ai.hermes.gateway"]]
+
+
+def test_launchd_start_bootstraps_then_kickstarts(monkeypatch, tmp_path):
+    helper = load_helper()
+    calls: list[list[str]] = []
+    plist_path = tmp_path / "ai.hermes.gateway.plist"
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        class Result:
+            returncode = 0
+        return Result()
+
+    monkeypatch.setattr(helper, "get_launchd_plist_path", lambda: plist_path)
+    monkeypatch.setattr(helper.subprocess, "run", fake_run)
+
+    helper.launchd_start()
+
+    target = f"gui/{helper.os.getuid()}/ai.hermes.gateway"
+    assert plist_path.exists()
+    assert calls == [
+        ["launchctl", "bootstrap", f"gui/{helper.os.getuid()}", str(plist_path)],
+        ["launchctl", "kickstart", target],
+    ]

--- a/tests/tools/test_wiki_include_tool.py
+++ b/tests/tools/test_wiki_include_tool.py
@@ -123,6 +123,102 @@ def test_missing_allowlisted_source_is_degraded_no_source(tmp_path):
     assert result["degraded_reason"] == "descriptor missing source label"
 
 
+def test_is_file_failure_returns_safe_degraded_response(tmp_path, monkeypatch):
+    root = tmp_path / "wiki"
+    root.mkdir()
+    page = root / "atlas-overview.md"
+    page.write_text("Atlas public overview\n", encoding="utf-8")
+
+    original_is_file = Path.is_file
+
+    def broken_is_file(self):
+        if self == page:
+            raise PermissionError(f"permission denied: {page}")
+        return original_is_file(self)
+
+    monkeypatch.setattr(Path, "is_file", broken_is_file)
+
+    result = wiki.read_wiki_include(
+        "atlas-public-overview",
+        "atlas-overview",
+        config=_cfg(root, page),
+    )
+
+    assert result["success"] is False
+    assert result["source"] == "atlas-wiki"
+    assert result["privacy"] == "least_sensitive"
+    assert result["freshness"] == "unavailable"
+    assert result["degraded"] is True
+    assert result["degraded_reason"] == "allowlisted wiki source is unreadable"
+    assert result["path"] == "wiki:atlas-overview.md"
+    assert str(page) not in result["error"]
+    assert str(tmp_path) not in result["error"]
+
+
+def test_stat_failure_returns_safe_degraded_response(tmp_path, monkeypatch):
+    root = tmp_path / "wiki"
+    root.mkdir()
+    page = root / "atlas-overview.md"
+    page.write_text("Atlas public overview\n", encoding="utf-8")
+
+    original_stat = Path.stat
+
+    def broken_stat(self, *args, **kwargs):
+        if self == page:
+            raise OSError(f"stat failed for {page}")
+        return original_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", broken_stat)
+
+    result = wiki.read_wiki_include(
+        "atlas-public-overview",
+        "atlas-overview",
+        config=_cfg(root, page),
+    )
+
+    assert result["success"] is False
+    assert result["source"] == "atlas-wiki"
+    assert result["privacy"] == "least_sensitive"
+    assert result["freshness"] == "unavailable"
+    assert result["degraded"] is True
+    assert result["degraded_reason"] == "allowlisted wiki source is unreadable"
+    assert result["path"] == "wiki:atlas-overview.md"
+    assert str(page) not in result["error"]
+    assert str(tmp_path) not in result["error"]
+
+
+def test_read_text_failure_returns_safe_degraded_response(tmp_path, monkeypatch):
+    root = tmp_path / "wiki"
+    root.mkdir()
+    page = root / "atlas-overview.md"
+    page.write_text("Atlas public overview\n", encoding="utf-8")
+
+    original_read_text = Path.read_text
+
+    def broken_read_text(self, *args, **kwargs):
+        if self == page:
+            raise OSError(f"read failed for {page}")
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", broken_read_text)
+
+    result = wiki.read_wiki_include(
+        "atlas-public-overview",
+        "atlas-overview",
+        config=_cfg(root, page),
+    )
+
+    assert result["success"] is False
+    assert result["source"] == "atlas-wiki"
+    assert result["privacy"] == "least_sensitive"
+    assert result["freshness"] == "unavailable"
+    assert result["degraded"] is True
+    assert result["degraded_reason"] == "allowlisted wiki source is unreadable"
+    assert result["path"] == "wiki:atlas-overview.md"
+    assert str(page) not in result["error"]
+    assert str(tmp_path) not in result["error"]
+
+
 def test_disabled_or_missing_source_returns_degraded_no_read(tmp_path, monkeypatch):
     page = tmp_path / "wiki" / "missing.md"
 

--- a/tests/tools/test_wiki_include_tool.py
+++ b/tests/tools/test_wiki_include_tool.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools import wiki_include_tool as wiki
+
+
+def _cfg(root: Path, path: Path, *, source: str = "atlas-wiki", subject: str = "atlas-overview"):
+    return {
+        "enabled": True,
+        "allowed_roots": [str(root)],
+        "allowlist": [
+            {
+                "id": "atlas-public-overview",
+                "family": "wiki",
+                "subject": subject,
+                "path": str(path),
+                "source": source,
+                "privacy": "least_sensitive",
+            }
+        ],
+    }
+
+
+def test_allowed_wiki_read_succeeds_with_labels_and_safe_path(tmp_path):
+    root = tmp_path / "wiki"
+    root.mkdir()
+    page = root / "atlas-overview.md"
+    page.write_text("Atlas public overview\n", encoding="utf-8")
+
+    result = wiki.read_wiki_include(
+        "atlas-public-overview",
+        "atlas-overview",
+        config=_cfg(root, page),
+    )
+
+    assert result["success"] is True
+    assert result["source"] == "atlas-wiki"
+    assert result["privacy"] == "least_sensitive"
+    assert result["freshness"].endswith("Z")
+    assert result["degraded"] is False
+    assert result["degraded_reason"] is None
+    assert result["path"] == "wiki:atlas-overview.md"
+    assert result["content"] == "Atlas public overview\n"
+    assert str(tmp_path) not in result["path"]
+
+
+def test_include_subject_mismatch_rejects_before_read(tmp_path, monkeypatch):
+    root = tmp_path / "wiki"
+    root.mkdir()
+    page = root / "atlas-overview.md"
+
+    def fail_read(*args, **kwargs):  # pragma: no cover - failure path assertion
+        raise AssertionError("read_text should not be called")
+
+    monkeypatch.setattr(Path, "read_text", fail_read)
+
+    with pytest.raises(wiki.WikiIncludeError, match="include/subject mismatch"):
+        wiki.read_wiki_include(
+            "atlas-public-overview",
+            "wrong-subject",
+            config=_cfg(root, page),
+        )
+
+
+def test_protected_private_path_rejects_before_read(tmp_path, monkeypatch):
+    root = tmp_path / "wiki"
+    protected = root / "private" / "atlas-overview.md"
+
+    def fail_read(*args, **kwargs):  # pragma: no cover - failure path assertion
+        raise AssertionError("read_text should not be called")
+
+    monkeypatch.setattr(Path, "read_text", fail_read)
+
+    with pytest.raises(wiki.WikiIncludeError, match="protected/private path"):
+        wiki.read_wiki_include(
+            "atlas-public-overview",
+            "atlas-overview",
+            config=_cfg(root, protected),
+        )
+
+
+def test_output_redacts_obvious_sensitive_values_and_is_log_safe(tmp_path):
+    root = tmp_path / "wiki"
+    root.mkdir()
+    page = root / "public.md"
+    page.write_text(
+        "Contact owner@example.com\napi_key=sk-live-test\nAuthorization: Bearer abcdefghijk\n",
+        encoding="utf-8",
+    )
+
+    result = wiki.read_wiki_include(
+        "atlas-public-overview",
+        "atlas-overview",
+        config=_cfg(root, page),
+    )
+
+    assert "owner@example.com" not in result["content"]
+    assert "sk-live-test" not in result["content"]
+    assert "abcdefghijk" not in result["content"]
+    assert "[REDACTED_EMAIL]" in result["content"]
+    assert "[REDACTED]" in result["content"]
+    assert str(tmp_path) not in result["path"]
+
+
+def test_missing_allowlisted_source_is_degraded_no_source(tmp_path):
+    root = tmp_path / "wiki"
+    root.mkdir()
+    page = root / "public.md"
+    page.write_text("Public atlas note\n", encoding="utf-8")
+
+    result = wiki.read_wiki_include(
+        "atlas-public-overview",
+        "atlas-overview",
+        config=_cfg(root, page, source=""),
+    )
+
+    assert result["success"] is True
+    assert result["source"] == "wiki:no_source_label"
+    assert result["degraded"] is True
+    assert result["degraded_reason"] == "descriptor missing source label"
+
+
+def test_disabled_or_missing_source_returns_degraded_no_read(tmp_path, monkeypatch):
+    page = tmp_path / "wiki" / "missing.md"
+
+    def fail_read(*args, **kwargs):  # pragma: no cover - failure path assertion
+        raise AssertionError("read_text should not be called")
+
+    monkeypatch.setattr(Path, "read_text", fail_read)
+
+    disabled = wiki.read_wiki_include("anything", "anything", config={"enabled": False})
+    assert disabled["success"] is False
+    assert disabled["degraded"] is True
+    assert disabled["degraded_reason"] == "memory_seam.wiki disabled"
+
+    missing = wiki.read_wiki_include(
+        "atlas-public-overview",
+        "atlas-overview",
+        config=_cfg(tmp_path / "wiki", page),
+    )
+    assert missing["success"] is False
+    assert missing["degraded"] is True
+    assert missing["degraded_reason"] == "allowlisted wiki source is missing"
+    assert missing["path"] == "wiki:missing.md"

--- a/tools/wiki_include_tool.py
+++ b/tools/wiki_include_tool.py
@@ -184,6 +184,27 @@ def _freshness_label(st_mtime: float) -> str:
     return dt.isoformat().replace("+00:00", "Z")
 
 
+def _degraded_filesystem_result(
+    include_id: str,
+    subject: str,
+    display_path: str,
+    source_label: str,
+    privacy_label: str,
+) -> Dict[str, Any]:
+    return {
+        "success": False,
+        "include_id": include_id,
+        "subject": subject,
+        "source": source_label or "wiki",
+        "privacy": privacy_label,
+        "freshness": "unavailable",
+        "degraded": True,
+        "degraded_reason": "allowlisted wiki source is unreadable",
+        "path": display_path,
+        "error": "allowlisted wiki source is unreadable",
+    }
+
+
 def read_wiki_include(include_id: str, subject: str, *, config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Read one explicitly allowlisted wiki include descriptor.
 
@@ -213,7 +234,12 @@ def read_wiki_include(include_id: str, subject: str, *, config: Optional[Dict[st
     source_label = str(desc.get("source") or "").strip()
     privacy_label = str(desc.get("privacy") or desc.get("privacy_label") or "least_sensitive").strip()
 
-    if not path.exists():
+    try:
+        exists = path.exists()
+    except OSError:
+        return _degraded_filesystem_result(include_id, subject, display_path, source_label, privacy_label)
+
+    if not exists:
         return {
             "success": False,
             "include_id": include_id,
@@ -226,15 +252,29 @@ def read_wiki_include(include_id: str, subject: str, *, config: Optional[Dict[st
             "path": display_path,
             "error": "allowlisted wiki source is missing",
         }
-    if not path.is_file():
+    try:
+        is_file = path.is_file()
+    except OSError:
+        return _degraded_filesystem_result(include_id, subject, display_path, source_label, privacy_label)
+
+    if not is_file:
         raise WikiIncludeError("wiki include rejected: descriptor path is not a file")
-    size = path.stat().st_size
+
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return _degraded_filesystem_result(include_id, subject, display_path, source_label, privacy_label)
+
     if size > int(cfg.get("max_bytes") or _MAX_WIKI_INCLUDE_BYTES):
         raise WikiIncludeError("wiki include rejected: file exceeds wiki include size limit")
 
-    text = path.read_text(encoding="utf-8", errors="replace")
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+        st = path.stat()
+    except OSError:
+        return _degraded_filesystem_result(include_id, subject, display_path, source_label, privacy_label)
+
     redacted = _redact_content(text)
-    st = path.stat()
     degraded = not bool(source_label)
     return {
         "success": True,

--- a/tools/wiki_include_tool.py
+++ b/tools/wiki_include_tool.py
@@ -1,0 +1,304 @@
+"""Default-off read-only wiki include family for Memory Seam.
+
+This tool is intentionally narrow: it can read only files named by explicit
+``memory_seam.wiki.allowlist`` descriptors in ``config.yaml``.  It never crawls
+wiki roots, never writes, and returns source/privacy/freshness/degraded labels
+with path details redacted to a safe display path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+from tools.registry import registry
+
+_MAX_WIKI_INCLUDE_BYTES = 128 * 1024
+_ALLOWED_SUFFIXES = {".md", ".markdown", ".txt"}
+_DENIED_PARTS = {
+    ".env",
+    ".git",
+    ".hermes",
+    ".ssh",
+    "auth.json",
+    "credentials",
+    "credential",
+    "private",
+    "protected",
+    "secret",
+    "secrets",
+    "session",
+    "sessions",
+    "state",
+    "transcript",
+    "transcripts",
+    "logs",
+}
+_SECRET_VALUE_RE = re.compile(
+    r"(?i)\b(api[_-]?key|token|secret|password|passwd|authorization)\b\s*[:=]\s*([^\s`'\"]+)"
+)
+_EMAIL_RE = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.I)
+_BEARER_RE = re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{8,}")
+
+
+class WikiIncludeError(ValueError):
+    """Expected user/config rejection for wiki include reads."""
+
+
+def _load_memory_seam_wiki_config() -> Dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        cfg = load_config_readonly() or {}
+    except Exception:
+        cfg = {}
+    seam = cfg.get("memory_seam") or {}
+    wiki = seam.get("wiki") or {}
+    return wiki if isinstance(wiki, dict) else {}
+
+
+def wiki_include_available() -> bool:
+    """Tool availability check: default-off until config explicitly enables it."""
+
+    cfg = _load_memory_seam_wiki_config()
+    return bool(cfg.get("enabled") is True and cfg.get("allowlist"))
+
+
+def _iter_descriptors(cfg: Dict[str, Any]) -> Iterable[Dict[str, Any]]:
+    allowlist = cfg.get("allowlist") or []
+    if isinstance(allowlist, dict):
+        allowlist = list(allowlist.values())
+    if not isinstance(allowlist, list):
+        return []
+    return [d for d in allowlist if isinstance(d, dict)]
+
+
+def _descriptor_id(desc: Dict[str, Any]) -> str:
+    return str(desc.get("id") or desc.get("include_id") or desc.get("name") or "").strip()
+
+
+def _find_descriptor(include_id: str, cfg: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    wanted = include_id.strip()
+    for desc in _iter_descriptors(cfg):
+        if _descriptor_id(desc) == wanted:
+            return desc
+    return None
+
+
+def _expand_path(raw: str) -> Path:
+    # Expand only local filesystem paths; no URI/network fetches in this slice.
+    if "://" in raw:
+        raise WikiIncludeError("wiki include rejected: descriptor path must be a local file path")
+    return Path(raw).expanduser().resolve(strict=False)
+
+
+def _default_wiki_root() -> Path:
+    # Tests and profiles can override by using explicit descriptor roots.  This
+    # fallback matches Atlas's sanitized wiki convention without requiring it.
+    return Path.home() / "atlas" / "shared" / "wiki"
+
+
+def _roots_for_descriptor(desc: Dict[str, Any], cfg: Dict[str, Any]) -> list[Path]:
+    roots_raw = desc.get("roots") or desc.get("allowed_roots") or cfg.get("allowed_roots")
+    if roots_raw is None:
+        roots_raw = [_default_wiki_root()]
+    if isinstance(roots_raw, (str, Path)):
+        roots_raw = [roots_raw]
+    roots: list[Path] = []
+    for item in roots_raw if isinstance(roots_raw, list) else []:
+        if item:
+            roots.append(_expand_path(str(item)))
+    return roots
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _safe_display_path(path: Path, roots: list[Path]) -> str:
+    for root in roots:
+        if _is_relative_to(path, root):
+            return f"wiki:{path.relative_to(root).as_posix()}"
+    return f"wiki:file:{hashlib.sha256(str(path).encode('utf-8')).hexdigest()[:12]}"
+
+
+def _has_denied_part(path: Path) -> Optional[str]:
+    for part in path.parts:
+        lowered = part.lower()
+        if lowered in _DENIED_PARTS:
+            return part
+        if any(marker in lowered for marker in ("private", "protected", "secret", "credential")):
+            return part
+    return None
+
+
+def _validate_before_read(desc: Dict[str, Any], cfg: Dict[str, Any], include_id: str, subject: str) -> tuple[Path, list[Path]]:
+    if (desc.get("family") or "wiki") != "wiki":
+        raise WikiIncludeError("wiki include rejected: descriptor family is not wiki")
+
+    expected_subject = str(desc.get("subject") or "").strip()
+    if not expected_subject:
+        raise WikiIncludeError("wiki include rejected: descriptor missing subject")
+    if subject.strip() != expected_subject:
+        raise WikiIncludeError("wiki include rejected: include/subject mismatch")
+
+    path_raw = str(desc.get("path") or desc.get("file") or "").strip()
+    if not path_raw:
+        raise WikiIncludeError("wiki include rejected: descriptor missing path")
+    path = _expand_path(path_raw)
+    roots = _roots_for_descriptor(desc, cfg)
+    if not roots:
+        raise WikiIncludeError("wiki include rejected: descriptor has no allowed roots")
+    if not any(_is_relative_to(path, root) for root in roots):
+        raise WikiIncludeError("wiki include rejected: descriptor path is outside allowed wiki roots")
+    relative_parts: list[str] = []
+    for root in roots:
+        if _is_relative_to(path, root):
+            relative_parts = list(path.relative_to(root).parts)
+            break
+    denied = _has_denied_part(Path(*relative_parts)) if relative_parts else None
+    if denied:
+        raise WikiIncludeError("wiki include rejected: protected/private path component is not readable")
+    if path.suffix.lower() not in _ALLOWED_SUFFIXES:
+        raise WikiIncludeError("wiki include rejected: unsupported wiki file suffix")
+    return path, roots
+
+
+def _redact_content(text: str) -> str:
+    text = _BEARER_RE.sub("Bearer [REDACTED]", text)
+    text = _SECRET_VALUE_RE.sub(lambda m: f"{m.group(1)}=[REDACTED]", text)
+    text = _EMAIL_RE.sub("[REDACTED_EMAIL]", text)
+    return text
+
+
+def _freshness_label(st_mtime: float) -> str:
+    dt = datetime.fromtimestamp(st_mtime, tz=timezone.utc)
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def read_wiki_include(include_id: str, subject: str, *, config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Read one explicitly allowlisted wiki include descriptor.
+
+    ``config`` is injectable for tests; production reads ``memory_seam.wiki``
+    from profile config.  All descriptor/subject/path privacy checks happen
+    before the first filesystem read/stat.
+    """
+
+    cfg = config if config is not None else _load_memory_seam_wiki_config()
+    if not bool(cfg.get("enabled") is True):
+        return {
+            "success": False,
+            "source": "wiki",
+            "privacy": "default_off",
+            "freshness": "unavailable",
+            "degraded": True,
+            "degraded_reason": "memory_seam.wiki disabled",
+            "error": "wiki include family is disabled",
+        }
+
+    desc = _find_descriptor(include_id, cfg)
+    if desc is None:
+        raise WikiIncludeError("wiki include rejected: include id is not allowlisted")
+
+    path, roots = _validate_before_read(desc, cfg, include_id, subject)
+    display_path = _safe_display_path(path, roots)
+    source_label = str(desc.get("source") or "").strip()
+    privacy_label = str(desc.get("privacy") or desc.get("privacy_label") or "least_sensitive").strip()
+
+    if not path.exists():
+        return {
+            "success": False,
+            "include_id": include_id,
+            "subject": subject,
+            "source": source_label or "wiki",
+            "privacy": privacy_label,
+            "freshness": "unavailable",
+            "degraded": True,
+            "degraded_reason": "allowlisted wiki source is missing",
+            "path": display_path,
+            "error": "allowlisted wiki source is missing",
+        }
+    if not path.is_file():
+        raise WikiIncludeError("wiki include rejected: descriptor path is not a file")
+    size = path.stat().st_size
+    if size > int(cfg.get("max_bytes") or _MAX_WIKI_INCLUDE_BYTES):
+        raise WikiIncludeError("wiki include rejected: file exceeds wiki include size limit")
+
+    text = path.read_text(encoding="utf-8", errors="replace")
+    redacted = _redact_content(text)
+    st = path.stat()
+    degraded = not bool(source_label)
+    return {
+        "success": True,
+        "include_id": include_id,
+        "subject": subject,
+        "source": source_label or "wiki:no_source_label",
+        "privacy": privacy_label,
+        "freshness": _freshness_label(st.st_mtime),
+        "degraded": degraded,
+        "degraded_reason": "descriptor missing source label" if degraded else None,
+        "path": display_path,
+        "bytes": size,
+        "content": redacted,
+    }
+
+
+def handle_wiki_include(args: Dict[str, Any], **_: Any) -> str:
+    include_id = str(args.get("include_id") or "").strip()
+    subject = str(args.get("subject") or "").strip()
+    if not include_id or not subject:
+        return json.dumps({"success": False, "error": "include_id and subject are required"})
+    try:
+        return json.dumps(read_wiki_include(include_id, subject), ensure_ascii=False)
+    except WikiIncludeError as exc:
+        return json.dumps(
+            {
+                "success": False,
+                "source": "wiki",
+                "privacy": "blocked_before_read",
+                "freshness": "unread",
+                "degraded": True,
+                "degraded_reason": "policy_rejected_before_read",
+                "error": str(exc),
+            }
+        )
+
+
+WIKI_INCLUDE_SCHEMA = {
+    "name": "wiki_include_read",
+    "description": (
+        "Read one explicitly allowlisted, sanitized Atlas wiki include. "
+        "Default-off and read-only; requires include_id plus matching subject. "
+        "Returns source/privacy/freshness/degraded labels and redacted content."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "include_id": {"type": "string", "description": "Allowlisted wiki descriptor id."},
+            "subject": {"type": "string", "description": "Expected descriptor subject; must match before any read."},
+        },
+        "required": ["include_id", "subject"],
+        "additionalProperties": False,
+    },
+}
+
+
+registry.register(
+    name="wiki_include_read",
+    toolset="memory-seam-wiki",
+    schema=WIKI_INCLUDE_SCHEMA,
+    handler=handle_wiki_include,
+    check_fn=wiki_include_available,
+    requires_env=[],
+    description="Read-only allowlisted sanitized wiki include",
+    emoji="📚",
+    max_result_size_chars=64_000,
+)

--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -112,6 +112,33 @@ The agent saves automatically — you don't need to ask. It saves when it learns
 - **Session-specific ephemera:** Temporary file paths, one-off debugging context
 - **Information already in context files:** SOUL.md and AGENTS.md content
 
+## Memory Seam wiki includes
+
+Hermes also has a default-off, read-only Memory Seam include family for least-sensitive Atlas wiki notes. It is not active unless you explicitly enable the `memory-seam-wiki` toolset and add exact descriptors to `memory_seam.wiki.allowlist`.
+
+Example:
+
+```yaml
+toolsets:
+  - hermes-cli
+  - memory-seam-wiki
+
+memory_seam:
+  wiki:
+    enabled: true
+    allowed_roots:
+      - ~/atlas/shared/wiki
+    allowlist:
+      - id: atlas-public-overview
+        family: wiki
+        subject: atlas-overview
+        path: ~/atlas/shared/wiki/sanitized/atlas-overview.md
+        source: atlas-wiki
+        privacy: least_sensitive
+```
+
+The `wiki_include_read` tool rejects requests before any filesystem read when the `include_id` is not allowlisted, the caller-provided `subject` does not match the descriptor, the path leaves the configured wiki root, or any path component looks private/protected/secret-bearing. Responses preserve `source`, `privacy`, `freshness`, and `degraded` labels and redact obvious secrets/emails from returned content. Missing files and missing source labels are reported as degraded rather than silently promoted to trusted context.
+
 ## Capacity Management
 
 Memory has strict character limits to keep system prompts bounded:


### PR DESCRIPTION
## Summary
- add default-off read-only wiki include toolset for explicitly allowlisted Memory Seam wiki descriptors
- enforce include/subject, root, suffix, and protected/private path checks before content reads
- preserve source/privacy/freshness/degraded labels with log-safe display paths and content redaction
- document config shape and add regression coverage

## Tests
- /Users/watson/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_wiki_include_tool.py -q
- /Users/watson/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_wiki_include_tool.py tests/tools/test_registry.py -q
- /Users/watson/.hermes/hermes-agent/venv/bin/python -m py_compile tools/wiki_include_tool.py tests/tools/test_wiki_include_tool.py