### PR TITLE
feat(tts): add Cloudflare Workers AI Aura TTS provider

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11519,11 +11519,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         _cprint(f"\n{_DIM}Voice mode disabled.{_RST}")
 
     def _toggle_voice_tts(self):
-        """Toggle TTS output for voice mode."""
-        if not self._voice_mode:
-            _cprint(f"{_DIM}Enable voice mode first: /voice on{_RST}")
-            return
+        """Toggle spoken output for assistant responses.
 
+        TTS output does not require microphone capture or STT.  Keep this
+        independent from ``/voice on`` so users can enable response speech in
+        environments without input audio libraries.
+        """
         with self._voice_lock:
             self._voice_tts = not self._voice_tts
         status = "enabled" if self._voice_tts else "disabled"
@@ -11532,6 +11533,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             from tools.tts_tool import check_tts_requirements
             if not check_tts_requirements():
                 _cprint(f"{_DIM}Warning: No TTS provider available. Install edge-tts or set API keys.{_RST}")
+        else:
+            self._voice_tts_done.set()
 
         _cprint(f"{_ACCENT}Voice TTS {status}.{_RST}")
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3900,6 +3900,22 @@ OPTIONAL_ENV_VARS = {
         "password": True,
         "category": "tool",
     },
+    "CLOUDFLARE_API_TOKEN": {
+        "description": "Cloudflare API token for Workers AI Aura TTS",
+        "prompt": "Cloudflare API token",
+        "url": "https://dash.cloudflare.com/profile/api-tokens",
+        "tools": ["text_to_speech"],
+        "password": True,
+        "category": "tool",
+    },
+    "CLOUDFLARE_ACCOUNT_ID": {
+        "description": "Cloudflare account ID for Workers AI Aura TTS",
+        "prompt": "Cloudflare account ID",
+        "url": "https://dash.cloudflare.com/",
+        "tools": ["text_to_speech"],
+        "password": False,
+        "category": "tool",
+    },
     "MISTRAL_API_KEY": {
         "description": "Mistral API key for Voxtral TTS and transcription (STT)",
         "prompt": "Mistral API key",

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -945,6 +945,7 @@ def _setup_tts_provider(config: dict):
         "minimax": "MiniMax TTS",
         "mistral": "Mistral Voxtral TTS",
         "gemini": "Google Gemini TTS",
+        "cloudflare": "Cloudflare Workers AI TTS",
         "neutts": "NeuTTS",
         "kittentts": "KittenTTS",
     }
@@ -969,11 +970,12 @@ def _setup_tts_provider(config: dict):
             "MiniMax TTS (high quality with voice cloning, needs API key)",
             "Mistral Voxtral TTS (multilingual, native Opus, needs API key)",
             "Google Gemini TTS (30 prebuilt voices, prompt-controllable, needs API key)",
+            "Cloudflare Workers AI Aura TTS (Deepgram voices, needs API token + account ID)",
             "NeuTTS (local on-device, free, ~300MB model download)",
             "KittenTTS (local on-device, free, lightweight ~25-80MB ONNX)",
         ]
     )
