### PR TITLE
feat: refine Mem0, compression, Korean tips, and compact TUI

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -957,6 +957,24 @@ class ContextCompressor(ContextEngine):
             "do not preserve their values."
         )
 
+        # Preservation checklist shared by both first-compaction and iterative-update prompts.
+        # This is deliberately explicit because smaller auxiliary models can otherwise
+        # produce fluent but lossy summaries that omit operationally critical details.
+        _preservation_checklist = """Before writing the summary, apply this internal 12-item preservation checklist. Do NOT include the checklist itself; use it to decide what must appear in the structured sections:
+1. Preserve the user's most recent unfulfilled request exactly in ## Active Task.
+2. Preserve numbered rules, safety constraints, approvals, and prohibitions.
+3. Preserve security-sensitive instructions without secret values; redact credentials as [REDACTED].
+4. Preserve exact file paths, repository/worktree names, branches, and working directories.
+5. Preserve exact commands run and their outcomes, including exit status when known.
+6. Preserve modified, created, deleted, or explicitly untested files and their current status.
+7. Preserve test/build/lint results with pass/fail counts and failing test names or errors.
+8. Preserve configuration values, model names, flags, hostnames, ports, and parameters.
+9. Preserve unresolved blockers, warnings, assumptions, and remaining risks.
+10. Preserve running/background processes, server URLs, PIDs/session IDs when relevant.
+11. Preserve user decisions and answered questions so they are not repeated.
+12. Preserve enough exact evidence for the next agent to verify state without guessing.
+If a detail may affect safety, correctness, money, external messages, credentials, files, tests, or user continuity, include it explicitly even when aggressively compressing."""
+
         # Shared structured template (used by both paths).
         _template_sections = f"""## Active Task
 [THE SINGLE MOST IMPORTANT FIELD. Copy the user's most recent request or
@@ -1029,6 +1047,9 @@ PREVIOUS SUMMARY:
 NEW TURNS TO INCORPORATE:
 {content_to_summarize}
 
+PRESERVATION CHECKLIST:
+{_preservation_checklist}
+
 Update the summary using this exact structure. PRESERVE all existing information that is still relevant. ADD new completed actions to the numbered list (continue numbering). Move items from "In Progress" to "Completed Actions" when done. Move answered questions to "Resolved Questions". Update "Active State" to reflect current state. Remove information only if it is clearly obsolete. CRITICAL: Update "## Active Task" to reflect the user's most recent unfulfilled request — this is the most important field for task continuity.
 
 {_template_sections}"""
@@ -1040,6 +1061,9 @@ Create a structured checkpoint summary for the conversation after earlier turns 
 
 TURNS TO SUMMARIZE:
 {content_to_summarize}
+
+PRESERVATION CHECKLIST:
+{_preservation_checklist}
 
 Use this exact structure:
 

--- a/cli.py
+++ b/cli.py
@@ -3665,7 +3665,12 @@ class HermesCLI:
                     text += " · ⚠ YOLO"
                 return self._trim_status_bar_text(text, width)
             if width < 76:
-                parts = [f"⚕ {snapshot['model_short']}", percent_label]
+                # Keep the graphical context meter visible even in compact
+                # terminals. The older compact branch only showed the percent,
+                # which made the status bar look like the visual meter had
+                # disappeared on narrow panes.
+                compact_bar = self._build_context_bar(percent, width=6)
+                parts = [f"⚕ {snapshot['model_short']}", compact_bar, percent_label]
                 compressions = snapshot.get("compressions", 0)
                 if compressions:
                     parts.append(f"🗜️ {compressions}")
@@ -3732,11 +3737,14 @@ class HermesCLI:
                 if width < 76:
                     compressions = snapshot.get("compressions", 0)
                     bg_count = snapshot.get("active_background_tasks", 0)
+                    bar_style = self._status_bar_context_style(percent)
                     frags = [
                         ("class:status-bar", " ⚕ "),
                         ("class:status-bar-strong", snapshot["model_short"]),
                         ("class:status-bar-dim", " · "),
-                        (self._status_bar_context_style(percent), percent_label),
+                        (bar_style, self._build_context_bar(percent, width=6)),
+                        ("class:status-bar-dim", " "),
+                        (bar_style, percent_label),
                     ]
                     if compressions:
                         frags.append(("class:status-bar-dim", " · "))

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -695,8 +695,12 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
 
     console.print()
     term_width = shutil.get_terminal_size().columns
