### PR TITLE
fix(gateway,acp): deliver plugin-transformed final_response through streaming gate

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1534,7 +1534,9 @@ class HermesACPAgent(acp.Agent):
                 )
             except Exception:
                 logger.debug("Failed to auto-title ACP session %s", session_id, exc_info=True)
-        if final_response and conn and not streamed_message:
+        if final_response and conn:
+            # Always deliver the final response — plugins may have transformed
+            # it after streaming finished (e.g. transform_llm_output hook).
             update = acp.update_agent_message_text(final_response)
             await conn.session_update(session_id, update)
 

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1534,9 +1534,11 @@ class HermesACPAgent(acp.Agent):
                 )
             except Exception:
                 logger.debug("Failed to auto-title ACP session %s", session_id, exc_info=True)
-        if final_response and conn:
-            # Always deliver the final response — plugins may have transformed
-            # it after streaming finished (e.g. transform_llm_output hook).
+        if final_response and conn and (not streamed_message or result.get("response_transformed")):
+            # Deliver the final response when streaming did not already send it,
+            # or when a plugin hook transformed the response after streaming
+            # finished (e.g. transform_llm_output) — otherwise the appended /
+            # rewritten text never reaches the client.
             update = acp.update_agent_message_text(final_response)
             await conn.session_update(session_id, update)
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4047,7 +4047,6 @@ def run_conversation(
                 model=agent.model,
                 platform=getattr(agent, "platform", None) or "",
             )
-            _response_transformed = False
             for _hook_result in _transform_results:
                 if isinstance(_hook_result, str) and _hook_result:
                     final_response = _hook_result

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4031,6 +4031,8 @@ def run_conversation(
         except Exception as _ver_err:
             logger.debug("file-mutation verifier footer failed: %s", _ver_err)
 
+    _response_transformed = False
+
     # Plugin hook: transform_llm_output
     # Fired once per turn after the tool-calling loop completes.
     # Plugins can transform the LLM's output text before it's returned.
@@ -4045,9 +4047,11 @@ def run_conversation(
                 model=agent.model,
                 platform=getattr(agent, "platform", None) or "",
             )
+            _response_transformed = False
             for _hook_result in _transform_results:
                 if isinstance(_hook_result, str) and _hook_result:
                     final_response = _hook_result
+                    _response_transformed = True
                     break  # First non-empty string wins
         except Exception as exc:
             logger.warning("transform_llm_output hook failed: %s", exc)
@@ -4099,6 +4103,7 @@ def run_conversation(
         "failed": failed,
         "partial": False,  # True only when stopped due to invalid tool calls
         "interrupted": interrupted,
+        "response_transformed": _response_transformed,
         "response_previewed": getattr(agent, "_response_was_previewed", False),
         "model": agent.model,
         "provider": agent.provider,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17053,6 +17053,7 @@ class GatewayRunner:
                 "context_length": _context_length,
                 "session_id": effective_session_id,
                 "response_previewed": result.get("response_previewed", False),
+                "response_transformed": result.get("response_transformed", False),
             }
         
         # Start progress message sender if enabled

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17704,6 +17704,28 @@ class GatewayRunner:
                     _content_delivered,
                 )
                 response["already_sent"] = True
+            elif not _is_empty_sentinel and _transformed and _sc is not None:
+                # Plugin hooks transformed the response after streaming — edit the
+                # existing streamed message instead of sending a duplicate.
+                _sc_msg_id = _sc.message_id
+                if _sc_msg_id:
+                    try:
+                        await _sc.adapter.edit_message(
+                            chat_id=source.chat_id,
+                            message_id=_sc_msg_id,
+                            content=response["final_response"],
+                            finalize=True,
+                        )
+                        response["already_sent"] = True
+                        logger.info(
+                            "Edited streamed message %s for session %s to include plugin-transformed content.",
+                            _sc_msg_id, session_key or "?",
+                        )
+                    except Exception as _edit_err:
+                        logger.warning(
+                            "Failed to edit streamed message for session %s: %s",
+                            session_key or "?", _edit_err,
+                        )
 
         # Schedule deletion of tracked temporary progress bubbles after the
         # final response lands. Failed runs skip this so bubbles remain as

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17690,7 +17690,11 @@ class GatewayRunner:
             _content_delivered = bool(
                 _sc and getattr(_sc, "final_content_delivered", False)
             )
