### PR TITLE
fix(provider/zai): probe endpoint in runtime_provider for Coding Plan keys

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -835,6 +835,17 @@ def _resolve_explicit_runtime(
             if provider in ("kimi-coding", "kimi-coding-cn"):
                 creds = resolve_api_key_provider_credentials(provider)
                 base_url = creds.get("base_url", "").rstrip("/")
+            elif provider == "zai":
+                from hermes_cli.auth import _resolve_zai_base_url
+                # Probe Z.AI endpoints to detect Coding Plan vs standard keys.
+                # Without this, config.yaml base_url (defaulting to /api/paas/v4)
+                # is used even when the key is a Coding Plan key that only works
+                # on /api/coding/paas/v4, causing HTTP 429 on every request.
+                creds = resolve_api_key_provider_credentials(provider)
+                _zai_key = creds.get("api_key", "")
+                base_url = _resolve_zai_base_url(
+                    _zai_key, pconfig.inference_base_url, env_url,
+                )
             else:
                 base_url = env_url or pconfig.inference_base_url
 


### PR DESCRIPTION
## Problem

Z.AI Coding Plan API keys only work on `/api/coding/paas/v4`, not the standard `/api/paas/v4`. When a user configures `provider: zai` in config.yaml (which defaults `base_url` to `/api/paas/v4`), Coding Plan keys get **HTTP 429 "Insufficient balance or no resource package"** on every request.

The existing `_resolve_zai_base_url()` in `auth.py` correctly probes all 4 Z.AI endpoints and auto-detects the right one per key type, but it was **only called from the credential_pool code path**. The main `_resolve_explicit_runtime()` path in `runtime_provider.py` bypassed the probe entirely.

## Root Cause

In `_resolve_explicit_runtime()` (runtime_provider.py:833-839), the `zai` provider falls into the generic `else` branch:

```python
else:
    base_url = env_url or pconfig.inference_base_url  # always paas/v4
```

No endpoint probe is performed. The `kimi-coding` provider already has a special branch here that calls its own resolver — `zai` needs the same treatment.

## Fix

Add a `zai`-specific branch that calls `_resolve_zai_base_url()` to probe and detect the correct endpoint, following the exact same pattern already used for `kimi-coding`. **11 lines added, 0 lines changed.**

## Verification

```
# Standard key → probe detects paas/v4 ✅
# Coding Plan key → probe detects coding/paas/v4 ✅ (was 429 before)
```

Tested on WSL2 with Coding Plan key:
- `paas/v4` returns 429
- `coding/paas/v4` returns 200
- After fix, gateway auto-detects coding endpoint

## Related

- #24915 — broader Z.AI provider overhaul (not yet merged)