### PR TITLE
fix(delegate): write timeout diagnostics for in-flight subagents

### DIFF
--- a/tests/tools/test_delegate_subagent_timeout_diagnostic.py
+++ b/tests/tools/test_delegate_subagent_timeout_diagnostic.py
@@ -1,18 +1,16 @@
 """Regression tests for subagent timeout diagnostic dump (issue #14726).
 
-When delegate_task's child subagent times out without having made any API
-call, a structured diagnostic file is written under
-``~/.hermes/logs/subagent-timeout-<sid>-<ts>.log``. This gives users a
-concrete artifact to inspect (worker thread stack, system prompt size,
-tool schema bytes, credential pool state, etc.) instead of the previous
+When delegate_task's child subagent times out, a structured diagnostic file is
+written under ``~/.hermes/logs/subagent-timeout-<sid>-<ts>.log``. This gives
+users a concrete artifact to inspect (worker thread stack, system prompt size,
+tool schema bytes, credential pool state, activity summary, etc.) instead of an
 opaque "subagent timed out" error.
 
 These tests pin:
 - the diagnostic writer's output format and content
-- the timeout branch in _run_single_child only dumps when api_calls == 0
+- the timeout branch in _run_single_child dumps for both 0-API-call and
+  in-flight nonzero-API-call timeouts
 - the error message surfaces the diagnostic path
-- api_calls > 0 timeouts do NOT write a dump (the old "stuck on slow API
-  call" explanation still applies)
 """
 from __future__ import annotations
 
@@ -233,8 +231,8 @@ class TestDumpSubagentTimeoutDiagnostic:
 # ── _run_single_child timeout branch wiring ───────────────────────────
 
 class TestRunSingleChildTimeoutDump:
-    """The timeout branch in _run_single_child must emit the diagnostic
-    dump when api_calls == 0, and must NOT emit it when api_calls > 0."""
+    """The timeout branch in _run_single_child must emit a diagnostic
+    dump for both 0-API-call and in-flight nonzero-API-call timeouts."""
 
     def _invoke_with_short_timeout(self, child, monkeypatch):
         """Run _run_single_child with a tiny timeout to force the timeout branch."""
@@ -268,19 +266,20 @@ class TestRunSingleChildTimeoutDump:
         assert "Diagnostic:" in result["error"]
         assert str(dump_path) in result["error"]
 
-    def test_nonzero_api_calls_skips_dump_and_uses_old_message(self, hermes_home, monkeypatch):
+    def test_nonzero_api_calls_writes_dump_and_keeps_inflight_timeout_message(self, hermes_home, monkeypatch):
         child = _StubChild(api_call_count=5, hang_seconds=10.0)
         result = self._invoke_with_short_timeout(child, monkeypatch)
 
         assert result["status"] == "timeout"
         assert result["api_calls"] == 5
-        # No diagnostic file should be written for timeouts that made
-        # actual API calls — the old generic "stuck on slow call" message
-        # still applies.
-        assert result.get("diagnostic_path") is None
+        assert result["diagnostic_path"] is not None
+        dump_path = Path(result["diagnostic_path"])
+        assert dump_path.is_file()
+        assert dump_path.parent == hermes_home / "logs"
+
         assert "stuck on a slow API call" in result["error"]
-        # And no subagent-timeout-* file should exist under logs/
-        logs_dir = hermes_home / "logs"
-        if logs_dir.is_dir():
-            dumps = list(logs_dir.glob("subagent-timeout-*.log"))
-            assert dumps == []
+        assert "Diagnostic:" in result["error"]
+        assert str(dump_path) in result["error"]
+
+        content = dump_path.read_text()
+        assert "api_call_count: 5" in content

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1531,9 +1531,11 @@ def _run_single_child(
                 duration,
             )
 
-            # When a subagent times out BEFORE making any API call, dump a
-            # diagnostic to help users (and us) see what the child was doing.
-            # See #14726 — without this, 0-API-call hangs are black boxes.
+            # When a subagent times out, dump a diagnostic to help users (and
+            # us) see what the child was doing. 0-API-call hangs need prompt /
+            # transport diagnostics; in-flight API/tool/network hangs need the
+            # same child activity and stack artifact so partial work is not a
+            # black box.
             diagnostic_path: Optional[str] = None
             child_api_calls = 0
             try:
@@ -1541,7 +1543,7 @@ def _run_single_child(
                 child_api_calls = int(_summary.get("api_call_count", 0) or 0)
             except Exception:
                 pass
-            if is_timeout and child_api_calls == 0:
+            if is_timeout:
                 diagnostic_path = _dump_subagent_timeout_diagnostic(
                     child=child,
                     task_index=task_index,
@@ -1552,8 +1554,9 @@ def _run_single_child(
                 )
                 if diagnostic_path:
                     logger.warning(
-                        "Subagent %d 0-API-call timeout — diagnostic written to %s",
+                        "Subagent %d timeout after %d API call(s) — diagnostic written to %s",
                         task_index,
+                        child_api_calls,
                         diagnostic_path,
                     )
 
@@ -1589,6 +1592,8 @@ def _run_single_child(
                         f"{child_api_calls} API call(s) completed — likely "
                         f"stuck on a slow API call or unresponsive network request."
                     )
+                    if diagnostic_path:
+                        _err += f" Diagnostic: {diagnostic_path}"
             else:
                 _err = str(_timeout_exc)
 


### PR DESCRIPTION
## Summary

Write subagent timeout diagnostics for all delegate subagent timeouts, including timeouts after one or more API calls have already completed.

Previously, timeout diagnostics were only written for 0-API-call hangs. This keeps that behavior and extends it to in-flight hangs so users still get a concrete diagnostic artifact when a child agent stalls during or after API/tool/network activity.

## Why

A timeout after nonzero API calls can still be opaque from the parent session: the child may be blocked in a slow API call, tool call, network request, or other stuck state. Without a diagnostic dump, users only see the generic timeout message and have no artifact to inspect.

The existing diagnostic file already captures useful state for this case, including:

- child activity summary
- API call count
- thread/stack information
- prompt/tool/context diagnostics
- credential/provider state where available

Surfacing the diagnostic path in the timeout error makes these hangs actionable without changing the timeout semantics.

## Changes

- Dump a diagnostic file for any subagent timeout, not only 0-API-call timeouts.
- Preserve the existing nonzero-API-call timeout wording about likely slow API/network activity.
- Append the diagnostic path to the error when a diagnostic was written.
- Update regression tests to cover nonzero-API-call timeout diagnostics.

## Test plan

```bash
python -m pytest tests/tools/test_delegate_subagent_timeout_diagnostic.py -q -o 'addopts='
```

Also run together with the related prompt cwd regression test:

```bash
python -m pytest \
  tests/agent/test_prompt_builder.py::TestEnvironmentHints::test_build_environment_hints_uses_terminal_cwd_for_local_backend \
  tests/tools/test_delegate_subagent_timeout_diagnostic.py \
  -q -o 'addopts='
```

Result:

```text
8 passed, 1 warning
```
