### PR TITLE
feat(ui): add Mission Control route and bound process notifications

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -352,6 +352,52 @@ def _telegramize_command_mentions(text: str, platform: Any) -> str:
     return _TELEGRAM_COMMAND_MENTION_RE.sub(_replace, text)
 
 
+def _format_background_process_user_notification(
+    session_id: str,
+    exit_code: Optional[int],
+    output: str,
+    *,
+    max_lines: int = 12,
+    max_chars: int = 900,
+) -> str:
+    """Render a bounded, human-readable background-process notification.
+
+    Gateway notifications go directly to messaging platforms, so they must not
+    look like synthetic model instructions and must not dump raw terminal walls.
+    """
+    from tools.ansi_strip import strip_ansi
+
+    status_icon = "✅" if exit_code == 0 else "❌"
+    status_word = "completed" if exit_code == 0 else "failed"
+    clean = strip_ansi(output or "")
+    clean = clean.replace("\r\n", "\n").replace("\r", "\n")
+    clean = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", "", clean)
+
+    lines = [line.rstrip() for line in clean.splitlines() if line.strip()]
+    omitted_lines = max(0, len(lines) - max_lines)
+    tail = "\n".join(lines[-max_lines:]) if lines else ""
+    omitted_chars = 0
+    if len(tail) > max_chars:
+        omitted_chars = len(tail) - max_chars
+        tail = tail[-max_chars:]
+        # Avoid starting mid-line when possible.
+        first_newline = tail.find("\n")
+        if first_newline != -1:
+            tail = tail[first_newline + 1 :]
+
+    summary = f"{status_icon} Background process `{session_id}` {status_word} (exit {exit_code})."
+    if not tail:
+        return f"{summary}\nNo output captured."
+
+    omission_parts = []
+    if omitted_lines:
+        omission_parts.append(f"{omitted_lines} earlier line{'s' if omitted_lines != 1 else ''}")
+    if omitted_chars:
+        omission_parts.append(f"{omitted_chars} earlier char{'s' if omitted_chars != 1 else ''}")
+    omission_note = f" ({', '.join(omission_parts)} omitted)" if omission_parts else ""
+    return f"{summary}\nLast output{omission_note}:\n```text\n{tail}\n```"
+
+
 # Only auto-continue interrupted gateway turns while the interruption is fresh.
 # Stale tool-tail/resume markers can otherwise revive an unrelated old task
 # after a gateway restart when the user's next message starts new work.
@@ -15030,10 +15076,10 @@ class GatewayRunner:
                     or (notify_mode == "error" and session.exit_code not in {0, None})
                 )
                 if should_notify:
