### PR TITLE
fix(gateway): transcribe configured Discord audio attachments

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -836,6 +836,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["allowed_topics"] = platform_cfg["allowed_topics"]
                 if "free_response_channels" in platform_cfg:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
+                if "transcribe_audio_attachment_channels" in platform_cfg:
+                    bridged["transcribe_audio_attachment_channels"] = platform_cfg["transcribe_audio_attachment_channels"]
                 if "mention_patterns" in platform_cfg:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
                 if "exclusive_bot_mentions" in platform_cfg:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7683,10 +7683,18 @@ class GatewayRunner:
                 mtype = event.media_types[i] if i < len(event.media_types) else ""
                 if mtype.startswith("image/") or event.message_type == MessageType.PHOTO:
                     image_paths.append(path)
-                # MessageType.AUDIO = audio file attachment (e.g. .mp3, .m4a) — never STT
-                # MessageType.VOICE = voice message (Opus/OGG) — always STT
+                # MessageType.AUDIO = audio file attachment (e.g. .mp3, .m4a).
+                # By default these are surfaced as files, not STT'd.  A trusted
+                # capture channel can opt in via
+                # discord.transcribe_audio_attachment_channels so iPhone/Discord
+                # voice notes that arrive as generic audio attachments still get
+                # transcribed.
+                # MessageType.VOICE = voice message (Opus/OGG) — always STT.
                 if event.message_type == MessageType.AUDIO:
-                    audio_file_paths.append(path)
+                    if self._should_transcribe_audio_attachment(source):
+                        audio_paths.append(path)
+                    else:
+                        audio_file_paths.append(path)
                 elif event.message_type == MessageType.VOICE or (
                     mtype.startswith("audio/")
                     and event.message_type not in {MessageType.AUDIO, MessageType.DOCUMENT}
@@ -14339,6 +14347,40 @@ class GatewayRunner:
                 return f"{prefix}\n\n{user_text}"
             return prefix
         return user_text
+
+    def _should_transcribe_audio_attachment(self, source) -> bool:
+        """Return whether generic audio attachments from this source should be STT'd.
+
+        Native voice messages are transcribed unconditionally elsewhere.  This
+        opt-in handles trusted channels whose mobile/webhook path uploads voice
+        notes as regular ``MessageType.AUDIO`` attachments.
+        """
+        _platform_cfg = self.config.platforms.get(source.platform)
+        if _platform_cfg is None:
+            return False
+
+        _raw_channels = (_platform_cfg.extra or {}).get("transcribe_audio_attachment_channels")
+        if isinstance(_raw_channels, (list, tuple, set)):
+            configured_channels = [str(v) for v in _raw_channels]
+        elif _raw_channels is not None:
+            configured_channels = [str(_raw_channels)]
+        else:
+            configured_channels = []
+
+        configured_lower = {v.lower() for v in configured_channels}
+        if "*" in configured_channels or "all" in configured_lower:
+            return True
+
+        source_channel_ids = {
+            str(v)
+            for v in (
+                getattr(source, "chat_id", None),
+                getattr(source, "parent_chat_id", None),
+                getattr(source, "thread_id", None),
+            )
+            if v is not None
+        }
+        return bool(source_channel_ids.intersection(configured_channels))
 
     async def _enrich_message_with_transcription(
         self,

--- a/tests/gateway/test_discord_audio_attachment_stt.py
+++ b/tests/gateway/test_discord_audio_attachment_stt.py
@@ -1,0 +1,113 @@
+"""Regression tests for Discord audio attachments that should be STT'd.
+
+The iPhone/Shortcut ingress path can upload a voice note as a generic
+``MessageType.AUDIO`` attachment instead of a native Discord voice message.  In
+trusted capture channels, config must be bridged and the gateway must opt those
+attachments into transcription so this path does not regress on update.
+"""
+
+from unittest.mock import MagicMock
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig, load_gateway_config
+from gateway.platforms.base import SessionSource
+from gateway.run import GatewayRunner
+
+
+def _runner_with_discord_channels(channels):
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(
+                extra={"transcribe_audio_attachment_channels": channels}
+            )
+        }
+    )
+    return runner
+
+
+def _discord_source(chat_id="voice-channel", *, parent_chat_id=None, thread_id=None):
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id=chat_id,
+        user_id="user1",
+        parent_chat_id=parent_chat_id,
+        thread_id=thread_id,
+    )
+
+
+def test_config_bridges_discord_transcribe_audio_attachment_channels(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "discord:\n"
+        "  transcribe_audio_attachment_channels:\n"
+        "    - \"1505333822944972842\"\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    config = load_gateway_config()
+
+    assert config.platforms[Platform.DISCORD].extra[
+        "transcribe_audio_attachment_channels"
+    ] == ["1505333822944972842"]
+
+
+def test_configured_discord_audio_attachment_channel_is_transcribed():
+    runner = _runner_with_discord_channels(["voice-channel"])
+
+    assert runner._should_transcribe_audio_attachment(
+        _discord_source(chat_id="voice-channel")
+    ) is True
+
+
+def test_unconfigured_discord_audio_attachment_channel_remains_file_attachment():
+    runner = _runner_with_discord_channels(["voice-channel"])
+
+    assert runner._should_transcribe_audio_attachment(
+        _discord_source(chat_id="general")
+    ) is False
+
+
+def test_discord_audio_attachment_thread_matches_parent_channel():
+    runner = _runner_with_discord_channels(["voice-channel"])
+
+    assert runner._should_transcribe_audio_attachment(
+        _discord_source(
+            chat_id="thread-id",
+            parent_chat_id="voice-channel",
+            thread_id="thread-id",
+        )
+    ) is True
+
+
+def test_discord_audio_attachment_all_sentinel_transcribes_any_channel():
+    runner = _runner_with_discord_channels(["all"])
+
+    assert runner._should_transcribe_audio_attachment(
+        _discord_source(chat_id="any-channel")
+    ) is True
+
+
+def test_missing_discord_audio_attachment_config_defaults_to_file_attachment():
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.DISCORD: PlatformConfig(extra={})}
+    )
+
+    assert runner._should_transcribe_audio_attachment(
+        _discord_source(chat_id="voice-channel")
+    ) is False
+
+
+def test_non_discord_or_missing_platform_config_defaults_to_file_attachment():
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(platforms={})
+    source = SessionSource(
+        platform=MagicMock(),
+        chat_id="voice-channel",
+        user_id="user1",
+    )
+
+    assert runner._should_transcribe_audio_attachment(source) is False


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

