### PR TITLE
feat(kanban): Linear linkage inheritance and models picker hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -829,7 +829,9 @@ kanban task.
   `init`, `create`, `list` (alias `ls`), `show`, `assign`, `link`,
   `unlink`, `comment`, `complete`, `block`, `unblock`, `archive`,
   `tail`, plus less-commonly-used `watch`, `stats`, `runs`, `log`,
-  `assignees`, `heartbeat`, `notify-*`, `dispatch`, `daemon`, `gc`.
+  `assignees`, `heartbeat`, `notify-*`, `dispatch`, `daemon`, `gc`,
+  `linear ensure` (idempotent Linear issue link — reuse, inherit from
+  parent, or create + backfill children).
 - **Worker/orchestrator toolset:** `tools/kanban_tools.py` exposes
   `kanban_show`, `kanban_complete`, `kanban_block`, `kanban_heartbeat`,
   `kanban_comment`, `kanban_create`, `kanban_link`; profiles that
@@ -842,6 +844,11 @@ kanban task.
 - **Plugin assets:** `plugins/kanban/dashboard/` (web UI) +
   `plugins/kanban/systemd/` (`hermes-kanban-dispatcher.service` for
   standalone dispatcher deployment).
+- **Linear linkage:** `hermes_cli/kanban_linear.py` + task columns
+  `linear_issue_id` / `linear_issue_url`. Configure
+  `kanban.linear.team` (team key, e.g. `ENG`) and `LINEAR_API_KEY`.
+  Children inherit the parent's issue via `task_links`; explicit child
+  links are preserved on parent backfill.
 
 Isolation model:
 - **Board** is the hard boundary — workers are spawned with

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1570,6 +1570,14 @@ DEFAULT_CONFIG = {
         # large bulk-load of triage tasks from spending a burst of aux
         # LLM calls in one tick. Excess tasks defer to the next tick.
         "auto_decompose_per_tick": 3,
+        # Linear.app issue linkage for kanban tasks (shared parent/children).
+        # Requires LINEAR_API_KEY in the environment. ``team`` is the team
+        # key (e.g. ENG) used when creating a new issue.
+        "linear": {
+            "enabled": True,
+            "team": "",
+            "default_priority": None,
+        },
         # Stale detection: running tasks that have exceeded this many
         # seconds without a heartbeat (since ``last_heartbeat_at``) are
         # auto-reclaimed to ``ready`` on the next dispatcher tick. The
@@ -3251,11 +3259,14 @@ def get_compatible_custom_providers(
             seen_name_url_pairs.add(pair)
 
     custom_providers = config.get("custom_providers")
-    if custom_providers is not None:
-        if not isinstance(custom_providers, list):
-            return []
+    if isinstance(custom_providers, list):
         for entry in custom_providers:
             _append_if_new(_normalize_custom_provider_entry(entry))
+    elif custom_providers is not None:
+        logger.warning(
+            "custom_providers must be a list, got %s — ignoring that key",
+            type(custom_providers).__name__,
+        )
 
     for entry in providers_dict_to_custom_providers(config.get("providers")):
         _append_if_new(entry)

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -816,6 +816,23 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="Emit one JSON object per task on stdout",
     )
 
+    # --- linear --- (ensure Linear issue link for a task)
+    p_linear = sub.add_parser(
+        "linear",
+        help="Linear issue linkage for kanban tasks (create, inherit, backfill children)",
+    )
+    linear_sub = p_linear.add_subparsers(dest="linear_action")
+    p_linear_ensure = linear_sub.add_parser(
+        "ensure",
+        help="Ensure this task has a Linear issue (reuse, inherit, or create)",
+    )
+    p_linear_ensure.add_argument("task_id", help="Kanban task id")
+    p_linear_ensure.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON result on stdout",
+    )
+
     # --- gc ---
     p_gc = sub.add_parser(
         "gc", help="Garbage-collect archived-task workspaces, old events, and old logs",
@@ -950,6 +967,7 @@ def kanban_command(args: argparse.Namespace) -> int:
         "specify":  _cmd_specify,
         "decompose":  _cmd_decompose,
         "gc":       _cmd_gc,
+        "linear":   _dispatch_linear,
     }
     handler = handlers.get(action)
     if not handler:
@@ -986,6 +1004,47 @@ def _profile_author() -> str:
 # ---------------------------------------------------------------------------
 # Boards management (hermes kanban boards …)
 # ---------------------------------------------------------------------------