-                    new_output = session.output_buffer[-1000:] if session.output_buffer else ""
-                    message_text = (
-                        f"[Background process {session_id} finished with exit code {session.exit_code}~ "
-                        f"Here's the final output:\n{new_output}]"
+                    message_text = _format_background_process_user_notification(
+                        session_id,
+                        session.exit_code,
+                        session.output_buffer or "",
                     )
                     adapter = None
                     for p, a in self.adapters.items():

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -394,6 +394,18 @@ def _format_background_process_user_notification(
         omission_parts.append(f"{omitted_lines} earlier line{'s' if omitted_lines != 1 else ''}")
     if omitted_chars:
         omission_parts.append(f"{omitted_chars} earlier char{'s' if omitted_chars != 1 else ''}")
+    # This text is sent directly to messaging platforms, not back through the
+    # model. Keep it inert: redact common secret shapes, prevent markdown code
+    # fence breakout, and neutralize mass/ping mentions.
+    tail = _redact_gateway_user_facing_secrets(tail)
+    tail = tail.replace("```", "`\u200b``")
+    tail = re.sub(
+        r"@(everyone|here)\b",
+        lambda match: f"@\u200b{match.group(1)}",
+        tail,
+        flags=re.IGNORECASE,
+    )
+
     omission_note = f" ({', '.join(omission_parts)} omitted)" if omission_parts else ""
     return f"{summary}\nLast output{omission_note}:\n```text\n{tail}\n```"
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2523,6 +2523,54 @@ class TestCodexAuxiliaryAdapterTimeout:
         assert fake_client.responses.kwargs["stream"] is True
         assert response.choices[0].message.content == "summary"
 
+    def test_backfills_when_completed_response_output_is_null(self):
+        output_item = SimpleNamespace(
+            type="message",
+            content=[SimpleNamespace(type="output_text", text="backfilled summary")],
+        )
+
+        class NullOutputStream:
+            def __iter__(self):
+                return iter((SimpleNamespace(type="response.output_item.done", item=output_item),))
+
+            def close(self):
+                pass
+
+        class FakeResponses:
+            def create(self, **kwargs):
+                assert kwargs.get("stream") is True
+                return NullOutputStream()
+
+        fake_client = SimpleNamespace(responses=FakeResponses())
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
+
+        response = adapter.create(messages=[{"role": "user", "content": "title this"}])
+
+        assert response.choices[0].message.content == "backfilled summary"
+
+    def test_synthesizes_text_delta_when_completed_response_output_is_null(self):
+        class NullOutputDeltaStream:
+            def __iter__(self):
+                return iter((
+                    SimpleNamespace(type="response.output_text.delta", delta="delta "),
+                    SimpleNamespace(type="response.output_text.delta", delta="summary"),
+                ))
+
+            def close(self):
+                pass
+
+        class FakeResponses:
+            def create(self, **kwargs):
+                assert kwargs.get("stream") is True
+                return NullOutputDeltaStream()
+
+        fake_client = SimpleNamespace(responses=FakeResponses())
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
+
+        response = adapter.create(messages=[{"role": "user", "content": "title this"}])
+
+        assert response.choices[0].message.content == "delta summary"
+
     def test_enforces_total_timeout_while_stream_keeps_emitting_events(self):
         class _SlowAliveCreateStream:
             def __iter__(self):

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -154,7 +154,7 @@ class TestLoadBackgroundNotificationsMode:
             "result",
             [SimpleNamespace(output_buffer="done\n", exited=True, exit_code=0)],
             1,
-            "finished with exit code 0",
+            "completed (exit 0)",
         ),
         # error mode: exit 0 → no notification
         (
@@ -168,14 +168,14 @@ class TestLoadBackgroundNotificationsMode:
             "error",
             [SimpleNamespace(output_buffer="traceback\n", exited=True, exit_code=1)],
             1,
-            "finished with exit code 1",
+            "failed (exit 1)",
         ),
         # all mode: exited → notifies
         (
             "all",
             [SimpleNamespace(output_buffer="ok\n", exited=True, exit_code=0)],
             1,
-            "finished with exit code 0",
+            "completed (exit 0)",
         ),
     ],
 )
