### PR TITLE
fix(vision): respect auxiliary.vision config so images stop silently routing to text-only main models

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4622,6 +4622,23 @@ def call_llm(
             async_mode=False,
         )
         if client is None and resolved_provider != "auto" and not resolved_base_url:
+            # When the user explicitly chose a non-aggregator vision provider
+            # but no client could be resolved, fail fast with a clear error
+            # instead of silently re-running the auto chain — which falls
+            # through to the user's main provider and produces confusing
+            # "unknown variant image_url, expected text" errors when that
+            # main model is text-only (DeepSeek V4, etc.).  Mirrors the
+            # non-vision branch below.  Issue #31179.
+            _explicit = (resolved_provider or "").strip().lower()
+            if _explicit and _explicit not in {"openrouter", "custom"}:
+                raise RuntimeError(
+                    f"auxiliary.vision.provider={_explicit!r} is set in "
+                    f"config.yaml but no client could be resolved. Check that "
+                    f"the provider name is valid (run: hermes config providers) "
+                    f"and that the corresponding API key is set "
+                    f"(e.g. {_explicit.upper().replace('-', '_')}_API_KEY), or "
+                    f"set auxiliary.vision.provider to 'auto' to use the default chain."
+                )
             logger.warning(
                 "Vision provider %s unavailable, falling back to auto vision backends",
                 resolved_provider,
@@ -5024,6 +5041,19 @@ async def async_call_llm(
             async_mode=True,
         )
         if client is None and resolved_provider != "auto" and not resolved_base_url:
+            # See call_llm() — fail fast on unresolved explicit vision
+            # providers instead of silently routing through the user's
+            # text-only main model.  Issue #31179.
+            _explicit = (resolved_provider or "").strip().lower()
+            if _explicit and _explicit not in {"openrouter", "custom"}:
+                raise RuntimeError(
+                    f"auxiliary.vision.provider={_explicit!r} is set in "
+                    f"config.yaml but no client could be resolved. Check that "
+                    f"the provider name is valid (run: hermes config providers) "
+                    f"and that the corresponding API key is set "
+                    f"(e.g. {_explicit.upper().replace('-', '_')}_API_KEY), or "
+                    f"set auxiliary.vision.provider to 'auto' to use the default chain."
+                )
             logger.warning(
                 "Vision provider %s unavailable, falling back to auto vision backends",
                 resolved_provider,

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -442,6 +442,14 @@ prompt_caching:
 #     download_timeout: 30   # Image HTTP download timeout (seconds)
 #                            # Increase for slow connections or self-hosted image servers
 #
+#   # Tip: pin a vision-capable side model when your main model is text-only.
+#   # The example below routes screenshots through GPT-4o-mini even when
+#   # model.default is DeepSeek/Kimi/etc.  Requires OPENAI_API_KEY in .env.
+#   #
+#   # vision:
+#   #   provider: "openai"
+#   #   model: "gpt-4o-mini"
+#
 #   # Web page scraping / summarization + browser page text extraction
 #   web_extract:
 #     provider: "auto"

--- a/plugins/model-providers/openai/__init__.py
+++ b/plugins/model-providers/openai/__init__.py
@@ -1,0 +1,43 @@
+"""Direct OpenAI (api.openai.com) provider profile.
+
+Routes ``provider: openai`` to ``https://api.openai.com/v1`` using
+``OPENAI_API_KEY`` for auth. Distinct from ``openai-codex`` (OAuth →
+Responses API for ChatGPT-account Codex) and from ``openrouter`` (the
+multi-vendor aggregator that historically also accepted ``OPENAI_API_KEY``
+for OpenAI-compat clients).
+
+Why this profile exists (issue #31179):
+
+Users who set ``auxiliary.vision.provider: openai`` — a natural choice for
+routing screenshots to GPT-4o-mini when the main model (e.g. DeepSeek V4)
+is text-only — used to hit a silent fallback to the main model because
+``openai`` was not a recognised provider name. Vision calls then 400'd
+with ``unknown variant image_url, expected text``.  Registering ``openai``
+as a first-class profile lets that config Just Work.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+openai = ProviderProfile(
+    name="openai",
+    aliases=("openai-direct", "openai_api"),
+    api_mode="chat_completions",
+    env_vars=("OPENAI_API_KEY",),
+    base_url="https://api.openai.com/v1",
+    auth_type="api_key",
+    display_name="OpenAI",
+    description="OpenAI — direct api.openai.com",
+    signup_url="https://platform.openai.com/api-keys",
+    fallback_models=(
+        "gpt-4o-mini",
+        "gpt-4o",
+        "gpt-4.1-mini",
+        "gpt-4.1",
+        "gpt-5",
+        "gpt-5-mini",
+    ),
+    default_aux_model="gpt-4o-mini",
+)
+
+register_provider(openai)

--- a/plugins/model-providers/openai/plugin.yaml
+++ b/plugins/model-providers/openai/plugin.yaml
@@ -1,0 +1,5 @@
+name: openai-provider
+kind: model-provider
+version: 1.0.0
+description: OpenAI (direct api.openai.com)
+author: Nous Research

--- a/tests/agent/test_vision_provider_routing_31179.py
+++ b/tests/agent/test_vision_provider_routing_31179.py
@@ -1,0 +1,308 @@
+"""Regression tests for issue #31179.
+
+When ``auxiliary.vision.provider`` is set to a non-aggregator provider
+(e.g. ``openai`` for direct GPT-4o-mini routing) but the provider can't
+be resolved, the previous behaviour silently fell back to the main agent
+provider — so vision calls landed on the user's text-only main model
+(DeepSeek V4 etc.) and 400'd with::
+
+    unknown variant `image_url`, expected `text`
+
+The fix is two-pronged:
+
+1. ``call_llm`` and ``async_call_llm`` now raise a clear error for
+   explicit vision providers that don't resolve, mirroring the
+   non-vision branch.  ``auto`` / ``openrouter`` / ``custom`` keep their
+   permissive behaviour because they're aggregator/default providers.
+2. ``openai`` is now a first-class provider that routes to
+   ``api.openai.com`` with ``OPENAI_API_KEY``, so the user's natural
+   config (``provider: openai``, ``model: gpt-4o-mini``) just works.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from agent.auxiliary_client import (
+    async_call_llm,
+    call_llm,
+    resolve_provider_client,
+    resolve_vision_provider_client,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for key in (
+        "OPENROUTER_API_KEY",
+        "OPENAI_BASE_URL",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "DEEPSEEK_API_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture
+def aux_vision_openai_config(monkeypatch):
+    """Simulate the user's #31179 config:
+
+        auxiliary:
+          vision:
+            provider: openai
+            model: gpt-4o-mini
+
+    on a host whose main provider is text-only (DeepSeek V4).
+    """
+
+    def fake_load_config():
+        return {
+            "model": {"provider": "deepseek", "default": "deepseek-v4-pro"},
+            "auxiliary": {
+                "vision": {"provider": "openai", "model": "gpt-4o-mini"}
+            },
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config", fake_load_config, raising=False
+    )
+    monkeypatch.setattr(
+        "agent.auxiliary_client._read_main_provider",
+        lambda: "deepseek",
+    )
+    monkeypatch.setattr(
+        "agent.auxiliary_client._read_main_model",
+        lambda: "deepseek-v4-pro",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fix 1 — explicit non-resolving vision provider raises instead of routing
+# to the main model.
+# ---------------------------------------------------------------------------
+
+
+class TestExplicitVisionProviderFailsLoud:
+    """The silent ``auto`` fallback for unresolved explicit vision providers
+    is the root cause of #31179 — verify it's gone.
+    """
+
+    def test_unknown_vision_provider_raises_runtime_error(self, monkeypatch):
+        """An unrecognised provider name must surface as a config error,
+        not silently route the image to the main model."""
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: {"provider": "totally-not-a-provider", "model": "x"},
+        )
+        # Guard: if the silent fallback path were still alive it would hit
+        # _resolve_auto via resolve_vision_provider_client(provider="auto")
+        # and route to the main provider's client.  Make any auto fallback
+        # explode loudly so the test catches the regression rather than
+        # masking it.
+        guard = MagicMock(
+            side_effect=AssertionError(
+                "resolve_vision_provider_client must NOT be called with "
+                "provider='auto' when the user explicitly set a non-auto "
+                "vision provider — issue #31179."
+            )
+        )
+        original = resolve_vision_provider_client
+
+        def wrapped(*args, **kwargs):
+            if kwargs.get("provider") == "auto":
+                guard()
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client.resolve_vision_provider_client", wrapped
+        )
+
+        with pytest.raises(RuntimeError, match="totally-not-a-provider"):
+            call_llm(
+                task="vision",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+    @pytest.mark.asyncio
+    async def test_unknown_vision_provider_raises_runtime_error_async(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: {"provider": "totally-not-a-provider", "model": "x"},
+        )
+        original = resolve_vision_provider_client
+
+        def wrapped(*args, **kwargs):
+            if kwargs.get("provider") == "auto":
+                raise AssertionError(
+                    "auto-fallback should NOT fire for explicit unresolved "
+                    "vision provider (#31179)"
+                )
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client.resolve_vision_provider_client", wrapped
+        )
+
+        with pytest.raises(RuntimeError, match="totally-not-a-provider"):
+            await async_call_llm(
+                task="vision",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+    def test_error_message_names_the_offending_env_var(self, monkeypatch):
+        """Error must tell the user which env var to set."""
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: {"provider": "openai", "model": "gpt-4o-mini"},
+        )
+        # Make the openai client resolution fail (no key) so we hit the
+        # raise.  Patch _get_cached_client so resolve_vision_provider_client
+        # returns (provider, None, None).
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_cached_client",
+            lambda *a, **kw: (None, None),
+        )
+        with pytest.raises(RuntimeError) as excinfo:
+            call_llm(
+                task="vision",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+        msg = str(excinfo.value)
+        assert "openai" in msg
+        # Hyphens in provider names get rewritten to underscores in env
+        # vars (e.g. openai-codex → OPENAI_CODEX_API_KEY).
+        assert "OPENAI_API_KEY" in msg
+
+    def test_openrouter_keeps_permissive_auto_fallback(self, monkeypatch):
+        """``openrouter`` is the aggregator default; if its client doesn't
+        resolve we still fall through to the auto chain.  Same behaviour
+        for ``custom``.  Guards against over-eager fix.
+        """
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: {"provider": "openrouter"},
+        )
+        # First call (provider=openrouter) returns no client; second call
+        # with provider=auto returns a usable mock.
+        fake_async_client = MagicMock(name="auto_fallback_client")
+        fake_async_client.base_url = "https://openrouter.ai/api/v1"
+
+        async def fake_create(**kwargs):
+            return MagicMock(
+                choices=[
+                    MagicMock(
+                        message=MagicMock(content="ok", role="assistant"),
+                        finish_reason="stop",
+                    )
+                ],
+                usage=None,
+            )
+
+        fake_async_client.chat.completions.create = fake_create
+
+        calls = []
+
+        def fake_resolve(*args, **kwargs):
+            calls.append(kwargs.get("provider"))
+            if kwargs.get("provider") == "openrouter":
+                return ("openrouter", None, None)
+            return ("openrouter", fake_async_client, "google/gemini-3-flash-preview")
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client.resolve_vision_provider_client", fake_resolve
+        )
+
+        # The call should succeed by falling back to auto — exactly the
+        # legacy behaviour we're preserving for aggregator/default names.
+        import asyncio
+
+        asyncio.get_event_loop().run_until_complete(
+            async_call_llm(
+                task="vision",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+        )
+
+        assert "openrouter" in calls
+        assert "auto" in calls
+
+
+# ---------------------------------------------------------------------------
+# Fix 2 — ``openai`` is registered as a first-class provider so the user's
+# natural config (provider: openai + OPENAI_API_KEY) Just Works.
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIProviderRegistered:
+    """``provider: openai`` must resolve to a real client against
+    ``api.openai.com`` using ``OPENAI_API_KEY`` (issue #31179).
+    """
+
+    def test_openai_is_in_provider_registry(self):
+        """Plugin auto-registration wires openai into PROVIDER_REGISTRY."""
+        from hermes_cli.auth import PROVIDER_REGISTRY
+
+        assert "openai" in PROVIDER_REGISTRY, (
+            "Expected the openai provider plugin to register itself in "
+            "PROVIDER_REGISTRY via providers/__init__.py auto-extension."
+        )
+        cfg = PROVIDER_REGISTRY["openai"]
+        assert cfg.auth_type == "api_key"
+        assert "OPENAI_API_KEY" in cfg.api_key_env_vars
+        assert "api.openai.com" in cfg.inference_base_url
+
+    def test_openai_profile_attributes(self):
+        """The provider profile itself carries the right metadata."""
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("openai")
+        assert profile is not None
+        assert profile.api_mode == "chat_completions"
+        assert profile.base_url == "https://api.openai.com/v1"
+        assert profile.default_aux_model == "gpt-4o-mini"
+        assert "OPENAI_API_KEY" in profile.env_vars
+
+    def test_resolve_provider_client_openai_with_key(self, monkeypatch):
+        """resolve_provider_client('openai', model) returns a client
+        pointing at api.openai.com when OPENAI_API_KEY is set.
+        """
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+        client, final_model = resolve_provider_client("openai", "gpt-4o-mini")
+        assert client is not None
+        assert "api.openai.com" in str(getattr(client, "base_url", ""))
+        assert final_model == "gpt-4o-mini"
+
+    def test_resolve_vision_provider_client_routes_to_openai(self, monkeypatch):
+        """User config ``auxiliary.vision.provider: openai`` resolves to
+        api.openai.com — not to the main model (DeepSeek/etc.).
+        """
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: {"provider": "openai", "model": "gpt-4o-mini"},
+        )
+        provider, client, model = resolve_vision_provider_client()
+        assert provider == "openai"
+        assert client is not None
+        assert "api.openai.com" in str(getattr(client, "base_url", ""))
+        assert model == "gpt-4o-mini"
+
+    def test_unset_openai_key_raises_clear_error(self, monkeypatch):
+        """When provider: openai is set but OPENAI_API_KEY is missing,
+        the explicit-provider gate (Fix 1) raises a clear error rather
+        than silently falling back to the main provider.
+        """
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: {"provider": "openai", "model": "gpt-4o-mini"},
+        )
+        with pytest.raises(RuntimeError, match="openai"):
+            call_llm(
+                task="vision",
+                messages=[{"role": "user", "content": "hi"}],
+            )

