### PR TITLE
fix(setup): patch python-olm bundled libolm for macOS Apple clang

### DIFF
--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -336,6 +336,106 @@ def _is_present(spec: str) -> bool:
         return False
 
 
+def _python_olm_macos_install(*, timeout: int = 300) -> _InstallResult | None:
+    """Pre-install python-olm from a patched source on macOS.
+
+    python-olm 3.2.16 bundles libolm source containing a C++ const-pointer
+    bug: ``T * const other_pos`` is declared then immediately incremented
+    (``++other_pos``), which is a hard compile error on Apple clang regardless
+    of ``-Werror``.  The upstream fix is a one-line removal of the spurious
+    ``const`` qualifier; this function applies it before letting pip build
+    the wheel.
+
+    Strategy:
+    1. Download the python-olm sdist from PyPI into a temp dir.
+    2. Patch ``libolm/include/olm/list.hh``.
+    3. ``pip install --no-build-isolation <patched-src-dir>`` so the fixed
+       source is built and installed into the active venv.
+
+    Once python-olm is installed, the subsequent ``mautrix[encryption]``
+    install sees the dep satisfied and skips it — no double-build.
+
+    Returns ``None`` when this path is not needed (non-macOS, or python-olm
+    already installed).  Returns an ``_InstallResult`` otherwise so callers
+    can surface failures.
+    """
+    if sys.platform != "darwin":
+        return None
+    if _is_satisfied("python-olm==3.2.16"):
+        return None
+
+    import tarfile
+    import tempfile
+    import urllib.request
+
+    # Pin matches what mautrix[encryption]==0.21.0 resolves to.
+    OLM_VERSION = "3.2.16"
+    OLM_URL = (
+        "https://files.pythonhosted.org/packages/source/p/python-olm/"
+        f"python-olm-{OLM_VERSION}.tar.gz"
+    )
+
+    try:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tarball = os.path.join(tmpdir, "python-olm.tar.gz")
+            logger.info(
+                "macOS: downloading python-olm %s for patched build", OLM_VERSION
+            )
+            urllib.request.urlretrieve(OLM_URL, tarball)
+
+            # Safe extraction: reject members whose resolved path escapes tmpdir.
+            tmpdir_real = os.path.realpath(tmpdir)
+            with tarfile.open(tarball, "r:gz") as tf:
+                for member in tf.getmembers():
+                    member_path = os.path.realpath(
+                        os.path.join(tmpdir_real, member.name)
+                    )
+                    if not member_path.startswith(tmpdir_real + os.sep):
+                        raise ValueError(
+                            f"tarball member escapes temp dir: {member.name!r}"
+                        )
+                tf.extractall(tmpdir)
+
+            # Fix: libolm/include/olm/list.hh declares `T * const other_pos`
+            # then does `++other_pos` — incrementing a const pointer is a hard
+            # error on Apple clang.  Remove the spurious `const`.
+            list_hh = os.path.join(
+                tmpdir,
+                f"python-olm-{OLM_VERSION}",
+                "libolm",
+                "include",
+                "olm",
+                "list.hh",
+            )
+            with open(list_hh, encoding="utf-8") as fh:
+                src = fh.read()
+            patched = src.replace(
+                "T * const other_pos = other._data",
+                "T * other_pos = other._data",
+            )
+            if patched != src:
+                with open(list_hh, "w", encoding="utf-8") as fh:
+                    fh.write(patched)
+                logger.debug("macOS: patched libolm list.hh const-pointer bug")
+            else:
+                logger.warning(
+                    "macOS: python-olm patch target not found in list.hh — "
+                    "upstream may have fixed the bug; proceeding without patch"
+                )
+
+            src_dir = os.path.join(tmpdir, f"python-olm-{OLM_VERSION}")
+            pip_cmd = [sys.executable, "-m", "pip"]
+            r = subprocess.run(
+                pip_cmd + ["install", "--no-build-isolation", src_dir],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+            return _InstallResult(r.returncode == 0, r.stdout or "", r.stderr or "")
+    except Exception as exc:
+        return _InstallResult(False, "", f"macOS python-olm patched install failed: {exc}")
+
+
 def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _InstallResult:
     """Install ``specs`` into the active venv using uv → pip → ensurepip ladder.
 
@@ -461,6 +561,22 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
             )
 
     logger.info("Lazy-installing %s for feature %r", " ".join(missing), feature)
+
+    # platform.matrix: on macOS, python-olm must be built from a patched
+    # source before the main install, because the bundled libolm 3.2.16
+    # has a C++ const-pointer bug that Apple clang rejects as a hard error.
+    # Pre-installing it here means mautrix[encryption] sees the dep satisfied
+    # and pip skips the broken bundled-source build entirely.
+    if feature == "platform.matrix":
+        pre = _python_olm_macos_install()
+        if pre is not None and not pre.success:
+            snippet = (pre.stderr or pre.stdout or "").strip()[-1000:]
+            raise FeatureUnavailable(
+                feature,
+                missing,
+                f"macOS pre-install of python-olm failed: {snippet or 'no output'}",
+            )
+
     result = _venv_pip_install(missing)
     if not result.success:
         # Surface the actual pip error so the user can debug PyPI-side


### PR DESCRIPTION
## Problem

On macOS with Apple clang (Xcode 15+), `ensure("platform.matrix")` always fails during the `mautrix[encryption]` install:

```
error: cannot assign to variable 'other_pos' with const-qualified type 'T *const'
  106 |             ++other_pos;
      |             ^ ~~~~~~~~~
make: *** [build/release/src/account.o] Error 1
× Getting requirements to build wheel did not run successfully.
```

`mautrix[encryption]` pulls in `python-olm 3.2.16`, which bundles its own libolm source. That source has a C++ bug in `libolm/include/olm/list.hh` — a local pointer variable is declared `T * const other_pos` then immediately incremented (`++other_pos`). Incrementing a const pointer is a hard compile error, not a warning, so `-Wno-error` cannot suppress it.

The same root cause was addressed for Docker in #27795 (`apt-get install libolm-dev`), but macOS users hit it every time Matrix E2EE lazy-install runs.

## Fix

When `ensure("platform.matrix")` runs on `darwin`, pre-install `python-olm` from a patched copy of the PyPI sdist before the main pip install. The patch is a single-line removal of the spurious `const` qualifier:

```diff
- T * const other_pos = other._data;
+ T * other_pos = other._data;
```

Once `python-olm` is installed, `mautrix[encryption]`'s dep-resolution sees it satisfied and pip skips the bundled-source build entirely — no double build, no churn on subsequent runs.

The patch function is idempotent: if the target line is absent (upstream fixed the bug), it logs a warning and continues without patching.

## Related

- #27795 — same root cause, Docker fix (`libolm-dev`)
- #14139 — long-term fix replacing `python-olm` with `fresholm`
- #31236 — today's fix for missing `asyncpg`/`aiosqlite` in Matrix E2EE

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/lazy_deps.py` — added `_python_olm_macos_install()` that downloads the sdist, patches `list.hh`, and installs via `pip --no-build-isolation`; hooked into `ensure()` for `platform.matrix` on darwin.

## Test

```bash
# On a fresh macOS venv without python-olm:
python -c "from tools.lazy_deps import ensure; ensure('platform.matrix')"
# Should complete without error and import mautrix + olm cleanly
python -c "import mautrix; import olm; print('ok')"
```