### PR TITLE
docs(auxiliary_client): correct provider chain doc rot (#31326)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -10,23 +10,27 @@ Resolution order for text tasks (auto mode):
   2. OpenRouter  (OPENROUTER_API_KEY)
   3. Nous Portal (~/.hermes/auth.json active provider)
   4. Custom endpoint (config.yaml model.base_url + OPENAI_API_KEY)
-  5. Native Anthropic
-  6. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, MiniMax-CN)
-  7. None
-
-Resolution order for vision/multimodal tasks (auto mode):
-  1. Selected main provider, if it is one of the supported vision backends below
-  2. OpenRouter
-  3. Nous Portal
-  4. Native Anthropic
-  5. Custom endpoint (for local vision models: Qwen-VL, LLaVA, Pixtral, etc.)
+  5. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, MiniMax-CN,
+     DeepSeek, Alibaba, etc.)
   6. None
 
-Codex OAuth (ChatGPT-account auth) is intentionally NOT in either
-fallback chain: OpenAI gates this endpoint behind an undocumented,
-shifting model allow-list, so "just try Codex with a hardcoded model"
-rots on its own.  Codex is used only when the user's main provider *is*
-openai-codex (Step 1 above) or when a caller explicitly requests it with
+Resolution order for vision/multimodal tasks (auto mode):
+  1. Selected main provider, if it is one of the supported vision backends
+     (skipped for ``nous`` unless a dedicated strict vision backend resolves,
+     and for providers known to lack image input — see
+     ``_PROVIDERS_WITHOUT_VISION``)
+  2. OpenRouter (vision-capable aggregator fallback)
+  3. Nous Portal (vision-capable aggregator fallback)
+  4. None
+
+Native Anthropic is *not* in either auto-detect chain — Anthropic is only
+used when the user's main provider is Anthropic (Step 1 of either chain)
+or when a caller explicitly requests it via ``auxiliary.<task>.provider``.
+Codex OAuth (ChatGPT-account auth) is also intentionally not in either
+chain: OpenAI gates this endpoint behind an undocumented, shifting model
+allow-list, so "just try Codex with a hardcoded model" rots on its own.
+Codex is used only when the user's main provider *is* openai-codex
+(Step 1 of the text chain) or when a caller explicitly requests it with
 a model (auxiliary.<task>.provider + auxiliary.<task>.model).
 
 Per-task overrides are configured in config.yaml under the ``auxiliary:`` section

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1064,6 +1064,55 @@ class TestGetProviderChain:
             chain = _get_provider_chain()
         assert chain[0] == ("openrouter", sentinel)
 
+    def test_module_docstring_matches_provider_chain(self):
+        """Regression for #31326: the module docstring must not advertise a
+        text-task auto-detect chain that ``_get_provider_chain()`` does not
+        return. Specifically, Native Anthropic must NOT appear in the text
+        auto-detect chain documented at the top of ``auxiliary_client.py``
+        because Anthropic is reached only via Step 1 (main provider = anthropic)
+        or via an explicit ``auxiliary.<task>.provider`` override.
+        """
+        import agent.auxiliary_client as _mod
+        doc = _mod.__doc__ or ""
+        # Find the text-task chain section.
+        text_section_marker = "Resolution order for text tasks"
+        vision_section_marker = "Resolution order for vision/multimodal tasks"
+        assert text_section_marker in doc
+        assert vision_section_marker in doc
+        text_section = doc.split(text_section_marker, 1)[1].split(vision_section_marker, 1)[0]
+        # Native Anthropic is documented elsewhere (the "Native Anthropic is
+        # *not* in either auto-detect chain" paragraph) but must not appear
+        # as a numbered step inside the text-task chain block itself.
+        for forbidden in ("Native Anthropic", "native anthropic"):
+            for line in text_section.splitlines():
+                stripped = line.strip()
+                if stripped.startswith(tuple(f"{i}." for i in range(1, 10))):
+                    assert forbidden not in stripped, (
+                        f"Text-task auto-detect chain still advertises {forbidden!r} "
+                        f"in docstring step: {stripped!r}. _get_provider_chain() does "
+                        f"not include Anthropic — keep the docstring in sync. (#31326)"
+                    )
+        # Sanity: the documented chain labels in the docstring match the labels
+        # actually returned by _get_provider_chain() (modulo Step 1 = main
+        # provider, which is described in prose rather than a chain entry).
+        chain_labels = {label for label, _ in _get_provider_chain()}
+        # _get_provider_chain entries map to docstring tokens:
+        #   openrouter → "OpenRouter"
+        #   nous       → "Nous Portal"
+        #   local/custom → "Custom endpoint"
+        #   api-key    → "Direct API-key providers"
+        for label, marker in [
+            ("openrouter", "OpenRouter"),
+            ("nous", "Nous Portal"),
+            ("local/custom", "Custom endpoint"),
+            ("api-key", "Direct API-key providers"),
+        ]:
+            if label in chain_labels:
+                assert marker in text_section, (
+                    f"_get_provider_chain() returns {label!r} but docstring "
+                    f"does not mention {marker!r} in the text-task chain section."
+                )
+
 
 class TestTryPaymentFallback:
     """_try_payment_fallback skips the failed provider and tries alternatives."""


### PR DESCRIPTION
## Summary

- The module docstring in `agent/auxiliary_client.py` advertised a text-task auto-detect chain with 7 steps (including **Native Anthropic** as step 5 and a separate **Custom endpoint** step), but `_get_provider_chain()` actually returns 4 entries: `openrouter`, `nous`, `local/custom`, `api-key`. Native Anthropic is **not** in the chain.
- The vision section similarly listed 6 steps (including Native Anthropic and Custom endpoint), but `_VISION_AUTO_PROVIDER_ORDER` is just `("openrouter", "nous")` with the main provider tried first.
- This rot drove a reporter to expect Anthropic fallback coverage for auxiliary tasks they did not actually have, and made the operator-facing `Auxiliary auto-detect: no provider available` warning misleading.
- This PR updates the docstring to match the actual chains for both text and vision tasks, and adds a regression test that fails if Native Anthropic is reintroduced as a numbered step in the text-task chain block or if `_get_provider_chain()` labels go out of sync with the docstring.

No behavior change — docstring + test only.

## Test Plan

- [x] `python -m pytest tests/agent/test_auxiliary_client.py::TestGetProviderChain -q -o 'addopts='` — 3 passed (including the new `test_module_docstring_matches_provider_chain`).

Related: PR #14433 attempted to fix the same docstring mismatch but was closed without merge — flagged by alt-glitch.

Closes #31326
