### PR TITLE
fix(kanban): terminate live workers on manual exits from running

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2860,6 +2860,7 @@ def complete_task(
     metadata: Optional[dict] = None,
     created_cards: Optional[Iterable[str]] = None,
     expected_run_id: Optional[int] = None,
+    signal_fn=None,
 ) -> bool:
     """Transition ``running|ready -> done`` and record ``result``.
 
@@ -2917,6 +2918,12 @@ def complete_task(
             raise HallucinatedCardsError(phantom_cards, task_id)
     else:
         verified_cards = []
+
+    _terminate_running_task_for_manual_exit(
+        conn, task_id,
+        expected_run_id=expected_run_id,
+        signal_fn=signal_fn,
+    )
 
     with write_txn(conn):
         if expected_run_id is None:
@@ -3254,8 +3261,14 @@ def block_task(
     *,
     reason: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    signal_fn=None,
 ) -> bool:
     """Transition ``running -> blocked``."""
+    _terminate_running_task_for_manual_exit(
+        conn, task_id,
+        expected_run_id=expected_run_id,
+        signal_fn=signal_fn,
+    )
     with write_txn(conn):
         if expected_run_id is None:
             cur = conn.execute(
@@ -3722,7 +3735,13 @@ def decompose_triage_task(
     return child_ids
 
 
-def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
+def archive_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    signal_fn=None,
+) -> bool:
+    _terminate_running_task_for_manual_exit(conn, task_id, signal_fn=signal_fn)
     with write_txn(conn):
         cur = conn.execute(
             "UPDATE tasks SET status = 'archived', "
@@ -3882,6 +3901,7 @@ def schedule_task(
     *,
     reason: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    signal_fn=None,
 ) -> bool:
     """Park a task in ``scheduled`` so it is waiting on time, not human input.
 
