### PR TITLE
fix(codex): allow headless app-server exec approvals

### DIFF
--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -708,7 +708,13 @@ class CodexAppServerSession:
             except Exception:
                 logger.exception("approval_callback raised on exec request")
                 return "decline"
-        return "decline"  # fail-closed when no callback wired
+        try:
+            from tools.approval import noninteractive_approval_choice
+            choice = noninteractive_approval_choice(command, env_type="local")
+            return _approval_choice_to_codex_decision(choice)
+        except Exception:
+            logger.exception("non-interactive approval guard raised on exec request")
+            return "decline"
 
     def _decide_apply_patch_approval(self, params: dict) -> str:
         if self._routing.auto_approve_apply_patch:

--- a/cli.py
+++ b/cli.py
@@ -10923,6 +10923,19 @@ class HermesCLI:
         """
         import time as _time
 
+        # Direct/single-query chat (`hermes chat -q`) does not create the
+        # prompt_toolkit Application that can render and answer the approval
+        # panel below. Use Hermes' headless guard policy instead of showing an
+        # invisible prompt and timing out. Interactive TUI sessions keep the
+        # normal approval UI because self._app is set.
+        if getattr(self, "_app", None) is None:
+            try:
+                from tools.approval import noninteractive_approval_choice
+                return noninteractive_approval_choice(command, env_type="local")
+            except Exception as e:
+                logger.error("Headless approval guard failed: %s", e, exc_info=True)
+                return "deny"
+
         with self._approval_lock:
             timeout = int(CLI_CONFIG.get("approvals", {}).get("timeout", 60))
             response_queue = queue.Queue()

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -417,6 +417,30 @@ class TestRunTurn:
 # ---- approval bridge ----
 
 class TestServerRequestRouting:
+    def test_exec_approval_no_callback_uses_noninteractive_guard_for_safe_command(self, monkeypatch):
+        """Headless codex app-server turns should not fail-closed just because
+        there is no prompt_toolkit approval callback. They should use Hermes'
+        normal non-interactive guard policy: hardline commands still block, but
+        ordinary local writes can proceed for one-shot/profile smoke tests."""
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+
+        client = FakeClient()
+        client.queue_server_request(
+            "item/commandExecution/requestApproval",
+            request_id="req-safe-write",
+            command="python -c \"open('/tmp/hermes_codex_safe.txt','w').write('ok')\"",
+            cwd="/tmp",
+        )
+        client.queue_notification(
+            "turn/completed", threadId="t",
+            turn={"id": "tu1", "status": "completed", "error": None},
+        )
+        s = make_session(client)  # no approval_callback wired in headless mode
+        s.run_turn("write a temp file", turn_timeout=1.0)
+        assert ("req-safe-write", {"decision": "accept"}) in client.responses
+
     def test_exec_approval_with_callback_approves_once(self):
         client = FakeClient()
         client.queue_server_request(

--- a/tests/hermes_cli/test_noninteractive_approval_callback.py
+++ b/tests/hermes_cli/test_noninteractive_approval_callback.py
@@ -1,0 +1,50 @@
+"""Regression tests for headless/single-query approval callbacks."""
+
+from __future__ import annotations
+
+import threading
+
+from cli import HermesCLI
+
+
+def _bare_cli_for_approval() -> HermesCLI:
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._app = None
+    cli._approval_lock = threading.Lock()
+    cli._approval_state = None
+    cli._approval_deadline = 0
+    cli._invalidate = lambda *args, **kwargs: None
+    return cli
+
+
+def test_headless_approval_callback_allows_noninteractive_safe_command(monkeypatch):
+    """`hermes chat -q` has no prompt_toolkit app to answer approvals.
+
+    The callback must therefore use Hermes' non-interactive guard policy instead
+    of showing an invisible prompt and timing out. Non-hardline commands should
+    return `once` so codex app-server write smoke tests can proceed.
+    """
+    import cli as cli_module
+
+    monkeypatch.setitem(cli_module.CLI_CONFIG.setdefault("approvals", {}), "timeout", 0)
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+
+    cli = _bare_cli_for_approval()
+    assert cli._approval_callback(
+        "python -c \"open('/tmp/hermes_cli_headless.txt','w').write('ok')\"",
+        "Codex requests exec in /tmp",
+    ) == "once"
+
+
+def test_headless_approval_callback_still_denies_hardline(monkeypatch):
+    import cli as cli_module
+
+    monkeypatch.setitem(cli_module.CLI_CONFIG.setdefault("approvals", {}), "timeout", 0)
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+
+    cli = _bare_cli_for_approval()
+    assert cli._approval_callback("rm -rf /", "Codex requests exec in /") == "deny"

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1420,5 +1420,37 @@ def check_all_command_guards(command: str, env_type: str,
             "user_approved": True, "description": combined_desc}
 
 
+def noninteractive_approval_choice(command: str, env_type: str = "local") -> str:
+    """Return a CLI-style approval choice for a headless command request.
+
+    This is used by runtimes that receive a command-approval request outside a
+    prompt_toolkit UI (notably `hermes chat -q` with codex app-server). It
+    deliberately reuses `check_all_command_guards()` so the hardline floor,
+    sudo-stdin guard, yolo/session state, and cron deny/approve policy stay the
+    single source of truth. We temporarily clear CLI/gateway approval markers
+    so the guard takes its documented non-interactive branch instead of trying
+    to prompt through an unavailable UI.
+
+    Returns `once` when the command may proceed, otherwise `deny`.
+    """
+    saved = {
+        "HERMES_INTERACTIVE": os.environ.get("HERMES_INTERACTIVE"),
+        "HERMES_EXEC_ASK": os.environ.get("HERMES_EXEC_ASK"),
+    }
+    try:
+        os.environ.pop("HERMES_INTERACTIVE", None)
+        os.environ.pop("HERMES_EXEC_ASK", None)
+        result = check_all_command_guards(
+            command, env_type, approval_callback=None
+        )
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+    return "once" if result.get("approved") else "deny"
+
+
 # Load permanent allowlist from config on module import
 load_permanent_allowlist()


### PR DESCRIPTION
## Summary
- Use the non-interactive approval guard when codex app-server receives exec approval requests without a prompt_toolkit callback.
- Keep hardline commands denied while allowing safe headless one-shot/profile smoke tests to proceed.

## Test Plan
- [x] `tests/tools/test_approval.py`
- [x] `tests/agent/transports/test_codex_app_server_session.py`
- [x] `tests/hermes_cli/test_noninteractive_approval_callback.py`

Uploaded from LangLang production local patch after rebasing on the latest `origin/main`.
