### PR TITLE
feat: add fal-ai/flux-pro/v1.1 to FAL image generation catalog

### DIFF
--- a/tests/tools/test_image_generation.py
+++ b/tests/tools/test_image_generation.py
@@ -179,6 +179,45 @@ class TestGptImage2Presets:
         assert "seed" not in p
 
 
+class TestFluxProV11Payload:
+    """FLUX Pro v1.1 uses preset enum sizes with jpeg/sync_mode=False/
+    safety_tolerance="6"/enhance_prompt=False defaults."""
+
+    MODEL = "fal-ai/flux-pro/v1.1"
+
+    def test_landscape_uses_preset(self, image_tool):
+        p = image_tool._build_fal_payload(self.MODEL, "hello", "landscape")
+        assert p["image_size"] == "landscape_16_9"
+
+    def test_square_uses_preset(self, image_tool):
+        p = image_tool._build_fal_payload(self.MODEL, "hello", "square")
+        assert p["image_size"] == "square_hd"
+
+    def test_portrait_uses_preset(self, image_tool):
+        p = image_tool._build_fal_payload(self.MODEL, "hello", "portrait")
+        assert p["image_size"] == "portrait_16_9"
+
+    def test_default_output_format_is_jpeg(self, image_tool):
+        p = image_tool._build_fal_payload(self.MODEL, "hello", "square")
+        assert p["output_format"] == "jpeg"
+
+    def test_default_sync_mode_is_false(self, image_tool):
+        p = image_tool._build_fal_payload(self.MODEL, "hello", "square")
+        assert p["sync_mode"] is False
+
+    def test_default_safety_tolerance_is_6(self, image_tool):
+        p = image_tool._build_fal_payload(self.MODEL, "hello", "square")
+        assert p["safety_tolerance"] == "6"
+
+    def test_default_enhance_prompt_is_false(self, image_tool):
+        p = image_tool._build_fal_payload(self.MODEL, "hello", "square")
+        assert p["enhance_prompt"] is False
+
+    def test_num_images_default_is_1(self, image_tool):
+        p = image_tool._build_fal_payload(self.MODEL, "hello", "square")
+        assert p["num_images"] == 1
+
+
 # ---------------------------------------------------------------------------
 # Supports whitelist — the main safety property
 # ---------------------------------------------------------------------------

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -125,6 +125,30 @@ FAL_MODELS: Dict[str, Dict[str, Any]] = {
         },
         "max_reference_images": 9,
     },
+    "fal-ai/flux-pro/v1.1": {
+        "display": "FLUX Pro v1.1",
+        "speed": "~8s",
+        "strengths": "BFL original Flux Pro, studio-grade photorealism",
+        "price": "$0.04/MP",
+        "size_style": "image_size_preset",
+        "sizes": {
+            "landscape": "landscape_16_9",
+            "square": "square_hd",
+            "portrait": "portrait_16_9",
+        },
+        "defaults": {
+            "num_images": 1,
+            "output_format": "jpeg",
+            "sync_mode": False,
+            "safety_tolerance": "6",
+            "enhance_prompt": False,
+        },
+        "supports": {
+            "prompt", "image_size", "num_images", "output_format",
+            "sync_mode", "seed", "safety_tolerance", "enhance_prompt",
+        },
+        "upscale": False,
+    },
     "fal-ai/flux-2-pro": {
         "display": "FLUX 2 Pro",
         "speed": "~6s",

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -398,6 +398,30 @@ FAL_MODELS: Dict[str, Dict[str, Any]] = {
         },
         "max_reference_images": 3,
     },