-    providers.extend(["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts"])
+    providers.extend(["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "cloudflare", "neutts", "kittentts"])
     choices.append(f"Keep current ({current_label})")
     keep_current_idx = len(choices) - 1
     idx = prompt_choice("Select TTS provider:", choices, keep_current_idx)
@@ -1136,6 +1138,30 @@ def _setup_tts_provider(config: dict):
             else:
                 print_warning("No API key provided. Falling back to Edge TTS.")
                 selected = "edge"
+
+    elif selected == "cloudflare":
+        existing = get_env_value("CLOUDFLARE_API_TOKEN")
+        if not existing:
+            print()
+            api_key = prompt("Cloudflare API token for TTS", password=True)
+            if api_key:
+                save_env_value("CLOUDFLARE_API_TOKEN", api_key)
+                print_success("Cloudflare API token saved")
+            else:
+                print_warning("No API token provided. Falling back to Edge TTS.")
+                selected = "edge"
+
+        if selected == "cloudflare":
+            existing_acct = get_env_value("CLOUDFLARE_ACCOUNT_ID")
+            if not existing_acct:
+                print()
+                acct_id = prompt("Cloudflare account ID")
+                if acct_id:
+                    save_env_value("CLOUDFLARE_ACCOUNT_ID", acct_id)
+                    print_success("Cloudflare account ID saved")
+                else:
+                    print_warning("No account ID provided. Falling back to Edge TTS.")
+                    selected = "edge"
 
     elif selected == "kittentts":
         # Check if already installed

--- a/plugins/tts/cloudflare/__init__.py
+++ b/plugins/tts/cloudflare/__init__.py
@@ -1,0 +1,300 @@
+"""Cloudflare Workers AI Aura TTS backend.
+
+Wraps the Cloudflare Workers AI Text-to-Speech endpoint (Deepgram Aura
+models) as a :class:`agent.tts_provider.TTSProvider` implementation.
+
+Cloudflare's free tier for Workers AI includes Deepgram Aura voices with
+generous limits, making this a valuable addition alongside the built-in
+Edge (free but network-dependent) and paid providers (OpenAI, ElevenLabs).
+
+This is a **plugin** provider — it registers via
+``ctx.register_tts_provider()`` and is dispatched by
+``tools.tts_tool._dispatch_to_plugin_provider()`` only when
+``tts.provider: cloudflare`` is set in config and the name is neither a
+built-in nor a command-type provider.  See issue #30398 for the plugin
+provider design.
+
+Configuration
+-------------
+Credentials are read from environment variables:
+
+* ``CLOUDFLARE_API_TOKEN`` — Cloudflare API token with Workers AI access.
+* ``CLOUDFLARE_ACCOUNT_ID`` — Cloudflare account ID.
+
+Per-provider options (all optional, with sensible defaults) are read
+from the ``tts.cloudflare`` section of ``config.yaml``:
+
+.. code-block:: yaml
+
+   tts:
+     provider: cloudflare
+     cloudflare:
+       model: "@cf/deepgram/aura-2-en"   # default
+       voice: "asteria"                  # default
+       encoding: "mp3"                   # default
+       base_url: "https://api.cloudflare.com/client/v4/accounts"
+
+The dispatcher also forwards ``voice`` / ``model`` / ``format`` from
+the top-level ``tts.voice`` / ``tts.model`` / ``tts.output_format``
+config keys; those take precedence over the ``tts.cloudflare`` section
+when set.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+from agent.tts_provider import TTSProvider
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+DEFAULT_MODEL = "@cf/deepgram/aura-2-en"
+DEFAULT_VOICE = "asteria"
+DEFAULT_ENCODING = "mp3"
+DEFAULT_BASE_URL = "https://api.cloudflare.com/client/v4/accounts"
+
+# Cloudflare Aura practical sync cap; Workers AI docs do not publish a
+# hard per-request limit.  Aligned with Gemini / Edge (5000).
+MAX_TEXT_LENGTH = 5000
+
+# Cloudflare Workers AI ``encoding`` values.
+_VALID_ENCODINGS = frozenset({"mp3", "linear16", "ulaw"})
+
+# Aura English voices available on @cf/deepgram/aura-2-en.
+_AURA_VOICES = [
+    "asteria",
+    "luna",
+    "stella",
+    "athena",
+    "hera",
+    "orion",
+    "arcas",
+    "perseus",
+    "boreas",
+    "zeus",
+]
+
+
+def _get_env(name: str) -> str:
+    """Return a stripped env var value, or empty string."""
+    return str(os.environ.get(name, "")).strip()
+
+
+def _load_cf_config() -> Dict[str, Any]:
+    """Read the ``tts.cloudflare`` config section (best-effort).
+
+    Returns an empty dict when the section is absent or config can't be
+    loaded — the caller falls back to defaults.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        cfg = load_config_readonly() or {}
+        tts = cfg.get("tts")
+        if not isinstance(tts, dict):
+            return {}
+        section = tts.get("cloudflare")
+        return section if isinstance(section, dict) else {}
+    except Exception:  # noqa: BLE001 — config is best-effort
+        return {}
+
+
+class CloudflareTTSProvider(TTSProvider):
+    """Cloudflare Workers AI (Deepgram Aura) TTS backend."""
+
+    @property
+    def name(self) -> str:
+        return "cloudflare"
+
+    @property
+    def display_name(self) -> str:
+        return "Cloudflare Workers AI"
+
+    def is_available(self) -> bool:
+        """Available when both Cloudflare credentials are set."""
+        return bool(_get_env("CLOUDFLARE_API_TOKEN")) and bool(
+            _get_env("CLOUDFLARE_ACCOUNT_ID")
+        )
+
+    def list_voices(self) -> List[Dict[str, Any]]:
+        """Return the Aura voice catalog."""
+        return [
+            {
+                "id": voice,
+                "display": f"{voice.capitalize()} — Aura English",
+                "language": "en-US",
+            }
+            for voice in _AURA_VOICES
+        ]
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "id": DEFAULT_MODEL,
+                "display": "Deepgram Aura 2 English",
+                "languages": ["en"],
+                "max_text_length": MAX_TEXT_LENGTH,
+            }
+        ]
+
+    def default_model(self) -> Optional[str]:
+        return DEFAULT_MODEL
+
+    def default_voice(self) -> Optional[str]:
+        return DEFAULT_VOICE
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Cloudflare Workers AI",
+            "badge": "free",
+            "tag": "Deepgram Aura voices — free Workers AI tier",
+            "env_vars": [
+                {
+                    "key": "CLOUDFLARE_API_TOKEN",
+                    "prompt": "Cloudflare API token",
+                    "url": "https://dash.cloudflare.com/profile/api-tokens",
+                },
+                {
+                    "key": "CLOUDFLARE_ACCOUNT_ID",
+                    "prompt": "Cloudflare account ID",
+                    "url": "https://dash.cloudflare.com/",
+                },
+            ],
+        }
+
+    @property
+    def voice_compatible(self) -> bool:
+        # Output is MP3 — the dispatcher runs ffmpeg → Opus conversion for
+        # voice-bubble delivery when this is True, matching Edge / MiniMax /
+        # xAI built-in providers.
+        return True
+
+    # ------------------------------------------------------------------
+    # Synthesis
+    # ------------------------------------------------------------------
+
+    def synthesize(
+        self,
+        text: str,
+        output_path: str,
+        *,
+        voice: Optional[str] = None,
+        model: Optional[str] = None,
+        speed: Optional[float] = None,
+        format: str = "mp3",
+        **extra: Any,
+    ) -> str:
+        """Synthesize *text* via the Cloudflare Workers AI TTS endpoint.
+
+        Writes raw audio bytes to *output_path* and returns the path.
+        Raises on failure — the dispatcher converts exceptions to the
+        standard ``{success: False, error: ...}`` JSON envelope.
+        """
+        import requests
+
+        api_token = _get_env("CLOUDFLARE_API_TOKEN")
+        account_id = _get_env("CLOUDFLARE_ACCOUNT_ID")
+        if not api_token or not account_id:
+            raise ValueError(
+                "CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID must be set. "
+                "Create a Cloudflare API token with Workers AI access."
+            )
+
+        # Config resolution: dispatcher kwargs (top-level tts.voice /
+        # tts.model / tts.output_format) override the tts.cloudflare
+        # section, which overrides the built-in defaults.
+        cf_config = _load_cf_config()
+
+        resolved_model = str(model or cf_config.get("model") or DEFAULT_MODEL).strip()
+        base_url = (
+            str(cf_config.get("base_url") or DEFAULT_BASE_URL).strip().rstrip("/")
+        )
+        resolved_voice = str(
+            voice or cf_config.get("voice") or cf_config.get("speaker") or DEFAULT_VOICE
+        ).strip()
+
+        # Map the dispatcher ``format`` to a Cloudflare ``encoding``.
+        # Cloudflare supports mp3, linear16, ulaw.  When the requested
+        # format is wav we use linear16 (PCM) so the output is correct;
+        # anything else falls back to mp3.
+        encoding = str(cf_config.get("encoding") or "").strip().lower()
+        if not encoding:
+            fmt = (format or "mp3").lower().strip()
+            if fmt == "wav":
+                encoding = "linear16"
+            elif fmt in _VALID_ENCODINGS:
+                encoding = fmt
+            else:
+                encoding = DEFAULT_ENCODING
+
+        payload: Dict[str, Any] = {
+            "text": text,
+            "speaker": resolved_voice,
+            "encoding": encoding,
+        }
+        for key in ("container", "sample_rate", "bit_rate"):
+            value = cf_config.get(key)
+            if value not in (None, ""):
+                payload[key] = value
+
+        response = requests.post(
+            f"{base_url}/{account_id}/ai/run/{resolved_model}",
+            headers={
+                "Authorization": f"Bearer {api_token}",
+                "Content-Type": "application/json",
+            },
+            json=payload,
+            timeout=60,
+        )
+
+        status_code = getattr(response, "status_code", 200)
+        if not isinstance(status_code, int):
+            status_code = 200
+        if status_code != 200:
+            detail = ""
+            try:
+                body = response.json()
+                errors = body.get("errors") if isinstance(body, dict) else None
+                if errors:
+                    first = errors[0] if isinstance(errors, list) else errors
+                    detail = (
+                        first.get("message", "")
+                        if isinstance(first, dict)
+                        else str(first)
+                    )
+                if not detail and isinstance(body, dict):
+                    error = body.get("error")
+                    detail = error.get("message", "") if isinstance(error, dict) else ""
+            except Exception:
+                detail = getattr(response, "text", "")[:300]
+            raise RuntimeError(
+                f"Cloudflare TTS API error (HTTP {status_code}): "
+                f"{detail or 'unknown error'}"
+            )
+
+        response.raise_for_status()
+        audio_bytes = response.content
+
+        if not audio_bytes:
+            raise RuntimeError("Cloudflare Aura TTS returned empty audio data")
+
+        with open(output_path, "wb") as f:
+            f.write(audio_bytes)
+
+        return output_path
+
+
+# ---------------------------------------------------------------------------
+# Plugin entry point
+# ---------------------------------------------------------------------------
+
+
+def register(ctx) -> None:
+    """Plugin entry point — wire CloudflareTTSProvider into the registry."""
+    ctx.register_tts_provider(CloudflareTTSProvider())

