### PR TITLE
fix(signal): strip bot self-mention from group messages before agent dispatch

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -552,6 +552,17 @@ class SignalAdapter(BasePlatformAdapter):
                     "Signal: ignoring group message (require_mention=true, bot not mentioned)"
                 )
                 return
+            # Strip the bot's own @mention from the message text so the agent
+            # doesn't misinterpret "@+15551234567 say hello" as a directive to
+            # contact that phone number. _render_mentions replaces the Signal
+            # ￼ placeholder with @<number-or-uuid>, which looks like an
+            # addressee to the LLM rather than a self-reference.
+            if account_norm:
+                text = text.replace(f"@{account_norm}", "").strip()
+                # Also strip if the mention was rendered using the bot's UUID
+                bot_uuid = self._recipient_uuid_by_number.get(account_norm)
+                if bot_uuid:
+                    text = text.replace(f"@{bot_uuid}", "").strip()
 
         # Extract quote (reply-to) context from Signal dataMessage
         quote_data = data_message.get("quote") or {}


### PR DESCRIPTION
## Problem

When \`SIGNAL_REQUIRE_MENTION=true\`, adding the bot to a Signal group and addressing it with \`@BotName\` produces garbled responses.

**Root cause:** Signal encodes @mentions as the Unicode object replacement character \`U+FFFC\` with out-of-band metadata. The \`_render_mentions\` helper faithfully replaces that placeholder with \`@<phone-number>\` (or \`@<uuid>\`). So a user message like:

> \`@Friday\` say hello

arrives at the agent as:

> \`@+15551234567\` say hello

The LLM then reads \`@+15551234567\` as an *addressee* — a contact to message — rather than a self-reference to the bot. The response reflects that misread (e.g. *"Hello sent to Burton! 👋"* instead of *"Hello! How can I help?"*).

The \`require_mention=false\` path is unaffected because users don't type \`@BotName\`, so \`U+FFFC\` never appears in the message body.

## Fix

After the mention filter confirms the bot was addressed, strip the bot's own rendered \`@mention\` (by phone number, and by UUID if cached from a prior envelope) from the message text before dispatching to the agent.

\`\`\`python
if account_norm:
    text = text.replace(f"@{account_norm}", "").strip()
    bot_uuid = self._recipient_uuid_by_number.get(account_norm)
    if bot_uuid:
        text = text.replace(f"@{bot_uuid}", "").strip()
\`\`\`

Edge case handled: if someone sends *only* \`@BotName\` with no other text, stripping leaves an empty string which the existing contentless-envelope check catches — no spurious agent turn is triggered.

## Test plan

- [ ] Set \`SIGNAL_REQUIRE_MENTION=true\`, add bot to a Signal group
- [ ] Send \`@BotName say hello\` — agent should respond naturally to "say hello", not as if contacting a phone number
- [ ] Send just \`@BotName\` with no other text — bot should stay silent
- [ ] Verify \`SIGNAL_REQUIRE_MENTION=false\` (default) behavior is unchanged