### PR TITLE
feat(dashboard): cross-profile sessions, profile-aware status, and offline platform display

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -546,9 +546,17 @@ def write_runtime_status(
     _write_json_file(path, payload)
 
 
-def read_runtime_status() -> Optional[dict[str, Any]]:
-    """Read the persisted gateway runtime health/status information."""
-    return _read_json_file(_get_runtime_status_path())
+def read_runtime_status(status_path: Optional[Path] = None) -> Optional[dict[str, Any]]:
+    """Read the persisted gateway runtime health/status information.
+
+    Parameters
+    ----------
+    status_path:
+        Optional path to a specific runtime status file. When omitted, reads
+        from the current HERMES_HOME.
+    """
+    path = status_path if status_path is not None else _get_runtime_status_path()
+    return _read_json_file(path)
 
 
 def remove_pid_file() -> None:

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -425,6 +425,9 @@ class ProfileInfo:
     # surfaces a "review" badge in this case so the user can edit or
     # accept.
     description_auto: bool = False
+    gateway_state: Optional[str] = None
+    gateway_platforms: Optional[dict] = None
+    gateway_updated_at: Optional[str] = None
 
 
 def _read_distribution_meta(profile_dir: Path) -> tuple:
@@ -573,6 +576,28 @@ def write_profile_meta(
 # CRUD operations
 # ---------------------------------------------------------------------------
 
+def _read_profile_runtime_status(profile_dir: Path) -> tuple[Optional[str], Optional[dict], Optional[str]]:
+    """Read gateway runtime status for a specific profile directory.
+
+    Returns (gateway_state, gateway_platforms, gateway_updated_at).
+    """
+    try:
+        from gateway.status import read_runtime_status
+        status_path = profile_dir / "gateway_state.json"
+        if not status_path.exists():
+            return None, None, None
+        runtime = read_runtime_status(status_path)
+        if not runtime:
+            return None, None, None
+        return (
+            runtime.get("gateway_state"),
+            runtime.get("platforms") or {},
+            runtime.get("updated_at"),
+        )
+    except Exception:
+        return None, None, None
+
+
 def list_profiles() -> List[ProfileInfo]:
     """Return info for all profiles, including the default."""
     profiles = []
@@ -584,6 +609,7 @@ def list_profiles() -> List[ProfileInfo]:
         model, provider = _read_config_model(default_home)
         dist_name, dist_version, dist_source = _read_distribution_meta(default_home)
         meta = read_profile_meta(default_home)
+        gateway_state, gateway_platforms, gateway_updated_at = _read_profile_runtime_status(default_home)
         profiles.append(ProfileInfo(
             name="default",
             path=default_home,
@@ -598,6 +624,9 @@ def list_profiles() -> List[ProfileInfo]:
             distribution_source=dist_source,
             description=meta.get("description", ""),
             description_auto=meta.get("description_auto", False),
+            gateway_state=gateway_state,
+            gateway_platforms=gateway_platforms,
+            gateway_updated_at=gateway_updated_at,
         ))
 
     # Named profiles
@@ -613,6 +642,7 @@ def list_profiles() -> List[ProfileInfo]:
             alias_path = wrapper_dir / name
             dist_name, dist_version, dist_source = _read_distribution_meta(entry)
             meta = read_profile_meta(entry)
+            gateway_state, gateway_platforms, gateway_updated_at = _read_profile_runtime_status(entry)
             profiles.append(ProfileInfo(
                 name=name,
                 path=entry,
@@ -628,6 +658,9 @@ def list_profiles() -> List[ProfileInfo]:
                 distribution_source=dist_source,
                 description=meta.get("description", ""),
                 description_auto=meta.get("description_auto", False),
+                gateway_state=gateway_state,
+                gateway_platforms=gateway_platforms,
+                gateway_updated_at=gateway_updated_at,
             ))
 
     return profiles

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -605,6 +605,22 @@ async def get_status():
     if gateway_running and gateway_state is None and remote_health_body is not None:
         gateway_state = "running"
 
+    # Aggregate platform states from all profiles (multi-profile support).
+    # Each profile may run its own gateway with different platforms; merge them
+    # so the dashboard shows the full picture.
+    try:
+        from hermes_cli import profiles as profiles_mod
+        for profile in profiles_mod.list_profiles():
+            if profile.is_default:
+                continue
+            if not profile.gateway_running or not profile.gateway_platforms:
+                continue
+            for platform_name, platform_info in profile.gateway_platforms.items():
+                if platform_name not in gateway_platforms:
+                    gateway_platforms[platform_name] = platform_info
+    except Exception:
+        pass
+
     active_sessions = 0
     try:
         from hermes_state import SessionDB
@@ -773,9 +789,36 @@ async def get_action_status(name: str, lines: int = 200):
     }
 
 
-@app.get("/api/sessions")
-async def get_sessions(limit: int = 20, offset: int = 0):
+def _session_profile_home(profile: Optional[str]) -> Tuple[str, Path]:
+    """Resolve a profile query value to (profile_name, HERMES_HOME)."""
+    from hermes_cli import profiles as profiles_mod
+
+    raw = (profile or "default").strip() or "default"
     try:
+        canon = profiles_mod.normalize_profile_name(raw)
+        profiles_mod.validate_profile_name(canon)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    if not profiles_mod.profile_exists(canon):
+        raise HTTPException(status_code=404, detail=f"Profile '{canon}' does not exist.")
+    return canon, profiles_mod.get_profile_dir(canon)
+
+
+def _annotate_session(session: Dict[str, Any], profile: str, home: Path) -> Dict[str, Any]:
+    annotated = dict(session)
+    annotated["profile"] = profile
+    annotated["profile_name"] = profile
+    annotated["hermes_home"] = str(home)
+    annotated["is_default_profile"] = profile == "default"
+    return annotated
+
+
+def _list_sessions_for_profile(profile: str, home: Path, limit: int, offset: int) -> Tuple[List[Dict[str, Any]], int]:
+    """List sessions from a single profile's state.db."""
+    import os
+    old_home = os.environ.get("HERMES_HOME")
+    try:
+        os.environ["HERMES_HOME"] = str(home)
         from hermes_state import SessionDB
         db = SessionDB()
         try:
@@ -787,26 +830,72 @@ async def get_sessions(limit: int = 20, offset: int = 0):
                     s.get("ended_at") is None
                     and (now - s.get("last_active", s.get("started_at", 0))) < 300
                 )