-            if not _is_empty_sentinel and (_streamed or _previewed or _content_delivered):
+            # Plugin hooks (e.g. transform_llm_output) may have appended content
+            # after streaming finished — when the response was transformed, always
+            # send the final version so the appended content reaches the client.
+            _transformed = bool(response.get("response_transformed"))
+            if not _is_empty_sentinel and not _transformed and (_streamed or _previewed or _content_delivered):
                 logger.info(
                     "Suppressing normal final send for session %s: final delivery already confirmed (streamed=%s previewed=%s content_delivered=%s).",
                     session_key or "?",

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -198,11 +198,6 @@ class GatewayStreamConsumer:
         return self._message_id
 
     @property
-    def accumulated_text(self) -> str:
-        """The accumulated streamed text (without think-block content)."""
-        return self._accumulated
-
-    @property
     def final_content_delivered(self) -> bool:
         """True when the final response content reached the user, even if
         the subsequent cosmetic edit (cursor removal) failed."""

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -193,6 +193,16 @@ class GatewayStreamConsumer:
         return self._final_response_sent
 
     @property
+    def message_id(self) -> str | None:
+        """The Discord/chat message ID of the last-sent or edited message."""
+        return self._message_id
+
+    @property
+    def accumulated_text(self) -> str:
+        """The accumulated streamed text (without think-block content)."""
+        return self._accumulated
+
+    @property
     def final_content_delivered(self) -> bool:
         """True when the final response content reached the user, even if
         the subsequent cosmetic edit (cursor removal) failed."""

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -47,6 +47,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 AUTHOR_MAP = {
     # teknium (multiple emails)
     "teknium1@gmail.com": "teknium1",
+    "kenyon1977@gmail.com": "kenyonxu",
     "cipherframe@users.noreply.github.com": "CipherFrame",
     "me@promplate.dev": "CNSeniorious000",
     "yichengqiao21@gmail.com": "YarrowQiao",

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1204,6 +1204,48 @@ class TestPrompt:
         assert agent_chunks[0].content.text == "streamed answer"
 
     @pytest.mark.asyncio
+    async def test_prompt_delivers_transformed_response_after_streaming(self, agent):
+        """If a transform_llm_output plugin hook modifies the response after
+        streaming, ACP must deliver the transformed final_response so the
+        appended/rewritten text reaches the client.
+        """
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+
+        def mock_run(*args, **kwargs):
+            state.agent.stream_delta_callback("original answer")
+            return {
+                "final_response": "original answer\n\n[plugin appended this]",
+                "response_transformed": True,
+                "messages": [],
+            }
+
+        state.agent.run_conversation = mock_run
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        prompt = [TextContentBlock(type="text", text="hello")]
+        await agent.prompt(prompt=prompt, session_id=new_resp.session_id)
+
+        updates = [
+            call.kwargs.get("update") or call.args[1]
+            for call in mock_conn.session_update.call_args_list
+        ]
+        # The streamed chunk and the post-stream transformed message should
+        # both be present (final delivery is a separate update_agent_message_text
+        # call carrying the full transformed text).
+        all_texts = [
+            getattr(getattr(u, "content", None), "text", None)
+            for u in updates
+        ]
+        assert any(
+            text and "[plugin appended this]" in text for text in all_texts
+        ), f"expected transformed final to be delivered, got: {all_texts!r}"
+
+
+    @pytest.mark.asyncio
     async def test_prompt_auto_titles_session(self, agent):
         new_resp = await agent.new_session(cwd=".")
         state = agent.session_manager.get_session(new_resp.session_id)

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -942,6 +942,62 @@ async def test_run_agent_matrix_streaming_omits_cursor(monkeypatch, tmp_path):
     assert any("Continuing to refine:" in text for text in all_text)
 
 
+class TransformedStreamAgent:
+    """Streams a response, then signals the gateway that a plugin hook
+    (``transform_llm_output``) modified the final text after streaming
+    finished. ``run_conversation`` returns ``response_transformed=True``
+    plus a ``final_response`` that diverges from what was streamed.
+    """
+
+    def __init__(self, **kwargs):
+        self.stream_delta_callback = kwargs.get("stream_delta_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        if self.stream_delta_callback:
+            self.stream_delta_callback("original answer")
+        return {
+            "final_response": "original answer\n\n[plugin appended this]",
+            "response_previewed": True,
+            "response_transformed": True,
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+@pytest.mark.asyncio
+async def test_transformed_response_edits_streamed_message_in_place(monkeypatch, tmp_path):
+    """When a transform_llm_output hook modifies the response after streaming,
+    the gateway must edit the existing streamed message in place with the full
+    transformed content (so plugins like content filters / appenders reach the
+    user) and still mark already_sent=True (no duplicate send).
+    """
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        TransformedStreamAgent,
+        session_id="sess-transformed-stream",
+        config_data={
+            "display": {"tool_progress": "off", "interim_assistant_messages": False},
+            "streaming": {"enabled": True, "edit_interval": 0.01, "buffer_threshold": 1},
+        },
+        platform=Platform.MATRIX,
+        chat_id="!room:matrix.example.org",
+        chat_type="group",
+        thread_id="$thread",
+        adapter_cls=MetadataEditProgressCaptureAdapter,
+    )
+
+    # Final delivery happened (no duplicate send fallback).
+    assert result.get("already_sent") is True
+    # The transformed final text reached the user — appended portion is present
+    # in an edit_message call (not just in the streamed sends).
+    edited_texts = [e["content"] for e in adapter.edits]
+    assert any("[plugin appended this]" in text for text in edited_texts), (
+        f"expected transformed text in adapter.edits, got: {edited_texts!r}"
+    )
+
+
 @pytest.mark.asyncio
 async def test_run_agent_queued_message_does_not_treat_commentary_as_final(monkeypatch, tmp_path):
     QueuedCommentaryAgent.calls = 0


### PR DESCRIPTION
Plugin hooks on `transform_llm_output` now reach end users on streaming platforms (Discord, Telegram, ACP, etc.). Before this, the hook's output was silently discarded after the stream completed.

## Changes
- `agent/conversation_loop.py`: set `response_transformed=True` in the run dict when a hook returns a non-empty string.
- `gateway/run.py`: propagate the flag through `run_sync()`; when set, edit the existing streamed message in place with the transformed text instead of suppressing the final send (no duplicate message).
- `gateway/stream_consumer.py`: expose `message_id` so the gateway can target the streamed bubble.
- `acp_adapter/server.py`: deliver the final response after streaming when `response_transformed=True` (otherwise keep the existing `not streamed_message` guard so non-transformed streams don't double-send).
- Regression tests in `tests/gateway/test_run_progress_topics.py` and `tests/acp/test_server.py`.

## Validation
| | Before | After |
|---|---|---|
| transform_llm_output hook output on streaming Discord/Telegram/Matrix | silently dropped | edited into the streamed message |
| transform_llm_output hook output via ACP | dropped when streamed | delivered as the final `update_agent_message_text` |
| Non-transformed streamed response on ACP | single `agent_message_chunk` | unchanged (no duplicate) |
| Normal streaming (no transform) | already_sent=True, no duplicate | unchanged |

Targeted suite: 112 passed in tests/acp/test_server.py + tests/gateway/test_run_progress_topics.py + tests/test_transform_llm_output_hook.py.

## Credit
Salvages PR #29119 by @kenyonxu — original commits cherry-picked, contributor authorship preserved.


## Infographic

![PR #31433 — plugin-transformed responses survive the streaming gate](https://v3b.fal.media/files/b/0a9b7cf8/kfeU0iqkgTlsUvxGRuwFj_Zam9YkHb.png)
