### PR TITLE
feat: add LLM Wiki memory provider

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,20 @@ jobs:
           # Single stable key. main always overwrites, PRs always find it.
           key: test-durations
 
+      - name: Checkout standalone LLM Wiki source of truth
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: michaelkrauty/hermes-llm-wiki
+          ref: v0.1.1
+          path: .llm-wiki-standalone
+
+      - name: Verify standalone LLM Wiki dependency ref
+        run: |
+          python scripts/check_git_ref.py https://github.com/michaelkrauty/hermes-llm-wiki.git v0.1.1
+          if [ "${HERMES_LLM_WIKI_CHECK_REMOTE_REF:-}" = "1" ]; then
+            python scripts/check_git_ref.py https://github.com/michaelkrauty/hermes-llm-wiki.git v0.1.1 --remote
+          fi
+
       - name: Install ripgrep (prebuilt binary)
         run: |
           set -euo pipefail
@@ -63,7 +77,32 @@ jobs:
         run: |
           uv venv .venv --python 3.11
           source .venv/bin/activate
+          uv pip install -e .llm-wiki-standalone
           uv pip install -e ".[all,dev]"
+
+      - name: Verify LLM Wiki standalone import boundary
+        run: |
+          source .venv/bin/activate
+          python scripts/check_llm_wiki_standalone_import.py --standalone-root .llm-wiki-standalone
+          python scripts/check_llm_wiki_standalone_import.py --standalone-root .llm-wiki-standalone --install-standalone
+          LLM_WIKI_TESTS=(
+            tests/plugins/memory/test_llm_wiki_agent_agnostic_adapter.py
+            tests/plugins/memory/test_llm_wiki_provider.py
+            tests/plugins/memory/test_llm_wiki_hybrid_search.py
+            tests/plugins/memory/test_llm_wiki_vector_core_compat.py
+            tests/plugins/memory/test_llm_wiki_caretaker.py
+            tests/plugins/memory/test_llm_wiki_source_integrity.py
+            tests/plugins/memory/test_llm_wiki_engine_source_hash.py
+            tests/plugins/memory/test_llm_wiki_embedding_cache.py
+            tests/plugins/memory/test_llm_wiki_maintenance.py
+            tests/plugins/memory/test_llm_wiki_retrieval_introspection.py
+          )
+          LLM_WIKI_PYTEST_ARGS=()
+          for test_path in "${LLM_WIKI_TESTS[@]}"; do
+            LLM_WIKI_PYTEST_ARGS+=(--pytest "$test_path")
+          done
+          python scripts/check_llm_wiki_standalone_import.py --standalone-root .llm-wiki-standalone "${LLM_WIKI_PYTEST_ARGS[@]}"
+          python scripts/check_llm_wiki_standalone_import.py --standalone-root .llm-wiki-standalone --install-standalone "${LLM_WIKI_PYTEST_ARGS[@]}"
 
       - name: Run tests (slice ${{ matrix.slice }}/6)
         # Per-file isolation via scripts/run_tests_parallel.py: discovers

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -202,6 +202,7 @@ def init_agent(
     checkpoint_max_total_size_mb: int = 500,
     checkpoint_max_file_size_mb: int = 10,
     pass_session_id: bool = False,
+    agent_context: str | None = None,
 ):
     """
     Initialize the AI Agent.
@@ -264,6 +265,7 @@ def init_agent(
     agent.quiet_mode = quiet_mode
     agent.ephemeral_system_prompt = ephemeral_system_prompt
     agent.platform = platform  # "cli", "telegram", "discord", "whatsapp", etc.
+    agent.agent_context = (agent_context or os.environ.get("HERMES_AGENT_CONTEXT") or "primary").strip() or "primary"
     agent._user_id = user_id  # Platform user identifier (gateway sessions)
     agent._user_name = user_name
     agent._chat_id = chat_id
@@ -1100,7 +1102,7 @@ def init_agent(
                         "session_id": agent.session_id,
                         "platform": platform or "cli",
                         "hermes_home": str(get_hermes_home()),
-                        "agent_context": "primary",
+                        "agent_context": getattr(agent, "agent_context", None) or "primary",
                     }
                     # Thread session title for memory provider scoping
                     # (e.g. honcho uses this to derive chat-scoped session keys)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -665,7 +665,7 @@ class _CodexCompletionsAdapter:
         # by auxiliary calls such as context compression; if the timeout is not
         # forwarded and enforced, a Codex Responses stream can sit behind a
         # dead-looking CLI until the user force-interrupts the whole session.
-        timeout = kwargs.get("timeout")
+        timeout = _normalize_aux_timeout(kwargs.get("timeout"), default=None)
         if timeout is not None:
             resp_kwargs["timeout"] = timeout
 
@@ -747,7 +747,8 @@ class _CodexCompletionsAdapter:
         timeout_timer: Optional[threading.Timer] = None
 
         def _timeout_message() -> str:
-            return f"Codex auxiliary Responses stream exceeded {float(total_timeout):.1f}s total timeout"
+            timeout_text = float(total_timeout) if total_timeout is not None else 0.0
+            return f"Codex auxiliary Responses stream exceeded {timeout_text:.1f}s total timeout"
 
         def _close_client_on_timeout() -> None:
             timed_out.set()
@@ -2553,7 +2554,7 @@ def _retry_same_provider_sync(
     temperature: Optional[float],
     max_tokens: Optional[int],
     tools: Optional[list],
-    effective_timeout: float,
+    effective_timeout: Optional[float],
     effective_extra_body: dict,
 ) -> Any:
     if task == "vision":
@@ -2610,7 +2611,7 @@ async def _retry_same_provider_async(
     temperature: Optional[float],
     max_tokens: Optional[int],
     tools: Optional[list],
-    effective_timeout: float,
+    effective_timeout: Optional[float],
     effective_extra_body: dict,
 ) -> Any:
     if task == "vision":
@@ -4357,18 +4358,34 @@ def _get_auxiliary_task_config(task: str) -> Dict[str, Any]:
     return task_config if isinstance(task_config, dict) else {}
 
 
-def _get_task_timeout(task: str, default: float = _DEFAULT_AUX_TIMEOUT) -> float:
-    """Read timeout from auxiliary.{task}.timeout in config, falling back to *default*."""
+def _normalize_aux_timeout(raw: Any, default: Optional[float] = _DEFAULT_AUX_TIMEOUT) -> Optional[float]:
+    """Normalize auxiliary timeout values.
+
+    ``0`` and negative values intentionally mean "no timeout" for auxiliary
+    tasks.  Passing raw ``0`` through to the OpenAI/httpx layer is interpreted as
+    an already-expired deadline and surfaces as immediate ``Connection error``
+    failures during context compression.
+    """
+    if raw is None:
+        return default
+    try:
+        value = float(raw)
+    except (ValueError, TypeError):
+        return default
+    if value <= 0:
+        return None
+    return value
+
+
+def _get_task_timeout(task: str, default: Optional[float] = _DEFAULT_AUX_TIMEOUT) -> Optional[float]:
+    """Read timeout from auxiliary.{task}.timeout in config, falling back to *default*.
+
+    Configured ``0`` or negative timeout values disable the timeout.
+    """
     if not task:
         return default
     task_config = _get_auxiliary_task_config(task)
-    raw = task_config.get("timeout")
-    if raw is not None:
-        try:
-            return float(raw)
-        except (ValueError, TypeError):
-            pass
-    return default
+    return _normalize_aux_timeout(task_config.get("timeout"), default=default)
 
 
 def _get_task_extra_body(task: str) -> Dict[str, Any]:
@@ -4456,7 +4473,7 @@ def _build_call_kwargs(
     temperature: Optional[float] = None,
     max_tokens: Optional[int] = None,
     tools: Optional[list] = None,
-    timeout: float = 30.0,
+    timeout: Optional[float] = 30.0,
     extra_body: Optional[dict] = None,
     base_url: Optional[str] = None,
 ) -> dict:
@@ -4671,7 +4688,7 @@ def call_llm(
                 f"No LLM provider configured for task={task} provider={resolved_provider}. "
                 f"Run: hermes setup")
 
-    effective_timeout = timeout if timeout is not None else _get_task_timeout(task)
+    effective_timeout = _get_task_timeout(task) if timeout is None else _normalize_aux_timeout(timeout, default=None)
 
     # Log what we're about to do — makes auxiliary operations visible
     _base_info = str(getattr(client, "base_url", resolved_base_url) or "")
@@ -5065,7 +5082,7 @@ async def async_call_llm(
                 f"No LLM provider configured for task={task} provider={resolved_provider}. "
                 f"Run: hermes setup")
 
-    effective_timeout = timeout if timeout is not None else _get_task_timeout(task)
+    effective_timeout = _get_task_timeout(task) if timeout is None else _normalize_aux_timeout(timeout, default=None)
 
     # Pass the client's actual base_url (not just resolved_base_url) so
     # endpoint-specific temperature overrides can distinguish

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -888,7 +888,26 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
             )]
             response.output = output
         else:
-            raise RuntimeError("Responses API returned no output items")
+            response_status = str(getattr(response, "status", "") or "").strip().lower()
+            incomplete_details = getattr(response, "incomplete_details", None)
+            if isinstance(incomplete_details, dict):
+                incomplete_reason = incomplete_details.get("reason")
+            else:
+                incomplete_reason = getattr(incomplete_details, "reason", None)
+            if response_status == "incomplete" and incomplete_reason in {"max_output_tokens", "length"}:
+                logger.debug(
+                    "Codex response has empty output with internal output ceiling; "
+                    "synthesizing empty incomplete assistant item for continuation."
+                )
+                output = [SimpleNamespace(
+                    type="message",
+                    role="assistant",
+                    status="incomplete",
+                    content=[SimpleNamespace(type="output_text", text="")],
+                )]
+                response.output = output
+            else:
+                raise RuntimeError("Responses API returned no output items")
 
     response_status = getattr(response, "status", None)
     if isinstance(response_status, str):
@@ -936,6 +955,14 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
             message_text = _extract_responses_message_text(item)
             if message_text:
                 content_parts.append(message_text)
+            if message_text or item_status in {"queued", "in_progress", "incomplete"}:
+                # Preserve incomplete message items even when their visible
+                # content is empty.  chatgpt.com/backend-api/codex can return
+                # status=incomplete / reason=max_output_tokens with output=[];
+                # we synthesize an empty incomplete message above.  If that
+                # state is not replayed, the continuation request is identical
+                # to the failed request and can hit the same backend ceiling
+                # repeatedly with zero progress.
                 raw_message_item: Dict[str, Any] = {
                     "type": "message",
                     "role": "assistant",

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -118,6 +118,40 @@ def _ollama_context_limit_error(agent: Any, request_tokens: int) -> Optional[str
     )
 
 
+def _inject_ephemeral_context_into_user_message(
+    msg: Dict[str, Any],
+    *,
+    messages: List[Dict[str, Any]],
+    message_index: int,
+    current_turn_user_idx: int,
+    memory_prefetch: str = "",
+    plugin_user_context: str = "",
+) -> Dict[str, Any]:
+    """Return an API-copy of a message with ephemeral recall context injected.
+
+    The persisted ``messages`` history is never mutated. Injection is restricted
+    to the current turn's string user message so memory prefetch cannot leak into
+    older turns or multimodal/content-block payloads.
+    """
+
+    api_msg = msg.copy()
+    if message_index != current_turn_user_idx or msg.get("role") != "user":
+        return api_msg
+
+    injections: list[str] = []
+    if memory_prefetch:
+        fenced = build_memory_context_block(memory_prefetch)
+        if fenced:
+            injections.append(fenced)
+    if plugin_user_context:
+        injections.append(plugin_user_context)
+    if injections:
+        base = api_msg.get("content", "")
+        if isinstance(base, str):
+            api_msg["content"] = base + "\n\n" + "\n\n".join(injections)
+    return api_msg
+
+
 def _ra():
     """Lazy reference to ``run_agent`` so callers can patch
     ``run_agent.handle_function_call`` / ``run_agent._set_interrupt`` /
