### PR TITLE
chore: bump patch release versions

### DIFF
--- a/acp_registry/agent.json
+++ b/acp_registry/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "hermes-agent",
   "name": "Hermes Agent",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Self-improving open-source AI agent by Nous Research with ACP editor integration, persistent memory, skills, and rich tool support.",
   "repository": "https://github.com/NousResearch/hermes-agent",
   "website": "https://hermes-agent.nousresearch.com/docs/user-guide/features/acp",
@@ -9,7 +9,7 @@
   "license": "MIT",
   "distribution": {
     "uvx": {
-      "package": "hermes-agent[acp]==0.14.0",
+      "package": "hermes-agent[acp]==0.14.1",
       "args": ["hermes-acp"]
     }
   }

--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -14,8 +14,8 @@ Provides subcommands for:
 import os
 import sys
 
-__version__ = "0.14.0"
-__release_date__ = "2026.5.16"
+__version__ = "0.14.1"
+__release_date__ = "2026.5.23"
 
 
 def _ensure_utf8():

--- a/plugins/platforms/ntfy/plugin.yaml
+++ b/plugins/platforms/ntfy/plugin.yaml
@@ -1,7 +1,7 @@
 name: ntfy-platform
 label: ntfy
 kind: platform
-version: 1.0.0
+version: 1.0.1
 description: >
   ntfy push-notification gateway adapter for Hermes Agent.
   Subscribes to a topic on ntfy.sh or any self-hosted ntfy server via

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-agent"
-version = "0.14.0"
+version = "0.14.1"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1589,7 +1589,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.14.0"
+version = "0.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Summary
- Bump Hermes Agent package patch version from 0.14.0 to 0.14.1
- Refresh release date to 2026.5.23
- Keep ACP registry and uv lock metadata in sync with the package version
- Bump the ntfy platform plugin patch version from 1.0.0 to 1.0.1

## Test Plan
- `python -m pytest tests/scripts/test_release_acp_registry.py tests/gateway/test_ntfy_plugin.py -q`
