### PR TITLE
fix(kanban): make idempotent task creation atomic

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1633,21 +1633,6 @@ def create_task(
             )
         skills_list = cleaned
 
-    # Idempotency check — return the existing task instead of creating a
-    # duplicate. Done BEFORE entering write_txn to keep the fast path fast
-    # and to avoid holding a write lock during the lookup. Race is
-    # acceptable: two concurrent creators with the same key might both
-    # insert, at which point both rows exist but the next lookup stabilises.
-    if idempotency_key:
-        row = conn.execute(
-            "SELECT id FROM tasks WHERE idempotency_key = ? "
-            "AND status != 'archived' "
-            "ORDER BY created_at DESC LIMIT 1",
-            (idempotency_key,),
-        ).fetchone()
-        if row:
-            return row["id"]
-
     now = int(time.time())
 
     # Resolve workspace_path from board-level default_workdir when the
@@ -1664,6 +1649,18 @@ def create_task(
         task_id = _new_task_id()
         try:
             with write_txn(conn):
+                # Keep the idempotency lookup in the same critical section as
+                # the insert so concurrent writers with the same key cannot
+                # both observe "missing" and create duplicate active tasks.
+                if idempotency_key:
+                    row = conn.execute(
+                        "SELECT id FROM tasks WHERE idempotency_key = ? "
+                        "AND status != 'archived' "
+                        "ORDER BY created_at DESC LIMIT 1",
+                        (idempotency_key,),
+                    ).fetchone()
+                    if row:
+                        return row["id"]
                 # Determine task status from parent status, unless the caller
                 # parks it directly in blocked for human-ops review or in
                 # triage for a specifier.

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import concurrent.futures
 import os
 import sqlite3
+import threading
 import time
 from pathlib import Path
 
@@ -210,6 +211,39 @@ def test_branch_name_requires_worktree_workspace(kanban_home):
             workspace_kind="scratch",
             branch_name="wt/bad",
         )
+
+
+def test_create_task_idempotency_key_is_atomic_under_concurrency(kanban_home):
+    """Concurrent creates with the same idempotency key must dedupe to one row."""
+    barrier = threading.Barrier(2)
+    original_write_txn = kb.write_txn
+
+    def gated_write_txn(conn):
+        barrier.wait(timeout=5)
+        return original_write_txn(conn)
+
+    def attempt(worker_id):
+        with kb.connect() as conn:
+            return kb.create_task(
+                conn,
+                title=f"dupe-{worker_id}",
+                idempotency_key="dup-key",
+            )
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(kb, "write_txn", gated_write_txn)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as ex:
+            task_ids = list(ex.map(attempt, range(2)))
+
+    with kb.connect() as conn:
+        rows = conn.execute(
+            "SELECT id FROM tasks WHERE idempotency_key = ?",
+            ("dup-key",),
+        ).fetchall()
+
+    assert task_ids[0] == task_ids[1]
+    assert len(rows) == 1
+    assert rows[0]["id"] == task_ids[0]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION

## Summary
This change makes `create_task()` truly idempotent under concurrency by moving the `idempotency_key` lookup into the same `BEGIN IMMEDIATE` write transaction as the insert. That closes the race where two concurrent writers could both miss the pre-transaction lookup and create duplicate active tasks.

A deterministic regression test was added to force two concurrent creators through the same critical section and assert that both calls return the same `task_id` and only one row is persisted.

## Scope
- `hermes_cli/kanban_db.py`
- `tests/hermes_cli/test_kanban_db.py`

## Validation
- ✅ `uv run pytest tests/hermes_cli/test_kanban_db.py -k idempotency --timeout-method=thread`
  - Result: `1 passed, 165 deselected`
- ✅ `uv run pytest tests/hermes_cli/test_kanban_db.py -k "create_task_no_parents_is_ready or create_task_with_parent_is_todo_until_parent_done or create_task_idempotency_key_is_atomic_under_concurrency" --timeout-method=thread`
  - Result: `3 passed, 163 deselected`
- ⚠️ `uv run pytest tests/hermes_cli/test_kanban_db.py --timeout-method=thread`
  - Result: `163 passed, 3 failed`
  - Failing tests:
    - `test_resolve_hermes_argv_prefers_path_shim`
    - `test_resolve_hermes_argv_hermes_bin_bare_name_uses_path`
    - `test_resolve_hermes_argv_falls_back_to_module_form_when_no_path_shim`
  - Note: these failures are outside this patch and were triggered locally on this Windows environment after `uv run` created `.venv\Scripts\hermes.EXE`, which changes `_resolve_hermes_argv()` path resolution behavior.

## Risk
- Low.
- No schema change.
- Behavior change is isolated to the idempotent create path.

## Reviewer Note
Expected behavior after this patch: two concurrent `create_task(..., idempotency_key="same-key")` calls now converge on a single persisted task instead of producing duplicate rows.