### PR TITLE
fix(subprocess): apply PYTHONUTF8 to env builders + direct spawns (#31420)

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -106,6 +106,11 @@ def _resolve_home_dir() -> str:
 def _build_subprocess_env() -> dict[str, str]:
     env = os.environ.copy()
     env["HOME"] = _resolve_home_dir()
+    # Force UTF-8 stdio for the Copilot ACP child on Windows so its JSON-RPC
+    # frames and stderr don't blow up on non-ASCII content in CP936/CP1252
+    # locales (#31420).  No-op on POSIX.
+    from hermes_cli._subprocess_compat import apply_windows_utf8_env as _utf8
+    _utf8(env)
     return env
 
 

--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -79,6 +79,12 @@ class CodexAppServerClient:
             spawn_env.update(env)
         if codex_home:
             spawn_env["CODEX_HOME"] = codex_home
+        # Force UTF-8 stdio for the codex subprocess on Windows so non-ASCII
+        # output in user-visible logs / app-server frames doesn't trip the
+        # legacy code page encoder (#31420).  No-op on POSIX; honors an
+        # explicit user ``PYTHONUTF8=0`` via ``setdefault``.
+        from hermes_cli._subprocess_compat import apply_windows_utf8_env as _utf8
+        _utf8(spawn_env)
 
         app_server_args = list(extra_args or [])
         # Kanban workers must be able to write their handoff/status back to

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -35,6 +35,7 @@ from typing import Optional, Sequence
 
 __all__ = [
     "IS_WINDOWS",
+    "apply_windows_utf8_env",
     "resolve_node_command",
     "windows_detach_flags",
     "windows_hide_flags",
@@ -86,6 +87,56 @@ def resolve_node_command(name: str, argv: Sequence[str]) -> list[str]:
     if resolved:
         return [resolved, *argv]
     return [name, *argv]
+
+
+# -----------------------------------------------------------------------------
+# UTF-8 stdio for Python subprocesses
+# -----------------------------------------------------------------------------
+
+
+def apply_windows_utf8_env(env: dict) -> dict:
+    """Ensure a subprocess env dict carries UTF-8 stdio knobs on Windows.
+
+    Mutates and returns *env* (in place; the return value is for fluent
+    chaining).  No-op on POSIX — Linux/macOS already inherit UTF-8 from
+    the locale.
+
+    What it sets (only when the keys are not already present, so explicit
+    user overrides win):
+
+      * ``PYTHONUTF8=1`` — PEP 540 UTF-8 Mode.  Forces ``sys.stdin/out/err``
+        and ``open()``'s default encoding to UTF-8 in any Python child,
+        regardless of the active Windows code page (CP936 on zh-CN,
+        CP1252 on en-US, CP932 on ja-JP, …).  Without this knob, a
+        child Python process emitting non-ASCII output crashes with::
+
+            UnicodeEncodeError: 'gbk' codec can't encode character '\\u4e2d'
+
+        in non-en-US Windows locales.  See #31420.
+      * ``PYTHONIOENCODING=utf-8`` — belt-and-suspenders for older Python
+        builds that don't pick up ``PYTHONUTF8`` (or for code that
+        explicitly inspects ``PYTHONIOENCODING``).  Also harmless on
+        POSIX, but we still gate to Windows so we don't pollute env
+        snapshots in tests / dotfiles audits unnecessarily.
+
+    Why ``setdefault``: a user that has *already* set ``PYTHONUTF8=0``
+    in their env (rare but legitimate — e.g. debugging Windows codepage
+    behavior) must keep their opt-out.  ``setdefault`` honors that
+    intent.
+
+    Use from any code path that builds an explicit ``env=`` dict for
+    ``subprocess.Popen`` / ``asyncio.create_subprocess_exec`` etc.
+    Helpers that already start from ``os.environ`` *do* inherit
+    Hermes's bootstrap-time ``PYTHONUTF8=1`` (set by
+    :func:`hermes_cli._ensure_utf8`), but applying this is still safe
+    and protects callers reached without going through the Hermes CLI
+    entry point (library imports, scripts, vendored tools, tests).
+    """
+    if not IS_WINDOWS:
+        return env
+    env.setdefault("PYTHONUTF8", "1")
+    env.setdefault("PYTHONIOENCODING", "utf-8")
+    return env
 
 
 # -----------------------------------------------------------------------------

--- a/tests/test_windows_utf8_subprocess_env_31420.py
+++ b/tests/test_windows_utf8_subprocess_env_31420.py
@@ -1,0 +1,247 @@
+"""Regression for #31420: Windows subprocess env must carry PYTHONUTF8=1.
+
+On Windows, when Hermes spawns a Python subprocess WITHOUT explicitly
+setting ``PYTHONUTF8=1`` in the child's env, the child uses the system
+**legacy code page** for stdio — ``CP936`` on zh-CN, ``CP1252`` on en-US,
+``CP932`` on ja-JP, etc. — and any non-ASCII output (Chinese / Japanese /
+Korean / emoji / math symbols / …) raises ``UnicodeEncodeError`` or
+becomes mojibake.
+
+The fix adds a centralized helper
+``hermes_cli._subprocess_compat.apply_windows_utf8_env`` and applies it
+to the env-builder chokepoints used by the terminal tool, process
+registry, code-execution sandbox, and a couple of direct subprocess
+sites (Copilot ACP client, Codex app-server transport).  These tests
+cover both the helper's contract and the call-site wiring.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli._subprocess_compat import apply_windows_utf8_env
+
+
+# ---------------------------------------------------------------------------
+# Helper unit tests — contract guarantees
+# ---------------------------------------------------------------------------
+
+
+class TestApplyWindowsUtf8Env:
+    """``apply_windows_utf8_env`` is the single source of truth for the
+    Windows-only ``PYTHONUTF8`` / ``PYTHONIOENCODING`` injection.
+    """
+
+    def test_sets_both_keys_on_windows(self):
+        with patch("hermes_cli._subprocess_compat.IS_WINDOWS", True):
+            env: dict[str, str] = {}
+            result = apply_windows_utf8_env(env)
+            assert result is env, "must mutate-and-return for fluent chaining"
+            assert env["PYTHONUTF8"] == "1"
+            assert env["PYTHONIOENCODING"] == "utf-8"
+
+    def test_no_op_on_posix(self):
+        """On Linux/macOS the helper must not add Windows-specific knobs.
+
+        UTF-8 is the locale default on POSIX so the env vars are
+        unnecessary, and adding them would pollute env snapshots in
+        tests / dotfiles audits / docker layer caches.
+        """
+        with patch("hermes_cli._subprocess_compat.IS_WINDOWS", False):
+            env: dict[str, str] = {}
+            result = apply_windows_utf8_env(env)
+            assert result is env
+            assert "PYTHONUTF8" not in env
+            assert "PYTHONIOENCODING" not in env
+
+    def test_setdefault_honors_explicit_pythonutf8_zero(self):
+        """A user that explicitly opted out via ``PYTHONUTF8=0`` (rare but
+        legitimate — debugging Windows codepage behavior) must keep that
+        intent.  ``setdefault`` is what guarantees this.
+        """
+        with patch("hermes_cli._subprocess_compat.IS_WINDOWS", True):
+            env = {"PYTHONUTF8": "0"}
+            apply_windows_utf8_env(env)
+            assert env["PYTHONUTF8"] == "0", (
+                "must not clobber an explicit user opt-out"
+            )
+            assert env["PYTHONIOENCODING"] == "utf-8"
+
+    def test_setdefault_honors_explicit_pythonioencoding(self):
+        with patch("hermes_cli._subprocess_compat.IS_WINDOWS", True):
+            env = {"PYTHONIOENCODING": "latin-1"}
+            apply_windows_utf8_env(env)
+            assert env["PYTHONIOENCODING"] == "latin-1"
+            # PYTHONUTF8 was not set explicitly, so it gets the default.
+            assert env["PYTHONUTF8"] == "1"
+
+    def test_idempotent(self):
+        """Calling twice must yield the same result as calling once."""
+        with patch("hermes_cli._subprocess_compat.IS_WINDOWS", True):
+            env: dict[str, str] = {}
+            apply_windows_utf8_env(env)
+            snapshot = dict(env)
+            apply_windows_utf8_env(env)
+            assert env == snapshot
+
+    def test_preserves_other_keys(self):
+        with patch("hermes_cli._subprocess_compat.IS_WINDOWS", True):
+            env = {"PATH": "C:\\Windows", "FOO": "bar"}
+            apply_windows_utf8_env(env)
+            assert env["PATH"] == "C:\\Windows"
+            assert env["FOO"] == "bar"
+            assert env["PYTHONUTF8"] == "1"
+
+
+# ---------------------------------------------------------------------------
+# Call-site wiring — the helper has to actually be invoked from the
+# env-builders, otherwise the centralization is decorative.
+# ---------------------------------------------------------------------------
+
+
+class TestEnvBuilderWiring:
+    """Pin the call-sites so a future refactor can't silently drop the
+    UTF-8 injection at any of the chokepoints.
+    """
+
+    def test_sanitize_subprocess_env_injects_utf8_on_windows(self):
+        """``_sanitize_subprocess_env`` is the env helper used by both the
+        process registry (``hermes process``) and the code-execution
+        sandbox.  Must inject ``PYTHONUTF8=1`` on Windows.
+        """
+        from tools.environments import local as local_env_mod
+
+        # Simulate a Windows host with a clean inherited env (the bug
+        # repro: nothing has set PYTHONUTF8 yet).
+        with patch.object(local_env_mod, "_IS_WINDOWS", True), patch(
+            "hermes_cli._subprocess_compat.IS_WINDOWS", True
+        ), patch.object(
+            local_env_mod, "get_subprocess_home", return_value=None, create=True
+        ):
+            sanitized = local_env_mod._sanitize_subprocess_env(
+                {"PATH": "C:\\Windows"}, None
+            )
+        assert sanitized.get("PYTHONUTF8") == "1", (
+            "_sanitize_subprocess_env must call apply_windows_utf8_env so "
+            "the terminal tool / process registry don't crash with "
+            "UnicodeEncodeError on CP936/CP1252 locales (#31420)."
+        )
+        assert sanitized.get("PYTHONIOENCODING") == "utf-8"
+
+    def test_sanitize_subprocess_env_no_op_on_posix(self):
+        """The injection must be Windows-only; POSIX shouldn't get the
+        env vars planted speculatively (would change subprocess-env
+        snapshots that some tests assert on).
+        """
+        from tools.environments import local as local_env_mod
+
+        with patch.object(local_env_mod, "_IS_WINDOWS", False), patch(
+            "hermes_cli._subprocess_compat.IS_WINDOWS", False
+        ), patch.object(
+            local_env_mod, "get_subprocess_home", return_value=None, create=True
+        ):
+            sanitized = local_env_mod._sanitize_subprocess_env(
+                {"PATH": "/usr/bin"}, None
+            )
+        assert "PYTHONUTF8" not in sanitized
+        assert "PYTHONIOENCODING" not in sanitized
+
+    def test_make_run_env_injects_utf8_on_windows(self):
+        """``_make_run_env`` is the env helper used by the synchronous
+        terminal tool (the foreground ``terminal`` action).  Same fix
+        required.
+        """
+        from tools.environments import local as local_env_mod
+
+        with patch.object(local_env_mod, "_IS_WINDOWS", True), patch(
+            "hermes_cli._subprocess_compat.IS_WINDOWS", True
+        ), patch.object(
+            local_env_mod, "get_subprocess_home", return_value=None, create=True
+        ), patch.dict(os.environ, {"PATH": "C:\\Windows"}, clear=True):
+            run_env = local_env_mod._make_run_env({})
+        assert run_env.get("PYTHONUTF8") == "1"
+        assert run_env.get("PYTHONIOENCODING") == "utf-8"
+
+    def test_make_run_env_no_op_on_posix(self):
+        from tools.environments import local as local_env_mod
+
+        with patch.object(local_env_mod, "_IS_WINDOWS", False), patch(
+            "hermes_cli._subprocess_compat.IS_WINDOWS", False
+        ), patch.object(
+            local_env_mod, "get_subprocess_home", return_value=None, create=True
+        ), patch.dict(os.environ, {"PATH": "/usr/bin"}, clear=True):
+            run_env = local_env_mod._make_run_env({})
+        assert "PYTHONUTF8" not in run_env
+        assert "PYTHONIOENCODING" not in run_env
+
+    def test_make_run_env_respects_explicit_user_opt_out(self):
+        """If the inherited env already says ``PYTHONUTF8=0``,
+        ``_make_run_env`` must keep that — the user explicitly opted
+        out.
+        """
+        from tools.environments import local as local_env_mod
+
+        with patch.object(local_env_mod, "_IS_WINDOWS", True), patch(
+            "hermes_cli._subprocess_compat.IS_WINDOWS", True
+        ), patch.object(
+            local_env_mod, "get_subprocess_home", return_value=None, create=True
+        ), patch.dict(
+            os.environ,
+            {"PATH": "C:\\Windows", "PYTHONUTF8": "0"},
+            clear=True,
+        ):
+            run_env = local_env_mod._make_run_env({})
+        assert run_env.get("PYTHONUTF8") == "0", (
+            "explicit user opt-out via PYTHONUTF8=0 must be preserved"
+        )
+
+    def test_copilot_acp_build_subprocess_env_injects_utf8_on_windows(self):
+        """The Copilot ACP client builds its own env via
+        ``_build_subprocess_env``; pin the wiring even though the spawned
+        binary is currently Node — defense in depth keeps the contract
+        consistent across helpers and protects future Python-based
+        replacements.
+        """
+        from agent import copilot_acp_client as cac
+
+        with patch("hermes_cli._subprocess_compat.IS_WINDOWS", True), patch.object(
+            cac, "_resolve_home_dir", return_value="C:\\Users\\u\\.hermes"
+        ), patch.dict(os.environ, {"PATH": "C:\\Windows"}, clear=True):
+            env = cac._build_subprocess_env()
+        assert env.get("PYTHONUTF8") == "1"
+        assert env.get("PYTHONIOENCODING") == "utf-8"
+
+    def test_codex_app_server_spawn_env_invokes_helper(self):
+        """``CodexAppServer.__init__`` must call ``apply_windows_utf8_env``
+        on its spawn env before launching the codex subprocess.  Codex is
+        currently Rust, but it can spawn Python child tools (kanban
+        writebacks etc.); planting PYTHONUTF8 in its env keeps those
+        grandchildren safe on CP936/CP1252 locales (#31420).
+
+        Source-level check rather than a behavioural one: the constructor
+        starts subprocesses and reader threads, which makes mocking
+        brittle, but the wiring is a single line we can grep for.
+        """
+        import inspect
+
+        from agent.transports.codex_app_server import CodexAppServerClient
+
+        src = inspect.getsource(CodexAppServerClient.__init__)
+        assert "apply_windows_utf8_env" in src, (
+            "CodexAppServerClient.__init__ must call "
+            "apply_windows_utf8_env on spawn_env before subprocess.Popen "
+            "so non-ASCII output from any Python grandchildren doesn't "
+            "crash on CP936/CP1252 Windows locales. See #31420."
+        )
+        # The call must come BEFORE the Popen invocation, otherwise the
+        # env dict reaches the child unmodified.
+        helper_idx = src.find("apply_windows_utf8_env")
+        popen_idx = src.find("subprocess.Popen")
+        assert helper_idx != -1 and popen_idx != -1
+        assert helper_idx < popen_idx, (
+            "apply_windows_utf8_env must be invoked BEFORE subprocess.Popen, "
+            "otherwise the codex child gets the unmodified env."
+        )

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -213,6 +213,13 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     if _profile_home:
         sanitized["HOME"] = _profile_home
 
+    # Force UTF-8 stdio for Python children on Windows so non-ASCII output
+    # (Chinese/Japanese/emoji/...) doesn't crash with UnicodeEncodeError on
+    # CP936 / CP1252 / CP932 locales.  No-op on POSIX.  Honors explicit
+    # ``PYTHONUTF8=0`` in the inherited env via ``setdefault``.  Issue #31420.
+    from hermes_cli._subprocess_compat import apply_windows_utf8_env as _utf8
+    _utf8(sanitized)
+
     return sanitized
 
 
@@ -327,6 +334,11 @@ def _make_run_env(env: dict) -> dict:
                 run_env[var_name] = value
     except Exception:
         pass
+
+    # Force UTF-8 stdio for Python children on Windows (#31420).  No-op on
+    # POSIX; honors an explicit ``PYTHONUTF8=0`` via ``setdefault``.
+    from hermes_cli._subprocess_compat import apply_windows_utf8_env as _utf8
+    _utf8(run_env)
 
     return run_env
 


### PR DESCRIPTION
## What does this PR do?

Stops Python subprocesses spawned by Hermes from crashing with ``UnicodeEncodeError`` (or producing mojibake) on Windows when the system code page is non-UTF-8 — CP936 (zh-CN), CP1252 (en-US), CP932 (ja-JP), CP949 (ko-KR), etc. Fixes #31420.

The reporter's repro is a one-liner:

```python
proc = await asyncio.create_subprocess_exec(
    "python", "-c", "print('中文 emoji 🎉')",
    stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
)
```

On a CP936 box without ``PYTHONUTF8=1`` in the child env, this 400s with ``UnicodeEncodeError: 'gbk' codec can't encode character '\u4e2d'``. ``hermes_cli/_ensure_utf8`` already plants ``PYTHONUTF8=1`` in ``os.environ`` at bootstrap, but several subprocess sites construct an explicit ``env=`` dict and don't carry that knob along — so the fix is for those env builders to opt into it.

## Three pieces

1. **New helper** ``hermes_cli._subprocess_compat.apply_windows_utf8_env(env)`` — mutates and returns the env dict. Sets ``PYTHONUTF8=1`` and ``PYTHONIOENCODING=utf-8`` on Windows via ``setdefault`` so explicit user opt-outs (``PYTHONUTF8=0``, custom ``PYTHONIOENCODING``) are preserved. No-op on POSIX. Lives next to the existing Windows-only shims (``resolve_node_command``, ``windows_detach_flags``, …) so the next person reaching for one helper sees the rest.

2. **Audit + apply at the env-builder chokepoints**:
   * ``tools/environments/local.py::_sanitize_subprocess_env`` — terminal tool + process registry path.
   * ``tools/environments/local.py::_make_run_env`` — synchronous terminal-action path.
   * ``agent/copilot_acp_client.py::_build_subprocess_env`` — Copilot ACP client; defensive in case future Python grandchildren are spawned, harmless on the Node binary today.
   * ``agent/transports/codex_app_server.py::CodexAppServerClient.__init__`` — codex spawn env, applied before ``subprocess.Popen``. Codex itself is Rust but its app-server can spawn Python tools (kanban writebacks etc.).

3. **Regression tests** — 13 tests covering the helper contract (Windows+POSIX, idempotency, ``setdefault`` semantics, opt-out preservation) and call-site wiring (each chokepoint plants the right keys on Windows, stays quiet on POSIX, and respects ``PYTHONUTF8=0`` from the inherited env).

The ``code_execution_tool`` sandbox already set both keys inline; this PR doesn't touch that path. Non-Python subprocesses (Node bridges, ``bws``, git, codex Rust binary) are unaffected by ``PYTHONUTF8`` — the helper is harmless on those env dicts and protects future Python additions.

## Related Issue

Fixes #31420

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- ``hermes_cli/_subprocess_compat.py`` — new ``apply_windows_utf8_env`` helper, exported from ``__all__``.
- ``tools/environments/local.py`` — both env helpers call the new helper after their existing scrub / profile-HOME steps.
- ``agent/copilot_acp_client.py`` — ``_build_subprocess_env`` applies the helper.
- ``agent/transports/codex_app_server.py`` — ``CodexAppServerClient.__init__`` applies the helper before ``subprocess.Popen``.
- ``tests/test_windows_utf8_subprocess_env_31420.py`` — **13 new tests** across two classes (``TestApplyWindowsUtf8Env`` for the helper contract, ``TestEnvBuilderWiring`` for the call-site wiring + a source-level ordering guard for the codex spawn).

Backwards compatible:

- ``setdefault`` semantics → no observable change for users who already had ``PYTHONUTF8`` / ``PYTHONIOENCODING`` set in their shell env.
- POSIX is a no-op → no env-snapshot drift on Linux/macOS test fixtures.
- The existing ``hermes_cli._ensure_utf8`` bootstrap still plants the keys in ``os.environ``; this PR is defense-in-depth at the explicit-``env=`` sites.

## How to Test

```bash
# New regression suite (13 tests, ~0.2s)
./scripts/run_tests.sh tests/test_windows_utf8_subprocess_env_31420.py

# Adjacent UTF-8 / env-passthrough suites (no regressions)
./scripts/run_tests.sh \
    tests/tools/test_code_execution_windows_env.py \
    tests/tools/test_windows_native_support.py \
    tests/test_hermes_bootstrap.py \
    tests/test_subprocess_home_isolation.py \
    tests/tools/test_env_passthrough.py \
    tests/test_windows_utf8_subprocess_env_31420.py
# expected: 142 passed, 8 skipped (the 8 skips are platform-conditional Windows-only tests)
```

End-to-end behaviour on a Windows zh-CN host after the fix:

```
PS> hermes
> Run: python -c "print('中文 emoji 🎉')"
中文 emoji 🎉
```

Pre-fix on the same host the terminal tool returned a non-zero exit code with ``UnicodeEncodeError: 'gbk' codec can't encode character '\u4e2d' in position 0`` in stderr.

## Checklist

- [x] Conventional Commits (``feat(subprocess):``, ``fix(subprocess):``, ``test(subprocess):``)
- [x] 3 focused commits, single author
- [x] 13 new tests pass; 142 adjacent tests still green; no linter errors
- [x] Tested on macOS 15.6 (darwin 24.6.0), Python 3.12
- [x] No new flags, no schema migration, no API surface change
- [x] Backwards compatible — explicit ``PYTHONUTF8=0`` opt-outs preserved via ``setdefault``
