### PR TITLE
feat(web): add ScrapeCreators search provider

### DIFF
--- a/agent/web_search_registry.py
+++ b/agent/web_search_registry.py
@@ -17,7 +17,7 @@ The active provider is chosen by configuration with this precedence:
 3. If exactly one capability-eligible provider is registered AND available,
    use it.
 4. Legacy preference order — ``firecrawl`` → ``parallel`` → ``tavily`` →
-   ``exa`` → ``searxng`` → ``brave-free`` → ``ddgs`` — filtered by
+   ``exa`` → ``scrapecreators`` → ``searxng`` → ``brave-free`` → ``ddgs`` — filtered by
    availability. Matches the historic ``tools.web_tools._get_backend()``
    candidate order so installs that never set a config key keep landing
    on the same provider they did before the plugin migration.
@@ -124,6 +124,7 @@ _LEGACY_PREFERENCE = (
     "parallel",
     "tavily",
     "exa",
+    "scrapecreators",
     "searxng",
     "brave-free",
     "ddgs",
@@ -148,7 +149,7 @@ def _resolve(configured: Optional[str], *, capability: str) -> Optional[WebSearc
 
     3. **Legacy preference walk, filtered by availability.** Walk the
        :data:`_LEGACY_PREFERENCE` order (firecrawl → parallel → tavily →
-       exa → searxng → brave-free → ddgs) looking for a provider whose
+       exa → scrapecreators → searxng → brave-free → ddgs) looking for a provider whose
        ``supports_<capability>()`` is True AND whose ``is_available()`` is
        True. Matches the historic ``tools.web_tools._get_backend()``
        candidate order so users with credentials but no explicit config

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1779,7 +1779,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 23,
+    "_config_version": 24,
 }
 
 # =============================================================================
@@ -1794,6 +1794,7 @@ ENV_VARS_BY_VERSION: Dict[int, List[str]] = {
     5: ["WHATSAPP_ENABLED", "WHATSAPP_MODE", "WHATSAPP_ALLOWED_USERS",
         "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_ALLOWED_USERS"],
     10: ["TAVILY_API_KEY"],
+    24: ["SCRAPECREATORS_API_KEY"],
     11: ["TERMINAL_MODAL_MODE"],
 }
 
@@ -2272,6 +2273,14 @@ OPTIONAL_ENV_VARS = {
         "prompt": "Tavily API key",
         "url": "https://app.tavily.com/home",
         "tools": ["web_search", "web_extract", "web_crawl"],
+        "password": True,
+        "category": "tool",
+    },
+    "SCRAPECREATORS_API_KEY": {
+        "description": "ScrapeCreators API key for Google web search",
+        "prompt": "ScrapeCreators API key",
+        "url": "https://scrapecreators.com/",
+        "tools": ["web_search"],
         "password": True,
         "category": "tool",
     },
@@ -5040,6 +5049,7 @@ def show_config():
         ("PARALLEL_API_KEY", "Parallel"),
         ("FIRECRAWL_API_KEY", "Firecrawl"),
         ("TAVILY_API_KEY", "Tavily"),
+        ("SCRAPECREATORS_API_KEY", "ScrapeCreators"),
         ("BROWSERBASE_API_KEY", "Browserbase"),
         ("BROWSER_USE_API_KEY", "Browser Use"),
         ("FAL_KEY", "FAL"),
@@ -5233,7 +5243,7 @@ def set_config_value(key: str, value: str):
         'OPENROUTER_API_KEY', 'OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'VOICE_TOOLS_OPENAI_KEY',
         'EXA_API_KEY', 'PARALLEL_API_KEY', 'FIRECRAWL_API_KEY', 'FIRECRAWL_API_URL',
         'FIRECRAWL_GATEWAY_URL', 'TOOL_GATEWAY_DOMAIN', 'TOOL_GATEWAY_SCHEME',
