### PR TITLE
feat(gateway): eager typing indicator during agent thinking phase

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1323,6 +1323,15 @@ class BasePlatformAdapter(ABC):
         # Chats where typing indicator is paused (e.g. during approval waits).
         # _keep_typing skips send_typing when the chat_id is in this set.
         self._typing_paused: set = set()
+        # Eager typing tasks keyed by chat_id — see _start_eager_typing.
+        self._eager_typing_tasks: Dict[str, asyncio.Task] = {}
+
+    # Adapters with short platform-side typing expiry (Telegram/Discord ~5s)
+    # should override these in the subclass so the refresh cadence stays
+    # below the expiry window.  Per-deployment overrides go through
+    # ``platforms.<name>.extra.eager_typing_interval`` in config.yaml.
+    EAGER_TYPING_DEFAULT_INTERVAL: float = 8.0
+    EAGER_TYPING_DEFAULT_MAX_ITERATIONS: int = 12
 
     @property
     def message_len_fn(self) -> Callable[[str], int]:
@@ -2294,6 +2303,185 @@ class BasePlatformAdapter(ABC):
                     pass
             self._typing_paused.discard(chat_id)
 
+    def _eager_typing_enabled(self) -> bool:
+        """Whether eager typing is enabled for this adapter.
+
+        Disabled by default — opt in per platform via
+        ``platforms.<name>.extra.eager_typing: true`` in ``config.yaml``.
+        Adapters that do not override :py:meth:`send_typing` skip eager
+        typing entirely so Email / SMS / Webhook see no behavior change
+        regardless of the config flag.
+        """
+        if type(self).send_typing is BasePlatformAdapter.send_typing:
+            return False
+        return bool(self.config.extra.get("eager_typing", False))
+
+    def _eager_typing_interval(self) -> float:
+        override = self.config.extra.get("eager_typing_interval")
+        if override is not None:
+            try:
+                value = float(override)
+                if value > 0:
+                    return value
+            except (TypeError, ValueError):
+                pass
+        return float(self.EAGER_TYPING_DEFAULT_INTERVAL)
+
+    def _eager_typing_max_iterations(self) -> int:
+        override = self.config.extra.get("eager_typing_max_iterations")
+        if override is not None:
+            try:
+                value = int(override)
+                if value > 0:
+                    return value
+            except (TypeError, ValueError):
+                pass
+        return int(self.EAGER_TYPING_DEFAULT_MAX_ITERATIONS)
+
+    async def _start_eager_typing(
+        self,
+        chat_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[asyncio.Task]:
+        """Fire-and-refresh a typing indicator during the pre-response phase.
+
+        Called from :py:meth:`handle_message` the moment an inbound event has
+        been parsed so the user sees a typing bubble during the agent's
+        "thinking" phase — before tool calls and reasoning emit any tokens.
+        Returns the task so callers can cancel it when response delivery
+        starts; :py:meth:`_process_message_background` cancels it before the
+        main :py:meth:`_keep_typing` loop takes over so the two never
+        double-fire.
+
+        No-ops (returning ``None``) when :py:meth:`_eager_typing_enabled`
+        returns ``False`` (default) or when no ``chat_id`` is provided.
+        """
+        if not chat_id or not self._eager_typing_enabled():
+            return None
+
+        existing = self._eager_typing_tasks.get(chat_id)
+        if existing is not None and not existing.done():
+            return existing
+        if existing is not None:
+            self._eager_typing_tasks.pop(chat_id, None)
+
+        interval = self._eager_typing_interval()
+        max_iterations = self._eager_typing_max_iterations()
+        send_typing_timeout = max(0.25, min(1.5, interval - 0.25))
+
+        async def _loop() -> None:
+            cancelled = False
+            try:
+                for _ in range(max_iterations):
+                    if chat_id in self._typing_paused:
+                        await asyncio.sleep(interval)
+                        continue
+                    try:
+                        await asyncio.wait_for(
+                            self.send_typing(chat_id, metadata=metadata),
+                            timeout=send_typing_timeout,
+                        )
+                    except asyncio.TimeoutError:
+                        pass
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as typing_err:
+                        logger.debug(
+                            "[%s] eager send_typing error (non-fatal): %s",
+                            self.name, typing_err,
+                        )
+                    await asyncio.sleep(interval)
+            except asyncio.CancelledError:
+                cancelled = True
+                raise
+            finally:
+                # Natural exit (max_iterations reached, no canceller exists)
+                # must clear platform-side typing state so Discord's self-
+                # refreshing send_typing loop doesn't keep pinging forever
+                # and Matrix's set_typing(timeout=30000) bubble doesn't
+                # linger up to 30s — the issue #6016 class of bug.
+                # On cancel, the canceller is responsible for stop_typing
+                # (so _cancel_eager_typing's suppress_stop flag controls
+                # the handoff flicker case).
+                if not cancelled:
+                    stop_typing_fn = getattr(self, "stop_typing", None)
+                    if stop_typing_fn is not None:
+                        try:
+                            await stop_typing_fn(chat_id)
+                        except asyncio.CancelledError:
+                            raise
+                        except Exception:
+                            logger.debug(
+                                "[%s] eager stop_typing error on natural exit",
+                                self.name, exc_info=True,
+                            )
+
+        task = asyncio.create_task(_loop())
+        self._eager_typing_tasks[chat_id] = task
+        return task
+
+    async def _cancel_eager_typing(
+        self,
+        chat_id: str,
+        *,
+        suppress_stop: bool = False,
+    ) -> None:
+        """Cancel and await cleanup of the eager typing task for ``chat_id``.
+
+        Safe to call from anywhere — no-ops if there is no active eager
+        task.  Bounded by a 0.5s wait so a stuck send_typing inside the
+        eager loop can't stall the caller.
+
+        ``suppress_stop`` skips the post-cancel ``stop_typing`` call.  Pass
+        ``True`` only from the handoff site in ``_process_message_background``
+        where ``_keep_typing`` is about to re-fire ``send_typing`` on the
+        same chat — calling ``stop_typing`` there would briefly clear the
+        platform-side bubble and let it flicker before the next refresh.
+        Every other cancel path (early-exit in ``handle_message``, shutdown,
+        orphaned eager fires) MUST leave ``suppress_stop=False`` so the
+        platform indicator is actually cleared.
+        """
+        if not chat_id:
+            return
+        task = self._eager_typing_tasks.pop(chat_id, None)
+        if task is None or task.done():
+            if not suppress_stop:
+                stop_typing_fn = getattr(self, "stop_typing", None)
+                if stop_typing_fn is not None:
+                    try:
+                        await stop_typing_fn(chat_id)
+                    except Exception:
+                        logger.debug(
+                            "[%s] stop_typing failed during cancel of done/missing eager task",
+                            self.name, exc_info=True,
+                        )
+            return
+        task.cancel()
+        try:
+            await asyncio.wait_for(asyncio.shield(task), timeout=0.5)
+        except (asyncio.CancelledError, asyncio.TimeoutError):
+            pass
+        except Exception:
+            logger.debug(
+                "[%s] _cancel_eager_typing unexpected error",
+                self.name, exc_info=True,
+            )
+        if suppress_stop:
+            return
+        # Belt-and-suspenders: the eager loop's own finally already calls
+        # stop_typing on cancellation, but if the task was wedged past the
+        # 0.5s shield window we still want the platform indicator cleared
+        # before we hand control back to the caller.
+        stop_typing_fn = getattr(self, "stop_typing", None)
+        if stop_typing_fn is not None:
+            try:
+                await stop_typing_fn(chat_id)
+            except Exception:
+                logger.debug(
+                    "[%s] stop_typing failed during eager cancel",
+                    self.name, exc_info=True,
+                )
+
     def pause_typing_for_chat(self, chat_id: str) -> None:
         """Pause typing indicator for a chat (e.g. during approval waits).
 
@@ -2821,109 +3009,84 @@ class BasePlatformAdapter(ABC):
             return
 
         coerce_plaintext_gateway_command(event)
-        
-        session_key = build_session_key(
-            event.source,
-            group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
-            thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
-        )
 
-        # On-entry self-heal: if the adapter still has an _active_sessions
-        # entry for this key but the owner task has already exited (done or
-        # cancelled), the lock is stale.  Clear it and fall through to
-        # normal dispatch so the user isn't trapped behind a dead guard —
-        # this is the split-brain tail described in issue #11016.
-        if session_key in self._active_sessions:
-            self._heal_stale_session_lock(session_key)
-
-        # Check if there's already an active handler for this session
-        if session_key in self._active_sessions:
-            # Certain commands must bypass the active-session guard and be
-            # dispatched directly to the gateway runner.  Without this, they
-            # are queued as pending messages and either:
-            #   - leak into the conversation as user text (/stop, /new), or
-            #   - deadlock (/approve, /deny — agent is blocked on Event.wait)
-            #
-            # Dispatch inline: call the message handler directly and send the
-            # response.  Do NOT use _process_message_background — it manages
-            # session lifecycle and its cleanup races with the running task
-            # (see PR #4926).
-            cmd = event.get_command()
-            from hermes_cli.commands import should_bypass_active_session
-
-            if should_bypass_active_session(cmd):
-                # /stop, /new, /reset must cancel the in-flight adapter task
-                # and preserve ordering of queued follow-ups.  Route those
-                # through the dedicated handoff path that serializes
-                # cancellation + runner response + pending drain.
-                if cmd in {"stop", "new", "reset"}:
-                    try:
-                        await self._dispatch_active_session_command(event, session_key, cmd)
-                    except Exception as e:
-                        logger.error(
-                            "[%s] Command '/%s' dispatch failed: %s",
-                            self.name, cmd, e, exc_info=True,
-                        )
-                    return
-
-                # Other bypass commands (/approve, /deny, /status,
-                # /background, /restart) just need direct dispatch — they
-                # don't cancel the running task.
-                logger.debug(
-                    "[%s] Command '/%s' bypassing active-session guard for %s",
-                    self.name, cmd, session_key,
+        # Eager typing: fires immediately so the user sees a typing bubble
+        # during the agent's thinking phase, before _keep_typing starts
+        # inside _process_message_background.  Ownership transfers to the
+        # background task on the spawn path (handed_off=True); the finally
+        # block cancels it for early-exit paths.
+        chat_id_for_typing = getattr(event.source, "chat_id", None)
+        eager_metadata = None
+        if chat_id_for_typing:
+            try:
+                eager_metadata = _thread_metadata_for_source(
+                    event.source, _reply_anchor_for_event(event)
                 )
-                try:
-                    _thread_meta = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
-                    response = await self._message_handler(event)
-                    _text, _eph_ttl = self._unwrap_ephemeral(response)
-                    if _text:
-                        _r = await self._send_with_retry(
-                            chat_id=event.source.chat_id,
-                            content=_text,
-                            reply_to=_reply_anchor_for_event(event),
-                            metadata=_thread_meta,
-                        )
-                        if _eph_ttl > 0 and _r.success and _r.message_id:
-                            self._schedule_ephemeral_delete(
-                                chat_id=event.source.chat_id,
-                                message_id=_r.message_id,
-                                ttl_seconds=_eph_ttl,
+            except Exception:
+                eager_metadata = None
+            try:
+                await self._start_eager_typing(chat_id_for_typing, metadata=eager_metadata)
+            except Exception:
+                logger.debug(
+                    "[%s] _start_eager_typing failed; continuing without eager typing",
+                    self.name, exc_info=True,
+                )
+        handed_off_to_background = False
+
+        try:
+            session_key = build_session_key(
+                event.source,
+                group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
+                thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
+            )
+
+            # On-entry self-heal: if the adapter still has an _active_sessions
+            # entry for this key but the owner task has already exited (done or
+            # cancelled), the lock is stale.  Clear it and fall through to
+            # normal dispatch so the user isn't trapped behind a dead guard —
+            # this is the split-brain tail described in issue #11016.
+            if session_key in self._active_sessions:
+                self._heal_stale_session_lock(session_key)
+
+            # Check if there's already an active handler for this session
+            if session_key in self._active_sessions:
+                # Certain commands must bypass the active-session guard and be
+                # dispatched directly to the gateway runner.  Without this, they
+                # are queued as pending messages and either:
+                #   - leak into the conversation as user text (/stop, /new), or
+                #   - deadlock (/approve, /deny — agent is blocked on Event.wait)
+                #
+                # Dispatch inline: call the message handler directly and send the
+                # response.  Do NOT use _process_message_background — it manages
+                # session lifecycle and its cleanup races with the running task
+                # (see PR #4926).
+                cmd = event.get_command()
+                from hermes_cli.commands import should_bypass_active_session
+
+                if should_bypass_active_session(cmd):
+                    # /stop, /new, /reset must cancel the in-flight adapter task
+                    # and preserve ordering of queued follow-ups.  Route those
+                    # through the dedicated handoff path that serializes
+                    # cancellation + runner response + pending drain.
+                    if cmd in {"stop", "new", "reset"}:
+                        try:
+                            await self._dispatch_active_session_command(event, session_key, cmd)
+                        except Exception as e:
+                            logger.error(
+                                "[%s] Command '/%s' dispatch failed: %s",
+                                self.name, cmd, e, exc_info=True,
                             )
-                except Exception as e:
-                    logger.error("[%s] Command '/%s' dispatch failed: %s", self.name, cmd, e, exc_info=True)
-                return
+                        return
 
-            # Clarify text-capture bypass: if the agent is blocked on a
-            # clarify_tool call awaiting a free-form text response (open-
-            # ended clarify, or user picked "Other"), the next non-command
-            # message in this session MUST reach the runner so the
-            # clarify-intercept can resolve it and unblock the agent.
-            #
-            # Without this bypass: the message gets queued in
-            # _pending_messages AND triggers an interrupt, killing the
-            # agent run mid-clarify and discarding the user's answer.
-            # Same shape as the /approve deadlock fix (PR #4926) — both
-            # cases are "agent thread blocked on Event.wait, message must
-            # reach the resolver before being treated as a new turn."
-            if not cmd:
-                try:
-                    from tools import clarify_gateway as _clarify_mod
-                    _has_text_clarify = (
-                        _clarify_mod.get_pending_for_session(session_key) is not None
-                    )
-                except Exception:
-                    _has_text_clarify = False
-
-                if _has_text_clarify:
+                    # Other bypass commands (/approve, /deny, /status,
+                    # /background, /restart) just need direct dispatch — they
+                    # don't cancel the running task.
                     logger.debug(
-                        "[%s] Routing message to clarify text-intercept for %s",
-                        self.name, session_key,
+                        "[%s] Command '/%s' bypassing active-session guard for %s",
+                        self.name, cmd, session_key,
                     )
                     try:
-                        _thread_meta = _thread_metadata_for_source(
-                            event.source, _reply_anchor_for_event(event)
-                        )
+                        _thread_meta = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
                         response = await self._message_handler(event)
                         _text, _eph_ttl = self._unwrap_ephemeral(response)
                         if _text:
@@ -2940,59 +3103,120 @@ class BasePlatformAdapter(ABC):
                                     ttl_seconds=_eph_ttl,
                                 )
                     except Exception as e:
-                        logger.error(
-                            "[%s] Clarify text-intercept dispatch failed: %s",
-                            self.name, e, exc_info=True,
-                        )
+                        logger.error("[%s] Command '/%s' dispatch failed: %s", self.name, cmd, e, exc_info=True)
                     return
 
-            if self._busy_session_handler is not None:
-                try:
-                    if await self._busy_session_handler(event, session_key):
+                # Clarify text-capture bypass: if the agent is blocked on a
+                # clarify_tool call awaiting a free-form text response (open-
+                # ended clarify, or user picked "Other"), the next non-command
+                # message in this session MUST reach the runner so the
+                # clarify-intercept can resolve it and unblock the agent.
+                #
+                # Without this bypass: the message gets queued in
+                # _pending_messages AND triggers an interrupt, killing the
+                # agent run mid-clarify and discarding the user's answer.
+                # Same shape as the /approve deadlock fix (PR #4926) — both
+                # cases are "agent thread blocked on Event.wait, message must
+                # reach the resolver before being treated as a new turn."
+                if not cmd:
+                    try:
+                        from tools import clarify_gateway as _clarify_mod
+                        _has_text_clarify = (
+                            _clarify_mod.get_pending_for_session(session_key) is not None
+                        )
+                    except Exception:
+                        _has_text_clarify = False
+
+                    if _has_text_clarify:
+                        logger.debug(
+                            "[%s] Routing message to clarify text-intercept for %s",
+                            self.name, session_key,
+                        )
+                        try:
+                            _thread_meta = _thread_metadata_for_source(
+                                event.source, _reply_anchor_for_event(event)
+                            )
+                            response = await self._message_handler(event)
+                            _text, _eph_ttl = self._unwrap_ephemeral(response)
+                            if _text:
+                                _r = await self._send_with_retry(
+                                    chat_id=event.source.chat_id,
+                                    content=_text,
+                                    reply_to=_reply_anchor_for_event(event),
+                                    metadata=_thread_meta,
+                                )
+                                if _eph_ttl > 0 and _r.success and _r.message_id:
+                                    self._schedule_ephemeral_delete(
+                                        chat_id=event.source.chat_id,
+                                        message_id=_r.message_id,
+                                        ttl_seconds=_eph_ttl,
+                                    )
+                        except Exception as e:
+                            logger.error(
+                                "[%s] Clarify text-intercept dispatch failed: %s",
+                                self.name, e, exc_info=True,
+                            )
                         return
-                except Exception as e:
-                    logger.error("[%s] Busy-session handler failed: %s", self.name, e, exc_info=True)
 
-            # Special case: photo bursts/albums frequently arrive as multiple near-
-            # simultaneous messages. Queue them without interrupting the active run,
-            # then process them immediately after the current task finishes.
-            if event.message_type == MessageType.PHOTO:
-                logger.debug("[%s] Queuing photo follow-up for session %s without interrupt", self.name, session_key)
-                merge_pending_message_event(self._pending_messages, session_key, event)
-                return  # Don't interrupt now - will run after current task completes
+                if self._busy_session_handler is not None:
+                    try:
+                        if await self._busy_session_handler(event, session_key):
+                            return
+                    except Exception as e:
+                        logger.error("[%s] Busy-session handler failed: %s", self.name, e, exc_info=True)
 
-            # Default behavior for non-photo follow-ups: interrupt the running agent.
-            #
-            # Use merge_text=True so rapid TEXT follow-ups (#4469) accumulate
-            # into the single pending slot instead of clobbering each other.
-            # Without merging, three rapid messages "A", "B", "C" land like:
-            #   _pending_messages[k] = A  (interrupts)
-            #   _pending_messages[k] = B  (replaces A before consumer reads)
-            #   _pending_messages[k] = C  (replaces B)
-            # ...and only "C" reaches the next turn.  merge_pending_message_event
-            # already does the right thing for photo/media bursts; the
-            # ``merge_text=True`` flag extends that to plain TEXT events.
-            # Same shape as the Telegram bursty-grace path in gateway/run.py.
-            logger.debug("[%s] New message while session %s is active — triggering interrupt", self.name, session_key)
-            merge_pending_message_event(
-                self._pending_messages,
-                session_key,
-                event,
-                merge_text=True,
-            )
-            # Signal the interrupt (the processing task checks this)
-            self._active_sessions[session_key].set()
-            return  # Don't process now - will be handled after current task finishes
-        
-        # Mark session as active BEFORE spawning background task to close
-        # the race window where a second message arriving before the task
-        # starts would also pass the _active_sessions check and spawn a
-        # duplicate task.  (grammY sequentialize / aiogram EventIsolation
-        # pattern — set the guard synchronously, not inside the task.)
-        # _start_session_processing installs the guard AND the owner-task
-        # mapping atomically so stale-lock detection works.
-        self._start_session_processing(event, session_key)
-    
+                # Special case: photo bursts/albums frequently arrive as multiple near-
+                # simultaneous messages. Queue them without interrupting the active run,
+                # then process them immediately after the current task finishes.
+                if event.message_type == MessageType.PHOTO:
+                    logger.debug("[%s] Queuing photo follow-up for session %s without interrupt", self.name, session_key)
+                    merge_pending_message_event(self._pending_messages, session_key, event)
+                    return  # Don't interrupt now - will run after current task completes
+
+                # Default behavior for non-photo follow-ups: interrupt the running agent.
+                #
+                # Use merge_text=True so rapid TEXT follow-ups (#4469) accumulate
+                # into the single pending slot instead of clobbering each other.
+                # Without merging, three rapid messages "A", "B", "C" land like:
+                #   _pending_messages[k] = A  (interrupts)
+                #   _pending_messages[k] = B  (replaces A before consumer reads)
+                #   _pending_messages[k] = C  (replaces B)
+                # ...and only "C" reaches the next turn.  merge_pending_message_event
+                # already does the right thing for photo/media bursts; the
+                # ``merge_text=True`` flag extends that to plain TEXT events.
+                # Same shape as the Telegram bursty-grace path in gateway/run.py.
+                logger.debug("[%s] New message while session %s is active — triggering interrupt", self.name, session_key)
+                merge_pending_message_event(
+                    self._pending_messages,
+                    session_key,
+                    event,
+                    merge_text=True,
+                )
+                # Signal the interrupt (the processing task checks this)
+                self._active_sessions[session_key].set()
+                return  # Don't process now - will be handled after current task finishes
+
+            # Mark session as active BEFORE spawning background task to close
+            # the race window where a second message arriving before the task
+            # starts would also pass the _active_sessions check and spawn a
+            # duplicate task.  (grammY sequentialize / aiogram EventIsolation
+            # pattern — set the guard synchronously, not inside the task.)
+            # _start_session_processing installs the guard AND the owner-task
+            # mapping atomically so stale-lock detection works.
+            if self._start_session_processing(event, session_key):
+                # Background task owns the eager typing task now.  It will
+                # cancel it before starting the main _keep_typing loop.
+                handed_off_to_background = True
+        finally:
+            if not handed_off_to_background and chat_id_for_typing:
+                try:
+                    await self._cancel_eager_typing(chat_id_for_typing)
+                except Exception:
+                    logger.debug(
+                        "[%s] _cancel_eager_typing failed during handle_message unwind",
+                        self.name, exc_info=True,
+                    )
+
     @staticmethod
     def _get_human_delay() -> float:
         """
@@ -3039,7 +3263,26 @@ class BasePlatformAdapter(ABC):
         # Fall back to a new Event only if the entry was removed externally.
         interrupt_event = self._active_sessions.get(session_key) or asyncio.Event()
         self._active_sessions[session_key] = interrupt_event
-        
+
+        # Cancel eager typing started by handle_message() before _keep_typing
+        # takes over the refresh.  Without this the two tasks would race on
+        # send_typing for the same chat_id.  suppress_stop=True is critical
+        # here: _keep_typing is about to re-fire send_typing on the next tick,
+        # and a stop_typing call between cancel and re-fire causes a visible
+        # bubble flicker on platforms with persistent typing state (Discord,
+        # Matrix).  Every other _cancel_eager_typing call must keep the
+        # default so orphaned eager fires don't leak stale typing indicators.
+        try:
+            await self._cancel_eager_typing(
+                event.source.chat_id,
+                suppress_stop=True,
+            )
+        except Exception:
+            logger.debug(
+                "[%s] _cancel_eager_typing failed at background-task entry",
+                self.name, exc_info=True,
+            )
+
         # Start continuous typing indicator (refreshes every 2 seconds)
         _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
         _keep_typing_kwargs = {"metadata": _thread_metadata}
@@ -3545,6 +3788,25 @@ class BasePlatformAdapter(ABC):
         self._session_tasks.clear()
         self._pending_messages.clear()
         self._active_sessions.clear()
+        # The eager loop no longer self-stops on cancel (so suppress_stop=True
+        # at the handoff site works), which means shutdown must call
+        # stop_typing explicitly to clear any persistent platform-side bubbles
+        # owned by Matrix / Discord internal refresh loops.
+        eager_chat_ids = list(self._eager_typing_tasks.keys())
+        for chat_id, eager_task in list(self._eager_typing_tasks.items()):
+            if eager_task is not None and not eager_task.done():
+                eager_task.cancel()
+        self._eager_typing_tasks.clear()
+        stop_typing_fn = getattr(self, "stop_typing", None)
+        if stop_typing_fn is not None:
+            for chat_id in eager_chat_ids:
+                try:
+                    await stop_typing_fn(chat_id)
+                except Exception:
+                    logger.debug(
+                        "[%s] stop_typing failed during shutdown drain for %s",
+                        self.name, chat_id, exc_info=True,
+                    )
 
     def has_pending_interrupt(self, session_key: str) -> bool:
         """Check if there's a pending interrupt for a session."""

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -925,6 +925,17 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             media_urls=media_urls,
             media_types=media_types,
         )
