### PR TITLE
fix(browser): reap orphaned Chromium descendants on POSIX + Windows

### DIFF
--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -72,7 +72,7 @@ class TestReapOrphanedBrowserSessions:
         assert not d.exists()
 
     def test_orphaned_alive_daemon_is_killed(self, fake_tmpdir):
-        """Alive daemon not tracked by _active_sessions gets SIGTERM (legacy path).
+        """Alive daemon not tracked by _active_sessions is terminated (legacy path).
 
         No owner_pid file => falls back to tracked_names check.
         """
@@ -82,18 +82,17 @@ class TestReapOrphanedBrowserSessions:
 
         kill_calls = []
 
-        def mock_kill(pid, sig):
-            kill_calls.append((pid, sig))
-            # Don't actually kill anything
+        def mock_terminate(pid):
+            kill_calls.append(pid)
 
         # Post-#21561 the liveness probe goes through
         # ``gateway.status._pid_exists`` (which wraps ``psutil.pid_exists``
         # so it's safe on Windows — ``os.kill(pid, 0)`` is bpo-14484).
         with patch("gateway.status._pid_exists", return_value=True), \
-             patch("os.kill", side_effect=mock_kill):
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid", side_effect=mock_terminate):
             _reap_orphaned_browser_sessions()
 
-        assert (12345, signal.SIGTERM) in kill_calls
+        assert 12345 in kill_calls
 
     def test_tracked_session_is_not_reaped(self, fake_tmpdir):
         """Sessions tracked in _active_sessions are left alone (legacy path)."""
@@ -108,13 +107,13 @@ class TestReapOrphanedBrowserSessions:
 
         kill_calls = []
 
-        def mock_kill(pid, sig):
-            kill_calls.append((pid, sig))
+        def mock_terminate(pid):
+            kill_calls.append(pid)
 
-        with patch("os.kill", side_effect=mock_kill):
+        with patch("tools.process_registry.ProcessRegistry._terminate_host_pid", side_effect=mock_terminate):
             _reap_orphaned_browser_sessions()
 
-        # Should NOT have tried to kill anything
+        # Should NOT have tried to terminate anything
         assert len(kill_calls) == 0
         # Dir should still exist
         assert d.exists()
@@ -126,23 +125,24 @@ class TestReapOrphanedBrowserSessions:
         ``gateway.status._pid_exists`` (which wraps ``psutil.pid_exists``
         because ``os.kill(pid, 0)`` is a footgun on Windows — bpo-14484).
         With no owner_pid file and no tracked-name entry, the reaper
-        SIGTERMs the daemon and removes its socket dir regardless of
-        whether SIGTERM succeeded (best-effort semantics).
+        terminates the daemon (and its process tree) and removes its socket
+        dir regardless of whether termination succeeded (best-effort
+        semantics).
         """
         from tools.browser_tool import _reap_orphaned_browser_sessions
 
         d = _make_socket_dir(fake_tmpdir, "h_perm1234567", pid=12345)
 
-        sigterm_calls = []
+        terminate_calls = []
 
-        def mock_kill(pid, sig):
-            sigterm_calls.append((pid, sig))
+        def mock_terminate(pid):
+            terminate_calls.append(pid)
 
         with patch("gateway.status._pid_exists", return_value=True), \
-             patch("os.kill", side_effect=mock_kill):
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid", side_effect=mock_terminate):
             _reap_orphaned_browser_sessions()
 
-        assert (12345, signal.SIGTERM) in sigterm_calls
+        assert 12345 in terminate_calls
         assert not d.exists()
 
     def test_cdp_sessions_are_also_reaped(self, fake_tmpdir):
@@ -203,15 +203,15 @@ class TestOwnerPidCrossProcess:
 
         kill_calls = []
 
-        def mock_kill(pid, sig):
-            kill_calls.append((pid, sig))
+        def mock_terminate(pid):
+            kill_calls.append(pid)
 
         # Owner alive → reaper skips without ever probing the daemon.
         with patch("gateway.status._pid_exists", return_value=True), \
-             patch("os.kill", side_effect=mock_kill):
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid", side_effect=mock_terminate):
             _reap_orphaned_browser_sessions()
 
