### PR TITLE
fix(honcho): fall back to direct target peer cards

### DIFF
--- a/.paperclip_artifacts/candidate-skip-ledger.jsonl
+++ b/.paperclip_artifacts/candidate-skip-ledger.jsonl
@@ -1,0 +1,4 @@
+{"issue":31224,"url":"https://github.com/NousResearch/hermes-agent/issues/31224","reason":"active_linked_closing_pr","evidence_pr_url":"https://github.com/NousResearch/hermes-agent/pull/31218"}
+{"issue":31155,"url":"https://github.com/NousResearch/hermes-agent/issues/31155","reason":"already_fixed_on_main","evidence_pr_url":"https://github.com/NousResearch/hermes-agent/pull/26486"}
+{"issue":31137,"url":"https://github.com/NousResearch/hermes-agent/issues/31137","reason":"active_linked_closing_pr","evidence_pr_url":"https://github.com/NousResearch/hermes-agent/pull/31138"}
+{"issue":31169,"url":"https://github.com/NousResearch/hermes-agent/issues/31169","reason":"already_fixed_on_main","evidence_pr_url":"https://github.com/NousResearch/hermes-agent/pull/31090"}

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1072,8 +1072,7 @@ class HonchoMemoryProvider(MemoryProvider):
           1. Observation is disabled for this peer
           2. Card hasn't accumulated yet (fresh peer, not enough dialectic
              cycles — dialectic cadence runs every N turns)
-          3. Self-hosted Honcho backend doesn't support peer cards
-             (honcho-ai server < 3.x)
+          3. Backend / SDK lookup path still isn't surfacing an existing card
         """
         cfg = self._config
         reasons: List[str] = []
@@ -1103,8 +1102,9 @@ class HonchoMemoryProvider(MemoryProvider):
         if not reasons:
             reasons.append(
                 "peer card has no facts yet — Honcho's dialectic layer builds "
-                "this over time from observed turns; self-hosted Honcho < 3.x "
-                "does not support peer cards at all"
+                "this over time from observed turns; some self-hosted Honcho "
+                "deployments or SDK versions may also expose peer cards "
+                "inconsistently"
             )
 
         return {

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -1017,7 +1017,14 @@ class HonchoSessionManager:
 
         try:
             observer_peer_id, target_peer_id = self._resolve_observer_target(session, peer)
-            return self._fetch_peer_card(observer_peer_id, target=target_peer_id)
+            card = self._fetch_peer_card(observer_peer_id, target=target_peer_id)
+            if card or not target_peer_id or target_peer_id == observer_peer_id:
+                return card
+
+            # Some self-hosted / SDK combinations can return an empty card for
+            # observer->target lookups even though the target peer itself has a
+            # populated card. Fall back to the target peer's direct self-card.
+            return self._fetch_peer_card(target_peer_id)
         except Exception as e:
             logger.debug("Failed to fetch peer card from Honcho: %s", e)
             return []

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -212,6 +212,18 @@ class TestPeerLookupHelpers:
         assert mgr.get_peer_card(session.key) == ["Name: Robert"]
         assistant_peer.get_card.assert_called_once_with(target=session.user_peer_id)
 
+    def test_get_peer_card_falls_back_to_target_self_lookup_when_targeted_card_is_empty(self):
+        mgr, session = self._make_cached_manager()
+        assistant_peer = MagicMock()
+        assistant_peer.get_card.return_value = []
+        user_peer = MagicMock()
+        user_peer.get_card.return_value = ["Name: Robert"]
+        mgr._get_or_create_peer = MagicMock(side_effect=[assistant_peer, user_peer])
+
+        assert mgr.get_peer_card(session.key) == ["Name: Robert"]
+        assistant_peer.get_card.assert_called_once_with(target=session.user_peer_id)
+        user_peer.get_card.assert_called_once_with()
+
     def test_search_context_uses_assistant_perspective_with_target(self):
         mgr, session = self._make_cached_manager()
         assistant_peer = MagicMock()


### PR DESCRIPTION
## Summary
- fall back to the target peer's direct self-card when the observer-target Honcho lookup returns an empty card
- update the empty `honcho_profile` hint so it no longer claims all self-hosted Honcho < 3.x behavior applies to every empty result
- add a regression test covering the self-hosted-style empty targeted lookup path

## Testing
- `env -i PATH="$PATH" HOME="$HOME" TZ=UTC LANG=C.UTF-8 LC_ALL=C.UTF-8 PYTHONHASHSEED=0 /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest -q -o addopts="" tests/honcho_plugin/test_session.py tests/honcho_plugin/test_empty_profile_hint.py`
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m ruff check plugins/memory/honcho/session.py plugins/memory/honcho/__init__.py tests/honcho_plugin/test_session.py`
- `git diff --check`

Closes #31219.
