### PR TITLE
fix(pty_bridge): drop SIGHUP and lengthen SIGTERM grace to avoid racing the TUI gateway shutdown handler

### DIFF
--- a/hermes_cli/pty_bridge.py
+++ b/hermes_cli/pty_bridge.py
@@ -202,25 +202,74 @@ class PtyBridge:
     # -- teardown ---------------------------------------------------------
 
     def close(self) -> None:
-        """Terminate the child (SIGTERM → 0.5s grace → SIGKILL) and close fds.
+        """Terminate the child (SIGTERM → grace → SIGKILL) and close fds.
 
         Idempotent.  Reaping the child is important so we don't leak
         zombies across the lifetime of the dashboard process.
+
+        Signal escalation rationale (2026-05-24):
+
+        Old sequence ``SIGHUP → SIGTERM → SIGKILL`` with 0.5s per stage
+        races the TUI gateway's own shutdown handler. Reproduction:
+        opening a second dashboard tab while the first is mid-vision
+        triggers the first tab's WebSocketDisconnect → ``bridge.close()``,
+        which fires SIGHUP and SIGTERM in the same second. The
+        ``hermes --tui`` Node process and its spawned ``tui_gateway.entry``
+        Python child (parent=Node) both end up in
+        ``tui_gateway_crash.log`` recording two signals at the same
+        timestamp because the 0.5s grace is shorter than the cascade
+        of node death → child SIGHUP from parent death → Python signal
+        handler atexit drain.
+
+        ``tui_gateway/entry.py``'s signal handler installs a ~1s daemon
+        timer (``_DEFAULT_SHUTDOWN_GRACE_S = 1.0``, configurable via
+        ``HERMES_TUI_GATEWAY_SHUTDOWN_GRACE_S``) for atexit before
+        falling back to ``os._exit(0)``. 0.5s per stage is shorter
+        than that grace, so the cascade hits the child mid-cleanup.
+
+        New sequence: send SIGTERM once and give the child enough time
+        for its own graceful shutdown before escalating to SIGKILL.
+        SIGHUP is dropped — closing the master fd in
+        ``self._proc.close(force=True)`` already delivers EOF on stdin,
+        which is the kernel-level signal that the controlling terminal
+        is gone. Adding SIGHUP on top duplicates the signal and races
+        the gateway's shutdown handler.
+
+        Grace is tunable via ``HERMES_PTY_BRIDGE_TERM_GRACE_S`` for
+        callers that need faster teardown (tests) or slower (heavy
+        gateway state with cron jobs / long-running tools mid-flight).
         """
         if self._closed:
             return
         self._closed = True
 
-        # SIGHUP is the conventional "your terminal went away" signal.
-        # We escalate if the child ignores it.
-        for sig in (signal.SIGHUP, signal.SIGTERM, signal.SIGKILL):  # windows-footgun: ok — POSIX-only module (imports fcntl/termios/ptyprocess at top)
+        # Default to 2.0s — enough for the TUI gateway's 1s atexit
+        # window plus IPC/socket cleanup, while still being snappy for
+        # interactive tab-close. Override for tests via
+        # HERMES_PTY_BRIDGE_TERM_GRACE_S=<float>.
+        try:
+            term_grace_s = float(
+                os.environ.get("HERMES_PTY_BRIDGE_TERM_GRACE_S", "2.0")
+            )
+        except (TypeError, ValueError):
+            term_grace_s = 2.0
+        if term_grace_s <= 0:
+            term_grace_s = 2.0
+
+        # SIGTERM with grace, then SIGKILL.  windows-footgun: ok — POSIX-only
+        # module (imports fcntl/termios/ptyprocess at top, _PTY_AVAILABLE
+        # gates Windows out).
+        for sig, deadline_s in (
+            (signal.SIGTERM, term_grace_s),
+            (signal.SIGKILL, 0.5),
+        ):
             if not self._proc.isalive():
                 break
             try:
                 self._proc.kill(sig)
             except Exception:
                 pass
-            deadline = time.monotonic() + 0.5
+            deadline = time.monotonic() + deadline_s
             while self._proc.isalive() and time.monotonic() < deadline:
                 time.sleep(0.02)
 

--- a/tests/hermes_cli/test_pty_bridge.py
+++ b/tests/hermes_cli/test_pty_bridge.py
@@ -145,6 +145,112 @@ class TestPtyBridgeClose:
                 break
         assert reaped, f"pid {pid} still running after close()"
 
+    def test_close_does_not_send_sighup(self, monkeypatch):
+        """Regression: ``close()`` used to fire SIGHUP → SIGTERM → SIGKILL
+        with 0.5s per stage. The first two signals landed on the child
+        within the same second, racing the TUI gateway's own
+        ``_log_signal`` shutdown handler (`tui_gateway/entry.py`) which
+        installs a 1s daemon timer for atexit drain.
+
+        Reproduction (real-world, captured 2026-05-24):
+        Opening a second ``hermes dashboard --tui`` browser tab while
+        the first is mid-vision triggers the first tab's
+        ``WebSocketDisconnect`` → ``bridge.close()``. The 0.5s-per-stage
+        cascade resulted in ``tui_gateway_crash.log`` recording both
+        SIGHUP and SIGTERM at the same timestamp.
+
+        Fix: drop SIGHUP entirely. Closing the master fd in
+        ``self._proc.close(force=True)`` already delivers EOF on the
+        child's stdin, which is the kernel's way of signalling the
+        controlling terminal is gone — sending SIGHUP on top duplicates
+        the signal and races the child's own shutdown handler.
+        """
+        # Set a very short grace so the test runs fast; SIGHUP behavior
+        # is independent of grace duration.
+        monkeypatch.setenv("HERMES_PTY_BRIDGE_TERM_GRACE_S", "0.2")
+
+        # Use a tempfile marker the child writes if it receives SIGHUP.
+        import tempfile
+        marker = tempfile.NamedTemporaryFile(
+            prefix="pty_bridge_sighup_", suffix=".marker", delete=False
+        )
+        marker.close()
+        os.unlink(marker.name)  # we want the SIGHUP handler to create it
+
+        # Child: trap SIGHUP and write the marker. Trap SIGTERM and exit
+        # cleanly. If close() sends SIGHUP first (old behavior), the
+        # marker will be created. If close() sends only SIGTERM (new
+        # behavior), the marker won't exist.
+        bridge = PtyBridge.spawn([
+            "/bin/sh", "-c",
+            f"trap 'echo HUP > {marker.name}; exit 0' HUP; "
+            "trap 'exit 0' TERM; "
+            "while true; do sleep 0.05; done",
+        ])
+        time.sleep(0.2)  # let trap install
+        bridge.close()
+        time.sleep(0.3)  # give the SIGHUP handler time to create marker
+
+        try:
+            assert not os.path.exists(marker.name), (
+                "SIGHUP marker was created — close() still sends SIGHUP "
+                "(should be SIGTERM only, with master-fd-close as the "
+                "controlling-terminal-gone signal)"
+            )
+        finally:
+            try:
+                os.unlink(marker.name)
+            except FileNotFoundError:
+                pass
+
+    def test_close_grace_lets_child_finish_atexit(self, monkeypatch):
+        """SIGTERM grace must let the child run a small graceful shutdown
+        before SIGKILL. Default grace is 2.0s in production; tunable for
+        tests via HERMES_PTY_BRIDGE_TERM_GRACE_S.
+
+        Verifies a child trapping SIGTERM and exiting cleanly inside the
+        grace window is reaped naturally — not killed by SIGKILL.
+        """
+        monkeypatch.setenv("HERMES_PTY_BRIDGE_TERM_GRACE_S", "1.0")
+
+        # Child traps SIGTERM, prints a marker, exits 0 after 0.2s —
+        # well inside 1.0s grace. If close() incorrectly delivers SIGKILL
+        # before the grace expires, the trap output would never reach
+        # stdout (SIGKILL is uncatchable).
+        bridge = PtyBridge.spawn([
+            "/bin/sh", "-c",
+            "trap 'echo TERM_TRAPPED; sleep 0.2; exit 0' TERM; "
+            "while true; do sleep 0.05; done",
+        ])
+        time.sleep(0.2)  # let trap install
+        pid = bridge.pid
+
+        before_close = time.monotonic()
+        bridge.close()
+        elapsed = time.monotonic() - before_close
+
+        # The child should have exited via SIGTERM trap in < 1.0s
+        # (0.2s sleep + ~0.05s overhead). If we ran the full grace +
+        # SIGKILL stage, elapsed would be > 1.0s. Allow generous slack
+        # for slow CI: < 1.5s confirms SIGKILL never fired.
+        assert elapsed < 1.5, (
+            f"close() took {elapsed:.2f}s — SIGKILL likely fired before "
+            f"SIGTERM grace expired. Expected child to exit via SIGTERM "
+            f"trap in ~0.25s."
+        )
+
+        # Confirm reaped.
+        deadline = time.monotonic() + 1.0
+        reaped = False
+        while time.monotonic() < deadline:
+            try:
+                os.kill(pid, 0)
+                time.sleep(0.02)
+            except ProcessLookupError:
+                reaped = True
+                break
+        assert reaped, f"pid {pid} still running after close()"
+
 
 @skip_on_windows
 class TestPtyBridgeEnv:


### PR DESCRIPTION
## What this fixes

`PtyBridge.close()` (used by the dashboard `/api/pty` WebSocket bridge) sent
`SIGHUP → SIGTERM → SIGKILL` with 0.5s per stage. The 0.5s grace is shorter
than the TUI gateway's own atexit window (`tui_gateway/entry.py` installs a
daemon timer with `_DEFAULT_SHUTDOWN_GRACE_S = 1.0` before falling back to
`os._exit(0)`), so the cascade hits the gateway child mid-cleanup.

This resurfaces as the symptom in #27282 (`gateway exits mid-turn …`) and
#14036 (byterover variant): the gateway child records two signals in
`tui_gateway_crash.log` at the same timestamp and the user sees a "gateway
exited" banner mid-turn.

## Reproduction (real-world, captured 2026-05-24 on Linux WSL2)

1. Run `hermes dashboard --tui`, open the embedded chat in browser tab A.
2. Issue a tool call that holds the gateway busy for 30+ seconds (vision
   analysis routed through a queued main provider works reliably here —
   easy to reproduce with `browser_vision` against a busy upstream model
   where another concurrent turn is using the same provider).
3. Open a second tab B pointing at the same dashboard URL.
4. Tab A's WebSocket disconnects → `pty_ws` finally clause fires
   `bridge.close()` → cascade hits the gateway mid-vision.

`tui_gateway_crash.log` records:

```
=== SIGHUP received · 2026-05-24 06:06:22 ===
main-thread stack:
  File "tui_gateway/entry.py", line 227, in main
    for raw in sys.stdin:

=== SIGTERM received · 2026-05-24 06:06:22 ===
main-thread stack:
  File "tui_gateway/entry.py", line 227, in main
    for raw in sys.stdin:
```

Same timestamp because the 0.5s grace is shorter than the gateway's
own 1s atexit window.

## Root cause

Two interacting bugs in `PtyBridge.close()`:

1. **SIGHUP is redundant.** Closing the master fd in
   `self._proc.close(force=True)` already delivers EOF on the child's
   stdin — that's the kernel-level signal that the controlling terminal
   is gone. Sending `SIGHUP` on top duplicates the signal and races the
   child's own `_log_signal` shutdown handler.
2. **0.5s grace per stage is too short.** The TUI gateway's signal
   handler needs ~1s for atexit drain (`tui_gateway/entry.py:51`), so
   the next `SIGTERM` lands while the gateway is still trying to finish
   its previous shutdown. Then `SIGKILL` arrives 0.5s later, before the
   gateway has had time to flush.

## Fix

- Drop `SIGHUP` from the escalation. Closing the master fd is enough.
- Send `SIGTERM` with a 2.0s default grace (covers the 1s atexit window
  + IPC/socket cleanup), tunable via `HERMES_PTY_BRIDGE_TERM_GRACE_S`.
- Keep `SIGKILL` as the last-resort 0.5s safety net.

This aligns the teardown sequence with the timing PR #17118 already
established for the gateway side ("1s daemon timer for atexit before
`os._exit(0)` fallback").

## Test plan

- New regression test
  `TestPtyBridgeClose::test_close_does_not_send_sighup` — child traps
  SIGHUP and writes a marker file; assert marker is never created.
- New regression test
  `TestPtyBridgeClose::test_close_grace_lets_child_finish_atexit` — child
  traps SIGTERM and exits in 0.2s; assert `close()` completes in <1.5s
  (proves we exited via the TERM trap, not the SIGKILL stage).
- Existing tests: `test_close_is_idempotent`,
  `test_close_terminates_long_running_child` still pass unchanged.
- Full suite: `tests/hermes_cli/ tests/tui_gateway/` 5164 passed,
  3 skipped, 0 new failures (2 pre-existing fails on `test_setup_irc` and
  `test_update_hangup_protection` reproduce on unmodified main).

## Related issues / PRs

- #27282 — same symptom on macOS (`gateway exit · stdin EOF`); I added a
  Linux WSL2 reproduction comment with this same diagnosis
- #14036 — byterover variant of the same root cause
- #17118 (merged) — gateway-side hardening with 1s atexit window; this
  PR aligns the bridge-side timing
- #30114 (open) — UI-side automatic transport restart fallback;
  complementary

## Caveats / disclosures

- **AI-assisted.** This patch was diagnosed and drafted with AI
  assistance, then locally reviewed and verified end-to-end (read the
  source paths, traced the signal flow, confirmed the gateway's atexit
  timer constant, ran the new tests + full suite).
- **Untested platforms**: macOS (I don't have one). The change is
  POSIX-generic — no Linux-specific syscalls — but happy to wait on a
  macOS-side check if a maintainer can verify.
- **What this does NOT fix**:
  - Vision tool blocking on a queued main provider (upstream concurrency
    limit, not a hermes-agent issue) — this PR only prevents the
    cascade-induced crash.
  - The dashboard UI doesn't show a clear error when the bridge dies —
    that's #30114's territory.