-        'TOOL_GATEWAY_USER_TOKEN', 'TAVILY_API_KEY',
+        'TOOL_GATEWAY_USER_TOKEN', 'TAVILY_API_KEY', 'SCRAPECREATORS_API_KEY',
         'BROWSERBASE_API_KEY', 'BROWSERBASE_PROJECT_ID', 'BROWSER_USE_API_KEY',
         'FAL_KEY', 'TELEGRAM_BOT_TOKEN', 'DISCORD_BOT_TOKEN',
         'TERMINAL_SSH_HOST', 'TERMINAL_SSH_USER', 'TERMINAL_SSH_KEY',

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -284,6 +284,7 @@ def get_nous_subscription_features(
     direct_firecrawl = bool(get_env_value("FIRECRAWL_API_KEY") or get_env_value("FIRECRAWL_API_URL"))
     direct_parallel = bool(get_env_value("PARALLEL_API_KEY"))
     direct_tavily = bool(get_env_value("TAVILY_API_KEY"))
+    direct_scrapecreators = bool(get_env_value("SCRAPECREATORS_API_KEY"))
     direct_searxng = bool(get_env_value("SEARXNG_URL"))
     direct_fal = fal_key_is_configured()
     direct_openai_tts = bool(resolve_openai_audio_api_key())
@@ -299,6 +300,7 @@ def get_nous_subscription_features(
         direct_exa = False
         direct_parallel = False
         direct_tavily = False
+        direct_scrapecreators = False
     if image_use_gateway:
         direct_fal = False
     if tts_use_gateway:
@@ -328,6 +330,7 @@ def get_nous_subscription_features(
             or (web_backend == "firecrawl" and direct_firecrawl)
             or (web_backend == "parallel" and direct_parallel)
             or (web_backend == "tavily" and direct_tavily)
+            or (web_backend == "scrapecreators" and direct_scrapecreators)
             or (web_backend == "searxng" and direct_searxng)
             # Per-capability overrides: search_backend or extract_backend may be set
             # without web.backend (using the new split config from #20061)
@@ -336,10 +339,11 @@ def get_nous_subscription_features(
             or (web_search_backend == "firecrawl" and direct_firecrawl)
             or (web_search_backend == "parallel" and direct_parallel)
             or (web_search_backend == "tavily" and direct_tavily)
+            or (web_search_backend == "scrapecreators" and direct_scrapecreators)
         )
     )
     web_available = bool(
-        managed_web_available or direct_exa or direct_firecrawl or direct_parallel or direct_tavily or direct_searxng
+        managed_web_available or direct_exa or direct_firecrawl or direct_parallel or direct_tavily or direct_scrapecreators or direct_searxng
     )
 
     image_managed = image_tool_enabled and managed_image_available and not direct_fal
@@ -522,6 +526,7 @@ def apply_nous_managed_defaults(
     if "web" in selected_toolsets and not features.web.explicit_configured and not (
         get_env_value("PARALLEL_API_KEY")
         or get_env_value("TAVILY_API_KEY")
+        or get_env_value("SCRAPECREATORS_API_KEY")
         or get_env_value("FIRECRAWL_API_KEY")
         or get_env_value("FIRECRAWL_API_URL")
     ):
@@ -568,6 +573,7 @@ def _get_gateway_direct_credentials() -> Dict[str, bool]:
             or get_env_value("FIRECRAWL_API_URL")
             or get_env_value("PARALLEL_API_KEY")
             or get_env_value("TAVILY_API_KEY")
+            or get_env_value("SCRAPECREATORS_API_KEY")
             or get_env_value("EXA_API_KEY")
         ),
         "image_gen": fal_key_is_configured(),

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -384,7 +384,7 @@ def _print_setup_summary(config: dict, hermes_home):
     else:
         tool_status.append(("Mixture of Agents", False, "OPENROUTER_API_KEY"))
 
-    # Web tools (Exa, Parallel, Firecrawl, or Tavily)
+    # Web tools (Exa, Parallel, Firecrawl, Tavily, ScrapeCreators, or SearXNG)
     if subscription_features.web.managed_by_nous:
         tool_status.append(("Web Search & Extract (Nous subscription)", True, None))
     elif subscription_features.web.available:
@@ -393,7 +393,7 @@ def _print_setup_summary(config: dict, hermes_home):
             label = f"Web Search & Extract ({subscription_features.web.current_provider})"
         tool_status.append((label, True, None))
     else:
-        tool_status.append(("Web Search & Extract", False, "EXA_API_KEY, PARALLEL_API_KEY, FIRECRAWL_API_KEY/FIRECRAWL_API_URL, TAVILY_API_KEY, or SEARXNG_URL"))
+        tool_status.append(("Web Search & Extract", False, "EXA_API_KEY, PARALLEL_API_KEY, FIRECRAWL_API_KEY/FIRECRAWL_API_URL, TAVILY_API_KEY, SCRAPECREATORS_API_KEY, or SEARXNG_URL"))
 
     # Browser tools (local Chromium, Camofox, Browserbase, Browser Use, or Firecrawl)
     browser_provider = subscription_features.browser.current_provider

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -138,6 +138,7 @@ def show_status(args):
         "MiniMax-CN": "MINIMAX_CN_API_KEY",
         "Firecrawl": "FIRECRAWL_API_KEY",
         "Tavily": "TAVILY_API_KEY",
+        "ScrapeCreators": "SCRAPECREATORS_API_KEY",
         "Browser Use": "BROWSER_USE_API_KEY",  # Optional — local browser works without this
         "Browserbase": "BROWSERBASE_API_KEY",  # Optional — direct credentials only
         "FAL": "FAL_KEY",

--- a/plugins/web/scrapecreators/__init__.py
+++ b/plugins/web/scrapecreators/__init__.py
@@ -1,0 +1,10 @@
+"""ScrapeCreators web search plugin — bundled, auto-loaded."""
+
+from __future__ import annotations
+
+from plugins.web.scrapecreators.provider import ScrapeCreatorsWebSearchProvider
+
+
+def register(ctx) -> None:
+    """Register the ScrapeCreators Google Search provider."""
+    ctx.register_web_search_provider(ScrapeCreatorsWebSearchProvider())

--- a/plugins/web/scrapecreators/plugin.yaml
+++ b/plugins/web/scrapecreators/plugin.yaml
@@ -1,0 +1,7 @@
+name: web-scrapecreators
+version: 1.0.0
+description: "ScrapeCreators Google Search — search via /v1/google/search. Requires SCRAPECREATORS_API_KEY (https://scrapecreators.com)."
+author: NousResearch
+kind: backend
+provides_web_providers:
+  - scrapecreators

--- a/plugins/web/scrapecreators/provider.py
+++ b/plugins/web/scrapecreators/provider.py
@@ -1,0 +1,167 @@
+"""ScrapeCreators Google Search — plugin form.
+
+Routes ``web_search`` tool calls through ScrapeCreators' Google Search API
+and normalizes results into Hermes' standard ``{title, url, description,
+position}`` rows.
+
+Reference: https://scrapecreators.com/
+
+Config keys this provider responds to::
+
+    web:
+      search_backend: "scrapecreators"   # explicit per-capability
+      backend: "scrapecreators"          # shared fallback
+
+Optional knobs (under ``web.scrapecreators`` in ``config.yaml``)::
+
+    web:
+      scrapecreators:
+        base_url: "https://api.scrapecreators.com/v1"
+        timeout: 30
+
+Auth env var::
+
+    SCRAPECREATORS_API_KEY=...
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List
+
+import httpx
+
+from agent.web_search_provider import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = "https://api.scrapecreators.com/v1"
+DEFAULT_TIMEOUT = 30
+
+
+def _load_scrapecreators_config() -> Dict[str, Any]:
+    """Read ``web.scrapecreators`` from config.yaml (returns {} on miss)."""
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        web_section = cfg.get("web") if isinstance(cfg, dict) else None
+        section = web_section.get("scrapecreators") if isinstance(web_section, dict) else None
+        return section if isinstance(section, dict) else {}
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Could not load web.scrapecreators config: %s", exc)
+        return {}
+
+
+def _coerce_timeout(value: Any) -> float:
+    try:
+        timeout = float(value)
+    except (TypeError, ValueError):
+        return float(DEFAULT_TIMEOUT)
+    return max(1.0, timeout)
+
+
+def _normalize_results(payload: Dict[str, Any], limit: int) -> List[Dict[str, Any]]:
+    """Normalize known ScrapeCreators Google Search payload shapes."""
+    candidates = (
+        payload.get("results"),
+        payload.get("organic_results"),
+        (payload.get("data") or {}).get("results") if isinstance(payload.get("data"), dict) else None,
+        (payload.get("data") or {}).get("organic_results") if isinstance(payload.get("data"), dict) else None,
+    )
+    raw_results = next((items for items in candidates if isinstance(items, list)), [])
+
+    web_results: List[Dict[str, Any]] = []
+    for i, hit in enumerate(raw_results[:limit]):
+        if not isinstance(hit, dict):
+            continue
+        url = str(hit.get("url") or hit.get("link") or hit.get("href") or "")
+        web_results.append(
+            {
+                "title": str(hit.get("title") or ""),
+                "url": url,
+                "description": str(hit.get("description") or hit.get("snippet") or hit.get("body") or ""),
+                "position": int(hit.get("position") or hit.get("rank") or i + 1),
+            }
+        )
+    return web_results
+
+
+class ScrapeCreatorsWebSearchProvider(WebSearchProvider):
+    """Search-only provider backed by ScrapeCreators' Google Search API."""
+
+    @property
+    def name(self) -> str:
+        return "scrapecreators"
+
+    @property
+    def display_name(self) -> str:
+        return "ScrapeCreators Google Search"
+
+    def is_available(self) -> bool:
+        """Cheap availability probe — requires ``SCRAPECREATORS_API_KEY``."""
+        return bool(os.getenv("SCRAPECREATORS_API_KEY", "").strip())
+
+    def supports_search(self) -> bool:
+        return True
+
+    def supports_extract(self) -> bool:
+        return False
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        api_key = os.getenv("SCRAPECREATORS_API_KEY", "").strip()
+        if not api_key:
+            return {"success": False, "error": "SCRAPECREATORS_API_KEY is not set"}
+
+        safe_limit = max(1, int(limit or 5))
+        cfg = _load_scrapecreators_config()
+        base_url = str(cfg.get("base_url") or os.getenv("SCRAPECREATORS_BASE_URL") or DEFAULT_BASE_URL).rstrip("/")
+        timeout = _coerce_timeout(cfg.get("timeout") or os.getenv("SCRAPECREATORS_TIMEOUT"))
+
+        try:
+            resp = httpx.get(
+                f"{base_url}/google/search",
+                params={"query": query},
+                headers={
+                    "x-api-key": api_key,
+                    "accept": "application/json",
+                    "user-agent": "Hermes-Agent/1.0",
+                },
+                timeout=timeout,
+            )
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            logger.warning("ScrapeCreators HTTP error: %s", exc)
+            return {
+                "success": False,
+                "error": f"ScrapeCreators returned HTTP {exc.response.status_code}",
+            }
+        except httpx.RequestError as exc:
+            logger.warning("ScrapeCreators request error: %s", exc)
+            return {"success": False, "error": f"Could not reach ScrapeCreators: {exc}"}
+
+        try:
+            payload = resp.json()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("ScrapeCreators response parse error: %s", exc)
+            return {"success": False, "error": "Could not parse ScrapeCreators response as JSON"}
+
+        web_results = _normalize_results(payload, safe_limit)
+        logger.info("ScrapeCreators search '%s': %d results (limit %d)", query, len(web_results), safe_limit)
+        return {"success": True, "data": {"web": web_results}}
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "ScrapeCreators Google Search",
+            "badge": "search",
+            "tag": "Google web search via ScrapeCreators /v1/google/search (search only)",
+            "env_vars": [
+                {
+                    "key": "SCRAPECREATORS_API_KEY",
+                    "prompt": "ScrapeCreators API key",
+                    "url": "https://scrapecreators.com/",
+                },
+            ],
+            "web_backend": "scrapecreators",
+        }

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -485,6 +485,22 @@ class TestOptionalEnvVarsRegistry:
             all_vars.extend(vars_list)
         assert "TAVILY_API_KEY" in all_vars
 
+    def test_scrapecreators_api_key_registered(self):
+        """SCRAPECREATORS_API_KEY is listed in OPTIONAL_ENV_VARS."""
+        from hermes_cli.config import OPTIONAL_ENV_VARS
+        assert "SCRAPECREATORS_API_KEY" in OPTIONAL_ENV_VARS
+        assert OPTIONAL_ENV_VARS["SCRAPECREATORS_API_KEY"]["category"] == "tool"
+        assert OPTIONAL_ENV_VARS["SCRAPECREATORS_API_KEY"]["password"] is True
+        assert OPTIONAL_ENV_VARS["SCRAPECREATORS_API_KEY"]["tools"] == ["web_search"]
+
+    def test_scrapecreators_in_env_vars_by_version(self):
+        """SCRAPECREATORS_API_KEY is listed in ENV_VARS_BY_VERSION."""
+        from hermes_cli.config import ENV_VARS_BY_VERSION
+        all_vars = []
+        for vars_list in ENV_VARS_BY_VERSION.values():
+            all_vars.extend(vars_list)
+        assert "SCRAPECREATORS_API_KEY" in all_vars
+
 
 class TestAnthropicTokenMigration:
     """Test that config version 8→9 clears ANTHROPIC_TOKEN."""

--- a/tests/plugins/web/test_scrapecreators_provider.py
+++ b/tests/plugins/web/test_scrapecreators_provider.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from plugins.web.scrapecreators.provider import ScrapeCreatorsWebSearchProvider
+
+
+def test_scrapecreators_availability_requires_key(monkeypatch):
+    provider = ScrapeCreatorsWebSearchProvider()
+
+    monkeypatch.delenv("SCRAPECREATORS_API_KEY", raising=False)
+    assert provider.is_available() is False
+
+    monkeypatch.setenv("SCRAPECREATORS_API_KEY", "key")
+    assert provider.is_available() is True
+
+
+def test_scrapecreators_search_normalizes_google_results(monkeypatch):
+    monkeypatch.setenv("SCRAPECREATORS_API_KEY", "key")
+    response = MagicMock()
+    response.json.return_value = {
+        "results": [
+            {
+                "title": "OpenAI",
+                "url": "https://openai.com/",
+                "description": "AI research",
+                "position": 3,
+            }
+        ]
+    }
+    response.raise_for_status.return_value = None
+
+    with patch("plugins.web.scrapecreators.provider.httpx.get", return_value=response) as get:
+        result = ScrapeCreatorsWebSearchProvider().search("OpenAI", limit=1)
+
+    assert result == {
+        "success": True,
+        "data": {
+            "web": [
+                {
+                    "title": "OpenAI",
+                    "url": "https://openai.com/",
+                    "description": "AI research",
+                    "position": 3,
+                }
+            ]
+        },
+    }
+    assert get.call_args.kwargs["params"] == {"query": "OpenAI"}
+    assert get.call_args.kwargs["headers"]["x-api-key"] == "key"
+
+
+def test_scrapecreators_search_accepts_nested_data_shape(monkeypatch):
+    monkeypatch.setenv("SCRAPECREATORS_API_KEY", "key")
+    response = MagicMock()
+    response.json.return_value = {
+        "data": {
+            "organic_results": [
+                {
+                    "title": "Docs",
+                    "link": "https://example.com/docs",
+                    "snippet": "Example documentation",
+                    "rank": 2,
+                }
+            ]
+        }
+    }
+    response.raise_for_status.return_value = None
+
+    with patch("plugins.web.scrapecreators.provider.httpx.get", return_value=response):
+        result = ScrapeCreatorsWebSearchProvider().search("docs", limit=5)
+
+    assert result["success"] is True
+    assert result["data"]["web"] == [
+        {
+            "title": "Docs",
+            "url": "https://example.com/docs",
+            "description": "Example documentation",
+            "position": 2,
+        }
+    ]

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -48,6 +48,7 @@ def _clear_web_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_USER_TOKEN",
         "XAI_API_KEY",
+        "SCRAPECREATORS_API_KEY",
     ):
         monkeypatch.delenv(k, raising=False)
 
