### PR TITLE
fix(agent): guard flock(LOCK_UN) against OSError in google_oauth

### DIFF
--- a/agent/google_oauth.py
+++ b/agent/google_oauth.py
@@ -226,7 +226,10 @@ def _credentials_lock(timeout_seconds: float = LOCK_TIMEOUT_SECONDS):
                 try:
                     import fcntl
 
-                    fcntl.flock(fd, fcntl.LOCK_UN)
+                    try:
+                        fcntl.flock(fd, fcntl.LOCK_UN)
+                    except OSError:
+                        pass
                 except ImportError:
                     try:
                         import msvcrt  # type: ignore[import-not-found]


### PR DESCRIPTION
## Problem

`fcntl.flock(fd, fcntl.LOCK_UN)` in `agent/google_oauth.py:229` is inside `try/except ImportError` but NOT wrapped in `try/except OSError`. If the unlock raises `OSError` (e.g., `EBADF` — bad file descriptor), the exception propagates unexpectedly during cleanup.

The `msvcrt` (Windows) code path already had proper `except OSError: pass` guard, but the POSIX `fcntl` path did not — an asymmetry that can cause lock-related crashes on Linux/macOS.

## Fix

Wrapped `fcntl.flock(fd, LOCK_UN)` in `try/except OSError: pass`, matching the existing `msvcrt` guard pattern.

## Before vs After

| Path | Before | After |
|------|--------|-------|
| POSIX (fcntl) | OSError propagates | Caught and ignored |
| Windows (msvcrt) | Already guarded | No change |

## Files Changed

- `agent/google_oauth.py` — 1 site patched (+4/-1 lines)