### PR TITLE
feat(plugins): add secret guard plugin

### DIFF
--- a/plugins/secret-guard/__init__.py
+++ b/plugins/secret-guard/__init__.py
@@ -1,0 +1,257 @@
+"""Block and redact GitHub PAT-like credentials.
+
+The plugin protects multiple boundaries:
+
+- ``pre_gateway_dispatch`` blocks inbound gateway messages before they reach
+  the agent loop.
+- ``pre_tool_call`` blocks tool calls whose arguments contain sensitive tokens
+  or upstream scanner notices.
+- transform hooks redact credentials from tool results, terminal output, and
+  final assistant output.
+
+Detection records are written without payloads or matched substrings.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+LOGGER = logging.getLogger(__name__)
+REDACTION = "[REDACTED_GITHUB_PAT]"
+SCAN_NOTICE_REDACTION = "[REDACTED_SECURITY_SCAN_NOTICE]"
+
+# GitHub token families are matched by provider-specific prefixes. The regex
+# strings are assembled from fragments so source scanners do not flag this file
+# as containing a token-like literal.
+SHORT_PREFIX_PATTERN = r"\b" + "gh" + r"[pousr]_[A-Za-z0-9_]{30,255}\b"
+FINE_GRAINED_PREFIX_PATTERN = r"\b" + "github" + r"_pat_[A-Za-z0-9_]{50,255}\b"
+SECRET_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(SHORT_PREFIX_PATTERN),
+    re.compile(FINE_GRAINED_PREFIX_PATTERN),
+)
+
+# Some frontends/security layers replace the actual secret with a diagnostic
+# notice before Hermes sees the text. Treat those as sensitive too: the token
+# is already gone, but we still want to skip the agent/tool path and tell the
+# user to revoke/rotate. These regex strings are also assembled from fragments
+# to keep repository scanners quiet.
+SCAN_NOTICE_PATTERN = r"Security scan\s*[—:-].*" + "Git" + r"Hub PAT detected"
+PROVIDER_NOTICE_PATTERN = "credential matching a known " + "provider pattern"
+SECURITY_SCAN_NOTICE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(SCAN_NOTICE_PATTERN, re.IGNORECASE | re.DOTALL),
+    re.compile(PROVIDER_NOTICE_PATTERN, re.IGNORECASE),
+)
+
+INBOUND_WARNING = (
+    "⚠️ This message appears to contain a GitHub PAT/token. "
+    "It will not be passed to the agent or tools. "
+    "If this was a real token, revoke/rotate it in GitHub immediately. "
+    "Store secrets in `~/.hermes/.env`, a credential pool, or environment variables instead."
+)
+
+
+def _log_file():
+    return get_hermes_home() / "logs" / "secret_guard.log"
+
+
+def _to_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, ensure_ascii=False, sort_keys=True, default=str)
+    except Exception:
+        return str(value)
+
+
+def _has_secret(text: str | None) -> bool:
+    candidate = text or ""
+    return any(pattern.search(candidate) for pattern in SECRET_PATTERNS)
+
+
+def _has_security_scan_notice(text: str | None) -> bool:
+    candidate = text or ""
+    return any(pattern.search(candidate) for pattern in SECURITY_SCAN_NOTICE_PATTERNS)
+
+
+def _should_block_sensitive(text: str | None) -> bool:
+    return _has_secret(text) or _has_security_scan_notice(text)
+
+
+def _redact(text: str | None) -> str | None:
+    if text is None:
+        return None
+    redacted = text
+    for pattern in SECRET_PATTERNS:
+        redacted = pattern.sub(REDACTION, redacted)
+    for pattern in SECURITY_SCAN_NOTICE_PATTERNS:
+        redacted = pattern.sub(SCAN_NOTICE_REDACTION, redacted)
+    return redacted
+
+
+def _platform_name(platform: Any) -> str:
+    return str(getattr(platform, "value", platform) or "").lower()
+
+
+def _thread_metadata(source: Any, event: Any) -> dict[str, Any] | None:
+    """Best-effort metadata to reply in the same Telegram topic/thread."""
+    thread_id = getattr(source, "thread_id", None)
+    if thread_id is None:
+        return None
+
+    metadata: dict[str, Any] = {"thread_id": thread_id}
+    if _platform_name(getattr(source, "platform", None)) == "telegram" and getattr(source, "chat_type", None) == "dm":
+        metadata["telegram_dm_topic_reply_fallback"] = True
+        tid = str(thread_id)
+        if tid and tid != "1":
+            metadata["direct_messages_topic_id"] = tid
+        anchor = getattr(event, "message_id", None) or getattr(source, "message_id", None)
+        if anchor is not None:
+            metadata["telegram_reply_to_message_id"] = str(anchor)
+    return metadata
+
+
+def _log_detection(where: str, **fields: Any) -> None:
+    try:
+        log_file = _log_file()
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        entry = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "where": where,
+            **fields,
+        }
+        # Never log payloads or matched substrings here.
+        with log_file.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry, ensure_ascii=False, default=str) + "\n")
+    except Exception as exc:  # pragma: no cover - logging must never break flow
+        LOGGER.debug("secret-guard log write failed: %s", exc)
+
+
+def _schedule_warning(gateway: Any, source: Any, event: Any) -> None:
+    try:
+        adapter = getattr(gateway, "adapters", {}).get(getattr(source, "platform", None))
+        chat_id = getattr(source, "chat_id", None)
+        if not adapter or not chat_id:
+            return
+
+        coro = adapter.send(
+            chat_id,
+            INBOUND_WARNING,
+            metadata=_thread_metadata(source, event),
+        )
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(coro)
+        except RuntimeError:
+            # CLI/unit-test fallback: no running event loop, so just close the coroutine.
+            try:
+                coro.close()
+            except Exception:
+                pass
+    except Exception as exc:  # pragma: no cover - notification failure should not pass secret onward
+        LOGGER.warning("secret-guard failed to schedule gateway warning: %s", exc)
+
+
+def pre_gateway_dispatch(event: Any, gateway: Any, session_store: Any = None, **kwargs: Any):
+    text = getattr(event, "text", "") or ""
+    if not _should_block_sensitive(text):
+        return None
+
+    source = getattr(event, "source", None)
+    _log_detection(
+        "pre_gateway_dispatch",
+        platform=_platform_name(getattr(source, "platform", None)),
+        chat_id=getattr(source, "chat_id", None),
+        user_id=getattr(source, "user_id", None),
+        message_id=getattr(event, "message_id", None),
+        scan_notice=_has_security_scan_notice(text),
+    )
+    _schedule_warning(gateway, source, event)
+    return {"action": "skip", "reason": "secret-guard: sensitive-credential-detected"}
+
+
+def block_tool_call(tool_name: str, args: dict, task_id: str = "", **kwargs: Any):
+    text = _to_text(args)
+    if not _should_block_sensitive(text):
+        return None
+
+    _log_detection(
+        "pre_tool_call",
+        tool_name=tool_name,
+        task_id=task_id,
+        scan_notice=_has_security_scan_notice(text),
+    )
+    return {
+        "action": "block",
+        "message": (
+            "Security policy blocked this tool call: GitHub PAT-like credential "
+            "was detected in tool arguments. If this was a real token, revoke/rotate it; "
+            "use ~/.hermes/.env, credential pools, or environment variables instead."
+        ),
+    }
+
+
+def redact_tool_result(
+    tool_name: str,
+    result: str,
+    args: dict | None = None,
+    task_id: str | None = None,
+    **kwargs: Any,
+):
+    # model_tools invokes this hook with keyword `args=...`.
+    # Keep **kwargs for forward compatibility with future hook fields.
+    redacted = _redact(result)
+    if redacted != result:
+        _log_detection("transform_tool_result", tool_name=tool_name, task_id=task_id)
+        return redacted
+    return None
+
+
+def redact_terminal_output(
+    command: str = "",
+    output: str = "",
+    exit_code: int | None = None,
+    cwd: str = "",
+    task_id: str | None = None,
+    **kwargs: Any,
+):
+    # Terminal hook call sites have evolved; keep all fields optional and
+    # accept **kwargs so the guard remains compatible across Hermes versions.
+    if not output and isinstance(kwargs.get("result"), str):
+        output = kwargs["result"]
+    redacted = _redact(output)
+    if redacted != output:
+        _log_detection("transform_terminal_output", exit_code=exit_code, cwd=cwd, task_id=task_id)
+        return redacted
+    return None
+
+
+def redact_llm_output(
+    response_text: str,
+    session_id: str = "",
+    model: str = "",
+    platform: str = "",
+    **kwargs: Any,
+):
+    redacted = _redact(response_text)
+    if redacted != response_text:
+        _log_detection("transform_llm_output", session_id=session_id, model=model, platform=platform)
+        return redacted
+    return None
+
+
+def register(ctx):
+    LOGGER.info("secret-guard plugin loaded: registering gateway/tool/output hooks")
+    ctx.register_hook("pre_gateway_dispatch", pre_gateway_dispatch)
+    ctx.register_hook("pre_tool_call", block_tool_call)
+    ctx.register_hook("transform_tool_result", redact_tool_result)
+    ctx.register_hook("transform_terminal_output", redact_terminal_output)
+    ctx.register_hook("transform_llm_output", redact_llm_output)

--- a/plugins/secret-guard/plugin.yaml
+++ b/plugins/secret-guard/plugin.yaml
@@ -1,0 +1,11 @@
+name: secret-guard
+version: 1.0.0
+description: "Blocks GitHub PAT-like credentials before they reach tools or the agent."
+author: "Hermes Agent contributors"
+kind: standalone
+hooks:
+  - pre_gateway_dispatch
+  - pre_tool_call
+  - transform_tool_result
+  - transform_terminal_output
+  - transform_llm_output

--- a/tests/test_secret_guard_plugin.py
+++ b/tests/test_secret_guard_plugin.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+
+import yaml
+
+import hermes_cli.plugins as plugins_mod
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PLUGIN_DIR = ROOT / "plugins" / "secret-guard"
+
+
+def _load_plugin_module():
+    spec = importlib.util.spec_from_file_location(
+        "secret_guard_test_plugin", PLUGIN_DIR / "__init__.py"
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _short_secret() -> str:
+    return "gh" + "p_" + ("A" * 30)
+
+
+def _fine_grained_secret() -> str:
+    return "github" + "_pat_" + ("B" * 50)
+
+
+def _scan_notice() -> str:
+    return (
+        "Security scan "
+        + "— "
+        + "Git"
+        + "Hub PAT detected: a credential matching a known "
+        + "provider pattern was found."
+    )
+
+
+def test_secret_patterns_detect_and_redact_without_leaking_to_logs(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+    plugin = _load_plugin_module()
+
+    text = f"alpha {_short_secret()} beta {_fine_grained_secret()} gamma {_scan_notice()}"
+
+    assert plugin._has_secret(text)
+    assert plugin._has_security_scan_notice(text)
+    assert plugin._should_block_sensitive(text)
+
+    redacted = plugin._redact(text)
+    assert plugin.REDACTION in redacted
+    assert plugin.SCAN_NOTICE_REDACTION in redacted
+    assert _short_secret() not in redacted
+    assert _fine_grained_secret() not in redacted
+
+    plugin._log_detection("unit", tool_name="example", scan_notice=True)
+    log_text = (tmp_path / "hermes_home" / "logs" / "secret_guard.log").read_text(
+        encoding="utf-8"
+    )
+    assert _short_secret() not in log_text
+    assert _fine_grained_secret() not in log_text
+    entry = json.loads(log_text.splitlines()[-1])
+    assert entry["where"] == "unit"
+    assert entry["scan_notice"] is True
+
+
+def test_pre_tool_call_blocks_sensitive_args_and_allows_normal_args(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+    plugin = _load_plugin_module()
+
+    assert plugin.block_tool_call("terminal", {"command": "echo safe"}) is None
+
+    blocked = plugin.block_tool_call(
+        "terminal", {"command": "echo " + _scan_notice()}, task_id="task-1", future="ok"
+    )
+    assert blocked["action"] == "block"
+    assert "sensitive" not in blocked["message"].lower()
+    assert "GitHub PAT-like credential" in blocked["message"]
+
+    log_text = (tmp_path / "hermes_home" / "logs" / "secret_guard.log").read_text(
+        encoding="utf-8"
+    )
+    entry = json.loads(log_text.splitlines()[-1])
+    assert entry["where"] == "pre_tool_call"
+    assert entry["tool_name"] == "terminal"
+    assert entry["task_id"] == "task-1"
+    assert entry["scan_notice"] is True
+
+
+def test_transform_hooks_redact_with_tolerant_signatures(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+    plugin = _load_plugin_module()
+
+    tool_result = plugin.redact_tool_result(
+        "demo", "result " + _short_secret(), args={"x": 1}, unexpected="field"
+    )
+    terminal_result = plugin.redact_terminal_output(
+        result="terminal " + _fine_grained_secret(), unknown="field"
+    )
+    llm_result = plugin.redact_llm_output(
+        "assistant " + _scan_notice(), session_id="s", model="m", platform="telegram"
+    )
+
+    assert tool_result == "result " + plugin.REDACTION
+    assert terminal_result == "terminal " + plugin.REDACTION
+    assert plugin.SCAN_NOTICE_REDACTION in llm_result
+    assert "Security scan" not in llm_result
+    assert "provider pattern" not in llm_result
+
+
+def test_pre_gateway_dispatch_skips_and_schedules_warning(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+    plugin = _load_plugin_module()
+
+    sends: list[tuple[str, str, dict | None]] = []
+
+    class Adapter:
+        async def send(self, chat_id, text, metadata=None):
+            sends.append((chat_id, text, metadata))
+
+    async def _run():
+        source = SimpleNamespace(
+            platform="telegram",
+            chat_id="chat-1",
+            user_id="user-1",
+            thread_id="thread-1",
+            chat_type="dm",
+            message_id="source-message",
+        )
+        event = SimpleNamespace(
+            text="please inspect " + _short_secret(),
+            source=source,
+            message_id="event-message",
+        )
+        gateway = SimpleNamespace(adapters={"telegram": Adapter()})
+
+        result = plugin.pre_gateway_dispatch(event=event, gateway=gateway, extra="ignored")
+        await asyncio.sleep(0)
+        return result
+
+    result = asyncio.run(_run())
+
+    assert result == {
+        "action": "skip",
+        "reason": "secret-guard: sensitive-credential-detected",
+    }
+    assert sends
+    chat_id, warning, metadata = sends[0]
+    assert chat_id == "chat-1"
+    assert "revoke/rotate" in warning
+    assert metadata["thread_id"] == "thread-1"
+    assert metadata["direct_messages_topic_id"] == "thread-1"
+    assert metadata["telegram_reply_to_message_id"] == "event-message"
+
+
+def test_bundled_plugin_registers_expected_hooks(monkeypatch, tmp_path):
+    hermes_home = tmp_path / "hermes_home"
+    bundled = tmp_path / "bundled_plugins"
+    shutil.copytree(PLUGIN_DIR, bundled / "secret-guard")
+    (hermes_home / "plugins").mkdir(parents=True)
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": {"enabled": ["secret-guard"]}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(bundled))
+
+    plugins_mod._plugin_manager = plugins_mod.PluginManager()
+    plugins_mod.discover_plugins()
+
+    loaded = plugins_mod._plugin_manager._plugins["secret-guard"]
+    assert loaded.enabled is True
+    assert set(loaded.hooks_registered) == {
+        "pre_gateway_dispatch",
+        "pre_tool_call",
+        "transform_tool_result",
+        "transform_terminal_output",
+        "transform_llm_output",
+    }


### PR DESCRIPTION
## What

Adds an opt-in bundled `secret-guard` plugin that protects Hermes from GitHub PAT-like credential exposure across multiple hook boundaries:

- `pre_gateway_dispatch`: blocks inbound gateway messages before they reach the agent loop and sends a warning reply.
- `pre_tool_call`: blocks tool calls whose arguments contain a matching credential or scanner notice.
- `transform_tool_result`, `transform_terminal_output`, `transform_llm_output`: redact matching credentials/notices before they are persisted or shown.

Detection events are logged to `~/.hermes/logs/secret_guard.log` without payloads or matched substrings.

## Why

Credential scanner notices and accidental pasted tokens can otherwise enter the agent context or tool layer. This plugin provides a defense-in-depth example using the existing Hermes hook lifecycle.

## Security notes

- Does not log credential payloads.
- Uses synthetic test strings only; no real tokens are stored in tests.
- Keeps hook signatures tolerant with `**kwargs` for forward/backward compatibility across Hermes versions.
- Assembles scanner-sensitive test/regex literals from fragments so repository secret scanners do not flag the plugin source itself.

## Testing

Ran locally on Linux:

```bash
python3 -m py_compile plugins/secret-guard/__init__.py tests/test_secret_guard_plugin.py
PYTEST_ADDOPTS='' pytest -q -o addopts='' tests/test_secret_guard_plugin.py
```

Result: `5 passed`.

Note: this checkout's shared environment did not have `pytest-timeout`, so the focused pytest run clears repo addopts with `-o addopts=''`.
