### PR TITLE
feat: add advisory skill recommendations

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12280,6 +12280,22 @@ Examples:
         "which skills will load for that profile.",
     )
 
+    skills_recommend = skills_subparsers.add_parser(
+        "recommend",
+        help="Recommend relevant installed skills for a task (advisory only; does not load them)",
+        description=(
+            "Read-only advisory wrapper around local pgvector skill recall. "
+            "This command prints recommended skills for manual loading; it does not "
+            "autoload skills, mutate prompts, edit config, or install runtime hooks."
+        ),
+    )
+    skills_recommend.add_argument("query", help="Natural-language task/query")
+    skills_recommend.add_argument("--top-k", type=int, default=3, help="Max recommendations (default: 3)")
+    skills_recommend.add_argument("--min-score", type=float, default=0.04, help="Minimum confidence score (default: 0.04)")
+    skills_recommend.add_argument("--no-min-score", action="store_true", help="Disable confidence threshold")
+    skills_recommend.add_argument("--show-scores", action="store_true", help="Show hybrid scores")
+    skills_recommend.add_argument("--wrapper", default=None, help="Override recommendation wrapper path (testing/debugging)")
+
     skills_check = skills_subparsers.add_parser(
         "check", help="Check installed hub skills for updates"
     )

--- a/hermes_cli/skill_recommend.py
+++ b/hermes_cli/skill_recommend.py
@@ -1,0 +1,130 @@
+"""Read-only advisory skill recommendations for the Hermes CLI.
+
+This module is intentionally a thin CLI/manual wrapper around the Phase 2H
+local pgvector recommendation script.  It does not load skills, edit config,
+mutate prompts, install hooks, or write telemetry.  The only action is a
+foreground subprocess call that returns advisory text for a human/operator to
+use manually.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+DEFAULT_WRAPPER = Path.home() / ".hermes" / "scripts" / "pgvector_recommended_skills.py"
+DEFAULT_TOP_K = 3
+DEFAULT_MIN_SCORE = 0.04
+
+Runner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+def _format_min_score(value: float | None) -> str:
+    if value is None:
+        return "None"
+    return f"{value:g}"
+
+
+def recommend_skills(
+    query: str,
+    *,
+    top_k: int = DEFAULT_TOP_K,
+    min_score: float | None = DEFAULT_MIN_SCORE,
+    wrapper_path: str | Path | None = None,
+    runner: Runner = subprocess.run,
+) -> dict[str, Any]:
+    """Return advisory skill recommendations for ``query``.
+
+    The wrapped script is invoked with ``--json`` and deliberately without
+    ``--log-event`` or any flag that would load skills or mutate runtime state.
+    """
+    if top_k < 1 or top_k > 20:
+        raise ValueError("top_k must be between 1 and 20")
+
+    wrapper = Path(wrapper_path) if wrapper_path is not None else DEFAULT_WRAPPER
+    if not wrapper.exists():
+        raise FileNotFoundError(f"recommendation wrapper not found: {wrapper}")
+
+    cmd: list[str] = [str(wrapper), query, "--top-k", str(top_k)]
+    if min_score is None:
+        cmd.append("--no-min-score")
+    else:
+        cmd += ["--min-score", _format_min_score(min_score)]
+    cmd.append("--json")
+
+    proc = runner(cmd, text=True, capture_output=True, check=False)
+    if proc.returncode != 0:
+        message = (proc.stderr or proc.stdout or f"wrapper exited with {proc.returncode}").strip()
+        raise RuntimeError(message)
+
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"recommendation wrapper returned invalid JSON: {exc}") from exc
+
+    payload.setdefault("scope", {})
+    payload["scope"].setdefault("manual_only", True)
+    payload["scope"].setdefault("loads_skills", False)
+    payload["scope"].setdefault("runtime_coupling", False)
+    payload["scope"].setdefault("config_changes", False)
+    payload["scope"].setdefault("db_writes", False)
+    return payload
+
+
+def render_recommendations(payload: dict[str, Any], *, show_scores: bool = False) -> str:
+    """Render recommendation JSON as compact human-readable advisory text."""
+    query = payload.get("query") or ""
+    diagnostics = payload.get("diagnostics") or {}
+    recommendations = payload.get("recommendations") or []
+
+    lines: list[str] = ["Recommended skills:"]
+    if not recommendations:
+        lines.append("No confident skill recommendation found.")
+    else:
+        for idx, rec in enumerate(recommendations, start=1):
+            rank = rec.get("rank") or idx
+            name = rec.get("skill_name") or rec.get("name") or "<unknown>"
+            rel_path = rec.get("relative_path") or ""
+            line = f"{rank}. {name}"
+            if rel_path:
+                line += f" — {rel_path}"
+            score = rec.get("score")
+            if show_scores and score is not None:
+                try:
+                    line += f" — score {float(score):.6f}"
+                except (TypeError, ValueError):
+                    line += f" — score {score}"
+            lines.append(line)
+
+    if query:
+        lines.extend(["", f"Query: {query}"])
+    min_score = diagnostics.get("min_score", payload.get("min_score"))
+    if min_score is not None:
+        lines.append(f"Min score: {min_score}")
+
+    lines.extend(
+        [
+            "",
+            "Advisory only: no runtime hooks, autoloading, prompt mutation, or config changes.",
+            "No skills were loaded. Load any recommendation manually with /skill <name> or hermes -s <name>.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def recommend_and_render(
+    query: str,
+    *,
+    top_k: int = DEFAULT_TOP_K,
+    min_score: float | None = DEFAULT_MIN_SCORE,
+    wrapper_path: str | Path | None = None,
+    show_scores: bool = False,
+) -> str:
+    payload = recommend_skills(
+        query,
+        top_k=top_k,
+        min_score=min_score,
+        wrapper_path=wrapper_path,
+    )
+    return render_recommendations(payload, show_scores=show_scores)

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1398,6 +1398,7 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
 
     Examples:
         /skills search kubernetes
+        /skills recommend review this pull request --top-k 2 --show-scores
         /skills install openai/skills/skill-creator
         /skills install openai/skills/skill-creator --force
         /skills install https://example.com/path/SKILL.md
@@ -1474,6 +1475,54 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
                 query_parts.append(args[i])
                 i += 1
         do_search(" ".join(query_parts), source=source, limit=limit, console=c)
+
+    elif action == "recommend":
+        if not args:
+            c.print("[bold red]Usage:[/] /skills recommend <query> [--top-k N] [--min-score F|--no-min-score] [--show-scores]\n")
+            c.print("[dim]Advisory only: prints suggestions for manual loading; does not load skills.[/]\n")
+            return
+        from hermes_cli import skill_recommend
+
+        top_k = 3
+        min_score = 0.04
+        no_min_score = False
+        show_scores = False
+        query_parts = []
+        i = 0
+        while i < len(args):
+            if args[i] == "--top-k" and i + 1 < len(args):
+                try:
+                    top_k = int(args[i + 1])
+                except ValueError:
+                    pass
+                i += 2
+            elif args[i] == "--min-score" and i + 1 < len(args):
+                try:
+                    min_score = float(args[i + 1])
+                except ValueError:
+                    pass
+                i += 2
+            elif args[i] == "--no-min-score":
+                no_min_score = True
+                i += 1
+            elif args[i] == "--show-scores":
+                show_scores = True
+                i += 1
+            else:
+                query_parts.append(args[i])
+                i += 1
+        query = " ".join(query_parts).strip()
+        if not query:
+            c.print("[bold red]Usage:[/] /skills recommend <query> [--top-k N] [--min-score F|--no-min-score] [--show-scores]\n")
+            c.print("[dim]Advisory only: prints suggestions for manual loading; does not load skills.[/]\n")
+            return
+        payload = skill_recommend.recommend_skills(
+            query,
+            top_k=top_k,
+            min_score=None if no_min_score else min_score,
+            wrapper_path=None,
+        )
+        c.print(skill_recommend.render_recommendations(payload, show_scores=show_scores))
 
     elif action == "install":
         if not args:
@@ -1597,6 +1646,7 @@ def _print_skills_help(console: Console) -> None:
         "[bold]Skills Hub Commands:[/]\n\n"
         "  [cyan]browse[/] [--source official]   Browse all available skills (paginated)\n"
         "  [cyan]search[/] <query>              Search registries for skills\n"
+        "  [cyan]recommend[/] <query>           Advisory; does not load skills\n"
         "  [cyan]install[/] <identifier>        Install a skill (with security scan)\n"
         "  [cyan]inspect[/] <identifier>        Preview a skill without installing\n"
         "  [cyan]list[/] [--source hub|builtin|local] [--enabled-only]\n"

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1319,8 +1319,9 @@ def do_snapshot_import(input_path: str, force: bool = False,
 # CLI argparse entry point
 # ---------------------------------------------------------------------------
 
-def skills_command(args) -> None:
+def skills_command(args, console: Optional[Console] = None) -> None:
     """Router for `hermes skills <subcommand>` — called from hermes_cli/main.py."""
+    c = console or _console
     action = getattr(args, "skills_action", None)
 
     if action == "browse":
@@ -1337,7 +1338,19 @@ def skills_command(args) -> None:
         do_list(
             source_filter=args.source,
             enabled_only=getattr(args, "enabled_only", False),
+            console=c,
         )
+    elif action == "recommend":
+        from hermes_cli.skill_recommend import recommend_skills, render_recommendations
+
+        min_score = None if getattr(args, "no_min_score", False) else getattr(args, "min_score", 0.04)
+        payload = recommend_skills(
+            args.query,
+            top_k=getattr(args, "top_k", 3),
+            min_score=min_score,
+            wrapper_path=getattr(args, "wrapper", None),
+        )
+        c.print(render_recommendations(payload, show_scores=getattr(args, "show_scores", False)))
     elif action == "check":
         do_check(name=getattr(args, "name", None))
     elif action == "update":
@@ -1371,7 +1384,7 @@ def skills_command(args) -> None:
             return
         do_tap(tap_action, repo=repo)
     else:
-        _console.print("Usage: hermes skills [browse|search|install|inspect|list|check|update|audit|uninstall|reset|publish|snapshot|tap]\n")
+        _console.print("Usage: hermes skills [browse|search|recommend|install|inspect|list|check|update|audit|uninstall|reset|publish|snapshot|tap]\n")
         _console.print("Run 'hermes skills <command> --help' for details.\n")
 
 

--- a/tests/hermes_cli/test_skills_recommend.py
+++ b/tests/hermes_cli/test_skills_recommend.py
@@ -118,3 +118,85 @@ def test_skills_command_recommend_routes_to_read_only_advisory_output(monkeypatc
     assert "hermes-agent" in output
     assert "Advisory only" in output
     assert "No skills were loaded" in output
+
+
+def test_skills_slash_help_mentions_recommend_advisory_command():
+    from hermes_cli.skills_hub import handle_skills_slash
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+
+    handle_skills_slash("/skills help", console=console)
+    output = sink.getvalue()
+
+    assert "recommend" in output
+    assert "advisory" in output.lower()
+    assert "does not load" in output.lower()
+
+
+def test_handle_skills_slash_recommend_is_advisory_only(monkeypatch):
+    import hermes_cli.skill_recommend as skill_recommend
+    from hermes_cli.skills_hub import handle_skills_slash
+
+    calls = []
+
+    def fake_recommend_skills(query, top_k=3, min_score=0.04, wrapper_path=None):
+        calls.append({
+            "query": query,
+            "top_k": top_k,
+            "min_score": min_score,
+            "wrapper_path": wrapper_path,
+        })
+        return {
+            "query": query,
+            "scope": {
+                "manual_only": True,
+                "loads_skills": False,
+                "runtime_coupling": False,
+                "db_writes": False,
+            },
+            "recommendations": [
+                {
+                    "rank": 1,
+                    "skill_name": "github-code-review",
+                    "relative_path": "github/github-code-review/SKILL.md",
+                    "score": 0.188875,
+                }
+            ],
+            "diagnostics": {"min_score": min_score},
+        }
+
+    monkeypatch.setattr(skill_recommend, "recommend_skills", fake_recommend_skills)
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+
+    handle_skills_slash(
+        "/skills recommend review this pull request --top-k 2 --min-score 0.05 --show-scores",
+        console=console,
+    )
+    output = sink.getvalue()
+
+    assert calls == [{
+        "query": "review this pull request",
+        "top_k": 2,
+        "min_score": 0.05,
+        "wrapper_path": None,
+    }]
+    assert "github-code-review" in output
+    assert "score 0.188875" in output
+    assert "Advisory only" in output
+    assert "No skills were loaded" in output
+
+
+def test_handle_skills_slash_recommend_requires_query():
+    from hermes_cli.skills_hub import handle_skills_slash
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+
+    handle_skills_slash("/skills recommend", console=console)
+    output = sink.getvalue()
+
+    assert "Usage:" in output
+    assert "/skills recommend <query>" in output

--- a/tests/hermes_cli/test_skills_recommend.py
+++ b/tests/hermes_cli/test_skills_recommend.py
@@ -1,0 +1,120 @@
+import json
+from io import StringIO
+from pathlib import Path
+from types import SimpleNamespace
+
+from rich.console import Console
+
+
+def test_recommend_skills_invokes_manual_wrapper_without_loading_or_logging(tmp_path):
+    from hermes_cli.skill_recommend import recommend_skills
+
+    calls = []
+
+    def fake_run(cmd, text, capture_output, check):
+        calls.append(cmd)
+        payload = {
+            "phase": "2H",
+            "query": "review this pull request",
+            "scope": {
+                "manual_only": True,
+                "loads_skills": False,
+                "runtime_coupling": False,
+                "db_writes": False,
+            },
+            "recommendations": [
+                {
+                    "rank": 1,
+                    "skill_name": "github-code-review",
+                    "relative_path": "github/github-code-review/SKILL.md",
+                    "score": 0.188875,
+                }
+            ],
+        }
+        return SimpleNamespace(returncode=0, stdout=json.dumps(payload), stderr="")
+
+    wrapper = tmp_path / "pgvector_recommended_skills.py"
+    wrapper.write_text("#!/usr/bin/env python3\n")
+
+    result = recommend_skills(
+        "review this pull request",
+        top_k=3,
+        min_score=0.04,
+        wrapper_path=wrapper,
+        runner=fake_run,
+    )
+
+    assert result["recommendations"][0]["skill_name"] == "github-code-review"
+    assert result["scope"]["loads_skills"] is False
+    assert result["scope"]["runtime_coupling"] is False
+    assert "--log-event" not in calls[0]
+    assert calls[0] == [str(wrapper), "review this pull request", "--top-k", "3", "--min-score", "0.04", "--json"]
+
+
+def test_render_recommendations_is_advisory_and_human_readable():
+    from hermes_cli.skill_recommend import render_recommendations
+
+    output = render_recommendations(
+        {
+            "query": "review this pull request",
+            "recommendations": [
+                {
+                    "rank": 1,
+                    "skill_name": "github-code-review",
+                    "relative_path": "github/github-code-review/SKILL.md",
+                    "score": 0.188875,
+                }
+            ],
+            "diagnostics": {"min_score": 0.04},
+        },
+        show_scores=True,
+    )
+
+    assert "Recommended skills:" in output
+    assert "github-code-review" in output
+    assert "github/github-code-review/SKILL.md" in output
+    assert "score 0.188875" in output
+    assert "Advisory only" in output
+    assert "No skills were loaded" in output
+
+
+def test_skills_command_recommend_routes_to_read_only_advisory_output(monkeypatch):
+    import hermes_cli.skills_hub as skills_hub
+
+    def fake_recommend_skills(query, top_k=3, min_score=0.04, wrapper_path=None):
+        assert query == "restart hermes gateway safely"
+        assert top_k == 3
+        assert min_score == 0.04
+        assert wrapper_path is None
+        return {
+            "query": query,
+            "recommendations": [
+                {
+                    "rank": 1,
+                    "skill_name": "hermes-agent",
+                    "relative_path": "autonomous-ai-agents/hermes-agent/SKILL.md",
+                    "score": 0.2,
+                }
+            ],
+            "diagnostics": {"min_score": min_score},
+        }
+
+    monkeypatch.setattr(skills_hub, "recommend_skills", fake_recommend_skills, raising=False)
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    args = SimpleNamespace(
+        skills_action="recommend",
+        query="restart hermes gateway safely",
+        top_k=3,
+        min_score=0.04,
+        wrapper=None,
+        show_scores=True,
+    )
+
+    skills_hub.skills_command(args, console=console)
+    output = sink.getvalue()
+
+    assert "hermes-agent" in output
+    assert "Advisory only" in output
+    assert "No skills were loaded" in output


### PR DESCRIPTION
## Summary
- Add `hermes skills recommend <query>` as an advisory/manual skill recommendation CLI command.
- Add interactive `/skills recommend <query>` support with matching advisory output.
- Add help/discoverability for recommendation flags and safe manual-load guidance.

## Safety boundary
- Advisory only: no automatic skill loading.
- No runtime hooks.
- No prompt mutation.
- No config changes.
- No install/update side effects.
- Recommendations remain user-controlled/manual-load instructions.

## Validation
- `python -m pytest tests/hermes_cli/test_skills_recommend.py tests/hermes_cli/test_skills_hub.py tests/hermes_cli/test_skills_subparser.py tests/hermes_cli/test_commands.py tests/agent/test_skill_commands.py tests/agent/test_skill_utils.py tests/tools/test_skills_tool.py tests/tools/test_skill_usage.py -q`
- Result: `358 passed, 1 warning in 8.79s`

## Notes
- Broader repo test wrapper currently selects `.venv/bin/python`, which does not have `pytest` installed. The active repo `venv/bin/python` does have pytest and was used for validation.
- `ui-tui/package-lock.json` has unrelated local lockfile churn and is intentionally left unstaged/out of this PR.
