### PR TITLE
fix(cli): show last-turn preview after /resume so restored context is visible (#30351)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6625,8 +6625,49 @@ class HermesCLI:
                 f" ({msg_count} user message{'s' if msg_count != 1 else ''},"
                 f" {len(self.conversation_history)} total)"
             )
+            # Show a short preview of the last user + assistant turn so users
+            # have visible confirmation that the previous context was restored.
+            # The classic CLI does not re-render the full transcript on resume
+            # (TUI ships a dedicated overlay for that); without this preview
+            # users — especially on native Windows terminals where there is no
+            # scrollback restored — cannot tell whether /resume actually
+            # loaded the prior conversation. See #30351.
+            self._show_resume_context_preview()
         else:
             _cprint(f"  ↻ Resumed session {target_id}{title_part} — no messages, starting fresh.")
+
+    def _show_resume_context_preview(self, preview_limit: int = 240) -> None:
+        """Print a one-line preview of the last user + assistant turn after /resume.
+
+        Kept intentionally compact so it does not flood the terminal. Use
+        /history to view the full restored transcript.
+        """
+        last_user = None
+        last_assistant = None
+        for msg in reversed(self.conversation_history or []):
+            role = msg.get("role")
+            if role == "assistant" and last_assistant is None:
+                content = msg.get("content")
+                if content:
+                    last_assistant = str(content)
+            elif role == "user" and last_user is None:
+                content = msg.get("content")
+                if content:
+                    last_user = str(content)
+            if last_user and last_assistant:
+                break
+
+        def _truncate(text: str) -> str:
+            text = " ".join(text.split())
+            return text if len(text) <= preview_limit else text[:preview_limit] + "..."
+
+        if last_user or last_assistant:
+            _cprint("  Last turn:")
+            if last_user:
+                _cprint(f"    [You] {_truncate(last_user)}")
+            if last_assistant:
+                _cprint(f"    [Hermes] {_truncate(last_assistant)}")
+            _cprint("  Use /history for the full restored transcript.")
 
     def _handle_sessions_command(self, cmd_original: str) -> None:
         """Handle /sessions [list|<id_or_title>] — browse or resume previous sessions.

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -411,6 +411,93 @@ class TestHistoryDisplay:
         assert "Recent sessions" in output
         assert "Checking Running Hermes Agent" in output
 
+    def test_resume_prints_last_turn_preview(self, capsys):
+        """/resume into a session with prior history should print a short
+        preview of the last user + assistant turn so users have visible
+        confirmation that the prior context was actually restored. Regression
+        for #30351 (native Windows terminal users could not tell whether the
+        previous conversation context had been restored after `/resume`).
+        """
+        import cli as _cli_mod
+        cli = _make_cli()
+        cli.session_id = "current"
+        cli._session_db = MagicMock()
+        cli._session_db.get_session.return_value = {
+            "id": "20260401_201329_d85961",
+            "title": "Prior Conversation",
+        }
+        cli._session_db.resolve_resume_session_id.return_value = "20260401_201329_d85961"
+        cli._session_db.get_messages_as_conversation.return_value = [
+            {"role": "user", "content": "first message that should not be previewed"},
+            {"role": "assistant", "content": "early assistant reply"},
+            {"role": "user", "content": "what is the meaning of life?"},
+            {"role": "assistant", "content": "Forty-two, give or take."},
+        ]
+        cli.agent = None  # skip the agent-sync branch
+
+        printed = []
+        with patch.object(_cli_mod, "_cprint", side_effect=lambda t: printed.append(t)):
+            cli._handle_resume_command("/resume 20260401_201329_d85961")
+        output = "\n".join(printed)
+
+        assert "Resumed session 20260401_201329_d85961" in output
+        # Header for the new preview block.
+        assert "Last turn:" in output
+        # Last user + last assistant content is shown.
+        assert "what is the meaning of life?" in output
+        assert "Forty-two" in output
+        # Earlier turns are NOT printed in the preview.
+        assert "first message that should not be previewed" not in output
+        assert "early assistant reply" not in output
+        # Tip about /history is surfaced.
+        assert "/history" in output
+
+    def test_resume_preview_truncates_long_messages(self):
+        """Long restored turns are truncated so the preview stays compact."""
+        import cli as _cli_mod
+        cli = _make_cli()
+        cli.session_id = "current"
+        cli._session_db = MagicMock()
+        cli._session_db.get_session.return_value = {"id": "sess_long", "title": "Long"}
+        cli._session_db.resolve_resume_session_id.return_value = "sess_long"
+        long_assistant = "x" * 1000
+        cli._session_db.get_messages_as_conversation.return_value = [
+            {"role": "user", "content": "tiny user msg"},
+            {"role": "assistant", "content": long_assistant},
+        ]
+        cli.agent = None
+
+        printed = []
+        with patch.object(_cli_mod, "_cprint", side_effect=lambda t: printed.append(t)):
+            cli._handle_resume_command("/resume sess_long")
+        output = "\n".join(printed)
+
+        assert "Last turn:" in output
+        assert "tiny user msg" in output
+        # Trailing ellipsis indicates truncation; full 1000-char string is not printed.
+        assert "..." in output
+        assert long_assistant not in output
+
+    def test_resume_empty_session_skips_preview(self):
+        """Empty resumed sessions still print the 'starting fresh' line and
+        must NOT print the 'Last turn:' preview header."""
+        import cli as _cli_mod
+        cli = _make_cli()
+        cli.session_id = "current"
+        cli._session_db = MagicMock()
+        cli._session_db.get_session.return_value = {"id": "sess_empty", "title": "Empty"}
+        cli._session_db.resolve_resume_session_id.return_value = "sess_empty"
+        cli._session_db.get_messages_as_conversation.return_value = []
+        cli.agent = None
+
+        printed = []
+        with patch.object(_cli_mod, "_cprint", side_effect=lambda t: printed.append(t)):
+            cli._handle_resume_command("/resume sess_empty")
+        output = "\n".join(printed)
+
+        assert "starting fresh" in output
+        assert "Last turn:" not in output
+
     def test_sessions_with_target_delegates_to_resume(self):
         """/sessions <id_or_title> behaves identically to /resume <id_or_title>.
 


### PR DESCRIPTION
## Summary

- After `/resume`, the classic CLI prints only `↻ Resumed session <id> (N user messages, M total)` and returns to the prompt. The full transcript is not re-rendered (the TUI ships a dedicated overlay for that), so on native Windows 11 terminals — where there is no scrollback that survives the resume — users cannot tell whether the previous conversation context was actually restored.
- This PR adds a compact `Last turn:` preview after every successful `/resume` that has restored history: one `[You]` line + one `[Hermes]` line (both truncated to 240 chars), plus a tip to use `/history` for the full transcript.
- Empty resumed sessions are unchanged: they still print `starting fresh` and no preview header.
- Self-contained: no behavior change outside `_handle_resume_command` and the new `_show_resume_context_preview` helper.

## Test Plan

- [x] `python -m pytest tests/cli/test_cli_init.py -q -o 'addopts=' -k 'resume or sessions'` — 10 passed (3 new + 7 existing resume/sessions tests still green).
  - new: `test_resume_prints_last_turn_preview` — asserts last user + last assistant content is rendered and earlier turns are not.
  - new: `test_resume_preview_truncates_long_messages` — verifies the 240-char cap with ellipsis suffix.
  - new: `test_resume_empty_session_skips_preview` — asserts the `starting fresh` branch does not print a `Last turn:` header.

Closes #30351