--- a/plugins/tts/cloudflare/plugin.yaml
+++ b/plugins/tts/cloudflare/plugin.yaml
@@ -1,0 +1,8 @@
+name: cloudflare
+version: 1.0.0
+description: "Cloudflare Workers AI Aura TTS backend (Deepgram Aura voices). Free tier with generous limits."
+author: NousResearch
+kind: backend
+requires_env:
+  - CLOUDFLARE_API_TOKEN
+  - CLOUDFLARE_ACCOUNT_ID

--- a/tests/hermes_cli/test_plugins_tts_registration.py
+++ b/tests/hermes_cli/test_plugins_tts_registration.py
@@ -109,10 +109,13 @@ class TestRegisterTTSProvider:
             mgr = PluginManager()
             mgr.discover_and_load()
 
-        # Plugin loaded (register returned normally), but registry empty.
+        # Plugin loaded (register returned normally), but the bad plugin's
+        # non-provider was rejected — only bundled backends (e.g. cloudflare)
+        # may be present from discover_and_load().
         assert mgr._plugins["bad-tts-plugin"].enabled is True
         assert tts_registry.get_provider("not a provider") is None
-        assert tts_registry.list_providers() == []
+        registered_names = {p.name for p in tts_registry.list_providers()}
+        assert "not a provider" not in registered_names
         assert "does not inherit from TTSProvider" in caplog.text
 
         tts_registry._reset_for_tests()

--- a/tests/hermes_cli/test_tts_picker.py
+++ b/tests/hermes_cli/test_tts_picker.py
@@ -34,8 +34,13 @@ class _FakeTTSProvider(TTSProvider):
 
 
 @pytest.fixture(autouse=True)
-def _reset_registry():
+def _reset_registry(monkeypatch):
     tts_registry._reset_for_tests()
+    # Prevent bundled plugin auto-discovery from re-populating the
+    # registry during these unit tests — we control registry contents
+    # directly via register_provider().
+    from hermes_cli import plugins as _plugins_mod
+    monkeypatch.setattr(_plugins_mod, "_ensure_plugins_discovered", lambda *a, **k: None)
     yield
     tts_registry._reset_for_tests()
 