@@ -84,6 +85,7 @@ class TestBundledPluginsRegister:
             "exa",
             "firecrawl",
             "parallel",
+            "scrapecreators",
             "searxng",
             "tavily",
             "xai",
@@ -102,6 +104,8 @@ class TestBundledPluginsRegister:
             # disabled in the migration (fell through to a legacy inline
             # path); the follow-up commit enabled it natively.
             ("firecrawl", True, True, True),
+            # scrapecreators: search-only Google Search API.
+            ("scrapecreators", True, False, False),
             # xai: search-only via Grok's agentic web_search tool.
             ("xai", True, False, False),
         ],
@@ -124,7 +128,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "scrapecreators", "xai"],
     )
     def test_each_plugin_has_name_and_display_name(self, plugin_name: str) -> None:
         _ensure_plugins_loaded()
@@ -137,7 +141,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "scrapecreators", "xai"],
     )
     def test_each_plugin_has_setup_schema(self, plugin_name: str) -> None:
         """``get_setup_schema()`` returns a dict the picker can consume."""
@@ -252,6 +256,16 @@ class TestIsAvailable:
         assert p is not None
         assert p.is_available() is False  # no XAI_API_KEY, no auth.json
         monkeypatch.setenv("XAI_API_KEY", "real")
+        assert p.is_available() is True
+
+    def test_scrapecreators_requires_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("scrapecreators")
+        assert p is not None
+        assert p.is_available() is False
+        monkeypatch.setenv("SCRAPECREATORS_API_KEY", "real")
         assert p.is_available() is True
 
 
