### PR TITLE
fix(tui): align active-session-file ID with DB session_key

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1040,7 +1040,15 @@ def _print_tui_exit_summary(
         db = SessionDB()
         session = db.get_session(target)
         if not session:
-            return
+            # Active session file may have a stale/incorrect ID (TUI sid
+            # differs from DB session_key). Fall back via resume param or
+            # last-session heuristic.
+            target = session_id or _resolve_last_session(source="tui")
+            if not target:
+                return
+            session = db.get_session(target)
+            if not session:
+                return
 
         title = db.get_session_title(target)
         message_count = int(session.get("message_count") or 0)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2277,6 +2277,7 @@ def _(rid, params: dict) -> dict:
         rid,
         {
             "session_id": sid,
+            "db_session_id": key,
             "info": {
                 "model": _resolve_model(),
                 "tools": {},

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -147,7 +147,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
       resetSession()
       setSessionStartedAt(Date.now())
 
-      writeActiveSessionFile(r.session_id)
+      writeActiveSessionFile(r.db_session_id ?? r.session_id)
       patchUiState({
         info,
         sid: r.session_id,

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -110,6 +110,7 @@ export interface SetupStatusResponse {
 // ── Session lifecycle ────────────────────────────────────────────────
 
 export interface SessionCreateResponse {
+  db_session_id?: string
   info?: SessionInfo & { config_warning?: string; credential_warning?: string }
   session_id: string
 }


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Fixes TUI exit not showing token usage statistics.

Root cause: The TUI has two different session IDs:

ID              Format                  Source
──────────────  ──────────────────────  ──────────────────────────────────────
TUI sid         a1b2c3d4 (8-char hex)   session.create response → session_id
DB session_key  20260518_110824_abc123  SQLite state.db key written by AIAgent

When newSession calls writeActiveSessionFile(session_id), it stores the TUI sid. On exit, _print_tui_exit_summary reads that file and queries the DB with it — but the DB has no record under the TUI sid, so tokens show as 0.

Fix (4 files, +12 / -2):

• tui_gateway/server.py: session.create response now includes db_session_id alongside the TUI sid
• ui-tui/src/gatewayTypes.ts: declare optional db_session_id field
• ui-tui/src/app/useSessionLifecycle.ts: write db_session_id ?? session_id to the active session file
• hermes_cli/main.py: _print_tui_exit_summary falls back to session_id / last-session heuristic when the active session file ID misses in the DB

Tested: TUI exit now prints Session: <title> • <N> msgs • <total> tokens (↑<in> / ↓<out> / ◎<cache_read> / ◇<cache_write> / ⟅⟆)


## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

