### PR TITLE
fix(kanban): stop treating board default_workdir as a scratch workspace

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1652,12 +1652,21 @@ def create_task(
 
     # Resolve workspace_path from board-level default_workdir when the
     # caller did not specify one explicitly.
+    #
+    # A board default points at an existing shared working directory
+    # (typically a repo checkout), not a per-task scratch root. If we
+    # only fill in ``workspace_path`` and leave ``workspace_kind`` as
+    # the default ``scratch``, task completion will treat that shared
+    # directory like an ephemeral scratch workspace and delete it. Make
+    # inherited board defaults explicit ``dir`` workspaces instead.
     if workspace_path is None:
         board_slug = board if board else get_current_board()
         board_meta = read_board_metadata(board_slug)
         board_default = board_meta.get("default_workdir")
         if board_default:
             workspace_path = str(board_default)
+            if workspace_kind == "scratch":
+                workspace_kind = "dir"
 
     # Retry once on the extremely unlikely id collision.
     for attempt in range(2):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2465,7 +2465,7 @@ def test_task_dict_survives_corrupt_created_at(tmp_path, monkeypatch):
 
 
 def test_create_task_without_workspace_inherits_board_default_workdir(kanban_home, monkeypatch):
-    """Board with default_workdir → create_task without workspace_path → inherits default."""
+    """Board default_workdir becomes an explicit shared-dir workspace."""
     default_wd = "/home/user/project"
     kb.create_board("work-proj", default_workdir=default_wd)
 
@@ -2473,6 +2473,7 @@ def test_create_task_without_workspace_inherits_board_default_workdir(kanban_hom
         tid = kb.create_task(conn, title="inherited", board="work-proj")
         t = kb.get_task(conn, tid)
     assert t is not None
+    assert t.workspace_kind == "dir"
     assert t.workspace_path == default_wd
 
 
@@ -2498,6 +2499,26 @@ def test_create_task_with_explicit_workspace_ignores_board_default(kanban_home):
     assert t is not None
     assert t.workspace_path == explicit
     assert t.workspace_path != "/board/default"
+
+
+def test_complete_task_preserves_inherited_board_default_workdir(kanban_home, tmp_path):
+    """Inherited board defaults must not be deleted as scratch workspaces."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    marker = repo / "keep.txt"
+    marker.write_text("important", encoding="utf-8")
+    kb.create_board("shared-dir-board", default_workdir=str(repo))
+
+    with kb.connect(board="shared-dir-board") as conn:
+        tid = kb.create_task(conn, title="preserve repo", board="shared-dir-board")
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.workspace_kind == "dir"
+        assert task.workspace_path == str(repo)
+        assert kb.complete_task(conn, tid, result="ok") is True
+
+    assert repo.exists(), "board default workdir was deleted on completion"
+    assert marker.exists(), "files inside board default workdir were deleted"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes a Kanban bug where a board `default_workdir` was inherited as `workspace_path` but still treated as `scratch`.

That made shared board workdirs unsafe:
- multiple tasks could point at the same path
- completing a task could delete that shared directory during scratch cleanup

This change promotes inherited board defaults to `dir` workspaces instead.

## Files
- `hermes_cli/kanban_db.py`
- `tests/hermes_cli/test_kanban_db.py`

## Validation
Passed:
- `python -m pytest tests/hermes_cli/test_kanban_db.py -k default_workdir -q --no-isolate -o addopts="" -p no:timeout`

Result:
- `2 passed, 164 deselected in 0.83s`