--- a/tests/plugins/tts/test_cloudflare_provider.py
+++ b/tests/plugins/tts/test_cloudflare_provider.py
@@ -1,0 +1,403 @@
+"""Tests for the Cloudflare Workers AI Aura TTS plugin.
+
+Covers the ``TTSProvider`` ABC surface, credential validation, the
+``synthesize()`` HTTP path, config resolution, and end-to-end dispatch
+via ``text_to_speech_tool`` through the plugin registry.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    for key in (
+        "CLOUDFLARE_API_TOKEN",
+        "CLOUDFLARE_ACCOUNT_ID",
+        "HERMES_SESSION_PLATFORM",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Provider surface
+# ---------------------------------------------------------------------------
+
+
+class TestCloudflareProviderSurface:
+    def test_name(self):
+        from plugins.tts.cloudflare import CloudflareTTSProvider
+
+        assert CloudflareTTSProvider().name == "cloudflare"
+
+    def test_display_name(self):
+        from plugins.tts.cloudflare import CloudflareTTSProvider
+
+        assert CloudflareTTSProvider().display_name == "Cloudflare Workers AI"
+
+    def test_default_model(self):
+        from plugins.tts.cloudflare import CloudflareTTSProvider
+
+        assert CloudflareTTSProvider().default_model() == "@cf/deepgram/aura-2-en"
+
+    def test_default_voice(self):
+        from plugins.tts.cloudflare import CloudflareTTSProvider
+
+        assert CloudflareTTSProvider().default_voice() == "asteria"
+
+    def test_list_voices_non_empty(self):
+        from plugins.tts.cloudflare import CloudflareTTSProvider
+
+        voices = CloudflareTTSProvider().list_voices()
+        assert len(voices) >= 5
+        ids = {v["id"] for v in voices}
+        assert "asteria" in ids
+        for entry in voices:
+            assert "id" in entry
+            assert "language" in entry
+
+    def test_list_models(self):
+        from plugins.tts.cloudflare import CloudflareTTSProvider
+
+        models = CloudflareTTSProvider().list_models()
+        assert len(models) == 1
+        assert models[0]["id"] == "@cf/deepgram/aura-2-en"
+        assert models[0]["max_text_length"] == 5000
+
+    def test_setup_schema_advertises_credentials(self):
+        from plugins.tts.cloudflare import CloudflareTTSProvider
+
+        schema = CloudflareTTSProvider().get_setup_schema()
+        assert schema["name"] == "Cloudflare Workers AI"
+        assert schema["badge"] == "free"
+        env_keys = {entry["key"] for entry in schema.get("env_vars", [])}
+        assert "CLOUDFLARE_API_TOKEN" in env_keys
+        assert "CLOUDFLARE_ACCOUNT_ID" in env_keys
+
+    def test_voice_compatible_is_true(self):
+        from plugins.tts.cloudflare import CloudflareTTSProvider
+
+        assert CloudflareTTSProvider().voice_compatible is True
+
+    def test_name_not_in_builtin_set(self):
+        """The plugin name must not collide with a built-in provider."""
+        from tools.tts_tool import BUILTIN_TTS_PROVIDERS
+
+        assert "cloudflare" not in BUILTIN_TTS_PROVIDERS
+
+
+class TestCloudflareProviderAvailability:
+    def test_available_with_credentials(self, monkeypatch):
+        from plugins.tts.cloudflare import CloudflareTTSProvider
+
+        monkeypatch.setenv("CLOUDFLARE_API_TOKEN", "cf-token")
+        monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "acct-123")
+        assert CloudflareTTSProvider().is_available() is True
+
+    def test_unavailable_without_token(self, monkeypatch):
+        from plugins.tts.cloudflare import CloudflareTTSProvider
+
+        monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "acct-123")
+        assert CloudflareTTSProvider().is_available() is False
+
+    def test_unavailable_without_account_id(self, monkeypatch):
+        from plugins.tts.cloudflare import CloudflareTTSProvider
+
+        monkeypatch.setenv("CLOUDFLARE_API_TOKEN", "cf-token")
+        assert CloudflareTTSProvider().is_available() is False
+
+    def test_unavailable_without_anything(self):
+        from plugins.tts.cloudflare import CloudflareTTSProvider
+
+        assert CloudflareTTSProvider().is_available() is False
+
+
+# ---------------------------------------------------------------------------
+# Synthesize
+# ---------------------------------------------------------------------------
+
+
+class TestCloudflareSynthesize:
+    def test_missing_credentials_raises_value_error(self, tmp_path):
+        from plugins.tts.cloudflare import CloudflareTTSProvider
+
+        with pytest.raises(
+            ValueError, match="CLOUDFLARE_API_TOKEN.*CLOUDFLARE_ACCOUNT_ID"
+        ):
+            CloudflareTTSProvider().synthesize("Hello", str(tmp_path / "out.mp3"))
+
+    def test_posts_to_aura_endpoint_and_writes_audio(self, tmp_path, monkeypatch):
+        from plugins.tts.cloudflare import CloudflareTTSProvider
+
+        monkeypatch.setenv("CLOUDFLARE_API_TOKEN", "cf-token")
+        monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "acct-123")
+        response = MagicMock()
+        response.content = b"mp3-bytes"
+        response.status_code = 200
+        response.raise_for_status = MagicMock()
+
+        output_path = str(tmp_path / "out.mp3")
+        with patch("requests.post", return_value=response) as mock_post:
+            result = CloudflareTTSProvider().synthesize("Hello", output_path)
+
+        assert result == output_path
+        assert (tmp_path / "out.mp3").read_bytes() == b"mp3-bytes"
+        endpoint = mock_post.call_args[0][0]
+        assert endpoint == (
+            "https://api.cloudflare.com/client/v4/accounts/"
+            "acct-123/ai/run/@cf/deepgram/aura-2-en"
+        )
+        kwargs = mock_post.call_args[1]
+        assert kwargs["headers"]["Authorization"] == "Bearer cf-token"
+        assert kwargs["headers"]["Content-Type"] == "application/json"
+        assert kwargs["json"] == {
+            "text": "Hello",
+            "speaker": "asteria",
+            "encoding": "mp3",
+        }
+
+    def test_dispatcher_kwargs_override_defaults(self, tmp_path, monkeypatch):
+        from plugins.tts.cloudflare import CloudflareTTSProvider
+
+        monkeypatch.setenv("CLOUDFLARE_API_TOKEN", "cf-token")
+        monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "acct-123")
+        response = MagicMock()
+        response.content = b"audio"
+        response.status_code = 200
+        response.raise_for_status = MagicMock()
+
+        with patch("requests.post", return_value=response) as mock_post:
+            CloudflareTTSProvider().synthesize(
+                "Hi",
+                str(tmp_path / "out.mp3"),
+                voice="zeus",
+                model="@cf/deepgram/aura-2-en",
+                format="mp3",
+            )
+
+        assert mock_post.call_args[1]["json"]["speaker"] == "zeus"
+
+    def test_config_section_overrides_defaults(self, tmp_path, monkeypatch):
+        from plugins.tts.cloudflare import CloudflareTTSProvider
+
+        monkeypatch.setenv("CLOUDFLARE_API_TOKEN", "cf-token")
+        monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "acct-123")
+        response = MagicMock()
+        response.content = b"audio"
+        response.status_code = 200
+        response.raise_for_status = MagicMock()
+
+        fake_config = {
+            "tts": {
+                "cloudflare": {
+                    "model": "@cf/deepgram/aura-2-en",
+                    "voice": "luna",
+                    "encoding": "linear16",
+                    "container": "wav",
+                    "sample_rate": 24000,
+                    "bit_rate": 128000,
+                    "base_url": "https://cf.example/client/v4/accounts",
+                }
+            }
+        }
+        with (
+            patch(
+                "plugins.tts.cloudflare._load_cf_config",
+                return_value=fake_config["tts"]["cloudflare"],
+            ),
+            patch("requests.post", return_value=response) as mock_post,
+        ):
+            CloudflareTTSProvider().synthesize("Hi", str(tmp_path / "out.wav"))
+
+        assert mock_post.call_args[0][0] == (
+            "https://cf.example/client/v4/accounts/"
+            "acct-123/ai/run/@cf/deepgram/aura-2-en"
+        )
+        assert mock_post.call_args[1]["json"] == {
+            "text": "Hi",
+            "speaker": "luna",
+            "encoding": "linear16",
+            "container": "wav",
+            "sample_rate": 24000,
+            "bit_rate": 128000,
+        }
+
+    def test_dispatcher_kwargs_override_config_section(self, tmp_path, monkeypatch):
+        """Dispatcher voice/model kwargs win over the tts.cloudflare section."""
+        from plugins.tts.cloudflare import CloudflareTTSProvider
+
+        monkeypatch.setenv("CLOUDFLARE_API_TOKEN", "cf-token")
+        monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "acct-123")
+        response = MagicMock()
+        response.content = b"audio"
+        response.status_code = 200
+        response.raise_for_status = MagicMock()
+
+        cf_config = {
+            "voice": "luna",
+            "model": "@cf/deepgram/aura-2-en",
+            "encoding": "mp3",
+        }
+        with (
+            patch("plugins.tts.cloudflare._load_cf_config", return_value=cf_config),
+            patch("requests.post", return_value=response) as mock_post,
+        ):
+            CloudflareTTSProvider().synthesize(
+                "Hi",
+                str(tmp_path / "out.mp3"),
+                voice="zeus",
+            )
+
+        assert mock_post.call_args[1]["json"]["speaker"] == "zeus"
+
+    def test_api_error_raises_runtime_error(self, tmp_path, monkeypatch):
+        from plugins.tts.cloudflare import CloudflareTTSProvider
+
+        monkeypatch.setenv("CLOUDFLARE_API_TOKEN", "cf-token")
+        monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "acct-123")
+        response = MagicMock()
+        response.status_code = 401
+        response.json.return_value = {"errors": [{"message": "Invalid API token"}]}
+
+        with patch("requests.post", return_value=response):
+            with pytest.raises(RuntimeError, match="HTTP 401.*Invalid API token"):
+                CloudflareTTSProvider().synthesize("Hello", str(tmp_path / "out.mp3"))
+
+    def test_empty_audio_raises_runtime_error(self, tmp_path, monkeypatch):
+        from plugins.tts.cloudflare import CloudflareTTSProvider
+
+        monkeypatch.setenv("CLOUDFLARE_API_TOKEN", "cf-token")
+        monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "acct-123")
+        response = MagicMock()
+        response.status_code = 200
+        response.content = b""
+        response.raise_for_status = MagicMock()
+
+        with patch("requests.post", return_value=response):
+            with pytest.raises(RuntimeError, match="empty audio data"):
+                CloudflareTTSProvider().synthesize("Hello", str(tmp_path / "out.mp3"))
+
+    def test_format_wav_maps_to_linear16(self, tmp_path, monkeypatch):
+        from plugins.tts.cloudflare import CloudflareTTSProvider
+
+        monkeypatch.setenv("CLOUDFLARE_API_TOKEN", "cf-token")
+        monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "acct-123")
+        response = MagicMock()
+        response.content = b"audio"
+        response.status_code = 200
+        response.raise_for_status = MagicMock()
+
+        with patch("requests.post", return_value=response) as mock_post:
+            CloudflareTTSProvider().synthesize(
+                "Hi",
+                str(tmp_path / "out.wav"),
+                format="wav",
+            )
+
+        assert mock_post.call_args[1]["json"]["encoding"] == "linear16"
+
+
+# ---------------------------------------------------------------------------
+# Plugin registration
+# ---------------------------------------------------------------------------
+
+
+class TestCloudflareRegistration:
+    def test_register_calls_register_tts_provider(self):
+        from plugins.tts.cloudflare import CloudflareTTSProvider, register
+
+        ctx = MagicMock()
+        register(ctx)
+
+        ctx.register_tts_provider.assert_called_once()
+        provider = ctx.register_tts_provider.call_args[0][0]
+        assert isinstance(provider, CloudflareTTSProvider)
+        assert provider.name == "cloudflare"
+
+    def test_registry_accepts_cloudflare_name(self):
+        """The registry must accept 'cloudflare' (not a built-in name)."""
+        from agent.tts_registry import (
+            _BUILTIN_NAMES,
+            register_provider,
+            _reset_for_tests,
+        )
+        from plugins.tts.cloudflare import CloudflareTTSProvider
+
+        _reset_for_tests()
+        assert "cloudflare" not in _BUILTIN_NAMES
+        register_provider(CloudflareTTSProvider())
+        from agent.tts_registry import get_provider
+
+        assert get_provider("cloudflare") is not None
+        _reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end dispatch via text_to_speech_tool
+# ---------------------------------------------------------------------------
+
+
+class TestCloudflareDispatch:
+    def test_text_to_speech_routes_to_plugin(self, tmp_path, monkeypatch):
+        """text_to_speech_tool dispatches to the plugin when provider=cloudflare."""
+        from agent import tts_registry
+        from plugins.tts.cloudflare import CloudflareTTSProvider
+
+        tts_registry._reset_for_tests()
+        tts_registry.register_provider(CloudflareTTSProvider())
+        monkeypatch.setenv("CLOUDFLARE_API_TOKEN", "cf-token")
+        monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "acct-123")
+
+        response = MagicMock()
+        response.content = b"audio-bytes"
+        response.status_code = 200
+        response.raise_for_status = MagicMock()
+
+        from tools import tts_tool
+
+        monkeypatch.setattr(
+            tts_tool, "_load_tts_config", lambda: {"provider": "cloudflare"}
+        )
+        try:
+            with patch("requests.post", return_value=response) as mock_post:
+                result = json.loads(
+                    tts_tool.text_to_speech_tool("Hello", str(tmp_path / "out.mp3"))
+                )
+            assert result["success"] is True
+            assert result["provider"] == "cloudflare"
+            assert mock_post.call_args[1]["json"]["text"] == "Hello"
+        finally:
+            tts_registry._reset_for_tests()
+
+    def test_check_tts_requirements_satisfied_by_plugin(self, monkeypatch):
+        """check_tts_requirements returns True when the plugin is available."""
+        from agent import tts_registry
+        from plugins.tts.cloudflare import CloudflareTTSProvider
+
+        tts_registry._reset_for_tests()
+        tts_registry.register_provider(CloudflareTTSProvider())
+        monkeypatch.setenv("CLOUDFLARE_API_TOKEN", "cf-token")
+        monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "acct-123")
+
+        from tools import tts_tool
+
+        monkeypatch.setattr(
+            tts_tool, "_has_any_command_tts_provider", lambda *a, **k: False
+        )
+        try:
+            with (
+                patch("tools.tts_tool._import_edge_tts", side_effect=ImportError),
+                patch("tools.tts_tool._import_elevenlabs", side_effect=ImportError),
+                patch("tools.tts_tool._import_openai_client", side_effect=ImportError),
+                patch("tools.tts_tool._import_mistral_client", side_effect=ImportError),
+                patch("tools.tts_tool._check_neutts_available", return_value=False),
+                patch("tools.tts_tool._check_kittentts_available", return_value=False),
+                patch("tools.tts_tool._check_piper_available", return_value=False),
+            ):
+                assert tts_tool.check_tts_requirements() is True
+        finally:
+            tts_registry._reset_for_tests()

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -862,6 +862,35 @@ class TestHandleVoiceCommandReal:
                     for c in mock_cp.call_args_list)
 
 
+class TestToggleVoiceTtsReal:
+    """Tests TTS-only output toggle behavior.
+
+    TTS output is decoupled from voice mode (microphone/STT) so users can
+    enable spoken assistant responses without input audio libraries.
+    """
+
+    @patch("cli._cprint")
+    @patch("tools.tts_tool.check_tts_requirements", return_value=True)
+    def test_tts_toggle_does_not_require_voice_mode(self, _check, mock_cp):
+        cli = _make_voice_cli(_voice_mode=False, _voice_tts=False)
+
+        cli._toggle_voice_tts()
+
+        assert cli._voice_tts is True
+        assert any("Voice TTS enabled" in str(call) for call in mock_cp.call_args_list)
+        assert not any("Enable voice mode first" in str(call) for call in mock_cp.call_args_list)
+
+    @patch("cli._cprint")
+    def test_tts_toggle_off_does_not_require_voice_mode(self, mock_cp):
+        cli = _make_voice_cli(_voice_mode=False, _voice_tts=True)
+
+        cli._toggle_voice_tts()
+
+        assert cli._voice_tts is False
+        assert cli._voice_tts_done.is_set()
+        assert any("Voice TTS disabled" in str(call) for call in mock_cp.call_args_list)
+
+
 class TestEnableVoiceModeReal:
     """Tests _enable_voice_mode with real CLI instance."""
 

--- a/tests/tui_gateway/test_voice_toggle.py
+++ b/tests/tui_gateway/test_voice_toggle.py
@@ -1,0 +1,114 @@
+"""Tests for the ``voice.toggle`` TTS action in tui_gateway.
+
+Verifies that TTS output can be toggled independently of voice mode
+(microphone/STT), mirroring the classic CLI's ``_toggle_voice_tts``
+which no longer gates on ``_voice_mode``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    yield home
+
+
+@pytest.fixture()
+def server(hermes_home):
+    with patch.dict(
+        "sys.modules",
+        {
+            "hermes_cli.env_loader": MagicMock(),
+            "hermes_cli.banner": MagicMock(),
+        },
+    ):
+        mod = importlib.import_module("tui_gateway.server")
+        yield mod
+        mod._sessions.clear()
+        mod._pending.clear()
+        mod._answers.clear()
+
+
+@pytest.fixture()
+def session(server):
+    sid = "sid-voice-test"
+    session_key = "tui-voice-session-1"
+    s = {
+        "session_key": session_key,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "attached_images": [],
+        "cols": 120,
+    }
+    server._sessions[sid] = s
+    return sid, session_key, s
+
+
+def _call(server, method, **params):
+    handler = server._methods[method]
+    return handler(1, params)
+
+
+# ── voice.toggle tts — independent of voice mode ─────────────────────
+
+
+class TestVoiceToggleTts:
+    def test_tts_toggle_on_without_voice_mode(self, server, session, monkeypatch):
+        """TTS can be enabled even when voice mode is OFF."""
+        monkeypatch.setenv("HERMES_VOICE", "0")
+        monkeypatch.setenv("HERMES_VOICE_TTS", "0")
+
+        r = _call(server, "voice.toggle", action="tts")
+
+        assert "error" not in r
+        assert r["result"]["tts"] is True
+        # Voice mode stays off — TTS is independent.
+        assert r["result"]["enabled"] is False
+        assert server._voice_tts_enabled() is True
+
+    def test_tts_toggle_off_without_voice_mode(self, server, session, monkeypatch):
+        """TTS can be disabled even when voice mode is OFF."""
+        monkeypatch.setenv("HERMES_VOICE", "0")
+        monkeypatch.setenv("HERMES_VOICE_TTS", "1")
+
+        r = _call(server, "voice.toggle", action="tts")
+
+        assert "error" not in r
+        assert r["result"]["tts"] is False
+        assert r["result"]["enabled"] is False
+        assert server._voice_tts_enabled() is False
+
+    def test_tts_toggle_with_voice_mode_on(self, server, session, monkeypatch):
+        """TTS toggle still works when voice mode is ON."""
+        monkeypatch.setenv("HERMES_VOICE", "1")
+        monkeypatch.setenv("HERMES_VOICE_TTS", "0")
+
+        r = _call(server, "voice.toggle", action="tts")
+
+        assert "error" not in r
+        assert r["result"]["tts"] is True
+        assert r["result"]["enabled"] is True
+
+    def test_tts_toggle_no_error_code(self, server, session, monkeypatch):
+        """The old 4014 'enable voice mode first' error must not fire."""
+        monkeypatch.setenv("HERMES_VOICE", "0")
+        monkeypatch.setenv("HERMES_VOICE_TTS", "0")
+
+        r = _call(server, "voice.toggle", action="tts")
+
+        # Success, not an error envelope.
+        assert "error" not in r
+        assert r["result"]["tts"] is True

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -888,6 +888,28 @@ def _has_any_command_tts_provider(tts_config: Optional[Dict[str, Any]] = None) -
     return False
 
 