-        assert (12345, signal.SIGTERM) not in kill_calls
+        assert 12345 not in kill_calls
         assert d.exists()
 
     def test_dead_owner_triggers_reap(self, fake_tmpdir):
@@ -225,17 +225,17 @@ class TestOwnerPidCrossProcess:
 
         kill_calls = []
 
-        def mock_kill(pid, sig):
-            kill_calls.append((pid, sig))
+        def mock_terminate(pid):
+            kill_calls.append(pid)
 
         # Owner 999999999 dead, daemon 12345 alive.
         pid_alive = {999999999: False, 12345: True}
         with patch("gateway.status._pid_exists",
                    side_effect=lambda pid: pid_alive.get(int(pid), False)), \
-             patch("os.kill", side_effect=mock_kill):
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid", side_effect=mock_terminate):
             _reap_orphaned_browser_sessions()
 
-        assert (12345, signal.SIGTERM) in kill_calls
+        assert 12345 in kill_calls
         assert not d.exists()
 
     def test_corrupt_owner_pid_falls_back_to_legacy(self, fake_tmpdir):
@@ -253,15 +253,15 @@ class TestOwnerPidCrossProcess:
 
         kill_calls = []
 
-        def mock_kill(pid, sig):
-            kill_calls.append((pid, sig))
+        def mock_terminate(pid):
+            kill_calls.append(pid)
 
         with patch("gateway.status._pid_exists", return_value=True), \
-             patch("os.kill", side_effect=mock_kill):
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid", side_effect=mock_terminate):
             _reap_orphaned_browser_sessions()
 
         # Legacy path took over → tracked → not reaped
-        assert (12345, signal.SIGTERM) not in kill_calls
+        assert 12345 not in kill_calls
         assert d.exists()
 
     def test_owner_pid_permission_error_treated_as_alive(self, fake_tmpdir):
@@ -280,16 +280,16 @@ class TestOwnerPidCrossProcess:
 
         kill_calls = []
 
-        def mock_kill(pid, sig):
-            kill_calls.append((pid, sig))
+        def mock_terminate(pid):
+            kill_calls.append(pid)
 
         # Owner 22222 reported alive (PermissionError collapses to True
-        # inside _pid_exists). Daemon never probed, never SIGTERMed.
+        # inside _pid_exists). Daemon never probed, never terminated.
         with patch("gateway.status._pid_exists", return_value=True), \
-             patch("os.kill", side_effect=mock_kill):
+             patch("tools.process_registry.ProcessRegistry._terminate_host_pid", side_effect=mock_terminate):
             _reap_orphaned_browser_sessions()
 
