### PR TITLE
fix(gateway): suppress repeated backend connection errors

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -191,6 +191,62 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
     }
 
 
+def _is_transient_codex_runtime_failure(error: Exception | str) -> bool:
+    """Recognize a dead or wedged app-server transport, not local config bugs."""
+    if isinstance(error, (TimeoutError, ConnectionError, BrokenPipeError)):
+        return True
+    message = str(error).lower()
+    return any(
+        marker in message
+        for marker in (
+            "app-server subprocess exited unexpectedly",
+            "app-server process exited unexpectedly",
+            "codex went silent for",
+            "turn timed out after",
+            "turn/start timed out",
+        )
+    )
+
+
+def _codex_failure_fields(
+    agent,
+    error: Exception | str | None,
+    *,
+    retired: bool = False,
+    provider_error_code: str | None = None,
+) -> dict[str, Any]:
+    """Classify Codex app-server failures with the shared agent taxonomy."""
+    if error is None:
+        return {}
+    from agent.error_classifier import classify_api_error
+
+    exception = error if isinstance(error, Exception) else RuntimeError(str(error))
+    classified = classify_api_error(
+        exception,
+        provider=getattr(agent, "provider", "") or "",
+        model=getattr(agent, "model", "") or "",
+    )
+    reason = classified.reason.value
+    if (
+        reason == "unknown"
+        and str(provider_error_code or "").strip().lower()
+        in {"internal_error", "internal_server_error"}
+    ):
+        reason = "server_error"
+    if (
+        retired
+        and reason == "unknown"
+        and _is_transient_codex_runtime_failure(error)
+    ):
+        # Retirement alone can also mean deterministic local configuration or
+        # protocol failure. Promote only stable dead/wedged transport signals.
+        reason = "server_error"
+    return {
+        "failed": True,
+        "failure_reason": reason,
+    }
+
+
 def _record_codex_app_server_compaction(
     agent,
     turn,
@@ -731,6 +787,11 @@ def run_codex_app_server_turn(
                 else {}
             ),
             "error": str(exc),
+            **(
+                {}
+                if _user_interrupted
+                else _codex_failure_fields(agent, exc, retired=True)
+            ),
         }
 
     # This runtime bypasses the normal conversation-loop finalizer. Mirror its
@@ -859,6 +920,7 @@ def run_codex_app_server_turn(
         except Exception:
             logger.debug("background review spawn raised", exc_info=True)
 
+    _failed = bool(turn.error and not _user_interrupted)
     return {
         "final_response": turn.final_text,
         "messages": messages,
@@ -872,6 +934,16 @@ def run_codex_app_server_turn(
             else {}
         ),
         "error": turn.error,
+        **(
+            _codex_failure_fields(
+                agent,
+                turn.error,
+                retired=bool(getattr(turn, "should_retire", False)),
+                provider_error_code=getattr(turn, "error_code", None),
+            )
+            if _failed
+            else {}
+        ),
         # The codex app-server runtime IS an early-return path that bypasses
         # conversation_loop, but we flush the projected assistant/tool messages
         # ourselves above (see the _flush_messages_to_session_db call after

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -208,33 +208,89 @@ def _is_transient_codex_runtime_failure(error: Exception | str) -> bool:
     )
 
 
+def _codex_error_info_failure_reason(value: Any) -> str | None:
+    """Return the authoritative taxonomy reason for recognized protocol data.
+
+    App-server ``codexErrorInfo`` is structured provider metadata and must win
+    over rendered prose. In particular, an HTTP 401/429 cannot be promoted to
+    a backend outage merely because its message also says "timeout" or
+    "overloaded".
+    """
+    if isinstance(value, str):
+        if value == "serverOverloaded":
+            return "overloaded"
+        if value == "internalServerError":
+            return "server_error"
+        # A present but non-transient protocol variant is authoritative too.
+        return "unknown"
+    if isinstance(value, dict):
+        connection_variants = {
+            "httpConnectionFailed",
+            "responseStreamConnectionFailed",
+            "responseStreamDisconnected",
+            "responseTooManyFailedAttempts",
+        }
+        variant = next((key for key in connection_variants if key in value), None)
+        if variant is None:
+            return "unknown"
+        details = value.get(variant)
+        status = details.get("httpStatusCode") if isinstance(details, dict) else None
+        if status is None:
+            return "server_error"
+        if status in {401, 403}:
+            return "auth"
+        if status == 402:
+            return "billing"
+        if status == 408:
+            return "timeout"
+        if status == 429:
+            return "rate_limit"
+        if isinstance(status, int) and status >= 500:
+            return "server_error"
+        # Recognized protocol variant with a non-transient status. Keep it
+        # excluded even if rendered provider prose looks transient.
+        return "unknown"
+    return None
+
+
 def _codex_failure_fields(
     agent,
     error: Exception | str | None,
     *,
     retired: bool = False,
     provider_error_code: str | None = None,
+    codex_error_info: Any = None,
 ) -> dict[str, Any]:
     """Classify Codex app-server failures with the shared agent taxonomy."""
     if error is None:
         return {}
     from agent.error_classifier import classify_api_error
 
-    exception = error if isinstance(error, Exception) else RuntimeError(str(error))
-    classified = classify_api_error(
-        exception,
-        provider=getattr(agent, "provider", "") or "",
-        model=getattr(agent, "model", "") or "",
-    )
-    reason = classified.reason.value
-    if (
-        reason == "unknown"
-        and str(provider_error_code or "").strip().lower()
-        in {"internal_error", "internal_server_error"}
-    ):
-        reason = "server_error"
+    protocol_reason = _codex_error_info_failure_reason(codex_error_info)
+    normalized_code = str(provider_error_code or "").strip().lower()
+    if protocol_reason is not None:
+        reason = protocol_reason
+    else:
+        exception = error if isinstance(error, Exception) else RuntimeError(str(error))
+        classified = classify_api_error(
+            exception,
+            provider=getattr(agent, "provider", "") or "",
+            model=getattr(agent, "model", "") or "",
+        )
+        reason = classified.reason.value
+        if normalized_code:
+            # Top-level Responses error codes are also structured evidence.
+            # Only the explicit server variant is transient; generic
+            # ``internal_error`` and unknown codes remain unsuppressed.
+            reason = (
+                "server_error"
+                if normalized_code == "internal_server_error"
+                else "unknown"
+            )
     if (
         retired
+        and protocol_reason is None
+        and not normalized_code
         and reason == "unknown"
         and _is_transient_codex_runtime_failure(error)
     ):
@@ -940,6 +996,7 @@ def run_codex_app_server_turn(
                 turn.error,
                 retired=bool(getattr(turn, "should_retire", False)),
                 provider_error_code=getattr(turn, "error_code", None),
+                codex_error_info=getattr(turn, "codex_error_info", None),
             )
             if _failed
             else {}

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2961,6 +2961,30 @@ def run_conversation(
                     else:
                         _failure_hint = f"response time {api_duration:.1f}s"
 
+                    # Preserve the same machine-readable taxonomy used by the
+                    # exception path. Empty/invalid SDK responses can still
+                    # carry an authoritative provider status in
+                    # ``response.error.code``; chat gateways consume this
+                    # field to sanitize only genuine transient outages.
+                    if _resp_error_code in {504, 524}:
+                        _failure_reason = FailoverReason.timeout.value
+                    elif _resp_error_code in {503, 529}:
+                        _failure_reason = FailoverReason.overloaded.value
+                    elif _resp_error_code is not None and 500 <= _resp_error_code < 600:
+                        _failure_reason = FailoverReason.server_error.value
+                    elif _resp_error_code in {401, 403}:
+                        _failure_reason = FailoverReason.auth.value
+                    elif _resp_error_code == 402:
+                        _failure_reason = FailoverReason.billing.value
+                    elif _resp_error_code == 429:
+                        _failure_reason = FailoverReason.rate_limit.value
+                    elif _resp_error_code == 408:
+                        _failure_reason = FailoverReason.timeout.value
+                    elif _resp_error_code is not None and 400 <= _resp_error_code < 500:
+                        _failure_reason = FailoverReason.format_error.value
+                    else:
+                        _failure_reason = FailoverReason.unknown.value
+
                     agent._buffer_vprint(f"⚠️  Invalid API response (attempt {retry_count}/{max_retries}): {', '.join(error_details)}")
                     agent._buffer_vprint(f"   🏢 Provider: {provider_name}")
                     cleaned_provider_error = agent._clean_error_message(error_msg)
@@ -2990,7 +3014,8 @@ def run_conversation(
                             "completed": False,
                             "api_calls": api_call_count,
                             "error": _final_response,
-                            "failed": True  # Mark as failure for filtering
+                            "failed": True,  # Mark as failure for filtering
+                            "failure_reason": _failure_reason,
                         }
                     
                     # Backoff before retry — jittered exponential: 5s base, 120s cap

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5689,6 +5689,7 @@ def run_conversation(
                         "completed": False,
                         "failed": True,
                         "error": _nonretryable_summary,
+                        "failure_reason": classified.reason.value,
                     }
 
                 if retry_count >= max_retries:

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -70,6 +70,7 @@ class TurnResult:
     tool_iterations: int = 0
     interrupted: bool = False
     error: Optional[str] = None  # Set if turn ended in a non-recoverable error
+    error_code: Optional[str] = None  # Structured provider/Responses error code
     turn_id: Optional[str] = None
     thread_id: Optional[str] = None
     token_usage_last: Optional[dict[str, Any]] = None
@@ -741,6 +742,13 @@ class CodexAppServerSession:
                         (note.get("params") or {}).get("turn") or {}
                     ).get("error")
                     if err_obj:
+                        raw_error_code = (
+                            err_obj.get("code")
+                            if isinstance(err_obj, dict)
+                            else getattr(err_obj, "code", None)
+                        )
+                        if raw_error_code:
+                            result.error_code = str(raw_error_code).strip() or None
                         err_msg = _format_responses_error(err_obj, str(turn_status))
                         # If the turn failed for an auth/refresh reason,
                         # rewrite the error into a re-auth hint AND mark

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -71,6 +71,9 @@ class TurnResult:
     interrupted: bool = False
     error: Optional[str] = None  # Set if turn ended in a non-recoverable error
     error_code: Optional[str] = None  # Structured provider/Responses error code
+    # Stable app-server v2 ``TurnError.codexErrorInfo`` value. Keep the full
+    # protocol object separate from rendered text and the top-level code.
+    codex_error_info: Any = None
     turn_id: Optional[str] = None
     thread_id: Optional[str] = None
     token_usage_last: Optional[dict[str, Any]] = None
@@ -742,6 +745,8 @@ class CodexAppServerSession:
                         (note.get("params") or {}).get("turn") or {}
                     ).get("error")
                     if err_obj:
