### PR TITLE
fix(tui): stop slash dropdown from chopping last char of /goal

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1619,6 +1619,26 @@ def test_complete_slash_includes_provider_alias():
     assert any(item["text"] == "provider" for item in resp["result"]["items"])
 
 
+def test_complete_slash_returns_plain_string_fields():
+    # prompt_toolkit hands us FormattedText (a list subclass) for
+    # display/display_meta; the TUI's CompletionItem contract is plain
+    # strings, and shipping the raw list trips Ink's row layout into
+    # 1-char truncation of the next column (/goal → /goa).
+    resp = server.handle_request(
+        {"id": "1", "method": "complete.slash", "params": {"text": "/g"}}
+    )
+
+    items = resp["result"]["items"]
+    goal = next((it for it in items if it["text"] == "goal"), None)
+    assert goal is not None
+    assert isinstance(goal["display"], str), goal["display"]
+    assert isinstance(goal["meta"], str), goal["meta"]
+    assert goal["display"] == "/goal"
+    for item in items:
+        assert isinstance(item["display"], str), item
+        assert isinstance(item["meta"], str), item
+
+
 def test_complete_slash_includes_tui_details_command():
     resp = server.handle_request(
         {"id": "1", "method": "complete.slash", "params": {"text": "/det"}}

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5382,7 +5382,12 @@ def _(rid, params: dict) -> dict:
         items = [
             {
                 "text": c.text,
-                "display": c.display or c.text,
+                # prompt_toolkit gives us FormattedText (a list of (style,
+                # text) tuples) for display/display_meta. Serialize both as
+                # plain strings — the TUI's CompletionItem.display contract
+                # is a string, and sending the raw list trips Ink's row
+                # layout into 1-char truncation of the next column.
+                "display": to_plain_text(c.display) if c.display else c.text,
                 "meta": to_plain_text(c.display_meta) if c.display_meta else "",
             }
             for c in completer.get_completions(doc, None)

--- a/ui-tui/src/components/appOverlays.tsx
+++ b/ui-tui/src/components/appOverlays.tsx
@@ -187,10 +187,15 @@ export function FloatingOverlays({
                   key={`${start + i}:${item.text}:${item.display}:${item.meta ?? ''}`}
                   width="100%"
                 >
-                  <Text bold color={theme.color.label}>
-                    {' '}
-                    {item.display}
-                  </Text>
+                  {/* flexShrink=0 — when meta overflows the row, Ink/Yoga
+                      otherwise shaves the last char off the display column
+                      (e.g. /goal renders as /goa). */}
+                  <Box flexShrink={0}>
+                    <Text bold color={theme.color.label}>
+                      {' '}
+                      {item.display}
+                    </Text>
+                  </Box>
                   {item.meta ? (
                     <Text
                       backgroundColor={active ? theme.color.completionMetaCurrentBg : theme.color.completionMetaBg}


### PR DESCRIPTION
## Summary
- `tui_gateway/server.py` was sending `c.display` from prompt_toolkit's `Completion` straight into the JSON-RPC payload. prompt_toolkit normalises that into `FormattedText` (a `list` subclass), so the wire format became `[["", "/goal"]]` instead of the plain string `CompletionItem.display` declares — meta was already routed through `to_plain_text`, display wasn't.
- Wrapped the display column in `appOverlays.tsx` with `<Box flexShrink={0}>`. With `flexDirection="row"` and a long meta sibling, Ink/Yoga otherwise shrinks the *first* column by one cell when the row overflows, lopping the trailing character off the command name.
- Added a `complete.slash` regression test asserting `display` and `meta` are always plain strings (covers the FormattedText leak).

## Context
Visible as `/goal` rendering as `/goa` in the slash-command dropdown in `hermes --tui`. `/goal` triggers it reliably because its meta string is the longest of any built-in command (description + embedded `[text | pause | resume | clear | status]` usage hint). The same layout bug also clips `/gquota` → `/gquot` when paired with a meta long enough to overflow.

Verified the truncation reproduces against a real Ink render, both before the fix (`/goa`, `/gquot`) and that it disappears after (`/goal`, `/gquota`).

## Test plan
- `python -m pytest tests/test_tui_gateway_server.py -k complete_slash` — 6 passed (incl. new test).
- `scripts/run_tests.sh tests/tui_gateway/` — 84 passed.
- `npx vitest run src/__tests__/useCompletion.test.ts` — 4 passed.
- `npm run type-check` only surfaces pre-existing errors in `packages/hermes-ink/src/utils/execFileNoThrow.ts` and `src/app/useMainApp.ts` that exist on `main`; none touch the changed files.