### PR TITLE
fix(agent): inject streamed final_response into messages before persistence (#31269)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -229,6 +229,71 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
             )
 
 
+_EMPTY_RESPONSE_SENTINEL = "(empty)"
+
+
+def _ensure_final_response_in_messages(
+    messages: List[Dict],
+    final_response: Optional[str],
+) -> bool:
+    """Inject *final_response* as a structured assistant message when missing.
+
+    Several break paths in :func:`run_conversation` set ``final_response``
+    from already-streamed content (partial-stream recovery, prior-turn
+    fallback, etc.) and exit *without* appending a structured ``{"role":
+    "assistant", "content": ...}`` dict to the ``messages`` list.  The
+    happy text-response path at the bottom of the inner loop *does*
+    append one (via ``_build_assistant_message``), so under normal
+    streaming there's nothing to do here.
+
+    The bridge-worker path (``hermes_bridge.py`` / ``state.db``) flushes
+    persistence by index — ``_flush_messages_to_session_db`` writes
+    ``messages[_last_flushed_db_idx:]``.  When the streaming response
+    never lands as a dict in ``messages``, that slice is empty and the
+    assistant reply silently never reaches the database even though the
+    user *saw* it streamed in the WebUI.  See #31269.
+
+    This helper is the safety net: call it right before the FINAL
+    ``_persist_session`` and any structured assistant turn that was
+    missing gets restored.  Returns ``True`` when an injection happened
+    so callers can log it.
+
+    Skips injection when:
+      * ``final_response`` is ``None`` / empty / whitespace-only;
+      * ``final_response`` equals the ``"(empty)"`` sentinel (handled by
+        the empty-response scaffolding pop);
+      * the trailing ``messages`` entry is already an assistant message
+        whose ``content`` matches ``final_response`` (the happy path).
+
+    Issue #31269.
+    """
+    if not isinstance(final_response, str):
+        return False
+    text = final_response.strip()
+    if not text or text == _EMPTY_RESPONSE_SENTINEL:
+        return False
+
+    if messages and isinstance(messages[-1], dict):
+        last = messages[-1]
+        if last.get("role") == "assistant":
+            existing = last.get("content")
+            if isinstance(existing, str) and existing.strip() == text:
+                return False
+            # Assistant message at tail with tool_calls but no content:
+            # the model called tools and never produced text. Don't
+            # smuggle a recovered partial-stream reply into that turn —
+            # append a fresh assistant turn so the structure stays
+            # ``assistant(tool_calls) → tool(...) → assistant(text)`` —
+            # which is what the bridge then flushes.
+
+    messages.append({
+        "role": "assistant",
+        "content": final_response,
+        "_injected_from_final_response": True,
+    })
+    return True
+
+
 def run_conversation(
     agent,
     user_message: str,
@@ -3960,6 +4025,25 @@ def run_conversation(
     # can replay assistant("(empty)") / recovery nudges and fall into the
     # same empty-response loop again.
     agent._drop_trailing_empty_response_scaffolding(messages)
+
+    # Safety net for #31269: a few break paths above (partial-stream
+    # recovery, prior-turn-content fallback) set ``final_response`` from
+    # already-streamed bytes WITHOUT appending a structured assistant
+    # message dict.  The bridge worker flushes ``state.db`` by index
+    # (``_flush_messages_to_session_db`` writes ``messages[idx:]``) so a
+    # missing dict means the assistant reply silently never reaches the
+    # database — even though the user *saw* it streamed in the WebUI.
+    # Inject here so every persisted session contains the reply the user
+    # was shown.  Idempotent on the happy path (no-op when
+    # ``messages[-1]`` already carries this content).
+    if _ensure_final_response_in_messages(messages, final_response):
+        logger.debug(
+            "Injected streamed final_response into messages tail before "
+            "persistence — exit_reason=%s session=%s len=%d",
+            _turn_exit_reason, agent.session_id or "none",
+            len(final_response or ""),
+        )
+
     agent._persist_session(messages, conversation_history)
 
     # ── Turn-exit diagnostic log ─────────────────────────────────────

--- a/tests/run_agent/test_final_response_injection_31269.py
+++ b/tests/run_agent/test_final_response_injection_31269.py
@@ -1,0 +1,262 @@
+"""Regression tests for issue #31269.
+
+The bridge worker's ``state.db`` flush path
+(``_flush_messages_to_session_db``) writes ``messages[idx:]`` — anything
+not in the structured ``messages`` list silently never reaches disk.
+A few break paths in ``run_conversation`` set ``final_response`` from
+already-streamed bytes (partial-stream recovery, prior-turn content
+fallback) without appending the matching structured assistant message
+dict, so the user *saw* the reply in the WebUI but the database row
+was never written.
+
+The fix is a safety net in ``conversation_loop._ensure_final_response_in_messages``
+called right before the final ``_persist_session``: any non-empty
+``final_response`` that isn't already at the messages tail gets
+appended as ``{"role": "assistant", "content": <text>,
+"_injected_from_final_response": True}``.  These tests guard the
+helper's behaviour and the end-to-end persistence path.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent.conversation_loop import _ensure_final_response_in_messages
+
+
+class TestEnsureFinalResponseInMessages:
+    """Direct unit tests for the injection helper."""
+
+    def test_injects_when_messages_tail_lacks_assistant_reply(self):
+        """The original #31269 case — bridge tail is the user message only."""
+        messages = [
+            {"role": "user", "content": "what's 2+2?"},
+        ]
+
+        injected = _ensure_final_response_in_messages(messages, "2+2 is 4.")
+
+        assert injected is True
+        assert messages[-1] == {
+            "role": "assistant",
+            "content": "2+2 is 4.",
+            "_injected_from_final_response": True,
+        }
+
+    def test_injects_after_tool_result_partial_stream_recovery(self):
+        """Partial-stream-recovery: tool turns ran, model went silent, callback
+        already streamed prior content; final_response gets recovered from
+        the streamed buffer but never appended to messages.
+        """
+        messages = [
+            {"role": "user", "content": "search for X"},
+            {"role": "assistant", "content": None,
+             "tool_calls": [{"id": "1", "function": {"name": "search", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "1", "content": "results..."},
+        ]
+
+        injected = _ensure_final_response_in_messages(messages, "Found 3 results.")
+
+        assert injected is True
+        assert len(messages) == 4
+        assert messages[-1]["role"] == "assistant"
+        assert messages[-1]["content"] == "Found 3 results."
+        assert messages[-1]["_injected_from_final_response"] is True
+
+    def test_no_op_when_assistant_tail_already_has_matching_content(self):
+        """Happy text-response path: ``_build_assistant_message`` already
+        appended the structured dict — no double-append.
+        """
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello there"},
+        ]
+        original_len = len(messages)
+
+        injected = _ensure_final_response_in_messages(messages, "hello there")
+
+        assert injected is False
+        assert len(messages) == original_len
+
+    def test_no_op_when_assistant_tail_matches_after_strip(self):
+        """Whitespace differences between final_response and messages tail
+        shouldn't trigger spurious double-injection.
+        """
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "  hello there  "},
+        ]
+        original_len = len(messages)
+
+        injected = _ensure_final_response_in_messages(messages, "hello there\n")
+
+        assert injected is False
+        assert len(messages) == original_len
+
+    @pytest.mark.parametrize("value", [None, "", "   ", "\n\t  "])
+    def test_no_op_when_final_response_is_empty_or_whitespace(self, value):
+        """Empty/whitespace final_response means no real reply was produced."""
+        messages = [{"role": "user", "content": "hi"}]
+        original = list(messages)
+
+        injected = _ensure_final_response_in_messages(messages, value)
+
+        assert injected is False
+        assert messages == original
+
+    def test_no_op_for_empty_response_sentinel(self):
+        """The ``(empty)`` sentinel is a user-facing failure marker; the
+        empty-response scaffolding path handles its own persistence and
+        we must not append it as a real assistant reply.
+        """
+        messages = [{"role": "user", "content": "hi"}]
+        original = list(messages)
+
+        injected = _ensure_final_response_in_messages(messages, "(empty)")
+
+        assert injected is False
+        assert messages == original
+
+    def test_no_op_when_final_response_not_a_string(self):
+        """Defence against caller passing a non-string (e.g. None object)."""
+        messages = [{"role": "user", "content": "hi"}]
+        original = list(messages)
+
+        for value in (123, [], {"role": "assistant"}, object()):
+            injected = _ensure_final_response_in_messages(messages, value)
+            assert injected is False
+            assert messages == original
+
+    def test_inject_after_assistant_tool_calls_only(self):
+        """Tail is ``assistant(tool_calls=...)`` with no content — the helper
+        must still append (this is a different turn's text, not the same one).
+        """
+        messages = [
+            {"role": "user", "content": "do X"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "1", "function": {"name": "X", "arguments": "{}"}}],
+            },
+        ]
+
+        injected = _ensure_final_response_in_messages(messages, "I did X.")
+
+        assert injected is True
+        assert len(messages) == 3
+        assert messages[-1]["content"] == "I did X."
+
+    def test_inject_when_messages_empty(self):
+        """Edge case: empty messages list with a recovered final_response."""
+        messages: list = []
+
+        injected = _ensure_final_response_in_messages(messages, "hi")
+
+        assert injected is True
+        assert len(messages) == 1
+        assert messages[0]["content"] == "hi"
+
+    def test_inject_when_assistant_tail_has_different_content(self):
+        """The recovered final_response disagrees with what's at the tail
+        (e.g. partial stream that produced different text than the
+        already-appended ``(empty)`` recovery message has been popped) —
+        the recovered text wins.
+        """
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "earlier content"},
+        ]
+
+        injected = _ensure_final_response_in_messages(messages, "recovered later content")
+
+        assert injected is True
+        assert messages[-1]["content"] == "recovered later content"
+        assert messages[-1]["_injected_from_final_response"] is True
+        # Earlier assistant message preserved
+        assert messages[-2]["content"] == "earlier content"
+
+
+class TestEndToEndBridgePersistence:
+    """End-to-end check: ``_persist_session`` writes the injected reply
+    to ``state.db`` exactly the way the bridge worker would.
+    """
+
+    def test_injected_assistant_message_reaches_session_db(self):
+        """Reproduces the diagnostic from the issue: messages list ends at
+        the user turn, ``_last_flushed_db_idx`` already covers it; without
+        the fix, ``state.db`` gets nothing on this persist call.
+        """
+        from run_agent import AIAgent
+
+        agent = AIAgent.__new__(AIAgent)
+        agent._session_db = MagicMock()
+        agent._session_db_created = True
+        agent.session_id = "session-31269"
+        agent._last_flushed_db_idx = 1   # bridge already flushed the user turn
+        agent._persist_user_message_idx = 0
+        agent._persist_user_message_override = None
+        agent._session_messages = []
+        agent.save_session_log = False
+
+        # Pre-state matches the diagnostic: 1 user message, no assistant
+        # reply yet, but final_response holds the streamed bytes.
+        messages = [{"role": "user", "content": "what's 2+2?"}]
+        final_response = "2+2 is 4."
+
+        injected = _ensure_final_response_in_messages(messages, final_response)
+        assert injected is True
+
+        agent._persist_session(messages, conversation_history=[])
+
+        # The new assistant message must have been written.
+        write_kwargs_list = [
+            c.kwargs for c in agent._session_db.append_message.call_args_list
+        ]
+        roles = [k.get("role") for k in write_kwargs_list]
+        contents = [k.get("content") for k in write_kwargs_list]
+        assert "assistant" in roles, (
+            "Bridge worker would have lost the assistant reply — #31269 "
+            "regression. Rows actually written: %r" % write_kwargs_list
+        )
+        idx = roles.index("assistant")
+        assert contents[idx] == "2+2 is 4."
+
+    def test_happy_path_no_double_persist(self):
+        """When the conversation loop already appended the assistant message
+        (the normal text-response path), the safety-net injection must not
+        cause a duplicate row.
+        """
+        from run_agent import AIAgent
+
+        agent = AIAgent.__new__(AIAgent)
+        agent._session_db = MagicMock()
+        agent._session_db_created = True
+        agent.session_id = "session-happy"
+        agent._last_flushed_db_idx = 1
+        agent._persist_user_message_idx = 0
+        agent._persist_user_message_override = None
+        agent._session_messages = []
+        agent.save_session_log = False
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},   # already appended
+        ]
+
+        injected = _ensure_final_response_in_messages(messages, "hello")
+        assert injected is False
+
+        agent._persist_session(messages, conversation_history=[])
+
+        write_kwargs_list = [
+            c.kwargs for c in agent._session_db.append_message.call_args_list
+        ]
+        assistant_writes = [
+            k for k in write_kwargs_list if k.get("role") == "assistant"
+        ]
+        assert len(assistant_writes) == 1, (
+            "Happy path must produce exactly one assistant row — got %d"
+            % len(assistant_writes)
+        )
+        assert assistant_writes[0]["content"] == "hello"


