### PR TITLE
fix: handle JSON schema union types for Kimi tools

### DIFF
--- a/agent/moonshot_schema.py
+++ b/agent/moonshot_schema.py
@@ -27,6 +27,9 @@ and MoonshotAI/kimi-cli#1595:
    single object schema applied to every array element.  Collapse tuple
    ``items`` to the first element schema (or ``{}`` if the tuple is empty).
    (Ported from anomalyco/opencode#24730.)
+6. JSON Schema type unions (``type: ["string", "null"]``) are valid in
+   draft schemas but Moonshot expects a single scalar type.  Collapse to the
+   first non-null scalar type before doing scalar enum cleanup.
 
 The ``#/definitions/...`` → ``#/$defs/...`` rewrite for draft-07 refs is
 handled separately in ``tools/mcp_tool._normalize_mcp_input_schema`` so it
@@ -48,6 +51,27 @@ _SCHEMA_LIST_KEYS = frozenset({"anyOf", "oneOf", "allOf", "prefixItems"})
 
 # Keys whose values are a single nested schema.
 _SCHEMA_NODE_KEYS = frozenset({"items", "contains", "not", "additionalProperties", "propertyNames"})
+
+
+def _scalar_schema_type(value: Any) -> str | None:
+    """Return a scalar JSON-Schema type from ``value`` if one is present.
+
+    Standard JSON Schema permits union types such as ``["string", "null"]``.
+    Moonshot's flavored validator wants a single scalar type, and the old
+    membership checks used sets directly against ``node["type"]``.  When MCP
+    tools supplied a list-type union, that raised ``TypeError: unhashable type:
+    'list'`` before the request ever reached the provider.
+    """
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    if isinstance(value, list):
+        for item in value:
+            scalar = _scalar_schema_type(item)
+            if scalar and scalar != "null":
+                return scalar
+        return None
+    return None
 
 
 def _repair_schema(node: Any, is_schema: bool = True) -> Any:
@@ -109,7 +133,7 @@ def _repair_schema(node: Any, is_schema: bool = True) -> Any:
     if "anyOf" in repaired and isinstance(repaired["anyOf"], list):
         repaired.pop("type", None)
         non_null = [b for b in repaired["anyOf"]
-                    if isinstance(b, dict) and b.get("type") != "null"]
+                    if isinstance(b, dict) and _scalar_schema_type(b.get("type")) != "null"]
         if non_null and len(non_null) < len(repaired["anyOf"]):
             # Drop the anyOf wrapper — keep only the non-null branch.
             # If there's a single non-null branch, promote it and fall
@@ -131,6 +155,16 @@ def _repair_schema(node: Any, is_schema: bool = True) -> Any:
     # parameter schemas — strip it.
     repaired.pop("nullable", None)
 
+    # Rule 6: collapse JSON-Schema union types to a scalar Moonshot type.
+    # Keep this before missing-type inference and enum cleanup so both paths
+    # can treat node["type"] as hashable/scalar.
+    if "type" in repaired and isinstance(repaired.get("type"), list):
+        scalar_type = _scalar_schema_type(repaired.get("type"))
+        if scalar_type:
+            repaired["type"] = scalar_type
+        else:
+            repaired.pop("type", None)
+
     # Rule 1: property schemas without type need one.  $ref nodes are exempt
     # — their type comes from the referenced definition.
     # Fill missing type BEFORE Rule 3 so enum cleanup can check the type.
@@ -143,7 +177,7 @@ def _repair_schema(node: Any, is_schema: bool = True) -> Any:
     # Strip null and empty-string from enum values, and if the enum becomes
     # empty, drop it entirely.
     if "enum" in repaired and isinstance(repaired["enum"], list):
-        node_type = repaired.get("type")
+        node_type = _scalar_schema_type(repaired.get("type"))
         if node_type in {"string", "integer", "number", "boolean"}:
             cleaned = [v for v in repaired["enum"]
                        if v is not None and v != ""]
@@ -166,8 +200,11 @@ def _repair_schema(node: Any, is_schema: bool = True) -> Any:
 
 def _fill_missing_type(node: Dict[str, Any]) -> Dict[str, Any]:
     """Infer a reasonable ``type`` if this schema node has none."""
-    if "type" in node and node["type"] not in {None, ""}:
-        return node
+    existing_type = _scalar_schema_type(node.get("type"))
+    if existing_type:
+        if node.get("type") == existing_type:
+            return node
+        return {**node, "type": existing_type}
 
     # Heuristic: presence of ``properties`` → object, ``items`` → array, ``enum``
     # → type of first enum value, else fall back to ``string`` (safest scalar).