+def _has_any_plugin_tts_provider() -> bool:
+    """Return True when any plugin-registered TTS provider is available.
+
+    Checks the plugin TTS registry (issue #30398) for providers whose
+    ``is_available()`` returns True.  This makes ``check_tts_requirements``
+    plugin-aware so a configured plugin backend (e.g. Cloudflare Workers AI)
+    satisfies the TTS availability check without a vendor-specific entry
+    in the built-in probe list.
+    """
+    try:
+        from agent.tts_registry import list_providers
+        from hermes_cli.plugins import _ensure_plugins_discovered
+
+        _ensure_plugins_discovered()
+        for provider in list_providers():
+            if provider.is_available():
+                return True
+    except Exception:  # noqa: BLE001 — discovery failure is non-fatal
+        pass
+    return False
+
+
 # ===========================================================================
 # ffmpeg Opus conversion (Edge TTS MP3 -> OGG Opus for Telegram)
 # ===========================================================================
@@ -2471,13 +2493,16 @@ def check_tts_requirements() -> bool:
 
     Edge TTS needs no API key and is the default, so if the package
     is installed, TTS is available. A user-declared command provider
-    also satisfies the requirement.
+    or a plugin-registered provider also satisfies the requirement.
 
     Returns:
         bool: True if at least one provider can work.
     """
     # Any configured command provider counts as available.
     if _has_any_command_tts_provider():
+        return True
+    # Any available plugin-registered provider counts as available.
+    if _has_any_plugin_tts_provider():
         return True
     try:
         _import_edge_tts()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -13375,8 +13375,10 @@ def _(rid, params: dict) -> dict:
       off also tears down any active continuous recording loop. Does NOT
       start recording on its own; recording is driven by ``voice.record``
       (Ctrl+B) after mode is on, matching cli.py's enable/Ctrl+B split.
-    * ``tts`` — toggle speech-output of agent replies. Requires mode on
-      (mirrors CLI's _toggle_voice_tts guard).
+    * ``tts`` — toggle speech-output of agent replies. TTS output does
+      not require voice mode (microphone/STT); keep it independent so
+      users can hear responses without input audio libraries (mirrors
+      CLI's ``_toggle_voice_tts``).
     """
     action = params.get("action", "status")
 
