### PR TITLE
fix(wecom_callback): add proxy support and fix /start infinite loop

### DIFF
--- a/gateway/platforms/wecom_callback.py
+++ b/gateway/platforms/wecom_callback.py
@@ -36,7 +36,13 @@ except ImportError:
     HTTPX_AVAILABLE = False
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+    resolve_proxy_url,
+)
 from gateway.platforms.wecom_crypto import WXBizMsgCrypt, WeComCryptoError
 
 logger = logging.getLogger(__name__)
@@ -121,7 +127,14 @@ class WecomCallbackAdapter(BasePlatformAdapter):
         try:
             # Tighter keepalive so idle CLOSE_WAIT drains promptly (#18451).
             from gateway.platforms._http_client_limits import platform_httpx_limits
-            self._http_client = httpx.AsyncClient(timeout=20.0, limits=platform_httpx_limits())
+            proxy_url = resolve_proxy_url("WECOM_CALLBACK_PROXY", target_hosts=["qyapi.weixin.qq.com"])
+            if proxy_url:
+                logger.info("[WecomCallback] Using proxy: %s", proxy_url)
+            self._http_client = httpx.AsyncClient(
+                timeout=20.0,
+                limits=platform_httpx_limits(),
+                proxy=proxy_url,
+            )
             self._app = web.Application()
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get(self._path, self._handle_verify)
@@ -331,7 +344,7 @@ class WecomCallbackAdapter(BasePlatformAdapter):
         scoped_chat_id = self._user_app_key(corp_id, user_id)
         content = root.findtext("Content", default="").strip()
         if not content and msg_type == "event":
-            content = "/start"
+            return None
         msg_id = (
             root.findtext("MsgId")
             or f"{user_id}:{root.findtext('CreateTime', default='0')}"


### PR DESCRIPTION
## Summary

Two targeted fixes for the WeCom (企业微信) callback adapter discovered during production deployment of a self-built WeCom app.

## Changes

### 1. Per-platform proxy support (`WECOM_CALLBACK_PROXY`)

WeCom self-built apps require API callers to use a whitelisted IP. When the Hermes host has a dynamic PPPoE IP, a forward proxy is needed to route only the callback adapter's outbound traffic through a fixed public IP.

- Uses `resolve_proxy_url("WECOM_CALLBACK_PROXY", target_hosts=["qyapi.weixin.qq.com"])` for platform-specific proxy resolution
- Only affects `wecom_callback` outbound traffic (message/send API calls)
- Other platforms (feishu, wecom WS, LLM APIs) continue to use direct connections
- No global `HTTPS_PROXY` pollution — follows the existing platform-env-var pattern from base.py

### 2. Fix `/start` infinite loop

- Blank WeCom event messages were synthesized as `/start`
- `/start` is not a recognized gateway command, triggering an "unknown command" reply
- The reply triggered another WeCom event, creating an infinite loop
- Fix: return `None` for blank events (silently acknowledge), consistent with how `enter_agent` and `subscribe` events are already handled

## Test Plan

- [x] Tested in production deployment with a WeCom self-built app
- [x] Token refresh succeeds through forward proxy
- [x] `/start` loop eliminated — zero occurrences after fix
- [x] No impact on feishu, wecom WebSocket, or LLM API connectivity
- [ ] Add unit tests for blank event handling

## Diff Stats

- File changed: 1 (`gateway/platforms/wecom_callback.py`)
- Lines changed: ~30 (imports + proxy setup + fix one line)
- Signal-to-noise: >95%