+
+def _dispatch_linear(args: argparse.Namespace) -> int:
+    """Handle ``hermes kanban linear <action>``."""
+    sub = getattr(args, "linear_action", None) or "ensure"
+    if sub == "ensure":
+        return _cmd_linear_ensure(args)
+    print(f"kanban linear: unknown action {sub!r}", file=sys.stderr)
+    return 2
+
+
+def _cmd_linear_ensure(args: argparse.Namespace) -> int:
+    from hermes_cli import kanban_linear
+
+    task_id = getattr(args, "task_id", None)
+    if not task_id:
+        print("kanban linear ensure: task_id is required", file=sys.stderr)
+        return 2
+    want_json = bool(getattr(args, "json", False))
+    with kb.connect() as conn:
+        try:
+            task = kanban_linear.ensure_linear_issue_for_task(conn, task_id)
+        except ValueError as exc:
+            print(f"kanban linear: {exc}", file=sys.stderr)
+            return 1
+        except kanban_linear.LinearKanbanError as exc:
+            print(f"kanban linear: {exc}", file=sys.stderr)
+            return 1
+    if want_json:
+        print(json.dumps({
+            "ok": True,
+            "task_id": task.id,
+            "linear_issue_id": task.linear_issue_id,
+            "linear_issue_url": task.linear_issue_url,
+        }))
+    else:
+        print(
+            f"Linear: {task.linear_issue_url or '(none)'} "
+            f"({task.linear_issue_id or 'no id'})"
+        )
+    return 0
+
 
 def _dispatch_boards(args: argparse.Namespace) -> int:
     """Handle ``hermes kanban boards <action>``.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -658,6 +658,9 @@ class Task:
     # set the env var. Lets clients render a per-session board without
     # relying on tenant + time-window heuristics.
     session_id: Optional[str] = None
+    # External Linear issue linkage (shared by umbrella tasks and children).
+    linear_issue_id: Optional[str] = None
+    linear_issue_url: Optional[str] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -726,6 +729,12 @@ class Task:
             ),
             session_id=(
                 row["session_id"] if "session_id" in keys else None
+            ),
+            linear_issue_id=(
+                row["linear_issue_id"] if "linear_issue_id" in keys else None
+            ),
+            linear_issue_url=(
+                row["linear_issue_url"] if "linear_issue_url" in keys else None
             ),
         )
 
@@ -864,7 +873,11 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- for tasks created from the CLI, dashboard, or any path that doesn't
     -- set the env var. Indexed so per-session list queries stay cheap on
     -- larger boards.
-    session_id           TEXT
+    session_id           TEXT,
+  -- Linear.app issue linkage (uuid + browser url). Children inherit the
+  -- parent's issue instead of creating duplicates.
+    linear_issue_id      TEXT,
+    linear_issue_url     TEXT
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -1354,6 +1367,15 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             conn, "tasks", "session_id", "session_id TEXT"
         )
 
+    if "linear_issue_id" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "linear_issue_id", "linear_issue_id TEXT"
+        )
+    if "linear_issue_url" not in cols:
+        _add_column_if_missing(
+            conn, "tasks", "linear_issue_url", "linear_issue_url TEXT"
+        )
+
     # Indexes over additive ``tasks`` columns must be created after the
     # columns exist. Keeping them in SCHEMA_SQL breaks legacy boards: SQLite
     # parses each statement in ``executescript`` against the live schema, so a
@@ -1750,6 +1772,8 @@ def create_task(
                         "skills": list(skills_list) if skills_list else None,
                     },
                 )
+            if parents:
+                inherit_linear_from_parents(conn, task_id)
             return task_id
         except sqlite3.IntegrityError:
             if attempt == 1:
@@ -1877,6 +1901,99 @@ def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) 
 
 
 # ---------------------------------------------------------------------------
+# Linear issue linkage
+# ---------------------------------------------------------------------------
+
+def set_linear_link(
+    conn: sqlite3.Connection,
+    task_id: str,
+    linear_issue_id: str,
+    linear_issue_url: str,
+    *,
+    propagate: bool = True,
+    source: str = "linked",
+) -> bool:
+    """Persist Linear issue ids on a task and optionally backfill children.
+
+    Does not overwrite a child that already has its own ``linear_issue_id``
+    (explicit override). Returns False when the task does not exist.
+    """
+    issue_id = str(linear_issue_id).strip()
+    issue_url = str(linear_issue_url).strip()
+    if not issue_id or not issue_url:
+        raise ValueError("linear_issue_id and linear_issue_url are required")
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT linear_issue_id, linear_issue_url FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if row is None:
+            return False
+        if row["linear_issue_id"] == issue_id and row["linear_issue_url"] == issue_url:
+            return True
+        conn.execute(
+            "UPDATE tasks SET linear_issue_id = ?, linear_issue_url = ? WHERE id = ?",
+            (issue_id, issue_url, task_id),
+        )
+        _append_event(
+            conn,
+            task_id,
+            "linear_linked",
+            {
+                "linear_issue_id": issue_id,
+                "linear_issue_url": issue_url,
+                "source": source,
+            },
+        )
+    if propagate:
+        propagate_linear_to_children(conn, task_id, issue_id, issue_url)
+    return True
+
+
+def propagate_linear_to_children(
+    conn: sqlite3.Connection,
+    parent_id: str,
+    linear_issue_id: str,
+    linear_issue_url: str,
+) -> int:
+    """Copy the parent's Linear link onto descendants that lack one."""
+    updated = 0
+    for child_id in child_ids(conn, parent_id):
+        child = get_task(conn, child_id)
+        if child is None or child.linear_issue_id:
+            continue
+        if set_linear_link(
+            conn,
+            child_id,
+            linear_issue_id,
+            linear_issue_url,
+            propagate=True,
+            source="inherited",
+        ):
+            updated += 1
+    return updated
+
+
+def inherit_linear_from_parents(conn: sqlite3.Connection, task_id: str) -> bool:
+    """If any parent has a Linear link, copy it onto ``task_id`` when unset."""
+    task = get_task(conn, task_id)
+    if task is None or task.linear_issue_id:
+        return False
+    for parent_id in parent_ids(conn, task_id):
+        parent = get_task(conn, parent_id)
+        if parent and parent.linear_issue_id and parent.linear_issue_url:
+            return set_linear_link(
+                conn,
+                task_id,
+                parent.linear_issue_id,
+                parent.linear_issue_url,
+                propagate=False,
+                source="inherited",
+            )
+    return False
+
+
+# ---------------------------------------------------------------------------
 # Links
 # ---------------------------------------------------------------------------
 
@@ -1908,6 +2025,7 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
             conn, child_id, "linked",
             {"parent": parent_id, "child": child_id},
         )