-    if term_width >= 95:
-        _logo = _bskin.banner_logo if _bskin and hasattr(_bskin, 'banner_logo') and _bskin.banner_logo else HERMES_AGENT_LOGO
+    _logo = _bskin.banner_logo if _bskin and hasattr(_bskin, 'banner_logo') and _bskin.banner_logo else HERMES_AGENT_LOGO
+    # Custom user skins may provide a compact startup image; allow those on
+    # standard 80-column terminals while preserving the built-in logo's wider
+    # 95-column guard.
+    min_logo_width = 80 if (_bskin and getattr(_bskin, "banner_logo", "")) else 95
+    if term_width >= min_logo_width:
         console.print(_logo)
         console.print()
     console.print(outer_panel)

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -473,13 +473,47 @@ TIPS = [
 ]
 
 
-def get_random_tip(exclude_recent: int = 0) -> str:
+KOREAN_TIPS = [
+    "/background <프롬프트>는 현재 대화를 막지 않고 별도 세션에서 작업을 실행합니다.",
+    "/queue <프롬프트>는 지금 진행 중인 응답을 끊지 않고 다음 턴에 이어서 처리합니다.",
+    "/new 제목을 쓰면 새 세션을 만들면서 바로 이름을 붙일 수 있습니다.",
+    "/resume은 이름 붙인 세션을 다시 이어서 엽니다.",
+    "/model <모델명>으로 세션 중에도 모델을 바꿀 수 있습니다.",
+    "/reasoning high는 중요한 판단에서 사고 깊이를 올립니다. 기본은 medium이면 충분합니다.",
+    "/verbose는 도구 진행 표시를 off → new → all → verbose 순서로 바꿉니다.",
+    "/stop은 에이전트가 띄운 백그라운드 프로세스를 정리합니다.",
+    "/usage는 현재 세션의 토큰·비용·시간을 보여줍니다.",
+    "/profile은 현재 프로필과 Hermes 홈 경로를 확인합니다.",
+    "@file:경로 를 메시지에 넣으면 해당 파일 내용을 바로 참고시킬 수 있습니다.",
+    "@diff는 아직 커밋하지 않은 git 변경분을 컨텍스트로 넣습니다.",
+    "Ctrl+C는 진행 중인 작업을 중단합니다. 2초 안에 두 번 누르면 강제 종료합니다.",
+    "Windows Terminal에서는 줄바꿈에 Alt+Enter 대신 Ctrl+Enter를 쓰는 편이 안전합니다.",
+    "긴 작업은 /background로 보내면 현재 대화는 계속 쓸 수 있습니다.",
+    "비용을 줄이려면 쓰지 않는 toolset과 skill을 꺼두는 게 가장 효과적입니다.",
+    "config.yaml의 display.language를 ko로 두면 게이트웨이 고정 문구가 한국어로 나옵니다.",
+    "이미지·파일은 MEDIA: 태그나 로컬 경로를 포함하면 플랫폼 첨부로 전송됩니다.",
+    "cron은 반복 알림용, OpenClaw 기존 자동화와 겹치면 먼저 영향 범위를 확인하는 게 안전합니다.",
+    "Hermes는 PM/검증, OpenClaw/태기는 백엔드 자동화로 나누면 운영이 깔끔합니다.",
+]
+
+
+def get_random_tip(exclude_recent: int = 0, lang: str | None = None) -> str:
     """Return a random tip string.
 
     Args:
         exclude_recent: not used currently; reserved for future
             deduplication across sessions.
+        lang: optional language override. Korean uses a curated localized corpus;
+            other languages fall back to the full English corpus.
     """
+    try:
+        if lang is None:
+            from agent.i18n import get_language
+            lang = get_language()
+    except Exception:
+        lang = None
+    if str(lang or "").lower() in {"ko", "ko-kr", "korean", "한국어"}:
+        return random.choice(KOREAN_TIPS)
     return random.choice(TIPS)
 
 

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -76,7 +76,18 @@ PROFILE_SCHEMA = {
         "Retrieve all stored memories about the user — preferences, facts, "
         "project context. Fast, no reranking. Use at conversation start."
     ),
-    "parameters": {"type": "object", "properties": {}, "required": []},
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "limit": {"type": "integer", "description": "Max memories to return (default: 100, max: 200)."},
+            "categories": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional Mem0 categories to filter by.",
+            },
+        },
+        "required": [],
+    },
 }
 
 SEARCH_SCHEMA = {
@@ -91,6 +102,17 @@ SEARCH_SCHEMA = {
             "query": {"type": "string", "description": "What to search for."},
             "rerank": {"type": "boolean", "description": "Enable reranking for precision (default: false)."},
             "top_k": {"type": "integer", "description": "Max results (default: 10, max: 50)."},
+            "threshold": {"type": "number", "description": "Optional relevance threshold; pass 0.0 to disable filtering."},
+            "categories": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional Mem0 categories to filter by.",
+            },
+            "fields": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional fields to request from Mem0, e.g. memory,score,created_at,categories.",
+            },
         },
         "required": ["query"],
     },
