### PR TITLE
feat(feishu): add sender profile prefixes for shared groups

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -858,6 +858,12 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["group_allow_admin_from"] = platform_cfg["group_allow_admin_from"]
                 if "group_user_allowed_commands" in platform_cfg:
                     bridged["group_user_allowed_commands"] = platform_cfg["group_user_allowed_commands"]
+                if "sender_profiles" in platform_cfg:
+                    sender_profiles = platform_cfg["sender_profiles"]
+                    if isinstance(sender_profiles, dict):
+                        bridged["sender_profiles"] = {str(k): v for k, v in sender_profiles.items()}
+                    else:
+                        bridged["sender_profiles"] = sender_profiles
                 if plat in {Platform.DISCORD, Platform.SLACK} and "channel_skill_bindings" in platform_cfg:
                     bridged["channel_skill_bindings"] = platform_cfg["channel_skill_bindings"]
                 if "channel_prompts" in platform_cfg:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -925,6 +925,7 @@ from gateway.session import (
     build_session_context_prompt,
     build_session_key,
     is_shared_multi_user_session,
+    prefix_shared_sender_message,
 )
 from gateway.delivery import DeliveryRouter
 from gateway.platforms.base import (
@@ -15510,6 +15511,20 @@ class GatewayRunner:
         This is run in a thread pool to not block the event loop.
         Supports interruption via new messages.
         """
+        # In shared group/thread sessions, inject the sender relationship into
+        # the actual user turn before it reaches either the local agent or proxy.
+        # This prevents non-owner/unknown group participants from being treated
+        # as the root persona's "主人" just because they share the transcript.
+        try:
+            if is_shared_multi_user_session(
+                source,
+                group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),
+                thread_sessions_per_user=getattr(self.config, "thread_sessions_per_user", False),
+            ):
+                message = prefix_shared_sender_message(message, source, self.config)
+        except Exception:
+            logger.debug("Failed to prefix shared-session sender metadata", exc_info=True)
+
         # ---- Proxy mode: delegate to remote API server ----
         if self._get_proxy_url():
             return await self._run_agent_via_proxy(

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -192,6 +192,95 @@ class SessionContext:
         }
 
 
+def _coerce_sender_profile_map(config: GatewayConfig, platform: Platform) -> Dict[str, Dict[str, Any]]:
+    """Return the configured sender profile map for a platform.
+
+    Profiles intentionally live in platform ``extra`` config so operators can
+    define relationship/addressing rules without hard-coding private IDs in
+    source. Keys are usually platform user IDs (Feishu ``open_id``/``user_id``
+    or ``union_id``), but each profile may also expose ``ids``/``aliases``.
+    """
+    try:
+        platform_cfg = config.platforms.get(platform)
+        raw = (platform_cfg.extra or {}).get("sender_profiles") if platform_cfg else None
+    except Exception:
+        raw = None
+    if not isinstance(raw, dict):
+        return {}
+    return {str(k): v for k, v in raw.items() if isinstance(v, dict)}
+
+
+def _lookup_sender_profile(
+    source: SessionSource,
+    config: GatewayConfig,
+) -> Optional[Dict[str, Any]]:
+    profiles = _coerce_sender_profile_map(config, source.platform)
+    if not profiles:
+        return None
+    candidates = [
+        source.user_id,
+        source.user_id_alt,
+        source.user_name,
+    ]
+    for candidate in candidates:
+        if candidate and str(candidate) in profiles:
+            return profiles[str(candidate)]
+    for profile in profiles.values():
+        aliases = profile.get("ids") or profile.get("aliases") or []
+        if isinstance(aliases, (str, int)):
+            aliases = [aliases]
+        alias_set = {str(v) for v in aliases if v is not None}
+        if any(candidate and str(candidate) in alias_set for candidate in candidates):
+            return profile
+    return None
+
+
+def _speaker_fallback_name(source: SessionSource) -> str:
+    if source.user_name:
+        return str(source.user_name).strip()
+    if source.platform == Platform.FEISHU and source.user_id:
+        return f"unknown Feishu user {source.user_id}"
+    return str(source.user_id or source.user_id_alt or "unknown user")
+
+
+def format_shared_sender_prefix(source: SessionSource, config: GatewayConfig) -> str:
+    """Format the per-message sender prefix for shared multi-user sessions.
+
+    The prefix is deliberately stronger than a display name: it carries the
+    relationship/addressing rule into the user turn so a shared group does not
+    inherit the root persona's "主人" address term for every participant. Unknown
+    participants fall back to an explicit non-owner label instead of bare text.
+    """
+    profile = _lookup_sender_profile(source, config) or {}
+    name = str(profile.get("name") or profile.get("display_name") or _speaker_fallback_name(source)).strip()
+    role = str(profile.get("role") or ("unknown" if not profile else "participant")).strip()
+    relationship = str(profile.get("relationship") or "").strip()
+    address_as = str(profile.get("address_as") or ("对方/这位用户" if not profile else name)).strip()
+    not_owner = bool(profile.get("not_owner")) or role.lower() in {"unknown", "collaborator", "guest", "client"}
+
+    parts = [f"Speaker: {name}", f"role: {role}"]
+    if relationship:
+        parts.append(f"relationship: {relationship}")
+    if address_as:
+        parts.append(f"address_as: {address_as}")
+    if not_owner:
+        parts.append("not_owner: true")
+    return "[" + " | ".join(parts) + "]"
+
+
+def prefix_shared_sender_message(
+    message: str,
+    source: SessionSource,
+    config: GatewayConfig,
+) -> str:
+    """Prepend sender relationship metadata to a shared-session user message."""
+    prefix = format_shared_sender_prefix(source, config)
+    text = str(message or "")
+    if text.startswith(prefix):
+        return text
+    return f"{prefix}\n{text}" if text else prefix
+
+
 _PII_SAFE_PLATFORMS = frozenset({
     Platform.WHATSAPP,
     Platform.SIGNAL,
@@ -303,8 +392,9 @@ def build_session_context_prompt(
     if context.shared_multi_user_session:
         session_label = "Multi-user thread" if context.source.thread_id else "Multi-user session"
         lines.append(
-            f"**Session type:** {session_label} — messages are prefixed "
-            "with [sender name]. Multiple users may participate."
+            f"**Session type:** {session_label} — each user turn is prefixed "
+            "with [Speaker: ... | role: ... | address_as: ...]. Multiple users may participate; "
+            "do not infer that every participant is the owner/主人."
         )
     elif context.source.user_name:
         lines.append(f"**User:** {context.source.user_name}")

--- a/tests/gateway/test_sender_profiles.py
+++ b/tests/gateway/test_sender_profiles.py
@@ -1,0 +1,81 @@
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.session import SessionSource
+
+
+def _config_with_profiles():
+    return GatewayConfig(
+        platforms={
+            Platform.FEISHU: PlatformConfig(
+                enabled=True,
+                extra={
+                    "sender_profiles": {
+                        "ou_owner": {
+                            "name": "孙炜臻",
+                            "role": "owner",
+                            "relationship": "主人 / LangLang owner",
+                            "address_as": "主人",
+                        },
+                        "ou_collab": {
+                            "name": "小鱼",
+                            "role": "collaborator",
+                            "relationship": "工作群协作方，不是主人",
+                            "address_as": "小鱼",
+                            "not_owner": True,
+                        },
+                    }
+                },
+            )
+        },
+        group_sessions_per_user=False,
+    )
+
+
+def test_shared_sender_prefix_uses_configured_owner_relationship():
+    from gateway.session import format_shared_sender_prefix
+
+    cfg = _config_with_profiles()
+    src = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_workgroup",
+        chat_type="group",
+        user_id="ou_owner",
+        user_name="Raw Owner Name",
+    )
+
+    assert format_shared_sender_prefix(src, cfg) == (
+        "[Speaker: 孙炜臻 | role: owner | relationship: 主人 / LangLang owner | address_as: 主人]"
+    )
+
+
+def test_shared_sender_prefix_marks_configured_non_owner_collaborator():
+    from gateway.session import format_shared_sender_prefix
+
+    cfg = _config_with_profiles()
+    src = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_workgroup",
+        chat_type="group",
+        user_id="ou_collab",
+        user_name="Raw Collab Name",
+    )
+
+    assert format_shared_sender_prefix(src, cfg) == (
+        "[Speaker: 小鱼 | role: collaborator | relationship: 工作群协作方，不是主人 | address_as: 小鱼 | not_owner: true]"
+    )
+
+
+def test_shared_sender_prefix_unknown_sender_has_safe_non_owner_fallback():
+    from gateway.session import format_shared_sender_prefix
+
+    cfg = _config_with_profiles()
+    src = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_workgroup",
+        chat_type="group",
+        user_id="ou_unknown",
+        user_name=None,
+    )
+
+    assert format_shared_sender_prefix(src, cfg) == (
+        "[Speaker: unknown Feishu user ou_unknown | role: unknown | address_as: 对方/这位用户 | not_owner: true]"
+    )


### PR DESCRIPTION
## Summary
- Bridge sender_profiles from Feishu platform config into shared group/thread sessions.
- Prefix shared-session user turns with speaker/role/addressing metadata so non-owner participants are not treated as the root owner persona.

## Test Plan
- [x] `tests/gateway/test_sender_profiles.py`

Uploaded from LangLang production local patch after rebasing on the latest `origin/main`.