+    inherit_linear_from_parents(conn, child_id)
 
 
 def _would_cycle(conn: sqlite3.Connection, parent_id: str, child_id: str) -> bool:
@@ -3716,6 +3834,16 @@ def decompose_triage_task(
         if root_row["status"] != "triage":
             return None
         tenant = root_row["tenant"]
+        root_linear = conn.execute(
+            "SELECT linear_issue_id, linear_issue_url FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        root_linear_id = (
+            root_linear["linear_issue_id"] if root_linear else None
+        )
+        root_linear_url = (
+            root_linear["linear_issue_url"] if root_linear else None
+        )
 
         # Create children. Status is 'todo' regardless of parents — we
         # link them under the root AFTER creation so the dispatcher
@@ -3729,8 +3857,8 @@ def decompose_triage_task(
             conn.execute(
                 "INSERT INTO tasks "
                 "(id, title, body, assignee, status, workspace_kind, "
-                " tenant, created_at, created_by) "
-                "VALUES (?, ?, ?, ?, 'todo', 'scratch', ?, ?, ?)",
+                " tenant, created_at, created_by, linear_issue_id, linear_issue_url) "
+                "VALUES (?, ?, ?, ?, 'todo', 'scratch', ?, ?, ?, ?, ?)",
                 (
                     new_id,
                     title,
@@ -3739,6 +3867,8 @@ def decompose_triage_task(
                     tenant,
                     now,
                     (author or "decomposer"),
+                    root_linear_id,
+                    root_linear_url,
                 ),
             )
             _append_event(

--- a/hermes_cli/kanban_linear.py
+++ b/hermes_cli/kanban_linear.py
@@ -1,0 +1,219 @@
+"""Kanban ↔ Linear issue linkage (idempotent create + parent/child inheritance)."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from hermes_cli import kanban_db as kb
+
+logger = logging.getLogger(__name__)
+
+LINEAR_API_URL = "https://api.linear.app/graphql"
+
+
+class LinearKanbanError(RuntimeError):
+    """Linear API or configuration failure for kanban linkage."""
+
+
+@dataclass(frozen=True)
+class LinearKanbanConfig:
+    """Resolved ``kanban.linear`` settings plus env fallbacks."""
+
+    enabled: bool
+    team: str
+    default_priority: Optional[int] = None
+
+    @classmethod
+    def from_runtime_config(cls, config: Optional[dict] = None) -> "LinearKanbanConfig":
+        if config is None:
+            from hermes_cli.config import load_config
+
+            config = load_config()
+        kanban_cfg = (config or {}).get("kanban") or {}
+        linear_cfg = kanban_cfg.get("linear") or {}
+        if not isinstance(linear_cfg, dict):
+            linear_cfg = {}
+        enabled = linear_cfg.get("enabled")
+        if enabled is None:
+            enabled = bool(os.environ.get("LINEAR_API_KEY", "").strip())
+        else:
+            enabled = bool(enabled)
+        team = (
+            str(linear_cfg.get("team") or linear_cfg.get("team_id") or "")
+            .strip()
+        )
+        prio = linear_cfg.get("default_priority")
+        default_priority = int(prio) if prio is not None else None
+        return cls(enabled=enabled, team=team, default_priority=default_priority)
+
+    def api_key(self) -> str:
+        return os.environ.get("LINEAR_API_KEY", "").strip()
+
+
+def _gql(query: str, variables: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+    key = os.environ.get("LINEAR_API_KEY", "").strip()
+    if not key:
+        raise LinearKanbanError(
+            "LINEAR_API_KEY is not set (Linear Settings → API → personal key)"
+        )
+    payload: dict[str, Any] = {"query": query}
+    if variables:
+        payload["variables"] = variables
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        LINEAR_API_URL,
+        data=data,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": key,
+            "User-Agent": "hermes-agent-kanban-linear/1.0",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            body = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace")
+        raise LinearKanbanError(f"Linear HTTP {exc.code}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise LinearKanbanError(f"Linear network error: {exc}") from exc
+
+    result = json.loads(body)
+    if result.get("errors"):
+        raise LinearKanbanError(
+            f"Linear GraphQL errors: {json.dumps(result['errors'], ensure_ascii=False)}"
+        )
+    return result.get("data") or {}
+
+
+def _resolve_team_id(team_ref: str) -> str:
+    """Resolve a team key (ENG) or UUID to Linear team id."""
+    ref = team_ref.strip()
+    if not ref:
+        raise LinearKanbanError(
+            "kanban.linear.team is not configured (set team key, e.g. ENG)"
+        )
+    if len(ref) == 36 and ref.count("-") == 4:
+        return ref
+    q = """query($key: String!) {
+      teams(filter: { key: { eq: $key } }, first: 1) {
+        nodes { id key name }
+      }
+    }"""
+    nodes = _gql(q, {"key": ref.upper()}).get("teams", {}).get("nodes") or []
+    if not nodes:
+        raise LinearKanbanError(f"Linear team not found for key {ref!r}")
+    return str(nodes[0]["id"])
+
+
+def _create_linear_issue(
+    *,
+    title: str,
+    description: Optional[str],
+    team_ref: str,
+    priority: Optional[int] = None,
+) -> tuple[str, str]:
+    team_id = _resolve_team_id(team_ref)
+    inp: dict[str, Any] = {"title": title.strip(), "teamId": team_id}
+    if description:
+        inp["description"] = description
+    if priority is not None:
+        inp["priority"] = int(priority)
+    q = """mutation($input: IssueCreateInput!) {
+      issueCreate(input: $input) {
+        success
+        issue { id identifier title url }
+      }
+    }"""
+    payload = _gql(q, {"input": inp}).get("issueCreate") or {}
+    if not payload.get("success"):
+        raise LinearKanbanError("Linear issueCreate returned success=false")
+    issue = payload.get("issue") or {}
+    issue_id = issue.get("id")
+    issue_url = issue.get("url")
+    if not issue_id or not issue_url:
+        raise LinearKanbanError("Linear issueCreate missing id or url")
+    return str(issue_id), str(issue_url)
+
+
+def ensure_linear_issue_for_task(
+    conn,
+    task_id: str,
+    *,
+    config: Optional[LinearKanbanConfig] = None,
+    force_create: bool = False,
+) -> kb.Task:
+    """Ensure ``task_id`` has a Linear issue link (reuse, inherit, or create).
+
+    When ``force_create`` is false (default), an existing ``linear_issue_id``
+    on the task is returned as-is. When true, a missing link still follows
+    inherit-then-create, but an existing link is not replaced.
+    """
+    cfg = config or LinearKanbanConfig.from_runtime_config()
+    task = kb.get_task(conn, task_id)
+    if task is None:
+        raise ValueError(f"unknown task: {task_id}")
+    if task.linear_issue_id and not force_create:
+        return task
+
+    for parent_id in kb.parent_ids(conn, task_id):
+        parent = kb.get_task(conn, parent_id)
+        if parent and parent.linear_issue_id and parent.linear_issue_url:
+            updated = kb.set_linear_link(
+                conn,
+                task_id,
+                parent.linear_issue_id,
+                parent.linear_issue_url,
+                propagate=False,
+                source="inherited",
+            )
+            if updated:
+                logger.info(
+                    "kanban linear: task %s inherited issue from parent %s",
+                    task_id,
+                    parent_id,
+                )
+            out = kb.get_task(conn, task_id)
+            return out if out is not None else task
+
+    if not cfg.enabled:
+        return task
+    if not cfg.api_key():
+        raise LinearKanbanError("Linear linkage is enabled but LINEAR_API_KEY is unset")
+    if not cfg.team:
+        raise LinearKanbanError("kanban.linear.team is required to create issues")
+
+    body = task.body or ""
+    desc_parts = [body] if body.strip() else []
+    desc_parts.append(f"Hermes kanban task: `{task.id}`")
+    description = "\n\n".join(desc_parts)
+
+    issue_id, issue_url = _create_linear_issue(
+        title=task.title,
+        description=description,
+        team_ref=cfg.team,
+        priority=cfg.default_priority,
+    )
+    updated = kb.set_linear_link(
+        conn,
+        task_id,
+        issue_id,
+        issue_url,
+        propagate=True,
+        source="created",
+    )
+    if updated:
+        logger.info(
+            "kanban linear: created issue for task %s → %s",
+            task_id,
+            issue_url,
+        )
+    out = kb.get_task(conn, task_id)
+    return out if out is not None else task

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1170,7 +1170,15 @@ def list_authenticated_providers(
     # Ollama Cloud uses dynamic discovery (no static curated list)
     if "ollama-cloud" not in curated:
         from hermes_cli.models import fetch_ollama_cloud_models
-        curated["ollama-cloud"] = fetch_ollama_cloud_models()
+        try:
+            curated["ollama-cloud"] = fetch_ollama_cloud_models()
+        except Exception as exc:
+            logger.warning(
+                "ollama-cloud model discovery failed — picker will omit or "
+                "fall back to curated list: %s",
+                exc,
+            )
+            curated["ollama-cloud"] = curated.get("ollama-cloud") or []
     # LM Studio has no static catalog — probe its native /api/v1/models
     # endpoint live so the picker reflects whatever the user has loaded.
     # Base URL precedence: LM_BASE_URL env var > active config's base_url

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -8,6 +8,7 @@ Add, remove, or reorder entries here — both `hermes setup` and
 from __future__ import annotations
 
 import json
+import logging
 import os
 import urllib.request
 import urllib.error
@@ -17,6 +18,8 @@ from pathlib import Path
 from typing import Any, NamedTuple, Optional
 
 from hermes_cli import __version__ as _HERMES_VERSION
+
+logger = logging.getLogger(__name__)
 
 # Identify ourselves so endpoints fronted by Cloudflare's Browser Integrity
 # Check (error 1010) don't reject the default ``Python-urllib/*`` signature.
@@ -3094,6 +3097,19 @@ def probe_api_models(
             "used_fallback": False,
         }
 
+    if not _is_http_base_url(normalized):
+        logger.warning(
+            "Skipping /models probe — base_url is not http(s): %r",
+            normalized[:80],
+        )
+        return {
+            "models": None,
+            "probed_url": None,
+            "resolved_base_url": normalized,
+            "suggested_base_url": None,
+            "used_fallback": False,
+        }
+
     if _is_github_models_base_url(normalized):
         models = _fetch_github_models(api_key=api_key, timeout=timeout)
         return {
@@ -3202,6 +3218,38 @@ def fetch_api_models(
 _OLLAMA_CLOUD_CACHE_TTL = 3600  # 1 hour
 
 
+def _is_http_base_url(url: str) -> bool:
+    """True when ``url`` looks like an OpenAI-compatible http(s) API root."""
+    normalized = (url or "").strip().lower()
+    return normalized.startswith("http://") or normalized.startswith("https://")
+
+
+def _resolve_http_base_url(
+    env_var: str,
+    default: str,
+    *,
+    label: str,
+) -> str:
+    """Read an http(s) base URL from ``env_var``, else return ``default``.
+
+    Misconfigured installs sometimes paste an API key into ``OLLAMA_BASE_URL``
+    (or a custom provider ``base_url``). urllib then raises
+    ``ValueError: unknown url type`` and the whole model picker 500s — see
+    remote logs 2026-05-24. Never treat non-URL values as a base URL.
+    """
+    raw = (os.getenv(env_var, "") or "").strip()
+    if raw and _is_http_base_url(raw):
+        return raw.rstrip("/")
+    if raw:
+        logger.warning(
+            "%s is set for %s but is not an http(s) URL — using default %s",
+            env_var,
+            label,
+            default,
+        )
+    return (default or "").strip().rstrip("/")
+
+
 def _strip_ollama_cloud_suffix(model_id: str) -> str:
     """Strip :cloud / -cloud suffixes that models.dev appends to Ollama Cloud IDs.
 
@@ -3285,7 +3333,17 @@ def fetch_ollama_cloud_models(
     if not api_key:
         api_key = os.getenv("OLLAMA_API_KEY", "")
     if not base_url:
-        base_url = os.getenv("OLLAMA_BASE_URL", "") or "https://ollama.com/v1"
+        base_url = _resolve_http_base_url(
+            "OLLAMA_BASE_URL",
+            "https://ollama.com/v1",
+            label="ollama-cloud",
+        )
+    elif not _is_http_base_url(base_url):
+        logger.warning(
+            "ollama-cloud base_url %r is not http(s) — using https://ollama.com/v1",
+            str(base_url)[:80],
+        )
+        base_url = "https://ollama.com/v1"
 
     live_models: list[str] = []
     if api_key:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1000,9 +1000,16 @@ def get_model_options():
         from hermes_cli.inventory import build_models_payload, load_picker_context
 
         return build_models_payload(load_picker_context(), max_models=50)
-    except Exception:
+    except Exception as exc:
         _log.exception("GET /api/model/options failed")
-        raise HTTPException(status_code=500, detail="Failed to list model options")
+        detail = "Failed to list model options"
+        msg = str(exc).lower()
+        if "unknown url type" in msg:
+            detail += (
+                " — a provider base URL in config or .env is not http(s) "
+                "(often OLLAMA_BASE_URL set to an API key). Check ~/.hermes/.env"
+            )
+        raise HTTPException(status_code=500, detail=detail) from exc
 
 
 @app.get("/api/model/auxiliary")

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -2537,6 +2537,16 @@
               ? h(Badge, { variant: "outline", className: "hermes-kanban-tag",
                            title: `Tenant: ${t.tenant}. Free-form tag for grouping tasks (customer, project, team).` }, t.tenant)
               : null,
+            t.linear_issue_url
+              ? h("a", {
+                  className: "hermes-kanban-linear-badge",
+                  href: t.linear_issue_url,
+                  target: "_blank",
+                  rel: "noopener noreferrer",
+                  title: "Open linked Linear issue (shared with parent/children)",
+                  onClick: function (e) { e.stopPropagation(); },
+                }, "Linear")
+              : null,
             progress
               ? h("span", {
                   className: cn(
@@ -2846,6 +2856,17 @@
       });
     };
 
+    const doLinearEnsure = function () {
+      return SDK.fetchJSON(
+        withBoard(`${API}/tasks/${encodeURIComponent(props.taskId)}/linear`, boardSlug),
+        { method: "POST", headers: { "Content-Type": "application/json" }, body: "{}" },
+      ).then(function (res) {
+        load();
+        props.onRefresh();
+        return res;
+      });
+    };
+
     const addLink = function (parentId) {
       return SDK.fetchJSON(withBoard(`${API}/links`, boardSlug), {
         method: "POST",
@@ -2938,6 +2959,7 @@
           onPatch: doPatch,
           onSpecify: doSpecify,
           onDecompose: doDecompose,
+          onLinearEnsure: doLinearEnsure,
           onAddParent: addLink,
           onRemoveParent: removeLink,
           onAddChild: addChild,
@@ -2997,6 +3019,17 @@
         h(AssigneeEditor, { task: t, onPatch: props.onPatch }),
         h(PriorityEditor, { task: t, onPatch: props.onPatch }),
         t.tenant ? h(MetaRow, { label: tx(i18n, "tenant", "Tenant"), value: t.tenant }) : null,
+        t.linear_issue_url
+          ? h("div", { className: "hermes-kanban-drawer-meta-row" },
+              h("span", { className: "hermes-kanban-drawer-meta-label" }, "Linear"),
+              h("a", {
+                className: "hermes-kanban-linear-link",
+                href: t.linear_issue_url,
+                target: "_blank",
+                rel: "noopener noreferrer",
+              }, t.linear_issue_id || t.linear_issue_url),
+            )
+          : null,
         h(MetaRow, {
           label: tx(i18n, "workspace", "Workspace"),
           value: `${t.workspace_kind}${t.workspace_path ? ": " + t.workspace_path : ""}`,
@@ -3012,6 +3045,7 @@
         onPatch: props.onPatch,
         onSpecify: props.onSpecify,
         onDecompose: props.onDecompose,
+        onLinearEnsure: props.onLinearEnsure,
       }),
       h(DiagnosticsSection, {
         task: t,
@@ -3478,6 +3512,8 @@
     const [specifyMsg, setSpecifyMsg] = useState(null);
     const [decomposeBusy, setDecomposeBusy] = useState(false);
     const [decomposeMsg, setDecomposeMsg] = useState(null);
+    const [linearBusy, setLinearBusy] = useState(false);
+    const [linearMsg, setLinearMsg] = useState(null);
     const b = function (label, patch, enabled, confirmMsg) {
       return h(Button, {
         onClick: function () { if (enabled !== false) props.onPatch(patch, { confirm: confirmMsg }); },
@@ -3569,10 +3605,52 @@
         }, decomposeBusy ? "Decomposing…" : "⚗ Decompose")
       : null;
 
+    const linearButton = (props.onLinearEnsure && !task.linear_issue_url)
+      ? h(Button, {
+          onClick: function () {
+            if (linearBusy) return;
+            setLinearBusy(true);
+            setLinearMsg(null);
+            props.onLinearEnsure().then(function (res) {
+              if (res && res.ok) {
+                setLinearMsg({
+                  ok: true,
+                  text: res.linear_issue_url
+                    ? `Linked: ${res.linear_issue_url}`
+                    : "Linear issue linked",
+                });
+              } else {
+                setLinearMsg({
+                  ok: false,
+                  text: "Linear link failed: " + ((res && res.detail) || "unknown error"),
+                });
+              }
+            }).catch(function (err) {
+              setLinearMsg({
+                ok: false,
+                text: "Linear link failed: " + (err.message || String(err)),
+              });
+            }).then(function () {
+              setLinearBusy(false);
+            });
+          },
+          disabled: linearBusy,
+          size: "sm",
+        }, linearBusy ? "Linking…" : "◇ Linear")
+      : (task.linear_issue_url
+          ? h("a", {
+              className: "hermes-kanban-linear-drawer-link",
+              href: task.linear_issue_url,
+              target: "_blank",
+              rel: "noopener noreferrer",
+            }, "◇ Open Linear")
+          : null);
+
     return h("div", null,
       h("div", { className: "hermes-kanban-actions" },
         specifyButton,
         decomposeButton,
+        linearButton,
         b("→ triage",  { status: "triage" },   task.status !== "triage"),
         b("→ ready",   { status: "ready" },    task.status !== "ready"),
         // No direct → running button: /tasks/:id PATCH rejects status=running
@@ -3599,6 +3677,11 @@
           ? "hermes-kanban-msg-ok"
           : "hermes-kanban-msg-err",
       }, decomposeMsg.text) : null,
+      linearMsg ? h("div", {
+        className: linearMsg.ok
+          ? "hermes-kanban-msg-ok"
+          : "hermes-kanban-msg-err",
+      }, linearMsg.text) : null,
     );
   }
 

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -1499,6 +1499,26 @@
   cursor: pointer;
 }
 
+/* ---- Linear issue linkage -------------------------------------------- */
+
+.hermes-kanban-linear-badge,
+.hermes-kanban-linear-link,
+.hermes-kanban-linear-drawer-link {
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-decoration: none;
+  color: var(--color-primary);
+  border: 1px solid color-mix(in srgb, var(--color-primary) 45%, transparent);
+  border-radius: 999px;
+  padding: 0.05rem 0.4rem;
+  line-height: 1.3;
+}
+.hermes-kanban-linear-badge:hover,
+.hermes-kanban-linear-drawer-link:hover {
+  text-decoration: underline;
+}
+
 /* ---- Trash drop zone ------------------------------------------------- */
 
 .hermes-kanban-trash {

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1972,6 +1972,36 @@ class DecomposeBody(BaseModel):
     author: Optional[str] = None
 
 
+@router.post("/tasks/{task_id}/linear")
+def ensure_linear_issue_endpoint(
+    task_id: str,
+    board: Optional[str] = Query(None),
+):
+    """Create or inherit a Linear issue for this kanban task.
+
+    Idempotent: reuses an existing link, inherits from a linked parent, or
+    creates a new Linear issue and backfills unlinked children.
+    """
+    board = _resolve_board(board)
+    conn = _conn(board=board)
+    try:
+        from hermes_cli import kanban_linear  # noqa: WPS433 (intentional)
+
+        task = kanban_linear.ensure_linear_issue_for_task(conn, task_id)
+        return {
+            "ok": True,
+            "task": _task_dict(task),
+            "linear_issue_id": task.linear_issue_id,
+            "linear_issue_url": task.linear_issue_url,
+        }
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except kanban_linear.LinearKanbanError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    finally:
+        conn.close()
+
+
 @router.post("/tasks/{task_id}/decompose")
 def decompose_task_endpoint(
     task_id: str,

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -81,6 +81,26 @@ def test_load_picker_context_string_model_legacy_shape():
     assert ctx.current_base_url == ""
 
 
+def test_get_compatible_custom_providers_still_reads_providers_when_custom_is_wrong_type():
+    """Malformed custom_providers must not skip the v12 providers: dict."""
+    from hermes_cli.config import get_compatible_custom_providers
+
+    cfg = {
+        "custom_providers": {"bad": "shape"},
+        "providers": {
+            "my-endpoint": {
+                "name": "My Endpoint",
+                "base_url": "https://example.com/v1",
+                "api_key": "sk-test",
+                "model": "m1",
+            }
+        },
+    }
+    rows = get_compatible_custom_providers(cfg)
+    assert len(rows) == 1
+    assert rows[0]["name"] == "My Endpoint"
+
+
 def test_load_picker_context_empty_config():
     cfg = _cfg()
     with patch("hermes_cli.config.load_config", return_value=cfg):

--- a/tests/hermes_cli/test_kanban_linear.py
+++ b/tests/hermes_cli/test_kanban_linear.py
@@ -1,0 +1,181 @@
+"""Tests for kanban ↔ Linear issue linkage."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_linear as kl
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("LINEAR_API_KEY", "lin_api_test_key")
+    monkeypatch.setattr(__import__("pathlib").Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def test_migration_adds_linear_columns(kanban_home):
+    with kb.connect() as conn:
+        cols = {
+            row["name"]
+            for row in conn.execute("PRAGMA table_info(tasks)")
+        }
+    assert "linear_issue_id" in cols
+    assert "linear_issue_url" in cols
+
+
+def test_create_child_inherits_parent_linear_link(kanban_home):
+    with kb.connect() as conn:
+        parent_id = kb.create_task(conn, title="umbrella", assignee="ops")
+        kb.set_linear_link(
+            conn,
+            parent_id,
+            "issue-parent-uuid",
+            "https://linear.app/acme/issue/ENG-1",
+            propagate=False,
+        )
+        child_id = kb.create_task(
+            conn,
+            title="child work",
+            assignee="ops",
+            parents=[parent_id],
+        )
+        child = kb.get_task(conn, child_id)
+    assert child is not None
+    assert child.linear_issue_id == "issue-parent-uuid"
+    assert child.linear_issue_url == "https://linear.app/acme/issue/ENG-1"
+
+
+def test_propagate_backfills_existing_children(kanban_home):
+    with kb.connect() as conn:
+        parent_id = kb.create_task(conn, title="umbrella", assignee="ops")
+        child_id = kb.create_task(
+            conn,
+            title="child",
+            assignee="ops",
+            parents=[parent_id],
+        )
+        kb.set_linear_link(
+            conn,
+            parent_id,
+            "issue-99",
+            "https://linear.app/acme/issue/ENG-99",
+            propagate=True,
+        )
+        child = kb.get_task(conn, child_id)
+    assert child is not None
+    assert child.linear_issue_id == "issue-99"
+
+
+def test_child_override_not_overwritten_on_propagate(kanban_home):
+    with kb.connect() as conn:
+        parent_id = kb.create_task(conn, title="umbrella", assignee="ops")
+        child_id = kb.create_task(
+            conn,
+            title="child",
+            assignee="ops",
+            parents=[parent_id],
+        )
+        kb.set_linear_link(
+            conn,
+            child_id,
+            "issue-child-only",
+            "https://linear.app/acme/issue/ENG-2",
+            propagate=False,
+        )
+        kb.set_linear_link(
+            conn,
+            parent_id,
+            "issue-parent",
+            "https://linear.app/acme/issue/ENG-1",
+            propagate=True,
+        )
+        child = kb.get_task(conn, child_id)
+    assert child is not None
+    assert child.linear_issue_id == "issue-child-only"
+
+
+def test_ensure_reuses_existing_link(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="already linked", assignee="ops")
+        kb.set_linear_link(
+            conn,
+            task_id,
+            "existing-id",
+            "https://linear.app/acme/issue/ENG-5",
+            propagate=False,
+        )
+        with patch.object(kl, "_create_linear_issue") as mock_create:
+            task = kl.ensure_linear_issue_for_task(
+                conn,
+                task_id,
+                config=kl.LinearKanbanConfig(enabled=True, team="ENG"),
+            )
+    assert task.linear_issue_id == "existing-id"
+    mock_create.assert_not_called()
+
+
+def test_ensure_inherits_from_parent_instead_of_create(kanban_home):
+    with kb.connect() as conn:
+        parent_id = kb.create_task(conn, title="parent", assignee="ops")
+        kb.set_linear_link(
+            conn,
+            parent_id,
+            "parent-issue",
+            "https://linear.app/acme/issue/ENG-9",
+            propagate=False,
+        )
+        child_id = kb.create_task(
+            conn,
+            title="child",
+            assignee="ops",
+            parents=[parent_id],
+        )
+        # Simulate a child created before parent was linked.
+        conn.execute(
+            "UPDATE tasks SET linear_issue_id = NULL, linear_issue_url = NULL "
+            "WHERE id = ?",
+            (child_id,),
+        )
+        with patch.object(kl, "_create_linear_issue") as mock_create:
+            task = kl.ensure_linear_issue_for_task(
+                conn,
+                child_id,
+                config=kl.LinearKanbanConfig(enabled=True, team="ENG"),
+            )
+    assert task.linear_issue_id == "parent-issue"
+    mock_create.assert_not_called()
+
+
+def test_ensure_creates_and_propagates(kanban_home):
+    with kb.connect() as conn:
+        parent_id = kb.create_task(conn, title="umbrella", assignee="ops")
+        child_id = kb.create_task(
+            conn,
+            title="child",
+            assignee="ops",
+            parents=[parent_id],
+        )
+        conn.execute(
+            "UPDATE tasks SET linear_issue_id = NULL, linear_issue_url = NULL "
+            "WHERE id = ?",
+            (child_id,),
+        )
+        cfg = kl.LinearKanbanConfig(enabled=True, team="ENG")
+        with patch.object(
+            kl,
+            "_create_linear_issue",
+            return_value=("new-uuid", "https://linear.app/acme/issue/ENG-42"),
+        ):
+            parent = kl.ensure_linear_issue_for_task(conn, parent_id, config=cfg)
+        child = kb.get_task(conn, child_id)
+    assert parent.linear_issue_id == "new-uuid"
+    assert child is not None
+    assert child.linear_issue_id == "new-uuid"

--- a/tests/hermes_cli/test_ollama_cloud_provider.py
+++ b/tests/hermes_cli/test_ollama_cloud_provider.py
@@ -204,6 +204,42 @@ class TestOllamaCloudMergedDiscovery:
         assert "nemotron-3-super" in result  # from models.dev only
         assert result.count("glm-5") == 1    # no duplicates
 
+    def test_invalid_ollama_base_url_does_not_crash(self, tmp_path, monkeypatch):
+        """OLLAMA_BASE_URL must be http(s); API keys pasted there must not 500 the picker."""
+        from hermes_cli.models import fetch_ollama_cloud_models
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("OLLAMA_API_KEY", "test-key")
+        monkeypatch.setenv("OLLAMA_BASE_URL", "not-a-url-looks-like-api-key")
+
+        mock_mdev = {
+            "ollama-cloud": {
+                "models": {
+                    "glm-5": {"tool_call": True},
+                }
+            }
+        }
+        with patch("hermes_cli.models.fetch_api_models") as mock_api, \
+             patch("agent.models_dev.fetch_models_dev", return_value=mock_mdev):
+            result = fetch_ollama_cloud_models(force_refresh=True)
+            mock_api.assert_called_once()
+            _key, base_url = mock_api.call_args[0][:2]
+            assert _key == "test-key"
+            assert base_url == "https://ollama.com/v1"
+        assert "glm-5" in result
+
+    def test_list_authenticated_providers_survives_invalid_ollama_base_url(
+        self, monkeypatch,
+    ):
+        """One bad Ollama env must not take down /api/model/options."""
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        monkeypatch.setenv("OLLAMA_API_KEY", "test-key")
+        monkeypatch.setenv("OLLAMA_BASE_URL", "definitely-not-a-url")
+        providers = list_authenticated_providers(max_models=8)
+        slugs = {p["slug"] for p in providers}
+        assert "openrouter" in slugs or len(slugs) > 0
+
     def test_falls_back_to_models_dev_without_api_key(self, tmp_path, monkeypatch):
         """Without API key, only models.dev results are returned."""
         from hermes_cli.models import fetch_ollama_cloud_models

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -125,6 +125,16 @@ class TestWebServerEndpoints:
         assert "hermes_home" in data
         assert "active_sessions" in data
 
+    def test_get_model_options_survives_invalid_ollama_base_url(self, monkeypatch):
+        """Mis-set OLLAMA_BASE_URL must not 500 the Models page picker."""
+        monkeypatch.setenv("OLLAMA_API_KEY", "test-key")
+        monkeypatch.setenv("OLLAMA_BASE_URL", "not-an-http-url")
+        resp = self.client.get("/api/model/options")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert "providers" in data
+        assert isinstance(data["providers"], list)
+
     def test_get_status_filters_unconfigured_gateway_platforms(self, monkeypatch):
         import gateway.config as gateway_config
         import hermes_cli.web_server as web_server

--- a/web/src/components/ModelPickerDialog.tsx
+++ b/web/src/components/ModelPickerDialog.tsx
@@ -46,6 +46,35 @@ interface ModelOptionsResponse {
   providers?: ModelOptionProvider[];
 }
 
+/** User-facing message for model-options load failures (no raw status dumps). */
+function formatModelOptionsError(raw: string): string {
+  const trimmed = raw.trim();
+  const statusMatch = trimmed.match(/^(\d{3}):\s*(.+)$/s);
+  const body = statusMatch ? statusMatch[2].trim() : trimmed;
+  try {
+    const parsed = JSON.parse(body) as { detail?: unknown };
+    if (typeof parsed.detail === "string" && parsed.detail.trim()) {
+      return parsed.detail.trim();
+    }
+  } catch {
+    // not JSON — use body as-is
+  }
+  if (body.length > 0 && body.length < 400) {
+    return body;
+  }
+  return "Could not load model providers. Check the dashboard server logs.";
+}
+
+function formatCurrentModelLabel(model: string, provider: string): string {
+  if (model.trim()) {
+    return model;
+  }
+  if (provider.trim() && provider !== "auto") {
+    return "(provider default)";
+  }
+  return "(not configured)";
+}
+
 interface Props {
   /** Chat-mode: when present, picker emits a slash command via onSubmit. */
   gw?: GatewayClient;
@@ -117,7 +146,8 @@ export function ModelPickerDialog(props: Props) {
       })
       .catch((e) => {
         if (closedRef.current) return;
-        setError(e instanceof Error ? e.message : String(e));
+        const raw = e instanceof Error ? e.message : String(e);
+        setError(formatModelOptionsError(raw));
         setLoading(false);
       });
 
@@ -232,7 +262,7 @@ export function ModelPickerDialog(props: Props) {
             {title}
           </h2>
           <p className="text-xs text-muted-foreground mt-1 font-mono">
-            current: {currentModel || "(unknown)"}
+            current: {formatCurrentModelLabel(currentModel, currentProviderSlug)}
             {currentProviderSlug && ` · ${currentProviderSlug}`}
           </p>
         </header>


### PR DESCRIPTION
## Summary
- Add `kanban_linear` CLI module and DB support for inheriting Linear team linkage on kanban cards.
- Harden model listing when provider `base_url` env vars are not valid http(s) URLs (fixes Models page 500 from misconfigured `OLLAMA_BASE_URL`).
- Update kanban dashboard dist assets, ModelPickerDialog, tests, and AGENTS.md operator notes.

## Test plan
- [x] `python3 -m pytest tests/hermes_cli/test_kanban_linear.py tests/hermes_cli/test_ollama_cloud_provider.py -q -o addopts=` (54 passed)
- [ ] `hermes kanban linear` subcommands against a board with `kanban.linear.team` configured
- [ ] Dashboard Models → Set Main Model loads provider list (no 500)
- [ ] openclaw-1: deploy branch and restart `hermes-gateway` after merge


Made with [Cursor](https://cursor.com)