### PR TITLE
fix: preserve shared gh auth in profile subprocesses

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -106,6 +106,12 @@ def _resolve_home_dir() -> str:
 def _build_subprocess_env() -> dict[str, str]:
     env = os.environ.copy()
     env["HOME"] = _resolve_home_dir()
+    try:
+        from hermes_constants import inject_shared_gh_config_dir
+
+        inject_shared_gh_config_dir(env)
+    except Exception:
+        pass
     return env
 
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -882,11 +882,12 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
     run_env = os.environ.copy()
     run_env["HERMES_HOME"] = str(_get_hermes_home())
     try:
-        from hermes_constants import get_subprocess_home
+        from hermes_constants import get_subprocess_home, inject_shared_gh_config_dir
 
         profile_home = get_subprocess_home()
         if profile_home:
             run_env["HOME"] = profile_home
+        inject_shared_gh_config_dir(run_env)
     except Exception:
         pass
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5311,6 +5311,12 @@ def _default_spawn(
         # This only happens in test fixtures where the isolated
         # HERMES_HOME never had profiles created.
         pass
+    try:
+        from hermes_constants import inject_shared_gh_config_dir
+
+        inject_shared_gh_config_dir(env)
+    except Exception:
+        pass
     if task.tenant:
         env["HERMES_TENANT"] = task.tenant
     env["HERMES_KANBAN_TASK"] = task.id

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -5,6 +5,7 @@ without risk of circular imports.
 """
 
 import os
+import pwd
 import sysconfig
 from contextvars import ContextVar, Token
 from pathlib import Path
@@ -279,6 +280,48 @@ def get_subprocess_home() -> str | None:
     if os.path.isdir(profile_home):
         return profile_home
     return None
+
+
+def get_shared_gh_config_dir() -> str | None:
+    """Return the non-profile-isolated GitHub CLI config dir, if discoverable.
+
+    Hermes profile subprocesses intentionally rewrite ``HOME`` to
+    ``{HERMES_HOME}/home`` so git/ssh/npm configs remain profile-scoped.
+    GitHub CLI auth is a special case: users often authenticate once in their
+    real OS account, and profile HOME isolation would otherwise hide
+    ``~/.config/gh`` from `gh auth status`, `gh pr view`, and related worker
+    subprocesses. This helper resolves the shared gh config directory from:
+
+    1. ``XDG_CONFIG_HOME/gh`` when present
+    2. the real passwd home ``~/.config/gh`` as a POSIX fallback
+
+    Returns ``None`` when no plausible directory exists on disk.
+    """
+    xdg_config_home = os.environ.get("XDG_CONFIG_HOME", "").strip()
+    if xdg_config_home:
+        gh_dir = Path(xdg_config_home) / "gh"
+        if gh_dir.is_dir():
+            return str(gh_dir)
+
+    try:
+        real_home = pwd.getpwuid(os.getuid()).pw_dir.strip()
+    except Exception:
+        real_home = ""
+    if real_home:
+        gh_dir = Path(real_home) / ".config" / "gh"
+        if gh_dir.is_dir():
+            return str(gh_dir)
+
+    return None
+
+
+def inject_shared_gh_config_dir(env: dict[str, str]) -> None:
+    """Set GH_CONFIG_DIR in-place when a shared GitHub CLI config exists."""
+    if env.get("GH_CONFIG_DIR"):
+        return
+    gh_dir = get_shared_gh_config_dir()
+    if gh_dir:
+        env["GH_CONFIG_DIR"] = gh_dir
 
 
 VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh")

--- a/tests/test_subprocess_home_isolation.py
+++ b/tests/test_subprocess_home_isolation.py
@@ -10,6 +10,7 @@ See: https://github.com/NousResearch/hermes-agent/issues/4426
 import os
 import threading
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -74,6 +75,31 @@ class TestGetSubprocessHome:
         assert home_a != home_b
         assert home_a.endswith("alpha/home")
         assert home_b.endswith("beta/home")
+
+
+class TestGetSharedGhConfigDir:
+    """Unit tests for hermes_constants.get_shared_gh_config_dir()."""
+
+    def test_prefers_xdg_config_home_when_present(self, tmp_path, monkeypatch):
+        xdg_root = tmp_path / "xdg"
+        gh_dir = xdg_root / "gh"
+        gh_dir.mkdir(parents=True)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_root))
+
+        from hermes_constants import get_shared_gh_config_dir
+
+        assert get_shared_gh_config_dir() == str(gh_dir)
+
+    def test_falls_back_to_real_user_home_when_xdg_missing(self, tmp_path, monkeypatch):
+        real_home = tmp_path / "real-home"
+        gh_dir = real_home / ".config" / "gh"
+        gh_dir.mkdir(parents=True)
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+        with patch("pwd.getpwuid", return_value=SimpleNamespace(pw_dir=str(real_home))):
+            from hermes_constants import get_shared_gh_config_dir
+
+            assert get_shared_gh_config_dir() == str(gh_dir)
 
     def test_context_override_is_thread_local(self, tmp_path, monkeypatch):
         root = tmp_path / "root"
@@ -179,6 +205,44 @@ class TestMakeRunEnvHomeInjection:
         assert result["HERMES_HOME"] == str(profile)
         assert result["HOME"] == str(profile / "home")
 
+    def test_injects_gh_config_dir_from_xdg_config_home(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "home").mkdir()
+        xdg_root = tmp_path / "xdg"
+        gh_dir = xdg_root / "gh"
+        gh_dir.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HOME", "/root")
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_root))
+
+        from tools.environments.local import _make_run_env
+        result = _make_run_env({})
+
+        assert result["HOME"] == str(hermes_home / "home")
+        assert result["GH_CONFIG_DIR"] == str(gh_dir)
+
+    def test_injects_gh_config_dir_from_real_home_fallback(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "home").mkdir()
+        real_home = tmp_path / "real-home"
+        gh_dir = real_home / ".config" / "gh"
+        gh_dir.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HOME", "/root")
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+        from tools.environments.local import _make_run_env
+
+        with patch("pwd.getpwuid", return_value=SimpleNamespace(pw_dir=str(real_home))):
+            result = _make_run_env({})
+
+        assert result["HOME"] == str(hermes_home / "home")
+        assert result["GH_CONFIG_DIR"] == str(gh_dir)
+
 
 # ---------------------------------------------------------------------------
 # _sanitize_subprocess_env() injection
@@ -230,6 +294,25 @@ class TestSanitizeSubprocessEnvHomeInjection:
 
         assert result["HERMES_HOME"] == str(profile)
         assert result["HOME"] == str(profile / "home")
+
+    def test_injects_gh_config_dir_for_background_processes(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "home").mkdir()
+        real_home = tmp_path / "real-home"
+        gh_dir = real_home / ".config" / "gh"
+        gh_dir.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+        base_env = {"HOME": "/root", "PATH": "/usr/bin", "USER": "root"}
+        from tools.environments.local import _sanitize_subprocess_env
+
+        with patch("pwd.getpwuid", return_value=SimpleNamespace(pw_dir=str(real_home))):
+            result = _sanitize_subprocess_env(base_env)
+
+        assert result["HOME"] == str(hermes_home / "home")
+        assert result["GH_CONFIG_DIR"] == str(gh_dir)
 
 
 # ---------------------------------------------------------------------------

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1215,10 +1215,11 @@ def execute_code(
 
         # Per-profile HOME isolation: redirect system tool configs into
         # {HERMES_HOME}/home/ when that directory exists.
-        from hermes_constants import get_subprocess_home
+        from hermes_constants import get_subprocess_home, inject_shared_gh_config_dir
         _profile_home = get_subprocess_home()
         if _profile_home:
             child_env["HOME"] = _profile_home
+        inject_shared_gh_config_dir(child_env)
 
         # Resolve interpreter + CWD based on execute_code mode.
         #   - strict : today's behavior (sys.executable + tmpdir CWD).

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -208,10 +208,11 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     _inject_context_hermes_home(sanitized)
 
     # Per-profile HOME isolation for background processes (same as _make_run_env).
-    from hermes_constants import get_subprocess_home
+    from hermes_constants import get_subprocess_home, inject_shared_gh_config_dir
     _profile_home = get_subprocess_home()
     if _profile_home:
         sanitized["HOME"] = _profile_home
+    inject_shared_gh_config_dir(sanitized)
 
     return sanitized
 
@@ -312,10 +313,11 @@ def _make_run_env(env: dict) -> dict:
     # Per-profile HOME isolation: redirect system tool configs (git, ssh, gh,
     # npm …) into {HERMES_HOME}/home/ when that directory exists.  Only the
     # subprocess sees the override — the Python process keeps the real HOME.
-    from hermes_constants import get_subprocess_home
+    from hermes_constants import get_subprocess_home, inject_shared_gh_config_dir
     _profile_home = get_subprocess_home()
     if _profile_home:
         run_env["HOME"] = _profile_home
+    inject_shared_gh_config_dir(run_env)
 
     # Inject ContextVar-based session vars into subprocess env.
     # ContextVars don't propagate to child processes, so we bridge them here.


### PR DESCRIPTION
## Summary
- add a shared GH config resolver based on XDG config or the real passwd home
- inject GH_CONFIG_DIR into profile-isolated subprocess env builders and kanban worker spawn env
- cover terminal/background env injection with subprocess-home isolation tests

## Testing
- python -m pytest tests/test_subprocess_home_isolation.py -q -o addopts=""
- python - <<'PY'
  imported modified modules and verified PM/worker envs return gh auth status + gh pr view success with GH_CONFIG_DIR=/home/mordecai/.config/gh
  PY