### PR TITLE
fix(dashboard): drain-driven PTY backpressure recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,10 @@ models-dev-upstream/
 hermes_cli/tui_dist/*
 hermes_cli/scripts/
 docs/superpowers/*
+docs/superpowers/**.oryx-avior.ts.net.*
+
+# Kapy CLI config and TLS certs (local only)
+.kapy/
+*.crt
+*.key
+

--- a/hermes_cli/pty_bridge.py
+++ b/hermes_cli/pty_bridge.py
@@ -199,6 +199,22 @@ class PtyBridge:
         except OSError:
             pass
 
+    def sigwinch(self) -> None:
+        """Send SIGWINCH to the child process (foreground process group).
+
+        Unlike :meth:`resize`, this delivers the signal unconditionally
+        regardless of whether the terminal dimensions have changed.  Used
+        by the PTY watchdog to recover a stalled Ink render pipeline —
+        Ink's ``handleResize`` cancels stale throttle/drain timers and
+        forces a full repaint on SIGWINCH.
+        """
+        if self._closed:
+            return
+        try:
+            os.kill(self._proc.pid, signal.SIGWINCH)
+        except (OSError, ProcessLookupError):
+            pass
+
     # -- teardown ---------------------------------------------------------
 
     def close(self) -> None:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3290,6 +3290,12 @@ except ImportError as _pty_import_err:  # pragma: no cover - Windows-only path
 
 _RESIZE_RE = re.compile(rb"\x1b\[RESIZE:(\d+);(\d+)\]")
 _PTY_READ_CHUNK_TIMEOUT = 0.2
+# If the PTY produces no output for this many seconds, send a SIGWINCH to
+# the child process.  Ink's handleResize cancels stale throttle/drain timers
+# and forces a full repaint — this "shakes loose" a render pipeline that
+# has gone silent due to backpressure stall (stdout.write returning false,
+# drain callback never firing) or throttle trailing-edge suppression.
+_PTY_WATCHDOG_SECONDS = 30
 _VALID_CHANNEL_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
 # Starlette's TestClient reports the peer as "testclient"; treat it as
 # loopback so tests don't need to rewrite request scope.
@@ -3461,7 +3467,16 @@ async def pty_ws(ws: WebSocket) -> None:
     loop = asyncio.get_running_loop()
 
     # --- reader task: PTY master → WebSocket ----------------------------
+    # Track the last time the PTY produced output.  If the Ink TUI's render
+    # pipeline silently stalls (backpressure on stdout.write, lost drain
+    # callback, or throttle trailing-edge suppression), no bytes flow from
+    # the PTY for an extended period.  A SIGWINCH forces Ink's handleResize
+    # which cancels stale timers and forces a full repaint — recovering the
+    # stuck render without the user having to resize the browser window.
+    _last_pty_output = time.monotonic()
+
     async def pump_pty_to_ws() -> None:
+        nonlocal _last_pty_output
         while True:
             chunk = await loop.run_in_executor(
                 None, bridge.read, _PTY_READ_CHUNK_TIMEOUT
@@ -3469,8 +3484,24 @@ async def pty_ws(ws: WebSocket) -> None:
             if chunk is None:  # EOF
                 return
             if not chunk:  # no data this tick; yield control and retry
+                # --- Watchdog: if no output for > _PTY_WATCHDOG_SECONDS,
+                # send a SIGWINCH to nudge Ink into a repaint.  Unlike
+                # TIOCSWINSZ (which only signals on dimension change),
+                # SIGWINCH is delivered unconditionally — Ink's handleResize
+                # cancels stale throttle/drain timers and forces a full
+                # repaint, recovering a stalled render pipeline.
+                if (time.monotonic() - _last_pty_output) > _PTY_WATCHDOG_SECONDS:
+                    _log.debug(
+                        "PTY watchdog: no output for %.0fs, sending SIGWINCH "
+                        "to pid %d to recover stalled render",
+                        time.monotonic() - _last_pty_output,
+                        bridge.pid,
+                    )
+                    _last_pty_output = time.monotonic()  # reset to avoid rapid re-fire
+                    bridge.sigwinch()
                 await asyncio.sleep(0)
                 continue
+            _last_pty_output = time.monotonic()
             try:
                 await ws.send_bytes(chunk)
             except Exception:

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -1128,6 +1128,15 @@ export default class Ink {
     // 250fps self-oscillator that locked the event loop after resize.
     if (frame.scrollDrainPending) {
       this.drainTimer = setTimeout(() => this.onRender(), FRAME_INTERVAL_MS >> 2)
+    } else if (backpressure && this.drainTimer === null) {
+      // Backpressure recovery: when stdout.write() returns false (pipe
+      // buffer full), the drain callback may never fire — the PTY/WebSocket
+      // bridge can stall, or the Node write queue can buffer indefinitely.
+      // Without a follow-up render, the throttle sees no new state changes
+      // and the pipeline goes permanently silent. Schedule a watchdog render
+      // to ensure the TUI recovers once the pipe drains or the PTY watchdog
+      // (SIGWINCH) forces a repaint.
+      this.drainTimer = setTimeout(() => this.onRender(), FRAME_INTERVAL_MS * 4)
     }
 
     const yogaMs = getLastYogaMs()

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -99,6 +99,10 @@ const TranscriptPane = memo(function TranscriptPane({
         ref={transcript.scrollRef}
         stickyScroll
       >
+        {/* Spacer pins messages to the bottom when content is shorter than
+            the viewport. flexGrow takes remaining free space; when content
+            overflows (no free space), it collapses to 0 automatically. */}
+        <Box flexGrow={1} />
         <Box flexDirection="column" paddingX={1}>
           {transcript.virtualHistory.topSpacer > 0 ? <Box height={transcript.virtualHistory.topSpacer} /> : null}
 


### PR DESCRIPTION
**Problem**
The dashboard's PTY/TUI render pipeline can silently stall when streaming Bash execution output. Two failure modes:
1. **Backpressure stall** – `stdout.write()` returns `false` (pipe buffer full), but the `drain` callback never fires. Node's write queue buffers indefinitely and the TUI goes permanently silent.
2. **Throttle suppression** – Ink's `onRender` throttle swallows trailing-edge updates after resize or rapid output, leaving stale/broken screen state.

There was no recovery path other than the user manually resizing the browser window.

**Solution**
Replace the `setInterval` watchdog timer with drain-event-driven backpressure handling plus a targeted PTY-level recovery:

1. **`pty_bridge.py`** – adds `sigwinch()` to deliver `SIGWINCH` to the child process unconditionally. Ink's `handleResize` cancels stale throttle/drain timers and forces a full repaint.
2. **`web_server.py`** – tracks `_last_pty_output`. If no bytes flow for > 30 s, sends `SIGWINCH` via the bridge to "shake loose" a stalled render.
3. **`ink.tsx`** – adds backpressure recovery: when `stdout.write()` returns `false` and no drain callback is pending, schedules a watchdog render after 4 frame intervals.
4. **`appLayout.tsx`** – adds a flex spacer so short content stays bottom-aligned without relying on sticky-scroll bottom-margin tricks that blank the TUI.

All changes are additive; existing test timeout and PTY teardown logic is unchanged.

**Testing Notes**
- Observed on Raspberry Pi 5 dashboard deployment with Caddy reverse-proxy.
- Before fix: stalls after ~30 s of heavy output. After fix: continuous stream, no manual resize needed.

---

cc @NousResearch/hermes-maintainers
