### PR TITLE
fix(kanban): guard write_txn ROLLBACK against SQLite auto-abort

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1478,7 +1478,14 @@ def write_txn(conn: sqlite3.Connection):
     try:
         yield conn
     except Exception:
-        conn.execute("ROLLBACK")
+        try:
+            conn.execute("ROLLBACK")
+        except sqlite3.OperationalError as exc:
+            # SQLite can auto-abort the transaction before we reach the
+            # explicit rollback; keep the original exception in that case.
+            msg = str(exc).lower()
+            if "cannot rollback" not in msg and "no transaction is active" not in msg:
+                raise
         raise
     else:
         conn.execute("COMMIT")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -445,6 +445,7 @@ AUTHOR_MAP = {
     "barnacleboy.jezzahehn@agentmail.to": "JezzaHehn",
     "254021826+dodo-reach@users.noreply.github.com": "dodo-reach",
     "259807879+Bartok9@users.noreply.github.com": "Bartok9",
+    "crayfish-ai@users.noreply.github.com": "crayfish-ai",
     "270082434+crayfish-ai@users.noreply.github.com": "crayfish-ai",
     "241404605+MestreY0d4-Uninter@users.noreply.github.com": "MestreY0d4-Uninter",
     "268667990+Roy-oss1@users.noreply.github.com": "Roy-oss1",

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2012,6 +2012,30 @@ def test_connect_falls_back_to_delete_on_locking_protocol(kanban_home, caplog):
     conn.close()
 
 
+def test_write_txn_ignores_no_active_transaction_rollback_error():
+    """Rollback guard must preserve the original failure when SQLite already aborted."""
+
+    class _Conn:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def execute(self, sql, *args, **kwargs):
+            self.calls.append(sql)
+            if sql == "ROLLBACK":
+                raise sqlite3.OperationalError(
+                    "cannot rollback - no transaction is active"
+                )
+            return None
+
+    conn = _Conn()
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with kb.write_txn(conn):  # type: ignore[arg-type]
+            raise RuntimeError("boom")
+
+    assert conn.calls == ["BEGIN IMMEDIATE", "ROLLBACK"]
+
+
 def test_unlink_tasks_triggers_recompute_ready(kanban_home):
     """Regression test for issue #22459.
 


### PR DESCRIPTION
Guard kanban_db write_txn against SQLite auto-abort by wrapping rollback in exception handler.