### PR TITLE
i18n: localize dangerous command approval UI to Chinese

### DIFF
--- a/acp_adapter/permissions.py
+++ b/acp_adapter/permissions.py
@@ -41,13 +41,13 @@ def _permission_option_supports_kind(kind: str) -> bool:
 def _build_permission_options(*, allow_permanent: bool) -> list[PermissionOption]:
     """Return ACP options that match Hermes approval semantics."""
     options = [
-        PermissionOption(option_id="allow_once", kind="allow_once", name="Allow once"),
+        PermissionOption(option_id="allow_once", kind="allow_once", name="允许一次"),
         PermissionOption(
             option_id="allow_session",
             # ACP has no session-scoped kind, so use the closest persistent
             # hint while keeping Hermes semantics in the option id.
             kind="allow_always",
-            name="Allow for session",
+            name="本次会话允许",
         ),
     ]
     if allow_permanent:
@@ -55,10 +55,10 @@ def _build_permission_options(*, allow_permanent: bool) -> list[PermissionOption
             PermissionOption(
                 option_id="allow_always",
                 kind="allow_always",
-                name="Allow always",
+                name="总是允许",
             ),
         )
-    options.append(PermissionOption(option_id="deny", kind="reject_once", name="Deny"))
+    options.append(PermissionOption(option_id="deny", kind="reject_once", name="拒绝"))
     if _permission_option_supports_kind("reject_always"):
         options.append(
             PermissionOption(

--- a/cli.py
+++ b/cli.py
@@ -11054,14 +11054,14 @@ class HermesCLI:
         selected = state.get("selected", 0)
         show_full = state.get("show_full", False)
 
-        title = "⚠️  Dangerous Command"
+        title = "⚠️  危险命令"
         cmd_display = command if show_full or len(command) <= 70 else command[:70] + '...'
         choice_labels = {
-            "once": "Allow once",
-            "session": "Allow for this session",
-            "always": "Add to permanent allowlist",
-            "deny": "Deny",
-            "view": "Show full command",
+            "once": "允许一次",
+            "session": "本次会话允许",
+            "always": "加入永久白名单",
+            "deny": "拒绝",
+            "view": "显示完整命令",
         }
 
         preview_lines = _wrap_panel_text(description, 60)

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -152,8 +152,8 @@ class TestCliApprovalUi:
 
         assert lines[0].startswith("╭")
         assert "Dangerous Command" not in lines[0]
-        assert any("Dangerous Command" in line for line in lines[1:3])
-        assert "Show full command" in rendered
+        assert any("危险命令" in line for line in lines[1:3])
+        assert "显示完整命令" in rendered
         assert "githubcli-archive-keyring.gpg" not in rendered
 
     def test_approval_display_shows_full_command_after_view(self):
@@ -215,10 +215,10 @@ class TestCliApprovalUi:
 
         # Every choice must render — this is the core bug: approve/deny were
         # getting clipped off the bottom of the panel.
-        assert "Allow once" in rendered
-        assert "Allow for this session" in rendered
-        assert "Add to permanent allowlist" in rendered
-        assert "Deny" in rendered
+        assert "允许一次" in rendered
+        assert "本次会话允许" in rendered
+        assert "加入永久白名单" in rendered
+        assert "拒绝" in rendered
 
         # The bottom border must render (i.e. the panel is self-contained).
         assert rendered.rstrip().endswith("╯")
@@ -252,8 +252,8 @@ class TestCliApprovalUi:
         # Command visible.
         assert "rm -rf /var/log/apache2/*.log" in rendered
         # All four choices visible.
-        for label in ("Allow once", "Allow for this session",
-                      "Add to permanent allowlist", "Deny"):
+        for label in ("允许一次", "本次会话允许",
+                      "加入永久白名单", "拒绝"):
             assert label in rendered, f"choice {label!r} missing"
 
     def test_approval_display_truncates_giant_command_in_view_mode(self):
@@ -283,8 +283,8 @@ class TestCliApprovalUi:
         rendered = "".join(text for _style, text in fragments)
 
         # All four choices visible even with a huge command.
-        for label in ("Allow once", "Allow for this session",
-                      "Add to permanent allowlist", "Deny"):
+        for label in ("允许一次", "本次会话允许",
+                      "加入永久白名单", "拒绝"):
             assert label in rendered, f"choice {label!r} missing"
 
         # Command got truncated with a marker.

--- a/ui-tui/src/components/prompts.tsx
+++ b/ui-tui/src/components/prompts.tsx
@@ -8,7 +8,7 @@ import type { ApprovalReq, ClarifyReq, ConfirmReq } from '../types.js'
 import { TextInput } from './textInput.js'
 
 const OPTS = ['once', 'session', 'always', 'deny'] as const
-const LABELS = { always: 'Always allow', deny: 'Deny', once: 'Allow once', session: 'Allow this session' } as const
+const LABELS = { always: '总是允许', deny: '拒绝', once: '允许一次', session: '本次会话允许' } as const
 const CMD_PREVIEW_LINES = 10
 
 type ApprovalKey = {
@@ -80,7 +80,7 @@ export function ApprovalPrompt({ onChoice, req, t }: ApprovalPromptProps) {
   return (
     <Box borderColor={t.color.warn} borderStyle="double" flexDirection="column" paddingX={1}>
       <Text bold color={t.color.warn}>
-        ⚠ approval required · {req.description}
+        ⚠ 需要批准 · {req.description}
       </Text>
 
       <Box flexDirection="column" paddingLeft={1}>
@@ -108,7 +108,7 @@ export function ApprovalPrompt({ onChoice, req, t }: ApprovalPromptProps) {
         </Text>
       ))}
 
-      <Text color={t.color.muted}>↑/↓ select · Enter confirm · 1-4 quick pick · Esc/Ctrl+C deny</Text>
+      <Text color={t.color.muted}>↑/↓ 选择 · Enter 确认 · 1-4 快速选择 · Esc/Ctrl+C 拒绝</Text>
     </Box>
   )
 }


### PR DESCRIPTION
## Summary

将 Hermes 的安全批准（Dangerous Command / approval required）对话框的所有英文提示文本翻译为中文。

## Changes

| File | Changes |
|------|---------|
| `cli.py` | Title "Dangerous Command" → "危险命令", all 5 choice labels localized |
| `ui-tui/src/components/prompts.tsx` | TUI mode labels, title, and shortcut hint localized |
| `acp_adapter/permissions.py` | ACP permission option names localized |
| `tests/cli/test_cli_approval_ui.py` | Test assertions updated to match new Chinese text |

## Testing

All 11 approval UI tests pass:
```
11 passed in 0.77s
```