### PR TITLE
fix(security): move HERMES_CRON_SESSION from os.environ to contextvars

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1332,11 +1332,10 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
     # Mark this as a cron session so the approval system can apply cron_mode.
     # This env var is process-wide and persists for the lifetime of the
     # scheduler process — every job this process runs is a cron job.
-    os.environ["HERMES_CRON_SESSION"] = "1"
-
     # Use ContextVars for per-job session/delivery state so parallel jobs
     # don't clobber each other's targets (os.environ is process-global).
     from gateway.session_context import set_session_vars, clear_session_vars, _VAR_MAP
+    set_session_vars({"HERMES_CRON_SESSION": "1"})
 
     # Cron execution is an internal scheduler context, not a live inbound
     # gateway message. Do not seed HERMES_SESSION_* contextvars from the


### PR DESCRIPTION
fix(security): move HERMES_CRON_SESSION from os.environ to contextvars

os.environ["HERMES_CRON_SESSION"] is process-global and persists for the
scheduler lifetime, polluting interactive gateway sessions and potentially
silently downgrading approval security.

Uses the existing contextvar pattern at scheduler.py:1362 for per-job state.