@@ -202,6 +202,38 @@ async def test_run_process_watcher_respects_notification_mode(
     if expected_fragment is not None:
         sent_message = adapter.send.await_args.args[1]
         assert expected_fragment in sent_message
+
+
+@pytest.mark.asyncio
+async def test_finished_notification_strips_ansi_and_bounds_output(monkeypatch, tmp_path):
+    import tools.process_registry as pr_module
+
+    raw_output = (
+        "\x1b[0;1;31mFAILED\x1b[0m noisy banner\n"
+        + "\n".join(f"line {i}" for i in range(30))
+        + "\n"
+    )
+    sessions = [SimpleNamespace(output_buffer=raw_output, exited=True, exit_code=1)]
+    monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "error")
+    adapter = runner.adapters[Platform.TELEGRAM]
+
+    await runner._run_process_watcher(_watcher_dict())
+
+    sent_message = adapter.send.await_args.args[1]
+    assert sent_message.startswith("❌ Background process `proc_test` failed (exit 1).")
+    assert "```text" in sent_message
+    assert "\x1b" not in sent_message
+    assert "Here's the final output" not in sent_message
+    assert "FAILED noisy banner" not in sent_message
+    assert "line 18" in sent_message
+    assert "line 0" not in sent_message
+    assert len(sent_message) < 1200
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -14,7 +14,11 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from gateway.config import GatewayConfig, Platform
-from gateway.run import GatewayRunner, _parse_session_key
+from gateway.run import (
+    GatewayRunner,
+    _format_background_process_user_notification,
+    _parse_session_key,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -234,6 +238,21 @@ async def test_finished_notification_strips_ansi_and_bounds_output(monkeypatch, 
     assert "line 18" in sent_message
     assert "line 0" not in sent_message
     assert len(sent_message) < 1200
+
+
+def test_finished_notification_redacts_and_escapes_user_facing_tail():
+    sent_message = _format_background_process_user_notification(
+        "proc_test",
+        1,
+        "leak sk-testSECRET1234567890 and @everyone\n```\nbreakout\n```\n",
+    )
+
+    assert "sk-testSECRET" not in sent_message
+    assert "[REDACTED]" in sent_message
+    assert "@everyone" not in sent_message
+    assert "@\u200beveryone" in sent_message
+    assert "\n```\nbreakout" not in sent_message
+    assert "`\u200b``" in sent_message
 
 
 @pytest.mark.asyncio

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -68,7 +68,6 @@ import ProfilesPage from "@/pages/ProfilesPage";
 import SkillsPage from "@/pages/SkillsPage";
 import PluginsPage from "@/pages/PluginsPage";
 import ChatPage from "@/pages/ChatPage";
-import MissionControlPage from "@/pages/MissionControlPage";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { ThemeSwitcher } from "@/components/ThemeSwitcher";
 import { useI18n } from "@/i18n";
@@ -109,7 +108,6 @@ const CHAT_NAV_ITEM: NavItem = {
  */
 const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/": RootRedirect,
-  "/mission-control": MissionControlPage,
   "/sessions": SessionsPage,
   "/analytics": AnalyticsPage,
   "/models": ModelsPage,
@@ -319,11 +317,10 @@ export default function App() {
   const normalizedPath = pathname.replace(/\/$/, "") || "/";
   const isChatRoute = normalizedPath === "/chat";
   const isMissionControlRoute = normalizedPath === "/mission-control";
-  // When embedded chat is on, the terminal host should be visible on
-  // both /chat and /mission-control.  On any other route (sessions,
-  // analytics, etc.) the persistent host stays hidden.
-  const showPersistentChat =
-    isChatRoute || isMissionControlRoute;
+  // Keep the persistent PTY host scoped to the real chat route.  /mission-control
+  // is owned by the Mission Control dashboard plugin when installed; rendering
+  // the chat host there hides the plugin page and leaves a blank terminal panel.
+  const showPersistentChat = isChatRoute;
   const embeddedChat = isDashboardEmbeddedChatEnabled();
 
   // `dashboard.show_token_analytics` gates the Analytics nav item.  The

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -68,6 +68,7 @@ import ProfilesPage from "@/pages/ProfilesPage";
 import SkillsPage from "@/pages/SkillsPage";
 import PluginsPage from "@/pages/PluginsPage";
 import ChatPage from "@/pages/ChatPage";
+import MissionControlPage from "@/pages/MissionControlPage";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { ThemeSwitcher } from "@/components/ThemeSwitcher";
 import { useI18n } from "@/i18n";
@@ -79,7 +80,7 @@ import { isDashboardEmbeddedChatEnabled } from "@/lib/dashboard-flags";
 import { api } from "@/lib/api";
 
 function RootRedirect() {
-  return <Navigate to="/sessions" replace />;
+  return <Navigate to="/mission-control" replace />;
 }
 
 function UnknownRouteFallback({ pluginsLoading }: { pluginsLoading: boolean }) {
@@ -108,6 +109,7 @@ const CHAT_NAV_ITEM: NavItem = {
  */
 const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/": RootRedirect,
+  "/mission-control": MissionControlPage,
   "/sessions": SessionsPage,
   "/analytics": AnalyticsPage,
   "/models": ModelsPage,
@@ -316,6 +318,12 @@ export default function App() {
   const isDocsRoute = pathname === "/docs" || pathname === "/docs/";
   const normalizedPath = pathname.replace(/\/$/, "") || "/";
   const isChatRoute = normalizedPath === "/chat";
+  const isMissionControlRoute = normalizedPath === "/mission-control";
+  // When embedded chat is on, the terminal host should be visible on
+  // both /chat and /mission-control.  On any other route (sessions,
+  // analytics, etc.) the persistent host stays hidden.
+  const showPersistentChat =
+    isChatRoute || isMissionControlRoute;
   const embeddedChat = isDashboardEmbeddedChatEnabled();
 
   // `dashboard.show_token_analytics` gates the Analytics nav item.  The
@@ -427,6 +435,7 @@ export default function App() {
       <Backdrop />
       <PluginSlot name="backdrop" />
 
+      {!isMissionControlRoute && (
       <header
         className={cn(
           "lg:hidden fixed top-0 left-0 right-0 z-40 min-h-14",
@@ -459,6 +468,7 @@ export default function App() {
           {t.app.brand}
         </Typography>
       </header>
+      )}
 
       {mobileOpen && (
         <Button
@@ -593,19 +603,20 @@ export default function App() {
               className={cn(
                 "relative z-2 flex min-w-0 min-h-0 flex-1 flex-col",
                 "px-3 sm:px-6",
-                isChatRoute
-                  ? "pb-0 pt-1 sm:pt-2 lg:pt-4"
-                  : "pt-2 sm:pt-4 lg:pt-6",
+                showPersistentChat
+                  ? "pb-3 pt-1 sm:pb-4 sm:pt-2 lg:pt-4"
+                  : "pt-2 sm:pt-4 lg:pt-6 pb-4 sm:pb-8",
                 isDocsRoute && "min-h-0 flex-1",
+                isMissionControlRoute && "min-h-0 flex-1",
               )}
             >
               <PluginSlot name="pre-main" />
               <div
                 className={cn(
                   "w-full min-w-0",
-                  !isChatRoute &&
+                  !showPersistentChat &&
                     "pb-[calc(2rem+env(safe-area-inset-bottom,0px))] lg:pb-8",
-                  (isDocsRoute || isChatRoute) &&
+                  (isDocsRoute || showPersistentChat) &&
                     "min-h-0 flex flex-1 flex-col",
                 )}
               >
@@ -624,7 +635,7 @@ export default function App() {
                 {embeddedChat &&
                   !chatOverriddenByPlugin &&
                   (pluginsLoading ? (
-                    isChatRoute ? (
+                    showPersistentChat ? (
                       <div
                         className="flex min-h-0 min-w-0 flex-1 items-center justify-center"
                         aria-busy="true"
@@ -638,14 +649,14 @@ export default function App() {
                     ) : null
                   ) : (
                     <div
-                      data-chat-active={isChatRoute ? "true" : "false"}
+                      data-chat-active={showPersistentChat ? "true" : "false"}
                       className={cn(
                         "min-h-0 min-w-0",
-                        isChatRoute ? "flex flex-1 flex-col" : "hidden",
+                        showPersistentChat ? "flex flex-1 flex-col" : "hidden",
                       )}
-                      aria-hidden={!isChatRoute}
+                      aria-hidden={!showPersistentChat}
                     >
-                      <ChatPage isActive={isChatRoute} />
+                      <ChatPage isActive={showPersistentChat} />
                     </div>
                   ))}
               </div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -68,6 +68,7 @@ import ProfilesPage from "@/pages/ProfilesPage";
 import SkillsPage from "@/pages/SkillsPage";
 import PluginsPage from "@/pages/PluginsPage";
 import ChatPage from "@/pages/ChatPage";
+import MissionControlPage from "@/pages/MissionControlPage";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { ThemeSwitcher } from "@/components/ThemeSwitcher";
 import { useI18n } from "@/i18n";
@@ -108,6 +109,7 @@ const CHAT_NAV_ITEM: NavItem = {
  */
 const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/": RootRedirect,
+  "/mission-control": MissionControlPage,
   "/sessions": SessionsPage,
   "/analytics": AnalyticsPage,
   "/models": ModelsPage,
@@ -481,8 +483,14 @@ export default function App() {
 
       <PluginSlot name="header-banner" />
 
-      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden pt-14 lg:pt-0">
+      <div
+        className={cn(
+          "flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden",
+          isMissionControlRoute ? "pt-0" : "pt-14 lg:pt-0",
+        )}
+      >
         <div className="flex min-h-0 min-w-0 flex-1">
+          {!isMissionControlRoute && (
           <aside
             id="app-sidebar"
             aria-label={t.app.navigation}
@@ -594,15 +602,18 @@ export default function App() {
             <AuthWidget />
             <SidebarFooter />
           </aside>
+          )}
 
           <PageHeaderProvider pluginTabs={pluginTabMeta}>
             <div
               className={cn(
                 "relative z-2 flex min-w-0 min-h-0 flex-1 flex-col",
-                "px-3 sm:px-6",
-                showPersistentChat
-                  ? "pb-3 pt-1 sm:pb-4 sm:pt-2 lg:pt-4"
-                  : "pt-2 sm:pt-4 lg:pt-6 pb-4 sm:pb-8",
+                isMissionControlRoute ? "px-0" : "px-3 sm:px-6",
+                isMissionControlRoute
+                  ? "p-0"
+                  : showPersistentChat
+                    ? "pb-3 pt-1 sm:pb-4 sm:pt-2 lg:pt-4"
+                    : "pt-2 sm:pt-4 lg:pt-6 pb-4 sm:pb-8",
                 isDocsRoute && "min-h-0 flex-1",
                 isMissionControlRoute && "min-h-0 flex-1",
               )}
@@ -613,7 +624,7 @@ export default function App() {
                   "w-full min-w-0",
                   !showPersistentChat &&
                     "pb-[calc(2rem+env(safe-area-inset-bottom,0px))] lg:pb-8",
-                  (isDocsRoute || showPersistentChat) &&
+                  (isDocsRoute || showPersistentChat || isMissionControlRoute) &&
                     "min-h-0 flex flex-1 flex-col",
                 )}
               >

--- a/web/src/contexts/PageHeaderProvider.tsx
+++ b/web/src/contexts/PageHeaderProvider.tsx
@@ -38,6 +38,8 @@ export function PageHeaderProvider({
   /** Env jump-nav is wide — stack below title on small screens so KEYS stays readable. */
   const isEnvRoute =
     pathname === "/env" || pathname.startsWith("/env/");
+  const isMissionControlRoute =
+    pathname === "/mission-control" || pathname === "/mission-control/";
 
   const value = useMemo(
     () => ({
@@ -51,6 +53,7 @@ export function PageHeaderProvider({
   return (
     <PageHeaderContext.Provider value={value}>
       <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden">
+        {!isMissionControlRoute && (
         <header
           className={cn(
             "z-1 w-full shrink-0",
@@ -120,6 +123,7 @@ export function PageHeaderProvider({
             ) : null}
           </div>
         </header>
+        )}
 
         <main
           className={cn(

--- a/web/src/pages/MissionControlPage.tsx
+++ b/web/src/pages/MissionControlPage.tsx
@@ -1,0 +1,181 @@
+/**
+ * MissionControlPage — the root landing page for the dashboard.
+ *
+ * When the user hits /mission-control (or is redirected there from /),
+ * they see a clean, header-less interface with the embedded chat terminal
+ * as the primary interaction surface.
+ *
+ * Layout:
+ *   - Full-height dark canvas
+ *   - Top: "HERMES MISSION CONTROL" label (subtle, branding)
+ *   - Center: Chat terminal (the xterm PTY embed from ChatPage)
+ *   - Bottom: minimal status strip
+ *
+ * This page intentionally avoids:
+ *   - The primary objective display (per user request)
+ *   - JSON output in the Agents tab (cleaner display)
+ *   - Command tab with separate readability issues
+ */
+
+import { useEffect, useState } from "react";
+import { Terminal, Shield, Activity } from "lucide-react";
+import { api } from "@/lib/api";
+import type { StatusResponse } from "@/lib/api";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Badge } from "@nous-research/ui/ui/components/badge";
+import { isDashboardEmbeddedChatEnabled } from "@/lib/dashboard-flags";
+
+function StatusPill({
+  icon: Icon,
+  label,
+  status,
+}: {
+  icon: React.ElementType;
+  label: string;
+  status: string;
+}) {
+  const colorMap: Record<string, string> = {
+    running: "text-success",
+    active: "text-success",
+    online: "text-success",
+    stopped: "text-destructive",
+    error: "text-destructive",
+  };
+  const color = colorMap[status.toLowerCase()] ?? "text-muted-foreground";
+
+  return (
+    <div className="flex items-center gap-2 rounded-sm border border-border/50 px-3 py-1.5 bg-background/30">
+      <Icon className={`h-3.5 w-3.5 shrink-0 ${color}`} />
+      <div className="flex flex-col">
+        <span className="text-[10px] text-muted-foreground uppercase tracking-wider">
+          {label}
+        </span>
+        <span className={`text-xs font-mono-ui capitalize ${color}`}>
+          {status}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function GreetingBanner() {
+  const [hour, setHour] = useState(new Date().getHours());
+
+  useEffect(() => {
+    const timer = setInterval(() => setHour(new Date().getHours()), 60000);
+    return () => clearInterval(timer);
+  }, []);
+
+  const timeGreeting = hour >= 5 && hour < 12 ? "Good morning" :
+    hour >= 12 && hour < 17 ? "Good afternoon" :
+    hour >= 17 && hour < 22 ? "Good evening" : "Good night";
+
+  return (
+    <div className="flex flex-col items-center gap-1 py-6 text-center">
+      <div className="flex items-center gap-2 mb-1">
+        <Terminal className="h-5 w-5 text-muted-foreground/60" />
+        <h1 className="text-2xl font-bold tracking-[0.2em] uppercase text-foreground/90"
+            style={{ fontFamily: "var(--font-brand)" }}>
+          Mission Control
+        </h1>
+        <Shield className="h-5 w-5 text-muted-foreground/60" />
+      </div>
+      <p className="text-sm text-muted-foreground/60 tracking-wide">
+        {timeGreeting}
+      </p>
+    </div>
+  );
+}
+
+function SystemStrip({ status }: { status: StatusResponse | null }) {
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-3 px-4 py-3 mt-2">
+      <StatusPill
+        icon={Activity}
+        label="Gateway"
+        status={status?.gateway_running ? "running" : "stopped"}
+      />
+      <Badge tone="outline" className="text-[10px] px-2 py-0.5">
+        v{status?.version ?? "unknown"}
+      </Badge>
+    </div>
+  );
+}
+
+/**
+ * MissionControlPage is the main dashboard entry point.
+ *
+ * Key design decisions:
+ * 1. NO page header — handled by App.tsx (isMissionControlRoute check)
+ * 2. NO sidebar — the terminal IS the interface
+ * 3. Clean greeting banner instead of primary objective
+ * 4. System status strip at bottom (optional, collapses when terminal is active)
+ *
+ * The embedded chat terminal (ChatPage) is rendered by the App shell when
+ * embeddedChat is enabled via the --tui flag. This page just provides the
+ * layout container and context for the terminal.
+ */
+export default function MissionControlPage() {
+  const [status, setStatus] = useState<StatusResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Check if we're in embedded chat mode — the terminal renders outside
+  // the <Routes> block in App.tsx, so this page just needs to exist
+  // to claim the URL path and provide context.
+  const embeddedChat = isDashboardEmbeddedChatEnabled();
+
+  // Load status on mount
+  useEffect(() => {
+    api.getStatus()
+      .then(setStatus)
+      .catch((err) => setError(String(err)));
+  }, []);
+
+  // When embeddedChat is true, the terminal renders persistently in App.tsx
+  // outside <Routes>. This page serves as a "sink" — it renders nothing
+  // visually (the terminal is already mounted) but claims the /mission-control
+  // URL path so the redirect from / works and the header stays hidden.
+  if (embeddedChat) {
+    return null;
+  }
+
+  // Fallback when embedded chat is NOT enabled: show a static page
+  // telling the user to enable --tui mode for the terminal.
+  return (
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col items-center justify-center p-6">
+      <GreetingBanner />
+
+      {error && (
+        <div className="mb-4 px-4 py-2 bg-destructive/10 border border-destructive/20 rounded-sm text-sm text-destructive">
+          Failed to load status: {error}
+        </div>
+      )}
+
+      <SystemStrip status={status} />
+
+      <div className="mt-8 text-center">
+        <p className="text-muted-foreground mb-3">
+          The embedded chat terminal requires the dashboard to run with the
+          <code className="ml-1 mr-2 px-1.5 py-0.5 bg-border/50 rounded text-xs font-mono-ui">--tui</code>
+          flag.
+        </p>
+        <p className="text-xs text-muted-foreground/50">
+          Start the dashboard with:
+          <code className="ml-1 mr-2 px-1.5 py-0.5 bg-border/50 rounded text-xs font-mono-ui">
+            hermes dashboard --tui
+          </code>
+        </p>
+      </div>
+
+      <div className="mt-8 flex gap-3">
+        <Button
+          ghost
+          onClick={() => (window.location.href = "/sessions")}
+          className="text-xs tracking-wider uppercase opacity-60 hover:opacity-100"
+        >
+          Browse Sessions
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add /mission-control as the dashboard landing route with a headerless Mission Control layout and persistent embedded chat visibility
- Restore the Mission Control plugin/route integration after upstream dashboard changes
- Replace raw gateway background-process completion dumps with concise, bounded user-facing notifications
- Strip ANSI/control characters and cap notification output to the last bounded lines/chars

## Test Plan
- [x] python -m pytest tests/gateway/test_background_process_notifications.py -o 'addopts=' -q
- [ ] npm run build (blocked locally by existing @nous-research/ui checkbox module resolution errors in ModelPickerDialog/ProfilesPage/plugins registry)