### PR TITLE
fix(telegram): queue voice follow-ups instead of interrupting in-flight reply (#31328)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3116,11 +3116,22 @@ class BasePlatformAdapter(ABC):
                 except Exception as e:
                     logger.error("[%s] Busy-session handler failed: %s", self.name, e, exc_info=True)
 
-            # Special case: photo bursts/albums frequently arrive as multiple near-
-            # simultaneous messages. Queue them without interrupting the active run,
-            # then process them immediately after the current task finishes.
-            if event.message_type == MessageType.PHOTO:
-                logger.debug("[%s] Queuing photo follow-up for session %s without interrupt", self.name, session_key)
+            # Special case: photo and voice bursts frequently arrive as multiple
+            # near-simultaneous messages (album uploads, rapid voice notes).
+            # Queue them without interrupting the active run, then process them
+            # immediately after the current task finishes.
+            #
+            # Without this for voice (#31328): voice 2 lands while voice 1 is
+            # still being processed → interrupt sets, voice 1's response is
+            # suppressed by the stale-response check below, voice 1 is silently
+            # dropped from the session.  Photo bursts already had this
+            # protection; voice/audio bursts have the same UX shape so they
+            # follow the same contract.
+            if event.message_type in (MessageType.PHOTO, MessageType.VOICE):
+                logger.debug(
+                    "[%s] Queuing %s follow-up for session %s without interrupt",
+                    self.name, event.message_type.value, session_key,
+                )
                 merge_pending_message_event(self._pending_messages, session_key, event)
                 return  # Don't interrupt now - will run after current task completes
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7049,8 +7049,11 @@ class GatewayRunner:
                     f"mid-turn. Wait for the current response or `/stop` first."
                 )
 
-            if event.message_type == MessageType.PHOTO:
-                logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key)
+            if event.message_type in (MessageType.PHOTO, MessageType.VOICE):
+                logger.debug(
+                    "PRIORITY %s follow-up for session %s — queueing without interrupt",
+                    event.message_type.value, _quick_key,
+                )
                 adapter = self.adapters.get(source.platform)
                 if adapter:
                     merge_pending_message_event(adapter._pending_messages, _quick_key, event)

--- a/tests/gateway/test_interrupt_key_match.py
+++ b/tests/gateway/test_interrupt_key_match.py
@@ -148,3 +148,36 @@ class TestInterruptKeyConsistency:
         assert queued is event
         assert queued.media_urls == ["/tmp/photo-a.jpg"]
         assert interrupt_event.is_set() is False
+
+    @pytest.mark.asyncio
+    async def test_voice_followup_is_queued_without_interrupt(self):
+        """Voice follow-ups should queue behind the active run, not interrupt it (#31328).
+
+        Without this: a rapid second voice note arriving mid-processing sets
+        the interrupt Event, which makes the stale-response check in
+        ``_process_message_background`` swallow the in-flight reply.  Voice 1's
+        response is silently dropped from the user's session.  Photo bursts
+        already had this protection — voice bursts have the same UX shape.
+        """
+        adapter = StubAdapter()
+        adapter.set_message_handler(lambda event: asyncio.sleep(0, result=None))
+
+        source = _source("-1001234", "group")
+        session_key = build_session_key(source)
+        interrupt_event = asyncio.Event()
+        adapter._active_sessions[session_key] = interrupt_event
+
+        event = MessageEvent(
+            text="",
+            source=source,
+            message_type=MessageType.VOICE,
+            message_id="2",
+            media_urls=["/tmp/voice-b.ogg"],
+            media_types=["audio/ogg"],
+        )
+        await adapter.handle_message(event)
+
+        queued = adapter._pending_messages[session_key]
+        assert queued is event
+        assert queued.media_urls == ["/tmp/voice-b.ogg"]
+        assert interrupt_event.is_set() is False

--- a/tests/gateway/test_telegram_photo_interrupts.py
+++ b/tests/gateway/test_telegram_photo_interrupts.py
@@ -47,3 +47,34 @@ async def test_handle_message_does_not_priority_interrupt_photo_followup():
     assert result is None
     running_agent.interrupt.assert_not_called()
     assert runner.adapters[Platform.TELEGRAM]._pending_messages[session_key] is event
