### PR TITLE
fix(prompt): honor TERMINAL_CWD in local environment hints

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -781,7 +781,10 @@ def build_environment_hints() -> str:
 
         host_lines.append(f"User home directory: {os.path.expanduser('~')}")
         try:
-            host_lines.append(f"Current working directory: {os.getcwd()}")
+            current_cwd = os.getenv("TERMINAL_CWD") or os.getcwd()
+            host_lines.append(
+                f"Current working directory: {os.path.expanduser(current_cwd)}"
+            )
         except OSError:
             pass
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -875,6 +875,33 @@ class TestEnvironmentHints:
         assert "hostname" not in result
         assert "WSL" not in result
 
+    def test_build_environment_hints_uses_terminal_cwd_for_local_backend(
+        self, monkeypatch, tmp_path
+    ):
+        """Local-backend prompt cwd must match the terminal tool's default cwd.
+
+        Cron/worktree launchers set TERMINAL_CWD without chdir-ing the Hermes
+        process. If the prompt advertises os.getcwd() instead, the model may
+        pass that stale path back as an explicit terminal(workdir=...),
+        overriding the correct session default.
+        """
+        import agent.prompt_builder as _pb
+        import sys, platform
+
+        session_cwd = tmp_path / "project"
+        session_cwd.mkdir()
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+        monkeypatch.setattr(platform, "release", lambda: "6.8.0-generic")
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        monkeypatch.setenv("TERMINAL_CWD", str(session_cwd))
+        _pb._clear_backend_probe_cache()
+
+        result = _pb.build_environment_hints()
+
+        assert f"Current working directory: {session_cwd}" in result
+
     def test_build_environment_hints_on_windows_local(self, monkeypatch):
         import agent.prompt_builder as _pb
         import sys


### PR DESCRIPTION
## Summary

Use `TERMINAL_CWD` when building local environment hints so the prompt reports the same current working directory that the terminal tool will use by default.

If `TERMINAL_CWD` is not set, the existing `os.getcwd()` behavior is preserved.

## Why

Long-running Hermes processes can be launched from one directory while a session, cron job, worktree, or worker is configured to run terminal commands from another directory.

In that case, the terminal tool may correctly default to `TERMINAL_CWD`, but the prompt still reports the process cwd from `os.getcwd()`. This can mislead the model into passing the stale prompt cwd back as an explicit `workdir`, overriding the intended terminal default.

## Changes

- Prefer `TERMINAL_CWD` over `os.getcwd()` in `build_environment_hints()`.
- Expand `~` in the reported cwd for consistency.
- Add a regression test covering local-backend environment hints with `TERMINAL_CWD`.

## Test plan

```bash
python -m pytest tests/agent/test_prompt_builder.py::TestEnvironmentHints::test_build_environment_hints_uses_terminal_cwd_for_local_backend -q -o 'addopts='
```

Also run together with the related delegate timeout diagnostic tests:

```bash
python -m pytest \
  tests/agent/test_prompt_builder.py::TestEnvironmentHints::test_build_environment_hints_uses_terminal_cwd_for_local_backend \
  tests/tools/test_delegate_subagent_timeout_diagnostic.py \
  -q -o 'addopts='
```

Result:

```text
8 passed, 1 warning
```
