### PR TITLE
fix(tools): guard websockets import in browser_supervisor

### DIFF
--- a/tests/tools/test_browser_supervisor_import_safety.py
+++ b/tests/tools/test_browser_supervisor_import_safety.py
@@ -1,0 +1,67 @@
+"""Import-safety regression tests for ``tools.browser_supervisor``.
+
+Issue #31005: the Homebrew bottle ships a slim venv that omits
+``websockets`` (a transitive dependency that hermes-agent does not declare
+as its own runtime dep). Before the fix, the top-level
+``import websockets`` in ``tools/browser_supervisor.py`` raised
+``ModuleNotFoundError`` whenever tool discovery touched the module, and
+``hermes`` startup logged
+``Could not import tool module tools.browser_dialog_tool: No module named 'websockets'``
+because ``browser_dialog_tool`` imports ``SUPERVISOR_REGISTRY`` from
+``browser_supervisor`` at module level.
+
+These tests prove:
+
+1. ``tools.browser_supervisor`` continues to import cleanly even when
+   ``websockets`` is unavailable.
+2. The downstream ``tools.browser_dialog_tool`` also imports cleanly, so
+   tool registration no longer fails at startup.
+3. Attempting to actually start a supervisor without ``websockets`` raises
+   a clear ``ImportError`` pointing to the install command, instead of a
+   confusing ``NameError`` deep inside the background thread.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+
+def _reload_supervisor_module(monkeypatch: pytest.MonkeyPatch, available: bool):
+    """Reload ``tools.browser_supervisor`` with websockets present or absent."""
+    if not available:
+        monkeypatch.setitem(sys.modules, "websockets", None)
+        monkeypatch.setitem(sys.modules, "websockets.asyncio", None)
+        monkeypatch.setitem(sys.modules, "websockets.asyncio.client", None)
+    sys.modules.pop("tools.browser_supervisor", None)
+    sys.modules.pop("tools.browser_dialog_tool", None)
+    return importlib.import_module("tools.browser_supervisor")
+
+
+def test_browser_supervisor_imports_without_websockets(monkeypatch):
+    module = _reload_supervisor_module(monkeypatch, available=False)
+    assert module._WS_AVAILABLE is False
+    assert module.SUPERVISOR_REGISTRY is not None
+
+
+def test_browser_dialog_tool_imports_without_websockets(monkeypatch):
+    _reload_supervisor_module(monkeypatch, available=False)
+    dialog = importlib.import_module("tools.browser_dialog_tool")
+    assert dialog.SUPERVISOR_REGISTRY is not None
+
+
+def test_supervisor_start_raises_clear_importerror_without_websockets(monkeypatch):
+    module = _reload_supervisor_module(monkeypatch, available=False)
+    supervisor = module.CDPSupervisor(task_id="t", cdp_url="ws://example/devtools")
+    with pytest.raises(ImportError, match="websockets"):
+        supervisor.start()
+
+
+def test_browser_supervisor_module_state_with_websockets_present():
+    pytest.importorskip("websockets")
+    sys.modules.pop("tools.browser_supervisor", None)
+    module = importlib.import_module("tools.browser_supervisor")
+    assert module._WS_AVAILABLE is True
+    assert module.websockets is not None

--- a/tests/tools/test_browser_supervisor_import_safety.py
+++ b/tests/tools/test_browser_supervisor_import_safety.py
@@ -17,26 +17,50 @@ These tests prove:
 2. The downstream ``tools.browser_dialog_tool`` also imports cleanly, so
    tool registration no longer fails at startup.
 3. Attempting to actually start a supervisor without ``websockets`` raises
-   a clear ``ImportError`` pointing to the install command, instead of a
+   a clear ImportError pointing to the install command, instead of a
    confusing ``NameError`` deep inside the background thread.
 """
 
 from __future__ import annotations
 
+import builtins
 import importlib
 import sys
 
 import pytest
 
 
