### PR TITLE
fix(gateway): process Feishu thread @mention-only messages instead of dropping (#31336)

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3289,9 +3289,26 @@ class FeishuAdapter(BasePlatformAdapter):
                 inbound_type = MessageType.COMMAND
 
         # Guard runs post-strip so a pure "@Bot" message (stripped to "") is dropped.
+        # Exception: in thread/topic context a bare @mention is a valid ping — the user
+        # is addressing the bot inside a 话题 thread where explicit text may be absent.
+        # Dropping it silently prevents the bot from ever responding in threads when
+        # users open with just "@Bot" (a common UX pattern on Feishu).
         if inbound_type == MessageType.TEXT and not text and not media_urls:
-            logger.debug("[Feishu] Ignoring empty text message id=%s", message_id)
-            return
+            _thread_context = (
+                getattr(message, "thread_id", None)
+                or getattr(message, "root_id", None)
+            )
+            _has_self_mention = any(m.is_self for m in mentions)
+            if _thread_context and _has_self_mention:
+                # Synthesise a minimal ping text so the agent can respond in the thread.
+                text = "[Mentioned]"
+                logger.debug(
+                    "[Feishu] Thread mention-only message id=%s — synthesising ping text",
+                    message_id,
+                )
+            else:
+                logger.debug("[Feishu] Ignoring empty text message id=%s", message_id)
+                return
 
         if inbound_type != MessageType.COMMAND:
             hint = _build_mention_hint(mentions)

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2301,6 +2301,162 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
         self.assertNotIn("[Mentioned:", event.text)
         self.assertTrue(event.text.startswith("/model"))
 
+    def test_mid_text_self_mention_preserved(self):
+        adapter = self._build_adapter()
+        bot_mention = SimpleNamespace(
+            key="@_user_1",
+            id=SimpleNamespace(open_id="ou_bot", user_id=""),
+            name="Hermes",
+        )
+        message = SimpleNamespace(
+            content=json.dumps({"text": "stop pinging @_user_1 please"}),
+            message_type="text",
+            message_id="m4",
+            mentions=[bot_mention],
+            chat_id="oc_chat",
+            parent_id=None,
+            upper_message_id=None,
+            thread_id=None,
+        )
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=None,
+                chat_type="group",
+                message_id="m4",
+            )
+        )
+        event = adapter._dispatch_inbound_event.call_args.args[0]
+        self.assertEqual(event.text, "stop pinging @Hermes please")
+
+    def test_pure_self_mention_message_is_ignored(self):
+        """A message containing only '@Bot' (no body, no media) must not dispatch.
+
+        Regression guard: the rendered '@Hermes' slips past the pre-strip empty
+        guard; the post-strip guard must catch it.
+        """
+        adapter = self._build_adapter()
+        bot_mention = SimpleNamespace(
+            key="@_user_1",
+            id=SimpleNamespace(open_id="ou_bot", user_id=""),
+            name="Hermes",
+        )
+        message = SimpleNamespace(
+            content=json.dumps({"text": "@_user_1"}),
+            message_type="text",
+            message_id="m5",
+            mentions=[bot_mention],
+            chat_id="oc_chat",
+            parent_id=None,
+            upper_message_id=None,
+            thread_id=None,
+        )
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message, message=message, sender_id=None,
+                chat_type="group", message_id="m5",
+            )
+        )
+        adapter._dispatch_inbound_event.assert_not_called()
+
+    def test_thread_mention_only_message_is_processed_not_dropped(self):
+        """Bare @Bot in a thread (root_id set) synthesises '[Mentioned]' and dispatches.
+
+        Regression for #31336: Feishu 话题/thread @mention-only messages were
+        silently dropped because _strip_edge_self_mentions removed all text,
+        triggering the empty-text guard. In thread context with a self-mention
+        we now synthesise a minimal ping text so the bot can respond.
+        """
+        from gateway.platforms.base import MessageType
+
+        adapter = self._build_adapter()
+        bot_mention = SimpleNamespace(
+            key="@_user_1",
+            id=SimpleNamespace(open_id="ou_bot", user_id=""),
+            name="Hermes",
+        )
+        message = SimpleNamespace(
+            content=json.dumps({"text": "@_user_1"}),
+            message_type="text",
+            message_id="m_thread_ping",
+            mentions=[bot_mention],
+            chat_id="oc_chat",
+            parent_id=None,
+            upper_message_id=None,
+            thread_id=None,
+            root_id="om_thread_root_123",  # indicates thread context
+        )
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message, message=message, sender_id=None,
+                chat_type="group", message_id="m_thread_ping",
+            )
+        )
+        adapter._dispatch_inbound_event.assert_called_once()
+        event = adapter._dispatch_inbound_event.call_args.args[0]
+        self.assertEqual(event.message_type, MessageType.TEXT)
+        self.assertIn("[Mentioned]", event.text)
+
+    def test_thread_mention_only_message_via_thread_id_field(self):
+        """Same as above but using thread_id instead of root_id (both are valid)."""
+        from gateway.platforms.base import MessageType
+
+        adapter = self._build_adapter()
+        bot_mention = SimpleNamespace(
+            key="@_user_1",
+            id=SimpleNamespace(open_id="ou_bot", user_id=""),
+            name="Hermes",
+        )
+        message = SimpleNamespace(
+            content=json.dumps({"text": "@_user_1"}),
+            message_type="text",
+            message_id="m_thread_ping2",
+            mentions=[bot_mention],
+            chat_id="oc_chat",
+            parent_id=None,
+            upper_message_id=None,
+            thread_id="omt_thread_abc",  # thread_id field set
+            root_id=None,
+        )
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message, message=message, sender_id=None,
+                chat_type="group", message_id="m_thread_ping2",
+            )
+        )
+        adapter._dispatch_inbound_event.assert_called_once()
+        event = adapter._dispatch_inbound_event.call_args.args[0]
+        self.assertEqual(event.message_type, MessageType.TEXT)
+        self.assertIn("[Mentioned]", event.text)
+
+    def test_non_thread_mention_only_message_still_dropped(self):
+        """Outside thread context a bare @Bot is still dropped (no over-firing)."""
+        adapter = self._build_adapter()
+        bot_mention = SimpleNamespace(
+            key="@_user_1",
+            id=SimpleNamespace(open_id="ou_bot", user_id=""),
+            name="Hermes",
+        )
+        message = SimpleNamespace(
+            content=json.dumps({"text": "@_user_1"}),
+            message_type="text",
+            message_id="m_no_thread",
+            mentions=[bot_mention],
+            chat_id="oc_chat",
+            parent_id=None,
+            upper_message_id=None,
+            thread_id=None,
+            root_id=None,  # no thread context
+        )
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message, message=message, sender_id=None,
+                chat_type="group", message_id="m_no_thread",
+            )
+        )
+        adapter._dispatch_inbound_event.assert_not_called()
+
 
 class TestFeishuFetchMessageText(unittest.TestCase):
     def _build_adapter(self):


