### PR TITLE
fix: quarantine kanban boards after sqlite disk I/O errors

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5216,14 +5216,27 @@ class GatewayRunner:
                 return (resolved, None, None)
             return (resolved, stat.st_mtime_ns, stat.st_size)
 
-        def _is_corrupt_board_db_error(exc: Exception) -> bool:
+        def _disabled_board_db_error_message(exc: Exception) -> str | None:
             if not isinstance(exc, sqlite3.DatabaseError):
-                return False
+                return None
             msg = str(exc).lower()
-            return (
+            if (
                 "file is not a database" in msg
                 or "database disk image is malformed" in msg
-            )
+            ):
+                return (
+                    "is not a valid SQLite database; disabling dispatch for this "
+                    "board until the file changes or the gateway restarts. Move "
+                    "or restore the file, then run `hermes kanban init` if you "
+                    "need a fresh board."
+                )
+            if "disk i/o error" in msg:
+                return (
+                    "hit SQLite disk I/O errors; disabling dispatch for this board "
+                    "until the file changes or the gateway restarts. Check the "
+                    "filesystem and restore the board database before retrying."
+                )
+            return None
 
         def _tick_once_for_board(slug: str) -> "Optional[object]":
             """Run one dispatch_once for a specific board.
@@ -5262,16 +5275,14 @@ class GatewayRunner:
                     stale_timeout_seconds=stale_timeout_seconds,
                 )
             except sqlite3.DatabaseError as exc:
-                if _is_corrupt_board_db_error(exc):
+                disabled_reason = _disabled_board_db_error_message(exc)
+                if disabled_reason is not None:
                     disabled_corrupt_boards[slug] = fingerprint
                     logger.error(
-                        "kanban dispatcher: board %s database %s is not a valid "
-                        "SQLite database; disabling dispatch for this board "
-                        "until the file changes or the gateway restarts. Move "
-                        "or restore the file, then run `hermes kanban init` if "
-                        "you need a fresh board.",
+                        "kanban dispatcher: board %s database %s %s",
                         slug,
                         fingerprint[0],
+                        disabled_reason,
                     )
                     return None
                 logger.exception("kanban dispatcher: tick failed on board %s", slug)

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -3682,6 +3682,80 @@ def test_gateway_dispatcher_disables_corrupt_board_without_traceback(
     assert calls["connect"] == 5
 
 
+def test_gateway_dispatcher_disables_board_on_disk_io_error_without_traceback(
+    monkeypatch, tmp_path, caplog
+):
+    """Persistent SQLite disk I/O errors log once and stop retrying per tick."""
+    import asyncio
+    import logging
+    import sqlite3
+
+    from gateway.run import GatewayRunner
+    import hermes_cli.config as _cfg_mod
+    import hermes_cli.kanban_db as _kb
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    flaky_db = tmp_path / "kanban.db"
+    flaky_db.write_text("placeholder", encoding="utf-8")
+
+    monkeypatch.setattr(
+        _cfg_mod,
+        "load_config",
+        lambda: {
+            "kanban": {
+                "dispatch_in_gateway": True,
+                "dispatch_interval_seconds": 1,
+            }
+        },
+    )
+    monkeypatch.setattr(
+        _kb,
+        "list_boards",
+        lambda include_archived=False: [{"slug": _kb.DEFAULT_BOARD}],
+    )
+    monkeypatch.setattr(
+        _kb,
+        "read_board_metadata",
+        lambda slug: {"slug": slug},
+    )
+    monkeypatch.setattr(_kb, "kanban_db_path", lambda board=None: flaky_db)
+
+    calls = {"connect": 0, "to_thread": 0}
+
+    def _connect(*args, **kwargs):
+        calls["connect"] += 1
+        raise sqlite3.OperationalError("disk I/O error")
+
+    async def _to_thread(fn, *args, **kwargs):
+        calls["to_thread"] += 1
+        result = fn(*args, **kwargs)
+        if calls["to_thread"] >= 4:
+            runner._running = False
+        return result
+
+    async def _sleep(_delay):
+        return None
+
+    monkeypatch.setattr(_kb, "connect", _connect)
+    monkeypatch.setattr("gateway.run.asyncio.to_thread", _to_thread)
+    monkeypatch.setattr("gateway.run.asyncio.sleep", _sleep)
+
+    with caplog.at_level(logging.ERROR, logger="gateway.run"):
+        asyncio.run(
+            asyncio.wait_for(
+                runner._kanban_dispatcher_watcher(),
+                timeout=3.0,
+            )
+        )
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert sum("SQLite disk I/O errors" in msg for msg in messages) == 1
+    assert not any("tick failed on board" in msg for msg in messages)
+    assert not any(record.exc_info for record in caplog.records)
+    assert calls["connect"] == 5
+
+
 # ---------------------------------------------------------------------------
 # Hallucination gate (created_cards verify + prose scan)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- quarantine kanban board DB fingerprints on repeated sqlite disk I/O errors in dispatcher ticks
- suppress per-tick traceback spam while the bad DB fingerprint remains unchanged
- add regression coverage for repeated disk I/O and corrupt-board handling

## Test Plan
- pytest -q tests/hermes_cli/test_kanban_core_functionality.py -k "disk_io_error_without_traceback or corrupt_board_without_traceback"
- pytest -q tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_notify.py