### PR TITLE
fix: clear skills system-prompt cache on /reload-skills when skills change

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -348,11 +348,11 @@ def reload_skills() -> Dict[str, Any]:
     slash-command map (``agent.skill_commands._skill_commands``) reflects
     skills added or removed on disk.
 
-    This does NOT invalidate the skills system-prompt cache. Skills are
-    called by name via ``/skill-name``, ``skills_list``, or ``skill_view``
-    — they don't need to be in the system prompt for the model to use them.
-    Keeping the prompt cache intact preserves prefix caching across the
-    reload, so a user invoking ``/reload-skills`` pays no cache-reset cost.
+    When skills are added or removed, this also clears the skills
+    system-prompt cache (both in-process LRU and disk snapshot) so the
+    ``<available_skills>`` block in future sessions reflects the new
+    catalog. When no skills changed the cache is left intact — prefix
+    caching across the reload is preserved in the common no-op case.
 
     Returns:
         Dict with keys::
@@ -396,6 +396,17 @@ def reload_skills() -> Dict[str, Any]:
     # For removed skills, use the description we had cached pre-rescan
     # (the skill file is gone so we can't re-read it).
     removed = [{"name": n, "description": before[n]} for n in removed_names]
+
+    # Clear the skills system-prompt cache when skills changed on disk
+    # so the ``<available_skills>`` block in future sessions reflects the
+    # new catalog. Skip the clear when nothing changed — that's the common
+    # no-op case and we want to preserve prefix caching across the reload.
+    if added or removed:
+        try:
+            from agent.prompt_builder import clear_skills_system_prompt_cache
+            clear_skills_system_prompt_cache(clear_snapshot=True)
+        except Exception:
+            pass  # Best-effort; don't fail the reload over a cache clear
 
     return {
         "added": added,

--- a/cli.py
+++ b/cli.py
@@ -10133,14 +10133,12 @@ class HermesCLI:
         """Reload skills: rescan ~/.hermes/skills/ and queue a note for the
         next user turn.
 
-        Skills don't need to live in the system prompt for the model to use
-        them (they're invoked via ``/skill-name``, ``skills_list``, or
-        ``skill_view`` at runtime), so this does NOT clear the prompt cache.
-        It rescans the slash-command map, prints the diff for the user, and
-        — if any skills were added or removed — queues a one-shot note that
-        gets prepended to the next user message. This preserves message
-        alternation (no phantom user turn injected out of band) and keeps
-        prompt caching intact.
+        When skills are added or removed, the skills system-prompt cache is
+        cleared so the ``<available_skills>`` block reflects the new catalog
+        in future sessions. The slash-command map is rescanned, the diff is
+        printed for the user, and a one-shot note is queued for the next turn
+        so the model sees the updated skill catalog. This preserves message
+        alternation (no phantom user turn injected out of band).
         """
         try:
             from agent.skill_commands import reload_skills, get_skill_commands

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13131,10 +13131,11 @@ class GatewayRunner:
     async def _handle_reload_skills_command(self, event: MessageEvent) -> str:
         """Handle /reload-skills — rescan skills dir, queue a note for next turn.
 
-        Skills don't need to be in the system prompt for the model to use
-        them (they're invoked via ``/skill-name``, ``skills_list``, or
-        ``skill_view`` at runtime), so this does NOT clear the prompt cache
-        — prefix caching stays intact.
+        When skills are added or removed, the skills system-prompt cache is
+        cleared so the ``<available_skills>`` block in future sessions reflects
+        the new catalog. The slash-command map is rescanned, adapters refresh
+        their platform-side state, and a one-shot note is queued for the next
+        user turn so the model sees the diff.
 
         If any skills were added or removed, a one-shot note is queued on
         ``self._pending_skills_reload_notes[session_key]``. The gateway

--- a/tests/agent/test_skill_commands_reload.py
+++ b/tests/agent/test_skill_commands_reload.py
@@ -2,9 +2,8 @@
 
 Covers the helper that powers ``/reload-skills`` (CLI + gateway slash command).
 The helper rescans the skills directory and returns a diff of what changed.
-It does NOT invalidate the skills system-prompt cache — skills are invoked
-at runtime via ``/skill-name``, ``skills_list``, or ``skill_view`` and don't
-need to live in the system prompt.
+When skills are added or removed it also clears the skills system-prompt cache
+so the ``<available_skills>`` block in future sessions reflects the new catalog.
 
 ``added`` and ``removed`` are lists of ``{"name": str, "description": str}``
 dicts. Descriptions are truncated to 60 chars.
@@ -137,12 +136,13 @@ class TestReloadSkillsHelper:
         assert result["added"] == []
         assert result["removed"] == []
 
-    def test_does_not_invalidate_prompt_cache_snapshot(self, hermes_home):
-        """reload_skills must NOT delete the skills prompt-cache snapshot.
+    def test_preserves_snapshot_when_no_skills_changed(self, hermes_home):
+        """reload_skills preserves the prompt-cache snapshot when nothing changed.
 
-        Skills are called at runtime — the system prompt doesn't need to
-        mention them for the model to use them — so reloading them should
-        preserve prefix caching.
+        When no skills are added or removed the cache is left intact so
+        prefix caching across the reload is preserved in the common no-op
+        case. The test creates a snapshot, calls reload without touching
+        any skill files, and verifies the snapshot survives.
         """
         from agent.prompt_builder import _skills_prompt_snapshot_path
         from agent.skill_commands import reload_skills
@@ -155,6 +155,34 @@ class TestReloadSkillsHelper:
         reload_skills()
 
         assert snapshot.exists(), (
-            "prompt cache snapshot should be preserved — skills don't live "
-            "in the system prompt so there's no reason to invalidate it"
+            "prompt cache snapshot should be preserved when no skills "
+            "changed — clearing it would waste a cold-path rescan"
+        )
+
+    def test_clears_snapshot_when_skills_added(self, hermes_home):
+        """reload_skills clears the prompt-cache snapshot when skills change.
+
+        When a new skill is detected, the system-prompt cache must be
+        invalidated so the ``<available_skills>`` block in future sessions
+        reflects the new catalog.
+        """
+        from agent.prompt_builder import _skills_prompt_snapshot_path
+        from agent.skill_commands import reload_skills, get_skill_commands
+
+        # Prime the cache
+        get_skill_commands()
+
+        # Create a snapshot that should be cleared
+        snapshot = _skills_prompt_snapshot_path()
+        snapshot.parent.mkdir(parents=True, exist_ok=True)
+        snapshot.write_text("{}")
+        assert snapshot.exists()
+
+        # Add a new skill and reload
+        _write_skill(hermes_home / "skills", "new-skill", "brand new")
+        reload_skills()
+
+        assert not snapshot.exists(), (
+            "prompt cache snapshot should be cleared when a new skill is "
+            "added so the <available_skills> block reflects the change"
         )


### PR DESCRIPTION
## Problem

`/reload-skills` only refreshed the slash-command map (`_skill_commands`) but did NOT clear the skills system-prompt cache (`_SKILLS_PROMPT_CACHE` and disk snapshot) managed by `build_skills_system_prompt()`. 

This meant:
- New skills appeared in `hermes skills list` (uses `_find_all_skills()` path)
- But the `<available_skills>` block in the system prompt was stale (uses `build_skills_system_prompt()` → cached result)
- The model could not discover the new skill on its own — the user had to type an explicit `/skill-name`

Reproduction: 
1. Create a new skill in `~/.hermes/skills/` 
2. Run `/reload-skills` → CLI reports the skill as added ✅
3. Start a new session → check `<available_skills>` block → skill missing ❌

Root cause: `build_skills_system_prompt()` has its own two-layer cache (in-process LRU + disk snapshot) that is independent of `_find_all_skills()`. `/reload-skills` only touched the latter.

## Fix

`reload_skills()` now calls `clear_skills_system_prompt_cache(clear_snapshot=True)` when skills are added or removed. The cache is preserved when nothing changed (the common no-op case).

### Changes

| File | Change |
|------|--------|
| `agent/skill_commands.py` | Call `clear_skills_system_prompt_cache()` when `added` or `removed` is non-empty; update docstring |
| `cli.py` | Update `_reload_skills` docstring |
| `gateway/run.py` | Update `_handle_reload_skills_command` docstring |
| `tests/agent/test_skill_commands_reload.py` | Rename snapshot test + add `test_clears_snapshot_when_skills_added` |

## Tests

```
tests/agent/test_skill_commands_reload.py::TestReloadSkillsHelper::test_returns_expected_keys PASSED
tests/agent/test_skill_commands_reload.py::TestReloadSkillsHelper::test_detects_newly_added_skill_with_description PASSED
tests/agent/test_skill_commands_reload.py::TestReloadSkillsHelper::test_detects_removed_skill_carries_description PASSED
tests/agent/test_skill_commands_reload.py::TestReloadSkillsHelper::test_description_passes_through_verbatim PASSED
tests/agent/test_skill_commands_reload.py::TestReloadSkillsHelper::test_unchanged_skills_appear_in_unchanged_list PASSED
tests/agent/test_skill_commands_reload.py::TestReloadSkillsHelper::test_preserves_snapshot_when_no_skills_changed PASSED
tests/agent/test_skill_commands_reload.py::TestReloadSkillsHelper::test_clears_snapshot_when_skills_added PASSED
```

All 36 prompt_builder skill-related tests also pass.