### PR TITLE
fix: improve Telegram video metadata and transport log noise

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -15,6 +15,7 @@ import os
 import tempfile
 import html as _html
 import re
+import subprocess
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Any
 
@@ -3804,22 +3805,116 @@ class TelegramAdapter(BasePlatformAdapter):
                 reply_to_message_id=reply_to_id,
                 reply_to_mode=self._reply_to_mode
             )
-            with open(video_path, "rb") as f:
-                msg = await self._send_with_dm_topic_reply_anchor_retry(
-                    self._bot.send_video,
-                    {
-                        "chat_id": int(chat_id),
-                        "video": f,
-                        "caption": caption[:1024] if caption else None,
-                        "reply_to_message_id": reply_to_id,
-                        **thread_kwargs,
-                        **self._notification_kwargs(metadata),
-                    },
-                    metadata,
-                    reply_to_id,
-                    "video",
-                    reset_media=lambda: f.seek(0),
+            # Telegram can sometimes infer a poor cover/aspect ratio for freshly
+            # encoded MP4s unless dimensions and thumbnail are supplied explicitly.
+            # Probe the local file and pass width/height/duration so native video
+            # messages preserve vertical 9:16 display in clients.
+            video_kwargs: Dict[str, Any] = {}
+            thumb_path: Optional[str] = None
+            thumb_file = None
+            try:
+                probe = await asyncio.to_thread(
+                    subprocess.run,
+                    [
+                        "ffprobe",
+                        "-v",
+                        "error",
+                        "-select_streams",
+                        "v:0",
+                        "-show_entries",
+                        "stream=width,height,duration",
+                        "-of",
+                        "json",
+                        video_path,
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
                 )
+                if probe.returncode == 0 and probe.stdout:
+                    info = json.loads(probe.stdout)
+                    stream = (info.get("streams") or [{}])[0]
+                    width = int(stream.get("width") or 0)
+                    height = int(stream.get("height") or 0)
+                    try:
+                        duration = float(stream.get("duration") or 0)
+                    except (TypeError, ValueError):
+                        duration = 0
+                    if width > 0 and height > 0:
+                        video_kwargs.update({"width": width, "height": height})
+                    if duration > 0:
+                        video_kwargs["duration"] = int(round(duration))
+
+                fd, thumb_path = tempfile.mkstemp(suffix=".jpg", prefix="telegram_video_thumb_")
+                os.close(fd)
+                thumb = await asyncio.to_thread(
+                    subprocess.run,
+                    [
+                        "ffmpeg",
+                        "-y",
+                        "-hide_banner",
+                        "-loglevel",
+                        "error",
+                        "-ss",
+                        "1",
+                        "-i",
+                        video_path,
+                        "-frames:v",
+                        "1",
+                        "-vf",
+                        "scale=320:320:force_original_aspect_ratio=decrease:flags=lanczos",
+                        thumb_path,
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=20,
+                )
+                if thumb.returncode == 0 and os.path.exists(thumb_path) and os.path.getsize(thumb_path) > 0:
+                    thumb_file = open(thumb_path, "rb")
+                    video_kwargs["thumbnail"] = thumb_file
+                else:
+                    if thumb_path and os.path.exists(thumb_path):
+                        os.unlink(thumb_path)
+                    thumb_path = None
+            except Exception as meta_exc:
+                logger.debug("Failed to prepare Telegram video metadata/thumbnail for %s: %s", video_path, meta_exc)
+                if thumb_path and os.path.exists(thumb_path):
+                    try:
+                        os.unlink(thumb_path)
+                    except OSError:
+                        pass
+                thumb_path = None
+
+            try:
+                with open(video_path, "rb") as f:
+                    msg = await self._send_with_dm_topic_reply_anchor_retry(
+                        self._bot.send_video,
+                        {
+                            "chat_id": int(chat_id),
+                            "video": f,
+                            "caption": caption[:1024] if caption else None,
+                            "reply_to_message_id": reply_to_id,
+                            "supports_streaming": True,
+                            **video_kwargs,
+                            **thread_kwargs,
+                            **self._notification_kwargs(metadata),
+                        },
+                        metadata,
+                        reply_to_id,
+                        "video",
+                        reset_media=lambda: (
+                            f.seek(0),
+                            thumb_file.seek(0) if thumb_file is not None else None,
+                        ),
+                    )
+            finally:
+                if thumb_file is not None:
+                    thumb_file.close()
+                if thumb_path and os.path.exists(thumb_path):
+                    try:
+                        os.unlink(thumb_path)
+                    except OSError:
+                        pass
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
             print(f"[{self.name}] Failed to send video: {e}")

--- a/gateway/platforms/telegram_network.py
+++ b/gateway/platforms/telegram_network.py
@@ -92,7 +92,7 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
                     async with self._sticky_lock:
                         if self._sticky_ip != ip:
                             self._sticky_ip = ip
-                            logger.warning(
+                            logger.info(
                                 "[Telegram] Primary api.telegram.org path unreachable; using sticky fallback IP %s",
                                 ip,
                             )
@@ -105,18 +105,18 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
                     async with self._sticky_lock:
                         if self._sticky_ip == ip:
                             self._sticky_ip = None
-                            logger.warning(
+                            logger.info(
                                 "[Telegram] Sticky fallback IP %s failed; resetting to primary DNS path",
                                 ip,
                             )
                 if ip is None:
-                    logger.warning(
+                    logger.debug(
                         "[Telegram] Primary api.telegram.org connection failed (%s); trying fallback IPs %s",
                         exc,
                         ", ".join(self._fallback_ips),
                     )
                     continue
-                logger.warning("[Telegram] Fallback IP %s failed: %s", ip, exc)
+                logger.debug("[Telegram] Fallback IP %s failed: %s", ip, exc)
                 continue
 
         if last_error is None:

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -64,6 +64,14 @@ _NOISY_LOGGERS = (
     "markdown_it",
 )
 
+# Streamable-HTTP MCP clients can emit low-level post-writer errors during
+# transient upstream 503s even when Hermes retries/fails gracefully at the tool
+# layer. Keep those internals out of errors.log; user-visible failures still
+# surface via tools.mcp_tool and tool results.
+_QUIET_TRANSPORT_LOGGERS = {
+    "mcp.client.streamable_http": logging.CRITICAL,
+}
+
 
 # ---------------------------------------------------------------------------
 # Public session context API
@@ -254,6 +262,8 @@ def setup_logging(
     # Suppress noisy third-party loggers.
     for name in _NOISY_LOGGERS:
         logging.getLogger(name).setLevel(logging.WARNING)
+    for name, quiet_level in _QUIET_TRANSPORT_LOGGERS.items():
+        logging.getLogger(name).setLevel(quiet_level)
 
     _logging_initialized = True
     return log_dir
@@ -287,6 +297,8 @@ def setup_verbose_logging() -> None:
     # Keep third-party libraries at WARNING to reduce noise.
     for name in _NOISY_LOGGERS:
         logging.getLogger(name).setLevel(logging.WARNING)
+    for name, quiet_level in _QUIET_TRANSPORT_LOGGERS.items():
+        logging.getLogger(name).setLevel(quiet_level)
     # rex-deploy at INFO for sandbox status.
     logging.getLogger("rex-deploy").setLevel(logging.INFO)
 

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -846,6 +846,72 @@ class TestSendVideo:
         connected_adapter._bot.send_video.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_send_video_passes_probe_metadata_and_thumbnail(
+        self, connected_adapter, tmp_path, monkeypatch
+    ):
+        test_file = tmp_path / "vertical.mp4"
+        test_file.write_bytes(b"\x00\x00\x00\x1c" + b"ftyp" + b"\x00" * 100)
+
+        def fake_run(cmd, **_kwargs):
+            if cmd[0] == "ffprobe":
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout='{ "streams": [{ "width": 1080, "height": 1920, "duration": "3.4" }] }',
+                )
+            if cmd[0] == "ffmpeg":
+                assert any("scale=320:320:force_original_aspect_ratio=decrease" in part for part in cmd)
+                with open(cmd[-1], "wb") as thumb:
+                    thumb.write(b"jpeg-bytes")
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        monkeypatch.setattr("gateway.platforms.telegram.subprocess.run", fake_run)
+        mock_msg = MagicMock()
+        mock_msg.message_id = 202
+        connected_adapter._bot.send_video = AsyncMock(return_value=mock_msg)
+
+        result = await connected_adapter.send_video(
+            chat_id="12345",
+            video_path=str(test_file),
+        )
+
+        assert result.success is True
+        call_kwargs = connected_adapter._bot.send_video.call_args.kwargs
+        assert call_kwargs["supports_streaming"] is True
+        assert call_kwargs["width"] == 1080
+        assert call_kwargs["height"] == 1920
+        assert call_kwargs["duration"] == 3
+        assert "thumbnail" in call_kwargs
+        assert call_kwargs["thumbnail"].closed is True
+
+    @pytest.mark.asyncio
+    async def test_send_video_continues_when_probe_tools_fail(
+        self, connected_adapter, tmp_path, monkeypatch
+    ):
+        test_file = tmp_path / "clip.mp4"
+        test_file.write_bytes(b"\x00\x00\x00\x1c" + b"ftyp" + b"\x00" * 100)
+
+        def fake_run(_cmd, **_kwargs):
+            raise FileNotFoundError("ffmpeg/ffprobe not installed")
+
+        monkeypatch.setattr("gateway.platforms.telegram.subprocess.run", fake_run)
+        mock_msg = MagicMock()
+        mock_msg.message_id = 203
+        connected_adapter._bot.send_video = AsyncMock(return_value=mock_msg)
+
+        result = await connected_adapter.send_video(
+            chat_id="12345",
+            video_path=str(test_file),
+        )
+
+        assert result.success is True
+        call_kwargs = connected_adapter._bot.send_video.call_args.kwargs
+        assert call_kwargs["supports_streaming"] is True
+        assert "width" not in call_kwargs
+        assert "height" not in call_kwargs
+        assert "thumbnail" not in call_kwargs
+
+    @pytest.mark.asyncio
     async def test_send_video_file_not_found(self, connected_adapter):
         result = await connected_adapter.send_video(
             chat_id="12345",

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1611,7 +1611,7 @@ class MCPServerTask:
                         self._ready.set()
                         return
 
-                    logger.warning(
+                    logger.info(
                         "MCP server '%s' initial connection failed "
                         "(attempt %d/%d), retrying in %.0fs: %s",
                         self.name, initial_retries,
@@ -1644,7 +1644,7 @@ class MCPServerTask:
                     )
                     return
 
-                logger.warning(
+                logger.info(
                     "MCP server '%s' connection lost (attempt %d/%d), "
                     "reconnecting in %.0fs: %s",
                     self.name, retries, _MAX_RECONNECT_RETRIES,


### PR DESCRIPTION
## Summary
- pass explicit width, height, duration, `supports_streaming`, and a bounded thumbnail when Telegram sends native video uploads
- keep video sends working when `ffprobe`/`ffmpeg` are missing or fail, and clean up temporary thumbnail files/handles
- demote expected transient Telegram fallback-IP and MCP reconnect transport logs so recoverable network noise does not pollute warning/error logs

## Test Plan
- `python -m pytest -q -o 'addopts=' tests/gateway/test_telegram_documents.py::TestSendVideo tests/gateway/test_telegram_network.py tests/gateway/test_telegram_network_reconnect.py tests/tools/test_mcp_tool.py tests/tools/test_mcp_stability.py tests/test_hermes_logging.py`
- `ruff check gateway/platforms/telegram.py gateway/platforms/telegram_network.py hermes_logging.py tools/mcp_tool.py tests/gateway/test_telegram_documents.py`

## Notes
- Thumbnail generation bounds both axes with `force_original_aspect_ratio=decrease` to stay within Telegram thumbnail dimensions for vertical videos.
- Final MCP connection failure/auth warnings remain warnings; this only demotes retry/transient paths and a noisy low-level streamable HTTP logger.
