### PR TITLE
docs: clarify Anthropic OAuth policy risk

### DIFF
--- a/website/docs/developer-guide/provider-runtime.md
+++ b/website/docs/developer-guide/provider-runtime.md
@@ -129,7 +129,7 @@ When provider resolution selects `anthropic`, Hermes uses:
 - the native Anthropic Messages API
 - `agent/anthropic_adapter.py` for translation
 
-Credential resolution for native Anthropic now prefers refreshable Claude Code credentials over copied env tokens when both are present. In practice that means:
+Credential resolution for native Anthropic supports API keys and OAuth-like Claude credentials. `ANTHROPIC_API_KEY` is the recommended path for normal third-party use; Claude/claude.ai OAuth and Claude Code credential reuse are policy-sensitive and should only be used when Anthropic explicitly permits the use case. When multiple Anthropic credentials exist, `hermes auth list anthropic` shows the selected credential; remove/suppress OAuth entries with `hermes auth remove anthropic <index-or-label>` before relying on API-key auth. Mechanically, Hermes handles those credential sources as follows:
 
 - Claude Code credential files are treated as the preferred source when they include refreshable auth
 - manual `ANTHROPIC_TOKEN` / `CLAUDE_CODE_OAUTH_TOKEN` values still work as explicit overrides

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -104,7 +104,7 @@ Good defaults:
 |----------|-----------|---------------|
 | **Nous Portal** | Subscription-based, zero-config | OAuth login via `hermes model` |
 | **OpenAI Codex** | ChatGPT OAuth, uses Codex models | Device code auth via `hermes model` |
-| **Anthropic** | Claude models directly — Max plan + extra usage credits (OAuth), or API key for pay-per-token | `hermes model` → OAuth login (requires Max + extra credits), or an Anthropic API key |
+| **Anthropic** | Claude models directly through Anthropic's API | `ANTHROPIC_API_KEY` recommended; Claude/claude.ai OAuth is policy-sensitive for third-party clients and should be used only when Anthropic explicitly permits your use case |
 | **OpenRouter** | Multi-provider routing across many models | Enter your API key |
 | **Z.AI** | GLM / Zhipu-hosted models | Set `GLM_API_KEY` / `ZAI_API_KEY` |
 | **Kimi / Moonshot** | Moonshot-hosted coding and chat models | Set `KIMI_API_KEY` (or the Kimi-Coding-specific `KIMI_CODING_API_KEY`) |

--- a/website/docs/guides/oauth-over-ssh.md
+++ b/website/docs/guides/oauth-over-ssh.md
@@ -50,7 +50,7 @@ Hermes uses the **same PKCE verifier, state and nonce** for both paths, so the u
 |----------|---------------|----------------|
 | `xai-oauth` (Grok SuperGrok) | `56121` | Yes, when Hermes is remote |
 | Spotify | `43827` | Yes, when Hermes is remote |