### PR DESCRIPTION
## What does this PR do?

Fixes #31269: bridge-worker silently drops assistant replies from ``state.db``.

The bridge worker (``hermes_bridge.py``) and ``state.db`` flush by index — ``_flush_messages_to_session_db`` writes ``messages[_last_flushed_db_idx:]``, so anything not in the structured ``messages`` list silently never reaches disk.  A few break paths in ``run_conversation`` set ``final_response`` from already-streamed bytes WITHOUT appending the matching ``{"role": "assistant", "content": ...}`` dict:

* **Partial-stream recovery** (``conversation_loop.py:~3543``) — stream died mid-flight, the streamed buffer is recovered as the reply, ``break``.
* **Prior-turn-content fallback** (``conversation_loop.py:~3569``) — empty follow-up after housekeeping tools, the earlier turn's text is reused, ``break``.

In both cases the user *saw* the reply in the WebUI (it streamed through the Socket.IO callback) but ``state.db`` ended up with only the user message.  The diagnostic in the issue captured this exactly:

```
[hermes-bridge-worker:default] [DBG-BUG2] NOTHING TO FLUSH! flush_from=490 msg_len=490 last_asst_role=assistant
```

— the slice was empty because the dict never landed.

Two small additions wired together:

1. **Safety-net helper** (``agent/conversation_loop.py``) — adds module-level ``_ensure_final_response_in_messages(messages, final_response)`` that appends a structured ``{"role": "assistant", "content": <text>, "_injected_from_final_response": True}`` dict when the messages tail doesn't already carry the streamed reply.  Idempotent on the happy text-response path (the loop already appended its own dict at line ~3833).  Whitespace-tolerant matching avoids spurious double-injection.  Skipped for ``None`` / empty / whitespace ``final_response`` and for the ``"(empty)"`` user-facing failure sentinel — those have their own persistence semantics.  Wired in right before the FINAL ``_persist_session`` (after scaffolding cleanup so it doesn't fight the empty-response sentinel pop).

