### PR TITLE
fix(security): remove HERMES_ security control vars from subprocess env

### DIFF
--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -78,8 +78,7 @@ MAX_STDERR_BYTES = 10_000    # 10 KB
 # match either a safe prefix or, on Windows, an OS-essential name.
 _SAFE_ENV_PREFIXES = ("PATH", "HOME", "USER", "LANG", "LC_", "TERM",
                       "TMPDIR", "TMP", "TEMP", "SHELL", "LOGNAME",
-                      "XDG_", "PYTHONPATH", "VIRTUAL_ENV", "CONDA",
-                      "HERMES_")
+                      "XDG_", "PYTHONPATH", "VIRTUAL_ENV", "CONDA")
 _SECRET_SUBSTRINGS = ("KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIAL",
                       "PASSWD", "AUTH")
 


### PR DESCRIPTION
fix(security): remove HERMES_ security control vars from subprocess env

_SAFE_ENV_PREFIXES included HERMES_ which leaks HERMES_YOLO_MODE,
HERMES_ACCEPT_HOOKS, and HERMES_CRON_SESSION to subprocesses, allowing
children to discover the agent security posture and potentially escalate.