+
+
+@pytest.mark.asyncio
+async def test_handle_message_does_not_priority_interrupt_voice_followup():
+    """Voice follow-ups must be queued, not interrupt the running agent (#31328).
+
+    Rapid voice notes are a natural input pattern (the user keeps recording
+    while the bot is replying to the previous one). Interrupting drops the
+    in-flight response on the floor; the user's previous voice gets no reply
+    at all. Mirror the photo-burst contract: queue and let the current turn
+    complete first.
+    """
+    runner = _make_runner()
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="67890", chat_type="dm", user_id="u2")
+    session_key = build_session_key(source)
+    running_agent = MagicMock()
+    runner._running_agents[session_key] = running_agent
+
+    event = MessageEvent(
+        text="",
+        message_type=MessageType.VOICE,
+        source=source,
+        media_urls=["/tmp/voice-b.ogg"],
+        media_types=["audio/ogg"],
+    )
+
+    result = await runner._handle_message(event)
+
+    assert result is None
+    running_agent.interrupt.assert_not_called()
+    assert runner.adapters[Platform.TELEGRAM]._pending_messages[session_key] is event


### PR DESCRIPTION
## What

Extends the existing PHOTO queue-don't-interrupt special case in both `BasePlatformAdapter.handle_message` and `GatewayRunner._handle_message` to also cover `MessageType.VOICE`.

## Why

When a user sends voice notes in rapid succession, voice 2 arriving mid-processing of voice 1 currently:

1. Hits the active-session branch in `BasePlatformAdapter.handle_message`
2. Falls past the PHOTO-only exception → executes the default "interrupt" path
3. Sets the per-session `interrupt_event` and queues into `_pending_messages`
4. Voice 1's `_process_message_background` task finishes, generates a reply, then the stale-response check at base.py:3255-3265 — `interrupt_event.is_set() and session_key in self._pending_messages` — silently sets `response = None`
5. Voice 1 is dropped from the conversation: no `response ready` log, no `Sending response`, no JSONL entry. The user sees no reply for voice 1, only the merged voices 2+3 batch turn arrives.

This matches the symptom the reporter observed — voice 2 had a `conversation turn: history=6` log but no `response ready` line and no session JSONL entry, while voices 3+4 went on to produce a normal batched response.

Photo bursts already had this protection (added long ago for albums). Rapid voice notes have the same UX shape — the user is providing more inputs, not requesting an interrupt — so they follow the same contract.

After the fix:
- Voice 1's reply is delivered normally
- Voice 2 (and any further voices that arrive while voice 1 is still in flight) accumulate in `_pending_messages` via `merge_pending_message_event`, which already extends `media_urls` for events that both have media — so multiple late-arriving voices land in a single merged event
- When voice 1 finishes, the existing pending-drain logic in `_process_message_background` spawns a fresh turn for the merged batch — exactly the behavior the reporter described as expected ("merge late-arriving voices" path)

This is option (a) from the issue (\"wait for in-flight turns to finish before starting a new batch\") implemented as the same queue-don't-interrupt pattern as photo bursts, rather than inventing new mid-flight merge semantics.

Scope kept narrow: only `MessageType.VOICE` is added (not AUDIO/VIDEO/STICKER/DOCUMENT) to match the reported issue precisely. The same shape likely applies to AUDIO/VIDEO and could be extended in a follow-up; happy to broaden in this PR if reviewers prefer.

## Test

- `tests/gateway/test_interrupt_key_match.py::test_voice_followup_is_queued_without_interrupt` — adapter-level: VOICE event during active session must queue into `_pending_messages` without setting `interrupt_event`
- `tests/gateway/test_telegram_photo_interrupts.py::test_handle_message_does_not_priority_interrupt_voice_followup` — runner-level: VOICE event arriving with a registered running agent must queue without calling `running_agent.interrupt()`

Both new tests are direct mirrors of the existing photo-followup tests, so they enforce the same contract for voice that has been working for photos.

Verification:
- 9/9 tests pass in the two modified files
- Both new tests fail without the production change and pass with it (regression guard confirmed)
- 74/74 surrounding gateway tests remain green (`test_session_race_guard`, `test_active_session_text_merge`, `test_queue_consumption`, `test_telegram_text_batching`, `test_busy_session_ack`, `test_duplicate_reply_suppression`)

## Platform

telegram (the path is shared by all platforms that route through `BasePlatformAdapter.handle_message`, but the bug surfaces most clearly on Telegram where voice notes are common)

## Issue

Closes #31328