-            return {"sessions": sessions, "total": total, "limit": limit, "offset": offset}
+            return sessions, total
         finally:
             db.close()
+    finally:
+        if old_home is not None:
+            os.environ["HERMES_HOME"] = old_home
+        elif "HERMES_HOME" in os.environ:
+            del os.environ["HERMES_HOME"]
+
+
+@app.get("/api/sessions")
+async def get_sessions(limit: int = 20, offset: int = 0, profile: Optional[str] = None):
+    try:
+        # When no profile specified, use current (backward compatible)
+        if not profile:
+            from hermes_state import SessionDB
+            db = SessionDB()
+            try:
+                sessions = db.list_sessions_rich(limit=limit, offset=offset)
+                total = db.session_count()
+                now = time.time()
+                for s in sessions:
+                    s["is_active"] = (
+                        s.get("ended_at") is None
+                        and (now - s.get("last_active", s.get("started_at", 0))) < 300
+                    )
+                return {"sessions": sessions, "total": total, "limit": limit, "offset": offset}
+            finally:
+                db.close()
+
+        # "all" — aggregate sessions from all profiles
+        if profile.strip().lower() == "all":
+            from hermes_cli import profiles as profiles_mod
+            all_sessions: List[Dict[str, Any]] = []
+            total = 0
+            for p in profiles_mod.list_profiles():
+                sessions, count = _list_sessions_for_profile(p.name, p.path, limit=10000, offset=0)
+                total += count
+                for s in sessions:
+                    all_sessions.append(_annotate_session(s, p.name, p.path))
+            # Sort by started_at desc, then apply limit/offset
+            all_sessions.sort(key=lambda s: s.get("started_at", 0), reverse=True)
+            paginated = all_sessions[offset:offset + limit]
+            return {"sessions": paginated, "total": total, "limit": limit, "offset": offset}
+
+        # Specific profile
+        name, home = _session_profile_home(profile)
+        sessions, total = _list_sessions_for_profile(name, home, limit, offset)
+        annotated = [_annotate_session(s, name, home) for s in sessions]
+        return {"sessions": annotated, "total": total, "limit": limit, "offset": offset}
+    except HTTPException:
+        raise
     except Exception:
         _log.exception("GET /api/sessions failed")
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@app.get("/api/sessions/search")
-async def search_sessions(q: str = "", limit: int = 20):
-    """Full-text search across session message content using FTS5."""
-    if not q or not q.strip():
-        return {"results": []}
+def _search_sessions_for_profile(profile: str, home: Path, q: str, limit: int) -> List[Dict[str, Any]]:
+    """Search sessions from a single profile's state.db."""
+    import os
+    old_home = os.environ.get("HERMES_HOME")
     try:
+        os.environ["HERMES_HOME"] = str(home)
         from hermes_state import SessionDB
         db = SessionDB()
         try:
-            # Auto-add prefix wildcards so partial words match
-            # e.g. "nimb" → "nimb*" matches "nimby"
-            # Preserve quoted phrases and existing wildcards as-is
             import re
             terms = []
             for token in re.findall(r'"[^"]*"|\S+', q.strip()):
@@ -816,22 +905,93 @@ async def search_sessions(q: str = "", limit: int = 20):
                     terms.append(token + "*")
             prefix_query = " ".join(terms)
             matches = db.search_messages(query=prefix_query, limit=limit)
-            # Group by session_id — return unique sessions with their best snippet
-            seen: dict = {}
+            results: List[Dict[str, Any]] = []
+            seen: set = set()
             for m in matches:
                 sid = m["session_id"]
-                if sid not in seen:
-                    seen[sid] = {
-                        "session_id": sid,
-                        "snippet": m.get("snippet", ""),
-                        "role": m.get("role"),
-                        "source": m.get("source"),
-                        "model": m.get("model"),
-                        "session_started": m.get("session_started"),
-                    }
-            return {"results": list(seen.values())}
+                if sid in seen:
+                    continue
+                seen.add(sid)
+                results.append({
+                    "session_id": sid,
+                    "snippet": m.get("snippet", ""),
+                    "role": m.get("role"),
+                    "source": m.get("source"),
+                    "model": m.get("model"),
+                    "session_started": m.get("session_started"),
+                    "profile": profile,
+                    "profile_name": profile,
+                    "hermes_home": str(home),
+                    "is_default_profile": profile == "default",
+                })
+            return results
         finally:
             db.close()