--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -46,19 +46,19 @@ def test_bundled_plugins_discovered():
         assert (child / "plugin.yaml").exists(), f"{child.name} missing plugin.yaml"
 
 
-def test_all_34_profiles_register():
-    """After discovery, the registry must contain exactly 34 distinct profiles."""
+def test_all_35_profiles_register():
+    """After discovery, the registry must contain exactly 35 distinct profiles."""
     _clear_provider_caches()
     from providers import list_providers
 
     profiles = list_providers()
     names = sorted(p.name for p in profiles)
-    assert len(names) == 34, f"Expected 34 profiles, got {len(names)}: {names}"
+    assert len(names) == 35, f"Expected 35 profiles, got {len(names)}: {names}"
 
     # Spot-check representative providers from different categories
     for required in (
         "openrouter", "anthropic", "custom", "bedrock", "openai-codex",
-        "minimax-oauth", "gmi", "xiaomi", "alibaba-coding-plan",
+        "openai", "minimax-oauth", "gmi", "xiaomi", "alibaba-coding-plan",
     ):
         assert required in names, f"Missing profile: {required}"
 


### PR DESCRIPTION
## What does this PR do?

Stops `vision_analyze` and `browser_vision` from silently routing images to the user's text-only main model when `auxiliary.vision` is explicitly configured to a side provider. Fixes the `unknown variant image_url, expected text` symptom from #31179.

