### PR TITLE
fix(pricing): add Gemini 3.x pricing snapshots and normalize provider

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -384,6 +384,50 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
     # Google Gemini
     (
         "google",
+        "gemini-3.5-flash",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("1.50"),
+        output_cost_per_million=Decimal("9.00"),
+        cache_read_cost_per_million=Decimal("0.15"),
+        source="official_docs_snapshot",
+        source_url="https://ai.google.dev/pricing",
+        pricing_version="google-pricing-2026-05-19",
+    ),
+    (
+        "google",
+        "gemini-3.1-flash-lite",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.25"),
+        output_cost_per_million=Decimal("1.50"),
+        cache_read_cost_per_million=Decimal("0.025"),
+        source="official_docs_snapshot",
+        source_url="https://ai.google.dev/pricing",
+        pricing_version="google-pricing-2026-05-19",
+    ),
+    (
+        "google",
+        "gemini-3.1-flash-lite-preview",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.25"),
+        output_cost_per_million=Decimal("1.50"),
+        cache_read_cost_per_million=Decimal("0.025"),
+        source="official_docs_snapshot",
+        source_url="https://ai.google.dev/pricing",
+        pricing_version="google-pricing-2026-05-19",
+    ),
+    (
+        "google",
+        "gemini-3-flash-preview",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.50"),
+        output_cost_per_million=Decimal("3.00"),
+        cache_read_cost_per_million=Decimal("0.05"),
+        source="official_docs_snapshot",
+        source_url="https://ai.google.dev/pricing",
+        pricing_version="google-pricing-2026-05-19",
+    ),
+    (
+        "google",
         "gemini-2.5-pro",
     ): PricingEntry(
         input_cost_per_million=Decimal("1.25"),
@@ -546,6 +590,8 @@ def resolve_billing_route(
         return BillingRoute(provider="anthropic", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name == "openai":
         return BillingRoute(provider="openai", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
+    if provider_name in {"google", "gemini", "google-gemini", "google-ai-studio"}:
+        return BillingRoute(provider="google", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name in {"minimax", "minimax-cn"}:
         return BillingRoute(provider=provider_name, model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name in {"custom", "local"} or (base and "localhost" in base):

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -224,3 +224,66 @@ def test_deepseek_v4_pro_estimate_usage_cost():
     assert result.amount_usd is not None
     # 1M input × $1.74/M + 500K output × $3.48/M = $1.74 + $1.74 = $3.48
     assert float(result.amount_usd) == 3.48
+
+
+def test_gemini_35_flash_pricing_entry_exists():
+    """Ensure gemini-3.5-flash has a pricing entry and provider mapping works."""
+    entry = get_pricing_entry(
+        "gemini-3.5-flash",
+        provider="gemini",
+    )
+
+    assert entry is not None
+    assert entry.input_cost_per_million is not None
+    assert entry.output_cost_per_million is not None
+    assert entry.cache_read_cost_per_million is not None
+    assert float(entry.input_cost_per_million) == 1.50
+    assert float(entry.output_cost_per_million) == 9.00
+    assert float(entry.cache_read_cost_per_million) == 0.15
+
+
+def test_gemini_35_flash_estimate_usage_cost():
+    """Ensure gemini-3.5-flash sessions get a dollar estimate with mapped provider."""
+    result = estimate_usage_cost(
+        "gemini-3.5-flash",
+        CanonicalUsage(input_tokens=1000000, output_tokens=500000, cache_read_tokens=200000),
+        provider="gemini",
+    )
+
+    assert result.status == "estimated"
+    assert result.amount_usd is not None
+    # 1M input × $1.50/M + 500K output × $9.00/M + 200K cache_read × $0.15/M
+    # = $1.50 + $4.50 + $0.03 = $6.03
+    assert float(result.amount_usd) == 6.03
+
+
+def test_gemini_31_flash_lite_pricing_entry_exists():
+    """Ensure gemini-3.1-flash-lite has a pricing entry and provider mapping works."""
+    entry = get_pricing_entry(
+        "gemini-3.1-flash-lite",
+        provider="gemini",
+    )
+
+    assert entry is not None
+    assert entry.input_cost_per_million is not None
+    assert entry.output_cost_per_million is not None
+    assert entry.cache_read_cost_per_million is not None
+    assert float(entry.input_cost_per_million) == 0.25
+    assert float(entry.output_cost_per_million) == 1.50
+    assert float(entry.cache_read_cost_per_million) == 0.025
+
+
+def test_gemini_3_flash_preview_pricing_entry_exists():
+    """Ensure gemini-3-flash-preview has a pricing entry and provider mapping works."""
+    entry = get_pricing_entry(
+        "gemini-3-flash-preview",
+        provider="gemini",
+    )
+
+    assert entry is not None
+    assert entry.input_cost_per_million is not None
+    assert entry.output_cost_per_million is not None
+    assert entry.cache_read_cost_per_million is not None
+    assert float(entry.input_cost_per_million) == 0.50
+    assert float(entry.output_cost_per_million) == 3.00
+    assert float(entry.cache_read_cost_per_million) == 0.05


### PR DESCRIPTION
What does this PR do?

  This PR fixes a bug where sessions using Google Gemini models (via the gemini provider) would display estimated costs as $0.00 (or n/a) in the Web Dashboard, /insights, and CLI status bar.

  It solves two problems:
  1. Provider Mapping Gap: The static pricing table _OFFICIAL_DOCS_PRICING maps Google models under the "google" key. However, the canonical provider identifier used for API calls is "gemini". Since resolve_billing_route did not normalize "gemini" (or "google-gemini"/"google-ai-studio") to "google", billing checks resulted in "unknown" routes and $0.00 costs.
  2. Missing 3.x Models: Static pricing snapshots were missing for the latest Gemini 3.x generation, leaving models like gemini-3.5-flash and gemini-3.1-flash-lite with no base cost definition.

  This PR normalizes Gemini provider aliases during billing route resolution and seeds standard pricing snapshots for the 3.x family, enabling accurate local cost metrics.


Related Issue

  Fixes # <!-- (If no issue exists, this is a standalone improvement to support the 3.x family) -->

  Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [x] ✅ Tests (adding or improving test coverage)

  Changes Made

  - agent/usage_pricing.py:
    - Normalized "gemini", "google-gemini", and "google-ai-studio" to the canonical "google" billing provider inside resolve_billing_route().
    - Added pricing snapshots for standard and cached tokens under the "google" key for the following models:
      - gemini-3.5-flash ($1.50/M input, $9.00/M output, $0.15/M cache-read)
      - gemini-3.1-flash-lite ($0.25/M input, $1.50/M output, $0.025/M cache-read)
      - gemini-3.1-flash-lite-preview ($0.25/M input, $1.50/M output, $0.025/M cache-read)
      - gemini-3-flash-preview ($0.50/M input, $3.00/M output, $0.05/M cache-read)
  - tests/agent/test_usage_pricing.py:
    - Added unit tests checking the existence of these new pricing entries.
    - Added integrated test asserting that estimate_usage_cost successfully calculates the expected cost breakdown when invoked under the "gemini" provider namespace.

  How to Test

  1. Run the targeted pricing test suite to ensure mapping and math calculations work flawlessly:
     bash
     pytest tests/agent/test_usage_pricing.py

  2. Verify in a live session that costs are now actively logged and displayed on subsequent turns when using provider: gemini and any of the supported 3.x models.

  Checklist

  Code

  - [x] I've read the Contributing Guide
  - [x] My commit messages follow Conventional Commits (feat(pricing): add Gemini 3.x pricing snapshots and normalize provider)
  - [x] I searched for existing PRs to make sure this isn't a duplicate
  - [x] My PR contains only changes related to this fix/feature (no unrelated commits)
  - [x] I've run pytest tests/ -q and all tests pass (pricing tests verified passing locally)
  - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - [x] My platform is: Raspberry Pi OS (Linux debian-based, ARM64)

  Documentation & Housekeeping

  - [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
  - [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
  - [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
  - [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

  Screenshots / Logs

  bash
  tests/agent/test_usage_pricing.py ...............                        [100%]
  ============================== 15 passed in 0.86s ==============================