### PR TITLE
fix(chat): sanitize empty assistant content before requests

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -166,6 +166,16 @@ class ChatCompletionsTransport(ProviderTransport):
                     if isinstance(tc, dict):
                         tc.pop("call_id", None)
                         tc.pop("response_item_id", None)
+        # Strict providers like Anthropic/Bedrock reject assistant messages with empty content.
+        for msg in sanitized:
+            if not isinstance(msg, dict):
+                continue
+            if msg.get("role") == "assistant":
+                c = msg.get("content")
+                if c is None or (isinstance(c, str) and not c.strip()):
+                    msg["content"] = "(tool call)" if msg.get("tool_calls") else "(empty)"
+                elif isinstance(c, list) and len(c) == 0:
+                    msg["content"] = "(tool call)" if msg.get("tool_calls") else "(empty)"
         return sanitized
 
     def convert_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary

Sanitize assistant messages with empty content before sending Chat Completions requests.

Strict Anthropic-compatible providers such as AWS Bedrock Anthropic reject assistant messages with empty content.

During tool / skill execution, Hermes can produce:

```json
{
  "role": "assistant",
  "content": ""
}
```

This causes HTTP 400:

```
messages: text content blocks must be non-empty
```

## Fix

Normalize empty assistant content before sending requests.
