### PR TITLE
feat(browser): add native CloakBrowser backend

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -707,6 +707,12 @@ DEFAULT_CONFIG = {
             # Rehydrate tab_id from Camofox before creating a new tab.
             "adopt_existing_tab": False,
         },
+        "cloakbrowser": {
+            # Native stealth Chromium backend via the Python cloakbrowser package.
+            # When enabled, browser tools route through tools/browser_cloak.py
+            # instead of agent-browser/Camofox. BROWSER_CDP_URL still wins.
+            "enabled": False,
+        },
     },
 
     # Filesystem checkpoints — automatic snapshots before destructive file ops.

--- a/tests/tools/test_browser_cloak.py
+++ b/tests/tools/test_browser_cloak.py
@@ -1,0 +1,43 @@
+"""Tests for the native CloakBrowser backend integration."""
+
+import json
+from unittest.mock import patch
+
+
+def test_cloakbrowser_mode_env_enabled_and_cdp_override_takes_precedence(monkeypatch):
+    from tools.browser_cloak import is_cloakbrowser_mode
+
+    monkeypatch.setenv("CLOAKBROWSER_ENABLED", "true")
+    monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+    assert is_cloakbrowser_mode() is True
+
+    monkeypatch.setenv("BROWSER_CDP_URL", "http://127.0.0.1:9222")
+    assert is_cloakbrowser_mode() is False
+
+
+def test_browser_navigate_routes_to_cloakbrowser_before_camofox(monkeypatch):
+    import tools.browser_tool as bt
+
+    monkeypatch.setattr(bt, "_is_cloakbrowser_mode", lambda: True)
+    monkeypatch.setattr(bt, "_is_camofox_mode", lambda: True)
+
+    with patch("tools.browser_cloak.cloakbrowser_navigate", return_value=json.dumps({"success": True, "backend": "cloakbrowser"})) as cloak_nav, \
+         patch("tools.browser_camofox.camofox_navigate", return_value=json.dumps({"success": True, "backend": "camofox"})) as camo_nav:
+        result = json.loads(bt.browser_navigate("https://example.com", task_id="pytest-cloak"))
+
+    assert result["success"] is True
+    assert result["backend"] == "cloakbrowser"
+    cloak_nav.assert_called_once_with("https://example.com", "pytest-cloak")
+    camo_nav.assert_not_called()
+
+
+def test_check_browser_requirements_uses_cloakbrowser_availability(monkeypatch):
+    import tools.browser_tool as bt
+
+    monkeypatch.setattr(bt, "_is_cloakbrowser_mode", lambda: True)
+
+    monkeypatch.setattr("tools.browser_cloak.check_cloakbrowser_available", lambda: True)
+    assert bt.check_browser_requirements() is True
+
+    monkeypatch.setattr("tools.browser_cloak.check_cloakbrowser_available", lambda: False)
+    assert bt.check_browser_requirements() is False

