### PR TITLE
fix(install): detect actual Hermes install target

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -309,6 +309,28 @@ get_hermes_command_path() {
     fi
 }
 
+resolve_install_python() {
+    if [ -x "$INSTALL_DIR/venv/bin/python" ]; then
+        echo "$INSTALL_DIR/venv/bin/python"
+    elif [ -n "${PYTHON_PATH:-}" ] && [ -x "$PYTHON_PATH" ]; then
+        echo "$PYTHON_PATH"
+    elif command -v python >/dev/null 2>&1; then
+        command -v python
+    else
+        return 1
+    fi
+}
+
+resolve_install_hermes_bin() {
+    if [ -x "$INSTALL_DIR/venv/bin/hermes" ]; then
+        echo "$INSTALL_DIR/venv/bin/hermes"
+    elif command -v hermes >/dev/null 2>&1; then
+        command -v hermes
+    else
+        return 1
+    fi
+}
+
 # ============================================================================
 # System detection
 # ============================================================================
@@ -1260,14 +1282,14 @@ PY
 setup_path() {
     log_info "Setting up hermes command..."
 
-    if [ "$USE_VENV" = true ]; then
-        HERMES_BIN="$INSTALL_DIR/venv/bin/hermes"
-    else
-        HERMES_BIN="$(which hermes 2>/dev/null || echo "")"
-        if [ -z "$HERMES_BIN" ]; then
+    HERMES_BIN="$(resolve_install_hermes_bin 2>/dev/null || echo "")"
+    if [ -z "$HERMES_BIN" ]; then
+        if [ "$USE_VENV" = false ]; then
             log_warn "hermes not found on PATH after install"
-            return 0
+        else
+            log_warn "hermes entry point not found after install"
         fi
+        return 0
     fi
 
     # Verify the entry point script was actually generated
@@ -1478,7 +1500,9 @@ SOUL_EOF
 
     # Seed bundled skills into ~/.hermes/skills/ (manifest-based, one-time per skill)
     log_info "Syncing bundled skills to ~/.hermes/skills/ ..."
-    if "$INSTALL_DIR/venv/bin/python" "$INSTALL_DIR/tools/skills_sync.py" 2>/dev/null; then
+    local install_python
+    install_python="$(resolve_install_python 2>/dev/null || echo "")"
+    if [ -n "$install_python" ] && "$install_python" "$INSTALL_DIR/tools/skills_sync.py" 2>/dev/null; then
         log_success "Skills synced to ~/.hermes/skills/"
     else
         # Fallback: simple directory copy if Python sync fails
@@ -1717,13 +1741,17 @@ run_setup_wizard() {
 
     cd "$INSTALL_DIR"
 
-    # Run hermes setup using the venv Python directly (no activation needed).
+    # Run hermes setup with the interpreter that actually has Hermes installed.
     # Redirect stdin from /dev/tty so interactive prompts work when piped from curl.
-    if [ "$USE_VENV" = true ]; then
-        "$INSTALL_DIR/venv/bin/python" -m hermes_cli.main setup < /dev/tty
-    else
-        python -m hermes_cli.main setup < /dev/tty
+    local install_python
+    install_python="$(resolve_install_python 2>/dev/null || echo "")"
+    if [ -z "$install_python" ]; then
+        log_warn "Python interpreter for Hermes install not found"
+        log_info "Try: python -m hermes_cli.main setup"
+        return 0
     fi
+
+    "$install_python" -m hermes_cli.main setup < /dev/tty
 }
 
 maybe_start_gateway() {

--- a/tests/test_install_sh_actual_install_target.py
+++ b/tests/test_install_sh_actual_install_target.py
@@ -1,0 +1,131 @@
+"""Regression tests for install.sh actual install target detection.
+
+When ``--no-venv`` is passed, the installer can still end up with a
+``$INSTALL_DIR/venv`` if the lockfile-backed ``uv sync`` path materializes one.
+The installer must then reuse the *actual* interpreter / entry point it
+installed, rather than blindly following the ``USE_VENV`` flag in later steps.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import stat
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def _extract_function(name: str) -> str:
+    """Return the full shell function definition for ``name``."""
+    text = INSTALL_SH.read_text()
+    match = re.search(
+        rf"^{re.escape(name)}\(\)\s*\{{.*?^\}}",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None, f"{name}() not found in scripts/install.sh"
+    return match.group(0)
+
+
+def _make_executable(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def test_install_followup_steps_use_resolved_install_target() -> None:
+    """Static guard: installer follow-up steps should share helper-based lookup."""
+    text = INSTALL_SH.read_text()
+
+    assert "resolve_install_python()" in text
+    assert "resolve_install_hermes_bin()" in text
+
+    setup_path = _extract_function("setup_path")
+    assert 'HERMES_BIN="$(resolve_install_hermes_bin' in setup_path
+
+    run_setup_wizard = _extract_function("run_setup_wizard")
+    assert 'install_python="$(resolve_install_python' in run_setup_wizard
+    assert '"$install_python" -m hermes_cli.main setup < /dev/tty' in run_setup_wizard
+
+    copy_config_templates = _extract_function("copy_config_templates")
+    assert 'install_python="$(resolve_install_python' in copy_config_templates
+    assert '"$install_python" "$INSTALL_DIR/tools/skills_sync.py"' in copy_config_templates
+
+
+def test_resolve_install_hermes_bin_prefers_uv_managed_venv(tmp_path: Path) -> None:
+    """Behavioral repro: prefer venv/bin/hermes over a PATH fallback."""
+    helper = _extract_function("resolve_install_hermes_bin")
+
+    install_dir = tmp_path / "install"
+    venv_bin = install_dir / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    uv_hermes = venv_bin / "hermes"
+    _make_executable(uv_hermes, "#!/bin/sh\necho uv-hermes\n")
+
+    path_bin = tmp_path / "path-bin"
+    path_bin.mkdir()
+    path_hermes = path_bin / "hermes"
+    _make_executable(path_hermes, "#!/bin/sh\necho path-hermes\n")
+
+    script = f"""
+set -e
+INSTALL_DIR={install_dir!s}
+{helper}
+resolve_install_hermes_bin
+"""
+    env = os.environ.copy()
+    env["PATH"] = f"{path_bin}:{env['PATH']}"
+    result = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        env=env,
+    )
+    assert result.returncode == 0, (
+        f"resolve_install_hermes_bin failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert result.stdout.strip() == str(uv_hermes)
+
+
+def test_resolve_install_python_prefers_uv_managed_venv(tmp_path: Path) -> None:
+    """Behavioral repro: prefer venv/bin/python over PYTHON_PATH and PATH."""
+    helper = _extract_function("resolve_install_python")
+
+    install_dir = tmp_path / "install"
+    venv_bin = install_dir / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    uv_python = venv_bin / "python"
+    _make_executable(uv_python, "#!/bin/sh\necho uv-python\n")
+
+    explicit_python = tmp_path / "explicit-python"
+    _make_executable(explicit_python, "#!/bin/sh\necho explicit-python\n")
+
+    path_bin = tmp_path / "path-bin"
+    path_bin.mkdir()
+    path_python = path_bin / "python"
+    _make_executable(path_python, "#!/bin/sh\necho path-python\n")
+
+    script = f"""
+set -e
+INSTALL_DIR={install_dir!s}
+PYTHON_PATH={explicit_python!s}
+{helper}
+resolve_install_python
+"""
+    env = os.environ.copy()
+    env["PATH"] = f"{path_bin}:{env['PATH']}"
+    result = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        env=env,
+    )
+    assert result.returncode == 0, (
+        f"resolve_install_python failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert result.stdout.strip() == str(uv_python)


### PR DESCRIPTION
 ## Summary

  Fix #31383

 `install.sh --no-venv` installs that still end up creating `INSTALL_DIR/venv` during the lockfile-backed `uv sync --extra all --locked` path.

  Instead of assuming `USE_VENV=false` means Hermes was installed onto the system interpreter / PATH, the installer now resolves the actual install target first and reuses it consistently across:
  - launcher/shim creation in `setup_path()`
  - bundled skill sync
  - the setup wizard entrypoint

  ## Problem

  When `--no-venv` is passed, `setup_path()` previously skipped `INSTALL_DIR/venv/bin/hermes` entirely and only ran `which hermes`. If the lockfile install path still created a venv, the Hermes entrypoint existed at:

  `$INSTALL_DIR/venv/bin/hermes`

  but no `~/.local/bin/hermes` shim was created.

  The same mismatch also affected follow-up steps that assumed `USE_VENV=false` meant `python -m hermes_cli.main setup` should work from the ambient interpreter.

  ## Changes

  - add `resolve_install_python()`
  - add `resolve_install_hermes_bin()`
  - use resolved Hermes binary in `setup_path()`
  - use resolved Python interpreter for bundled `skills_sync.py`
  - use resolved Python interpreter for `hermes setup`

## Testing

  - `bash -n scripts/install.sh`
  - `python3 -m pytest -q -o addopts= tests/test_install_sh_actual_install_target.py`

  Expected result:

  - `3 passed`

  Regression coverage added in `tests/test_install_sh_actual_install_target.py`:

  - Static guard that `setup_path()`, bundled `skills_sync`, and `run_setup_wizard()` all use the shared actual-install-target helpers instead of branching directly on `USE_VENV`.
  - Behavioral test that `resolve_install_hermes_bin()` prefers `$INSTALL_DIR/venv/bin/hermes` over a PATH `hermes` fallback when uv materialized a venv.
  - Behavioral test that `resolve_install_python()` prefers `$INSTALL_DIR/venv/bin/python` over `PYTHON_PATH` / PATH fallbacks so post-install follow-up steps run against the interpreter that actually has Hermes installed.