--- a/tests/agent/test_moonshot_schema.py
+++ b/tests/agent/test_moonshot_schema.py
@@ -119,6 +119,62 @@ class TestMissingTypeFilled:
         assert out["properties"]["payload"]["$ref"] == "#/$defs/Payload"
 
 
+class TestUnionTypeCollapsed:
+    """Rule 6: JSON-Schema type unions must not crash Moonshot sanitizer."""
+
+    def test_type_list_collapses_to_first_non_null_scalar(self):
+        params = {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": ["string", "null"],
+                    "enum": ["alpha", "", None],
+                },
+            },
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        query = out["properties"]["query"]
+        assert query["type"] == "string"
+        assert query["enum"] == ["alpha"]
+
+    def test_type_list_all_null_gets_inferred(self):
+        params = {
+            "type": "object",
+            "properties": {
+                "tags": {"type": ["null", ""], "items": {"type": "string"}},
+            },
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        assert out["properties"]["tags"]["type"] == "array"
+
+    def test_sanitize_tool_list_handles_list_valued_type(self):
+        """Regression for Ollama/Kimi fallback: tool schemas can include
+        list-valued JSON-Schema ``type`` entries from current tool metadata.
+        """
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "example",
+                    "description": "Example",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "choices": {
+                                "type": ["array", "null"],
+                                "items": {"type": ["string", "null"]},
+                            }
+                        },
+                    },
+                },
+            }
+        ]
+        out = sanitize_moonshot_tools(tools)
+        choices = out[0]["function"]["parameters"]["properties"]["choices"]
+        assert choices["type"] == "array"
+        assert choices["items"]["type"] == "string"
+
+
 class TestAnyOfParentType:
     """Rule 2: type must not appear at the anyOf parent level.
 


### PR DESCRIPTION
## What does this PR do?

Fixes a local schema-preparation crash in the Kimi/Moonshot tool-schema sanitizer when a tool schema uses JSON Schema union syntax for nullable fields, for example:
json
{ "type": ["string", "null"] }
or:
json
{ "type": ["array", "null"] }
This is valid JSON Schema, but the Kimi/Moonshot sanitizer assumed `type` was always a scalar string. It then used the value in set-membership checks, such as:
python
node_type in {"string", "number", "integer", "boolean", "array", "object"}
When `node_type` is a list, Python raises:
text
TypeError: unhashable type: 'list'
The failure happens before the request is sent to the provider, so it appears as a local client-side failure rather than a Kimi/Ollama API response.

This PR normalises supported union `type` values before the sanitiser performs scalar-only logic.

## Root cause

The sanitizer did not account for list-valued JSON Schema `type` fields.

Valid general JSON Schema:
json
{
  "type": "object",
  "properties": {
    "choices": {
      "type": ["array", "null"],
      "items": {
        "type": ["string", "null"]
      }
    }
  }
}
Kimi-compatible sanitized form:
json
{
  "type": "object",
  "properties": {
    "choices": {
      "type": "array",
      "items": {
        "type": "string"
      }
    }
  }
}
## Changes Made

- `agent/moonshot_schema.py`
  - Adds scalar normalization for JSON Schema `type` values.
  - Collapses nullable unions such as `["string", "null"]` to `"string"`.
  - Collapses nullable array unions such as `["array", "null"]` to `"array"`.
  - Handles empty/all-null type lists through the existing inference fallback.
  - Updates enum cleanup and `anyOf` null-branch handling to use the normalized scalar type.

- `tests/agent/test_moonshot_schema.py`
  - Adds regression coverage for nullable union types.
  - Verifies list-valued `type` fields no longer raise `TypeError`.
  - Verifies sanitized Kimi/Moonshot tool schemas no longer contain list-valued `type` fields in the affected paths.

## Related Issue

N/A — no linked issue.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behaviour change)
- [ ] 🎯 New skill (bundled or hub)

## How to Test

Run the targeted regression tests:
bash
python -m pytest tests/agent/test_moonshot_schema.py tests/agent/test_model_metadata.py -q -o addopts='' --timeout=30 --timeout-method=signal
Expected result:
text
147 passed
Optional manual check:

Use a Kimi/Moonshot model with tools enabled where at least one tool schema includes nullable union syntax,x, such as:
json
"type": ["array", "null"]
Schemapreparations should be completed without:
text
TypeError: unhashable type: 'list'
## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q`, and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A: code-path bug fix only
- [x] I've updated `cli-config.yaml.example` — N/A: no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A: no architecture/workflow changes
- [x] I've considered cross-platform impact — pure Python schemanormalisation, no platform-specific behaviour
- [x] I've updated tool descriptions/schemas — N/A: sanitizer behavior only, no tool contract changes

## Screenshots / Logs

Targeted test output:
text
147 passed in 2.27s