### PR TITLE
fix: persist finalized closure gate responses

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -20,7 +20,7 @@ import json
 import logging
 import os
 from types import SimpleNamespace
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +32,7 @@ def run_codex_app_server_turn(
     original_user_message: Any,
     messages: List[Dict[str, Any]],
     effective_task_id: str,
+    conversation_history: Optional[List[Dict[str, Any]]] = None,
     should_review_memory: bool = False,
 ) -> Dict[str, Any]:
     """Codex app-server runtime path. Hands the entire turn to a `codex
@@ -66,6 +67,11 @@ def run_codex_app_server_turn(
     # return reaches us. Do NOT append again — that would duplicate.
 
     try:
+        agent._reset_stream_delivery_tracking()
+    except Exception:
+        logger.debug("codex app-server stream tracking reset raised", exc_info=True)
+
+    try:
         turn = agent._codex_session.run_turn(user_input=user_message)
     except Exception as exc:
         logger.exception("codex app-server turn failed")
@@ -76,6 +82,15 @@ def run_codex_app_server_turn(
         except Exception:
             pass
         agent._codex_session = None
+        try:
+            agent._cleanup_task_resources(effective_task_id)
+        except Exception:
+            logger.debug("codex app-server cleanup after crash raised", exc_info=True)
+        try:
+            agent._persist_session(messages, conversation_history)
+        except Exception:
+            logger.debug("codex app-server persist after crash raised", exc_info=True)
+        agent._stream_callback = None
         return {
             "final_response": (
                 f"Codex app-server turn failed: {exc}. "
@@ -110,6 +125,63 @@ def run_codex_app_server_turn(
     if turn.projected_messages:
         messages.extend(turn.projected_messages)
 
+    final_text = turn.final_text
+    previous_final_text = final_text
+    if final_text and not turn.interrupted and turn.error is None:
+        # Keep the Codex app-server early-return path aligned with the normal
+        # conversation loop's finalization order: verifier footer → output
+        # transform hook → closure gate.  This must happen before message sync
+        # and persistence so visible, streamed, returned, and durable transcript
+        # text all describe the same final response.
+        try:
+            failed_mutations = getattr(agent, "_turn_failed_file_mutations", None) or {}
+            if failed_mutations and agent._file_mutation_verifier_enabled():
+                footer = agent._format_file_mutation_failure_footer(failed_mutations)
+                if footer:
+                    final_text = final_text.rstrip() + "\n\n" + footer
+        except Exception:
+            logger.debug("codex app-server file-mutation verifier raised", exc_info=True)
+
+        try:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook
+
+            transform_results = _invoke_hook(
+                "transform_llm_output",
+                response_text=final_text,
+                session_id=agent.session_id or "",
+                model=agent.model,
+                platform=getattr(agent, "platform", None) or "",
+            )
+            for hook_result in transform_results:
+                if isinstance(hook_result, str) and hook_result:
+                    final_text = hook_result
+                    break
+        except Exception:
+            logger.debug("codex app-server transform_llm_output hook raised", exc_info=True)
+
+        try:
+            if agent._closure_gate_enabled():
+                final_text = agent._apply_closure_gate_footer(final_text)
+        except Exception:
+            logger.debug("codex app-server closure gate raised", exc_info=True)
+
+    if final_text and final_text != previous_final_text and not turn.interrupted and turn.error is None:
+        try:
+            agent._emit_postprocessed_stream_suffix(
+                previous_final_text or "",
+                final_text,
+            )
+        except Exception:
+            logger.debug("codex app-server stream suffix raised", exc_info=True)
+        try:
+            agent._sync_final_response_to_messages(
+                messages,
+                final_text,
+                previous_response=previous_final_text,
+            )
+        except Exception:
+            logger.debug("codex app-server message sync raised", exc_info=True)
+
     # Counter ticks for the agent-improvement loop.
     # _turns_since_memory and _user_turn_count are ALREADY incremented
     # in the run_conversation() pre-loop block (lines ~11793-11817) so we
@@ -138,7 +210,7 @@ def run_codex_app_server_turn(
         try:
             agent._sync_external_memory_for_turn(
                 original_user_message=original_user_message,
-                final_response=turn.final_text,
+                final_response=final_text,
                 interrupted=False,
             )
         except Exception:
@@ -148,7 +220,7 @@ def run_codex_app_server_turn(
     # path (line ~15449). Only fires when a trigger actually tripped AND
     # we have a real final response.
     if (
-        turn.final_text
+        final_text
         and not turn.interrupted
         and (should_review_memory or should_review_skills)
     ):
@@ -161,11 +233,26 @@ def run_codex_app_server_turn(
         except Exception:
             logger.debug("background review spawn raised", exc_info=True)
 
+    completed = not turn.interrupted and turn.error is None
+    try:
+        agent._cleanup_task_resources(effective_task_id)
+    except Exception:
+        logger.debug("codex app-server cleanup raised", exc_info=True)
+    try:
+        agent._persist_session(messages, conversation_history)
+    except Exception:
+        logger.debug("codex app-server persist raised", exc_info=True)
+    try:
+        agent.clear_interrupt()
+    except Exception:
+        logger.debug("codex app-server clear_interrupt raised", exc_info=True)
+    agent._stream_callback = None
+
     return {
-        "final_response": turn.final_text,
+        "final_response": final_text,
         "messages": messages,
         "api_calls": 1,  # one app-server "turn" maps to one logical API call
-        "completed": not turn.interrupted and turn.error is None,
+        "completed": completed,
         "partial": turn.interrupted or turn.error is not None,
         "error": turn.error,
         "codex_thread_id": turn.thread_id,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -637,6 +637,7 @@ def run_conversation(
             user_message=user_message,
             original_user_message=original_user_message,
             messages=messages,
+            conversation_history=conversation_history,
             effective_task_id=effective_task_id,
             should_review_memory=_should_review_memory,
         )
@@ -3948,63 +3949,20 @@ def run_conversation(
         and not failed
     )
 
-    # Save trajectory if enabled.  ``user_message`` may be a multimodal
-    # list of parts; the trajectory format wants a plain string.
-    agent._save_trajectory(messages, _summarize_user_message_for_log(user_message), completed)
-
-    # Clean up VM and browser for this task after conversation completes
+    # Clean up VM and browser for this task after conversation completes.
     agent._cleanup_task_resources(effective_task_id)
 
-    # Persist session to both JSON log and SQLite only after private retry
-    # scaffolding has been removed. Otherwise a later user "continue" turn
-    # can replay assistant("(empty)") / recovery nudges and fall into the
-    # same empty-response loop again.
+    # Remove private retry scaffolding before final-response postprocessing and
+    # persistence. Otherwise a later user "continue" turn can replay
+    # assistant("(empty)") / recovery nudges and fall into the same
+    # empty-response loop again.
     agent._drop_trailing_empty_response_scaffolding(messages)
-    agent._persist_session(messages, conversation_history)
 
-    # ── Turn-exit diagnostic log ─────────────────────────────────────
-    # Always logged at INFO so agent.log captures WHY every turn ended.
-    # When the last message is a tool result (agent was mid-work), log
-    # at WARNING — this is the "just stops" scenario users report.
-    _last_msg_role = messages[-1].get("role") if messages else None
-    _last_tool_name = None
-    if _last_msg_role == "tool":
-        # Walk back to find the assistant message with the tool call
-        for _m in reversed(messages):
-            if _m.get("role") == "assistant" and _m.get("tool_calls"):
-                _tcs = _m["tool_calls"]
-                if _tcs and isinstance(_tcs[0], dict):
-                    _last_tool_name = _tcs[-1].get("function", {}).get("name")
-                break
-
-    _turn_tool_count = sum(
-        1 for m in messages
-        if isinstance(m, dict) and m.get("role") == "assistant" and m.get("tool_calls")
-    )
-    _resp_len = len(final_response) if final_response else 0
-    _budget_used = agent.iteration_budget.used if agent.iteration_budget else 0
-    _budget_max = agent.iteration_budget.max_total if agent.iteration_budget else 0
-
-    _diag_msg = (
-        "Turn ended: reason=%s model=%s api_calls=%d/%d budget=%d/%d "
-        "tool_turns=%d last_msg_role=%s response_len=%d session=%s"
-    )
-    _diag_args = (
-        _turn_exit_reason, agent.model, api_call_count, agent.max_iterations,
-        _budget_used, _budget_max,
-        _turn_tool_count, _last_msg_role, _resp_len,
-        agent.session_id or "none",
-    )
-
-    if _last_msg_role == "tool" and not interrupted:
-        # Agent was mid-work — this is the "just stops" case.
-        logger.warning(
-            "Turn ended with pending tool result (agent may appear stuck). "
-            + _diag_msg + " last_tool=%s",
-            *_diag_args, _last_tool_name,
-        )
-    else:
-        logger.info(_diag_msg, *_diag_args)
+    # Runtime-side postprocessors must run BEFORE persistence. The closure gate
+    # and file-mutation verifier are safety boundaries; if they only appear in
+    # the returned result but not in the session log / SQLite transcript, resume
+    # and gateway consumers lose the boundary.
+    _pre_postprocess_final_response = final_response
 
     # File-mutation verifier footer.
     # If one or more ``write_file`` / ``patch`` calls failed during this
@@ -4051,6 +4009,85 @@ def run_conversation(
                     break  # First non-empty string wins
         except Exception as exc:
             logger.warning("transform_llm_output hook failed: %s", exc)
+
+    # Closure gate footer.
+    # This is deliberately runtime-side rather than prompt-only: opted-in
+    # profiles get a compact status/proof boundary appended when the model's
+    # final text lacks an explicit closure record.  Apply after output
+    # transforms so plugins cannot accidentally strip the gate.
+    if final_response and not interrupted:
+        try:
+            if agent._closure_gate_enabled():
+                final_response = agent._apply_closure_gate_footer(final_response)
+        except Exception as _closure_err:
+            logger.debug("closure gate footer failed: %s", _closure_err)
+
+    if final_response and not interrupted:
+        try:
+            agent._emit_postprocessed_stream_suffix(
+                _pre_postprocess_final_response or "",
+                final_response,
+            )
+        except Exception as _stream_sync_err:
+            logger.debug("postprocessed stream suffix failed: %s", _stream_sync_err)
+        try:
+            agent._sync_final_response_to_messages(
+                messages,
+                final_response,
+                previous_response=_pre_postprocess_final_response,
+            )
+        except Exception as _message_sync_err:
+            logger.debug("final response message sync failed: %s", _message_sync_err)
+
+    # Save trajectory and persist only after postprocessed final_response has
+    # been synced back into messages, so all durable transcripts match exactly
+    # what the caller receives.
+    agent._save_trajectory(messages, _summarize_user_message_for_log(user_message), completed)
+    agent._persist_session(messages, conversation_history)
+
+    # ── Turn-exit diagnostic log ─────────────────────────────────────
+    # Always logged at INFO so agent.log captures WHY every turn ended.
+    # When the last message is a tool result (agent was mid-work), log
+    # at WARNING — this is the "just stops" scenario users report.
+    _last_msg_role = messages[-1].get("role") if messages else None
+    _last_tool_name = None
+    if _last_msg_role == "tool":
+        # Walk back to find the assistant message with the tool call
+        for _m in reversed(messages):
+            if _m.get("role") == "assistant" and _m.get("tool_calls"):
+                _tcs = _m["tool_calls"]
+                if _tcs and isinstance(_tcs[0], dict):
+                    _last_tool_name = _tcs[-1].get("function", {}).get("name")
+                break
+
+    _turn_tool_count = sum(
+        1 for m in messages
+        if isinstance(m, dict) and m.get("role") == "assistant" and m.get("tool_calls")
+    )
+    _resp_len = len(final_response) if final_response else 0
+    _budget_used = agent.iteration_budget.used if agent.iteration_budget else 0
+    _budget_max = agent.iteration_budget.max_total if agent.iteration_budget else 0
+
+    _diag_msg = (
+        "Turn ended: reason=%s model=%s api_calls=%d/%d budget=%d/%d "
+        "tool_turns=%d last_msg_role=%s response_len=%d session=%s"
+    )
+    _diag_args = (
+        _turn_exit_reason, agent.model, api_call_count, agent.max_iterations,
+        _budget_used, _budget_max,
+        _turn_tool_count, _last_msg_role, _resp_len,
+        agent.session_id or "none",
+    )
+
+    if _last_msg_role == "tool" and not interrupted:
+        # Agent was mid-work — this is the "just stops" case.
+        logger.warning(
+            "Turn ended with pending tool result (agent may appear stuck). "
+            + _diag_msg + " last_tool=%s",
+            *_diag_args, _last_tool_name,
+        )
+    else:
+        logger.info(_diag_msg, *_diag_args)
 
     # Plugin hook: post_llm_call
     # Fired once per turn after the tool-calling loop completes.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1033,6 +1033,12 @@ DEFAULT_CONFIG = {
         # class of over-claim that otherwise forces users to run
         # `git status` to verify edits landed.  Set false to suppress.
         "file_mutation_verifier": True,
+        # Final-response closure gate.  Off by default globally; profiles can
+        # opt in to require a compact status/proof boundary before the response
+        # leaves the runtime.  HERMES_CLOSURE_GATE overrides this value.
+        "closure_gate": {
+            "enabled": False,
+        },
         "show_cost": False,       # Show $ cost in the status bar (off by default)
         "skin": "default",
         # UI language for static user-facing messages (approval prompts, a

--- a/run_agent.py
+++ b/run_agent.py
@@ -1875,6 +1875,50 @@ class AIAgent:
             lines.append(f"  • … and {remaining} more")
         return "\n".join(lines)
 
+    def _closure_gate_enabled(self) -> bool:
+        """Check whether the final-response closure gate is on.
+
+        Config path: ``display.closure_gate.enabled`` or legacy bool
+        ``display.closure_gate``.  ``HERMES_CLOSURE_GATE`` overrides config.
+        Default is off so only profiles that opt in receive the advisory.
+        """
+        try:
+            env = os.environ.get("HERMES_CLOSURE_GATE")
+            if env is not None:
+                return env.strip().lower() not in {"0", "false", "no", "off"}
+            try:
+                from hermes_cli.config import load_config as _load_config
+                _cfg = _load_config() or {}
+            except Exception:
+                _cfg = {}
+            _display = _cfg.get("display") if isinstance(_cfg, dict) else None
+            if isinstance(_display, dict) and "closure_gate" in _display:
+                _gate = _display.get("closure_gate")
+                if isinstance(_gate, dict):
+                    return bool(_gate.get("enabled", False))
+                return bool(_gate)
+        except Exception:
+            pass
+        return False
+
+    @staticmethod
+    def _has_closure_gate_record(text: str) -> bool:
+        """Return True when the response already has status/proof closure."""
+        if not text:
+            return False
+        return bool(re.search(r"(?im)^\s*status\s*=.+\bproof\s*=", text))
+
+    def _apply_closure_gate_footer(self, final_response: str) -> str:
+        """Append a compact proof/status advisory unless one already exists."""
+        if not final_response or self._has_closure_gate_record(final_response):
+            return final_response
+        footer = (
+            "Closure gate: status=unverified "
+            "proof=missing explicit status/proof closure "
+            "boundary=do not treat this as verified completion without checked evidence"
+        )
+        return final_response.rstrip() + "\n\n" + footer
+
     def _apply_pending_steer_to_tool_results(self, messages: list, num_tool_msgs: int) -> None:
         """Forwarder — see ``agent.agent_runtime_helpers.apply_pending_steer_to_tool_results``."""
         from agent.agent_runtime_helpers import apply_pending_steer_to_tool_results
@@ -3025,6 +3069,86 @@ class AIAgent:
                 getattr(self, "_current_streamed_assistant_text", "") + text
             )
 
+    def _sync_final_response_to_messages(
+        self,
+        messages: list,
+        final_response: str,
+        *,
+        previous_response: str | None = None,
+    ) -> bool:
+        """Keep the durable final assistant message aligned with postprocessing.
+
+        Runtime-side postprocessors (plugin output transforms, verifier footers,
+        closure-gate footers) run after the model's final assistant message has
+        already been appended to ``messages``.  Without this sync, callers see a
+        guarded ``final_response`` while the persisted transcript keeps the
+        unguarded text, so resume/gateway/session consumers lose the boundary.
+        """
+        if not isinstance(messages, list) or not isinstance(final_response, str):
+            return False
+        if previous_response is not None and final_response == previous_response:
+            return False
+
+        for msg in reversed(messages):
+            if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                continue
+            content = msg.get("content")
+            if previous_response is None:
+                if msg.get("tool_calls"):
+                    return False
+                msg["content"] = final_response
+                return True
+            if content == previous_response:
+                msg["content"] = final_response
+                return True
+            if isinstance(content, str) and content.strip() == previous_response.strip():
+                msg["content"] = final_response
+                return True
+            # The latest assistant message did not match the text being
+            # postprocessed; do not risk rewriting an earlier/tool-call turn.
+            return False
+        return False
+
+    def _emit_postprocessed_stream_suffix(
+        self,
+        previous_response: str,
+        final_response: str,
+    ) -> bool:
+        """Emit only newly-added postprocessing text after streamed output.
+
+        If the model already streamed ``previous_response`` to the UI and a
+        runtime footer later extends it, send just the suffix so the visible
+        stream matches the final returned text without replaying the answer.
+        """
+        if not isinstance(previous_response, str) or not isinstance(final_response, str):
+            return False
+        if not final_response or final_response == previous_response:
+            return False
+        streamed = getattr(self, "_current_streamed_assistant_text", "") or ""
+        if not streamed or streamed != previous_response:
+            return False
+        if not final_response.startswith(previous_response):
+            return False
+        suffix = final_response[len(previous_response):]
+        if not suffix:
+            return False
+        callbacks = [
+            cb for cb in (
+                getattr(self, "stream_delta_callback", None),
+                getattr(self, "_stream_callback", None),
+            ) if cb is not None
+        ]
+        delivered = False
+        for cb in callbacks:
+            try:
+                cb(suffix)
+                delivered = True
+            except Exception:
+                logger.debug("postprocessed stream suffix callback failed", exc_info=True)
+        if delivered:
+            self._record_streamed_assistant_text(suffix)
+        return delivered
+
     @staticmethod
     def _normalize_interim_visible_text(text: str) -> str:
         if not isinstance(text, str):
@@ -4084,11 +4208,12 @@ class AIAgent:
         original_user_message: Any,
         messages: List[Dict[str, Any]],
         effective_task_id: str,
+        conversation_history: Optional[List[Dict[str, Any]]] = None,
         should_review_memory: bool = False,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.codex_runtime.run_codex_app_server_turn``."""
         from agent.codex_runtime import run_codex_app_server_turn