+
+        # Fire eager typing right here in the webhook handler — before the
+        # background handle_message task spawns — so the typing bubble shows
+        # up in iMessage within ~100ms of webhook receipt instead of waiting
+        # for the agent dispatch pipeline to come online.  handle_message's
+        # own eager_typing call is idempotent and will reuse this task.
+        try:
+            await self._start_eager_typing(session_chat_id)
+        except Exception:
+            logger.debug("[bluebubbles] eager typing start failed", exc_info=True)
+
         task = asyncio.create_task(self.handle_message(event))
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -550,6 +550,14 @@ class DiscordAdapter(BasePlatformAdapter):
     # Auto-disconnect from voice channel after this many seconds of inactivity
     VOICE_TIMEOUT = 300
 
+    # Discord's typing indicator expires after ~10s.  send_typing already
+    # spawns a self-refreshing 8s loop internally (see send_typing below),
+    # so 8s here matches that cadence without adding API pressure.  The
+    # eager loop typically only fires send_typing once before handing off
+    # to _keep_typing because subsequent send_typing calls early-return
+    # (chat_id in self._typing_tasks).
+    EAGER_TYPING_DEFAULT_INTERVAL: float = 8.0
+
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.DISCORD)
         self._client: Optional[commands.Bot] = None

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -332,6 +332,12 @@ class TelegramAdapter(BasePlatformAdapter):
     MEDIA_GROUP_WAIT_SECONDS = 0.8
     _GENERAL_TOPIC_THREAD_ID = "1"
 