@@ -495,6 +509,17 @@ class TestErrorResponseShapes:
         from agent.web_search_registry import get_provider
 
         p = get_provider("xai")
+        assert p is not None
+        result = p.search("test", limit=5)
+        assert isinstance(result, dict)
+        assert result.get("success") is False
+        assert "error" in result
+
+    def test_scrapecreators_search_returns_error_dict_when_unconfigured(self) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("scrapecreators")
         assert p is not None
         result = p.search("test", limit=5)
         assert isinstance(result, dict)

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -259,6 +259,7 @@ class TestBackendSelection:
         "TOOL_GATEWAY_SCHEME",
         "TOOL_GATEWAY_USER_TOKEN",
         "TAVILY_API_KEY",
+        "SCRAPECREATORS_API_KEY",
     )
 
     def setup_method(self):
@@ -324,6 +325,12 @@ class TestBackendSelection:
         with patch("tools.web_tools._load_web_config", return_value={"backend": "Tavily"}):
             assert _get_backend() == "tavily"
 
+    def test_config_scrapecreators(self):
+        """web.backend=scrapecreators in config → 'scrapecreators'."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "scrapecreators"}):
+            assert _get_backend() == "scrapecreators"
+
     # ── Fallback (no web.backend in config) ───────────────────────────
 
     def test_fallback_parallel_only_key(self):
@@ -353,6 +360,13 @@ class TestBackendSelection:
         with patch("tools.web_tools._load_web_config", return_value={}), \
              patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}):
             assert _get_backend() == "tavily"
+
+    def test_fallback_scrapecreators_only_key(self):
+        """Only SCRAPECREATORS_API_KEY set → 'scrapecreators'."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={}), \
+             patch.dict(os.environ, {"SCRAPECREATORS_API_KEY": "sc-test"}):
+            assert _get_backend() == "scrapecreators"
 
     def test_fallback_tavily_with_firecrawl_prefers_firecrawl(self):
         """Tavily + Firecrawl keys, no config → 'firecrawl' (backward compat)."""
