### PR TITLE
fix(security): enable guard_agent_created by default

### DIFF
--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -59,9 +59,7 @@ except ImportError:
 def _guard_agent_created_enabled() -> bool:
     """Read skills.guard_agent_created from config (default False).
 
-    Off by default because the agent can already execute the same code
-    paths via terminal() with no gate, so the scan adds friction without
-    meaningful security.  Users who want belt-and-suspenders can turn it
+    Enabled by default so agent-created skills are scanned for threats.  Users who want belt-and-suspenders can turn it
     on via `hermes config set skills.guard_agent_created true`.
     """
     try:
@@ -69,7 +67,7 @@ def _guard_agent_created_enabled() -> bool:
         cfg = load_config()
         return is_truthy_value(
             cfg_get(cfg, "skills", "guard_agent_created"),
-            default=False,
+            default=True,
         )
     except Exception:
         return False


### PR DESCRIPTION
Changes `skills.guard_agent_created` default from `False` to `True`.

Agent-created skills loaded into the system prompt without scanning can include prompt injection payloads affecting agent behavior even without calling `terminal()`. The original rationale that "agent can execute same code via terminal()" misses that system prompt injection is a different class of threat.