### PR TITLE
fix(dingtalk): finalize open streaming cards before disconnect

### DIFF
--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -358,6 +358,19 @@ class DingTalkAdapter(BasePlatformAdapter):
             await asyncio.gather(*self._bg_tasks, return_exceptions=True)
             self._bg_tasks.clear()
 
+        # Finalize any open streaming cards before the HTTP client closes so
+        # they don't stay stuck in streaming state on DingTalk's UI after
+        # a gateway restart.  _close_streaming_siblings handles its own
+        # per-card exceptions; the outer try is a safety net for token fetch.
+        for _chat_id in list(self._streaming_cards):
+            try:
+                await self._close_streaming_siblings(_chat_id)
+            except Exception as _exc:
+                logger.debug(
+                    "[%s] Failed to finalize streaming card on disconnect for %s: %s",
+                    self.name, _chat_id, _exc,
+                )
+
         if self._http_client:
             await self._http_client.aclose()
             self._http_client = None

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -407,6 +407,36 @@ class TestConnect:
         assert len(adapter._dedup._seen) == 0
         assert adapter._http_client is None
 
+    @pytest.mark.asyncio
+    async def test_disconnect_finalizes_open_streaming_cards(self):
+        """Streaming cards must be finalized before HTTP client closes."""
+        from unittest.mock import AsyncMock, patch
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._http_client = AsyncMock()
+        adapter._stream_task = None
+        adapter._streaming_cards = {
+            "chat-1": {"track-a": "last content"},
+            "chat-2": {"track-b": "other"},
+        }
+
+        close_calls = []
+
+        async def fake_close_siblings(chat_id):
+            # HTTP client must still be alive at call time.
+            assert adapter._http_client is not None, (
+                "HTTP client was already closed before card finalization"
+            )
+            close_calls.append(chat_id)
+            adapter._streaming_cards.pop(chat_id, None)
+
+        with patch.object(adapter, "_close_streaming_siblings", side_effect=fake_close_siblings):
+            await adapter.disconnect()
+
+        assert set(close_calls) == {"chat-1", "chat-2"}
+        assert adapter._streaming_cards == {}
+        assert adapter._http_client is None
+
 
 # ---------------------------------------------------------------------------
 # Platform enum


### PR DESCRIPTION
Salvage of #30878 by @AhmetArif0 onto current main.

## Summary
On gateway restart/shutdown, DingTalk AI-card tool-progress cards that were opened with `finalize=False` stayed stuck in streaming state on DingTalk's UI forever. `disconnect()` ordered `_streaming_cards.clear()` AFTER `_http_client.aclose()`, so cards were never finalized — and the cleared map meant the next session couldn't recover them either.

## Root cause
`_close_streaming_siblings()` needs the HTTP client alive (`_get_access_token` + card-update API). Moving the clear earlier wasn't enough — finalization itself had to happen before `aclose()`.

## Fix
12-line loop in `gateway/platforms/dingtalk.py` `disconnect()` that iterates open `_streaming_cards` and finalizes each via `_close_streaming_siblings(chat_id)` BEFORE `_http_client.aclose()`. `_streaming_cards.clear()` remains as a safety net.

## Validation
- New regression test `test_disconnect_finalizes_open_streaming_cards` asserts HTTP client is alive at finalization time.
- All 68 `tests/gateway/test_dingtalk.py` pass locally.

Closes #30878.

## Infographic

![dingtalk-finalize-streaming-cards-on-disconnect](https://v3b.fal.media/files/b/0a9b7221/-WhJzYHe_5E-OJvVHZDOH_Pe0fmkgS.png)