+    # Telegram's sendChatAction typing indicator expires after ~5 seconds.
+    # Match the existing _keep_typing cadence (2.0s) so the eager bubble
+    # stays alive across refreshes without flickering at expiry.  Users can
+    # still override via platforms.telegram.extra.eager_typing_interval.
+    EAGER_TYPING_DEFAULT_INTERVAL: float = 2.0
+
     # Telegram's edit_message applies MarkdownV2 formatting only on the
     # finalize=True path.  Without this flag, stream_consumer._send_or_edit
     # short-circuits when the raw text is unchanged between the last streamed

--- a/tests/gateway/test_eager_typing.py
+++ b/tests/gateway/test_eager_typing.py
@@ -1,0 +1,452 @@
+"""Tests for BasePlatformAdapter eager typing.
+
+Eager typing fires a ``send_typing`` indicator the moment ``handle_message`` is
+called so the user sees a typing bubble during the agent's "thinking" phase —
+before the ``_keep_typing`` loop spawned inside ``_process_message_background``
+takes over.  These tests cover:
+
+* the eager loop fires within ~100ms of webhook/handle_message entry
+* the eager task is cancelled before ``_keep_typing`` starts (no double-fire)
+* the eager task is cancelled on early-exit paths of ``handle_message``
+* the feature defaults to disabled and respects ``eager_typing: false``
+* adapters that do not override ``send_typing`` (Email / SMS / Webhook)
+  silently skip the eager loop regardless of the config flag
+"""
+
+import asyncio
+import time
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    Platform,
+    PlatformConfig,
+    SendResult,
+)
+
+
+class _SlowAgentAdapter(BasePlatformAdapter):
+    """Adapter that overrides send_typing so eager typing is enabled."""
+
+    def __init__(self, extra: Optional[dict] = None):
+        if extra is None:
+            extra = {"eager_typing": True}
+        super().__init__(
+            PlatformConfig(enabled=True, token="t", extra=extra),
+            Platform.TELEGRAM,
+        )
+        self.typing_calls: list[tuple[float, str]] = []
+        self.stop_typing_calls: list[str] = []
+        self._start_time = time.monotonic()
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        self._mark_disconnected()
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return SendResult(success=True, message_id="m1")
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        self.typing_calls.append((time.monotonic() - self._start_time, chat_id))
+
+    async def stop_typing(self, chat_id: str) -> None:
+        self.stop_typing_calls.append(chat_id)
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id, "type": "dm"}
+
+
+class _NoTypingAdapter(BasePlatformAdapter):
+    """Adapter that does NOT override send_typing — eager typing must no-op."""
+
+    def __init__(self):
+        super().__init__(
+            PlatformConfig(enabled=True, token="t", extra={"eager_typing": True}),
+            Platform.EMAIL,
+        )
+        self.send_typing_called = False
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        self._mark_disconnected()
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return SendResult(success=True, message_id="m1")
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id, "type": "dm"}
+
+
+def _make_event(chat_id: str = "user-1", text: str = "hi") -> MessageEvent:
+    adapter = _SlowAgentAdapter()
+    source = adapter.build_source(chat_id=chat_id, chat_type="dm", user_id=chat_id)
+    return MessageEvent(text=text, message_type=MessageType.TEXT, source=source)
+
+
+class TestEagerTypingFiresImmediately:
+    @pytest.mark.asyncio
+    async def test_send_typing_called_within_100ms_of_handle_message(self):
+        """The whole point of eager typing — the user must see a bubble fast,
+        before the agent has done any meaningful work."""
+        adapter = _SlowAgentAdapter()
+
+        async def slow_handler(event):
+            await asyncio.sleep(2.0)
+            return "done"
+
+        adapter.set_message_handler(slow_handler)
+
+        event = _make_event()
+        task = asyncio.create_task(adapter.handle_message(event))
+        try:
+            await asyncio.sleep(0.1)
+            assert adapter.typing_calls, (
+                "expected send_typing to fire within 100ms of handle_message entry"
+            )
+            first_call_at = adapter.typing_calls[0][0]
+            assert first_call_at < 0.15, (
+                f"first send_typing fired at {first_call_at*1000:.1f}ms — too slow"
+            )
+            assert adapter.typing_calls[0][1] == "user-1"
+        finally:
+            await adapter.cancel_background_tasks()
+            task.cancel()
+            try:
+                await asyncio.wait_for(task, timeout=1.0)
+            except (asyncio.CancelledError, asyncio.TimeoutError):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_eager_task_cancelled_before_keep_typing_starts(self):
+        """The eager task must be cancelled inside _process_message_background
+        before _keep_typing kicks in, so the two never double-fire."""
+        adapter = _SlowAgentAdapter()
+        keep_typing_started = asyncio.Event()
+        eager_task_at_kt_start: list[Optional[asyncio.Task]] = []
+
+        original_keep_typing = adapter._keep_typing
+
+        async def tracking_keep_typing(*args, **kwargs):
+            eager_task_at_kt_start.append(
+                adapter._eager_typing_tasks.get(event.source.chat_id)
+            )
+            keep_typing_started.set()
+            return await original_keep_typing(*args, **kwargs)
+
+        adapter._keep_typing = tracking_keep_typing
+
+        async def quick_handler(evt):
+            await asyncio.sleep(0.3)
+            return "done"
+
+        adapter.set_message_handler(quick_handler)
+        event = _make_event(chat_id="kt-test")
+        task = asyncio.create_task(adapter.handle_message(event))
+        try:
+            await asyncio.wait_for(keep_typing_started.wait(), timeout=2.0)
+            assert eager_task_at_kt_start[0] is None, (
+                "eager typing task was still in _eager_typing_tasks dict when "
+                "_keep_typing started — they would double-fire"
+            )
+        finally:
+            await adapter.cancel_background_tasks()
+            task.cancel()
+            try:
+                await asyncio.wait_for(task, timeout=1.0)
+            except (asyncio.CancelledError, asyncio.TimeoutError):
+                pass
+
+
+class TestEagerTypingConfig:
+    @pytest.mark.asyncio
+    async def test_disabled_by_default(self):
+        """Without explicit opt-in the eager loop must not be created —
+        backward-compat: deployments that don't set eager_typing see the
+        existing _keep_typing behavior only."""
+        adapter = _SlowAgentAdapter(extra={})
+        assert adapter._eager_typing_enabled() is False
+        result = await adapter._start_eager_typing("chat-default")
+        assert result is None, (
+            "_start_eager_typing returned a task despite eager_typing being "
+            "absent from config.extra — default must be disabled"
+        )
+        assert "chat-default" not in adapter._eager_typing_tasks
+
+    @pytest.mark.asyncio
+    async def test_explicit_false_disables(self):
+        adapter = _SlowAgentAdapter(extra={"eager_typing": False})
+        assert adapter._eager_typing_enabled() is False
+        result = await adapter._start_eager_typing("chat-off")
+        assert result is None
+        assert "chat-off" not in adapter._eager_typing_tasks
+
+    @pytest.mark.asyncio
+    async def test_no_op_when_send_typing_not_overridden(self):
+        """Email / SMS / Webhook don't implement send_typing — eager typing
+        must silently no-op even when eager_typing: true is set."""
+        adapter = _NoTypingAdapter()
+        assert adapter._eager_typing_enabled() is False
+        result = await adapter._start_eager_typing("chat-1")
+        assert result is None, (
+            "eager typing returned a task on an adapter without send_typing — "
+            "would log spam against a no-op send_typing"
+        )
+
+    @pytest.mark.asyncio
+    async def test_interval_override_respected(self):
+        adapter = _SlowAgentAdapter(
+            extra={"eager_typing": True, "eager_typing_interval": 2.5}
+        )
+        assert adapter._eager_typing_interval() == 2.5
+
+    @pytest.mark.asyncio
+    async def test_max_iterations_override_respected(self):
+        adapter = _SlowAgentAdapter(
+            extra={"eager_typing": True, "eager_typing_max_iterations": 3}
+        )
+        assert adapter._eager_typing_max_iterations() == 3
+
+    @pytest.mark.asyncio
+    async def test_invalid_interval_falls_back_to_default(self):
+        adapter = _SlowAgentAdapter(
+            extra={"eager_typing": True, "eager_typing_interval": "not-a-number"}
+        )
+        assert adapter._eager_typing_interval() == BasePlatformAdapter.EAGER_TYPING_DEFAULT_INTERVAL
+
+
+class TestEagerTypingLifecycle:
+    @pytest.mark.asyncio
+    async def test_idempotent_start_returns_existing_task(self):
+        """An adapter that fires _start_eager_typing both from its webhook
+        handler AND from handle_message (the canonical BlueBubbles pattern)
+        must not spawn two competing tasks."""
+        adapter = _SlowAgentAdapter()
+        first = await adapter._start_eager_typing("chat-A")
+        second = await adapter._start_eager_typing("chat-A")
+        try:
+            assert first is not None
+            assert second is first, (
+                "second _start_eager_typing call spawned a new task instead "
+                "of returning the in-flight one — would race itself"
+            )
+        finally:
+            await adapter._cancel_eager_typing("chat-A")
+
+    @pytest.mark.asyncio
+    async def test_cancel_eager_typing_clears_entry(self):
+        adapter = _SlowAgentAdapter()
+        task = await adapter._start_eager_typing("chat-B")
+        assert task is not None
+        assert "chat-B" in adapter._eager_typing_tasks
+        await adapter._cancel_eager_typing("chat-B")
+        assert "chat-B" not in adapter._eager_typing_tasks
+
+    @pytest.mark.asyncio
+    async def test_cancel_eager_typing_no_op_for_unknown_chat(self):
+        adapter = _SlowAgentAdapter()
+        await adapter._cancel_eager_typing("never-started")
+
+    @pytest.mark.asyncio
+    async def test_max_iterations_bounds_runaway_loop(self):
+        """The eager loop must stop on its own after max_iterations, so a
+        crash in the handler can't leave it running forever."""
+        adapter = _SlowAgentAdapter(
+            extra={
+                "eager_typing": True,
+                "eager_typing_interval": 0.05,
+                "eager_typing_max_iterations": 3,
+            }
+        )
+        task = await adapter._start_eager_typing("chat-C")
+        assert task is not None
+        await asyncio.wait_for(task, timeout=1.0)
+        assert task.done()
+        assert len(adapter.typing_calls) <= 3, (
+            f"expected at most 3 typing calls within max_iterations, "
+            f"got {len(adapter.typing_calls)}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_paused_chat_skips_eager_typing(self):
+        adapter = _SlowAgentAdapter(
+            extra={
+                "eager_typing": True,
+                "eager_typing_interval": 0.05,
+                "eager_typing_max_iterations": 3,
+            }
+        )
+        adapter._typing_paused.add("paused-chat")
+        task = await adapter._start_eager_typing("paused-chat")
+        assert task is not None
+        await asyncio.wait_for(task, timeout=1.0)
+        assert adapter.typing_calls == [], (
+            f"eager send_typing fired on a paused chat: {adapter.typing_calls}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_handle_message_early_exit_cancels_eager(self):
+        """If handle_message takes an early-exit path (no background task
+        spawned), the finally block must cancel the eager task — otherwise
+        it lingers for ~max_iterations * interval seconds firing useless
+        send_typing calls."""
+        adapter = _SlowAgentAdapter()
+
+        async def handler(evt):
+            return ""
+
+        adapter.set_message_handler(handler)
+
+        async def busy_handler(evt, session_key):
+            return True
+
+        adapter._busy_session_handler = busy_handler
+        session_key = "agent:main:telegram:dm:early-exit-test"
+        adapter._active_sessions[session_key] = asyncio.Event()
+
+        event = MessageEvent(
+            text="hi",
+            message_type=MessageType.TEXT,
+            source=adapter.build_source(
+                chat_id="early-exit-test", chat_type="dm", user_id="early-exit-test"
+            ),
+        )
+        from gateway.platforms.base import build_session_key as _bsk
+        computed_key = _bsk(event.source, group_sessions_per_user=True, thread_sessions_per_user=False)
+        adapter._active_sessions[computed_key] = asyncio.Event()
+
+        await adapter.handle_message(event)
+        assert "early-exit-test" not in adapter._eager_typing_tasks, (
+            "eager task was not cancelled on the busy-session early-exit path"
+        )
+
+    @pytest.mark.asyncio
+    async def test_cancel_calls_stop_typing_by_default(self):
+        """Regression guard for the #6016 class of bug: every cancel path
+        except the explicit handoff must call stop_typing so platforms
+        with persistent typing state (Matrix's 30s set_typing(timeout),
+        Discord's self-refreshing internal loop) don't leak a stale
+        bubble.  Asserts that _cancel_eager_typing fires stop_typing
+        when suppress_stop is left at its default (False)."""
+        adapter = _SlowAgentAdapter(
+            extra={
+                "eager_typing": True,
+                "eager_typing_interval": 5.0,
+                "eager_typing_max_iterations": 12,
+            }
+        )
+        task = await adapter._start_eager_typing("chat-stop")
+        assert task is not None
+        await asyncio.sleep(0.05)
+        adapter.stop_typing_calls.clear()
+        await adapter._cancel_eager_typing("chat-stop")
+        assert "chat-stop" in adapter.stop_typing_calls, (
+            "stop_typing was NOT called after _cancel_eager_typing — "
+            "platforms with persistent typing state (Matrix, Discord) "
+            "would leak a stale bubble"
+        )
+
+    @pytest.mark.asyncio
+    async def test_handoff_cancel_suppresses_stop_typing(self):
+        """The handoff site in _process_message_background passes
+        suppress_stop=True because _keep_typing is about to re-fire
+        send_typing immediately, and a stop_typing in between would
+        cause a visible bubble flicker on Discord and Matrix.  This
+        test pins that contract so future refactors don't accidentally
+        drop the flag and reintroduce flicker."""
+        adapter = _SlowAgentAdapter(
+            extra={
+                "eager_typing": True,
+                "eager_typing_interval": 5.0,
+                "eager_typing_max_iterations": 12,
+            }
+        )
+        task = await adapter._start_eager_typing("chat-handoff")
+        assert task is not None
+        await asyncio.sleep(0.05)
+        adapter.stop_typing_calls.clear()
+        await adapter._cancel_eager_typing("chat-handoff", suppress_stop=True)
+        assert adapter.stop_typing_calls == [], (
+            f"stop_typing was called despite suppress_stop=True — "
+            f"would cause typing-bubble flicker on Discord/Matrix at "
+            f"the eager→_keep_typing handoff. calls={adapter.stop_typing_calls}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_handle_message_early_exit_calls_stop_typing(self):
+        """End-to-end: when handle_message takes the busy-session early
+        exit path, the final stop_typing must reach the adapter so
+        Matrix's set_typing(timeout=30000) bubble doesn't linger for
+        up to 30 seconds after the user's message is rejected."""
+        adapter = _SlowAgentAdapter(
+            extra={
+                "eager_typing": True,
+                "eager_typing_interval": 5.0,
+                "eager_typing_max_iterations": 12,
+            }
+        )
+
+        async def handler(evt):
+            return ""
+
+        adapter.set_message_handler(handler)
+
+        async def busy_handler(evt, session_key):
+            return True
+
+        adapter._busy_session_handler = busy_handler
+
+        event = MessageEvent(
+            text="hi",
+            message_type=MessageType.TEXT,
+            source=adapter.build_source(
+                chat_id="stop-on-busy", chat_type="dm", user_id="stop-on-busy"
+            ),
+        )
+        from gateway.platforms.base import build_session_key as _bsk
+        computed_key = _bsk(
+            event.source,
+            group_sessions_per_user=True,
+            thread_sessions_per_user=False,
+        )
+        adapter._active_sessions[computed_key] = asyncio.Event()
+        adapter.stop_typing_calls.clear()
+
+        await adapter.handle_message(event)
+        assert "stop-on-busy" in adapter.stop_typing_calls, (
+            f"stop_typing was NOT called on the busy-session early-exit "
+            f"path — eager bubble would linger. "
+            f"stop_typing_calls={adapter.stop_typing_calls}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_loop_natural_exit_calls_stop_typing(self):
+        """When the eager loop hits max_iterations and exits naturally
+        (no explicit cancel — e.g. handle_message crashed before the
+        finally block reached _cancel_eager_typing), the loop's own
+        finally must still call stop_typing.  Without this, Discord's
+        self-refreshing internal typing task would keep pinging forever."""
+        adapter = _SlowAgentAdapter(
+            extra={
+                "eager_typing": True,
+                "eager_typing_interval": 0.05,
+                "eager_typing_max_iterations": 2,
+            }
+        )
+        task = await adapter._start_eager_typing("chat-natural")
+        assert task is not None
+        await asyncio.wait_for(task, timeout=1.0)
+        assert "chat-natural" in adapter.stop_typing_calls, (
+            f"stop_typing was NOT called when the eager loop exited "
+            f"on max_iterations — Discord's internal refresh loop "
+            f"would keep pinging forever. "
+            f"stop_typing_calls={adapter.stop_typing_calls}"
+        )

--- a/website/docs/user-guide/messaging/bluebubbles.md
+++ b/website/docs/user-guide/messaging/bluebubbles.md
@@ -110,6 +110,19 @@ Love, like, dislike, laugh, emphasize, and question reactions. Requires the Blue
 ### Typing Indicators
 Shows "typing..." in the iMessage conversation while the agent is processing. Requires Private API.
 
+Enable **eager typing** to fire the bubble the instant a webhook lands — before reasoning and tool calls run — so users see immediate feedback during long thinking phases:
+
+```yaml
+platforms:
+  bluebubbles:
+    extra:
+      eager_typing: true
+      # eager_typing_interval: 8.0          # optional, defaults to 8s
+      # eager_typing_max_iterations: 12     # optional safety ceiling
+```
+
+See [Typing Indicators](./index.md#typing-indicators) for the full reference and per-platform tuning notes.
+
 ### Read Receipts
 Automatically marks messages as read after processing. Requires Private API.
 

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -294,6 +294,38 @@ When enabled, the bot sends status messages as it works:
 🐍 execute_code...
 ```
 
+## Typing Indicators
+
+On platforms that support a typing indicator (see the **Typing** column in the [Platform Comparison](#platform-comparison)), Hermes already shows "typing…" while it's sending or streaming a response. The agent's "thinking" phase — reasoning, tool calls, model latency — happens *before* any tokens are produced, so on slow turns (10–30 seconds of tool work or long reasoning) the platform can briefly look idle.
+
+Set `eager_typing: true` on a platform's `extra` block to fire the typing indicator the moment the inbound webhook lands, before the agent dispatch pipeline runs. The eager loop hands off to the existing typing refresh once response delivery starts, so the bubble stays visible through the whole turn.
+
+```yaml
+platforms:
+  bluebubbles:
+    enabled: true
+    extra:
+      eager_typing: true              # default: false
+      # eager_typing_interval: 8.0    # optional — defaults to the per-adapter value
+      # eager_typing_max_iterations: 12  # safety ceiling, ~interval * iterations
+  telegram:
+    enabled: true
+    extra:
+      eager_typing: true              # default interval already 2.0s for Telegram
+```
+
+**Per-platform tuning:**
+
+- **BlueBubbles (iMessage)**: default 8 s interval. Needs Private API + helper connected. When the helper is offline, eager typing silently no-ops — there is no degraded mode. BlueBubbles' webhook entrypoint also fires eager typing *before* the agent dispatch task spawns, shaving ~tens of ms off perceived latency.
+- **Telegram**: per-adapter default of **2.0 s** (Telegram's `sendChatAction` expires at ~5 s). No tuning needed — just set `eager_typing: true`.
+- **Discord**: per-adapter default of **8.0 s** matching Discord's internal self-refreshing typing loop. The eager loop typically fires `send_typing` once and then defers to that internal refresh.
+- **Slack / Signal / WhatsApp / Matrix / Feishu / WeCom / Weixin**: support typing indicators with normal one-shot semantics — the default 8 s interval is conservative and works without tuning, but match the platform's expiry window if you observe the bubble flickering.
+- **Email / SMS / Webhook / Mattermost / DingTalk / Home Assistant / MS Graph / QQ / Yuanbao**: either have no typing API or implement `send_typing` as an explicit no-op. Eager typing has no observable effect on these adapters regardless of the config flag — adapters that don't override `send_typing` at all (SMS, Webhook, MS Graph, QQ, API server) are auto-skipped at the gate.
+
+The eager loop always calls `stop_typing` on cancel (whether through the normal handoff to `_keep_typing`, an early-exit path in `handle_message`, or gateway shutdown) so platforms with persistent typing state — Matrix's 30 s `set_typing(timeout)`, Discord's self-refreshing internal loop — don't leak a lingering bubble. There is no observable "typing forever" failure mode if the agent crashes after the eager loop started.
+
+**Defaults**: `eager_typing` defaults to `false` so deployments that don't opt in see no behavioral change. The maximum loop runtime is `eager_typing_interval × eager_typing_max_iterations` (defaults: 96 s) — even if the response handler crashes, the eager loop stops itself.
+
 ## Background Sessions
 
 Run a prompt in a separate background session so the agent works on it independently while your main chat stays responsive:


### PR DESCRIPTION
## What

Adds a config-driven **eager typing** mechanism to `BasePlatformAdapter`. The platform's typing indicator now fires the moment an inbound message lands and stays live through the agent's "thinking" phase (reasoning + tool calls), then hands off to the existing `_keep_typing` refresh once response delivery starts.

**Disabled by default** — opt in per platform via `platforms.<name>.extra.eager_typing: true`. Backward-compatible with every existing deployment.

## Why

On platforms like BlueBubbles (iMessage), Telegram, Discord, and Matrix, the agent can spend 10–30+ seconds in reasoning / tool calls before producing the first response token. Today the typing bubble only fires once response delivery has begun, so users see no feedback during the slow part of the turn. Eager typing closes that visible gap.

## How

- [`gateway/platforms/base.py`](../blob/HA/eager-typing/gateway/platforms/base.py) — adds `_start_eager_typing` / `_cancel_eager_typing(suppress_stop=…)`, class-level `EAGER_TYPING_DEFAULT_INTERVAL` / `EAGER_TYPING_DEFAULT_MAX_ITERATIONS` constants, wraps `handle_message` in `try/finally` (handoff to background = leave eager running; every early-exit cancels it), cancels eager inside `_process_message_background` before `_keep_typing` takes over, drains eager tasks on shutdown.
- [`gateway/platforms/telegram.py`](../blob/HA/eager-typing/gateway/platforms/telegram.py) — `EAGER_TYPING_DEFAULT_INTERVAL = 2.0` (Telegram's `sendChatAction` expires ~5 s).
- [`gateway/platforms/discord.py`](../blob/HA/eager-typing/gateway/platforms/discord.py) — `EAGER_TYPING_DEFAULT_INTERVAL = 8.0` matching Discord's internal refresh cadence.
- [`gateway/platforms/bluebubbles.py`](../blob/HA/eager-typing/gateway/platforms/bluebubbles.py) — `_handle_webhook` fires eager typing one step earlier (idempotent reuse) to shave webhook-to-bubble latency.
- [`tests/gateway/test_eager_typing.py`](../blob/HA/eager-typing/tests/gateway/test_eager_typing.py) — 18 tests covering fire-within-100ms, handoff-before-keep_typing, disabled-by-default, no-op for adapters without `send_typing`, idempotent start, max-iterations bound, paused-chat skip, early-exit cancel, **`stop_typing` cancel contract** (regression coverage for the #6016 class of bug — Matrix's 30 s `set_typing(timeout)` linger, Discord's self-refreshing send_typing forever-pinging), handoff-suppresses-stop, and natural-exit cleanup.
- Docs: new [Typing Indicators](../blob/HA/eager-typing/website/docs/user-guide/messaging/index.md) section + a pointer in [BlueBubbles docs](../blob/HA/eager-typing/website/docs/user-guide/messaging/bluebubbles.md).

## stop_typing contract (load-bearing)

Every eager cancel path calls `stop_typing` so platforms with persistent typing state can't leak bubbles. The single exception is the eager → `_keep_typing` handoff inside `_process_message_background`, which uses `suppress_stop=True` because `_keep_typing` is about to re-fire `send_typing` on the next tick — calling `stop_typing` in between would cause a visible flicker on Discord and Matrix. The contract is pinned by three regression tests.

## Migration

- **Auto-enabled when `eager_typing: true`**: telegram (default 2 s), discord (default 8 s), bluebubbles, slack, signal, whatsapp, matrix, feishu, wecom, weixin.
- **No-op even with flag set**: email, dingtalk, homeassistant, mattermost, yuanbao (their `send_typing` overrides are explicit no-ops).
- **Auto-skipped at the gate**: sms, webhook, msgraph_webhook, qqbot, api_server, wecom_callback (no `send_typing` override at all).

## Verification

`scripts/run_tests.sh tests/gateway/` — **5435 passed, 74 skipped, 0 failed in 77 s.**
