### PR TITLE
fix(kanban): send reclaimed review runs back to review instead of ready

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2133,6 +2133,53 @@ def _current_run_id(conn: sqlite3.Connection, task_id: str) -> Optional[int]:
     return int(row["current_run_id"]) if row and row["current_run_id"] else None
 
 
+def _resume_status_for_run(
+    conn: sqlite3.Connection,
+    run_id: Optional[int],
+    *,
+    default: str = "ready",
+) -> str:
+    """Return the lane a failed/reclaimed run should resume in.
+
+    Review tasks are claimed through :func:`claim_review_task`, which records
+    ``source_status='review'`` on the run's ``claimed`` event. Recovery paths
+    must preserve that lane; otherwise a failed review run falls back into the
+    normal ready queue and gets respawned as a regular worker instead of a
+    review worker.
+    """
+    if run_id is None:
+        return default
+    row = conn.execute(
+        "SELECT payload FROM task_events "
+        "WHERE run_id = ? AND kind = 'claimed' "
+        "ORDER BY id DESC LIMIT 1",
+        (int(run_id),),
+    ).fetchone()
+    if not row or not row["payload"]:
+        return default
+    try:
+        payload = json.loads(row["payload"])
+    except (TypeError, ValueError):
+        return default
+    if not isinstance(payload, dict):
+        return default
+    if str(payload.get("source_status") or "").strip().lower() == "review":
+        return "review"
+    return default
+
+
+def _resume_status_for_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    default: str = "ready",
+) -> str:
+    """Return the lane the task's active run should resume in."""
+    return _resume_status_for_run(
+        conn, _current_run_id(conn, task_id), default=default,
+    )
+
+
 def _synthesize_ended_run(
     conn: sqlite3.Connection,
     task_id: str,
@@ -2580,12 +2627,13 @@ def release_stale_claims(
             row["worker_pid"], row["claim_lock"], signal_fn=signal_fn,
         )
         with write_txn(conn):
+            resume_status = _resume_status_for_task(conn, row["id"])
             cur = conn.execute(
-                "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                "UPDATE tasks SET status = ?, claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL "
                 "WHERE id = ? AND status = 'running' AND claim_lock IS ? "
                 "AND claim_expires IS NOT NULL AND claim_expires < ?",
-                (row["id"], row["claim_lock"], now),
+                (resume_status, row["id"], row["claim_lock"], now),
             )
             if cur.rowcount != 1:
                 continue
@@ -2626,7 +2674,7 @@ def reclaim_task(
     reason: Optional[str] = None,
     signal_fn=None,
 ) -> bool:
-    """Operator-driven reclaim: release the claim and reset to ``ready``.
+    """Operator-driven reclaim: release the claim and requeue the task.
 
     Unlike :func:`release_stale_claims` which only acts on tasks whose
     ``claim_expires`` has passed, this function reclaims immediately
@@ -2651,12 +2699,13 @@ def reclaim_task(
         row["worker_pid"], prev_lock, signal_fn=signal_fn,
     )
     with write_txn(conn):
+        resume_status = _resume_status_for_task(conn, task_id)
         cur = conn.execute(
-            "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+            "UPDATE tasks SET status = ?, claim_lock = NULL, "
             "claim_expires = NULL, worker_pid = NULL "
             "WHERE id = ? AND status IN ('running', 'ready', 'blocked') "
             "AND claim_lock IS ?",
-            (task_id, prev_lock),
+            (resume_status, task_id, prev_lock),
         )
         if cur.rowcount != 1:
             return False
@@ -4182,7 +4231,7 @@ def enforce_max_runtime(
     """Terminate workers whose per-task ``max_runtime_seconds`` has elapsed.
 
     Sends SIGTERM, waits a short grace window, then SIGKILL. Emits a
-    ``timed_out`` event and drops the task back to ``ready`` so the next
+    ``timed_out`` event and drops the task back to its dispatch lane so the next
     dispatcher tick re-spawns it — unless the spawn-failure circuit
     breaker has already given up, in which case the task stays blocked
     where ``_record_spawn_failure`` parked it.
@@ -4246,12 +4295,13 @@ def enforce_max_runtime(
                     pass
 
         with write_txn(conn):
+            resume_status = _resume_status_for_task(conn, tid)
             cur = conn.execute(
-                "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                "UPDATE tasks SET status = ?, claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL, "
                 "last_heartbeat_at = NULL "
                 "WHERE id = ? AND status = 'running'",
-                (tid,),
+                (resume_status, tid),
             )
             if cur.rowcount == 1:
                 payload = {
@@ -4363,12 +4413,13 @@ def detect_stale_running(
         )
 
         with write_txn(conn):
+            resume_status = _resume_status_for_task(conn, tid)
             cur = conn.execute(
-                "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                "UPDATE tasks SET status = ?, claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL, "
                 "last_heartbeat_at = NULL "
                 "WHERE id = ? AND status = 'running'",
-                (tid,),
+                (resume_status, tid),
             )
             if cur.rowcount != 1:
                 continue
@@ -4443,7 +4494,7 @@ def _error_fingerprint(error_text: str) -> str:
 def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     """Reclaim ``running`` tasks whose worker PID is no longer alive.
 
-    Appends a ``crashed`` event and drops the task back to ``ready``.
+    Appends a ``crashed`` event and drops the task back to its dispatch lane.
     Different from ``release_stale_claims``: this checks liveness
     immediately rather than waiting for the claim TTL.
 
@@ -4513,11 +4564,12 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     event_payload["exit_kind"] = kind
                     event_payload["exit_code"] = code
 
+            resume_status = _resume_status_for_task(conn, row["id"])
             cur = conn.execute(
-                "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                "UPDATE tasks SET status = ?, claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL "
                 "WHERE id = ? AND status = 'running'",
-                (row["id"],),
+                (resume_status, row["id"]),
             )
             if cur.rowcount == 1:
                 run_id = _end_run(
@@ -4604,11 +4656,11 @@ def _record_task_failure(
 
     * ``release_claim=True, end_run=True`` — spawn-failure path.
       Caller has a running task with an open run; this transitions
-      it back to ``ready`` (or ``blocked`` when the breaker trips),
+      it back to its dispatch lane (or ``blocked`` when the breaker trips),
       releases the claim, and closes the run with ``outcome=<outcome>``.
 
     * ``release_claim=False, end_run=False`` — timeout/crash path.
-      Caller has ALREADY flipped the task to ``ready`` and closed the
+      Caller has ALREADY flipped the task to its dispatch lane and closed the
       run with the appropriate outcome. This just increments the
       counter; if the breaker trips, the task is re-transitioned
       ``ready → blocked`` and a ``gave_up`` event is emitted.
@@ -4699,13 +4751,14 @@ def _record_task_failure(
         else:
             # Below threshold.
             if release_claim:
-                # Spawn path: transition running → ready + clear claim.
+                resume_status = _resume_status_for_task(conn, task_id)
+                # Spawn path: transition running back to its dispatch lane.
                 conn.execute(
-                    "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                    "UPDATE tasks SET status = ?, claim_lock = NULL, "
                     "claim_expires = NULL, worker_pid = NULL, "
                     "consecutive_failures = ?, last_failure_error = ? "
                     "WHERE id = ? AND status = 'running'",
-                    (failures, error[:500], task_id),
+                    (resume_status, failures, error[:500], task_id),
                 )
             else:
                 # Timeout/crash path: task is already at ``ready`` via

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2736,6 +2736,59 @@ def test_dispatch_review_does_not_claim_ready_tasks(
         claimed = kb.claim_review_task(conn, t)
     assert claimed is None
 
+
+def test_reclaim_review_task_returns_to_review(kanban_home):
+    """Manual reclaim must preserve the review lane for review runs."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="review me", assignee="alice")
+        _set_task_status(conn, t, "review")
+        claimed = kb.claim_review_task(conn, t, claimer="review:1")
+
+        assert claimed is not None
+        assert kb.reclaim_task(conn, t, reason="operator reclaim") is True
+        assert kb.get_task(conn, t).status == "review"
+
+
+def test_stale_reclaim_review_task_returns_to_review(kanban_home, monkeypatch):
+    """TTL reclaim must not demote review runs into the ready queue."""
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="review me", assignee="alice")
+        _set_task_status(conn, t, "review")
+        host = _kb._claimer_id().split(":", 1)[0]
+        claimed = kb.claim_review_task(conn, t, claimer=f"{host}:review")
+
+        assert claimed is not None
+        kb._set_worker_pid(conn, t, 12345)
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ? WHERE id = ?",
+            (int(time.time()) - 3600, t),
+        )
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+
+        assert kb.release_stale_claims(conn, signal_fn=lambda _pid, _sig: None) == 1
+        assert kb.get_task(conn, t).status == "review"
+
+
+def test_dispatch_review_spawn_failure_returns_to_review(
+    kanban_home, all_assignees_spawnable,
+):
+    """A failed review spawn should stay in the review lane for retry."""
+
+    def boom(_task, _workspace, board=None):
+        raise RuntimeError("spawn blew up")
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="review me", assignee="alice")
+        _set_task_status(conn, t, "review")
+        res = kb.dispatch_once(conn, spawn_fn=boom, failure_limit=2)
+
+        assert res.auto_blocked == []
+        task = kb.get_task(conn, t)
+        assert task.status == "review"
+        assert task.consecutive_failures == 1
+
 # Stale detection — detect_stale_running
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes a Kanban review-lane regression where failed or reclaimed review runs could fall back into the normal `ready` queue.

## What changed

- Added a small helper in `kanban_db.py` to recover the correct resume lane from the active run's `claimed` event metadata.
- Applied that resume-lane logic to review recovery paths:
  - manual reclaim
  - stale-claim reclaim
  - stale-running reclaim
  - timeout recovery
  - crash recovery
  - spawn-failure retry
- Added regression tests covering:
  - manual reclaim of a review task
  - stale reclaim of a review task
  - review spawn failure retry staying in `review`

## Why

`claim_review_task()` records `source_status="review"`, but several retry/recovery paths were resetting those tasks to `ready`. That caused review work to be re-dispatched as normal worker work instead of staying in the review lane.

## Validation

Local checks performed during the fix:
- `py_compile` passed for:
  - `hermes_cli/kanban_db.py`
  - `tests/hermes_cli/test_kanban_db.py`
- Direct Python repro checks passed for:
  - manual reclaim keeps review tasks in `review`
  - stale reclaim keeps review tasks in `review`
  - failed review spawn stays in `review` and increments failure count

Targeted pytest results 
- `tests/hermes_cli/test_kanban_db.py -k "review and (reclaim or spawn_failure)"`
  - `3 passed, 165 deselected`
- `tests/hermes_cli/test_kanban_db.py -k "claim_review_task or stale_claim or detect_crashed_workers or max_runtime"`
  - `12 passed, 156 deselected`

