### PR TITLE
fix: expose context engine tools with saved toolsets

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -67,6 +67,7 @@ CONFIGURABLE_TOOLSETS = [
     ("skills",          "📚 Skills",                    "list, view, manage"),
     ("todo",            "📋 Task Planning",             "todo"),
     ("memory",          "💾 Memory",                    "persistent memory across sessions"),
+    ("context_engine",  "🧩 Context Engine",            "runtime tools from the active context engine"),
     ("session_search",  "🔎 Session Search",            "search past conversations"),
     ("clarify",         "❓ Clarifying Questions",      "clarify"),
     ("delegation",      "👥 Task Delegation",           "delegate_task"),
@@ -1293,6 +1294,24 @@ def _get_platform_tools(
                 # New plugin not yet seen by hermes tools — default enabled
                 enabled_toolsets.add(pts)
             # else: known but not in config = user disabled it
+
+    # Context-engine tools are runtime-provided by the active engine, so they
+    # are not part of any static platform composite. When a non-default engine
+    # is selected, keep its recovery/status tools available even after a user
+    # saves an explicit platform toolset list. Preserve the explicit empty-list
+    # contract: selecting no configurable tools means no context-engine tools
+    # either unless the user adds ``context_engine`` manually later.
+    context_cfg = config.get("context") or {}
+    if not isinstance(context_cfg, dict):
+        context_cfg = {}
+    context_engine_name = str(context_cfg.get("engine") or "compressor").strip().lower()
+    explicit_empty_selection = (
+        platform in platform_toolsets
+        and isinstance(platform_toolsets.get(platform), list)
+        and not toolset_names
+    )
+    if context_engine_name and context_engine_name != "compressor" and not explicit_empty_selection:
+        enabled_toolsets.add("context_engine")
 
     # Preserve any explicit non-configurable toolset entries (for example,
     # custom toolsets or MCP server names saved in platform_toolsets).

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -79,6 +79,46 @@ def test_get_platform_tools_uses_default_when_platform_not_configured():
 def test_configurable_toolsets_include_messaging():
     assert any(ts_key == "messaging" for ts_key, _, _ in CONFIGURABLE_TOOLSETS)
 
+
+def test_configurable_toolsets_include_context_engine():
+    assert any(ts_key == "context_engine" for ts_key, _, _ in CONFIGURABLE_TOOLSETS)
+
+
+def test_get_platform_tools_active_context_engine_is_enabled_for_explicit_config():
+    config = {
+        "context": {"engine": "lcm"},
+        "platform_toolsets": {"cli": ["web", "terminal"]},
+    }
+
+    enabled = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+
+    assert "context_engine" in enabled
+    assert "web" in enabled
+    assert "terminal" in enabled
+
+
+def test_get_platform_tools_context_engine_not_added_for_default_compressor():
+    config = {
+        "context": {"engine": "compressor"},
+        "platform_toolsets": {"cli": ["web", "terminal"]},
+    }
+
+    enabled = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+
+    assert "context_engine" not in enabled
+
+
+def test_get_platform_tools_context_engine_respects_explicit_empty_selection():
+    config = {
+        "context": {"engine": "lcm"},
+        "platform_toolsets": {"cli": []},
+    }
+
+    enabled = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+
+    assert "context_engine" not in enabled
+
+
 def test_get_platform_tools_default_telegram_includes_messaging():
     enabled = _get_platform_tools({}, "telegram")
 

--- a/tests/run_agent/test_plugin_context_engine_init.py
+++ b/tests/run_agent/test_plugin_context_engine_init.py
@@ -26,6 +26,17 @@ class _StubEngine(ContextEngine):
         return messages
 
 
+class _ToolEngine(_StubEngine):
+    def get_tool_schemas(self):
+        return [
+            {
+                "name": "stub_recover",
+                "description": "Recover context from the stub engine.",
+                "parameters": {"type": "object", "properties": {}},
+            }
+        ]
+
+
 def test_plugin_engine_gets_context_length_on_init():
     """Plugin context engine should have context_length set during AIAgent init."""
     engine = _StubEngine()
@@ -54,6 +65,46 @@ def test_plugin_engine_gets_context_length_on_init():
     assert agent.context_compressor is engine
     assert engine.context_length == 204_800
     assert engine.threshold_tokens == int(204_800 * engine.threshold_percent)
+
+
+def test_active_context_engine_tools_survive_explicit_platform_toolsets():
+    """LCM-style recovery tools must survive saved `hermes tools` lists."""
+    engine = _ToolEngine()
+    cfg = {
+        "context": {"engine": "stub"},
+        "platform_toolsets": {"cli": ["web", "terminal"]},
+        "agent": {},
+    }
+
+    from hermes_cli.tools_config import _get_platform_tools
+
+    enabled_toolsets = _get_platform_tools(cfg, "cli", include_default_mcp_servers=False)
+    assert "context_engine" in enabled_toolsets
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.context_engine.load_context_engine", return_value=engine),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            enabled_toolsets=sorted(enabled_toolsets),
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert "stub_recover" in getattr(agent, "valid_tool_names", set())
+    assert "stub_recover" in {
+        tool.get("function", {}).get("name")
+        for tool in getattr(agent, "tools", [])
+    }
 
 
 def test_plugin_engine_update_model_args():

--- a/toolsets.py
+++ b/toolsets.py
@@ -205,6 +205,12 @@ TOOLSETS = {
         "tools": ["memory"],
         "includes": []
     },
+
+    "context_engine": {
+        "description": "Runtime tools exposed by the active context engine",
+        "tools": [],
+        "includes": []
+    },
     
     "session_search": {
         "description": "Search and recall past conversations with summarization",


### PR DESCRIPTION
## What does this PR do?

Fixes context-engine tool exposure when a platform has a saved toolset list from `hermes tools`.

Context engines such as `hermes-lcm` expose runtime tools through `get_tool_schemas()`, but `AIAgent` only injects those schemas when the `context_engine` toolset is enabled. Saved platform lists like `web`, `terminal`, etc. did not include that toolset, so active LCM sessions could run with `context.engine: lcm` while the model never saw the `lcm_*` tools.

This adds a first-class `context_engine` toolset and auto-enables it when a non-default context engine is configured, while preserving the explicit empty-selection behavior.

## Related Issue

Related: stephenschoettler/hermes-lcm#200

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `toolsets.py`
  - Adds a static `context_engine` toolset entry for runtime-provided context-engine tools.
- `hermes_cli/tools_config.py`
  - Adds `context_engine` to the configurable toolset list.
  - Auto-enables `context_engine` for non-default `context.engine` values, unless the platform selection is explicitly empty.
- `tests/hermes_cli/test_tools_config.py`
  - Adds regressions for context-engine toolset visibility with explicit platform toolsets, default compressor behavior, and explicit empty selection.
- `tests/run_agent/test_plugin_context_engine_init.py`
  - Adds an end-to-end regression proving a plugin context engine's tool schema reaches `AIAgent.valid_tool_names` after platform tool resolution.

## How to Test

1. Run focused validation:
   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_tools_config.py tests/run_agent/test_plugin_context_engine_init.py tests/test_model_tools.py tests/test_get_tool_definitions_cache_isolation.py -- -q --tb=short
   ```
   Result:
   ```text
   114 tests passed, 0 failed
   ```

2. Run static checks:
   ```bash
   uvx ruff check .
   python scripts/check-windows-footguns.py --all
   ```
   Result:
   ```text
   All checks passed!
   ✓ No Windows footguns found (502 file(s) scanned).
   ```

3. Broader local validation:
   ```bash
   scripts/run_tests.sh -- -q --tb=short
   ```
   Result:
   ```text
   25,165 tests passed, 4 failed
   ```
   The failures were in unrelated model-picker tests that hit this machine's live local Ollama `/models` endpoint and returned installed local models instead of the test fixture models:
   - `tests/hermes_cli/test_list_picker_providers.py::test_current_custom_endpoint_passthrough_marks_current_row`
   - `tests/hermes_cli/test_model_switch_custom_providers.py::test_list_authenticated_providers_groups_same_endpoint`
   - `tests/hermes_cli/test_model_switch_custom_providers.py::test_list_authenticated_providers_distinct_endpoints_stay_separate`
   - `tests/hermes_cli/test_model_switch_custom_providers.py::test_list_authenticated_providers_total_models_reflects_grouped_count`

4. Manual exercise of changed path:
   ```text
   Covered by the new AIAgent regression: `_get_platform_tools()` resolves `context_engine` for an active non-default engine, and the engine's `stub_recover` schema appears in `AIAgent.valid_tool_names` and `agent.tools`.
   ```

## Validation Status

- Focused regression tests: passing locally.
- Static checks: passing locally (`ruff`, Windows footguns).
- Broader local suite: run locally, blocked only by 4 unrelated local Ollama/model-picker fixture failures as noted above.
- GitHub PR checks: green on head `6bd2b5b437a3ae11f8ea42f93195000faf7151b1`.
  - Passing: dependency bounds, supply-chain scan, attribution, common ancestor, e2e, ruff/ty, Windows footguns, Nix, Docker builds, and `test (1)` through `test (6)`.
  - Skipped: expected publish/duration jobs (`merge`, `move-latest`, `save-durations`).
- Merge state: `CLEAN` when rechecked after the green rerun.
- Full-suite checklist is intentionally unchecked because local full validation did not finish green for unrelated local provider/fixture failures.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 7.0.5-arch1-1 x86_64, Python 3.14.5

### Documentation and Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A

## For New Skills

N/A.

## Screenshots / Logs

```text
Before: active non-default context engines could expose schemas via get_tool_schemas(), but saved platform toolset lists omitted `context_engine`, so `AIAgent` suppressed those schemas.

After: `_get_platform_tools()` includes `context_engine` for non-default context engines, and the regression confirms the runtime schema reaches `AIAgent.valid_tool_names`.
```
