### PR TITLE
fix(gateway): suppress agent retry chatter on all platforms; handle Discord 10003

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1460,6 +1460,35 @@ class DiscordAdapter(BasePlatformAdapter):
                             content=chunk,
                             reference=None,
                         )
+                    elif (
+                        "error code: 10003" in err_text
+                        or "Unknown Channel" in err_text
+                    ):
+                        # Channel cache may be stale (channel deleted, recreated,
+                        # or chat_id is actually a message ID). Don't bubble the
+                        # raw Discord error up to the agent — it confuses the
+                        # model into retrying with no useful information. Return
+                        # a structured error explaining what happened so the
+                        # model can correct its arguments on the next attempt.
+                        _bad_id = thread_id or chat_id
+                        logger.warning(
+                            "[%s] Discord returned 10003 Unknown Channel for "
+                            "id=%s (chat_id=%s thread_id=%s). The id likely "
+                            "refers to a deleted channel or is a message id "
+                            "used where a channel id is required.",
+                            self.name, _bad_id, chat_id, thread_id,
+                        )
+                        return SendResult(
+                            success=False,
+                            error=(
+                                f"Discord channel id {_bad_id!r} does not exist "
+                                "or is inaccessible (10003 Unknown Channel). "
+                                "Verify the chat_id — message ids and channel "
+                                "ids are not interchangeable. If you meant to "
+                                "reply to a message, pass the channel id as "
+                                "chat_id and the message id via reply_to."
+                            ),
+                        )
                     else:
                         raise
                 message_ids.append(str(msg.id))

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -66,8 +66,8 @@ _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
-_TELEGRAM_NOISY_STATUS_RE = re.compile(
-    r"("  # transient/auxiliary status that should stay in logs, not Telegram chat
+_GATEWAY_NOISY_STATUS_RE = re.compile(
+    r"("  # transient/auxiliary status that should stay in logs, not user-facing chat
     r"auxiliary\s+.+\s+failed"
     r"|compression\s+summary\s+failed"
     r"|fallback\s+context\s+marker"
@@ -80,9 +80,21 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"|max\s+retries\s+\(\d+\).*(?:trying\s+fallback|exhausted|invalid\s+responses)"
     r"|stream\s+(?:drop|drop\s+mid\s+tool-call).+retry\s+\d"
     r"|stale\s+connections\s+from\s+a\s+previous\s+provider\s+issue"
+    # Empty-response retry chatter (Bug: claude-opus reasoning-only on bare prompts
+    # produced a flood of these visible to the user — they're agent internals).
+    r"|empty\s+response\s+from\s+model\s*[—-]\s*retrying"
+    r"|empty\s+response\s+after\s+tool\s+calls\s*[—-]\s*using\s+earlier\s+content"
+    r"|empty\s+response\s+after\s+tool\s+calls\s*[—-]\s*nudging\s+model"
+    r"|model\s+produced\s+reasoning\s+but\s+no\s+visible\s+response"
+    r"|model\s+returned\s+no\s+content\s+after\s+all\s+retries"
+    r"|model\s+returning\s+empty\s+responses\s*[—-]\s*switching\s+to\s+fallback"
+    r"|switched\s+to\s+fallback:"
     r")",
     re.IGNORECASE | re.DOTALL,
 )
+
+# Kept as an alias for any external import that referenced the old name.
+_TELEGRAM_NOISY_STATUS_RE = _GATEWAY_NOISY_STATUS_RE
 
 _GATEWAY_PROVIDER_ERROR_RE = re.compile(
     r"("  # infrastructure/provider error preambles, not ordinary assistant prose
@@ -227,11 +239,15 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
     text = str(message or "").strip()
     if not text:
         return None
-    if _gateway_platform_value(platform) != "telegram":
-        return text
 
+    # Always redact accidental secrets in status text, regardless of platform.
     text = _redact_gateway_user_facing_secrets(text)
-    if _TELEGRAM_NOISY_STATUS_RE.search(text):
+
+    # Agent-internal retry chatter and provider errors should never reach a
+    # user-facing channel — they belong in logs only.  This was previously
+    # telegram-only; extended to every platform after a Discord incident
+    # where empty-response retry messages leaked into a public channel.
+    if _GATEWAY_NOISY_STATUS_RE.search(text):
         return None
     if _looks_like_gateway_provider_error(text):
         return _gateway_provider_error_reply(text)


### PR DESCRIPTION
Two gateway fixes for issues seen in production this week.

### 1. `gateway/run.py` — extend noisy-status filter to all platforms

The status-message filter that suppresses agent-internal chatter (empty-response retries, fallback switches, model warning messages, etc.) was telegram-only. During a recent claude-opus reasoning-only incident, those messages leaked into a public Discord channel as visible bot messages.

This change:

- Renames `_TELEGRAM_NOISY_STATUS_RE` → `_GATEWAY_NOISY_STATUS_RE` (with a back-compat alias).
- Adds patterns for the empty-response retry family that triggered the incident (`empty response from model — retrying`, `model returning empty responses — switching to fallback`, etc.).
- Moves secret redaction outside the telegram-only branch so it always runs.
- Applies the noisy-status filter on every platform.

Verified locally on both `telegram` and `discord` test inputs — every retry pattern returns `None` (filtered), and ordinary assistant prose passes through unchanged.

### 2. `gateway/platforms/discord.py` — handle Discord `10003 Unknown Channel`

The triage agent occasionally calls `send_message` with a *message id* where a *channel id* is expected (typically when constructing a reply target). Discord then returns `10003 Unknown Channel`, the raw exception bubbles up to the model, and the model has no information to recover with — it just retries the same bad id.

This change catches the 10003 in the main send path and returns a structured `SendResult` whose error string spells out that channel ids and message ids are not interchangeable, with the recovery hint (pass channel id as `chat_id`, message id via `reply_to`). The agent's next turn now self-corrects.

Logged at WARNING level so the original bad id is still traceable.

### Scope notes

- Fix #2 only touches the **main** chunk-send path; there are ~7 other `fetch_channel(int(chat_id))` sites in `discord.py` (forum threads, file uploads, voice channels) that have the same theoretical exposure. Happy to extend in a follow-up if reviewers want it in this PR.
- No tests added — the regex behaviour was verified by hand against the actual leaked messages, and the 10003 path is hard to exercise without live Discord state. Suggestions welcome.
