### PR TITLE
Auto-push LINE slow responses

### DIFF
--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -1078,11 +1078,30 @@ class LineAdapter(BasePlatformAdapter):
         if _is_system_bypass(content):
             return await self._send_text_chunks(chat_id, content, force_push=False)
 
-        # If the chat has a PENDING postback button outstanding, route the
-        # response into the cache for the user to fetch via tap.
+        # If the chat has a PENDING postback button outstanding, keep the
+        # answer available for the button but also push it automatically.
+        # The button is only a reply-token placeholder; requiring a manual
+        # tap after the agent is done makes normal LINE conversations look
+        # stuck.
         pending_rid = self._pending_buttons.get(chat_id)
         if pending_rid:
             self._cache.set_ready(pending_rid, content)
+            result = await self._send_text_chunks(chat_id, content, force_push=True)
+            if result.success:
+                self._cache.mark_delivered(pending_rid)
+                self._pending_buttons.pop(chat_id, None)
+                logger.info(
+                    "LINE: auto-pushed cached slow response for chat %s (rid=%s)",
+                    chat_id,
+                    pending_rid,
+                )
+                return result
+            logger.warning(
+                "LINE: slow response auto-push failed for chat %s (rid=%s): %s",
+                chat_id,
+                pending_rid,
+                result.error,
+            )
             return SendResult(success=True, message_id=pending_rid)
 
         return await self._send_text_chunks(chat_id, content, force_push=False)
@@ -1102,7 +1121,9 @@ class LineAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=None)
         messages = [_text_message(c) for c in chunks][:LINE_MAX_MESSAGES_PER_CALL]
 
-        token, used_reply = self._consume_reply_token(chat_id)
+        token, used_reply = ("", False)
+        if not force_push:
+            token, used_reply = self._consume_reply_token(chat_id)
         if used_reply and not force_push:
             try:
                 await self._client.reply(token, messages)

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -356,17 +356,28 @@ class TestSendRouting:
         assert not result.success
         assert "network" in result.error
 
-    def test_send_pending_button_caches_response(self, adapter):
+    def test_send_pending_button_auto_pushes_and_marks_delivered(self, adapter):
         # Simulate that the slow-LLM postback button has fired.
         rid = adapter._cache.register_pending("Uchat")
         adapter._pending_buttons["Uchat"] = rid
         result = asyncio.run(adapter.send("Uchat", "the answer"))
         assert result.success
-        # Response must have been cached, not pushed/replied.
+        # The answer remains cached for the old button, but it is also
+        # pushed automatically so the chat does not appear stuck.
         adapter._client.reply.assert_not_called()
-        adapter._client.push.assert_not_called()
-        assert adapter._cache.get(rid).state is State.READY
+        adapter._client.push.assert_called_once()
+        assert adapter._cache.get(rid).state is State.DELIVERED
         assert adapter._cache.get(rid).payload == "the answer"
+        assert "Uchat" not in adapter._pending_buttons
+
+    def test_force_push_does_not_consume_reply_token(self, adapter):
+        import time as _time
+        adapter._reply_tokens["Uchat"] = ("rt-token", _time.time() + 30)
+        result = asyncio.run(adapter._send_text_chunks("Uchat", "hello", force_push=True))
+        assert result.success
+        adapter._client.reply.assert_not_called()
+        adapter._client.push.assert_called_once()
+        assert adapter._reply_tokens["Uchat"][0] == "rt-token"
 
     def test_send_system_bypass_skips_postback_cache(self, adapter):
         # Even with a pending button, system busy-acks must surface visibly.


### PR DESCRIPTION
## Summary
- auto-push cached LINE slow responses when a pending postback button exists
- mark the cached response delivered and clear pending button state after successful push
- avoid consuming reply tokens for explicit force-push sends

## Tests
- /Users/liyingpang/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_line_plugin.py