@@ -13440,8 +13442,10 @@ def _(rid, params: dict) -> dict:
         )
 
     if action == "tts":
-        if not _voice_mode_enabled():
-            return _err(rid, 4014, "enable voice mode first: /voice on")
+        # TTS output is independent of voice mode (microphone/STT) — mirrors
+        # cli.py's _toggle_voice_tts, which no longer gates on _voice_mode.
+        # Users can enable spoken replies in environments without input
+        # audio libraries.
         new_value = not _voice_tts_enabled()
         # Runtime-only flag (CLI parity) — see voice.toggle on/off above.
         os.environ["HERMES_VOICE_TTS"] = "1" if new_value else "0"
@@ -13452,7 +13456,7 @@ def _(rid, params: dict) -> dict:
         return _ok(
             rid,
             {
-                "enabled": True,
+                "enabled": _voice_mode_enabled(),
                 "record_key": _voice_record_key(),
                 "tts": new_value,
             },

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -152,6 +152,8 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `KREA_API_KEY` | Krea API key for Krea 2 image generation ([krea.ai](https://krea.ai/)) |
 | `GROQ_API_KEY` | Groq Whisper STT API key ([groq.com](https://groq.com/)) |
 | `ELEVENLABS_API_KEY` | ElevenLabs premium TTS voices ([elevenlabs.io](https://elevenlabs.io/)) |
+| `CLOUDFLARE_API_TOKEN` | Cloudflare Workers AI Aura TTS ([dash.cloudflare.com](https://dash.cloudflare.com)) |
+| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account ID for Workers AI TTS |
 | `STT_GROQ_MODEL` | Override the Groq STT model (default: `whisper-large-v3-turbo`) |
 | `GROQ_BASE_URL` | Override the Groq OpenAI-compatible STT endpoint |
 | `STT_OPENAI_MODEL` | Override the OpenAI STT model (default: `whisper-1`) |

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -14,7 +14,7 @@ If you have a paid [Nous Portal](https://portal.nousresearch.com) subscription, 
 
 ## Text-to-Speech
 
-Convert text to speech with ten providers:
+Convert text to speech with eleven providers:
 
 | Provider | Quality | Cost | API Key |
 |----------|---------|------|---------|
@@ -25,6 +25,7 @@ Convert text to speech with ten providers:
 | **Mistral (Voxtral TTS)** | Excellent | Paid | `MISTRAL_API_KEY` |
 | **Google Gemini TTS** | Excellent | Free tier | `GEMINI_API_KEY` |
 | **xAI TTS** | Excellent | Paid | `XAI_API_KEY` |
+| **Cloudflare Workers AI** | Good | Free tier | `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` |
 | **NeuTTS** | Good | Free (local) | None needed |
 | **KittenTTS** | Good | Free (local) | None needed |
 | **Piper** | Good | Free (local) | None needed |
@@ -43,7 +44,7 @@ Convert text to speech with ten providers:
 ```yaml
 # In ~/.hermes/config.yaml
 tts:
-  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "neutts" | "kittentts" | "piper"
+  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "cloudflare" | "neutts" | "kittentts" | "piper"
   speed: 1.0                    # Global speed multiplier (provider-specific settings override this)
   edge:
     voice: "en-US-AriaNeural"   # 322 voices, 74 languages
@@ -70,6 +71,11 @@ tts:
     voice: "Kore"               # 30 prebuilt voices: Zephyr, Puck, Kore, Enceladus, Gacrux, etc.
     audio_tags: false           # Enable hidden Gemini 3.1 TTS audio-tag insertion
     persona_prompt_file: ""      # Optional Markdown/text file with Gemini voice direction
+  cloudflare:
+    model: "@cf/deepgram/aura-2-en"   # Deepgram Aura models on Cloudflare Workers AI
+    voice: "asteria"                  # asteria, luna, stella, athena, hera, orion, arcas, perseus, boreas, zeus
+    encoding: "mp3"                   # mp3 (default), linear16, ulaw
+    # base_url: "https://api.cloudflare.com/client/v4/accounts"  # override if using a custom endpoint
   xai:
     voice_id: "eve"             # or a custom voice ID — see docs below
     language: "en"              # ISO 639-1 code
@@ -140,6 +146,7 @@ Each provider has a documented per-request input-character cap. Hermes truncates
 | MiniMax | 10000 |
 | Mistral | 4000 |
 | Google Gemini | 32000 |
+| Cloudflare Workers AI | 5000 |
 | ElevenLabs | Model-aware (see below) |
 | NeuTTS | 2000 |
 | KittenTTS | 2000 |
@@ -174,6 +181,7 @@ Telegram voice bubbles require Opus/OGG audio format:
 - **MiniMax TTS** outputs MP3 and needs **ffmpeg** to convert for Telegram voice bubbles
 - **Google Gemini TTS** outputs raw PCM and uses **ffmpeg** to encode Opus directly for Telegram voice bubbles
 - **xAI TTS** outputs MP3 and needs **ffmpeg** to convert for Telegram voice bubbles
+- **Cloudflare Workers AI** outputs MP3 and needs **ffmpeg** to convert for Telegram voice bubbles
 - **NeuTTS** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
 - **KittenTTS** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
 - **Piper** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
@@ -189,7 +197,7 @@ brew install ffmpeg
 sudo dnf install ffmpeg
 ```
 
-Without ffmpeg, Edge TTS, MiniMax TTS, NeuTTS, KittenTTS, and Piper audio are sent as regular audio files (playable, but shown as a rectangular player instead of a voice bubble).
+Without ffmpeg, Edge TTS, MiniMax TTS, Cloudflare Workers AI, NeuTTS, KittenTTS, and Piper audio are sent as regular audio files (playable, but shown as a rectangular player instead of a voice bubble).
 
 :::tip
 If you want voice bubbles without installing ffmpeg, switch to the OpenAI, ElevenLabs, or Mistral provider.
@@ -344,6 +352,14 @@ For TTS engines that can't be expressed as a single shell command — Python SDK
 | OAuth refresh flow (not a static bearer token) | **Plugin** |
 
 Built-ins always win, and command providers win over a same-name plugin — so plugins are safe to register against any non-built-in name without worrying about shadowing your existing config.
+
+:::note
+The **Cloudflare Workers AI** provider listed in the table above is
+itself a bundled plugin (`plugins/tts/cloudflare/`). It auto-loads as a
+`kind: backend` plugin and registers via `ctx.register_tts_provider()`,
+so `tts.provider: cloudflare` routes through the same plugin dispatch
+path described here — no manual `hermes plugins enable` step is needed.
+:::
 
 #### Minimal plugin
 


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Adds **Cloudflare Workers AI Aura TTS** as a built-in TTS provider. Cloudflare's free tier for Workers AI includes Deepgram Aura voices with generous limits, making it a valuable addition alongside existing Edge (free but network-dependent) and paid providers like OpenAI / ElevenLabs.

Also fixes a bug where TTS spoken output couldn't be enabled independently of voice mode (microphone STT). Previously, `/voice tts` was silently ignored unless `/voice on` was also active, which forced users to install heavy STT/audio input libraries just to hear spoken responses.

The implementation follows the established provider pattern already used by Gemini, xAI, and MiniMax — config-driven with env var fallbacks, no new PyPI dependencies, and wired into the interactive setup wizard.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `tools/tts_tool.py` — add `_generate_cloudflare_tts()` handler, `cloudflare` config key in `_get_tts_config()`, provider dispatch wiring, and schema description update
- `hermes_cli/config.py` — register `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` in `OPTIONAL_ENV_VARS` and `tts.cloudflare` defaults in `DEFAULT_CONFIG`
- `hermes_cli/setup.py` — add Cloudflare to interactive TTS provider setup (prompts for token + account ID, falls back to Edge TTS on skip)
- `cli.py` — remove guard preventing `/voice tts` toggle without full voice mode; set `_voice_tts_done` on disable to avoid hangs
- `website/docs/user-guide/features/tts.md` — document Cloudflare provider (config, limits, ffmpeg note)
- `website/docs/reference/environment-variables.md` — add `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`
- `tests/tools/test_tts_cloudflare.py` — new test coverage for credential validation, endpoint dispatch, config override wiring
- `tests/tools/test_tts_max_text_length.py` — Cloudflare 5000-char cap coverage
- `tests/tools/test_voice_cli_integration.py` — TTS toggle decoupled from voice mode

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. **Cloudflare TTS voice output:**
   ```bash
   export CLOUDFLARE_API_TOKEN="your_token"
   export CLOUDFLARE_ACCOUNT_ID="your_account_id"
   hermes --toolsets tts -q "Say hello in a Cloudflare voice"
   ```
   Should return a playable MP3 file URL/path.

2. **Config override:**
   ```yaml
   tts:
     provider: cloudflare
     cloudflare:
       model: "@cf/deepgram/aura-2-en"
       voice: "asteria"
       encoding: "mp3"
   ```
   Verify the config values are picked up in debug output.

3. **Voice mode bug fix (no mic libraries needed):**
   Run `hermes` interactively, type `/voice tts`. Without this fix, it silently does nothing if STT libraries are missing. With this fix, it enables spoken responses.

4. **Tests:**
   ```bash
   scripts/run_tests.sh tests/tools/test_tts_cloudflare.py tests/tools/test_tts_max_text_length.py tests/tools/test_voice_cli_integration.py
   ```
   All tests pass (310 passed in TTS/voice scope).

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no TTS section exists in example file)
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

