### PR TITLE
fix(bedrock): route Bedrock API key setup to native bedrock provider

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5337,32 +5337,27 @@ def _model_flow_bedrock_api_key(config, region, current_model=""):
     if selected:
         _save_model_choice(selected)
 
-        # Save as custom provider pointing to bedrock-mantle
+        # Use native bedrock provider (bearer token auth handles credentials)
         cfg = load_config()
         model = cfg.get("model")
         if not isinstance(model, dict):
             model = {"default": model} if model else {}
             cfg["model"] = model
-        model["provider"] = "custom"
-        model["base_url"] = mantle_base_url
-        model.pop("api_mode", None)  # chat_completions is the default
+        model["provider"] = "bedrock"
+        model.pop("base_url", None)
+        model.pop("api_mode", None)
 
-        # Also save region in bedrock config for reference
+        # Save region in bedrock config
         bedrock_cfg = cfg.get("bedrock", {})
         if not isinstance(bedrock_cfg, dict):
             bedrock_cfg = {}
         bedrock_cfg["region"] = region
         cfg["bedrock"] = bedrock_cfg
 
-        # Save the API key env var name so hermes knows where to find it
-        save_env_value("OPENAI_API_KEY", existing_key)
-        save_env_value("OPENAI_BASE_URL", mantle_base_url)
-
         save_config(cfg)
         deactivate_provider()
 
         print(f"  Default model set to: {selected} (via Bedrock API Key, {region})")
-        print(f"  Endpoint: {mantle_base_url}")
     else:
         print("  No change.")
 


### PR DESCRIPTION
## Summary

`_model_flow_bedrock_api_key()` in `hermes_cli/main.py` was saving the model config with `provider: custom` and `base_url: <bedrock-mantle endpoint>`, expecting all calls to flow through `/v1/chat/completions`. That endpoint does not serve `anthropic.claude-*` models, so users who picked a Claude model in this setup flow ended up with a config that could not actually run inference.

This PR switches the saved provider to `bedrock` (so Claude models are reached via the native Bedrock API) and drops the now-unused `OPENAI_API_KEY` / `OPENAI_BASE_URL` writes and the mantle endpoint print.

## Scope

Originally this branch also touched `agent/bedrock_adapter.py` to wire `AWS_BEARER_TOKEN_BEDROCK` into the boto3 client. That part overlaps with the already-open #24507 (and #26531 on the `api_mode` side), so I dropped it here per @alt-glitch's feedback. This PR is now limited to the `main.py` setup-flow fix, which is independent of those two PRs.

Related: #24507, #26531, #29309.

## Test plan

- [ ] Run `hermes` setup, pick the Bedrock API key flow with a Claude model
- [ ] Verify the saved config has `model.provider == "bedrock"` (not `custom`) and no `base_url`
- [ ] Verify `OPENAI_API_KEY` / `OPENAI_BASE_URL` are not written by this flow
- [ ] Verify non-Claude Bedrock flows still work