### PR TITLE
fix(skills): agentskills.io spec compliance for tags/platforms frontmatter (rebased)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -926,7 +926,7 @@ def _build_snapshot_entry(
         category = "general"
         skill_name = skill_file.parent.name
 
-    platforms = frontmatter.get("platforms") or []
+    platforms = frontmatter.get("platforms") or frontmatter.get("metadata", {}).get("platforms") or []
     if isinstance(platforms, str):
         platforms = [platforms]
 

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -137,7 +137,7 @@ def skill_matches_platform(frontmatter: Dict[str, Any]) -> bool:
     If the field is absent or empty the skill is compatible with **all**
     platforms (backward-compatible default).
     """
-    platforms = frontmatter.get("platforms")
+    platforms = frontmatter.get("platforms") or frontmatter.get("metadata", {}).get("platforms")
     if not platforms:
         return True
     if not isinstance(platforms, list):

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -102,63 +102,6 @@ def test_iter_skill_index_files_prunes_dependency_dirs(tmp_path):
     assert found == [real / "SKILL.md"]
 
 
-# ── agentskills.io spec compliance: platforms/tags under metadata ───────────
-
-
-def test_platforms_top_level_still_works():
-    """Top-level platforms field (legacy) is still read correctly."""
-    frontmatter = {"platforms": ["linux"]}
-    # We can't fully test platform matching without mocking sys.platform,
-    # but we can verify the field is read without error.
-    # On non-linux this returns False; on linux True. Either way, no crash.
-    result = skill_matches_platform(frontmatter)
-    assert isinstance(result, bool)
-
-
-def test_platforms_under_metadata_fallback():
-    """agentskills.io format: platforms under metadata is also read."""
-    frontmatter = {"metadata": {"platforms": ["linux"]}}
-    result = skill_matches_platform(frontmatter)
-    assert isinstance(result, bool)
-
-
-def test_metadata_platforms_fallback_when_top_level_absent():
-    """When top-level platforms is absent, metadata.platforms is used."""
-    from unittest.mock import patch
-
-    frontmatter = {"metadata": {"platforms": ["nonexistent-platform-xyz"]}}
-    with patch("agent.skill_utils.sys.platform", "linux"):
-        assert skill_matches_platform(frontmatter) is False
-
-
-def test_metadata_tags_fallback_in_parse_frontmatter():
-    """Tags under metadata: block are found by parse_frontmatter."""
-    from agent.skill_utils import parse_frontmatter
-
-    content = "---\nname: test-skill\ndescription: test\nmetadata:\n  tags: [ai, ml]\n---\nBody text."
-    frontmatter, body = parse_frontmatter(content)
-    assert frontmatter.get("metadata", {}).get("tags") == ["ai", "ml"]
-
-
-def test_tags_top_level_still_read_by_skill_manage():
-    """Top-level tags in SKILL.md are still returned by skill_manage."""
-    from tools.skills_tool import _parse_tags
-
-    assert _parse_tags("ai, ml") == ["ai", "ml"]
-    assert _parse_tags("[ai, ml]") == ["ai", "ml"]
-    assert _parse_tags("") == []
-
-
-def test_tags_metadata_fallback():
-    """_parse_tags handles metadata.tags fallback correctly."""
-    from tools.skills_tool import _parse_tags
-
-    # _parse_tags just parses a string; the fallback logic is in the caller
-    # (skills_tool.py). Here we verify the parser itself works with both formats.
-    assert _parse_tags("fine-tuning, llm") == ["fine-tuning", "llm"]
-    assert _parse_tags("[fine-tuning, llm]") == ["fine-tuning", "llm"]
-
-
 # ── skill_matches_platform on Termux ──────────────────────────────────────
 
 
@@ -254,3 +197,60 @@ class TestSkillMatchesPlatformTermux:
             "agent.skill_utils.is_termux", return_value=False
         ):
             assert skill_matches_platform(fm) is True
+
+# ── agentskills.io spec compliance: platforms/tags under metadata ───────────
+
+
+def test_platforms_top_level_still_works():
+    """Top-level platforms field (legacy) is still read correctly."""
+    frontmatter = {"platforms": ["linux"]}
+    # We can't fully test platform matching without mocking sys.platform,
+    # but we can verify the field is read without error.
+    # On non-linux this returns False; on linux True. Either way, no crash.
+    result = skill_matches_platform(frontmatter)
+    assert isinstance(result, bool)
+
+
+def test_platforms_under_metadata_fallback():
+    """agentskills.io format: platforms under metadata is also read."""
+    frontmatter = {"metadata": {"platforms": ["linux"]}}
+    result = skill_matches_platform(frontmatter)
+    assert isinstance(result, bool)
+
+
+def test_metadata_platforms_fallback_when_top_level_absent():
+    """When top-level platforms is absent, metadata.platforms is used."""
+    from unittest.mock import patch
+
+    frontmatter = {"metadata": {"platforms": ["nonexistent-platform-xyz"]}}
+    with patch("agent.skill_utils.sys.platform", "linux"):
+        assert skill_matches_platform(frontmatter) is False
+
+
+def test_metadata_tags_fallback_in_parse_frontmatter():
+    """Tags under metadata: block are found by parse_frontmatter."""
+    from agent.skill_utils import parse_frontmatter
+
+    content = "---\nname: test-skill\ndescription: test\nmetadata:\n  tags: [ai, ml]\n---\nBody text."
+    frontmatter, body = parse_frontmatter(content)
+    assert frontmatter.get("metadata", {}).get("tags") == ["ai", "ml"]
+
+
+def test_tags_top_level_still_read_by_skill_manage():
+    """Top-level tags in SKILL.md are still returned by skill_manage."""
+    from tools.skills_tool import _parse_tags
+
+    assert _parse_tags("ai, ml") == ["ai", "ml"]
+    assert _parse_tags("[ai, ml]") == ["ai", "ml"]
+    assert _parse_tags("") == []
+
+
+def test_tags_metadata_fallback():
+    """_parse_tags handles metadata.tags fallback correctly."""
+    from tools.skills_tool import _parse_tags
+
+    # _parse_tags just parses a string; the fallback logic is in the caller
+    # (skills_tool.py). Here we verify the parser itself works with both formats.
+    assert _parse_tags("fine-tuning, llm") == ["fine-tuning", "llm"]
+    assert _parse_tags("[fine-tuning, llm]") == ["fine-tuning", "llm"]
+

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -1,6 +1,6 @@
 """Tests for agent/skill_utils.py."""
 
-from agent.skill_utils import extract_skill_conditions, iter_skill_index_files
+from agent.skill_utils import extract_skill_conditions, iter_skill_index_files, skill_matches_platform
 
 
 def test_metadata_as_dict_with_hermes():
@@ -94,3 +94,60 @@ def test_iter_skill_index_files_prunes_dependency_dirs(tmp_path):
     found = list(iter_skill_index_files(tmp_path, "SKILL.md"))
 
     assert found == [real / "SKILL.md"]
+
+
+# ── agentskills.io spec compliance: platforms/tags under metadata ───────────
+
+
+def test_platforms_top_level_still_works():
+    """Top-level platforms field (legacy) is still read correctly."""
+    frontmatter = {"platforms": ["linux"]}
+    # We can't fully test platform matching without mocking sys.platform,
+    # but we can verify the field is read without error.
+    # On non-linux this returns False; on linux True. Either way, no crash.
+    result = skill_matches_platform(frontmatter)
+    assert isinstance(result, bool)
+
+
+def test_platforms_under_metadata_fallback():
+    """agentskills.io format: platforms under metadata is also read."""
+    frontmatter = {"metadata": {"platforms": ["linux"]}}
+    result = skill_matches_platform(frontmatter)
+    assert isinstance(result, bool)
+
+
+def test_metadata_platforms_fallback_when_top_level_absent():
+    """When top-level platforms is absent, metadata.platforms is used."""
+    from unittest.mock import patch
+
+    frontmatter = {"metadata": {"platforms": ["nonexistent-platform-xyz"]}}
+    with patch("agent.skill_utils.sys.platform", "linux"):
+        assert skill_matches_platform(frontmatter) is False
+
+
+def test_metadata_tags_fallback_in_parse_frontmatter():
+    """Tags under metadata: block are found by parse_frontmatter."""
+    from agent.skill_utils import parse_frontmatter
+
+    content = "---\nname: test-skill\ndescription: test\nmetadata:\n  tags: [ai, ml]\n---\nBody text."
+    frontmatter, body = parse_frontmatter(content)
+    assert frontmatter.get("metadata", {}).get("tags") == ["ai", "ml"]
+
+
+def test_tags_top_level_still_read_by_skill_manage():
+    """Top-level tags in SKILL.md are still returned by skill_manage."""
+    from tools.skills_tool import _parse_tags
+
+    assert _parse_tags("ai, ml") == ["ai", "ml"]
+    assert _parse_tags("[ai, ml]") == ["ai", "ml"]
+    assert _parse_tags("") == []
+
+
+def test_tags_metadata_fallback():
+    """_parse_tags handles metadata.tags fallback correctly."""
+    from tools.skills_tool import _parse_tags
+
+    # _parse_tags just parses a string; the fallback logic is in the caller
+    # (skills_tool.py). Here we verify the parser itself works with both formats.
+    assert _parse_tags("fine-tuning, llm") == ["fine-tuning", "llm"]
+    assert _parse_tags("[fine-tuning, llm]") == ["fine-tuning", "llm"]

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -1,6 +1,12 @@
 """Tests for agent/skill_utils.py."""
 
-from agent.skill_utils import extract_skill_conditions, iter_skill_index_files, skill_matches_platform
+from unittest.mock import patch
+
+from agent.skill_utils import (
+    extract_skill_conditions,
+    iter_skill_index_files,
+    skill_matches_platform,
+)
 
 
 def test_metadata_as_dict_with_hermes():
@@ -151,3 +157,100 @@ def test_tags_metadata_fallback():
     # (skills_tool.py). Here we verify the parser itself works with both formats.
     assert _parse_tags("fine-tuning, llm") == ["fine-tuning", "llm"]
     assert _parse_tags("[fine-tuning, llm]") == ["fine-tuning", "llm"]
+
+
+# ── skill_matches_platform on Termux ──────────────────────────────────────
+
+
+class TestSkillMatchesPlatformTermux:
+    """Termux is Linux userland on Android. Skills tagged platforms:[linux]
+    must load there regardless of whether Python reports sys.platform as
+    "linux" (pre-3.13) or "android" (3.13+). Reported by user @LikiusInik
+    in May 2026 — only 3 built-in skills appeared on Termux because every
+    github/productivity/mlops skill is tagged platforms:[linux,macos,windows]
+    and sys.platform=="android" did not start with "linux".
+    """
+
+    def test_no_platforms_field_matches_everywhere(self):
+        # Backward-compat default — skills without a platforms tag load
+        # on any OS, Termux included.
+        with patch("agent.skill_utils.sys.platform", "android"), patch(
+            "agent.skill_utils.is_termux", return_value=True
+        ):
+            assert skill_matches_platform({}) is True
+            assert skill_matches_platform({"name": "foo"}) is True
+
+    def test_linux_skill_loads_on_termux_android_platform(self):
+        # Python 3.13+ on Termux reports sys.platform == "android".
+        fm = {"platforms": ["linux"]}
+        with patch("agent.skill_utils.sys.platform", "android"), patch(
+            "agent.skill_utils.is_termux", return_value=True
+        ):
+            assert skill_matches_platform(fm) is True
+
+    def test_linux_macos_windows_skill_loads_on_termux(self):
+        # The common "[linux, macos, windows]" tag used by github-*,
+        # productivity, mlops, etc.
+        fm = {"platforms": ["linux", "macos", "windows"]}
+        with patch("agent.skill_utils.sys.platform", "android"), patch(
+            "agent.skill_utils.is_termux", return_value=True
+        ):
+            assert skill_matches_platform(fm) is True
+
+    def test_linux_skill_loads_on_termux_linux_platform(self):
+        # Pre-3.13 Termux reports sys.platform == "linux" already — this
+        # works without the Termux escape hatch but must still pass.
+        fm = {"platforms": ["linux"]}
+        with patch("agent.skill_utils.sys.platform", "linux"), patch(
+            "agent.skill_utils.is_termux", return_value=True
+        ):
+            assert skill_matches_platform(fm) is True
+
+    def test_macos_only_skill_still_excluded_on_termux(self):
+        # macOS-only skills (apple-notes, imessage, ...) should NOT load
+        # on Termux. The Termux fallback only widens platforms:[linux,...].
+        fm = {"platforms": ["macos"]}
+        with patch("agent.skill_utils.sys.platform", "android"), patch(
+            "agent.skill_utils.is_termux", return_value=True
+        ):
+            assert skill_matches_platform(fm) is False
+
+    def test_windows_only_skill_still_excluded_on_termux(self):
+        fm = {"platforms": ["windows"]}
+        with patch("agent.skill_utils.sys.platform", "android"), patch(
+            "agent.skill_utils.is_termux", return_value=True
+        ):
+            assert skill_matches_platform(fm) is False
+
+    def test_explicit_termux_or_android_tag_matches(self):
+        # Skills can also opt in explicitly via platforms:[termux] or
+        # platforms:[android] — both should match a Termux session.
+        with patch("agent.skill_utils.sys.platform", "android"), patch(
+            "agent.skill_utils.is_termux", return_value=True
+        ):
+            assert skill_matches_platform({"platforms": ["termux"]}) is True
+            assert skill_matches_platform({"platforms": ["android"]}) is True
+
+    def test_non_termux_android_does_not_widen(self):
+        # If we're somehow on a plain Android Python (not Termux), don't
+        # silently load Linux skills — Termux is the supported environment.
+        fm = {"platforms": ["linux"]}
+        with patch("agent.skill_utils.sys.platform", "android"), patch(
+            "agent.skill_utils.is_termux", return_value=False
+        ):
+            assert skill_matches_platform(fm) is False
+
+    def test_linux_skill_on_real_linux_unaffected(self):
+        # The non-Termux Linux path must not change.
+        fm = {"platforms": ["linux"]}
+        with patch("agent.skill_utils.sys.platform", "linux"), patch(
+            "agent.skill_utils.is_termux", return_value=False
+        ):
+            assert skill_matches_platform(fm) is True
+
+    def test_macos_skill_on_real_macos_unaffected(self):
+        fm = {"platforms": ["macos"]}
+        with patch("agent.skill_utils.sys.platform", "darwin"), patch(
+            "agent.skill_utils.is_termux", return_value=False
+        ):
+            assert skill_matches_platform(fm) is True

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1274,9 +1274,9 @@ def skill_view(
         if isinstance(metadata, dict):
             hermes_meta = metadata.get("hermes", {}) or {}
 
-        tags = _parse_tags(hermes_meta.get("tags") or frontmatter.get("tags", ""))
+        tags = _parse_tags(hermes_meta.get("tags") or frontmatter.get("tags") or (metadata.get("tags") if isinstance(metadata, dict) else "") or "")
         related_skills = _parse_tags(
-            hermes_meta.get("related_skills") or frontmatter.get("related_skills", "")
+            hermes_meta.get("related_skills") or frontmatter.get("related_skills") or (metadata.get("related_skills") if isinstance(metadata, dict) else "") or ""
         )
 
         # Build linked files structure for clear discovery


### PR DESCRIPTION
## Summary

Makes Hermes skill loading backward-compatible with the [agentskills.io](https://agentskills.io) spec (adopted by Anthropic, NVIDIA, 40+ clients). Skills with `tags` and `platforms` under `metadata:` now load correctly alongside the existing top-level format.

## Problem

Issue #30080: Skills using the agentskills.io spec (fields under `metadata:` block) were not recognized by Hermes.

## Changes

- `agent/prompt_builder.py:929` — fallback to `metadata.platforms`
- `agent/skill_utils.py:140` — same fallback for platform matching
- `tools/skills_tool.py:1277` — fallback to `metadata.tags` and `metadata.related_skills`
- `tests/agent/test_skill_utils.py` — 6 new tests + resolved merge conflict with Termux platform tests

Fully backward-compatible. Fixes #30080.

Note: Clean rebase of previously closed #30978, cherry-picked onto latest main.