-| `anthropic` (Claude Pro/Max) | n/a | No — paste-the-code flow |
+| `anthropic` (Claude OAuth/setup-token) | n/a | No — paste-the-code flow; policy-sensitive for third-party clients, prefer API keys unless Anthropic explicitly permits your use case |
 | `openai-codex` (ChatGPT Plus/Pro) | n/a | No — device code flow |
 | `minimax`, `nous-portal` | n/a | No — device code flow |
 

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -18,7 +18,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **OpenAI Codex** | `hermes model` (ChatGPT OAuth, uses Codex models) |
 | **GitHub Copilot** | `hermes model` (OAuth device code flow, `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `gh auth token`) |
 | **GitHub Copilot ACP** | `hermes model` (spawns local `copilot --acp --stdio`) |
-| **Anthropic** | `hermes model` (Claude Max + extra usage credits via OAuth; also supports Anthropic API key or manual setup-token — see note below) |
+| **Anthropic** | `ANTHROPIC_API_KEY` in `~/.hermes/.env` (recommended). Claude/claude.ai OAuth is experimental and should only be used when Anthropic explicitly permits your use case — see policy note below. |
 | **OpenRouter** | `OPENROUTER_API_KEY` in `~/.hermes/.env` |
 | **NovitaAI** | `NOVITA_API_KEY` in `~/.hermes/.env` (provider: `novita`, 200+ models, Model API, Agent Sandbox, GPU Cloud) |
 | **AI Gateway** | `AI_GATEWAY_API_KEY` in `~/.hermes/.env` (provider: `ai-gateway`) |
@@ -181,32 +181,49 @@ If the portal invalidates the refresh token (password change, manual revoke, ses
 
 ### Anthropic (Native)
 
-Use Claude models directly through the Anthropic API — no OpenRouter proxy needed. Supports three auth methods:
+Use Claude models directly through the Anthropic API — no OpenRouter proxy needed.
+For most users, the safest and clearest setup is an Anthropic Console API key:
 
-:::caution Requires Claude Max "extra usage" credits
-When you authenticate via `hermes model` → Anthropic OAuth (or via `hermes auth add anthropic --type oauth`), Hermes routes as Claude Code against your Anthropic account. **It only works if you're on a Claude Max plan and have purchased extra usage credits.** The base Max plan allowance (the usage included in Claude Code by default) is not consumed by Hermes — only the extra/overage credits you've added on top are. Claude Pro subscribers cannot use this path.
+```bash
+export ANTHROPIC_API_KEY=***
+hermes chat --provider anthropic --model claude-sonnet-4-6
+```
 
-If you don't have Max + extra credits, use an `ANTHROPIC_API_KEY` instead — requests are billed pay-per-token against that key's organization (standard API pricing, independent of any Claude subscription).
+:::warning Claude/claude.ai OAuth policy risk
+Hermes has experimental support for Claude OAuth/setup-token credentials (`hermes model` → Anthropic OAuth, `hermes auth add anthropic --type oauth`, `ANTHROPIC_TOKEN`, and auto-detected Claude Code credentials). Only use this path if Anthropic explicitly permits your use case.
+
+Anthropic's [Consumer Terms](https://www.anthropic.com/legal/consumer-terms) restrict automated/non-human access except through an Anthropic API key or where otherwise explicitly permitted. Anthropic's [Claude Agent SDK docs](https://code.claude.com/docs/en/agent-sdk/overview) also state that, unless previously approved, third-party developers may not offer claude.ai login or rate limits for their products and should use API-key authentication instead.
+
+That means a working OAuth prompt or token exchange is not, by itself, permission to route Hermes through Claude subscription limits. If you are unsure, use `ANTHROPIC_API_KEY` instead.
+
+If you already have Claude Code or Hermes Anthropic OAuth credentials, check the active source before assuming your API key is being used:
+
+```bash
+hermes auth list anthropic
+# If an OAuth credential is selected, remove/suppress it before relying on API-key auth:
+hermes auth remove anthropic <index-or-label>
+hermes auth add anthropic --type api-key
+```
 :::
 
 ```bash
-# With an API key (pay-per-token)
+# Recommended: API key (pay-per-token, governed by Anthropic's API terms)
 export ANTHROPIC_API_KEY=***
 hermes chat --provider anthropic --model claude-sonnet-4-6
 
-# Preferred: authenticate through `hermes model`
-# Hermes will use Claude Code's credential store directly when available
-hermes model
-
-# Manual override with a setup-token (fallback / legacy)
-export ANTHROPIC_TOKEN=***  # setup-token or manual OAuth token
+# Experimental / policy-sensitive: Claude OAuth credentials
+hermes auth add anthropic --type oauth
 hermes chat --provider anthropic
 
-# Auto-detect Claude Code credentials (if you already use Claude Code)
-hermes chat --provider anthropic  # reads Claude Code credential files automatically
+# Experimental / policy-sensitive: manual setup-token override
+export ANTHROPIC_TOKEN=***
+hermes chat --provider anthropic
+
+# Also experimental / policy-sensitive: auto-detect Claude Code credentials
+hermes chat --provider anthropic  # reads Claude Code credential files when available
 ```
 
-When you choose Anthropic OAuth through `hermes model`, Hermes prefers Claude Code's own credential store over copying the token into `~/.hermes/.env`. That keeps refreshable Claude credentials refreshable.
+When Anthropic OAuth is used, Hermes prefers Claude Code's own credential store over copying the token into `~/.hermes/.env`. That keeps refreshable Claude credentials refreshable, but does not change the policy considerations above.
 
 Or set it permanently:
 ```yaml

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -69,7 +69,7 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 | `HERMES_GEMINI_CLIENT_SECRET` | OAuth client secret for `google-gemini-cli` (optional) |
 | `HERMES_GEMINI_PROJECT_ID` | GCP project ID for paid Gemini tiers (free tier auto-provisions) |
 | `ANTHROPIC_API_KEY` | Anthropic Console API key ([console.anthropic.com](https://console.anthropic.com/)) |
-| `ANTHROPIC_TOKEN` | Manual or legacy Anthropic OAuth/setup-token override |
+| `ANTHROPIC_TOKEN` | Manual or legacy Anthropic OAuth/setup-token override. Policy-sensitive: prefer `ANTHROPIC_API_KEY` unless Anthropic explicitly permits your OAuth use case. |
 | `DASHSCOPE_API_KEY` | Qwen Cloud (Alibaba DashScope) API key for Qwen models ([modelstudio.console.alibabacloud.com](https://modelstudio.console.alibabacloud.com/)) |
 | `DASHSCOPE_BASE_URL` | Custom DashScope base URL (default: `https://dashscope-intl.aliyuncs.com/compatible-mode/v1`; use `https://dashscope.aliyuncs.com/compatible-mode/v1` for mainland-China region) |
 | `DEEPSEEK_API_KEY` | DeepSeek API key for direct DeepSeek access ([platform.deepseek.com](https://platform.deepseek.com/api_keys)) |
@@ -109,7 +109,7 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 
 ## Provider Auth (OAuth)
 
-For native Anthropic auth, Hermes prefers Claude Code's own credential files when they exist because those credentials can refresh automatically. **OAuth against Anthropic requires a Claude Max plan with purchased extra usage credits** — Hermes routes as Claude Code, which only draws from the Max plan's extra/overage credits, not the base Max allowance, and does not work on Claude Pro. Without Max + extra credits, use an API key instead. Environment variables such as `ANTHROPIC_TOKEN` remain useful as manual overrides, but they are no longer the preferred path for Claude Max login.
+For native Anthropic auth, `ANTHROPIC_API_KEY` is the recommended path. Hermes can also read Claude Code credential files and `ANTHROPIC_TOKEN`/`CLAUDE_CODE_OAUTH_TOKEN` overrides, but Claude/claude.ai OAuth is policy-sensitive for third-party clients. Anthropic's published guidance says third-party developers should use API-key authentication unless they have prior approval to offer claude.ai login or rate limits. Use OAuth only if Anthropic explicitly permits your use case. If `hermes auth list anthropic` shows an OAuth credential selected, remove/suppress it with `hermes auth remove anthropic <index-or-label>` before relying on API-key auth. See [AI Providers](../integrations/providers.md#anthropic-native) for the full policy note.
 
 | Variable | Description |
 |----------|-------------|

--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -19,7 +19,7 @@ Hermes Agent works with any OpenAI-compatible API. Supported providers include:
 - **[OpenRouter](https://openrouter.ai/)** — access hundreds of models through one API key (recommended for flexibility)
 - **Nous Portal** — Nous Research's own inference endpoint
 - **OpenAI** — GPT-5.4, GPT-5-codex, GPT-4.1, GPT-4o, etc.
-- **Anthropic** — Claude models (direct API, OAuth via `hermes login anthropic`, OpenRouter, or any compatible proxy)
+- **Anthropic** — Claude models via `ANTHROPIC_API_KEY`, OpenRouter, or any compatible proxy. Claude/claude.ai OAuth in third-party clients is policy-sensitive; use it only when Anthropic explicitly permits your use case.
 - **Google** — Gemini models (direct API via `gemini` provider, the `google-gemini-cli` OAuth provider, OpenRouter, or compatible proxy)
 - **z.ai / ZhipuAI** — GLM models
 - **Kimi / Moonshot AI** — Kimi models

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -40,7 +40,8 @@ hermes auth add openrouter --api-key sk-or-v1-your-second-key
 # Add a second Anthropic key
 hermes auth add anthropic --type api-key --api-key sk-ant-api03-your-second-key
 
-# Add an Anthropic OAuth credential (requires Claude Max plan + extra usage credits)
+# Add an Anthropic OAuth credential only if Anthropic explicitly permits your use case
+# (third-party claude.ai OAuth/rate-limit use is policy-sensitive; API keys are safer)
 hermes auth add anthropic --type oauth
 # Opens browser for OAuth login
 ```


### PR DESCRIPTION
## Summary
- Recommend `ANTHROPIC_API_KEY` as the safest/default Anthropic setup path.
- Mark Claude/claude.ai OAuth, setup-token, and Claude Code credential reuse as experimental/policy-sensitive unless Anthropic explicitly permits the use case.
- Add guidance to check `hermes auth list anthropic` and remove/suppress OAuth credentials before relying on API-key auth.
- Update provider, quickstart, FAQ, env var, credential pool, OAuth-over-SSH, and provider runtime docs for consistency.

## Why
Anthropic's Consumer Terms and Claude Agent SDK guidance make third-party claude.ai login/rate-limit use policy-sensitive unless explicitly approved. The prior docs could read as if Claude subscription OAuth was a normal recommended path. This makes the safer API-key path clear and avoids implying permission from a working token exchange alone.

## Validation
- `npm ci`
- `npm run build` ✅ exited 0
  - Existing/pre-existing Docusaurus broken-link and broken-anchor warnings remain, especially in localized docs.
  - Prebuild skipped populated Skills Hub extraction because local Python lacks `yaml`, but the build completed.
- `git diff --check` ✅
- `npm run lint:diagrams` ⚠️ could not run locally because `ascii-guard` is not installed/available after `npm ci`.
