### PR TITLE
feat(gateway): support multiple email accounts

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1271,15 +1271,30 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     email_pwd = os.getenv("EMAIL_PASSWORD")
     email_imap = os.getenv("EMAIL_IMAP_HOST")
     email_smtp = os.getenv("EMAIL_SMTP_HOST")
-    if all([email_addr, email_pwd, email_imap, email_smtp]):
+    email_accounts_raw = os.getenv("EMAIL_ACCOUNTS", "").strip()
+    email_accounts = []
+    if email_accounts_raw:
+        try:
+            parsed_accounts = json.loads(email_accounts_raw)
+            if isinstance(parsed_accounts, list):
+                email_accounts = [acct for acct in parsed_accounts if isinstance(acct, dict)]
+            else:
+                logger.warning("EMAIL_ACCOUNTS must be a JSON list of account objects")
+        except json.JSONDecodeError as e:
+            logger.warning("Invalid EMAIL_ACCOUNTS JSON: %s", e)
+
+    if email_accounts or all([email_addr, email_pwd, email_imap, email_smtp]):
         if Platform.EMAIL not in config.platforms:
             config.platforms[Platform.EMAIL] = PlatformConfig()
         config.platforms[Platform.EMAIL].enabled = True
-        config.platforms[Platform.EMAIL].extra.update({
-            "address": email_addr,
-            "imap_host": email_imap,
-            "smtp_host": email_smtp,
-        })
+        if email_accounts:
+            config.platforms[Platform.EMAIL].extra["accounts"] = email_accounts
+        if all([email_addr, email_pwd, email_imap, email_smtp]):
+            config.platforms[Platform.EMAIL].extra.update({
+                "address": email_addr,
+                "imap_host": email_imap,
+                "smtp_host": email_smtp,
+            })
     email_home = os.getenv("EMAIL_HOME_ADDRESS")
     if email_home and Platform.EMAIL in config.platforms:
         config.platforms[Platform.EMAIL].home_channel = HomeChannel(

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -18,6 +18,7 @@ Environment variables:
 import asyncio
 import email as email_lib
 import imaplib
+import json
 import logging
 import os
 import re
@@ -54,7 +55,7 @@ _NOREPLY_PATTERNS = (
 # RFC headers that indicate bulk/automated mail
 _AUTOMATED_HEADERS = {
     "Auto-Submitted": lambda v: v.lower() != "no",
-    "Precedence": lambda v: v.lower() in ("bulk", "list", "junk"),
+    "Precedence": lambda v: v.lower() in {"bulk", "list", "junk"},
     "X-Auto-Response-Suppress": lambda v: bool(v),
     "List-Unsubscribe": lambda v: bool(v),
 }
@@ -64,6 +65,29 @@ MAX_MESSAGE_LENGTH = 50_000
 
 # Supported image extensions for inline detection
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
+
+def _send_imap_id(imap: "imaplib.IMAP4") -> None:
+    """Send RFC 2971 IMAP ID command identifying this client.
+
+    Required by 163/NetEase mailbox after LOGIN: without it, every UID
+    SEARCH/FETCH returns ``BYE Unsafe Login`` and disconnects.  Other
+    IMAP servers either honor it silently or reject the unknown command;
+    we swallow failures so non-supporting servers keep working.
+    """
+    try:
+        try:
+            from hermes_cli import __version__ as _hermes_version
+        except Exception:  # noqa: BLE001 — keep ID best-effort if import fails
+            _hermes_version = "0"
+        imap.xatom(
+            "ID",
+            f'("name" "hermes-agent" "version" "{_hermes_version}" '
+            '"vendor" "NousResearch" '
+            '"support-email" "noreply@nousresearch.com")',
+        )
+    except Exception as e:  # noqa: BLE001 — best-effort, never fatal
+        logger.debug("[Email] IMAP ID command not accepted: %s", e)
+
 
 def _is_automated_sender(address: str, headers: dict) -> bool:
     """Return True if this email is from an automated/noreply source."""
@@ -76,15 +100,74 @@ def _is_automated_sender(address: str, headers: dict) -> bool:
             return True
     return False
     
+def _coerce_port(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _load_email_accounts_from_env() -> List[Dict[str, Any]]:
+    """Load additional email account definitions from EMAIL_ACCOUNTS JSON."""
+    raw = os.getenv("EMAIL_ACCOUNTS", "").strip()
+    if not raw:
+        return []
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return [acct for acct in parsed if isinstance(acct, dict)]
+
+
+def _normalize_email_account(data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Normalize one email account config dict, resolving optional password_env."""
+    address = str(data.get("address") or data.get("email") or "").strip()
+    password = str(data.get("password") or "")
+    password_env = str(data.get("password_env") or "").strip()
+    if not password and password_env:
+        password = os.getenv(password_env, "")
+    imap_host = str(data.get("imap_host") or data.get("imap") or "").strip()
+    smtp_host = str(data.get("smtp_host") or data.get("smtp") or "").strip()
+    if not all([address, password, imap_host, smtp_host]):
+        return None
+    return {
+        "address": address,
+        "password": password,
+        "imap_host": imap_host,
+        "imap_port": _coerce_port(data.get("imap_port"), 993),
+        "smtp_host": smtp_host,
+        "smtp_port": _coerce_port(data.get("smtp_port"), 587),
+    }
+
+
+def _default_email_account_from_env() -> Optional[Dict[str, Any]]:
+    return _normalize_email_account({
+        "address": os.getenv("EMAIL_ADDRESS", ""),
+        "password": os.getenv("EMAIL_PASSWORD", ""),
+        "imap_host": os.getenv("EMAIL_IMAP_HOST", ""),
+        "imap_port": os.getenv("EMAIL_IMAP_PORT", "993"),
+        "smtp_host": os.getenv("EMAIL_SMTP_HOST", ""),
+        "smtp_port": os.getenv("EMAIL_SMTP_PORT", "587"),
+    })
+
+
+def has_configured_email_accounts(config: Optional[PlatformConfig] = None) -> bool:
+    """Return True if env vars or PlatformConfig define at least one account."""
+    account_defs = []
+    if config and isinstance(config.extra, dict):
+        account_defs = config.extra.get("accounts") or []
+    if not account_defs:
+        account_defs = _load_email_accounts_from_env()
+    if any(_normalize_email_account(acct) for acct in account_defs if isinstance(acct, dict)):
+        return True
+    return bool(_default_email_account_from_env())
+
+
 def check_email_requirements() -> bool:
     """Check if email platform dependencies are available."""
-    addr = os.getenv("EMAIL_ADDRESS")
-    pwd = os.getenv("EMAIL_PASSWORD")
-    imap = os.getenv("EMAIL_IMAP_HOST")
-    smtp = os.getenv("EMAIL_SMTP_HOST")
-    if not all([addr, pwd, imap, smtp]):
-        return False
-    return True
+    return has_configured_email_accounts()
 
 
 def _decode_header_value(raw: str) -> str:
@@ -180,7 +263,7 @@ def _extract_attachments(
             continue
         # Skip text/plain and text/html body parts
         content_type = part.get_content_type()
-        if content_type in ("text/plain", "text/html") and "attachment" not in disposition:
+        if content_type in {"text/plain", "text/html"} and "attachment" not in disposition:
             continue
 
         filename = part.get_filename()
@@ -225,19 +308,36 @@ class EmailAdapter(BasePlatformAdapter):
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.EMAIL)
 
-        self._address = os.getenv("EMAIL_ADDRESS", "")
-        self._password = os.getenv("EMAIL_PASSWORD", "")
-        self._imap_host = os.getenv("EMAIL_IMAP_HOST", "")
-        self._imap_port = int(os.getenv("EMAIL_IMAP_PORT", "993"))
-        self._smtp_host = os.getenv("EMAIL_SMTP_HOST", "")
-        self._smtp_port = int(os.getenv("EMAIL_SMTP_PORT", "587"))
+        extra = config.extra or {}
+        account_defs = extra.get("accounts") or _load_email_accounts_from_env()
+        self._accounts: List[Dict[str, Any]] = [
+            acct for acct in (_normalize_email_account(a) for a in account_defs) if acct
+        ]
+        default_account = _default_email_account_from_env()
+        if not self._accounts and default_account:
+            self._accounts.append(default_account)
+
+        primary = self._accounts[0] if self._accounts else {
+            "address": os.getenv("EMAIL_ADDRESS", ""),
+            "password": os.getenv("EMAIL_PASSWORD", ""),
+            "imap_host": os.getenv("EMAIL_IMAP_HOST", ""),
+            "imap_port": _coerce_port(os.getenv("EMAIL_IMAP_PORT", "993"), 993),
+            "smtp_host": os.getenv("EMAIL_SMTP_HOST", ""),
+            "smtp_port": _coerce_port(os.getenv("EMAIL_SMTP_PORT", "587"), 587),
+        }
+        # Backward-compatible attributes used by existing tests and callers.
+        self._address = primary.get("address", "")
+        self._password = primary.get("password", "")
+        self._imap_host = primary.get("imap_host", "")
+        self._imap_port = primary.get("imap_port", 993)
+        self._smtp_host = primary.get("smtp_host", "")
+        self._smtp_port = primary.get("smtp_port", 587)
         self._poll_interval = int(os.getenv("EMAIL_POLL_INTERVAL", "15"))
 
         # Skip attachments — configured via config.yaml:
         #   platforms:
         #     email:
         #       skip_attachments: true
-        extra = config.extra or {}
         self._skip_attachments = extra.get("skip_attachments", False)
 
         # Track message IDs we've already processed to avoid duplicates
@@ -248,7 +348,8 @@ class EmailAdapter(BasePlatformAdapter):
         # Map chat_id (sender email) -> last subject + message-id for threading
         self._thread_context: Dict[str, Dict[str, str]] = {}
 
-        logger.info("[Email] Adapter initialized for %s", self._address)
+        account_addresses = ", ".join(a["address"] for a in self._accounts) or self._address
+        logger.info("[Email] Adapter initialized for %s", account_addresses)
 
     def _trim_seen_uids(self) -> None:
         """Keep only the most recent UIDs to prevent unbounded memory growth.
@@ -270,40 +371,76 @@ class EmailAdapter(BasePlatformAdapter):
             # Fallback: just clear old entries if sort fails
             self._seen_uids = set(list(self._seen_uids)[-self._seen_uids_max // 2:])
 
+    def _uid_key(self, account: Dict[str, Any], uid: bytes) -> Any:
+        """Namespace UIDs by account when multiple mailboxes are configured."""
+        if len(self._accounts) <= 1:
+            return uid
+        return (account["address"].lower(), uid)
+
+    def _account_for_recipient(self, to_addr: str) -> Dict[str, Any]:
+        ctx = self._thread_context.get(to_addr, {})
+        account_address = ctx.get("account_address")
+        if account_address:
+            for account in self._accounts:
+                if account["address"].lower() == account_address.lower():
+                    return account
+        return self._accounts[0] if self._accounts else {
+            "address": self._address,
+            "password": self._password,
+            "smtp_host": self._smtp_host,
+            "smtp_port": self._smtp_port,
+        }
+
     async def connect(self) -> bool:
         """Connect to the IMAP server and start polling for new messages."""
-        try:
-            # Test IMAP connection
-            imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
-            imap.login(self._address, self._password)
-            # Mark all existing messages as seen so we only process new ones
-            imap.select("INBOX")
-            status, data = imap.uid("search", None, "ALL")
-            if status == "OK" and data and data[0]:
-                for uid in data[0].split():
-                    self._seen_uids.add(uid)
-            # Keep only the most recent UIDs to prevent unbounded growth
-            self._trim_seen_uids()
-            imap.logout()
-            logger.info("[Email] IMAP connection test passed. %d existing messages skipped.", len(self._seen_uids))
-        except Exception as e:
-            logger.error("[Email] IMAP connection failed: %s", e)
+        if not self._accounts:
+            logger.error("[Email] No email accounts configured")
             return False
 
-        try:
-            # Test SMTP connection
-            smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
-            smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
-            smtp.quit()
-            logger.info("[Email] SMTP connection test passed.")
-        except Exception as e:
-            logger.error("[Email] SMTP connection failed: %s", e)
-            return False
+        for account in self._accounts:
+            try:
+                # Test IMAP connection
+                imap = imaplib.IMAP4_SSL(account["imap_host"], account["imap_port"], timeout=30)
+                try:
+                    imap.login(account["address"], account["password"])
+                    _send_imap_id(imap)
+                    # Mark all existing messages as seen so we only process new ones
+                    imap.select("INBOX")
+                    status, data = imap.uid("search", None, "ALL")
+                    if status == "OK" and data and data[0]:
+                        for uid in data[0].split():
+                            self._seen_uids.add(self._uid_key(account, uid))
+                    # Keep only the most recent UIDs to prevent unbounded growth
+                    self._trim_seen_uids()
+                finally:
+                    try:
+                        imap.logout()
+                    except Exception:
+                        pass
+                logger.info("[Email] IMAP connection test passed for %s. %d existing messages skipped.", account["address"], len(self._seen_uids))
+            except Exception as e:
+                logger.error("[Email] IMAP connection failed for %s: %s", account["address"], e)
+                return False
+
+            try:
+                # Test SMTP connection
+                smtp = smtplib.SMTP(account["smtp_host"], account["smtp_port"], timeout=30)
+                try:
+                    smtp.starttls(context=ssl.create_default_context())
+                    smtp.login(account["address"], account["password"])
+                finally:
+                    try:
+                        smtp.quit()
+                    except Exception:
+                        smtp.close()
+                logger.info("[Email] SMTP connection test passed for %s.", account["address"])
+            except Exception as e:
+                logger.error("[Email] SMTP connection failed for %s: %s", account["address"], e)
+                return False
 
         self._running = True
         self._poll_task = asyncio.create_task(self._poll_loop())
-        print(f"[Email] Connected as {self._address}")
+        print(f"[Email] Connected as {', '.join(a['address'] for a in self._accounts)}")
         return True
 
     async def disconnect(self) -> None:
@@ -340,75 +477,85 @@ class EmailAdapter(BasePlatformAdapter):
     def _fetch_new_messages(self) -> List[Dict[str, Any]]:
         """Fetch new (unseen) messages from IMAP. Runs in executor thread."""
         results = []
-        try:
-            imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
+        for account in (self._accounts or [{
+            "address": self._address,
+            "password": self._password,
+            "imap_host": self._imap_host,
+            "imap_port": self._imap_port,
+        }]):
             try:
-                imap.login(self._address, self._password)
-                imap.select("INBOX")
-
-                status, data = imap.uid("search", None, "UNSEEN")
-                if status != "OK" or not data or not data[0]:
-                    return results
-
-                for uid in data[0].split():
-                    if uid in self._seen_uids:
-                        continue
-                    self._seen_uids.add(uid)
-                    # Trim periodically to prevent unbounded memory growth
-                    if len(self._seen_uids) > self._seen_uids_max:
-                        self._trim_seen_uids()
-
-                    status, msg_data = imap.uid("fetch", uid, "(RFC822)")
-                    if status != "OK":
-                        continue
-
-                    raw_email = msg_data[0][1]
-                    msg = email_lib.message_from_bytes(raw_email)
-
-                    sender_raw = msg.get("From", "")
-                    sender_addr = _extract_email_address(sender_raw)
-                    sender_name = _decode_header_value(sender_raw)
-                    # Remove email from name if present
-                    if "<" in sender_name:
-                        sender_name = sender_name.split("<")[0].strip().strip('"')
-
-                    subject = _decode_header_value(msg.get("Subject", "(no subject)"))
-                    message_id = msg.get("Message-ID", "")
-                    in_reply_to = msg.get("In-Reply-To", "")
-                    # Skip automated/noreply senders before any processing
-                    msg_headers = dict(msg.items())
-                    if _is_automated_sender(sender_addr, msg_headers):
-                        logger.debug("[Email] Skipping automated sender: %s", sender_addr)
-                        continue
-                    body = _extract_text_body(msg)
-                    attachments = _extract_attachments(msg, skip_attachments=self._skip_attachments)
-
-                    results.append({
-                        "uid": uid,
-                        "sender_addr": sender_addr,
-                        "sender_name": sender_name,
-                        "subject": subject,
-                        "message_id": message_id,
-                        "in_reply_to": in_reply_to,
-                        "body": body,
-                        "attachments": attachments,
-                        "date": msg.get("Date", ""),
-                    })
-            finally:
+                imap = imaplib.IMAP4_SSL(account["imap_host"], account["imap_port"], timeout=30)
                 try:
-                    imap.logout()
-                except Exception:
-                    pass
-        except Exception as e:
-            logger.error("[Email] IMAP fetch error: %s", e)
+                    imap.login(account["address"], account["password"])
+                    _send_imap_id(imap)
+                    imap.select("INBOX")
+
+                    status, data = imap.uid("search", None, "UNSEEN")
+                    if status != "OK" or not data or not data[0]:
+                        continue
+
+                    for uid in data[0].split():
+                        uid_key = self._uid_key(account, uid)
+                        if uid_key in self._seen_uids:
+                            continue
+                        self._seen_uids.add(uid_key)
+                        # Trim periodically to prevent unbounded memory growth
+                        if len(self._seen_uids) > self._seen_uids_max:
+                            self._trim_seen_uids()
+
+                        status, msg_data = imap.uid("fetch", uid, "(RFC822)")
+                        if status != "OK":
+                            continue
+
+                        raw_email = msg_data[0][1]
+                        msg = email_lib.message_from_bytes(raw_email)
+
+                        sender_raw = msg.get("From", "")
+                        sender_addr = _extract_email_address(sender_raw)
+                        sender_name = _decode_header_value(sender_raw)
+                        # Remove email from name if present
+                        if "<" in sender_name:
+                            sender_name = sender_name.split("<")[0].strip().strip('"')
+
+                        subject = _decode_header_value(msg.get("Subject", "(no subject)"))
+                        message_id = msg.get("Message-ID", "")
+                        in_reply_to = msg.get("In-Reply-To", "")
+                        # Skip automated/noreply senders before any processing
+                        msg_headers = dict(msg.items())
+                        if _is_automated_sender(sender_addr, msg_headers):
+                            logger.debug("[Email] Skipping automated sender: %s", sender_addr)
+                            continue
+                        body = _extract_text_body(msg)
+                        attachments = _extract_attachments(msg, skip_attachments=self._skip_attachments)
+
+                        results.append({
+                            "uid": uid,
+                            "account_address": account["address"],
+                            "sender_addr": sender_addr,
+                            "sender_name": sender_name,
+                            "subject": subject,
+                            "message_id": message_id,
+                            "in_reply_to": in_reply_to,
+                            "body": body,
+                            "attachments": attachments,
+                            "date": msg.get("Date", ""),
+                        })
+                finally:
+                    try:
+                        imap.logout()
+                    except Exception:
+                        pass
+            except Exception as e:
+                logger.error("[Email] IMAP fetch error for %s: %s", account.get("address", "<unknown>"), e)
         return results
 
     async def _dispatch_message(self, msg_data: Dict[str, Any]) -> None:
         """Convert a fetched email into a MessageEvent and dispatch it."""
         sender_addr = msg_data["sender_addr"]
 
-        # Skip self-messages
-        if sender_addr == self._address.lower():
+        # Skip self-messages from any configured account
+        own_addresses = {account["address"].lower() for account in self._accounts}
+        if sender_addr.lower() in own_addresses or sender_addr == self._address.lower():
             return
 
         # Never reply to automated senders
@@ -452,6 +599,7 @@ class EmailAdapter(BasePlatformAdapter):
         self._thread_context[sender_addr] = {
             "subject": subject,
             "message_id": msg_data["message_id"],
+            "account_address": msg_data.get("account_address", self._address),
         }
 
         source = self.build_source(
@@ -500,8 +648,9 @@ class EmailAdapter(BasePlatformAdapter):
         reply_to_msg_id: Optional[str] = None,
     ) -> str:
         """Send an email via SMTP. Runs in executor thread."""
+        account = self._account_for_recipient(to_addr)
         msg = MIMEMultipart()
-        msg["From"] = self._address
+        msg["From"] = account["address"]
         msg["To"] = to_addr
 
         # Thread context for reply
@@ -518,15 +667,15 @@ class EmailAdapter(BasePlatformAdapter):
             msg["References"] = original_msg_id
 
         msg["Date"] = formatdate(localtime=True)
-        msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"
+        msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{account['address'].split('@')[1]}>"
         msg["Message-ID"] = msg_id
 
         msg.attach(MIMEText(body, "plain", "utf-8"))
 
-        smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
+        smtp = smtplib.SMTP(account["smtp_host"], account["smtp_port"], timeout=30)
         try:
             smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
+            smtp.login(account["address"], account["password"])
             smtp.send_message(msg)
         finally:
             try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4238,9 +4238,13 @@ class GatewayRunner:
             return HomeAssistantAdapter(config)
 
         elif platform == Platform.EMAIL:
-            from gateway.platforms.email import EmailAdapter, check_email_requirements
-            if not check_email_requirements():
-                logger.warning("Email: EMAIL_ADDRESS, EMAIL_PASSWORD, EMAIL_IMAP_HOST, or EMAIL_SMTP_HOST not set")
+            from gateway.platforms.email import (
+                EmailAdapter,
+                check_email_requirements,
+                has_configured_email_accounts,
+            )
+            if not check_email_requirements() and not has_configured_email_accounts(config):
+                logger.warning("Email: configure EMAIL_ACCOUNTS or EMAIL_ADDRESS, EMAIL_PASSWORD, EMAIL_IMAP_HOST, and EMAIL_SMTP_HOST")
                 return None
             return EmailAdapter(config)
 

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -13,6 +13,7 @@ Covers:
 """
 
 import os
+import json
 import unittest
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
@@ -57,6 +58,33 @@ class TestConfigEnvOverrides(unittest.TestCase):
         self.assertIsNotNone(home)
         self.assertEqual(home.chat_id, "user@test.com")
 
+    @patch.dict(os.environ, {
+        "EMAIL_ACCOUNTS": json.dumps([
+            {
+                "address": "daemon@test.com",
+                "password": "daemon-secret",
+                "imap_host": "imap.daemon.test",
+                "smtp_host": "smtp.daemon.test",
+            },
+            {
+                "address": "brice@test.com",
+                "password": "brice-secret",
+                "imap_host": "imap.brice.test",
+                "smtp_host": "smtp.brice.test",
+            },
+        ]),
+    }, clear=True)
+    def test_email_accounts_loaded_from_env_json(self):
+        from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+        self.assertIn(Platform.EMAIL, config.platforms)
+        self.assertTrue(config.platforms[Platform.EMAIL].enabled)
+        self.assertEqual(
+            [acct["address"] for acct in config.platforms[Platform.EMAIL].extra["accounts"]],
+            ["daemon@test.com", "brice@test.com"],
+        )
+
     @patch.dict(os.environ, {}, clear=True)
     def test_email_not_loaded_without_env(self):
         from gateway.config import GatewayConfig, Platform, _apply_env_overrides
@@ -88,6 +116,20 @@ class TestCheckRequirements(unittest.TestCase):
     def test_requirements_empty_env(self):
         from gateway.platforms.email import check_email_requirements
         self.assertFalse(check_email_requirements())
+
+    @patch.dict(os.environ, {
+        "EMAIL_ACCOUNTS": json.dumps([
+            {
+                "address": "daemon@test.com",
+                "password": "secret",
+                "imap_host": "imap.test.com",
+                "smtp_host": "smtp.test.com",
+            }
+        ]),
+    }, clear=True)
+    def test_requirements_met_with_email_accounts_json(self):
+        from gateway.platforms.email import check_email_requirements
+        self.assertTrue(check_email_requirements())
 
 
 class TestHelperFunctions(unittest.TestCase):
@@ -947,6 +989,82 @@ class TestPollLoop(unittest.TestCase):
 
         self.assertEqual(len(dispatched), 1)
         self.assertEqual(dispatched[0]["subject"], "Inbox Test")
+
+
+class TestMultiAccountEmail(unittest.TestCase):
+    """Test multi-account email adapter behavior."""
+
+    def _make_adapter(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.email import EmailAdapter
+        return EmailAdapter(PlatformConfig(enabled=True, extra={
+            "accounts": [
+                {
+                    "address": "daemon@test.com",
+                    "password": "daemon-secret",
+                    "imap_host": "imap.daemon.test",
+                    "smtp_host": "smtp.daemon.test",
+                },
+                {
+                    "address": "brice@test.com",
+                    "password": "brice-secret",
+                    "imap_host": "imap.brice.test",
+                    "smtp_host": "smtp.brice.test",
+                },
+            ]
+        }))
+
+    def test_fetch_new_messages_namespaces_seen_uids_by_account(self):
+        adapter = self._make_adapter()
+
+        def make_raw(sender, subject):
+            raw_email = MIMEText("Hello", "plain", "utf-8")
+            raw_email["From"] = sender
+            raw_email["Subject"] = subject
+            raw_email["Message-ID"] = f"<{subject}@test.com>"
+            return raw_email.as_bytes()
+
+        def make_imap(raw):
+            mock_imap = MagicMock()
+            def uid_handler(command, *args):
+                if command == "search":
+                    return ("OK", [b"1"])
+                if command == "fetch":
+                    return ("OK", [(b"1", raw)])
+                return ("NO", [])
+            mock_imap.uid.side_effect = uid_handler
+            return mock_imap
+
+        imaps = {
+            "imap.daemon.test": make_imap(make_raw("sender1@test.com", "Daemon Inbox")),
+            "imap.brice.test": make_imap(make_raw("sender2@test.com", "Brice Inbox")),
+        }
+
+        with patch("imaplib.IMAP4_SSL", side_effect=lambda host, port, timeout: imaps[host]):
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual([r["subject"] for r in results], ["Daemon Inbox", "Brice Inbox"])
+        self.assertEqual([r["account_address"] for r in results], ["daemon@test.com", "brice@test.com"])
+        self.assertIn(("daemon@test.com", b"1"), adapter._seen_uids)
+        self.assertIn(("brice@test.com", b"1"), adapter._seen_uids)
+
+    def test_reply_uses_account_that_received_original_message(self):
+        adapter = self._make_adapter()
+        adapter._thread_context["sender@test.com"] = {
+            "subject": "Question",
+            "message_id": "<original@test.com>",
+            "account_address": "brice@test.com",
+        }
+        mock_smtp = MagicMock()
+
+        with patch("smtplib.SMTP", return_value=mock_smtp) as mock_smtp_ctor:
+            adapter._send_email("sender@test.com", "Reply")
+
+        mock_smtp_ctor.assert_called_once_with("smtp.brice.test", 587, timeout=30)
+        mock_smtp.login.assert_called_once_with("brice@test.com", "brice-secret")
+        sent_msg = mock_smtp.send_message.call_args[0][0]
+        self.assertEqual(sent_msg["From"], "brice@test.com")
+        self.assertEqual(sent_msg["To"], "sender@test.com")
 
 
 class TestSendEmailStandalone(unittest.TestCase):

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -295,6 +295,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `EMAIL_IMAP_PORT` | IMAP port |
 | `EMAIL_SMTP_HOST` | SMTP hostname for the email adapter |
 | `EMAIL_SMTP_PORT` | SMTP port |
+| `EMAIL_ACCOUNTS` | JSON list of IMAP/SMTP account objects for multi-account email polling |
 | `EMAIL_ALLOWED_USERS` | Comma-separated email addresses allowed to message the bot |
 | `EMAIL_HOME_ADDRESS` | Default recipient for proactive email delivery |
 | `EMAIL_HOME_ADDRESS_NAME` | Display name for the email home target |

--- a/website/docs/user-guide/messaging/email.md
+++ b/website/docs/user-guide/messaging/email.md
@@ -74,6 +74,32 @@ EMAIL_POLL_INTERVAL=15                 # Seconds between inbox checks (default: 
 EMAIL_HOME_ADDRESS=your@email.com      # Default delivery target for cron jobs
 ```
 
+### Multiple IMAP/SMTP Accounts
+
+For advanced setups, set `EMAIL_ACCOUNTS` to a JSON list instead of the single-account variables above. The gateway tests every account at startup, polls each inbox, and replies from the account that received the original email:
+
+```bash
+EMAIL_ACCOUNTS='[
+  {
+    "address": "hermes@example.com",
+    "password_env": "HERMES_EMAIL_PASSWORD",
+    "imap_host": "imap.example.com",
+    "smtp_host": "smtp.example.com"
+  },
+  {
+    "address": "assistant@example.org",
+    "password_env": "ASSISTANT_EMAIL_PASSWORD",
+    "imap_host": "imap.example.org",
+    "smtp_host": "smtp.example.org",
+    "imap_port": 993,
+    "smtp_port": 587
+  }
+]'
+```
+
+Use `password_env` to keep account passwords in separate environment variables. A literal `password` field is also supported for compatibility, but `password_env` is preferred.
+
+
 ---
 
 ## Step 2: Start the Gateway
@@ -178,13 +204,16 @@ Email access follows the same pattern as all other Hermes platforms:
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `EMAIL_ADDRESS` | Yes | — | Agent's email address |
-| `EMAIL_PASSWORD` | Yes | — | Email password or app password |
-| `EMAIL_IMAP_HOST` | Yes | — | IMAP server host (e.g., `imap.gmail.com`) |
-| `EMAIL_SMTP_HOST` | Yes | — | SMTP server host (e.g., `smtp.gmail.com`) |
+| `EMAIL_ADDRESS` | Yes* | — | Agent's email address |
+| `EMAIL_PASSWORD` | Yes* | — | Email password or app password |
+| `EMAIL_IMAP_HOST` | Yes* | — | IMAP server host (e.g., `imap.gmail.com`) |
+| `EMAIL_SMTP_HOST` | Yes* | — | SMTP server host (e.g., `smtp.gmail.com`) |
+| `EMAIL_ACCOUNTS` | Yes* | — | JSON list of account objects for multi-account polling; replaces the single-account variables when set |
 | `EMAIL_IMAP_PORT` | No | `993` | IMAP server port |
 | `EMAIL_SMTP_PORT` | No | `587` | SMTP server port |
 | `EMAIL_POLL_INTERVAL` | No | `15` | Seconds between inbox checks |
 | `EMAIL_ALLOWED_USERS` | No | — | Comma-separated allowed sender addresses |
 | `EMAIL_HOME_ADDRESS` | No | — | Default delivery target for cron jobs |
 | `EMAIL_ALLOW_ALL_USERS` | No | `false` | Allow all senders (not recommended) |
+
+*Configure either the single-account variables (`EMAIL_ADDRESS`, `EMAIL_PASSWORD`, `EMAIL_IMAP_HOST`, `EMAIL_SMTP_HOST`) or `EMAIL_ACCOUNTS`.


### PR DESCRIPTION
## Summary
- add `EMAIL_ACCOUNTS` JSON configuration for polling multiple IMAP/SMTP accounts from the email gateway
- namespace seen IMAP UIDs by account and keep single-account env var behavior backward-compatible
- send replies from the account that received the original email
- document multi-account setup and add regression tests

## Test Plan
- [x] `/home/pi/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_email.py -q`
- [x] `/home/pi/.hermes/hermes-agent/venv/bin/python -m py_compile gateway/platforms/email.py gateway/config.py gateway/run.py`

Note: I also ran `tests/gateway` on the newer upstream-base worktree before rebasing onto the fork base; unrelated existing/environment failures appeared in API server/SMS port binding and Telegram parse-mode tests, while the targeted email tests passed.
