### PR TITLE
fix(gateway): replace deprecated datetime.utcnow() in bluebubbles

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -14,7 +14,7 @@ import logging
 import os
 import re
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
 
@@ -393,7 +393,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         payload = {
             "addresses": [address],
             "message": message,
-            "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
+            "tempGuid": f"temp-{datetime.now(timezone.utc).timestamp()}",
         }
         try:
             res = await self._api_post("/api/v1/chat/new", payload)
@@ -449,7 +449,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 )
             payload: Dict[str, Any] = {
                 "chatGuid": guid,
-                "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
+                "tempGuid": f"temp-{datetime.now(timezone.utc).timestamp()}",
                 "message": chunk,
             }
             if reply_to and self._private_api_enabled and self._helper_connected:


### PR DESCRIPTION
## Problem

`datetime.utcnow()` is deprecated since Python 3.12 and emits `DeprecationWarning`. Two occurrences in `gateway/platforms/bluebubbles.py` (lines 383, 439) use it for `tempGuid` generation.

## Fix

Replace `datetime.utcnow()` with `datetime.now(timezone.utc)`. Both produce equivalent UTC timestamps, and `.timestamp()` works identically on both naive and aware datetimes.

Added `timezone` to the existing `from datetime import datetime` import.

## Impact

- Zero behavioral change — timestamps are identical
- Eliminates `DeprecationWarning` on Python 3.12+
- Follows the pattern already used elsewhere in the codebase

## Files Changed

- `gateway/platforms/bluebubbles.py` — import + 2 call sites (+3/-3 lines)