### PR TITLE
docs(mcp): add registry metadata

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.NousResearch/hermes-agent",
+  "title": "Hermes Agent",
+  "description": "Bridge Hermes conversations, messaging targets, events, and approvals over MCP.",
+  "version": "0.14.0",
+  "websiteUrl": "https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp",
+  "repository": {
+    "url": "https://github.com/NousResearch/hermes-agent",
+    "source": "github",
+    "id": "1024554267"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "hermes-agent[mcp]",
+      "version": "0.14.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp"
+        },
+        {
+          "type": "positional",
+          "value": "serve"
+        }
+      ]
+    }
+  ]
+}

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -502,6 +502,20 @@ hermes mcp serve
 
 This starts a stdio MCP server. The MCP client (not you) manages the process lifecycle.
 
+If you install from PyPI for MCP clients or registries, include the MCP extra:
+
+```bash
+pip install "hermes-agent[mcp]"
+```
+
+Some MCP clients do not yet understand Python package extras in registry metadata. For those clients, preinstall Hermes with the command above, then configure the explicit `hermes mcp serve` command shown below.
+
+### Registry metadata
+
+Hermes includes a root [`server.json`](https://github.com/NousResearch/hermes-agent/blob/main/server.json) for MCP registries and MCP-aware clients. The metadata points clients at the PyPI package `hermes-agent[mcp]` and encodes the fixed launch arguments `mcp serve`, so clients start the MCP server instead of the normal interactive Hermes CLI.
+
+Open-source usage remains fully supported. For production gateway/MCP deployment help, use the [Nous Research Discord](https://discord.gg/NousResearch) for community support or contact [Nous Research](https://nousresearch.com) about commercial support.
+
 ### MCP client configuration
 
 Add Hermes to your MCP client config. For example, in Claude Code's `~/.claude/claude_desktop_config.json`:


### PR DESCRIPTION
## Summary
- Add root `server.json` metadata for MCP registry/client discovery of Hermes Agent's MCP server mode
- Encode the PyPI package as `hermes-agent[mcp]` and fixed launch arguments `mcp serve`
- Document PyPI extra installation, fallback configuration for clients that cannot parse extras, and support paths

## Validation
- Validated `server.json` against `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`
- Ran `git diff --check`
- Completed second-agent review for schema correctness, install/run metadata, link validity, and support-language tone

## Notes
- The new `server.json` GitHub blob link in docs will resolve after this PR merges to `main`.
