### PR TITLE
Guard Kanban scratch workspace cleanup

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1518,8 +1518,11 @@ def create_task(
     now = int(time.time())
 
     # Resolve workspace_path from board-level default_workdir when the
-    # caller did not specify one explicitly.
-    if workspace_path is None:
+    # caller did not specify one explicitly.  Board defaults represent
+    # persistent project checkouts, so only persistent workspace kinds may
+    # inherit them.  Scratch workspaces are auto-deleted on completion and
+    # must stay under the per-board scratch root created by resolve_workspace.
+    if workspace_path is None and workspace_kind in {"dir", "worktree"}:
         board_slug = board if board else get_current_board()
         board_meta = read_board_metadata(board_slug)
         board_default = board_meta.get("default_workdir")
@@ -2904,13 +2907,50 @@ def complete_task(
 # Workspace / tmux cleanup
 # ---------------------------------------------------------------------------
 
+def _path_is_strict_child_of(path: Path, root: Path) -> bool:
+    """Return True when path is below root after best-effort resolution."""
+    try:
+        resolved_path = path.resolve()
+        resolved_root = root.resolve()
+        resolved_path.relative_to(resolved_root)
+        return resolved_path != resolved_root
+    except (OSError, ValueError):
+        return False
+
+
+def _is_safe_scratch_workspace_path(path: Path) -> bool:
+    """Return whether a scratch workspace path is safe to auto-delete.
+
+    Scratch cleanup is destructive by design, but only for Hermes-created
+    scratch directories.  Real project checkouts can appear in legacy/misfiled
+    rows (workspace_kind='scratch' + workspace_path=<repo>); those must never
+    be removed on task completion.
+    """
+    override = os.environ.get("HERMES_KANBAN_WORKSPACES_ROOT", "").strip()
+    if override and _path_is_strict_child_of(path, Path(override).expanduser()):
+        return True
+
+    root = kanban_home()
+    allowed_roots = [
+        root / "kanban" / "workspaces",
+    ]
+    boards_root = root / "kanban" / "boards"
+    if boards_root.is_dir():
+        allowed_roots.extend(
+            child / "workspaces" for child in boards_root.iterdir() if child.is_dir()
+        )
+
+    return any(_path_is_strict_child_of(path, allowed) for allowed in allowed_roots)
+
+
 def _cleanup_workspace(conn: sqlite3.Connection, task_id: str) -> None:
     """Remove a task's scratch workspace dir and kill its stale tmux session.
 
     Called from :func:`complete_task` after the DB transaction commits.
     Best-effort — any error is swallowed so cleanup never blocks task completion.
-    Only ``scratch`` workspaces are removed; ``worktree`` and ``dir`` workspaces
-    are intentionally preserved.
+    Only ``scratch`` workspaces under Hermes' Kanban scratch roots are removed;
+    ``worktree`` and ``dir`` workspaces are intentionally preserved, and legacy
+    misclassified scratch rows pointing at real project folders are refused.
     """
     try:
         row = conn.execute(
@@ -2924,10 +2964,13 @@ def _cleanup_workspace(conn: sqlite3.Connection, task_id: str) -> None:
         if kind != "scratch" or not path:
             return
         import shutil
-        wp = Path(path)
+        wp = Path(path).expanduser()
         if wp.is_dir():
-            shutil.rmtree(wp, ignore_errors=True)
-            _log.debug("Removed scratch workspace: %s", wp)
+            if not _is_safe_scratch_workspace_path(wp):
+                _log.warning("Refusing to remove scratch workspace outside Kanban scratch roots: %s", wp)
+            else:
+                shutil.rmtree(wp, ignore_errors=True)
+                _log.debug("Removed scratch workspace: %s", wp)
         # Also kill the tmux session for the worker that owned this task,
         # if the tmux session is now dead (worker process exited).
         _cleanup_worker_tmux(conn, task_id)

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2464,13 +2464,31 @@ def test_task_dict_survives_corrupt_created_at(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_create_task_without_workspace_inherits_board_default_workdir(kanban_home, monkeypatch):
-    """Board with default_workdir → create_task without workspace_path → inherits default."""
+def test_create_task_scratch_without_workspace_ignores_board_default_workdir(kanban_home, monkeypatch):
+    """Scratch tasks must not inherit default_workdir; scratch paths are auto-deleted."""
     default_wd = "/home/user/project"
     kb.create_board("work-proj", default_workdir=default_wd)
 
     with kb.connect(board="work-proj") as conn:
-        tid = kb.create_task(conn, title="inherited", board="work-proj")
+        tid = kb.create_task(conn, title="scratch", board="work-proj")
+        t = kb.get_task(conn, tid)
+    assert t is not None
+    assert t.workspace_kind == "scratch"
+    assert t.workspace_path is None
+
+
+def test_create_task_dir_without_workspace_inherits_board_default_workdir(kanban_home, monkeypatch):
+    """Board default_workdir is for persistent dir/worktree workspaces, not scratch."""
+    default_wd = "/home/user/project"
+    kb.create_board("work-proj", default_workdir=default_wd)
+
+    with kb.connect(board="work-proj") as conn:
+        tid = kb.create_task(
+            conn,
+            title="inherited",
+            workspace_kind="dir",
+            board="work-proj",
+        )
         t = kb.get_task(conn, tid)
     assert t is not None
     assert t.workspace_path == default_wd
@@ -2498,6 +2516,68 @@ def test_create_task_with_explicit_workspace_ignores_board_default(kanban_home):
     assert t is not None
     assert t.workspace_path == explicit
     assert t.workspace_path != "/board/default"
+
+
+def test_complete_task_refuses_to_delete_scratch_workspace_outside_kanban_root(kanban_home, tmp_path):
+    """Misclassified scratch tasks must not rmtree a real project checkout."""
+    kb.create_board("guard-board")
+    project_dir = tmp_path / "Workspace-nep" / "real-repo"
+    project_dir.mkdir(parents=True)
+    marker = project_dir / "keep.txt"
+    marker.write_text("important", encoding="utf-8")
+
+    with kb.connect(board="guard-board") as conn:
+        tid = kb.create_task(
+            conn,
+            title="dangerous legacy row",
+            workspace_kind="scratch",
+            workspace_path=str(project_dir),
+            board="guard-board",
+        )
+        assert kb.complete_task(conn, tid, result="done") is True
+
+    assert project_dir.is_dir()
+    assert marker.read_text(encoding="utf-8") == "important"
+
+
+def test_complete_task_deletes_scratch_workspace_inside_kanban_root(kanban_home):
+    """Legitimate scratch workspaces under the Kanban workspaces root are cleaned."""
+    kb.create_board("cleanup-board")
+
+    with kb.connect(board="cleanup-board") as conn:
+        tid = kb.create_task(conn, title="scratch", board="cleanup-board")
+        task = kb.claim_task(conn, tid)
+        assert task is not None
+        workspace = kb.resolve_workspace(task, board="cleanup-board")
+        kb.set_workspace_path(conn, tid, str(workspace))
+        marker = workspace / "temp.txt"
+        marker.write_text("artifact", encoding="utf-8")
+
+        assert kb.complete_task(conn, tid, result="done") is True
+
+    assert not workspace.exists()
+
+
+def test_complete_task_refuses_to_delete_workspaces_root_itself(kanban_home):
+    """Even a scratch task must not delete the entire board workspaces root."""
+    kb.create_board("root-guard-board")
+    root = kb.workspaces_root("root-guard-board")
+    root.mkdir(parents=True, exist_ok=True)
+    marker = root / "keep-root.txt"
+    marker.write_text("important", encoding="utf-8")
+
+    with kb.connect(board="root-guard-board") as conn:
+        tid = kb.create_task(
+            conn,
+            title="malformed root path",
+            workspace_kind="scratch",
+            workspace_path=str(root),
+            board="root-guard-board",
+        )
+        assert kb.complete_task(conn, tid, result="done") is True
+
+    assert root.is_dir()
+    assert marker.read_text(encoding="utf-8") == "important"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Prevent scratch tasks from inheriting board default_workdir, which can point at a real repo checkout
- Restrict destructive scratch cleanup to strict children of Kanban workspace roots
- Keep tmux cleanup best-effort even when refusing unsafe path deletion
- Add regression coverage for real repo paths, valid scratch paths, and workspace-root guard

## Verification
- ./scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py

## Recovery note
This fixes the workspace deletion root cause observed locally; existing dangerous task rows were separately migrated from scratch to dir in the affected local Kanban DBs.