### PR TITLE
fix: preserve compression session splits on gateway errors

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -480,6 +480,24 @@ def _uses_telegram_observed_group_context(channel_prompt: Optional[str]) -> bool
     return bool(channel_prompt and _TELEGRAM_OBSERVED_CONTEXT_PROMPT_MARKER in channel_prompt)
 
 
+def _history_offset_for_session_split(
+    *,
+    original_session_id: str,
+    effective_session_id: str,
+    original_history_len: int,
+) -> int:
+    """Return the transcript slice offset after an agent run.
+
+    Automatic context compression creates a new continuation session and
+    returns a shortened compressed message list. In that case the old history
+    length points past the end of the compressed list, so the gateway must write
+    the entire compressed continuation to JSONL.
+    """
+    if effective_session_id and effective_session_id != original_session_id:
+        return 0
+    return original_history_len
+
+
 def _build_gateway_agent_history(
     history: List[Dict[str, Any]],
     *,
@@ -1540,6 +1558,89 @@ def _preserve_queued_followup_history_offset(
     merged = dict(followup_result)
     merged["history_offset"] = current_offset
     return merged
+
+
+def _messages_to_persist_after_agent_run(
+    *,
+    agent_result: dict,
+    current_session_id: str,
+    original_session_id: str,
+    agent_messages: list,
+    message_text: Any,
+    timestamp: str,
+    platform_message_id: Optional[str] = None,
+    session_db_available: bool = False,
+) -> tuple[list[dict], bool]:
+    """Return transcript rows to persist for an agent result.
+
+    Normal transient failures persist only the current user message so retrying
+    keeps the user's request.  A compression session split is different: the
+    agent result's message list is already the new continuation transcript, so
+    persisting only the user turn would duplicate the tail and skip the compacted
+    summary for stores that rely on the gateway persistence path.
+
+    The returned ``skip_db`` flag mirrors the existing successful-turn path: if
+    SessionDB is available, the agent has already flushed these messages itself
+    and the gateway should only perform any non-DB compatibility write.
+    """
+
+    split_session = bool(
+        original_session_id
+        and current_session_id
+        and current_session_id != original_session_id
+    )
+    if not split_session:
+        entry = {"role": "user", "content": message_text, "timestamp": timestamp}
+        if platform_message_id:
+            entry["message_id"] = str(platform_message_id)
+        return [entry], False
+
+    history_len = agent_result.get("history_offset", 0)
+    if not isinstance(history_len, int) or history_len < 0:
+        history_len = 0
+    new_messages = agent_messages[history_len:] if len(agent_messages) > history_len else []
+    if not new_messages:
+        entry = {"role": "user", "content": message_text, "timestamp": timestamp}
+        if platform_message_id:
+            entry["message_id"] = str(platform_message_id)
+        return [entry], False
+
+    def _is_compaction_summary_content(content: Any) -> bool:
+        if not isinstance(content, str):
+            return False
+        stripped = content.lstrip()
+        return stripped.startswith("[CONTEXT COMPACTION") or stripped.startswith("[CONTEXT SUMMARY]")
+
+    def _content_matches_message_text(content: Any) -> bool:
+        if content == message_text:
+            return True
+        if isinstance(content, list) and isinstance(message_text, str):
+            text_parts = [
+                str(part.get("text", ""))
+                for part in content
+                if isinstance(part, dict) and part.get("type") == "text"
+            ]
+            return bool(text_parts) and "\n".join(text_parts) == message_text
+        return False
+
+    rows: list[dict] = []
+    user_msg_id_attached = False
+    fallback_user_without_msg_id: Optional[dict] = None
+    for msg in new_messages:
+        if msg.get("role") == "system":
+            continue
+        entry = {**msg, "timestamp": timestamp}
+        if msg.get("role") == "user" and "message_id" not in entry:
+            content = entry.get("content")
+            if not _is_compaction_summary_content(content):
+                fallback_user_without_msg_id = entry
+            if platform_message_id and _content_matches_message_text(content):
+                entry["message_id"] = str(platform_message_id)
+                user_msg_id_attached = True
+        rows.append(entry)
+    if platform_message_id and not user_msg_id_attached and fallback_user_without_msg_id is not None:
+        fallback_user_without_msg_id["message_id"] = str(platform_message_id)
+    return rows, bool(session_db_available)
 
 
 class GatewayRunner:
@@ -8509,6 +8610,10 @@ class GatewayRunner:
             }
             await self.hooks.emit("agent:start", hook_ctx)
 
+            # Capture before _run_agent(): context compression can mutate the
+            # shared SessionEntry via session_store._entries while returning.
+            _original_session_id_for_turn = session_entry.session_id
+
             # Run the agent
             agent_result = await self._run_agent(
                 message=message_text,
@@ -8781,17 +8886,32 @@ class GatewayRunner:
             if is_context_overflow_failure:
                 pass  # handled above — skip all transcript writes
             elif agent_failed_early:
-                # Transient failure (429/timeout/5xx): persist only the user
+                # Transient failure (429/timeout/5xx): persist the user's
                 # message so the next message can load a transcript that
                 # reflects what was said.  Skip the assistant error text since
                 # it's a gateway-generated hint, not model output. (#7100)
-                _user_entry = {"role": "user", "content": message_text, "timestamp": ts}
-                if event.message_id:
-                    _user_entry["message_id"] = str(event.message_id)
-                self.session_store.append_to_transcript(
-                    session_entry.session_id,
-                    _user_entry,
+                #
+                # If the agent compressed into a continuation session before
+                # failing, its returned message list is the new session's full
+                # compacted transcript.  Preserve that slice (and avoid a DB
+                # duplicate when the agent already flushed it) instead of
+                # appending only another copy of the current user turn.
+                _rows_to_persist, _skip_db_for_rows = _messages_to_persist_after_agent_run(
+                    agent_result=agent_result,
+                    current_session_id=session_entry.session_id,
+                    original_session_id=_original_session_id_for_turn,
+                    agent_messages=agent_messages,
+                    message_text=message_text,
+                    timestamp=ts,
+                    platform_message_id=event.message_id,
+                    session_db_available=self._session_db is not None,
                 )
+                for _row in _rows_to_persist:
+                    self.session_store.append_to_transcript(
+                        session_entry.session_id,
+                        _row,
+                        skip_db=_skip_db_for_rows,
+                    )
             else:
                 history_len = agent_result.get("history_offset", len(history))
                 new_messages = agent_messages[history_len:] if len(agent_messages) > history_len else []
@@ -8816,29 +8936,51 @@ class GatewayRunner:
                     # to prevent the duplicate-write bug (#860).  We still write
                     # to JSONL for backward compatibility and as a backup.
                     agent_persisted = self._session_db is not None
-                    # Attach the inbound platform message_id to the first user
-                    # entry written this turn so platform-level quote-resolution
-                    # (e.g. Yuanbao QuoteContextMiddleware's transcript fallback)
-                    # can find earlier @bot messages by their original message_id.
-                    _user_msg_id_attached = False
-                    for msg in new_messages:
-                        # Skip system messages (they're rebuilt each run)
-                        if msg.get("role") == "system":
-                            continue
-                        # Add timestamp to each message for debugging
-                        entry = {**msg, "timestamp": ts}
-                        if (
-                            not _user_msg_id_attached
-                            and msg.get("role") == "user"
-                            and event.message_id
-                            and "message_id" not in entry
-                        ):
-                            entry["message_id"] = str(event.message_id)
-                            _user_msg_id_attached = True
-                        self.session_store.append_to_transcript(
-                            session_entry.session_id, entry,
-                            skip_db=agent_persisted,
+                    if session_entry.session_id != _original_session_id_for_turn:
+                        # Compression splits replay the compacted continuation from
+                        # offset 0.  Reuse the same row builder as failed paths so
+                        # platform message_id binds to the real current user turn,
+                        # not the compaction summary row.
+                        _rows_to_persist, _skip_db_for_rows = _messages_to_persist_after_agent_run(
+                            agent_result=agent_result,
+                            current_session_id=session_entry.session_id,
+                            original_session_id=_original_session_id_for_turn,
+                            agent_messages=agent_messages,
+                            message_text=message_text,
+                            timestamp=ts,
+                            platform_message_id=event.message_id,
+                            session_db_available=self._session_db is not None,
                         )
+                        for _row in _rows_to_persist:
+                            self.session_store.append_to_transcript(
+                                session_entry.session_id,
+                                _row,
+                                skip_db=_skip_db_for_rows,
+                            )
+                    else:
+                        # Attach the inbound platform message_id to the first user
+                        # entry written this turn so platform-level quote-resolution
+                        # (e.g. Yuanbao QuoteContextMiddleware's transcript fallback)
+                        # can find earlier @bot messages by their original message_id.
+                        _user_msg_id_attached = False
+                        for msg in new_messages:
+                            # Skip system messages (they're rebuilt each run)
+                            if msg.get("role") == "system":
+                                continue
+                            # Add timestamp to each message for debugging
+                            entry = {**msg, "timestamp": ts}
+                            if (
+                                not _user_msg_id_attached
+                                and msg.get("role") == "user"
+                                and event.message_id
+                                and "message_id" not in entry
+                            ):
+                                entry["message_id"] = str(event.message_id)
+                                _user_msg_id_attached = True
+                            self.session_store.append_to_transcript(
+                                session_entry.session_id, entry,
+                                skip_db=agent_persisted,
+                            )
             
             # Token counts and model are now persisted by the agent directly.
             # Keep only last_prompt_tokens here for context-window tracking and
@@ -16841,6 +16983,32 @@ class GatewayRunner:
                 _context_length = getattr(_agent.context_compressor, "context_length", 0) or 0
             _resolved_model = getattr(_agent, "model", None) if _agent else None
 
+            # Sync session_id before any return: the agent may have created a
+            # new session during mid-run context compression (_compress_context
+            # splits sessions). Error/no-response paths must update the session
+            # store too, otherwise the next message reloads the stale
+            # pre-compression transcript.
+            agent = agent_holder[0]
+            _session_was_split = False
+            if agent and session_key and hasattr(agent, 'session_id') and agent.session_id != session_id:
+                _session_was_split = True
+                logger.info(
+                    "Session split detected: %s → %s (compression)",
+                    session_id, agent.session_id,
+                )
+                entry = self.session_store._entries.get(session_key)
+                if entry:
+                    entry.session_id = agent.session_id
+                    self.session_store._save()
+
+            effective_session_id = getattr(agent, 'session_id', session_id) if agent else session_id
+            effective_session_id = effective_session_id or session_id
+            _effective_history_offset = _history_offset_for_session_split(
+                original_session_id=session_id,
+                effective_session_id=effective_session_id,
+                original_history_len=len(agent_history),
+            )
+
             if not final_response:
                 error_msg = f"⚠️ {result['error']}" if result.get("error") else ""
                 return {
@@ -16855,12 +17023,13 @@ class GatewayRunner:
                     "error": result.get("error"),
                     "compression_exhausted": result.get("compression_exhausted", False),
                     "tools": tools_holder[0] or [],
-                    "history_offset": len(agent_history),
+                    "history_offset": _effective_history_offset,
                     "last_prompt_tokens": _last_prompt_toks,
                     "input_tokens": _input_toks,
                     "output_tokens": _output_toks,
                     "model": _resolved_model,
                     "context_length": _context_length,
+                    "session_id": effective_session_id,
                 }
             
             # Scan tool results for MEDIA:<path> tags that need to be delivered
@@ -16905,62 +17074,37 @@ class GatewayRunner:
                         unique_tags.insert(0, "[[audio_as_voice]]")
                     final_response = final_response + "\n" + "\n".join(unique_tags)
             
-            # Sync session_id: the agent may have created a new session during
-            # mid-run context compression (_compress_context splits sessions).
-            # If so, update the session store entry so the NEXT message loads
-            # the compressed transcript, not the stale pre-compression one.
-            agent = agent_holder[0]
-            _session_was_split = False
-            if agent and session_key and hasattr(agent, 'session_id') and agent.session_id != session_id:
-                _session_was_split = True
-                logger.info(
-                    "Session split detected: %s → %s (compression)",
-                    session_id, agent.session_id,
-                )
-                entry = self.session_store._entries.get(session_key)
-                if entry:
-                    entry.session_id = agent.session_id
-                    self.session_store._save()
-
-                # If this is a Telegram DM and source.thread_id was lost during
-                # the session split (synthetic / recovered event), restore it
-                # from the binding so _thread_metadata_for_source produces the
-                # correct message_thread_id instead of routing to the General
-                # thread.  Failure here is non-fatal — we log and continue;
-                # worst case the message lands in General, which is the
-                # pre-fix behaviour.
-                if (
-                    getattr(source, "platform", None) == Platform.TELEGRAM
-                    and getattr(source, "chat_type", None) == "dm"
-                    and getattr(source, "thread_id", None) is None
-                    and self._session_db is not None
-                ):
-                    try:
-                        _binding = self._session_db.get_telegram_topic_binding_by_session(
-                            session_id=agent.session_id,
-                        )
-                        if _binding and _binding.get("thread_id"):
-                            source.thread_id = str(_binding["thread_id"])
-                            logger.debug(
-                                "Restored source.thread_id=%s from binding after session split %s → %s",
-                                source.thread_id,
-                                session_id,
-                                agent.session_id,
-                            )
-                    except Exception:
+            # If this is a Telegram DM and source.thread_id was lost during the
+            # session split (synthetic / recovered event), restore it from the
+            # binding so _thread_metadata_for_source produces the correct
+            # message_thread_id instead of routing to the General thread.
+            # Failure here is non-fatal — we log and continue; worst case the
+            # message lands in General, which is the pre-fix behaviour.
+            if (
+                _session_was_split
+                and agent
+                and getattr(source, "platform", None) == Platform.TELEGRAM
+                and getattr(source, "chat_type", None) == "dm"
+                and getattr(source, "thread_id", None) is None
+                and self._session_db is not None
+            ):
+                try:
+                    _binding = self._session_db.get_telegram_topic_binding_by_session(
+                        session_id=agent.session_id,
+                    )
+                    if _binding and _binding.get("thread_id"):
+                        source.thread_id = str(_binding["thread_id"])
                         logger.debug(
-                            "Failed to restore thread_id from binding after session split",
-                            exc_info=True,
+                            "Restored source.thread_id=%s from binding after session split %s → %s",
+                            source.thread_id,
+                            session_id,
+                            agent.session_id,
                         )
-
-            effective_session_id = getattr(agent, 'session_id', session_id) if agent else session_id
-
-            # When compression created a new session, the messages list was
-            # shortened.  Using the original history offset would produce an
-            # empty new_messages slice, causing the gateway to write only a
-            # user/assistant pair — losing the compressed summary and tail.
-            # Reset to 0 so the gateway writes ALL compressed messages.
-            _effective_history_offset = 0 if _session_was_split else len(agent_history)
+                except Exception:
+                    logger.debug(
+                        "Failed to restore thread_id from binding after session split",
+                        exc_info=True,
+                    )
 
             # Auto-generate session title after first exchange (non-blocking)
             if final_response and self._session_db:

--- a/tests/test_compression_session_split_persistence.py
+++ b/tests/test_compression_session_split_persistence.py
@@ -1,0 +1,428 @@
+"""Regression tests for context compression session splits.
+
+When automatic compression creates a continuation session, both persistence
+layers must treat the compressed message list as the new session's complete
+history.  Keeping the old history offset causes the compressed summary/tail to
+be skipped, so the next turn resumes an effectively empty continuation.
+"""
+
+import sys
+import types
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+
+def _mock_response(content="OK", finish_reason="stop"):
+    msg = SimpleNamespace(
+        content=content,
+        tool_calls=None,
+        reasoning_content=None,
+        reasoning=None,
+    )
+    choice = SimpleNamespace(message=msg, finish_reason=finish_reason)
+    resp = SimpleNamespace(choices=[choice], model="test/model", usage=None)
+    return resp
+
+
+def _make_413_error():
+    err = Exception("Request entity too large")
+    err.status_code = 413
+    return err
+
+
+class TestAgentSessionSplitPersistence:
+    def _make_agent(self, session_db):
+        from run_agent import AIAgent
+
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="x",
+                base_url="https://example.invalid/v1",
+                model="test/model",
+                quiet_mode=True,
+                session_id="original-session",
+                session_db=session_db,
+                enabled_toolsets=[],
+                skip_context_files=True,
+                skip_memory=True,
+                save_trajectories=False,
+            )
+        agent.client = MagicMock()
+        agent.tools = []
+        agent._cached_system_prompt = "system prompt"
+        agent._use_prompt_caching = False
+        agent.tool_delay = 0
+        return agent
+
+    def test_413_compression_split_flushes_compressed_messages_to_new_session(self, tmp_path):
+        """A stale pre-compression history offset must not skip the new session."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "sessions.db")
+        agent = self._make_agent(db)
+
+        long_history = [
+            {"role": "user" if i % 2 == 0 else "assistant", "content": f"old message {i}"}
+            for i in range(40)
+        ]
+        compressed_messages = [
+            {"role": "user", "content": "[CONTEXT COMPACTION] summary of the old session"},
+            {"role": "user", "content": "fresh question after compression"},
+        ]
+
+        def fake_compress(messages, system_message, **kwargs):
+            agent.session_id = "compressed-session"
+            db.create_session(
+                session_id="compressed-session",
+                source="qqbot",
+                model="test/model",
+                parent_session_id="original-session",
+            )
+            agent._last_flushed_db_idx = 0
+            return list(compressed_messages), "compressed system prompt"
+
+        agent.client.chat.completions.create.side_effect = [
+            _make_413_error(),
+            _mock_response("final answer after compression"),
+        ]
+
+        with (
+            patch.object(agent, "_compress_context", side_effect=fake_compress),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch("run_agent.time.sleep", return_value=None),
+        ):
+            result = agent.run_conversation(
+                "fresh question after compression",
+                conversation_history=long_history,
+            )
+
+        assert result["completed"] is True
+        rows = db.get_messages("compressed-session")
+        contents = [row.get("content") for row in rows]
+        assert any(
+            "[CONTEXT COMPACTION] summary of the old session" in str(content)
+            for content in contents
+        )
+        assert "final answer after compression" in contents
+
+
+def test_gateway_history_offset_resets_when_session_split():
+    from gateway.run import _history_offset_for_session_split
+
+    assert _history_offset_for_session_split(
+        original_session_id="original-session",
+        effective_session_id="compressed-session",
+        original_history_len=40,
+    ) == 0
+
+
+def test_gateway_history_offset_preserves_normal_session():
+    from gateway.run import _history_offset_for_session_split
+
+    assert _history_offset_for_session_split(
+        original_session_id="same-session",
+        effective_session_id="same-session",
+        original_history_len=40,
+    ) == 40
+
+
+@pytest.mark.asyncio
+async def test_gateway_error_response_preserves_session_split(monkeypatch, tmp_path):
+    """Even no-final-response paths must persist compressed continuations."""
+    from gateway.config import Platform
+    from gateway.session import SessionSource
+    import gateway.run as gateway_run
+    import run_agent
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            self.session_id = kwargs["session_id"]
+            self.tools = []
+            self.context_compressor = SimpleNamespace(last_prompt_tokens=123)
+
+        def run_conversation(self, message, conversation_history=None, task_id=None):
+            self.session_id = "compressed-session"
+            return {
+                "final_response": None,
+                "messages": [
+                    {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+                    {"role": "user", "content": message},
+                ],
+                "api_calls": 1,
+                "error": "compression retry failed",
+                "completed": False,
+            }
+
+    class FakeSessionStore:
+        def __init__(self):
+            self._entries = {
+                "session-key": SimpleNamespace(session_id="original-session")
+            }
+            self.saved = False
+
+        def _save(self):
+            self.saved = True
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner.hooks = SimpleNamespace(loaded_hooks=False, emit=AsyncMock())
+    runner.session_store = FakeSessionStore()
+    runner._provider_routing = {}
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._reasoning_config = None
+    runner._fallback_model = None
+    runner._session_db = None
+    runner._running_agents = {}
+    runner._get_or_create_gateway_honcho = lambda _session_key: (None, None)
+
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "off")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda *a, **k: "test/model")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"api_key": "***", "base_url": "https://example.invalid/v1"},
+    )
+    monkeypatch.setattr(run_agent, "AIAgent", FakeAgent)
+
+    result = await runner._run_agent(
+        message="fresh question",
+        context_prompt="",
+        history=[
+            {"role": "session_meta", "tools": []},
+            {"role": "user", "content": "old message"},
+            {"role": "assistant", "content": "old answer"},
+        ],
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="chat", chat_type="dm"),
+        session_id="original-session",
+        session_key="session-key",
+    )
+
+    assert result["final_response"] == "⚠️ compression retry failed"
+    assert result["session_id"] == "compressed-session"
+    assert result["history_offset"] == 0
+    assert runner.session_store._entries["session-key"].session_id == "compressed-session"
+    assert runner.session_store.saved is True
+
+def test_gateway_split_failed_path_uses_compressed_messages_not_duplicate_user():
+    from gateway.run import _messages_to_persist_after_agent_run
+
+    agent_messages = [
+        {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+        {"role": "user", "content": "fresh question"},
+    ]
+    messages, skip_db = _messages_to_persist_after_agent_run(
+        agent_result={
+            "failed": True,
+            "session_id": "compressed-session",
+            "history_offset": 0,
+            "messages": agent_messages,
+        },
+        current_session_id="compressed-session",
+        original_session_id="original-session",
+        agent_messages=agent_messages,
+        message_text="fresh question",
+        timestamp="2026-01-01T00:00:00",
+        platform_message_id="msg-1",
+        session_db_available=True,
+    )
+
+    assert [msg["content"] for msg in messages] == [
+        "[CONTEXT COMPACTION] summary",
+        "fresh question",
+    ]
+    assert messages[1]["message_id"] == "msg-1"
+    assert skip_db is True
+
+
+def test_gateway_split_failed_path_does_not_bind_message_id_to_compaction_summary():
+    from gateway.run import _messages_to_persist_after_agent_run
+
+    agent_messages = [
+        {"role": "user", "content": "[CONTEXT COMPACTION — REFERENCE ONLY] summary"},
+        {"role": "user", "content": [{"type": "text", "text": "fresh question"}]},
+    ]
+    messages, skip_db = _messages_to_persist_after_agent_run(
+        agent_result={
+            "failed": True,
+            "session_id": "compressed-session",
+            "history_offset": 0,
+            "messages": agent_messages,
+        },
+        current_session_id="compressed-session",
+        original_session_id="original-session",
+        agent_messages=agent_messages,
+        message_text="fresh question",
+        timestamp="2026-01-01T00:00:00",
+        platform_message_id="msg-1",
+        session_db_available=True,
+    )
+
+    assert "message_id" not in messages[0]
+    assert messages[1]["message_id"] == "msg-1"
+    assert skip_db is True
+
+
+def _make_split_persistence_runner(monkeypatch, tmp_path, agent_result):
+    import gateway.run as gateway_run
+    from gateway.config import GatewayConfig, Platform, PlatformConfig
+    from gateway.session import SessionEntry
+
+    entry = SessionEntry(
+        session_key="agent:main:telegram:dm:chat:user",
+        session_id="original-session",
+        created_at=datetime(2026, 1, 1, 0, 0, 0),
+        updated_at=datetime(2026, 1, 1, 0, 0, 1),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    appended = []
+
+    class FakeSessionStore:
+        config = GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake-token")}
+        )
+
+        def get_or_create_session(self, source):
+            return entry
+
+        def load_transcript(self, session_id):
+            return [
+                {"role": "user", "content": "old message"},
+                {"role": "assistant", "content": "old answer"},
+            ]
+
+        def append_to_transcript(self, session_id, message, skip_db=False):
+            appended.append((session_id, dict(message), skip_db))
+
+        def update_session(self, *args, **kwargs):
+            pass
+
+        def clear_resume_pending(self, *args, **kwargs):
+            pass
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.config = FakeSessionStore.config
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = FakeSessionStore()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = object()
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._get_or_create_gateway_honcho = lambda _session_key: (None, None)
+    runner._is_session_run_current = lambda _session_key, _generation: True
+
+    async def fake_run_agent(*args, **kwargs):
+        # Simulate _run_agent's real split side effect: it mutates the shared
+        # SessionEntry before _handle_message_with_agent persists rows.
+        entry.session_id = "compressed-session"
+        return dict(agent_result)
+
+    runner._run_agent = fake_run_agent
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+    return runner, entry, appended
+
+
+@pytest.mark.asyncio
+async def test_gateway_failed_split_persistence_uses_original_session_id_before_entry_mutation(monkeypatch, tmp_path):
+    from gateway.config import Platform
+    from gateway.platforms.base import MessageEvent
+    from gateway.session import SessionSource
+
+    runner, entry, appended = _make_split_persistence_runner(
+        monkeypatch,
+        tmp_path,
+        {
+            "final_response": "",
+            "failed": True,
+            "error": "compression retry failed",
+            "messages": [
+                {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+                {"role": "user", "content": "fresh question"},
+            ],
+            "history_offset": 0,
+            "tools": [],
+            "last_prompt_tokens": 0,
+            "session_id": "compressed-session",
+        },
+    )
+
+    event = MessageEvent(
+        text="fresh question",
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="chat", chat_type="dm", user_id="user"),
+        message_id="msg-1",
+    )
+
+    result = await runner._handle_message_with_agent(event, event.source, entry.session_key, 1)
+
+    assert "compression retry failed" in result
+    persisted = [row for _sid, row, _skip_db in appended]
+    assert [row["content"] for row in persisted] == [
+        "[CONTEXT COMPACTION] summary",
+        "fresh question",
+    ]
+    assert "message_id" not in persisted[0]
+    assert persisted[1]["message_id"] == "msg-1"
+    assert all(sid == "compressed-session" for sid, _row, _skip_db in appended)
+    assert all(skip_db is True for _sid, _row, skip_db in appended)
+
+
+@pytest.mark.asyncio
+async def test_gateway_success_split_message_id_skips_compaction_summary(monkeypatch, tmp_path):
+    from gateway.config import Platform
+    from gateway.platforms.base import MessageEvent
+    from gateway.session import SessionSource
+
+    runner, entry, appended = _make_split_persistence_runner(
+        monkeypatch,
+        tmp_path,
+        {
+            "final_response": "final answer",
+            "messages": [
+                {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+                {"role": "user", "content": [{"type": "text", "text": "fresh question"}]},
+                {"role": "assistant", "content": "final answer"},
+            ],
+            "history_offset": 0,
+            "tools": [],
+            "last_prompt_tokens": 0,
+            "session_id": "compressed-session",
+        },
+    )
+
+    event = MessageEvent(
+        text="fresh question",
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="chat", chat_type="dm", user_id="user"),
+        message_id="msg-1",
+    )
+
+    result = await runner._handle_message_with_agent(event, event.source, entry.session_key, 1)
+
+    assert result == "final answer"
+    persisted = [row for _sid, row, _skip_db in appended]
+    assert [row["content"] for row in persisted] == [
+        "[CONTEXT COMPACTION] summary",
+        [{"type": "text", "text": "fresh question"}],
+        "final answer",
+    ]
+    assert "message_id" not in persisted[0]
+    assert persisted[1]["message_id"] == "msg-1"


### PR DESCRIPTION
## Summary
- Preserve compression-created continuation session IDs on gateway error/no-final-response paths.
- Return `history_offset=0` when a mid-run compression split changes the effective session.
- Add regression coverage for error response session split persistence.

## Test Plan
- `python -m pytest -q -o addopts='' tests/test_compression_session_split_persistence.py` — 4 passed
- `python -m pytest -q -o addopts='' tests/gateway/test_session.py tests/gateway/test_session_hygiene.py tests/gateway/test_base_topic_sessions.py` — 54 passed
- `python -m py_compile gateway/run.py tests/test_compression_session_split_persistence.py`

## Notes
- Local collection of `tests/test_413_compression.py` is blocked by missing environment dependency `fire` (`ModuleNotFoundError: No module named 'fire'`), not by this diff.
