### PR TITLE
fix(skills): skip skill slash commands that collide with core Hermes commands

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -259,6 +259,29 @@ def _build_skill_message(
 
     return "\n".join(parts)
 
+_CORE_COMMAND_NAMES: Optional[set] = None
+
+
+def _get_core_command_names() -> set:
+    """Return the set of reserved core command names (lowercase).
+
+    Core Hermes CLI commands (and their aliases) take precedence over
+    skill-generated slash commands.  This set is computed once at first
+    call and cached in the module-level _CORE_COMMAND_NAMES variable.
+    """
+    global _CORE_COMMAND_NAMES
+    if _CORE_COMMAND_NAMES is not None:
+        return _CORE_COMMAND_NAMES
+    _CORE_COMMAND_NAMES = set()
+    try:
+        from hermes_cli.commands import COMMAND_REGISTRY
+        for cmd in COMMAND_REGISTRY:
+            _CORE_COMMAND_NAMES.add(cmd.name.lower())
+            for alias in cmd.aliases:
+                _CORE_COMMAND_NAMES.add(alias.lower())
+    except ImportError:
+        pass
+    return _CORE_COMMAND_NAMES
 
 def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     """Scan ~/.hermes/skills/ and return a mapping of /command -> skill info.
@@ -313,7 +336,19 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     cmd_name = _SKILL_MULTI_HYPHEN.sub('-', cmd_name).strip('-')
                     if not cmd_name:
                         continue
+                    # Skip if this skill's auto-generated /command collides
+                    # with a core Hermes CLI slash command (e.g. /handoff,
+                    # /config).  The skill remains loadable via /skill <name>.
+                    if cmd_name in _get_core_command_names():
+                        logger.warning(
+                            "Skill '%s' generates slash command '/%s' which "
+                            "collides with a core Hermes command. Skipping "
+                            "auto-generated command. Load via '/skill %s' instead.",
+                            name, cmd_name, name,
+                        )
+                        continue
                     _skill_commands[f"/{cmd_name}"] = {
+
                         "name": name,
                         "description": description or f"Invoke the {name} skill",
                         "skill_md_path": str(skill_md),

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -377,6 +377,14 @@ class TestScanSkillCommands:
         assert "/sonarr-v3v4-api" in result
         assert any("/" in k[1:] for k in result) is False  # no unescaped /
 
+    def test_skill_collides_with_core_command_is_skipped(self, tmp_path):
+        """A skill whose auto-generated /command collides with a core Hermes
+        command (e.g. 'handoff') should be excluded from the slash-command map.
+        The skill remains loadable via /skill <name>."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "handoff")
+            result = scan_skill_commands()
+        assert "/handoff" not in result
 
 class TestResolveSkillCommandKey:
     """Telegram bot-command names disallow hyphens, so the menu registers


### PR DESCRIPTION
## What does this PR 
Adds collision detection to scan_skill_commands() so that a skill whose auto-generated /command would shadow a core Hermes slash command is skipped with a warning. The skill remains fully functional via /skill <name>.
    
## Related Issue
    
## Type of Change
- [x] Bug fix
    
 ## Changes Made
- agent/skill_commands.py — Added _get_core_command_names() helper that builds a cached set of reserved command names from COMMAND_REGISTRY. Added a check in scan_skill_commands() that skips registration when a skill's auto-generated slug collides with a core command, logging a warning with instructions to use /skill <name> instead.
- tests/agent/test_skill_commands.py — Added test_skill_collides_with_core_command_is_skipped that creates a skill named "handoff" and verifies it is excluded from the slash-command map.
    
## How to Test
1. Create a skill at ~/.hermes/skills/handoff/SKILL.md with name: handoff in its frontmatter
2. Run hermes and check /help — /handoff should NOT appear under Skill Commands
3. Verify the skill still loads: /skill handoff should work
4. Check the logs for the collision warning
    
Or run the test: pytest tests/agent/test_skill_commands.py::TestScanSkillCommands::test_skill_collides_with_core_command_is_skipped -v
    
## Checklist
- [x] Read Contributing Guide
- [x] Commit follows Conventional Commits: fix(skills): ...
- [x] Searched for existing PRs — none found
- [x] Only changes related to this fix
- [x] Ran pytest tests/ -q — 8 pre-existing failures on main unrelated to this change; our specific tests all pass
- [x] Added tests for changes
- [x] Tested on: Linux (Debian 13, Python 3.13.5)
- [x] Documentation: N/A
- [x] Config changes: N/A
- [x] Architecture changes: N/A
- [x] Cross-platform: N/A (pure Python logic, no OS-specific code)
- [x] Tool descriptions: N/A