### PR TITLE
fix(security): change tirith_fail_open default to False

### DIFF
--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -71,7 +71,7 @@ def _load_security_config() -> dict:
         "tirith_enabled": True,
         "tirith_path": "tirith",
         "tirith_timeout": 5,
-        "tirith_fail_open": True,
+        "tirith_fail_open": False,
     }
     try:
         from hermes_cli.config import load_config


### PR DESCRIPTION
fix(security): change tirith_fail_open default to False

When the tirith security scanner is missing or times out, the current True
default silently allows all content through. Installations without tirith
have no security scanning for 24+ hours until the next install attempt.