2. **Regression tests** (``tests/run_agent/test_final_response_injection_31269.py``) — 15 focused tests including the bridge-worker diagnostic replay (``_last_flushed_db_idx=1`` covering the user turn, no assistant dict, asserts the SQLite append actually receives the assistant row).

## Related Issue

Fixes #31269

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- ``agent/conversation_loop.py`` — new ``_EMPTY_RESPONSE_SENTINEL`` constant and ``_ensure_final_response_in_messages`` helper; integration call between ``_drop_trailing_empty_response_scaffolding`` and the FINAL ``_persist_session`` at ``run_conversation``'s tail; debug-level log when injection happened so post-mortems can correlate with the turn's exit reason.
- ``tests/run_agent/test_final_response_injection_31269.py`` — 15 unit + end-to-end regression tests (NEW FILE).

Backwards compatible: every existing exit path keeps working, the helper is idempotent, the new ``_injected_from_final_response`` flag is a transparent debugging marker that no existing consumer reads.

## How to Test

```bash
# New regression suite
python -m pytest tests/run_agent/test_final_response_injection_31269.py -v
# expected: 15 passed

# Adjacent run_agent suites — confirms no regression in persistence /
# dedup / scaffolding-cleanup paths
python -m pytest tests/run_agent/test_run_agent.py tests/run_agent/test_860_dedup.py tests/run_agent/test_final_response_injection_31269.py -q
# expected: 362 passed

# Focused conversation-loop / partial-stream / persist sweep
python -m pytest tests/run_agent -k 'conversation_loop or partial_stream or persist or session_db' -q
# expected: 33 passed
```

