### PR TITLE
fix(qqbot): avoid closed websocket busy loop

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -692,6 +692,9 @@ class QQAdapter(BasePlatformAdapter):
             elif msg.type in {aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR}:
                 raise RuntimeError("WebSocket closed")
 
+        if self._running:
+            raise RuntimeError("WebSocket closed")
+
     async def _heartbeat_loop(self) -> None:
         """Send periodic heartbeats (QQ Gateway expects op 1 heartbeat with latest seq).
 

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -410,6 +410,28 @@ class TestQQCloseError:
 
 
 # ---------------------------------------------------------------------------
+# _read_events
+# ---------------------------------------------------------------------------
+
+class TestReadEvents:
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot import QQAdapter
+        return QQAdapter(_make_config(**extra))
+
+    @pytest.mark.asyncio
+    async def test_closed_websocket_raises_instead_of_returning_silently(self):
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter._running = True
+        closed_ws = SimpleNamespace(closed=True, receive=mock.AsyncMock())
+        adapter._ws = closed_ws
+
+        with pytest.raises(RuntimeError, match="WebSocket closed"):
+            await adapter._read_events()
+
+        closed_ws.receive.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
 # _dispatch_payload
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes a QQBot gateway edge case where a closed WebSocket can make the gateway spin in a tight reconnect/read loop instead of backing off.

Changes:
- make `QQAdapter._read_events()` raise `RuntimeError("WebSocket closed")` when the receive loop exits while the adapter is still running
- prevent `_listen_loop` from treating an already-closed websocket as a clean read-loop return
- add a regression test that verifies a pre-closed websocket raises and does not call/await `receive()`

## How this was encountered

I hit this on a long-running local Hermes gateway with Discord, Weixin, and QQBot enabled. After a transient network/DNS disruption, QQBot reported WebSocket close/reconnect failures. The gateway process stayed alive under launchd, but it stopped responding normally:

- gateway process was still running
- CPU stayed around ~100%
- Discord started reporting `heartbeat blocked` for many hours
- QQBot appeared connected/reconnecting in logs, but platform traffic was not handled reliably
- a normal `hermes gateway restart` could not cleanly recover the wedged process; launchd SIGKILL was needed to let the service relaunch

Root cause: if `_read_events()` is entered while `self._ws.closed` is already true, this condition is false immediately:

```py
while self._running and self._ws and not self._ws.closed:
    msg = await self._ws.receive()
```

Before this PR, that meant `_read_events()` returned silently. `_listen_loop()` then treated the return as a clean read-loop exit and immediately started the next loop iteration, which can create a no-sleep/no-backoff busy loop around the closed websocket state.

## How to reproduce

The new regression test captures the minimal reproducer:

1. create a `QQAdapter`
2. set `adapter._running = True`
3. assign `adapter._ws` to an object where `closed == True`
4. call `await adapter._read_events()`

Before this fix:
- `_read_events()` returned silently
- the test failed with `DID NOT RAISE RuntimeError`
- the outer listen loop could continue spinning

After this fix:
- `_read_events()` raises `RuntimeError("WebSocket closed")`
- `receive()` is not awaited for an already-closed websocket
- `_listen_loop()` takes the existing exception/reconnect path instead of resetting disconnect counters as if the read loop ended cleanly

## Sanitized logs from the incident

Gateway log samples:

```text
WARNING gateway.platforms.qqbot.adapter: [QQBot:<app_id>] WebSocket closed: code=4009 reason=Session timed out
WARNING gateway.platforms.qqbot.adapter: [QQBot:<app_id>] Reconnect failed: Failed to get QQ Bot gateway URL: [Errno 8] nodename nor servname provided, or not known
INFO gateway.run: ✓ qqbot connected
INFO gateway.run: Gateway running with 3 platform(s)
```

`gateway.error.log` showed the cross-platform symptom: Discord heartbeat warnings while the event loop traceback pointed into the QQBot adapter read loop:

```text
WARNING discord.gateway: Shard ID None heartbeat blocked for more than 25320 seconds.
Loop thread traceback (most recent call last):
  File "/Users/<user>/.hermes/hermes-agent/gateway/platforms/qqbot/adapter.py", line 492, in _listen_loop
    await self._read_events()
  File "/Users/<user>/.hermes/hermes-agent/gateway/platforms/qqbot/adapter.py", line 654, in _read_events
    async def _read_events(self) -> None:

WARNING discord.gateway: Shard ID None heartbeat blocked for more than 25330 seconds.
Loop thread traceback (most recent call last):
  File "/Users/<user>/.hermes/hermes-agent/gateway/platforms/qqbot/adapter.py", line 492, in _listen_loop
    await self._read_events()
  File "/Users/<user>/.hermes/hermes-agent/gateway/platforms/qqbot/adapter.py", line 659, in _read_events
  File "/Users/<user>/.hermes/hermes-agent/venv/lib/python3.11/site-packages/aiohttp/client_ws.py", line 197, in closed
```

A later warning showed the same wedged gateway had been blocked for much longer:

```text
WARNING discord.gateway: Shard ID None heartbeat blocked for more than 74060 seconds.
```

All user paths and long identifiers above are redacted.

## Fix result

With this PR, the already-closed websocket path now raises and flows into the existing `_listen_loop()` exception handler/backoff logic. This avoids the observed busy-loop failure mode and allows QQBot reconnect handling to behave like other websocket-close errors.

After applying the local patch and restarting the gateway, the service recovered:

```text
INFO gateway.run: ✓ qqbot connected
INFO gateway.run: Gateway running with 3 platform(s)
```

The local gateway CPU dropped from ~100% back to idle after relaunch.

## Test Plan

```bash
venv/bin/python -m pytest tests/gateway/test_qqbot.py tests/gateway/test_platform_http_client_limits.py -q -o 'addopts='
```

Result:

```text
166 passed, 4 warnings in 3.34s
```

The warnings are pre-existing coroutine warnings from unrelated QQBot tests; the new regression test passes.