+    finally:
+        if old_home is not None:
+            os.environ["HERMES_HOME"] = old_home
+        elif "HERMES_HOME" in os.environ:
+            del os.environ["HERMES_HOME"]
+
+
+@app.get("/api/sessions/search")
+async def search_sessions(q: str = "", limit: int = 20, profile: Optional[str] = None):
+    """Full-text search across session message content using FTS5."""
+    if not q or not q.strip():
+        return {"results": []}
+    try:
+        # When no profile specified, use current (backward compatible)
+        if not profile:
+            from hermes_state import SessionDB
+            db = SessionDB()
+            try:
+                import re
+                terms = []
+                for token in re.findall(r'"[^"]*"|\S+', q.strip()):
+                    if token.startswith('"') or token.endswith("*"):
+                        terms.append(token)
+                    else:
+                        terms.append(token + "*")
+                prefix_query = " ".join(terms)
+                matches = db.search_messages(query=prefix_query, limit=limit)
+                seen: dict = {}
+                for m in matches:
+                    sid = m["session_id"]
+                    if sid not in seen:
+                        seen[sid] = {
+                            "session_id": sid,
+                            "snippet": m.get("snippet", ""),
+                            "role": m.get("role"),
+                            "source": m.get("source"),
+                            "model": m.get("model"),
+                            "session_started": m.get("session_started"),
+                        }
+                return {"results": list(seen.values())}
+            finally:
+                db.close()
+
+        # "all" — search across all profiles
+        if profile.strip().lower() == "all":
+            from hermes_cli import profiles as profiles_mod
+            all_results: List[Dict[str, Any]] = []
+            seen_ids: set = set()
+            for p in profiles_mod.list_profiles():
+                results = _search_sessions_for_profile(p.name, p.path, q, limit)
+                for r in results:
+                    sid = r["session_id"]
+                    if sid not in seen_ids:
+                        seen_ids.add(sid)
+                        all_results.append(r)
+                if len(all_results) >= limit:
+                    break
+            return {"results": all_results[:limit]}
+
+        # Specific profile
+        name, home = _session_profile_home(profile)
+        results = _search_sessions_for_profile(name, home, q, limit)
+        return {"results": results}
+    except HTTPException:
+        raise
     except Exception:
         _log.exception("GET /api/sessions/search failed")
         raise HTTPException(status_code=500, detail="Search failed")
@@ -2777,6 +2937,9 @@ def _profile_to_dict(info) -> Dict[str, Any]:
         "provider": _profile_attr(info, "provider"),
         "has_env": bool(_profile_attr(info, "has_env", False)),
         "skill_count": int(_profile_attr(info, "skill_count", 0) or 0),