+    "fal-ai/flux-pro/v1.1": {
+        "display": "FLUX Pro v1.1",
+        "speed": "~8s",
+        "strengths": "Production-ready 1024×1024, all aspect ratios",
+        "price": "$0.04/MP",
+        "size_style": "image_size_preset",
+        "sizes": {
+            "landscape": "landscape_16_9",
+            "square": "square_hd",
+            "portrait": "portrait_16_9",
+        },
+        "defaults": {
+            "num_images": 1,
+            "output_format": "jpeg",
+            "safety_tolerance": "6",
+            "enhance_prompt": False,
+            "sync_mode": False,
+        },
+        "supports": {
+            "prompt", "image_size", "num_images", "output_format",
+            "safety_tolerance", "enhance_prompt", "seed", "sync_mode",
+        },
+        "upscale": False,
+    },
     # Krea 2 on FAL — same model family as ``plugins/image_gen/krea``, but billed
     # through FAL / the FAL managed gateway. Native ``krea-2-*`` ids route to the
     # dedicated Krea plugin instead.

--- a/website/docs/user-guide/features/image-generation.md
+++ b/website/docs/user-guide/features/image-generation.md
@@ -1,13 +1,13 @@
 ---
 title: Image Generation
-description: Generate images via FAL.ai — 11 models including FLUX 2, GPT Image (1.5 & 2), Nano Banana Pro, Ideogram, Recraft V4 Pro, Krea 2, and more, selectable via `hermes tools`.
+description: Generate images via FAL.ai — 12 models including FLUX 2, FLUX Pro v1.1, GPT Image (1.5 & 2), Nano Banana Pro, Ideogram, Recraft V4 Pro, Krea 2, and more, selectable via `hermes tools`.
 sidebar_label: Image Generation
 sidebar_position: 6
 ---
 
 # Image Generation
 
-Hermes Agent generates images from text prompts via FAL.ai. Eleven models are supported out of the box, each with different speed, quality, and cost tradeoffs. The active model is user-configurable via `hermes tools` and persists in `config.yaml`.
+Hermes Agent generates images from text prompts via FAL.ai. Twelve models are supported out of the box, each with different speed, quality, and cost tradeoffs. The active model is user-configurable via `hermes tools` and persists in `config.yaml`.
 
 ## Supported Models
 
@@ -15,6 +15,7 @@ Hermes Agent generates images from text prompts via FAL.ai. Eleven models are su
 |---|---|---|---|
 | `fal-ai/flux-2/klein/9b` *(default)* | `<1s` | Fast, crisp text | $0.006/MP |
 | `fal-ai/flux-2-pro` | ~6s | Studio photorealism | $0.03/MP |
+| `fal-ai/flux-pro/v1.1` | ~8s | Production-ready 1024×1024, all aspect ratios | $0.04/MP |
 | `fal-ai/z-image/turbo` | ~2s | Bilingual EN/CN, 6B params | $0.005/MP |
 | `fal-ai/nano-banana-pro` | ~8s | Gemini 3 Pro, reasoning depth, text rendering | $0.15/image (1K) |
 | `fal-ai/gpt-image-1.5` | ~15s | Prompt adherence | $0.034/image |


### PR DESCRIPTION
## Summary

Adds Black Forest Labs **FLUX Pro v1.1** (fal-ai/flux-pro/v1.1) to the FAL.ai image generation model catalog.

## Changes

- Added new model entry to `FAL_MODELS` in `tools/image_generation_tool.py`
- Parameters match the [official fal.ai API schema](https://fal.ai/models/fal-ai/flux-pro/v1.1):
  - `image_size` (preset enum)
  - `num_images` (1-4)
  - `output_format` (jpeg/png)
  - `safety_tolerance` (1-6)
  - `enhance_prompt` (boolean)
  - `seed` (integer)
  - `sync_mode` (defaults to false → HTTPS URLs for gateway delivery)
- No upscaler chaining (`upscale: false`) — API returns production-ready output
- Price: $0.04/megapixel

## Verification

- Tested with direct API calls against fal.ai — HTTPS URL returned correctly (not base64 data URI)
- Model generates 1024x1024 images in ~8s
- Works across all aspect ratios (square_hd, landscape_16_9, portrait_16_9)