@@ -574,6 +608,7 @@ def run_conversation(
     interrupted = False
     failed = False
     codex_ack_continuations = 0
+    codex_incomplete_compression_attempted = False
     length_continue_retries = 0
     truncated_tool_call_retries = 0
     truncated_response_parts: List[str] = []
@@ -787,25 +822,14 @@ def run_conversation(
 
         api_messages = []
         for idx, msg in enumerate(messages):
-            api_msg = msg.copy()
-
-            # Inject ephemeral context into the current turn's user message.
-            # Sources: memory manager prefetch + plugin pre_llm_call hooks
-            # with target="user_message" (the default).  Both are
-            # API-call-time only — the original message in `messages` is
-            # never mutated, so nothing leaks into session persistence.
-            if idx == current_turn_user_idx and msg.get("role") == "user":
-                _injections = []
-                if _ext_prefetch_cache:
-                    _fenced = build_memory_context_block(_ext_prefetch_cache)
-                    if _fenced:
-                        _injections.append(_fenced)
-                if _plugin_user_context:
-                    _injections.append(_plugin_user_context)
-                if _injections:
-                    _base = api_msg.get("content", "")
-                    if isinstance(_base, str):
-                        api_msg["content"] = _base + "\n\n" + "\n\n".join(_injections)
+            api_msg = _inject_ephemeral_context_into_user_message(
+                msg,
+                messages=messages,
+                message_index=idx,
+                current_turn_user_idx=current_turn_user_idx,
+                memory_prefetch=_ext_prefetch_cache,
+                plugin_user_context=_plugin_user_context,
+            )
 
             # For ALL assistant messages, pass reasoning back to the API
             # This ensures multi-turn reasoning context is preserved
@@ -1192,18 +1216,39 @@ def run_conversation(
                                 error_details.append(f"response.status={_codex_resp_status}: {_codex_error_msg}")
                             else:
                                 # output_text fallback: stream backfill may have failed
-                                # but normalize can still recover from output_text
+                                # but normalize can still recover from output_text.
+                                # Codex can also return a terminal
+                                # status=incomplete/reason=max_output_tokens with no
+                                # output items even when Hermes did NOT send
+                                # max_output_tokens; that is a recoverable continuation
+                                # signal, not a malformed provider response.
                                 _out_text = getattr(response, "output_text", None)
                                 _out_text_stripped = _out_text.strip() if isinstance(_out_text, str) else ""
+                                _resp_status = str(getattr(response, "status", "") or "").strip().lower()
+                                _resp_incomplete = getattr(response, "incomplete_details", None)
+                                if isinstance(_resp_incomplete, dict):
+                                    _resp_incomplete_reason = _resp_incomplete.get("reason")
+                                else:
+                                    _resp_incomplete_reason = getattr(_resp_incomplete, "reason", None)
+                                _is_empty_internal_output_ceiling = (
+                                    _resp_status == "incomplete"
+                                    and _resp_incomplete_reason in {"max_output_tokens", "length"}
+                                )
                                 if _out_text_stripped:
                                     logger.debug(
                                         "Codex response.output is empty but output_text is present "
                                         "(%d chars); deferring to normalization.",
                                         len(_out_text_stripped),
                                     )
+                                elif _is_empty_internal_output_ceiling:
+                                    logger.warning(
+                                        "Codex response.output is empty with internal output ceiling "
+                                        "(status=%s, incomplete_details=%s, model=%s); deferring to continuation. %s",
+                                        _resp_status, _resp_incomplete,
+                                        getattr(response, "model", None),
+                                        f"api_mode={agent.api_mode} provider={agent.provider}",
+                                    )
                                 else:
-                                    _resp_status = getattr(response, "status", None)
-                                    _resp_incomplete = getattr(response, "incomplete_details", None)
                                     logger.warning(
                                         "Codex response.output is empty after stream backfill "
                                         "(status=%s, incomplete_details=%s, model=%s). %s",
@@ -1378,17 +1423,14 @@ def run_conversation(
 
                 # Check finish_reason before proceeding
                 if agent.api_mode == "codex_responses":
-                    status = getattr(response, "status", None)
-                    incomplete_details = getattr(response, "incomplete_details", None)
-                    incomplete_reason = None
-                    if isinstance(incomplete_details, dict):
-                        incomplete_reason = incomplete_details.get("reason")
-                    else:
-                        incomplete_reason = getattr(incomplete_details, "reason", None)
-                    if status == "incomplete" and incomplete_reason in {"max_output_tokens", "length"}:
-                        finish_reason = "length"
-                    else:
-                        finish_reason = "stop"
+                    # Do not map Codex status=incomplete/reason=max_output_tokens
+                    # to generic finish_reason='length' here. The ChatGPT Codex
+                    # backend can emit that terminal event because of its own
+                    # internal output ceiling even when Hermes omitted
+                    # max_output_tokens. Let the Codex normalizer classify it
+                    # later so the Codex-specific incomplete-continuation path
+                    # can recover instead of surfacing a raw truncation error.
+                    finish_reason = "stop"
                 elif agent.api_mode == "anthropic_messages":
                     _tfr = agent._get_transport()
                     finish_reason = _tfr.map_finish_reason(response.stop_reason)
@@ -3179,10 +3221,72 @@ def run_conversation(
                     agent._session_messages = messages
                     continue
 
+                # chatgpt.com/backend-api/codex can get stuck returning
+                # empty status=incomplete/reason=max_output_tokens near its
+                # effective context ceiling.  Replaying the synthetic
+                # incomplete item changes the request, but if the backend is
+                # out of headroom it may still return another empty incomplete
+                # forever.  Treat three consecutive empty/opaque incompletes
+                # with a large prompt as a context-pressure signal: compact
+                # once, reset the incomplete retry counter, and give the model
+                # a fresh continuation attempt instead of immediately handing
+                # the user a dead-end error.
+                _codex_prompt_tokens = agent.context_compressor.last_prompt_tokens
+                if _codex_prompt_tokens <= 0:
+                    _codex_prompt_tokens = estimate_request_tokens_rough(
+                        messages,
+                        system_prompt=active_system_prompt or "",
+                        tools=agent.tools or None,
+                    )
+                _codex_near_internal_ceiling = _codex_prompt_tokens >= 240_000
+                _codex_should_compact = (
+                    agent.compression_enabled
+                    and not codex_incomplete_compression_attempted
+                    and len(messages) > agent.context_compressor.protect_first_n
+                                      + agent.context_compressor.protect_last_n + 1
+                    and (
+                        agent.context_compressor.should_compress(_codex_prompt_tokens)
+                        or _codex_near_internal_ceiling
+                    )
+                )
+                if _codex_should_compact:
+                    codex_incomplete_compression_attempted = True
+                    original_len = len(messages)
+                    agent._emit_status(
+                        f"🗜️ Codex repeatedly hit its internal output ceiling near "
+                        f"context pressure (~{_codex_prompt_tokens:,} tokens) — compacting and retrying..."
+                    )
+                    messages, active_system_prompt = agent._compress_context(
+                        messages,
+                        system_message,
+                        approx_tokens=_codex_prompt_tokens,
+                        task_id=effective_task_id,
+                    )
+                    if len(messages) < original_len:
+                        conversation_history = None
+                        agent._codex_incomplete_retries = 0
+                        agent._empty_content_retries = 0
+                        agent._thinking_prefill_retries = 0
+                        agent._last_content_with_tools = None
+                        agent._last_content_tools_all_housekeeping = False
+                        agent._mute_post_response = False
+                        agent._session_messages = messages
+                        continue
+
                 agent._codex_incomplete_retries = 0
                 agent._persist_session(messages, conversation_history)
+                _codex_incomplete_response = (
+                    "⚠️ **Codex internal output ceiling hit**\n\n"
+                    "The ChatGPT Codex backend ended the response with "
+                    "`status=incomplete` / `reason=max_output_tokens` before "
+                    "returning visible text. Hermes did not send `max_output_tokens` "
+                    "for this backend; this is the backend's internal output ceiling.\n\n"
+                    "I tried continuing the turn 3 times and it remained incomplete. "
+                    "Try a smaller next step, lower reasoning effort, or restart the "
+                    "turn after reducing context."
+                )
                 return {
-                    "final_response": None,
+                    "final_response": _codex_incomplete_response,
                     "messages": messages,
                     "api_calls": api_call_count,
                     "completed": False,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1584,6 +1584,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             load_soul_identity=True,
             skip_memory=True,  # Cron system prompts would corrupt user representations
             platform="cron",
+            agent_context="cron",
             session_id=_cron_session_id,
             session_db=_session_db,
         )

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -912,7 +912,7 @@ DEFAULT_CONFIG = {
             "model": "",
             "base_url": "",
             "api_key": "",
-            "timeout": 120,        # seconds — compression summarises large contexts; increase for local models
+            "timeout": 120,        # seconds — compression summarises large contexts; set 0 to disable request timeout
             "extra_body": {},
         },
         # Note: session_search no longer uses an auxiliary LLM (PR #27590 —

--- a/plugins/memory/llm_wiki/README.md
+++ b/plugins/memory/llm_wiki/README.md
@@ -1,0 +1,114 @@
+# LLM Wiki Memory Provider
+
+`llm_wiki` is a local-first, source-backed durable memory provider for Hermes Agent.
+
+It stores long-term knowledge as Markdown wiki pages, indexes chunks with Qdrant, and exposes read-first tools to Hermes. It is intended for agent-owned, source-backed, inspectable knowledge rather than automatic transcript summarization, human-review proposal queues, or hidden hosted memory.
+
+## What this provider is for
+
+Use LLM Wiki when memory should be:
+
+- inspectable as normal files
+- reviewable with Git diffs
+- source-backed and citeable
+- editable by humans
+- backed up as a folder
+- kept local by default
+
+Use Honcho/Mem0/Supermemory-style providers when you want automatic user modeling or hosted semantic memory. Use Hermes built-in `MEMORY.md`/`USER.md` for tiny boot-critical facts.
+
+## Safety defaults
+
+- `sync_turn()` is a no-op. Normal conversation turns are not automatically written.
+- `system_prompt_block()` is tiny and does not dump wiki content into the prompt.
+- `prefetch()` is bounded and cited.
+- `wiki_query` defaults to `file_result=false` and `log_query=false`.
+- `wiki_lint` defaults to `write_log=false`.
+- `wiki_ingest` defaults to `dry_run=true`, but all file ingest is limited to the primary agent context because dry-runs still read local files for analysis.
+- Search/status auto-sync the vector index in trusted writable contexts; no manual `wiki_reindex` tool is exposed.
+- `wiki_search.limit` is clamped.
+- `wiki_read` validates paths stay under the configured wiki root and caps oversized output.
+- Engine-generated slugs and ingest source categories are validated before path construction.
+- Automatic index sync upserts replacement vectors before deleting stale chunks, avoiding destructive rebuild-first behavior.
+
+## Config
+
+```yaml
+memory:
+  provider: llm_wiki
+
+wiki:
+  path: ~/.hermes/wiki/personal
+  name: personal
+  embedding:
+    url: http://localhost:8000
+    model: text-embedding-3-small
+    dim: 1536
+  vector_store:
+    url: http://localhost:6333
+    collection_prefix: hermes_wiki
+  llm:
+    url: https://openrouter.ai/api/v1
+    model: openai/gpt-5.5
+```
+
+## Dependencies
+
+The provider package is bundled with Hermes. Heavy search dependencies are optional:
+
+```bash
+pip install 'hermes-agent[llm-wiki]'
+```
+
+Provider discovery does not require `qdrant-client`; the engine lazily ensures the `memory.llm_wiki` dependency when a real wiki operation needs it.
+
+Runtime services:
+
+- Qdrant HTTP endpoint, default `http://localhost:6333`
+- OpenAI-compatible embedding endpoint, default `http://localhost:8000`
+- OpenAI-compatible chat endpoint for `wiki_query`, default `https://openrouter.ai/api/v1`
+
+## Retrieval evals
+
+Use the read-only retrieval eval runner to catch regressions in page recall:
+
+```bash
+hermes-wiki-eval ~/.hermes/wiki/personal/evals/retrieval.yaml --config ~/.hermes/config.yaml --pretty
+# or: python -m hermes_wiki.eval ...
+```
+
+`--config` is authoritative when supplied: the file must exist and contain the intended `wiki:` settings; the runner will not silently fall back to another profile/config.
+
+Case file shape:
+
+```yaml
+cases:
+  - query: How autonomous should Hermes be?
+    expected_pages:
+      - concepts/user-autonomy-operating-policy.md
+      - entities/hermes.md
+    top_k: 5
+```
+
+The eval runner validates page-path presence only. It does not generate text, write wiki files, ingest sources, or reindex vectors. It still embeds eval query text and reads from the configured vector store, so use local/private endpoints for sensitive eval cases.
+
+## Canonical updates
+
+Trusted primary Hermes contexts can maintain existing canonical pages directly with `wiki_update` when the change is source-backed and auditable. Read-only contexts such as MCP, cron, batch jobs, and subagents can search/query/introspect/lint but do not create proposal queues or mutate canonical pages.
+
+## Maintenance reports
+
+Use `hermes-wiki-maintenance` for a read-only health report over local wiki markdown:
+
+```bash
+hermes-wiki-maintenance --config ~/.hermes/config.yaml
+hermes-wiki-maintenance --config ~/.hermes/config.yaml --json
+```
+
+It checks broken wikilinks, orphan pages, and pages without source coverage. By default it only prints a report. `--write-report reports/maintenance.md` requires explicit `--config` and writes only under the dedicated `reports/` namespace; it does not ingest sources, reindex vectors, or mutate canonical entity/concept pages.
+
+## Privacy note
+
+Indexing sends wiki/source text to the configured embedding endpoint. `wiki_query` sends retrieved snippets plus the question to the configured chat endpoint. For sensitive memory, use local OpenAI-compatible endpoints and do not put secrets in wiki pages.
+
+See `website/docs/user-guide/features/llm-wiki-memory.md` for user-facing docs.

--- a/plugins/memory/llm_wiki/__init__.py
+++ b/plugins/memory/llm_wiki/__init__.py
@@ -1,0 +1,546 @@
+"""LLM Wiki memory provider.
+
+First-class MemoryProvider wrapper for Hermes LLM Wiki. The provider is
+intentionally read-first: rich durable memory should be retrieved explicitly
+or via bounded prefetch, not dumped into every prompt.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import math
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+import yaml
+
+from agent.memory_provider import MemoryProvider
+
+
+def _module_file(module: Any) -> Path | None:
+    raw = getattr(module, "__file__", None)
+    if not raw:
+        return None
+    try:
+        return Path(str(raw)).resolve()
+    except OSError:
+        return None
+
+
+def _purge_non_standalone_wiki_modules(root: Path) -> None:
+    """Drop preloaded hermes_wiki modules that did not come from the standalone root."""
+    for name, module in list(sys.modules.items()):
+        if name != "hermes_wiki" and not name.startswith("hermes_wiki."):
+            continue
+        module_file = _module_file(module)
+        if module_file is not None and root in module_file.parents:
+            continue
+        sys.modules.pop(name, None)
+
+
+def _prefer_standalone_core_from_env() -> None:
+    """Opt in to resolving core hermes_wiki from a source checkout."""
+    configured = os.environ.get("HERMES_LLM_WIKI_STANDALONE_ROOT", "").strip()
+    if not configured:
+        return
+    root = Path(configured).expanduser().resolve()
+    if root.name == "hermes_wiki":
+        root = root.parent
+    package_init = root / "hermes_wiki" / "__init__.py"
+    if not package_init.exists():
+        raise RuntimeError(f"HERMES_LLM_WIKI_STANDALONE_ROOT does not contain hermes_wiki: {root}")
+    root_text = str(root)
+    sys.path[:] = [entry for entry in sys.path if Path(entry or ".").resolve() != root]
+    sys.path.insert(0, root_text)
+    _purge_non_standalone_wiki_modules(root)
+
+
+_prefer_standalone_core_from_env()
+
+_CORE_IMPORT_ERROR: Exception | None = None
+WikiCapabilities = Any
+LLMWikiToolAdapter = None
+WikiEngine = None
+capability_preset = None
+
+
+def _load_core_symbols() -> bool:
+    """Import standalone hermes_wiki symbols if the package is available."""
+    global _CORE_IMPORT_ERROR, WikiCapabilities, LLMWikiToolAdapter, capability_preset
+    if LLMWikiToolAdapter is not None and capability_preset is not None:
+        return True
+    try:
+        from hermes_wiki.capabilities import WikiCapabilities as imported_capabilities
+        from hermes_wiki.capabilities import capability_preset as imported_capability_preset
+        from hermes_wiki.tool_adapter import LLMWikiToolAdapter as imported_adapter
+    except Exception as exc:  # pragma: no cover - exact import failure shape is environment-specific
+        _CORE_IMPORT_ERROR = exc
+        return False
+    WikiCapabilities = imported_capabilities
+    LLMWikiToolAdapter = imported_adapter
+    capability_preset = imported_capability_preset
+    _CORE_IMPORT_ERROR = None
+    return True
+
+
+def _capability_preset(context: str):
+    if _load_core_symbols() and capability_preset is not None:
+        return capability_preset(context)
+    return None
+
+
+class _UnavailableCapabilities:
+    can_read = False
+    can_query = False
+    can_lint = False
+    can_ingest = False
+    can_mutate_canonical = False
+
+    def allows(self, _capability: str) -> bool:
+        return False
+
+
+class LLMWikiMemoryProvider(MemoryProvider):
+
+    """MemoryProvider facade for the Hermes LLM Wiki."""
+
+    def __init__(self) -> None:
+        self._session_id = ""
+        self._hermes_home = ""
+        self._agent_context = "primary"
+        self._capabilities: Any = _capability_preset("primary") or _UnavailableCapabilities()
+        self.wiki_path = Path.home() / ".hermes" / "wiki" / "personal"
+        self.wiki_name = "personal"
+        self._engine_instance = None
+        self.prefetch_limit = 3
+        self.prefetch_max_chars = 1200
+        self.search_max_limit = 20
+        self.read_max_chars = 64_000
+
+    @property
+    def name(self) -> str:
+        return "llm_wiki"
+
+    def is_available(self) -> bool:
+        try:
+            if importlib.util.find_spec("hermes_wiki.engine") is not None:
+                return True
+        except ModuleNotFoundError:
+            pass
+        try:
+            from tools.lazy_deps import LAZY_DEPS
+
+            return "memory.llm_wiki" in LAZY_DEPS
+        except Exception:
+            return False
+
+    def initialize(self, session_id: str, **kwargs: Any) -> None:
+        self._session_id = session_id
+        self._hermes_home = str(kwargs.get("hermes_home") or "")
+        self._agent_context = str(kwargs.get("agent_context") or "primary").strip().lower() or "primary"
+        if self._agent_context in {"primary", "interactive", "owner", "trusted"}:
+            self._ensure_optional_deps()
+        _load_core_symbols()
+        self._capabilities = _capability_preset(self._agent_context) or _UnavailableCapabilities()
+        self._load_wiki_config()
+
+    def system_prompt_block(self) -> str:
+        return (
+            "LLM Wiki memory is source-backed durable knowledge. Lean on it proactively: "
+            "use wiki_search whenever durable memory could improve correctness, continuity, "
+            "or personalization: preferences, prior decisions, project status, architecture, "
+            "policies, goals, current/next work, or what's next. Do not wait for explicit "
+            "memory requests. Prefetch snippets are only hints; use wiki_read/wiki_query for "
+            "fuller context or synthesis. Reference wiki/source pages when memory materially "
+            "shapes an answer. Keep the wiki current: trusted primary contexts use wiki_update "
+            "for source-backed canonical updates; read-only contexts search/query/introspect "
+            "without durable writes."
+        )
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if not self._capabilities.can_read:
+            return ""
+        query = (query or "").strip()
+        if not query:
+            return ""
+        try:
+            searcher = getattr(self._engine(), "search", None)
+            if searcher is None:
+                return ""
+            results = searcher.search(query, limit=self.prefetch_limit, exclude_sources=True)
+        except Exception:
+            return ""
+        return self._format_prefetch_results(results)
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        return None
+
+    def _format_prefetch_results(self, results: Any) -> str:
+        if not results:
+            return ""
+        header = "LLM Wiki relevant context (source-backed hints; lean on wiki_search/wiki_read/wiki_query before final answers when memory may matter):"
+        lines = [header]
+        remaining = self.prefetch_max_chars - len(header) - 1
+        for result in results:
+            data = self._search_result_to_dict(result)
+            page_path = data["page_path"]
+            title = data["title"] or page_path or "Untitled"
+            text = " ".join(data["text"].split())
+            score = data["score"]
+            score_text = f" score={score:.3f}" if isinstance(score, (int, float)) else ""
+            prefix = f"- [{page_path}] {title}{score_text}: "
+            if len(prefix) >= remaining:
+                break
+            snippet = text[: max(0, min(260, remaining - len(prefix) - 1))]
+            line = prefix + snippet
+            if len(line) > remaining:
+                break
+            lines.append(line)
+            remaining -= len(line) + 1
+            if remaining <= 40:
+                break
+        return "\n".join(lines)[: self.prefetch_max_chars]
+
+    def _search_result_to_dict(self, result: Any) -> Dict[str, Any]:
+        if isinstance(result, dict):
+            return {
+                "page_path": str(result.get("page_path", "")),
+                "title": str(result.get("title", "")),
+                "page_type": str(result.get("page_type", "")),
+                "chunk_index": result.get("chunk_index", 0),
+                "text": str(result.get("text", "")),
+                "score": result.get("score"),
+                "tags": result.get("tags", []),
+            }
+        return {
+            "page_path": str(getattr(result, "page_path", "")),
+            "title": str(getattr(result, "title", "")),
+            "page_type": str(getattr(result, "page_type", "")),
+            "chunk_index": getattr(result, "chunk_index", 0),
+            "text": str(getattr(result, "text", "")),
+            "score": getattr(result, "score", None),
+            "tags": getattr(result, "tags", []),
+        }
+
+    def _load_wiki_config(self) -> None:
+        config = self._wiki_config()
+        self.wiki_name = config.wiki_name
+        self.wiki_path = config.wiki_path
+
+    def _config_path(self) -> Path:
+        hermes_home = Path(self._hermes_home).expanduser() if self._hermes_home else Path.home() / ".hermes"
+        return hermes_home / "config.yaml"
+
+    def _load_config_data(self) -> Dict[str, Any]:
+        config_path = self._config_path()
+        if not config_path.exists():
+            return {}
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        return data if isinstance(data, dict) else {}
+
+    def _wiki_config(self):
+        from hermes_wiki.config import WikiConfig
+
+        data = self._load_config_data()
+        if "wiki" not in data:
+            hermes_home = Path(self._hermes_home).expanduser() if self._hermes_home else Path.home() / ".hermes"
+            data = {"wiki": {"path": str(hermes_home / "wiki" / "personal"), "name": "personal"}}
+        return WikiConfig.from_dict(data)
+
+    def get_config_schema(self) -> List[Dict[str, Any]]:
+        return [
+            {"key": "path", "description": "Filesystem path for the LLM Wiki", "default": "~/.hermes/wiki/personal"},
+            {"key": "name", "description": "Wiki name used for vector collection suffix", "default": "personal"},
+            {"key": "embedding_url", "description": "OpenAI-compatible embedding endpoint", "default": "http://localhost:8000"},
+            {"key": "embedding_model", "description": "Embedding model name", "default": "text-embedding-3-small"},
+            {"key": "embedding_dim", "description": "Embedding vector dimension", "default": 1536},
+            {"key": "qdrant_url", "description": "Qdrant HTTP URL", "default": "http://localhost:6333"},
+            {"key": "collection_prefix", "description": "Qdrant collection prefix", "default": "hermes_wiki"},
+            {"key": "llm_url", "description": "OpenAI-compatible LLM endpoint for wiki_query", "default": "https://openrouter.ai/api/v1"},
+            {"key": "llm_model", "description": "LLM model used by wiki_query", "default": "openai/gpt-5.5"},
+        ]
+
+    def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
+        config_path = Path(hermes_home).expanduser() / "config.yaml"
+        data: Dict[str, Any] = {}
+        if config_path.exists():
+            loaded = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+            data = loaded if isinstance(loaded, dict) else {}
+
+        wiki = data.setdefault("wiki", {})
+        if not isinstance(wiki, dict):
+            wiki = {}
+            data["wiki"] = wiki
+
+        def set_if_present(key: str, section: Dict[str, Any], dest: str | None = None, *, cast=None) -> None:
+            if key not in values or values[key] in (None, ""):
+                return
+            value = values[key]
+            if cast is not None:
+                value = cast(value)
+            section[dest or key] = value
+
+        set_if_present("path", wiki)
+        set_if_present("name", wiki)
+        embedding = wiki.setdefault("embedding", {})
+        vector = wiki.setdefault("vector_store", {})
+        llm = wiki.setdefault("llm", {})
+        set_if_present("embedding_url", embedding, "url")
+        set_if_present("embedding_model", embedding, "model")
+        set_if_present("embedding_dim", embedding, "dim", cast=int)
+        set_if_present("qdrant_url", vector, "url")
+        set_if_present("collection_prefix", vector)
+        set_if_present("llm_url", llm, "url")
+        set_if_present("llm_model", llm, "model")
+
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+    def _ensure_optional_deps(self) -> None:
+        try:
+            from tools.lazy_deps import ensure as lazy_ensure
+
+            lazy_ensure("memory.llm_wiki", prompt=False)
+        except ImportError:
+            return
+
+    def _engine(self):
+        if self._engine_instance is None:
+            if self._writes_allowed():
+                self._ensure_optional_deps()
+            engine_cls = WikiEngine
+            if engine_cls is None:
+                try:
+                    from hermes_wiki.engine import WikiEngine as imported_engine
+                except Exception as exc:  # pragma: no cover - exercised by integration tests later
+                    raise RuntimeError("LLM Wiki engine is not importable") from exc
+                engine_cls = imported_engine
+            self._engine_instance = engine_cls(self._wiki_config(), read_only=not self._writes_allowed())
+        return self._engine_instance
+
+    def _adapter(self):
+        if not _load_core_symbols() or LLMWikiToolAdapter is None:
+            raise RuntimeError("LLM Wiki core package is not importable")
+        return LLMWikiToolAdapter(
+            config=self._wiki_config(),
+            engine_factory=self._engine,
+            capabilities=self._capabilities,
+        )
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        if not self.is_available():
+            return []
+        schemas = self._adapter().tool_schemas()
+        names = {schema.get("name") for schema in schemas}
+        if "wiki_read" not in names and self._capabilities.can_read:
+            read_schema = {
+                "name": "wiki_read",
+                "description": "Read a wiki page by slug or relative path.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "page": {"type": "string", "description": "Page slug or relative markdown path."},
+                    },
+                    "required": ["page"],
+                },
+            }
+            insert_at = next(
+                (idx + 1 for idx, schema in enumerate(schemas) if schema.get("name") == "wiki_search"),
+                len(schemas),
+            )
+            schemas.insert(insert_at, read_schema)
+        return schemas
+
+    @staticmethod
+    def _as_bool(value: Any, default: bool = False) -> bool:
+        """Parse bool-like tool arguments without accidental truthiness escalation."""
+        if value is None:
+            return default
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, (int, float)):
+            if isinstance(value, float) and not math.isfinite(value):
+                return default
+            return value != 0
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"1", "true", "yes", "y", "on", "enabled", "enable", "allow", "allowed"}:
+                return True
+            if normalized in {"0", "false", "no", "n", "off", "disabled", "disable", "deny", "denied", ""}:
+                return False
+        return default
+
+    def _clamp_limit(self, value: Any, default: int = 5) -> int:
+        try:
+            limit = int(value)
+        except (TypeError, ValueError, OverflowError):
+            limit = default
+        return max(1, min(self.search_max_limit, limit))
+
+    @staticmethod
+    def _jsonable(value: Any) -> Any:
+        if isinstance(value, dict):
+            return {str(key): LLMWikiMemoryProvider._jsonable(item) for key, item in value.items()}
+        if isinstance(value, (list, tuple)):
+            return [LLMWikiMemoryProvider._jsonable(item) for item in value]
+        if isinstance(value, float):
+            return value if math.isfinite(value) else None
+        return value
+
+    @classmethod
+    def _json_dumps(cls, value: Any) -> str:
+        return json.dumps(cls._jsonable(value), indent=2, default=str, allow_nan=False)
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs: Any) -> str:
+        args = args or {}
+        if tool_name == "wiki_capabilities":
+            result = self._adapter().call("wiki_capabilities", args)
+            # The shared adapter reports its agent-agnostic surface. Hermes adds
+            # a native wiki_read wrapper in get_tool_schemas(); report the
+            # actual Hermes provider surface so tool availability diagnostics do
+            # not lie to the model/operator.
+            result["exposed_tools"] = [schema["name"] for schema in self.get_tool_schemas()]
+            return self._json_dumps(result)
+        if tool_name == "wiki_update":
+            try:
+                return self._json_dumps(self._adapter().call("wiki_update", args))
+            except (PermissionError, ValueError, FileNotFoundError) as exc:
+                return f"Error: {exc}"
+        if tool_name == "wiki_status":
+            if not self._capabilities.allows("status"):
+                return self._capability_blocked("wiki_status", "status")
+            return self._json_dumps(self._engine().status())
+        if tool_name == "wiki_orient":
+            if not self._capabilities.allows("read"):
+                return self._capability_blocked("wiki_orient", "read")
+            return str(self._engine().orient())
+        if tool_name == "wiki_query":
+            if not self._capabilities.allows("query"):
+                return self._capability_blocked("wiki_query", "query")
+            question = str(args.get("question") or "").strip()
+            if not question:
+                return "Error: question is required"
+            file_result = self._as_bool(args.get("file_result"), False)
+            log_query = self._as_bool(args.get("log_query"), False)
+            if (file_result or log_query) and not self._writes_allowed():
+                return self._write_blocked("wiki_query")
+            return str(
+                self._engine().query(
+                    question,
+                    file_result=file_result,
+                    log_query=log_query,
+                )
+            )
+        if tool_name == "wiki_introspect":
+            query = str(args.get("query") or "").strip()
+            if not query:
+                return "Error: query is required"
+            try:
+                return self._json_dumps(self._adapter().call("wiki_introspect", args))
+            except (PermissionError, ValueError) as exc:
+                return f"Error: {exc}"
+        if tool_name == "wiki_read":
+            if not self._capabilities.allows("read"):
+                return self._capability_blocked("wiki_read", "read")
+            page = str(args.get("page") or "").strip()
+            if not page:
+                return "Error: page is required"
+            return self._read_page(page)
+        if tool_name == "wiki_search":
+            query = str(args.get("query") or "").strip()
+            if not query:
+                return "Error: query is required"
+            adapter = LLMWikiToolAdapter(
+                config=self._wiki_config(),
+                engine_factory=self._engine,
+                capabilities=self._capabilities,
+            )
+            try:
+                results = adapter.call(
+                    "wiki_search",
+                    {
+                        "query": query,
+                        "limit": args.get("limit", 5),
+                        "exclude_sources": args.get("exclude_sources", False),
+                        "search_mode": args.get("search_mode", "dense"),
+                    },
+                )
+            except (PermissionError, ValueError) as exc:
+                return f"Error: {exc}"
+            return self._json_dumps(results)
+        if tool_name == "wiki_lint":
+            if not self._capabilities.allows("read"):
+                return self._capability_blocked("wiki_lint", "read")
+            write_log = self._as_bool(args.get("write_log"), False)
+            if write_log and not self._writes_allowed():
+                return self._write_blocked("wiki_lint")
+            return self._json_dumps(self._engine().lint(write_log=write_log))
+        if tool_name == "wiki_ingest":
+            file_path = str(args.get("file_path") or "").strip()
+            if not file_path:
+                return "Error: file_path is required"
+            if not self._writes_allowed():
+                return self._write_blocked("wiki_ingest")
+            dry_run = self._as_bool(args.get("dry_run"), True)
+            return self._json_dumps(self._engine().ingest_file(file_path, dry_run=dry_run))
+        return super().handle_tool_call(tool_name, args, **kwargs)
+
+    def _writes_allowed(self) -> bool:
+        return self._capabilities.can_mutate_canonical or self._capabilities.can_ingest
+
+    def _write_blocked(self, operation: str) -> str:
+        return (
+            f"Blocked {operation}: LLM Wiki file ingest and durable writes are disabled in "
+            f"agent_context={self._agent_context!r}; use a primary agent context."
+        )
+
+    def _capability_blocked(self, operation: str, capability: str) -> str:
+        return (
+            f"Error: LLM Wiki capability denied: {capability} for {operation} "
+            f"in agent_context={self._agent_context!r}."
+        )
+
+    def _read_page(self, page: str) -> str:
+        path = self._resolve_page_path(page)
+        if path is None:
+            return f"Error: wiki page not found: {page}"
+        text = path.read_text(encoding="utf-8")
+        if len(text) <= self.read_max_chars:
+            return text
+        return text[: self.read_max_chars] + f"\n\n[truncated: {len(text) - self.read_max_chars} additional characters omitted]"
+
+    def _resolve_page_path(self, page: str) -> Path | None:
+        raw = str(page or "").strip()
+        if not raw:
+            return None
+
+        requested = Path(raw)
+        candidates: list[Path]
+        if requested.is_absolute():
+            candidates = [requested]
+        else:
+            candidates = [self.wiki_path / requested]
+            if requested.suffix == "":
+                candidates.append(self.wiki_path / f"{raw}.md")
+            if len(requested.parts) == 1:
+                slug = requested.stem if requested.suffix == ".md" else raw
+                for subdir in ("entities", "concepts", "comparisons", "queries"):
+                    candidates.append(self.wiki_path / subdir / f"{slug}.md")
+
+        wiki_root = self.wiki_path.resolve()
+        for candidate in candidates:
+            resolved = candidate.resolve()
+            if wiki_root not in resolved.parents and resolved != wiki_root:
+                return None
+            if resolved.exists() and resolved.is_file():
+                return resolved
+        return None
+
+
+def register(ctx: Any) -> None:
+    """Register the LLM Wiki memory provider with Hermes plugin context."""
+
+    ctx.register_memory_provider(LLMWikiMemoryProvider())

--- a/plugins/memory/llm_wiki/plugin.yaml
+++ b/plugins/memory/llm_wiki/plugin.yaml
@@ -1,0 +1,6 @@
+name: llm_wiki
+version: 0.1.0
+description: "LLM Wiki — source-backed durable memory provider for Hermes."
+requires_env: []
+hooks:
+  - prefetch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,9 @@ modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 vercel = ["vercel==0.5.7"]
 hindsight = ["hindsight-client==0.6.1"]
+llm-wiki = [
+  "hermes-llm-wiki @ git+https://github.com/michaelkrauty/hermes-llm-wiki.git@v0.1.1",
+]
 dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "pytest-timeout==2.4.0", "mcp==1.26.0", "ty==0.0.21", "ruff==0.15.10"]
 messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.13.3", "brotlicffi==1.2.0.1", "slack-bolt==1.27.0", "slack-sdk==3.40.1", "qrcode==7.4.2"]
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
@@ -221,6 +224,8 @@ plugins = [
   "*/dashboard/manifest.json",
   "*/dashboard/dist/*",
   "*/dashboard/dist/**/*",
+  "memory/llm_wiki/plugin.yaml",
+  "memory/llm_wiki/README.md",
 ]
 
 [tool.setuptools.packages.find]

--- a/run_agent.py
+++ b/run_agent.py
@@ -412,6 +412,7 @@ class AIAgent:
         checkpoint_max_total_size_mb: int = 500,
         checkpoint_max_file_size_mb: int = 10,
         pass_session_id: bool = False,
+        agent_context: str | None = None,
     ):
         """Forwarder — see ``agent.agent_init.init_agent``."""
         from agent.agent_init import init_agent
@@ -481,6 +482,7 @@ class AIAgent:
             checkpoint_max_total_size_mb=checkpoint_max_total_size_mb,
             checkpoint_max_file_size_mb=checkpoint_max_file_size_mb,
             pass_session_id=pass_session_id,
+            agent_context=agent_context,
         )
 
     def _get_session_db_for_recall(self):

--- a/scripts/check_git_ref.py
+++ b/scripts/check_git_ref.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Validate a pinned Git dependency ref, with optional remote resolution.
+
+Default mode is offline: validate that the ref is a stable release tag or full
+SHA. Set --remote to call `git ls-remote` and verify the ref exists upstream.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+
+_FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+_RELEASE_TAG_RE = re.compile(r"^v\d+\.\d+\.\d+$")
+
+
+def ref_format_ok(ref: str) -> bool:
+    return bool(_FULL_SHA_RE.fullmatch(ref) or _RELEASE_TAG_RE.fullmatch(ref))
+
+
+def verify_remote(repo_url: str, ref: str) -> None:
+    candidates = [ref]
+    if _RELEASE_TAG_RE.fullmatch(ref):
+        candidates = [f"refs/tags/{ref}", f"refs/tags/{ref}^{{}}"]
+    completed = subprocess.run(
+        ["git", "ls-remote", repo_url, *candidates],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    if ref not in completed.stdout:
+        raise RuntimeError(f"ref {ref!r} was not found in {repo_url}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate a pinned Git dependency ref")
+    parser.add_argument("repo_url")
+    parser.add_argument("ref")
+    parser.add_argument("--remote", action="store_true", help="verify the ref with git ls-remote")
+    args = parser.parse_args(argv)
+
+    if not ref_format_ok(args.ref):
+        print(f"invalid ref format: {args.ref!r}", file=sys.stderr)
+        return 2
+    print(f"ref format ok: {args.ref}")
+
+    if not args.remote:
+        print("remote check skipped")
+        return 0
+
+    try:
+        verify_remote(args.repo_url, args.ref)
+    except Exception as exc:
+        print(f"remote check failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"remote ref ok: {args.ref}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_llm_wiki_standalone_import.py
+++ b/scripts/check_llm_wiki_standalone_import.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Smoke-test Hermes LLM Wiki against standalone core without vendored shadowing.
+
+Temporary migration helper: until Hermes removes the top-level vendored
+`hermes_wiki/` package, this creates a small shadow-free overlay of the Hermes
+repo that exposes Hermes-native adapter code (`plugins/`, `agent/`, `tools/`)
+without exposing the vendored core. A subprocess then imports the LLM Wiki memory
+provider and verifies `hermes_wiki` resolves from the standalone package path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+OVERLAY_ENTRIES = (
+    "agent",
+    "plugins",
+    "tools",
+    "hermes_cli",
+)
+OVERLAY_FILES = ("pyproject.toml",)
+TEST_OVERLAY_ENTRIES = ("tests",)
+
+
+def _link_or_copy(source: Path, dest: Path) -> None:
+    if dest.exists() or dest.is_symlink():
+        if dest.is_dir() and not dest.is_symlink():
+            shutil.rmtree(dest)
+        else:
+            dest.unlink()
+    try:
+        dest.symlink_to(source, target_is_directory=source.is_dir())
+    except OSError:
+        if source.is_dir():
+            shutil.copytree(source, dest)
+        else:
+            shutil.copy2(source, dest)
+
+
+def build_shadow_free_overlay(repo_root: Path, overlay_root: Path, *, include_tests: bool = False) -> Path:
+    """Expose Hermes adapter code in overlay_root while omitting vendored hermes_wiki."""
+    repo_root = repo_root.resolve()
+    overlay_root.mkdir(parents=True, exist_ok=True)
+    entries = OVERLAY_ENTRIES + (TEST_OVERLAY_ENTRIES if include_tests else ())
+    for entry in entries:
+        source = repo_root / entry
+        if source.exists():
+            _link_or_copy(source, overlay_root / entry)
+    for entry in OVERLAY_FILES:
+        source = repo_root / entry
+        if source.exists():
+            _link_or_copy(source, overlay_root / entry)
+    for source in sorted(repo_root.glob("*.py")):
+        if source.name != "__init__.py":
+            _link_or_copy(source, overlay_root / source.name)
+    vendored = overlay_root / "hermes_wiki"
+    if vendored.exists() or vendored.is_symlink():
+        if vendored.is_dir() and not vendored.is_symlink():
+            shutil.rmtree(vendored)
+        else:
+            vendored.unlink()
+    return overlay_root
+
+
+def standalone_import_root(path: str | Path) -> Path:
+    """Return a sys.path entry for a standalone checkout or hermes_wiki package dir."""
+    raw = Path(path).expanduser().resolve()
+    if raw.name == "hermes_wiki":
+        return raw.parent
+    return raw
+
+
+def run_import_smoke(standalone_root: Path, *, repo_root: Path = ROOT, python: str = sys.executable) -> dict[str, object]:
+    standalone_root = standalone_import_root(standalone_root)
+    if not (standalone_root / "hermes_wiki" / "__init__.py").exists():
+        raise FileNotFoundError(f"standalone hermes_wiki package not found under {standalone_root}")
+
+    with tempfile.TemporaryDirectory(prefix="hermes-llm-wiki-shadow-free-") as tmp:
+        overlay = build_shadow_free_overlay(repo_root, Path(tmp) / "overlay")
+        env = os.environ.copy()
+        existing_pythonpath = env.get("PYTHONPATH", "")
+        env["PYTHONPATH"] = os.pathsep.join(
+            part for part in [str(overlay), str(standalone_root), existing_pythonpath] if part
+        )
+        code = r'''
+import json
+from pathlib import Path
+
+import hermes_wiki
+from plugins.memory.llm_wiki import LLMWikiMemoryProvider
+
+provider = LLMWikiMemoryProvider()
+schemas = provider.get_tool_schemas()
+print(json.dumps({
+    "hermes_wiki_file": str(Path(hermes_wiki.__file__).resolve()),
+    "provider_available": provider.is_available(),
+    "tool_names": [schema.get("name") for schema in schemas],
+}, sort_keys=True))
+'''
+        completed = subprocess.run(
+            [python, "-c", code],
+            cwd=overlay,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+    payload = json.loads(completed.stdout)
+    imported = Path(str(payload["hermes_wiki_file"])).resolve()
+    vendored = (repo_root / "hermes_wiki").resolve()
+    if vendored == imported or vendored in imported.parents:
+        raise RuntimeError(f"hermes_wiki resolved to vendored Hermes copy: {imported}")
+    if standalone_root.resolve() not in imported.parents:
+        raise RuntimeError(f"hermes_wiki did not resolve from standalone root {standalone_root}: {imported}")
+    required_tools = {"wiki_search", "wiki_query", "wiki_update"}
+    missing_tools = sorted(required_tools - set(payload.get("tool_names") or []))
+    if missing_tools:
+        raise RuntimeError(f"LLM Wiki provider missing expected tools: {', '.join(missing_tools)}")
+    return payload
+
+
+def run_pytest_smoke(
+    standalone_root: Path,
+    *,
+    repo_root: Path = ROOT,
+    test_paths: list[str] | tuple[str, ...] = (),
+    python: str = sys.executable,
+) -> dict[str, object]:
+    """Run selected Hermes tests from a shadow-free overlay against standalone core."""
+    standalone_root = standalone_import_root(standalone_root)
+    if not (standalone_root / "hermes_wiki" / "__init__.py").exists():
+        raise FileNotFoundError(f"standalone hermes_wiki package not found under {standalone_root}")
+    selected_tests = list(test_paths) or [
+        "tests/plugins/memory/test_llm_wiki_provider.py",
+        "tests/plugins/memory/test_llm_wiki_agent_agnostic_adapter.py",
+    ]
+
+    with tempfile.TemporaryDirectory(prefix="hermes-llm-wiki-pytest-") as tmp:
+        overlay = build_shadow_free_overlay(repo_root, Path(tmp) / "overlay", include_tests=True)
+        env = os.environ.copy()
+        existing_pythonpath = env.get("PYTHONPATH", "")
+        env["PYTHONPATH"] = os.pathsep.join(
+            part for part in [str(overlay), str(standalone_root), existing_pythonpath] if part
+        )
+        completed = subprocess.run(
+            [python, "-m", "pytest", "-o", "addopts=", *selected_tests, "-q"],
+            cwd=overlay,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        return {
+            "standalone_root": str(standalone_root),
+            "test_paths": selected_tests,
+            "pytest_stdout": completed.stdout,
+            "pytest_stderr": completed.stderr,
+        }
+
+
+def _install_standalone_wheel(
+    standalone_root: Path,
+    target_dir: Path,
+    *,
+    python: str = sys.executable,
+) -> Path:
+    """Build standalone wheel and install it into target_dir without dependencies."""
+    standalone_root = standalone_import_root(standalone_root)
+    if not (standalone_root / "pyproject.toml").exists():
+        raise FileNotFoundError(f"standalone pyproject.toml not found under {standalone_root}")
+    dist_dir = target_dir.parent / "dist"
+    subprocess.run(
+        ["uv", "build", "--wheel", "--out-dir", str(dist_dir)],
+        cwd=standalone_root,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    wheels = sorted(dist_dir.glob("*.whl"))
+    if len(wheels) != 1:
+        raise RuntimeError(f"expected one standalone wheel, found {len(wheels)}")
+    subprocess.run(
+        [python, "-m", "pip", "install", "--no-deps", "--target", str(target_dir), str(wheels[0])],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return wheels[0]
+
+
+def run_installed_import_smoke(
+    standalone_root: Path,
+    *,
+    repo_root: Path = ROOT,
+    python: str = sys.executable,
+) -> dict[str, object]:
+    """Build/install standalone into a temp target, then run the shadow-free smoke."""
+    standalone_root = standalone_import_root(standalone_root)
+    with tempfile.TemporaryDirectory(prefix="hermes-llm-wiki-installed-") as tmp:
+        target_dir = Path(tmp) / "site"
+        wheel = _install_standalone_wheel(standalone_root, target_dir, python=python)
+        payload = run_import_smoke(target_dir, repo_root=repo_root, python=python)
+        payload["installed_wheel"] = wheel.name
+        return payload
+
+
+def run_installed_pytest_smoke(
+    standalone_root: Path,
+    *,
+    repo_root: Path = ROOT,
+    test_paths: list[str] | tuple[str, ...] = (),
+    python: str = sys.executable,
+) -> dict[str, object]:
+    """Build/install standalone, then run selected Hermes tests without vendored core."""
+    standalone_root = standalone_import_root(standalone_root)
+    with tempfile.TemporaryDirectory(prefix="hermes-llm-wiki-installed-pytest-") as tmp:
+        target_dir = Path(tmp) / "site"
+        wheel = _install_standalone_wheel(standalone_root, target_dir, python=python)
+        payload = run_pytest_smoke(target_dir, repo_root=repo_root, test_paths=test_paths, python=python)
+        payload["installed_wheel"] = wheel.name
+        return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Verify Hermes LLM Wiki can import standalone core without vendored shadowing")
+    parser.add_argument("--standalone-root", required=True, help="Path to standalone hermes-llm-wiki repo or its hermes_wiki package")
+    parser.add_argument("--repo-root", default=str(ROOT), help="Path to Hermes Agent repository root")
+    parser.add_argument(
+        "--install-standalone",
+        action="store_true",
+        help="Build and install standalone wheel into a temp target before running the import smoke",
+    )
+    parser.add_argument(
+        "--pytest",
+        action="append",
+        default=[],
+        metavar="TEST_PATH",
+        help="Run a selected Hermes pytest path from a shadow-free overlay against standalone core",
+    )
+    args = parser.parse_args(argv)
+
+    if args.pytest and args.install_standalone:
+        payload = run_installed_pytest_smoke(
+            Path(args.standalone_root),
+            repo_root=Path(args.repo_root),
+            test_paths=args.pytest,
+        )
+        print("LLM Wiki installed package pytest smoke passed")
+    elif args.pytest:
+        payload = run_pytest_smoke(Path(args.standalone_root), repo_root=Path(args.repo_root), test_paths=args.pytest)
+        print("LLM Wiki standalone pytest smoke passed")
+    elif args.install_standalone:
+        payload = run_installed_import_smoke(Path(args.standalone_root), repo_root=Path(args.repo_root))
+        print("LLM Wiki installed package import smoke passed")
+    else:
+        payload = run_import_smoke(Path(args.standalone_root), repo_root=Path(args.repo_root))
+        print("LLM Wiki standalone import smoke passed")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -28,6 +28,7 @@ from agent.auxiliary_client import (
     _resolve_auto,
     _resolve_xai_oauth_for_aux,
     _CodexCompletionsAdapter,
+    _get_task_timeout,
 )
 
 
@@ -2326,6 +2327,57 @@ class TestVisionAutoSkipsKimiCoding:
         })
 
 
+class TestAuxiliaryTimeoutNormalization:
+    def test_config_timeout_zero_disables_timeout(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"auxiliary": {"compression": {"timeout": 0}}},
+        )
+
+        assert _get_task_timeout("compression") is None
+
+    def test_config_negative_timeout_disables_timeout(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"auxiliary": {"compression": {"timeout": -1}}},
+        )
+
+        assert _get_task_timeout("compression") is None
+
+    def test_call_llm_explicit_timeout_zero_forwards_none(self, monkeypatch):
+        captured = {}
+
+        class FakeCompletions:
+            def create(self, **kwargs):
+                captured.update(kwargs)
+                return SimpleNamespace(
+                    choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+                )
+
+        fake_client = SimpleNamespace(
+            chat=SimpleNamespace(completions=FakeCompletions()),
+            base_url="https://example.test/v1",
+        )
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            lambda task, provider, model, base_url, api_key: ("custom", "test-model", "https://example.test/v1", "k", None),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_cached_client",
+            lambda *args, **kwargs: (fake_client, "test-model"),
+        )
+        monkeypatch.setattr("agent.auxiliary_client._get_task_extra_body", lambda task: {})
+
+        call_llm(
+            task="compression",
+            messages=[{"role": "user", "content": "summarize"}],
+            timeout=0,
+        )
+
+        assert captured["timeout"] is None
+
+
 class TestCodexAuxiliaryAdapterTimeout:
     def test_forwards_timeout_to_responses_stream(self):
         class FakeStream:
@@ -2364,6 +2416,45 @@ class TestCodexAuxiliaryAdapterTimeout:
         )
 
         assert fake_client.responses.kwargs["timeout"] == 12.5
+        assert response.choices[0].message.content == "summary"
+
+    def test_timeout_zero_is_not_forwarded_to_responses_stream(self):
+        class FakeStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                return iter(())
+
+            def get_final_response(self):
+                return SimpleNamespace(
+                    output=[SimpleNamespace(
+                        type="message",
+                        content=[SimpleNamespace(type="output_text", text="summary")],
+                    )],
+                    usage=None,
+                )
+
+        class FakeResponses:
+            def __init__(self):
+                self.kwargs = None
+
+            def stream(self, **kwargs):
+                self.kwargs = kwargs
+                return FakeStream()
+
+        fake_client = SimpleNamespace(responses=FakeResponses())
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
+
+        response = adapter.create(
+            messages=[{"role": "user", "content": "summarize this"}],
+            timeout=0,
+        )
+
+        assert "timeout" not in fake_client.responses.kwargs
         assert response.choices[0].message.content == "summary"
 
     def test_enforces_total_timeout_while_stream_keeps_emitting_events(self):

--- a/tests/agent/test_memory_prefetch_injection.py
+++ b/tests/agent/test_memory_prefetch_injection.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from agent.conversation_loop import _inject_ephemeral_context_into_user_message
+
+
+def test_injects_memory_prefetch_into_current_user_message_without_mutating_history():
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "What should Hermes call the user?"},
+    ]
+
+    api_msg = _inject_ephemeral_context_into_user_message(
+        messages[1],
+        messages=messages,
+        message_index=1,
+        current_turn_user_idx=1,
+        memory_prefetch="LLM Wiki relevant context: Mike page",
+        plugin_user_context="",
+    )
+
+    assert "What should Hermes call the user?" in api_msg["content"]
+    assert "LLM Wiki relevant context: Mike page" in api_msg["content"]
+    assert messages[1]["content"] == "What should Hermes call the user?"
+
+
+def test_does_not_inject_memory_prefetch_into_old_user_message():
+    old_user = {"role": "user", "content": "old"}
+
+    api_msg = _inject_ephemeral_context_into_user_message(
+        old_user,
+        messages=[old_user],
+        message_index=0,
+        current_turn_user_idx=1,
+        memory_prefetch="LLM Wiki relevant context: should not appear",
+        plugin_user_context="",
+    )
+
+    assert api_msg["content"] == "old"
+
+
+def test_preserves_non_string_user_content_blocks():
+    blocks = [{"type": "text", "text": "hello"}]
+    user_msg = {"role": "user", "content": blocks}
+
+    api_msg = _inject_ephemeral_context_into_user_message(
+        user_msg,
+        messages=[user_msg],
+        message_index=0,
+        current_turn_user_idx=0,
+        memory_prefetch="LLM Wiki relevant context: block",
+        plugin_user_context="",
+    )
+
+    assert api_msg["content"] == blocks
+    assert user_msg["content"] == blocks

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -806,6 +806,7 @@ class TestMemoryContextFencing:
         assert combined.index("weather") < fence_start
 
 
+
 # ---------------------------------------------------------------------------
 # AIAgent.commit_memory_session — routes to MemoryManager.on_session_end
 # ---------------------------------------------------------------------------
@@ -991,6 +992,79 @@ class TestOnMemoryWriteBridge:
         mgr.on_memory_write("add", "user", "test")
         # Good provider still received the call despite bad provider crashing
         assert good.memory_writes == [("add", "user", "test")]
+
+
+class TestAIAgentMemoryProviderContext:
+    def test_explicit_agent_context_reaches_memory_provider(self, tmp_path):
+        from run_agent import AIAgent
+
+        provider = FakeMemoryProvider("context-provider")
+        cfg = {"memory": {"provider": "context-provider"}}
+
+        with patch("run_agent.OpenAI"), \
+            patch("hermes_cli.config.load_config", return_value=cfg), \
+            patch("agent.agent_init.get_hermes_home", return_value=tmp_path), \
+            patch("plugins.memory.load_memory_provider", return_value=provider):
+            AIAgent(
+                api_key="key",
+                base_url="https://openrouter.ai/api/v1",
+                model="test/model",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=False,
+                platform="cron",
+                agent_context="cron",
+            )
+
+        assert provider.initialized is True
+        assert provider._init_kwargs["agent_context"] == "cron"
+        assert provider._init_kwargs["platform"] == "cron"
+
+    def test_agent_context_env_fallback_reaches_memory_provider(self, tmp_path, monkeypatch):
+        from run_agent import AIAgent
+
+        provider = FakeMemoryProvider("context-provider")
+        cfg = {"memory": {"provider": "context-provider"}}
+        monkeypatch.setenv("HERMES_AGENT_CONTEXT", "batch")
+
+        with patch("run_agent.OpenAI"), \
+            patch("hermes_cli.config.load_config", return_value=cfg), \
+            patch("agent.agent_init.get_hermes_home", return_value=tmp_path), \
+            patch("plugins.memory.load_memory_provider", return_value=provider):
+            AIAgent(
+                api_key="key",
+                base_url="https://openrouter.ai/api/v1",
+                model="test/model",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=False,
+                platform="cli",
+            )
+
+        assert provider._init_kwargs["agent_context"] == "batch"
+
+    def test_cli_platform_defaults_to_primary_agent_context(self, tmp_path, monkeypatch):
+        from run_agent import AIAgent
+
+        provider = FakeMemoryProvider("context-provider")
+        cfg = {"memory": {"provider": "context-provider"}}
+        monkeypatch.delenv("HERMES_AGENT_CONTEXT", raising=False)
+
+        with patch("run_agent.OpenAI"), \
+            patch("hermes_cli.config.load_config", return_value=cfg), \
+            patch("agent.agent_init.get_hermes_home", return_value=tmp_path), \
+            patch("plugins.memory.load_memory_provider", return_value=provider):
+            AIAgent(
+                api_key="key",
+                base_url="https://openrouter.ai/api/v1",
+                model="test/model",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=False,
+                platform="cli",
+            )
+
+        assert provider._init_kwargs["agent_context"] == "primary"
 
 
 class TestHonchoCadenceTracking:

--- a/tests/plugins/memory/test_llm_wiki_agent_agnostic_adapter.py
+++ b/tests/plugins/memory/test_llm_wiki_agent_agnostic_adapter.py
@@ -1,0 +1,517 @@
+"""Hermes integration tests for agent-agnostic LLM Wiki adapter primitives."""
+
+from __future__ import annotations
+
+import ast
+import math
+from pathlib import Path
+
+import json
+
+import pytest
+
+import hermes_wiki.tool_adapter as tool_adapter_module
+from agent.memory_manager import MemoryManager
+from hermes_wiki.capabilities import WikiCapabilities, capability_preset
+from hermes_wiki.mcp_server import build_mcp_server, mcp_tool_names_for_context
+from hermes_wiki.tool_adapter import LLMWikiToolAdapter
+from plugins.memory.llm_wiki import LLMWikiMemoryProvider
+
+
+class FakeConfig:
+    def __init__(self, wiki_path):
+        self.wiki_path = wiki_path
+
+
+class FakeSearch:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def search(self, query, limit=5, exclude_sources=False, search_mode="dense"):
+        self.calls.append((query, limit, exclude_sources, search_mode))
+        return [
+            {
+                "page_path": "concepts/example.md",
+                "title": "Example",
+                "text": "ExactModelName appears here",
+                "score": 0.9,
+            }
+        ]
+
+
+class FakeEngine:
+    def __init__(self) -> None:
+        self.search = FakeSearch()
+        self.query_calls = []
+        self.ingest_calls = []
+        self.update_calls = []
+        self.reindex_calls = 0
+
+    def status(self):
+        return {"wiki": "/tmp/wiki", "total_pages": 1}
+
+    def orient(self):
+        return "# Orientation"
+
+    def query(self, question, file_result=False, log_query=False):
+        self.query_calls.append((question, file_result, log_query))
+        return {"answer": "ok", "file_result": file_result, "log_query": log_query}
+
+    def lint(self, write_log=False):
+        return {"issues": [], "write_log": write_log}
+
+    def ingest_file(self, file_path, dry_run=True):
+        self.ingest_calls.append((file_path, dry_run))
+        return {"file_path": file_path, "dry_run": dry_run}
+
+    def update_page(self, page, body, *, frontmatter_updates=None, source_refs=None, reason="", reindex=True):
+        self.update_calls.append((page, body, frontmatter_updates or {}, source_refs or [], reason, reindex))
+        return {"page": page, "updated": True, "chunks_indexed": 2}
+
+    def reindex(self):
+        self.reindex_calls += 1
+        return {"ok": True}
+
+
+def test_tool_adapter_default_engine_factory_uses_writable_engine_for_trusted_context(monkeypatch):
+    constructed = []
+
+    class Engine:
+        def __init__(self, config, *, read_only=True):
+            constructed.append(read_only)
+
+        def status(self):
+            return {"initialized": True}
+
+    monkeypatch.setattr(tool_adapter_module, "WikiEngine", Engine)
+
+    LLMWikiToolAdapter(capabilities=capability_preset("mcp")).call("wiki_status", {})
+    LLMWikiToolAdapter(capabilities=capability_preset("primary")).call("wiki_status", {})
+
+    assert constructed == [True, False]
+
+
+def test_capability_presets_are_host_agnostic_and_safe_by_default():
+    mcp = capability_preset("mcp")
+    primary = capability_preset("primary")
+    unknown = capability_preset("openclaw-worker")
+
+    assert mcp.can_read is True
+    assert mcp.can_query is True
+    assert mcp.can_ingest is False
+    assert unknown == mcp
+    assert primary.can_ingest is True
+    assert primary.can_mutate_canonical is True
+
+
+def test_tool_adapter_schemas_are_filtered_to_granted_capabilities():
+    mcp_adapter = LLMWikiToolAdapter(engine_factory=FakeEngine, capabilities=capability_preset("mcp"))
+    trusted_adapter = LLMWikiToolAdapter(engine_factory=FakeEngine, capabilities=capability_preset("primary"))
+
+    mcp_tool_names = {schema["name"] for schema in mcp_adapter.tool_schemas()}
+    trusted_tool_names = {schema["name"] for schema in trusted_adapter.tool_schemas()}
+
+    assert "wiki_capabilities" in mcp_tool_names
+    assert "wiki_search" in mcp_tool_names
+    assert "wiki_query" in mcp_tool_names
+    assert "wiki_propose" not in mcp_tool_names
+    assert "wiki_ingest" not in mcp_tool_names
+    assert "wiki_reindex" not in mcp_tool_names
+    assert "wiki_update" not in mcp_tool_names
+    assert "wiki_ingest" in trusted_tool_names
+    assert "wiki_reindex" not in trusted_tool_names
+    assert "wiki_update" in trusted_tool_names
+
+
+def test_tool_adapter_reports_capabilities_for_external_agents():
+    adapter = LLMWikiToolAdapter(engine_factory=FakeEngine, capabilities=capability_preset("mcp"))
+
+    result = adapter.call("wiki_capabilities", {})
+
+    assert result["can_read"] is True
+    assert result["can_query"] is True
+    assert result["can_ingest"] is False
+    assert result["safe_default"] is True
+    assert "wiki_propose" not in result["exposed_tools"]
+
+
+def test_tool_adapter_rejects_removed_proposal_tool(tmp_path):
+    adapter = LLMWikiToolAdapter(config=FakeConfig(tmp_path / "wiki"), engine_factory=FakeEngine, capabilities=capability_preset("mcp"))
+
+    with pytest.raises(KeyError, match="wiki_propose"):
+        adapter.call(
+            "wiki_propose",
+            {
+                "title": "Remember adapter contract",
+                "source_refs": ["raw/articles/adapter-contract.md"],
+                "queue": True,
+            },
+        )
+
+    assert not (tmp_path / "wiki" / "proposals").exists()
+
+
+def test_mcp_tool_names_follow_context_capabilities():
+    default_names = set(mcp_tool_names_for_context("mcp"))
+    trusted_names = set(mcp_tool_names_for_context("primary"))
+
+    assert "wiki_capabilities" in default_names
+    assert "wiki_search" in default_names
+    assert "wiki_query" in default_names
+    assert "wiki_ingest" not in default_names
+    assert "wiki_reindex" not in default_names
+    assert "wiki_update" not in default_names
+    assert "wiki_ingest" in trusted_names
+    assert "wiki_reindex" not in trusted_names
+    assert "wiki_update" in trusted_names
+
+
+def test_mcp_server_registers_canonical_update_only_for_trusted_context():
+    default_server = build_mcp_server(engine_factory=FakeEngine, context="mcp")
+    trusted_server = build_mcp_server(engine_factory=FakeEngine, context="primary")
+
+    default_names = {tool.name for tool in default_server._tool_manager.list_tools()}
+    trusted_names = {tool.name for tool in trusted_server._tool_manager.list_tools()}
+
+    assert "wiki_update" not in default_names
+    assert "wiki_update" in trusted_names
+
+
+def test_tool_adapter_denies_mcp_ingest_direct_dispatch_and_preserves_hybrid_search():
+    engine = FakeEngine()
+    adapter = LLMWikiToolAdapter(engine_factory=lambda: engine, capabilities=capability_preset("mcp"))
+
+    search_result = adapter.call(
+        "wiki_search",
+        {"query": "ExactModelName", "limit": 99, "exclude_sources": True, "search_mode": "hybrid"},
+    )
+    try:
+        adapter.call("wiki_ingest", {"file_path": "/tmp/source.md", "dry_run": True})
+    except PermissionError as exc:
+        assert "ingest" in str(exc)
+    else:  # pragma: no cover - explicit failure path
+        raise AssertionError("ingest direct dispatch should be denied outside primary context")
+
+    assert engine.search.calls == [("ExactModelName", 20, True, "hybrid")]
+    assert search_result[0]["page_path"] == "concepts/example.md"
+    assert engine.ingest_calls == []
+
+
+def test_tool_adapter_denies_requested_query_and_lint_writes_without_capability():
+    engine = FakeEngine()
+    adapter = LLMWikiToolAdapter(engine_factory=lambda: engine, capabilities=capability_preset("mcp"))
+
+    assert adapter.call("wiki_query", {"question": "What next?", "file_result": False, "log_query": False})["answer"] == "ok"
+
+    for tool_name, args, expected in (
+        ("wiki_query", {"question": "What next?", "file_result": True}, "mutate_canonical"),
+        ("wiki_query", {"question": "What next?", "log_query": True}, "log_query"),
+        ("wiki_lint", {"write_log": True}, "write_report"),
+    ):
+        try:
+            adapter.call(tool_name, args)
+        except PermissionError as exc:
+            assert expected in str(exc)
+        else:  # pragma: no cover - explicit failure path
+            raise AssertionError(f"{tool_name} should deny requested side effect")
+
+    assert engine.query_calls == [("What next?", False, False)]
+
+
+def test_tool_adapter_does_not_expose_manual_reindex_tool():
+    adapter = LLMWikiToolAdapter(engine_factory=FakeEngine, capabilities=capability_preset("subagent"))
+
+    try:
+        adapter.call("wiki_reindex", {})
+    except KeyError as exc:
+        assert "wiki_reindex" in str(exc)
+    else:  # pragma: no cover - explicit failure path
+        raise AssertionError("wiki_reindex should not be a manually callable LLM tool")
+
+
+def test_tool_adapter_denies_canonical_update_without_primary_capability():
+    engine = FakeEngine()
+    adapter = LLMWikiToolAdapter(engine_factory=lambda: engine, capabilities=capability_preset("mcp"))
+
+    try:
+        adapter.call(
+            "wiki_update",
+            {
+                "page": "concepts/memory-policy.md",
+                "body": "# Memory Policy\n\nUpdated body.",
+                "source_refs": ["raw/articles/source.md"],
+                "reason": "source-backed correction",
+            },
+        )
+    except PermissionError as exc:
+        assert "mutate_canonical" in str(exc)
+    else:  # pragma: no cover - explicit failure path
+        raise AssertionError("canonical update should be denied outside primary context")
+
+    assert engine.update_calls == []
+
+
+def test_tool_adapter_allows_primary_canonical_update():
+    engine = FakeEngine()
+    adapter = LLMWikiToolAdapter(engine_factory=lambda: engine, capabilities=capability_preset("primary"))
+
+    result = adapter.call(
+        "wiki_update",
+        {
+            "page": "concepts/memory-policy.md",
+            "body": "# Memory Policy\n\nUpdated body.",
+            "frontmatter_updates": {"confidence": "high"},
+            "source_refs": ["raw/articles/source.md"],
+            "reason": "source-backed correction",
+        },
+    )
+
+    assert result == {"page": "concepts/memory-policy.md", "updated": True, "chunks_indexed": 2}
+    assert engine.update_calls == [(
+        "concepts/memory-policy.md",
+        "# Memory Policy\n\nUpdated body.",
+        {"confidence": "high"},
+        ["raw/articles/source.md"],
+        "source-backed correction",
+        True,
+    )]
+
+
+def test_hermes_provider_system_prompt_routes_memory_relevant_questions_to_wiki_tools():
+    provider = LLMWikiMemoryProvider()
+
+    block = provider.system_prompt_block()
+
+    assert "use wiki_search whenever durable memory could improve correctness" in block
+    assert "prior decisions" in block
+    assert "preferences" in block
+    assert "goals" in block
+    assert "what's next" in block
+    assert "Do not wait for explicit memory requests" in block
+    assert "Prefetch snippets are only hints" in block
+    assert "Reference wiki/source pages" in block
+    assert "Keep the wiki current" in block
+    assert "wiki_search" in block
+    assert "wiki_read" in block
+    assert "wiki_query" in block
+    assert "wiki_update" in block
+    assert "wiki_propose" not in block
+    assert "proposal" not in block.lower()
+
+
+def test_hermes_provider_exposes_shared_capability_and_update_tools():
+    provider = LLMWikiMemoryProvider()
+    tool_names = {schema["name"] for schema in provider.get_tool_schemas()}
+
+    assert "wiki_capabilities" in tool_names
+    assert "wiki_propose" not in tool_names
+    assert "wiki_search" in tool_names
+    assert "wiki_read" in tool_names
+
+
+def test_hermes_provider_handles_shared_capabilities_tool(tmp_path):
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="cron")
+
+    result = json.loads(provider.handle_tool_call("wiki_capabilities", {}))
+
+    assert result["can_read"] is True
+    assert "can_queue_proposal" not in result
+    assert result["can_ingest"] is False
+    assert "wiki_propose" not in result["exposed_tools"]
+    assert "wiki_read" in result["exposed_tools"]
+
+
+def test_hermes_provider_bool_parser_has_no_python_truthiness_fallback():
+    source = Path("plugins/memory/llm_wiki/__init__.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    violations = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef) or node.name != "_as_bool":
+            continue
+        for child in ast.walk(node):
+            if not isinstance(child, ast.Call):
+                continue
+            func = child.func
+            if not isinstance(func, ast.Name) or func.id != "bool" or len(child.args) != 1:
+                continue
+            arg = child.args[0]
+            if isinstance(arg, ast.Name) and arg.id == "value":
+                violations.append(child.lineno)
+
+    assert violations == []
+
+
+def test_hermes_provider_bool_args_fail_closed_for_ambiguous_values(monkeypatch, tmp_path):
+    engine = FakeEngine()
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+    monkeypatch.setattr(provider, "_engine", lambda: engine)
+
+    query = provider.handle_tool_call(
+        "wiki_query",
+        {"question": "what", "file_result": ["yes"], "log_query": {"enabled": True}},
+    )
+    nan_query = provider.handle_tool_call("wiki_query", {"question": "nan", "file_result": math.nan, "log_query": math.nan})
+    ingest = json.loads(provider.handle_tool_call("wiki_ingest", {"file_path": "/tmp/source.md", "dry_run": math.nan}))
+
+    assert "file_result': False" in query or '"file_result": false' in query.lower()
+    assert "log_query': False" in query or '"log_query": false' in query.lower()
+    assert "file_result': False" in nan_query or '"file_result": false' in nan_query.lower()
+    assert "log_query': False" in nan_query or '"log_query": false' in nan_query.lower()
+    assert ingest["dry_run"] is True
+    assert engine.ingest_calls == [("/tmp/source.md", True)]
+
+
+def test_hermes_provider_handles_shared_introspection_tool(monkeypatch, tmp_path):
+    if "wiki_introspect" not in {schema["name"] for schema in LLMWikiToolAdapter(engine_factory=FakeEngine, capabilities=capability_preset("mcp")).tool_schemas()}:
+        pytest.skip("standalone hermes-llm-wiki version does not expose wiki_introspect yet")
+    engine = FakeEngine()
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="cron")
+    monkeypatch.setattr(provider, "_engine", lambda: engine)
+
+    payload = json.loads(
+        provider.handle_tool_call(
+            "wiki_introspect",
+            {
+                "query": "ExactModelName",
+                "top_k": "2",
+                "expected_pages": ["concepts/example.md"],
+                "compare_modes": True,
+            },
+        )
+    )
+
+    assert payload["passed"] is True
+    assert set(payload["modes"]) == {"dense", "sparse", "hybrid"}
+    assert payload["modes"]["dense"]["expected_pages"] == ["concepts/example.md"]
+
+
+def test_hermes_provider_rejects_ambiguous_introspection_mode_args(monkeypatch, tmp_path):
+    if "wiki_introspect" not in {schema["name"] for schema in LLMWikiToolAdapter(engine_factory=FakeEngine, capabilities=capability_preset("mcp")).tool_schemas()}:
+        pytest.skip("standalone hermes-llm-wiki version does not expose wiki_introspect yet")
+    engine = FakeEngine()
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="cron")
+    monkeypatch.setattr(provider, "_engine", lambda: engine)
+
+    result = provider.handle_tool_call(
+        "wiki_introspect",
+        {"query": "ExactModelName", "compare_modes": True, "search_mode": "hybrid"},
+    )
+
+    assert "Error:" in result
+    assert "compare_modes" in result
+
+
+def test_hermes_provider_rejects_removed_proposal_tool(monkeypatch, tmp_path):
+    class AdapterShouldNotBeCalled:
+        def call(self, name, args):  # pragma: no cover - failure path
+            raise AssertionError("removed proposal tool must not delegate")
+
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="cron")
+    monkeypatch.setattr(provider, "_adapter", lambda: AdapterShouldNotBeCalled())
+
+    with pytest.raises(NotImplementedError, match="wiki_propose"):
+        provider.handle_tool_call("wiki_propose", {"title": "Removed", "queue": True})
+
+    assert not (tmp_path / "wiki" / "personal" / "proposals").exists()
+
+
+def test_memory_manager_routes_llm_wiki_shared_tools(tmp_path):
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="cron")
+    manager = MemoryManager()
+    manager.add_provider(provider)
+
+    assert manager.has_tool("wiki_capabilities")
+    assert not manager.has_tool("wiki_propose")
+    result = json.loads(manager.handle_tool_call("wiki_capabilities", {}))
+    assert "can_queue_proposal" not in result
+
+
+def test_hermes_provider_maps_agent_context_to_generic_capabilities(tmp_path):
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="cron")
+
+    assert isinstance(provider._capabilities, WikiCapabilities)
+    assert provider._capabilities == capability_preset("cron")
+    assert provider._writes_allowed() is False
+
+
+def test_hermes_provider_returns_error_for_invalid_search_mode(monkeypatch, tmp_path):
+    engine = FakeEngine()
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+    monkeypatch.setattr(provider, "_engine", lambda: engine)
+
+    result = provider.handle_tool_call("wiki_search", {"query": "ExactModelName", "search_mode": "bogus"})
+
+    assert "Error:" in result
+    assert "search_mode" in result
+    assert engine.search.calls == []
+
+
+def test_hermes_provider_uses_tool_adapter_for_shared_search_semantics(monkeypatch, tmp_path):
+    engine = FakeEngine()
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+    monkeypatch.setattr(provider, "_engine", lambda: engine)
+
+    payload = json.loads(
+        provider.handle_tool_call(
+            "wiki_search",
+            {"query": "ExactModelName", "limit": "99", "exclude_sources": "true", "search_mode": "hybrid"},
+        )
+    )
+
+    assert engine.search.calls == [("ExactModelName", 20, True, "hybrid")]
+    assert payload[0]["page_path"] == "concepts/example.md"
+
+def test_disabled_context_provider_blocks_direct_read_tools(monkeypatch, tmp_path):
+    page = tmp_path / "wiki" / "personal" / "concepts" / "secret.md"
+    page.parent.mkdir(parents=True)
+    page.write_text("# Secret\n\nShould not be readable", encoding="utf-8")
+
+    engine = FakeEngine()
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="disabled")
+    monkeypatch.setattr(provider, "_engine", lambda: engine)
+
+    status = provider.handle_tool_call("wiki_status", {})
+    orient = provider.handle_tool_call("wiki_orient", {})
+    read = provider.handle_tool_call("wiki_read", {"page": "concepts/secret.md"})
+
+    assert "capability denied" in status.lower()
+    assert "capability denied" in orient.lower()
+    assert "capability denied" in read.lower()
+    assert "Should not be readable" not in read
+
+
+def test_disabled_context_provider_prefetch_is_noop(monkeypatch, tmp_path):
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="disabled")
+    monkeypatch.setattr(
+        provider,
+        "_engine",
+        lambda: (_ for _ in ()).throw(AssertionError("disabled prefetch must not load engine")),
+    )
+
+    assert provider.prefetch("memory policy") == ""
+
+
+def test_disabled_context_provider_blocks_direct_query_and_lint(monkeypatch, tmp_path):
+    engine = FakeEngine()
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="disabled")
+    monkeypatch.setattr(provider, "_engine", lambda: engine)
+
+    query = provider.handle_tool_call("wiki_query", {"question": "What should be blocked?"})
+    lint = provider.handle_tool_call("wiki_lint", {})
+
+    assert "capability denied" in query.lower()
+    assert "capability denied" in lint.lower()
+    assert engine.query_calls == []

--- a/tests/plugins/memory/test_llm_wiki_caretaker.py
+++ b/tests/plugins/memory/test_llm_wiki_caretaker.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+import yaml
+
+from hermes_wiki.caretaker import (
+    caretaker_report_to_dict,
+    render_caretaker_report,
+    run_caretaker,
+)
+from hermes_wiki.caretaker import (
+    main as caretaker_main,
+)
+from hermes_wiki.config import WikiConfig
+from hermes_wiki.frontmatter import write_page
+
+
+class FakeSearchResult:
+    def __init__(self, page_path: str):
+        self.page_path = page_path
+
+
+class FakeSearcher:
+    def __init__(self, results_by_query):
+        self.results_by_query = results_by_query
+        self.calls = []
+
+    def search(self, query, limit=5):
+        self.calls.append((query, limit))
+        return self.results_by_query.get(query, [])
+
+
+def _write_page(config: WikiConfig, rel_path: str, fm: dict, body: str):
+    path = config.wiki_path / rel_path
+    write_page(path, fm, body)
+    return path
+
+
+def test_caretaker_ignores_legacy_proposal_directory(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    proposal_path = config.wiki_path / "proposals" / "pending-memory.md"
+    proposal_path.parent.mkdir(parents=True)
+    proposal_path.write_text("---\ntitle: Pending memory\nstatus: pending\n---\nBody.\n", encoding="utf-8")
+    before = proposal_path.read_text(encoding="utf-8")
+
+    report = run_caretaker(config)
+
+    assert proposal_path.read_text(encoding="utf-8") == before
+    assert not hasattr(report.maintenance, "pending_proposals")
+    assert report.has_blockers is False
+    assert all(action.kind != "review_pending_proposal" for action in report.actions)
+
+
+def test_caretaker_runs_retrieval_eval_when_cases_are_supplied(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    cases_path = tmp_path / "retrieval.yaml"
+    cases_path.write_text(
+        yaml.safe_dump([
+            {
+                "query": "How should Hermes use memory?",
+                "expected_pages": ["concepts/hermes-memory.md"],
+                "top_k": 2,
+            }
+        ]),
+        encoding="utf-8",
+    )
+    searcher = FakeSearcher({"How should Hermes use memory?": [FakeSearchResult("concepts/hermes-memory.md")]})
+
+    report = run_caretaker(config, eval_cases_path=cases_path, searcher=searcher)
+
+    assert report.retrieval_eval is not None
+    assert report.retrieval_eval.passed is True
+    assert searcher.calls == [("How should Hermes use memory?", 2)]
+    assert report.has_blockers is False
+
+
+def test_caretaker_marks_eval_failure_as_blocker(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    cases_path = tmp_path / "retrieval.yaml"
+    cases_path.write_text(
+        yaml.safe_dump([
+            {
+                "query": "What is the user's preferred name?",
+                "expected_pages": ["entities/example-user.md"],
+            }
+        ]),
+        encoding="utf-8",
+    )
+    searcher = FakeSearcher({"What is the user's preferred name?": [FakeSearchResult("entities/hermes.md")]})
+
+    report = run_caretaker(config, eval_cases_path=cases_path, searcher=searcher)
+
+    assert report.has_blockers is True
+    assert any(action.kind == "fix_retrieval_regression" and action.severity == "error" for action in report.actions)
+
+
+def test_caretaker_rejects_nonscalar_eval_path_and_compare_modes(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+
+    for bad_path in ({"path": "retrieval.yaml"}, ""):
+        with pytest.raises(ValueError, match="eval_cases_path"):
+            run_caretaker(config, eval_cases_path=bad_path)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="compare_modes"):
+        run_caretaker(config, compare_modes={"enabled": True})  # type: ignore[arg-type]
+
+
+def test_caretaker_report_to_dict_is_json_serializable(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+
+    payload = caretaker_report_to_dict(run_caretaker(config))
+
+    assert json.loads(json.dumps(payload))["maintenance"]["total_pages"] == 0
+    assert "actions" in payload
+
+
+def test_render_caretaker_report_is_agent_native(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+
+    text = render_caretaker_report(run_caretaker(config))
+
+    assert "# LLM Wiki Caretaker Report" in text
+    assert "## Agent actions" in text
+    assert "Human UI" not in text
+
+
+def test_caretaker_cli_is_quiet_when_healthy(tmp_path, capsys):
+    config_path = tmp_path / "config.yaml"
+    wiki_path = tmp_path / "wiki"
+    config_path.write_text(f"wiki:\n  path: {wiki_path}\n  name: test\n", encoding="utf-8")
+
+    code = caretaker_main(["--config", str(config_path), "--quiet"])
+
+    assert code == 0
+    assert capsys.readouterr().out == ""
+    assert not wiki_path.exists()
+
+
+def test_caretaker_cli_writes_report_only_to_reports_namespace(tmp_path, capsys):
+    config_path = tmp_path / "config.yaml"
+    wiki_path = tmp_path / "wiki"
+    config_path.write_text(f"wiki:\n  path: {wiki_path}\n  name: test\n", encoding="utf-8")
+
+    code = caretaker_main(["--config", str(config_path), "--write-report", "reports/caretaker.md"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 0
+    assert payload == {"path": str(wiki_path / "reports" / "caretaker.md"), "written": True}
+    assert (wiki_path / "reports" / "caretaker.md").exists()
+
+
+def test_caretaker_cli_rejects_write_report_outside_reports(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    wiki_path = tmp_path / "wiki"
+    config_path.write_text(f"wiki:\n  path: {wiki_path}\n  name: test\n", encoding="utf-8")
+    canonical = _write_page(
+        WikiConfig(wiki_path=wiki_path, wiki_name="test"),
+        "concepts/existing.md",
+        {"title": "Existing", "type": "concept", "sources": ["raw/articles/source.md"]},
+        "Original.",
+    )
+    before = canonical.read_text(encoding="utf-8")
+
+    with pytest.raises(SystemExit):
+        caretaker_main(["--config", str(config_path), "--write-report", "concepts/existing.md"])
+
+    assert canonical.read_text(encoding="utf-8") == before
+
+
+def test_caretaker_can_include_nonblocking_retrieval_mode_comparison(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    cases_path = tmp_path / "retrieval.yaml"
+    cases_path.write_text(
+        yaml.safe_dump([{"query": "literal", "expected_pages": ["concepts/package.md"]}]),
+        encoding="utf-8",
+    )
+
+    class ModeAwareSearcher:
+        def search(self, query, limit=5, **kwargs):
+            if kwargs.get("search_mode") == "sparse":
+                return [FakeSearchResult("concepts/noise.md")]
+            return [FakeSearchResult("concepts/package.md")]
+
+    report = run_caretaker(config, eval_cases_path=cases_path, searcher=ModeAwareSearcher(), compare_modes=True)
+    payload = caretaker_report_to_dict(report)
+
+    assert report.has_blockers is False
+    assert payload["retrieval_eval"]["passed"] is True
+    assert payload["retrieval_mode_comparison"]["passed"] is False
+    assert payload["retrieval_mode_comparison"]["failed_modes"] == ["sparse"]
+    assert payload["retrieval_mode_comparison"]["summary"]["dense"] == {
+        "passed": True,
+        "failures": 0,
+        "total": 1,
+    }
+
+
+def test_caretaker_cli_compare_modes_includes_summary(tmp_path, monkeypatch, capsys):
+    config_path = tmp_path / "config.yaml"
+    wiki_path = tmp_path / "wiki"
+    evals_path = wiki_path / "evals" / "retrieval.yaml"
+    evals_path.parent.mkdir(parents=True)
+    config_path.write_text(f"wiki:\n  path: {wiki_path}\n  name: test\n", encoding="utf-8")
+    evals_path.write_text(
+        yaml.safe_dump([{"query": "literal", "expected_pages": ["concepts/package.md"]}]),
+        encoding="utf-8",
+    )
+
+    class FakeWikiSearch:
+        def __init__(self, config, ensure_collection=False):
+            pass
+
+        def search(self, query, limit=5, **kwargs):
+            return [FakeSearchResult("concepts/package.md")]
+
+    def fake_build_searcher(config_path=None):
+        return FakeWikiSearch(None)
+
+    monkeypatch.setattr("hermes_wiki.caretaker._build_searcher", fake_build_searcher)
+
+    code = caretaker_main(["--config", str(config_path), "--compare-modes", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert code == 0
+    assert payload["retrieval_mode_comparison"]["summary"]["hybrid"] == {
+        "passed": True,
+        "failures": 0,
+        "total": 1,
+    }
+
+
+def test_render_caretaker_report_includes_mode_comparison_summary(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    cases_path = tmp_path / "retrieval.yaml"
+    cases_path.write_text(
+        yaml.safe_dump([{"query": "literal", "expected_pages": ["concepts/package.md"]}]),
+        encoding="utf-8",
+    )
+
+    class ModeAwareSearcher:
+        def search(self, query, limit=5, **kwargs):
+            if kwargs.get("search_mode") == "sparse":
+                return [FakeSearchResult("concepts/noise.md")]
+            return [FakeSearchResult("concepts/package.md")]
+
+    text = render_caretaker_report(
+        run_caretaker(config, eval_cases_path=cases_path, searcher=ModeAwareSearcher(), compare_modes=True)
+    )
+
+    assert "- Retrieval mode comparison: dense=passed, sparse=failed, hybrid=passed" in text
+    assert "diagnostic" in text.lower()
+
+
+class CaretakerLeakyObject:
+    def __str__(self):
+        return "CARETAKER-LEAK"
+
+
+def test_caretaker_report_to_dict_normalizes_malformed_direct_actions():
+    from hermes_wiki.caretaker import CaretakerAction, CaretakerReport
+    from hermes_wiki.maintenance import MaintenanceReport
+
+    report = CaretakerReport(
+        maintenance=MaintenanceReport(),
+        actions=[
+            CaretakerAction(
+                kind=CaretakerLeakyObject(),  # type: ignore[arg-type]
+                severity=CaretakerLeakyObject(),  # type: ignore[arg-type]
+                message=CaretakerLeakyObject(),  # type: ignore[arg-type]
+                autonomous=CaretakerLeakyObject(),  # type: ignore[arg-type]
+                file_path=CaretakerLeakyObject(),  # type: ignore[arg-type]
+            )
+        ],
+    )
+
+    payload = caretaker_report_to_dict(report)
+    assert payload["has_blockers"] is False
+    assert payload["actions"] == [
+        {"kind": "inspect", "severity": "info", "message": "", "autonomous": False, "file_path": None}
+    ]
+    assert "CARETAKER-LEAK" not in str(payload)
+
+
+def test_render_caretaker_report_normalizes_malformed_direct_actions():
+    from hermes_wiki.caretaker import CaretakerAction, CaretakerReport
+    from hermes_wiki.maintenance import MaintenanceReport
+
+    report = CaretakerReport(
+        maintenance=MaintenanceReport(),
+        actions=[
+            CaretakerAction(
+                kind=CaretakerLeakyObject(),  # type: ignore[arg-type]
+                severity=CaretakerLeakyObject(),  # type: ignore[arg-type]
+                message=CaretakerLeakyObject(),  # type: ignore[arg-type]
+                autonomous=CaretakerLeakyObject(),  # type: ignore[arg-type]
+                file_path=CaretakerLeakyObject(),  # type: ignore[arg-type]
+            )
+        ],
+    )
+
+    text = render_caretaker_report(report)
+
+    assert "CARETAKER-LEAK" not in text
+    assert "- Blockers: no" in text
+    assert "- **info / inspect / needs evidence**: " in text

--- a/tests/plugins/memory/test_llm_wiki_embedding_cache.py
+++ b/tests/plugins/memory/test_llm_wiki_embedding_cache.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import sqlite3
+
+from vector_core.embeddings import EmbeddingCache as VectorCoreEmbeddingCache
+from vector_core.embeddings import SyncEmbeddingClient as VectorCoreEmbeddingClient
+
+from hermes_wiki.config import WikiConfig
+from hermes_wiki.search import EmbeddingCache, WikiSearch, _EmbeddingClient
+
+
+class _FakeVectorCoreClient:
+    def __init__(self):
+        self.calls: list[list[str]] = []
+        self.closed = False
+
+    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        self.calls.append(list(texts))
+        return [[float(len(text)), float(idx)] for idx, text in enumerate(texts)]
+
+    def close(self):
+        self.closed = True
+
+
+def _embedder(tmp_path, *, max_entries=100):
+    config = WikiConfig(
+        embedding_model="test-model",
+        embedding_dim=2,
+        embedding_cache_path=tmp_path / "embeddings.db",
+        embedding_cache_max_entries=max_entries,
+    )
+    embedder = _EmbeddingClient.__new__(_EmbeddingClient)
+    embedder._client = _FakeVectorCoreClient()
+    embedder._model = config.embedding_model
+    embedder._dim = config.embedding_dim
+    embedder._cache = EmbeddingCache(config.embedding_cache_path, max_entries=config.embedding_cache_max_entries)
+    return embedder
+
+
+def test_embedding_cache_wraps_vector_core_cache(tmp_path):
+    cache = EmbeddingCache(tmp_path / "cache.db", max_entries=10)
+
+    assert isinstance(cache._vector_cache, VectorCoreEmbeddingCache)
+    assert cache.cache_path == tmp_path / "cache.db"
+
+
+def test_embedding_client_instantiates_vector_core_embedding_client(tmp_path):
+    config = WikiConfig(
+        embedding_url="http://embedding.test/v1",
+        embedding_model="test-model",
+        embedding_dim=2,
+        embedding_cache_path=tmp_path / "embeddings.db",
+    )
+
+    embedder = _EmbeddingClient(config)
+
+    assert isinstance(embedder._client, VectorCoreEmbeddingClient)
+    assert embedder._client.base_url == "http://embedding.test"
+    assert embedder._client.model == "test-model"
+    assert embedder._client.dim == 2
+
+
+def test_embedding_cache_round_trips_json_vectors_and_tracks_stats(tmp_path):
+    cache = EmbeddingCache(tmp_path / "cache.db", max_entries=10)
+    key = cache.key_for("hello", model="model-a", dim=2)
+
+    assert cache.get(key) is None
+    cache.set(key, [1.0, 2.5], model="model-a", dim=2)
+
+    assert cache.get(key) == [1.0, 2.5]
+    stats = cache.stats()
+    assert stats["entries"] == 1
+    assert stats["hits"] == 1
+    assert stats["misses"] == 1
+    assert stats["hit_rate"] == 0.5
+
+
+def test_embedding_cache_keys_include_model_and_dimension(tmp_path):
+    cache = EmbeddingCache(tmp_path / "cache.db")
+
+    text = "same text"
+    assert cache.key_for(text, model="model-a", dim=2) != cache.key_for(text, model="model-b", dim=2)
+    assert cache.key_for(text, model="model-a", dim=2) != cache.key_for(text, model="model-a", dim=4)
+
+
+def test_embedding_cache_deletes_corrupt_rows_as_misses(tmp_path):
+    cache = EmbeddingCache(tmp_path / "cache.db")
+    key = cache.key_for("bad", model="model-a", dim=2)
+    with sqlite3.connect(cache.cache_path) as conn:
+        conn.execute(
+            "INSERT INTO embeddings (content_hash, embedding, model, dim, created_at, accessed_at) VALUES (?, ?, ?, ?, '', '')",
+            (key, b"not-json", "model-a", 2),
+        )
+
+    assert cache.get(key) is None
+    with sqlite3.connect(cache.cache_path) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM embeddings WHERE content_hash = ?", (key,)).fetchone()[0]
+    assert count == 0
+
+
+def test_embedding_cache_lru_eviction_respects_max_entries(tmp_path):
+    cache = EmbeddingCache(tmp_path / "cache.db", max_entries=2)
+    for text in ["one", "two", "three"]:
+        key = cache.key_for(text, model="model-a", dim=2)
+        cache.set(key, [1.0, 2.0], model="model-a", dim=2)
+
+    assert cache.stats()["entries"] == 2
+    assert cache.get(cache.key_for("three", model="model-a", dim=2)) == [1.0, 2.0]
+
+
+def test_embedding_client_uses_persistent_cache_for_duplicate_texts(tmp_path):
+    embedder = _embedder(tmp_path)
+
+    assert embedder.embed_batch(["alpha", "alpha", "beta"]) == [[5.0, 0.0], [5.0, 0.0], [4.0, 1.0]]
+    assert embedder._client.calls == [["alpha", "beta"]]
+
+    assert embedder.embed_batch(["alpha", "beta"]) == [[5.0, 0.0], [4.0, 1.0]]
+    assert embedder._client.calls == [["alpha", "beta"]]
+
+
+def test_embedding_client_cache_survives_new_embedder_instance(tmp_path):
+    first = _embedder(tmp_path)
+    assert first.embed_single("alpha") == [5.0, 0.0]
+    assert first._client.calls == [["alpha"]]
+
+    second = _embedder(tmp_path)
+    assert second.embed_single("alpha") == [5.0, 0.0]
+    assert second._client.calls == []
+
+
+def test_embedding_client_can_disable_cache_for_read_only_contexts(tmp_path):
+    config = WikiConfig(
+        embedding_model="test-model",
+        embedding_dim=2,
+        embedding_cache_path=tmp_path / "embeddings.db",
+    )
+    embedder = _EmbeddingClient.__new__(_EmbeddingClient)
+    embedder._client = _FakeVectorCoreClient()
+    embedder._model = config.embedding_model
+    embedder._dim = config.embedding_dim
+    embedder._cache = None
+
+    assert embedder.embed_batch(["alpha", "alpha"]) == [[5.0, 0.0], [5.0, 0.0]]
+    assert embedder._client.calls == [["alpha"]]
+    assert not config.embedding_cache_path.exists()
+
+
+def test_wiki_search_read_only_disables_embedding_cache(monkeypatch, tmp_path):
+    captured = {}
+
+    class FakeQdrantClient:
+        def __init__(self, url):
+            self.url = url
+
+    class FakeEmbeddingClient:
+        def __init__(self, config, *, cache_enabled=True):
+            captured["cache_enabled"] = cache_enabled
+
+    monkeypatch.setattr("hermes_wiki.search._EmbeddingClient", FakeEmbeddingClient)
+    monkeypatch.setattr("qdrant_client.QdrantClient", FakeQdrantClient)
+
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    WikiSearch(config, ensure_collection=False, read_only=True)
+
+    assert captured["cache_enabled"] is False

--- a/tests/plugins/memory/test_llm_wiki_engine_source_hash.py
+++ b/tests/plugins/memory/test_llm_wiki_engine_source_hash.py
@@ -1,0 +1,70 @@
+"""Regression tests for raw source hashing during ingest/lint."""
+
+from __future__ import annotations
+
+from hermes_wiki.config import WikiConfig
+from hermes_wiki.engine import WikiEngine
+
+
+class DummyLLM:
+    def analyze_source(self, **kwargs):
+        return {"entities": [], "concepts": [], "key_facts": []}
+
+
+class DummyIndexer:
+    def __init__(self, config):
+        self.config = config
+
+    def list_entity_slugs(self):
+        return []
+
+    def list_concept_slugs(self):
+        return []
+
+    def list_all_slugs(self):
+        return []
+
+    def get_all_pages(self):
+        return {}
+
+    def list_sources(self):
+        return [{"path": "raw/articles/example-source.md"}]
+
+    def read_index(self):
+        return ""
+
+    def append_log(self, *args, **kwargs):
+        return None
+
+
+class DummySearch:
+    def search(self, *args, **kwargs):
+        return []
+
+    def collection_stats(self):
+        return {"points": 0}
+
+    def index_page(self, *args, **kwargs):
+        return 0
+
+    def index_source(self, *args, **kwargs):
+        return 0
+
+
+def _engine(tmp_path):
+    engine = WikiEngine.__new__(WikiEngine)
+    engine.config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    engine.llm = DummyLLM()
+    engine.indexer = DummyIndexer(engine.config)
+    engine.search = DummySearch()
+    engine.read_only = False
+    return engine
+
+
+def test_ingested_raw_source_hash_matches_lint_body_hash(tmp_path):
+    engine = _engine(tmp_path)
+
+    engine.ingest_text("# Example Source\n\nBody text.\n", "Example Source", dry_run=False)
+    report = engine.lint(write_log=False)
+
+    assert not [issue for issue in report.issues if issue.category == "source_drift"]

--- a/tests/plugins/memory/test_llm_wiki_hybrid_search.py
+++ b/tests/plugins/memory/test_llm_wiki_hybrid_search.py
@@ -1,0 +1,293 @@
+from types import SimpleNamespace
+
+from hermes_wiki.config import WikiConfig
+from hermes_wiki.search import WikiSearch, WikiSearchResult
+
+
+def _result(page_path, *, score, chunk_index=0, title=None, page_type="concept", text="", tags=None):
+    return WikiSearchResult(
+        page_path=page_path,
+        title=title or page_path.rsplit("/", 1)[-1].removesuffix(".md"),
+        page_type=page_type,
+        chunk_index=chunk_index,
+        text=text,
+        score=score,
+        tags=tags or [],
+    )
+
+
+class FakeScrollClient:
+    def __init__(self, payloads):
+        self.payloads = payloads
+        self.scroll_calls = []
+
+    def scroll(self, **kwargs):
+        self.scroll_calls.append(kwargs)
+        return [SimpleNamespace(payload=payload) for payload in self.payloads], None
+
+
+class FakeDenseSearch(WikiSearch):
+    def __init__(self, dense_results, lexical_payloads):
+        self.config = WikiConfig(wiki_name="test")
+        self._dense_results = dense_results
+        self._client = FakeScrollClient(lexical_payloads)
+
+    def _dense_search(self, query, *, limit, page_type=None, tags=None, exclude_sources=False):
+        return self._dense_results[:limit]
+
+
+def test_literal_tokenizer_is_imported_from_vector_core():
+    from vector_core.search import tokenize_literal_query
+
+    from hermes_wiki.search import tokenize_for_sparse_search
+
+    assert tokenize_for_sparse_search is tokenize_literal_query
+
+
+def test_tokenize_for_sparse_search_keeps_paths_ids_and_acronyms():
+    from hermes_wiki.search import tokenize_for_sparse_search
+
+    assert tokenize_for_sparse_search("Exact-Identifier-8B concepts/foo_bar.md GPT-5.5") == [
+        "exact",
+        "identifier",
+        "8b",
+        "concepts",
+        "foo_bar",
+        "md",
+        "gpt",
+        "5",
+        "5",
+    ]
+
+
+def test_reciprocal_rank_fusion_promotes_results_seen_by_both_rankers():
+    from hermes_wiki.search import reciprocal_rank_fusion
+
+    dense = [
+        _result("concepts/dense-only.md", score=0.99),
+        _result("concepts/shared.md", score=0.90),
+    ]
+    sparse = [
+        _result("concepts/shared.md", score=4.0),
+        _result("concepts/sparse-only.md", score=3.0),
+    ]
+
+    fused = reciprocal_rank_fusion([dense, sparse], limit=3, k=10)
+
+    assert [r.page_path for r in fused] == [
+        "concepts/shared.md",
+        "concepts/dense-only.md",
+        "concepts/sparse-only.md",
+    ]
+    assert fused[0].score > fused[1].score
+
+
+def test_sparse_search_scores_literal_query_terms_from_payloads():
+    searcher = WikiSearch.__new__(WikiSearch)
+    searcher.config = WikiConfig(wiki_name="test")
+    searcher._client = FakeScrollClient([
+        {
+            "page_path": "concepts/random.md",
+            "title": "Random",
+            "page_type": "concept",
+            "chunk_index": 0,
+            "text": "semantic discussion without the literal token",
+            "tags": [],
+        },
+        {
+            "page_path": "entities/exact-embedding-8b.md",
+            "title": "Exact3 Embedding 8B",
+            "page_type": "entity",
+            "chunk_index": 0,
+            "text": "Local embedding endpoint for Exact-Identifier-8B",
+            "tags": ["embedding"],
+        },
+    ])
+
+    results = searcher.sparse_search("Exact-Identifier-8B", limit=2)
+
+    assert [r.page_path for r in results] == ["entities/exact-embedding-8b.md"]
+    assert results[0].score > 0
+    assert searcher._client.scroll_calls[0]["collection_name"] == "llm_wiki_test"
+
+
+def test_sparse_search_honors_filters_and_exclude_sources():
+    searcher = WikiSearch.__new__(WikiSearch)
+    searcher.config = WikiConfig(wiki_name="test")
+    searcher._client = FakeScrollClient([
+        {
+            "page_path": "raw/articles/exact.md",
+            "title": "Exact Source",
+            "page_type": "source",
+            "chunk_index": 0,
+            "text": "Exact-Identifier-8B",
+            "tags": [],
+        },
+        {
+            "page_path": "entities/exact.md",
+            "title": "Exact Entity",
+            "page_type": "entity",
+            "chunk_index": 0,
+            "text": "Exact-Identifier-8B",
+            "tags": ["embedding"],
+        },
+        {
+            "page_path": "concepts/exact.md",
+            "title": "Exact Concept",
+            "page_type": "concept",
+            "chunk_index": 0,
+            "text": "Exact-Identifier-8B",
+            "tags": ["embedding"],
+        },
+    ])
+
+    results = searcher.sparse_search(
+        "Exact-Identifier-8B",
+        limit=5,
+        page_type="entity",
+        tags=["embedding"],
+        exclude_sources=True,
+    )
+
+    assert [r.page_path for r in results] == ["entities/exact.md"]
+
+
+def test_hybrid_search_fuses_dense_and_sparse_results():
+    searcher = FakeDenseSearch(
+        dense_results=[
+            _result("concepts/semantic.md", score=0.99),
+            _result("entities/exact-embedding-8b.md", score=0.60),
+        ],
+        lexical_payloads=[
+            {
+                "page_path": "entities/exact-embedding-8b.md",
+                "title": "Exact3 Embedding 8B",
+                "page_type": "entity",
+                "chunk_index": 0,
+                "text": "Exact-Identifier-8B literal config key",
+                "tags": ["embedding"],
+            },
+            {
+                "page_path": "concepts/path-only.md",
+                "title": "Path Only",
+                "page_type": "concept",
+                "chunk_index": 0,
+                "text": "Exact-Identifier-8B appears here too",
+                "tags": [],
+            },
+        ],
+    )
+
+    results = searcher.search("Exact-Identifier-8B", limit=3, search_mode="hybrid")
+
+    assert [r.page_path for r in results] == [
+        "entities/exact-embedding-8b.md",
+        "concepts/semantic.md",
+        "concepts/path-only.md",
+    ]
+
+
+def test_search_defaults_to_dense_mode_for_backward_compatibility():
+    searcher = FakeDenseSearch(
+        dense_results=[_result("concepts/semantic.md", score=0.99)],
+        lexical_payloads=[
+            {
+                "page_path": "entities/exact-embedding-8b.md",
+                "title": "Exact3 Embedding 8B",
+                "page_type": "entity",
+                "chunk_index": 0,
+                "text": "Exact-Identifier-8B",
+                "tags": [],
+            }
+        ],
+    )
+
+    results = searcher.search("Exact-Identifier-8B", limit=2)
+
+    assert [r.page_path for r in results] == ["concepts/semantic.md"]
+    assert searcher._client.scroll_calls == []
+
+
+def test_search_supports_sparse_only_mode():
+    searcher = FakeDenseSearch(
+        dense_results=[_result("concepts/semantic.md", score=0.99)],
+        lexical_payloads=[
+            {
+                "page_path": "entities/exact-embedding-8b.md",
+                "title": "Exact3 Embedding 8B",
+                "page_type": "entity",
+                "chunk_index": 0,
+                "text": "Exact-Identifier-8B",
+                "tags": [],
+            }
+        ],
+    )
+
+    results = searcher.search("Exact-Identifier-8B", limit=2, search_mode="sparse")
+
+    assert [r.page_path for r in results] == ["entities/exact-embedding-8b.md"]
+
+
+class AutoSyncSearch(WikiSearch):
+    def __init__(self, tmp_path):
+        wiki_path = tmp_path / "wiki"
+        for subdir in ["concepts", "entities", "comparisons", "queries", "raw/articles"]:
+            (wiki_path / subdir).mkdir(parents=True, exist_ok=True)
+        self.config = WikiConfig(wiki_path=wiki_path, wiki_name="test")
+        self.read_only = False
+        self._client = FakeScrollClient([
+            {
+                "page_path": "concepts/changed.md",
+                "content_hash": "old-hash",
+                "mtime": 1.0,
+                "size": 1,
+            },
+            {
+                "page_path": "concepts/deleted.md",
+                "content_hash": "deleted-hash",
+                "mtime": 1.0,
+                "size": 1,
+            },
+        ])
+        self.indexed_pages = []
+        self.indexed_sources = []
+        self.deleted_paths = []
+
+    def _ensure_collection(self):
+        pass
+
+    def _dense_search(self, query, *, limit, page_type=None, tags=None, exclude_sources=False):
+        return [_result("concepts/changed.md", score=0.9)]
+
+    def index_page(self, page_path):
+        self.indexed_pages.append(str(page_path.relative_to(self.config.wiki_path)))
+        return 1
+
+    def index_source(self, source_path):
+        self.indexed_sources.append(str(source_path.relative_to(self.config.wiki_path)))
+        return 1
+
+    def _delete_page_chunks(self, rel_path):
+        self.deleted_paths.append(rel_path)
+
+
+def test_search_auto_syncs_incremental_wiki_index_before_retrieval(tmp_path):
+    searcher = AutoSyncSearch(tmp_path)
+    (searcher.config.wiki_path / "concepts/changed.md").write_text(
+        "---\ntitle: Changed\ntype: concept\n---\n\nChanged body", encoding="utf-8"
+    )
+    (searcher.config.wiki_path / "concepts/new.md").write_text(
+        "---\ntitle: New\ntype: concept\n---\n\nNew body", encoding="utf-8"
+    )
+    (searcher.config.wiki_path / "raw/articles/source.md").write_text(
+        "---\ningested: 2026-05-22\n---\n\nSource body", encoding="utf-8"
+    )
+    for ignored in ["SCHEMA.md", "index.md", "log.md"]:
+        (searcher.config.wiki_path / ignored).write_text("ignored", encoding="utf-8")
+
+    results = searcher.search("changed", limit=1)
+
+    assert [result.page_path for result in results] == ["concepts/changed.md"]
+    assert searcher.indexed_pages == ["concepts/changed.md", "concepts/new.md"]
+    assert searcher.indexed_sources == ["raw/articles/source.md"]
+    assert searcher.deleted_paths == ["concepts/deleted.md"]

--- a/tests/plugins/memory/test_llm_wiki_maintenance.py
+++ b/tests/plugins/memory/test_llm_wiki_maintenance.py
@@ -1,0 +1,325 @@
+import json
+
+import pytest
+
+from hermes_wiki.config import WikiConfig
+from hermes_wiki.frontmatter import write_page
+from hermes_wiki.maintenance import (
+    generate_maintenance_report,
+    maintenance_report_to_dict,
+    render_maintenance_report,
+)
+from hermes_wiki.maintenance import main as maintenance_main
+
+
+def _write_page(config, rel_path, fm, body):
+    path = config.wiki_path / rel_path
+    write_page(path, fm, body)
+    return path
+
+
+def test_generate_maintenance_report_detects_broken_links_and_orphans(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    _write_page(
+        config,
+        "concepts/a.md",
+        {"title": "A", "type": "concept", "created": "2026-01-01", "updated": "2026-01-01"},
+        "Links to [[Missing Page]].",
+    )
+    _write_page(
+        config,
+        "concepts/orphan.md",
+        {"title": "Orphan", "type": "concept", "created": "2026-01-01", "updated": "2026-01-01"},
+        "No inbound links.",
+    )
+
+    report = generate_maintenance_report(config)
+
+    categories = {issue.category for issue in report.issues}
+    assert "broken_link" in categories
+    assert "orphan_page" in categories
+    assert report.total_pages == 2
+    assert report.broken_links == 1
+    assert report.orphan_pages >= 1
+
+
+def test_generate_maintenance_report_ignores_legacy_proposal_directory(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    legacy = config.wiki_path / "proposals" / "old.md"
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text("---\ntitle: Old proposal\nstatus: pending\n---\nBody.\n", encoding="utf-8")
+
+    report = generate_maintenance_report(config)
+    payload = maintenance_report_to_dict(report)
+
+    assert not hasattr(report, "pending_proposals")
+    assert "pending_proposals" not in payload
+    assert all(issue.category != "pending_proposal" for issue in report.issues)
+
+
+def test_generate_maintenance_report_detects_source_coverage_gap(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    _write_page(
+        config,
+        "concepts/no-source.md",
+        {"title": "No Source", "type": "concept", "created": "2026-01-01", "updated": "2026-01-01"},
+        "This page has no provenance marker.",
+    )
+
+    report = generate_maintenance_report(config)
+    assert report.pages_without_sources == 1
+    assert any(issue.category == "missing_source_coverage" for issue in report.issues)
+
+
+def test_generate_maintenance_report_tolerates_non_mapping_frontmatter(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    page = config.wiki_path / "concepts" / "bad.md"
+    page.parent.mkdir(parents=True)
+    page.write_text("---\n- not\n- mapping\n---\n[[missing]]\n", encoding="utf-8")
+
+    report = generate_maintenance_report(config)
+
+    assert report.total_pages == 1
+    assert report.broken_links == 1
+
+
+def test_maintenance_helpers_reject_nonscalar_config_and_report_paths(tmp_path):
+    from hermes_wiki.maintenance import _load_explicit_wiki_config, _validate_report_path
+
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    with pytest.raises(ValueError, match="config_path"):
+        _load_explicit_wiki_config({"path": "config.yaml"})  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="report_path"):
+        _validate_report_path(config, {"path": "reports/out.md"})  # type: ignore[arg-type]
+
+
+def test_generate_maintenance_report_rejects_malformed_source_coverage_paths(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    page = config.wiki_path / "concepts" / "bad-source-paths.md"
+    page.parent.mkdir(parents=True)
+    page.write_text(
+        "---\n"
+        "title: Bad Source Paths\n"
+        "type: concept\n"
+        "created: '2026-01-01'\n"
+        "updated: '2026-01-01'\n"
+        "sources:\n"
+        "  - /etc/hosts\n"
+        "  - raw/articles/../../outside.md\n"
+        "---\n\n"
+        "Body cites ^[raw/articles/../../outside.md].\n",
+        encoding="utf-8",
+    )
+
+    report = generate_maintenance_report(config)
+
+    assert report.pages_without_sources == 1
+    categories = {issue.category for issue in report.issues if issue.file_path == "concepts/bad-source-paths.md"}
+    assert "invalid_source_path" in categories
+    assert "missing_source_coverage" in categories
+
+
+def test_generate_maintenance_report_rejects_nonscalar_source_entries(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    page = config.wiki_path / "concepts/object-source.md"
+    page.parent.mkdir(parents=True)
+    page.write_text(
+        "---\n"
+        "title: Object Source\n"
+        "type: concept\n"
+        "created: '2026-01-01'\n"
+        "updated: '2026-01-01'\n"
+        "sources:\n  - path: raw/articles/source.md\n"
+        "---\n\n"
+        "This page has object-shaped provenance only.\n",
+        encoding="utf-8",
+    )
+
+    report = generate_maintenance_report(config)
+
+    assert report.pages_without_sources == 1
+    assert any(
+        issue.category == "missing_source_coverage" and issue.file_path == "concepts/object-source.md"
+        for issue in report.issues
+    )
+
+
+def test_maintenance_report_to_dict_is_json_serializable(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    _write_page(
+        config,
+        "concepts/a.md",
+        {"title": "A", "type": "concept", "created": "2026-01-01", "updated": "2026-01-01"},
+        "Body.",
+    )
+
+    payload = maintenance_report_to_dict(generate_maintenance_report(config))
+
+    assert json.loads(json.dumps(payload))["total_pages"] == 1
+    assert "issues" in payload
+
+
+def test_render_maintenance_report_contains_summary(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+    _write_page(
+        config,
+        "concepts/a.md",
+        {"title": "A", "type": "concept", "created": "2026-01-01", "updated": "2026-01-01"},
+        "Body.",
+    )
+
+    text = render_maintenance_report(generate_maintenance_report(config))
+
+    assert "# LLM Wiki Maintenance Report" in text
+    assert "Pages:" in text
+    assert "Issues:" in text
+
+
+def test_maintenance_cli_is_read_only_by_default(tmp_path, capsys):
+    config_path = tmp_path / "config.yaml"
+    wiki_path = tmp_path / "wiki"
+    config_path.write_text(f"wiki:\n  path: {wiki_path}\n  name: test\n", encoding="utf-8")
+
+    code = maintenance_main(["--config", str(config_path)])
+
+    assert code == 0
+    assert "# LLM Wiki Maintenance Report" in capsys.readouterr().out
+    assert not wiki_path.exists()
+
+
+def test_maintenance_cli_write_report_requires_explicit_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "ambient-home"))
+
+    try:
+        maintenance_main(["--write-report", "reports/maintenance.md"])
+    except SystemExit:
+        pass
+
+    assert not (tmp_path / "ambient-home").exists()
+
+
+def test_maintenance_cli_write_report_allows_reports_namespace_only(tmp_path, capsys):
+    config_path = tmp_path / "config.yaml"
+    wiki_path = tmp_path / "wiki"
+    config_path.write_text(f"wiki:\n  path: {wiki_path}\n  name: test\n", encoding="utf-8")
+
+    code = maintenance_main(["--config", str(config_path), "--write-report", "reports/maintenance.md"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 0
+    assert payload == {"path": str(wiki_path / "reports" / "maintenance.md"), "written": True}
+    assert (wiki_path / "reports" / "maintenance.md").exists()
+
+
+def test_maintenance_cli_write_report_rejects_canonical_paths(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    wiki_path = tmp_path / "wiki"
+    config_path.write_text(f"wiki:\n  path: {wiki_path}\n  name: test\n", encoding="utf-8")
+    canonical = _write_page(
+        WikiConfig(wiki_path=wiki_path, wiki_name="test"),
+        "concepts/existing.md",
+        {"title": "Existing", "type": "concept", "created": "2026-01-01", "updated": "2026-01-01"},
+        "Original canonical content.",
+    )
+    before = canonical.read_text(encoding="utf-8")
+
+    try:
+        maintenance_main(["--config", str(config_path), "--write-report", "concepts/existing.md"])
+    except SystemExit:
+        pass
+
+    assert canonical.read_text(encoding="utf-8") == before
+
+
+def test_maintenance_cli_write_report_rejects_traversal(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    wiki_path = tmp_path / "wiki"
+    config_path.write_text(f"wiki:\n  path: {wiki_path}\n  name: test\n", encoding="utf-8")
+
+    try:
+        maintenance_main(["--config", str(config_path), "--write-report", "../outside.md"])
+    except SystemExit:
+        pass
+
+    assert not (tmp_path / "outside.md").exists()
+
+
+class MaintenanceLeakyObject:
+    def __str__(self):
+        return "MAINTENANCE-LEAK"
+
+
+def test_maintenance_report_to_dict_normalizes_malformed_direct_fields():
+    from hermes_wiki.maintenance import MaintenanceReport, maintenance_report_to_dict
+    from hermes_wiki.models import LintIssue
+
+    report = MaintenanceReport(
+        issues=[
+            LintIssue(
+                severity=MaintenanceLeakyObject(),  # type: ignore[arg-type]
+                category=MaintenanceLeakyObject(),  # type: ignore[arg-type]
+                message=MaintenanceLeakyObject(),  # type: ignore[arg-type]
+                file_path=MaintenanceLeakyObject(),  # type: ignore[arg-type]
+                suggestion=MaintenanceLeakyObject(),  # type: ignore[arg-type]
+            )
+        ],
+        total_pages=MaintenanceLeakyObject(),  # type: ignore[arg-type]
+        total_sources=-1,
+        total_links=2.5,  # type: ignore[arg-type]
+        broken_links=True,  # type: ignore[arg-type]
+        orphan_pages=MaintenanceLeakyObject(),  # type: ignore[arg-type]
+        pages_without_sources=MaintenanceLeakyObject(),  # type: ignore[arg-type]
+    )
+
+    payload = maintenance_report_to_dict(report)
+    assert payload == {
+        "total_pages": 0,
+        "total_sources": 0,
+        "total_links": 0,
+        "broken_links": 0,
+        "orphan_pages": 0,
+        "pages_without_sources": 0,
+        "errors": 0,
+        "warnings": 0,
+        "infos": 0,
+        "issues": [
+            {
+                "severity": "info",
+                "category": "unknown",
+                "message": "",
+                "file_path": None,
+                "suggestion": None,
+            }
+        ],
+    }
+    assert "MAINTENANCE-LEAK" not in str(payload)
+
+
+def test_render_maintenance_report_normalizes_malformed_direct_fields():
+    from hermes_wiki.maintenance import MaintenanceReport, render_maintenance_report
+    from hermes_wiki.models import LintIssue
+
+    report = MaintenanceReport(
+        issues=[
+            LintIssue(
+                severity=MaintenanceLeakyObject(),  # type: ignore[arg-type]
+                category=MaintenanceLeakyObject(),  # type: ignore[arg-type]
+                message=MaintenanceLeakyObject(),  # type: ignore[arg-type]
+                file_path=MaintenanceLeakyObject(),  # type: ignore[arg-type]
+                suggestion=MaintenanceLeakyObject(),  # type: ignore[arg-type]
+            )
+        ],
+        total_pages=MaintenanceLeakyObject(),  # type: ignore[arg-type]
+        total_sources=MaintenanceLeakyObject(),  # type: ignore[arg-type]
+        total_links=MaintenanceLeakyObject(),  # type: ignore[arg-type]
+        broken_links=MaintenanceLeakyObject(),  # type: ignore[arg-type]
+        orphan_pages=MaintenanceLeakyObject(),  # type: ignore[arg-type]
+        pages_without_sources=MaintenanceLeakyObject(),  # type: ignore[arg-type]
+    )
+
+    text = render_maintenance_report(report)
+
+    assert "MAINTENANCE-LEAK" not in text
+    assert "- Pages: 0" in text
+    assert "- Issues: 1 (0 errors, 0 warnings, 0 info)" in text
+    assert "**info / unknown**" in text

--- a/tests/plugins/memory/test_llm_wiki_provider.py
+++ b/tests/plugins/memory/test_llm_wiki_provider.py
@@ -1,0 +1,1298 @@
+"""Tests for the LLM Wiki memory provider."""
+
+from __future__ import annotations
+
+import json
+import math
+import tomllib
+from pathlib import Path
+
+import pytest
+import yaml
+
+from hermes_wiki.config import WikiConfig
+from hermes_wiki.engine import WikiEngine
+from hermes_wiki.eval import (
+    RetrievalEvalCase,
+    _build_searcher,
+    evaluate_retrieval,
+    load_retrieval_cases,
+    main as eval_main,
+    result_to_dict,
+)
+from hermes_wiki.frontmatter import parse_frontmatter, write_page
+from hermes_wiki.indexer import WikiIndexer
+from hermes_wiki.search import WikiSearch
+from agent.memory_manager import MemoryManager
+from plugins.memory import load_memory_provider
+from plugins.memory.llm_wiki import LLMWikiMemoryProvider, register
+
+
+class DummyPluginContext:
+    def __init__(self) -> None:
+        self.registered = []
+
+    def register_memory_provider(self, provider) -> None:
+        self.registered.append(provider)
+
+
+def test_provider_name():
+    provider = LLMWikiMemoryProvider()
+
+    assert provider.name == "llm_wiki"
+
+
+class FakeRetrievalSearcher:
+    def __init__(self, results_by_query):
+        self.results_by_query = results_by_query
+        self.calls = []
+
+    def search(self, query, limit=5):
+        self.calls.append((query, limit))
+        return self.results_by_query.get(query, [])
+
+
+def test_retrieval_eval_passes_when_expected_page_is_in_top_k():
+    searcher = FakeRetrievalSearcher(
+        {
+            "How autonomous should Hermes be?": [
+                {"page_path": "entities/hermes.md", "title": "Hermes", "score": 0.8},
+                {"page_path": "concepts/user-autonomy-operating-policy.md", "title": "Policy", "score": 0.7},
+            ],
+        }
+    )
+
+    results = evaluate_retrieval(
+        searcher,
+        [
+            RetrievalEvalCase(
+                query="How autonomous should Hermes be?",
+                expected_pages={"concepts/user-autonomy-operating-policy.md"},
+                top_k=2,
+            )
+        ],
+    )
+
+    assert results.passed is True
+    assert results.total == 1
+    assert results.failures == []
+    assert searcher.calls == [("How autonomous should Hermes be?", 2)]
+
+
+def test_retrieval_eval_reports_missing_expected_pages():
+    searcher = FakeRetrievalSearcher(
+        {
+            "What are the memory boundaries?": [
+                {"page_path": "entities/hermes.md", "title": "Hermes", "score": 0.8},
+            ],
+        }
+    )
+
+    results = evaluate_retrieval(
+        searcher,
+        [
+            RetrievalEvalCase(
+                query="What are the memory boundaries?",
+                expected_pages={"concepts/context-injection-policy.md", "concepts/manual-curated-ingestion.md"},
+                top_k=3,
+            )
+        ],
+    )
+
+    assert results.passed is False
+    assert results.total == 1
+    assert results.failures[0].query == "What are the memory boundaries?"
+    assert results.failures[0].missing_pages == {
+        "concepts/context-injection-policy.md",
+        "concepts/manual-curated-ingestion.md",
+    }
+    assert results.failures[0].retrieved_pages == ["entities/hermes.md"]
+
+
+def test_retrieval_eval_accepts_object_search_results():
+    class Result:
+        page_path = "concepts/context-injection-policy.md"
+        title = "Context Injection Policy"
+        score = 0.9
+
+    searcher = FakeRetrievalSearcher({"How should memory context be injected?": [Result()]})
+
+    results = evaluate_retrieval(
+        searcher,
+        [
+            RetrievalEvalCase(
+                query="How should memory context be injected?",
+                expected_pages={"concepts/context-injection-policy.md"},
+            )
+        ],
+    )
+
+    assert results.passed is True
+    assert results.cases[0].retrieved_pages == ["concepts/context-injection-policy.md"]
+
+
+def test_retrieval_eval_deduplicates_retrieved_pages_preserving_order():
+    searcher = FakeRetrievalSearcher(
+        {
+            "What did we decide about memory?": [
+                {"page_path": "concepts/memory-log-wiki-boundary.md"},
+                {"page_path": "concepts/memory-log-wiki-boundary.md"},
+                {"page_path": "concepts/manual-curated-ingestion.md"},
+            ],
+        }
+    )
+
+    results = evaluate_retrieval(
+        searcher,
+        [
+            RetrievalEvalCase(
+                query="What did we decide about memory?",
+                expected_pages={"concepts/manual-curated-ingestion.md"},
+            )
+        ],
+    )
+
+    assert results.cases[0].retrieved_pages == [
+        "concepts/memory-log-wiki-boundary.md",
+        "concepts/manual-curated-ingestion.md",
+    ]
+
+
+def test_load_retrieval_cases_from_yaml(tmp_path):
+    cases_path = tmp_path / "cases.yaml"
+    cases_path.write_text(
+        """
+cases:
+  - query: How autonomous should Hermes be?
+    expected_pages:
+      - concepts/user-autonomy-operating-policy.md
+      - entities/hermes.md
+    top_k: 7
+""".strip(),
+        encoding="utf-8",
+    )
+
+    cases = load_retrieval_cases(cases_path)
+
+    assert cases == [
+        RetrievalEvalCase(
+            query="How autonomous should Hermes be?",
+            expected_pages={"concepts/user-autonomy-operating-policy.md", "entities/hermes.md"},
+            top_k=7,
+        )
+    ]
+
+
+def test_load_retrieval_cases_from_json_list(tmp_path):
+    cases_path = tmp_path / "cases.json"
+    cases_path.write_text(
+        json.dumps(
+            [
+                {
+                    "query": "What should Hermes call the example user?",
+                    "expected_pages": "entities/example-user.md",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    cases = load_retrieval_cases(cases_path)
+
+    assert cases == [
+        RetrievalEvalCase(
+            query="What should Hermes call the example user?",
+            expected_pages={"entities/example-user.md"},
+            top_k=5,
+        )
+    ]
+
+
+def test_load_retrieval_cases_rejects_unsafe_entries(tmp_path):
+    cases_path = tmp_path / "cases.yaml"
+    cases_path.write_text("cases:\n  - expected_pages: []\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="query"):
+        load_retrieval_cases(cases_path)
+
+
+def test_load_retrieval_cases_rejects_traversal_expected_pages(tmp_path):
+    cases_path = tmp_path / "cases.yaml"
+    cases_path.write_text(
+        "cases:\n  - query: unsafe\n    expected_pages:\n      - ../outside.md\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="relative wiki page paths"):
+        load_retrieval_cases(cases_path)
+
+
+def test_result_to_dict_is_json_serializable():
+    result = evaluate_retrieval(
+        FakeRetrievalSearcher({"query": [{"page_path": "concepts/a.md"}]}),
+        [RetrievalEvalCase(query="query", expected_pages={"concepts/a.md"})],
+    )
+
+    payload = result_to_dict(result)
+
+    assert payload["passed"] is True
+    assert payload["total"] == 1
+    assert payload["failures"] == 0
+    assert payload["cases"][0]["query"] == "query"
+    assert payload["cases"][0]["passed"] is True
+    assert payload["cases"][0]["expected_pages"] == ["concepts/a.md"]
+    assert payload["cases"][0]["retrieved_pages"] == ["concepts/a.md"]
+    assert payload["cases"][0]["missing_pages"] == []
+    if "search_mode" in payload["cases"][0]:
+        assert payload["cases"][0]["search_mode"] == "dense"
+    json.dumps(payload)
+
+
+def test_retrieval_eval_main_returns_nonzero_on_failure(tmp_path, monkeypatch, capsys):
+    cases_path = tmp_path / "cases.yaml"
+    cases_path.write_text(
+        "cases:\n  - query: missing\n    expected_pages:\n      - concepts/missing.md\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("hermes_wiki.eval._build_searcher", lambda config_path=None: FakeRetrievalSearcher({"missing": []}))
+
+    code = eval_main([str(cases_path), "--pretty"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 1
+    assert payload["passed"] is False
+    assert payload["cases"][0]["missing_pages"] == ["concepts/missing.md"]
+
+
+def test_retrieval_eval_main_returns_zero_on_success(tmp_path, monkeypatch, capsys):
+    cases_path = tmp_path / "cases.json"
+    cases_path.write_text(
+        json.dumps([{"query": "ok", "expected_pages": ["concepts/ok.md"]}]),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "hermes_wiki.eval._build_searcher",
+        lambda config_path=None: FakeRetrievalSearcher({"ok": [{"page_path": "concepts/ok.md"}]}),
+    )
+
+    code = eval_main([str(cases_path)])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 0
+    assert payload["passed"] is True
+    assert payload["total"] == 1
+
+
+def test_retrieval_eval_build_searcher_rejects_missing_explicit_config(tmp_path):
+    with pytest.raises(FileNotFoundError, match="LLM Wiki config not found"):
+        _build_searcher(str(tmp_path / "missing.yaml"))
+
+
+def test_retrieval_eval_build_searcher_rejects_explicit_config_without_wiki(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("memory:\n  provider: llm_wiki\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="no wiki section"):
+        _build_searcher(str(config_path))
+
+
+def test_retrieval_eval_build_searcher_rejects_malformed_wiki_config_sections(tmp_path):
+    for config_text, message in [
+        ("wiki: true\n", "wiki config section"),
+        ("wiki:\n  embedding: true\n", "wiki.embedding"),
+        ("wiki:\n  vector_store: true\n", "wiki.vector_store"),
+        ("wiki:\n  llm: true\n", "wiki.llm"),
+    ]:
+        config_path = tmp_path / f"config-{abs(hash(config_text))}.yaml"
+        config_path.write_text(config_text, encoding="utf-8")
+
+        with pytest.raises(ValueError, match=message):
+            _build_searcher(str(config_path))
+
+
+def test_frontmatter_requires_delimiter_on_own_line():
+    text = "---\ntitle: Demo\n--- appears in the body, not as a delimiter\n"
+
+    fm, body = parse_frontmatter(text)
+
+    assert fm == {}
+    assert body == text.strip()
+
+
+def test_write_page_replaces_existing_file_atomically(tmp_path):
+    page = tmp_path / "concepts" / "memory.md"
+    write_page(page, {"title": "Old"}, "old body")
+
+    write_page(page, {"title": "New"}, "new body")
+
+    text = page.read_text(encoding="utf-8")
+    assert "title: New" in text
+    assert "new body" in text
+    assert not list(page.parent.glob(".memory.md.*.tmp"))
+
+
+def test_log_rotation_preserves_existing_archive(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki", log_rotation_threshold=1)
+    config.ensure_dirs()
+    config.log_path.write_text("# Wiki Log\n\n## [2026-01-01] old | entry\n", encoding="utf-8")
+    existing_archive = config.wiki_path / "log-2026.md"
+    existing_archive.write_text("older archived logs\n", encoding="utf-8")
+    indexer = WikiIndexer(config)
+
+    indexer.append_log("test", "new entry")
+
+    archives = sorted(config.wiki_path.glob("log-2026*.md"))
+    assert existing_archive in archives
+    assert existing_archive.read_text(encoding="utf-8") == "older archived logs\n"
+    assert len(archives) == 2
+
+
+def test_search_index_page_embeds_before_deleting_existing_chunks(tmp_path):
+    class FailingEmbedder:
+        def embed_batch(self, texts):
+            raise RuntimeError("embedding down")
+
+    search = WikiSearch.__new__(WikiSearch)
+    search.config = WikiConfig(wiki_path=tmp_path / "wiki")
+    search.config.ensure_dirs()
+    page = search.config.concepts_dir / "memory.md"
+    write_page(page, {"title": "Memory", "type": "concept"}, "Body text")
+    search._embedder = FailingEmbedder()
+    search._delete_page_chunks = lambda rel_path: (_ for _ in ()).throw(AssertionError("deleted before embed"))
+
+    try:
+        search.index_page(page)
+    except RuntimeError as exc:
+        assert "embedding down" in str(exc)
+    else:
+        raise AssertionError("expected embedding failure")
+
+
+def test_search_index_page_upserts_before_deleting_stale_chunks(tmp_path):
+    class Embedder:
+        def embed_batch(self, texts):
+            return [[0.1, 0.2, 0.3, 0.4] for _ in texts]
+
+    class Client:
+        def upsert(self, *args, **kwargs):
+            raise RuntimeError("qdrant down")
+
+    search = WikiSearch.__new__(WikiSearch)
+    search.config = WikiConfig(wiki_path=tmp_path / "wiki", embedding_dim=4)
+    search.config.ensure_dirs()
+    page = search.config.concepts_dir / "memory.md"
+    write_page(page, {"title": "Memory", "type": "concept"}, "Body text")
+    search._embedder = Embedder()
+    search._client = Client()
+    search._point = lambda point_id, vector, payload: {"id": point_id, "payload": payload}
+    search._delete_stale_page_chunks = lambda rel_path, keep_chunks: (_ for _ in ()).throw(
+        AssertionError("deleted stale chunks before successful upsert")
+    )
+
+    try:
+        search.index_page(page)
+    except RuntimeError as exc:
+        assert "qdrant down" in str(exc)
+    else:
+        raise AssertionError("expected upsert failure")
+
+
+def test_reindex_all_does_not_delete_collection_first(tmp_path):
+    class FakeClient:
+        def delete_collection(self, name):
+            raise AssertionError("collection should not be deleted before safe reindex")
+
+        def scroll(self, **kwargs):
+            return [], None
+
+    search = WikiSearch.__new__(WikiSearch)
+    search.config = WikiConfig(wiki_path=tmp_path / "wiki")
+    search.config.ensure_dirs()
+    search._client = FakeClient()
+    search._ensure_collection = lambda: None
+    search.index_page = lambda path: 1
+    search.index_source = lambda path: 1
+    search._existing_indexed_paths = lambda: set()
+    search._delete_page_chunks = lambda rel_path: None
+    write_page(search.config.concepts_dir / "memory.md", {"title": "Memory", "type": "concept"}, "Body text")
+
+    counts = search.reindex_all()
+
+    assert counts == {"pages": 1, "sources": 0, "chunks": 1}
+
+
+def test_engine_rejects_unsafe_llm_slugs(tmp_path):
+    engine = WikiEngine.__new__(WikiEngine)
+
+    assert engine._safe_slug("Memory Policy") == "memory-policy"
+    assert engine._safe_slug("../escape") is None
+    assert engine._safe_slug("/tmp/escape") is None
+    assert engine._safe_slug("safe/escape") is None
+
+
+def test_engine_safe_child_path_blocks_traversal(tmp_path):
+    engine = WikiEngine.__new__(WikiEngine)
+    root = tmp_path / "wiki" / "entities"
+    root.mkdir(parents=True)
+
+    assert engine._safe_child_path(root, "memory").parent == root.resolve()
+    assert engine._safe_child_path(root, "../escape") is None
+
+
+def test_engine_ingest_text_rejects_unknown_source_type(tmp_path):
+    engine = WikiEngine.__new__(WikiEngine)
+    engine.config = WikiConfig(wiki_path=tmp_path / "wiki")
+
+    try:
+        engine.ingest_text("content", "Example", source_type="../../escape", dry_run=True)
+    except ValueError as exc:
+        assert "Unsupported source_type" in str(exc)
+    else:
+        raise AssertionError("unsafe source_type should be rejected before path construction")
+
+
+def test_engine_update_page_updates_existing_canonical_page_safely(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki")
+    config.ensure_dirs()
+    page = config.concepts_dir / "memory-policy.md"
+    write_page(
+        page,
+        {
+            "title": "Memory Policy",
+            "type": "concept",
+            "created": "2026-05-01",
+            "updated": "2026-05-01",
+            "sources": ["raw/articles/old.md"],
+        },
+        "# Memory Policy\n\nOld body.",
+    )
+
+    class FakeIndexer:
+        def __init__(self):
+            self.rebuilds = 0
+            self.logs = []
+
+        def rebuild_index(self):
+            self.rebuilds += 1
+            return 1
+
+        def append_log(self, action, subject, details=None):
+            self.logs.append((action, subject, details or []))
+
+    class FakeSearch:
+        def __init__(self):
+            self.indexed = []
+
+        def index_page(self, page_path):
+            self.indexed.append(page_path)
+            return 3
+
+    engine = WikiEngine.__new__(WikiEngine)
+    engine.config = config
+    engine.read_only = False
+    engine.indexer = FakeIndexer()
+    engine.search = FakeSearch()
+
+    result = engine.update_page(
+        "concepts/memory-policy.md",
+        "# Memory Policy\n\nNew body.",
+        frontmatter_updates={"confidence": "high"},
+        source_refs=["raw/articles/new.md", "raw/articles/old.md"],
+        reason="source-backed correction",
+    )
+
+    fm, body = parse_frontmatter(page.read_text(encoding="utf-8"))
+    assert body == "# Memory Policy\n\nNew body."
+    assert fm["confidence"] == "high"
+    assert fm["sources"] == ["raw/articles/old.md", "raw/articles/new.md"]
+    assert fm["updated"] != "2026-05-01"
+    assert result == {
+        "page": "concepts/memory-policy.md",
+        "updated": True,
+        "chunks_indexed": 3,
+    }
+    assert engine.indexer.rebuilds == 1
+    assert engine.indexer.logs == [(
+        "update",
+        "concepts/memory-policy.md",
+        ["source-backed correction", "Sources: raw/articles/new.md, raw/articles/old.md"],
+    )]
+    assert engine.search.indexed == [page]
+
+
+def test_engine_update_page_rejects_noncanonical_paths(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki")
+    config.ensure_dirs()
+    engine = WikiEngine.__new__(WikiEngine)
+    engine.config = config
+    engine.read_only = False
+
+    for page in ("raw/articles/source.md", "proposals/proposal.md", "../escape.md", "/tmp/escape.md"):
+        try:
+            engine.update_page(page, "body")
+        except ValueError as exc:
+            assert "canonical wiki page" in str(exc) or "Invalid page" in str(exc)
+        else:
+            raise AssertionError(f"unsafe update path should be rejected: {page}")
+
+
+def test_engine_update_page_rejects_read_only_engine(tmp_path):
+    config = WikiConfig(wiki_path=tmp_path / "wiki")
+    config.ensure_dirs()
+    engine = WikiEngine.__new__(WikiEngine)
+    engine.config = config
+    engine.read_only = True
+
+    try:
+        engine.update_page("concepts/memory-policy.md", "body")
+    except PermissionError as exc:
+        assert "read-only" in str(exc)
+    else:
+        raise AssertionError("read-only engine should not update canonical pages")
+
+
+def test_engine_read_only_constructor_does_not_create_storage(monkeypatch, tmp_path):
+    calls = []
+
+    class FakeSearch:
+        def __init__(self, config, *, ensure_collection=True, read_only=False):
+            calls.append(("search", ensure_collection, read_only))
+
+    class FakeLLM:
+        def __init__(self, config):
+            calls.append(("llm", None))
+
+    class FakeIndexer:
+        def __init__(self, config):
+            calls.append(("indexer", None))
+
+    monkeypatch.setattr("hermes_wiki.engine.WikiSearch", FakeSearch)
+    monkeypatch.setattr("hermes_wiki.engine.WikiLLM", FakeLLM)
+    monkeypatch.setattr("hermes_wiki.engine.WikiIndexer", FakeIndexer)
+    config = WikiConfig(wiki_path=tmp_path / "wiki")
+
+    engine = WikiEngine(config, read_only=True)
+
+    assert engine.read_only is True
+    assert not config.wiki_path.exists()
+    assert ("search", False, True) in calls
+
+
+def test_plugin_metadata_exists():
+    metadata_path = "plugins/memory/llm_wiki/plugin.yaml"
+
+    with open(metadata_path, encoding="utf-8") as f:
+        metadata = yaml.safe_load(f)
+
+    assert metadata["name"] == "llm_wiki"
+    assert "memory" in metadata["description"].lower()
+
+
+def test_plugin_metadata_is_included_as_package_data():
+    with open("pyproject.toml", "rb") as f:
+        pyproject = tomllib.load(f)
+
+    package_data = pyproject["tool"]["setuptools"]["package-data"]
+
+    assert "plugins" in package_data
+    assert "memory/llm_wiki/plugin.yaml" in package_data["plugins"]
+    assert "memory/llm_wiki/README.md" in package_data["plugins"]
+
+def test_llm_wiki_console_scripts_are_owned_by_standalone_package():
+    pyproject_path = Path(__file__).resolve().parents[3] / "pyproject.toml"
+    with pyproject_path.open("rb") as f:
+        data = tomllib.load(f)
+
+    scripts = data["project"]["scripts"]
+    assert "hermes-wiki-eval" not in scripts
+    assert "llm-wiki-eval" not in scripts
+    assert "llm-wiki-mcp" not in scripts
+
+
+def test_llm_wiki_mcp_server_uses_existing_mcp_extra():
+    with open("pyproject.toml", "rb") as f:
+        pyproject = tomllib.load(f)
+
+    assert "mcp==1.26.0" in pyproject["project"]["optional-dependencies"]["mcp"]
+
+
+def test_config_schema_exposes_local_wiki_settings():
+    provider = LLMWikiMemoryProvider()
+
+    fields = {field["key"]: field for field in provider.get_config_schema()}
+
+    assert {"path", "name", "embedding_url", "embedding_model", "embedding_dim", "qdrant_url"} <= set(fields)
+    assert fields["path"]["default"] == "~/.hermes/wiki/personal"
+    assert fields["embedding_url"]["default"] == "http://localhost:8000"
+
+
+def test_save_config_writes_wiki_section_without_clobbering_existing_config(tmp_path):
+    (tmp_path / "config.yaml").write_text("model:\n  default: gpt-test\n", encoding="utf-8")
+    provider = LLMWikiMemoryProvider()
+
+    provider.save_config(
+        {
+            "path": str(tmp_path / "wiki" / "memory"),
+            "name": "memory",
+            "embedding_url": "http://embeddings.local",
+            "embedding_model": "embed-test",
+            "embedding_dim": "1024",
+            "qdrant_url": "http://qdrant.local",
+            "collection_prefix": "wiki_test",
+            "llm_url": "http://llm.local/v1",
+            "llm_model": "gpt-test",
+        },
+        str(tmp_path),
+    )
+
+    saved = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+    assert saved["model"]["default"] == "gpt-test"
+    assert saved["wiki"]["path"] == str(tmp_path / "wiki" / "memory")
+    assert saved["wiki"]["name"] == "memory"
+    assert saved["wiki"]["embedding"]["url"] == "http://embeddings.local"
+    assert saved["wiki"]["embedding"]["model"] == "embed-test"
+    assert saved["wiki"]["embedding"]["dim"] == 1024
+    assert saved["wiki"]["vector_store"]["url"] == "http://qdrant.local"
+    assert saved["wiki"]["vector_store"]["collection_prefix"] == "wiki_test"
+    assert saved["wiki"]["llm"]["url"] == "http://llm.local/v1"
+    assert saved["wiki"]["llm"]["model"] == "gpt-test"
+
+
+def test_is_available_requires_standalone_wiki_package_not_optional_qdrant(monkeypatch):
+    provider = LLMWikiMemoryProvider()
+
+    def fake_find_spec(name):
+        if name == "hermes_wiki.engine":
+            return object()
+        if name == "qdrant_client":
+            return None
+        raise AssertionError(name)
+
+    monkeypatch.setattr("plugins.memory.llm_wiki.importlib.util.find_spec", fake_find_spec)
+
+    assert provider.is_available() is True
+
+
+def test_is_available_allows_lazy_install_when_standalone_package_missing(monkeypatch):
+    provider = LLMWikiMemoryProvider()
+
+    def fake_find_spec(name):
+        if name == "hermes_wiki.engine":
+            return None
+        raise AssertionError(name)
+
+    monkeypatch.setattr("plugins.memory.llm_wiki.importlib.util.find_spec", fake_find_spec)
+
+    assert provider.is_available() is True
+
+
+def test_primary_initialize_lazy_installs_before_loading_wiki_config(monkeypatch, tmp_path):
+    calls = []
+
+    monkeypatch.setattr("tools.lazy_deps.ensure", lambda feature, prompt=True: calls.append((feature, prompt)))
+    monkeypatch.setattr("plugins.memory.llm_wiki._load_core_symbols", lambda: calls.append("load_core") or True)
+    monkeypatch.setattr(LLMWikiMemoryProvider, "_load_wiki_config", lambda self: calls.append("load_config"))
+
+    provider = LLMWikiMemoryProvider()
+    calls.clear()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+
+    assert calls[:2] == [("memory.llm_wiki", False), "load_core"]
+    assert calls[-1] == "load_config"
+
+
+def test_non_primary_initialize_does_not_lazy_install(monkeypatch, tmp_path):
+    calls = []
+
+    monkeypatch.setattr("tools.lazy_deps.ensure", lambda feature, prompt=True: calls.append((feature, prompt)))
+    monkeypatch.setattr("plugins.memory.llm_wiki._load_core_symbols", lambda: calls.append("load_core") or True)
+    monkeypatch.setattr(LLMWikiMemoryProvider, "_load_wiki_config", lambda self: calls.append("load_config"))
+
+    provider = LLMWikiMemoryProvider()
+    calls.clear()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="cron")
+
+    assert ("memory.llm_wiki", False) not in calls
+    assert calls[-1] == "load_config"
+    assert calls.count("load_core") >= 1
+
+
+def test_engine_lazy_ensures_optional_deps(monkeypatch, tmp_path):
+    calls = []
+
+    class FakeWikiEngine:
+        def __init__(self, config, *, read_only=False):
+            calls.append((config, read_only))
+
+    monkeypatch.setattr("plugins.memory.llm_wiki.WikiEngine", FakeWikiEngine, raising=False)
+    monkeypatch.setattr("tools.lazy_deps.ensure", lambda feature, prompt=True: calls.append((feature, prompt)))
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+
+    provider._engine()
+
+    assert ("memory.llm_wiki", False) in calls
+
+
+def test_non_primary_engine_does_not_lazy_install_optional_deps(monkeypatch, tmp_path):
+    calls = []
+
+    class FakeWikiEngine:
+        def __init__(self, config, *, read_only=False):
+            calls.append((config, read_only))
+
+    monkeypatch.setattr("plugins.memory.llm_wiki.WikiEngine", FakeWikiEngine, raising=False)
+    monkeypatch.setattr("tools.lazy_deps.ensure", lambda feature, prompt=True: calls.append((feature, prompt)))
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="cron")
+
+    provider._engine()
+
+    assert ("memory.llm_wiki", False) not in calls
+    assert calls[0][1] is True
+
+
+def test_register_registers_provider():
+    ctx = DummyPluginContext()
+
+    register(ctx)
+
+    assert len(ctx.registered) == 1
+    assert isinstance(ctx.registered[0], LLMWikiMemoryProvider)
+
+
+def test_initialize_uses_hermes_home_for_default_wiki(tmp_path):
+    provider = LLMWikiMemoryProvider()
+
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+
+    assert provider.wiki_path == tmp_path / "wiki" / "personal"
+    assert provider.wiki_name == "personal"
+
+
+def test_initialize_reads_config_wiki_section(tmp_path, monkeypatch):
+    custom_wiki = tmp_path / "configured-wiki"
+    (tmp_path / "config.yaml").write_text(
+        "wiki:\n"
+        f"  path: {custom_wiki}\n"
+        "  name: hermes_memory\n"
+        "  embedding:\n"
+        "    url: http://embeddings.local\n"
+        "    model: text-embedding-test\n"
+        "    dim: 1024\n"
+        "  vector_store:\n"
+        "    url: http://qdrant.local\n"
+        "    collection_prefix: test_wiki\n"
+        "  llm:\n"
+        "    url: http://llm.local/v1\n"
+        "    model: gpt-test\n",
+        encoding="utf-8",
+    )
+    provider = LLMWikiMemoryProvider()
+
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+    wiki_config = provider._wiki_config()
+
+    assert provider.wiki_path == custom_wiki
+    assert provider.wiki_name == "hermes_memory"
+    assert wiki_config.embedding_url == "http://embeddings.local"
+    assert wiki_config.embedding_model == "text-embedding-test"
+    assert wiki_config.embedding_dim == 1024
+    assert wiki_config.qdrant_url == "http://qdrant.local"
+    assert wiki_config.collection_prefix == "test_wiki"
+    assert wiki_config.llm_base_url == "http://llm.local/v1"
+    assert wiki_config.llm_model == "gpt-test"
+
+
+def test_initialize_expands_home_in_config(tmp_path, monkeypatch):
+    fake_home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(fake_home))
+    (tmp_path / "config.yaml").write_text(
+        "wiki:\n"
+        "  path: ~/custom-wiki\n"
+        "  name: memory\n",
+        encoding="utf-8",
+    )
+    provider = LLMWikiMemoryProvider()
+
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+
+    assert provider.wiki_path == fake_home / "custom-wiki"
+    assert provider.wiki_name == "memory"
+
+
+def test_initialize_normalizes_agent_context_case(tmp_path):
+    provider = LLMWikiMemoryProvider()
+
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context=" Primary ")
+
+    assert provider._agent_context == "primary"
+    assert provider._writes_allowed() is True
+
+
+def test_initialize_does_not_construct_engine(monkeypatch, tmp_path):
+    called = False
+
+    def boom(*args, **kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("engine should be lazy")
+
+    monkeypatch.setattr("plugins.memory.llm_wiki.WikiEngine", boom, raising=False)
+    provider = LLMWikiMemoryProvider()
+
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+
+    assert called is False
+
+
+def test_engine_constructs_once_when_requested(monkeypatch, tmp_path):
+    calls = []
+
+    class FakeWikiEngine:
+        def __init__(self, config, *, read_only=False):
+            calls.append((config, read_only))
+
+    monkeypatch.setattr("plugins.memory.llm_wiki.WikiEngine", FakeWikiEngine, raising=False)
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+    monkeypatch.setattr(provider, "_ensure_optional_deps", lambda: None)
+
+    first = provider._engine()
+    second = provider._engine()
+
+    assert first is second
+    assert len(calls) == 1
+    assert calls[0][0].wiki_path == tmp_path / "wiki" / "personal"
+    assert calls[0][0].wiki_name == "personal"
+    assert calls[0][1] is False
+
+
+def test_non_primary_engine_is_constructed_read_only(monkeypatch, tmp_path):
+    calls = []
+
+    class FakeWikiEngine:
+        def __init__(self, config, *, read_only=False):
+            calls.append((config, read_only))
+
+    monkeypatch.setattr("plugins.memory.llm_wiki.WikiEngine", FakeWikiEngine, raising=False)
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="cron")
+    monkeypatch.setattr(provider, "_ensure_optional_deps", lambda: None)
+
+    provider._engine()
+
+    assert calls[0][0].wiki_path == tmp_path / "wiki" / "personal"
+    assert calls[0][1] is True
+
+
+def test_read_tool_schemas_present():
+    provider = LLMWikiMemoryProvider()
+
+    names = {schema["name"] for schema in provider.get_tool_schemas()}
+
+    assert {
+        "wiki_status",
+        "wiki_orient",
+        "wiki_search",
+        "wiki_read",
+        "wiki_query",
+    } <= names
+
+
+def test_query_tool_schema_defaults_to_read_only():
+    provider = LLMWikiMemoryProvider()
+
+    query_schema = next(schema for schema in provider.get_tool_schemas() if schema["name"] == "wiki_query")
+    properties = query_schema["parameters"]["properties"]
+
+    assert properties["file_result"].get("default") is False
+    assert properties["log_query"].get("default") is False
+
+
+class FakeEngine:
+    def __init__(self) -> None:
+        self.query_calls = []
+        self.reindex_calls = 0
+
+    def status(self):
+        return {"total_pages": 2, "sources": 1, "indexed_chunks": 7, "wiki": "/tmp/wiki"}
+
+    def orient(self):
+        return "# Wiki Orientation\nUseful index"
+
+    def query(self, question, file_result=False, log_query=False):
+        self.query_calls.append((question, file_result, log_query))
+        return "wiki answer"
+
+    def search(self, query, limit=5, exclude_sources=False):
+        return []
+
+    def lint(self, write_log=False):
+        return {"issues": [], "write_log": write_log}
+
+    def ingest_file(self, file_path, dry_run=True):
+        return {"file_path": str(file_path), "dry_run": dry_run}
+
+    def reindex(self):
+        self.reindex_calls += 1
+        return {"pages": 2, "sources": 1, "chunks": 7}
+
+
+def test_handle_status_tool_call_uses_engine(monkeypatch, tmp_path):
+    fake_engine = FakeEngine()
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+    monkeypatch.setattr(provider, "_engine", lambda: fake_engine)
+
+    result = provider.handle_tool_call("wiki_status", {})
+
+    assert "total_pages" in result
+    assert "2" in result
+
+
+def test_json_tool_results_do_not_emit_non_finite_numbers(monkeypatch, tmp_path):
+    class NonFiniteEngine(FakeEngine):
+        def status(self):
+            return {"score": math.nan, "nested": [math.inf, {"confidence": -math.inf}]}
+
+        def lint(self, write_log=False):
+            return {"score": math.nan, "write_log": write_log}
+
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+    monkeypatch.setattr(provider, "_engine", lambda: NonFiniteEngine())
+
+    status = provider.handle_tool_call("wiki_status", {})
+    lint = provider.handle_tool_call("wiki_lint", {})
+
+    assert "NaN" not in status
+    assert "Infinity" not in status
+    assert json.loads(status) == {"score": None, "nested": [None, {"confidence": None}]}
+    assert json.loads(lint) == {"score": None, "write_log": False}
+
+
+def test_handle_orient_tool_call_uses_engine(monkeypatch, tmp_path):
+    fake_engine = FakeEngine()
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+    monkeypatch.setattr(provider, "_engine", lambda: fake_engine)
+
+    result = provider.handle_tool_call("wiki_orient", {})
+
+    assert result == "# Wiki Orientation\nUseful index"
+
+
+def test_handle_query_defaults_to_read_only(monkeypatch, tmp_path):
+    fake_engine = FakeEngine()
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path))
+    monkeypatch.setattr(provider, "_engine", lambda: fake_engine)
+
+    result = provider.handle_tool_call("wiki_query", {"question": "What is memory?"})
+
+    assert "answer" in result
+    assert fake_engine.query_calls == [("What is memory?", False, False)]
+
+
+def test_boolean_tool_args_parse_string_false_as_false(monkeypatch, tmp_path):
+    fake_engine = FakeEngine()
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path))
+    monkeypatch.setattr(provider, "_engine", lambda: fake_engine)
+
+    provider.handle_tool_call(
+        "wiki_query",
+        {"question": "What is memory?", "file_result": "false", "log_query": "false"},
+    )
+
+    assert fake_engine.query_calls == [("What is memory?", False, False)]
+
+
+def test_write_booleans_parse_string_false_safely(monkeypatch, tmp_path):
+    fake_engine = FakeEngine()
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="cron")
+    monkeypatch.setattr(provider, "_engine", lambda: fake_engine)
+
+    result = provider.handle_tool_call("wiki_ingest", {"file_path": "source.md", "dry_run": "false"})
+
+    assert "blocked" in result.lower()
+
+
+def test_handle_read_page_by_relative_path(tmp_path):
+    page = tmp_path / "wiki" / "personal" / "concepts" / "memory.md"
+    page.parent.mkdir(parents=True)
+    page.write_text("# Memory\n\nUseful page", encoding="utf-8")
+
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+
+    result = provider.handle_tool_call("wiki_read", {"page": "concepts/memory.md"})
+
+    assert "# Memory" in result
+    assert "Useful page" in result
+
+
+def test_handle_read_page_by_bare_slug(tmp_path):
+    page = tmp_path / "wiki" / "personal" / "concepts" / "memory-policy.md"
+    page.parent.mkdir(parents=True)
+    page.write_text("# Memory Policy\n\nSlug lookup works", encoding="utf-8")
+
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+
+    result = provider.handle_tool_call("wiki_read", {"page": "memory-policy"})
+
+    assert "# Memory Policy" in result
+    assert "Slug lookup works" in result
+
+
+def test_handle_read_page_blocks_traversal(tmp_path):
+    outside = tmp_path / "outside.md"
+    outside.write_text("secret", encoding="utf-8")
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+
+    result = provider.handle_tool_call("wiki_read", {"page": "../outside.md"})
+
+    assert "secret" not in result
+    assert "not found" in result.lower()
+
+
+def test_system_prompt_block_is_tiny_and_retrieval_oriented(tmp_path):
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+
+    block = provider.system_prompt_block()
+
+    assert "LLM Wiki" in block
+    assert "wiki_search" in block
+    assert "Prefetch snippets are only hints" in block
+    assert "what's next" in block
+    assert len(block) < 750
+
+
+def test_sync_turn_is_noop(monkeypatch, tmp_path):
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+    monkeypatch.setattr(provider, "_engine", lambda: (_ for _ in ()).throw(AssertionError("sync_turn must not load engine")))
+
+    provider.sync_turn("user", "assistant")
+
+
+def test_prefetch_returns_bounded_cited_results(monkeypatch, tmp_path):
+    class Result:
+        def __init__(self, page_path, title, text, score):
+            self.page_path = page_path
+            self.title = title
+            self.text = text
+            self.score = score
+
+    class Searcher:
+        def search(self, query, limit=3, exclude_sources=True):
+            assert exclude_sources is True
+            return [
+                Result("concepts/context.md", "Context Policy", "A" * 900, 0.91),
+                Result("entities/hermes.md", "Hermes", "B" * 900, 0.82),
+            ]
+
+    class Engine:
+        search = Searcher()
+
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+    monkeypatch.setattr(provider, "_engine", lambda: Engine())
+
+    result = provider.prefetch("memory policy")
+
+    assert "LLM Wiki relevant context" in result
+    assert "wiki_search/wiki_read/wiki_query" in result
+    assert "concepts/context.md" in result
+    assert "entities/hermes.md" in result
+    assert len(result) <= provider.prefetch_max_chars
+
+
+def test_prefetch_formats_dict_search_results(monkeypatch, tmp_path):
+    class Searcher:
+        def search(self, query, limit=3, exclude_sources=True):
+            return [{"page_path": "concepts/memory.md", "title": "Memory", "text": "Cited context", "score": 0.7}]
+
+    class Engine:
+        search = Searcher()
+
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+    monkeypatch.setattr(provider, "_engine", lambda: Engine())
+
+    result = provider.prefetch("memory")
+
+    assert "concepts/memory.md" in result
+    assert "Cited context" in result
+
+
+def test_write_tool_schemas_have_safe_defaults():
+    provider = LLMWikiMemoryProvider()
+    schemas = {schema["name"]: schema for schema in provider.get_tool_schemas()}
+
+    assert {"wiki_lint", "wiki_ingest"} <= set(schemas)
+    assert "wiki_reindex" not in schemas
+    assert schemas["wiki_lint"]["parameters"]["properties"]["write_log"]["default"] is False
+    assert schemas["wiki_ingest"]["parameters"]["properties"]["dry_run"]["default"] is True
+
+
+def test_lint_defaults_to_non_mutating(monkeypatch, tmp_path):
+    fake_engine = FakeEngine()
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+    monkeypatch.setattr(provider, "_engine", lambda: fake_engine)
+
+    result = provider.handle_tool_call("wiki_lint", {})
+
+    assert '"write_log": false' in result
+
+
+def test_ingest_actual_write_blocked_in_non_primary(monkeypatch, tmp_path):
+    fake_engine = FakeEngine()
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="subagent")
+    monkeypatch.setattr(provider, "_engine", lambda: fake_engine)
+
+    result = provider.handle_tool_call("wiki_ingest", {"file_path": "/tmp/source.md", "dry_run": False})
+
+    assert "blocked" in result.lower()
+    assert "subagent" in result
+
+
+def test_ingest_dry_run_blocked_in_non_primary(monkeypatch, tmp_path):
+    fake_engine = FakeEngine()
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="subagent")
+    monkeypatch.setattr(provider, "_engine", lambda: fake_engine)
+
+    result = provider.handle_tool_call("wiki_ingest", {"file_path": "/tmp/source.md"})
+
+    assert "blocked" in result.lower()
+    assert "subagent" in result
+
+
+def test_reindex_tool_is_not_exposed(monkeypatch, tmp_path):
+    fake_engine = FakeEngine()
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="cron")
+    monkeypatch.setattr(provider, "_engine", lambda: fake_engine)
+
+    try:
+        provider.handle_tool_call("wiki_reindex", {})
+    except NotImplementedError as exc:
+        assert "wiki_reindex" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("wiki_reindex should not be handled by the provider")
+    assert fake_engine.reindex_calls == 0
+
+
+def test_mutating_query_options_blocked_in_non_primary(monkeypatch, tmp_path):
+    fake_engine = FakeEngine()
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="subagent")
+    monkeypatch.setattr(provider, "_engine", lambda: fake_engine)
+
+    filed = provider.handle_tool_call("wiki_query", {"question": "save this", "file_result": True})
+    logged = provider.handle_tool_call("wiki_query", {"question": "log this", "log_query": True})
+
+    assert "blocked" in filed.lower()
+    assert "blocked" in logged.lower()
+    assert fake_engine.query_calls == []
+
+
+def test_lint_write_log_blocked_in_non_primary(monkeypatch, tmp_path):
+    fake_engine = FakeEngine()
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="cron")
+    monkeypatch.setattr(provider, "_engine", lambda: fake_engine)
+
+    result = provider.handle_tool_call("wiki_lint", {"write_log": True})
+
+    assert "blocked" in result.lower()
+    assert "cron" in result
+
+
+def test_search_limit_is_clamped(monkeypatch, tmp_path):
+    calls = []
+
+    class Searcher:
+        def search(self, query, limit=5):
+            calls.append(limit)
+            return []
+
+    class Engine:
+        search = Searcher()
+
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+    monkeypatch.setattr(provider, "_engine", lambda: Engine())
+
+    provider.handle_tool_call("wiki_search", {"query": "memory", "limit": 9999})
+    result = provider.handle_tool_call("wiki_search", {"query": "memory", "limit": -5})
+
+    assert "limit" in result
+    assert calls == [20]
+
+
+def test_read_page_is_output_bounded(tmp_path):
+    page = tmp_path / "wiki" / "personal" / "concepts" / "large.md"
+    page.parent.mkdir(parents=True)
+    page.write_text("x" * 150_000, encoding="utf-8")
+    provider = LLMWikiMemoryProvider()
+    provider.initialize("s1", hermes_home=str(tmp_path), agent_context="primary")
+
+    result = provider.handle_tool_call("wiki_read", {"page": "concepts/large.md"})
+
+    assert len(result) < 70_000
+    assert "truncated" in result.lower()
+
+
+def test_plugin_loader_returns_llm_wiki_provider():
+    provider = load_memory_provider("llm_wiki")
+
+    assert isinstance(provider, LLMWikiMemoryProvider)
+
+
+def test_memory_manager_routes_llm_wiki_tools(monkeypatch, tmp_path):
+    fake_engine = FakeEngine()
+    provider = LLMWikiMemoryProvider()
+    manager = MemoryManager()
+    manager.add_provider(provider)
+    manager.initialize_all("s1", hermes_home=str(tmp_path), agent_context="primary")
+    monkeypatch.setattr(provider, "_engine", lambda: fake_engine)
+
+    assert manager.has_tool("wiki_status")
+    result = manager.handle_tool_call("wiki_status", {})
+
+    assert "total_pages" in result
+
+
+def test_memory_manager_prefetches_llm_wiki_context(monkeypatch, tmp_path):
+    class Result:
+        page_path = "concepts/memory.md"
+        title = "Memory"
+        text = "Durable source-backed memory"
+        score = 0.99
+
+    class Searcher:
+        def search(self, query, limit=3, exclude_sources=True):
+            return [Result()]
+
+    class Engine:
+        search = Searcher()
+
+    provider = LLMWikiMemoryProvider()
+    manager = MemoryManager()
+    manager.add_provider(provider)
+    manager.initialize_all("s1", hermes_home=str(tmp_path), agent_context="primary")
+    monkeypatch.setattr(provider, "_engine", lambda: Engine())
+
+    result = manager.prefetch_all("memory")
+
+    assert "LLM Wiki relevant context" in result
+    assert "concepts/memory.md" in result

--- a/tests/plugins/memory/test_llm_wiki_public_docs_hygiene.py
+++ b/tests/plugins/memory/test_llm_wiki_public_docs_hygiene.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+DOC_PATHS = [
+    Path("website/docs/user-guide/features/llm-wiki-memory.md"),
+    Path("website/docs/user-guide/features/memory-providers.md"),
+]
+
+FORBIDDEN_PUBLIC_DOC_SNIPPETS = [
+    "/home/kraut",
+    "hermes-dev",
+    "private repository",
+    "@claude",
+    "michaelkrauty",
+    "http://localhost:8011",
+    "gpt-4o-mini",
+]
+
+
+def test_llm_wiki_public_docs_do_not_leak_private_dogfood_paths():
+    for path in DOC_PATHS:
+        text = path.read_text(encoding="utf-8")
+        for snippet in FORBIDDEN_PUBLIC_DOC_SNIPPETS:
+            assert snippet not in text, f"{path} contains private dogfood snippet: {snippet}"

--- a/tests/plugins/memory/test_llm_wiki_retrieval_introspection.py
+++ b/tests/plugins/memory/test_llm_wiki_retrieval_introspection.py
@@ -1,0 +1,402 @@
+import json
+import math
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_wiki.search import WikiSearchResult
+
+
+class FakeSearcher:
+    def __init__(self, results):
+        self.results = results
+        self.calls = []
+
+    def search(self, query, limit=5, **kwargs):
+        self.calls.append({"query": query, "limit": limit, **kwargs})
+        return self.results[:limit]
+
+
+def _hit(page_path, *, score=0.5, chunk_index=0, page_type="concept", title=None, text="body text"):
+    return WikiSearchResult(
+        page_path=page_path,
+        title=title or page_path.rsplit("/", 1)[-1].removesuffix(".md"),
+        page_type=page_type,
+        chunk_index=chunk_index,
+        text=text,
+        score=score,
+        tags=["memory"],
+    )
+
+
+def test_introspection_config_loader_rejects_nonscalar_path():
+    from hermes_wiki.retrieval_introspection import _load_explicit_wiki_config
+
+    with pytest.raises(ValueError, match="config_path"):
+        _load_explicit_wiki_config({"path": "config.yaml"})  # type: ignore[arg-type]
+
+
+def test_introspect_retrieval_reports_ranked_chunks_and_page_coverage():
+    from hermes_wiki.retrieval_introspection import introspect_retrieval, introspection_to_dict
+
+    searcher = FakeSearcher([
+        _hit("concepts/memory.md", score=0.91, chunk_index=0, text="First memory chunk"),
+        _hit("concepts/memory.md", score=0.83, chunk_index=1, text="Second memory chunk"),
+        _hit("entities/hermes.md", score=0.77, page_type="entity", text="Hermes entity chunk"),
+    ])
+
+    report = introspect_retrieval(
+        searcher,
+        "How should Hermes use memory?",
+        top_k=3,
+        expected_pages={"concepts/memory.md", "entities/missing.md"},
+    )
+    data = introspection_to_dict(report)
+
+    assert searcher.calls == [{"query": "How should Hermes use memory?", "limit": 3}]
+    assert data["query"] == "How should Hermes use memory?"
+    assert data["search_mode"] == "dense"
+    assert data["top_k"] == 3
+    assert [hit["rank"] for hit in data["hits"]] == [1, 2, 3]
+    assert data["hits"][0] == {
+        "rank": 1,
+        "page_path": "concepts/memory.md",
+        "title": "memory",
+        "page_type": "concept",
+        "chunk_index": 0,
+        "score": 0.91,
+        "tags": ["memory"],
+        "text_preview": "First memory chunk",
+    }
+    assert data["pages"] == [
+        {"page_path": "concepts/memory.md", "best_rank": 1, "best_score": 0.91, "hit_count": 2},
+        {"page_path": "entities/hermes.md", "best_rank": 3, "best_score": 0.77, "hit_count": 1},
+    ]
+    assert data["expected_pages"] == ["concepts/memory.md", "entities/missing.md"]
+    assert data["missing_expected_pages"] == ["entities/missing.md"]
+    assert not data["passed_expected_pages"]
+
+
+def test_introspection_serializes_non_finite_scores_as_null():
+    from hermes_wiki.retrieval_introspection import introspect_retrieval, introspection_to_dict
+
+    report = introspect_retrieval(
+        FakeSearcher([
+            SimpleNamespace(
+                page_path="concepts/nan.md",
+                title="nan",
+                page_type="concept",
+                chunk_index=0,
+                text="body",
+                score=math.nan,
+                tags=["memory"],
+            ),
+            SimpleNamespace(
+                page_path="concepts/inf.md",
+                title="inf",
+                page_type="concept",
+                chunk_index=0,
+                text="body",
+                score=math.inf,
+                tags=["memory"],
+            ),
+            SimpleNamespace(
+                page_path="concepts/neg-inf.md",
+                title="neg-inf",
+                page_type="concept",
+                chunk_index=0,
+                text="body",
+                score=-math.inf,
+                tags=["memory"],
+            ),
+        ]),
+        "score query",
+        top_k=3,
+    )
+    data = introspection_to_dict(report)
+
+    assert [hit["score"] for hit in data["hits"]] == [None, None, None]
+    assert [page["best_score"] for page in data["pages"]] == [None, None, None]
+    json.dumps(data, allow_nan=False)
+
+
+def test_introspect_retrieval_passes_page_type_and_exclude_source_filters():
+    from hermes_wiki.retrieval_introspection import introspect_retrieval
+
+    searcher = FakeSearcher([_hit("entities/hermes.md", page_type="entity")])
+
+    introspect_retrieval(
+        searcher,
+        "Hermes",
+        top_k=1,
+        page_type="entity",
+        exclude_sources=True,
+        search_mode="hybrid",
+    )
+
+    assert searcher.calls == [
+        {"query": "Hermes", "limit": 1, "page_type": "entity", "exclude_sources": True, "search_mode": "hybrid"}
+    ]
+
+
+def test_introspect_retrieval_clamps_top_k_to_bounded_range():
+    from hermes_wiki.retrieval_introspection import introspect_retrieval
+
+    searcher = FakeSearcher([_hit(f"concepts/{idx}.md") for idx in range(30)])
+    report = introspect_retrieval(searcher, "memory", top_k=999999)
+
+    assert searcher.calls[0] == {"query": "memory", "limit": 20}
+    assert report.top_k == 20
+
+
+def test_introspect_retrieval_rejects_invalid_top_k():
+    from hermes_wiki.retrieval_introspection import introspect_retrieval
+
+    for top_k in (math.inf, math.nan, 2.5, "2.5", {"limit": 2}, True):
+        with pytest.raises(ValueError, match="top_k"):
+            introspect_retrieval(FakeSearcher([]), "memory", top_k=top_k)  # type: ignore[arg-type]
+
+
+def test_introspect_retrieval_rejects_unsafe_expected_pages():
+    from hermes_wiki.retrieval_introspection import introspect_retrieval
+
+    with pytest.raises(ValueError, match="expected_pages"):
+        introspect_retrieval(FakeSearcher([]), "query", expected_pages={"../secrets.md"})
+
+
+def test_introspect_retrieval_rejects_nonscalar_expected_pages():
+    from hermes_wiki.retrieval_introspection import introspect_retrieval
+
+    for expected_pages in ({}, {"concepts/ok.md", ("concepts/nested.md",)}, {"concepts/ok.md", 42}):
+        with pytest.raises(ValueError, match="expected_pages"):
+            introspect_retrieval(FakeSearcher([]), "query", expected_pages=expected_pages)  # type: ignore[arg-type]
+
+
+def test_introspect_retrieval_rejects_nonscalar_query_and_search_mode():
+    from hermes_wiki.retrieval_introspection import introspect_retrieval
+
+    with pytest.raises(ValueError, match="query"):
+        introspect_retrieval(FakeSearcher([]), {"text": "query"})  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="search_mode"):
+        introspect_retrieval(FakeSearcher([]), "query", search_mode={"mode": "dense"})  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="page_type"):
+        introspect_retrieval(FakeSearcher([]), "query", page_type={"type": "concept"})  # type: ignore[arg-type]
+
+
+def test_retrieval_introspection_rejects_nonbool_exclude_sources():
+    from hermes_wiki.retrieval_introspection import (
+        compare_retrieval_introspection,
+        introspect_retrieval,
+    )
+
+    for exclude_sources in ({"enabled": True}, [True], "false", 1):
+        with pytest.raises(ValueError, match="exclude_sources"):
+            introspect_retrieval(FakeSearcher([]), "query", exclude_sources=exclude_sources)  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="exclude_sources"):
+            compare_retrieval_introspection(FakeSearcher([]), "query", exclude_sources=exclude_sources)  # type: ignore[arg-type]
+
+
+def test_introspect_retrieval_normalizes_malformed_hit_fields():
+    from types import SimpleNamespace
+
+    from hermes_wiki.retrieval_introspection import introspect_retrieval, introspection_to_dict
+
+    report = introspect_retrieval(
+        FakeSearcher([
+            SimpleNamespace(
+                page_path="concepts/malformed.md",
+                title={"bad": "title"},
+                page_type=["concept"],
+                chunk_index=2.5,
+                score=float("nan"),
+                tags="not-a-list",
+                text={"body": "bad"},
+            )
+        ]),
+        "query",
+        expected_pages={"concepts/malformed.md"},
+    )
+    payload = introspection_to_dict(report)
+
+    assert payload["hits"][0]["page_path"] == "concepts/malformed.md"
+    assert payload["hits"][0]["title"] == ""
+    assert payload["hits"][0]["page_type"] == ""
+    assert payload["hits"][0]["chunk_index"] == 0
+    assert payload["hits"][0]["score"] is None
+    assert payload["hits"][0]["tags"] == ["not-a-list"]
+    assert payload["hits"][0]["text_preview"] == ""
+
+
+def test_render_introspection_markdown_is_agent_readable():
+    from hermes_wiki.retrieval_introspection import (
+        introspect_retrieval,
+        render_introspection_markdown,
+    )
+
+    report = introspect_retrieval(
+        FakeSearcher([_hit("concepts/memory.md", score=0.91, text="A" * 300)]),
+        "memory query",
+        expected_pages={"concepts/memory.md"},
+    )
+
+    markdown = render_introspection_markdown(report)
+
+    assert "# LLM Wiki Retrieval Introspection" in markdown
+    assert "Query: `memory query`" in markdown
+    assert "- ✅ Expected page coverage passed" in markdown
+    assert "| 1 | `concepts/memory.md` | 0.91 | concept | 0 |" in markdown
+    assert "A" * 220 not in markdown
+
+
+def test_cli_json_uses_explicit_config_and_prints_stable_shape(tmp_path, monkeypatch, capsys):
+    from hermes_wiki import retrieval_introspection
+
+    config_path = tmp_path / "config.yaml"
+    wiki_path = tmp_path / "wiki"
+    config_path.write_text(f"wiki:\n  path: {wiki_path}\n  name: test\n", encoding="utf-8")
+
+    class FakeWikiSearch:
+        def __init__(self, config, ensure_collection=False):
+            self.config = config
+            self.ensure_collection = ensure_collection
+
+        def search(self, query, limit=5, **kwargs):
+            return [_hit("concepts/memory.md", score=0.99)]
+
+    monkeypatch.setattr(retrieval_introspection, "WikiSearch", FakeWikiSearch)
+
+    rc = retrieval_introspection.main([
+        "memory query",
+        "--config",
+        str(config_path),
+        "--expected-page",
+        "concepts/memory.md",
+        "--json",
+    ])
+    out = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert out["query"] == "memory query"
+    assert out["hits"][0]["page_path"] == "concepts/memory.md"
+    assert out["passed_expected_pages"] is True
+
+
+def test_cli_returns_nonzero_when_expected_pages_are_missing(tmp_path, monkeypatch, capsys):
+    from hermes_wiki import retrieval_introspection
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(f"wiki:\n  path: {tmp_path / 'wiki'}\n  name: test\n", encoding="utf-8")
+
+    class FakeWikiSearch:
+        def __init__(self, config, ensure_collection=False):
+            pass
+
+        def search(self, query, limit=5, **kwargs):
+            return [_hit("entities/hermes.md")]
+
+    monkeypatch.setattr(retrieval_introspection, "WikiSearch", FakeWikiSearch)
+
+    rc = retrieval_introspection.main([
+        "memory query",
+        "--config",
+        str(config_path),
+        "--expected-page",
+        "concepts/missing.md",
+        "--json",
+    ])
+    out = json.loads(capsys.readouterr().out)
+
+    assert rc == 1
+    assert out["missing_expected_pages"] == ["concepts/missing.md"]
+
+
+def test_cli_requires_explicit_config_when_requested_path_is_missing(tmp_path):
+    from hermes_wiki.retrieval_introspection import main
+
+    with pytest.raises(SystemExit):
+        main(["query", "--config", str(tmp_path / "missing.yaml")])
+
+
+def test_compare_retrieval_introspection_summarizes_modes():
+    from hermes_wiki.retrieval_introspection import compare_retrieval_introspection
+
+    class ModeAwareSearcher:
+        def __init__(self):
+            self.calls = []
+
+        def search(self, query, limit=5, **kwargs):
+            self.calls.append({"query": query, "limit": limit, **kwargs})
+            if kwargs.get("search_mode") == "sparse":
+                return [_hit("concepts/noise.md")]
+            return [_hit("concepts/memory.md")]
+
+    searcher = ModeAwareSearcher()
+    payload = compare_retrieval_introspection(
+        searcher,
+        "memory query",
+        top_k=2,
+        expected_pages={"concepts/memory.md"},
+    )
+
+    assert payload["passed"] is False
+    assert payload["failed_modes"] == ["sparse"]
+    assert payload["summary"] == {
+        "dense": {"passed_expected_pages": True, "missing_expected_pages": []},
+        "sparse": {"passed_expected_pages": False, "missing_expected_pages": ["concepts/memory.md"]},
+        "hybrid": {"passed_expected_pages": True, "missing_expected_pages": []},
+    }
+    assert searcher.calls == [
+        {"query": "memory query", "limit": 2},
+        {"query": "memory query", "limit": 2, "search_mode": "sparse"},
+        {"query": "memory query", "limit": 2, "search_mode": "hybrid"},
+    ]
+
+
+def test_cli_compare_modes_json_outputs_summary(tmp_path, monkeypatch, capsys):
+    from hermes_wiki import retrieval_introspection
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(f"wiki:\n  path: {tmp_path / 'wiki'}\n  name: test\n", encoding="utf-8")
+
+    class FakeWikiSearch:
+        def __init__(self, config, ensure_collection=False):
+            pass
+
+        def search(self, query, limit=5, **kwargs):
+            if kwargs.get("search_mode") == "sparse":
+                return [_hit("concepts/noise.md")]
+            return [_hit("concepts/memory.md")]
+
+    monkeypatch.setattr(retrieval_introspection, "WikiSearch", FakeWikiSearch)
+
+    rc = retrieval_introspection.main([
+        "memory query",
+        "--config",
+        str(config_path),
+        "--expected-page",
+        "concepts/memory.md",
+        "--compare-modes",
+        "--json",
+    ])
+    out = json.loads(capsys.readouterr().out)
+
+    assert rc == 1
+    assert out["failed_modes"] == ["sparse"]
+    assert out["modes"]["hybrid"]["passed_expected_pages"] is True
+
+
+def test_cli_compare_modes_rejects_search_mode(tmp_path):
+    from hermes_wiki.retrieval_introspection import main
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(f"wiki:\n  path: {tmp_path / 'wiki'}\n  name: test\n", encoding="utf-8")
+
+    with pytest.raises(SystemExit):
+        main([
+            "memory query",
+            "--config",
+            str(config_path),
+            "--compare-modes",
+            "--search-mode",
+            "hybrid",
+        ])

--- a/tests/plugins/memory/test_llm_wiki_source_integrity.py
+++ b/tests/plugins/memory/test_llm_wiki_source_integrity.py
@@ -1,0 +1,237 @@
+"""Tests for explicit LLM Wiki raw-source hash audit/repair."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from hermes_wiki.config import WikiConfig
+from hermes_wiki.frontmatter import read_page, write_page
+from hermes_wiki.source_integrity import (
+    audit_source_hashes,
+    repair_source_hashes,
+    source_integrity_report_to_dict,
+)
+from hermes_wiki.source_integrity import (
+    main as source_integrity_main,
+)
+
+
+def _config(tmp_path):
+    return WikiConfig(wiki_path=tmp_path / "wiki", wiki_name="test")
+
+
+def _write_source(config, rel_path="raw/articles/source.md", body="# Source\n\nBody.", sha256="0" * 64):
+    path = config.wiki_path / rel_path
+    write_page(path, {"source_url": "", "ingested": "2026-01-01", "sha256": sha256}, body)
+    return path
+
+
+def test_audit_source_hashes_detects_drift_without_writing(tmp_path):
+    config = _config(tmp_path)
+    source_path = _write_source(config)
+    before = source_path.read_text(encoding="utf-8")
+
+    report = audit_source_hashes(config)
+
+    assert report.total_sources == 1
+    assert report.drifted_sources == 1
+    assert report.records[0].relative_path == "raw/articles/source.md"
+    assert report.records[0].status == "drifted"
+    assert source_path.read_text(encoding="utf-8") == before
+
+
+def test_repair_source_hashes_updates_only_raw_source_frontmatter(tmp_path):
+    config = _config(tmp_path)
+    source_path = _write_source(config)
+    canonical = config.wiki_path / "concepts" / "canonical.md"
+    write_page(
+        canonical,
+        {"title": "Canonical", "type": "concept", "created": "2026-01-01", "updated": "2026-01-01"},
+        "Canonical body.",
+    )
+    canonical_before = canonical.read_text(encoding="utf-8")
+
+    report = repair_source_hashes(config, write=True)
+    fm, body = read_page(source_path)
+    after = audit_source_hashes(config)
+
+    assert report.updated_sources == 1
+    assert fm["sha256"] == report.records[0].actual_sha256
+    assert body == "# Source\n\nBody."
+    assert canonical.read_text(encoding="utf-8") == canonical_before
+    assert after.drifted_sources == 0
+
+
+def test_repair_source_hashes_rejects_nonbool_write_flag(tmp_path):
+    config = _config(tmp_path)
+    source_path = _write_source(config)
+    before = source_path.read_text(encoding="utf-8")
+
+    with pytest.raises(ValueError, match="write"):
+        repair_source_hashes(config, write={"enabled": True})  # type: ignore[arg-type]
+
+    assert source_path.read_text(encoding="utf-8") == before
+
+
+def test_source_integrity_report_to_dict_is_json_serializable(tmp_path):
+    config = _config(tmp_path)
+    _write_source(config)
+
+    payload = source_integrity_report_to_dict(audit_source_hashes(config))
+
+    assert json.loads(json.dumps(payload))["drifted_sources"] == 1
+    assert payload["records"][0]["status"] == "drifted"
+
+
+def test_audit_source_hashes_tolerates_non_mapping_frontmatter(tmp_path):
+    config = _config(tmp_path)
+    source = config.raw_dir / "articles" / "bad.md"
+    source.parent.mkdir(parents=True)
+    source.write_text("---\nscalar\n---\nsource body\n", encoding="utf-8")
+
+    report = audit_source_hashes(config)
+
+    assert report.total_sources == 1
+    assert report.missing_hashes == 1
+
+
+def test_audit_source_hashes_treats_nonscalar_sha256_as_missing(tmp_path):
+    config = _config(tmp_path)
+    source = config.wiki_path / "raw/articles/source.md"
+    source.parent.mkdir(parents=True)
+    source.write_text("---\nsource_url: ''\ningested: '2026-01-01'\nsha256:\n  bad: hash\n---\n\n# Source\n\nBody.\n", encoding="utf-8")
+
+    report = audit_source_hashes(config)
+    record = report.records[0]
+
+    assert report.missing_hashes == 1
+    assert record.status == "missing_hash"
+    assert record.stored_sha256 is None
+
+
+def test_audit_source_hashes_treats_malformed_scalar_sha256_as_missing(tmp_path):
+    config = _config(tmp_path)
+    source = _write_source(config, sha256="abc123")
+    before = source.read_text(encoding="utf-8")
+
+    report = audit_source_hashes(config)
+    record = report.records[0]
+
+    assert report.missing_hashes == 1
+    assert report.drifted_sources == 0
+    assert record.status == "missing_hash"
+    assert record.stored_sha256 is None
+    assert source.read_text(encoding="utf-8") == before
+
+
+def test_explicit_config_loader_rejects_nonscalar_path():
+    from hermes_wiki.source_integrity import _load_explicit_wiki_config
+
+    with pytest.raises(ValueError, match="config_path"):
+        _load_explicit_wiki_config({"path": "config.yaml"})  # type: ignore[arg-type]
+
+
+
+def test_cli_audit_is_read_only_by_default(tmp_path, capsys):
+    config = _config(tmp_path)
+    source_path = _write_source(config)
+    before = source_path.read_text(encoding="utf-8")
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(f"wiki:\n  path: {config.wiki_path}\n  name: test\n", encoding="utf-8")
+
+    code = source_integrity_main(["--config", str(config_path), "--json"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 1
+    assert payload["drifted_sources"] == 1
+    assert source_path.read_text(encoding="utf-8") == before
+
+
+def test_cli_repair_requires_explicit_config(tmp_path, monkeypatch):
+    ambient_home = tmp_path / "ambient"
+    monkeypatch.setenv("LLM_WIKI_HOME", str(ambient_home))
+
+    try:
+        source_integrity_main(["--repair"])
+    except SystemExit:
+        pass
+
+    assert not ambient_home.exists()
+
+
+def test_cli_repair_updates_hash_with_explicit_config(tmp_path, capsys):
+    config = _config(tmp_path)
+    _write_source(config)
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(f"wiki:\n  path: {config.wiki_path}\n  name: test\n", encoding="utf-8")
+
+    code = source_integrity_main(["--config", str(config_path), "--repair", "--json"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 0
+    assert payload["updated_sources"] == 1
+    assert audit_source_hashes(config).drifted_sources == 0
+
+
+class SourceIntegrityLeakyObject:
+    def __str__(self):
+        return "SOURCE-INTEGRITY-LEAK"
+
+
+def test_source_integrity_report_to_dict_normalizes_malformed_direct_records():
+    from hermes_wiki.source_integrity import SourceHashRecord, SourceIntegrityReport
+
+    report = SourceIntegrityReport(
+        records=[
+            SourceHashRecord(
+                relative_path=SourceIntegrityLeakyObject(),  # type: ignore[arg-type]
+                stored_sha256=SourceIntegrityLeakyObject(),  # type: ignore[arg-type]
+                actual_sha256=SourceIntegrityLeakyObject(),  # type: ignore[arg-type]
+                status=SourceIntegrityLeakyObject(),  # type: ignore[arg-type]
+            ),
+            SourceIntegrityLeakyObject(),  # type: ignore[list-item]
+        ],
+        updated_sources=SourceIntegrityLeakyObject(),  # type: ignore[arg-type]
+    )
+
+    payload = source_integrity_report_to_dict(report)
+    assert payload == {
+        "total_sources": 1,
+        "ok_sources": 0,
+        "missing_hashes": 0,
+        "drifted_sources": 0,
+        "updated_sources": 0,
+        "records": [
+            {"relative_path": "", "stored_sha256": None, "actual_sha256": "", "status": "unknown"}
+        ],
+    }
+    assert "SOURCE-INTEGRITY-LEAK" not in str(payload)
+
+
+def test_render_source_integrity_report_normalizes_malformed_direct_records():
+    from hermes_wiki.source_integrity import (
+        SourceHashRecord,
+        SourceIntegrityReport,
+        render_source_integrity_report,
+    )
+
+    report = SourceIntegrityReport(
+        records=[
+            SourceHashRecord(
+                relative_path=SourceIntegrityLeakyObject(),  # type: ignore[arg-type]
+                stored_sha256=None,
+                actual_sha256="abc123",
+                status=SourceIntegrityLeakyObject(),  # type: ignore[arg-type]
+            ),
+            SourceIntegrityLeakyObject(),  # type: ignore[list-item]
+        ],
+        updated_sources=SourceIntegrityLeakyObject(),  # type: ignore[arg-type]
+    )
+
+    rendered = render_source_integrity_report(report)
+    assert "SOURCE-INTEGRITY-LEAK" not in rendered
+    assert "- Sources: 1" in rendered
+    assert "- Updated sources: 0" in rendered
+    assert "- **unknown** ``" in rendered

--- a/tests/plugins/memory/test_llm_wiki_standalone_sync.py
+++ b/tests/plugins/memory/test_llm_wiki_standalone_sync.py
@@ -1,0 +1,366 @@
+"""Guards for using standalone hermes-llm-wiki directly from Hermes.
+
+Hermes should not carry a duplicate `hermes_wiki/` core package. The
+standalone `hermes-llm-wiki` package is the DRY source of truth; Hermes keeps
+only its native provider adapter under `plugins/memory/llm_wiki`.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts import check_llm_wiki_standalone_import as standalone_import
+
+build_shadow_free_overlay = standalone_import.build_shadow_free_overlay
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+VENDORED_CORE = REPO_ROOT / "hermes_wiki"
+
+
+def standalone_core_path(raw_path: str | None = None) -> Path:
+    configured = raw_path or os.environ.get("LLM_WIKI_STANDALONE_CORE")
+    if not configured:
+        pytest.skip("LLM_WIKI_STANDALONE_CORE is not set")
+    return Path(configured).expanduser().resolve()
+
+
+def test_hermes_does_not_vendor_llm_wiki_core():
+    assert not VENDORED_CORE.exists()
+
+
+def test_hermes_package_does_not_ship_llm_wiki_core():
+    pyproject = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+
+    assert '"hermes_wiki"' not in pyproject
+    assert '"hermes_wiki.*"' not in pyproject
+    assert "hermes-wiki-eval =" not in pyproject
+    assert "llm-wiki-mcp =" not in pyproject
+
+
+def test_ci_can_verify_pinned_standalone_tag_when_network_check_enabled():
+    script = REPO_ROOT / "scripts" / "check_git_ref.py"
+    assert script.exists()
+    text = _workflow_text()
+
+    assert "HERMES_LLM_WIKI_CHECK_REMOTE_REF" in text
+    assert "python scripts/check_git_ref.py https://github.com/michaelkrauty/hermes-llm-wiki.git v0.1.1" in text
+
+
+def test_git_ref_guard_validates_release_tag_format_offline():
+    script = REPO_ROOT / "scripts" / "check_git_ref.py"
+    completed = subprocess.run(
+        [standalone_import.sys.executable, str(script), "https://github.com/michaelkrauty/hermes-llm-wiki.git", "v0.1.1"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    assert "ref format ok" in completed.stdout
+    assert "remote check skipped" in completed.stdout
+
+
+def test_ci_installs_standalone_llm_wiki_instead_of_syncing_vendored_core():
+    text = _workflow_text()
+
+    assert "repository: michaelkrauty/hermes-llm-wiki" in text
+    assert "uv pip install -e .llm-wiki-standalone" in text
+    assert "scripts/sync_llm_wiki_core.py" not in text
+    assert "Verify vendored LLM Wiki core sync" not in text
+
+
+def test_shadow_free_overlay_excludes_any_llm_wiki_core_copy(tmp_path):
+    repo = tmp_path / "repo"
+    (repo / "agent").mkdir(parents=True)
+    (repo / "plugins").mkdir()
+    (repo / "tools").mkdir()
+    (repo / "hermes_wiki").mkdir()
+    (repo / "agent" / "memory_provider.py").write_text("", encoding="utf-8")
+    (repo / "plugins" / "__init__.py").write_text("", encoding="utf-8")
+    (repo / "tools" / "__init__.py").write_text("", encoding="utf-8")
+    (repo / "hermes_wiki" / "__init__.py").write_text("", encoding="utf-8")
+
+    overlay = tmp_path / "overlay"
+
+    build_shadow_free_overlay(repo, overlay)
+
+    assert (overlay / "agent").exists()
+    assert (overlay / "plugins").exists()
+    assert (overlay / "tools").exists()
+    assert not (overlay / "hermes_wiki").exists()
+
+
+def _workflow_text() -> str:
+    return (REPO_ROOT / ".github" / "workflows" / "tests.yml").read_text(encoding="utf-8")
+
+
+def _workflow_shadow_free_tests(text: str) -> set[str]:
+    lines = text.splitlines()
+    try:
+        start = next(i for i, line in enumerate(lines) if line.strip() == "LLM_WIKI_TESTS=(")
+    except StopIteration:  # pragma: no cover - assertion below gives clearer failure
+        return set()
+    selected = set()
+    for line in lines[start + 1:]:
+        stripped = line.strip()
+        if stripped == ")":
+            break
+        if stripped:
+            selected.add(stripped)
+    return selected
+
+
+def test_ci_runs_standalone_import_smoke():
+    text = _workflow_text()
+
+    assert "python scripts/check_llm_wiki_standalone_import.py --standalone-root .llm-wiki-standalone" in text
+    assert "python scripts/check_llm_wiki_standalone_import.py --standalone-root .llm-wiki-standalone --install-standalone" in text
+    assert "LLM_WIKI_TESTS=(" in text
+    assert "tests/plugins/memory/test_llm_wiki_provider.py" in text
+    assert "tests/plugins/memory/test_llm_wiki_caretaker.py" in text
+    assert "tests/plugins/memory/test_llm_wiki_maintenance.py" in text
+    assert "test_llm_wiki_proposals.py" not in text
+    assert "test_llm_wiki_proposal_lifecycle.py" not in text
+    assert "test_llm_wiki_caretaker_orchestrator.py" not in text
+    assert "${LLM_WIKI_PYTEST_ARGS[@]}" in text
+    assert "python scripts/check_llm_wiki_standalone_import.py --standalone-root .llm-wiki-standalone \"${LLM_WIKI_PYTEST_ARGS[@]}\"" in text
+    assert "python scripts/check_llm_wiki_standalone_import.py --standalone-root .llm-wiki-standalone --install-standalone \"${LLM_WIKI_PYTEST_ARGS[@]}\"" in text
+    assert "assert repo_vendored" not in text
+    assert "import hermes_wiki as preloaded" not in text
+
+
+def test_ci_shadow_free_smoke_covers_core_llm_wiki_test_suites():
+    selected = _workflow_shadow_free_tests(_workflow_text())
+    all_llm_wiki_tests = {
+        str(path.relative_to(REPO_ROOT))
+        for path in (REPO_ROOT / "tests" / "plugins" / "memory").glob("test_llm_wiki*.py")
+    }
+    # These tests validate Hermes-local docs/CI overlay behavior itself rather
+    # than the standalone core package boundary, so they are intentionally not
+    # part of the shadow-free core smoke.
+    excluded = {
+        "tests/plugins/memory/test_llm_wiki_public_docs_hygiene.py",
+        "tests/plugins/memory/test_llm_wiki_standalone_sync.py",
+    }
+
+    assert selected == all_llm_wiki_tests - excluded
+
+
+def test_cli_can_run_installed_package_import_smoke(monkeypatch, tmp_path, capsys):
+    calls = []
+
+    def fake_run_installed_import_smoke(standalone_root, *, repo_root=standalone_import.ROOT, python=standalone_import.sys.executable):
+        calls.append((standalone_root, repo_root, python))
+        return {"hermes_wiki_file": "/tmp/site-packages/hermes_wiki/__init__.py", "tool_names": ["wiki_search"]}
+
+    monkeypatch.setattr(standalone_import, "run_installed_import_smoke", fake_run_installed_import_smoke)
+
+    result = standalone_import.main([
+        "--standalone-root",
+        str(tmp_path / "standalone"),
+        "--install-standalone",
+    ])
+
+    assert result == 0
+    assert calls == [(tmp_path / "standalone", standalone_import.ROOT, standalone_import.sys.executable)]
+    assert "installed package import smoke passed" in capsys.readouterr().out
+
+
+def test_shadow_free_overlay_can_include_tests_without_vendored_core(tmp_path):
+    repo = tmp_path / "repo"
+    (repo / "agent").mkdir(parents=True)
+    (repo / "plugins").mkdir()
+    (repo / "tools").mkdir()
+    (repo / "tests").mkdir()
+    (repo / "hermes_wiki").mkdir()
+    (repo / "tests" / "test_example.py").write_text("def test_example():\n    assert True\n", encoding="utf-8")
+    (repo / "hermes_wiki" / "__init__.py").write_text("", encoding="utf-8")
+
+    overlay = tmp_path / "overlay"
+
+    standalone_import.build_shadow_free_overlay(repo, overlay, include_tests=True)
+
+    assert (overlay / "tests" / "test_example.py").exists()
+    assert not (overlay / "hermes_wiki").exists()
+
+
+def test_run_pytest_smoke_uses_shadow_free_overlay(monkeypatch, tmp_path):
+    standalone = tmp_path / "standalone"
+    (standalone / "hermes_wiki").mkdir(parents=True)
+    (standalone / "hermes_wiki" / "__init__.py").write_text("", encoding="utf-8")
+    repo = tmp_path / "repo"
+    (repo / "agent").mkdir(parents=True)
+    (repo / "plugins").mkdir()
+    (repo / "tools").mkdir()
+    (repo / "tests").mkdir()
+    (repo / "hermes_wiki").mkdir()
+    (repo / "tests" / "test_example.py").write_text("def test_example():\n    assert True\n", encoding="utf-8")
+
+    calls = []
+
+    def fake_run(args, *, cwd, env, text, capture_output, check):
+        calls.append({"args": args, "cwd": cwd, "env": env, "check": check})
+        assert not (Path(cwd) / "hermes_wiki").exists()
+        return standalone_import.subprocess.CompletedProcess(args, 0, stdout="passed", stderr="")
+
+    monkeypatch.setattr(standalone_import.subprocess, "run", fake_run)
+
+    payload = standalone_import.run_pytest_smoke(
+        standalone,
+        repo_root=repo,
+        test_paths=["tests/test_example.py"],
+        python="python-test",
+    )
+
+    assert payload["pytest_stdout"] == "passed"
+    assert calls[0]["args"] == ["python-test", "-m", "pytest", "-o", "addopts=", "tests/test_example.py", "-q"]
+    assert str(standalone) in calls[0]["env"]["PYTHONPATH"]
+
+
+def test_cli_can_run_pytest_smoke(monkeypatch, tmp_path, capsys):
+    calls = []
+
+    def fake_run_pytest_smoke(standalone_root, *, repo_root=standalone_import.ROOT, test_paths=(), python=standalone_import.sys.executable):
+        calls.append((standalone_root, repo_root, tuple(test_paths), python))
+        return {"pytest_stdout": "ok"}
+
+    monkeypatch.setattr(standalone_import, "run_pytest_smoke", fake_run_pytest_smoke)
+
+    result = standalone_import.main([
+        "--standalone-root",
+        str(tmp_path / "standalone"),
+        "--pytest",
+        "tests/plugins/memory/test_llm_wiki_provider.py",
+    ])
+
+    assert result == 0
+    assert calls == [(
+        tmp_path / "standalone",
+        standalone_import.ROOT,
+        ("tests/plugins/memory/test_llm_wiki_provider.py",),
+        standalone_import.sys.executable,
+    )]
+    assert "pytest smoke passed" in capsys.readouterr().out
+
+
+def test_cli_can_run_installed_pytest_smoke(monkeypatch, tmp_path, capsys):
+    calls = []
+
+    def fake_run_installed_pytest_smoke(standalone_root, *, repo_root=standalone_import.ROOT, test_paths=(), python=standalone_import.sys.executable):
+        calls.append((standalone_root, repo_root, tuple(test_paths), python))
+        return {"pytest_stdout": "ok", "installed_wheel": "hermes_llm_wiki-0.1.0-py3-none-any.whl"}
+
+    monkeypatch.setattr(standalone_import, "run_installed_pytest_smoke", fake_run_installed_pytest_smoke)
+
+    result = standalone_import.main([
+        "--standalone-root",
+        str(tmp_path / "standalone"),
+        "--install-standalone",
+        "--pytest",
+        "tests/plugins/memory/test_llm_wiki_provider.py",
+    ])
+
+    assert result == 0
+    assert calls == [(
+        tmp_path / "standalone",
+        standalone_import.ROOT,
+        ("tests/plugins/memory/test_llm_wiki_provider.py",),
+        standalone_import.sys.executable,
+    )]
+    assert "installed package pytest smoke passed" in capsys.readouterr().out
+
+
+def test_provider_module_imports_when_standalone_core_missing():
+    code = """
+import importlib.abc
+import json
+import sys
+
+class BlockHermesWiki(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == 'hermes_wiki' or fullname.startswith('hermes_wiki.'):
+            raise ModuleNotFoundError(fullname)
+        return None
+
+sys.meta_path.insert(0, BlockHermesWiki())
+from plugins.memory.llm_wiki import LLMWikiMemoryProvider
+provider = LLMWikiMemoryProvider()
+print(json.dumps({'available': provider.is_available()}))
+"""
+    completed = standalone_import.subprocess.run(
+        [standalone_import.sys.executable, "-c", code],
+        cwd=REPO_ROOT,
+        env=os.environ.copy(),
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    payload = standalone_import.json.loads(completed.stdout)
+
+    assert payload == {"available": True}
+
+
+def test_provider_imports_installed_standalone_core_from_repo_root():
+    code = """
+import json
+from pathlib import Path
+from plugins.memory.llm_wiki import LLMWikiMemoryProvider
+import hermes_wiki
+provider = LLMWikiMemoryProvider()
+print(json.dumps({
+    "hermes_wiki_file": str(Path(hermes_wiki.__file__).resolve()),
+    "available": provider.is_available(),
+}))
+"""
+    completed = standalone_import.subprocess.run(
+        [standalone_import.sys.executable, "-c", code],
+        cwd=REPO_ROOT,
+        env=os.environ.copy(),
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    payload = standalone_import.json.loads(completed.stdout)
+
+    imported = Path(payload["hermes_wiki_file"]).resolve()
+    assert payload["available"] is True
+    assert VENDORED_CORE not in imported.parents
+    assert "site-packages" in imported.parts or standalone_core_path() in imported.parents
+
+
+def test_runtime_opt_in_can_use_standalone_checkout_from_repo_root():
+    standalone_root = standalone_core_path().parent
+    if not (standalone_root / "hermes_wiki" / "__init__.py").exists():
+        return
+
+    code = """
+import json
+from pathlib import Path
+from plugins.memory.llm_wiki import LLMWikiMemoryProvider
+import hermes_wiki
+provider = LLMWikiMemoryProvider()
+print(json.dumps({
+    "hermes_wiki_file": str(Path(hermes_wiki.__file__).resolve()),
+    "available": provider.is_available(),
+}))
+"""
+    env = os.environ.copy()
+    env["HERMES_LLM_WIKI_STANDALONE_ROOT"] = str(standalone_root)
+    completed = standalone_import.subprocess.run(
+        [standalone_import.sys.executable, "-c", code],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    payload = standalone_import.json.loads(completed.stdout)
+
+    imported = Path(payload["hermes_wiki_file"]).resolve()
+    assert payload["available"] is True
+    assert standalone_root in imported.parents
+    assert VENDORED_CORE not in imported.parents

--- a/tests/plugins/memory/test_llm_wiki_vector_core_compat.py
+++ b/tests/plugins/memory/test_llm_wiki_vector_core_compat.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+import pytest
+
+
+def test_search_hard_fails_when_vector_core_search_helpers_are_too_old(monkeypatch):
+    """LLM Wiki has a hard vector-core dependency.
+
+    Missing generic search helpers mean the installed vector-core is too old and
+    should be upgraded, rather than silently falling back to duplicated LLM Wiki
+    implementations.
+    """
+
+    fake_vector_core = types.ModuleType("vector_core")
+    fake_search = types.ModuleType("vector_core.search")
+    monkeypatch.setitem(sys.modules, "vector_core", fake_vector_core)
+    monkeypatch.setitem(sys.modules, "vector_core.search", fake_search)
+    sys.modules.pop("hermes_wiki.search", None)
+
+    with pytest.raises(ImportError):
+        importlib.import_module("hermes_wiki.search")

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -123,6 +123,16 @@ def _codex_incomplete_message_response(text: str):
     )
 
 
+def _codex_max_output_empty_response(input_tokens: int = 10):
+    return SimpleNamespace(
+        output=[],
+        usage=SimpleNamespace(input_tokens=input_tokens, output_tokens=0, total_tokens=input_tokens),
+        status="incomplete",
+        incomplete_details=SimpleNamespace(reason="max_output_tokens"),
+        model="gpt-5-codex",
+    )
+
+
 def _codex_commentary_message_response(text: str):
     return SimpleNamespace(
         output=[
@@ -1122,6 +1132,126 @@ def test_run_conversation_codex_continues_after_incomplete_interim_message(monke
         for msg in result["messages"]
     )
     assert any(msg.get("role") == "tool" and msg.get("tool_call_id") == "call_1" for msg in result["messages"])
+
+
+def test_run_conversation_codex_continues_after_internal_max_output_empty_response(monkeypatch):
+    """chatgpt.com Codex can return status=incomplete/reason=max_output_tokens
+    even though Hermes did not send max_output_tokens. Treat it as a Codex
+    incomplete turn and continue, rather than surfacing the generic truncation
+    warning as the final user response.
+    """
+    agent = _build_agent(monkeypatch)
+    responses = [
+        _codex_max_output_empty_response(),
+        _codex_message_response("Recovered after internal output ceiling."),
+    ]
+    monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: responses.pop(0))
+
+    result = agent.run_conversation("finish the patch")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "Recovered after internal output ceiling."
+    assert result.get("error") is None
+
+
+def test_run_conversation_codex_replays_empty_incomplete_state_on_continuation(monkeypatch):
+    """An empty internal-ceiling Codex response must change the next request.
+
+    Without replaying a synthetic incomplete assistant item, Hermes sends the
+    exact same Responses input again and the backend can repeat
+    status=incomplete/reason=max_output_tokens forever with zero streamed text.
+    """
+    agent = _build_agent(monkeypatch)
+    requests = []
+    responses = [
+        _codex_max_output_empty_response(),
+        _codex_message_response("Recovered after replaying incomplete state."),
+    ]
+
+    def fake_call(api_kwargs):
+        requests.append(api_kwargs)
+        return responses.pop(0)
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", fake_call)
+
+    result = agent.run_conversation("finish the patch")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "Recovered after replaying incomplete state."
+    assert len(requests) == 2
+    second_input = requests[1]["input"]
+    assert any(
+        item.get("type") == "message"
+        and item.get("role") == "assistant"
+        and item.get("status") == "incomplete"
+        and item.get("content") == [{"type": "output_text", "text": ""}]
+        for item in second_input
+    )
+
+
+def test_run_conversation_codex_compresses_on_repeated_empty_internal_ceiling(monkeypatch):
+    """Repeated empty Codex internal-ceiling events near the context limit should
+    compact once and continue, not stop with the user-facing ceiling error.
+    """
+    agent = _build_agent(monkeypatch)
+    agent.max_iterations = 5
+    agent.compression_enabled = True
+    agent.context_compressor.context_length = 272_000
+    agent.context_compressor.threshold_tokens = 136_000
+    compressed = []
+    responses = [
+        _codex_max_output_empty_response(input_tokens=271_477),
+        _codex_max_output_empty_response(input_tokens=271_477),
+        _codex_max_output_empty_response(input_tokens=271_477),
+        _codex_message_response("Recovered after compacting repeated Codex incomplete state."),
+    ]
+
+    def fake_call(api_kwargs):
+        return responses.pop(0)
+
+    def fake_compress(messages, system_message, *, approx_tokens=None, task_id="default", focus_topic=None, force=False):
+        compressed.append(approx_tokens)
+        compacted = [
+            messages[0],
+            {"role": "system", "content": "[compressed prior Codex continuation state]"},
+            messages[-1],
+        ]
+        return compacted, agent._cached_system_prompt
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", fake_call)
+    monkeypatch.setattr(agent, "_compress_context", fake_compress)
+
+    result = agent.run_conversation(
+        "finish the patch",
+        conversation_history=[
+            {"role": "user" if i % 2 == 0 else "assistant", "content": f"prior message {i}"}
+            for i in range(30)
+        ],
+    )
+
+    assert result["completed"] is True
+    assert result["final_response"] == "Recovered after compacting repeated Codex incomplete state."
+    assert compressed == [271_477]
+    assert result.get("error") is None
+
+
+def test_run_conversation_codex_internal_max_output_exhaustion_is_user_friendly(monkeypatch):
+    """If every Codex continuation attempt hits the backend's internal output
+    ceiling before visible text when no compression pressure is present, don't
+    send the raw generic truncation marker as the final gateway response.
+    """
+    agent = _build_agent(monkeypatch)
+    responses = [_codex_max_output_empty_response() for _ in range(3)]
+    monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: responses.pop(0))
+
+    result = agent.run_conversation("finish the patch")
+
+    assert result["completed"] is False
+    assert result["partial"] is True
+    assert result["final_response"] is not None
+    assert "Response truncated due to output length limit" not in result["final_response"]
+    assert "Codex" in result["final_response"]
+    assert "internal output" in result["final_response"]
 
 
 def test_normalize_codex_response_marks_commentary_only_message_as_incomplete(monkeypatch):

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -12,7 +12,9 @@ call is mocked — we never actually shell out during unit tests.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Iterator
+import tomllib
 
 import pytest
 
@@ -68,6 +70,34 @@ class TestSpecSafety:
     def test_unsafe_specs_rejected(self, spec):
         assert not ld._spec_is_safe(spec), \
             f"expected {spec!r} to be rejected"
+
+    def test_vetted_llm_wiki_git_spec_is_allowed_for_llm_wiki(self):
+        specs = ld.feature_specs("memory.llm_wiki")
+        llm_wiki_specs = [spec for spec in specs if spec.startswith("hermes-llm-wiki @ git+")]
+
+        assert len(llm_wiki_specs) == 1
+        assert ld._spec_is_safe(llm_wiki_specs[0])
+        assert "github.com/michaelkrauty/hermes-llm-wiki.git" in llm_wiki_specs[0]
+        assert llm_wiki_specs[0].rsplit("@", 1)[-1]
+
+    def test_llm_wiki_dependency_uses_release_tag_not_raw_sha(self):
+        specs = ld.feature_specs("memory.llm_wiki")
+        llm_wiki_specs = [spec for spec in specs if spec.startswith("hermes-llm-wiki @ git+")]
+
+        assert len(llm_wiki_specs) == 1
+        ref = llm_wiki_specs[0].rsplit("@", 1)[-1]
+        assert ref == "v0.1.1"
+
+    def test_llm_wiki_lazy_spec_matches_optional_extra(self):
+        pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
+        with pyproject_path.open("rb") as f:
+            pyproject = tomllib.load(f)
+        extra_specs = pyproject["project"]["optional-dependencies"]["llm-wiki"]
+        lazy_specs = ld.feature_specs("memory.llm_wiki")
+
+        assert lazy_specs == tuple(extra_specs)
+        assert not any(spec.startswith("vector-core @") for spec in lazy_specs)
+        assert not any(spec.startswith("qdrant-client") for spec in lazy_specs)
 
 
 # ---------------------------------------------------------------------------

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1121,6 +1121,7 @@ def _build_child_agent(
         ephemeral_system_prompt=child_prompt,
         log_prefix=f"[subagent-{task_index}]",
         platform=parent_agent.platform,
+        agent_context="subagent",
         skip_context_files=True,
         skip_memory=True,
         clarify_callback=None,

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -26,9 +26,11 @@ Security model:
 
 * **Venv-scoped only.** Installs target ``sys.executable`` in the active
   venv. We never touch the system Python.
-* **PyPI by package name only.** Specs may be ``"package>=1.0,<2"`` etc.
-  We do NOT support ``--index-url`` overrides, ``git+https://``, file:
-  paths, or any other input that could be hijacked by a malicious config.
+* **PyPI by package name by default.** Specs may be ``"package>=1.0,<2"`` etc.
+  Direct Git references are rejected except for explicitly vetted,
+  commit-pinned public GitHub dependencies that appear in :data:`LAZY_DEPS`.
+  We do NOT support ``--index-url`` overrides, file: paths, or any other
+  input that could be hijacked by a malicious config.
 * **Allowlist.** Only specs that appear in :data:`LAZY_DEPS` can be
   installed via this path. A typo in feature name doesn't get the user
   install-anything semantics.
@@ -118,6 +120,9 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # ─── Memory providers ──────────────────────────────────────────────────
     "memory.honcho": ("honcho-ai==2.0.1",),
     "memory.hindsight": ("hindsight-client==0.6.1",),
+    "memory.llm_wiki": (
+        "hermes-llm-wiki @ git+https://github.com/michaelkrauty/hermes-llm-wiki.git@v0.1.1",
+    ),
 
     # ─── Messaging platforms (lazy-installable on demand) ──────────────────
     "platform.telegram": ("python-telegram-bot[webhooks]==22.6",),
@@ -183,6 +188,14 @@ _SAFE_SPEC = re.compile(
     r"$"
 )
 
+_SAFE_DIRECT_GIT_SPEC = re.compile(
+    r"^(?:"
+    r"vector-core @ git\+https://github\.com/michaelkrauty/vector-core\.git@"
+    r"|hermes-llm-wiki @ git\+https://github\.com/michaelkrauty/hermes-llm-wiki\.git@"
+    r")"
+    r"(?:[0-9a-f]{40}|v\d+\.\d+\.\d+)$"
+)
+
 
 class FeatureUnavailable(RuntimeError):
     """A lazily-installable feature is missing and cannot be made available.
@@ -238,11 +251,13 @@ def _allow_lazy_installs() -> bool:
 
 
 def _spec_is_safe(spec: str) -> bool:
-    """Reject pip specs that contain URLs, paths, or shell metacharacters."""
+    """Reject pip specs that contain unvetted URLs, paths, or shell metacharacters."""
     if not spec or len(spec) > 200:
         return False
     if any(ch in spec for ch in (";", "|", "&", "`", "$", "\n", "\r", "\t", "\\")):
         return False
+    if _SAFE_DIRECT_GIT_SPEC.match(spec):
+        return True
     if spec.startswith(("-", "/", ".")) or "://" in spec or "@" in spec:
         return False
     return bool(_SAFE_SPEC.match(spec))
@@ -265,6 +280,9 @@ def _specifier_from_spec(spec: str) -> str:
     ``"mautrix[encryption]>=0.20,<1"`` → ``">=0.20,<1"``
     ``"package"`` → ``""`` (no version constraint)
     """
+    if _SAFE_DIRECT_GIT_SPEC.match(spec):
+        return ""
+
     # Strip the package name + optional [extras] block.
     m = re.match(r"^[A-Za-z0-9_][A-Za-z0-9_.\-]*(?:\[[A-Za-z0-9_,\-]+\])?", spec)
     if not m:

--- a/uv.lock
+++ b/uv.lock
@@ -1553,6 +1553,57 @@ wheels = [
 ]
 
 [[package]]
+name = "grpcio"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/db/1d56e5f5823257b291962d6c0ce106146c6447f405b60b234c4f222a7cde/grpcio-1.80.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:dfab85db094068ff42e2a3563f60ab3dddcc9d6488a35abf0132daec13209c8a", size = 6055009, upload-time = "2026-03-30T08:46:46.265Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/18/c83f3cad64c5ca63bca7e91e5e46b0d026afc5af9d0a9972472ceba294b3/grpcio-1.80.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5c07e82e822e1161354e32da2662f741a4944ea955f9f580ec8fb409dd6f6060", size = 12035295, upload-time = "2026-03-30T08:46:49.099Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/8e/e14966b435be2dda99fbe89db9525ea436edc79780431a1c2875a3582644/grpcio-1.80.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ba0915d51fd4ced2db5ff719f84e270afe0e2d4c45a7bdb1e8d036e4502928c2", size = 6610297, upload-time = "2026-03-30T08:46:52.123Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/26/d5eb38f42ce0e3fdc8174ea4d52036ef8d58cc4426cb800f2610f625dd75/grpcio-1.80.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:3cb8130ba457d2aa09fa6b7c3ed6b6e4e6a2685fce63cb803d479576c4d80e21", size = 7300208, upload-time = "2026-03-30T08:46:54.859Z" },
+    { url = "https://files.pythonhosted.org/packages/25/51/bd267c989f85a17a5b3eea65a6feb4ff672af41ca614e5a0279cc0ea381c/grpcio-1.80.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:09e5e478b3d14afd23f12e49e8b44c8684ac3c5f08561c43a5b9691c54d136ab", size = 6813442, upload-time = "2026-03-30T08:46:57.056Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d9/d80eef735b19e9169e30164bbf889b46f9df9127598a83d174eb13a48b26/grpcio-1.80.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:00168469238b022500e486c1c33916acf2f2a9b2c022202cf8a1885d2e3073c1", size = 7414743, upload-time = "2026-03-30T08:46:59.682Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f2/567f5bd5054398ed6b0509b9a30900376dcf2786bd936812098808b49d8d/grpcio-1.80.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8502122a3cc1714038e39a0b071acb1207ca7844208d5ea0d091317555ee7106", size = 8426046, upload-time = "2026-03-30T08:47:02.474Z" },
+    { url = "https://files.pythonhosted.org/packages/62/29/73ef0141b4732ff5eacd68430ff2512a65c004696997f70476a83e548e7e/grpcio-1.80.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ce1794f4ea6cc3ca29463f42d665c32ba1b964b48958a66497917fe9069f26e6", size = 7851641, upload-time = "2026-03-30T08:47:05.462Z" },
+    { url = "https://files.pythonhosted.org/packages/46/69/abbfa360eb229a8623bab5f5a4f8105e445bd38ce81a89514ba55d281ad0/grpcio-1.80.0-cp311-cp311-win32.whl", hash = "sha256:51b4a7189b0bef2aa30adce3c78f09c83526cf3dddb24c6a96555e3b97340440", size = 4154368, upload-time = "2026-03-30T08:47:08.027Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d4/ae92206d01183b08613e846076115f5ac5991bae358d2a749fa864da5699/grpcio-1.80.0-cp311-cp311-win_amd64.whl", hash = "sha256:02e64bb0bb2da14d947a49e6f120a75e947250aebe65f9629b62bb1f5c14e6e9", size = 4894235, upload-time = "2026-03-30T08:47:10.839Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e8/a2b749265eb3415abc94f2e619bbd9e9707bebdda787e61c593004ec927a/grpcio-1.80.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:c624cc9f1008361014378c9d776de7182b11fe8b2e5a81bc69f23a295f2a1ad0", size = 6015616, upload-time = "2026-03-30T08:47:13.428Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/97/b1282161a15d699d1e90c360df18d19165a045ce1c343c7f313f5e8a0b77/grpcio-1.80.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:f49eddcac43c3bf350c0385366a58f36bed8cc2c0ec35ef7b74b49e56552c0c2", size = 12014204, upload-time = "2026-03-30T08:47:15.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/d319c6e997b50c155ac5a8cb12f5173d5b42677510e886d250d50264949d/grpcio-1.80.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d334591df610ab94714048e0d5b4f3dd5ad1bee74dfec11eee344220077a79de", size = 6563866, upload-time = "2026-03-30T08:47:18.588Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/f6/fdd975a2cb4d78eb67769a7b3b3830970bfa2e919f1decf724ae4445f42c/grpcio-1.80.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0cb517eb1d0d0aaf1d87af7cc5b801d686557c1d88b2619f5e31fab3c2315921", size = 7273060, upload-time = "2026-03-30T08:47:21.113Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f0/a3deb5feba60d9538a962913e37bd2e69a195f1c3376a3dd44fe0427e996/grpcio-1.80.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4e78c4ac0d97dc2e569b2f4bcbbb447491167cb358d1a389fc4af71ab6f70411", size = 6782121, upload-time = "2026-03-30T08:47:23.827Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/84/36c6dcfddc093e108141f757c407902a05085e0c328007cb090d56646cdf/grpcio-1.80.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2ed770b4c06984f3b47eb0517b1c69ad0b84ef3f40128f51448433be904634cd", size = 7383811, upload-time = "2026-03-30T08:47:26.517Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ef/f3a77e3dc5b471a0ec86c564c98d6adfa3510d38f8ee99010410858d591e/grpcio-1.80.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:256507e2f524092f1473071a05e65a5b10d84b82e3ff24c5b571513cfaa61e2f", size = 8393860, upload-time = "2026-03-30T08:47:29.439Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8d/9d4d27ed7f33d109c50d6b5ce578a9914aa68edab75d65869a17e630a8d1/grpcio-1.80.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9a6284a5d907c37db53350645567c522be314bac859a64a7a5ca63b77bb7958f", size = 7830132, upload-time = "2026-03-30T08:47:33.254Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e4/9990b41c6d7a44e1e9dee8ac11d7a9802ba1378b40d77468a7761d1ad288/grpcio-1.80.0-cp312-cp312-win32.whl", hash = "sha256:c71309cfce2f22be26aa4a847357c502db6c621f1a49825ae98aa0907595b193", size = 4140904, upload-time = "2026-03-30T08:47:35.319Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/2c/296f6138caca1f4b92a31ace4ae1b87dab692fc16a7a3417af3bb3c805bf/grpcio-1.80.0-cp312-cp312-win_amd64.whl", hash = "sha256:9fe648599c0e37594c4809d81a9e77bd138cc82eb8baa71b6a86af65426723ff", size = 4880944, upload-time = "2026-03-30T08:47:37.831Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/7c3c25789e3f069e581dc342e03613c5b1cb012c4e8c7d9d5cf960a75856/grpcio-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e9e408fc016dffd20661f0126c53d8a31c2821b5c13c5d67a0f5ed5de93319ad", size = 6017243, upload-time = "2026-03-30T08:47:40.075Z" },
+    { url = "https://files.pythonhosted.org/packages/04/19/21a9806eb8240e174fd1ab0cd5b9aa948bb0e05c2f2f55f9d5d7405e6d08/grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:92d787312e613754d4d8b9ca6d3297e69994a7912a32fa38c4c4e01c272974b0", size = 12010840, upload-time = "2026-03-30T08:47:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3a/23347d35f76f639e807fb7a36fad3068aed100996849a33809591f26eca6/grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac393b58aa16991a2f1144ec578084d544038c12242da3a215966b512904d0f", size = 6567644, upload-time = "2026-03-30T08:47:46.806Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/40/96e07ecb604a6a67ae6ab151e3e35b132875d98bc68ec65f3e5ab3e781d7/grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:68e5851ac4b9afe07e7f84483803ad167852570d65326b34d54ca560bfa53fb6", size = 7277830, upload-time = "2026-03-30T08:47:49.643Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e2/da1506ecea1f34a5e365964644b35edef53803052b763ca214ba3870c856/grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:873ff5d17d68992ef6605330127425d2fc4e77e612fa3c3e0ed4e668685e3140", size = 6783216, upload-time = "2026-03-30T08:47:52.817Z" },
+    { url = "https://files.pythonhosted.org/packages/44/83/3b20ff58d0c3b7f6caaa3af9a4174d4023701df40a3f39f7f1c8e7c48f9d/grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2bea16af2750fd0a899bf1abd9022244418b55d1f37da2202249ba4ba673838d", size = 7385866, upload-time = "2026-03-30T08:47:55.687Z" },
+    { url = "https://files.pythonhosted.org/packages/47/45/55c507599c5520416de5eefecc927d6a0d7af55e91cfffb2e410607e5744/grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba0db34f7e1d803a878284cd70e4c63cb6ae2510ba51937bf8f45ba997cefcf7", size = 8391602, upload-time = "2026-03-30T08:47:58.303Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bb/dd06f4c24c01db9cf11341b547d0a016b2c90ed7dbbb086a5710df7dd1d7/grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8eb613f02d34721f1acf3626dfdb3545bd3c8505b0e52bf8b5710a28d02e8aa7", size = 7826752, upload-time = "2026-03-30T08:48:01.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/1e/9d67992ba23371fd63d4527096eb8c6b76d74d52b500df992a3343fd7251/grpcio-1.80.0-cp313-cp313-win32.whl", hash = "sha256:93b6f823810720912fd131f561f91f5fed0fda372b6b7028a2681b8194d5d294", size = 4142310, upload-time = "2026-03-30T08:48:04.594Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e6/283326a27da9e2c3038bc93eeea36fb118ce0b2d03922a9cda6688f53c5b/grpcio-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:e172cf795a3ba5246d3529e4d34c53db70e888fa582a8ffebd2e6e48bc0cba50", size = 4882833, upload-time = "2026-03-30T08:48:07.363Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/6d/e65307ce20f5a09244ba9e9d8476e99fb039de7154f37fb85f26978b59c3/grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e", size = 6017376, upload-time = "2026-03-30T08:48:10.005Z" },
+    { url = "https://files.pythonhosted.org/packages/69/10/9cef5d9650c72625a699c549940f0abb3c4bfdb5ed45a5ce431f92f31806/grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f", size = 12018133, upload-time = "2026-03-30T08:48:12.927Z" },
+    { url = "https://files.pythonhosted.org/packages/04/82/983aabaad82ba26113caceeb9091706a0696b25da004fe3defb5b346e15b/grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9", size = 6574748, upload-time = "2026-03-30T08:48:16.386Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d7/031666ef155aa0bf399ed7e19439656c38bbd143779ae0861b038ce82abd/grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14", size = 7277711, upload-time = "2026-03-30T08:48:19.627Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/43/f437a78f7f4f1d311804189e8f11fb311a01049b2e08557c1068d470cb2e/grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05", size = 6785372, upload-time = "2026-03-30T08:48:22.373Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3d/f6558e9c6296cb4227faa5c43c54a34c68d32654b829f53288313d16a86e/grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1", size = 7395268, upload-time = "2026-03-30T08:48:25.638Z" },
+    { url = "https://files.pythonhosted.org/packages/06/21/0fdd77e84720b08843c371a2efa6f2e19dbebf56adc72df73d891f5506f0/grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f", size = 8392000, upload-time = "2026-03-30T08:48:28.974Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477, upload-time = "2026-03-30T08:48:32.054Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563, upload-time = "2026-03-30T08:48:34.538Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457, upload-time = "2026-03-30T08:48:37.308Z" },
+]
+
+[[package]]
 name = "grpclib"
 version = "0.4.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1696,6 +1747,9 @@ homeassistant = [
 honcho = [
     { name = "honcho-ai" },
 ]
+llm-wiki = [
+    { name = "hermes-llm-wiki" },
+]
 matrix = [
     { name = "aiohttp-socks" },
     { name = "aiosqlite" },
@@ -1829,6 +1883,7 @@ requires-dist = [
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'termux-all'" },
     { name = "hermes-agent", extras = ["youtube"], marker = "extra == 'all'" },
+    { name = "hermes-llm-wiki", marker = "extra == 'llm-wiki'", git = "https://github.com/michaelkrauty/hermes-llm-wiki.git?rev=v0.1.1" },
     { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = "==0.6.1" },
     { name = "honcho-ai", marker = "extra == 'honcho'", specifier = "==2.0.1" },
     { name = "httpx", extras = ["socks"], specifier = "==0.28.1" },
@@ -1876,7 +1931,18 @@ requires-dist = [
     { name = "vercel", marker = "extra == 'vercel'", specifier = "==0.5.7" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "computer-use", "acp", "bedrock", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "llm-wiki", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "computer-use", "acp", "bedrock", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+
+[[package]]
+name = "hermes-llm-wiki"
+version = "0.1.1"
+source = { git = "https://github.com/michaelkrauty/hermes-llm-wiki.git?rev=v0.1.1#8c675d89cac7e9475c20ea3c20bbd0f357d8ce79" }
+dependencies = [
+    { name = "openai" },
+    { name = "pyyaml" },
+    { name = "qdrant-client" },
+    { name = "vector-core" },
+]
 
 [[package]]
 name = "hf-xet"
@@ -2027,6 +2093,9 @@ wheels = [
 ]
 
 [package.optional-dependencies]
+http2 = [
+    { name = "h2" },
+]
 socks = [
     { name = "socksio" },
 ]
@@ -3003,12 +3072,33 @@ wheels = [
 ]
 
 [[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "portalocker"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/77/65b857a69ed876e1951e88aaba60f5ce6120c33703f7cb61a3c894b8c1b6/portalocker-3.2.0.tar.gz", hash = "sha256:1f3002956a54a8c3730586c5c77bf18fae4149e07eaf1c29fc3faf4d5a3f89ac", size = 95644, upload-time = "2025-06-14T13:20:40.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/a6/38c8e2f318bf67d338f4d629e93b0b4b9af331f455f0390ea8ce4a099b26/portalocker-3.2.0-py3-none-any.whl", hash = "sha256:3cdc5f565312224bc570c49337bd21428bba0ef363bbcf58b9ef4a9f11779968", size = 22424, upload-time = "2025-06-14T13:20:38.083Z" },
 ]
 
 [[package]]
@@ -3646,6 +3736,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "qdrant-client"
+version = "1.16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "numpy" },
+    { name = "portalocker" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/68/fec3816a223c0b73b0e0036460be45c61ce2770ffb9197ac371e4f615ddc/qdrant_client-1.16.1.tar.gz", hash = "sha256:676c7c10fd4d4cb2981b8fcb32fd764f5f661b04b7334d024034d07212f971fd", size = 332130, upload-time = "2025-11-25T04:31:54.212Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/e2/60a20d04b0595c641516463168909c5bbcc192d3d6eacb637c1677109c6a/qdrant_client-1.16.1-py3-none-any.whl", hash = "sha256:1eefe89f66e8a468ba0de1680e28b441e69825cfb62e8fb2e457c15e24ce5e3b", size = 378481, upload-time = "2025-11-25T04:31:52.629Z" },
 ]
 
 [[package]]
@@ -4364,6 +4472,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
     { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
     { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "vector-core"
+version = "1.0.3"
+source = { git = "https://github.com/michaelkrauty/vector-core.git?rev=v1.0.3#fd8cfe850f61cfb3cda482575ee7c2ce04106e9c" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pathspec" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "qdrant-client" },
 ]
 
 [[package]]

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -906,7 +906,7 @@ auxiliary:
 ```
 
 :::tip
-Each auxiliary task has a configurable `timeout` (in seconds). Defaults: vision 120s, web_extract 360s, approval 30s, compression 120s. Increase these if you use slow local models for auxiliary tasks. Vision also has a separate `download_timeout` (default 30s) for the HTTP image download — increase this for slow connections or self-hosted image servers.
+Each auxiliary task has a configurable `timeout` (in seconds). Defaults: vision 120s, web_extract 360s, approval 30s, compression 120s. Increase these if you use slow local models for auxiliary tasks. Set a task timeout to `0` to disable the LLM request timeout entirely (useful for very slow context compression). Vision also has a separate `download_timeout` (default 30s) for the HTTP image download — increase this for slow connections or self-hosted image servers.
 :::
 
 :::info

--- a/website/docs/user-guide/features/llm-wiki-memory.md
+++ b/website/docs/user-guide/features/llm-wiki-memory.md
@@ -1,0 +1,311 @@
+---
+sidebar_position: 5
+title: "LLM Wiki Memory"
+description: "Local-first, source-backed durable memory for Hermes Agent"
+---
+
+# LLM Wiki Memory
+
+LLM Wiki is a local-first memory provider that stores durable knowledge as an inspectable Markdown wiki and indexes it for semantic retrieval. The core package is agent-agnostic: Hermes uses it as a native memory provider, and other agents can use the same substrate through the `llm-wiki-mcp` server or a thin adapter.
+
+It is intentionally **not** an automatic transcript summarizer. Normal conversation turns are not written into the wiki. Hermes can search and read the wiki during chat, but durable writes require explicit tool calls and are blocked in unsafe contexts. Use it when you want source-backed memory that stays under your control instead of a hidden hosted memory database.
+
+## When to use it
+
+Use LLM Wiki for:
+
+- project architecture and operating manuals
+- durable policy and conventions
+- research notes and source-backed conclusions
+- memory that should remain inspectable in Git or a folder backup
+- local/offline-first deployments
+
+Use other memory paths for other jobs:
+
+- **Built-in `MEMORY.md` / `USER.md`**: tiny boot-critical facts and preferences.
+- **Session search**: chronological recall of past conversations.
+- **Honcho/Mem0/Supermemory/etc.**: automatic user modeling or hosted semantic memory.
+
+## Install
+
+LLM Wiki's provider package is bundled with Hermes. Heavy vector-store dependencies are optional and lazy-loaded so normal Hermes installs stay small. The `llm-wiki` extra installs Qdrant plus Hermes's shared vector infrastructure dependency, `vector-core`, from a commit-pinned public GitHub ref until `vector-core` is published on PyPI.
+
+For an explicit install, use the optional dependency group:
+
+```bash
+pip install 'hermes-agent[llm-wiki]'
+```
+
+For MCP access from Claude Code, OpenClaw, or another MCP-capable host, also install Hermes' existing MCP extra:
+
+```bash
+pip install 'hermes-agent[llm-wiki,mcp]'
+llm-wiki-mcp --config ~/.hermes/config.yaml
+```
+
+If you only configure the provider, Hermes can still discover it without `qdrant-client` or `vector-core` installed. The first real engine/tool use will ask the lazy-dependency system to install the pinned optional dependencies, unless lazy installs are disabled in your security config.
+
+LLM Wiki also expects:
+
+- a Qdrant HTTP endpoint, default `http://localhost:6333`
+- an OpenAI-compatible embedding endpoint, default `http://localhost:8000`
+- an OpenAI-compatible chat endpoint for `wiki_query`, default `https://openrouter.ai/api/v1`
+
+For a local Qdrant server:
+
+```bash
+docker run -p 6333:6333 -v "$PWD/qdrant_storage:/qdrant/storage" qdrant/qdrant
+```
+
+## Configure
+
+Run the memory setup wizard and select `llm_wiki`:
+
+```bash
+hermes memory setup
+```
+
+Manual `~/.hermes/config.yaml` example:
+
+```yaml
+memory:
+  provider: llm_wiki
+
+wiki:
+  path: ~/.hermes/wiki/personal
+  name: personal
+  embedding:
+    url: http://localhost:8000
+    model: ExactModelName
+    dim: 1536
+    # Optional; defaults to <wiki path>/.cache/embeddings.sqlite3
+    cache_path: ~/.hermes/wiki/personal/.cache/embeddings.sqlite3
+    cache_max_entries: 100000
+  vector_store:
+    url: http://localhost:6333
+    collection_prefix: hermes_wiki
+  llm:
+    url: https://openrouter.ai/api/v1
+    model: openai/gpt-5.5
+```
+
+Do not put secrets in wiki pages. If an endpoint needs an API key, keep it in `.env` or your provider-specific config; do not commit it with the wiki.
+
+:::tip Local privacy profile
+For sensitive personal or company memory, point both embedding and chat URLs at local OpenAI-compatible services. Search indexing sends wiki/source text to the embedding endpoint, and `wiki_query` sends retrieved snippets plus your question to the configured chat endpoint. Local endpoints keep that loop on your machine.
+:::
+
+## Wiki layout
+
+A wiki is a folder with Markdown files:
+
+```text
+~/.hermes/wiki/personal/
+├── SCHEMA.md
+├── index.md
+├── log.md
+├── entities/
+├── concepts/
+├── comparisons/
+├── queries/
+└── raw/
+    ├── articles/
+    ├── papers/
+    └── transcripts/
+```
+
+Raw sources live under `raw/`. Generated or curated pages cite those sources with provenance markers such as:
+
+```markdown
+This fact came from a source. ^[raw/articles/example.md]
+```
+
+## Tools
+
+When enabled, the provider exposes these tools:
+
+| Tool | Purpose | Mutates durable memory? |
+| --- | --- | --- |
+| `wiki_status` | Show wiki path, page counts, collection stats, recent activity | No |
+| `wiki_orient` | Read orientation/index information | No |
+| `wiki_search` | Semantic search over indexed wiki chunks | No |
+| `wiki_read` | Read a wiki page by slug or relative path | No |
+| `wiki_query` | Ask an LLM-backed question against wiki context | No by default |
+| `wiki_lint` | Validate links, provenance, source hashes, vector health | No by default |
+| `wiki_ingest` | Ingest a curated source file | Dry-run by default; primary context only |
+
+Safe defaults:
+
+- `wiki_query`: `file_result=false`, `log_query=false`
+- `wiki_lint`: `write_log=false`
+- `wiki_ingest`: `dry_run=true`; blocked outside the primary agent context because even dry-runs read local files and submit their content for analysis
+- `wiki_search.limit` is clamped to a small bounded range
+- `wiki_read` rejects path traversal and truncates oversized pages
+- `sync_turn()` is a no-op; chat turns are not automatically canonized
+- prefetch is bounded, cited, and retrieval-only
+- writes are blocked outside the primary agent context
+- host integrations map their execution context to a generic `WikiCapabilities` policy; unknown/MCP/subagent/cron contexts default to read/query/introspection only, not durable writes
+
+## Package boundary during split-out
+
+The LLM Wiki core package lives in the standalone `hermes-llm-wiki` repository.
+Hermes Agent no longer carries a duplicate top-level `hermes_wiki/` mirror;
+it keeps only the native provider adapter under `plugins/memory/llm_wiki/`.
+Install the `llm-wiki` extra or let the `memory.llm_wiki` lazy dependency install
+the standalone package when the provider is first used.
+
+For local development against a checkout of the standalone package, install it
+into the active Hermes environment before running LLM Wiki tests:
+
+```bash
+uv pip install -e /path/to/hermes-llm-wiki
+pytest -o addopts='' tests/plugins/memory/test_llm_wiki_provider.py -q
+```
+
+## MCP and generic CLI aliases
+
+Hermes keeps the native memory provider for prompt prefetch and execution-context gating, but the same LLM Wiki core can be exposed to other agents with MCP:
+
+```bash
+llm-wiki-mcp --config ~/.hermes/config.yaml          # safe read-first MCP context
+llm-wiki-mcp --config ~/.hermes/config.yaml --context primary  # trusted local interactive only
+```
+
+Use the default MCP context for Claude Code, OpenClaw workers, subagents, cron jobs, and background automations. `--context primary` enables canonical ingest/update-style capabilities and should only be used in a local, user-controlled, interactive session. Index freshness is automatic in trusted writable contexts rather than a separate reindex tool.
+
+The MCP surface is capability-filtered. Default `mcp` context advertises only tools the external agent may actually use:
+
+| Context | Exposed tool classes |
+| --- | --- |
+| `mcp`, unknown, Claude Code, OpenClaw, subagent, cron, batch | `wiki_capabilities`, status/orientation, read/search/query/introspection/lint |
+| `primary`, `trusted`, `owner`, `interactive` | all read/query tools plus `wiki_ingest` and trusted `wiki_update` where available |
+| `disabled`, `none`, `off` | `wiki_capabilities` only |
+
+External agents should call `wiki_capabilities` first. It returns the generic `WikiCapabilities` booleans plus `exposed_tools`, so hosts do not need Hermes-specific assumptions. Denied mutating tools are not advertised in default MCP schemas, and direct calls still enforce the same capability checks.
+
+Generic `llm-wiki-*` CLI aliases are available alongside the older `hermes-wiki-*` names while the core package is being split out. Examples:
+
+```bash
+llm-wiki-maintenance --config ~/.hermes/config.yaml
+llm-wiki-source-integrity --config ~/.hermes/config.yaml --json
+llm-wiki-caretaker --config ~/.hermes/config.yaml --quiet
+```
+
+## Operational workflow
+
+1. Put a source document somewhere on disk.
+2. Ask Hermes to dry-run ingestion first:
+
+   ```text
+   Use wiki_ingest on /path/to/source.md with dry_run=true.
+   ```
+
+3. Review the dry-run ingest plan.
+4. If it is safe and intentional, run the actual ingest from a primary Hermes session:
+
+   ```text
+   Ingest /path/to/source.md into LLM Wiki with dry_run=false.
+   ```
+
+5. Run lint when needed; search/status keep the vector index fresh automatically in trusted writable contexts.
+
+   ```text
+   Run wiki_lint with write_log=false.
+   ```
+
+6. Keep a small retrieval eval file for important recall expectations and run it after changes:
+
+   ```yaml
+   # ~/.hermes/wiki/personal/evals/retrieval.yaml
+   cases:
+     - query: How autonomous should Hermes be?
+       expected_pages:
+         - concepts/user-autonomy-operating-policy.md
+         - entities/hermes.md
+       top_k: 5
+   ```
+
+   ```bash
+   hermes-wiki-eval ~/.hermes/wiki/personal/evals/retrieval.yaml --config ~/.hermes/config.yaml --pretty
+   # or: python -m hermes_wiki.eval ...
+   ```
+
+   `--config` is authoritative when supplied: the file must exist and contain the intended `wiki:` settings; the runner will not silently fall back to another profile/config.
+
+   Retrieval evals are read-only. They validate that expected page paths appear in search results; they do not generate answers, write wiki pages, ingest sources, or reindex vectors. They still embed eval query text and read from the configured vector store, so use local/private endpoints for sensitive eval cases.
+
+7. Inspect retrieval hits for one query when evals fail or recall looks suspicious:
+
+   ```bash
+   hermes-wiki-introspect "How autonomous should Hermes be?" \
+     --config ~/.hermes/config.yaml \
+     --expected-page concepts/user-autonomy-operating-policy.md
+   hermes-wiki-introspect "What should Hermes call the user?" --config ~/.hermes/config.yaml --json
+   hermes-wiki-introspect "ExactModelName" --config ~/.hermes/config.yaml --search-mode hybrid --json
+   ```
+
+   Retrieval introspection is read-only. It reports the original query, search mode, top-k, ranked chunk hits, scores, page/source paths, deduplicated page coverage, and missing expected pages. `--search-mode` can be `dense` (default/backward compatible), `sparse` (lexical payload matching for literal names, commands, config keys, and paths), or `hybrid` (dense+sparse Reciprocal Rank Fusion). It does not generate answers, write wiki pages, ingest sources, reindex vectors, or log queries. Like evals, dense/hybrid modes may embed the inspected query and read from the configured vector store; sparse mode scans indexed payload text.
+
+8. Generate a read-only maintenance report:
+
+   ```bash
+   hermes-wiki-maintenance --config ~/.hermes/config.yaml
+   hermes-wiki-maintenance --config ~/.hermes/config.yaml --json
+   ```
+
+   This checks broken wikilinks, orphan pages, and pages without source coverage. By default it only prints a report. `--write-report reports/maintenance.md` requires explicit `--config` and writes only under the dedicated `reports/` namespace; it does not ingest sources, reindex vectors, or mutate canonical entity/concept pages.
+
+9. Audit or explicitly repair raw-source hash frontmatter:
+
+   ```bash
+   llm-wiki-source-integrity --config ~/.hermes/config.yaml --json
+   llm-wiki-source-integrity --config ~/.hermes/config.yaml --repair --json
+   ```
+
+   Source integrity audit is read-only by default. `--repair` requires explicit `--config` and only updates `sha256` frontmatter on existing `raw/**/*.md` source files to match the parsed Markdown body. It does not edit canonical pages, ingest sources, reindex vectors, or write logs.
+
+10. Run the agent-native caretaker loop for cron/watchdog-style memory health:
+
+   ```bash
+   hermes-wiki-caretaker --config ~/.hermes/config.yaml
+   hermes-wiki-caretaker --config ~/.hermes/config.yaml --quiet
+   hermes-wiki-caretaker --config ~/.hermes/config.yaml --json
+   ```
+
+   The caretaker combines maintenance checks with retrieval evals from `<wiki>/evals/retrieval.yaml` when present, then classifies next actions for Hermes (`repair_broken_link`, `fix_retrieval_regression`, etc.). It is read-first and agent-native: no ingest, no reindex, no canonical page mutation, no query logging, no proposal queue, and no chat-model calls. `--quiet` prints nothing when there are no blockers, making it suitable for watchdog scripts that only alert on retrieval regressions or hard maintenance errors. `--write-report reports/caretaker.md` requires explicit `--config` and writes only under `reports/`.
+
+## Safety model
+
+LLM Wiki treats durable memory as the agent-owned, source-backed canonical memory substrate, not a scratchpad or human-review proposal queue.
+
+- No automatic writes from normal conversation flow.
+- No whole-wiki prompt dumps.
+- No path traversal in `wiki_read`.
+- Durable write tools are blocked in cron/subagent/batch/compression/retrieval contexts.
+- Ingest source categories are allowlisted before they become paths.
+- Automatic index sync upserts replacement vectors before deleting stale chunks, so embedding failures do not wipe existing search results.
+- Dense embedding calls use vector-core's persistent SQLite embedding cache and OpenAI-compatible embedding client. Hermes namespaces cache keys by model, embedding dimension, and text content hash; cache values are JSON-serialized and LRU-evicted by `wiki.embedding.cache_max_entries`.
+- Raw sources are hash-checked by lint so accidental drift is visible.
+- Markdown pages are human-readable and can be reviewed with normal Git tools.
+
+## Troubleshooting
+
+**Provider not available**
+
+Install the extra and restart Hermes:
+
+```bash
+pip install 'hermes-agent[llm-wiki]'
+```
+
+**Search fails**
+
+Check Qdrant and embedding endpoint health. The embedding URL should be OpenAI-compatible; Hermes normalizes a URL like `http://localhost:8000` to `https://openrouter.ai/api/v1` internally.
+
+**Lint reports empty vector index**
+
+Confirm Qdrant and the embedding endpoint are available, then run a trusted primary-context search/status operation. LLM Wiki auto-syncs the vector index in writable trusted contexts; there is no manual `wiki_reindex` tool to remember.
+
+**Writes are blocked**
+
+This is expected in cron, subagents, batch jobs, and retrieval-only contexts. Re-run the operation from a primary interactive agent session, or keep `dry_run=true` for inspection.

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 4
 title: "Memory Providers"
-description: "External memory provider plugins — Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory"
+description: "External memory provider plugins — LLM Wiki, Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory"
 ---
 
 # Memory Providers
 
-Hermes Agent ships with 8 external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
+Hermes Agent ships with external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
 
 ## Quick Start
 
@@ -22,7 +22,7 @@ Or set manually in `~/.hermes/config.yaml`:
 
 ```yaml
 memory:
-  provider: openviking   # or honcho, mem0, hindsight, holographic, retaindb, byterover, supermemory
+  provider: llm_wiki     # or honcho, openviking, mem0, hindsight, holographic, retaindb, byterover, supermemory
 ```
 
 ## How It Works
@@ -39,6 +39,58 @@ When a memory provider is active, Hermes automatically:
 The built-in memory (MEMORY.md / USER.md) continues to work exactly as before. The external provider is additive.
 
 ## Available Providers
+
+### LLM Wiki
+
+Local-first, source-backed durable memory stored as an inspectable Markdown wiki with semantic search. Unlike providers that automatically canonize every conversation turn, LLM Wiki is intentionally **read-first and curated**: it exposes bounded, cited retrieval and explicit ingestion tools while keeping raw session history, logs, and durable knowledge separate.
+
+| | |
+|---|---|
+| **Best for** | Inspectable long-term knowledge, architecture notes, policy, project memory, open-source/local-first setups |
+| **Requires** | `qdrant-client` extra, a Qdrant endpoint, and OpenAI-compatible embedding/LLM endpoints for search/query |
+| **Data storage** | Local Markdown wiki + Qdrant vector collection |
+| **Cost** | Free/local if using local endpoints; depends on configured embedding/LLM services |
+
+**Tools (7):** `wiki_status`, `wiki_orient`, `wiki_search`, `wiki_read`, `wiki_query`, `wiki_lint`, `wiki_ingest`
+
+**Runtime behavior:**
+
+- Adds only a tiny system-prompt note that wiki memory exists.
+- Uses bounded, cited prefetch instead of dumping the whole wiki into context.
+- `sync_turn()` is a no-op: conversations are not automatically converted into durable wiki facts.
+- `wiki_query` defaults to read-only (`file_result=false`, `log_query=false`).
+- `wiki_lint` defaults to non-mutating (`write_log=false`).
+- `wiki_ingest` defaults to `dry_run=true`.
+- Durable writes such as actual ingest are blocked outside the primary agent context, so cron jobs, subagents, batch jobs, and compression paths do not mutate canonical memory by accident. Vector-index freshness is automatic in trusted writable contexts, not a separate LLM-triggered reindex tool.
+
+**Setup Wizard:**
+
+```bash
+hermes memory setup        # select "llm_wiki"
+```
+
+**Manual config:**
+
+```yaml
+memory:
+  provider: llm_wiki
+
+wiki:
+  path: ~/.hermes/wiki/personal
+  name: personal
+  embedding:
+    url: http://localhost:8000
+    model: text-embedding-3-small
+    dim: 1536
+  vector_store:
+    url: http://localhost:6333
+    collection_prefix: hermes_wiki
+  llm:
+    url: https://openrouter.ai/api/v1
+    model: openai/gpt-5.5
+```
+
+Use LLM Wiki when you want memory that can be inspected, edited, linted, backed up, and cited like documentation. See the dedicated [LLM Wiki Memory](./llm-wiki-memory) guide for setup, operations, and troubleshooting. Use session search for chronological recall of past conversations; use built-in MEMORY.md / USER.md for tiny boot-critical facts.
 
 ### Honcho
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -62,6 +62,7 @@ const sidebars: SidebarsConfig = {
             'user-guide/features/curator',
             'user-guide/features/memory',
             'user-guide/features/memory-providers',
+            'user-guide/features/llm-wiki-memory',
             'user-guide/features/context-files',
             'user-guide/features/context-references',
             'user-guide/features/personality',


### PR DESCRIPTION
## Summary
- add the Hermes LLM Wiki memory provider backed by the standalone `hermes-llm-wiki` package
- wire source-backed prefetch, trusted capability-gated update/introspection tooling, caretaker/maintenance/eval coverage, and docs
- pin the optional/lazy dependency to the published `hermes-llm-wiki` `v0.1.1` release and verify the Git ref in CI
- include regressions for auxiliary timeout normalization and Codex empty incomplete replay handling

## Test Plan
- `pytest -o addopts='' tests/plugins/memory/test_llm_wiki_agent_agnostic_adapter.py tests/plugins/memory/test_llm_wiki_provider.py tests/plugins/memory/test_llm_wiki_hybrid_search.py tests/plugins/memory/test_llm_wiki_vector_core_compat.py tests/plugins/memory/test_llm_wiki_caretaker.py tests/plugins/memory/test_llm_wiki_maintenance.py tests/plugins/memory/test_llm_wiki_standalone_sync.py tests/agent/test_memory_prefetch_injection.py tests/tools/test_lazy_deps.py tests/agent/test_auxiliary_client.py tests/run_agent/test_run_agent_codex_responses.py -q`
- `python scripts/check_llm_wiki_standalone_import.py --standalone-root /home/kraut/hermes-dev/hermes-llm-wiki --pytest tests/plugins/memory/test_llm_wiki_provider.py --pytest tests/plugins/memory/test_llm_wiki_agent_agnostic_adapter.py --pytest tests/plugins/memory/test_llm_wiki_hybrid_search.py`
- `python scripts/check_llm_wiki_standalone_import.py --standalone-root /home/kraut/hermes-dev/hermes-llm-wiki --install-standalone --pytest tests/plugins/memory/test_llm_wiki_provider.py --pytest tests/plugins/memory/test_llm_wiki_agent_agnostic_adapter.py --pytest tests/plugins/memory/test_llm_wiki_hybrid_search.py`
- `python scripts/check_git_ref.py https://github.com/michaelkrauty/hermes-llm-wiki.git v0.1.1`
- `HERMES_LLM_WIKI_CHECK_REMOTE_REF=1 python scripts/check_git_ref.py https://github.com/michaelkrauty/hermes-llm-wiki.git v0.1.1 --remote`