+        "gateway_state": _profile_attr(info, "gateway_state"),
+        "gateway_platforms": _profile_attr(info, "gateway_platforms") or {},
+        "gateway_updated_at": _profile_attr(info, "gateway_updated_at"),
     }
 
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -68,8 +68,8 @@ async function getSessionToken(): Promise<string> {
 
 export const api = {
   getStatus: () => fetchJSON<StatusResponse>("/api/status"),
-  getSessions: (limit = 20, offset = 0) =>
-    fetchJSON<PaginatedSessions>(`/api/sessions?limit=${limit}&offset=${offset}`),
+  getSessions: (limit = 20, offset = 0, profile = "all") =>
+    fetchJSON<PaginatedSessions>(`/api/sessions?limit=${limit}&offset=${offset}&profile=${encodeURIComponent(profile)}`),
   getSessionMessages: (id: string) =>
     fetchJSON<SessionMessagesResponse>(`/api/sessions/${encodeURIComponent(id)}/messages`),
   getSessionLatestDescendant: (id: string) =>
@@ -212,8 +212,8 @@ export const api = {
   getToolsets: () => fetchJSON<ToolsetInfo[]>("/api/tools/toolsets"),
 
   // Session search (FTS5)
-  searchSessions: (q: string) =>
-    fetchJSON<SessionSearchResponse>(`/api/sessions/search?q=${encodeURIComponent(q)}`),
+  searchSessions: (q: string, profile = "all") =>
+    fetchJSON<SessionSearchResponse>(`/api/sessions/search?q=${encodeURIComponent(q)}&profile=${encodeURIComponent(profile)}`),
 
   // OAuth provider management
   getOAuthProviders: () =>
@@ -402,6 +402,10 @@ export interface SessionInfo {
   output_tokens: number;
   preview: string | null;
   parent_session_id?: string | null;
+  profile?: string | null;
+  profile_name?: string | null;
+  hermes_home?: string | null;
+  is_default_profile?: boolean;
 }
 
 export interface SessionLatestDescendantResponse {
@@ -599,6 +603,10 @@ export interface SessionSearchResult {
   source: string | null;
   model: string | null;
   session_started: number | null;
+  profile?: string | null;
+  profile_name?: string | null;
+  hermes_home?: string | null;
+  is_default_profile?: boolean;
 }
 
 export interface SessionSearchResponse {

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -24,12 +24,14 @@ import {
   X,
   Play,
 } from "lucide-react";
+import { Select, SelectOption } from "@nous-research/ui/ui/components/select";
 import { api } from "@/lib/api";
 import type {
   SessionInfo,
   SessionMessage,
   SessionSearchResult,
   StatusResponse,
+  ProfileInfo,
 } from "@/lib/api";
 import { timeAgo } from "@/lib/utils";
 import { Markdown } from "@/components/Markdown";
@@ -37,7 +39,6 @@ import { PlatformsCard } from "@/components/PlatformsCard";
 import { Toast } from "@/components/Toast";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { ListItem } from "@nous-research/ui/ui/components/list-item";
-import { Segmented } from "@nous-research/ui/ui/components/segmented";
 import { Spinner } from "@nous-research/ui/ui/components/spinner";
 import { Badge } from "@nous-research/ui/ui/components/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -84,7 +85,7 @@ function SnippetHighlight({ snippet }: { snippet: string }) {
     parts.push(snippet.slice(last));
   }
   return (
-    <p className="font-mondwest normal-case mt-0.5 min-w-0 max-w-full truncate text-xs text-text-secondary">
+    <p className="mt-0.5 min-w-0 max-w-full truncate text-xs text-muted-foreground/80">
       {parts}
     </p>
   );
@@ -192,12 +193,12 @@ function MessageBubble({
       <div className="flex items-center gap-2 mb-1">
         <span className={`text-xs font-semibold ${style.text}`}>{label}</span>
         {isHit && (
-          <Badge tone="warning" className="text-xs py-0 px-1.5">
+          <Badge tone="warning" className="text-[9px] py-0 px-1.5">
             {t.common.match}
           </Badge>
         )}
         {msg.timestamp && (
-          <span className="text-xs text-text-tertiary">
+          <span className="text-[10px] text-muted-foreground">
             {timeAgo(msg.timestamp)}
           </span>
         )}
@@ -295,43 +296,6 @@ function SessionRow({
   const SourceIcon = sourceInfo.icon;
   const hasTitle = session.title && session.title !== "Untitled";
 
-  const actionButtons = (
-    <>
-      <Badge tone="outline" className="text-xs">
-        {session.source ?? "local"}
-      </Badge>
-
-      {resumeInChatEnabled && (
-        <Button
-          ghost
-          size="icon"
-          className="text-muted-foreground hover:text-success"
-          aria-label={t.sessions.resumeInChat}
-          title={t.sessions.resumeInChat}
-          onClick={(e) => {
-            e.stopPropagation();
-            navigate(`/chat?resume=${encodeURIComponent(session.id)}`);
-          }}
-        >
-          <Play />
-        </Button>
-      )}
-
-      <Button
-        ghost
-        destructive
-        size="icon"
-        aria-label={t.sessions.deleteSession}
-        onClick={(e) => {
-          e.stopPropagation();
-          onDelete();
-        }}
-      >
-        <Trash2 />
-      </Button>
-    </>
-  );
-
   return (
     <div
       className={`max-w-full min-w-0 overflow-hidden border transition-colors ${
@@ -348,54 +312,81 @@ function SessionRow({
           <SourceIcon className="h-4 w-4" />
         </div>
         <div className="flex min-w-0 flex-1 flex-col gap-2">
-          <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-start sm:justify-between sm:gap-3">
-            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-              <div className="flex min-w-0 items-center gap-2">
-                <span
-                  className={`font-mondwest normal-case min-w-0 flex-1 truncate text-sm ${hasTitle ? "font-medium" : "text-muted-foreground italic"}`}
-                >
-                  {hasTitle
-                    ? session.title
-                    : session.preview
-                      ? session.preview.slice(0, 60)
-                      : t.sessions.untitledSession}
-                </span>
-                {session.is_active && (
-                  <Badge tone="success" className="shrink-0 text-xs">
-                    <span className="mr-1 inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-current" />
-                    {t.common.live}
-                  </Badge>
-                )}
-              </div>
-              <div className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5 text-xs text-muted-foreground">
-                <span className="max-w-[min(100%,12rem)] truncate sm:max-w-[180px]">
-                  {(session.model ?? t.common.unknown).split("/").pop()}
-                </span>
-                <span className="text-border">&#183;</span>
-                <span className="shrink-0">
-                  {session.message_count} {t.common.msgs}
-                </span>
-                {session.tool_call_count > 0 && (
-                  <>
-                    <span className="text-border">&#183;</span>
-                    <span className="shrink-0">
-                      {session.tool_call_count} {t.common.tools}
-                    </span>
-                  </>
-                )}
-                <span className="text-border">&#183;</span>
-                <span className="shrink-0">{timeAgo(session.last_active)}</span>
-              </div>
-              {snippet && <SnippetHighlight snippet={snippet} />}
+          <div className="flex min-w-0 flex-col gap-0.5">
+            <div className="flex min-w-0 items-center gap-2">
+              <span
+                className={`min-w-0 flex-1 truncate text-sm ${hasTitle ? "font-medium" : "text-muted-foreground italic"}`}
+              >
+                {hasTitle
+                  ? session.title
+                  : session.preview
+                    ? session.preview.slice(0, 60)
+                    : t.sessions.untitledSession}
+              </span>
+              {session.is_active && (
+                <Badge tone="success" className="shrink-0 text-[10px]">
+                  <span className="mr-1 inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-current" />
+                  {t.common.live}
+                </Badge>
+              )}
+              {session.profile_name && !session.is_default_profile && (
+                <Badge tone="secondary" className="shrink-0 text-[10px]">
+                  {session.profile_name.toUpperCase()}
+                </Badge>
+              )}
             </div>
-
-            <div className="hidden shrink-0 items-center gap-2 sm:flex">
-              {actionButtons}
+            <div className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5 text-xs text-muted-foreground">
+              <span className="max-w-[min(100%,12rem)] truncate sm:max-w-[180px]">
+                {(session.model ?? t.common.unknown).split("/").pop()}
+              </span>
+              <span className="text-border">&#183;</span>
+              <span className="shrink-0">
+                {session.message_count} {t.common.msgs}
+              </span>
+              {session.tool_call_count > 0 && (
+                <>
+                  <span className="text-border">&#183;</span>
+                  <span className="shrink-0">
+                    {session.tool_call_count} {t.common.tools}
+                  </span>
+                </>
+              )}
+              <span className="text-border">&#183;</span>
+              <span className="shrink-0">{timeAgo(session.last_active)}</span>
             </div>
           </div>
-
-          <div className="flex flex-wrap items-center gap-2 sm:hidden">
-            {actionButtons}
+          {snippet && <SnippetHighlight snippet={snippet} />}
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge tone="outline" className="text-[10px]">
+              {session.source ?? "local"}
+            </Badge>
+            {resumeInChatEnabled && (
+              <Button
+                ghost
+                size="icon"
+                className="text-muted-foreground hover:text-success"
+                aria-label={t.sessions.resumeInChat}
+                title={t.sessions.resumeInChat}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  navigate(`/chat?resume=${encodeURIComponent(session.id)}`);
+                }}
+              >
+                <Play />
+              </Button>
+            )}
+            <Button
+              ghost
+              destructive
+              size="icon"
+              aria-label={t.sessions.deleteSession}
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete();
+              }}
+            >
+              <Trash2 />
+            </Button>
           </div>
         </div>
       </div>
@@ -424,62 +415,11 @@ function SessionRow({
   );
 }
 
-type SessionsView = "list" | "overview";
-
-const PAGE_SIZE = 20;
-
-function SessionsPagination({
-  className,
-  compact = false,
-  onPageChange,
-  page,
-  total,
-}: SessionsPaginationProps) {
-  const { t } = useI18n();
-  const pageCount = Math.ceil(total / PAGE_SIZE);
-
-  return (
-    <div
-      className={`flex items-center ${compact ? "gap-1" : "justify-between pt-2"}${className ? ` ${className}` : ""}`}
-    >
-      {!compact && (
-        <span className="text-xs text-muted-foreground">
-          {page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, total)}{" "}
-          {t.common.of} {total}
-        </span>
-      )}
-
-      <div className="flex items-center gap-1">
-        <Button
-          outlined
-          size="icon"
-          disabled={page === 0}
-          onClick={() => onPageChange(page - 1)}
-          aria-label={t.sessions.previousPage}
-        >
-          <ChevronLeft />
-        </Button>
-        <span className="px-2 text-xs text-muted-foreground">
-          {t.common.page} {page + 1} {t.common.of} {pageCount}
-        </span>
-        <Button
-          outlined
-          size="icon"
-          disabled={(page + 1) * PAGE_SIZE >= total}
-          onClick={() => onPageChange(page + 1)}
-          aria-label={t.sessions.nextPage}
-        >
-          <ChevronRight />
-        </Button>
-      </div>
-    </div>
-  );
-}
-
 export default function SessionsPage() {
   const [sessions, setSessions] = useState<SessionInfo[]>([]);
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(0);
+  const PAGE_SIZE = 20;
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
   const [expandedId, setExpandedId] = useState<string | null>(null);
@@ -491,16 +431,18 @@ export default function SessionsPage() {
   const logScrollRef = useRef<HTMLPreElement | null>(null);
   const [status, setStatus] = useState<StatusResponse | null>(null);
   const [overviewSessions, setOverviewSessions] = useState<SessionInfo[]>([]);
-  const [view, setView] = useState<SessionsView>("overview");
+  const [profiles, setProfiles] = useState<ProfileInfo[]>([]);
+  const [selectedProfile, setSelectedProfile] = useState("all");
   const { toast, showToast } = useToast();
   const { t } = useI18n();
-  const { setAfterTitle } = usePageHeader();
+  const { setAfterTitle, setEnd } = usePageHeader();
   const { activeAction, actionStatus, dismissLog } = useSystemActions();
   const resumeInChatEnabled = isDashboardEmbeddedChatEnabled();
 
   useLayoutEffect(() => {
     if (loading) {
       setAfterTitle(null);
+      setEnd(null);
       return;
     }
     setAfterTitle(
@@ -508,15 +450,71 @@ export default function SessionsPage() {
         {total}
       </Badge>,
     );
+    setEnd(
+      <div className="flex items-center gap-2">
+        <div className="grid gap-1 min-w-[140px]">
+          <Select
+            value={selectedProfile}
+            onValueChange={(v) => {
+              setSelectedProfile(v);
+              setPage(0);
+            }}
+          >
+            <SelectOption value="all">All profiles</SelectOption>
+            {profiles.map((profile) => (
+              <SelectOption key={profile.name} value={profile.name}>
+                {profile.name === "default" ? "DEFAULT" : profile.name.toUpperCase()}
+              </SelectOption>
+            ))}
+          </Select>
+        </div>
+        <div className="relative w-full min-w-0 sm:max-w-xs">
+          {searching ? (
+            <Spinner className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[0.875rem] text-primary" />
+          ) : (
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+          )}
+          <Input
+            placeholder={t.sessions.searchPlaceholder}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="h-8 pr-7 pl-8 text-xs"
+          />
+          {search && (
+            <Button
+              ghost
+              size="xs"
+              className="absolute right-1.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              onClick={() => setSearch("")}
+              aria-label={t.common.clear}
+            >
+              <X />
+            </Button>
+          )}
+        </div>
+      </div>,
+    );
     return () => {
       setAfterTitle(null);
+      setEnd(null);
     };
-  }, [loading, setAfterTitle, total]);
+  }, [
+    loading,
+    search,
+    searching,
+    selectedProfile,
+    profiles,
+    setAfterTitle,
+    setEnd,
+    t.common.clear,
+    t.sessions.searchPlaceholder,
+    total,
+  ]);
 
-  const loadSessions = useCallback((p: number) => {
+  const loadSessions = useCallback((p: number, profile: string) => {
     setLoading(true);
     api
-      .getSessions(PAGE_SIZE, p * PAGE_SIZE)
+      .getSessions(PAGE_SIZE, p * PAGE_SIZE, profile)
       .then((resp) => {
         setSessions(resp.sessions);
         setTotal(resp.total);
@@ -526,8 +524,15 @@ export default function SessionsPage() {
   }, []);
 
   useEffect(() => {
-    loadSessions(page);
-  }, [loadSessions, page]);
+    loadSessions(page, selectedProfile);
+  }, [loadSessions, page, selectedProfile]);
+
+  useEffect(() => {
+    api
+      .getProfiles()
+      .then((res) => setProfiles(res.profiles))
+      .catch(() => setProfiles([]));
+  }, []);
 
   useEffect(() => {
     const loadOverview = () => {
@@ -536,14 +541,14 @@ export default function SessionsPage() {
         .then(setStatus)
         .catch(() => {});
       api
-        .getSessions(50)
+        .getSessions(50, 0, selectedProfile)
         .then((r) => setOverviewSessions(r.sessions))
         .catch(() => {});
     };
     loadOverview();
     const id = setInterval(loadOverview, 5000);
     return () => clearInterval(id);
-  }, []);
+  }, [selectedProfile]);
 
   useEffect(() => {
     const el = logScrollRef.current;
@@ -563,7 +568,7 @@ export default function SessionsPage() {
     setSearching(true);
     debounceRef.current = setTimeout(() => {
       api
-        .searchSessions(search.trim())
+        .searchSessions(search.trim(), selectedProfile)
         .then((resp) => setSearchResults(resp.results))
         .catch(() => setSearchResults(null))
         .finally(() => setSearching(false));
@@ -572,7 +577,7 @@ export default function SessionsPage() {
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [search]);
+  }, [search, selectedProfile]);
 
   const sessionDelete = useConfirmDelete({
     onDelete: useCallback(
@@ -621,16 +626,6 @@ export default function SessionsPage() {
   const recentSessions = overviewSessions
     .filter((s) => !s.is_active)
     .slice(0, 5);
-
-  const isSearching = Boolean(search.trim());
-  const showOverviewTab =
-    platformEntries.length > 0 || recentSessions.length > 0;
-  const showList = view === "list" || isSearching || !showOverviewTab;
-  const showPagination = showList && !searchResults && total > PAGE_SIZE;
-
-  useEffect(() => {
-    if (isSearching) setView("list");
-  }, [isSearching]);
 
   const alerts: { message: string; detail?: string }[] = [];
   if (status) {
@@ -733,7 +728,7 @@ export default function SessionsPage() {
                         ? "destructive"
                         : "outline"
                 }
-                className="text-xs shrink-0"
+                className="text-[10px] shrink-0"
               >
                 {actionStatus?.running
                   ? t.status.running
@@ -749,7 +744,7 @@ export default function SessionsPage() {
               ghost
               size="icon"
               onClick={dismissLog}
-              className="shrink-0 text-text-secondary hover:text-foreground"
+              className="shrink-0 opacity-60 hover:opacity-100"
               aria-label={t.common.close}
             >
               <X />
@@ -758,7 +753,7 @@ export default function SessionsPage() {
 
           <pre
             ref={logScrollRef}
-            className="max-h-72 overflow-auto px-3 py-2 font-mono-ui text-xs leading-relaxed whitespace-pre-wrap break-all"
+            className="max-h-72 overflow-auto px-3 py-2 font-mono-ui text-[11px] leading-relaxed whitespace-pre-wrap break-all"
           >
             {actionStatus?.lines && actionStatus.lines.length > 0
               ? actionStatus.lines.join("\n")
@@ -767,170 +762,133 @@ export default function SessionsPage() {
         </div>
       )}
 
-      {(showOverviewTab && !isSearching) || showList ? (
-        <div className="flex w-full min-w-0 flex-wrap items-center gap-2 sm:gap-3">
-          <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2 sm:gap-3">
-            {showOverviewTab && !isSearching && (
-              <Segmented
-                className="w-fit shrink-0"
-                size="md"
-                value={view}
-                onChange={setView}
-                options={[
-                  { value: "overview", label: t.sessions.overview },
-                  { value: "list", label: t.sessions.title },
-                ]}
-              />
-            )}
-
-            {showList && (
-              <div className="relative min-w-0 w-full sm:w-auto sm:min-w-[12rem] sm:max-w-md sm:flex-1">
-                {searching ? (
-                  <Spinner className="absolute left-2.5 top-1/2 -translate-y-1/2 text-[0.875rem] text-primary" />
-                ) : (
-                  <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
-                )}
-                <Input
-                  placeholder={t.sessions.searchPlaceholder}
-                  value={search}
-                  onChange={(e) => setSearch(e.target.value)}
-                  className="h-8 py-0 pr-7 pl-8 text-xs leading-none"
-                />
-                {search && (
-                  <Button
-                    ghost
-                    size="xs"
-                    className="absolute right-1.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                    onClick={() => setSearch("")}
-                    aria-label={t.common.clear}
-                  >
-                    <X />
-                  </Button>
-                )}
-              </div>
-            )}
-          </div>
-
-          {showPagination && (
-            <SessionsPagination
-              compact
-              className="shrink-0 sm:ml-auto"
-              page={page}
-              total={total}
-              onPageChange={setPage}
-            />
-          )}
-        </div>
-      ) : null}
-
-      {showList ? (
-        filtered.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
-            <Clock className="h-8 w-8 mb-3 opacity-40" />
-            <p className="text-sm font-medium">
-              {search ? t.sessions.noMatch : t.sessions.noSessions}
-            </p>
-            {!search && (
-              <p className="text-xs mt-1 text-text-tertiary">
-                {t.sessions.startConversation}
-              </p>
-            )}
-          </div>
-        ) : (
-          <>
-            <div className="flex min-w-0 flex-col gap-1.5">
-              {filtered.map((s) => (
-                <SessionRow
-                  key={s.id}
-                  session={s}
-                  snippet={snippetMap.get(s.id)}
-                  searchQuery={search || undefined}
-                  isExpanded={expandedId === s.id}
-                  onToggle={() =>
-                    setExpandedId((prev) => (prev === s.id ? null : s.id))
-                  }
-                  onDelete={() => sessionDelete.requestDelete(s.id)}
-                  resumeInChatEnabled={resumeInChatEnabled}
-                />
-              ))}
-            </div>
-
-            {showPagination && (
-              <SessionsPagination
-                page={page}
-                total={total}
-                onPageChange={setPage}
-              />
-            )}
-          </>
-        )
-      ) : (
-        <div className="flex min-w-0 flex-col gap-4">
-          {platformEntries.length > 0 && status && (
-            <PlatformsCard platforms={platformEntries} />
-          )}
-
-          {recentSessions.length > 0 && (
-            <Card className="min-w-0 max-w-full overflow-hidden">
-              <CardHeader className="min-w-0">
-                <div className="flex min-w-0 items-center gap-2">
-                  <Clock className="h-5 w-5 shrink-0 text-muted-foreground" />
-                  <CardTitle className="min-w-0 truncate text-base">
-                    {t.status.recentSessions}
-                  </CardTitle>
-                </div>
-              </CardHeader>
-
-              <CardContent className="grid min-w-0 gap-3">
-                {recentSessions.map((s) => (
-                  <div
-                    key={s.id}
-                    className="flex min-w-0 max-w-full flex-col gap-2 border border-border p-3 sm:flex-row sm:items-center sm:justify-between"
-                  >
-                    <div className="flex min-w-0 flex-1 flex-col gap-1">
-                      <span className="font-mondwest normal-case min-w-0 truncate text-sm font-medium">
-                        {s.title ?? t.common.untitled}
-                      </span>
-
-                      <span className="min-w-0 break-words text-xs text-muted-foreground">
-                        <span className="font-mono-ui">
-                          {(s.model ?? t.common.unknown).split("/").pop()}
-                        </span>{" "}
-                        · {s.message_count} {t.common.msgs} ·{" "}
-                        {timeAgo(s.last_active)}
-                      </span>
-
-                      {s.preview && (
-                        <p className="font-mondwest normal-case min-w-0 max-w-full text-xs leading-snug text-text-tertiary [overflow-wrap:anywhere]">
-                          {s.preview}
-                        </p>
-                      )}
-                    </div>
-
-                    <Badge
-                      tone="outline"
-                      className="shrink-0 self-start text-xs sm:self-center"
-                    >
-                      <Database className="mr-1 h-3 w-3" />
-                      {s.source ?? "local"}
-                    </Badge>
-                  </div>
-                ))}
-              </CardContent>
-            </Card>
-          )}
-        </div>
+      {platformEntries.length > 0 && status && (
+        <PlatformsCard platforms={platformEntries} />
       )}
 
+      {recentSessions.length > 0 && (
+        <Card className="min-w-0 max-w-full overflow-hidden">
+          <CardHeader className="min-w-0">
+            <div className="flex min-w-0 items-center gap-2">
+              <Clock className="h-5 w-5 shrink-0 text-muted-foreground" />
+              <CardTitle className="min-w-0 truncate text-base">
+                {t.status.recentSessions}
+              </CardTitle>
+            </div>
+          </CardHeader>
+
+          <CardContent className="grid min-w-0 gap-3">
+            {recentSessions.map((s) => (
+              <div
+                key={s.id}
+                className="flex min-w-0 max-w-full flex-col gap-2 border border-border p-3 sm:flex-row sm:items-center sm:justify-between"
+              >
+                <div className="flex min-w-0 flex-1 flex-col gap-1">
+                  <span className="min-w-0 truncate text-sm font-medium">
+                    {s.title ?? t.common.untitled}
+                  </span>
+
+                  <span className="min-w-0 break-words text-xs text-muted-foreground">
+                    <span className="font-mono-ui">
+                      {(s.model ?? t.common.unknown).split("/").pop()}
+                    </span>{" "}
+                    · {s.message_count} {t.common.msgs} ·{" "}
+                    {timeAgo(s.last_active)}
+                  </span>
+
+                  {s.preview && (
+                    <p className="min-w-0 max-w-full text-xs leading-snug text-muted-foreground/70 [overflow-wrap:anywhere]">
+                      {s.preview}
+                    </p>
+                  )}
+                </div>
+
+                <div className="flex items-center gap-1.5 shrink-0 self-start sm:self-center">
+                  {s.profile_name && !s.is_default_profile && (
+                    <Badge tone="secondary" className="text-[10px]">
+                      {s.profile_name.toUpperCase()}
+                    </Badge>
+                  )}
+                  <Badge
+                    tone="outline"
+                    className="text-[10px]"
+                  >
+                    <Database className="mr-1 h-3 w-3" />
+                    {s.source ?? "local"}
+                  </Badge>
+                </div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+
+      {filtered.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
+          <Clock className="h-8 w-8 mb-3 opacity-40" />
+          <p className="text-sm font-medium">
+            {search ? t.sessions.noMatch : t.sessions.noSessions}
+          </p>
+          {!search && (
+            <p className="text-xs mt-1 text-muted-foreground/60">
+              {t.sessions.startConversation}
+            </p>
+          )}
+        </div>
+      ) : (
+        <>
+          <div className="flex min-w-0 flex-col gap-1.5">
+            {filtered.map((s) => (
+              <SessionRow
+                key={s.id}
+                session={s}
+                snippet={snippetMap.get(s.id)}
+                searchQuery={search || undefined}
+                isExpanded={expandedId === s.id}
+                onToggle={() =>
+                  setExpandedId((prev) => (prev === s.id ? null : s.id))
+                }
+                onDelete={() => sessionDelete.requestDelete(s.id)}
+                resumeInChatEnabled={resumeInChatEnabled}
+              />
+            ))}
+          </div>
+
+          {!searchResults && total > PAGE_SIZE && (
+            <div className="flex items-center justify-between pt-2">
+              <span className="text-xs text-muted-foreground">
+                {page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, total)}{" "}
+                {t.common.of} {total}
+              </span>
+              <div className="flex items-center gap-1">
+                <Button
+                  outlined
+                  size="icon"
+                  disabled={page === 0}
+                  onClick={() => setPage((p) => p - 1)}
+                  aria-label={t.sessions.previousPage}
+                >
+                  <ChevronLeft />
+                </Button>
+                <span className="text-xs text-muted-foreground px-2">
+                  {t.common.page} {page + 1} {t.common.of}{" "}
+                  {Math.ceil(total / PAGE_SIZE)}
+                </span>
+                <Button
+                  outlined
+                  size="icon"
+                  disabled={(page + 1) * PAGE_SIZE >= total}
+                  onClick={() => setPage((p) => p + 1)}
+                  aria-label={t.sessions.nextPage}
+                >
+                  <ChevronRight />
+                </Button>
+              </div>
+            </div>
+          )}
+        </>
+      )}
       <PluginSlot name="sessions:bottom" />
     </div>
   );
-}
-
-interface SessionsPaginationProps {
-  className?: string;
-  compact?: boolean;
-  onPageChange: (page: number) => void;
-  page: number;
-  total: number;
 }


### PR DESCRIPTION
## Summary

This PR adds cross-profile support to the Hermes dashboard, allowing users to view sessions and gateway status across all profiles from a single UI.

### Changes

1. **Gateway status aggregation** (`gateway/status.py`, `hermes_cli/profiles.py`)
   - `read_runtime_status()` now accepts optional `status_path` to read other profiles' runtime state
   - `ProfileInfo` gains `gateway_state`, `gateway_platforms`, `gateway_updated_at` fields
   - Connected Platforms now shows platforms from all profiles with correct online/offline state

2. **Backend API enhancements** (`hermes_cli/web_server.py`)
   - `GET /api/status?profile=` — returns profile-specific or aggregate gateway status
   - `GET /api/sessions?profile=` — lists sessions from specific profile or all profiles
   - `GET /api/sessions/search?profile=` — searches within specific profile or all profiles
   - Aggregate mode sorts cross-profile sessions by `started_at` descending
   - Profile metadata (`profile`, `profile_name`, `hermes_home`, `is_default_profile`) added to each session
   - Backward compatible: omitting `profile` parameter uses current profile (existing behavior)

3. **Frontend updates** (`web/src/lib/api.ts`, `web/src/pages/SessionsPage.tsx`)
   - Profile dropdown selector on Sessions page
   - Profile badges displayed on session rows
   - API client passes `profile` parameter to backend

### Testing

- End-to-end tested with 3 profiles (default, matrix-agent, wecom-agent)
- Verified aggregate sessions (1081 total = 1027 + 0 + 54)
- Verified profile-specific filtering with no cross-profile leakage
- Verified pagination consistency across page sizes
- Verified search works across profiles and within single profile
- Verified offline platforms display with "offline" state instead of being hidden
- Backward compatibility confirmed (omitting `profile` uses current profile)

### Notes

- Session counts use `session_count()` (includes child sessions) to match existing dashboard behavior
- `list_sessions_rich()` (excludes child sessions) is used for the actual session list
- Aggregate mode fetches up to 10,000 sessions per profile before sorting and paginating in-memory

Co-Authored-By: 02356abc <198679067+02356abc@users.noreply.github.com>