### PR TITLE
Add Antfarm operator bridge command

### DIFF
--- a/hermes_cli/antfarm_bridge.py
+++ b/hermes_cli/antfarm_bridge.py
@@ -1,0 +1,164 @@
+"""Hermes operator bridge for Antfarm Software Factory commands.
+
+Hermes is the operator/control plane. Antfarm remains runtime truth. This
+module keeps that boundary explicit by invoking the Antfarm operator CLI for
+factory mutations, then optionally annotating Hermes Kanban cards with the
+returned FactoryItem/audit identifiers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from typing import Any, Optional
+
+
+def _antfarm_bin() -> str:
+    return os.environ.get("ANTFARM_BIN", "antfarm")
+
+
+def _run_antfarm(args: list[str]) -> dict[str, Any]:
+    proc = subprocess.run(
+        [_antfarm_bin(), "factory", "operator", *args],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if proc.returncode != 0:
+        detail = proc.stderr.strip() or proc.stdout.strip() or f"exit {proc.returncode}"
+        raise RuntimeError(f"antfarm operator command failed: {detail}")
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"antfarm operator returned non-JSON output: {proc.stdout[:500]}") from exc
+
+
+def _add_optional_flag(cmd: list[str], flag: str, value: Optional[str]) -> None:
+    if value:
+        cmd.extend([flag, value])
+
+
+def _bind_kanban_task(*, board: Optional[str], task_id: Optional[str], factory_item_id: str, audit_event_id: str, author: str) -> None:
+    if not task_id:
+        return
+    from hermes_cli import kanban_db as kb
+
+    kb.init_db(board=board)
+    conn = kb.connect(board=board)
+    body = (
+        f"FactoryItem linked: {factory_item_id}\n"
+        f"Antfarm dashboard_audit_event: {audit_event_id}"
+    )
+    kb.add_comment(conn, task_id, author, body)
+
+
+def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:
+    parser = parent_subparsers.add_parser(
+        "antfarm",
+        help="Operate Antfarm Software Factory through the orchestrator bridge",
+        description=(
+            "Hermes-side operator commands for Antfarm Software Factory. "
+            "Mutations invoke `antfarm factory operator ...`; Hermes does not "
+            "write Antfarm runtime DB tables directly."
+        ),
+    )
+    sub = parser.add_subparsers(dest="antfarm_action")
+
+    p_intake = sub.add_parser("intake", help="Create or link an Antfarm FactoryItem")
+    p_intake.add_argument("--title", required=True)
+    p_intake.add_argument("--factory-item-id", default=None)
+    p_intake.add_argument("--description", default=None)
+    p_intake.add_argument("--repo", default=None)
+    p_intake.add_argument("--issue-url", default=None)
+    p_intake.add_argument("--priority", default=None)
+    p_intake.add_argument("--kanban-task", default=None)
+    p_intake.add_argument("--board", default=None)
+    p_intake.add_argument("--operator", default="hermes")
+
+    p_gate = sub.add_parser("approve-gate", help="Approve or waive a factory gate")
+    p_gate.add_argument("--factory-item-id", required=True)
+    p_gate.add_argument("--factory-run-id", default=None)
+    p_gate.add_argument("--gate", required=True)
+    p_gate.add_argument("--evidence-url", default=None)
+    p_gate.add_argument("--operator", default="hermes")
+
+    for name in ("pause-run", "resume-run", "retry-run"):
+        p_run = sub.add_parser(name, help=f"{name.replace('-', ' ')} through Antfarm orchestrator")
+        p_run.add_argument("--factory-run-id", required=True)
+        p_run.add_argument("--expected-updated-at", default=None)
+        p_run.add_argument("--reason", default=None)
+        p_run.add_argument("--operator", default="hermes")
+
+    p_audit = sub.add_parser("audit", help="List Antfarm dashboard audit events")
+    p_audit.add_argument("--factory-item-id", default=None)
+    p_audit.add_argument("--factory-run-id", default=None)
+    p_audit.add_argument("--limit", default=None)
+
+    return parser
+
+
+def antfarm_command(args: argparse.Namespace) -> int:
+    action = getattr(args, "antfarm_action", None)
+    if not action:
+        print("Missing antfarm action. Use `hermes antfarm --help`.", file=sys.stderr)
+        return 2
+
+    try:
+        if action == "intake":
+            cmd = ["intake", "--title", args.title, "--operator", args.operator, "--source", "hermes-kanban"]
+            _add_optional_flag(cmd, "--factory-item-id", args.factory_item_id)
+            _add_optional_flag(cmd, "--description", args.description)
+            _add_optional_flag(cmd, "--repo", args.repo)
+            _add_optional_flag(cmd, "--issue-url", args.issue_url)
+            _add_optional_flag(cmd, "--priority", args.priority)
+            _add_optional_flag(cmd, "--external-ref", f"kanban:{args.kanban_task}" if args.kanban_task else None)
+            result = _run_antfarm(cmd)
+            factory_item_id = str(result.get("factory_item_id") or "")
+            audit_event_id = str(result.get("audit_event_id") or "")
+            if factory_item_id and audit_event_id:
+                _bind_kanban_task(
+                    board=args.board,
+                    task_id=args.kanban_task,
+                    factory_item_id=factory_item_id,
+                    audit_event_id=audit_event_id,
+                    author=args.operator,
+                )
+            print(json.dumps(result, indent=2, ensure_ascii=False))
+            return 0
+
+        if action == "approve-gate":
+            cmd = [
+                "approve-gate",
+                "--factory-item-id", args.factory_item_id,
+                "--gate", args.gate,
+                "--operator", args.operator,
+            ]
+            _add_optional_flag(cmd, "--factory-run-id", args.factory_run_id)
+            _add_optional_flag(cmd, "--evidence-url", args.evidence_url)
+            print(json.dumps(_run_antfarm(cmd), indent=2, ensure_ascii=False))
+            return 0
+
+        if action in {"pause-run", "resume-run", "retry-run"}:
+            cmd = [action, "--factory-run-id", args.factory_run_id, "--operator", args.operator]
+            _add_optional_flag(cmd, "--expected-updated-at", args.expected_updated_at)
+            _add_optional_flag(cmd, "--reason", args.reason)
+            print(json.dumps(_run_antfarm(cmd), indent=2, ensure_ascii=False))
+            return 0
+
+        if action == "audit":
+            cmd = ["audit"]
+            _add_optional_flag(cmd, "--factory-item-id", args.factory_item_id)
+            _add_optional_flag(cmd, "--factory-run-id", args.factory_run_id)
+            _add_optional_flag(cmd, "--limit", args.limit)
+            print(json.dumps(_run_antfarm(cmd), indent=2, ensure_ascii=False))
+            return 0
+
+        print(f"Unknown antfarm action: {action}", file=sys.stderr)
+        return 2
+    except Exception as exc:
+        print(str(exc), file=sys.stderr)
+        return 1

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6168,6 +6168,13 @@ def cmd_kanban(args):
     return kanban_command(args)
 
 
+def cmd_antfarm(args):
+    """Operate Antfarm Software Factory through the Hermes bridge."""
+    from hermes_cli.antfarm_bridge import antfarm_command
+
+    return antfarm_command(args)
+
+
 def cmd_hooks(args):
     """Shell-hook inspection and management."""
     from hermes_cli.hooks import hooks_command
@@ -10674,7 +10681,7 @@ def _build_provider_choices() -> list[str]:
 # to parse.
 _BUILTIN_SUBCOMMANDS = frozenset(
     {
-        "acp", "auth", "backup", "bundles", "checkpoints", "claw", "completion",
+        "acp", "antfarm", "auth", "backup", "bundles", "checkpoints", "claw", "completion",
         "computer-use",
         "config", "cron", "curator", "dashboard", "debug", "doctor",
         "dump", "fallback", "gateway", "hooks", "import", "insights",
@@ -11911,6 +11918,14 @@ def main():
 
     kanban_parser = _build_kanban_parser(subparsers)
     kanban_parser.set_defaults(func=cmd_kanban)
+
+    # =========================================================================
+    # antfarm command — Software Factory operator bridge
+    # =========================================================================
+    from hermes_cli.antfarm_bridge import build_parser as _build_antfarm_parser
+
+    antfarm_parser = _build_antfarm_parser(subparsers)
+    antfarm_parser.set_defaults(func=cmd_antfarm)
 
     # =========================================================================
     # hooks command — shell-hook inspection and management

--- a/tests/hermes_cli/test_antfarm_bridge.py
+++ b/tests/hermes_cli/test_antfarm_bridge.py
@@ -1,0 +1,94 @@
+import json
+import subprocess
+
+from hermes_cli import antfarm_bridge
+
+
+def test_intake_calls_antfarm_operator_and_binds_kanban(monkeypatch):
+    calls = []
+    bindings = []
+
+    def fake_run(cmd, check, text, stdout, stderr):
+        calls.append(cmd)
+        assert check is False
+        assert text is True
+        assert stdout == subprocess.PIPE
+        assert stderr == subprocess.PIPE
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout=json.dumps({"ok": True, "factory_item_id": "fi_123", "audit_event_id": "ae_123"}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(antfarm_bridge.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        antfarm_bridge,
+        "_bind_kanban_task",
+        lambda **kwargs: bindings.append(kwargs),
+    )
+
+    parser = antfarm_bridge.build_parser(_Subparsers())
+    args = parser.parse_args([
+        "intake",
+        "--title", "Build command audit bridge",
+        "--repo", "fchaudhryspear/antfarm",
+        "--kanban-task", "t_123",
+        "--board", "factory",
+    ])
+
+    assert antfarm_bridge.antfarm_command(args) == 0
+    assert calls == [[
+        "antfarm",
+        "factory",
+        "operator",
+        "intake",
+        "--title", "Build command audit bridge",
+        "--operator", "hermes",
+        "--source", "hermes-kanban",
+        "--repo", "fchaudhryspear/antfarm",
+        "--external-ref", "kanban:t_123",
+    ]]
+    assert bindings == [{
+        "board": "factory",
+        "task_id": "t_123",
+        "factory_item_id": "fi_123",
+        "audit_event_id": "ae_123",
+        "author": "hermes",
+    }]
+
+
+def test_pause_resume_retry_commands_call_antfarm_without_kanban_db(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, check, text, stdout, stderr):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout=json.dumps({"ok": True, "command": cmd[3], "audit_event_id": "ae"}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(antfarm_bridge.subprocess, "run", fake_run)
+    parser = antfarm_bridge.build_parser(_Subparsers())
+
+    for action in ("pause-run", "resume-run", "retry-run"):
+        args = parser.parse_args([
+            action,
+            "--factory-run-id", "fr_123",
+            "--expected-updated-at", "2026-05-24T00:00:00.000Z",
+            "--reason", "operator smoke",
+        ])
+        assert antfarm_bridge.antfarm_command(args) == 0
+
+    assert [call[3] for call in calls] == ["pause-run", "resume-run", "retry-run"]
+    assert all(call[:3] == ["antfarm", "factory", "operator"] for call in calls)
+
+
+class _Subparsers:
+    def add_parser(self, *args, **kwargs):
+        import argparse
+
+        parser = argparse.ArgumentParser(prog=args[0])
+        return parser


### PR DESCRIPTION
## Summary
- add hermes antfarm operator commands for the Agent Swarm v3 Software Factory bridge
- route mutations through antfarm factory operator instead of direct Antfarm DB writes
- bind intake results back to Hermes Kanban comments with FactoryItem and Antfarm audit event IDs
- cover intake binding and pause/resume/retry subprocess routing

## Validation
- scripts/run_tests.sh tests/hermes_cli/test_antfarm_bridge.py
- /Users/faisalshomemacmini/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main antfarm --help
- git diff --check

Linear: ADP-389