+                        if isinstance(err_obj, dict):
+                            result.codex_error_info = err_obj.get("codexErrorInfo")
                         raw_error_code = (
                             err_obj.get("code")
                             if isinstance(err_obj, dict)

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -147,6 +147,20 @@ class GatewayAuthorizationMixin:
             # fail and suppress streamed delivery for those profiles.
             adapters = getattr(self, "adapters", None) or {}
             return adapters.get(Platform.RELAY)
+        # ``source.profile`` names the runtime selected by profile_routes, not
+        # necessarily the credential that received the message. build_source()
+        # stamps the transport owner's profile separately and does not serialize
+        # it. If the original weakref is stale after reconnect, resolve the new
+        # generation from that owner instead of an unrelated routed profile.
+        source_attrs = getattr(source, "__dict__", {})
+        if (
+            isinstance(source_attrs, dict)
+            and "_transport_profile" in source_attrs
+        ):
+            return self._authorization_adapter(
+                getattr(source, "platform", None),
+                source_attrs.get("_transport_profile"),
+            )
         # ``getattr`` guards test fixtures that build a bare source via
         # SimpleNamespace and omit ``profile`` (see AGENTS.md pitfall #17).
         return self._authorization_adapter(
@@ -189,6 +203,20 @@ class GatewayAuthorizationMixin:
             ).items():
                 if adapter is profile_adapters.get(platform):
                     return profile
+        source_attrs = getattr(source, "__dict__", {})
+        if (
+            isinstance(source_attrs, dict)
+            and "_transport_profile" in source_attrs
+        ):
+            transport_profile = source_attrs.get("_transport_profile")
+            transport_adapter = self._authorization_adapter(
+                platform, transport_profile
+            )
+            if transport_adapter is not None and transport_adapter is (
+                getattr(self, "adapters", None) or {}
+            ).get(platform):
+                return None
+            return transport_profile
         return getattr(source, "profile", None)
 
     def _adapter_authorization_is_upstream(

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2361,6 +2361,47 @@ _RETRYABLE_ERROR_PATTERNS = (
 )
 
 
+# How long to suppress a repeat backend-unavailable notice for the same
+# session and error type.  An outage lasting longer than this posts one
+# more notice, which is the intent — the user should be reminded the
+# backend is still down, just not once per message.
+_LLM_CONNECTION_ERROR_COOLDOWN_SECONDS = 300.0
+
+# Hard cap on tracked sessions.  Expired entries are dropped on write, so
+# this only binds when many distinct sessions fail inside one cooldown
+# window; the oldest entry is then evicted.
+_LLM_ERROR_TRACKER_MAX_SESSIONS = 1024
+
+
+def _is_llm_connection_error(exc: BaseException) -> bool:
+    """Return True for transient backend transport failures.
+
+    Classification is by exception type name against
+    ``agent.error_classifier._TRANSPORT_ERROR_TYPES`` — the same set the
+    agent runtime uses to decide what is worth a retry — so the two cannot
+    drift apart, plus ``ConnectionError`` by instance.
+
+    The instance arm is needed because the name set lists ``ConnectionError``
+    but not every subclass, and ``ConnectionRefusedError`` — a backend that
+    is simply down — is the common case here.  ``ConnectionError`` is narrow:
+    its subclasses are all genuine transport failures (refused, reset,
+    aborted, broken pipe).
+
+    Deliberately *not* widened to ``OSError``, which is what the agent
+    runtime can afford at the call site but this catch cannot: it is
+    adapter-wide and also guards filesystem and platform work, where a
+    ``FileNotFoundError`` or ``PermissionError`` is not a backend outage and
+    must keep its actionable detail.
+    """
+    if isinstance(exc, ConnectionError):
+        return True
+    try:
+        from agent.error_classifier import _TRANSPORT_ERROR_TYPES
+    except Exception:  # pragma: no cover - agent package unavailable
+        return False
+    return type(exc).__name__ in _TRANSPORT_ERROR_TYPES
+
+
 # Type for message handlers.  Handlers may return a plain string (normal
 # reply), an ``EphemeralReply`` to opt the reply into auto-deletion, or
 # ``None`` when the response was already delivered (e.g. via streaming).
@@ -2676,6 +2717,11 @@ class BasePlatformAdapter(ABC):
         # Chats where typing indicator is paused (e.g. during approval waits).
         # _keep_typing skips send_typing when the chat_id is in this set.
         self._typing_paused: set = set()
+        # Last user-visible backend-unavailable notice per session:
+        # session_key -> (error_type, monotonic_timestamp).  Pruned on write
+        # by _record_llm_error_notice; never grows past
+        # _LLM_ERROR_TRACKER_MAX_SESSIONS.
+        self._llm_error_last_posted: dict[str, tuple[str, float]] = {}
         # Dynamic working-state status text per chat (chat_id -> phrase).
         # Set by the gateway on tool starts ("is running pytest…") and read
         # by adapters whose typing indicator renders text (Slack's
@@ -5351,6 +5397,42 @@ class BasePlatformAdapter(ABC):
             max_ms = 2500
         return random.uniform(min_ms / 1000.0, max_ms / 1000.0)
 
+    def _llm_error_notice_suppressed(
+        self, session_key: str, error_type: str, now: float
+    ) -> bool:
+        """True when this session already saw this notice inside the cooldown."""
+        previous = self._llm_error_last_posted.get(session_key)
+        if previous is None:
+            return False
+        previous_type, previous_ts = previous
+        return (
+            previous_type == error_type
+            and now - previous_ts < _LLM_CONNECTION_ERROR_COOLDOWN_SECONDS
+        )
+
+    def _record_llm_error_notice(
+        self, session_key: str, error_type: str, now: float
+    ) -> None:
+        """Record a posted notice, dropping expired and surplus entries.
+
+        Called only on backend failures, so the O(n) prune is cheap and
+        keeps the map from retaining every session key for the lifetime of
+        the adapter.
+        """
+        tracker = self._llm_error_last_posted
+        expired = [
+            key for key, (_, ts) in tracker.items()
+            if now - ts >= _LLM_CONNECTION_ERROR_COOLDOWN_SECONDS
+        ]
+        for key in expired:
+            del tracker[key]
+        # Only reachable when >1024 distinct sessions fail inside one
+        # cooldown window; evict oldest-first so live sessions survive.
+        while len(tracker) >= _LLM_ERROR_TRACKER_MAX_SESSIONS:
+            oldest = min(tracker, key=lambda k: tracker[k][1])
+            del tracker[oldest]
+        tracker[session_key] = (error_type, now)
+
     async def _process_message_background(self, event: MessageEvent, session_key: str) -> None:
         """Background task that actually processes the message."""
         # Track delivery outcomes for the processing-complete hook
@@ -5868,20 +5950,44 @@ class BasePlatformAdapter(ABC):
         except Exception as e:
             await self._run_processing_hook("on_processing_complete", event, ProcessingOutcome.FAILURE)
             logger.error("[%s] Error handling message: %s", self.name, e, exc_info=True)
-            # Send the error to the user so they aren't left with radio silence
+            # Send the error to the user so they aren't left with radio silence.
+            # Backend transport failures get a sanitized notice with a short
+            # per-session cooldown, so an outage does not repeat the same
+            # message once per inbound message.  Everything else keeps the
+            # existing detailed report.
             try:
                 error_type = type(e).__name__
-                error_detail = str(e)[:300] if str(e) else "no details available"
                 _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
-                await self.send(
-                    chat_id=event.source.chat_id,
-                    content=(
-                        f"Sorry, I encountered an error ({error_type}).\n"
-                        f"{error_detail}\n"
-                        "Try again or use /reset to start a fresh session."
-                    ),
-                    metadata=_thread_metadata,
-                )
+                if _is_llm_connection_error(e):
+                    now = time.monotonic()
+                    if self._llm_error_notice_suppressed(session_key, error_type, now):
+                        logger.info(
+                            "[%s] Suppressing duplicate backend-unavailable notice "
+                            "(%s) for session %s",
+                            self.name, error_type, session_key,
+                        )
+                        return
+                    self._record_llm_error_notice(session_key, error_type, now)
+                    await self.send(
+                        chat_id=event.source.chat_id,
+                        content=(
+                            "The AI backend is temporarily unavailable. "
+                            "I'll resume automatically when it comes back; "
+                            "no action needed."
+                        ),
+                        metadata=_thread_metadata,
+                    )
+                else:
+                    error_detail = str(e)[:300] if str(e) else "no details available"
+                    await self.send(
+                        chat_id=event.source.chat_id,
+                        content=(
+                            f"Sorry, I encountered an error ({error_type}).\n"
+                            f"{error_detail}\n"
+                            "Try again or use /reset to start a fresh session."
+                        ),
+                        metadata=_thread_metadata,
+                    )
             except Exception as notify_err:
                 logger.error(
                     "[%s] Failed to send error notification to user: %s",

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2660,6 +2660,114 @@ class EphemeralReply(str):
         return str.__str__(self)
 
 
+class BackendUnavailableReply(str):
+    """Sanitized transient-backend failure returned by ``GatewayRunner``.
+
+    This marker crosses the normal handler boundary without provider details.
+    The adapter suppresses repeats per session and records the cooldown only
+    after the platform acknowledges delivery.
+    """
+
+    @property
+    def text(self) -> str:
+        return str.__str__(self)
+
+
+class BackendNoticeState:
+    """Runner-scoped cooldown and in-flight claims for backend notices.
+
+    Adapter generations can overlap during reconnect. A contender waits for
+    the active owner's delivery result: successful delivery suppresses it,
+    while failed or cancelled delivery lets exactly one waiter take over.
+    """
+
+    def __init__(self) -> None:
+        self.posted: dict[str, tuple[str, float]] = {}
+        self.inflight: set[tuple[str, str]] = set()
+        self._claim_results: dict[
+            tuple[str, str], asyncio.Future[bool]
+        ] = {}
+        self._delivery_tasks: set[asyncio.Task[Any]] = set()
+
+    def track_delivery_task(self, task: asyncio.Task[Any]) -> None:
+        """Keep an acknowledgement-ambiguous notice send alive after cancellation."""
+        self._delivery_tasks.add(task)
+
+        def _consume_result(completed: asyncio.Task[Any]) -> None:
+            self._delivery_tasks.discard(completed)
+            if completed.cancelled():
+                return
+            try:
+                completed.exception()
+            except asyncio.CancelledError:
+                pass
+
+        task.add_done_callback(_consume_result)
+
+    def _prune(self, now: float) -> None:
+        expired = [
+            key
+            for key, (_, timestamp) in self.posted.items()
+            if now - timestamp >= _LLM_CONNECTION_ERROR_COOLDOWN_SECONDS
+        ]
+        for key in expired:
+            del self.posted[key]
+
+    def is_suppressed(self, session_key: str, notice_kind: str, now: float) -> bool:
+        self._prune(now)
+        previous = self.posted.get(session_key)
+        return bool(
+            previous is not None
+            and previous[0] == notice_kind
+            and now - previous[1] < _LLM_CONNECTION_ERROR_COOLDOWN_SECONDS
+        )
+
+    async def claim(self, session_key: str, notice_kind: str) -> bool:
+        claim = (session_key, notice_kind)
+        while True:
+            if self.is_suppressed(session_key, notice_kind, time.monotonic()):
+                return False
+
+            owner_result = self._claim_results.get(claim)
+            if owner_result is None:
+                self.inflight.add(claim)
+                self._claim_results[claim] = (
+                    asyncio.get_running_loop().create_future()
+                )
+                return True
+
+            # Cancelling a reconnect generation must not cancel the shared
+            # completion signal and strand the owner or other waiters.
+            delivered = await asyncio.shield(owner_result)
+            if delivered:
+                return False
+            # The owner failed or was cancelled. Race other waiters for a new
+            # claim; one wins and the rest await that new owner.
+
+    def finish_claim(
+        self,
+        session_key: str,
+        notice_kind: str,
+        now: float,
+        *,
+        delivered: bool,
+    ) -> None:
+        claim = (session_key, notice_kind)
+        owner_result = self._claim_results.pop(claim, None)
+        self.inflight.discard(claim)
+        if delivered:
+            self.record(session_key, notice_kind, now)
+        if owner_result is not None and not owner_result.done():
+            owner_result.set_result(delivered)
+
+    def record(self, session_key: str, notice_kind: str, now: float) -> None:
+        self._prune(now)
+        while len(self.posted) >= _LLM_ERROR_TRACKER_MAX_SESSIONS:
+            oldest = min(self.posted, key=lambda key: self.posted[key][1])
+            del self.posted[oldest]
+        self.posted[session_key] = (notice_kind, now)
+
+
 def _invalidate_pending_stt_cache(event: MessageEvent) -> None:
     """Clear gateway-side STT cache attrs when media is merged into an event.
 
@@ -2768,10 +2876,26 @@ _RETRYABLE_ERROR_PATTERNS = (
 )
 
 
+# How long to suppress a repeat backend-unavailable notice for the same
+# session.  An outage lasting longer than this posts one
+# more notice, which is the intent — the user should be reminded the
+# backend is still down, just not once per message.
+_LLM_CONNECTION_ERROR_COOLDOWN_SECONDS = 300.0
+
+# Hard cap on tracked sessions.  Expired entries are dropped on write, so
+# this only binds when many distinct sessions fail inside one cooldown
+# window; the oldest entry is then evicted.
+_LLM_ERROR_TRACKER_MAX_SESSIONS = 1024
+
+
 # Type for message handlers.  Handlers may return a plain string (normal
-# reply), an ``EphemeralReply`` to opt the reply into auto-deletion, or
+# reply), an ``EphemeralReply`` to opt the reply into auto-deletion, a
+# ``BackendUnavailableReply`` for delivery-aware outage suppression, or
 # ``None`` when the response was already delivered (e.g. via streaming).
-MessageHandler = Callable[[MessageEvent], Awaitable[Optional[Union[str, "EphemeralReply"]]]]
+MessageHandler = Callable[
+    [MessageEvent],
+    Awaitable[Optional[Union[str, "EphemeralReply", "BackendUnavailableReply"]]],
+]
 
 
 def resolve_channel_prompt(
@@ -3093,6 +3217,16 @@ class BasePlatformAdapter(ABC):
         # Chats where typing indicator is paused (e.g. during approval waits).
         # _keep_typing skips send_typing when the chat_id is in this set.
         self._typing_paused: set = set()
+        # Last user-visible backend-unavailable notice per session:
+        # session_key -> (notice_kind, monotonic_timestamp).  Pruned on write
+        # by _record_llm_error_notice; never grows past
+        # _LLM_ERROR_TRACKER_MAX_SESSIONS.
+        self._backend_notice_state = BackendNoticeState()
+        # Logical profile namespace used only for runner-shared backend notice
+        # state. The adapter's local session key deliberately keeps the legacy
+        # ``agent:main`` namespace, even for multiplexed secondary adapters.
+        self._backend_notice_profile: Optional[str] = None
+        self._llm_error_last_posted = self._backend_notice_state.posted
         # Dynamic working-state status text per chat (chat_id -> phrase).
         # Set by the gateway on tool starts ("is running pytest…") and read
         # by adapters whose typing indicator renders text (Slack's
@@ -6160,6 +6294,73 @@ class BasePlatformAdapter(ABC):
             max_ms = 2500
         return random.uniform(min_ms / 1000.0, max_ms / 1000.0)
 
+    def _llm_error_notice_suppressed(
+        self,
+        session_key: str,
+        notice_kind: str,
+        now: float,
+        *,
+        source: Optional[SessionSource] = None,
+    ) -> bool:
+        """True when this session already saw this notice inside the cooldown."""
+        session_key = self._backend_notice_session_key(session_key, source)
+        return self._backend_notice_state.is_suppressed(
+            session_key, notice_kind, now
+        )
+
+    def _backend_notice_session_key(
+        self,
+        session_key: str,
+        source: Optional[SessionSource] = None,
+    ) -> str:
+        """Restore the logical profile namespace for shared notice state.
+
+        ``handle_message`` builds its adapter-local key before a secondary
+        profile handler stamps ``source.profile`` and intentionally omits the
+        multiplex profile. Reusing that raw key in runner-wide state would let
+        independent profile credentials suppress each other's notices.
+        """
+        profile = str(
+            (getattr(source, "profile", None) if source is not None else None)
+            or self._backend_notice_profile
+            or "default"
+        ).strip() or "default"
+        # Namespace even the default profile explicitly. Its legacy session key
+        # uses ``agent:main:...`` and would otherwise collide with a valid
+        # multiplex profile literally named ``main``.
+        return f"profile:{profile}:{session_key}"
+
+    def set_backend_notice_state(
+        self,
+        state: BackendNoticeState,
+        profile_name: Optional[str] = None,
+    ) -> None:
+        """Share claims across reconnects within one logical profile."""
+        self._backend_notice_state = state
+        self._backend_notice_profile = str(profile_name or "").strip() or None
+        # Compatibility for diagnostics/tests that inspect the old map.
+        self._llm_error_last_posted = state.posted
+
+    def _record_llm_error_notice(
+        self,
+        session_key: str,
+        notice_kind: str,
+        now: float,
+        *,
+        source: Optional[SessionSource] = None,
+    ) -> None:
+        """Record a posted notice, dropping expired and surplus entries.
+
+        Called only on backend failures, so the O(n) prune is cheap and
+        keeps the map from retaining every session key for the lifetime of
+        the adapter.
+        """
+        self._backend_notice_state.record(
+            self._backend_notice_session_key(session_key, source),
+            notice_kind,
+            now,
+        )
+
     async def _process_message_background(self, event: MessageEvent, session_key: str) -> None:
         """Background task that actually processes the message."""
         # Track delivery outcomes for the processing-complete hook
@@ -6213,6 +6414,9 @@ class BasePlatformAdapter(ABC):
 
             # Call the handler (this can take a while with tool calls)
             response = await self._message_handler(event)
+            is_backend_unavailable_response = isinstance(
+                response, BackendUnavailableReply
+            )
             is_ephemeral_response = isinstance(response, EphemeralReply)
 
             # Slash-command handlers may return an EphemeralReply sentinel to
@@ -6339,7 +6543,8 @@ class BasePlatformAdapter(ABC):
                 _tts_path = None
                 _tts_paths: List[str] = []
                 _tts_requested_path = None
-                if (self._should_auto_tts_for_chat(event.source.chat_id)
+                if (not is_backend_unavailable_response
+                        and self._should_auto_tts_for_chat(event.source.chat_id)
                         and event.message_type == MessageType.VOICE
                         and text_content
                         and not media_files
@@ -6432,8 +6637,46 @@ class BasePlatformAdapter(ABC):
                 # adapter while its in-flight handler was still producing a
                 # final response; that response is a new message, so resolve
                 # the current transport before sending it.
-                if text_content and not _tts_caption_delivered:
+                delivery_adapter = None
+                backend_notice_claimed = False
+                backend_notice_suppressed = False
+                backend_notice_session_key = session_key
+                if (
+                    text_content
+                    and not _tts_caption_delivered
+                    and is_backend_unavailable_response
+                ):
+                    # Resolve and retain the exact adapter that will send the
+                    # notice. A reconnect can replace the transport between
+                    # handler completion and final delivery; checking an old
+                    # adapter's tracker and then sending through a new one
+                    # would bypass the replacement's live cooldown.
                     delivery_adapter = self._final_delivery_adapter(event.source)
+                    backend_notice_session_key = (
+                        delivery_adapter._backend_notice_session_key(
+                            session_key, event.source
+                        )
+                    )
+                    backend_notice_claimed = (
+                        await delivery_adapter._backend_notice_state.claim(
+                            backend_notice_session_key,
+                            "backend_unavailable",
+                        )
+                    )
+                    if not backend_notice_claimed:
+                        backend_notice_suppressed = True
+                        logger.info(
+                            "[%s] Suppressing duplicate backend-unavailable "
+                            "notice for session %s",
+                            delivery_adapter.name,
+                            session_key,
+                        )
+                        text_content = ""
+                if text_content and not _tts_caption_delivered:
+                    delivery_adapter = (
+                        delivery_adapter
+                        or self._final_delivery_adapter(event.source)
+                    )
                     logger.info(
                         "[%s] Sending response (%d chars) to %s",
                         delivery_adapter.name,
@@ -6450,9 +6693,13 @@ class BasePlatformAdapter(ABC):
                     # Slash-command and ephemeral replies are cheap to
                     # regenerate and are not recorded.
                     _obligation_id = None
-                    if not is_ephemeral_response and not str(
-                        event.text or ""
-                    ).lstrip().startswith(("/", self.typed_command_prefix or "!")):
+                    if (
+                        not is_ephemeral_response
+                        and not is_backend_unavailable_response
+                        and not str(event.text or "").lstrip().startswith(
+                            ("/", self.typed_command_prefix or "!")
+                        )
+                    ):
                         try:
                             from gateway.delivery_ledger import (
                                 compute_obligation_id,
@@ -6483,12 +6730,55 @@ class BasePlatformAdapter(ABC):
                         except Exception:
                             logger.debug("delivery ledger record failed", exc_info=True)
                             _obligation_id = None
-                    result = await delivery_adapter._send_with_retry(
-                        chat_id=event.source.chat_id,
-                        content=text_content,
-                        reply_to=_reply_anchor,
-                        metadata=_final_thread_metadata,
-                    )
+                    if backend_notice_claimed:
+                        async def _send_and_finish_backend_notice_claim():
+                            try:
+                                send_result = await delivery_adapter._send_with_retry(
+                                    chat_id=event.source.chat_id,
+                                    content=text_content,
+                                    reply_to=_reply_anchor,
+                                    metadata=_final_thread_metadata,
+                                )
+                            except BaseException:
+                                delivery_adapter._backend_notice_state.finish_claim(
+                                    backend_notice_session_key,
+                                    "backend_unavailable",
+                                    time.monotonic(),
+                                    delivered=False,
+                                )
+                                raise
+                            delivery_adapter._backend_notice_state.finish_claim(
+                                backend_notice_session_key,
+                                "backend_unavailable",
+                                time.monotonic(),
+                                delivered=bool(
+                                    getattr(send_result, "success", False)
+                                ),
+                            )
+                            return send_result
+
+                        send_task = asyncio.create_task(
+                            _send_and_finish_backend_notice_claim()
+                        )
+                        try:
+                            result = await asyncio.shield(send_task)
+                        except asyncio.CancelledError:
+                            # Once platform delivery has started, cancellation
+                            # is acknowledgement-ambiguous. Runner-scoped state
+                            # holds the send task across adapter replacement and
+                            # resolves contenders only when the platform result
+                            # is known, while this processor unwinds promptly.
+                            delivery_adapter._backend_notice_state.track_delivery_task(
+                                send_task
+                            )
+                            raise
+                    else:
+                        result = await delivery_adapter._send_with_retry(
+                            chat_id=event.source.chat_id,
+                            content=text_content,
+                            reply_to=_reply_anchor,
+                            metadata=_final_thread_metadata,
+                        )
                     _record_delivery(result)
                     if _obligation_id is not None:
                         try:
@@ -6668,7 +6958,11 @@ class BasePlatformAdapter(ABC):
                     delivery_attempted or _tts_caption_delivered
                     or images or local_files or media_files
                 )
-                if not _anything_delivered and _response_pre_extract.strip():
+                if (
+                    not _anything_delivered
+                    and not backend_notice_suppressed
+                    and _response_pre_extract.strip()
+                ):
                     logger.error(
                         "[%s] response_delivery_dropped: non-empty response "
                         "(%d chars) produced no delivered message or attachment "
@@ -6676,8 +6970,13 @@ class BasePlatformAdapter(ABC):
                         self.name, len(_response_pre_extract), event.source.chat_id,
                     )
 
-            # Determine overall success for the processing hook
-            processing_ok = delivery_succeeded if delivery_attempted else not bool(response)
+            # Determine overall success for the processing hook.  A delivered
+            # backend-unavailable notice is still a failed agent turn.
+            processing_ok = (
+                False
+                if is_backend_unavailable_response
+                else (delivery_succeeded if delivery_attempted else not bool(response))
+            )
             # Clean up the per-turn streaming-TTS flag (#60671).
             self._streaming_tts_completed_turns.discard(
                 self._streaming_tts_turn_key(
@@ -6747,17 +7046,20 @@ class BasePlatformAdapter(ABC):
         except Exception as e:
             await self._run_processing_hook("on_processing_complete", event, ProcessingOutcome.FAILURE)
             logger.error("[%s] Error handling message: %s", self.name, e, exc_info=True)
-            # Send the error to the user so they aren't left with radio silence
+            # Send the error to the user so they aren't left with radio silence.
+            # Backend failures are explicitly marked by GatewayRunner before
+            # this delivery layer.  Exceptions raised here may instead be
+            # platform, media, storage, or hook failures and must not be
+            # mislabeled as an AI-backend outage.
             try:
-                error_type = type(e).__name__
-                error_detail = str(e)[:300] if str(e) else "no details available"
-                _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
+                _thread_metadata = _thread_metadata_for_source(
+                    event.source, _reply_anchor_for_event(event)
+                )
                 await self.send(
                     chat_id=event.source.chat_id,
                     content=(
-                        f"Sorry, I encountered an error ({error_type}).\n"
-                        f"{error_detail}\n"
-                        "Try again or use /reset to start a fresh session."
+                        "Sorry, I encountered an internal error. "
+                        "Please try again or use /reset to start a fresh session."
                     ),
                     metadata=_thread_metadata,
                 )

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3226,6 +3226,10 @@ class BasePlatformAdapter(ABC):
         # state. The adapter's local session key deliberately keeps the legacy
         # ``agent:main`` namespace, even for multiplexed secondary adapters.
         self._backend_notice_profile: Optional[str] = None
+        # Profile whose credential/connection owns this transport. Unlike a
+        # SessionSource's runtime ``profile``, this does not change when a chat
+        # route selects another agent profile for the turn.
+        self._transport_profile: Optional[str] = None
         self._llm_error_last_posted = self._backend_notice_state.posted
         # Dynamic working-state status text per chat (chat_id -> phrase).
         # Set by the gateway on tool starts ("is running pytest…") and read
@@ -6313,22 +6317,19 @@ class BasePlatformAdapter(ABC):
         session_key: str,
         source: Optional[SessionSource] = None,
     ) -> str:
-        """Restore the logical profile namespace for shared notice state.
+        """Return an injective profile/session key for runner-wide notice state.
 
-        ``handle_message`` builds its adapter-local key before a secondary
-        profile handler stamps ``source.profile`` and intentionally omits the
-        multiplex profile. Reusing that raw key in runner-wide state would let
-        independent profile credentials suppress each other's notices.
+        Adapter-local session keys are built before multiplex routing stamps the
+        source profile. Always prefix the logical profile, including ``default``.
+        Length-prefixing keeps the encoding unambiguous even if plugin profiles
+        or session keys contain separators.
         """
         profile = str(
             (getattr(source, "profile", None) if source is not None else None)
             or self._backend_notice_profile
             or "default"
         ).strip() or "default"
-        # Namespace even the default profile explicitly. Its legacy session key
-        # uses ``agent:main:...`` and would otherwise collide with a valid
-        # multiplex profile literally named ``main``.
-        return f"profile:{profile}:{session_key}"
+        return f"profile:{len(profile)}:{profile}:{session_key}"
 
     def set_backend_notice_state(
         self,
@@ -7367,6 +7368,14 @@ class BasePlatformAdapter(ABC):
         # SessionSource.to_dict(). The live receiving adapter is authoritative
         # for this turn even when profile_routes selects a different runtime.
         source._transport_adapter_ref = weakref.ref(self)
+        # The weakref identifies this exact generation while it remains in the
+        # runner registry. Preserve its owning profile independently so a turn
+        # that outlives a reconnect can resolve the replacement generation.
+        setattr(
+            source,
+            "_transport_profile",
+            getattr(self, "_transport_profile", None),
+        )
         # Keep this transport-only fail-closed signal out of SessionSource
         # serialization/session identity. The shared gateway handler consumes it
         # before auth, hooks, or session setup, so every adapter drops matched

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5996,14 +5996,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         adapter: Any,
         profile_name: Optional[str] = None,
     ) -> None:
-        """Wire profile-scoped cooldown state across adapter reconnects."""
+        """Wire runner routing and profile-scoped state across reconnects."""
+        # All adapters participate in replacement routing, including direct
+        # built-ins created outside plugin factories.
+        adapter.gateway_runner = self
+        if not profile_name:
+            try:
+                profile_name = self._active_profile_name()
+            except Exception:
+                profile_name = None
+        # ``source.profile`` is the runtime/session namespace and may be changed
+        # by a chat-based profile route. Keep the credential/transport owner
+        # separately so an in-flight turn can find this adapter's replacement.
+        adapter._transport_profile = str(profile_name or "").strip() or None
         setter = getattr(adapter, "set_backend_notice_state", None)
         if callable(setter):
-            if not profile_name:
-                try:
-                    profile_name = self._active_profile_name()
-                except Exception:
-                    profile_name = None
             setter(
                 self._backend_notice_state_for_adapters(),
                 profile_name=profile_name,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2463,6 +2463,8 @@ from gateway.kanban_watchers import GatewayKanbanWatchersMixin
 from gateway.slash_commands import GatewaySlashCommandsMixin
 from gateway.turn_context import TurnContext
 from gateway.platforms.base import (
+    BackendNoticeState,
+    BackendUnavailableReply,
     BasePlatformAdapter,
     EphemeralReply,
     MessageEvent,
@@ -2499,6 +2501,31 @@ from gateway.whatsapp_identity import (
 
 
 logger = logging.getLogger(__name__)
+
+
+_BACKEND_UNAVAILABLE_FAILURE_REASONS = frozenset({
+    "overloaded",
+    "server_error",
+    "timeout",
+})
+_BACKEND_UNAVAILABLE_NOTICE = (
+    "The AI backend is temporarily unavailable. "
+    "Please try sending your message again in a moment."
+)
+
+
+def _is_backend_unavailable_agent_result(agent_result: dict) -> bool:
+    """Whether a failed agent result represents a transient backend outage.
+
+    The agent retry loop emits this structured classification.  Do not infer
+    it from exceptions at the adapter layer, where a connection failure may
+    belong to Slack, Telegram, media delivery, storage, or another subsystem.
+    """
+    return bool(
+        agent_result.get("failed")
+        and agent_result.get("failure_reason")
+        in _BACKEND_UNAVAILABLE_FAILURE_REASONS
+    )
 
 
 _OWN_POLICY_OPEN_ENV = {
@@ -5956,6 +5983,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self.__dict__["_sessions"] = sessions
         return sessions
 
+    def _backend_notice_state_for_adapters(self) -> BackendNoticeState:
+        """Return runner-owned notice state, tolerating partial test runners."""
+        state = self.__dict__.get("_backend_notice_state")
+        if state is None:
+            state = BackendNoticeState()
+            self.__dict__["_backend_notice_state"] = state
+        return state
+
+    def _share_backend_notice_state(
+        self,
+        adapter: Any,
+        profile_name: Optional[str] = None,
+    ) -> None:
+        """Wire profile-scoped cooldown state across adapter reconnects."""
+        setter = getattr(adapter, "set_backend_notice_state", None)
+        if callable(setter):
+            if not profile_name:
+                try:
+                    profile_name = self._active_profile_name()
+                except Exception:
+                    profile_name = None
+            setter(
+                self._backend_notice_state_for_adapters(),
+                profile_name=profile_name,
+            )
+
     def _session_state(self, session_key: str) -> "SessionState":
         """Get-or-create the :class:`SessionState` for ``session_key``."""
         sessions = self._sessions_map()
@@ -6014,6 +6067,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             logger.debug("could not set multiplex-active flag", exc_info=True)
         self.adapters: Dict[Platform, BasePlatformAdapter] = {}
+        self._backend_notice_state = BackendNoticeState()
         # Multi-profile multiplexing: adapters for NON-default profiles live
         # here, keyed by profile name then Platform. self.adapters stays the
         # default/active profile's map so the ~93 existing self.adapters[...]
@@ -11502,6 +11556,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # secondary profile: authorization and prompt rendering both run
             # before the narrower agent-turn scope is installed.
             adapter.set_message_handler(self._primary_message_handler())
+            self._share_backend_notice_state(adapter)
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
             adapter.set_session_store(self.session_store)
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
@@ -12887,6 +12942,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         continue
 
                     adapter.set_message_handler(self._primary_message_handler())
+                    self._share_backend_notice_state(adapter)
                     adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
                     adapter.set_session_store(self.session_store)
                     adapter.set_busy_session_handler(self._handle_active_session_busy_message)
@@ -13862,6 +13918,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     ) -> None:
         """Install the profile-scoped handlers shared by startup and reconnect."""
         adapter.set_message_handler(self._make_profile_message_handler(profile_name))
+        self._share_backend_notice_state(adapter, profile_name=profile_name)
         adapter.set_fatal_error_handler(
             self._make_profile_fatal_error_handler(profile_name, platform)
         )
@@ -18866,6 +18923,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     session_entry.session_id,
                 )
                 response = ""
+
+            # The retry loop already classified provider failures.  Mark
+            # transient backend outages explicitly so the adapter can suppress
+            # only this safe notice and arm its cooldown after delivery.
+            if (
+                not _gateway_surface_passes_raw_text(source.platform)
+                and _is_backend_unavailable_agent_result(agent_result)
+            ):
+                return BackendUnavailableReply(_BACKEND_UNAVAILABLE_NOTICE)
 
             # Auto voice reply: send TTS audio before the text response
             _already_sent = bool(agent_result.get("already_sent"))

--- a/tests/agent/test_codex_app_server_persist.py
+++ b/tests/agent/test_codex_app_server_persist.py
@@ -58,6 +58,10 @@ def _make_agent(session_db=None, session_id="sess-codex"):
     agent._session_db = session_db
     agent._session_db_created = True
     agent.session_id = session_id
+    agent.provider = "openai-codex"
+    agent.model = "gpt-5-codex"
+    agent._interrupt_requested = False
+    agent._interrupt_message = None
     return agent
 
 
@@ -102,6 +106,145 @@ def test_codex_user_interrupt_is_reported_and_cleared():
     assert result["interrupt_message"] == "new correction"
     agent.clear_interrupt.assert_called_once_with()
     assert agent._interrupt_requested is False
+
+
+def test_codex_runtime_exception_emits_structured_timeout_failure():
+    agent = _make_agent(session_db=None)
+    agent._codex_session.run_turn.side_effect = TimeoutError(
+        "request to https://api.example.invalid timed out"
+    )
+
+    result = run_codex_app_server_turn(
+        agent,
+        user_message="hello",
+        original_user_message="hello",
+        messages=[{"role": "user", "content": "hello"}],
+        effective_task_id="task-1",
+    )
+
+    assert result["failed"] is True
+    assert result["failure_reason"] == "timeout"
+
+
+def test_codex_runtime_exception_classifies_dead_subprocess_failure():
+    agent = _make_agent(session_db=None)
+    agent._codex_session.run_turn.side_effect = RuntimeError(
+        "codex app-server subprocess exited unexpectedly"
+    )
+
+    result = run_codex_app_server_turn(
+        agent,
+        user_message="hello",
+        original_user_message="hello",
+        messages=[{"role": "user", "content": "hello"}],
+        effective_task_id="task-1",
+    )
+
+    assert result["failed"] is True
+    assert result["failure_reason"] == "server_error"
+
+
+def test_codex_runtime_generic_exception_stays_unknown():
+    agent = _make_agent(session_db=None)
+    agent._codex_session.run_turn.side_effect = RuntimeError(
+        "invalid app-server configuration"
+    )
+
+    result = run_codex_app_server_turn(
+        agent,
+        user_message="hello",
+        original_user_message="hello",
+        messages=[{"role": "user", "content": "hello"}],
+        effective_task_id="task-1",
+    )
+
+    assert result["failed"] is True
+    assert result["failure_reason"] == "unknown"
+
+
+def test_codex_terminal_internal_error_is_server_failure():
+    agent = _make_agent(session_db=None)
+    turn = _make_turn()
+    turn.final_text = ""
+    turn.error = (
+        "turn ended status=failed: internal_error: "
+        "The server had an error processing your request"
+    )
+    turn.error_code = "internal_error"
+    agent._codex_session.run_turn.return_value = turn
+
+    result = run_codex_app_server_turn(
+        agent,
+        user_message="hello",
+        original_user_message="hello",
+        messages=[{"role": "user", "content": "hello"}],
+        effective_task_id="task-1",
+    )
+
+    assert result["failed"] is True
+    assert result["failure_reason"] == "server_error"
+
+
+def test_codex_timeout_turn_result_emits_structured_failure():
+    agent = _make_agent(session_db=None)
+    turn = _make_turn()
+    turn.final_text = ""
+    turn.error = "codex app-server turn timed out after 600s"
+    turn.interrupted = True
+    turn.should_retire = True
+    agent._codex_session.run_turn.return_value = turn
+
+    result = run_codex_app_server_turn(
+        agent,
+        user_message="hello",
+        original_user_message="hello",
+        messages=[{"role": "user", "content": "hello"}],
+        effective_task_id="task-1",
+    )
+
+    assert result["failed"] is True
+    assert result["failure_reason"] == "timeout"
+    assert result["interrupted"] is False
+
+
+def test_codex_retired_dead_subprocess_failure_becomes_server_error():
+    agent = _make_agent(session_db=None)
+    turn = _make_turn()
+    turn.final_text = ""
+    turn.error = "codex app-server subprocess exited unexpectedly"
+    turn.should_retire = True
+    agent._codex_session.run_turn.return_value = turn
+
+    result = run_codex_app_server_turn(
+        agent,
+        user_message="hello",
+        original_user_message="hello",
+        messages=[{"role": "user", "content": "hello"}],
+        effective_task_id="task-1",
+    )
+
+    assert result["failed"] is True
+    assert result["failure_reason"] == "server_error"
+
+
+def test_codex_auth_failure_is_not_promoted_to_backend_outage():
+    agent = _make_agent(session_db=None)
+    turn = _make_turn()
+    turn.final_text = ""
+    turn.error = "Codex OAuth token expired; run codex login"
+    turn.should_retire = True
+    agent._codex_session.run_turn.return_value = turn
+
+    result = run_codex_app_server_turn(
+        agent,
+        user_message="hello",
+        original_user_message="hello",
+        messages=[{"role": "user", "content": "hello"}],
+        effective_task_id="task-1",
+    )
+
+    assert result["failed"] is True
+    assert result["failure_reason"] == "auth"
 
 
 def test_codex_turn_persists_each_message_exactly_once():

--- a/tests/agent/test_codex_app_server_persist.py
+++ b/tests/agent/test_codex_app_server_persist.py
@@ -23,8 +23,6 @@ duplicate the user turn (#860 / #42039). This test locks in:
 3. The gateway resolution expression preserves standard-runtime behaviour.
 """
 
-import tempfile
-from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -43,6 +41,8 @@ def _make_turn():
         tool_iterations=0,
         final_text="CODEX_ASSISTANT",
         should_retire=False,
+        error_code=None,
+        codex_error_info=None,
     )
 
 
@@ -162,7 +162,7 @@ def test_codex_runtime_generic_exception_stays_unknown():
     assert result["failure_reason"] == "unknown"
 
 
-def test_codex_terminal_internal_error_is_server_failure():
+def test_codex_protocol_internal_server_error_is_server_failure():
     agent = _make_agent(session_db=None)
     turn = _make_turn()
     turn.final_text = ""
@@ -171,6 +171,7 @@ def test_codex_terminal_internal_error_is_server_failure():
         "The server had an error processing your request"
     )
     turn.error_code = "internal_error"
+    turn.codex_error_info = "internalServerError"
     agent._codex_session.run_turn.return_value = turn
 
     result = run_codex_app_server_turn(
@@ -183,6 +184,108 @@ def test_codex_terminal_internal_error_is_server_failure():
 
     assert result["failed"] is True
     assert result["failure_reason"] == "server_error"
+
+
+def test_codex_top_level_internal_error_without_protocol_evidence_stays_unknown():
+    agent = _make_agent(session_db=None)
+    turn = _make_turn()
+    turn.final_text = ""
+    turn.error = "turn ended status=failed: server overloaded"
+    turn.error_code = "internal_error"
+    turn.should_retire = True
+    agent._codex_session.run_turn.return_value = turn
+
+    result = run_codex_app_server_turn(
+        agent,
+        user_message="hello",
+        original_user_message="hello",
+        messages=[{"role": "user", "content": "hello"}],
+        effective_task_id="task-1",
+    )
+
+    assert result["failed"] is True
+    assert result["failure_reason"] == "unknown"
+
+
+def _run_codex_protocol_failure(codex_error_info, prose):
+    agent = _make_agent(session_db=None)
+    turn = _make_turn()
+    turn.final_text = ""
+    turn.error = f"turn ended status=failed: {prose}"
+    turn.codex_error_info = codex_error_info
+    agent._codex_session.run_turn.return_value = turn
+    return run_codex_app_server_turn(
+        agent,
+        user_message="hello",
+        original_user_message="hello",
+        messages=[{"role": "user", "content": "hello"}],
+        effective_task_id="task-1",
+    )
+
+
+def test_codex_unknown_protocol_variant_overrides_transient_prose():
+    result = _run_codex_protocol_failure(
+        "other",
+        "server overloaded",
+    )
+
+    assert result["failure_reason"] == "unknown"
+
+
+def test_codex_protocol_status_matrix():
+    cases = [
+        (403, "auth"),
+        (402, "billing"),
+        (408, "timeout"),
+        (500, "server_error"),
+        (503, "server_error"),
+    ]
+    for status, expected in cases:
+        result = _run_codex_protocol_failure(
+            {"responseStreamDisconnected": {"httpStatusCode": status}},
+            "opaque provider prose",
+        )
+        assert result["failure_reason"] == expected
+
+
+def test_codex_protocol_401_overrides_timeout_prose():
+    result = _run_codex_protocol_failure(
+        {"httpConnectionFailed": {"httpStatusCode": 401}},
+        "request timed out",
+    )
+
+    assert result["failure_reason"] == "auth"
+
+
+def test_codex_protocol_429_overrides_overload_prose():
+    result = _run_codex_protocol_failure(
+        {"responseStreamConnectionFailed": {"httpStatusCode": 429}},
+        "server overloaded",
+    )
+
+    assert result["failure_reason"] == "rate_limit"
+
+
+def test_codex_protocol_400_overrides_transient_prose_and_retirement():
+    agent = _make_agent(session_db=None)
+    turn = _make_turn()
+    turn.final_text = ""
+    turn.error = "turn ended status=failed: turn timed out after 30s"
+    turn.codex_error_info = {
+        "httpConnectionFailed": {"httpStatusCode": 400},
+    }
+    turn.should_retire = True
+    agent._codex_session.run_turn.return_value = turn
+
+    result = run_codex_app_server_turn(
+        agent,
+        user_message="hello",
+        original_user_message="hello",
+        messages=[{"role": "user", "content": "hello"}],
+        effective_task_id="task-1",
+    )
+
+    assert result["failure_reason"] == "unknown"
 
 
 def test_codex_timeout_turn_result_emits_structured_failure():
@@ -247,14 +350,13 @@ def test_codex_auth_failure_is_not_promoted_to_backend_outage():
     assert result["failure_reason"] == "auth"
 
 
-def test_codex_turn_persists_each_message_exactly_once():
+def test_codex_turn_persists_each_message_exactly_once(tmp_path):
     """The user turn (flushed at turn start) must not be duplicated; the
     projected assistant message must land once.  Uses a real SessionDB and the
     real AIAgent._flush_messages_to_session_db to prove no #860/#42039
     duplicate-write regression on the codex path."""
-    tmp = tempfile.mkdtemp(prefix="codex_persist_")
+    db = SessionDB(tmp_path / "state.db")
     try:
-        db = SessionDB(Path(tmp) / "state.db")
         sid = "sess-codex-once"
         db.create_session(session_id=sid, source="telegram", model="codex")
 
@@ -299,9 +401,7 @@ def test_codex_turn_persists_each_message_exactly_once():
         hits = {r["session_id"] for r in db.search_messages("CODEX_ASSISTANT")}
         assert sid in hits
     finally:
-        import shutil
-
-        shutil.rmtree(tmp)
+        db.close()
 
 
 class TestGatewayPersistedResolution:

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -209,6 +209,26 @@ class TestRunTurn:
         # turn_id propagated for downstream session-DB linkage
         assert r.turn_id == "turn-fake-001"
 
+    def test_failed_turn_preserves_structured_provider_error_code(self):
+        client = FakeClient()
+        client.queue_notification(
+            "turn/completed",
+            threadId="t",
+            turn={
+                "id": "tu1",
+                "status": "failed",
+                "error": {
+                    "code": "internal_error",
+                    "message": "The server had an error processing your request",
+                },
+            },
+        )
+
+        result = make_session(client).run_turn("hi", turn_timeout=2.0)
+
+        assert result.error_code == "internal_error"
+        assert "internal_error" in (result.error or "")
+
 
 
     def test_foreign_completion_in_server_request_drain_is_ignored(self):

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -220,6 +220,9 @@ class TestRunTurn:
                 "error": {
                     "code": "internal_error",
                     "message": "The server had an error processing your request",
+                    "codexErrorInfo": {
+                        "httpConnectionFailed": {"httpStatusCode": 401}
+                    },
                 },
             },
         )
@@ -227,6 +230,9 @@ class TestRunTurn:
         result = make_session(client).run_turn("hi", turn_timeout=2.0)
 
         assert result.error_code == "internal_error"
+        assert result.codex_error_info == {
+            "httpConnectionFailed": {"httpStatusCode": 401}
+        }
         assert "internal_error" in (result.error or "")
 
 

--- a/tests/gateway/test_backend_unavailable_notices.py
+++ b/tests/gateway/test_backend_unavailable_notices.py
@@ -1,0 +1,743 @@
+"""Regression coverage for backend-unavailable notices at the real gateway boundary."""
+
+import asyncio
+import time
+from datetime import datetime
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import (
+    BackendNoticeState,
+    BackendUnavailableReply,
+    _LLM_CONNECTION_ERROR_COOLDOWN_SECONDS,
+    _LLM_ERROR_TRACKER_MAX_SESSIONS,
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    ProcessingOutcome,
+    SendResult,
+)
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+_NOTICE = (
+    "The AI backend is temporarily unavailable. "
+    "Please try sending your message again in a moment."
+)
+
+
+class CaptureSlackAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(
+            PlatformConfig(enabled=True, token="fake-token"), Platform.SLACK
+        )
+        self.sent = []
+        self.processing_hooks = []
+        self.delivery_results = []
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id=f"slack-{len(self.sent)}")
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+    async def on_processing_start(self, event: MessageEvent) -> None:
+        self.processing_hooks.append(("start", event.message_id))
+
+    async def on_processing_complete(
+        self, event: MessageEvent, outcome: ProcessingOutcome
+    ) -> None:
+        self.processing_hooks.append(("complete", event.message_id, outcome))
+
+
+class FailingDeliverySlackAdapter(CaptureSlackAdapter):
+    async def _send_with_retry(self, *args, **kwargs) -> SendResult:
+        result = self.delivery_results.pop(0)
+        if result.success:
+            self.sent.append(
+                {
+                    "chat_id": kwargs["chat_id"],
+                    "content": kwargs["content"],
+                    "reply_to": kwargs.get("reply_to"),
+                    "metadata": kwargs.get("metadata"),
+                }
+            )
+        return result
+
+
+def _backend_failure(error: str) -> dict:
+    return {
+        "final_response": f"API call failed after 3 retries: {error}",
+        "messages": [{"role": "user", "content": "hello"}],
+        "tools": [],
+        "history_offset": 0,
+        "api_calls": 3,
+        "failed": True,
+        "failure_reason": "timeout",
+        "completed": False,
+        "interrupted": False,
+        "error": error,
+        "last_prompt_tokens": 0,
+    }
+
+
+def _successful_result(text: str = "normal response") -> dict:
+    return {
+        "final_response": text,
+        "messages": [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": text},
+        ],
+        "tools": [],
+        "history_offset": 0,
+        "api_calls": 1,
+        "failed": False,
+        "completed": True,
+        "interrupted": False,
+        "last_prompt_tokens": 0,
+    }
+
+
+def _make_runner(adapter: CaptureSlackAdapter, results: list[dict]) -> gateway_run.GatewayRunner:
+    runner = cast(Any, object.__new__(gateway_run.GatewayRunner))
+    runner.config = GatewayConfig(
+        platforms={Platform.SLACK: PlatformConfig(enabled=True, token="fake-token")}
+    )
+    runner.adapters = {Platform.SLACK: adapter}
+    runner._backend_notice_state = BackendNoticeState()
+    runner._share_backend_notice_state(adapter, profile_name="default")
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key="agent:main:slack:channel:C123:171717",
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.SLACK,
+        chat_type="channel",
+    )
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+    runner.session_store.has_platform_message_id = MagicMock(return_value=False)
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._is_user_authorized = lambda source: True
+    runner._set_session_env = lambda context: []
+    runner._run_agent = AsyncMock(side_effect=results)
+    return runner
+
+
+def _make_event(message_id: str) -> MessageEvent:
+    return MessageEvent(
+        text="hello",
+        source=SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C123",
+            chat_type="channel",
+            thread_id="171717",
+            user_id="U123",
+        ),
+        message_id=message_id,
+    )
+
+
+def _wire_runner(monkeypatch, tmp_path, adapter, results):
+    runner = _make_runner(adapter, results)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"}
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length", lambda *_args, **_kwargs: 100
+    )
+    monkeypatch.setenv("SLACK_HOME_CHANNEL", "C123")
+    adapter.set_message_handler(runner._handle_message)
+    adapter._keep_typing = lambda *_args, **_kwargs: asyncio.Event().wait()
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_real_gateway_path_sanitizes_backend_transport_failure(monkeypatch, tmp_path):
+    raw_error = "APIConnectionError: connection refused at https://api.example.com/v1"
+    adapter = CaptureSlackAdapter()
+    _wire_runner(monkeypatch, tmp_path, adapter, [_backend_failure(raw_error)])
+
+    event = _make_event("m-1")
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    assert [message["content"] for message in adapter.sent] == [_NOTICE]
+    assert "api.example.com" not in adapter.sent[0]["content"]
+    assert adapter.processing_hooks[-1] == (
+        "complete",
+        "m-1",
+        ProcessingOutcome.FAILURE,
+    )
+
+
+@pytest.mark.asyncio
+async def test_mixed_transport_exceptions_share_one_cooldown(
+    monkeypatch, tmp_path, caplog
+):
+    adapter = CaptureSlackAdapter()
+    _wire_runner(
+        monkeypatch,
+        tmp_path,
+        adapter,
+        [
+            _backend_failure("ConnectError: connection refused"),
+            _backend_failure("APITimeoutError: read timed out"),
+        ],
+    )
+
+    for message_id in ("m-1", "m-2"):
+        event = _make_event(message_id)
+        await adapter._process_message_background(event, build_session_key(event.source))
+
+    assert [message["content"] for message in adapter.sent] == [_NOTICE]
+    assert "response_delivery_dropped" not in caplog.text
+    assert [hook for hook in adapter.processing_hooks if hook[0] == "complete"] == [
+        ("complete", "m-1", ProcessingOutcome.FAILURE),
+        ("complete", "m-2", ProcessingOutcome.FAILURE),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_notice_posts_again_after_cooldown(monkeypatch, tmp_path):
+    adapter = CaptureSlackAdapter()
+    _wire_runner(
+        monkeypatch,
+        tmp_path,
+        adapter,
+        [
+            _backend_failure("ConnectError: connection refused"),
+            _backend_failure("ConnectError: connection refused"),
+        ],
+    )
+
+    first = _make_event("m-1")
+    await adapter._process_message_background(first, build_session_key(first.source))
+    (session_key,) = adapter._llm_error_last_posted
+    kind, timestamp = adapter._llm_error_last_posted[session_key]
+    adapter._llm_error_last_posted[session_key] = (
+        kind,
+        timestamp - _LLM_CONNECTION_ERROR_COOLDOWN_SECONDS - 1.0,
+    )
+
+    second = _make_event("m-2")
+    await adapter._process_message_background(second, build_session_key(second.source))
+
+    assert [message["content"] for message in adapter.sent] == [_NOTICE, _NOTICE]
+
+
+@pytest.mark.asyncio
+async def test_failed_notice_delivery_does_not_arm_cooldown(monkeypatch, tmp_path):
+    adapter = FailingDeliverySlackAdapter()
+    adapter.delivery_results = [
+        SendResult(success=False, error="Slack unavailable"),
+        SendResult(success=True, message_id="slack-2"),
+    ]
+    _wire_runner(
+        monkeypatch,
+        tmp_path,
+        adapter,
+        [
+            _backend_failure("ConnectError: connection refused"),
+            _backend_failure("ConnectError: connection refused"),
+        ],
+    )
+
+    for message_id in ("m-1", "m-2"):
+        event = _make_event(message_id)
+        await adapter._process_message_background(event, build_session_key(event.source))
+
+    assert [message["content"] for message in adapter.sent] == [_NOTICE]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_notice_delivery_releases_inflight_claim(monkeypatch, tmp_path):
+    adapter = CaptureSlackAdapter()
+    _wire_runner(
+        monkeypatch,
+        tmp_path,
+        adapter,
+        [_backend_failure("ConnectError: connection refused")],
+    )
+    event = _make_event("m-1")
+    session_key = build_session_key(event.source)
+
+    async def cancel_delivery(*_args, **_kwargs):
+        raise asyncio.CancelledError
+
+    adapter._send_with_retry = cancel_delivery
+
+    with pytest.raises(asyncio.CancelledError):
+        await adapter._process_message_background(event, session_key)
+
+    assert adapter._backend_notice_state.inflight == set()
+    assert adapter._llm_error_last_posted == {}
+
+
+@pytest.mark.asyncio
+async def test_reconnect_rechecks_cooldown_on_adapter_that_will_send(
+    monkeypatch, tmp_path
+):
+    stale_adapter = CaptureSlackAdapter()
+    runner = _wire_runner(
+        monkeypatch,
+        tmp_path,
+        stale_adapter,
+        [_backend_failure("ConnectError: connection refused")],
+    )
+    cast(Any, stale_adapter).gateway_runner = runner
+
+    replacement = CaptureSlackAdapter()
+    cast(Any, replacement).gateway_runner = runner
+    replacement.set_backend_notice_state(runner._backend_notice_state)
+    event = _make_event("m-1")
+    session_key = build_session_key(event.source)
+    replacement._record_llm_error_notice(
+        session_key,
+        "backend_unavailable",
+        time.monotonic(),
+    )
+
+    original_unwrap = stale_adapter._unwrap_ephemeral
+
+    def replace_before_delivery(response):
+        runner.adapters[Platform.SLACK] = replacement
+        return original_unwrap(response)
+
+    stale_adapter._unwrap_ephemeral = replace_before_delivery
+
+    await stale_adapter._process_message_background(event, session_key)
+
+    assert replacement.sent == []
+    assert stale_adapter.sent == []
+
+
+@pytest.mark.asyncio
+async def test_concurrent_adapter_generations_share_one_inflight_claim(
+    monkeypatch, tmp_path
+):
+    first = CaptureSlackAdapter()
+    runner = _wire_runner(
+        monkeypatch,
+        tmp_path,
+        first,
+        [_backend_failure("ConnectError: connection refused")],
+    )
+    cast(Any, first).gateway_runner = runner
+
+    second = CaptureSlackAdapter()
+    second.set_backend_notice_state(runner._backend_notice_state)
+    cast(Any, second).gateway_runner = runner
+    second.set_message_handler(AsyncMock(return_value=BackendUnavailableReply(_NOTICE)))
+
+    async def keep_typing(*_args, **_kwargs):
+        await asyncio.Event().wait()
+
+    second._keep_typing = keep_typing
+
+    send_started = asyncio.Event()
+    release_send = asyncio.Event()
+
+    async def hold_first_send(*args, **kwargs):
+        send_started.set()
+        await release_send.wait()
+        first.sent.append({"content": kwargs["content"]})
+        return SendResult(success=True, message_id="first")
+
+    first._send_with_retry = hold_first_send
+    first_event = _make_event("m-1")
+    second_event = _make_event("m-2")
+    session_key = build_session_key(first_event.source)
+
+    first_task = asyncio.create_task(
+        first._process_message_background(first_event, session_key)
+    )
+    await send_started.wait()
+    runner.adapters[Platform.SLACK] = second
+    second_task = asyncio.create_task(
+        second._process_message_background(second_event, session_key)
+    )
+    await asyncio.sleep(0)
+    assert second_task.done() is False
+    release_send.set()
+    await asyncio.gather(first_task, second_task)
+
+    assert len(first.sent) == 1
+    assert second.sent == []
+
+
+@pytest.mark.asyncio
+async def test_replacement_retries_notice_after_inflight_owner_delivery_fails(
+    monkeypatch, tmp_path
+):
+    first = CaptureSlackAdapter()
+    runner = _wire_runner(
+        monkeypatch,
+        tmp_path,
+        first,
+        [_backend_failure("ConnectError: connection refused")],
+    )
+    cast(Any, first).gateway_runner = runner
+
+    second = CaptureSlackAdapter()
+    second.set_backend_notice_state(runner._backend_notice_state)
+    cast(Any, second).gateway_runner = runner
+    second.set_message_handler(AsyncMock(return_value=BackendUnavailableReply(_NOTICE)))
+
+    async def keep_typing(*_args, **_kwargs):
+        await asyncio.Event().wait()
+
+    second._keep_typing = keep_typing
+
+    send_started = asyncio.Event()
+    release_send = asyncio.Event()
+
+    async def fail_first_send(*_args, **_kwargs):
+        send_started.set()
+        await release_send.wait()
+        return SendResult(success=False, error="stale transport disconnected")
+
+    first._send_with_retry = fail_first_send
+    first_event = _make_event("m-1")
+    second_event = _make_event("m-2")
+    session_key = build_session_key(first_event.source)
+
+    first_task = asyncio.create_task(
+        first._process_message_background(first_event, session_key)
+    )
+    await send_started.wait()
+    runner.adapters[Platform.SLACK] = second
+    second_task = asyncio.create_task(
+        second._process_message_background(second_event, session_key)
+    )
+    await asyncio.sleep(0)
+    assert second_task.done() is False
+
+    release_send.set()
+    await asyncio.gather(first_task, second_task)
+
+    assert first.sent == []
+    assert [message["content"] for message in second.sent] == [_NOTICE]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_owner_waits_for_ambiguous_send_success_before_suppressing(
+    monkeypatch, tmp_path
+):
+    first = CaptureSlackAdapter()
+    runner = _wire_runner(
+        monkeypatch,
+        tmp_path,
+        first,
+        [_backend_failure("ConnectError: connection refused")],
+    )
+    cast(Any, first).gateway_runner = runner
+
+    second = CaptureSlackAdapter()
+    second.set_backend_notice_state(runner._backend_notice_state)
+    cast(Any, second).gateway_runner = runner
+    second.set_message_handler(AsyncMock(return_value=BackendUnavailableReply(_NOTICE)))
+
+    async def keep_typing(*_args, **_kwargs):
+        await asyncio.Event().wait()
+
+    second._keep_typing = keep_typing
+    send_started = asyncio.Event()
+    release_send = asyncio.Event()
+
+    async def ambiguous_send(*_args, **kwargs):
+        send_started.set()
+        await release_send.wait()
+        first.sent.append({"content": kwargs["content"]})
+        return SendResult(success=True, message_id="first")
+
+    first._send_with_retry = ambiguous_send
+    first_event = _make_event("m-1")
+    second_event = _make_event("m-2")
+    session_key = build_session_key(first_event.source)
+    first_task = asyncio.create_task(
+        first._process_message_background(first_event, session_key)
+    )
+    await send_started.wait()
+    runner.adapters[Platform.SLACK] = second
+    second_task = asyncio.create_task(
+        second._process_message_background(second_event, session_key)
+    )
+    await asyncio.sleep(0)
+
+    first_task.cancel()
+    await asyncio.sleep(0)
+    assert first_task.done() is False
+    assert second_task.done() is False
+    release_send.set()
+    with pytest.raises(asyncio.CancelledError):
+        await first_task
+    await second_task
+
+    assert [message["content"] for message in first.sent] == [_NOTICE]
+    assert second.sent == []
+
+
+@pytest.mark.asyncio
+async def test_cancelled_owner_releases_waiter_after_definite_send_failure(
+    monkeypatch, tmp_path
+):
+    first = CaptureSlackAdapter()
+    runner = _wire_runner(
+        monkeypatch,
+        tmp_path,
+        first,
+        [_backend_failure("ConnectError: connection refused")],
+    )
+    cast(Any, first).gateway_runner = runner
+
+    second = CaptureSlackAdapter()
+    second.set_backend_notice_state(runner._backend_notice_state)
+    cast(Any, second).gateway_runner = runner
+    second.set_message_handler(AsyncMock(return_value=BackendUnavailableReply(_NOTICE)))
+
+    async def keep_typing(*_args, **_kwargs):
+        await asyncio.Event().wait()
+
+    second._keep_typing = keep_typing
+    send_started = asyncio.Event()
+    release_send = asyncio.Event()
+
+    async def definite_failure(*_args, **_kwargs):
+        send_started.set()
+        await release_send.wait()
+        return SendResult(success=False, error="stale transport disconnected")
+
+    first._send_with_retry = definite_failure
+    first_event = _make_event("m-1")
+    second_event = _make_event("m-2")
+    session_key = build_session_key(first_event.source)
+    first_task = asyncio.create_task(
+        first._process_message_background(first_event, session_key)
+    )
+    await send_started.wait()
+    runner.adapters[Platform.SLACK] = second
+    second_task = asyncio.create_task(
+        second._process_message_background(second_event, session_key)
+    )
+    await asyncio.sleep(0)
+
+    first_task.cancel()
+    await asyncio.sleep(0)
+    assert first_task.done() is False
+    assert second_task.done() is False
+    release_send.set()
+    with pytest.raises(asyncio.CancelledError):
+        await first_task
+    await second_task
+
+    assert first.sent == []
+    assert [message["content"] for message in second.sent] == [_NOTICE]
+
+
+@pytest.mark.asyncio
+async def test_shared_runner_state_does_not_cross_suppress_profiles():
+    state = BackendNoticeState()
+    first = CaptureSlackAdapter()
+    second = CaptureSlackAdapter()
+    first.set_backend_notice_state(state, profile_name="alpha")
+    second.set_backend_notice_state(state, profile_name="beta")
+    first.set_message_handler(AsyncMock(return_value=BackendUnavailableReply(_NOTICE)))
+    second.set_message_handler(AsyncMock(return_value=BackendUnavailableReply(_NOTICE)))
+
+    async def keep_typing(*_args, **_kwargs):
+        await asyncio.Event().wait()
+
+    first._keep_typing = keep_typing
+    second._keep_typing = keep_typing
+    first_event = _make_event("m-alpha")
+    second_event = _make_event("m-beta")
+    raw_session_key = build_session_key(first_event.source)
+
+    await first._process_message_background(first_event, raw_session_key)
+    await second._process_message_background(second_event, raw_session_key)
+
+    assert [message["content"] for message in first.sent] == [_NOTICE]
+    assert [message["content"] for message in second.sent] == [_NOTICE]
+    assert set(state.posted) == {
+        "profile:alpha:agent:main:slack:channel:C123:171717",
+        "profile:beta:agent:main:slack:channel:C123:171717",
+    }
+
+
+@pytest.mark.asyncio
+async def test_default_profile_does_not_collide_with_named_main_profile():
+    state = BackendNoticeState()
+    default_adapter = CaptureSlackAdapter()
+    named_main_adapter = CaptureSlackAdapter()
+    default_adapter.set_backend_notice_state(state, profile_name="default")
+    named_main_adapter.set_backend_notice_state(state, profile_name="main")
+    default_adapter.set_message_handler(
+        AsyncMock(return_value=BackendUnavailableReply(_NOTICE))
+    )
+    named_main_adapter.set_message_handler(
+        AsyncMock(return_value=BackendUnavailableReply(_NOTICE))
+    )
+
+    async def keep_typing(*_args, **_kwargs):
+        await asyncio.Event().wait()
+
+    default_adapter._keep_typing = keep_typing
+    named_main_adapter._keep_typing = keep_typing
+    default_event = _make_event("m-default")
+    named_main_event = _make_event("m-main")
+    raw_session_key = build_session_key(default_event.source)
+
+    await default_adapter._process_message_background(default_event, raw_session_key)
+    await named_main_adapter._process_message_background(
+        named_main_event, raw_session_key
+    )
+
+    assert [message["content"] for message in default_adapter.sent] == [_NOTICE]
+    assert [message["content"] for message in named_main_adapter.sent] == [_NOTICE]
+    assert set(state.posted) == {
+        "profile:default:agent:main:slack:channel:C123:171717",
+        "profile:main:agent:main:slack:channel:C123:171717",
+    }
+
+
+@pytest.mark.asyncio
+async def test_backend_notice_skips_auto_tts(monkeypatch, tmp_path):
+    adapter = CaptureSlackAdapter()
+    _wire_runner(
+        monkeypatch,
+        tmp_path,
+        adapter,
+        [_backend_failure("ConnectError: connection refused")],
+    )
+    adapter._should_auto_tts_for_chat = lambda chat_id: True
+    adapter.play_tts = AsyncMock(
+        side_effect=AssertionError("backend notice must stay on text delivery path")
+    )
+    event = _make_event("m-1")
+    event.message_type = MessageType.VOICE
+
+    await adapter._process_message_background(
+        event,
+        build_session_key(event.source),
+    )
+
+    adapter.play_tts.assert_not_awaited()
+    assert [message["content"] for message in adapter.sent] == [_NOTICE]
+
+
+@pytest.mark.asyncio
+async def test_platform_send_connection_error_is_not_backend_outage(monkeypatch, tmp_path):
+    adapter = CaptureSlackAdapter()
+    _wire_runner(monkeypatch, tmp_path, adapter, [_successful_result()])
+
+    async def fail_platform_delivery(*args, **kwargs):
+        raise ConnectionError(
+            "Slack socket disconnected at "
+            "https://hooks.slack.com/services/private?token=super-secret-token"
+        )
+
+    adapter._send_with_retry = fail_platform_delivery
+    event = _make_event("m-1")
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    contents = [message["content"] for message in adapter.sent]
+    assert _NOTICE not in contents
+    assert contents == [
+        "Sorry, I encountered an internal error. "
+        "Please try again or use /reset to start a fresh session."
+    ]
+    assert "hooks.slack.com" not in contents[0]
+    assert "super-secret-token" not in contents[0]
+
+
+@pytest.mark.parametrize(
+    ("failure_reason", "expected"),
+    [
+        ("timeout", True),
+        ("overloaded", True),
+        ("server_error", True),
+        ("rate_limit", False),
+        ("auth_permanent", False),
+        ("billing", False),
+        ("context_overflow", False),
+    ],
+)
+def test_only_transient_backend_failures_get_outage_marker(failure_reason, expected):
+    result = _backend_failure("provider failed")
+    result["failure_reason"] = failure_reason
+    assert gateway_run._is_backend_unavailable_agent_result(result) is expected
+
+
+@pytest.mark.parametrize(
+    "platform",
+    [Platform.LOCAL, Platform.API_SERVER, Platform.WEBHOOK, Platform.MSGRAPH_WEBHOOK],
+)
+def test_programmatic_surfaces_are_excluded_from_notice_marker(platform):
+    assert gateway_run._gateway_surface_passes_raw_text(platform) is True
+
+
+def test_notice_tracker_prunes_expired_sessions():
+    adapter = CaptureSlackAdapter()
+    now = time.monotonic()
+    stale = now - _LLM_CONNECTION_ERROR_COOLDOWN_SECONDS - 1.0
+    for index in range(50):
+        adapter._llm_error_last_posted[f"stale-{index}"] = (
+            "backend_unavailable",
+            stale,
+        )
+
+    adapter._record_llm_error_notice("live", "backend_unavailable", now)
+
+    assert set(adapter._llm_error_last_posted) == {"profile:default:live"}
+
+
+def test_notice_tracker_is_bounded():
+    adapter = CaptureSlackAdapter()
+    now = time.monotonic()
+    overflow = _LLM_ERROR_TRACKER_MAX_SESSIONS + 200
+
+    for index in range(overflow):
+        adapter._record_llm_error_notice(
+            f"session-{index}",
+            "backend_unavailable",
+            now + index * 0.001,
+        )
+
+    assert len(adapter._llm_error_last_posted) <= _LLM_ERROR_TRACKER_MAX_SESSIONS
+    assert (
+        f"profile:default:session-{overflow - 1}"
+        in adapter._llm_error_last_posted
+    )
+    assert "session-0" not in adapter._llm_error_last_posted

--- a/tests/gateway/test_backend_unavailable_notices.py
+++ b/tests/gateway/test_backend_unavailable_notices.py
@@ -591,8 +591,8 @@ async def test_shared_runner_state_does_not_cross_suppress_profiles():
     assert [message["content"] for message in first.sent] == [_NOTICE]
     assert [message["content"] for message in second.sent] == [_NOTICE]
     assert set(state.posted) == {
-        "profile:alpha:agent:main:slack:channel:C123:171717",
-        "profile:beta:agent:main:slack:channel:C123:171717",
+        "profile:5:alpha:agent:main:slack:channel:C123:171717",
+        "profile:4:beta:agent:main:slack:channel:C123:171717",
     }
 
 
@@ -627,9 +627,149 @@ async def test_default_profile_does_not_collide_with_named_main_profile():
     assert [message["content"] for message in default_adapter.sent] == [_NOTICE]
     assert [message["content"] for message in named_main_adapter.sent] == [_NOTICE]
     assert set(state.posted) == {
-        "profile:default:agent:main:slack:channel:C123:171717",
-        "profile:main:agent:main:slack:channel:C123:171717",
+        "profile:7:default:agent:main:slack:channel:C123:171717",
+        "profile:4:main:agent:main:slack:channel:C123:171717",
     }
+
+
+def test_shared_notice_state_wiring_attaches_runner_for_direct_builtins():
+    adapter = CaptureSlackAdapter()
+    runner = cast(Any, object.__new__(gateway_run.GatewayRunner))
+    runner._backend_notice_state = BackendNoticeState()
+
+    runner._share_backend_notice_state(adapter, profile_name="default")
+
+    assert cast(Any, adapter).gateway_runner is runner
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("routed_profile_has_slack", [False, True])
+async def test_routed_runtime_reconnect_uses_primary_transport_replacement(
+    monkeypatch,
+    tmp_path,
+    routed_profile_has_slack,
+):
+    stale_adapter = CaptureSlackAdapter()
+    runner = _wire_runner(
+        monkeypatch,
+        tmp_path,
+        stale_adapter,
+        [_backend_failure("ConnectError: connection refused")],
+    )
+    runner._profile_name_for_source = lambda source: "routed"
+
+    replacement = CaptureSlackAdapter()
+    runner._share_backend_notice_state(replacement, profile_name="default")
+
+    routed_adapter = CaptureSlackAdapter()
+    runner._share_backend_notice_state(routed_adapter, profile_name="routed")
+    runner._profile_adapters = (
+        {"routed": {Platform.SLACK: routed_adapter}}
+        if routed_profile_has_slack
+        else {}
+    )
+
+    source = stale_adapter.build_source(
+        chat_id="C123",
+        chat_type="channel",
+        thread_id="171717",
+        user_id="U123",
+        message_id="m-routed",
+    )
+    assert source.profile == "routed"
+    assert "_transport_profile" not in source.to_dict()
+    event = MessageEvent(text="hello", source=source, message_id="m-routed")
+    session_key = build_session_key(source)
+
+    # The runtime route is independent from the bot credential that received
+    # this turn. A primary reconnect must retain the primary transport even if
+    # the routed profile happens to own another adapter for the same platform.
+    runner.adapters[Platform.SLACK] = replacement
+    assert runner._adapter_for_source(source) is replacement
+    assert runner._adapter_profile_for_source(source) is None
+    await stale_adapter._process_message_background(event, session_key)
+
+    assert stale_adapter.sent == []
+    assert routed_adapter.sent == []
+    assert [message["content"] for message in replacement.sent] == [_NOTICE]
+    assert replacement._llm_error_notice_suppressed(
+        session_key,
+        "backend_unavailable",
+        time.monotonic(),
+        source=source,
+    )
+
+
+@pytest.mark.asyncio
+async def test_routed_runtime_reconnect_uses_secondary_transport_replacement(
+    monkeypatch,
+    tmp_path,
+):
+    stale_adapter = CaptureSlackAdapter()
+    runner = _wire_runner(
+        monkeypatch,
+        tmp_path,
+        stale_adapter,
+        [_backend_failure("ConnectError: connection refused")],
+    )
+    runner._profile_name_for_source = lambda source: "routed"
+
+    primary_adapter = CaptureSlackAdapter()
+    runner._share_backend_notice_state(primary_adapter, profile_name="default")
+    runner.adapters[Platform.SLACK] = primary_adapter
+
+    runner._share_backend_notice_state(stale_adapter, profile_name="coder")
+    routed_adapter = CaptureSlackAdapter()
+    runner._share_backend_notice_state(routed_adapter, profile_name="routed")
+    runner._profile_adapters = {
+        "coder": {Platform.SLACK: stale_adapter},
+        "routed": {Platform.SLACK: routed_adapter},
+    }
+
+    source = stale_adapter.build_source(
+        chat_id="C123",
+        chat_type="channel",
+        thread_id="171717",
+        user_id="U123",
+        message_id="m-secondary-routed",
+    )
+    assert source.profile == "routed"
+    assert "_transport_profile" not in source.to_dict()
+    event = MessageEvent(
+        text="hello",
+        source=source,
+        message_id="m-secondary-routed",
+    )
+
+    replacement = CaptureSlackAdapter()
+    runner._share_backend_notice_state(replacement, profile_name="coder")
+    runner._profile_adapters["coder"][Platform.SLACK] = replacement
+
+    assert runner._adapter_for_source(source) is replacement
+    assert runner._adapter_profile_for_source(source) == "coder"
+    await stale_adapter._process_message_background(event, build_session_key(source))
+
+    assert stale_adapter.sent == []
+    assert primary_adapter.sent == []
+    assert routed_adapter.sent == []
+    assert [message["content"] for message in replacement.sent] == [_NOTICE]
+    assert replacement._llm_error_notice_suppressed(
+        build_session_key(source),
+        "backend_unavailable",
+        time.monotonic(),
+        source=source,
+    )
+
+
+def test_missing_secondary_transport_owner_keeps_secondary_policy_scope():
+    runner = cast(Any, object.__new__(gateway_run.GatewayRunner))
+    runner.adapters = {}
+    runner._profile_adapters = {}
+    source = SessionSource(platform=Platform.SLACK, chat_id="C123")
+    setattr(source, "_transport_profile", "coder")
+
+    assert runner._adapter_for_source(source) is None
+    assert runner._adapter_profile_for_source(source) == "coder"
 
 
 @pytest.mark.asyncio
@@ -720,7 +860,7 @@ def test_notice_tracker_prunes_expired_sessions():
 
     adapter._record_llm_error_notice("live", "backend_unavailable", now)
 
-    assert set(adapter._llm_error_last_posted) == {"profile:default:live"}
+    assert set(adapter._llm_error_last_posted) == {"profile:7:default:live"}
 
 
 def test_notice_tracker_is_bounded():
@@ -737,7 +877,7 @@ def test_notice_tracker_is_bounded():
 
     assert len(adapter._llm_error_last_posted) <= _LLM_ERROR_TRACKER_MAX_SESSIONS
     assert (
-        f"profile:default:session-{overflow - 1}"
+        f"profile:7:default:session-{overflow - 1}"
         in adapter._llm_error_last_posted
     )
     assert "session-0" not in adapter._llm_error_last_posted

--- a/tests/gateway/test_delivery_ledger_producer.py
+++ b/tests/gateway/test_delivery_ledger_producer.py
@@ -15,7 +15,13 @@ import pytest
 
 from gateway import delivery_ledger as dl
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.platforms.base import (
+    BackendUnavailableReply,
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+)
 from gateway.session import SessionSource
 
 
@@ -121,6 +127,18 @@ class TestProducerHook:
         rows = _rows()
         assert len(rows) == 1
         assert rows[0][1] == "failed"
+
+    @pytest.mark.asyncio
+    async def test_backend_notice_is_not_durably_replayed_as_plain_text(self):
+        adapter = _Adapter()
+        await _run(
+            adapter,
+            _event(),
+            BackendUnavailableReply("backend unavailable"),
+        )
+
+        assert adapter.sent == ["backend unavailable"]
+        assert _rows() == []
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1,24 +1,32 @@
 """Tests for gateway/platforms/base.py — MessageEvent, media extraction, message truncation."""
 
+import asyncio
 import os
 import time
 from unittest.mock import patch
 
 import pytest
 
+from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
     GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE,
     MessageEvent,
+    ProcessingOutcome,
+    SendResult,
     cache_audio_from_bytes,
     cache_image_from_bytes,
     cache_video_from_bytes,
     safe_url_for_log,
     utf16_len,
     validate_inbound_media_size,
+    _LLM_CONNECTION_ERROR_COOLDOWN_SECONDS,
+    _LLM_ERROR_TRACKER_MAX_SESSIONS,
+    _is_llm_connection_error,
     _log_safe_path,
     _prefix_within_utf16_limit,
 )
+from gateway.session import SessionSource, build_session_key
 
 
 def test_media_delivery_denies_encrypted_bitwarden_cache(tmp_path, monkeypatch):
@@ -2199,3 +2207,247 @@ class TestMediaFallbackDoesNotLeakHostPath:
         sent_text = adapter.sent[0]["content"]
         assert "Here's the daily summary." in sent_text
         assert self.SENSITIVE_PATH not in sent_text
+
+
+# ---------------------------------------------------------------------------
+# Backend-unavailable notices — classification, cooldown, tracker bounds
+# ---------------------------------------------------------------------------
+
+
+class _ProviderAPIConnectionError(Exception):
+    """Stand-in for the OpenAI SDK error.
+
+    Classification is by exception *type name*, so the test double must be
+    named exactly as the SDK class is.  Renamed via ``__name__`` below.
+    """
+
+
+_ProviderAPIConnectionError.__name__ = "APIConnectionError"
+
+
+class _ErrorReportingAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="fake-token"), Platform.TELEGRAM)
+        self.sent = []
+        self.processing_hooks = []
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.sent.append({"chat_id": chat_id, "content": content, "metadata": metadata})
+        return SendResult(success=True, message_id=str(len(self.sent)))
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+    async def on_processing_complete(self, event, outcome) -> None:
+        self.processing_hooks.append((event.message_id, outcome))
+
+
+def _make_error_event(message_id: str = "msg-1") -> MessageEvent:
+    return MessageEvent(
+        text="hello",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="chat-1",
+            chat_type="dm",
+            user_id="user-1",
+        ),
+        message_id=message_id,
+    )
+
+
+class TestLLMConnectionErrorClassification:
+    """The classifier must agree with the agent runtime's transport set."""
+
+    @pytest.mark.parametrize(
+        "type_name",
+        [
+            "APIConnectionError",
+            "APITimeoutError",
+            "ConnectError",
+            "ConnectTimeout",
+            "PoolTimeout",
+            "RemoteProtocolError",
+        ],
+    )
+    def test_provider_transport_types_are_backend_errors(self, type_name):
+        exc_type = type(type_name, (Exception,), {})
+        assert _is_llm_connection_error(exc_type("transport failure")) is True
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            ConnectionRefusedError("refused"),
+            ConnectionResetError("reset"),
+            TimeoutError("timed out"),
+        ],
+    )
+    def test_builtin_connection_types_are_backend_errors(self, exc):
+        assert _is_llm_connection_error(exc) is True
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            FileNotFoundError("/var/hermes/media/missing.png"),
+            PermissionError("/etc/hermes/secrets.env"),
+            IsADirectoryError("/tmp/hermes"),
+            RuntimeError("boom"),
+            ValueError("bad value"),
+        ],
+    )
+    def test_non_backend_failures_are_not_backend_errors(self, exc):
+        """OSError subclasses from filesystem work must keep their detail."""
+        assert _is_llm_connection_error(exc) is False
+
+
+class TestGatewayErrorReporting:
+    @staticmethod
+    async def _quiet_typing(_chat_id, interval=2.0, metadata=None):
+        await asyncio.Event().wait()
+
+    def _adapter_with_error(self, exc):
+        adapter = _ErrorReportingAdapter()
+        adapter._keep_typing = self._quiet_typing
+
+        async def handler(_event):
+            await asyncio.sleep(0)
+            raise exc
+
+        adapter.set_message_handler(handler)
+        return adapter
+
+    async def _run(self, adapter, message_id="msg-1"):
+        event = _make_error_event(message_id)
+        await adapter._process_message_background(event, build_session_key(event.source))
+        return event
+
+    @pytest.mark.asyncio
+    async def test_provider_transport_error_gets_sanitized_notice(self):
+        adapter = self._adapter_with_error(
+            _ProviderAPIConnectionError("Connection error to https://api.example.com/v1")
+        )
+
+        await self._run(adapter)
+
+        assert len(adapter.sent) == 1
+        content = adapter.sent[0]["content"]
+        assert content == (
+            "The AI backend is temporarily unavailable. "
+            "I'll resume automatically when it comes back; no action needed."
+        )
+        assert "APIConnectionError" not in content
+        assert "api.example.com" not in content
+
+    @pytest.mark.asyncio
+    async def test_non_backend_oserror_keeps_actionable_detail(self):
+        """A filesystem failure under the same catch must not be sanitized."""
+        adapter = self._adapter_with_error(
+            FileNotFoundError("/var/hermes/media/report.pdf missing")
+        )
+
+        await self._run(adapter)
+
+        assert len(adapter.sent) == 1
+        content = adapter.sent[0]["content"]
+        assert "FileNotFoundError" in content
+        assert "/var/hermes/media/report.pdf missing" in content
+        assert "backend is temporarily unavailable" not in content
+
+    @pytest.mark.asyncio
+    async def test_non_connection_error_keeps_detailed_notice(self):
+        adapter = self._adapter_with_error(RuntimeError("boom"))
+
+        await self._run(adapter)
+
+        assert adapter.sent[0]["content"] == (
+            "Sorry, I encountered an error (RuntimeError).\n"
+            "boom\n"
+            "Try again or use /reset to start a fresh session."
+        )
+
+    @pytest.mark.asyncio
+    async def test_repeated_error_is_suppressed_during_cooldown(self):
+        adapter = self._adapter_with_error(ConnectionRefusedError("refused"))
+
+        await self._run(adapter, "msg-1")
+        await self._run(adapter, "msg-2")
+
+        assert len(adapter.sent) == 1
+        # Processing still completes for both — only the notice is suppressed.
+        assert adapter.processing_hooks == [
+            ("msg-1", ProcessingOutcome.FAILURE),
+            ("msg-2", ProcessingOutcome.FAILURE),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_notice_posts_again_after_cooldown_expires(self):
+        adapter = self._adapter_with_error(ConnectionRefusedError("refused"))
+
+        await self._run(adapter, "msg-1")
+        assert len(adapter.sent) == 1
+
+        # Backdate the recorded notice past the cooldown window.
+        (session_key,) = adapter._llm_error_last_posted
+        error_type, ts = adapter._llm_error_last_posted[session_key]
+        adapter._llm_error_last_posted[session_key] = (
+            error_type,
+            ts - _LLM_CONNECTION_ERROR_COOLDOWN_SECONDS - 1.0,
+        )
+
+        await self._run(adapter, "msg-2")
+        assert len(adapter.sent) == 2
+
+    @pytest.mark.asyncio
+    async def test_distinct_error_type_is_not_suppressed(self):
+        adapter = _ErrorReportingAdapter()
+        adapter._keep_typing = self._quiet_typing
+        errors = [ConnectionRefusedError("refused"), ConnectionResetError("reset")]
+
+        async def handler(_event):
+            await asyncio.sleep(0)
+            raise errors.pop(0)
+
+        adapter.set_message_handler(handler)
+
+        await self._run(adapter, "msg-1")
+        await self._run(adapter, "msg-2")
+
+        assert len(adapter.sent) == 2
+
+
+class TestLLMErrorTrackerBounds:
+    """The cooldown map must not retain every session key forever."""
+
+    def _adapter(self):
+        return _ErrorReportingAdapter()
+
+    def test_expired_entries_are_pruned_on_write(self):
+        adapter = self._adapter()
+        now = time.monotonic()
+        stale_ts = now - _LLM_CONNECTION_ERROR_COOLDOWN_SECONDS - 1.0
+        for i in range(50):
+            adapter._llm_error_last_posted[f"stale-{i}"] = ("ConnectionError", stale_ts)
+
+        adapter._record_llm_error_notice("live", "ConnectionError", now)
+
+        assert set(adapter._llm_error_last_posted) == {"live"}
+
+    def test_tracker_is_bounded_when_all_entries_are_live(self):
+        adapter = self._adapter()
+        now = time.monotonic()
+        overflow = _LLM_ERROR_TRACKER_MAX_SESSIONS + 200
+
+        for i in range(overflow):
+            # Ascending timestamps inside the window: nothing expires, so the
+            # hard cap is what has to hold.
+            adapter._record_llm_error_notice(f"session-{i}", "ConnectionError", now + i * 0.001)
+
+        assert len(adapter._llm_error_last_posted) <= _LLM_ERROR_TRACKER_MAX_SESSIONS
+        # Oldest-first eviction keeps the most recent sessions.
+        assert f"session-{overflow - 1}" in adapter._llm_error_last_posted
+        assert "session-0" not in adapter._llm_error_last_posted

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4599,6 +4599,50 @@ class TestRetryExhaustion:
         assert "error" in result
         assert "Invalid API response" in result["error"]
         assert result.get("final_response") == result["error"]
+        assert result["failure_reason"] == "unknown"
+
+    @pytest.mark.parametrize(
+        ("status_code", "failure_reason"),
+        [
+            (401, "auth"),
+            (402, "billing"),
+            (408, "timeout"),
+            (429, "rate_limit"),
+            (500, "server_error"),
+            (502, "server_error"),
+            (503, "overloaded"),
+            (504, "timeout"),
+            (524, "timeout"),
+            (529, "overloaded"),
+        ],
+    )
+    def test_invalid_response_status_carries_structured_reason(
+        self, agent, status_code, failure_reason
+    ):
+        """Production invalid-response returns preserve status taxonomy."""
+        self._setup_agent(agent)
+        agent._api_max_retries = 1
+        bad_resp = SimpleNamespace(
+            choices=[],
+            error=SimpleNamespace(code=status_code),
+            model="test/model",
+            usage=None,
+        )
+        agent.client.chat.completions.create.return_value = bad_resp
+        from agent import conversation_loop as _conv_loop
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch("run_agent.time", self._make_fast_time_mock()),
+            patch.object(_conv_loop, "time", self._make_fast_time_mock()),
+            patch.object(_conv_loop, "jittered_backoff", lambda *a, **k: 0.0),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["failed"] is True
+        assert result["failure_reason"] == failure_reason
 
     def test_transient_failure_result_carries_structured_reason(self, agent):
         self._setup_agent(agent)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4600,6 +4600,52 @@ class TestRetryExhaustion:
         assert "Invalid API response" in result["error"]
         assert result.get("final_response") == result["error"]
 
+    def test_transient_failure_result_carries_structured_reason(self, agent):
+        self._setup_agent(agent)
+        agent._api_max_retries = 1
+
+        from agent import conversation_loop as _conv_loop
+
+        with (
+            patch.object(
+                agent,
+                "_interruptible_api_call",
+                side_effect=TimeoutError("provider request timed out"),
+            ),
+            patch.object(agent, "_try_recover_primary_transport", return_value=False),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(_conv_loop, "jittered_backoff", lambda *a, **k: 0.0),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["failed"] is True
+        assert result["failure_reason"] == "timeout"
+
+    def test_nonretryable_auth_result_carries_structured_excluded_reason(self, agent):
+        self._setup_agent(agent)
+        agent._fallback_chain = []
+        agent._fallback_index = 0
+
+        class UnauthorizedError(RuntimeError):
+            status_code = 401
+
+        with (
+            patch.object(
+                agent,
+                "_interruptible_api_call",
+                side_effect=UnauthorizedError("invalid API key"),
+            ),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["failed"] is True
+        assert result["failure_reason"] == "auth"
+
     def test_invalid_response_retry_completes_one_logical_call(self, agent):
         self._setup_agent(agent)
         agent.client.chat.completions.create.side_effect = [


### PR DESCRIPTION
## Problem

During an LLM backend outage, gateway adapters could post raw exception details for every inbound message. That both exposed internal endpoint/provider detail and flooded a chat while the backend remained unavailable.

## Approach

This revision handles the signal at the producer and delivery boundaries rather than classifying arbitrary adapter exceptions:

- Standard and Codex app-server turns return a structured `failure_reason` using the shared agent taxonomy.
- Terminal invalid/empty standard-runtime responses preserve the same structured status taxonomy, including 401/402/408/429/500/502/503/504/524/529 and unknown-without-status.
- Codex app-server terminal failures preserve protocol-defined `turn.error.codexErrorInfo` and the separate top-level provider error code. Structured status/code metadata is authoritative over rendered provider prose: 401/403 map to auth, 402 to billing, 408 to timeout, 429 to rate-limit, and 5xx/statusless connection variants to backend outages. Generic `internal_error`, auth, quota/rate-limit, context, bad-request, sandbox, local/config, and unknown failures remain excluded; only explicit `internal_server_error` is transient at the top-level code layer.
- Human chat surfaces receive a fixed sanitized notice for `timeout`, `overloaded`, and `server_error`; API, webhook, and local/programmatic surfaces retain the raw error.
- The notice cooldown is shared across reconnect generations but scoped by logical adapter/profile plus session key, preventing both reconnect duplicates and cross-profile suppression.
- Every built-in and registry adapter receives the runner back-reference at the common startup/reconnect wiring seam, so final delivery resolves the live adapter generation on all chat platforms.
- Routed agent profiles remain independent from the credential/transport owner: in-flight turns resolve the correct primary or secondary replacement generation after reconnect without serializing transport provenance.
- An atomic claim prevents concurrent old/new adapters from double-posting. Cooldown starts only after successful platform delivery; failed or cancelled delivery releases the claim so one waiter can retry.
- Sanitized outage notices bypass auto-TTS/caption processing and the durable delivery ledger.
- Human-facing delivery fallbacks use fixed text; raw transport diagnostics remain confined to logs.
- Cooldown state is bounded and prunes expired entries.

## Validation

Focused producer/transport/delivery and compaction-compatibility suite:

```text
95 passed, 0 failed
```

Full standard-runtime test file:

```text
255 passed, 0 failed
```

Full gateway comparison against the immediately previous published revision using the same interpreter and environment:

```text
candidate:                   5274 passed, 37 skipped, 7 failed
previous published revision: 5269 passed, 37 skipped, 7 failed
```

The candidate's five additional passes are its added gateway regressions. The seven failures are identical on both trees and are environment-sensitive Discord attachment, URL/DNS, runtime-home, and optional WeCom callback cases in this environment:

- `tests/gateway/test_discord_send.py::test_send_video_uses_path_based_files_kwarg`
- `tests/gateway/test_discord_send.py::test_send_video_fails_loud_when_message_has_no_attachments`
- `tests/gateway/test_discord_send.py::test_send_file_attachment_forum_uses_files_kwarg`
- `tests/gateway/test_send_multiple_images.py::TestDiscordMultiImage::test_url_batch_follows_safe_redirect_location_header`
- `tests/gateway/test_session_store_prune.py::test_session_store_default_db_uses_runtime_hermes_home`
- `tests/gateway/test_wecom_callback.py::TestWecomCallbackEventConstruction::test_build_event_extracts_text_message`
- `tests/gateway/test_wecom_callback.py::TestWecomCallbackPollLoop::test_poll_loop_dispatches_handle_message`

Upstream `main` advanced once during final review. A synthetic merge of exact candidate `2ed0a5ca1e640a720ed06406b4eb126e3faee0e0` with `5fffe560661c87d988c4ef2834df14bfb8acba55` was conflict-free; 55 overlap-focused gateway/runtime tests passed, Ruff and AST checks passed, and the qualified merge tree is `a61aeb883abd8edc254c0731521df68a95fae015`.

Also clean:

- Ruff on all changed files
- AST parsing on all changed Python files
- `git diff --check`
- secret-shaped diff scan
- independent frozen-tree adversarial review: **SHIP**, no findings

The branch contains the reviewed implementation plus focused follow-up work for delivery-fallback sanitization, structured Codex/reconnect correctness, routed transport ownership, and standard-runtime failure-reason closure.
