### PR TITLE
fix(kanban): migrate additive columns before indexing

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1353,7 +1353,6 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         _add_column_if_missing(
             conn, "tasks", "session_id", "session_id TEXT"
         )
-
     # Indexes over additive ``tasks`` columns must be created after the
     # columns exist. Keeping them in SCHEMA_SQL breaks legacy boards: SQLite
     # parses each statement in ``executescript`` against the live schema, so a

--- a/tests/hermes_cli/test_kanban_db_init.py
+++ b/tests/hermes_cli/test_kanban_db_init.py
@@ -1,9 +1,72 @@
 from __future__ import annotations
 
+import sqlite3
 import threading
 from pathlib import Path
 
 from hermes_cli import kanban_db as kb
+
+
+def test_connect_migrates_legacy_indexed_columns_before_creating_indexes(tmp_path):
+    db_path = tmp_path / "legacy-kanban.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE tasks (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                body TEXT,
+                assignee TEXT,
+                status TEXT NOT NULL,
+                priority INTEGER DEFAULT 0,
+                created_by TEXT,
+                created_at INTEGER NOT NULL,
+                started_at INTEGER,
+                completed_at INTEGER,
+                workspace_kind TEXT NOT NULL DEFAULT 'scratch',
+                workspace_path TEXT,
+                branch_name TEXT,
+                claim_lock TEXT,
+                claim_expires INTEGER,
+                tenant TEXT,
+                result TEXT,
+                idempotency_key TEXT,
+                consecutive_failures INTEGER NOT NULL DEFAULT 0,
+                worker_pid INTEGER,
+                last_failure_error TEXT,
+                max_runtime_seconds INTEGER,
+                last_heartbeat_at INTEGER,
+                current_run_id INTEGER,
+                workflow_template_id TEXT,
+                current_step_key TEXT,
+                skills TEXT,
+                model_override TEXT,
+                max_retries INTEGER
+            );
+            CREATE TABLE task_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                task_id TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                payload TEXT,
+                created_at INTEGER NOT NULL
+            );
+            """
+        )
+    finally:
+        conn.close()
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+    with kb.connect(db_path) as migrated:
+        task_cols = {row["name"] for row in migrated.execute("PRAGMA table_info(tasks)")}
+        event_cols = {row["name"] for row in migrated.execute("PRAGMA table_info(task_events)")}
+        task_indexes = {row["name"] for row in migrated.execute("PRAGMA index_list(tasks)")}
+        event_indexes = {row["name"] for row in migrated.execute("PRAGMA index_list(task_events)")}
+
+    assert "session_id" in task_cols
+    assert "run_id" in event_cols
+    assert "idx_tasks_session_id" in task_indexes
+    assert "idx_events_run" in event_indexes
 
 
 def test_connect_initialization_is_thread_safe(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Ensure legacy Kanban board databases add session_id/run_id before indexes over those additive columns are created.
- Add regression coverage for the legacy board shape.

## Test Plan
- [x] `tests/hermes_cli/test_kanban_db_init.py`

Uploaded from LangLang production local patch after rebasing on the latest `origin/main`.
