### PR TITLE
fix(telegram): detect wedged send path after reconnect storms (#31165)

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -15,6 +15,7 @@ import os
 import tempfile
 import html as _html
 import re
+import time as _time
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Any
 
@@ -429,6 +430,15 @@ class TelegramAdapter(BasePlatformAdapter):
         self._polling_conflict_count: int = 0
         self._polling_network_error_count: int = 0
         self._polling_error_callback_ref = None
+        # Send-path health tracking.  After sustained reconnect storms
+        # (Bad Gateway / TimedOut), the PTB httpx client can enter a
+        # wedged state where send_message returns a valid Message
+        # object but the message never reaches the recipient.  This flag
+        # gates a post-send getMe() probe that catches the wedge and
+        # surfaces a failure so callers (cron, send_message_tool) can
+        # fall back to a fresh HTTP session.
+        self._send_path_degraded: bool = False
+        self._last_reconnect_error_at: float = 0.0
         # DM Topics: map of topic_name -> message_thread_id (populated at startup)
         self._dm_topics: Dict[str, int] = {}
         # Track forum chats where we've already registered bot commands
@@ -875,6 +885,8 @@ class TelegramAdapter(BasePlatformAdapter):
 
         self._polling_network_error_count += 1
         attempt = self._polling_network_error_count
+        self._send_path_degraded = True
+        self._last_reconnect_error_at = _time.monotonic()
 
         if attempt > MAX_NETWORK_RETRIES:
             message = (
@@ -971,6 +983,12 @@ class TelegramAdapter(BasePlatformAdapter):
 
         try:
             await asyncio.wait_for(self._app.bot.get_me(), PROBE_TIMEOUT)
+            # Polling heartbeat passed — the Bot client is responsive.
+            # Clear the degraded flag so send() stops probing and
+            # callers (cron) trust live-adapter results again.
+            if self._send_path_degraded:
+                logger.info("[%s] Send-path health probe passed, clearing degraded flag", self.name)
+                self._send_path_degraded = False
         except Exception as probe_err:
             logger.warning(
                 "[%s] Polling heartbeat probe failed %ds after reconnect: %s",
@@ -1871,6 +1889,27 @@ class TelegramAdapter(BasePlatformAdapter):
                                 continue
                         raise
                 message_ids.append(str(msg.message_id))
+
+            # After a reconnect storm the PTB httpx pool can be wedged:
+            # send_message returns a valid Message (real message_id) but
+            # the message never reaches the recipient.  Probe the send
+            # path with a lightweight getMe() so callers see a failure
+            # and can fall through to the standalone delivery path.
+            if self._send_path_degraded and self._bot:
+                try:
+                    await asyncio.wait_for(self._bot.get_me(), 5)
+                    logger.info("[%s] Post-send health probe passed, clearing degraded flag", self.name)
+                    self._send_path_degraded = False
+                except Exception as probe_err:
+                    logger.warning(
+                        "[%s] Post-send health probe failed (send path still wedged): %s",
+                        self.name, probe_err,
+                    )
+                    return SendResult(
+                        success=False,
+                        error=f"send_path_degraded: {probe_err}",
+                        retryable=True,
+                    )
 
             # Re-trigger typing indicator after sending a message.
             # Telegram clears the typing state when a new message is delivered,

--- a/tests/gateway/test_telegram_send_path_health.py
+++ b/tests/gateway/test_telegram_send_path_health.py
@@ -1,0 +1,140 @@
+"""Tests for TelegramAdapter send-path health tracking after reconnect storms.
+
+After sustained Bad Gateway / TimedOut reconnect cycles, the PTB httpx client
+can enter a wedged state where send_message returns a valid Message but the
+message never arrives.  The _send_path_degraded flag gates a post-send getMe()
+probe that catches the wedge and surfaces SendResult(success=False).
+"""
+import asyncio
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    telegram_mod = MagicMock()
+    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    telegram_mod.constants.ChatType.GROUP = "group"
+    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
+    telegram_mod.constants.ChatType.CHANNEL = "channel"
+    telegram_mod.constants.ChatType.PRIVATE = "private"
+
+    telegram_mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    telegram_mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    telegram_mod.error.BadRequest = type("BadRequest", (Exception,), {})
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, telegram_mod)
+    sys.modules.setdefault("telegram.error", telegram_mod.error)
+
+
+_ensure_telegram_mock()
+
+from gateway.platforms.telegram import TelegramAdapter  # noqa: E402
+
+
+def _make_adapter() -> TelegramAdapter:
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    # Wire up a mock bot so send() doesn't bail on "Not connected"
+    adapter._bot = MagicMock()
+    adapter._bot.get_me = AsyncMock(return_value=MagicMock())
+    adapter._bot.send_message = AsyncMock(return_value=MagicMock(message_id=42))
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# _send_path_degraded flag
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_send_path_healthy_by_default():
+    """send() should not probe getMe() when the adapter is healthy."""
+    adapter = _make_adapter()
+    assert adapter._send_path_degraded is False
+
+    result = await adapter.send("123", "hello world")
+
+    assert result.success is True
+    assert result.message_id == "42"
+    # getMe() should NOT have been called — no probe needed
+    adapter._bot.get_me.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_path_degraded_probe_passes_clears_flag():
+    """When degraded, send() probes getMe() and clears the flag on success."""
+    adapter = _make_adapter()
+    adapter._send_path_degraded = True
+
+    result = await adapter.send("123", "hello")
+
+    assert result.success is True
+    adapter._bot.get_me.assert_awaited_once()
+    assert adapter._send_path_degraded is False
+
+
+@pytest.mark.asyncio
+async def test_send_path_degraded_probe_fails_returns_failure():
+    """When degraded and getMe() probe fails, send() returns success=False
+    so callers (cron live-adapter) fall through to standalone delivery."""
+    adapter = _make_adapter()
+    adapter._send_path_degraded = True
+    adapter._bot.get_me = AsyncMock(side_effect=OSError("connection reset"))
+
+    result = await adapter.send("123", "hello")
+
+    assert result.success is False
+    assert "send_path_degraded" in result.error
+    assert result.retryable is True
+    # Flag stays True so the next send also probes
+    assert adapter._send_path_degraded is True
+
+
+@pytest.mark.asyncio
+async def test_reconnect_storm_sets_degraded_flag(monkeypatch):
+    """_handle_polling_network_error should set _send_path_degraded=True."""
+    adapter = _make_adapter()
+    # Wire up a mock app with updater for the reconnect path
+    adapter._app = MagicMock()
+    adapter._app.updater = MagicMock()
+    adapter._app.updater.running = False
+    adapter._app.updater.stop = AsyncMock()
+    adapter._app.updater.start_polling = AsyncMock()
+    adapter._polling_error_callback_ref = AsyncMock()
+
+    import gateway.platforms.telegram as tg_mod
+    monkeypatch.setattr(tg_mod, "Update", MagicMock(ALL_TYPES=[]))
+
+    # Simulate a single reconnect error (attempt 1/10)
+    await adapter._handle_polling_network_error(OSError("Bad Gateway"))
+
+    assert adapter._send_path_degraded is True
+
+
+@pytest.mark.asyncio
+async def test_verify_polling_clears_degraded_flag():
+    """_verify_polling_after_reconnect should clear the degraded flag
+    when the getMe() heartbeat probe passes."""
+    adapter = _make_adapter()
+    adapter._send_path_degraded = True
+
+    # Wire up a mock app with running updater
+    adapter._app = MagicMock()
+    adapter._app.updater = MagicMock()
+    adapter._app.updater.running = True
+    adapter._app.bot = MagicMock()
+    adapter._app.bot.get_me = AsyncMock(return_value=MagicMock())
+
+    # Speed up: patch the heartbeat delay to 0
+    with patch("gateway.platforms.telegram.asyncio.sleep", new_callable=AsyncMock):
+        await adapter._verify_polling_after_reconnect()
+
+    assert adapter._send_path_degraded is False


### PR DESCRIPTION
## Problem

Cron jobs configured with `deliver: telegram:<chat_id>` can silently drop messages after the Telegram gateway experiences a reconnect storm (sustained Bad Gateway / TimedOut errors). The gateway logs report successful delivery (`delivered to telegram:... via live adapter`) but the message never arrives in Telegram. No error is surfaced to the user.

## Root Cause

After prolonged network error cycles, the python-telegram-bot library's internal httpx connection pool can enter a wedged state where:
- `bot.send_message()` returns a valid `Message` object (real `message_id`, no exception)
- The HTTP request is never actually transmitted to Telegram's API
- The polling path (`getUpdates`) recovers independently via reconnection logic
- The send path (`sendMessage`) silently fails with no error signal

The cron scheduler's live-adapter delivery path trusts the adapter's `SendResult.success` return value, so a wedged send looks identical to a successful delivery.

## Fix

Add send-path health tracking to `TelegramAdapter`:

1. **`_send_path_degraded` flag** — set `True` when `_handle_polling_network_error` fires (reconnect storm detected)
2. **Post-send probe** — when degraded, `send()` runs a lightweight `getMe()` after the actual send. If the probe times out (5s) or fails, return `SendResult(success=False)` instead of the false-positive result
3. **Flag clearing** — `_verify_polling_after_reconnect` clears the flag after a successful `getMe()` probe confirms recovery
4. **Fallback** — returning `success=False` lets the cron scheduler's existing fallback mechanism deliver via the standalone path (fresh HTTP session)

**Files changed**: `gateway/platforms/telegram.py` (+39 lines)

## Changes

- `gateway/platforms/telegram.py`: Added `_send_path_degraded`, `_last_reconnect_error_at` fields; reconnect storm detection in error handler; post-send health probe in `send()`; flag clearing in reconnect verification

## How to Test

1. `./venv/bin/python3 -m pytest tests/gateway/test_telegram_send_path_health.py -v` — 5 new tests
2. `./venv/bin/python3 -m pytest tests/gateway/ -v` — all existing gateway tests pass
3. Manual: trigger a Telegram reconnect storm, observe that cron delivery falls back to standalone path instead of silent drop