### PR TITLE
feat(acp): add YOLO session mode

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -504,13 +504,17 @@ class HermesACPAgent(acp.Agent):
     _MODE_DEFAULT = "default"
     _MODE_ACCEPT_EDITS = "accept_edits"
     _MODE_DONT_ASK = "dont_ask"
+    _MODE_YOLO = "yolo"
     _MODE_TO_EDIT_APPROVAL_POLICY = {
         _MODE_DEFAULT: "ask",
         _MODE_ACCEPT_EDITS: "workspace_session",
         _MODE_DONT_ASK: "session",
+        _MODE_YOLO: "session",
     }
     _EDIT_APPROVAL_POLICY_TO_MODE = {
-        value: key for key, value in _MODE_TO_EDIT_APPROVAL_POLICY.items()
+        "ask": _MODE_DEFAULT,
+        "workspace_session": _MODE_ACCEPT_EDITS,
+        "session": _MODE_DONT_ASK,
     }
 
     def __init__(self, session_manager: SessionManager | None = None):
@@ -556,6 +560,11 @@ class HermesACPAgent(acp.Agent):
                     name="Don't Ask",
                     description="Auto-allow file edits for this session except sensitive paths.",
                 ),
+                SessionMode(
+                    id=self._MODE_YOLO,
+                    name="YOLO",
+                    description="Auto-allow file edits and dangerous terminal commands for this session except hard safety blocks.",
+                ),
             ],
         )
 
@@ -563,6 +572,19 @@ class HermesACPAgent(acp.Agent):
         mode = str(getattr(state, "mode", "") or self._MODE_DEFAULT)
         policy = self._MODE_TO_EDIT_APPROVAL_POLICY.get(mode, self._EDIT_APPROVAL_POLICY_DEFAULT)
         return policy, state.cwd
+
+    def _sync_terminal_yolo_for_mode(self, session_id: str, mode: str) -> None:
+        """Mirror ACP YOLO mode into Hermes' session-scoped terminal bypass."""
+
+        try:
+            from tools.approval import disable_session_yolo, enable_session_yolo
+
+            if mode == self._MODE_YOLO:
+                enable_session_yolo(session_id)
+            else:
+                disable_session_yolo(session_id)
+        except Exception:
+            logger.debug("Could not sync ACP terminal YOLO mode", exc_info=True)
 
     @staticmethod
     def _encode_model_choice(provider: str | None, model: str | None) -> str:
@@ -1921,6 +1943,7 @@ class HermesACPAgent(acp.Agent):
         if normalized_mode not in self._MODE_TO_EDIT_APPROVAL_POLICY:
             normalized_mode = self._MODE_DEFAULT
         setattr(state, "mode", normalized_mode)
+        self._sync_terminal_yolo_for_mode(session_id, normalized_mode)
         self.session_manager.save_session(session_id)
         logger.info("Session %s: mode switched to %s", session_id, normalized_mode)
         return SetSessionModeResponse()
@@ -1937,6 +1960,7 @@ class HermesACPAgent(acp.Agent):
         if str(config_id) == self._EDIT_APPROVAL_POLICY_CONFIG_ID:
             mode = self._EDIT_APPROVAL_POLICY_TO_MODE.get(str(value), self._MODE_DEFAULT)
             setattr(state, "mode", mode)
+            self._sync_terminal_yolo_for_mode(session_id, mode)
         else:
             options = getattr(state, "config_options", None)
             if not isinstance(options, dict):

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -66,7 +66,36 @@ async def test_new_session_exposes_edit_approvals_as_modes_not_config_options(ag
         ("default", "Default"),
         ("accept_edits", "Accept Edits"),
         ("dont_ask", "Don't Ask"),
+        ("yolo", "YOLO"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_yolo_mode_enables_terminal_yolo_and_switching_away_disables(agent):
+    from tools.approval import clear_session, is_session_yolo_enabled
+
+    resp = await agent.new_session(cwd="/tmp")
+    try:
+        update = await agent.set_session_mode(
+            mode_id="yolo",
+            session_id=resp.session_id,
+        )
+        state = agent.session_manager.get_session(resp.session_id)
+
+        assert isinstance(update, SetSessionModeResponse)
+        assert getattr(state, "mode", None) == "yolo"
+        assert is_session_yolo_enabled(resp.session_id)
+        assert agent._edit_approval_policy_for_state(state) == ("session", "/tmp")
+
+        await agent.set_session_mode(
+            mode_id="dont_ask",
+            session_id=resp.session_id,
+        )
+
+        assert getattr(state, "mode", None) == "dont_ask"
+        assert not is_session_yolo_enabled(resp.session_id)
+    finally:
+        clear_session(resp.session_id)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Adds an explicit ACP `YOLO` session mode that mirrors Hermes TUI `/yolo` semantics for an ACP session.

Before this change, ACP exposed edit-approval modes (`Default`, `Accept Edits`, `Don't Ask`), but there was no ACP mode that also toggled Hermes' terminal approval bypass. `Don't Ask` only covered ACP edit approvals, while TUI `/yolo` covers dangerous terminal-command approvals.

ACP clients need an explicit mode that mirrors Hermes TUI `/yolo` semantics for trusted autonomous coding sessions, instead of making editor users choose between edit-only auto-approval and global approval bypasses.

This PR adds `yolo` as a distinct ACP session mode. It maps to session edit auto-approval, like `dont_ask`, and additionally enables Hermes' existing session-scoped terminal YOLO bypass for the ACP session. Leaving `yolo` disables the session terminal bypass.

Safety boundaries are preserved:

- legacy `edit_approval_policy=session` still maps to `dont_ask`, not `yolo`
- sensitive edit paths still prompt/block according to existing edit approval policy
- hardline dangerous-command blocks remain intact
- no global `approvals.mode: off` config is introduced

## Related Issue

No exact issue found. Related context: #27862, #29410, #29678.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `acp_adapter/server.py`
  - Advertise ACP session mode `yolo` / `YOLO` alongside `default`, `accept_edits`, and `dont_ask`.
  - Map `yolo` to the existing session edit auto-approval policy.
  - Enable session-scoped terminal YOLO when entering `yolo`.
  - Disable session-scoped terminal YOLO when leaving `yolo`.
  - Preserve backwards-compatible `edit_approval_policy=session` → `dont_ask` behavior.
- `tests/acp/test_server.py`
  - Add regression coverage for advertised ACP mode list.
  - Add regression coverage that `yolo` synchronizes terminal session YOLO and non-yolo modes disable it.

## How to Test

```bash
git diff --check origin/main...HEAD
scripts/run_tests.sh tests/acp/test_server.py -- -q
scripts/run_tests.sh tests/acp -- -q
python scripts/check-windows-footguns.py --diff origin/main
python -m acp_adapter.entry --help
```

Verified locally on Linux/Arch:

- `git diff --check origin/main...HEAD` — clean
- `scripts/run_tests.sh tests/acp/test_server.py -- -q` — 78 passed
- `scripts/run_tests.sh tests/acp -- -q` — 275 passed
- `python scripts/check-windows-footguns.py --diff origin/main` — no Windows footguns
- `python -m acp_adapter.entry --help` — help output renders

No real interactive ACP editor smoke test was run.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux / Arch

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, no docs surface changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — session-mode Python logic only; Windows-footgun check clean
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Focused ACP test output:

```text
scripts/run_tests.sh tests/acp -- -q
# 12 files, 275 tests passed
```
