### PR TITLE
docs(agent): fix auxiliary_client docstring — remove phantom 'Native Anthropic' step (#31326)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -12,17 +12,24 @@ Resolution order for text tasks (auto mode):
   4. Custom endpoint (config.yaml model.base_url + OPENAI_API_KEY)
   5. Direct API-key providers from PROVIDER_REGISTRY — z.ai/GLM, Kimi/Moonshot,
      MiniMax, MiniMax-CN, and (when explicitly configured) native Anthropic.
-     Anthropic is NOT attempted automatically via Claude Code credentials;
-     only when ``auxiliary.*.provider: anthropic`` or a matching API key is
-     present in the credential pool.
+     Anthropic is NOT attempted automatically via Claude Code credentials; it
+     is only used when ``is_provider_explicitly_configured("anthropic")`` is
+     true — i.e. the auth.json active provider is anthropic, config.yaml
+     ``model.provider`` is anthropic, a usable ``ANTHROPIC_API_KEY`` env var
+     is set, or an explicitly-added credential-pool entry exists
+     (ambient borrowed sources like Claude Code's OAuth token are excluded).
   6. None
 
 Resolution order for vision/multimodal tasks (auto mode):
   1. Selected main provider, if it is one of the supported vision backends below
   2. OpenRouter
   3. Nous Portal
-  4. Custom endpoint (for local vision models: Qwen-VL, LLaVA, Pixtral, etc.)
-  5. None
+  4. None
+
+  Custom endpoints (local vision models: Qwen-VL, LLaVA, Pixtral, etc.) are
+  NOT an automatic fourth fallback — auto routing returns after Nous Portal.
+  A custom endpoint is used only when it is the selected main provider or via
+  an explicit ``base_url`` override.
 
   Note: Native Anthropic is NOT in the vision auto-detect chain.  Use
   ``auxiliary.vision.provider: anthropic`` to opt in explicitly.

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -10,17 +10,22 @@ Resolution order for text tasks (auto mode):
   2. OpenRouter  (OPENROUTER_API_KEY)
   3. Nous Portal (~/.hermes/auth.json active provider)
   4. Custom endpoint (config.yaml model.base_url + OPENAI_API_KEY)
-  5. Native Anthropic
-  6. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, MiniMax-CN)
-  7. None
+  5. Direct API-key providers from PROVIDER_REGISTRY — z.ai/GLM, Kimi/Moonshot,
+     MiniMax, MiniMax-CN, and (when explicitly configured) native Anthropic.
+     Anthropic is NOT attempted automatically via Claude Code credentials;
+     only when ``auxiliary.*.provider: anthropic`` or a matching API key is
+     present in the credential pool.
+  6. None
 
 Resolution order for vision/multimodal tasks (auto mode):
   1. Selected main provider, if it is one of the supported vision backends below
   2. OpenRouter
   3. Nous Portal
-  4. Native Anthropic
-  5. Custom endpoint (for local vision models: Qwen-VL, LLaVA, Pixtral, etc.)
-  6. None
+  4. Custom endpoint (for local vision models: Qwen-VL, LLaVA, Pixtral, etc.)
+  5. None
+
+  Note: Native Anthropic is NOT in the vision auto-detect chain.  Use
+  ``auxiliary.vision.provider: anthropic`` to opt in explicitly.
 
 Codex OAuth (ChatGPT-account auth) is intentionally NOT in either
 fallback chain: OpenAI gates this endpoint behind an undocumented,

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -12,9 +12,12 @@ Resolution order for text tasks (auto mode):
   4. Custom endpoint (config.yaml model.base_url + OPENAI_API_KEY)
   5. Direct API-key providers from PROVIDER_REGISTRY — z.ai/GLM, Kimi/Moonshot,
      MiniMax, MiniMax-CN, and (when explicitly configured) native Anthropic.
-     Anthropic is NOT attempted automatically via Claude Code credentials;
-     only when ``auxiliary.*.provider: anthropic`` or a matching API key is
-     present in the credential pool.
+     Anthropic is NOT attempted automatically via Claude Code credentials; it
+     is only used when ``is_provider_explicitly_configured("anthropic")`` is
+     true — i.e. the auth.json active provider is anthropic, config.yaml
+     ``model.provider`` is anthropic, a usable ``ANTHROPIC_API_KEY`` env var
+     is set, or an explicitly-added credential-pool entry exists
+     (ambient borrowed sources like Claude Code's OAuth token are excluded).
   6. None
 
 OpenRouter fallback cost guard: ``auxiliary.free_only: true`` restricts the
@@ -25,8 +28,12 @@ Resolution order for vision/multimodal tasks (auto mode):
   1. Selected main provider, if it is one of the supported vision backends below
   2. OpenRouter
   3. Nous Portal
-  4. Custom endpoint (for local vision models: Qwen-VL, LLaVA, Pixtral, etc.)
-  5. None
+  4. None
+
+  Custom endpoints (local vision models: Qwen-VL, LLaVA, Pixtral, etc.) are
+  NOT an automatic fourth fallback — auto routing returns after Nous Portal.
+  A custom endpoint is used only when it is the selected main provider or via
+  an explicit ``base_url`` override.
 
   Note: Native Anthropic is NOT in the vision auto-detect chain.  Use
   ``auxiliary.vision.provider: anthropic`` to opt in explicitly.

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -10,9 +10,12 @@ Resolution order for text tasks (auto mode):
   2. OpenRouter  (OPENROUTER_API_KEY)
   3. Nous Portal (~/.hermes/auth.json active provider)
   4. Custom endpoint (config.yaml model.base_url + OPENAI_API_KEY)
-  5. Native Anthropic
-  6. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, MiniMax-CN)
-  7. None
+  5. Direct API-key providers from PROVIDER_REGISTRY — z.ai/GLM, Kimi/Moonshot,
+     MiniMax, MiniMax-CN, and (when explicitly configured) native Anthropic.
+     Anthropic is NOT attempted automatically via Claude Code credentials;
+     only when ``auxiliary.*.provider: anthropic`` or a matching API key is
+     present in the credential pool.
+  6. None
 
 OpenRouter fallback cost guard: ``auxiliary.free_only: true`` restricts the
 step-2 fallback to ``:free`` SKUs; ``auxiliary.openrouter_model`` overrides
@@ -22,9 +25,11 @@ Resolution order for vision/multimodal tasks (auto mode):
   1. Selected main provider, if it is one of the supported vision backends below
   2. OpenRouter
   3. Nous Portal
-  4. Native Anthropic
-  5. Custom endpoint (for local vision models: Qwen-VL, LLaVA, Pixtral, etc.)
-  6. None
+  4. Custom endpoint (for local vision models: Qwen-VL, LLaVA, Pixtral, etc.)
+  5. None
+
+  Note: Native Anthropic is NOT in the vision auto-detect chain.  Use
+  ``auxiliary.vision.provider: anthropic`` to opt in explicitly.
 
 Codex OAuth (ChatGPT-account auth) is intentionally NOT in either
 fallback chain: OpenAI gates this endpoint behind an undocumented,


### PR DESCRIPTION
## Problem

Closes #31326.

The module-level docstring in `agent/auxiliary_client.py` (lines 7–23) has been inaccurate for some time:

**Text chain**: Listed `5. Native Anthropic` as a standalone auto-detect step. It is not. Anthropic lives *inside* `_resolve_api_key_provider` (the `"api-key"` entry in `_get_provider_chain`) behind an explicit-configuration guard. Claude Code credentials are **not** tried automatically as a text fallback — only when the operator has `auxiliary.*.provider: anthropic` configured or a matching API key in the credential pool.

**Vision chain**: Listed `4. Native Anthropic` in the auto-detect order. Anthropic is absent from the vision auto-select path entirely (`get_available_vision_backends` / `_get_vision_chain`). It is only reachable via explicit `auxiliary.vision.provider: anthropic`.

As noted by collaborator @alt-glitch, PR #14433 previously attempted to fix this but was closed without merge. The issue remains valid on current `main`.

## Changes

| Location | Before | After |
|---|---|---|
| Text chain step 5 | `5. Native Anthropic` | Merged into step 5 api-key description; Anthropic explicitly requires opt-in |
| Text chain step 6 | `6. Direct API-key providers` | Removed (now part of step 5) |
| Vision chain step 4 | `4. Native Anthropic` | Removed; added explicit opt-in note |

No behaviour change — documentation only.

## Verification

The actual `_get_provider_chain` (text) and `get_available_vision_backends` (vision) remain unchanged; the docstring now accurately describes both.