--- a/tools/browser_cloak.py
+++ b/tools/browser_cloak.py
@@ -1,0 +1,348 @@
+"""Native CloakBrowser backend for Hermes browser tools.
+
+CloakBrowser is a stealth Chromium Playwright wrapper.  This module keeps the
+same high-level contract as the regular browser tool backend while avoiding the
+agent-browser CLI and the Camofox REST server.
+
+Enable with either:
+- CLOAKBROWSER_ENABLED=true
+- browser.cloakbrowser.enabled: true in config.yaml
+
+A live CDP override (BROWSER_CDP_URL) always takes precedence so /browser
+connect keeps operating on the user-selected browser.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import tempfile
+import threading
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from hermes_cli.config import load_config
+from tools.registry import tool_error
+from utils import is_truthy_value
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TIMEOUT_MS = 60_000
+_SCROLL_PIXELS = 500
+_ACTION_SELECTOR = ", ".join(
+    [
+        "a",
+        "button",
+        "input",
+        "textarea",
+        "select",
+        "summary",
+        "[role=button]",
+        "[role=link]",
+        "[role=checkbox]",
+        "[role=radio]",
+        "[role=tab]",
+        "[role=menuitem]",
+        "[contenteditable=true]",
+        "[onclick]",
+    ]
+)
+
+_sessions: Dict[str, Dict[str, Any]] = {}
+_sessions_lock = threading.Lock()
+
+
+def _cfg_enabled() -> bool:
+    try:
+        browser_cfg = load_config().get("browser", {})
+        cloak_cfg = browser_cfg.get("cloakbrowser", {}) if isinstance(browser_cfg, dict) else {}
+        if isinstance(cloak_cfg, dict):
+            return bool(cloak_cfg.get("enabled"))
+    except Exception as exc:
+        logger.debug("Could not read browser.cloakbrowser.enabled: %s", exc)
+    return False
+
+
+def is_cloakbrowser_mode() -> bool:
+    """Return True when CloakBrowser backend is enabled.
+
+    CDP override wins because it represents an explicit user/browser connect.
+    """
+    if os.getenv("BROWSER_CDP_URL", "").strip():
+        return False
+    return is_truthy_value(os.getenv("CLOAKBROWSER_ENABLED", "")) or _cfg_enabled()
+
+
+def check_cloakbrowser_available() -> bool:
+    """True when the Python package and browser binary are available."""
+    if not is_cloakbrowser_mode():
+        return False
+    try:
+        import cloakbrowser  # noqa: F401
+        from cloakbrowser import ensure_binary
+
+        ensure_binary()
+        return True
+    except Exception as exc:
+        logger.debug("CloakBrowser unavailable: %s", exc)
+        return False
+
+
+def _get_session(task_id: Optional[str]) -> Dict[str, Any]:
+    task_id = task_id or "default"
+    with _sessions_lock:
+        session = _sessions.get(task_id)
+        if session:
+            return session
+
+    from cloakbrowser import launch
+
+    headless = not is_truthy_value(os.getenv("CLOAKBROWSER_HEADFUL", ""))
+    humanize = is_truthy_value(os.getenv("CLOAKBROWSER_HUMANIZE", "true"))
+    browser = launch(headless=headless, humanize=humanize)
+    context = browser.new_context()
+    page = context.new_page()
+    page.set_default_timeout(_DEFAULT_TIMEOUT_MS)
+    session = {
+        "browser": browser,
+        "context": context,
+        "page": page,
+        "refs": {},
+    }
+    with _sessions_lock:
+        existing = _sessions.get(task_id)
+        if existing:
+            try:
+                browser.close()
+            except Exception:
+                pass
+            return existing
+        _sessions[task_id] = session
+    return session
+
+
+def _page(task_id: Optional[str]):
+    return _get_session(task_id)["page"]
+
+
+def _json(data: Dict[str, Any]) -> str:
+    return json.dumps(data, ensure_ascii=False)
+
+
+def _clean_ref(ref: str) -> str:
+    return (ref or "").lstrip("@")
+
+
+def _locator_for_ref(session: Dict[str, Any], ref: str):
+    clean = _clean_ref(ref)
+    if not clean:
+        raise ValueError("Empty element ref")
+    selector = session.get("refs", {}).get(clean) or f'[data-hermes-ref="{clean}"]'
+    return session["page"].locator(selector).first()
+
+
+def _refresh_refs(session: Dict[str, Any]) -> int:
+    page = session["page"]
+    refs = page.evaluate(
+        """
+        (selector) => {
+          const nodes = Array.from(document.querySelectorAll(selector));
+          const refs = {};
+          let idx = 1;
+          for (const el of nodes) {
+            const rect = el.getBoundingClientRect();
+            const style = window.getComputedStyle(el);
+            const visible = rect.width > 0 && rect.height > 0 && style.visibility !== 'hidden' && style.display !== 'none';
+            if (!visible) continue;
+            const ref = `e${idx++}`;
+            el.setAttribute('data-hermes-ref', ref);
+            refs[ref] = `[data-hermes-ref="${ref}"]`;
+          }
+          return refs;
+        }
+        """,
+        _ACTION_SELECTOR,
+    )
+    session["refs"] = refs or {}
+    return len(session["refs"])
+
+
+def _compact_refs_text(session: Dict[str, Any]) -> str:
+    page = session["page"]
+    items = page.evaluate(
+        """
+        () => Array.from(document.querySelectorAll('[data-hermes-ref]')).map(el => ({
+          ref: el.getAttribute('data-hermes-ref'),
+          tag: el.tagName.toLowerCase(),
+          role: el.getAttribute('role') || '',
+          text: (el.innerText || el.getAttribute('aria-label') || el.getAttribute('placeholder') || el.getAttribute('alt') || el.value || '').trim().slice(0, 120),
+          href: el.getAttribute('href') || ''
+        }))
+        """
+    )
+    lines = []
+    for item in items or []:
+        label = item.get("text") or item.get("href") or item.get("tag")
+        role = item.get("role") or item.get("tag")
+        lines.append(f'- {role} "{label}" [@{item.get("ref")}]')
+    return "\n".join(lines)
+
+
+def _snapshot_text(session: Dict[str, Any], full: bool = False) -> str:
+    page = session["page"]
+    try:
+        snap = page.locator("body").aria_snapshot(timeout=10_000)
+    except Exception:
+        snap = page.content()
+    ref_count = _refresh_refs(session)
+    refs = _compact_refs_text(session)
+    if refs:
+        snap = f"{snap}\n\nInteractive elements:\n{refs}"
+    if not full and len(snap) > 8000:
+        snap = snap[:8000] + f"\n\n[Snapshot truncated; {ref_count} interactive elements indexed]"
+    return snap
+
+
+def cloakbrowser_navigate(url: str, task_id: Optional[str] = None) -> str:
+    try:
+        session = _get_session(task_id)
+        page = session["page"]
+        page.goto(url, wait_until="domcontentloaded", timeout=_DEFAULT_TIMEOUT_MS)
+        try:
+            page.wait_for_load_state("networkidle", timeout=5_000)
+        except Exception:
+            pass
+        snapshot = _snapshot_text(session, full=False)
+        return _json({
+            "success": True,
+            "backend": "cloakbrowser",
+            "url": page.url,
+            "title": page.title(),
+            "snapshot": snapshot,
+            "element_count": len(session.get("refs", {})),
+        })
+    except Exception as exc:
+        return tool_error(f"CloakBrowser navigation failed: {exc}", success=False)
+
+
+def cloakbrowser_snapshot(full: bool = False, task_id: Optional[str] = None, user_task: Optional[str] = None) -> str:
+    try:
+        session = _get_session(task_id)
+        snapshot = _snapshot_text(session, full=full)
+        return _json({"success": True, "snapshot": snapshot, "element_count": len(session.get("refs", {}))})
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+def cloakbrowser_click(ref: str, task_id: Optional[str] = None) -> str:
+    try:
+        session = _get_session(task_id)
+        loc = _locator_for_ref(session, ref)
+        loc.click()
+        return _json({"success": True, "clicked": _clean_ref(ref), "url": session["page"].url})
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+def cloakbrowser_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
+    try:
+        session = _get_session(task_id)
+        loc = _locator_for_ref(session, ref)
+        loc.fill("")
+        loc.type(text)
+        return _json({"success": True, "typed": text, "element": _clean_ref(ref)})
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+def cloakbrowser_scroll(direction: str, task_id: Optional[str] = None) -> str:
+    try:
+        page = _page(task_id)
+        delta = _SCROLL_PIXELS if direction == "down" else -_SCROLL_PIXELS
+        page.mouse.wheel(0, delta)
+        return _json({"success": True, "scrolled": direction})
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+def cloakbrowser_back(task_id: Optional[str] = None) -> str:
+    try:
+        page = _page(task_id)
+        page.go_back(wait_until="domcontentloaded")
+        return _json({"success": True, "url": page.url})
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+def cloakbrowser_press(key: str, task_id: Optional[str] = None) -> str:
+    try:
+        _page(task_id).keyboard.press(key)
+        return _json({"success": True, "pressed": key})
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+def cloakbrowser_get_images(task_id: Optional[str] = None) -> str:
+    try:
+        page = _page(task_id)
+        images = page.evaluate(
+            """
+            () => Array.from(document.images).map(img => ({
+              src: img.currentSrc || img.src || '',
+              alt: img.alt || ''
+            })).filter(x => x.src || x.alt)
+            """
+        )
+        return _json({"success": True, "images": images or [], "count": len(images or [])})
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+def cloakbrowser_console(clear: bool = False, expression: Optional[str] = None, task_id: Optional[str] = None) -> str:
+    try:
+        page = _page(task_id)
+        result: Dict[str, Any] = {"success": True}
+        if expression:
+            result["result"] = page.evaluate(expression)
+        else:
+            result["messages"] = []
+            result["errors"] = []
+        return _json(result)
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+def cloakbrowser_screenshot(task_id: Optional[str] = None) -> str:
+    session = _get_session(task_id)
+    path = Path(tempfile.gettempdir()) / f"hermes_cloak_{os.getpid()}_{task_id or 'default'}.png"
+    session["page"].screenshot(path=str(path), full_page=True)
+    return str(path)
+
+
+def cloakbrowser_vision(question: str, annotate: bool = False, task_id: Optional[str] = None) -> str:
+    try:
+        path = cloakbrowser_screenshot(task_id)
+        from tools.vision_tool import analyze_image
+
+        analysis = analyze_image(str(path), question)
+        return _json({"success": True, "analysis": analysis, "screenshot_path": str(path)})
+    except Exception as exc:
+        return tool_error(str(exc), success=False)
+
+
+def cloakbrowser_close(task_id: Optional[str] = None) -> str:
+    task_id = task_id or "default"
+    with _sessions_lock:
+        session = _sessions.pop(task_id, None)
+    if session:
+        try:
+            session["browser"].close()
+        except Exception as exc:
+            return _json({"success": True, "closed": True, "warning": str(exc)})
+    return _json({"success": True, "closed": True})
+
+
+def cloakbrowser_soft_cleanup(task_id: Optional[str] = None) -> bool:
+    return False

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -111,6 +111,15 @@ try:
 except ImportError:
     _is_camofox_mode = lambda: False  # noqa: E731
 
+# CloakBrowser native stealth Chromium backend (optional).  This routes browser
+# operations through the Python Playwright wrapper instead of the agent-browser
+# CLI or the Camofox REST server.  CDP overrides still take precedence inside
+# browser_cloak.is_cloakbrowser_mode().
+try:
+    from tools.browser_cloak import is_cloakbrowser_mode as _is_cloakbrowser_mode
+except ImportError:
+    _is_cloakbrowser_mode = lambda: False  # noqa: E731
+
 logger = logging.getLogger(__name__)
 
 # Standard PATH entries for environments with minimal PATH (e.g. systemd services).
@@ -2354,6 +2363,13 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
             "blocked_by_policy": {"host": blocked["host"], "rule": blocked["rule"], "source": blocked["source"]},
         })
 
+    # CloakBrowser backend — delegate after safety checks pass.  Check before
+    # Camofox so users can enable CloakBrowser as a replacement without having
+    # to remove an existing CAMOFOX_URL from their environment.
+    if _is_cloakbrowser_mode():
+        from tools.browser_cloak import cloakbrowser_navigate
+        return cloakbrowser_navigate(url, task_id)
+
     # Camofox backend — delegate after safety checks pass
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_navigate
@@ -2501,6 +2517,10 @@ def browser_snapshot(
     Returns:
         JSON string with page snapshot
     """
