### PR TITLE
feat(docker): label sandbox containers for safe cleanup automation (#31221)

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -484,6 +484,36 @@ def test_run_as_host_user_default_off(monkeypatch):
     )
 
 
+def test_sandbox_labels_present_for_safe_cleanup_targeting(monkeypatch):
+    """Spawned containers must carry io.hermes.sandbox=true so external
+    cleanup automation can target only Hermes-managed containers via
+    `docker container prune --filter label=io.hermes.sandbox=true`.
+
+    `docker container prune` does not support --name filters, so the
+    `hermes-<hex>` naming prefix alone is insufficient on shared hosts.
+    """
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(task_id="my-task-id")
+
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    run_args = run_calls[0][0]
+
+    label_values = [
+        run_args[i + 1]
+        for i, flag in enumerate(run_args[:-1])
+        if flag == "--label"
+    ]
+    assert "io.hermes.sandbox=true" in label_values, (
+        f"missing io.hermes.sandbox=true label in docker run args: {run_args}"
+    )
+    assert "io.hermes.sandbox.task_id=my-task-id" in label_values, (
+        f"missing task_id label in docker run args: {run_args}"
+    )
+
+
 def test_run_as_host_user_warns_and_skips_when_no_posix_ids(monkeypatch, caplog):
     """On platforms without POSIX getuid/getgid, log a warning and leave the
     container at its image default user (no --user flag, full cap set)."""

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -503,10 +503,20 @@ class DockerEnvironment(BaseEnvironment):
 
         # Start the container directly via `docker run -d`.
         container_name = f"hermes-{uuid.uuid4().hex[:8]}"
+        # Labels let external cleanup automation safely target only
+        # Hermes-spawned containers (e.g.
+        # `docker container prune --filter label=io.hermes.sandbox=true`).
+        # `docker container prune` does not accept --name filters, so the
+        # naming prefix alone is not enough on shared hosts.
+        label_args = [
+            "--label", "io.hermes.sandbox=true",
+            "--label", f"io.hermes.sandbox.task_id={task_id}",
+        ]
         run_cmd = [
             self._docker_exe, "run", "-d",
             "--init",           # tini/catatonit as PID 1 — reaps zombie children
             "--name", container_name,
+            *label_args,
             "-w", cwd,
             *all_run_args,
             image,


### PR DESCRIPTION
## Summary
Add `io.hermes.sandbox=true` and `io.hermes.sandbox.task_id=<task_id>` labels to every container spawned by the Docker terminal backend so external cleanup automation can safely scope `docker container prune` to only Hermes-managed containers on shared hosts.

## Why
The Docker backend spawns one container per `hermes_ask` call (named `hermes-<8hex>`) and these persist as `Exited` after the call (no `--rm`, by design — useful for post-mortem `docker logs`). The natural cleanup recommendation is:

```bash
docker container prune -f --filter "until=24h"
```

But `docker container prune` only supports `until` and `label` filters — **not `name`**. Without a label, users on shared Docker hosts have to script around `docker ps + docker inspect` timestamps + shell date math.

## Fix
- `tools/environments/docker.py`: add `--label io.hermes.sandbox=true` and `--label io.hermes.sandbox.task_id=<task_id>` to the `docker run -d` command. The label scheme follows the OCI reverse-domain convention. Purely additive — existing behavior unchanged.

Users can then automate cleanup safely on any host:

```bash
docker container prune -f \
    --filter "until=24h" \
    --filter "label=io.hermes.sandbox=true"
```

## Test plan
- [x] New test `test_sandbox_labels_present_for_safe_cleanup_targeting` asserts both labels appear in the `docker run` argv and that the `task_id` label carries the caller-supplied value.
- [x] Full `tests/tools/test_docker_environment.py` suite passes locally (24 passed) under Python 3.12.

Fixes #31221