### PR TITLE
fix(kanban): reject late-link after child start

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1884,19 +1884,38 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
             raise ValueError(
                 f"linking {parent_id} -> {child_id} would create a cycle"
             )
+        parent_status = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (parent_id,)
+        ).fetchone()["status"]
+        child = conn.execute(
+            "SELECT status, claim_lock FROM tasks WHERE id = ?", (child_id,)
+        ).fetchone()
+        if parent_status != "done":
+            child_status = child["status"]
+            child_claim_lock = child["claim_lock"]
+            if child_status == "ready" and not child_claim_lock:
+                conn.execute(
+                    "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
+                    (child_id,),
+                )
+                _append_event(
+                    conn,
+                    child_id,
+                    "depromoted",
+                    {
+                        "reason": "linked under unfinished parent",
+                        "parent_id": parent_id,
+                    },
+                )
+            elif child_status in {"running", "blocked", "done", "gave_up", "archived"} or child_claim_lock:
+                raise ValueError(
+                    f"cannot link {child_id} under unfinished parent {parent_id}: "
+                    f"child already started (status={child_status})"
+                )
         conn.execute(
             "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
             (parent_id, child_id),
         )
-        # If child was ready but parent is not yet done, demote child to todo.
-        parent_status = conn.execute(
-            "SELECT status FROM tasks WHERE id = ?", (parent_id,)
-        ).fetchone()["status"]
-        if parent_status != "done":
-            conn.execute(
-                "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
-                (child_id,),
-            )
         _append_event(
             conn, child_id, "linked",
             {"parent": parent_id, "child": child_id},

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -445,6 +445,7 @@ AUTHOR_MAP = {
     "barnacleboy.jezzahehn@agentmail.to": "JezzaHehn",
     "254021826+dodo-reach@users.noreply.github.com": "dodo-reach",
     "259807879+Bartok9@users.noreply.github.com": "Bartok9",
+    "crayfish-ai@users.noreply.github.com": "crayfish-ai",
     "270082434+crayfish-ai@users.noreply.github.com": "crayfish-ai",
     "241404605+MestreY0d4-Uninter@users.noreply.github.com": "MestreY0d4-Uninter",
     "268667990+Roy-oss1@users.noreply.github.com": "Roy-oss1",

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -223,6 +223,42 @@ def test_link_demotes_ready_child_to_todo_when_parent_not_done(kanban_home):
         assert kb.get_task(conn, b).status == "ready"
         kb.link_tasks(conn, a, b)
         assert kb.get_task(conn, b).status == "todo"
+        assert [e.kind for e in kb.list_events(conn, b)][-2:] == ["depromoted", "linked"]
+
+
+def test_link_rejects_running_child_when_parent_not_done(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", assignee="worker")
+        assert kb.claim_task(conn, child) is not None
+
+        with pytest.raises(ValueError, match="child already started"):
+            kb.link_tasks(conn, parent, child)
+
+        assert kb.get_task(conn, child).status == "running"
+        edge = conn.execute(
+            "SELECT 1 FROM task_links WHERE parent_id = ? AND child_id = ?",
+            (parent, child),
+        ).fetchone()
+        assert edge is None
+
+
+def test_link_rejects_blocked_child_when_parent_not_done(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", assignee="worker")
+        assert kb.claim_task(conn, child) is not None
+        assert kb.block_task(conn, child, reason="waiting on review")
+
+        with pytest.raises(ValueError, match="child already started"):
+            kb.link_tasks(conn, parent, child)
+
+        assert kb.get_task(conn, child).status == "blocked"
+        edge = conn.execute(
+            "SELECT 1 FROM task_links WHERE parent_id = ? AND child_id = ?",
+            (parent, child),
+        ).fetchone()
+        assert edge is None
 
 
 def test_link_keeps_ready_child_when_parent_already_done(kanban_home):


### PR DESCRIPTION
Reject kanban link requests when child task has already started to prevent stale state.