### PR TITLE
fix(tui): suppress mouse-residue leaks during Python launcher startup

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -65,6 +65,33 @@ import os
 import sys
 
 
+# Mouse-tracking residue suppression — runs BEFORE every other import on the
+# TUI hot path so the terminal stops emitting SGR/X10 mouse reports while the
+# Python launcher is still doing imports (≈100–300ms in raw cooked mode where
+# any incoming bytes are echoed straight back to the user's shell scrollback
+# as ``^[[<…M`` text). The TUI itself runs `resetTerminalModes()` again in
+# `entry.tsx`; this is just the earlier cousin. ``HERMES_TUI_NO_EARLY_DISABLE``
+# escapes the behaviour for diagnostics.
+def _suppress_mouse_residue_early() -> None:
+    if os.environ.get("HERMES_TUI_NO_EARLY_DISABLE") == "1":
+        return
+    if not (os.environ.get("HERMES_TUI") == "1" or "--tui" in sys.argv[1:]):
+        return
+    try:
+        # Disable every mouse-tracking variant we know about. Idempotent and
+        # safe to send even when no tracking is currently asserted.
+        os.write(
+            1,
+            b"\x1b[?1003l\x1b[?1002l\x1b[?1001l\x1b[?1000l\x1b[?9l"
+            b"\x1b[?1006l\x1b[?1005l\x1b[?1015l\x1b[?1016l\x1b[?2029l",
+        )
+    except OSError:
+        pass
+
+
+_suppress_mouse_residue_early()
+
+
 def _is_termux_startup_environment_fast() -> bool:
     """Tiny Termux check for pre-import startup shortcuts."""
     prefix = os.environ.get("PREFIX", "")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -67,9 +67,10 @@ import sys
 
 # Mouse-tracking residue suppression — runs BEFORE every other import on the
 # TUI hot path so the terminal stops emitting SGR/X10 mouse reports while the
-# Python launcher is still doing imports (≈100–300ms in raw cooked mode where
-# any incoming bytes are echoed straight back to the user's shell scrollback
-# as ``^[[<…M`` text). The TUI itself runs `resetTerminalModes()` again in
+# Python launcher is still doing imports (≈100–300ms in cooked + echo mode,
+# before the Node TUI takes stdin into raw mode). During that window any
+# incoming bytes are echoed straight back to the user's shell scrollback as
+# ``^[[<…M`` text. The TUI itself runs `resetTerminalModes()` again in
 # `entry.tsx`; this is just the earlier cousin. ``HERMES_TUI_NO_EARLY_DISABLE``
 # escapes the behaviour for diagnostics.
 def _suppress_mouse_residue_early() -> None:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -78,6 +78,11 @@ def _suppress_mouse_residue_early() -> None:
     if not (os.environ.get("HERMES_TUI") == "1" or "--tui" in sys.argv[1:]):
         return
     try:
