### PR TITLE
fix(hindsight): align lazy runtime dependency with 0.6.2

### DIFF
--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -117,7 +117,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
 
     # ─── Memory providers ──────────────────────────────────────────────────
     "memory.honcho": ("honcho-ai==2.0.1",),
-    "memory.hindsight": ("hindsight-client==0.6.1",),
+    "memory.hindsight": ("hindsight-client==0.6.2",),
 
     # ─── Messaging platforms (lazy-installable on demand) ──────────────────
     "platform.telegram": ("python-telegram-bot[webhooks]==22.6",),


### PR DESCRIPTION
## Summary
- Update the lazy-installed Hindsight client dependency from 0.6.1 to 0.6.2.
- Keeps the memory provider dependency aligned with the runtime API expected by current Hindsight integrations.

## Test Plan
- [x] `py_compile tools/lazy_deps.py`

Uploaded from LangLang production local patch after rebasing on the latest `origin/main`.