@@ -218,6 +240,25 @@ class Mem0MemoryProvider(MemoryProvider):
         return {"user_id": self._user_id, "agent_id": self._agent_id}
 
     @staticmethod
+    def _optional_list(value: Any) -> list | None:
+        """Normalize optional list-like tool arguments."""
+        if value is None or value == "":
+            return None
+        if isinstance(value, list):
+            return [str(v) for v in value if str(v)]
+        if isinstance(value, str):
+            return [part.strip() for part in value.split(",") if part.strip()]
+        return None
+
+    @staticmethod
+    def _bounded_int(value: Any, *, default: int, minimum: int, maximum: int) -> int:
+        try:
+            parsed = int(value)
+        except Exception:
+            parsed = default
+        return max(minimum, min(parsed, maximum))
+
+    @staticmethod
     def _unwrap_results(response: Any) -> list:
         """Normalize Mem0 API response — v2 wraps results in {"results": [...]}."""
         if isinstance(response, dict):
@@ -310,12 +351,39 @@ class Mem0MemoryProvider(MemoryProvider):
 
         if tool_name == "mem0_profile":
             try:
-                memories = self._unwrap_results(client.get_all(filters=self._read_filters()))
+                limit = self._bounded_int(args.get("limit", 100), default=100, minimum=1, maximum=200)
+                categories = self._optional_list(args.get("categories"))
+                page_size = min(limit, 100)
+                page = 1
+                memories = []
+                total_count = None
+                while len(memories) < limit:
+                    call_kwargs = {
+                        "filters": self._read_filters(),
+                        "page": page,
+                        "page_size": min(page_size, limit - len(memories)),
+                    }
+                    if categories is not None:
+                        call_kwargs["categories"] = categories
+                    response = client.get_all(**call_kwargs)
+                    if isinstance(response, dict):
+                        total_count = response.get("count", total_count)
+                    page_results = self._unwrap_results(response)
+                    if not page_results:
+                        break
+                    memories.extend(page_results)
+                    if len(page_results) < call_kwargs["page_size"]:
+                        break
+                    page += 1
                 self._record_success()
                 if not memories:
                     return json.dumps({"result": "No memories stored yet."})
                 lines = [m.get("memory", "") for m in memories if m.get("memory")]
-                return json.dumps({"result": "\n".join(lines), "count": len(lines)})
+                payload = {"result": "\n".join(lines), "count": len(lines)}
+                if total_count is not None:
+                    payload["total_count"] = total_count
+                    payload["truncated"] = len(lines) < total_count
+                return json.dumps(payload)
             except Exception as e:
                 self._record_failure()
                 return tool_error(f"Failed to fetch profile: {e}")
@@ -325,14 +393,23 @@ class Mem0MemoryProvider(MemoryProvider):
             if not query:
                 return tool_error("Missing required parameter: query")
             rerank = args.get("rerank", False)
-            top_k = min(int(args.get("top_k", 10)), 50)
+            top_k = self._bounded_int(args.get("top_k", 10), default=10, minimum=1, maximum=50)
+            categories = self._optional_list(args.get("categories"))
+            fields = self._optional_list(args.get("fields"))
             try:
-                results = self._unwrap_results(client.search(
-                    query=query,
-                    filters=self._read_filters(),
-                    rerank=rerank,
-                    top_k=top_k,
-                ))
+                call_kwargs = {
+                    "query": query,
+                    "filters": self._read_filters(),
+                    "rerank": rerank,
+                    "top_k": top_k,
+                }
+                if "threshold" in args and args.get("threshold") is not None:
+                    call_kwargs["threshold"] = float(args.get("threshold"))
+                if categories is not None:
+                    call_kwargs["categories"] = categories
+                if fields is not None:
+                    call_kwargs["fields"] = fields
+                results = self._unwrap_results(client.search(**call_kwargs))
                 self._record_success()
                 if not results:
                     return json.dumps({"result": "No relevant memories found."})

--- a/tests/hermes_cli/test_tips.py
+++ b/tests/hermes_cli/test_tips.py
@@ -1,7 +1,7 @@
 """Tests for hermes_cli/tips.py — random tip display at session start."""
 
 import pytest
-from hermes_cli.tips import TIPS, get_random_tip
+from hermes_cli.tips import KOREAN_TIPS, TIPS, get_random_tip
 
 
 class TestTipsCorpus:
@@ -42,8 +42,12 @@ class TestGetRandomTip:
         assert len(tip) > 0
 
     def test_returns_tip_from_corpus(self):
-        tip = get_random_tip()
+        tip = get_random_tip(lang="en")
         assert tip in TIPS
