### PR TITLE
fix(matrix): enforce allowed rooms for DMs

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1122,6 +1122,8 @@ def load_gateway_config() -> GatewayConfig:
                     os.environ["MATRIX_ALLOWED_ROOMS"] = str(ar)
                 if "auto_thread" in matrix_cfg and not os.getenv("MATRIX_AUTO_THREAD"):
                     os.environ["MATRIX_AUTO_THREAD"] = str(matrix_cfg["auto_thread"]).lower()
+                if "dm_auto_thread" in matrix_cfg and not os.getenv("MATRIX_DM_AUTO_THREAD"):
+                    os.environ["MATRIX_DM_AUTO_THREAD"] = str(matrix_cfg["dm_auto_thread"]).lower()
                 if "dm_mention_threads" in matrix_cfg and not os.getenv("MATRIX_DM_MENTION_THREADS"):
                     os.environ["MATRIX_DM_MENTION_THREADS"] = str(matrix_cfg["dm_mention_threads"]).lower()
 

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -18,7 +18,7 @@ Environment variables:
                             (eyes/checkmark/cross). Default: true
     MATRIX_REQUIRE_MENTION      Require @mention in rooms (default: true)
     MATRIX_FREE_RESPONSE_ROOMS  Comma-separated room IDs exempt from mention requirement (alias of matrix.free_response_rooms)
-    MATRIX_ALLOWED_ROOMS    Comma-separated room IDs; if set, bot ONLY responds in these rooms (whitelist, DMs exempt; alias of matrix.allowed_rooms)
+    MATRIX_ALLOWED_ROOMS    Comma-separated room IDs; if set, bot ONLY responds in these rooms (whitelist; alias of matrix.allowed_rooms)
     MATRIX_AUTO_THREAD          Auto-create threads for room messages (default: true)
     MATRIX_DM_AUTO_THREAD       Auto-create threads for DM messages (default: false)
     MATRIX_RECOVERY_KEY         Recovery key for cross-signing verification after device key rotation
@@ -392,7 +392,7 @@ class MatrixAdapter(BasePlatformAdapter):
             self._free_rooms: Set[str] = {
                 r.strip() for r in str(free_rooms_raw).split(",") if r.strip()
             }
-        # If non-empty, bot ONLY responds in these rooms (whitelist); DMs exempt.
+        # If non-empty, bot ONLY responds in these rooms (whitelist).
         allowed_rooms_raw = config.extra.get("allowed_rooms")
         if allowed_rooms_raw is None:
             allowed_rooms_raw = os.getenv("MATRIX_ALLOWED_ROOMS", "")
@@ -1697,20 +1697,22 @@ class MatrixAdapter(BasePlatformAdapter):
         )
         is_mentioned = self._is_bot_mentioned(body, formatted_body, mention_user_ids)
 
+        # allowed_rooms check (whitelist — must pass before other gating).
+        # When set, messages from rooms NOT in this whitelist are silently
+        # ignored, even if @mentioned. Apply this to DMs too: multi-profile
+        # setups may use several 1:1 rooms with the same Matrix account, and
+        # treating DMs as exempt lets every profile answer in every profile room.
+        if self._allowed_rooms and room_id not in self._allowed_rooms:
+            logger.debug(
+                "Matrix: ignoring message %s in %s — room not in "
+                "MATRIX_ALLOWED_ROOMS whitelist",
+                event_id,
+                room_id,
+            )
+            return None
+
         # Require-mention gating.
         if not is_dm:
-            # allowed_rooms check (whitelist — must pass before other gating).
-            # When set, messages from rooms NOT in this whitelist are silently
-            # ignored, even if @mentioned.  DMs are already excluded above.
-            if self._allowed_rooms and room_id not in self._allowed_rooms:
-                logger.debug(
-                    "Matrix: ignoring message %s in %s — room not in "
-                    "MATRIX_ALLOWED_ROOMS whitelist",
-                    event_id,
-                    room_id,
-                )
-                return None
-
             is_free_room = room_id in self._free_rooms
             in_bot_thread = bool(thread_id and thread_id in self._threads)
             if self._require_mention and not is_free_room and not in_bot_thread:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1412,6 +1412,9 @@ DEFAULT_CONFIG = {
         "require_mention": True,       # Require @mention to respond in rooms
         "free_response_rooms": "",     # Comma-separated room IDs where bot responds without mention
         "allowed_rooms": "",           # If set, bot ONLY responds in these room IDs (whitelist)
+        "auto_thread": True,            # Auto-create threads for group/room messages
+        "dm_auto_thread": False,        # Auto-create threads for DM messages
+        "dm_mention_threads": False,    # Auto-create DM threads only when the bot is @mentioned
     },
 
     # Approval mode for dangerous commands:

--- a/tests/gateway/test_allowed_channels_widening.py
+++ b/tests/gateway/test_allowed_channels_widening.py
@@ -330,21 +330,23 @@ class TestMatrixAllowedRooms:
         assert allowed == {"!room1:srv", "!room2:srv"}
 
     def test_block_logic(self):
-        """Replicates the matrix.py gate: if allowed non-empty and room not in it, drop."""
+        """Replicates the matrix.py gate: allowed_rooms applies to DMs too.
+
+        Matrix multi-profile setups may use several 1:1 rooms with the same
+        Matrix account; exempting DMs lets every profile answer in every
+        profile room.
+        """
         allowed = {"!allowed:srv"}
 
-        # Non-allowed room in group (is_dm=False) → blocked
         def would_process(room_id, is_dm):
-            if is_dm:
-                return True
             if allowed and room_id not in allowed:
                 return False
             return True
 
         assert would_process("!blocked:srv", is_dm=False) is False
         assert would_process("!allowed:srv", is_dm=False) is True
-        # DM always allowed
-        assert would_process("!blocked:srv", is_dm=True) is True
+        assert would_process("!blocked:srv", is_dm=True) is False
+        assert would_process("!allowed:srv", is_dm=True) is True
 
     def test_config_bridge(self, monkeypatch, tmp_path):
         from gateway.config import load_gateway_config


### PR DESCRIPTION
## Summary
- apply Matrix allowed_rooms whitelist before DM/mention gating
- bridge matrix.dm_auto_thread config into MATRIX_DM_AUTO_THREAD
- add default Matrix threading config keys and update whitelist test coverage

## Test Plan
- /home/chad/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_allowed_channels_widening.py -q