-def _reload_supervisor_module(monkeypatch: pytest.MonkeyPatch, available: bool):
+def _block_websockets_import(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch ``builtins.__import__`` to raise ``ImportError`` for ``websockets*``.
+
+    Mirrors the canonical pattern used in
+    ``tests/tools/test_memory_tool_import_fallback.py`` and
+    ``tests/gateway/test_discord_imports.py``: rather than setting
+    ``sys.modules[name] = None`` (which can leak through to attribute access),
+    intercept the import call itself so any form of ``import websockets`` /
+    ``from websockets... import X`` raises the same ``ImportError`` Python
+    would raise if the package were genuinely missing.
+    """
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "websockets" or name.startswith("websockets."):
+            raise ImportError(f"No module named '{name}'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+
+def _reload_supervisor_module(
+    monkeypatch: pytest.MonkeyPatch, available: bool
+):
     """Reload ``tools.browser_supervisor`` with websockets present or absent."""
     if not available:
-        monkeypatch.setitem(sys.modules, "websockets", None)
-        monkeypatch.setitem(sys.modules, "websockets.asyncio", None)
-        monkeypatch.setitem(sys.modules, "websockets.asyncio.client", None)
-    sys.modules.pop("tools.browser_supervisor", None)
-    sys.modules.pop("tools.browser_dialog_tool", None)
+        for cached in ("websockets", "websockets.asyncio", "websockets.asyncio.client"):
+            monkeypatch.delitem(sys.modules, cached, raising=False)
+        _block_websockets_import(monkeypatch)
+    monkeypatch.delitem(sys.modules, "tools.browser_supervisor", raising=False)
+    monkeypatch.delitem(sys.modules, "tools.browser_dialog_tool", raising=False)
     return importlib.import_module("tools.browser_supervisor")
 
 
@@ -57,6 +81,17 @@ def test_supervisor_start_raises_clear_importerror_without_websockets(monkeypatc
     supervisor = module.CDPSupervisor(task_id="t", cdp_url="ws://example/devtools")
     with pytest.raises(ImportError, match="websockets"):
         supervisor.start()
+
+
+def test_supervisor_importerror_message_includes_min_version_and_original(monkeypatch):
+    module = _reload_supervisor_module(monkeypatch, available=False)
+    supervisor = module.CDPSupervisor(task_id="t", cdp_url="ws://example/devtools")
+    with pytest.raises(ImportError) as exc:
+        supervisor.start()
+    message = str(exc.value)
+    assert ">=13" in message, "expected min-version hint in error message"
+    assert "pip install" in message
+    assert "original error" in message, "expected original ImportError detail"
 
 
 def test_browser_supervisor_module_state_with_websockets_present():

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -28,8 +28,41 @@ import time
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
-import websockets
-from websockets.asyncio.client import ClientConnection
+# ``websockets`` is a transitive dependency of hermes-agent (via fal_client and
+# firecrawl-py) but not a declared one, so packagers that build a slim venv
+# (notably the Homebrew bottle, see issue #31005) can omit it. Guard the
+# import so tool discovery — which imports ``browser_dialog_tool`` ->
+# ``browser_supervisor`` at startup — does not crash with
+# ``ModuleNotFoundError: No module named 'websockets'``. Mirrors the pattern
+# in ``tools/browser_cdp_tool.py``. The supervisor itself requires
+# websockets to function; ``_assert_websockets`` raises a clear ImportError
+# the first time anything actually tries to start a supervisor.
+try:
+    import websockets
+    from websockets.asyncio.client import ClientConnection
+
+    _WS_AVAILABLE = True
+except ImportError:
+    websockets = None  # type: ignore[assignment]
+    ClientConnection = Any  # type: ignore[assignment,misc]
+    _WS_AVAILABLE = False
+
+
+def _assert_websockets() -> None:
+    """Raise a clear ImportError when the optional ``websockets`` dep is missing.
+
+    Called from ``CDPSupervisor.start`` so callers that never spin up a
+    supervisor (which is most of them on a fresh install — the CDP path is
+    only reached when the user wires up a browser) do not pay an import-time
+    cost. Without this guard, missing ``websockets`` would surface as a
+    confusing ``NameError`` deep inside the supervisor's background thread.
+    """
+    if not _WS_AVAILABLE:
+        raise ImportError(
+            "The 'websockets' Python package is required to run the browser "
+            "CDP supervisor but is not installed. Install it with: "
+            "pip install websockets"
+        )
 
 logger = logging.getLogger(__name__)
 
@@ -328,6 +361,7 @@ class CDPSupervisor:
         supervisor is fully wired up — pending-dialog events will be captured
         as of the moment ``start()`` returns.
         """
+        _assert_websockets()
         if self._thread and self._thread.is_alive():
             return
         self._ready_event.clear()

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -42,10 +42,12 @@ try:
     from websockets.asyncio.client import ClientConnection
 
     _WS_AVAILABLE = True
-except ImportError:
+    _WS_IMPORT_ERROR: Optional[BaseException] = None
+except ImportError as exc:
     websockets = None  # type: ignore[assignment]
     ClientConnection = Any  # type: ignore[assignment,misc]
     _WS_AVAILABLE = False
+    _WS_IMPORT_ERROR = exc
 
 
 def _assert_websockets() -> None:
@@ -56,13 +58,20 @@ def _assert_websockets() -> None:
     only reached when the user wires up a browser) do not pay an import-time
     cost. Without this guard, missing ``websockets`` would surface as a
     confusing ``NameError`` deep inside the supervisor's background thread.
