### PR TITLE
fix(feishu): adapter-level WS reconnect on receive-loop death (#31367)

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -191,6 +191,23 @@ _MAX_TEXT_INJECT_BYTES = 100 * 1024
 _FEISHU_CONNECT_ATTEMPTS = 3
 _FEISHU_SEND_ATTEMPTS = 3
 _FEISHU_APP_LOCK_SCOPE = "feishu-app-id"
+
+# Adapter-level WebSocket reconnect (#31367).
+#
+# The lark_oapi SDK's receive loop frequently exits with
+# ``no close frame received or sent`` on Feishu's hosted WS server roughly
+# every 30 minutes (server-side keepalive cull).  The SDK's auto-reconnect
+# is unreliable for that error path — ``ws_client.start()`` returns and the
+# executor task completes — so without an adapter-level safety net the
+# adapter just sits there silently, which used to escalate to a full
+# gateway restart every half hour (all platforms disconnected, every
+# active session got the shutdown notification).
+#
+# These knobs tune how aggressively we try to recover the WS in-place
+# before falling back to the gateway-level fatal-error escalation path.
+_FEISHU_WS_RECONNECT_MAX_ATTEMPTS = 5
+_FEISHU_WS_RECONNECT_BASE_DELAY_SECONDS = 1.0
+_FEISHU_WS_RECONNECT_MAX_DELAY_SECONDS = 30.0
 _DEFAULT_TEXT_BATCH_DELAY_SECONDS = 0.6
 _DEFAULT_TEXT_BATCH_MAX_MESSAGES = 8
 _DEFAULT_TEXT_BATCH_MAX_CHARS = 4000
@@ -1426,6 +1443,11 @@ class FeishuAdapter(BasePlatformAdapter):
         self._ws_client: Optional[Any] = None
         self._ws_future: Optional[asyncio.Future] = None
         self._ws_thread_loop: Optional[asyncio.AbstractEventLoop] = None
+        # Guards against re-entrant adapter-level reconnect scheduling
+        # when ``_ws_future`` resolves multiple times during a single
+        # recovery (e.g. the new client we just spun up dies while the
+        # previous reconnect coroutine is still running).  Issue #31367.
+        self._ws_reconnect_in_progress: bool = False
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._webhook_runner: Optional[Any] = None
         self._webhook_site: Optional[Any] = None
@@ -4434,6 +4456,133 @@ class FeishuAdapter(BasePlatformAdapter):
             self._ws_client,
             self,
         )
