### PR TITLE
fix(security): sanitize command input in approval LLM prompt

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -875,10 +875,14 @@ def _smart_approve(command: str, description: str) -> str:
     try:
         from agent.auxiliary_client import call_llm
 
+        # Sanitize: truncate to 200 chars, strip newlines to prevent prompt injection
+        _safe_cmd = command[:200].replace("\n", " ").replace("\r", " ")
+        _safe_desc = description[:200].replace("\n", " ").replace("\r", " ")
+
         prompt = f"""You are a security reviewer for an AI coding agent. A terminal command was flagged by pattern matching as potentially dangerous.
 
-Command: {command}
-Flagged reason: {description}
+Command: {_safe_cmd}
+Flagged reason: {_safe_desc}
 
 Assess the ACTUAL risk of this command. Many flagged commands are false positives — for example, `python -c "print('hello')"` is flagged as "script execution via -c flag" but is completely harmless.
 


### PR DESCRIPTION
Command string directly interpolated into approval prompt (line 880) allows prompt injection. Fix truncates to 200 chars and strips newlines.