### PR TITLE
feat(gateway): add Mattermost clarify action buttons

### DIFF
--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -18,6 +18,7 @@ import json
 import logging
 import os
 import re
+import secrets
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -48,6 +49,21 @@ _CHANNEL_TYPE_MAP = {
 _RECONNECT_BASE_DELAY = 2.0
 _RECONNECT_MAX_DELAY = 60.0
 _RECONNECT_JITTER = 0.2
+
+# Mattermost action callback defaults for interactive clarify buttons.
+_DEFAULT_ACTIONS_HOST = "0.0.0.0"
+_DEFAULT_ACTIONS_PORT = 8769
+_ACTIONS_PATH = "/mattermost/actions"
+_MATTERMOST_ACTION_ID_RE = re.compile(r"[^A-Za-z0-9]")
+
+
+def _truthy(value: Any, default: bool = False) -> bool:
+    """Coerce common config/env truthy strings."""
+    if value is None or value == "":
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
 
 
 def check_mattermost_requirements() -> bool:
@@ -98,6 +114,35 @@ class MattermostAdapter(BasePlatformAdapter):
 
         # Dedup cache (prevent reprocessing)
         self._dedup = MessageDeduplicator()
+
+        # Optional interactive-message callback server for clarify buttons.
+        # Mattermost action buttons POST back to an integration URL; when
+        # configured, Hermes renders clarify choices as real buttons and
+        # resolves them through this lightweight aiohttp endpoint.
+        actions_url = (
+            config.extra.get("actions_url", "")
+            or os.getenv("MATTERMOST_ACTIONS_URL", "")
+        ).strip()
+        self._actions_url: str = actions_url.rstrip("/")
+        self._actions_enabled: bool = _truthy(
+            config.extra.get("actions_enabled", os.getenv("MATTERMOST_ACTIONS_ENABLED", "")),
+            default=bool(self._actions_url),
+        )
+        self._actions_host: str = (
+            config.extra.get("actions_host", "")
+            or os.getenv("MATTERMOST_ACTIONS_HOST", _DEFAULT_ACTIONS_HOST)
+        )
+        self._actions_port: int = int(
+            config.extra.get("actions_port", "")
+            or os.getenv("MATTERMOST_ACTIONS_PORT", str(_DEFAULT_ACTIONS_PORT))
+        )
+        self._actions_runner: Any = None
+        self._actions_server_ready: bool = False
+        # One-time action tokens keyed by the opaque value embedded in the
+        # Mattermost button context. Do not put reusable secrets in message
+        # props: post props may be visible via clients/API export.
+        self._clarify_action_tokens: Dict[str, Dict[str, Any]] = {}
+        self._approval_action_tokens: Dict[str, Dict[str, Any]] = {}
 
     # ------------------------------------------------------------------
     # HTTP helpers
@@ -223,6 +268,7 @@ class MattermostAdapter(BasePlatformAdapter):
 
         # Start WebSocket in background.
         self._ws_task = asyncio.create_task(self._ws_loop())
+        await self._start_actions_server()
         self._mark_connected()
         return True
 
@@ -243,6 +289,8 @@ class MattermostAdapter(BasePlatformAdapter):
         if self._ws:
             await self._ws.close()
             self._ws = None
+
+        await self._stop_actions_server()
 
         if self._session and not self._session.closed:
             await self._session.close()
@@ -299,6 +347,446 @@ class MattermostAdapter(BasePlatformAdapter):
             last_id = data["id"]
 
         return SendResult(success=True, message_id=last_id)
+
+    def _actions_endpoint_url(self, kind: str = "clarify") -> str:
+        """Return the Mattermost integration callback URL for action buttons."""
+        if not self._actions_url:
+            return ""
+        suffix = (kind or "clarify").strip("/")
+        base = self._actions_url.rstrip("/")
+        for known in ("/clarify", "/approval"):
+            if base.endswith(known):
+                base = base[: -len(known)]
+                break
+        return f"{base}/{suffix}"
+
+    async def send_exec_approval(
+        self,
+        chat_id: str,
+        command: str,
+        session_key: str,
+        description: str = "dangerous command",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Ask for dangerous-command approval with Mattermost action buttons."""
+        endpoint = self._actions_endpoint_url("approval")
+        if not self._actions_enabled or not endpoint or not self._actions_server_ready:
+            return SendResult(success=False, error="Mattermost action callback server is not ready")
+
+        expected_user_id = ""
+        thread_id = ""
+        if isinstance(metadata, dict):
+            expected_user_id = str(metadata.get("user_id") or "")
+            thread_id = str(metadata.get("thread_id") or "")
+
+        prompt_id = secrets.token_hex(6)
+
+        def _register_approval_token(choice: str) -> str:
+            token = secrets.token_urlsafe(24)
+            self._approval_action_tokens[token] = {
+                "session_key": session_key,
+                "chat_id": chat_id,
+                "thread_id": thread_id,
+                "expected_user_id": expected_user_id,
+                "choice": choice,
+            }
+            return token
+
+        button_defs = [
+            ("once", "Allow Once", "success"),
+            ("session", "Allow Session", "primary"),
+            ("always", "Always Allow", "primary"),
+            ("deny", "Deny", "danger"),
+        ]
+        actions: List[Dict[str, Any]] = []
+        for choice, label, style in button_defs:
+            token = _register_approval_token(choice)
+            actions.append({
+                # Mattermost action IDs must match [A-Za-z0-9]+ or the click
+                # 404s before reaching the integration callback.
+                "id": f"approval{prompt_id}{choice}",
+                "name": label,
+                "type": "button",
+                "style": style,
+                "integration": {
+                    "url": endpoint,
+                    "context": {
+                        "kind": "approval",
+                        "token": token,
+                    },
+                },
+            })
+
+        cmd_preview = command if len(command) <= 3200 else f"{command[:3197]}..."
+        payload: Dict[str, Any] = {
+            "channel_id": chat_id,
+            "message": "⚠️ **Dangerous command requires approval:**",
+            "props": {
+                "attachments": [{
+                    "text": f"```\n{cmd_preview}\n```\nReason: {description}",
+                    "actions": actions,
+                }],
+            },
+        }
+        if thread_id and self._reply_mode == "thread":
+            payload["root_id"] = await self._resolve_root_id(thread_id)
+
+        data = await self._api_post("posts", payload)
+        if not data or "id" not in data:
+            self._clear_approval_action_tokens(session_key)
+            return SendResult(success=False, error="Failed to create Mattermost approval post")
+        return SendResult(success=True, message_id=data.get("id"))
+
+    def _clear_approval_action_tokens(self, session_key: str) -> None:
+        """Drop all one-time Mattermost action tokens for an approval session."""
+        stale = [
+            token for token, state in self._approval_action_tokens.items()
+            if state.get("session_key") == session_key
+        ]
+        for token in stale:
+            self._approval_action_tokens.pop(token, None)
+
+    async def send_clarify(
+        self,
+        chat_id: str,
+        question: str,
+        choices: Optional[List[str]],
+        clarify_id: str,
+        session_key: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Ask a clarify question with Mattermost action buttons when possible."""
+        from tools import clarify_gateway as cm
+
+        # Open-ended questions still use text capture; there is no button UI to render.
+        if not choices:
+            cm.mark_awaiting_text(clarify_id)
+            return await self.send(chat_id, f"❓ {question}", metadata=metadata)
+
+        endpoint = self._actions_endpoint_url("clarify")
+        if not self._actions_enabled or not endpoint or not self._actions_server_ready:
+            # No live callback endpoint configured; preserve the BasePlatform numbered-text fallback.
+            return await super().send_clarify(chat_id, question, choices, clarify_id, session_key, metadata=metadata)
+
+        expected_user_id = ""
+        thread_id = ""
+        if isinstance(metadata, dict):
+            expected_user_id = str(metadata.get("user_id") or "")
+            thread_id = str(metadata.get("thread_id") or "")
+
+        actions: List[Dict[str, Any]] = []
+
+        def _register_action_token(choice_value: str, choice_index: Optional[int] = None) -> str:
+            token = secrets.token_urlsafe(24)
+            self._clarify_action_tokens[token] = {
+                "clarify_id": clarify_id,
+                "session_key": session_key,
+                "chat_id": chat_id,
+                "thread_id": thread_id,
+                "expected_user_id": expected_user_id,
+                "choice_index": choice_index,
+                "choice": choice_value,
+            }
+            return token
+
+        safe_clarify_id = _MATTERMOST_ACTION_ID_RE.sub("", str(clarify_id)) or "prompt"
+        for idx, choice in enumerate(choices):
+            label = str(choice)
+            display = label if len(label) <= 64 else f"{label[:61]}..."
+            token = _register_action_token(label, idx)
+            actions.append({
+                # Mattermost routes post actions through
+                # /api/v4/posts/{post_id}/actions/{action_id:[A-Za-z0-9]+};
+                # hyphens render fine but make clicks 404 before they reach
+                # our integration callback.
+                "id": f"clarify{safe_clarify_id}{idx}",
+                "name": f"{idx + 1}. {display}",
+                "type": "button",
+                "style": "default",
+                "integration": {
+                    "url": endpoint,
+                    "context": {
+                        "kind": "clarify",
+                        "token": token,
+                    },
+                },
+            })
+
+        other_token = _register_action_token("__other__", None)
+        actions.append({
+            "id": f"clarify{safe_clarify_id}other",
+            "name": "Other",
+            "type": "button",
+            "style": "primary",
+            "integration": {
+                "url": endpoint,
+                "context": {
+                    "kind": "clarify",
+                    "token": other_token,
+                },
+            },
+        })
+
+        payload: Dict[str, Any] = {
+            "channel_id": chat_id,
+            "message": f"❓ {question}",
+            "props": {
+                "attachments": [{
+                    "text": "Choose one of the options below, or click Other to type a custom answer.",
+                    "actions": actions,
+                }]
+            },
+        }
+        data = await self._api_post("posts", payload)
+        if not data or "id" not in data:
+            logger.warning("Mattermost clarify buttons failed; falling back to numbered text prompt")
+            self._clear_clarify_action_tokens(clarify_id)
+            return await super().send_clarify(chat_id, question, choices, clarify_id, session_key, metadata=metadata)
+        return SendResult(success=True, message_id=data.get("id"))
+
+    def _clear_clarify_action_tokens(self, clarify_id: str) -> None:
+        """Drop all one-time Mattermost action tokens for a clarify prompt."""
+        stale = [
+            token for token, state in self._clarify_action_tokens.items()
+            if state.get("clarify_id") == clarify_id
+        ]
+        for token in stale:
+            self._clarify_action_tokens.pop(token, None)
+
+    async def _start_actions_server(self) -> None:
+        """Start the optional Mattermost action callback server."""
+        if not self._actions_enabled or not self._actions_url or self._actions_runner:
+            return
+        try:
+            from aiohttp import web
+        except ImportError:
+            logger.warning("Mattermost action buttons disabled: aiohttp.web unavailable")
+            return
+
+        app = web.Application()
+        app.router.add_get(f"{_ACTIONS_PATH}/health", self._handle_actions_health)
+        app.router.add_post(f"{_ACTIONS_PATH}/clarify", self._handle_clarify_action_request)
+        app.router.add_post(f"{_ACTIONS_PATH}/approval", self._handle_approval_action_request)
+        try:
+            runner = web.AppRunner(app)
+            await runner.setup()
+            site = web.TCPSite(runner, self._actions_host, self._actions_port)
+            await site.start()
+        except Exception as exc:
+            logger.warning(
+                "Mattermost action buttons disabled: failed to listen on %s:%s (%s)",
+                self._actions_host,
+                self._actions_port,
+                exc,
+            )
+            try:
+                await runner.cleanup()  # type: ignore[possibly-undefined]
+            except Exception:
+                pass
+            return
+
+        self._actions_runner = runner
+        self._actions_server_ready = True
+        logger.info(
+            "Mattermost action callbacks listening on %s:%s%s (public URL: %s)",
+            self._actions_host,
+            self._actions_port,
+            _ACTIONS_PATH,
+            self._actions_url,
+        )
+
+    async def _stop_actions_server(self) -> None:
+        """Stop the optional Mattermost action callback server."""
+        runner = self._actions_runner
+        if not runner:
+            self._actions_server_ready = False
+            return
+        self._actions_runner = None
+        self._actions_server_ready = False
+        try:
+            await runner.cleanup()
+        except Exception:
+            logger.debug("Mattermost action callback cleanup failed", exc_info=True)
+
+    async def _handle_actions_health(self, request: Any) -> Any:
+        from aiohttp import web
+        return web.json_response({"ok": True, "platform": "mattermost"})
+
+    async def _handle_clarify_action_request(self, request: Any) -> Any:
+        from aiohttp import web
+        try:
+            payload = await request.json()
+        except Exception:
+            return web.json_response({"error": {"message": "Invalid JSON payload."}}, status=400)
+        response = await self._handle_clarify_action_payload(payload)
+        if "error" in response:
+            # Mattermost renders non-2xx action callback responses as the
+            # generic "Sorry, we could not find the page."  Return a normal
+            # interactive-message response with an ephemeral error instead so
+            # stale/timed-out buttons explain themselves without looking like a
+            # broken route.
+            error = response.get("error") or {}
+            message = error.get("message") if isinstance(error, dict) else ""
+            return web.json_response({"ephemeral_text": message or "This action is no longer available."})
+        return web.json_response(response)
+
+    async def _handle_approval_action_request(self, request: Any) -> Any:
+        from aiohttp import web
+        try:
+            payload = await request.json()
+        except Exception:
+            return web.json_response({"error": {"message": "Invalid JSON payload."}}, status=400)
+        response = await self._handle_approval_action_payload(payload)
+        if "error" in response:
+            error = response.get("error") or {}
+            message = error.get("message") if isinstance(error, dict) else ""
+            return web.json_response({"ephemeral_text": message or "This approval is no longer available."})
+        return web.json_response(response)
+
+    async def _handle_approval_action_payload(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Resolve a Mattermost dangerous-command approval button payload."""
+        from tools.approval import has_blocking_approval, resolve_gateway_approval
+
+        if not isinstance(payload, dict):
+            return {"error": {"message": "Invalid Mattermost action payload."}}
+        context = payload.get("context") or {}
+        if not isinstance(context, dict):
+            return {"error": {"message": "Invalid Mattermost action context."}}
+        if context.get("kind") != "approval":
+            return {"error": {"message": "Unsupported Mattermost action."}}
+
+        token = str(context.get("token") or "")
+        if not token:
+            return {"error": {"message": "Missing Mattermost action token."}}
+        state = self._approval_action_tokens.get(token)
+        if not state:
+            return {"error": {"message": "This approval is no longer waiting for an answer."}}
+
+        payload_channel_id = str(payload.get("channel_id") or "")
+        expected_channel_id = str(state.get("chat_id") or "")
+        if expected_channel_id and payload_channel_id and payload_channel_id != expected_channel_id:
+            return {"error": {"message": "This approval belongs to a different Mattermost channel."}}
+
+        expected_user_id = str(state.get("expected_user_id") or "")
+        payload_user_id = str(payload.get("user_id") or "")
+        if expected_user_id and payload_user_id != expected_user_id:
+            return {"error": {"message": "Only the user who was asked can approve this command."}}
+
+        session_key = str(state.get("session_key") or "")
+        choice = str(state.get("choice") or "")
+        if choice not in {"once", "session", "always", "deny"}:
+            self._approval_action_tokens.pop(token, None)
+            return {"error": {"message": "Invalid approval choice."}}
+        if not session_key or not has_blocking_approval(session_key):
+            self._clear_approval_action_tokens(session_key)
+            return {"error": {"message": "This approval is no longer waiting for an answer."}}
+
+        count = resolve_gateway_approval(session_key, choice)
+        self._clear_approval_action_tokens(session_key)
+        if not count:
+            return {"error": {"message": "This approval is no longer waiting for an answer."}}
+
+        if choice == "deny":
+            status = "❌ Denied"
+            ephemeral = "Denied. The command will not run."
+        elif choice == "session":
+            status = "✅ Approved for this session"
+            ephemeral = "Approved for this session."
+        elif choice == "always":
+            status = "✅ Approved permanently"
+            ephemeral = "Approved permanently."
+        else:
+            status = "✅ Approved once"
+            ephemeral = "Approved once."
+        return {
+            "update": {
+                "message": f"⚠️ **Dangerous command approval**\n\n{status}",
+                "props": {},
+            },
+            "ephemeral_text": ephemeral,
+        }
+
+    async def _handle_clarify_action_payload(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Resolve a Mattermost clarify button action payload."""
+        from tools import clarify_gateway as cm
+
+        if not isinstance(payload, dict):
+            return {"error": {"message": "Invalid Mattermost action payload."}}
+        context = payload.get("context") or {}
+        if not isinstance(context, dict):
+            return {"error": {"message": "Invalid Mattermost action context."}}
+        if context.get("kind") != "clarify":
+            return {"error": {"message": "Unsupported Mattermost action."}}
+
+        token = str(context.get("token") or "")
+        if not token:
+            return {"error": {"message": "Missing Mattermost action token."}}
+        state = self._clarify_action_tokens.get(token)
+        if not state:
+            return {"error": {"message": "This question is no longer waiting for an answer."}}
+
+        payload_channel_id = str(payload.get("channel_id") or "")
+        expected_channel_id = str(state.get("chat_id") or "")
+        if expected_channel_id and payload_channel_id and payload_channel_id != expected_channel_id:
+            return {"error": {"message": "This action belongs to a different Mattermost channel."}}
+
+        expected_user_id = str(state.get("expected_user_id") or "")
+        payload_user_id = str(payload.get("user_id") or "")
+        if expected_user_id and payload_user_id != expected_user_id:
+            return {"error": {"message": "Only the user who was asked can answer this question."}}
+
+        clarify_id = str(state.get("clarify_id") or "")
+        if not clarify_id:
+            self._clarify_action_tokens.pop(token, None)
+            return {"error": {"message": "Missing clarify id."}}
+
+        choice = state.get("choice")
+        if choice == "__other__":
+            if not cm.mark_awaiting_text(clarify_id):
+                self._clear_clarify_action_tokens(clarify_id)
+                return {"error": {"message": "This question is no longer waiting for an answer."}}
+            question = ""
+            with cm._lock:
+                entry = cm._entries.get(clarify_id)
+                if entry is not None:
+                    question = entry.question
+            self._clear_clarify_action_tokens(clarify_id)
+            return {
+                "update": {
+                    "message": f"❓ {question}\n\n✍️ Waiting for a typed answer..." if question else "✍️ Waiting for a typed answer...",
+                    "props": {},
+                },
+                "ephemeral_text": "Type your answer as a reply in this thread/channel.",
+            }
+
+        # Prefer the canonical choice from the pending clarify entry when an
+        # index is present, so button payload tampering cannot substitute text.
+        try:
+            raw_choice_index = state.get("choice_index")
+            choice_index = int(raw_choice_index) if raw_choice_index is not None else -1
+        except (TypeError, ValueError):
+            choice_index = -1
+        with cm._lock:
+            entry = cm._entries.get(clarify_id)
+            if entry and entry.choices and 0 <= choice_index < len(entry.choices):
+                choice = entry.choices[choice_index]
+            question = entry.question if entry else ""
+        if choice is None:
+            self._clarify_action_tokens.pop(token, None)
+            return {"error": {"message": "Missing choice."}}
+
+        resolved = cm.resolve_gateway_clarify(clarify_id, str(choice))
+        self._clear_clarify_action_tokens(clarify_id)
+        if not resolved:
+            return {"error": {"message": "This question is no longer waiting for an answer."}}
+        selected = str(choice)
+        return {
+            "update": {
+                "message": f"❓ {question}\n\n✅ Selected: {selected}" if question else f"✅ Selected: {selected}",
+                "props": {},
+            },
+            "ephemeral_text": f"Got it: {selected}",
+        }
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Return channel name and type."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16502,6 +16502,11 @@ class GatewayRunner:
                 except Exception:
                     pass
 
+                clarify_metadata = dict(_status_thread_metadata or {})
+                sender_user_id = getattr(source, "user_id", None)
+                if sender_user_id:
+                    clarify_metadata["user_id"] = str(sender_user_id)
+
                 send_ok = False
                 fut = safe_schedule_threadsafe(
                     _status_adapter.send_clarify(
@@ -16510,7 +16515,7 @@ class GatewayRunner:
                         choices=list(choices) if choices else None,
                         clarify_id=clarify_id,
                         session_key=session_key or "",
-                        metadata=_status_thread_metadata,
+                        metadata=clarify_metadata or None,
                     ),
                     _loop_for_step,
                     logger=logger,
@@ -16622,13 +16627,17 @@ class GatewayRunner:
                 # false positives from MagicMock auto-attribute creation in tests.
                 if getattr(type(_status_adapter), "send_exec_approval", None) is not None:
                     try:
+                        approval_metadata = dict(_status_thread_metadata or {})
+                        sender_user_id = getattr(source, "user_id", None)
+                        if sender_user_id:
+                            approval_metadata["user_id"] = str(sender_user_id)
                         _approval_fut = safe_schedule_threadsafe(
                             _status_adapter.send_exec_approval(
                                 chat_id=_status_chat_id,
                                 command=cmd,
                                 session_key=_approval_session_key,
                                 description=desc,
-                                metadata=_status_thread_metadata,
+                                metadata=approval_metadata or None,
                             ),
                             _loop_for_step,
                             logger=logger,

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -1,6 +1,7 @@
 """Tests for Mattermost platform adapter."""
 import json
 import os
+import re
 import time
 import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
@@ -75,7 +76,10 @@ def _make_adapter():
     config = PlatformConfig(
         enabled=True,
         token="test-token",
-        extra={"url": "https://mm.example.com"},
+        # Keep unit tests isolated from the developer machine's Mattermost
+        # channel whitelist. Individual tests can still patch env/config when
+        # they need to exercise gating behavior explicitly.
+        extra={"url": "https://mm.example.com", "allowed_channels": ""},
     )
     adapter = MattermostAdapter(config)
     return adapter
@@ -252,6 +256,339 @@ class TestMattermostSend:
         result = await self.adapter.send("channel_1", "Hello!")
 
         assert result.success is False
+
+
+# ---------------------------------------------------------------------------
+# Clarify buttons / interactive message actions
+# ---------------------------------------------------------------------------
+
+class TestMattermostClarifyButtons:
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter._session = MagicMock()
+        self.adapter._actions_enabled = True
+        self.adapter._actions_url = "http://hermes.local:8769/mattermost/actions"
+        self.adapter._actions_server_ready = True
+        from tools import clarify_gateway as cm
+        with cm._lock:
+            cm._entries.clear()
+            cm._session_index.clear()
+
+    def teardown_method(self):
+        from tools import clarify_gateway as cm
+        with cm._lock:
+            cm._entries.clear()
+            cm._session_index.clear()
+
+    def _mock_post_success(self, post_id="post_clarify"):
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": post_id})
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+
+    def _seed_action_token(self, token, clarify_id, choice, choice_index=None, **overrides):
+        state = {
+            "clarify_id": clarify_id,
+            "session_key": f"sk-{clarify_id}",
+            "chat_id": "channel_1",
+            "thread_id": "",
+            "expected_user_id": "user_123",
+            "choice_index": choice_index,
+            "choice": choice,
+        }
+        state.update(overrides)
+        self.adapter._clarify_action_tokens[token] = state
+
+    @pytest.mark.asyncio
+    async def test_multi_choice_posts_mattermost_actions(self):
+        self._mock_post_success("post_buttons")
+
+        result = await self.adapter.send_clarify(
+            chat_id="channel_1",
+            question="Pick a color",
+            choices=["red", "green", "blue"],
+            clarify_id="cidM",
+            session_key="sk-M",
+        )
+
+        assert result.success is True
+        assert result.message_id == "post_buttons"
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert payload["channel_id"] == "channel_1"
+        assert payload["message"] == "❓ Pick a color"
+        attachment = payload["props"]["attachments"][0]
+        assert "actions" in attachment
+        actions = attachment["actions"]
+        assert [a["name"] for a in actions] == ["1. red", "2. green", "3. blue", "Other"]
+        assert [a["id"] for a in actions] == [
+            "clarifycidM0",
+            "clarifycidM1",
+            "clarifycidM2",
+            "clarifycidMother",
+        ]
+        assert all(re.fullmatch(r"[A-Za-z0-9]+", a["id"]) for a in actions)
+        assert actions[0]["type"] == "button"
+        assert actions[0]["integration"]["url"] == "http://hermes.local:8769/mattermost/actions/clarify"
+        ctx = actions[1]["integration"]["context"]
+        assert ctx["kind"] == "clarify"
+        assert "token" in ctx
+        assert "secret" not in ctx
+        assert "clarify_id" not in ctx
+        token = ctx["token"]
+        assert self.adapter._clarify_action_tokens[token]["clarify_id"] == "cidM"
+        assert self.adapter._clarify_action_tokens[token]["choice_index"] == 1
+        assert self.adapter._clarify_action_tokens[token]["choice"] == "green"
+        other_ctx = actions[-1]["integration"]["context"]
+        assert self.adapter._clarify_action_tokens[other_ctx["token"]]["choice"] == "__other__"
+
+    @pytest.mark.asyncio
+    async def test_open_ended_uses_text_capture_fallback(self):
+        self._mock_post_success("post_text")
+        from tools import clarify_gateway as cm
+        with cm._lock:
+            cm._entries.clear()
+            cm._session_index.clear()
+        cm.register("cidOE", "sk-OE", "What is your name?", None)
+
+        result = await self.adapter.send_clarify(
+            chat_id="channel_1",
+            question="What is your name?",
+            choices=None,
+            clarify_id="cidOE",
+            session_key="sk-OE",
+        )
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert payload["message"] == "❓ What is your name?"
+        assert "props" not in payload
+        with cm._lock:
+            assert cm._entries["cidOE"].awaiting_text is True
+
+    @pytest.mark.asyncio
+    async def test_action_choice_resolves_clarify(self):
+        from tools import clarify_gateway as cm
+        with cm._lock:
+            cm._entries.clear()
+            cm._session_index.clear()
+        cm.register("cidA", "sk-A", "Pick", ["red", "green", "blue"])
+        self._seed_action_token("tok-green", "cidA", "green", choice_index=1)
+
+        response = await self.adapter._handle_clarify_action_payload({
+            "channel_id": "channel_1",
+            "user_id": "user_123",
+            "context": {
+                "kind": "clarify",
+                "token": "tok-green",
+            }
+        })
+
+        with cm._lock:
+            entry = cm._entries["cidA"]
+        assert entry.response == "green"
+        assert entry.event.is_set()
+        assert "update" in response
+        assert response["ephemeral_text"] == "Got it: green"
+
+    @pytest.mark.asyncio
+    async def test_action_other_marks_awaiting_text(self):
+        from tools import clarify_gateway as cm
+        with cm._lock:
+            cm._entries.clear()
+            cm._session_index.clear()
+        cm.register("cidOther", "sk-O", "Pick", ["red"])
+        self._seed_action_token("tok-other", "cidOther", "__other__")
+
+        response = await self.adapter._handle_clarify_action_payload({
+            "channel_id": "channel_1",
+            "user_id": "user_123",
+            "context": {
+                "kind": "clarify",
+                "token": "tok-other",
+            }
+        })
+
+        with cm._lock:
+            entry = cm._entries["cidOther"]
+        assert entry.awaiting_text is True
+        assert not entry.event.is_set()
+        assert response["ephemeral_text"].startswith("Type your answer")
+
+    @pytest.mark.asyncio
+    async def test_action_rejects_unknown_token(self):
+        response = await self.adapter._handle_clarify_action_payload({
+            "context": {
+                "kind": "clarify",
+                "token": "missing-token",
+            }
+        })
+
+        assert response == {"error": {"message": "This question is no longer waiting for an answer."}}
+
+    @pytest.mark.asyncio
+    async def test_action_rejects_wrong_user(self):
+        self._seed_action_token("tok-user", "cidUser", "red", expected_user_id="user_123")
+
+        response = await self.adapter._handle_clarify_action_payload({
+            "channel_id": "channel_1",
+            "user_id": "user_999",
+            "context": {"kind": "clarify", "token": "tok-user"},
+        })
+
+        assert response == {"error": {"message": "Only the user who was asked can answer this question."}}
+
+    @pytest.mark.asyncio
+    async def test_action_handler_returns_ephemeral_text_for_stale_button(self):
+        request = MagicMock()
+        request.json = AsyncMock(return_value={
+            "channel_id": "channel_1",
+            "user_id": "user_123",
+            "context": {"kind": "clarify", "token": "missing-token"},
+        })
+
+        response = await self.adapter._handle_clarify_action_request(request)
+
+        assert response.status == 200
+        body = json.loads(response.text)
+        assert body == {"ephemeral_text": "This question is no longer waiting for an answer."}
+
+
+# ---------------------------------------------------------------------------
+# Approval buttons / interactive message actions
+# ---------------------------------------------------------------------------
+
+class TestMattermostApprovalButtons:
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter._session = MagicMock()
+        self.adapter._actions_enabled = True
+        self.adapter._actions_url = "http://hermes.local:8769/mattermost/actions"
+        self.adapter._actions_server_ready = True
+        from tools import approval as am
+        with am._lock:
+            am._gateway_queues.clear()
+            am._gateway_notify_cbs.clear()
+            am._session_approved.clear()
+            am._pending.clear()
+
+    def teardown_method(self):
+        from tools import approval as am
+        with am._lock:
+            am._gateway_queues.clear()
+            am._gateway_notify_cbs.clear()
+            am._session_approved.clear()
+            am._pending.clear()
+
+    def _mock_post_success(self, post_id="post_approval"):
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": post_id})
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+
+    def _queue_approval(self, session_key="sk-approval"):
+        from tools import approval as am
+        entry = am._ApprovalEntry({"command": "curl http://192.168.1.7"})
+        with am._lock:
+            am._gateway_queues.setdefault(session_key, []).append(entry)
+        return entry
+
+    @pytest.mark.asyncio
+    async def test_send_exec_approval_posts_mattermost_actions(self):
+        self._mock_post_success("post_approval_buttons")
+
+        result = await self.adapter.send_exec_approval(
+            chat_id="channel_1",
+            command="curl http://192.168.1.7",
+            session_key="sk-approval",
+            description="URL uses raw IP address",
+            metadata={"user_id": "user_123"},
+        )
+
+        assert result.success is True
+        assert result.message_id == "post_approval_buttons"
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert payload["channel_id"] == "channel_1"
+        assert payload["message"] == "⚠️ **Dangerous command requires approval:**"
+        attachment = payload["props"]["attachments"][0]
+        assert "curl http://192.168.1.7" in attachment["text"]
+        actions = attachment["actions"]
+        assert [a["name"] for a in actions] == ["Allow Once", "Allow Session", "Always Allow", "Deny"]
+        assert all(re.fullmatch(r"[A-Za-z0-9]+", a["id"]) for a in actions)
+        assert actions[0]["integration"]["url"] == "http://hermes.local:8769/mattermost/actions/approval"
+        ctx = actions[0]["integration"]["context"]
+        assert ctx["kind"] == "approval"
+        assert "token" in ctx
+        assert "session_key" not in ctx
+        token = ctx["token"]
+        assert self.adapter._approval_action_tokens[token]["session_key"] == "sk-approval"
+        assert self.adapter._approval_action_tokens[token]["choice"] == "once"
+        assert self.adapter._approval_action_tokens[token]["expected_user_id"] == "user_123"
+
+    @pytest.mark.asyncio
+    async def test_approval_action_resolves_gateway_approval(self):
+        entry = self._queue_approval("sk-approval")
+        self.adapter._approval_action_tokens["tok-session"] = {
+            "session_key": "sk-approval",
+            "chat_id": "channel_1",
+            "thread_id": "",
+            "expected_user_id": "user_123",
+            "choice": "session",
+        }
+
+        response = await self.adapter._handle_approval_action_payload({
+            "channel_id": "channel_1",
+            "user_id": "user_123",
+            "context": {"kind": "approval", "token": "tok-session"},
+        })
+
+        assert entry.result == "session"
+        assert entry.event.is_set()
+        assert response["ephemeral_text"] == "Approved for this session."
+        assert response["update"]["props"] == {}
+        assert self.adapter._approval_action_tokens == {}
+
+    @pytest.mark.asyncio
+    async def test_approval_action_rejects_wrong_user_without_resolving(self):
+        entry = self._queue_approval("sk-approval")
+        self.adapter._approval_action_tokens["tok-once"] = {
+            "session_key": "sk-approval",
+            "chat_id": "channel_1",
+            "thread_id": "",
+            "expected_user_id": "user_123",
+            "choice": "once",
+        }
+
+        response = await self.adapter._handle_approval_action_payload({
+            "channel_id": "channel_1",
+            "user_id": "user_999",
+            "context": {"kind": "approval", "token": "tok-once"},
+        })
+
+        assert response == {"error": {"message": "Only the user who was asked can approve this command."}}
+        assert entry.result is None
+        assert not entry.event.is_set()
+        assert "tok-once" in self.adapter._approval_action_tokens
+
+    @pytest.mark.asyncio
+    async def test_approval_action_handler_returns_ephemeral_text_for_stale_button(self):
+        request = MagicMock()
+        request.json = AsyncMock(return_value={
+            "channel_id": "channel_1",
+            "user_id": "user_123",
+            "context": {"kind": "approval", "token": "missing-token"},
+        })
+
+        response = await self.adapter._handle_approval_action_request(request)
+
+        assert response.status == 200
+        body = json.loads(response.text)
+        assert body == {"ephemeral_text": "This approval is no longer waiting for an answer."}
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -392,6 +392,10 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `MATTERMOST_REQUIRE_MENTION` | Require `@mention` in channels (default: `true`). Set to `false` to respond to all messages. |
 | `MATTERMOST_FREE_RESPONSE_CHANNELS` | Comma-separated channel IDs where bot responds without `@mention` |
 | `MATTERMOST_REPLY_MODE` | Reply style: `thread` (threaded replies) or `off` (flat messages, default) |
+| `MATTERMOST_ACTIONS_ENABLED` | Enable Mattermost interactive clarify-button callbacks (`true`/`false`). Defaults to enabled when `MATTERMOST_ACTIONS_URL` is set. |
+| `MATTERMOST_ACTIONS_URL` | Base callback URL reachable by Mattermost, e.g. `https://hermes.example.com:8769/mattermost/actions` |
+| `MATTERMOST_ACTIONS_HOST` | Bind host for the callback listener (default: `0.0.0.0`) |
+| `MATTERMOST_ACTIONS_PORT` | Bind port for the callback listener (default: `8769`) |
 | `MATRIX_HOMESERVER` | Matrix homeserver URL (e.g. `https://matrix.org`) |
 | `MATRIX_ACCESS_TOKEN` | Matrix access token for bot authentication |
 | `MATRIX_USER_ID` | Matrix user ID (e.g. `@hermes:matrix.org`) — required for password login, optional with access token |

--- a/website/docs/user-guide/messaging/mattermost.md
+++ b/website/docs/user-guide/messaging/mattermost.md
@@ -155,6 +155,12 @@ MATTERMOST_ALLOWED_USERS=3uo8dkh1p7g1mfk49ear5fzs5c
 
 # Optional: channels where bot responds without @mention (comma-separated channel IDs)
 # MATTERMOST_FREE_RESPONSE_CHANNELS=channel_id_1,channel_id_2
+
+# Optional: interactive clarify buttons for multiple-choice questions
+# MATTERMOST_ACTIONS_ENABLED=true
+# MATTERMOST_ACTIONS_URL=https://hermes.example.com:8769/mattermost/actions
+# MATTERMOST_ACTIONS_HOST=0.0.0.0
+# MATTERMOST_ACTIONS_PORT=8769
 ```
 
 Optional behavior settings in `~/.hermes/config.yaml`:
@@ -196,6 +202,27 @@ MATTERMOST_HOME_CHANNEL=abc123def456ghi789jkl012mn
 ```
 
 Replace the ID with the actual channel ID (click the channel name → View Info → copy the ID).
+
+## Interactive Clarify Buttons
+
+Mattermost can render Hermes `clarify` multiple-choice questions as native interactive buttons. This requires a callback URL that Mattermost can reach; Hermes listens on `/mattermost/actions/clarify` and validates clicks with one-time server-side action tokens.
+
+Set `MATTERMOST_ACTIONS_URL` to the public/base URL for the callback endpoint, without the trailing `/clarify` segment. For example, if Hermes runs on a Tailscale host at `100.64.0.10`:
+
+```bash
+MATTERMOST_ACTIONS_ENABLED=true
+MATTERMOST_ACTIONS_URL=http://100.64.0.10:8769/mattermost/actions
+MATTERMOST_ACTIONS_HOST=0.0.0.0
+MATTERMOST_ACTIONS_PORT=8769
+```
+
+Verify the callback server after starting the gateway:
+
+```bash
+curl http://100.64.0.10:8769/mattermost/actions/health
+```
+
+If `MATTERMOST_ACTIONS_URL` is not configured or posting the interactive message fails, Hermes falls back to the plain numbered-text clarify prompt.
 
 ## Reply Mode
 


### PR DESCRIPTION
## Summary
- Add Mattermost interactive clarify buttons.
- Add callback token handling and fallback behavior.
- Document MATTERMOST_ACTIONS_* setup.

## Verification
- Pi: scripts/run_tests.sh tests/gateway/test_mattermost.py tests/gateway/test_telegram_clarify_buttons.py tests/gateway/test_discord_clarify_buttons.py - 80/80 passed.
- Pi: .venv/bin/python -m py_compile gateway/platforms/mattermost.py gateway/run.py - passed.
- Runtime: /mattermost/actions/health returned {ok: true, platform: mattermost}.
