### PR TITLE
fix(telegram): preserve observed group slash commands

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -4631,6 +4631,12 @@ class TelegramAdapter(BasePlatformAdapter):
         shared_source = self._telegram_group_observe_shared_source(event.source)
         observe_prompt = self._telegram_group_observe_channel_prompt()
         channel_prompt = f"{event.channel_prompt}\n\n{observe_prompt}" if event.channel_prompt else observe_prompt
+        if event.message_type == MessageType.COMMAND:
+            return dataclasses.replace(
+                event,
+                source=shared_source,
+                channel_prompt=channel_prompt,
+            )
         return dataclasses.replace(
             event,
             text=self._telegram_group_observe_attributed_text(event),

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -85,6 +85,7 @@ AUTHOR_MAP = {
     "yanglongwei06@gmail.com": "Alex-yang00",
     "teknium@nousresearch.com": "teknium1",
     "markuscontasul@gmail.com": "Glucksberg",
+    "80581902+Glucksberg@users.noreply.github.com": "Glucksberg",
     "piyushvp1@gmail.com": "thelumiereguy",
     "dskwelmcy@163.com": "dskwe",
     "421774554@qq.com": "wuli666",

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -313,6 +313,40 @@ def test_observed_group_context_replays_normally_without_telegram_prompt():
     assert agent_history == [{"role": "user", "content": "[Alice|111]\nside chatter"}]
 
 
+def test_observed_group_context_preserves_slash_command_text_for_dispatch():
+    from gateway.platforms.base import MessageEvent, MessageType, Platform, SessionSource
+
+    adapter = _make_adapter(
+        require_mention=True,
+        allowed_chats=["-100"],
+        group_allowed_chats=["-100"],
+        observe_unmentioned_group_messages=True,
+    )
+    event = MessageEvent(
+        text="/new@hermes_bot",
+        message_type=MessageType.COMMAND,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-100",
+            user_id="111",
+            user_name="Alice",
+            chat_type="group",
+            thread_id="7",
+        ),
+        raw_message=_group_message(
+            "/new@hermes_bot",
+            entities=[_bot_command_entity("/new@hermes_bot", "/new@hermes_bot")],
+        ),
+    )
+
+    attributed = adapter._apply_telegram_group_observe_attribution(event)
+
+    assert attributed.text == "/new@hermes_bot"
+    assert attributed.get_command() == "new"
+    assert attributed.source.user_id is None
+    assert "observed Telegram group context" in attributed.channel_prompt
+
+
 def test_unmentioned_group_observe_requires_chat_allowlist_for_shared_context():
     async def _run():
         adapter = _make_adapter(


### PR DESCRIPTION
Salvage of #31090 onto current main. Authorship preserved.

## Summary
Telegram observed-group attribution skips text-rewriting for `MessageType.COMMAND` events while still applying shared-source + observe channel prompt. Fixes regression from #30798 where addressed slash commands like `/new@bot` got prefixed with the speaker attribution (`[Alice|111]\n/new@bot`), bypassing the gateway dispatcher and falling through to the agent — blocking `/new`, `/stop`, etc. for users with `require_mention=true` + `observe_unmentioned_group_messages=true`.

## Verification
- Bug repros on current main: regression test fails with `'[Alice|111]\n/new@hermes_bot' == '/new@hermes_bot'`
- With fix: 40/40 in `tests/gateway/test_telegram_group_gating.py` pass

## Credit
Original PR by @Glucksberg (#31090) — same contributor who shipped #29653 and #30798 and is owning the regression with a clean focused fix + coverage.

## Infographic

![pr-31178-telegram-observed-command-dispatch](https://v3b.fal.media/files/b/0a9b6bfb/xCVo-x6FH69PYa0KkQ3Yk_JqPQ8C9M.png)