### PR DESCRIPTION
## Problem

Closes #31336.

In a Feishu 话题/thread chat, users commonly open a thread interaction with just `@Bot` (no other text). The gateway was silently dropping these messages — no response was generated and no `Inbound group message received` log line appeared.

## Root Cause

The inbound pipeline in `_process_inbound_message`:

1. `_extract_message_content` returns `text='@Bot'`
2. `_strip_edge_self_mentions` removes the self-mention → `text=''`
3. Empty-text guard fires: `if not text and not media_urls: return`
4. Message dropped silently

The guard was originally designed to discard bare `@Bot` pings in regular group chats (expected behaviour). But in a 话题 thread the same ping is a valid conversation starter — the user is addressing the bot inside a thread where the reply context is already established.

## Fix

Before dropping, check whether:
- the message has a `thread_id` or `root_id` (Feishu thread context indicators), **and**
- at least one of the extracted mention refs is `is_self=True`

When both conditions hold, synthesise a `[Mentioned]` ping text so the agent can respond inside the thread. Outside thread context the existing drop behaviour is preserved.

```python
# Before (dropped silently in thread context):
if inbound_type == MessageType.TEXT and not text and not media_urls:
    logger.debug("[Feishu] Ignoring empty text message id=%s", message_id)
    return

# After (thread @mentions become a [Mentioned] ping):
if inbound_type == MessageType.TEXT and not text and not media_urls:
    _thread_context = getattr(message, 'thread_id', None) or getattr(message, 'root_id', None)
    _has_self_mention = any(m.is_self for m in mentions)
    if _thread_context and _has_self_mention:
        text = '[Mentioned]'
        logger.debug("...")
    else:
        logger.debug("[Feishu] Ignoring empty text message id=%s", message_id)
        return
```

## Tests Added

| Test | Scenario |
|---|---|
| `test_thread_mention_only_message_is_processed_not_dropped` | `root_id` set — message dispatched with `[Mentioned]` text |
| `test_thread_mention_only_message_via_thread_id_field` | `thread_id` field set — same behaviour |
| `test_non_thread_mention_only_message_still_dropped` | No thread context — bare `@Bot` still dropped as before |

## How to Test

1. Add your Hermes bot to a Feishu group with topic/thread mode enabled
2. Create a 话题 thread in the group
3. Send `@BotName` in the thread (no other text)
4. Bot should respond; `[Feishu] Inbound group message received` appears in logs
5. Outside a thread, a bare `@Bot` message should still be ignored