### PR TITLE
fix: make Hindsight auto-retain opt-in

### DIFF
--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -81,9 +81,9 @@ Config file: `~/.hermes/hindsight/config.json`
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `auto_retain` | `true` | Automatically retain conversation turns |
+| `auto_retain` | `false` | Automatically retain conversation turns. Disabled by default because retention sends conversation data to the Hindsight cloud and may incur usage costs; enable explicitly when desired. |
 | `retain_async` | `true` | Process retain asynchronously on the Hindsight server |
-| `retain_every_n_turns` | `1` | Retain every N turns (1 = every turn) |
+| `retain_every_n_turns` | `10` | Retain every N turns (10 = every tenth turn); applies when `auto_retain` is enabled |
 | `retain_context` | `conversation between Hermes Agent and the User` | Context label for retained memories |
 | `retain_tags` | — | Default tags applied to retained memories; merged with per-call tool tags |
 | `retain_source` | — | Optional `metadata.source` attached to retained memories |

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -569,8 +569,8 @@ class HindsightMemoryProvider(MemoryProvider):
         self._recall_tags_match = "any"
 
         # Retain controls
-        self._auto_retain = True
-        self._retain_every_n_turns = 1
+        self._auto_retain = False
+        self._retain_every_n_turns = 10
         self._retain_async = True
         self._retain_context = "conversation between Hermes Agent and the User"
         self._turn_counter = 0
@@ -857,8 +857,8 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "recall_tags", "description": "Tags to filter when searching memories (comma-separated)", "default": ""},
             {"key": "recall_tags_match", "description": "Tag matching mode for recall", "default": "any", "choices": ["any", "all", "any_strict", "all_strict"]},
             {"key": "auto_recall", "description": "Automatically recall memories before each turn", "default": True},
-            {"key": "auto_retain", "description": "Automatically retain conversation turns", "default": True},
-            {"key": "retain_every_n_turns", "description": "Retain every N turns (1 = every turn)", "default": 1},
+            {"key": "auto_retain", "description": "Automatically retain conversation turns (cloud retain can incur usage costs)", "default": False},
+            {"key": "retain_every_n_turns", "description": "Retain every N turns (1 = every turn)", "default": 10},
             {"key": "retain_async","description": "Process retain asynchronously on the Hindsight server", "default": True},
             {"key": "retain_context", "description": "Context label for retained memories", "default": "conversation between Hermes Agent and the User"},
             {"key": "recall_max_tokens", "description": "Maximum tokens for recall results", "default": 4096},
@@ -1180,8 +1180,8 @@ class HindsightMemoryProvider(MemoryProvider):
         ).strip() or "Assistant"
 
         # Retain controls
-        self._auto_retain = self._config.get("auto_retain", True)
-        self._retain_every_n_turns = max(1, int(self._config.get("retain_every_n_turns", 1)))
+        self._auto_retain = self._config.get("auto_retain", False)
+        self._retain_every_n_turns = max(1, int(self._config.get("retain_every_n_turns", 10)))
         self._retain_context = self._config.get("retain_context", "conversation between Hermes Agent and the User")
 
         # Recall controls

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -96,6 +96,8 @@ def provider(tmp_path, monkeypatch):
         "bank_id": "test-bank",
         "budget": "mid",
         "memory_mode": "hybrid",
+        "auto_retain": True,
+        "retain_every_n_turns": 1,
     }
     config_path = tmp_path / "hindsight" / "config.json"
     config_path.parent.mkdir(parents=True, exist_ok=True)
@@ -122,6 +124,8 @@ def provider_with_config(tmp_path, monkeypatch):
             "bank_id": "test-bank",
             "budget": "mid",
             "memory_mode": "hybrid",
+            "auto_retain": True,
+            "retain_every_n_turns": 1,
         }
         config.update(overrides)
         config_path = tmp_path / "hindsight" / "config.json"
@@ -189,10 +193,28 @@ class TestSchemas:
 
 
 class TestConfig:
-    def test_default_values(self, provider):
-        assert provider._auto_retain is True
+    def test_default_values(self, tmp_path, monkeypatch):
+        config = {
+            "mode": "cloud",
+            "apiKey": "test-key",
+            "api_url": "http://localhost:9999",
+            "bank_id": "test-bank",
+            "budget": "mid",
+            "memory_mode": "hybrid",
+        }
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
+
+        provider = HindsightMemoryProvider()
+        provider.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
+
+        assert provider._auto_retain is False
         assert provider._auto_recall is True
-        assert provider._retain_every_n_turns == 1
+        assert provider._retain_every_n_turns == 10
         assert provider._recall_max_tokens == 4096
         assert provider._recall_max_input_chars == 800
         assert provider._tags is None
@@ -819,7 +841,14 @@ class TestSyncTurn:
 
     def test_sync_turn_parent_session_tag(self, tmp_path, monkeypatch):
         """When initialized with parent_session_id, parent tag is added."""
-        config = {"mode": "cloud", "apiKey": "k", "api_url": "http://x", "bank_id": "b"}
+        config = {
+            "mode": "cloud",
+            "apiKey": "k",
+            "api_url": "http://x",
+            "bank_id": "b",
+            "auto_retain": True,
+            "retain_every_n_turns": 1,
+        }
         config_path = tmp_path / "hindsight" / "config.json"
         config_path.parent.mkdir(parents=True, exist_ok=True)
         config_path.write_text(json.dumps(config))

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -356,9 +356,10 @@ The setup wizard installs dependencies automatically and only installs what's ne
 | `bank_id` | `hermes` | Memory bank identifier |
 | `recall_budget` | `mid` | Recall thoroughness: `low` / `mid` / `high` |
 | `memory_mode` | `hybrid` | `hybrid` (context + tools), `context` (auto-inject only), `tools` (tools only) |
-| `auto_retain` | `true` | Automatically retain conversation turns |
+| `auto_retain` | `false` | Automatically retain conversation turns. Disabled by default because retention sends conversation data to the Hindsight cloud and may incur usage costs; enable explicitly when desired. |
 | `auto_recall` | `true` | Automatically recall memories before each turn |
 | `retain_async` | `true` | Process retain asynchronously on the server |
+| `retain_every_n_turns` | `10` | Retain every N turns (10 = every tenth turn); applies when `auto_retain` is enabled |
 | `retain_context` | `conversation between Hermes Agent and the User` | Context label for retained memories |
 | `retain_tags` | — | Default tags applied to retained memories; merged with per-call tool tags |
 | `retain_source` | — | Optional `metadata.source` attached to retained memories |


### PR DESCRIPTION
## Summary
- Default Hindsight `auto_retain` to disabled so cloud retain is explicit opt-in.
- Raise the default retain cadence from every turn to every 10 turns when users enable it.
- Add a cost warning to the config schema and update Hindsight provider tests to keep sync-turn coverage explicit.

## Why
Automatic retain can send conversation turns to a paid cloud memory backend. Enabling that by default risks unexpected usage/costs, especially in coding sessions with large context.

## Test Plan
- `venv/bin/python -m py_compile plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py`
- `venv/bin/python -m pytest tests/plugins/memory/test_hindsight_provider.py -q -o 'addopts='`