+
+    def test_returns_korean_tip_when_requested(self):
+        tip = get_random_tip(lang="ko")
+        assert tip in KOREAN_TIPS
 
     def test_randomness(self):
         """Multiple calls should eventually return different tips."""

--- a/tests/plugins/memory/test_mem0_v2.py
+++ b/tests/plugins/memory/test_mem0_v2.py
@@ -12,11 +12,13 @@ from plugins.memory.mem0 import Mem0MemoryProvider
 class FakeClientV2:
     """Fake Mem0 client that returns v2-style dict responses and captures call kwargs."""
 
-    def __init__(self, search_results=None, all_results=None):
+    def __init__(self, search_results=None, all_results=None, all_pages=None):
         self._search_results = search_results or {"results": []}
         self._all_results = all_results or {"results": []}
+        self._all_pages = all_pages
         self.captured_search = {}
         self.captured_get_all = {}
+        self.captured_get_all_calls = []
         self.captured_add = []
 
     def search(self, **kwargs):
@@ -25,6 +27,10 @@ class FakeClientV2:
 
     def get_all(self, **kwargs):
         self.captured_get_all = kwargs
+        self.captured_get_all_calls.append(kwargs)
+        if self._all_pages is not None:
+            page = kwargs.get("page", 1)
+            return self._all_pages[page - 1] if page - 1 < len(self._all_pages) else {"results": []}
         return self._all_results
 
     def add(self, messages, **kwargs):
@@ -60,6 +66,25 @@ class TestMem0FiltersV2:
         # Must NOT have bare user_id kwarg
         assert "user_id" not in {k for k in client.captured_search if k != "filters"}
 
+    def test_search_passes_supported_options(self, monkeypatch):
+        client = FakeClientV2()
+        provider = self._make_provider(monkeypatch, client)
+
+        provider.handle_tool_call("mem0_search", {
+            "query": "hello",
+            "top_k": 99,
+            "rerank": True,
+            "threshold": 0.0,
+            "categories": ["preferences"],
+            "fields": "memory,score,created_at,categories",
+        })
+
+        assert client.captured_search["top_k"] == 50
+        assert client.captured_search["rerank"] is True
+        assert client.captured_search["threshold"] == 0.0
+        assert client.captured_search["categories"] == ["preferences"]
+        assert client.captured_search["fields"] == ["memory", "score", "created_at", "categories"]
+
     def test_profile_uses_filters(self, monkeypatch):
         client = FakeClientV2()
         provider = self._make_provider(monkeypatch, client)
@@ -68,6 +93,24 @@ class TestMem0FiltersV2:
 
         assert client.captured_get_all["filters"] == {"user_id": "u123"}
         assert "user_id" not in {k for k in client.captured_get_all if k != "filters"}
+
+    def test_profile_paginates_and_reports_truncation(self, monkeypatch):
+        client = FakeClientV2(all_pages=[
+            {"count": 3, "results": [{"memory": "alpha"}, {"memory": "beta"}]},
+            {"count": 3, "results": [{"memory": "gamma"}]},
+        ])
+        provider = self._make_provider(monkeypatch, client)
+
+        result = json.loads(provider.handle_tool_call("mem0_profile", {"limit": 2, "categories": "preferences"}))
+
+        assert result["count"] == 2
+        assert result["total_count"] == 3
+        assert result["truncated"] is True
+        assert "alpha" in result["result"]
+        assert "beta" in result["result"]
+        assert len(client.captured_get_all_calls) == 1
+        assert client.captured_get_all_calls[0]["page_size"] == 2
+        assert client.captured_get_all_calls[0]["categories"] == ["preferences"]
 
     def test_prefetch_uses_filters(self, monkeypatch):
         client = FakeClientV2()


### PR DESCRIPTION
## Summary
- add optional Mem0 profile/search arguments with pagination/truncation handling
- strengthen context compression prompts with an explicit preservation checklist for handoff-critical details
- add Korean startup tips selected by active language
- improve compact TUI status-bar context meter and custom skin logo rendering on 80-column terminals

## Test Plan
- [x] `venv/bin/python -m py_compile agent/context_compressor.py cli.py hermes_cli/banner.py hermes_cli/tips.py plugins/memory/mem0/__init__.py`
- [x] `git diff --check`
- [x] `venv/bin/python -m pytest tests/hermes_cli/test_tips.py tests/plugins/memory/test_mem0_v2.py tests/agent/test_context_compressor.py tests/agent/test_context_compressor_summary_continuity.py tests/hermes_cli/test_banner.py tests/cli/test_cli_status_bar.py -q -o 'addopts='` — 156 passed

## Notes
Draft PR for maintainers to review the four small overlays independently. The TUI custom-logo threshold change is intentionally scoped to custom skins only; built-in logo width guard stays unchanged.
