### PR TITLE
fix(gateway): preserve new Telegram DM topic lanes

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2272,13 +2272,14 @@ class GatewayRunner:
     ) -> Optional[str]:
         """Pin DM-topic routing to the user's last-active topic.
 
-        Telegram fragments topic-mode DMs two ways: a Reply on a message
-        in another topic delivers ``message_thread_id`` for *that* topic,
-        and ``_build_message_event`` strips the thread_id on plain replies
-        (#3206 — needed for non-topic users). Both route the user to the
-        wrong session. When topic mode is on, rewrite the thread_id to the
-        user's most-recent binding if the inbound id is missing/General or
-        not a known topic for this chat. Returns None to leave it alone.
+        Telegram can omit ``message_thread_id`` or surface General (``1``)
+        for some topic-mode DM replies. In those lobby-shaped cases, keep the
+        conversation attached to the user's most-recent bound topic.
+
+        Do not rewrite a non-lobby, previously-unbound thread id: a newly
+        created Telegram DM topic is also "unknown" until the first inbound
+        message is recorded, and rewriting it would send that brand-new topic's
+        answer into an older lane. Returns None to leave the source alone.
         """
         if (
             source.platform != Platform.TELEGRAM
@@ -2287,6 +2288,14 @@ class GatewayRunner:
             or not source.user_id
             or not self._telegram_topic_mode_enabled(source)
         ):
+            return None
+        inbound = str(source.thread_id or "")
+        is_lobby = not inbound or inbound in self._TELEGRAM_GENERAL_TOPIC_IDS
+        if not is_lobby:
+            # A non-lobby, unknown thread_id is most likely the first message in
+            # a brand-new Telegram DM topic. Preserve it so it can be recorded
+            # as a new independent lane below instead of hijacking the latest
+            # existing topic binding.
             return None
         session_db = getattr(self, "_session_db", None)
         if session_db is None:
@@ -2299,11 +2308,6 @@ class GatewayRunner:
             logger.debug("topic-recover: read failed", exc_info=True)
             return None
         if not bindings:
-            return None
-        inbound = str(source.thread_id or "")
-        is_lobby = not inbound or inbound in self._TELEGRAM_GENERAL_TOPIC_IDS
-        known = {str(b.get("thread_id") or "") for b in bindings}
-        if not is_lobby and inbound in known:
             return None
         user_id = str(source.user_id)
         for b in bindings:  # newest-first

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -98,6 +98,7 @@ _fake_telegram_ext.Application = object
 _fake_telegram_ext.CommandHandler = object
 _fake_telegram_ext.CallbackQueryHandler = object
 _fake_telegram_ext.MessageHandler = object
+_fake_telegram_ext.TypeHandler = object
 _fake_telegram_ext.ContextTypes = SimpleNamespace(DEFAULT_TYPE=object)
 _fake_telegram_ext.filters = object
 _fake_telegram_request = types.ModuleType("telegram.request")

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -1211,6 +1211,31 @@ def test_recover_returns_none_when_no_bindings_yet(tmp_path):
     assert runner._recover_telegram_topic_thread_id(_make_source(thread_id=None)) is None
 
 
+def test_recover_returns_none_for_brand_new_topic(tmp_path):
+    # Regression for #31086: bindings exist for a prior topic but the user
+    # opened a fresh one (thread_id "99999"). Recovery must return None so the
+    # new topic gets its own session rather than being silently merged into
+    # the previous topic's session. The hijack was self-reinforcing — because
+    # the rewrite ran before _record_telegram_topic_binding, the new topic's
+    # binding row never got written, so every subsequent message in that topic
+    # looked "unknown" and was hijacked again.
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    db.create_session(session_id="sess-old", source="telegram", user_id="208214988")
+    src_old = _make_source(thread_id="12345")
+    db.bind_telegram_topic(
+        chat_id=src_old.chat_id,
+        thread_id=src_old.thread_id,
+        user_id=src_old.user_id,
+        session_key=build_session_key(src_old),
+        session_id="sess-old",
+    )
+    runner = _make_runner(session_db=db)
+
+    # "99999" is non-lobby and not in the binding table — brand-new topic.
+    assert runner._recover_telegram_topic_thread_id(_make_source(thread_id="99999")) is None
+
+
 def test_list_telegram_topic_bindings_for_chat(tmp_path):
     db = SessionDB(db_path=tmp_path / "state.db")
     _seed_two_topic_bindings(db)

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -1175,13 +1175,15 @@ def test_recover_returns_none_for_known_topic(tmp_path):
     assert runner._recover_telegram_topic_thread_id(_make_source(thread_id="222")) is None
 
 
-def test_recover_rewrites_unknown_thread_id_to_most_recent(tmp_path):
-    # Cross-topic Reply leak: inbound thread_id is a Telegram-only id we never bound.
+def test_recover_preserves_unknown_thread_id_for_new_topic(tmp_path):
+    # A newly-created Telegram DM topic arrives with a real, previously-unbound
+    # message_thread_id. It must become its own session lane rather than being
+    # rewritten to whichever older topic was most recently active.
     db = SessionDB(db_path=tmp_path / "state.db")
     _seed_two_topic_bindings(db)
     runner = _make_runner(session_db=db)
 
-    assert runner._recover_telegram_topic_thread_id(_make_source(thread_id="9999")) == "222"
+    assert runner._recover_telegram_topic_thread_id(_make_source(thread_id="9999")) is None
 
 
 def test_recover_rewrites_lobby_thread_id_to_most_recent(tmp_path):


### PR DESCRIPTION
## Summary
Brand-new Telegram DM topics no longer get hijacked into the previous topic's session. `_recover_telegram_topic_thread_id` now only rewrites lobby/General thread_ids (preserving the #3206 strip recovery); any explicit, non-lobby thread_id is trusted as-is so a freshly-created topic can be recorded as its own lane.

Root cause (#31086): the recovery function ran *before* `_record_telegram_topic_binding`, and its "unknown non-lobby thread_id -> snap to most-recent" arm matched every new topic. The hijack was self-reinforcing because the new topic's binding row was never written, so every subsequent message looked unknown and was hijacked again.

## Changes
- `gateway/run.py`: drop the `inbound in known` short-circuit; non-lobby thread_ids return None unconditionally. Docstring rewritten.
- `tests/gateway/test_telegram_topic_mode.py`: invert the existing `test_recover_rewrites_unknown_thread_id_to_most_recent` -> `test_recover_preserves_unknown_thread_id_for_new_topic`, plus a new `test_recover_returns_none_for_brand_new_topic` regression that mirrors the live failure mode (one prior binding + a brand-new thread_id).
- `tests/gateway/test_telegram_thread_fallback.py`: stub `_fake_telegram_ext.TypeHandler` so the shared fake module covers all handler classes the real telegram-ext exposes.

## Validation
| | Result |
|---|---|
| `tests/gateway/test_telegram_topic_mode.py` | 43/43 pass |
| `tests/gateway/test_telegram_thread_fallback.py` | 41/41 pass |
| `tests/gateway/` (full suite) | 5820/5820 pass |

## Credit
- @Qwinty: original fix (#28605), cherry-picked with authorship preserved.
- @fabiosiqueira: brand-new-topic regression test pattern (#29287), added as co-author on the follow-up commit.
- @dillweed: filed #31086 with the bug analysis, fix proposal, and live-verified the patch (#31088), co-authored.

Closes #31086.
Supersedes #28605, #29287, #29546, #30422, #31088.

## Infographic

![Telegram DM topic hijack fix](https://v3b.fal.media/files/b/0a9b8c63/nJbofZejakdBua_U3KVvd_bGogBbug.png)