+
+    The minimum supported version is ``websockets>=13`` because the
+    ``websockets.asyncio.client`` module landed in 13.0 — older releases only
+    ship the legacy ``websockets.client`` API and will trigger the same
+    ImportError as a missing package.
     """
     if not _WS_AVAILABLE:
+        detail = f" (original error: {_WS_IMPORT_ERROR})" if _WS_IMPORT_ERROR else ""
         raise ImportError(
-            "The 'websockets' Python package is required to run the browser "
-            "CDP supervisor but is not installed. Install it with: "
-            "pip install websockets"
-        )
+            "The 'websockets' Python package (>=13) is required to run the "
+            "browser CDP supervisor but is not installed or is too old. "
+            "Install or upgrade it with: pip install -U 'websockets>=13'"
+            + detail
+        ) from _WS_IMPORT_ERROR
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## What does this PR do?

`tools/browser_supervisor.py` hard-imported `websockets` and `websockets.asyncio.client.ClientConnection` at module load. `websockets` is a transitive dep (via `fal_client` / `firecrawl-py`) that hermes-agent does not declare as a top-level runtime dep, so any packager that builds a slim venv from the project's runtime dependencies — notably the Homebrew bottle, see #31005 — omits it.

`tools/browser_dialog_tool.py` does `from tools.browser_supervisor import SUPERVISOR_REGISTRY` at module level, so tool discovery touches the supervisor module on every Hermes startup. On a fresh Homebrew install the result was

```
Could not import tool module tools.browser_dialog_tool: No module named 'websockets'
```

logged at every startup, with the browser dialog tool silently absent from the registry.

This PR mirrors the lazy-import pattern already used by `tools/browser_cdp_tool.py`: the websockets imports are wrapped in `try/except ImportError`, a `_WS_AVAILABLE` flag is exposed, and `CDPSupervisor.start()` calls a small `_assert_websockets()` helper that raises a clear `ImportError` pointing to the install command — instead of crashing with a confusing `NameError` deep inside the supervisor's background thread.

## Related Issue

Addresses the second symptom in #31005 (websockets-missing import crash on Homebrew bottle). The MCP packaging half of #31005 is a separate Homebrew formula change and is intentionally out of scope here.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/browser_supervisor.py` — wrap `import websockets` / `from websockets.asyncio.client import ClientConnection` in `try/except ImportError`; expose `_WS_AVAILABLE`; add `_assert_websockets()` helper; call it at the top of `CDPSupervisor.start()`.
- `tests/tools/test_browser_supervisor_import_safety.py` — new regression suite that proves the module imports cleanly with `websockets` patched out, that `browser_dialog_tool` imports cleanly via the same path, and that `start()` raises a clear `ImportError` with the install command when the dep is absent.

## How to Test

1. Reproduce the original crash (without this fix):
   ```bash
   uv run --with pytest --with pytest-timeout python3 -m pytest \
     tests/tools/test_browser_supervisor_import_safety.py::test_browser_dialog_tool_imports_without_websockets -v
   # FAILED with: ModuleNotFoundError: import of websockets halted; None in sys.modules
   ```
2. Apply this PR and rerun the full new suite:
   ```bash
   uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout --with websockets \
     python3 -m pytest tests/tools/test_browser_supervisor_import_safety.py -v
   # 4 passed
   ```
3. Adjacent supervisor + CDP tests unaffected:
   ```bash
   uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout --with websockets \
     python3 -m pytest tests/tools/test_browser_supervisor_healthcheck.py tests/tools/test_browser_cdp_tool.py -v
   # 23 passed
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — applies on every platform where `websockets` may be missing (Homebrew, AUR, Nix slim-venv builds)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (tool surface unchanged)

> Sibling code paths that may need the same fix: `tools/browser_supervisor.py` is now safe; `tools/browser_cdp_tool.py` already had this guard. I checked the other browser/CDP-adjacent modules (`tools/browser_tool.py`, `tools/browser_supervisor.py` callers) and none import `websockets` at module level. No widening needed.