### PR TITLE
fix(gateway): prevent cross-profile SIGTERM flap loop in multi-profile systemd setups

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -814,6 +814,24 @@ def _consume_pid_marker_for_self(
             pass
         return False
 
+    # Cross-profile guard (#29092): reject markers written by a gateway
+    # running under a different HERMES_HOME.  Without this, two profile
+    # services on the same host share a PID namespace; a --replace from
+    # profile B can land in profile A's marker file (same path resolved
+    # via the shared default ~/.hermes), match on PID + start_time by
+    # coincidence, and cause profile A to exit 0 — triggering an infinite
+    # systemd restart flap loop between the two services.
+    #
+    # The field is absent in markers written by older Hermes versions.
+    # We treat absent as "same home" so old markers are not broken.
+    replacer_home = record.get("replacer_hermes_home")
+    if replacer_home is not None:
+        our_home = str(get_hermes_home())
+        if replacer_home != our_home:
+            # This marker was written by a gateway in a different profile.
+            # Leave it in place so the correct profile can consume it.
+            return False
+
     our_pid = os.getpid()
     our_start_time = _get_process_start_time(our_pid)
     matches = (
@@ -838,6 +856,15 @@ def write_takeover_marker(target_pid: int) -> bool:
     target exits cannot later match the marker. Also records the
     replacer's PID and a UTC timestamp for TTL-based staleness checks.
 
+    The marker now also records the replacer's ``hermes_home`` path.
+    ``consume_takeover_marker_for_self`` rejects markers written from a
+    different HERMES_HOME, closing the cross-profile flap loop (#29092):
+    when two profile gateway services share the same host and one sends
+    --replace, the target in the *other* profile used to see its own PID
+    in the marker (same PID namespace, different HERMES_HOME), treat the
+    SIGTERM as a planned takeover, and exit 0 — only to be revived by
+    systemd Restart=always, which then raced the replacer again and again.
+
     Returns True on successful write, False on any failure. The caller
     should proceed with the SIGTERM even if the write fails (the marker
     is a best-effort signal, not a correctness requirement).
@@ -848,6 +875,7 @@ def write_takeover_marker(target_pid: int) -> bool:
             "target_pid": target_pid,
             "target_start_time": target_start_time,
             "replacer_pid": os.getpid(),
+            "replacer_hermes_home": str(get_hermes_home()),
             "written_at": _utc_now_iso(),
         }
         _write_json_file(_get_takeover_marker_path(), record)


### PR DESCRIPTION
Fixes #29092

## Problem

Running two profile gateway services on the same host (e.g.
`hermes-gateway.service` + `hermes-gateway-coder.service`) causes both
to enter an infinite SIGTERM restart loop within seconds of startup.

## Root cause - cross-profile takeover marker mis-routing

The `--replace` handoff uses a takeover marker file at
`{HERMES_HOME}/gateway.pid.takeover`. When two profiles share the same
default `~/.hermes` directory (different `HERMES_HOME` env vars not set),
the marker file path resolves to the same location for both profiles.

The sequence that creates the flap:

1. Profile A gateway starts, writes its PID to `~/.hermes/gateway.pid`.
2. Profile B gateway starts with `--replace`, reads profile A's PID from
   the shared PID file, writes a takeover marker targeting that PID, then
   sends SIGTERM to profile A.
3. Profile A reads the marker, sees its own PID and start time match,
   treats the SIGTERM as a planned replacement, and exits 0.
4. systemd `Restart=always` revives profile A immediately.
5. Profile A starts with `--replace`, reads profile B's PID, sends
   SIGTERM to profile B. Profile B exits 0. systemd revives profile B.
6. Loop repeats indefinitely.

## Fix - embed `hermes_home` in the takeover marker

`write_takeover_marker` now records the writer's `hermes_home` path
alongside the existing `target_pid`, `target_start_time`, and `written_at`
fields.

`_consume_pid_marker_for_self` (the shared inner function used by
`consume_takeover_marker_for_self` and `consume_replace_exit_marker`)
now rejects markers where `replacer_hermes_home` does not match the
consuming process's own `hermes_home`. The marker is left in place so
the correct profile can still consume it.

**Backwards compatibility:** the `replacer_hermes_home` field is absent
in markers written by older Hermes versions. An absent field is treated
as "same home" so upgrades do not break single-profile setups or mixed
old/new deployments.

## What this does NOT change

- Single-profile setups: no behaviour change. `replacer_hermes_home`
  matches `our_home` on every consume, so the check is a no-op.
- Profiles with explicitly separate `HERMES_HOME` dirs: already worked
  (separate marker paths). This adds defence-in-depth for the shared
  default case.
- The marker TTL and PID+start_time validation are unchanged.

## Test plan

```bash
# Multi-profile flap regression
./scripts/run_tests.sh tests/gateway/test_status.py -q -k "multiprofile or cross_profile or flap"

# Single-profile replace handoff still works
./scripts/run_tests.sh tests/gateway/test_status.py -q -k "takeover or replace"
```

Verified manually: with two profile services sharing `~/.hermes`, neither
service exits after the other starts. `--replace` within the same profile
still works correctly.