+        # Watch the executor for unexpected exit so we can reconnect at the
+        # adapter level instead of letting the gateway escalate to a full
+        # process restart when Feishu's WS server kicks us with
+        # ``no close frame received or sent`` every ~30min (#31367).
+        self._ws_future.add_done_callback(self._on_ws_thread_exit)
+
+    def _on_ws_thread_exit(self, future: "asyncio.Future[Any]") -> None:
+        """Done-callback for ``_ws_future`` — runs when the WS thread exits.
+
+        Two scenarios distinguish here:
+
+          * **Clean disconnect** — ``disconnect()`` ran first and called
+            ``_disable_websocket_auto_reconnect`` which clears
+            ``_ws_client``.  Nothing to do.
+          * **Unexpected death** — ``ws_client.start()`` returned because
+            the lark_oapi receive loop hit
+            ``no close frame received or sent`` and the SDK's own
+            reconnect logic gave up.  Schedule an adapter-level
+            reconnect on the main event loop so the gateway doesn't
+            have to restart every 30 minutes (#31367).
+
+        Idempotent and thread-safe: the callback fires from the executor
+        thread, so we hop back to the adapter's main loop via
+        ``call_soon_threadsafe`` before doing anything stateful.
+        """
+        if not self._running:
+            return
+        if self._ws_client is None:
+            return
+        if getattr(self, "_ws_reconnect_in_progress", False):
+            return
+
+        try:
+            exc = future.exception()
+        except (asyncio.CancelledError, Exception):  # noqa: BLE001
+            exc = None
+
+        main_loop = self._loop
+        if main_loop is None or main_loop.is_closed():
+            logger.warning(
+                "[Feishu] WebSocket thread exited but adapter loop is "
+                "unavailable; cannot schedule adapter-level reconnect."
+            )
+            return
+
+        logger.warning(
+            "[Feishu] WebSocket thread exited unexpectedly%s — "
+            "scheduling adapter-level reconnect (max %d attempts) "
+            "instead of escalating to a gateway restart (#31367).",
+            f" ({type(exc).__name__}: {exc})" if exc else "",
+            _FEISHU_WS_RECONNECT_MAX_ATTEMPTS,
+        )
+
+        def _schedule() -> None:
+            asyncio.ensure_future(
+                self._reconnect_websocket_after_unexpected_exit(),
+                loop=main_loop,
+            )
+
+        try:
+            main_loop.call_soon_threadsafe(_schedule)
+        except RuntimeError:
+            # Loop closed between the check and the schedule — give up
+            # silently; the gateway watcher will pick up the platform.
+            logger.debug(
+                "[Feishu] Could not schedule WS reconnect — main loop closed."
+            )
+
+    async def _reconnect_websocket_after_unexpected_exit(self) -> None:
+        """Re-establish the WS in-place; escalate to fatal only on full failure.
+
+        Replaces the prior every-30-minute gateway restart with a bounded
+        in-process recovery.  Tears down the dead executor + client refs,
+        then retries ``_connect_websocket`` with exponential backoff.
+        Only when every attempt fails do we set the platform's fatal
+        error retryable flag — the gateway's existing retryable-failure
+        watcher then queues the platform for background reconnection
+        (and the OTHER platforms keep running, unlike the previous
+        full-gateway-restart behavior).  Issue #31367.
+        """
+        if self._ws_reconnect_in_progress:
+            return
+        self._ws_reconnect_in_progress = True
+        try:
+            self._disable_websocket_auto_reconnect()
+            self._ws_future = None
+            self._ws_thread_loop = None
+
+            delay = _FEISHU_WS_RECONNECT_BASE_DELAY_SECONDS
+            for attempt in range(1, _FEISHU_WS_RECONNECT_MAX_ATTEMPTS + 1):
+                if not self._running:
+                    return
+                try:
+                    await self._connect_websocket()
+                    logger.info(
+                        "[Feishu] WebSocket reconnected after unexpected "
+                        "exit (attempt %d/%d).",
+                        attempt, _FEISHU_WS_RECONNECT_MAX_ATTEMPTS,
+                    )
+                    return
+                except Exception as exc:
+                    logger.warning(
+                        "[Feishu] WebSocket reconnect attempt %d/%d failed: %s",
+                        attempt, _FEISHU_WS_RECONNECT_MAX_ATTEMPTS, exc,
+                    )
+                if attempt < _FEISHU_WS_RECONNECT_MAX_ATTEMPTS:
+                    await asyncio.sleep(delay)
+                    delay = min(delay * 2, _FEISHU_WS_RECONNECT_MAX_DELAY_SECONDS)
+
+            message = (
+                f"Feishu WebSocket reconnect failed after "
+                f"{_FEISHU_WS_RECONNECT_MAX_ATTEMPTS} attempts; "
+                f"escalating to gateway-level recovery."
+            )
+            logger.error("[Feishu] %s", message)
+            self._set_fatal_error(
+                "feishu_ws_reconnect_failed", message, retryable=True,
+            )
+            try:
+                await self._notify_fatal_error()
+            except Exception as exc:
+                logger.debug(
+                    "[Feishu] _notify_fatal_error after WS reconnect "
+                    "exhaustion raised: %s", exc,
+                )
+        finally:
+            self._ws_reconnect_in_progress = False
 
     async def _connect_webhook(self) -> None:
         if not FEISHU_WEBHOOK_AVAILABLE:

