### PR TITLE
fix(env_loader): load doc-canonical ~/.hermes/.env when HERMES_HOME redirects (#31144)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5027,6 +5027,22 @@ def show_config():
     print(color("◆ Paths", Colors.CYAN, Colors.BOLD))
     print(f"  Config:       {get_config_path()}")
     print(f"  Secrets:      {get_env_path()}")
+    # When ``HERMES_HOME`` redirects the secrets file outside ``~/.hermes`` —
+    # the Windows installer's default — also surface the doc-canonical
+    # ``~/.hermes/.env`` so users editing the file the API-server / setup
+    # docs point at can see the gateway will pick it up too. Issue #31144.
+    try:
+        _doc_secrets = Path.home() / ".hermes" / ".env"
+        _live_secrets = get_env_path()
+        if _doc_secrets.exists():
+            try:
+                _same = _doc_secrets.samefile(_live_secrets)
+            except OSError:
+                _same = (_doc_secrets == _live_secrets)
+            if not _same:
+                print(f"  Secrets (~):  {_doc_secrets}  (also loaded; lower precedence)")
+    except Exception:
+        pass
     print(f"  Install:      {get_project_root()}")
     
     # API Keys

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -193,10 +193,19 @@ def load_hermes_dotenv(
     """Load Hermes environment files with user config taking precedence.
 
     Behavior:
-    - `~/.hermes/.env` overrides stale shell-exported values when present.
-    - project `.env` acts as a dev fallback and only fills missing values when
-      the user env exists.
-    - if no user env exists, the project `.env` also overrides stale shell vars.
+    - ``${HERMES_HOME}/.env`` overrides stale shell-exported values when present
+      (this is the data-directory's local secrets file — installer-written on
+      Windows, profile-specific in profile mode, container-volume in Docker).
+    - The doc-canonical ``~/.hermes/.env`` is also loaded when it exists and
+      differs from ``${HERMES_HOME}/.env``. Loaded *before* the HERMES_HOME
+      file so the latter still wins on key collisions, but loaded at all so
+      doc-mandated edits (``website/docs/user-guide/features/api-server.md``
+      tells users to add ``API_SERVER_ENABLED=true`` to ``~/.hermes/.env``)
+      actually take effect when the installer or operator has redirected
+      ``HERMES_HOME`` elsewhere. Issue #31144.
+    - project ``.env`` acts as a dev fallback and only fills missing values
+      when one of the user envs exists.
+    - if no user envs exist, the project ``.env`` also overrides stale shell vars.
     """
     loaded: list[Path] = []
 
@@ -204,11 +213,34 @@ def load_hermes_dotenv(
     user_env = home_path / ".env"
     project_env_path = Path(project_env) if project_env else None
 
+    # Doc-canonical secrets file. Loaded only when it exists *and* points at
+    # a different inode than ``user_env`` — common only when the installer /
+    # operator has redirected ``HERMES_HOME``. ``Path.samefile`` is the
+    # cross-platform way to compare (handles symlinks, junctions, case
+    # differences on Windows). Falls back to a plain string compare when
+    # either side doesn't exist on disk yet.
+    shared_user_env: Path | None = None
+    default_user_env = Path.home() / ".hermes" / ".env"
+    if default_user_env.exists():
+        try:
+            is_same_file = (
+                user_env.exists() and default_user_env.samefile(user_env)
+            )
+        except OSError:
+            is_same_file = (default_user_env == user_env)
+        if not is_same_file:
+            shared_user_env = default_user_env
+
     # Fix corrupted .env files before python-dotenv parses them (#8908).
-    if user_env.exists():
-        _sanitize_env_file_if_needed(user_env)
-    if project_env_path and project_env_path.exists():
-        _sanitize_env_file_if_needed(project_env_path)
+    for env_path in (shared_user_env, user_env, project_env_path):
+        if env_path and env_path.exists():
+            _sanitize_env_file_if_needed(env_path)
+
+    if shared_user_env and shared_user_env.exists():
+        # Doc-canonical file: low precedence so the HERMES_HOME-resolved
+        # file (loaded next) still wins on key collisions.
+        _load_dotenv_with_fallback(shared_user_env, override=True)
+        loaded.append(shared_user_env)
 
     if user_env.exists():
         _load_dotenv_with_fallback(user_env, override=True)

--- a/tests/hermes_cli/test_env_loader_31144.py
+++ b/tests/hermes_cli/test_env_loader_31144.py
@@ -1,0 +1,145 @@
+"""Regression tests for issue #31144.
+
+When ``HERMES_HOME`` is redirected outside ``~/.hermes`` (Windows installer
+layout, profile mode, Docker volume), edits to the doc-canonical
+``~/.hermes/.env`` were silently ignored because ``load_hermes_dotenv``
+resolved its single ``user_env`` slot via ``HERMES_HOME`` only. The fix
+loads the doc-canonical file too — at lower precedence so the
+HERMES_HOME-resolved file still wins on key collisions but doc-mandated
+edits actually take effect.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.env_loader import load_hermes_dotenv
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    """Redirect ``Path.home()`` so we don't touch the real user's ~."""
+    fake = tmp_path / "userhome"
+    fake.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake))
+    return fake
+
+
+def test_doc_canonical_env_loaded_when_hermes_home_redirected(fake_home, tmp_path, monkeypatch):
+    """``~/.hermes/.env`` must load even when HERMES_HOME points elsewhere.
+
+    This reproduces the Windows-installer layout from #31144: HERMES_HOME
+    is set to ``%LOCALAPPDATA%\\hermes`` but the user follows the docs and
+    edits ``~/.hermes/.env`` to enable the API server.
+    """
+    install_tree = tmp_path / "appdata" / "hermes"
+    install_tree.mkdir(parents=True)
+    install_env = install_tree / ".env"
+    install_env.write_text("HERMES_WEB_DIST=/install/web_dist\n", encoding="utf-8")
+
+    doc_dir = fake_home / ".hermes"
+    doc_dir.mkdir()
+    doc_env = doc_dir / ".env"
+    doc_env.write_text("API_SERVER_ENABLED=true\nAPI_SERVER_KEY=user-key\n", encoding="utf-8")
+
+    monkeypatch.delenv("API_SERVER_ENABLED", raising=False)
+    monkeypatch.delenv("API_SERVER_KEY", raising=False)
+    monkeypatch.delenv("HERMES_WEB_DIST", raising=False)
+
+    loaded = load_hermes_dotenv(hermes_home=install_tree)
+
+    assert doc_env in loaded
+    assert install_env in loaded
+    assert loaded.index(doc_env) < loaded.index(install_env)
+    assert os.getenv("API_SERVER_ENABLED") == "true"
+    assert os.getenv("API_SERVER_KEY") == "user-key"
+    assert os.getenv("HERMES_WEB_DIST") == "/install/web_dist"
+
+
+def test_hermes_home_env_wins_on_key_collision(fake_home, tmp_path, monkeypatch):
+    """HERMES_HOME-resolved ``.env`` must override the doc-canonical file.
+
+    Profile-mode users keep per-profile overrides in ``${HERMES_HOME}/.env``
+    while sharing common keys via ``~/.hermes/.env``. Profile-specific
+    values must win.
+    """
+    profile_root = tmp_path / "profile"
+    profile_root.mkdir()
+    (profile_root / ".env").write_text(
+        "OPENROUTER_API_KEY=profile-key\n", encoding="utf-8"
+    )
+
+    doc_dir = fake_home / ".hermes"
+    doc_dir.mkdir()
+    (doc_dir / ".env").write_text(
+        "OPENROUTER_API_KEY=shared-key\nGITHUB_TOKEN=ghp_shared\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    load_hermes_dotenv(hermes_home=profile_root)
+
+    assert os.getenv("OPENROUTER_API_KEY") == "profile-key"
+    assert os.getenv("GITHUB_TOKEN") == "ghp_shared"
+
+
+def test_doc_canonical_skipped_when_same_file_as_hermes_home(fake_home, monkeypatch):
+    """The fallback must NOT double-load when HERMES_HOME == ~/.hermes.
+
+    Standard installs (HERMES_HOME unset, or pointing at the canonical
+    ``~/.hermes``) used to have a single ``.env`` load — keep it that way
+    so we don't append a duplicate path to the loaded list.
+    """
+    canonical = fake_home / ".hermes"
+    canonical.mkdir()
+    env_file = canonical / ".env"
+    env_file.write_text("FOO=bar\n", encoding="utf-8")
+
+    monkeypatch.delenv("FOO", raising=False)
+
+    loaded = load_hermes_dotenv(hermes_home=canonical)
+
+    assert loaded == [env_file]
+    assert os.getenv("FOO") == "bar"
+
+
+def test_doc_canonical_absent_no_op(fake_home, tmp_path, monkeypatch):
+    """No ``~/.hermes/.env`` on disk → behavior unchanged from pre-fix."""
+    install_tree = tmp_path / "appdata" / "hermes"
+    install_tree.mkdir(parents=True)
+    (install_tree / ".env").write_text("FOO=installer\n", encoding="utf-8")
+
+    monkeypatch.delenv("FOO", raising=False)
+    assert not (fake_home / ".hermes" / ".env").exists()
+
+    loaded = load_hermes_dotenv(hermes_home=install_tree)
+
+    assert loaded == [install_tree / ".env"]
+    assert os.getenv("FOO") == "installer"
+
+
+def test_project_env_only_overrides_when_no_user_envs(fake_home, tmp_path, monkeypatch):
+    """project_env keeps its existing fallback semantics.
+
+    When neither the doc-canonical nor the HERMES_HOME ``.env`` exists,
+    project ``.env`` must still override stale shell vars (preserves
+    pre-#31144 behavior verified by ``test_env_loader.py``).
+    """
+    install_tree = tmp_path / "appdata" / "hermes"
+    install_tree.mkdir(parents=True)
+    project_env = tmp_path / "project" / ".env"
+    project_env.parent.mkdir()
+    project_env.write_text("OPENAI_BASE_URL=https://project.example/v1\n", encoding="utf-8")
+
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://stale.example/v1")
+    assert not (fake_home / ".hermes" / ".env").exists()
+
+    loaded = load_hermes_dotenv(hermes_home=install_tree, project_env=project_env)
+
+    assert loaded == [project_env]
+    assert os.getenv("OPENAI_BASE_URL") == "https://project.example/v1"


### PR DESCRIPTION
## What does this PR do?

Fixes #31144: when ``HERMES_HOME`` is redirected outside ``~/.hermes`` (the Windows installer's default of ``%LOCALAPPDATA%\hermes``, Docker volume layouts, profile mode), edits to the doc-canonical ``~/.hermes/.env`` were silently dropped on the floor. Users who followed ``website/docs/user-guide/features/api-server.md`` and added ``API_SERVER_ENABLED=true`` to ``~/.hermes/.env`` saw the gateway start with the API server still off — only ``WARNING gateway.run: No messaging platforms enabled.`` in stderr.

Three small additions wired together:

1. **Loader fallback** (``hermes_cli/env_loader.py``) — ``load_hermes_dotenv`` now also loads ``~/.hermes/.env`` when it exists *and* points at a different file than ``${HERMES_HOME}/.env``. Loaded BEFORE the HERMES_HOME-resolved file so the latter still wins on key collisions (preserves profile-mode per-profile overrides + Docker-volume secrets), but loaded at all so doc-mandated edits actually take effect. ``Path.samefile`` is used for the comparison so symlinks, Windows junctions, and case-only differences don't double-load.

2. **CLI surface** (``hermes_cli/config.py``) — ``hermes config show`` now prints the doc-canonical path next to the HERMES_HOME-resolved one whenever they diverge, with an ``(also loaded; lower precedence)`` suffix. The CLI now matches what the loader actually does, eliminating the silent disagreement that made the Windows-installer failure mode invisible.

3. **Regression tests** (``tests/hermes_cli/test_env_loader_31144.py``) — 5 focused tests including the original Windows-installer reproduction, the profile-mode collision case, and the no-double-load same-file path.

## Related Issue

Fixes #31144

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- ``hermes_cli/env_loader.py`` — add doc-canonical ``~/.hermes/.env`` fallback to ``load_hermes_dotenv`` with ``Path.samefile`` dedup; load at lower precedence than ``${HERMES_HOME}/.env`` so existing profile / Docker setups are unaffected.
- ``hermes_cli/config.py`` — ``show_config`` prints the doc-canonical path when it diverges from ``get_env_path()``, so the CLI agrees with what the loader will read.
- ``tests/hermes_cli/test_env_loader_31144.py`` — 5 new tests: doc-canonical loads when HERMES_HOME redirects, HERMES_HOME wins on key collision, no double-load when same file, no-op when ``~/.hermes/.env`` absent, project-env fallback unchanged.

Backwards compatible: ``loaded`` list grows by at most one path, only when the doc-canonical and HERMES_HOME files diverge. All existing precedence semantics preserved.

## How to Test

```bash
# New regression suite + existing env_loader tests
python -m pytest tests/hermes_cli/test_env_loader.py tests/hermes_cli/test_env_loader_31144.py
# expected: 11 passed
```

End-to-end before the fix (Windows install with ``HERMES_HOME=%LOCALAPPDATA%\hermes``):

```
> notepad %USERPROFILE%\.hermes\.env       # follow the API-server doc
  API_SERVER_ENABLED=true
> hermes gateway run
  WARNING gateway.run: No messaging platforms enabled.   # API server stayed off
```

After the fix:

```
> hermes config show
  Config:       C:\Users\anf07\AppData\Local\hermes\config.yaml
  Secrets:      C:\Users\anf07\AppData\Local\hermes\.env
  Secrets (~):  C:\Users\anf07\.hermes\.env  (also loaded; lower precedence)
> hermes gateway run
  INFO  gateway.run: API server enabled on 127.0.0.1:8745
```

## Checklist

- [x] Conventional Commits (``fix(env_loader):``, ``fix(config):``, ``test(env_loader):``)
- [x] 3 focused commits, single author
- [x] 5 new tests pass; all 6 pre-existing ``test_env_loader.py`` tests pass
- [x] No new config keys, no schema migration
- [x] Cross-platform: ``Path.samefile`` handles Windows junctions / case-insensitive paths