+    if _is_cloakbrowser_mode():
+        from tools.browser_cloak import cloakbrowser_snapshot
+        return cloakbrowser_snapshot(full, task_id, user_task)
+
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_snapshot
         return camofox_snapshot(full, task_id, user_task)
@@ -2565,6 +2585,10 @@ def browser_click(ref: str, task_id: Optional[str] = None) -> str:
     Returns:
         JSON string with click result
     """
+    if _is_cloakbrowser_mode():
+        from tools.browser_cloak import cloakbrowser_click
+        return cloakbrowser_click(ref, task_id)
+
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_click
         return camofox_click(ref, task_id)
@@ -2603,6 +2627,10 @@ def browser_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
     Returns:
         JSON string with type result
     """
+    if _is_cloakbrowser_mode():
+        from tools.browser_cloak import cloakbrowser_type
+        return cloakbrowser_type(ref, text, task_id)
+
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_type
         return camofox_type(ref, text, task_id)
@@ -2649,6 +2677,10 @@ def browser_scroll(direction: str, task_id: Optional[str] = None) -> str:
             "error": f"Invalid direction '{direction}'. Use 'up' or 'down'."
         }, ensure_ascii=False)
 
+    if _is_cloakbrowser_mode():
+        from tools.browser_cloak import cloakbrowser_scroll
+        return cloakbrowser_scroll(direction, task_id)
+
     # Single scroll with pixel amount instead of 5x subprocess calls.
     # agent-browser supports: agent-browser scroll down 500
     # ~500px is roughly half a viewport of travel.
