### PR TITLE
fix: fallback auxiliary calls on provider capacity errors

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2303,6 +2303,31 @@ def _is_rate_limit_error(exc: Exception) -> bool:
     return False
 
 
+def _is_server_capacity_error(exc: Exception) -> bool:
+    """Detect transient provider-side capacity failures worth rerouting.
+
+    Unlike request validation errors, these mean the chosen backend is
+    temporarily unable to serve an otherwise valid auxiliary request. Gemini's
+    endpoint commonly reports this as HTTP 503 with ``UNAVAILABLE`` / "high
+    demand"; treating it as capacity lets explicit auxiliary providers use
+    their configured ``fallback_chain`` instead of failing compression outright.
+    """
+    status = getattr(exc, "status_code", None)
+    if status in {502, 503, 504}:
+        return True
+    err_lower = str(exc).lower()
+    return any(kw in err_lower for kw in (
+        "error code: 503",
+        "status': 'unavailable'",
+        'status": "unavailable"',
+        "currently experiencing high demand",
+        "server overloaded",
+        "overloaded",
+        "temporarily unavailable",
+        "service unavailable",
+    ))
+
+
 def _is_connection_error(exc: Exception) -> bool:
     """Detect connection/network errors that warrant provider fallback.
 
@@ -2836,17 +2861,21 @@ def _try_configured_fallback_chain(
         label = f"fallback_chain[{i}]({fb_provider})"
 
         try:
-            fb_client = _resolve_single_provider(
-                fb_provider, fb_model, fb_base_url, fb_api_key)
+            fb_client, resolved_fb_model = resolve_provider_client(
+                provider=fb_provider,
+                model=fb_model or "",
+                explicit_base_url=fb_base_url or "",
+                explicit_api_key=fb_api_key or "",
+            )
         except Exception:
-            fb_client = None
+            fb_client, resolved_fb_model = None, None
 
         if fb_client is not None:
             logger.info(
                 "Auxiliary %s: %s on %s — configured fallback to %s (%s)",
-                task, reason, failed_provider, label, fb_model or "default",
+                task, reason, failed_provider, label, resolved_fb_model or fb_model or "default",
             )
-            return fb_client, fb_model, label
+            return fb_client, resolved_fb_model or fb_model, label
         tried.append(label)
 
     if tried:
@@ -4860,17 +4889,23 @@ def call_llm(
             _is_payment_error(first_err)
             or _is_connection_error(first_err)
             or _is_rate_limit_error(first_err)
+            or _is_server_capacity_error(first_err)
         )
         # Respect explicit provider choice for transient errors (auth, request
         # validation, etc.) but allow fallback when the provider clearly cannot
-        # serve the request due to capacity: payment/quota exhaustion and
-        # connection failures are capacity problems, not request constraints.
+        # serve the request due to capacity: payment/quota exhaustion,
+        # connection failures, and provider-side 5xx capacity errors are not
+        # request constraints.
         # See #26803: daily token quota (429 + "too many tokens per day") must
         # fall back just like a 402 credit error.
         is_auto = resolved_provider in {"auto", "", None}
         # Capacity errors bypass the explicit-provider gate: the provider
         # literally cannot serve this request regardless of user intent.
-        is_capacity_error = _is_payment_error(first_err) or _is_connection_error(first_err)
+        is_capacity_error = (
+            _is_payment_error(first_err)
+            or _is_connection_error(first_err)
+            or _is_server_capacity_error(first_err)
+        )
         if should_fallback and (is_auto or is_capacity_error):
             if _is_payment_error(first_err):
                 reason = "payment error"
@@ -4883,6 +4918,8 @@ def call_llm(
                 )
             elif _is_rate_limit_error(first_err):
                 reason = "rate limit"
+            elif _is_server_capacity_error(first_err):
+                reason = "server capacity error"
             else:
                 reason = "connection error"
             logger.info("Auxiliary %s: %s on %s (%s), trying fallback",
@@ -5222,12 +5259,18 @@ async def async_call_llm(
             _is_payment_error(first_err)
             or _is_connection_error(first_err)
             or _is_rate_limit_error(first_err)
+            or _is_server_capacity_error(first_err)
         )
-        # Capacity errors (payment/quota/connection) bypass the explicit-provider
-        # gate — the provider cannot serve the request regardless of user intent.
+        # Capacity errors (payment/quota/connection/provider-side 5xx) bypass
+        # the explicit-provider gate — the provider cannot serve the request
+        # regardless of user intent.
         # See #26803: daily token quota must fall back like a 402 credit error.
         is_auto = resolved_provider in {"auto", "", None}
-        is_capacity_error = _is_payment_error(first_err) or _is_connection_error(first_err)
+        is_capacity_error = (
+            _is_payment_error(first_err)
+            or _is_connection_error(first_err)
+            or _is_server_capacity_error(first_err)
+        )
         if should_fallback and (is_auto or is_capacity_error):
             if _is_payment_error(first_err):
                 reason = "payment error"
@@ -5236,6 +5279,8 @@ async def async_call_llm(
                 )
             elif _is_rate_limit_error(first_err):
                 reason = "rate limit"
+            elif _is_server_capacity_error(first_err):
+                reason = "server capacity error"
             else:
                 reason = "connection error"
             logger.info("Auxiliary %s (async): %s on %s (%s), trying fallback",

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -23,6 +23,7 @@ from agent.auxiliary_client import (
     _get_provider_chain,
     _is_payment_error,
     _is_rate_limit_error,
+    _is_server_capacity_error,
     _normalize_aux_provider,
     _try_payment_fallback,
     _resolve_auto,
@@ -1194,6 +1195,71 @@ class TestAuxiliaryFallbackLayering:
         exc = Exception("Payment Required: insufficient credits")
         exc.status_code = 402
         return exc
+
+    def _make_server_capacity_err(self):
+        exc = Exception("Error code: 503 - UNAVAILABLE high demand")
+        setattr(exc, "status_code", 503)
+        return exc
+
+    def test_server_capacity_error_detection(self):
+        assert _is_server_capacity_error(self._make_server_capacity_err())
+
+    def test_explicit_provider_503_uses_configured_chain_first(self, monkeypatch):
+        """Provider-side 5xx capacity errors should use fallback_chain for explicit aux providers."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+
+        primary_client = MagicMock()
+        primary_client.chat.completions.create.side_effect = self._make_server_capacity_err()
+
+        chain_client = MagicMock()
+        chain_client.chat.completions.create.return_value = MagicMock(choices=[
+            MagicMock(message=MagicMock(content="from configured chain"))
+        ])
+
+        main_called = MagicMock()
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary_client, "gemini-3.5-flash")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("gemini", "gemini-3.5-flash", None, None, None)), \
+             patch("agent.auxiliary_client._try_configured_fallback_chain",
+                   return_value=(chain_client, "gpt-5.4", "fallback_chain[0](openai-codex)")), \
+             patch("agent.auxiliary_client._try_main_agent_model_fallback",
+                   side_effect=main_called):
+            result = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        assert chain_client.chat.completions.create.called
+        main_called.assert_not_called()
+
+    def test_configured_fallback_chain_passes_explicit_base_url_and_model(self):
+        """fallback_chain entries should pass base_url/api_key through the explicit-override args."""
+        from agent.auxiliary_client import _try_configured_fallback_chain
+
+        fake_client = MagicMock()
+        with patch("agent.auxiliary_client._get_auxiliary_task_config", return_value={
+            "fallback_chain": [{
+                "provider": "openai-codex",
+                "model": "gpt-5.4",
+                "base_url": "https://chatgpt.com/backend-api/codex",
+                "api_key": "",
+            }]
+        }), patch("agent.auxiliary_client.resolve_provider_client",
+                  return_value=(fake_client, "gpt-5.4")) as resolve:
+            client, model, label = _try_configured_fallback_chain(
+                "compression", "gemini", reason="server capacity error")
+
+        assert client is fake_client
+        assert model == "gpt-5.4"
+        assert label == "fallback_chain[0](openai-codex)"
+        resolve.assert_called_once_with(
+            provider="openai-codex",
+            model="gpt-5.4",
+            explicit_base_url="https://chatgpt.com/backend-api/codex",
+            explicit_api_key="",
+        )
 
     def test_explicit_provider_uses_configured_chain_first(self, monkeypatch, caplog):
         """When a user has fallback_chain configured, it's tried BEFORE the main agent model."""


### PR DESCRIPTION
## Summary
- Treat provider-side capacity errors such as HTTP 502/503/504 and Gemini UNAVAILABLE/high-demand responses as fallback-worthy auxiliary failures.
- Preserve explicit auxiliary-provider fallback semantics by routing these capacity failures through auxiliary.<task>.fallback_chain before the main-model safety net.
- Fix configured fallback_chain resolution so entry base_url/api_key values are passed via explicit override arguments.

## Why
Gemini can return transient 503 UNAVAILABLE/high-demand errors for valid auxiliary requests such as context compression. Previously explicit auxiliary providers only fell back for payment/quota/connection/rate-limit paths, so compression could fail instead of using a configured fallback model.

## Test Plan
- venv/bin/python -m py_compile agent/auxiliary_client.py tests/agent/test_auxiliary_client.py
- venv/bin/python -m pytest tests/agent/test_auxiliary_client.py::TestAuxiliaryFallbackLayering -q -o 'addopts='
- venv/bin/python -m pytest tests/agent/test_unsupported_temperature_retry.py -q -o 'addopts='