Two small additions wired together:

1. **Loud failure on unresolved explicit vision provider** (`agent/auxiliary_client.py`) — `call_llm`/`async_call_llm`'s vision branch used to silently retry with `provider="auto"` whenever the configured provider returned no client, which falls through to the user's main provider. For users on text-only main models (DeepSeek V4, etc.) that turned a config error into a confusing inference 400. Mirror the non-vision branch: only `auto`/`openrouter`/`custom` keep their permissive auto-fallback (they're aggregator/default selectors); everything else surfaces a clear `RuntimeError` that names the env var the user needs to set.

2. **`openai` is now a first-class provider** (`plugins/model-providers/openai/`) — `auxiliary.vision.provider: openai` (with `OPENAI_API_KEY`) was an obvious config to write but had no plugin behind it, so `resolve_provider_client` returned `(None, None)` and the silent fallback in (1) hid the misconfiguration. The new profile routes to `https://api.openai.com/v1` with the chat-completions wire and `gpt-4o-mini` as the default aux model. The existing `OPENAI_API_KEY → openrouter` heuristic in `_resolve_active_auth_provider` still wins for auto-detection, so this is purely opt-in: only users who explicitly write `provider: openai` land on api.openai.com.

## Related Issue

Fixes #31179

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking config: \`provider: openai\` now resolves directly)

## Changes Made

- `agent/auxiliary_client.py` — vision branches in both `call_llm` and `async_call_llm` now raise a clear `RuntimeError` (with the offending env-var name) instead of silently retrying via `provider=\"auto\"` when the user explicitly chose a non-aggregator vision provider that didn't resolve. `auto`/`openrouter`/`custom` keep their existing auto-fallback semantics.
- `plugins/model-providers/openai/__init__.py` + `plugin.yaml` — new \`ProviderProfile(name=\"openai\", base_url=\"https://api.openai.com/v1\", env_vars=(\"OPENAI_API_KEY\",), default_aux_model=\"gpt-4o-mini\", aliases=(\"openai-direct\", \"openai_api\"))\`. Auto-discovered by `providers/__init__.py` and auto-extended into `PROVIDER_REGISTRY`.
- `cli-config.yaml.example` — added a copy-paste \`auxiliary.vision\` snippet showing the openai+gpt-4o-mini pattern for users on text-only main models.
- `tests/agent/test_vision_provider_routing_31179.py` — **9 new tests** across two suites (`TestExplicitVisionProviderFailsLoud` and `TestOpenAIProviderRegistered`) pinning the bug fix and the new provider registration end-to-end, including an async parity test and a guard that openrouter/custom keep their permissive auto-fallback.
- `tests/providers/test_plugin_discovery.py` — bumped the registered-profiles count from 34 → 35 to match the new \`openai\` profile.

Backwards compatible: no schema migration, no changed defaults, the auto-detection chain (`OPENAI_API_KEY → openrouter` heuristic) is untouched, and `provider: openai` was previously a config error so registering it can't break any existing setup.

## How to Test

\`\`\`bash
# New regression suite (9 tests, ~0.7s, hermetic — no real OpenAI calls)
./scripts/run_tests.sh tests/agent/test_vision_provider_routing_31179.py

# Adjacent regression sweeps — all pass on this branch
./scripts/run_tests.sh tests/agent/test_auxiliary_client.py \
    tests/agent/test_auxiliary_client_anthropic_custom.py \
    tests/agent/test_auxiliary_client_azure_foundry.py \
    tests/agent/test_image_routing.py \
    tests/providers/ tests/tools/test_vision_tools.py \
    tests/tools/test_computer_use_vision_routing.py \
    tests/hermes_cli/test_auth_provider_gate.py
# expected: all green (~520 tests)
\`\`\`

End-to-end behaviour after the fix, on the exact #31179 reporter config (DeepSeek V4 main model + \`auxiliary.vision.provider: openai\` + \`auxiliary.vision.model: gpt-4o-mini\` + \`OPENAI_API_KEY\` in .env):

\`\`\`
# Before
< vision_analyze(image_url=...) → 400 unknown variant \`image_url\`, expected \`text\`
                                  (DeepSeek's chat endpoint rejecting the image)

# After
> resolve_vision_provider_client() → (\"openai\", <OpenAI client base_url=https://api.openai.com/v1>, \"gpt-4o-mini\")
< vision_analyze(image_url=...) → routed to api.openai.com/v1/chat/completions on gpt-4o-mini
\`\`\`

If the user mistypes the provider (\`provider: opena1\`) or forgets \`OPENAI_API_KEY\`, they now see:

\`\`\`
RuntimeError: auxiliary.vision.provider='opena1' is set in config.yaml but no
              client could be resolved. Check that the provider name is valid
              (run: hermes config providers) and that the corresponding API
              key is set (e.g. OPENA1_API_KEY), or set
              auxiliary.vision.provider to 'auto' to use the default chain.
\`\`\`

…instead of the previous silent route-to-main-model behaviour that produced \`unknown variant image_url, expected text\` from a totally different endpoint.

## Checklist

- [x] Conventional Commits (\`fix(auxiliary-client):\`, \`feat(providers):\`, \`test(auxiliary-client):\`)
- [x] 3 focused commits, single author
- [x] 9 new tests pass; ~520 adjacent tests pass; profile-count guard updated 34 → 35
- [x] Tested on macOS 15.6 (darwin 24.6.0)
- [x] Updated \`cli-config.yaml.example\` with the openai+gpt-4o-mini side-model pattern
- [x] No new top-level config keys, no architecture change, no breakage of the \`OPENAI_API_KEY → openrouter\` auto-detection heuristic