+        # Skip when stdout is redirected (`hermes --tui … >log`, CI capture):
+        # the bytes can't reach the terminal anyway and would just pollute
+        # the log with raw CSI.
+        if not os.isatty(1):
+            return
         # Disable every mouse-tracking variant we know about. Idempotent and
         # safe to send even when no tracking is currently asserted.
         os.write(

--- a/tests/hermes_cli/test_tui_mouse_residue_suppression.py
+++ b/tests/hermes_cli/test_tui_mouse_residue_suppression.py
@@ -1,0 +1,92 @@
+"""Tests for the TUI-hot-path mouse-residue suppression.
+
+The Python launcher (`hermes --tui …`) has a ~100–300ms cold-start window
+where stdin is still in cooked + echo mode. If a previous Hermes session
+left DEC mouse-tracking asserted, any mouse motion during that window
+echoes literal ``^[[<…M`` text into the user's scrollback.
+
+`_suppress_mouse_residue_early()` writes the disable sequence to stdout
+before the heavy imports so the terminal stops emitting events ASAP.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+
+def _reload_main():
+    """Reimport `hermes_cli.main` from scratch so module-level code re-runs."""
+    sys.modules.pop("hermes_cli.main", None)
+    import hermes_cli.main  # noqa: F401
+
+
+class TestEarlyMouseDisable:
+    def _expected(self) -> bytes:
+        return (
+            b"\x1b[?1003l\x1b[?1002l\x1b[?1001l\x1b[?1000l\x1b[?9l"
+            b"\x1b[?1006l\x1b[?1005l\x1b[?1015l\x1b[?1016l\x1b[?2029l"
+        )
+
+    def test_writes_disable_sequence_when_tui_flag_in_argv(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["hermes", "--tui", "-c", "abc"])
+        monkeypatch.delenv("HERMES_TUI", raising=False)
+        monkeypatch.delenv("HERMES_TUI_NO_EARLY_DISABLE", raising=False)
+
+        with patch("os.write") as mock_write:
+            from hermes_cli.main import _suppress_mouse_residue_early
+
+            _suppress_mouse_residue_early()
+
+        mock_write.assert_called_once_with(1, self._expected())
+
+    def test_writes_disable_sequence_when_hermes_tui_env_set(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["hermes"])
+        monkeypatch.setenv("HERMES_TUI", "1")
+        monkeypatch.delenv("HERMES_TUI_NO_EARLY_DISABLE", raising=False)
+
+        with patch("os.write") as mock_write:
+            from hermes_cli.main import _suppress_mouse_residue_early
+
+            _suppress_mouse_residue_early()
+
+        mock_write.assert_called_once_with(1, self._expected())
+
+    def test_no_op_on_non_tui_invocation(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["hermes", "--version"])
+        monkeypatch.delenv("HERMES_TUI", raising=False)
+        monkeypatch.delenv("HERMES_TUI_NO_EARLY_DISABLE", raising=False)
+
+        with patch("os.write") as mock_write:
+            from hermes_cli.main import _suppress_mouse_residue_early
+
+            _suppress_mouse_residue_early()
+
+        mock_write.assert_not_called()
+
+    def test_respects_diagnostic_escape_hatch(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["hermes", "--tui"])
+        monkeypatch.delenv("HERMES_TUI", raising=False)
+        monkeypatch.setenv("HERMES_TUI_NO_EARLY_DISABLE", "1")
+
+        with patch("os.write") as mock_write:
+            from hermes_cli.main import _suppress_mouse_residue_early
+
+            _suppress_mouse_residue_early()
+
+        mock_write.assert_not_called()
+
+    def test_oserror_is_swallowed(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["hermes", "--tui"])
+        monkeypatch.delenv("HERMES_TUI", raising=False)
+        monkeypatch.delenv("HERMES_TUI_NO_EARLY_DISABLE", raising=False)
+
+        def boom(*_a, **_k):
+            raise OSError("stdout closed")
+
+        with patch("os.write", side_effect=boom):
+            from hermes_cli.main import _suppress_mouse_residue_early
+
+            # Must not propagate — startup hot path can never break.
+            _suppress_mouse_residue_early()

--- a/tests/hermes_cli/test_tui_mouse_residue_suppression.py
+++ b/tests/hermes_cli/test_tui_mouse_residue_suppression.py
@@ -11,35 +11,31 @@ before the heavy imports so the terminal stops emitting events ASAP.
 
 from __future__ import annotations
 
-import os
 import sys
 from unittest.mock import patch
 
+# Importing the module triggers `_suppress_mouse_residue_early()` at module
+# scope. Under the test runner argv (`pytest …`) it's a no-op, but we import
+# at file scope so individual tests don't race the import side-effect with
+# their `patch("os.write")` context.
+from hermes_cli.main import _suppress_mouse_residue_early
 
-def _reload_main():
-    """Reimport `hermes_cli.main` from scratch so module-level code re-runs."""
-    sys.modules.pop("hermes_cli.main", None)
-    import hermes_cli.main  # noqa: F401
+EXPECTED = (
+    b"\x1b[?1003l\x1b[?1002l\x1b[?1001l\x1b[?1000l\x1b[?9l"
+    b"\x1b[?1006l\x1b[?1005l\x1b[?1015l\x1b[?1016l\x1b[?2029l"
+)
 
 
 class TestEarlyMouseDisable:
-    def _expected(self) -> bytes:
-        return (
-            b"\x1b[?1003l\x1b[?1002l\x1b[?1001l\x1b[?1000l\x1b[?9l"
-            b"\x1b[?1006l\x1b[?1005l\x1b[?1015l\x1b[?1016l\x1b[?2029l"
-        )
-
     def test_writes_disable_sequence_when_tui_flag_in_argv(self, monkeypatch):
         monkeypatch.setattr(sys, "argv", ["hermes", "--tui", "-c", "abc"])
         monkeypatch.delenv("HERMES_TUI", raising=False)
         monkeypatch.delenv("HERMES_TUI_NO_EARLY_DISABLE", raising=False)
 
         with patch("os.write") as mock_write:
-            from hermes_cli.main import _suppress_mouse_residue_early
-
             _suppress_mouse_residue_early()
 
-        mock_write.assert_called_once_with(1, self._expected())
+        mock_write.assert_called_once_with(1, EXPECTED)
 
     def test_writes_disable_sequence_when_hermes_tui_env_set(self, monkeypatch):
         monkeypatch.setattr(sys, "argv", ["hermes"])
@@ -47,11 +43,9 @@ class TestEarlyMouseDisable:
         monkeypatch.delenv("HERMES_TUI_NO_EARLY_DISABLE", raising=False)
 
         with patch("os.write") as mock_write:
-            from hermes_cli.main import _suppress_mouse_residue_early
-
             _suppress_mouse_residue_early()
 
-        mock_write.assert_called_once_with(1, self._expected())
+        mock_write.assert_called_once_with(1, EXPECTED)
 
     def test_no_op_on_non_tui_invocation(self, monkeypatch):
         monkeypatch.setattr(sys, "argv", ["hermes", "--version"])
@@ -59,8 +53,6 @@ class TestEarlyMouseDisable:
         monkeypatch.delenv("HERMES_TUI_NO_EARLY_DISABLE", raising=False)
 
         with patch("os.write") as mock_write:
-            from hermes_cli.main import _suppress_mouse_residue_early
-
             _suppress_mouse_residue_early()
 
         mock_write.assert_not_called()
@@ -71,8 +63,6 @@ class TestEarlyMouseDisable:
         monkeypatch.setenv("HERMES_TUI_NO_EARLY_DISABLE", "1")
 
         with patch("os.write") as mock_write:
-            from hermes_cli.main import _suppress_mouse_residue_early
-
             _suppress_mouse_residue_early()
 
         mock_write.assert_not_called()
@@ -86,7 +76,5 @@ class TestEarlyMouseDisable:
             raise OSError("stdout closed")
 
         with patch("os.write", side_effect=boom):
-            from hermes_cli.main import _suppress_mouse_residue_early
-
             # Must not propagate — startup hot path can never break.
             _suppress_mouse_residue_early()

--- a/tests/hermes_cli/test_tui_mouse_residue_suppression.py
+++ b/tests/hermes_cli/test_tui_mouse_residue_suppression.py
@@ -32,7 +32,7 @@ class TestEarlyMouseDisable:
         monkeypatch.delenv("HERMES_TUI", raising=False)
         monkeypatch.delenv("HERMES_TUI_NO_EARLY_DISABLE", raising=False)
 
-        with patch("os.write") as mock_write:
+        with patch("os.isatty", return_value=True), patch("os.write") as mock_write:
             _suppress_mouse_residue_early()
 
         mock_write.assert_called_once_with(1, EXPECTED)
@@ -42,7 +42,7 @@ class TestEarlyMouseDisable:
         monkeypatch.setenv("HERMES_TUI", "1")
         monkeypatch.delenv("HERMES_TUI_NO_EARLY_DISABLE", raising=False)
 
-        with patch("os.write") as mock_write:
+        with patch("os.isatty", return_value=True), patch("os.write") as mock_write:
             _suppress_mouse_residue_early()
 
         mock_write.assert_called_once_with(1, EXPECTED)
@@ -67,6 +67,18 @@ class TestEarlyMouseDisable:
 
         mock_write.assert_not_called()
 
+    def test_skips_when_stdout_is_not_a_tty(self, monkeypatch):
+        # `hermes --tui … >log` or CI capture: pipe is fd 1, not a TTY. The
+        # bytes can't reach a terminal and would just pollute the log.
+        monkeypatch.setattr(sys, "argv", ["hermes", "--tui"])
+        monkeypatch.delenv("HERMES_TUI", raising=False)
+        monkeypatch.delenv("HERMES_TUI_NO_EARLY_DISABLE", raising=False)
+
+        with patch("os.isatty", return_value=False), patch("os.write") as mock_write:
+            _suppress_mouse_residue_early()
+
+        mock_write.assert_not_called()
+
     def test_oserror_is_swallowed(self, monkeypatch):
         monkeypatch.setattr(sys, "argv", ["hermes", "--tui"])
         monkeypatch.delenv("HERMES_TUI", raising=False)
@@ -75,6 +87,6 @@ class TestEarlyMouseDisable:
         def boom(*_a, **_k):
             raise OSError("stdout closed")
 
-        with patch("os.write", side_effect=boom):
+        with patch("os.isatty", return_value=True), patch("os.write", side_effect=boom):
             # Must not propagate — startup hot path can never break.
             _suppress_mouse_residue_early()


### PR DESCRIPTION
## Summary

\`hermes --tui …\` spends ~100–300ms inside the Python launcher (lazy imports, arg parsing, session resolution) before exec'ing the Node TUI binary. During that window stdin is still in **cooked + echo** mode. If a prior session left DEC mouse-tracking asserted (or the user spammed mouse movement while the previous session was opening), the terminal keeps emitting \`\\x1b[<…M\` SGR motion reports that get echoed straight back into the user's shell scrollback as literal \`^[[<…M\` text and sit there above the TUI banner.

## Repro

Bertl reported it on WSL2 / Ubuntu: \`hermes --tui -c <SESSION_ID>\` + mouse spam during the cold-start window. Variable — only happens when the user wins the race against the launcher reaching Node + raw-mode setup.

I reproduced the same shape with a PTY harness: inject SGR motion bytes immediately after \`pty.fork()\` and the leaked \`^[[<…M\` text appears in stdout before \`\\x1b[?1049h\` (alt-screen enter). Same byte-for-byte on \`main\` and on every open PR — this is **not** a regression from #31077 / #31176.

## Fix

The Node side already calls \`resetTerminalModes()\` in \`entry.tsx\`, but by then the race is already lost. This PR writes the mouse-tracking disable sequence at the very top of \`hermes_cli.main\`, before every heavy import:

\`\`\`python
def _suppress_mouse_residue_early() -> None:
    if os.environ.get(\"HERMES_TUI_NO_EARLY_DISABLE\") == \"1\":
        return
    if not (os.environ.get(\"HERMES_TUI\") == \"1\" or \"--tui\" in sys.argv[1:]):
        return
    try:
        os.write(1, b\"\\x1b[?1003l\\x1b[?1002l\\x1b[?1001l\\x1b[?1000l\\x1b[?9l\"
                    b\"\\x1b[?1006l\\x1b[?1005l\\x1b[?1015l\\x1b[?1016l\\x1b[?2029l\")
    except OSError:
        pass
\`\`\`

Once those bytes reach the terminal (one TTY round-trip, ~1ms) it stops emitting motion events. Race window shrinks from hundreds of ms to a few.

- Only fires for TUI invocations (gated on \`--tui\` arg or \`HERMES_TUI=1\`).
- \`HERMES_TUI_NO_EARLY_DISABLE=1\` opts out for diagnostics.
- All errors swallowed — the launcher hot path must never break.

## Tests

\`tests/hermes_cli/test_tui_mouse_residue_suppression.py\`:
- writes the disable sequence when \`--tui\` is in argv
- writes it when \`HERMES_TUI=1\` env is set
- no-op on non-TUI invocations (\`hermes --version\`)
- respects \`HERMES_TUI_NO_EARLY_DISABLE\` escape hatch
- swallows OSError on a broken stdout

\`\`\`
scripts/run_tests.sh tests/hermes_cli/test_tui_mouse_residue_suppression.py
=> 5 passed
\`\`\`

## Out of scope

- Doesn't address bytes that were already echoed *before* the Python process even started (those are in the terminal's frame buffer / scrollback before we exist).
- Doesn't change the Node-side cleanup behaviour — the existing \`resetTerminalModes()\` in \`entry.tsx\` and the alt-screen mount disable are unchanged.