@@ -3889,6 +3909,11 @@ def schedule_task(
     human action, or automation can later call ``unblock_task`` to re-gate them
     to ``ready`` (or ``todo`` if parents are still incomplete).
     """
+    _terminate_running_task_for_manual_exit(
+        conn, task_id,
+        expected_run_id=expected_run_id,
+        signal_fn=signal_fn,
+    )
     with write_txn(conn):
         params: list[Any] = [task_id]
         sql = """
@@ -4192,6 +4217,55 @@ def _terminate_reclaimed_worker(
 
     info["terminated"] = not _pid_alive(pid)
     return info
+
+
+def _terminate_running_task_for_manual_exit(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    expected_run_id: Optional[int] = None,
+    signal_fn=None,
+) -> dict[str, Any]:
+    """Best-effort termination for operator-forced exits from ``running``.
+
+    Manual transitions like complete/archive/block/schedule should not leave a
+    live worker behind. The exception is the in-band worker path: when the
+    worker itself is completing or blocking its own run, killing the current
+    process would abort the transition mid-flight.
+    """
+    info: dict[str, Any] = {
+        "prev_pid": None,
+        "host_local": False,
+        "termination_attempted": False,
+        "terminated": False,
+        "sigkill": False,
+    }
+    row = conn.execute(
+        "SELECT status, claim_lock, worker_pid, current_run_id "
+        "FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if row is None or row["status"] != "running":
+        return info
+
+    if (
+        expected_run_id is not None
+        and row["current_run_id"] != int(expected_run_id)
+    ):
+        return info
+
+    pid = row["worker_pid"]
+    if pid is None:
+        return info
+
+    info["prev_pid"] = int(pid)
+    if expected_run_id is not None and int(pid) == os.getpid():
+        info["self_skipped"] = True
+        return info
+
+    return _terminate_reclaimed_worker(
+        pid, row["claim_lock"], signal_fn=signal_fn,
+    )
 
 
 def heartbeat_worker(

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -800,6 +800,15 @@ def _set_status_direct(
     orphaned. ``running -> ready`` via drag-drop is the common case
     (user yanking a stuck worker back to the queue).
     """
+    prev = conn.execute(
+        "SELECT status FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if prev is None:
+        return False
+    if prev["status"] == "running" and new_status != "running":
+        kanban_db._terminate_running_task_for_manual_exit(conn, task_id)
+
     with kanban_db.write_txn(conn):
         # Snapshot current state so we know whether to close a run.
         prev = conn.execute(

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -671,6 +671,47 @@ def test_complete_records_result(kanban_home):
     assert task.completed_at is not None
 
 
+def test_complete_task_terminates_foreign_running_worker(kanban_home, monkeypatch):
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="worker")
+        kb.claim_task(conn, t)
+        kb._set_worker_pid(conn, t, 424242)
+
+        calls = []
+
+        def _fake_terminate(pid, claim_lock, *, signal_fn=None):
+            calls.append((pid, claim_lock))
+            return {"terminated": True}
+
+        monkeypatch.setattr(kb, "_terminate_reclaimed_worker", _fake_terminate)
+
+        assert kb.complete_task(conn, t, summary="closed by operator") is True
+        assert kb.get_task(conn, t).status == "done"
+        assert calls and calls[0][0] == 424242
+        assert calls[0][1]
+
+
+def test_complete_task_skips_terminating_self_worker(kanban_home, monkeypatch):
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="worker")
+        claimed = kb.claim_task(conn, t)
+        assert claimed is not None
+        kb._set_worker_pid(conn, t, os.getpid())
+        run_id = kb.latest_run(conn, t).id
+
+        def _unexpected(*_args, **_kwargs):
+            raise AssertionError("self-complete should not terminate current worker")
+
+        monkeypatch.setattr(kb, "_terminate_reclaimed_worker", _unexpected)
+
+        assert kb.complete_task(
+            conn, t,
+            summary="worker finished cleanly",
+            expected_run_id=run_id,
+        ) is True
+        assert kb.get_task(conn, t).status == "done"
+
+
 def test_block_then_unblock(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="x", assignee="a")
@@ -855,6 +896,27 @@ def test_archive_hides_from_default_list(kanban_home):
         assert kb.archive_task(conn, t)
         assert len(kb.list_tasks(conn)) == 0
         assert len(kb.list_tasks(conn, include_archived=True)) == 1
+
+
+def test_archive_task_terminates_foreign_running_worker(kanban_home, monkeypatch):
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="worker")
+        kb.claim_task(conn, t)
+        kb._set_worker_pid(conn, t, 434343)
+
+        calls = []
+
+        def _fake_terminate(pid, claim_lock, *, signal_fn=None):
+            calls.append((pid, claim_lock))
+            return {"terminated": True}
+
+        monkeypatch.setattr(kb, "_terminate_reclaimed_worker", _fake_terminate)
+
+        assert kb.archive_task(conn, t) is True
+        task = kb.get_task(conn, t)
+        assert task.status == "archived"
+        assert task.current_run_id is None
+        assert calls and calls[0][0] == 434343
 
 
 def test_delete_archived_task_removes_related_rows(kanban_home):

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1260,6 +1260,48 @@ def test_patch_status_archive_closes_running_run(client):
         conn.close()
 
 
+def test_patch_status_ready_terminates_running_worker(client, monkeypatch):
+    """Drag-drop off running must terminate the claimed worker first."""
+    plugin_api = sys.modules["hermes_dashboard_plugin_kanban_test"]
+
+    r = client.post("/api/plugins/kanban/tasks", json={"title": "drag", "assignee": "worker"})
+    tid = r.json()["task"]["id"]
+    conn = kb.connect()
+    try:
+        kb.claim_task(conn, tid)
+        kb._set_worker_pid(conn, tid, 515151)
+    finally:
+        conn.close()
+
+    calls = []
+
+    def _fake_terminate(conn, task_id, *, expected_run_id=None, signal_fn=None):
+        calls.append((task_id, expected_run_id))
+        return {"terminated": True}
+
+    monkeypatch.setattr(
+        plugin_api.kanban_db,
+        "_terminate_running_task_for_manual_exit",
+        _fake_terminate,
+    )
+
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{tid}",
+        json={"status": "ready"},
+    )
+    assert r.status_code == 200, r.text
+    assert calls == [(tid, None)]
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, tid)
+        assert task.status == "ready"
+        assert task.worker_pid is None
+        assert task.current_run_id is None
+    finally:
+        conn.close()
+
+
 def test_event_dict_includes_run_id(client):
     """GET /tasks/:id returns events with run_id populated."""
     r = client.post("/api/plugins/kanban/tasks", json={"title": "e", "assignee": "worker"})


### PR DESCRIPTION

## Summary
- Manual `running -> done/blocked/scheduled/archived` transitions now best-effort terminate the live claimed worker before clearing run metadata.
- Added a shared helper in `hermes_cli/kanban_db.py` so CLI/core paths and dashboard direct-status moves use the same worker termination logic.
- Preserved the self-completing worker path with a guard that skips killing the current process when the worker is closing its own run.
- Added regression coverage for `complete_task`, `archive_task`, and dashboard drag-drop off `running`.

## Validation
- PASS: `python -m pytest tests/hermes_cli/test_kanban_db.py tests/plugins/test_kanban_dashboard_plugin.py -q --timeout-method=thread -k "complete_task_terminates_foreign_running_worker or complete_task_skips_terminating_self_worker or archive_task_terminates_foreign_running_worker or patch_status_ready_terminates_running_worker or patch_status_archive_closes_running_run or patch_status_done_with_summary_and_metadata"`
  Result: `6 passed, 257 deselected`
- PASS: manual smoke repro with a real sleeping subprocess
  Result: `complete_ok=True`, `status=done`, `worker_pid=None`, `run_outcome=completed`, `proc_exited=True`, `returncode=15`

## Additional broader check
- PARTIAL: `python -m pytest tests/hermes_cli/test_kanban_db.py tests/plugins/test_kanban_dashboard_plugin.py --timeout-method=thread -vv --maxfail=3`
  Result before stop: `125 passed, 3 failed`
- The 3 failures were unrelated to this change and came from existing `_resolve_hermes_argv` expectations on this Windows/Python shim environment:
  - `test_resolve_hermes_argv_prefers_path_shim`
  - `test_resolve_hermes_argv_hermes_bin_bare_name_uses_path`
  - `test_resolve_hermes_argv_falls_back_to_module_form_when_no_path_shim`

## Notes
- I had to run pytest with `--timeout-method=thread` because this Windows environment does not support the default `SIGALRM` path used by `pytest-timeout`.
- There is also a non-blocking pytest temp cleanup `PermissionError` at process exit on this machine; it does not affect the kanban fix itself.