### PR TITLE
fix(kanban): reset failure counters after manual promote

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3319,7 +3319,11 @@ def promote_task(
     drives it from a deliberate operator action with an audit-trail
     entry. Refuses to promote if any parent dep is not in a terminal
     state (`done`/`archived`) unless ``force=True``. Does NOT change
-    assignee or claim state. Returns ``(True, None)`` on success and
+    assignee or claim state. Successful manual promotion also resets the
+    failure counter: this is an operator-driven recovery action, same as
+    ``unblock_task`` / ``reclaim_task``, so the next retry gets a fresh
+    budget instead of inheriting a stale ``gave_up`` streak. Returns
+    ``(True, None)`` on success and
     ``(False, reason)`` if refused. ``dry_run=True`` validates the
     promotion would succeed without mutating state.
     """
@@ -3370,7 +3374,7 @@ def promote_task(
             "promoted_manual",
             {"actor": actor, "reason": reason, "forced": force},
         )
-
+    _clear_failure_counter(conn, task_id)
     return True, None
 
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -701,6 +701,24 @@ def test_unblock_resets_failure_counters(kanban_home):
         assert task.last_failure_error is None
 
 
+def test_promote_resets_failure_counters(kanban_home):
+    """promote_task must reset consecutive_failures and last_failure_error."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="a")
+        conn.execute(
+            "UPDATE tasks SET status = 'blocked', consecutive_failures = 2, "
+            "last_failure_error = 'test error' WHERE id = ?",
+            (t,),
+        )
+        conn.commit()
+        ok, err = kb.promote_task(conn, t, actor="tester")
+        assert (ok, err) == (True, None)
+        task = kb.get_task(conn, t)
+        assert task.status == "ready"
+        assert task.consecutive_failures == 0
+        assert task.last_failure_error is None
+
+
 # ---------------------------------------------------------------------------
 # Parent-completion invariant at the claim gate (RCA t_a6acd07d)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION

## Summary

This PR fixes a Kanban recovery bug where `promote_task()` moved a task back to `ready` without clearing stale failure state. After a manual promote, the task now gets a fresh failure budget instead of inheriting the previous `gave_up` streak.

## Changes

- Reset `consecutive_failures` and `last_failure_error` after successful `promote_task()`
- Add a regression test covering manual promote failure-counter reset

## Testing

### Targeted regression
```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py -- -q -k promote_resets_failure_counters
```

Result:
- `1 passed`

### File-level verification
```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py -- -q
```

Result:
- `162 passed`
- `4 failed`

## Notes

The 4 failing tests are existing `_resolve_hermes_argv` failures and are unrelated to this change. The new Kanban regression test passed.

