### PR TITLE
fix(homeassistant): fall back when states listing fails

### DIFF
--- a/tests/tools/test_homeassistant_tool.py
+++ b/tests/tools/test_homeassistant_tool.py
@@ -12,6 +12,7 @@ import pytest
 from tools.homeassistant_tool import (
     _check_ha_available,
     _filter_and_summarize,
+    _async_list_entities,
     _build_service_payload,
     _parse_service_response,
     _get_headers,
@@ -110,6 +111,116 @@ class TestFilterAndSummarize:
 # ---------------------------------------------------------------------------
 # Service payload building
 # ---------------------------------------------------------------------------
+
+
+class TestAsyncListEntities:
+    @pytest.mark.asyncio
+    async def test_falls_back_to_template_api_on_states_5xx(self, monkeypatch):
+        """A broken /api/states payload should not make entity discovery unusable."""
+        import aiohttp
+
+        calls = []
+
+        class FakeResponse:
+            def __init__(self, *, status=200, json_data=None, text_data=None):
+                self.status = status
+                self._json_data = json_data
+                self._text_data = text_data
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            def raise_for_status(self):
+                if self.status >= 400:
+                    raise aiohttp.ClientResponseError(
+                        request_info=None,  # type: ignore[arg-type]
+                        history=(),
+                        status=self.status,
+                        message="Internal Server Error",
+                    )
+
+            async def json(self):
+                return self._json_data
+
+            async def text(self):
+                return self._text_data
+
+        class FakeSession:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            def get(self, url, **kwargs):
+                calls.append(("GET", url, kwargs))
+                return FakeResponse(status=500)
+
+            def post(self, url, **kwargs):
+                calls.append(("POST", url, kwargs))
+                assert url == "http://ha.local:8123/api/template"
+                assert kwargs["json"] == {
+                    "template": (
+                        "{% set ns = namespace(entities=[]) %}"
+                        "{% for s in states %}"
+                        "{% set ns.entities = ns.entities + [{"
+                        "'entity_id': s.entity_id, "
+                        "'state': s.state, "
+                        "'attributes': {"
+                        "'friendly_name': s.name, "
+                        "'area': area_name(s.entity_id) or ''"
+                        "}"
+                        "}] %}"
+                        "{% endfor %}"
+                        "{{ ns.entities | tojson }}"
+                    )
+                }
+                return FakeResponse(
+                    text_data=json.dumps(
+                        [
+                            {
+                                "entity_id": "light.kitchen",
+                                "state": "on",
+                                "attributes": {
+                                    "friendly_name": "Kitchen Light",
+                                    "area": "Kitchen",
+                                },
+                            },
+                            {
+                                "entity_id": "sensor.temperature",
+                                "state": "72",
+                                "attributes": {
+                                    "friendly_name": "Temperature",
+                                    "area": "Kitchen",
+                                },
+                            },
+                        ]
+                    )
+                )
+
+        monkeypatch.setattr(
+            "tools.homeassistant_tool._HASS_URL",
+            "http://ha.local:8123",
+        )
+        monkeypatch.setattr("tools.homeassistant_tool._HASS_TOKEN", "token")
+        monkeypatch.setattr(aiohttp, "ClientSession", FakeSession)
+
+        result = await _async_list_entities(domain="light", area="kitchen")
+
+        assert result == {
+            "count": 1,
+            "entities": [
+                {
+                    "entity_id": "light.kitchen",
+                    "state": "on",
+                    "friendly_name": "Kitchen Light",
+                }
+            ],
+        }
+        assert [method for method, _, _ in calls] == ["GET", "POST"]
 
 
 class TestBuildServicePayload:

--- a/tools/homeassistant_tool.py
+++ b/tools/homeassistant_tool.py
@@ -106,15 +106,48 @@ async def _async_list_entities(
     domain: Optional[str] = None,
     area: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Fetch entity states from HA and optionally filter by domain/area."""
+    """Fetch entity states from HA and optionally filter by domain/area.
+
+    Some HA instances can return HTTP 500 for ``/api/states`` when one
+    integration has a non-serializable state payload. Fall back to the template
+    API, which renders a compact entity list inside HA and often still works.
+    """
     import aiohttp
 
     hass_url, hass_token = _get_config()
+    headers = _get_headers(hass_token)
     url = f"{hass_url}/api/states"
     async with aiohttp.ClientSession() as session:
-        async with session.get(url, headers=_get_headers(hass_token), timeout=aiohttp.ClientTimeout(total=15)) as resp:
-            resp.raise_for_status()
-            states = await resp.json()
+        try:
+            async with session.get(url, headers=headers, timeout=aiohttp.ClientTimeout(total=15)) as resp:
+                resp.raise_for_status()
+                states = await resp.json()
+        except aiohttp.ClientResponseError as e:
+            if e.status < 500:
+                raise
+            template_url = f"{hass_url}/api/template"
+            template = (
+                "{% set ns = namespace(entities=[]) %}"
+                "{% for s in states %}"
+                "{% set ns.entities = ns.entities + [{"
+                "'entity_id': s.entity_id, "
+                "'state': s.state, "
+                "'attributes': {"
+                "'friendly_name': s.name, "
+                "'area': area_name(s.entity_id) or ''"
+                "}"
+                "}] %}"
+                "{% endfor %}"
+                "{{ ns.entities | tojson }}"
+            )
+            async with session.post(
+                template_url,
+                headers=headers,
+                json={"template": template},
+                timeout=aiohttp.ClientTimeout(total=15),
+            ) as resp:
+                resp.raise_for_status()
+                states = json.loads(await resp.text())
 
     return _filter_and_summarize(states, domain, area)
 


### PR DESCRIPTION
## What does this PR do?

Home Assistant entity discovery currently depends on `GET /api/states`. Some Home Assistant instances can return HTTP 500 for that endpoint when one integration exposes a state payload that HA cannot serialize for the REST response. When that happens, Hermes cannot list entities at all.

This PR keeps the normal `/api/states` behavior when it works, but falls back to Home Assistant's template API for 5xx responses. The fallback renders compact state records inside HA so Hermes can still discover entities and preserve domain/area filtering. 4xx errors are intentionally re-raised so auth, permission, and configuration problems remain visible.

## Related Issue

No dedicated issue found. This is related to broader Home Assistant tooling robustness work.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/homeassistant_tool.py`
  - Reuses one headers dict for Home Assistant REST calls.
  - Catches `aiohttp.ClientResponseError` from `/api/states`.
  - Re-raises `<500` errors so auth/config failures are not masked.
  - Falls back on `>=500` errors to `POST /api/template`.
  - Uses a fixed Jinja template to render compact state records with `entity_id`, `state`, `friendly_name`, and `area`.
  - Passes fallback results through the existing `_filter_and_summarize()` path.
- `tests/tools/test_homeassistant_tool.py`
  - Adds regression coverage for the 5xx fallback path.
  - Verifies the fallback calls `/api/template` after `/api/states` fails.
  - Verifies the template request body.
  - Verifies domain and area filtering still work on fallback results.

## How to Test

1. Run the Home Assistant tool tests:
   ```bash
   scripts/run_tests.sh tests/tools/test_homeassistant_tool.py
   ```
2. Run lint for the changed files:
   ```bash
   venv/bin/python -m ruff check tools/homeassistant_tool.py tests/tools/test_homeassistant_tool.py
   ```
3. Run the Windows compatibility footgun scan for the changed files:
   ```bash
   venv/bin/python scripts/check-windows-footguns.py tools/homeassistant_tool.py tests/tools/test_homeassistant_tool.py
   ```

Verified locally:

```text
scripts/run_tests.sh tests/tools/test_homeassistant_tool.py
# 69 tests passed, 0 failed

venv/bin/python -m ruff check tools/homeassistant_tool.py tests/tools/test_homeassistant_tool.py
# All checks passed!

venv/bin/python scripts/check-windows-footguns.py tools/homeassistant_tool.py tests/tools/test_homeassistant_tool.py
# No Windows footguns found
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 6.8.8-4-pve

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable. This is a backend tool behavior fix covered by tests.
