### PR TITLE
fix(bedrock): forward context-1m beta on native Converse adapter (#31277)

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -404,6 +404,75 @@ def is_anthropic_bedrock_model(model_id: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# 1M-context beta support (issue #31277)
+# ---------------------------------------------------------------------------
+# PR #16793 wired ``context-1m-2025-08-07`` into the OpenAI-compat Bedrock
+# path through ``agent/anthropic_adapter.py:build_anthropic_bedrock_client``.
+# That fix is invisible to users on the *native* Converse adapter — the
+# wizard's recommended default for direct AWS Bedrock without a proxy —
+# because Converse takes provider-specific betas via
+# ``additionalModelRequestFields={"anthropic_beta": [...]}`` rather than an
+# HTTP header.
+#
+# We gate the injection on an opt-in env var so accounts that don't have the
+# 1M-context entitlement on their Bedrock allowlist aren't broken: AWS will
+# refuse the request with ``ValidationException`` rather than silently
+# truncating, so an unconditional injection would regress every account
+# without the entitlement. Users who DO have it set
+# ``HERMES_BEDROCK_1M_CONTEXT=1`` once and forget about it.
+
+_BEDROCK_1M_CONTEXT_ENV = "HERMES_BEDROCK_1M_CONTEXT"
+_BEDROCK_CONTEXT_1M_BETA = "context-1m-2025-08-07"
+
+# Models that AWS Bedrock advertises 1M context for when the
+# ``context-1m-2025-08-07`` beta is on the request.  Match by substring
+# against the lower-cased model id so versioned/profile ids resolve too:
+# ``us.anthropic.claude-opus-4-7``, ``anthropic.claude-opus-4-6-20250514-v1:0``,
+# ``global.anthropic.claude-sonnet-4-6``, etc.
+_BEDROCK_1M_CAPABLE_PATTERNS: Tuple[str, ...] = (
+    "claude-opus-4-7",
+    "claude-opus-4.7",
+    "claude-opus-4-6",
+    "claude-opus-4.6",
+    "claude-sonnet-4-6",
+    "claude-sonnet-4.6",
+)
+
+
+def bedrock_1m_context_enabled(env: Optional[Dict[str, str]] = None) -> bool:
+    """Return True iff the user has opted into the Bedrock 1M-context beta.
+
+    Reads ``HERMES_BEDROCK_1M_CONTEXT`` from the supplied env (defaults to
+    ``os.environ``).  Accepts the project-wide truthy set (``1``, ``true``,
+    ``yes``, ``on``); anything else — including unset — is False.
+    Default-OFF on purpose: AWS hard-rejects the beta on accounts without
+    the entitlement, so an opt-in flag keeps the existing 200K behavior
+    for everyone who hasn't asked for 1M.
+    """
+    src = env if env is not None else os.environ
+    try:
+        from utils import is_truthy_value
+        return is_truthy_value(src.get(_BEDROCK_1M_CONTEXT_ENV))
+    except ImportError:  # pragma: no cover — utils is a sibling top-level module
+        val = (src.get(_BEDROCK_1M_CONTEXT_ENV) or "").strip().lower()
+        return val in {"1", "true", "yes", "on"}
+
+
+def is_anthropic_opus_4_1m_capable(model_id: str) -> bool:
+    """Return True if *model_id* is an Anthropic 1M-context-capable Claude.
+
+    Matches the model families AWS lists as 1M-eligible behind the
+    ``context-1m-2025-08-07`` beta — Opus 4.6/4.7 and Sonnet 4.6 — across
+    all the spelling variants Bedrock surfaces (regional inference
+    profiles, dot-vs-dash, versioned suffixes).
+    """
+    if not model_id:
+        return False
+    model_lower = model_id.lower()
+    return any(p in model_lower for p in _BEDROCK_1M_CAPABLE_PATTERNS)
+
+
+# ---------------------------------------------------------------------------
 # Message format conversion: OpenAI → Bedrock Converse
 # ---------------------------------------------------------------------------
 
@@ -882,10 +951,18 @@ def build_converse_kwargs(
     top_p: Optional[float] = None,
     stop_sequences: Optional[List[str]] = None,
     guardrail_config: Optional[Dict] = None,
+    additional_model_request_fields: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Build kwargs for ``bedrock-runtime.converse()`` or ``converse_stream()``.
 
     Converts OpenAI-format inputs to Converse API parameters.
+
+    When the user opts into ``HERMES_BEDROCK_1M_CONTEXT=1`` AND *model* is
+    an Anthropic Opus 4.6/4.7 or Sonnet 4.6 inference profile, the
+    ``context-1m-2025-08-07`` beta is merged into the request's
+    ``additionalModelRequestFields["anthropic_beta"]``.  Caller-supplied
+    betas are preserved (no clobbering); duplicates are de-duplicated.
+    Issue #31277.
     """
     system_prompt, converse_messages = convert_messages_to_converse(messages)
 
@@ -928,6 +1005,31 @@ def build_converse_kwargs(
     if guardrail_config:
         kwargs["guardrailConfig"] = guardrail_config
 
+    # ``additionalModelRequestFields`` is the Converse-API channel for
+    # provider-specific extensions; for Anthropic that's where the
+    # ``anthropic_beta`` array lives. Build the fields dict by:
+    #   1. starting from any caller-supplied dict (so future callers can
+    #      thread through extended-thinking / guardrail-trace betas etc.),
+    #   2. layering in the auto-injected 1M-context beta when both opt-in
+    #      and capability checks pass,
+    # then merge betas into a single de-duplicated list so we never clobber
+    # user-supplied entries.
+    extra_fields: Dict[str, Any] = {}
+    if additional_model_request_fields:
+        extra_fields.update(additional_model_request_fields)
+
+    if (
+        bedrock_1m_context_enabled()
+        and is_anthropic_opus_4_1m_capable(model)
+    ):
+        existing_betas = list(extra_fields.get("anthropic_beta") or [])
+        if _BEDROCK_CONTEXT_1M_BETA not in existing_betas:
+            existing_betas.append(_BEDROCK_CONTEXT_1M_BETA)
+        extra_fields["anthropic_beta"] = existing_betas
+
+    if extra_fields:
+        kwargs["additionalModelRequestFields"] = extra_fields
+
     return kwargs
 
 
@@ -941,6 +1043,7 @@ def call_converse(
     top_p: Optional[float] = None,
     stop_sequences: Optional[List[str]] = None,
     guardrail_config: Optional[Dict] = None,
+    additional_model_request_fields: Optional[Dict[str, Any]] = None,
 ) -> SimpleNamespace:
     """Call Bedrock Converse API (non-streaming) and return an OpenAI-compatible response.
 
@@ -956,6 +1059,7 @@ def call_converse(
         top_p=top_p,
         stop_sequences=stop_sequences,
         guardrail_config=guardrail_config,
+        additional_model_request_fields=additional_model_request_fields,
     )
 
     try:
@@ -982,6 +1086,7 @@ def call_converse_stream(
     top_p: Optional[float] = None,
     stop_sequences: Optional[List[str]] = None,
     guardrail_config: Optional[Dict] = None,
+    additional_model_request_fields: Optional[Dict[str, Any]] = None,
 ) -> SimpleNamespace:
     """Call Bedrock ConverseStream API and return an OpenAI-compatible response.
 
@@ -998,6 +1103,7 @@ def call_converse_stream(
         top_p=top_p,
         stop_sequences=stop_sequences,
         guardrail_config=guardrail_config,
+        additional_model_request_fields=additional_model_request_fields,
     )
 
     try:
@@ -1243,7 +1349,12 @@ def classify_bedrock_error(error_message: str) -> str:
 # detection is unavailable.
 
 BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
-    # Anthropic Claude models on Bedrock
+    # Anthropic Claude models on Bedrock.
+    # Values here are the *unbeta-d* defaults — Bedrock caps Opus 4.6/4.7
+    # and Sonnet 4.6 at 200K unless the request carries the
+    # ``context-1m-2025-08-07`` beta. ``get_bedrock_context_length`` returns
+    # 1M for those models when ``HERMES_BEDROCK_1M_CONTEXT`` is opted in.
+    "anthropic.claude-opus-4-7":     200_000,
     "anthropic.claude-opus-4-6":     200_000,
     "anthropic.claude-sonnet-4-6":   200_000,
     "anthropic.claude-sonnet-4-5":   200_000,
@@ -1278,7 +1389,18 @@ def get_bedrock_context_length(model_id: str) -> int:
 
     Uses substring matching so versioned IDs like
     ``anthropic.claude-sonnet-4-6-20250514-v1:0`` resolve correctly.
+
+    Returns 1M only when both:
+      * the user has opted into ``HERMES_BEDROCK_1M_CONTEXT``, AND
+      * the model is one of the Anthropic 1M-capable Claude families
+        (Opus 4.6/4.7, Sonnet 4.6).
+
+    Otherwise returns the unbeta-d default from ``BEDROCK_CONTEXT_LENGTHS``.
+    Issue #31277.
     """
+    if bedrock_1m_context_enabled() and is_anthropic_opus_4_1m_capable(model_id):
+        return 1_000_000
+
     model_lower = model_id.lower()
     best_key = ""
     best_val = BEDROCK_DEFAULT_CONTEXT_LENGTH

--- a/tests/agent/test_bedrock_1m_context.py
+++ b/tests/agent/test_bedrock_1m_context.py
@@ -7,9 +7,17 @@ caps these models at 200K even though ``model_metadata.py`` advertises 1M.
 
 These tests guard the invariant that the header is always emitted on the
 Bedrock client path, and that it survives the MiniMax bearer-auth strip.
+
+The ``TestBedrockConverse1MBeta`` and ``TestBedrockContextLength1M``
+classes cover the *native* Bedrock Converse adapter
+(``agent/bedrock_adapter.py``) — PR #16793 only patched the OpenAI-compat
+``AnthropicBedrock`` SDK path; users on the wizard's recommended
+``bedrock_converse`` provider were stuck at 200K. Issue #31277.
 """
 
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 
 class TestBedrockContext1MBeta:
@@ -61,3 +69,231 @@ class TestBedrockContext1MBeta:
         # Other common betas still present — no regression.
         assert "interleaved-thinking-2025-05-14" in beta_header
         assert "fine-grained-tool-streaming-2025-05-14" in beta_header
+
+
+# ---------------------------------------------------------------------------
+# Native Bedrock Converse adapter — issue #31277
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def bedrock_1m_opt_in(monkeypatch):
+    """Set ``HERMES_BEDROCK_1M_CONTEXT=1`` for the duration of the test."""
+    monkeypatch.setenv("HERMES_BEDROCK_1M_CONTEXT", "1")
+
+
+@pytest.fixture
+def bedrock_1m_opt_out(monkeypatch):
+    """Ensure the opt-in env var is unset (default behavior)."""
+    monkeypatch.delenv("HERMES_BEDROCK_1M_CONTEXT", raising=False)
+
+
+class TestBedrockConverseOptInGate:
+    """``HERMES_BEDROCK_1M_CONTEXT`` controls whether the beta is injected."""
+
+    def test_opt_in_truthy_values(self, monkeypatch):
+        from agent.bedrock_adapter import bedrock_1m_context_enabled
+
+        for val in ("1", "true", "yes", "on", "TRUE", "Yes"):
+            monkeypatch.setenv("HERMES_BEDROCK_1M_CONTEXT", val)
+            assert bedrock_1m_context_enabled() is True, val
+
+    def test_opt_out_default_and_falsy(self, monkeypatch):
+        from agent.bedrock_adapter import bedrock_1m_context_enabled
+
+        monkeypatch.delenv("HERMES_BEDROCK_1M_CONTEXT", raising=False)
+        assert bedrock_1m_context_enabled() is False
+
+        for val in ("0", "false", "no", "off", "", "  "):
+            monkeypatch.setenv("HERMES_BEDROCK_1M_CONTEXT", val)
+            assert bedrock_1m_context_enabled() is False, val
+
+
+class TestAnthropicOpus4Capability:
+    """``is_anthropic_opus_4_1m_capable`` matches all Bedrock spelling variants."""
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "anthropic.claude-opus-4-7",
+            "us.anthropic.claude-opus-4-7",
+            "global.anthropic.claude-opus-4-7-20260101-v1:0",
+            "anthropic.claude-opus-4-6",
+            "us.anthropic.claude-opus-4-6",
+            "anthropic.claude-sonnet-4-6",
+            "global.anthropic.claude-sonnet-4-6",
+            # Dot-spelling (OpenRouter-style) — unlikely on Bedrock but the
+            # lookup table accepts both so the matcher must too.
+            "anthropic.claude-opus-4.7",
+            "anthropic.claude-sonnet-4.6",
+        ],
+    )
+    def test_capable_models(self, model_id):
+        from agent.bedrock_adapter import is_anthropic_opus_4_1m_capable
+
+        assert is_anthropic_opus_4_1m_capable(model_id) is True, model_id
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "anthropic.claude-opus-4",
+            "anthropic.claude-sonnet-4",
+            "anthropic.claude-sonnet-4-5",
+            "anthropic.claude-haiku-4-5",
+            "anthropic.claude-3-5-sonnet",
+            "anthropic.claude-3-opus",
+            "amazon.nova-pro",
+            "meta.llama4-maverick",
+            "",
+            "claude-opus-4",
+        ],
+    )
+    def test_non_capable_models(self, model_id):
+        from agent.bedrock_adapter import is_anthropic_opus_4_1m_capable
+
+        assert is_anthropic_opus_4_1m_capable(model_id) is False, model_id
+
+
+class TestBedrockConverse1MBeta:
+    """``build_converse_kwargs`` injects the 1M beta when capable + opt-in."""
+
+    def test_opt_in_capable_model_injects_beta(self, bedrock_1m_opt_in):
+        from agent.bedrock_adapter import build_converse_kwargs
+
+        kwargs = build_converse_kwargs(
+            model="us.anthropic.claude-opus-4-7",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        assert kwargs.get("additionalModelRequestFields") == {
+            "anthropic_beta": ["context-1m-2025-08-07"],
+        }
+
+    def test_opt_in_capable_sonnet_46(self, bedrock_1m_opt_in):
+        from agent.bedrock_adapter import build_converse_kwargs
+
+        kwargs = build_converse_kwargs(
+            model="global.anthropic.claude-sonnet-4-6",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        assert kwargs["additionalModelRequestFields"]["anthropic_beta"] == [
+            "context-1m-2025-08-07"
+        ]
+
+    def test_opt_out_does_not_inject(self, bedrock_1m_opt_out):
+        from agent.bedrock_adapter import build_converse_kwargs
+
+        kwargs = build_converse_kwargs(
+            model="us.anthropic.claude-opus-4-7",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        assert "additionalModelRequestFields" not in kwargs
+
+    def test_opt_in_non_capable_model_does_not_inject(self, bedrock_1m_opt_in):
+        """Opus 4.0 / Sonnet 4 / Nova etc. don't get the beta even if opted in.
+
+        AWS rejects the beta on models that don't carry the entitlement, so
+        guarding by capability is mandatory — opt-in is necessary but not
+        sufficient.
+        """
+        from agent.bedrock_adapter import build_converse_kwargs
+
+        for model in (
+            "anthropic.claude-opus-4",
+            "anthropic.claude-sonnet-4-5",
+            "amazon.nova-pro",
+            "meta.llama4-maverick",
+        ):
+            kwargs = build_converse_kwargs(
+                model=model,
+                messages=[{"role": "user", "content": "hi"}],
+            )
+            assert "additionalModelRequestFields" not in kwargs, model
+
+    def test_caller_supplied_betas_are_merged_not_clobbered(self, bedrock_1m_opt_in):
+        """Future callers passing extended-thinking betas must not lose them."""
+        from agent.bedrock_adapter import build_converse_kwargs
+
+        kwargs = build_converse_kwargs(
+            model="us.anthropic.claude-opus-4-7",
+            messages=[{"role": "user", "content": "hi"}],
+            additional_model_request_fields={
+                "anthropic_beta": ["fine-grained-tool-streaming-2025-05-14"],
+                "extra_field": "preserved",
+            },
+        )
+
+        betas = kwargs["additionalModelRequestFields"]["anthropic_beta"]
+        assert "fine-grained-tool-streaming-2025-05-14" in betas
+        assert "context-1m-2025-08-07" in betas
+        assert kwargs["additionalModelRequestFields"]["extra_field"] == "preserved"
+
+    def test_no_double_injection_when_caller_already_has_1m_beta(self, bedrock_1m_opt_in):
+        """Caller-supplied 1M beta isn't duplicated."""
+        from agent.bedrock_adapter import build_converse_kwargs
+
+        kwargs = build_converse_kwargs(
+            model="us.anthropic.claude-opus-4-7",
+            messages=[{"role": "user", "content": "hi"}],
+            additional_model_request_fields={
+                "anthropic_beta": ["context-1m-2025-08-07"],
+            },
+        )
+
+        betas = kwargs["additionalModelRequestFields"]["anthropic_beta"]
+        assert betas.count("context-1m-2025-08-07") == 1
+
+    def test_opt_out_preserves_caller_supplied_extra_fields(self, bedrock_1m_opt_out):
+        """Caller-supplied additional fields survive even when opt-in is OFF."""
+        from agent.bedrock_adapter import build_converse_kwargs
+
+        kwargs = build_converse_kwargs(
+            model="us.anthropic.claude-opus-4-7",
+            messages=[{"role": "user", "content": "hi"}],
+            additional_model_request_fields={"some_other_field": 42},
+        )
+
+        assert kwargs["additionalModelRequestFields"] == {"some_other_field": 42}
+
+
+class TestBedrockContextLength1M:
+    """``get_bedrock_context_length`` returns 1M only with capability + opt-in."""
+
+    def test_opt_in_capable_returns_1m(self, bedrock_1m_opt_in):
+        from agent.bedrock_adapter import get_bedrock_context_length
+
+        for model in (
+            "us.anthropic.claude-opus-4-7",
+            "anthropic.claude-opus-4-7",
+            "anthropic.claude-opus-4-6",
+            "anthropic.claude-sonnet-4-6",
+        ):
+            assert get_bedrock_context_length(model) == 1_000_000, model
+
+    def test_opt_out_capable_returns_200k(self, bedrock_1m_opt_out):
+        """Default behavior preserved for accounts without the entitlement."""
+        from agent.bedrock_adapter import get_bedrock_context_length
+
+        for model in (
+            "us.anthropic.claude-opus-4-7",
+            "anthropic.claude-opus-4-6",
+            "anthropic.claude-sonnet-4-6",
+        ):
+            assert get_bedrock_context_length(model) == 200_000, model
+
+    def test_opt_in_non_capable_returns_default(self, bedrock_1m_opt_in):
+        """Opt-in does NOT bump non-1M-capable models above their cap."""
+        from agent.bedrock_adapter import get_bedrock_context_length
+
+        assert get_bedrock_context_length("anthropic.claude-sonnet-4-5") == 200_000
+        assert get_bedrock_context_length("anthropic.claude-3-5-sonnet") == 200_000
+        assert get_bedrock_context_length("amazon.nova-pro") == 300_000
+
+    def test_opus_4_7_in_static_table(self):
+        """Regression for the missing ``claude-opus-4-7`` table entry from #31277."""
+        from agent.bedrock_adapter import BEDROCK_CONTEXT_LENGTHS
+
+        assert "anthropic.claude-opus-4-7" in BEDROCK_CONTEXT_LENGTHS
+        assert BEDROCK_CONTEXT_LENGTHS["anthropic.claude-opus-4-7"] == 200_000

--- a/website/docs/guides/aws-bedrock.md
+++ b/website/docs/guides/aws-bedrock.md
@@ -88,6 +88,20 @@ bedrock:
     refresh_interval: 3600                     # Cache for 1 hour
 ```
 
+### 1M-context window for Claude Opus 4.6/4.7 + Sonnet 4.6
+
+AWS gates the 1M-context window for these models behind an account-level
+entitlement plus the `context-1m-2025-08-07` beta on every request. Once
+your AWS account has the entitlement on its allowlist, opt in with:
+
+```bash
+export HERMES_BEDROCK_1M_CONTEXT=1
+```
+
+When set, Hermes injects `additionalModelRequestFields={"anthropic_beta": ["context-1m-2025-08-07"]}` into every Converse / ConverseStream call for Opus 4.6/4.7 and Sonnet 4.6, and `model_metadata` reports a 1M context window for those models. Other models on the same account are unaffected — the beta is only sent for the capable Anthropic families.
+
+The flag is OFF by default because AWS rejects the beta with `ValidationException` on accounts without the entitlement, so an unconditional injection would regress every account that hasn't been allowlisted.
+
 ## Available Models
 
 Bedrock models use **inference profile IDs** for on-demand invocation. The `hermes model` picker shows these automatically, with recommended models at the top:


### PR DESCRIPTION
## What does this PR do?

Fixes #31277: PR #16793 wired ``context-1m-2025-08-07`` into the OpenAI-compat ``AnthropicBedrock`` SDK path through ``agent/anthropic_adapter.py:build_anthropic_bedrock_client``.  Users on the *native* ``bedrock_converse`` provider — the wizard's recommended default for direct AWS Bedrock without a Mantle/proxy — were stuck at 200K context on Opus 4.6/4.7 and Sonnet 4.6 because Converse takes provider-specific betas through ``additionalModelRequestFields={\"anthropic_beta\": [...]}``, not an HTTP header. ``BEDROCK_CONTEXT_LENGTHS`` was also missing the ``claude-opus-4-7`` row entirely so it fell through to the ``claude-opus-4`` substring (200K) rather than the 1M the entitlement allows.

Three small additions wired together:

1. **Adapter fix** (``agent/bedrock_adapter.py``) — adds the ``HERMES_BEDROCK_1M_CONTEXT`` env-var opt-in (default OFF — AWS hard-rejects the beta on accounts without the entitlement so an unconditional injection would regress every non-allowlisted account), ``bedrock_1m_context_enabled()`` truthy gate, ``is_anthropic_opus_4_1m_capable()`` capability matcher, ``additional_model_request_fields`` parameter on ``build_converse_kwargs`` / ``call_converse`` / ``call_converse_stream``, and the merging beta-injection logic.  ``BEDROCK_CONTEXT_LENGTHS`` gains the missing ``anthropic.claude-opus-4-7`` entry (200K base) and ``get_bedrock_context_length`` returns 1M only when both gates pass.
2. **Regression tests** (``tests/agent/test_bedrock_1m_context.py``) — 4 new test classes (32 cases including parametrize expansions) covering the opt-in gate's truthy/falsy semantics, the capability matcher across every Bedrock spelling variant, the inject / no-inject paths in ``build_converse_kwargs`` (incl. caller-supplied beta merging without clobbering or duplication), and the context-length lookup.  The pre-existing ``TestBedrockContext1MBeta`` (OpenAI-compat path from #16793) still passes — **34 tests total green**.
3. **Docs** (``website/docs/guides/aws-bedrock.md``) — documents the env-var opt-in, the entitlement gate, the model coverage, and why the flag defaults OFF.

## Related Issue

Fixes #31277

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- ``agent/bedrock_adapter.py`` — ``_BEDROCK_1M_CONTEXT_ENV``, ``_BEDROCK_CONTEXT_1M_BETA``, ``_BEDROCK_1M_CAPABLE_PATTERNS``, ``bedrock_1m_context_enabled()``, ``is_anthropic_opus_4_1m_capable()``; ``additional_model_request_fields`` parameter threaded through ``build_converse_kwargs`` / ``call_converse`` / ``call_converse_stream``; merging beta-injection in ``build_converse_kwargs``; ``anthropic.claude-opus-4-7`` row added to ``BEDROCK_CONTEXT_LENGTHS``; ``get_bedrock_context_length`` returns 1M only when both gates pass.
- ``tests/agent/test_bedrock_1m_context.py`` — 32 new test cases (4 classes) for the native Converse path; existing OpenAI-compat tests untouched.
- ``website/docs/guides/aws-bedrock.md`` — new "1M-context window for Claude Opus 4.6/4.7 + Sonnet 4.6" subsection.

Backwards compatible: every existing call site keeps working; the ``additional_model_request_fields`` parameter defaults to ``None``; opt-in defaults to OFF so accounts without the 1M entitlement see no behavior change.

## How to Test

```bash
# New + existing 1M-context tests (34 total)
python -m pytest tests/agent/test_bedrock_1m_context.py -v
# expected: 34 passed

# Wider regression sweep — bedrock + model_metadata + context_length
python -m pytest tests/agent -k 'bedrock or model_metadata or context_length' -q
# expected: 366 passed
```

End-to-end behaviour after the fix (account with the 1M entitlement):

```bash
$ export HERMES_BEDROCK_1M_CONTEXT=1
$ hermes chat
# banner now reports 1,000,000 context for claude-opus-4-7
# Converse calls send additionalModelRequestFields={"anthropic_beta":["context-1m-2025-08-07"]}
# AWS responds 200 OK; full 1M window available
```

Smoke test against real AWS Bedrock (per the issue body) returns HTTP 200 OK with the same wire format the adapter now produces:

```python
client.converse(
    modelId=\"us.anthropic.claude-opus-4-7\",
    messages=[{\"role\": \"user\", \"content\": [{\"text\": \"Say only: OK\"}]}],
    inferenceConfig={\"maxTokens\": 8},
    additionalModelRequestFields={\"anthropic_beta\": [\"context-1m-2025-08-07\"]},
)
# → STATUS: 200 OK, output: \"OK\"
```

## Checklist

- [x] Conventional Commits (``fix(bedrock):``, ``test(bedrock):``, ``docs(bedrock):``)
- [x] 3 focused commits, single author
- [x] 32 new tests pass; 2 pre-existing ``TestBedrockContext1MBeta`` tests still pass; 366 total bedrock/model_metadata/context_length tests pass
- [x] Tested on macOS 15.6 (darwin 24.6.0)
- [x] No new config keys (env-var opt-in only); no schema migration
- [x] Default behavior unchanged for accounts without the 1M entitlement