--- a/tests/gateway/test_feishu_ws_reconnect_31367.py
+++ b/tests/gateway/test_feishu_ws_reconnect_31367.py
@@ -1,0 +1,300 @@
+"""Regression tests for issue #31367.
+
+The lark_oapi WebSocket receive loop exits with
+``no close frame received or sent`` roughly every 30 minutes on Feishu's
+hosted WS server.  Before the fix, ``ws_client.start()`` returning was
+never observed by the adapter — the ``_ws_future`` resolved silently and
+the gateway eventually escalated to a full process restart that
+disconnected EVERY platform (DingTalk, Slack, etc.) and notified every
+active session.  ~48 restarts/day for users running Feishu.
+
+The fix adds ``FeishuAdapter._on_ws_thread_exit`` (a done-callback on
+``_ws_future``) and ``_reconnect_websocket_after_unexpected_exit``
+that recovers in-place with bounded backoff.  Only after the
+adapter-level retries are exhausted do we surface
+``_set_fatal_error(retryable=True)`` so the gateway's existing
+per-platform watcher can take over — the OTHER platforms keep running.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.feishu import (
+    FeishuAdapter,
+    _FEISHU_WS_RECONNECT_BASE_DELAY_SECONDS,
+    _FEISHU_WS_RECONNECT_MAX_ATTEMPTS,
+)
+
+
+@pytest.fixture
+def adapter(monkeypatch):
+    """A FeishuAdapter with the runtime knobs tests can poke directly."""
+    monkeypatch.setenv("FEISHU_APP_ID", "cli_app")
+    monkeypatch.setenv("FEISHU_APP_SECRET", "secret_app")
+    a = FeishuAdapter(PlatformConfig())
+    return a
+
+
+def _make_resolved_future(exc: Exception | None = None) -> asyncio.Future:
+    """A future that is already done with optional exception, no loop bound."""
+    fut: asyncio.Future = asyncio.Future()
+    if exc is not None:
+        fut.set_exception(exc)
+    else:
+        fut.set_result(None)
+    return fut
+
+
+# ---------------------------------------------------------------------------
+# _on_ws_thread_exit — gating logic
+# ---------------------------------------------------------------------------
+
+
+class TestOnWsThreadExitGating:
+    """Callback must distinguish clean disconnect from unexpected death."""
+
+    def test_no_op_when_running_is_false(self, adapter):
+        """Disconnect set ``_running = False`` first — callback no-ops."""
+        adapter._running = False
+        adapter._ws_client = MagicMock()  # would-be in-flight client
+        adapter._loop = MagicMock()
+
+        adapter._on_ws_thread_exit(_make_resolved_future())
+
+        adapter._loop.call_soon_threadsafe.assert_not_called()
+        assert adapter._ws_reconnect_in_progress is False
+
+    def test_no_op_when_ws_client_already_cleared(self, adapter):
+        """``_disable_websocket_auto_reconnect`` clears ``_ws_client`` —
+        the callback must treat that as a clean disconnect.
+        """
+        adapter._running = True
+        adapter._ws_client = None
+        adapter._loop = MagicMock()
+
+        adapter._on_ws_thread_exit(_make_resolved_future())
+
+        adapter._loop.call_soon_threadsafe.assert_not_called()
+
+    def test_no_op_when_reconnect_already_in_progress(self, adapter):
+        """Re-entrant invocations during recovery are dropped."""
+        adapter._running = True
+        adapter._ws_client = MagicMock()
+        adapter._loop = MagicMock()
+        adapter._ws_reconnect_in_progress = True
+
+        adapter._on_ws_thread_exit(_make_resolved_future())
+
+        adapter._loop.call_soon_threadsafe.assert_not_called()
+
+    def test_unexpected_death_schedules_reconnect_on_main_loop(self, adapter):
+        """The interesting case — fires ``call_soon_threadsafe(_schedule)``."""
+        adapter._running = True
+        adapter._ws_client = MagicMock()
+        loop = MagicMock()
+        loop.is_closed.return_value = False
+        adapter._loop = loop
+
+        adapter._on_ws_thread_exit(_make_resolved_future(RuntimeError("boom")))
+
+        loop.call_soon_threadsafe.assert_called_once()
+        # The scheduled callable must be a zero-arg function (matches
+        # call_soon_threadsafe contract).
+        scheduled = loop.call_soon_threadsafe.call_args.args[0]
+        assert callable(scheduled)
+
+    def test_no_op_when_main_loop_closed(self, adapter):
+        """A closed main loop means the gateway is shutting down — skip."""
+        adapter._running = True
+        adapter._ws_client = MagicMock()
+        loop = MagicMock()
+        loop.is_closed.return_value = True
+        adapter._loop = loop
+
+        adapter._on_ws_thread_exit(_make_resolved_future())
+
+        loop.call_soon_threadsafe.assert_not_called()
+
+    def test_no_op_when_main_loop_is_none(self, adapter):
+        adapter._running = True
+        adapter._ws_client = MagicMock()
+        adapter._loop = None
+
+        adapter._on_ws_thread_exit(_make_resolved_future())  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# _reconnect_websocket_after_unexpected_exit — retry loop semantics
+# ---------------------------------------------------------------------------
+
+
+class TestReconnectAfterUnexpectedExit:
+    """Bounded backoff, escalates only after retries exhaust."""
+
+    @pytest.mark.asyncio
+    async def test_first_attempt_succeeds_no_escalation(self, adapter, monkeypatch):
+        adapter._running = True
+        adapter._ws_client = MagicMock()
+        adapter._connect_websocket = AsyncMock()
+        adapter._notify_fatal_error = AsyncMock()
+        sleep_mock = AsyncMock()
+        monkeypatch.setattr("gateway.platforms.feishu.asyncio.sleep", sleep_mock)
+
+        await adapter._reconnect_websocket_after_unexpected_exit()
+
+        assert adapter._connect_websocket.await_count == 1
+        sleep_mock.assert_not_awaited()
+        adapter._notify_fatal_error.assert_not_awaited()
+        assert adapter.has_fatal_error is False
+        assert adapter._ws_reconnect_in_progress is False
+
+    @pytest.mark.asyncio
+    async def test_succeeds_on_retry_after_transient_failure(self, adapter, monkeypatch):
+        """Second attempt wins; backoff sleep was used between."""
+        adapter._running = True
+        adapter._ws_client = MagicMock()
+        adapter._connect_websocket = AsyncMock(
+            side_effect=[ConnectionError("first try fails"), None]
+        )
+        adapter._notify_fatal_error = AsyncMock()
+        sleep_mock = AsyncMock()
+        monkeypatch.setattr("gateway.platforms.feishu.asyncio.sleep", sleep_mock)
+
+        await adapter._reconnect_websocket_after_unexpected_exit()
+
+        assert adapter._connect_websocket.await_count == 2
+        # Slept at the configured base delay between attempts 1 and 2.
+        sleep_mock.assert_awaited_once_with(_FEISHU_WS_RECONNECT_BASE_DELAY_SECONDS)
+        adapter._notify_fatal_error.assert_not_awaited()
+        assert adapter.has_fatal_error is False
+
+    @pytest.mark.asyncio
+    async def test_escalates_after_all_attempts_fail(self, adapter, monkeypatch):
+        """Every attempt fails → ``_set_fatal_error(retryable=True)`` +
+        ``_notify_fatal_error()`` so the gateway watcher can take over.
+        """
+        adapter._running = True
+        adapter._ws_client = MagicMock()
+        adapter._connect_websocket = AsyncMock(side_effect=ConnectionError("nope"))
+        adapter._notify_fatal_error = AsyncMock()
+        monkeypatch.setattr(
+            "gateway.platforms.feishu.asyncio.sleep", AsyncMock()
+        )
+
+        await adapter._reconnect_websocket_after_unexpected_exit()
+
+        assert adapter._connect_websocket.await_count == _FEISHU_WS_RECONNECT_MAX_ATTEMPTS
+        adapter._notify_fatal_error.assert_awaited_once()
+        assert adapter.has_fatal_error is True
+        assert adapter.fatal_error_code == "feishu_ws_reconnect_failed"
+        assert adapter.fatal_error_retryable is True
+
+    @pytest.mark.asyncio
+    async def test_aborts_when_running_flips_false_mid_retry(self, adapter, monkeypatch):
+        """User disconnected mid-retry — stop trying, no escalation."""
+        adapter._running = True
+        adapter._ws_client = MagicMock()
+        adapter._notify_fatal_error = AsyncMock()
+
+        attempts = {"n": 0}
+
+        async def _flaky_connect():
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                # Simulate disconnect() racing with the retry loop.
+                adapter._running = False
+                raise ConnectionError("first attempt failed")
+
+        adapter._connect_websocket = AsyncMock(side_effect=_flaky_connect)
+        monkeypatch.setattr(
+            "gateway.platforms.feishu.asyncio.sleep", AsyncMock()
+        )
+
+        await adapter._reconnect_websocket_after_unexpected_exit()
+
+        # First attempt ran, then the retry loop saw _running=False and bailed.
+        assert adapter._connect_websocket.await_count == 1
+        adapter._notify_fatal_error.assert_not_awaited()
+        assert adapter.has_fatal_error is False
+
+    @pytest.mark.asyncio
+    async def test_reentrant_call_is_no_op(self, adapter):
+        """Second concurrent call returns immediately — guarded by the flag."""
+        adapter._running = True
+        adapter._ws_client = MagicMock()
+        adapter._connect_websocket = AsyncMock()
+        adapter._notify_fatal_error = AsyncMock()
+        adapter._ws_reconnect_in_progress = True  # pretend another run
+
+        await adapter._reconnect_websocket_after_unexpected_exit()
+
+        adapter._connect_websocket.assert_not_awaited()
+        adapter._notify_fatal_error.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_clears_dead_executor_state_before_reconnect(self, adapter, monkeypatch):
+        """Dead ``_ws_future`` / ``_ws_thread_loop`` must be wiped before
+        ``_connect_websocket`` is called so the new run gets fresh refs.
+        """
+        adapter._running = True
+        adapter._ws_client = MagicMock()
+        adapter._ws_future = MagicMock()
+        adapter._ws_thread_loop = MagicMock()
+
+        captured = {}
+
+        async def _capture():
+            captured["future"] = adapter._ws_future
+            captured["thread_loop"] = adapter._ws_thread_loop
+            captured["ws_client"] = adapter._ws_client
+
+        adapter._connect_websocket = AsyncMock(side_effect=_capture)
+        adapter._notify_fatal_error = AsyncMock()
+        monkeypatch.setattr(
+            "gateway.platforms.feishu.asyncio.sleep", AsyncMock()
+        )
+
+        await adapter._reconnect_websocket_after_unexpected_exit()
+
+        assert captured["future"] is None
+        assert captured["thread_loop"] is None
+        # ``_disable_websocket_auto_reconnect`` clears _ws_client too.
+        assert captured["ws_client"] is None
+
+
+# ---------------------------------------------------------------------------
+# Sanity: the fix doesn't break the happy path through ``disconnect()``.
+# ---------------------------------------------------------------------------
+
+
+class TestCleanDisconnectInteraction:
+    """Clean disconnect must not race with the new reconnect callback."""
+
+    def test_clean_disconnect_path_marks_no_reconnect_pending(self, adapter):
+        """Simulate the sequence:  disconnect() → _ws_future resolves.
+
+        ``disconnect()`` sets ``_running = False`` and calls
+        ``_disable_websocket_auto_reconnect`` which clears ``_ws_client``
+        BEFORE awaiting the future.  When the executor-thread callback
+        fires after that, both gates trip and the reconnect coroutine
+        is never scheduled.
+        """
+        # Pre-disconnect state
+        adapter._running = True
+        adapter._ws_client = MagicMock()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed.return_value = False
+
+        # disconnect() ran:
+        adapter._running = False
+        adapter._ws_client = None  # _disable_websocket_auto_reconnect clears it
+
+        adapter._on_ws_thread_exit(_make_resolved_future())
+
+        adapter._loop.call_soon_threadsafe.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

Stops Feishu's hosted-WS receive-loop death (`no close frame received or sent`) — which fires roughly every 30 minutes — from escalating to a full gateway restart that disconnects every other platform and notifies every active session. The recovery now happens in-place at the adapter level. Fixes #31367.

Two pieces wired together inside `gateway/platforms/feishu.py`:

1. **`_on_ws_thread_exit` done-callback** on `_ws_future`. The lark_oapi SDK's `ws_client.start()` returns silently when its receive loop exits, so the executor task completed with no observer. The callback distinguishes two cases:
   - **Clean disconnect** — `disconnect()` sets `_running=False` and `_disable_websocket_auto_reconnect()` clears `_ws_client`. Both gates trip and the callback no-ops, so the existing teardown path is untouched.
   - **Unexpected death** — the SDK exited mid-stream. Hop back to the adapter's main loop with `call_soon_threadsafe` and schedule the recovery coroutine.

2. **`_reconnect_websocket_after_unexpected_exit`** retry loop. Wipes the dead `_ws_future` / `_ws_thread_loop` / `_ws_client` refs, then re-runs `_connect_websocket` up to `_FEISHU_WS_RECONNECT_MAX_ATTEMPTS` (5) times with exponential backoff (1s → 2s → 4s → 8s → 16s, capped at 30s, total ~31s). Only when every attempt fails do we call `_set_fatal_error("feishu_ws_reconnect_failed", retryable=True)` + `_notify_fatal_error()` — the gateway's existing per-platform watcher then queues Feishu for background reconnection while the OTHER platforms keep running. A `_ws_reconnect_in_progress` flag guards against re-entrant scheduling when a freshly-spun client also dies during recovery.

## Related Issue

Fixes #31367

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/feishu.py` — three new tuning constants (`_FEISHU_WS_RECONNECT_MAX_ATTEMPTS=5`, `_FEISHU_WS_RECONNECT_BASE_DELAY_SECONDS=1.0`, `_FEISHU_WS_RECONNECT_MAX_DELAY_SECONDS=30.0`), `_ws_reconnect_in_progress` flag on `__init__`, `_on_ws_thread_exit` done-callback wired into `_connect_websocket`, and `_reconnect_websocket_after_unexpected_exit` coroutine.
- `tests/gateway/test_feishu_ws_reconnect_31367.py` — **13 new tests** across three classes covering the gating logic, the retry-loop semantics, and the clean-disconnect interaction.

Backwards compatible: no schema/config changes, no new env vars, no behavior change on the clean-disconnect path. The `lark_oapi` SDK is still doing all the WS framing work — we're only adding the safety net it's missing.

## How to Test

```bash
# New regression suite (13 tests, ~2.4s)
./scripts/run_tests.sh tests/gateway/test_feishu_ws_reconnect_31367.py

# Full Feishu regression (the existing 198 tests + the 13 new ones)
./scripts/run_tests.sh tests/gateway/test_feishu.py tests/gateway/test_feishu_ws_reconnect_31367.py
# expected: 211 passed
```

End-to-end behaviour after the fix, with the issue's reproduction sequence:

```
[Feishu] Connected in websocket mode (feishu)
... ~30 min later ...
[Lark] ERROR: receive message loop exit, err: no close frame received or sent
[Lark] INFO: disconnected to wss://msg-frontier.feishu.cn/...
[Feishu] WebSocket thread exited unexpectedly — scheduling adapter-level
         reconnect (max 5 attempts) instead of escalating to a gateway
         restart (#31367).
[Feishu] WebSocket reconnected after unexpected exit (attempt 1/5).
```

DingTalk and other connected platforms stay up across the event. Active sessions no longer receive the gateway-shutdown notification on the half-hour.

## Checklist

- [x] Conventional Commits (`fix(feishu):`, `test(feishu):`)
- [x] 2 focused commits, single author
- [x] 13 new tests pass; full Feishu suite (211 tests) green; no linter errors
- [x] Tested on macOS 15.6 (darwin 24.6.0), Python 3.12
- [x] No new config keys, no schema migration, no API surface change
- [x] Backwards compatible — clean-disconnect path verified unchanged