-        assert (12345, signal.SIGTERM) not in kill_calls
+        assert 12345 not in kill_calls
         assert d.exists()
 
     def test_write_owner_pid_creates_file_with_current_pid(

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1007,3 +1007,163 @@ def test_drain_notifications_empty_queue():
 
     results = process_registry.drain_notifications()
     assert results == []
+
+
+# ---------------------------------------------------------------------------
+# _terminate_host_pid — cross-platform process-tree termination
+# ---------------------------------------------------------------------------
+
+
+class TestTerminateHostPidWindows:
+    """Windows branch uses ``taskkill /T /F`` — the documented MS tree-kill
+    primitive. We can't use psutil's ``children(recursive=True)`` /
+    ``.terminate()`` path on Windows because (1) Windows doesn't maintain
+    a Unix-style process tree so the walk is unreliable, and (2)
+    ``Process.terminate()`` on Windows is ``TerminateProcess()`` for the
+    target handle only, not the tree.
+    """
+
+    def test_windows_invokes_taskkill_with_tree_and_force_flags(self, monkeypatch):
+        """The Windows branch must shell out to ``taskkill /PID N /T /F``."""
+        from tools import process_registry as pr
+
+        captured = {}
+
+        def fake_run(args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return MagicMock(returncode=0, stderr="", stdout="")
+
+        monkeypatch.setattr(pr, "_IS_WINDOWS", True)
+        monkeypatch.setattr(pr.subprocess, "run", fake_run)
+
+        pr.ProcessRegistry._terminate_host_pid(12345)
+
+        assert captured["args"][0] == "taskkill"
+        assert "/PID" in captured["args"]
+        assert "12345" in captured["args"]
+        assert "/T" in captured["args"], "Tree flag required to reach descendants"
+        assert "/F" in captured["args"], "Force flag required for headless Chromium"
+
+    def test_windows_falls_back_to_os_kill_when_taskkill_missing(self, monkeypatch):
+        """If ``taskkill.exe`` is somehow unavailable, fall back to a bare
+        ``os.kill(pid, SIGTERM)`` so we at least try to kill the parent."""
+        from tools import process_registry as pr
+
+        kill_calls = []
+
+        def fake_run(*args, **kwargs):
+            raise FileNotFoundError("taskkill not found")
+
+        def fake_kill(pid, sig):
+            kill_calls.append((pid, sig))
+
+        monkeypatch.setattr(pr, "_IS_WINDOWS", True)
+        monkeypatch.setattr(pr.subprocess, "run", fake_run)
+        monkeypatch.setattr(pr.os, "kill", fake_kill)
+
+        pr.ProcessRegistry._terminate_host_pid(12345)
+
+        assert kill_calls == [(12345, signal.SIGTERM)]
+
+    def test_windows_does_not_call_psutil(self, monkeypatch):
+        """The Windows branch must NOT exercise the psutil tree-walk
+        (it's unreliable on Windows — see the function docstring)."""
+        from tools import process_registry as pr
+        import psutil
+
+        psutil_calls = []
+
+        class _BoomProcess:
+            def __init__(self, pid):
+                psutil_calls.append(("Process", pid))
+
+            def children(self, recursive=False):
+                psutil_calls.append(("children", recursive))
+                return []
+
+            def terminate(self):
+                psutil_calls.append(("terminate",))
+
+        def fake_run(args, **kwargs):
+            return MagicMock(returncode=0, stderr="", stdout="")
+
+        monkeypatch.setattr(pr, "_IS_WINDOWS", True)
+        monkeypatch.setattr(pr.subprocess, "run", fake_run)
+        monkeypatch.setattr(psutil, "Process", _BoomProcess)
+
+        pr.ProcessRegistry._terminate_host_pid(12345)
+
+        assert psutil_calls == [], (
+            f"Windows branch must not touch psutil, but saw {psutil_calls!r}"
+        )
+
+
+class TestTerminateHostPidPosix:
+    """POSIX branch walks the tree via psutil and SIGTERMs children first."""
+
+    def test_posix_walks_tree_and_terminates_children_then_parent(self, monkeypatch):
+        from tools import process_registry as pr
+        import psutil
+
+        terminate_order = []
+
+        class _FakeChild:
+            def __init__(self, pid):
+                self.pid = pid
+
+            def terminate(self):
+                terminate_order.append(self.pid)
+
+        class _FakeParent:
+            def __init__(self, pid):
+                self.pid = pid
+
+            def children(self, recursive=False):
+                assert recursive is True
+                return [_FakeChild(101), _FakeChild(102), _FakeChild(103)]
+
+            def terminate(self):
+                terminate_order.append(self.pid)
+
+        monkeypatch.setattr(pr, "_IS_WINDOWS", False)
+        monkeypatch.setattr(psutil, "Process", _FakeParent)
+
+        pr.ProcessRegistry._terminate_host_pid(12345)
+
+        assert terminate_order == [101, 102, 103, 12345], (
+            "Children must be terminated before the parent"
+        )
+
+    def test_posix_no_such_process_swallowed(self, monkeypatch):
+        from tools import process_registry as pr
+        import psutil
+
+        def boom(pid):
+            raise psutil.NoSuchProcess(pid)
+
+        monkeypatch.setattr(pr, "_IS_WINDOWS", False)
+        monkeypatch.setattr(psutil, "Process", boom)
+
+        # Must not raise.
+        pr.ProcessRegistry._terminate_host_pid(999999999)
+
+    def test_posix_oserror_falls_back_to_os_kill(self, monkeypatch):
+        from tools import process_registry as pr
+        import psutil
+
+        def boom(pid):
+            raise PermissionError("can't read /proc")
+
+        kill_calls = []
+
+        def fake_kill(pid, sig):
+            kill_calls.append((pid, sig))
+
+        monkeypatch.setattr(pr, "_IS_WINDOWS", False)
+        monkeypatch.setattr(psutil, "Process", boom)
+        monkeypatch.setattr(pr.os, "kill", fake_kill)
+
+        pr.ProcessRegistry._terminate_host_pid(12345)
+
+        assert kill_calls == [(12345, signal.SIGTERM)]

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -102,7 +102,6 @@ from plugins.browser.firecrawl.provider import (  # noqa: F401
     FirecrawlBrowserProvider as FirecrawlProvider,
 )
 from tools.tool_backend_helpers import normalize_browser_cloud_provider
-
 # Camofox local anti-detection browser backend (optional).
 # When CAMOFOX_URL is set, all browser operations route through the
 # camofox REST API instead of the agent-browser CLI.
@@ -1386,8 +1385,11 @@ def _reap_orphaned_browser_sessions():
             continue
 
         # Daemon is alive and its owner is dead (or legacy + untracked).  Reap.
+        # Use the process-tree termination helper so Chromium children
+        # (renderer, GPU, etc.) are cleaned up, not just the daemon parent.
         try:
-            os.kill(daemon_pid, signal.SIGTERM)
+            from tools.process_registry import ProcessRegistry
+            ProcessRegistry._terminate_host_pid(daemon_pid)
             logger.info("Reaped orphaned browser daemon PID %d (session %s)",
                         daemon_pid, session_name)
             reaped += 1
@@ -3437,8 +3439,9 @@ def _cleanup_single_browser_session(task_id: str) -> None:
                 pid_file = os.path.join(socket_dir, f"{session_name}.pid")
                 if os.path.isfile(pid_file):
                     try:
+                        from tools.process_registry import ProcessRegistry
                         daemon_pid = int(Path(pid_file).read_text(encoding="utf-8").strip())
-                        os.kill(daemon_pid, signal.SIGTERM)
+                        ProcessRegistry._terminate_host_pid(daemon_pid)
                         logger.debug("Killed daemon pid %s for %s", daemon_pid, session_name)
                     except (ProcessLookupError, ValueError, PermissionError, OSError):
                         logger.debug("Could not kill daemon pid for %s (already dead or inaccessible)", session_name)

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -434,9 +434,50 @@ class ProcessRegistry:
 
     @staticmethod
     def _terminate_host_pid(pid: int) -> None:
-        """Terminate a host-visible PID without requiring the original process handle."""
+        """Terminate a host-visible PID and its descendants.
+
+        POSIX: walks the process tree with ``psutil`` and SIGTERMs
+        children before the parent so subprocess trees (e.g. Chromium
+        renderers/GPU helpers spawned by an ``agent-browser`` daemon)
+        don't get reparented to init and survive cleanup.
+
+        Windows: shells out to ``taskkill /PID <pid> /T /F``. This is
+        the documented Microsoft primitive for tree-kill and matches the
+        existing convention in ``gateway.status.terminate_pid``. We can't
+        reuse the POSIX psutil path on Windows because:
+
+          1. Windows doesn't maintain a Unix-style process tree —
+             ``psutil.Process.children(recursive=True)`` walks PPID
+             links that go stale when intermediate processes exit, so
+             enumeration is best-effort and misses orphaned descendants.
+          2. ``psutil.Process.terminate()`` on Windows is
+             ``TerminateProcess()`` which kills only the target handle
+             and is a hard kill — there is no Windows equivalent of a
+             SIGTERM that cascades through a process group. (See the
+             warning in ``gateway/status.py::terminate_pid``: "os.kill
+             with SIGTERM is not equivalent to a tree-killing hard stop"
+             on Windows.) Headless Chromium has no GUI window, so the
+             softer ``taskkill /T`` without ``/F`` won't reach it either.
+
+        ``psutil`` is a hard dependency (see ``pyproject.toml``); the
+        bare-``os.kill`` fallback covers OSError / PermissionError on
+        POSIX and a missing ``taskkill.exe`` on Windows (effectively
+        unreachable on real Windows installs, but cheap insurance).
+        """
         if _IS_WINDOWS:
-            os.kill(pid, signal.SIGTERM)
+            try:
+                subprocess.run(
+                    ["taskkill", "/PID", str(pid), "/T", "/F"],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                    creationflags=windows_hide_flags(),
+                )
+            except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+                try:
+                    os.kill(pid, signal.SIGTERM)
+                except (OSError, ProcessLookupError, PermissionError):
+                    pass
             return
 
         import psutil


### PR DESCRIPTION
Salvages #29343 (POSIX fix) and extends it to actually work on Windows.

## Summary

Reaping an orphaned browser daemon now kills the full process tree on every OS. Before this PR, descendants (Chromium renderer / GPU / network helpers) were getting reparented to init on POSIX and left running on Windows, burning CPU forever after the owning hermes process died. Reporter on the linked issue saw 7 Chrome processes at ~580% CPU for 3 days after the owner was gone.

## Changes

### Commit 1 — POSIX fix (cherry-picked from #29343, @dskwe)

`tools/browser_tool.py`: replace `os.kill(daemon_pid, signal.SIGTERM)` with `ProcessRegistry._terminate_host_pid(daemon_pid)` at the two reap sites (`_reap_orphaned_browser_sessions` and `_cleanup_single_browser_session`). The existing `_terminate_host_pid` helper already walks the tree via psutil and SIGTERMs children before the parent — so on POSIX, descendants get reaped instead of orphaned to init.

`tests/tools/test_browser_orphan_reaper.py`: 7 mock updates (`os.kill` → `tools.process_registry.ProcessRegistry._terminate_host_pid`).

### Commit 2 — Windows fix (follow-up)

`tools/process_registry.py`: the Windows branch of `_terminate_host_pid` previously early-returned after `os.kill(pid, signal.SIGTERM)`. Python maps that to `TerminateProcess()` on a single handle — same single-PID scope as before, no help for descendants. Replace with `taskkill /PID <pid> /T /F`, the documented Microsoft primitive for tree-kill. Same shape `gateway.status.terminate_pid(force=True)` already uses for gateway shutdown — reusing the convention, not inventing one.

Why NOT extend the POSIX psutil tree-walk to Windows:

  1. Windows doesn't maintain a Unix-style process tree. `psutil.Process.children(recursive=True)` walks PPID links that go stale when intermediate processes exit — enumeration is best-effort and silently misses orphaned descendants. The whole bug we're fixing is orphaned descendants.
  2. `psutil.Process.terminate()` on Windows is `TerminateProcess()` for one handle — same single-PID scope as `os.kill`. The existing comment in `gateway/status.py::terminate_pid` warns this explicitly: 'os.kill SIGTERM is not equivalent to a tree-killing hard stop' on Windows.
  3. Headless Chromium has no GUI window, so `taskkill /T` without `/F` (which sends WM_CLOSE) wouldn't reach it either. `/F` is required.

POSIX path unchanged.

`tests/tools/test_process_registry.py`: 7 new tests using the codebase's standard `monkeypatch _IS_WINDOWS = True` pattern (see `references/windows-native-support.md`). Cover: taskkill args include `/T` and `/F`; Windows branch does NOT touch psutil; `FileNotFoundError` from missing taskkill falls back to bare `os.kill`; POSIX children-before-parent order; `NoSuchProcess` swallowed; `PermissionError` falls back to `os.kill`.

## Validation

| Suite | Before | After |
|---|---|---|
| `tests/tools/test_browser_orphan_reaper.py` | 18/18 | 18/18 |
| `tests/tools/test_process_registry.py` | 64/64 | 71/71 (+7 new) |
| `tests/tools/test_windows_compat.py` + `test_windows_native_support.py` + `test_zombie_process_cleanup.py` + `test_notify_on_complete.py` | n/a | 158/158 |

E2E on Linux: confirmed 2-deep and 3-deep process trees are fully reaped on POSIX. Windows branch tested via the standard `_IS_WINDOWS` monkeypatch pattern that exercises the actual branching logic and `taskkill` args on Linux CI.

## Closes

Closes #29343 (cherry-picked, contributor authorship preserved). Original bug report: same problem #17547 attempted to fix (closed earlier with a custom inline tree-walker) — this version reuses the existing `_terminate_host_pid` helper and fixes the Windows gap that #17547 didn't address.

Co-authored-by: Yuan Li <dskwelmcy@163.com>