### PR TITLE
fix(kanban): preserve review lane across block and unblock

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2126,6 +2126,85 @@ def _end_run(
     return run_id
 
 
+def _event_payload_dict(raw: Any) -> dict[str, Any]:
+    """Best-effort JSON payload decoding for task_events rows."""
+    if isinstance(raw, dict):
+        return raw
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except Exception:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _current_run_source_status(
+    conn: sqlite3.Connection, task_id: str,
+) -> Optional[str]:
+    """Return the source lane for the task's active run, if known.
+
+    Review claims stamp ``source_status='review'`` onto their ``claimed``
+    event so downstream recovery paths can restore the review lane instead of
+    dropping back into the generic ready queue.
+    """
+    row = conn.execute(
+        "SELECT current_run_id FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if not row or not row["current_run_id"]:
+        return None
+    claimed = conn.execute(
+        "SELECT payload FROM task_events "
+        "WHERE task_id = ? AND kind = 'claimed' AND run_id = ? "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id, int(row["current_run_id"])),
+    ).fetchone()
+    if not claimed:
+        return None
+    source = _event_payload_dict(claimed["payload"]).get("source_status")
+    return str(source) if source else None
+
+
+def _latest_wait_resume_status(
+    conn: sqlite3.Connection, task_id: str,
+) -> Optional[str]:
+    """Return the most recent paused-lane resume target, if any.
+
+    ``blocked`` / ``scheduled`` events can carry ``resume_status`` when the
+    task should resume somewhere other than the generic ready/todo lanes.
+    Today this is used for review tasks so human pauses don't strip the
+    review-specific dispatcher path.
+    """
+    row = conn.execute(
+        "SELECT payload FROM task_events "
+        "WHERE task_id = ? AND kind IN ('blocked', 'scheduled') "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    if not row:
+        return None
+    resume_status = _event_payload_dict(row["payload"]).get("resume_status")
+    return str(resume_status) if resume_status else None
+
+
+def _pause_resume_status(
+    conn: sqlite3.Connection, task_id: str,
+) -> Optional[str]:
+    """Resolve which lane a paused task should return to when resumed."""
+    row = conn.execute(
+        "SELECT status FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if not row:
+        return None
+    if row["status"] in {"blocked", "scheduled"}:
+        return _latest_wait_resume_status(conn, task_id)
+    if row["status"] == "running":
+        return _current_run_source_status(conn, task_id)
+    return None
+
+
 def _current_run_id(conn: sqlite3.Connection, task_id: str) -> Optional[int]:
     row = conn.execute(
         "SELECT current_run_id FROM tasks WHERE id = ?", (task_id,),
@@ -3257,6 +3336,7 @@ def block_task(
 ) -> bool:
     """Transition ``running -> blocked``."""
     with write_txn(conn):
+        resume_status = _pause_resume_status(conn, task_id)
         if expected_run_id is None:
             cur = conn.execute(
                 """
@@ -3299,7 +3379,10 @@ def block_task(
                 outcome="blocked",
                 summary=reason,
             )
-        _append_event(conn, task_id, "blocked", {"reason": reason}, run_id=run_id)
+        payload = {"reason": reason}
+        if resume_status:
+            payload["resume_status"] = resume_status
+        _append_event(conn, task_id, "blocked", payload, run_id=run_id)
         return True
 
 
@@ -3386,6 +3469,7 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
     """
     now = int(time.time())
     with write_txn(conn):
+        resume_status = _latest_wait_resume_status(conn, task_id)
         stale = conn.execute(
             "SELECT current_run_id FROM tasks WHERE id = ? AND status IN ('blocked', 'scheduled')",
             (task_id,),
@@ -3414,7 +3498,10 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
             "WHERE l.child_id = ? AND p.status != 'done' LIMIT 1",
             (task_id,),
         ).fetchone()
-        new_status = "todo" if undone_parents else "ready"
+        if resume_status == "review":
+            new_status = "review"
+        else:
+            new_status = "todo" if undone_parents else "ready"
         cur = conn.execute(
             "UPDATE tasks SET status = ?, current_run_id = NULL, "
             "consecutive_failures = 0, last_failure_error = NULL "
@@ -3890,6 +3977,7 @@ def schedule_task(
     to ``ready`` (or ``todo`` if parents are still incomplete).
     """
     with write_txn(conn):
+        resume_status = _pause_resume_status(conn, task_id)
         params: list[Any] = [task_id]
         sql = """
             UPDATE tasks
@@ -3917,7 +4005,10 @@ def schedule_task(
                 outcome="scheduled",
                 summary=reason,
             )
-        _append_event(conn, task_id, "scheduled", {"reason": reason}, run_id=run_id)
+        payload = {"reason": reason}
+        if resume_status:
+            payload["resume_status"] = resume_status
+        _append_event(conn, task_id, "scheduled", payload, run_id=run_id)
         return True
 
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2600,6 +2600,51 @@ def test_claim_review_task_fails_when_already_claimed(kanban_home):
     assert second is None
 
 
+def test_unblock_review_task_restores_review_lane(kanban_home):
+    """Review tasks blocked mid-review must resume in the review lane."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="review me", assignee="alice")
+        _set_task_status(conn, t, "review")
+        claimed = kb.claim_review_task(conn, t)
+        assert claimed is not None
+
+        assert kb.block_task(conn, t, reason="need human")
+        blocked = kb.get_task(conn, t)
+        assert blocked.status == "blocked"
+
+        assert kb.unblock_task(conn, t) is True
+        resumed = kb.get_task(conn, t)
+        assert resumed.status == "review"
+
+        events = kb.list_events(conn, t)
+        blocked_event = next(e for e in events if e.kind == "blocked")
+        assert blocked_event.payload["resume_status"] == "review"
+        unblocked_event = next(e for e in reversed(events) if e.kind == "unblocked")
+        assert unblocked_event.payload == {"status": "review"}
+
+
+def test_unblock_scheduled_review_task_restores_review_lane(kanban_home):
+    """A scheduled follow-up from a blocked review task must still resume to review."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="review me later", assignee="alice")
+        _set_task_status(conn, t, "review")
+        claimed = kb.claim_review_task(conn, t)
+        assert claimed is not None
+
+        assert kb.block_task(conn, t, reason="need human")
+        assert kb.schedule_task(conn, t, reason="tomorrow") is True
+        assert kb.get_task(conn, t).status == "scheduled"
+
+        assert kb.unblock_task(conn, t) is True
+        resumed = kb.get_task(conn, t)
+        assert resumed.status == "review"
+
+        scheduled_event = next(
+            e for e in reversed(kb.list_events(conn, t)) if e.kind == "scheduled"
+        )
+        assert scheduled_event.payload["resume_status"] == "review"
+
+
 def test_dispatch_review_dry_run(kanban_home, all_assignees_spawnable):
     """dispatch_once dry-run sees review tasks and reports them as spawned."""
     with kb.connect() as conn:
@@ -2627,6 +2672,31 @@ def test_dispatch_review_spawns_with_correct_skills(
         t = kb.create_task(conn, title="review me", assignee="alice")
         _set_task_status(conn, t, "review")
         res = kb.dispatch_once(conn, spawn_fn=capture_spawn)
+    assert len(res.spawned) == 1
+    assert len(spawned_tasks) == 1
+    assert spawned_tasks[0].skills == ["sdlc-review"]
+
+
+def test_unblocked_review_task_dispatches_via_review_queue(
+    kanban_home, all_assignees_spawnable,
+):
+    """A human-unblocked review task must re-enter the review dispatcher path."""
+    spawned_tasks = []
+
+    def capture_spawn(task, workspace, board=None):
+        spawned_tasks.append(task)
+        return 42
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="review me", assignee="alice")
+        _set_task_status(conn, t, "review")
+        assert kb.claim_review_task(conn, t) is not None
+        assert kb.block_task(conn, t, reason="need human")
+        assert kb.unblock_task(conn, t) is True
+        assert kb.get_task(conn, t).status == "review"
+
+        res = kb.dispatch_once(conn, spawn_fn=capture_spawn)
+
     assert len(res.spawned) == 1
     assert len(spawned_tasks) == 1
     assert spawned_tasks[0].skills == ["sdlc-review"]


### PR DESCRIPTION

## Summary

This change fixes a real Kanban state-machine bug where tasks claimed from the `review` lane could lose their lane after `block -> unblock` or `block -> schedule -> unblock`, re-enter the generic `ready` queue, and get spawned without the `sdlc-review` skill.

The fix persists the intended resume lane as `resume_status` on `blocked` / `scheduled` events and restores `review` explicitly during `unblock_task()`. This keeps review tasks on the review dispatcher path and preserves reviewer-specific skill loading.

## Files Changed

- `hermes_cli/kanban_db.py`
- `tests/hermes_cli/test_kanban_db.py`

## Validation

### Targeted new regression tests

Command:
`.\.venv\Scripts\python.exe -m pytest -p no:timeout -o addopts='' tests\hermes_cli\test_kanban_db.py::test_unblock_review_task_restores_review_lane tests\hermes_cli\test_kanban_db.py::test_unblock_scheduled_review_task_restores_review_lane tests\hermes_cli\test_kanban_db.py::test_unblocked_review_task_dispatches_via_review_queue -q`

Result:
- `3 passed in 0.33s`

### Broader affected-surface regression sweep

Command:
`.\.venv\Scripts\python.exe -m pytest tests\hermes_cli\test_kanban_db.py -p no:timeout -o addopts='' -k "review or unblock" -q`

Result:
- `22 passed, 146 deselected in 0.88s`

### Diff hygiene

Command:
`git diff --check -- hermes_cli\kanban_db.py tests\hermes_cli\test_kanban_db.py`

Result:
- Passed
- Only line-ending warnings (`LF will be replaced by CRLF`) from the local Windows worktree

## Notes

- I also ran the full `tests/hermes_cli/test_kanban_db.py` file as a sanity check.
- That run still has 4 pre-existing, unrelated Windows failures in `_resolve_hermes_argv` tests.
- Those failures are outside this change surface; the review/unblock path introduced by this PR is green.

