### PR TITLE
fix: split script arguments from path in _run_job_script()

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -14,6 +14,7 @@ import contextvars
 import json
 import logging
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -832,7 +833,13 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
     scripts_dir.mkdir(parents=True, exist_ok=True)
     scripts_dir_resolved = scripts_dir.resolve()
 
-    raw = Path(script_path).expanduser()
+    # Split script path from arguments (e.g. "task_wrapper.py post_afternoon"
+    # → script_file="task_wrapper.py", script_args=["post_afternoon"])
+    _parts = shlex.split(script_path)
+    script_file = _parts[0]
+    script_args = _parts[1:]
+
+    raw = Path(script_file).expanduser()
     if raw.is_absolute():
         path = raw.resolve()
     else:
@@ -875,9 +882,9 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
                 "On Windows, install Git for Windows (which ships Git Bash) "
                 "or rewrite the script as Python (.py)."
             )
-        argv = [_bash, str(path)]
+        argv = [_bash, str(path)] + script_args
     else:
-        argv = [sys.executable, str(path)]
+        argv = [sys.executable, str(path)] + script_args
 
     run_env = os.environ.copy()
     run_env["HERMES_HOME"] = str(_get_hermes_home())

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -202,6 +202,7 @@ def test_script_with_arguments(self, cron_env):
         success, output = _run_job_script("echo_args.py foo bar baz")
         assert success is True
         assert output == "foo,bar,baz"
+
 class TestBuildJobPromptWithScript:
     """Test that script output is injected into the prompt."""
 

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -175,12 +175,12 @@ class TestRunJobScript:
         assert parsed["new_prs"][0]["number"] == 42
 
 
-def test_script_with_arguments(self, cron_env):
+    def test_script_with_arguments(self, cron_env):
         """Script field with arguments: 'script.py arg1 arg2' should split correctly."""
         from cron.scheduler import _run_job_script
 
         script = cron_env / "scripts" / "args_echo.py"
-        script.write_text(textwrap.dedent("""\\
+        script.write_text(textwrap.dedent("""\
             import sys
             print(" ".join(sys.argv[1:]))
         """))
@@ -194,7 +194,7 @@ def test_script_with_arguments(self, cron_env):
         from cron.scheduler import _run_job_script
 
         script = cron_env / "scripts" / "echo_args.py"
-        script.write_text(textwrap.dedent("""\\
+        script.write_text(textwrap.dedent("""\
             import sys
             print(",".join(sys.argv[1:]))
         """))

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -175,6 +175,33 @@ class TestRunJobScript:
         assert parsed["new_prs"][0]["number"] == 42
 
 
+def test_script_with_arguments(self, cron_env):
+        """Script field with arguments: 'script.py arg1 arg2' should split correctly."""
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "args_echo.py"
+        script.write_text(textwrap.dedent("""\\
+            import sys
+            print(" ".join(sys.argv[1:]))
+        """))
+
+        success, output = _run_job_script("args_echo.py hello world")
+        assert success is True
+        assert output == "hello world"
+
+    def test_script_with_arguments_relative_path(self, cron_env):
+        """Relative script path with arguments resolves correctly."""
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "echo_args.py"
+        script.write_text(textwrap.dedent("""\\
+            import sys
+            print(",".join(sys.argv[1:]))
+        """))
+
+        success, output = _run_job_script("echo_args.py foo bar baz")
+        assert success is True
+        assert output == "foo,bar,baz"
 class TestBuildJobPromptWithScript:
     """Test that script output is injected into the prompt."""
 


### PR DESCRIPTION
The cron scheduler's _run_job_script() treats the entire script field as a filename. When the script field contains arguments (e.g. "task_wrapper.py post_afternoon"), Path() looks for a file with that literal name, causing "Script not found" errors.

Fix: use shlex.split() to separate the script path from its arguments, validate only the path portion, and pass arguments to subprocess argv.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