End-to-end behaviour after the fix (TypeScript WebUI → bridge worker → ``state.db``):

```
User sends \"what's 2+2?\"
  ↓
Bridge worker → AIAgent.run_conversation()
  ↓ partial-stream recovery: stream died, _current_streamed_assistant_text = \"2+2 is 4.\"
  ↓ final_response = \"2+2 is 4.\"; break
  ↓ _drop_trailing_empty_response_scaffolding(messages)  # no scaffolding present
  ↓ _ensure_final_response_in_messages(messages, \"2+2 is 4.\")  # injects
  ↓     messages = [user(\"what's 2+2?\"), assistant(\"2+2 is 4.\", _injected=True)]
  ↓ _persist_session(messages, ...)
  ↓ _flush_messages_to_session_db: messages[1:] writes 1 row → state.db ✅
```

## Checklist

- [x] Conventional Commits (``fix(agent):``, ``test(agent):``)
- [x] 2 focused commits, single author
- [x] 15 new tests pass; 362 adjacent run_agent tests pass; 33 conversation-loop / persist tests pass
- [x] Tested on macOS 15.6 (darwin 24.6.0)
- [x] No new config keys, no schema migration
- [x] Idempotent on the happy text-response path (no duplicate writes)
- [x] Skips empty / sentinel ``final_response`` so empty-response semantics are preserved
