### PR TITLE
fix(tui): handle Warp Shift+Enter as newline on macOS

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2398,22 +2398,28 @@ _TERMINAL_INPUT_MODE_RESET_SEQ = (
 
 
 def _preserve_ctrl_enter_newline() -> bool:
-    """Detect environments where Ctrl+Enter must produce a newline, not submit.
+    """Detect environments where c-j (LF) must produce a newline, not submit.
 
-    Native Windows, WSL, SSH sessions, and Windows Terminal all send Ctrl+Enter
-    as bare LF (c-j). On those terminals c-j must NOT be bound to submit;
-    binding it to submit makes Ctrl+Enter (intended as 'newline like Alt+Enter')
-    submit instead. Local POSIX TTYs that deliver Enter as LF (docker exec,
+    Several terminals emit a distinct Enter-with-modifier keystroke as bare
+    LF (c-j), separate from plain Enter (c-m):
+      - Native Windows, WSL, SSH sessions, and Windows Terminal send
+        Ctrl+Enter as c-j (issue #22379).
+      - Warp (TERM_PROGRAM=WarpTerminal) sends Shift+Enter as c-j on macOS.
+
+    On those terminals c-j must NOT be bound to submit; binding it to submit
+    makes the user's intended 'newline like Alt+Enter' keystroke submit
+    instead. Local POSIX TTYs that deliver plain Enter as LF (docker exec,
     some thin PTYs without SSH) still need c-j bound to submit, so we keep
     that binding for those.
-
-    See issue #22379.
     """
     if sys.platform == "win32":
         return True
     if any(os.environ.get(v) for v in ("SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY")):
         return True
     if os.environ.get("WT_SESSION"):
+        return True
+    # Warp.dev sends Shift+Enter as c-j; keep it free for the newline handler.
+    if os.environ.get("TERM_PROGRAM", "").lower() == "warpterminal":
         return True
     if "microsoft" in os.environ.get("WSL_DISTRO_NAME", "").lower():
         return True

--- a/tests/cli/test_ctrl_enter_newline.py
+++ b/tests/cli/test_ctrl_enter_newline.py
@@ -51,6 +51,36 @@ def test_windows_terminal_session_preserves_newline():
             assert cli_mod._preserve_ctrl_enter_newline() is True
 
 
+def test_warp_terminal_preserves_newline_on_macos():
+    """Warp.dev emits Shift+Enter as bare LF (c-j) on macOS. Without the
+    Warp-aware gate, c-j gets bound to submit and Shift+Enter submits
+    instead of inserting a newline."""
+    import cli as cli_mod
+    with patch.object(sys, "platform", "darwin"):
+        with patch.dict(os.environ, {"TERM_PROGRAM": "WarpTerminal"}, clear=True):
+            with patch("builtins.open", side_effect=OSError("no /proc on mac")):
+                assert cli_mod._preserve_ctrl_enter_newline() is True
+
+
+def test_warp_terminal_case_insensitive():
+    """Match TERM_PROGRAM case-insensitively so a future capitalisation
+    tweak from Warp doesn't silently regress."""
+    import cli as cli_mod
+    with patch.object(sys, "platform", "darwin"):
+        with patch.dict(os.environ, {"TERM_PROGRAM": "warpterminal"}, clear=True):
+            with patch("builtins.open", side_effect=OSError("no /proc on mac")):
+                assert cli_mod._preserve_ctrl_enter_newline() is True
+
+
+def test_non_warp_term_program_does_not_preserve():
+    """iTerm2, Apple_Terminal, etc. shouldn't trip the Warp branch."""
+    import cli as cli_mod
+    with patch.object(sys, "platform", "darwin"):
+        with patch.dict(os.environ, {"TERM_PROGRAM": "iTerm.app"}, clear=True):
+            with patch("builtins.open", side_effect=OSError("no /proc on mac")):
+                assert cli_mod._preserve_ctrl_enter_newline() is False
+
+
 def test_pure_local_linux_does_not_preserve():
     """A bare local Linux TTY (no SSH/WSL/WT) keeps c-j → submit so docker exec
     style Enter-as-LF stays usable."""


### PR DESCRIPTION
## What does this PR do?

Makes Shift+Enter insert a newline (instead of submitting the prompt) when running the Hermes TUI inside Warp.dev on macOS.

Warp emits Shift+Enter as bare LF (`c-j`) on macOS, distinct from plain Enter (`c-m`). Hermes already has a `c-j → insert newline` handler in `cli.py` (around L12472) that gets registered conditionally via `_preserve_ctrl_enter_newline()`. That detector previously only returned True for Windows / WSL / SSH / Windows Terminal — the four environments known to send Ctrl+Enter as `c-j`. On Warp it returned False, so `c-j` got bound to submit and the newline handler was never registered. Net effect: Shift+Enter submitted instead of newlining.

The fix adds one branch to the detector: if `TERM_PROGRAM=WarpTerminal`, treat `c-j` as a newline-producing keystroke. Plain Enter (`c-m`) still submits, and the check is `TERM_PROGRAM`-specific so iTerm2, Apple_Terminal, etc. are unaffected.

## Related Issue

Fixes # <!-- no upstream issue; reported by a user in Discord -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py` — `_preserve_ctrl_enter_newline()` now also returns `True` when `TERM_PROGRAM.lower() == "warpterminal"`. Docstring updated to document Warp's Shift+Enter alongside Windows Terminal's Ctrl+Enter as the `c-j`-emitting case.
- `tests/cli/test_ctrl_enter_newline.py` — three new regression tests:
  - `test_warp_terminal_preserves_newline_on_macos` — proves the Warp branch fires on darwin.
  - `test_warp_terminal_case_insensitive` — pins the lowercase comparison so a future capitalisation tweak from Warp doesn't silently regress.
  - `test_non_warp_term_program_does_not_preserve` — pins iTerm2 / Apple_Terminal to the default behaviour.

## How to Test

1. Open Warp.dev on macOS and start a Hermes session.
2. Type some text, then press Shift+Enter — cursor should drop to a new line, draft preserved.
3. Press Enter — prompt submits as usual.

Diagnostic evidence Warp emits `c-j` for Shift+Enter on macOS 15.7.3:

```
$ python scripts/keystroke_diagnostic.py
# Press Shift+Enter:
key=<Keys.ControlJ: 'c-j'> data='\n'
```

Test suite:

```
$ source venv/bin/activate && pytest tests/cli/test_ctrl_enter_newline.py -v
============================== 12 passed in 0.35s ==============================
```

Broader cli suite (756 tests) still green:

```
$ pytest tests/cli/ -q --timeout=10 -x
756 passed, 2 warnings in 27.46s
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(tui):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/cli/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.7.3, Warp.dev

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the docstring on `_preserve_ctrl_enter_newline()` now lists Warp alongside Windows Terminal as a c-j-emitting case
- [x] I've updated `cli-config.yaml.example` — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A (no architecture change)
- [x] I've considered cross-platform impact — the change is gated on `TERM_PROGRAM=WarpTerminal`, so Linux/Windows behaviour is unchanged. Warp on Linux uses the same env var, so the fix applies there too if anyone runs the TUI in Warp Linux.
- [x] I've updated tool descriptions/schemas — N/A
