### PR TITLE
fix(tui): keep verbose tool progress off stderr

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1714,7 +1714,7 @@ def test_config_set_reasoning_updates_live_session_and_agent(tmp_path, monkeypat
     assert server._load_cfg()["display"]["sections"]["thinking"] == "hidden"
 
 
-def test_config_set_verbose_updates_session_mode_and_agent(tmp_path, monkeypatch):
+def test_config_set_verbose_keeps_agent_console_logging_off(tmp_path, monkeypatch):
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
     agent = types.SimpleNamespace(verbose_logging=False)
     server._sessions["sid"] = _session(agent=agent)
@@ -1729,7 +1729,7 @@ def test_config_set_verbose_updates_session_mode_and_agent(tmp_path, monkeypatch
 
     assert resp["result"]["value"] == "verbose"
     assert server._sessions["sid"]["tool_progress_mode"] == "verbose"
-    assert agent.verbose_logging is True
+    assert agent.verbose_logging is False
 
 
 def test_config_set_model_uses_live_switch_path(monkeypatch):

--- a/tests/tui_gateway/test_make_agent_provider.py
+++ b/tests/tui_gateway/test_make_agent_provider.py
@@ -60,6 +60,39 @@ def test_make_agent_passes_resolved_provider():
         assert call_kwargs.kwargs["api_mode"] == "anthropic_messages"
 
 
+def test_make_agent_keeps_console_logging_off_for_verbose_tool_progress():
+    """TUI verbose tool progress must not enable Python DEBUG stderr logging."""
+
+    fake_runtime = {
+        "provider": "anthropic",
+        "base_url": "https://api.anthropic.com",
+        "api_key": "sk-test-key",
+        "api_mode": "anthropic_messages",
+        "command": None,
+        "args": None,
+        "credential_pool": None,
+    }
+
+    with (
+        patch("tui_gateway.server._load_cfg", return_value={"agent": {}, "model": {}}),
+        patch("tui_gateway.server._get_db", return_value=MagicMock()),
+        patch("tui_gateway.server._load_tool_progress_mode", return_value="verbose"),
+        patch("tui_gateway.server._load_reasoning_config", return_value=None),
+        patch("tui_gateway.server._load_service_tier", return_value=None),
+        patch("tui_gateway.server._load_enabled_toolsets", return_value=None),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value=fake_runtime,
+        ),
+        patch("run_agent.AIAgent") as mock_agent,
+    ):
+        from tui_gateway.server import _make_agent
+
+        _make_agent("sid-verbose", "key-verbose")
+
+        assert mock_agent.call_args.kwargs["verbose_logging"] is False
+
+
 def test_make_agent_ignores_display_personality_without_system_prompt():
     """The TUI matches the classic CLI: personality only becomes active once
     it has been saved to agent.system_prompt."""

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2033,7 +2033,11 @@ def _make_agent(sid: str, key: str, session_id: str | None = None):
         acp_args=runtime.get("args"),
         credential_pool=runtime.get("credential_pool"),
         quiet_mode=True,
-        verbose_logging=_load_tool_progress_mode() == "verbose",
+        # TUI verbose tool progress is rendered through structured
+        # tool_progress_callback events.  Enabling Python verbose_logging here
+        # installs a DEBUG StreamHandler on stderr, which the TUI surfaces as
+        # gateway.stderr Activity lines during normal turns.
+        verbose_logging=False,
         reasoning_config=_load_reasoning_config(),
         service_tier=_load_service_tier(),
         enabled_toolsets=_load_enabled_toolsets(),
@@ -4020,7 +4024,7 @@ def _(rid, params: dict) -> dict:
             session["tool_progress_mode"] = nv
             agent = session.get("agent")
             if agent is not None:
-                agent.verbose_logging = nv == "verbose"
+                agent.verbose_logging = False
         return _ok(rid, {"key": key, "value": nv})
 
     if key == "yolo":


### PR DESCRIPTION
Fixes #31372

## Summary
- keep TUI `display.tool_progress=verbose` on structured tool-progress events only
- stop mapping TUI verbose mode to `AIAgent.verbose_logging`, which installs a DEBUG stderr handler
- keep live `/verbose` config changes from enabling Python console logging for existing TUI agents

## Verification
- `python -m pytest -o addopts='' tests/test_tui_gateway_server.py::test_config_set_verbose_keeps_agent_console_logging_off tests/tui_gateway/test_make_agent_provider.py::test_make_agent_keeps_console_logging_off_for_verbose_tool_progress -q`
- `git diff --check`

## Notes
- I also ran `python -m pytest -o addopts='' tests/test_tui_gateway_server.py tests/tui_gateway/test_make_agent_provider.py -q`; unrelated environment failures remain because this local env lacks `prompt_toolkit`. The targeted regression tests passed.