### PR TITLE
fix(tui): add missing setVoiceTts to createSlashHandler voice context

### DIFF
--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -676,7 +676,7 @@ export function useMainApp(gw: GatewayClient) {
         },
         slashFlightRef,
         transcript: { page, panel, send, setHistoryItems, sys, trimLastExchange: session.trimLastExchange },
-        voice: { setVoiceEnabled, setVoiceRecordKey }
+        voice: { setVoiceEnabled, setVoiceRecordKey, setVoiceTts }
       }),
     [
       catalog,


### PR DESCRIPTION
Follow-up to #30987.

The original PR added `voiceTts` state tracking but missed the third `voice` context injection site used by `createSlashHandler`. The other two sites (InputHandlerContext and GatewayEventHandlerContext) both got `setVoiceTts`, but the SlashHandlerContext at L679 was left unchanged.

This caused `/voice status` and `/voice tts` slash commands to fail silently — `ctx.voice.setVoiceTts` was `undefined`, throwing a TypeError that crashed the handler.

## Fix
Add `setVoiceTts` to the `createSlashHandler` voice context at `useMainApp.ts:679`.

## How to test
1. `hermes --tui`
2. `/voice status` — should work again and show TTS status