### PR TITLE
feat: add dashboard memory wiki

### DIFF
--- a/docs/plans/2026-05-23-memory-wiki.md
+++ b/docs/plans/2026-05-23-memory-wiki.md
@@ -1,0 +1,427 @@
+# Memory Wiki Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Build a dashboard page that turns Hermes session history into a navigable “memory wiki” with subject pages and daily logs, so a user can click into subjects, conversations, and work completed together.
+
+**Architecture:** Add a read-only analytics layer over the existing `state.db` session/message tables, exposed through new dashboard REST endpoints. The backend computes deterministic subjects from existing session titles, previews, user messages, assistant summaries, tool names, and date buckets; the React dashboard renders `/memory` with Overview, Subjects, Daily Logs, and detail panes that deep-link into existing session/message views.
+
+**Tech Stack:** Python/FastAPI dashboard backend (`hermes_cli/web_server.py`), SQLite `state.db` through `SessionDB`, React/Vite dashboard (`web/src`), TypeScript API client (`web/src/lib/api.ts`), existing dashboard UI components.
+
+---
+
+## Product Shape
+
+### Core UX
+
+1. New sidebar item: **Memory Wiki** at `/memory`.
+2. `/memory` shows:
+   - Search box across subjects and indexed conversations.
+   - Subject list/cards: subject name, aliases/keywords, conversation count, last touched, representative snippets.
+   - Daily logs: grouped by date, showing sessions, topics, and concrete “work done” summaries.
+   - Recent activity panel linking to existing session details.
+3. Clicking a subject opens `/memory/subjects/:slug`:
+   - Subject overview.
+   - Related sessions.
+   - Related messages/snippets.
+   - Timeline of days where that subject appeared.
+4. Clicking a day opens `/memory/days/:yyyy-mm-dd`:
+   - All sessions from that day.
+   - Subject chips for the day.
+   - “What we did” bullets derived from user/assistant messages and tool calls.
+5. Clicking any session/message reuses existing session APIs and route patterns where possible.
+
+### Backend Data Model — MVP
+
+No schema migration for v1. Compute on demand from `sessions` + `messages`:
+
+```ts
+type MemorySubject = {
+  slug: string;
+  name: string;
+  keywords: string[];
+  session_count: number;
+  message_count: number;
+  first_seen: number;
+  last_seen: number;
+  sessions: Array<{
+    id: string;
+    title?: string;
+    source: string;
+    started_at: number;
+    last_active: number;
+    preview: string;
+  }>;
+  snippets: Array<{
+    message_id: number;
+    session_id: string;
+    role: string;
+    timestamp: number;
+    text: string;
+  }>;
+};
+
+type DailyMemoryLog = {
+  date: string;
+  started_at_min: number;
+  last_active_max: number;
+  session_count: number;
+  message_count: number;
+  subjects: Array<{ slug: string; name: string; count: number }>;
+  sessions: SessionInfo[];
+  work_items: Array<{
+    session_id: string;
+    kind: "conversation" | "tool" | "coding" | "research" | "planning";
+    text: string;
+    timestamp: number;
+  }>;
+};
+```
+
+### Subject Extraction — MVP Heuristic
+
+Implement deterministic, local-only extraction first:
+
+1. Prefer session `title` when present.
+2. Add noun-ish keyword phrases from first user messages and session previews.
+3. Weight explicit project/file/tool mentions:
+   - paths like `foo/bar.py`, `web/src/App.tsx`
+   - package/repo names
+   - tool names from `tool_calls` / `tool_name`
+   - CamelCase identifiers and slash commands
+4. Remove generic stopwords and Hermes boilerplate.
+5. Normalize aliases into slugs (`memory wiki`, `Memory Wiki`, `memory-wiki` → `memory-wiki`).
+6. Return enough subjects for navigation, not perfect taxonomy. Later v2 can add an LLM summarization/indexing cron job.
+
+---
+
+## Task 1: Add Backend Memory Aggregation Helpers
+
+**Objective:** Create pure helper functions that query `state.db` and aggregate subjects/days without changing schema.
+
+**Files:**
+- Create: `hermes_cli/memory_wiki.py`
+- Test: `tests/hermes_cli/test_memory_wiki.py`
+
+**Step 1: Write failing tests for slugging and keyword extraction**
+
+Create `tests/hermes_cli/test_memory_wiki.py` with tests for:
+
+```python
+def test_slugify_subject_name():
+    from hermes_cli.memory_wiki import slugify_subject
+    assert slugify_subject("Memory Wiki") == "memory-wiki"
+    assert slugify_subject("web/src/App.tsx") == "web-src-app-tsx"
+
+
+def test_extract_subject_candidates_prefers_titles_and_paths():
+    from hermes_cli.memory_wiki import extract_subject_candidates
+    session = {"title": "Build memory wiki", "preview": "I want to build a memory wiki"}
+    messages = [
+        {"role": "user", "content": "Add /memory to web/src/App.tsx"},
+        {"role": "tool", "tool_name": "search_files", "content": ""},
+    ]
+    candidates = extract_subject_candidates(session, messages)
+    names = [c.name for c in candidates]
+    assert "memory wiki" in names
+    assert "web/src/App.tsx" in names
+    assert "search_files" in names
+```
+
+Run:
+
+```bash
+python -m pytest tests/hermes_cli/test_memory_wiki.py -q -o 'addopts='
+```
+
+Expected: FAIL because `hermes_cli.memory_wiki` does not exist.
+
+**Step 2: Implement helper module**
+
+In `hermes_cli/memory_wiki.py`, add:
+
+- `SubjectCandidate` dataclass.
+- `slugify_subject(name: str) -> str`.
+- `extract_subject_candidates(session: dict, messages: list[dict]) -> list[SubjectCandidate]`.
+- `_STOPWORDS` set.
+- Regexes for paths, CamelCase, quoted phrases, slash commands, and tool names.
+
+Keep dependencies stdlib-only.
+
+**Step 3: Verify tests pass**
+
+Run:
+
+```bash
+python -m pytest tests/hermes_cli/test_memory_wiki.py -q -o 'addopts='
+```
+
+Expected: PASS.
+
+---
+
+## Task 2: Add Subject and Day Aggregators
+
+**Objective:** Build functions that turn real `SessionDB` rows into API-ready dictionaries.
+
+**Files:**
+- Modify: `hermes_cli/memory_wiki.py`
+- Test: `tests/hermes_cli/test_memory_wiki.py`
+
+**Step 1: Add tests using a temporary `SessionDB`**
+
+Create tests that:
+
+1. Instantiate `SessionDB(db_path=tmp_path / "state.db")` if the constructor supports it; otherwise follow existing test patterns for temp Hermes home.
+2. Create sessions/messages.
+3. Assert `build_memory_overview(db)` returns subjects and daily logs.
+
+Search existing tests for `SessionDB(` to copy the repo’s temp-db pattern.
+
+**Step 2: Implement functions**
+
+Add:
+
+```python
+def build_memory_subjects(db, *, limit: int = 100, query: str | None = None) -> list[dict]: ...
+
+def get_memory_subject(db, slug: str) -> dict | None: ...
+
+def build_daily_logs(db, *, limit_days: int = 60) -> list[dict]: ...
+
+def get_daily_log(db, date: str) -> dict | None: ...
+
+def build_memory_overview(db, *, subject_limit: int = 50, day_limit: int = 30) -> dict: ...
+```
+
+Use `db.list_sessions_rich(limit=..., include_children=False, order_by_last_active=True)` and `db.get_messages(session_id)`.
+
+**Step 3: Verify targeted tests**
+
+```bash
+python -m pytest tests/hermes_cli/test_memory_wiki.py -q -o 'addopts='
+```
+
+Expected: PASS.
+
+---
+
+## Task 3: Add Dashboard API Endpoints
+
+**Objective:** Expose the memory wiki data through protected dashboard APIs.
+
+**Files:**
+- Modify: `hermes_cli/web_server.py`
+- Test: `tests/hermes_cli/test_web_server.py` or new `tests/hermes_cli/test_web_server_memory_wiki.py`
+
+**Step 1: Add failing endpoint tests**
+
+Test these routes:
+
+- `GET /api/memory/overview`
+- `GET /api/memory/subjects`
+- `GET /api/memory/subjects/{slug}`
+- `GET /api/memory/days`
+- `GET /api/memory/days/{date}`
+
+Follow existing `web_server` test auth-token patterns.
+
+**Step 2: Implement endpoints**
+
+Add near the sessions endpoints in `hermes_cli/web_server.py`:
+
+```python
+@app.get("/api/memory/overview")
+async def get_memory_overview(...): ...
+
+@app.get("/api/memory/subjects")
+async def get_memory_subjects(q: str = "", limit: int = 100): ...
+
+@app.get("/api/memory/subjects/{slug}")
+async def get_memory_subject(slug: str): ...
+
+@app.get("/api/memory/days")
+async def get_memory_days(limit: int = 60): ...
+
+@app.get("/api/memory/days/{date}")
+async def get_memory_day(date: str): ...
+```
+
+All endpoints should instantiate `SessionDB()`, call `hermes_cli.memory_wiki`, close DB in `finally`, log exceptions with `_log.exception`, and raise `HTTPException(500, ...)` on errors.
+
+**Step 3: Verify tests**
+
+```bash
+python -m pytest tests/hermes_cli/test_web_server_memory_wiki.py tests/hermes_cli/test_web_server.py -q -o 'addopts='
+```
+
+Expected: PASS.
+
+---
+
+## Task 4: Add TypeScript API Client Types
+
+**Objective:** Make memory APIs available to React with typed response shapes.
+
+**Files:**
+- Modify: `web/src/lib/api.ts`
+
+**Step 1: Add interfaces**
+
+Add `MemorySubject`, `DailyMemoryLog`, `MemoryOverviewResponse`, and endpoint response types near the existing session types.
+
+**Step 2: Add API methods**
+
+Add to `api`:
+
+```ts
+getMemoryOverview: () => fetchJSON<MemoryOverviewResponse>("/api/memory/overview"),
+getMemorySubjects: (q = "", limit = 100) => fetchJSON<MemorySubjectsResponse>(...),
+getMemorySubject: (slug: string) => fetchJSON<MemorySubjectResponse>(...),
+getMemoryDays: (limit = 60) => fetchJSON<MemoryDaysResponse>(...),
+getMemoryDay: (date: string) => fetchJSON<MemoryDayResponse>(...),
+```
+
+**Step 3: Verify TypeScript**
+
+```bash
+npm run typecheck
+```
+
+Expected: PASS.
+
+---
+
+## Task 5: Build Memory Wiki React Page
+
+**Objective:** Create `/memory` overview page with subjects, daily logs, search, and clickable session links.
+
+**Files:**
+- Create: `web/src/pages/MemoryWikiPage.tsx`
+- Modify: `web/src/App.tsx`
+- Modify: `web/src/i18n/en.ts` if nav labels require translation entries
+
+**Step 1: Create page skeleton**
+
+`MemoryWikiPage.tsx` should:
+
+- Load `api.getMemoryOverview()` on mount.
+- Show loading/error states matching other pages.
+- Render subject cards and daily log cards.
+- Provide a search input that calls `api.getMemorySubjects(q)` after debounce.
+- Link sessions to existing Sessions UI where available.
+
+**Step 2: Register route/nav**
+
+In `web/src/App.tsx`:
+
+- Import `MemoryWikiPage`.
+- Add `"/memory": MemoryWikiPage` to `BUILTIN_ROUTES_CORE`.
+- Add nav item `{ path: "/memory", labelKey: "memory", label: "Memory Wiki", icon: Database }` after Sessions.
+
+**Step 3: Verify typecheck/build**
+
+```bash
+npm run typecheck
+npm run build
+```
+
+Expected: PASS.
+
+---
+
+## Task 6: Add Subject and Day Detail Routes
+
+**Objective:** Support deep links for subject and daily-log detail pages.
+
+**Files:**
+- Modify: `web/src/pages/MemoryWikiPage.tsx` or create:
+  - `web/src/pages/MemorySubjectPage.tsx`
+  - `web/src/pages/MemoryDayPage.tsx`
+- Modify: `web/src/App.tsx`
+
+**Step 1: Add route components**
+
+Add detail components that read params via `useParams()` and fetch:
+
+- `/api/memory/subjects/{slug}`
+- `/api/memory/days/{date}`
+
+**Step 2: Register routes**
+
+Add routes:
+
+- `/memory/subjects/:slug`
+- `/memory/days/:date`
+
+If `BUILTIN_ROUTES_CORE` only supports static path strings, extend route construction minimally or handle subroutes inside a single `/memory/*` route.
+
+**Step 3: Verify browser navigation**
+
+```bash
+npm run typecheck
+npm run build
+```
+
+Expected: PASS.
+
+---
+
+## Task 7: Add Docs and Manual QA Checklist
+
+**Objective:** Document how to use the memory wiki and how privacy works.
+
+**Files:**
+- Create: `website/docs/user-guide/features/memory-wiki.md`
+- Modify docs sidebar if needed.
+
+**Content requirements:**
+
+- Explain that v1 is generated from local `~/.hermes/state.db` session history.
+- Explain no remote upload is required.
+- Explain subjects are deterministic heuristics and may be imperfect.
+- Explain daily logs are derived from sessions/messages and tool calls.
+- Include launch command:
+
+```bash
+hermes dashboard
+```
+
+or the repo’s current web command if different.
+
+**Manual QA:**
+
+1. Start dashboard.
+2. Open `/memory`.
+3. Confirm subjects load from real history.
+4. Search a known topic.
+5. Click subject.
+6. Click daily log.
+7. Click a session and confirm existing transcript view works.
+
+---
+
+## Task 8: Full Verification
+
+**Objective:** Run targeted backend/frontend checks before PR or merge.
+
+**Commands:**
+
+```bash
+python -m pytest tests/hermes_cli/test_memory_wiki.py tests/hermes_cli/test_web_server_memory_wiki.py -q -o 'addopts='
+npm run typecheck
+npm run build
+```
+
+If the dashboard has Playwright/e2e tests, add one smoke test for `/memory` and run the existing frontend test command.
+
+---
+
+## Future v2 Ideas
+
+- Persistent `memory_wiki_subjects`, `memory_wiki_subject_sessions`, and `memory_wiki_daily_logs` cache tables for faster large histories.
+- Background cron job to summarize each day and improve taxonomy with an auxiliary model.
+- Manual subject rename/merge/split UI.
+- Export to Markdown/Obsidian.
+- Backlinks from session pages to related subject pages.
+- Timeline graph of subject co-occurrence.