@@ -2690,6 +2722,10 @@ def browser_back(task_id: Optional[str] = None) -> str:
     Returns:
         JSON string with navigation result
     """
+    if _is_cloakbrowser_mode():
+        from tools.browser_cloak import cloakbrowser_back
+        return cloakbrowser_back(task_id)
+
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_back
         return camofox_back(task_id)
@@ -2723,6 +2759,10 @@ def browser_press(key: str, task_id: Optional[str] = None) -> str:
     Returns:
         JSON string with key press result
     """
+    if _is_cloakbrowser_mode():
+        from tools.browser_cloak import cloakbrowser_press
+        return cloakbrowser_press(key, task_id)
+
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_press
         return camofox_press(key, task_id)
@@ -2762,6 +2802,10 @@ def browser_console(clear: bool = False, expression: Optional[str] = None, task_
     Returns:
         JSON string with console messages/errors, or eval result
     """
+    if _is_cloakbrowser_mode():
+        from tools.browser_cloak import cloakbrowser_console
+        return cloakbrowser_console(clear, expression, task_id)
+
     # --- JS evaluation mode ---
     if expression is not None:
         return _browser_eval(expression, task_id)
@@ -2811,6 +2855,10 @@ def browser_console(clear: bool = False, expression: Optional[str] = None, task_
 
 def _browser_eval(expression: str, task_id: Optional[str] = None) -> str:
     """Evaluate a JavaScript expression in the page context and return the result."""
+    if _is_cloakbrowser_mode():
+        from tools.browser_cloak import cloakbrowser_console
+        return cloakbrowser_console(False, expression, task_id)
+
     if _is_camofox_mode():
         return _camofox_eval(expression, task_id)
 
@@ -2992,6 +3040,10 @@ def browser_get_images(task_id: Optional[str] = None) -> str:
     Returns:
         JSON string with list of images (src and alt)
     """
+    if _is_cloakbrowser_mode():
+        from tools.browser_cloak import cloakbrowser_get_images
+        return cloakbrowser_get_images(task_id)
+
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_get_images
         return camofox_get_images(task_id)
@@ -3063,6 +3115,10 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
     Returns:
         JSON string with vision analysis results and screenshot_path
     """
+    if _is_cloakbrowser_mode():
+        from tools.browser_cloak import cloakbrowser_vision
+        return cloakbrowser_vision(question, annotate, task_id)
+
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_vision
         return camofox_vision(question, annotate, task_id)
@@ -3379,6 +3435,15 @@ def _cleanup_single_browser_session(task_id: str) -> None:
     # before the backend tears down the underlying CDP endpoint.
     _stop_cdp_supervisor(task_id)
 
+    # Also clean up CloakBrowser session if running in native stealth mode.
+    if _is_cloakbrowser_mode():
+        try:
+            from tools.browser_cloak import cloakbrowser_close, cloakbrowser_soft_cleanup
+            if not cloakbrowser_soft_cleanup(task_id):
+                cloakbrowser_close(task_id)
+        except Exception as e:
+            logger.debug("CloakBrowser cleanup for task %s: %s", task_id, e)
+
     # Also clean up Camofox session if running in Camofox mode.
     # Skip full close when managed persistence is enabled — the browser
     # profile (and its session cookies) must survive across agent tasks.
@@ -3607,6 +3672,15 @@ def check_browser_requirements() -> bool:
     Returns:
         True if all requirements are met, False otherwise
     """
+    # CloakBrowser backend — only needs the Python package and patched Chromium
+    # binary, no agent-browser CLI or Camofox REST server.
+    if _is_cloakbrowser_mode():
+        try:
+            from tools.browser_cloak import check_cloakbrowser_available
+            return check_cloakbrowser_available()
+        except Exception:
+            return False
+
     # Camofox backend — only needs the server URL, no agent-browser CLI
     if _is_camofox_mode():
         return True


### PR DESCRIPTION
## Summary
- add an optional native CloakBrowser browser backend gated by `browser.cloakbrowser.enabled` or `CLOAKBROWSER_ENABLED`
- route browser tool operations through `tools/browser_cloak.py` before Camofox while preserving explicit `BROWSER_CDP_URL` override precedence
- add focused tests for mode detection, routing precedence, and requirements checks

## Test Plan
- `python -m pytest tests/tools/test_browser_cloak.py tests/tools/test_browser_homebrew_paths.py::TestBrowserRequirements -q -o 'addopts='`
- `python -m py_compile tools/browser_cloak.py tools/browser_tool.py hermes_cli/config.py`
- `python -m pytest tests/tools/test_browser_cloak.py tests/tools/test_browser_homebrew_paths.py::TestBrowserRequirements tests/tools/test_browser_cdp_override.py tests/tools/test_browser_camofox.py tests/tools/test_browser_cleanup.py -q -o 'addopts='`
- `CLOAKBROWSER_ENABLED=true python - <<'PY' ...` verified `check_browser_requirements()`, navigation to example.com, snapshot, and cleanup using the native CloakBrowser backend
