### PR TITLE
fix(launchd): self-heal missing plist in launchd_restart()

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3054,6 +3054,12 @@ def launchd_restart():
         # Job not loaded — bootstrap and start fresh
         print("↻ launchd job was unloaded; reloading")
         plist_path = get_launchd_plist_path()
+        # Self-heal: if the plist was deleted (e.g., incomplete setup wizard
+        # run) recreate it before bootstrapping — mirrors launchd_start().
+        if not plist_path.exists():
+            print("↻ launchd plist missing; regenerating service definition")
+            plist_path.parent.mkdir(parents=True, exist_ok=True)
+            plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
         subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
         subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)
         print("✓ Service restarted")


### PR DESCRIPTION

    What does this PR do?

    When the launchd plist is missing (e.g. incomplete setup wizard run), launchd_restart() fails with bootstrap failed: 5: Input/output error because it tries to bootstrap a non-existent file.

    Adds the same self-heal check already present in launchd_start(): if the plist doesn't exist, regenerate it with generate_launchd_plist() before calling launchctl bootstrap. This mirrors the pattern at line ~2943 in launchd_start().

    Related Issue

    <!-- No pre-existing issue filed — this PR is the first report. -->

    Type of Change

    - [x] 🐛 Bug fix (non-breaking change that fixes an issue)

    Changes Made

    - hermes_cli/gateway.py — Added plist existence check + regeneration in the fallback path of launchd_restart() (6 lines added)

    How to Test

    1. On macOS, delete the launchd plist: rm ~/Library/LaunchAgents/ai.hermes.gateway.plist
    2. Ensure the gateway is running: hermes gateway status
    3. Run hermes gateway restart
    4. Before fix: fails with Bootstrap failed: 5: Input/output error
    5. After fix: prints ↻ launchd plist missing; regenerating service definition and restarts successfully

    Checklist

    Code

    - [x] I've read the Contributing Guide
    - [x] My commit messages follow Conventional Commits (fix(launchd): ...)
    - [x] I searched for existing PRs to make sure this isn't a duplicate
    - [x] My PR contains only changes related to this fix
    - [x] I've run pytest tests/ -q and all tests pass (13/13 launchd tests pass)
    - [ ] I've added tests for my changes (covered by existing launchd tests)
    - [x] I've tested on my platform: macOS 15.6.1

    Documentation & Housekeeping

    - [x] N/A — no config keys, docs, or architecture changes
    - [x] Considered cross-platform impact: change is macOS-only (launchd_restart()), no effect on Linux/Windows

    Screenshots /Logs

    Before fix:

    ⚠ Gateway drain timed out after 180s — forcing launchd restart
    Could not find service "ai.hermes.gateway" in domain for user gui: 501
    ↻ launchd job was unloaded; reloading
    Bootstrap failed: 5: Input/output error
    ✗   Restart failed


    After fix:

    ↻ launchd job was unloaded; reloading
    ↻ launchd plist missing; regenerating service definition
    ✓ Service restarted