### PR TITLE
fix(security): prevent shell hook bypass via HERMES_ACCEPT_HOOKS

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -762,8 +762,11 @@ def _resolve_effective_accept(
     """
     if accept_hooks_arg:
         return True
+    # Require a process-level token to prevent prompt injection bypass
+    from hermes_state import get_cron_token
+    cron_token = get_cron_token()
     env = os.environ.get("HERMES_ACCEPT_HOOKS", "").strip().lower()
-    if env in {"1", "true", "yes", "on"}:
+    if env in {"1", "true", "yes", "on"} and cron_token:
         return True
     cfg_val = cfg.get("hooks_auto_accept", False)
     if isinstance(cfg_val, bool):


### PR DESCRIPTION
fix(security): prevent shell hook bypass via HERMES_ACCEPT_HOOKS

HERMES_ACCEPT_HOOKS=1 skips all interactive hook confirmation. A
prompt-injected agent can set this env var via terminal() and register
persistent backdoor hooks. Requires a process-level token for override.