--- a/hermes_cli/memory_wiki.py
+++ b/hermes_cli/memory_wiki.py
@@ -1,0 +1,503 @@
+"""Pure helper primitives for deriving Memory Wiki subjects.
+
+This module intentionally stays stdlib-only.  The helpers here are deterministic
+heuristics over session/message dictionaries; database aggregation is added in a
+later task.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import re
+
+
+@dataclass(frozen=True)
+class SubjectCandidate:
+    """A possible subject extracted from session metadata or messages."""
+
+    name: str
+    slug: str
+    score: int = 1
+    source: str = "text"
+
+
+_STOPWORDS = {
+    "a",
+    "about",
+    "add",
+    "agent",
+    "an",
+    "and",
+    "are",
+    "as",
+    "assistant",
+    "be",
+    "build",
+    "can",
+    "chat",
+    "conversation",
+    "debug",
+    "discuss",
+    "do",
+    "for",
+    "from",
+    "help",
+    "hermes",
+    "i",
+    "in",
+    "into",
+    "is",
+    "it",
+    "me",
+    "my",
+    "of",
+    "on",
+    "please",
+    "session",
+    "that",
+    "the",
+    "this",
+    "to",
+    "want",
+    "we",
+    "work",
+    "with",
+    "you",
+}
+
+_PACKAGE_NAMES = {
+    "django",
+    "fastapi",
+    "flask",
+    "hermes-agent",
+    "nextjs",
+    "nodejs",
+    "pytest",
+    "react",
+    "ruff",
+    "svelte",
+    "vite",
+    "vue",
+}
+
+_PATH_RE = re.compile(
+    r"(?<![\w.-])(?:[~.]?/)?(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+(?:\.[A-Za-z0-9]+)?"
+)
+_CAMEL_CASE_RE = re.compile(r"\b[A-Z][a-z0-9]+(?:[A-Z][a-z0-9]+)+\b")
+_TITLE_CASE_PHRASE_RE = re.compile(r"\b[A-Z][a-z0-9]+(?:\s+[A-Z][a-z0-9]+){1,3}\b")
+_QUOTED_PHRASE_RE = re.compile(r"[\"'“‘]([^\"'”’]{3,80})[\"'”’]")
+_SLASH_COMMAND_RE = re.compile(r"(?<!\S)/[A-Za-z][A-Za-z0-9_-]*\b")
+_TOOL_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$")
+_WORD_RE = re.compile(r"[A-Za-z][A-Za-z0-9_-]*")
+_PACKAGE_RE = re.compile(
+    r"\b(?:"
+    + "|".join(re.escape(name) for name in sorted(_PACKAGE_NAMES, key=len, reverse=True))
+    + r")\b",
+    re.IGNORECASE,
+)
+_REPO_STYLE_RE = re.compile(r"\b[a-z][a-z0-9]+(?:-[a-z0-9]+)+\b")
+
+
+def slugify_subject(name: str) -> str:
+    """Return a stable URL slug for a subject name."""
+
+    slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+    return slug or "subject"
+
+
+def extract_subject_candidates(session: dict, messages: list[dict]) -> list[SubjectCandidate]:
+    """Extract deterministic subject candidates from a session and its messages.
+
+    The heuristic favors explicit metadata and structured mentions: session
+    titles, paths, tool names, slash commands, quoted phrases, and CamelCase
+    identifiers.  Duplicate subjects are merged by slug while preserving the
+    first useful display name.
+    """
+
+    candidates: dict[str, SubjectCandidate] = {}
+
+    def add(name: str, *, score: int = 1, source: str = "text") -> None:
+        cleaned = _clean_candidate_name(name)
+        if not cleaned:
+            return
+        slug = slugify_subject(cleaned)
+        existing = candidates.get(slug)
+        if existing is None:
+            candidates[slug] = SubjectCandidate(cleaned, slug, score, source)
+        else:
+            candidates[slug] = SubjectCandidate(
+                existing.name,
+                existing.slug,
+                existing.score + score,
+                existing.source,
+            )
+
+    title = str(session.get("title") or "")
+    if title:
+        title_phrase = _keyword_phrase(title)
+        if title_phrase:
+            add(title_phrase, score=6, source="title")
+
+    preview = str(session.get("preview") or "")
+    _extract_from_text(preview, add, base_score=2)
+    preview_phrase = _keyword_phrase(preview)
+    if preview_phrase:
+        add(preview_phrase, score=2, source="preview")
+
+    first_user_text_seen = False
+    for message in messages:
+        tool_name = str(message.get("tool_name") or "")
+        if tool_name and _TOOL_NAME_RE.match(tool_name):
+            add(tool_name, score=5, source="tool")
+
+        tool_calls = message.get("tool_calls") or ()
+        if not isinstance(tool_calls, (list, tuple)):
+            tool_calls = ()
+        for tool_call in tool_calls:
+            if isinstance(tool_call, dict):
+                function = tool_call.get("function")
+                function_name = function.get("name") if isinstance(function, dict) else None
+                name = tool_call.get("name") or function_name
+                if name and _TOOL_NAME_RE.match(str(name)):
+                    add(str(name), score=5, source="tool")
+
+        content = str(message.get("content") or "")
+        is_user = message.get("role") == "user"
+        _extract_from_text(content, add, base_score=3 if is_user else 1)
+        if is_user and not first_user_text_seen:
+            first_user_text_seen = True
+            phrase = _keyword_phrase(content)
+            if phrase:
+                add(phrase, score=3, source="user_phrase")
+
+    return sorted(candidates.values(), key=lambda c: (-c.score, c.name.lower()))
+
+
+def _extract_from_text(text: str, add, *, base_score: int) -> None:
+    for match in _PATH_RE.findall(text):
+        add(match, score=base_score + 3, source="path")
+    for match in _QUOTED_PHRASE_RE.findall(text):
+        phrase = _keyword_phrase(match)
+        if phrase:
+            add(phrase, score=base_score + 2, source="quote")
+    for match in _SLASH_COMMAND_RE.findall(text):
+        add(match, score=base_score + 1, source="slash_command")
+    for match in _TITLE_CASE_PHRASE_RE.findall(text):
+        phrase = _keyword_phrase(match)
+        if phrase:
+            add(phrase, score=base_score + 2, source="title_case_phrase")
+    for match in _CAMEL_CASE_RE.findall(text):
+        add(match, score=base_score + 1, source="identifier")
+    for match in _PACKAGE_RE.findall(text):
+        add(match.lower(), score=base_score + 2, source="package")
+    for match in _REPO_STYLE_RE.findall(text):
+        add(match, score=base_score + 2, source="package")
+
+
+def _keyword_phrase(text: str) -> str:
+    normalized = re.sub(r"(?<=[A-Za-z0-9])[-_](?=[A-Za-z0-9])", " ", text)
+    words = [word.lower() for word in _WORD_RE.findall(normalized)]
+    words = [word for word in words if word not in _STOPWORDS and len(word) > 1]
+    if len(words) < 2:
+        return ""
+    return " ".join(words[:4])
+
+
+def _clean_candidate_name(name: str) -> str:
+    cleaned = " ".join(str(name).strip().split())
+    if not cleaned:
+        return ""
+    if cleaned.lower() in _STOPWORDS:
+        return ""
+    return cleaned
+
+
+def build_memory_subjects(db, *, limit: int = 100, query: str | None = None) -> list[dict]:
+    """Aggregate subject dictionaries from recent ``SessionDB`` sessions."""
+
+    if limit <= 0:
+        return []
+    sessions = _load_memory_sessions(db, limit=max(limit * 5, limit, 100))
+    subjects: dict[str, dict] = {}
+
+    for session, messages in sessions:
+        session_info = _session_info(session)
+        candidates = extract_subject_candidates(session, messages)
+        if not candidates:
+            continue
+        message_count = len(messages)
+        first_seen = _first_timestamp(session, messages)
+        last_seen = _last_timestamp(session, messages)
+        snippets_by_slug = _snippets_for_candidates(session, messages, candidates)
+
+        for candidate in candidates:
+            subject = subjects.setdefault(
+                candidate.slug,
+                {
+                    "slug": candidate.slug,
+                    "name": candidate.name,
+                    "keywords": [],
+                    "session_count": 0,
+                    "message_count": 0,
+                    "first_seen": first_seen,
+                    "last_seen": last_seen,
+                    "sessions": [],
+                    "snippets": [],
+                    "_score": 0,
+                    "_session_ids": set(),
+                },
+            )
+            subject["_score"] += candidate.score
+            if candidate.name not in subject["keywords"]:
+                subject["keywords"].append(candidate.name)
+            subject["first_seen"] = min(subject["first_seen"], first_seen)
+            subject["last_seen"] = max(subject["last_seen"], last_seen)
+            if session_info["id"] not in subject["_session_ids"]:
+                subject["_session_ids"].add(session_info["id"])
+                subject["sessions"].append(session_info)
+                subject["session_count"] += 1
+                subject["message_count"] += message_count
+            subject["snippets"].extend(snippets_by_slug.get(candidate.slug, []))
+
+    results = [_finalize_subject(subject) for subject in subjects.values()]
+    if query:
+        needle = query.lower().strip()
+        results = [
+            subject
+            for subject in results
+            if needle in subject["slug"]
+            or needle in subject["name"].lower()
+            or any(needle in keyword.lower() for keyword in subject["keywords"])
+        ]
+
+    results.sort(key=lambda s: (-s["session_count"], -s["last_seen"], s["name"].lower()))
+    return results[:limit]
+
+
+def get_memory_subject(db, slug: str) -> dict | None:
+    """Return one aggregated memory subject by slug, or ``None``."""
+
+    normalized = slugify_subject(slug)
+    for subject in build_memory_subjects(db, limit=1000):
+        if subject["slug"] == normalized:
+            return subject
+    return None
+
+
+def build_daily_logs(db, *, limit_days: int = 60) -> list[dict]:
+    """Aggregate recent sessions into API-ready day log dictionaries."""
+
+    if limit_days <= 0:
+        return []
+    sessions = _load_memory_sessions(db, limit=max(limit_days * 25, 100))
+    days: dict[str, dict] = {}
+
+    for session, messages in sessions:
+        day_key = _date_key(float(session.get("started_at") or _first_timestamp(session, messages)))
+        started = float(session.get("started_at") or _first_timestamp(session, messages))
+        last_active = _last_timestamp(session, messages)
+        day = days.setdefault(
+            day_key,
+            {
+                "date": day_key,
+                "started_at_min": started,
+                "last_active_max": last_active,
+                "session_count": 0,
+                "message_count": 0,
+                "subjects": [],
+                "sessions": [],
+                "work_items": [],
+                "_subjects": {},
+            },
+        )
+        day["started_at_min"] = min(day["started_at_min"], started)
+        day["last_active_max"] = max(day["last_active_max"], last_active)
+        day["session_count"] += 1
+        day["message_count"] += len(messages)
+        day["sessions"].append(_session_info(session))
+
+        for candidate in extract_subject_candidates(session, messages):
+            entry = day["_subjects"].setdefault(
+                candidate.slug,
+                {"slug": candidate.slug, "name": candidate.name, "count": 0},
+            )
+            entry["count"] += 1
+
+        day["work_items"].extend(_work_items_for_session(session, messages))
+
+    logs = []
+    for day in days.values():
+        subjects = list(day.pop("_subjects").values())
+        subjects.sort(key=lambda s: (-s["count"], s["name"].lower()))
+        day["subjects"] = subjects[:20]
+        day["sessions"].sort(key=lambda s: (-s["last_active"], s["id"]))
+        day["work_items"].sort(key=lambda w: (w["timestamp"], w["session_id"], w["text"]))
+        logs.append(day)
+
+    logs.sort(key=lambda d: d["date"], reverse=True)
+    return logs[:limit_days]
+
+
+def get_daily_log(db, date: str) -> dict | None:
+    """Return one daily memory log by ``YYYY-MM-DD`` date, or ``None``."""
+
+    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", date or ""):
+        return None
+    for day in build_daily_logs(db, limit_days=1000):
+        if day["date"] == date:
+            return day
+    return None
+
+
+def build_memory_overview(db, *, subject_limit: int = 50, day_limit: int = 30) -> dict:
+    """Return overview payload for Memory Wiki dashboard/API consumers."""
+
+    recent = db.list_sessions_rich(
+        limit=10,
+        include_children=False,
+        order_by_last_active=True,
+    )
+    return {
+        "subjects": build_memory_subjects(db, limit=subject_limit),
+        "daily_logs": build_daily_logs(db, limit_days=day_limit),
+        "recent_sessions": [_session_info(session) for session in recent],
+    }
+
+
+def _load_memory_sessions(db, *, limit: int) -> list[tuple[dict, list[dict]]]:
+    sessions = db.list_sessions_rich(
+        limit=limit,
+        include_children=False,
+        order_by_last_active=True,
+    )
+    return [(session, db.get_messages(session["id"])) for session in sessions]
+
+
+def _session_info(session: dict) -> dict:
+    return {
+        "id": session.get("id"),
+        "title": session.get("title"),
+        "source": session.get("source"),
+        "started_at": float(session.get("started_at") or 0),
+        "last_active": float(session.get("last_active") or session.get("started_at") or 0),
+        "preview": session.get("preview") or "",
+    }
+
+
+def _first_timestamp(session: dict, messages: list[dict]) -> float:
+    values = [float(m["timestamp"]) for m in messages if m.get("timestamp") is not None]
+    values.append(float(session.get("started_at") or 0))
+    return min(values)
+
+
+def _last_timestamp(session: dict, messages: list[dict]) -> float:
+    values = [float(m["timestamp"]) for m in messages if m.get("timestamp") is not None]
+    values.append(float(session.get("last_active") or session.get("started_at") or 0))
+    return max(values)
+
+
+def _date_key(timestamp: float) -> str:
+    """Return the local-calendar date key for ``timestamp``."""
+
+    return datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d")
+
+
+def _message_text(message: dict) -> str:
+    content = message.get("content")
+    if isinstance(content, str):
+        return " ".join(content.split())
+    if content is None:
+        return ""
+    return " ".join(str(content).split())
+
+
+def _snippets_for_candidates(
+    session: dict,
+    messages: list[dict],
+    candidates: list[SubjectCandidate],
+) -> dict[str, list[dict]]:
+    snippets: dict[str, list[dict]] = {candidate.slug: [] for candidate in candidates}
+    candidate_by_slug = {candidate.slug: candidate for candidate in candidates}
+    for message in messages:
+        text = _message_text(message)
+        haystack = " ".join((text, str(message.get("tool_name") or ""))).lower()
+        if not haystack.strip():
+            continue
+        for slug, candidate in candidate_by_slug.items():
+            terms = {candidate.name.lower(), slug.replace("-", " ")}
+            if any(term and term in haystack for term in terms):
+                snippets[slug].append(_snippet(session, message, text))
+                break
+
+    fallback = None
+    for message in messages:
+        text = _message_text(message)
+        if text:
+            fallback = _snippet(session, message, text)
+            break
+    if fallback:
+        for slug in snippets:
+            if not snippets[slug]:
+                snippets[slug].append(dict(fallback))
+    return snippets
+
+
+def _snippet(session: dict, message: dict, text: str) -> dict:
+    return {
+        "message_id": message.get("id"),
+        "session_id": session.get("id"),
+        "role": message.get("role"),
+        "timestamp": float(message.get("timestamp") or session.get("started_at") or 0),
+        "text": text[:240],
+    }
+
+
+def _finalize_subject(subject: dict) -> dict:
+    result = dict(subject)
+    result.pop("_score", None)
+    result.pop("_session_ids", None)
+    result["keywords"] = result["keywords"][:10]
+    result["sessions"].sort(key=lambda s: (-s["last_active"], s["id"]))
+    result["sessions"] = result["sessions"][:10]
+    result["snippets"].sort(key=lambda s: (s["timestamp"], s["session_id"], s.get("message_id") or 0))
+    result["snippets"] = result["snippets"][:5]
+    return result
+
+
+def _work_items_for_session(session: dict, messages: list[dict]) -> list[dict]:
+    items = []
+    for message in messages:
+        role = message.get("role")
+        text = _message_text(message)
+        tool_name = str(message.get("tool_name") or "")
+        if role == "tool" or tool_name:
+            label = tool_name or text or "tool call"
+            items.append(_work_item(session, message, "tool", f"Tool: {label}"))
+        elif role == "user" and text:
+            items.append(_work_item(session, message, _classify_work(text), text))
+        elif role == "assistant" and text:
+            lowered = text.lower()
+            if any(word in lowered for word in ("implemented", "added", "fixed", "updated")):
+                items.append(_work_item(session, message, _classify_work(text), text))
+    return items[:8]
+
+
+def _work_item(session: dict, message: dict, kind: str, text: str) -> dict:
+    return {
+        "session_id": session.get("id"),
+        "kind": kind,
+        "text": " ".join(text.split())[:240],
+        "timestamp": float(message.get("timestamp") or session.get("started_at") or 0),
+    }
+
+
+def _classify_work(text: str) -> str:
+    lowered = text.lower()
+    if any(word in lowered for word in ("test", "fix", "debug", "implement", "code", ".py", ".tsx")):
+        return "coding"
+    if any(word in lowered for word in ("research", "investigate", "review", "search")):
+        return "research"
+    if any(word in lowered for word in ("plan", "roadmap", "design")):
+        return "planning"
+    return "conversation"

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -860,6 +860,105 @@ def _normalize_config_for_web(config: Dict[str, Any]) -> Dict[str, Any]:
     return config
 
 
+@app.get("/api/memory/overview")
+async def get_memory_overview(subject_limit: int = 50, day_limit: int = 30):
+    try:
+        from hermes_state import SessionDB
+        from hermes_cli.memory_wiki import build_memory_overview
+
+        db = SessionDB()
+        try:
+            return build_memory_overview(
+                db,
+                subject_limit=max(1, min(subject_limit, 200)),
+                day_limit=max(1, min(day_limit, 120)),
+            )
+        finally:
+            db.close()
+    except Exception:
+        _log.exception("GET /api/memory/overview failed")
+        raise HTTPException(status_code=500, detail="Memory overview failed")
+
+
+@app.get("/api/memory/subjects")
+async def get_memory_subjects(q: str = "", limit: int = 100):
+    try:
+        from hermes_state import SessionDB
+        from hermes_cli.memory_wiki import build_memory_subjects
+
+        safe_limit = max(1, min(limit, 500))
+        query = q.strip()
+        db = SessionDB()
+        try:
+            subjects = build_memory_subjects(db, limit=safe_limit, query=query or None)
+            return {"subjects": subjects, "query": query, "limit": safe_limit}
+        finally:
+            db.close()
+    except Exception:
+        _log.exception("GET /api/memory/subjects failed")
+        raise HTTPException(status_code=500, detail="Memory subjects failed")
+
+
+@app.get("/api/memory/subjects/{slug}")
+async def get_memory_subject(slug: str):
+    try:
+        from hermes_state import SessionDB
+        from hermes_cli.memory_wiki import get_memory_subject as load_memory_subject
+
+        db = SessionDB()
+        try:
+            subject = load_memory_subject(db, slug)
+        finally:
+            db.close()
+        if subject is None:
+            raise HTTPException(status_code=404, detail="Memory subject not found")
+        return {"subject": subject}
+    except HTTPException:
+        raise
+    except Exception:
+        _log.exception("GET /api/memory/subjects/%s failed", slug)
+        raise HTTPException(status_code=500, detail="Memory subject failed")
+
+
+@app.get("/api/memory/days")
+async def get_memory_days(limit: int = 60):
+    try:
+        from hermes_state import SessionDB
+        from hermes_cli.memory_wiki import build_daily_logs
+
+        safe_limit = max(1, min(limit, 365))
+        db = SessionDB()
+        try:
+            daily_logs = build_daily_logs(db, limit_days=safe_limit)
+            return {"daily_logs": daily_logs, "limit": safe_limit}
+        finally:
+            db.close()
+    except Exception:
+        _log.exception("GET /api/memory/days failed")
+        raise HTTPException(status_code=500, detail="Memory days failed")
+
+
+@app.get("/api/memory/days/{date}")
+async def get_memory_day(date: str):
+    try:
+        from hermes_state import SessionDB
+        from hermes_cli.memory_wiki import get_daily_log
+
+        db = SessionDB()
+        try:
+            daily_log = get_daily_log(db, date)
+        finally:
+            db.close()
+        if daily_log is None:
+            raise HTTPException(status_code=404, detail="Memory day not found")
+        return {"daily_log": daily_log}
+    except HTTPException:
+        raise
+    except Exception:
+        _log.exception("GET /api/memory/days/%s failed", date)
+        raise HTTPException(status_code=500, detail="Memory day failed")
+
+
 @app.get("/api/config")
 async def get_config():
     config = _normalize_config_for_web(load_config())

--- a/tests/hermes_cli/test_memory_wiki.py
+++ b/tests/hermes_cli/test_memory_wiki.py
@@ -1,0 +1,280 @@
+def test_slugify_subject_name():
+    from hermes_cli.memory_wiki import slugify_subject
+
+    assert slugify_subject("Memory Wiki") == "memory-wiki"
+    assert slugify_subject("web/src/App.tsx") == "web-src-app-tsx"
+
+
+def test_slugify_subject_empty_and_punctuation_fallback():
+    from hermes_cli.memory_wiki import slugify_subject
+
+    assert slugify_subject("") == "subject"
+    assert slugify_subject("!!! --- ...") == "subject"
+
+
+def test_extract_subject_candidates_prefers_titles_and_paths():
+    from hermes_cli.memory_wiki import extract_subject_candidates
+
+    session = {"title": "Build memory wiki", "preview": "I want to build a memory wiki"}
+    messages = [
+        {"role": "user", "content": "Add /memory to web/src/App.tsx"},
+        {"role": "tool", "tool_name": "search_files", "content": ""},
+    ]
+    candidates = extract_subject_candidates(session, messages)
+    names = [c.name for c in candidates]
+    assert "memory wiki" in names
+    assert "web/src/App.tsx" in names
+    assert "search_files" in names
+
+
+def test_extract_subject_candidates_merges_duplicate_slugs_and_accumulates_score():
+    from hermes_cli.memory_wiki import extract_subject_candidates
+
+    candidates = extract_subject_candidates(
+        {"title": "Memory Wiki", "preview": "Let's discuss memory-wiki"},
+        [{"role": "user", "content": "Please work on memory wiki"}],
+    )
+
+    matches = [candidate for candidate in candidates if candidate.slug == "memory-wiki"]
+    assert len(matches) == 1
+    assert matches[0].score > 6
+
+
+def test_extract_subject_candidates_structured_text_mentions():
+    from hermes_cli.memory_wiki import extract_subject_candidates
+
+    candidates = extract_subject_candidates(
+        {},
+        [
+            {
+                "role": "user",
+                "content": 'Use "Memory Wiki" from /memory and update HermesAgent next.',
+            }
+        ],
+    )
+    names = {candidate.name for candidate in candidates}
+
+    assert "memory wiki" in names
+    assert "/memory" in names
+    assert "HermesAgent" in names
+
+
+def test_extract_subject_candidates_nested_tool_calls_and_malformed_tool_calls():
+    from hermes_cli.memory_wiki import extract_subject_candidates
+
+    candidates = extract_subject_candidates(
+        {},
+        [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"function": {"name": "search_files"}},
+                    {"function": "not-a-dict"},
+                    "not-a-dict",
+                ],
+            },
+            {"role": "assistant", "tool_calls": 123},
+        ],
+    )
+
+    names = {candidate.name for candidate in candidates}
+    assert "search_files" in names
+
+
+def test_extract_subject_candidates_first_user_keyword_phrase_and_package_mentions():
+    from hermes_cli.memory_wiki import extract_subject_candidates
+
+    candidates = extract_subject_candidates(
+        {},
+        [
+            {
+                "role": "user",
+                "content": "Can you help debug the FastAPI pytest plugin failure?",
+            },
+            {"role": "assistant", "content": "Sure."},
+        ],
+    )
+    by_slug = {candidate.slug: candidate for candidate in candidates}
+
+    assert "fastapi-pytest-plugin-failure" in by_slug
+    assert "fastapi" in by_slug
+    assert "pytest" in by_slug
+    assert "plugin" not in by_slug
+
+
+def test_extract_subject_candidates_hyphenated_title_alias():
+    from hermes_cli.memory_wiki import extract_subject_candidates
+
+    candidates = extract_subject_candidates({"title": "memory-wiki"}, [])
+
+    by_slug = {candidate.slug: candidate for candidate in candidates}
+
+    assert by_slug["memory-wiki"].name == "memory wiki"
+
+
+def test_build_memory_overview_aggregates_subjects_and_daily_logs(tmp_path):
+    from hermes_cli.memory_wiki import build_memory_overview
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("s-memory", "cli")
+        db.append_message("s-memory", "user", "Build the Memory Wiki in web/src/App.tsx")
+        db.append_message("s-memory", "assistant", "Added memory wiki subject cards.")
+        db.append_message("s-memory", "tool", "", tool_name="search_files")
+
+        db.create_session("s-fastapi", "discord")
+        db.append_message("s-fastapi", "user", "Debug FastAPI pytest plugin failure")
+        db.append_message("s-fastapi", "assistant", "Reviewed the pytest failure and planned a fix.")
+
+        overview = build_memory_overview(db, subject_limit=20, day_limit=10)
+    finally:
+        db.close()
+
+    assert set(overview) == {"subjects", "daily_logs", "recent_sessions"}
+
+    subjects_by_slug = {subject["slug"]: subject for subject in overview["subjects"]}
+    assert "memory-wiki" in subjects_by_slug
+    assert "web-src-app-tsx" in subjects_by_slug
+    assert subjects_by_slug["memory-wiki"]["session_count"] == 1
+    assert subjects_by_slug["memory-wiki"]["message_count"] >= 2
+    assert subjects_by_slug["memory-wiki"]["sessions"][0]["id"] == "s-memory"
+    assert subjects_by_slug["memory-wiki"]["snippets"]
+
+    assert len(overview["daily_logs"]) == 1
+    day = overview["daily_logs"][0]
+    assert day["session_count"] == 2
+    assert day["message_count"] == 5
+    assert {session["id"] for session in day["sessions"]} == {"s-memory", "s-fastapi"}
+    assert {subject["slug"] for subject in day["subjects"]} >= {"memory-wiki", "fastapi"}
+    assert any(item["kind"] == "tool" and "search_files" in item["text"] for item in day["work_items"])
+
+
+def test_memory_subject_and_daily_log_detail_lookup_and_query_filter(tmp_path):
+    from hermes_cli.memory_wiki import (
+        build_memory_subjects,
+        get_daily_log,
+        get_memory_subject,
+    )
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("s-memory", "cli")
+        db.append_message("s-memory", "user", "Build Memory Wiki dashboard")
+        db.append_message("s-memory", "assistant", "Implemented Memory Wiki helpers")
+        db.create_session("s-react", "cli")
+        db.append_message("s-react", "user", "Investigate React dashboard layout")
+
+        day = get_daily_log(db, "1970-01-02")
+        assert day is None
+
+        memory_subject = get_memory_subject(db, "memory-wiki")
+        missing_subject = get_memory_subject(db, "does-not-exist")
+        queried_subjects = build_memory_subjects(db, query="react")
+    finally:
+        db.close()
+
+    assert memory_subject is not None
+    assert memory_subject["slug"] == "memory-wiki"
+    assert memory_subject["sessions"][0]["id"] == "s-memory"
+    assert missing_subject is None
+    queried_slugs = [subject["slug"] for subject in queried_subjects]
+    assert "react" in queried_slugs
+    assert all("react" in subject["slug"] or "react" in subject["name"].lower() for subject in queried_subjects)
+
+
+class _MemoryWikiFakeDB:
+    def __init__(self, sessions=None, messages=None):
+        self.sessions = list(sessions or [])
+        self.messages = dict(messages or {})
+        self.list_limits = []
+        self.message_session_ids = []
+
+    def list_sessions_rich(self, *, limit, include_children, order_by_last_active):
+        self.list_limits.append(limit)
+        assert include_children is False
+        assert order_by_last_active is True
+        return self.sessions[:limit]
+
+    def get_messages(self, session_id):
+        self.message_session_ids.append(session_id)
+        return list(self.messages.get(session_id, []))
+
+
+class _FailingLoadDB:
+    def list_sessions_rich(self, **kwargs):
+        raise AssertionError("non-positive limits should not load sessions")
+
+
+def test_memory_wiki_aggregators_return_empty_for_empty_db():
+    from hermes_cli.memory_wiki import build_daily_logs, build_memory_subjects
+
+    db = _MemoryWikiFakeDB()
+
+    assert build_memory_subjects(db) == []
+    assert build_daily_logs(db) == []
+    assert db.list_limits == [500, 1500]
+    assert db.message_session_ids == []
+
+
+def test_memory_wiki_aggregators_handle_sessions_with_no_messages():
+    from hermes_cli.memory_wiki import build_daily_logs, build_memory_subjects
+
+    session = {
+        "id": "s-empty",
+        "title": "Memory Wiki",
+        "source": "cli",
+        "preview": "",
+        "started_at": 10.0,
+        "last_active": 10.0,
+    }
+    db = _MemoryWikiFakeDB([session], {"s-empty": []})
+
+    subjects = build_memory_subjects(db, limit=10)
+    logs = build_daily_logs(db, limit_days=10)
+
+    assert [subject["slug"] for subject in subjects] == ["memory-wiki"]
+    assert subjects[0]["message_count"] == 0
+    assert subjects[0]["snippets"] == []
+    assert len(logs) == 1
+    assert logs[0]["session_count"] == 1
+    assert logs[0]["message_count"] == 0
+    assert logs[0]["sessions"][0]["id"] == "s-empty"
+
+
+def test_memory_wiki_aggregators_do_not_load_for_zero_or_negative_limits():
+    from hermes_cli.memory_wiki import build_daily_logs, build_memory_subjects
+
+    db = _FailingLoadDB()
+
+    assert build_memory_subjects(db, limit=0) == []
+    assert build_memory_subjects(db, limit=-5) == []
+    assert build_daily_logs(db, limit_days=0) == []
+    assert build_daily_logs(db, limit_days=-5) == []
+
+
+def test_memory_wiki_aggregators_bound_loaded_history():
+    from hermes_cli.memory_wiki import build_daily_logs, build_memory_subjects
+
+    sessions = [
+        {
+            "id": f"s-{index}",
+            "title": f"Project Alpha{index} Topic",
+            "source": "cli",
+            "preview": "",
+            "started_at": float(index * 86400),
+            "last_active": float(index * 86400),
+        }
+        for index in range(120)
+    ]
+    db = _MemoryWikiFakeDB(sessions, {session["id"]: [] for session in sessions})
+
+    subjects = build_memory_subjects(db, limit=2)
+    logs = build_daily_logs(db, limit_days=2)
+
+    assert db.list_limits == [100, 100]
+    assert len(subjects) == 2
+    assert len(logs) == 2
+    assert len(db.message_session_ids) == 200
+    assert set(db.message_session_ids) == {f"s-{index}" for index in range(100)}

--- a/tests/hermes_cli/test_web_server_memory_wiki.py
+++ b/tests/hermes_cli/test_web_server_memory_wiki.py
@@ -1,0 +1,93 @@
+"""Dashboard API tests for Memory Wiki endpoints."""
+
+import pytest
+
+
+@pytest.fixture
+def memory_client(monkeypatch, _isolate_hermes_home):
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:
+        pytest.skip("fastapi/starlette not installed")
+
+    import hermes_state
+    from hermes_constants import get_hermes_home
+    from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+    db_path = get_hermes_home() / "state.db"
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", db_path)
+
+    db = hermes_state.SessionDB(db_path=db_path)
+    try:
+        db.create_session("s-memory", "discord")
+        db.append_message("s-memory", "user", "Build Memory Wiki dashboard in web/src/App.tsx")
+        db.append_message("s-memory", "assistant", "Implemented Memory Wiki subject cards.")
+        db.append_message("s-memory", "tool", "", tool_name="search_files")
+
+        db.create_session("s-fastapi", "cli")
+        db.append_message("s-fastapi", "user", "Debug FastAPI pytest failure")
+        db.append_message("s-fastapi", "assistant", "Planned and fixed the FastAPI route bug.")
+    finally:
+        db.close()
+
+    client = TestClient(app)
+    client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+    return client
+
+
+def test_memory_overview_endpoint(memory_client):
+    resp = memory_client.get("/api/memory/overview")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "subjects" in data
+    assert "daily_logs" in data
+    assert "recent_sessions" in data
+    assert any(subject["slug"] == "memory-wiki" for subject in data["subjects"])
+
+
+def test_memory_subjects_endpoint_supports_query(memory_client):
+    resp = memory_client.get("/api/memory/subjects?q=fastapi&limit=10")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["query"] == "fastapi"
+    assert data["limit"] == 10
+    assert any(subject["slug"] == "fastapi" for subject in data["subjects"])
+
+
+def test_memory_subject_detail_endpoint(memory_client):
+    resp = memory_client.get("/api/memory/subjects/memory-wiki")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["subject"]["slug"] == "memory-wiki"
+    assert data["subject"]["session_count"] >= 1
+
+
+def test_memory_subject_detail_returns_404(memory_client):
+    resp = memory_client.get("/api/memory/subjects/not-a-real-subject")
+
+    assert resp.status_code == 404
+
+
+def test_memory_days_and_day_detail_endpoints(memory_client):
+    days_resp = memory_client.get("/api/memory/days?limit=10")
+
+    assert days_resp.status_code == 200
+    days_data = days_resp.json()
+    assert days_data["limit"] == 10
+    assert days_data["daily_logs"]
+
+    date = days_data["daily_logs"][0]["date"]
+    day_resp = memory_client.get(f"/api/memory/days/{date}")
+    assert day_resp.status_code == 200
+    day_data = day_resp.json()
+    assert day_data["daily_log"]["date"] == date
+    assert day_data["daily_log"]["work_items"]
+
+
+def test_memory_day_detail_returns_404(memory_client):
+    resp = memory_client.get("/api/memory/days/1999-01-01")
+
+    assert resp.status_code == 404

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -59,6 +59,7 @@ import ConfigPage from "@/pages/ConfigPage";
 import DocsPage from "@/pages/DocsPage";
 import EnvPage from "@/pages/EnvPage";
 import SessionsPage from "@/pages/SessionsPage";
+import MemoryWikiPage, { MemoryDayPage, MemorySubjectPage } from "@/pages/MemoryWikiPage";
 import LogsPage from "@/pages/LogsPage";
 import AnalyticsPage from "@/pages/AnalyticsPage";
 import ModelsPage from "@/pages/ModelsPage";
@@ -108,6 +109,9 @@ const CHAT_NAV_ITEM: NavItem = {
 const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/": RootRedirect,
   "/sessions": SessionsPage,
+  "/memory": MemoryWikiPage,
+  "/memory/subjects/:slug": MemorySubjectPage,
+  "/memory/days/:date": MemoryDayPage,
   "/analytics": AnalyticsPage,
   "/models": ModelsPage,
   "/logs": LogsPage,
@@ -134,6 +138,12 @@ const BUILTIN_NAV_REST: NavItem[] = [
     labelKey: "sessions",
     label: "Sessions",
     icon: MessageSquare,
+  },
+  {
+    path: "/memory",
+    labelKey: "memory",
+    label: "Memory Wiki",
+    icon: Database,
   },
   {
     path: "/analytics",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -70,6 +70,19 @@ export const api = {
   getStatus: () => fetchJSON<StatusResponse>("/api/status"),
   getSessions: (limit = 20, offset = 0) =>
     fetchJSON<PaginatedSessions>(`/api/sessions?limit=${limit}&offset=${offset}`),
+  getMemoryOverview: () => fetchJSON<MemoryOverviewResponse>("/api/memory/overview"),
+  getMemorySubjects: (q = "", limit = 100) => {
+    const qs = new URLSearchParams();
+    if (q.trim()) qs.set("q", q.trim());
+    qs.set("limit", String(limit));
+    return fetchJSON<MemorySubjectsResponse>(`/api/memory/subjects?${qs.toString()}`);
+  },
+  getMemorySubject: (slug: string) =>
+    fetchJSON<MemorySubjectResponse>(`/api/memory/subjects/${encodeURIComponent(slug)}`),
+  getMemoryDays: (limit = 60) =>
+    fetchJSON<MemoryDaysResponse>(`/api/memory/days?limit=${limit}`),
+  getMemoryDay: (date: string) =>
+    fetchJSON<MemoryDayResponse>(`/api/memory/days/${encodeURIComponent(date)}`),
   getSessionMessages: (id: string) =>
     fetchJSON<SessionMessagesResponse>(`/api/sessions/${encodeURIComponent(id)}/messages`),
   getSessionLatestDescendant: (id: string) =>
@@ -416,6 +429,84 @@ export interface PaginatedSessions {
   total: number;
   limit: number;
   offset: number;
+}
+
+export interface MemorySessionInfo {
+  id: string;
+  title: string | null;
+  source: string | null;
+  started_at: number;
+  last_active: number;
+  preview: string;
+}
+
+export interface MemorySnippet {
+  message_id: number | null;
+  session_id: string;
+  role: string | null;
+  timestamp: number;
+  text: string;
+}
+
+export interface MemorySubject {
+  slug: string;
+  name: string;
+  keywords: string[];
+  session_count: number;
+  message_count: number;
+  first_seen: number;
+  last_seen: number;
+  sessions: MemorySessionInfo[];
+  snippets: MemorySnippet[];
+}
+
+export interface DailyMemorySubject {
+  slug: string;
+  name: string;
+  count: number;
+}
+
+export interface DailyMemoryWorkItem {
+  session_id: string;
+  kind: "conversation" | "tool" | "coding" | "research" | "planning";
+  text: string;
+  timestamp: number;
+}
+
+export interface DailyMemoryLog {
+  date: string;
+  started_at_min: number;
+  last_active_max: number;
+  session_count: number;
+  message_count: number;
+  subjects: DailyMemorySubject[];
+  sessions: MemorySessionInfo[];
+  work_items: DailyMemoryWorkItem[];
+}
+
+export interface MemoryOverviewResponse {
+  subjects: MemorySubject[];
+  daily_logs: DailyMemoryLog[];
+  recent_sessions: MemorySessionInfo[];
+}
+
+export interface MemorySubjectsResponse {
+  subjects: MemorySubject[];
+  query: string;
+  limit: number;
+}
+
+export interface MemorySubjectResponse {
+  subject: MemorySubject;
+}
+
+export interface MemoryDaysResponse {
+  daily_logs: DailyMemoryLog[];
+  limit: number;
+}
+
+export interface MemoryDayResponse {
+  daily_log: DailyMemoryLog;
 }
 
 export interface EnvVarInfo {

--- a/web/src/pages/MemoryWikiPage.tsx
+++ b/web/src/pages/MemoryWikiPage.tsx
@@ -1,0 +1,369 @@
+import { useEffect, useLayoutEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { CalendarDays, Database, MessageSquare, Search, Tags } from "lucide-react";
+import { Badge } from "@nous-research/ui/ui/components/badge";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { usePageHeader } from "@/contexts/usePageHeader";
+import { api } from "@/lib/api";
+import type {
+  DailyMemoryLog,
+  MemoryOverviewResponse,
+  MemorySessionInfo,
+  MemorySubject,
+} from "@/lib/api";
+
+function formatTime(timestamp: number): string {
+  if (!timestamp) return "Unknown";
+  return new Date(timestamp * 1000).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function formatDate(date: string): string {
+  try {
+    return new Date(`${date}T00:00:00`).toLocaleDateString(undefined, {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  } catch {
+    return date;
+  }
+}
+
+function PageShell({ children }: { children: React.ReactNode }) {
+  const { setEnd } = usePageHeader();
+  useLayoutEffect(() => {
+    setEnd(null);
+    return () => setEnd(null);
+  }, [setEnd]);
+  return <div className="space-y-6 p-4 sm:p-6">{children}</div>;
+}
+
+function LoadingState() {
+  return (
+    <PageShell>
+      <div className="flex min-h-[240px] items-center justify-center text-muted-foreground">
+        <Spinner className="mr-2 h-4 w-4" /> Loading memory wiki…
+      </div>
+    </PageShell>
+  );
+}
+
+function ErrorState({ message }: { message: string }) {
+  return (
+    <PageShell>
+      <Card>
+        <CardContent className="py-8 text-sm text-destructive">{message}</CardContent>
+      </Card>
+    </PageShell>
+  );
+}
+
+function StatCard({ label, value, icon: Icon }: { label: string; value: string | number; icon: typeof Database }) {
+  return (
+    <Card>
+      <CardContent className="flex items-center gap-3 py-5">
+        <Icon className="h-5 w-5 text-muted-foreground" />
+        <div>
+          <div className="text-2xl font-semibold leading-none">{value}</div>
+          <div className="mt-1 text-xs uppercase tracking-wide text-muted-foreground">{label}</div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function SessionList({ sessions }: { sessions: MemorySessionInfo[] }) {
+  if (sessions.length === 0) {
+    return <p className="text-sm text-muted-foreground">No sessions found.</p>;
+  }
+  return (
+    <div className="space-y-2">
+      {sessions.map((session) => (
+        <Link
+          key={session.id}
+          to="/sessions"
+          title={`Open Sessions to inspect ${session.id}`}
+          className="block rounded-md border border-border/60 p-3 transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <div className="flex flex-wrap items-center gap-2">
+            <MessageSquare className="h-4 w-4 text-muted-foreground" />
+            <span className="font-medium">{session.title || session.id}</span>
+            {session.source && <Badge tone="secondary">{session.source}</Badge>}
+            <span className="text-xs text-muted-foreground">{formatTime(session.last_active)}</span>
+          </div>
+          {session.preview && <p className="mt-2 line-clamp-2 text-sm text-muted-foreground">{session.preview}</p>}
+        </Link>
+      ))}
+    </div>
+  );
+}
+
+function SubjectCard({ subject }: { subject: MemorySubject }) {
+  return (
+    <Link to={`/memory/subjects/${subject.slug}`} className="block rounded-lg outline-none ring-offset-background focus-visible:ring-2 focus-visible:ring-ring">
+      <Card className="h-full transition-colors hover:bg-muted/30">
+        <CardHeader className="pb-3">
+          <div className="flex items-start justify-between gap-3">
+            <CardTitle className="text-base">{subject.name}</CardTitle>
+            <Badge>{subject.session_count} sessions</Badge>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="flex flex-wrap gap-1.5">
+            {subject.keywords.slice(0, 5).map((keyword) => (
+              <Badge key={keyword} tone="secondary">{keyword}</Badge>
+            ))}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {subject.message_count} messages · last touched {formatTime(subject.last_seen)}
+          </p>
+          {subject.snippets[0] && (
+            <p className="line-clamp-3 text-sm text-muted-foreground">{subject.snippets[0].text}</p>
+          )}
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}
+
+function DayCard({ day }: { day: DailyMemoryLog }) {
+  return (
+    <Link to={`/memory/days/${day.date}`} className="block rounded-lg outline-none ring-offset-background focus-visible:ring-2 focus-visible:ring-ring">
+      <Card className="transition-colors hover:bg-muted/30">
+        <CardHeader className="pb-3">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <CardTitle className="text-base">{formatDate(day.date)}</CardTitle>
+            <Badge>{day.session_count} sessions</Badge>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="flex flex-wrap gap-1.5">
+            {day.subjects.slice(0, 6).map((subject) => (
+              <Badge key={subject.slug} tone="secondary">{subject.name}</Badge>
+            ))}
+          </div>
+          <ul className="space-y-1 text-sm text-muted-foreground">
+            {day.work_items.slice(0, 3).map((item, idx) => (
+              <li key={`${item.session_id}-${item.timestamp}-${idx}`} className="line-clamp-1">
+                <span className="font-medium text-foreground/80">{item.kind}:</span> {item.text}
+              </li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}
+
+export default function MemoryWikiPage() {
+  const [overview, setOverview] = useState<MemoryOverviewResponse | null>(null);
+  const [search, setSearch] = useState("");
+  const [searchResults, setSearchResults] = useState<MemorySubject[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    api
+      .getMemoryOverview()
+      .then(setOverview)
+      .catch((err) => setError(err instanceof Error ? err.message : "Failed to load memory wiki"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    const trimmed = search.trim();
+    if (!trimmed) {
+      setSearchResults(null);
+      return;
+    }
+    let cancelled = false;
+    const timer = window.setTimeout(() => {
+      api
+        .getMemorySubjects(trimmed)
+        .then((resp) => {
+          if (!cancelled) setSearchResults(resp.subjects);
+        })
+        .catch(() => {
+          if (!cancelled) setSearchResults([]);
+        });
+    }, 250);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [search]);
+
+  const visibleSubjects = searchResults ?? overview?.subjects ?? [];
+
+  if (loading) return <LoadingState />;
+  if (error || !overview) return <ErrorState message={error ?? "Memory wiki unavailable"} />;
+
+  return (
+    <PageShell>
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Database className="h-4 w-4" /> Local session history
+        </div>
+        <h1 className="text-3xl font-semibold tracking-tight">Memory Wiki</h1>
+        <p className="max-w-3xl text-sm text-muted-foreground">
+          Browse deterministic subjects and daily logs generated from this Hermes profile’s local session database.
+        </p>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-3">
+        <StatCard icon={Tags} label="Subjects" value={overview.subjects.length} />
+        <StatCard icon={CalendarDays} label="Daily logs" value={overview.daily_logs.length} />
+        <StatCard icon={MessageSquare} label="Recent sessions" value={overview.recent_sessions.length} />
+      </div>
+
+      <div className="relative max-w-xl">
+        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <input
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder="Search subjects…"
+          className="w-full rounded-md border border-border bg-background py-2 pl-9 pr-3 text-sm outline-none ring-offset-background focus:ring-2 focus:ring-ring"
+        />
+      </div>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Subjects</h2>
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          {visibleSubjects.map((subject) => <SubjectCard key={subject.slug} subject={subject} />)}
+        </div>
+        {visibleSubjects.length === 0 && <p className="text-sm text-muted-foreground">No subjects match your search.</p>}
+      </section>
+
+      <section className="grid gap-6 xl:grid-cols-[2fr_1fr]">
+        <div className="space-y-3">
+          <h2 className="text-xl font-semibold">Daily Logs</h2>
+          <div className="space-y-3">
+            {overview.daily_logs.map((day) => <DayCard key={day.date} day={day} />)}
+          </div>
+        </div>
+        <Card>
+          <CardHeader><CardTitle className="text-base">Recent Activity</CardTitle></CardHeader>
+          <CardContent><SessionList sessions={overview.recent_sessions} /></CardContent>
+        </Card>
+      </section>
+    </PageShell>
+  );
+}
+
+export function MemorySubjectPage() {
+  const { slug = "" } = useParams();
+  const [subject, setSubject] = useState<MemorySubject | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    setSubject(null);
+    api
+      .getMemorySubject(slug)
+      .then((resp) => setSubject(resp.subject))
+      .catch((err) => setError(err instanceof Error ? err.message : "Failed to load subject"))
+      .finally(() => setLoading(false));
+  }, [slug]);
+
+  if (loading) return <LoadingState />;
+  if (error || !subject) return <ErrorState message={error ?? "Subject not found"} />;
+
+  return (
+    <PageShell>
+      <Link to="/memory"><Button ghost size="sm" className="border border-border">← Memory Wiki</Button></Link>
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold tracking-tight">{subject.name}</h1>
+        <p className="text-sm text-muted-foreground">
+          {subject.session_count} sessions · {subject.message_count} messages · first seen {formatTime(subject.first_seen)}
+        </p>
+        <div className="flex flex-wrap gap-1.5">
+          {subject.keywords.map((keyword) => <Badge key={keyword} tone="secondary">{keyword}</Badge>)}
+        </div>
+      </div>
+      <div className="grid gap-6 xl:grid-cols-[1fr_1fr]">
+        <Card>
+          <CardHeader><CardTitle className="text-base">Related Sessions</CardTitle></CardHeader>
+          <CardContent><SessionList sessions={subject.sessions} /></CardContent>
+        </Card>
+        <Card>
+          <CardHeader><CardTitle className="text-base">Snippets</CardTitle></CardHeader>
+          <CardContent className="space-y-3">
+            {subject.snippets.map((snippet) => (
+              <blockquote key={`${snippet.session_id}-${snippet.message_id}-${snippet.timestamp}`} className="border-l-2 border-border pl-3 text-sm text-muted-foreground">
+                <span className="font-medium text-foreground/80">{snippet.role ?? "message"}</span>: {snippet.text}
+              </blockquote>
+            ))}
+          </CardContent>
+        </Card>
+      </div>
+    </PageShell>
+  );
+}
+
+export function MemoryDayPage() {
+  const { date = "" } = useParams();
+  const [day, setDay] = useState<DailyMemoryLog | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    setDay(null);
+    api
+      .getMemoryDay(date)
+      .then((resp) => setDay(resp.daily_log))
+      .catch((err) => setError(err instanceof Error ? err.message : "Failed to load daily log"))
+      .finally(() => setLoading(false));
+  }, [date]);
+
+  if (loading) return <LoadingState />;
+  if (error || !day) return <ErrorState message={error ?? "Daily log not found"} />;
+
+  return (
+    <PageShell>
+      <Link to="/memory"><Button ghost size="sm" className="border border-border">← Memory Wiki</Button></Link>
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold tracking-tight">{formatDate(day.date)}</h1>
+        <p className="text-sm text-muted-foreground">
+          {day.session_count} sessions · {day.message_count} messages · active until {formatTime(day.last_active_max)}
+        </p>
+        <div className="flex flex-wrap gap-1.5">
+          {day.subjects.map((subject) => (
+            <Link key={subject.slug} to={`/memory/subjects/${subject.slug}`}>
+              <Badge tone="secondary">{subject.name}</Badge>
+            </Link>
+          ))}
+        </div>
+      </div>
+      <div className="grid gap-6 xl:grid-cols-[1fr_1fr]">
+        <Card>
+          <CardHeader><CardTitle className="text-base">What we did</CardTitle></CardHeader>
+          <CardContent>
+            <ul className="space-y-2 text-sm text-muted-foreground">
+              {day.work_items.map((item, idx) => (
+                <li key={`${item.session_id}-${item.timestamp}-${idx}`}>
+                  <span className="font-medium text-foreground/80">{item.kind}</span>: {item.text}
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader><CardTitle className="text-base">Sessions</CardTitle></CardHeader>
+          <CardContent><SessionList sessions={day.sessions} /></CardContent>
+        </Card>
+      </div>
+    </PageShell>
+  );
+}

--- a/website/docs/user-guide/features/memory-wiki.md
+++ b/website/docs/user-guide/features/memory-wiki.md
@@ -1,0 +1,42 @@
+# Memory Wiki
+
+The Memory Wiki is a dashboard view that turns your local Hermes session history into browsable subject pages and daily logs.
+
+## Launch
+
+Start the dashboard:
+
+```bash
+hermes dashboard
+```
+
+Then open `/memory` from the dashboard sidebar.
+
+## What it shows
+
+- **Subjects** — deterministic topics extracted from session titles, previews, user messages, file paths, package names, tool calls, and slash commands.
+- **Subject pages** — related sessions, message snippets, keywords, first-seen and last-touched metadata for a topic.
+- **Daily logs** — sessions grouped by local calendar date, with subject chips and “what we did” bullets derived from messages and tool calls.
+- **Recent activity** — recent sessions from the same local history database.
+
+## Privacy model
+
+Memory Wiki v1 is generated from your local Hermes profile database at `~/.hermes/state.db`. It does not require remote upload or a hosted index.
+
+The dashboard API computes the data on demand from the existing `sessions` and `messages` tables. No schema migration or persistent memory-wiki cache is required for v1.
+
+## Accuracy notes
+
+Subject extraction is intentionally heuristic and local-only. It normalizes obvious aliases such as `Memory Wiki`, `memory wiki`, and `memory-wiki`, but the taxonomy may be imperfect. Future versions may add manual merge/rename controls or optional summarization jobs.
+
+Daily-log work items are derived from user/assistant messages and tool calls. They are meant as navigation aids, not a canonical audit log.
+
+## Manual QA checklist
+
+1. Start the dashboard with `hermes dashboard`.
+2. Open `/memory`.
+3. Confirm subjects load from real local history.
+4. Search a known topic.
+5. Click a subject card and verify related sessions/snippets render.
+6. Click a daily log and verify work items and sessions render.
+7. Return to `/memory` using the back link.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -106,6 +106,7 @@ const sidebars: SidebarsConfig = {
           label: 'Management',
           items: [
             'user-guide/features/web-dashboard',
+            'user-guide/features/memory-wiki',
             'user-guide/features/extending-the-dashboard',
             'user-guide/features/subscription-proxy',
           ],


### PR DESCRIPTION
## Summary
- add local session-history Memory Wiki aggregation helpers and tests
- expose Memory Wiki dashboard API endpoints for overview, subjects, and daily logs
- add React dashboard pages/routes/sidebar entry plus TypeScript API types
- document Memory Wiki and register it in the docs sidebar

## Test Plan
- python -m pytest tests/hermes_cli/test_memory_wiki.py tests/hermes_cli/test_web_server_memory_wiki.py -q -o 'addopts='
- cd web && npm run build
- cd website && npm run build

Notes: website build exits 0 but emits pre-existing Docusaurus broken-link/anchor warnings unrelated to this page. Website prebuild also warns that PyYAML is unavailable and writes an empty generated skills.json locally.