### PR TITLE
fix(send_message): accept WhatsApp JID targets

### DIFF
--- a/tests/gateway/test_send_message_whatsapp_targets.py
+++ b/tests/gateway/test_send_message_whatsapp_targets.py
@@ -1,0 +1,79 @@
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from gateway.config import Platform
+from tools.send_message_tool import _parse_target_ref, send_message_tool
+
+
+def _run_async_immediately(coro):
+    return asyncio.run(coro)
+
+
+def test_parse_target_ref_accepts_whatsapp_lid_jid():
+    assert _parse_target_ref("whatsapp", "15551234567@lid") == (
+        "15551234567@lid",
+        None,
+        True,
+    )
+
+
+def test_parse_target_ref_accepts_whatsapp_phone_jid():
+    assert _parse_target_ref("whatsapp", "15551234567@s.whatsapp.net") == (
+        "15551234567@s.whatsapp.net",
+        None,
+        True,
+    )
+
+
+def test_parse_target_ref_accepts_whatsapp_group_jid():
+    assert _parse_target_ref("whatsapp", "120363001234567890@g.us") == (
+        "120363001234567890@g.us",
+        None,
+        True,
+    )
+
+
+def test_parse_target_ref_accepts_legacy_e164_whatsapp_target():
+    assert _parse_target_ref("whatsapp", "+15551234567") == (
+        "+15551234567",
+        None,
+        True,
+    )
+
+
+def test_send_message_whatsapp_lid_target_does_not_fall_back_to_home_channel():
+    whatsapp_cfg = SimpleNamespace(enabled=True, token="***", extra={})
+    home = SimpleNamespace(chat_id="operator-home@lid")
+    config = SimpleNamespace(
+        platforms={Platform.WHATSAPP: whatsapp_cfg},
+        get_home_channel=lambda _platform: home,
+    )
+
+    with patch("gateway.config.load_gateway_config", return_value=config), \
+         patch("tools.interrupt.is_interrupted", return_value=False), \
+         patch("model_tools._run_async", side_effect=_run_async_immediately), \
+         patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+         patch("gateway.mirror.mirror_to_session", return_value=True):
+        result = json.loads(
+            send_message_tool(
+                {
+                    "action": "send",
+                    "target": "whatsapp:15551234567@lid",
+                    "message": "hello",
+                }
+            )
+        )
+
+    assert result["success"] is True
+    assert "note" not in result
+    send_mock.assert_awaited_once_with(
+        Platform.WHATSAPP,
+        whatsapp_cfg,
+        "15551234567@lid",
+        "hello",
+        thread_id=None,
+        media_files=[],
+        force_document=False,
+    )

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -32,6 +32,9 @@ _SLACK_TARGET_RE = re.compile(r"^\s*([CGDU][A-Z0-9]{8,})\s*$")
 _SLACK_THREAD_TARGET_RE = re.compile(r"^\s*([CGD][A-Z0-9]{8,}):([^\s:]+)\s*$")
 _WEIXIN_TARGET_RE = re.compile(r"^\s*((?:wxid|gh|v\d+|wm|wb)_[A-Za-z0-9_-]+|[A-Za-z0-9._-]+@chatroom|filehelper)\s*$")
 _YUANBAO_TARGET_RE = re.compile(r"^\s*((?:group|direct):[^:]+)\s*$")
+# WhatsApp Baileys chat IDs are fully qualified routing targets. Accept them
+# as explicit so resolved DMs/groups do not fall back to the home channel.
+_WHATSAPP_JID_TARGET_RE = re.compile(r"^\s*([A-Za-z0-9._:-]+@(?:s\.whatsapp\.net|lid|g\.us))\s*$")
 # Discord snowflake IDs are numeric, same regex pattern as Telegram topic targets.
 _NUMERIC_TOPIC_RE = _TELEGRAM_TOPIC_TARGET_RE
 # Platforms that address recipients by phone number and accept E.164 format
@@ -368,6 +371,10 @@ def _parse_target_ref(platform_name: str, target_ref: str):
             # resolution path in send_message() can run.
             is_explicit = chat_id[0] not in {"U", "W"}
             return chat_id, None, is_explicit
+    if platform_name == "whatsapp":
+        match = _WHATSAPP_JID_TARGET_RE.fullmatch(target_ref)
+        if match:
+            return match.group(1), None, True
     if platform_name == "matrix":
         trimmed = target_ref.strip()
         split_idx = trimmed.rfind(":$")


### PR DESCRIPTION
## Summary

- accept WhatsApp Baileys JIDs (`@lid`, `@s.whatsapp.net`, `@g.us`) as explicit `send_message` targets
- prevent valid WhatsApp targets from falling through to home-channel delivery
- add regression coverage for direct LID, phone JID, group JID, legacy E.164, and the no-fallback behavior

## Problem

`send_message(target="whatsapp:<jid>", ...)` could receive a valid WhatsApp target such as `15551234567@lid`, but `_parse_target_ref()` did not recognize that format as explicit.

That left `chat_id` unset, so `_handle_send()` fell back to the configured WhatsApp home channel and reported success there instead of sending to the requested target.

This is the failure mode reported in #31396, and it is the same parser/fallback family as the existing WhatsApp misrouting issues.

## Fix

Add a WhatsApp JID target regex in `tools/send_message_tool.py` and treat these formats as explicit:

- `<number>@lid`
- `<number>@s.whatsapp.net`
- `<group>@g.us`

That keeps already-valid WhatsApp routing IDs out of the home-channel fallback path.

## Tests

Added `tests/gateway/test_send_message_whatsapp_targets.py` covering:

- direct LID JID target
- direct phone JID target
- direct group JID target
- legacy `+E.164` target still works
- `send_message(target="whatsapp:<lid>")` does not fall back to the configured home channel

### Verified locally

```bash
python3 -m pytest tests/gateway/test_send_message_whatsapp_targets.py -o addopts='' -q
```

5 passed

## Related issues

Fixes #31396
Related to #18646
Adjacent to #5472 and #14486