@@ -558,6 +572,7 @@ class TestCheckWebApiKey:
         "TOOL_GATEWAY_SCHEME",
         "TOOL_GATEWAY_USER_TOKEN",
         "TAVILY_API_KEY",
+        "SCRAPECREATORS_API_KEY",
     )
 
     def setup_method(self):

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -140,7 +140,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}:
+    if configured in {"parallel", "firecrawl", "tavily", "exa", "scrapecreators", "searxng", "brave-free", "ddgs", "xai"}:
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -153,6 +153,7 @@ def _get_backend() -> str:
         ("parallel", _has_env("PARALLEL_API_KEY")),
         ("tavily", _has_env("TAVILY_API_KEY")),
         ("exa", _has_env("EXA_API_KEY")),
+        ("scrapecreators", _has_env("SCRAPECREATORS_API_KEY")),
         ("searxng", _has_env("SEARXNG_URL")),
         ("brave-free", _has_env("BRAVE_SEARCH_API_KEY")),
         ("ddgs", _ddgs_package_importable()),
@@ -212,6 +213,8 @@ def _is_backend_available(backend: str) -> bool:
         return check_firecrawl_api_key()
     if backend == "tavily":
         return _has_env("TAVILY_API_KEY")
+    if backend == "scrapecreators":
+        return _has_env("SCRAPECREATORS_API_KEY")
     if backend == "searxng":
         return _has_env("SEARXNG_URL")
     if backend == "brave-free":
@@ -277,6 +280,7 @@ def _web_requires_env() -> list[str]:
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_SCHEME",
         "TOOL_GATEWAY_USER_TOKEN",
+        "SCRAPECREATORS_API_KEY",
     ]
 
 


### PR DESCRIPTION
## Summary
- add a bundled ScrapeCreators Google Search web provider plugin
- wire SCRAPECREATORS_API_KEY into web backend detection, setup/status, and config migration metadata
- add provider, registry, backend-selection, and config tests

## Test plan
- venv/bin/python -m pytest tests/plugins/web/test_scrapecreators_provider.py tests/plugins/web/test_web_search_provider_plugins.py tests/tools/test_web_tools_config.py tests/hermes_cli/test_config.py tests/gateway/test_whatsapp_reply_prefix.py -q
- /home/clawd/.local/bin/hermes config check
- local smoke: configured web.backend/search_backend=scrapecreators resolves active provider and returns 2 live results