-        return run_codex_app_server_turn(self, user_message=user_message, original_user_message=original_user_message, messages=messages, effective_task_id=effective_task_id, should_review_memory=should_review_memory)
+        return run_codex_app_server_turn(self, user_message=user_message, original_user_message=original_user_message, messages=messages, conversation_history=conversation_history, effective_task_id=effective_task_id, should_review_memory=should_review_memory)
 
 def main(
     query: str = None,

--- a/tests/run_agent/test_closure_gate.py
+++ b/tests/run_agent/test_closure_gate.py
@@ -1,0 +1,193 @@
+"""Tests for the configurable pre-final closure gate.
+
+The closure gate is intentionally runtime-side, not prompt-only: when enabled
+for a profile such as Peter, the final response must carry an explicit
+``status=... proof=...`` closure line or get an automatic advisory before it is
+returned to the user.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _bare_agent() -> AIAgent:
+    return object.__new__(AIAgent)
+
+
+def _mock_response(content: str = "Done."):
+    msg = SimpleNamespace(content=content, tool_calls=None)
+    choice = SimpleNamespace(message=msg, finish_reason="stop")
+    return SimpleNamespace(
+        choices=[choice],
+        model="test/model",
+        usage=SimpleNamespace(prompt_tokens=5, completion_tokens=3, total_tokens=8),
+    )
+
+
+def _make_agent_with_response(content: str) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            session_db=MagicMock(),
+            session_id="closure-gate-test",
+            platform="cli",
+        )
+    agent.client = MagicMock()
+    agent.client.chat.completions.create.return_value = _mock_response(content)
+    return agent
+
+
+class TestClosureGateEnabled:
+    def test_default_is_disabled(self, monkeypatch):
+        monkeypatch.delenv("HERMES_CLOSURE_GATE", raising=False)
+        import hermes_cli.config as _cfg_mod
+
+        monkeypatch.setattr(_cfg_mod, "load_config", lambda: {})
+        assert _bare_agent()._closure_gate_enabled() is False
+
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on"])
+    def test_env_enables(self, monkeypatch, value):
+        monkeypatch.setenv("HERMES_CLOSURE_GATE", value)
+        assert _bare_agent()._closure_gate_enabled() is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "FALSE", "no", "off"])
+    def test_env_disables_over_config(self, monkeypatch, value):
+        monkeypatch.setenv("HERMES_CLOSURE_GATE", value)
+        import hermes_cli.config as _cfg_mod
+
+        monkeypatch.setattr(
+            _cfg_mod,
+            "load_config",
+            lambda: {"display": {"closure_gate": {"enabled": True}}},
+        )
+        assert _bare_agent()._closure_gate_enabled() is False
+
+    def test_config_object_enables_when_no_env(self, monkeypatch):
+        monkeypatch.delenv("HERMES_CLOSURE_GATE", raising=False)
+        import hermes_cli.config as _cfg_mod
+
+        monkeypatch.setattr(
+            _cfg_mod,
+            "load_config",
+            lambda: {"display": {"closure_gate": {"enabled": True}}},
+        )
+        assert _bare_agent()._closure_gate_enabled() is True
+
+    def test_config_bool_enables_when_no_env(self, monkeypatch):
+        monkeypatch.delenv("HERMES_CLOSURE_GATE", raising=False)
+        import hermes_cli.config as _cfg_mod
+
+        monkeypatch.setattr(
+            _cfg_mod,
+            "load_config",
+            lambda: {"display": {"closure_gate": True}},
+        )
+        assert _bare_agent()._closure_gate_enabled() is True
+
+
+class TestClosureGateFooter:
+    def test_footer_added_when_missing_explicit_closure_line(self):
+        out = _bare_agent()._apply_closure_gate_footer("Done.")
+
+        assert out.startswith("Done.")
+        assert "Closure gate:" in out
+        assert "status=unverified" in out
+        assert "proof=missing explicit status/proof closure" in out
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Done.\n\nstatus=verified proof=pytest tests/run_agent/test_x.py",
+            "Done.\nstatus=done proof=git status reread after patch",
+            "Blocked.\nSTATUS=blocked PROOF=missing credentials",
+        ],
+    )
+    def test_footer_not_added_when_closure_line_present(self, text):
+        assert _bare_agent()._apply_closure_gate_footer(text) == text
+
+    def test_empty_response_not_augmented(self):
+        assert _bare_agent()._apply_closure_gate_footer("") == ""
+
+
+class TestClosureGateRuntimeHook:
+    def test_run_conversation_appends_footer_before_return_when_enabled(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CLOSURE_GATE", "1")
+        agent = _make_agent_with_response("Done.")
+
+        result = agent.run_conversation("finish the task")
+
+        assert result["final_response"].startswith("Done.")
+        assert "Closure gate:" in result["final_response"]
+        assert "status=unverified" in result["final_response"]
+
+    def test_run_conversation_syncs_footer_into_persisted_messages(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CLOSURE_GATE", "1")
+        agent = _make_agent_with_response("Done.")
+
+        result = agent.run_conversation("finish the task")
+
+        assert result["messages"][-1]["role"] == "assistant"
+        assert result["messages"][-1]["content"] == result["final_response"]
+        append_calls = getattr(agent._session_db.append_message, "call_args_list")
+        assistant_db_rows = [
+            call.kwargs
+            for call in append_calls
+            if call.kwargs.get("role") == "assistant"
+        ]
+        assert assistant_db_rows[-1]["content"] == result["final_response"]
+
+    def test_run_conversation_does_not_duplicate_explicit_closure(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CLOSURE_GATE", "1")
+        text = "Done.\n\nstatus=verified proof=targeted pytest passed"
+        agent = _make_agent_with_response(text)
+
+        result = agent.run_conversation("finish the task")
+
+        assert result["final_response"] == text
+
+
+class TestClosureGateDeliveryHelpers:
+    def test_sync_final_response_to_messages_replaces_latest_assistant_text(self):
+        messages = [
+            {"role": "user", "content": "go"},
+            {"role": "assistant", "content": "Done."},
+        ]
+        final = "Done.\n\nClosure gate: status=unverified proof=missing"
+
+        assert _bare_agent()._sync_final_response_to_messages(
+            messages,
+            final,
+            previous_response="Done.",
+        ) is True
+
+        assert messages[-1]["content"] == final
+
+    def test_stream_suffix_helper_emits_only_footer_after_streamed_answer(self):
+        agent = _bare_agent()
+        deltas = []
+        agent.stream_delta_callback = deltas.append
+        agent._stream_callback = None
+        agent._current_streamed_assistant_text = "Done."
+        agent._stream_think_scrubber = None
+        agent._stream_context_scrubber = None
+        agent._stream_needs_break = False
+        final = "Done.\n\nClosure gate: status=unverified proof=missing"
+
+        assert agent._emit_postprocessed_stream_suffix("Done.", final) is True
+
+        assert deltas == ["\n\nClosure gate: status=unverified proof=missing"]
+        assert agent._current_streamed_assistant_text == final

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -12,7 +12,7 @@ Verifies that:
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -49,7 +49,7 @@ def fake_session(monkeypatch):
     )
 
 
-def _make_codex_agent():
+def _make_codex_agent(*, session_db=None, session_id=None, stream_delta_callback=None):
     """Construct an AIAgent in codex_app_server mode without contacting any
     real provider. We pass api_mode explicitly so the constructor takes the
     fast path for direct credentials."""
@@ -61,6 +61,9 @@ def _make_codex_agent():
         quiet_mode=True,
         skip_context_files=True,
         skip_memory=True,
+        session_db=session_db,
+        session_id=session_id or "codex-app-server-test",
+        stream_delta_callback=stream_delta_callback,
     )
 
 
@@ -83,6 +86,199 @@ class TestRunConversationCodexPath:
         assert result["api_calls"] == 1
         assert result["codex_thread_id"] == "thread-stub-1"
         assert result["codex_turn_id"] == "turn-stub-1"
+
+    def test_closure_gate_applies_on_codex_app_server_path(self, fake_session, monkeypatch):
+        """Peter uses codex_app_server, which bypasses conversation_loop footer hooks."""
+        monkeypatch.setenv("HERMES_CLOSURE_GATE", "1")
+        agent = _make_codex_agent()
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("hello closure")
+
+        assert result["final_response"].startswith("echo: hello closure")
+        assert "Closure gate:" in result["final_response"]
+        assert "status=unverified" in result["final_response"]
+        assert result["messages"][-1]["content"] == result["final_response"]
+
+    def test_closure_gate_persists_codex_app_server_final_response_to_session_db(
+        self, fake_session, monkeypatch
+    ):
+        """The Codex early-return path must persist the gated assistant text."""
+        monkeypatch.setenv("HERMES_CLOSURE_GATE", "1")
+        session_db = MagicMock()
+        agent = _make_codex_agent(
+            session_db=session_db,
+            session_id="codex-app-server-db-closure-test",
+        )
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("hello persisted closure")
+
+        assistant_db_rows = [
+            call.kwargs
+            for call in session_db.append_message.call_args_list
+            if call.kwargs.get("role") == "assistant"
+        ]
+        assert assistant_db_rows
+        assert assistant_db_rows[-1]["content"] == result["final_response"]
+        assert "Closure gate:" in assistant_db_rows[-1]["content"]
+
+    def test_closure_gate_streams_only_footer_suffix_on_codex_app_server_path(
+        self, monkeypatch
+    ):
+        """If Codex already streamed the base answer, emit only the footer delta."""
+        deltas = []
+        base_text = "echo: streamed closure"
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            # Simulate the Codex runtime having already delivered the base text
+            # through a stream before final-response postprocessing adds a gate.
+            agent._record_streamed_assistant_text(base_text)
+            return TurnResult(
+                final_text=base_text,
+                projected_messages=[{"role": "assistant", "content": base_text}],
+                tool_iterations=0,
+                interrupted=False,
+                error=None,
+                turn_id="turn-stub-stream",
+                thread_id="thread-stub-stream",
+            )
+
+        monkeypatch.setenv("HERMES_CLOSURE_GATE", "1")
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession, "ensure_started", lambda self: "thread-stub-stream"
+        )
+        agent = _make_codex_agent(stream_delta_callback=deltas.append)
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("hello streamed closure")
+
+        expected_suffix = result["final_response"][len(base_text):]
+        assert expected_suffix.startswith("\n\nClosure gate:")
+        assert deltas == [expected_suffix]
+        assert deltas[0] != result["final_response"]
+        assert base_text not in deltas[0]
+
+    def test_codex_app_server_finalization_runs_verifier_before_message_sync(
+        self, monkeypatch
+    ):
+        """The early-return Codex path must keep verifier footer durable too."""
+        base_text = "echo: verifier closure"
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            setattr(
+                agent,
+                "_turn_failed_file_mutations",
+                {
+                    "/tmp/not-edited.md": {
+                        "tool": "patch",
+                        "error_preview": "Could not find old_string",
+                    }
+                },
+            )
+            return TurnResult(
+                final_text=base_text,
+                projected_messages=[{"role": "assistant", "content": base_text}],
+                tool_iterations=0,
+                interrupted=False,
+                error=None,
+                turn_id="turn-stub-verifier",
+                thread_id="thread-stub-verifier",
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession, "ensure_started", lambda self: "thread-stub-verifier"
+        )
+        session_db = MagicMock()
+        agent = _make_codex_agent(
+            session_db=session_db,
+            session_id="codex-app-server-verifier-test",
+        )
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("hello verifier")
+
+        assert result["final_response"].startswith(base_text)
+        assert "File-mutation verifier" in result["final_response"]
+        assert "/tmp/not-edited.md" in result["final_response"]
+        assert result["messages"][-1]["content"] == result["final_response"]
+
+        assistant_db_rows = [
+            call.kwargs
+            for call in session_db.append_message.call_args_list
+            if call.kwargs.get("role") == "assistant"
+        ]
+        assert assistant_db_rows[-1]["content"] == result["final_response"]
+
+    def test_codex_app_server_transform_runs_before_closure_and_stream_suffix(
+        self, monkeypatch
+    ):
+        """Codex finalization order matches normal runtime: transform, then closure."""
+        deltas = []
+        base_text = "echo: transform streamed"
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            agent._record_streamed_assistant_text(base_text)
+            return TurnResult(
+                final_text=base_text,
+                projected_messages=[{"role": "assistant", "content": base_text}],
+                tool_iterations=0,
+                interrupted=False,
+                error=None,
+                turn_id="turn-stub-transform",
+                thread_id="thread-stub-transform",
+            )
+
+        def fake_invoke_hook(hook_name, **kwargs):
+            if hook_name != "transform_llm_output":
+                return []
+            assert kwargs["response_text"] == base_text
+            return [kwargs["response_text"] + "\ntransformed=1"]
+
+        monkeypatch.setenv("HERMES_CLOSURE_GATE", "1")
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", fake_invoke_hook)
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession, "ensure_started", lambda self: "thread-stub-transform"
+        )
+        agent = _make_codex_agent(stream_delta_callback=deltas.append)
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("hello transform")
+
+        assert result["final_response"].startswith(base_text + "\ntransformed=1")
+        assert result["final_response"].rstrip().endswith(
+            "boundary=do not treat this as verified completion without checked evidence"
+        )
+        assert "Closure gate:" in result["final_response"]
+        expected_suffix = result["final_response"][len(base_text):]
+        assert deltas == [expected_suffix]
+        assert deltas[0].startswith("\ntransformed=1\n\nClosure gate:")
+        assert result["messages"][-1]["content"] == result["final_response"]
+
+    def test_closure_gate_not_duplicated_on_codex_app_server_path(self, monkeypatch):
+        from agent.transports.codex_app_server_session import CodexAppServerSession, TurnResult
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            text = "echo: done\n\nstatus=verified proof=fake codex test"
+            return TurnResult(
+                final_text=text,
+                projected_messages=[{"role": "assistant", "content": text}],
+                tool_iterations=0,
+                interrupted=False,
+                error=None,
+                turn_id="turn-stub-closure",
+                thread_id="thread-stub-closure",
+            )
+
+        monkeypatch.setenv("HERMES_CLOSURE_GATE", "1")
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession, "ensure_started", lambda self: "thread-stub-closure"
+        )
+        agent = _make_codex_agent()
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("hello closure")
+
+        assert result["final_response"].count("Closure gate:") == 0
+        assert result["final_response"].count("status=verified") == 1
 
     def test_projected_messages_are_spliced(self, fake_session):
         agent = _make_codex_agent()

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -950,6 +950,18 @@ class TestBuildAssistantMessage:
 class TestAuxiliaryClientProviderPriority:
     """Verify auxiliary client resolution doesn't break for any provider."""
 
+    @pytest.fixture(autouse=True)
+    def _clear_aux_unhealthy_cache(self):
+        # The auxiliary provider unhealthy cache is deliberately process-wide
+        # in production, but provider-priority tests patch credentials per
+        # test.  Reset it here so earlier run_agent tests cannot poison the
+        # fallback chain for this class in a full-suite run.
+        from agent.auxiliary_client import _reset_aux_unhealthy_cache
+
+        _reset_aux_unhealthy_cache()
+        yield
+        _reset_aux_unhealthy_cache()
+
     def test_openrouter_always_wins(self, monkeypatch):
         monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
         from agent.auxiliary_client import get_text_auxiliary_client


### PR DESCRIPTION
## Summary
- Move Hermes runtime final-response postprocessing before trajectory/session persistence so returned text, streamed text, canonical `messages`, and durable transcripts stay aligned.
- Wire the Codex app-server early-return path through equivalent finalization: file-mutation verifier footer, transform hook, closure gate, stream suffix, message sync, cleanup, persistence, and callback/interrupt clearing.
- Add regression coverage for normal closure-gate persistence, Codex persistence/stream parity, file-mutation verifier interaction, transform ordering, idempotent gate handling, and provider-priority unhealthy-cache test isolation.

## Real behavior proof
- Behavior or issue addressed: Closure-gate and verifier footers could be visible in the returned response but absent from persisted/resumable session history; Codex app-server could bypass the normal finalization block entirely.
- Real environment tested: macOS host, Hermes repo at `/Users/majordomo/.openclaw/workspace/vendor/hermes-agent`, branch `fix/finalize-closure-gate-persistence`, commit `7e9387f51`.
- Exact steps or command run after this patch:

```console
$ venv/bin/python -m pytest tests/run_agent/test_closure_gate.py tests/run_agent/test_codex_app_server_integration.py tests/run_agent/test_file_mutation_verifier.py -q
77 passed, 1 warning

$ venv/bin/python -m pytest tests/run_agent/test_provider_parity.py::TestAuxiliaryClientProviderPriority -q
4 passed, 1 warning

$ venv/bin/python -m py_compile agent/codex_runtime.py agent/conversation_loop.py run_agent.py tests/run_agent/test_closure_gate.py tests/run_agent/test_codex_app_server_integration.py tests/run_agent/test_provider_parity.py hermes_cli/config.py
# passed

$ git diff --check -- agent/codex_runtime.py agent/conversation_loop.py run_agent.py hermes_cli/config.py tests/run_agent/test_closure_gate.py tests/run_agent/test_codex_app_server_integration.py tests/run_agent/test_provider_parity.py
# passed

$ venv/bin/python -m pytest tests/run_agent -q
1446 passed, 3 skipped, 1 warning
```

- Evidence after fix: A clean detached worktree at commit `7e9387f51` was verified with targeted/static checks and the full `tests/run_agent` suite: `1446 passed, 3 skipped, 1 warning`.
- Observed result after fix: Regression tests now assert the finalized response is present in the returned result, canonical assistant message, session DB append payload, and streamed suffix behavior for both normal and Codex app-server paths.
- What was not tested: Live GitHub CI had not completed at PR creation time.

## Test plan
- [x] Targeted closure-gate/Codex/file-mutation verifier regression tests pass.
- [x] Provider-priority test isolation passes.
- [x] Full `tests/run_agent` suite passes in a clean detached worktree at the commit.
- [x] Python compile and `git diff --check` pass.

## Notes
- The first broad suite run exposed an unrelated/order-dependent provider-priority failure caused by `agent.auxiliary_client`'s process-wide unhealthy-provider cache. The patch resets that cache around provider-priority tests only, preserving production cache behavior while keeping mocked test credentials isolated.
