### PR TITLE
fix(kanban): harden SQLite against torn-write corruption (secure_delete + cell_size_check + synchronous=FULL)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1181,8 +1181,16 @@ def connect(
             # See hermes_state._WAL_INCOMPAT_MARKERS for detection logic.
             from hermes_state import apply_wal_with_fallback
             apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
-            conn.execute("PRAGMA synchronous=NORMAL")
+            # FULL (was NORMAL): fsync before each checkpoint to narrow the
+            # crash window that can leave a b-tree page header torn.
+            conn.execute("PRAGMA synchronous=FULL")
             conn.execute("PRAGMA foreign_keys=ON")
+            # Zero freed pages so a later torn write cannot expose stale
+            # cell content; persisted in the DB header for new DBs.
+            conn.execute("PRAGMA secure_delete=ON")
+            # Surface corrupt cells as read errors instead of silent
+            # wrong-data returns.
+            conn.execute("PRAGMA cell_size_check=ON")
             needs_init = resolved not in _INITIALIZED_PATHS
             if needs_init:
                 # Idempotent: runs CREATE TABLE IF NOT EXISTS + the additive

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -316,6 +316,7 @@ AUTHOR_MAP = {
     "yuxiangl490@gmail.com": "y0shua1ee",
     "manmit0x@gmail.com": "0xDevNinja",
     "stevekelly622@gmail.com": "steezkelly",
+    "steveonjava@gmail.com": "steveonjava",
     "brian@dralth.com": "btorresgil",
     "momowind@gmail.com": "momowind",
     "clockwork-codex@users.noreply.github.com": "misery-hl",

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3188,3 +3188,67 @@ def test_maybe_emit_scratch_tip_skips_non_scratch_workspaces(kanban_home, caplog
             ).fetchall()
             assert "tip_scratch_workspace" not in [e["kind"] for e in events]
 
+
+# ---------------------------------------------------------------------------
+# Connection pragmas (secure_delete, cell_size_check, synchronous=FULL)
+# ---------------------------------------------------------------------------
+
+
+def test_connect_sets_secure_delete_on(tmp_path):
+    """secure_delete=ON must be active on every new connection."""
+    db_path = tmp_path / "kanban.db"
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    with kb.connect(db_path=db_path) as conn:
+        row = conn.execute("PRAGMA secure_delete").fetchone()
+    assert row[0] == 1, f"expected secure_delete=1, got {row[0]}"
+
+
+def test_connect_sets_cell_size_check_on(tmp_path):
+    """cell_size_check=ON must be active on every new connection."""
+    db_path = tmp_path / "kanban.db"
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    with kb.connect(db_path=db_path) as conn:
+        row = conn.execute("PRAGMA cell_size_check").fetchone()
+    assert row[0] == 1, f"expected cell_size_check=1, got {row[0]}"
+
+
+def test_connect_sets_synchronous_full(tmp_path):
+    """synchronous must be FULL (=2), not NORMAL (=1)."""
+    db_path = tmp_path / "kanban.db"
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    with kb.connect(db_path=db_path) as conn:
+        row = conn.execute("PRAGMA synchronous").fetchone()
+    assert row[0] == 2, f"expected synchronous=2 (FULL), got {row[0]}"
+
+
+def test_connect_pragmas_applied_on_reconnect(tmp_path):
+    """All three pragmas must be re-applied on every connect(), not just the first."""
+    db_path = tmp_path / "kanban.db"
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    # First connection: write a task and close.
+    with kb.connect(db_path=db_path) as conn:
+        kb.create_task(conn, title="reconnect-check")
+    # Force re-init path by discarding path cache.
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    # Second connection: pragmas must still be applied.
+    with kb.connect(db_path=db_path) as conn:
+        assert conn.execute("PRAGMA secure_delete").fetchone()[0] == 1
+        assert conn.execute("PRAGMA cell_size_check").fetchone()[0] == 1
+        assert conn.execute("PRAGMA synchronous").fetchone()[0] == 2
+
+
+
+def test_pragmas_not_accidentally_disabled_by_migrate_path(tmp_path):
+    """Migration path must not reset connection pragmas."""
+    db_path = tmp_path / "legacy.db"
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    # Initialise with a fresh connect so schema + init run.
+    with kb.connect(db_path=db_path) as conn:
+        kb.create_task(conn, title="pre-migration-task")
+    # Simulate a re-entry through the init/migration path by discarding path cache.
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    with kb.connect(db_path=db_path) as conn:
+        assert conn.execute("PRAGMA secure_delete").fetchone()[0] == 1
+        assert conn.execute("PRAGMA cell_size_check").fetchone()[0] == 1
+        assert conn.execute("PRAGMA synchronous").fetchone()[0] == 2
+


### PR DESCRIPTION
## What does this PR do?

This PR adds three SQLite PRAGMA settings to the kanban database `connect()` function to protect against data corruption from torn writes and power loss:

- `PRAGMA secure_delete=ON` — zeros freed pages on disk so stale data can't resurface if a later write leaves the page incomplete
- `PRAGMA cell_size_check=ON` — catches corrupt cells as errors at read time instead of silently returning wrong data
- `PRAGMA synchronous=FULL` — requires full fsync before checkpoint, narrowing the window where a crash between WAL commit and main-db write could corrupt a b-tree page header

These are set on every connection. `secure_delete` also persists to the DB header on fresh DBs, so the protection survives process restarts.

**About disclosure:** This is a data integrity fix, not a security vulnerability under the project's SECURITY.md §3.2. Database hardening is explicitly welcome as a public PR here — it doesn't cross OS-level isolation boundaries and doesn't fall under the in-scope categories. No private disclosure needed.

## Related Issues

This PR addresses one piece of a broader cluster of open kanban-DB-corruption reports:

- Refs #30445 (kanban DB corruption risk from multi-gateway concurrent SQLite access)
- Refs #30896 (kanban: rapid worker spawn-crash loop corrupts board SQLite B-tree)
- Refs #30908 (kanban.db index corruption after frequent gateway restarts)

The three pragma changes here are defense-in-depth at the page layer; they do not fix the dispatcher-level write amplification or the gateway-restart latch in those issues but they reduce blast radius when those scenarios fire.

## Related PRs

- Refs #30645 (synchronous=FULL only) — this PR's `synchronous=FULL` change overlaps; the additional `secure_delete` and `cell_size_check` pragmas are unique to this PR. Up to maintainers which to land.
- Refs #30654 (state.db: synchronous=FULL + TRUNCATE checkpoint) — sibling DB, same pragma philosophy. Complementary.
- Refs #30700 (state.db: retry transient SQLite WAL setup failures, Fixes #30576) — adjacent error-recovery angle on the sibling DB.
- Refs #30969 (DB-backed dispatcher leases, fail-closed corrupt-DB backup, reconcile-completions safeguards) — same area of kanban_db.py, complementary scope (this PR is page-layer hardening; #30969 is dispatcher-layer hardening + recovery). The two PRs may merge-conflict on `kanban_db.py` but address different failure modes.
- Refs #30973 (synchronous=FULL + wal_autocheckpoint for a different root cause) — wal_autocheckpoint is orthogonal; not included here.

Refreshed prior-art snapshot at packaging time (2026-05-23 17:30 PT); these references reflect upstream state at PR open.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `PRAGMA secure_delete=ON` to `connect()` with a comment explaining why (Bug E forensics: torn-write signature, stale-cell-content exposure)
- Add `PRAGMA cell_size_check=ON` to `connect()`
- Change `PRAGMA synchronous=NORMAL` to `PRAGMA synchronous=FULL`
- Four new tests in `tests/hermes_cli/test_kanban_db.py`:
  - `test_connect_sets_secure_delete_on`
  - `test_connect_sets_cell_size_check_on`
  - `test_connect_sets_synchronous_full`
  - `test_connect_pragmas_applied_on_reconnect`

## How to Test

Run the kanban DB tests:

```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py -q
```

All four new tests pass, confirming each pragma is set on fresh and reconnected connections. Full test suite also passes (no behavior changes).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform


