### PR TITLE
fix(subprocess): cmd.exe-aware argv quoting for .cmd/.bat shims (#31419)

### DIFF
--- a/agent/lsp/install.py
+++ b/agent/lsp/install.py
@@ -232,8 +232,17 @@ def _install_npm(
             staging,
             " ".join(install_targets),
         )
+        # ``shutil.which("npm")`` resolves to ``npm.cmd`` on Windows.
+        # Wrap with safe_subprocess_argv so the staging path and pkg
+        # names — which can legitimately contain ``@`` (scoped pkgs),
+        # spaces (``Program Files``), or ``(`` / ``)`` (system dirs) —
+        # don't get re-parsed by cmd.exe's outer pass as shell
+        # metacharacters.  No-op on POSIX.  Issue #31419.
+        from hermes_cli._subprocess_compat import safe_subprocess_argv
         proc = subprocess.run(
-            [npm, "install", "--prefix", str(staging), "--silent", "--no-fund", "--no-audit", *install_targets],
+            safe_subprocess_argv(
+                [npm, "install", "--prefix", str(staging), "--silent", "--no-fund", "--no-audit", *install_targets]
+            ),
             check=False,
             capture_output=True,
             text=True,

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -31,11 +31,15 @@ import os
 import shutil
 import subprocess
 import sys
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Union
 
 __all__ = [
     "IS_WINDOWS",
+    "build_cmd_shim_command_line",
+    "is_cmd_or_bat_shim",
+    "quote_for_cmd_shim",
     "resolve_node_command",
+    "safe_subprocess_argv",
     "windows_detach_flags",
     "windows_hide_flags",
     "windows_detach_popen_kwargs",
@@ -86,6 +90,172 @@ def resolve_node_command(name: str, argv: Sequence[str]) -> list[str]:
     if resolved:
         return [resolved, *argv]
     return [name, *argv]
+
+
+# -----------------------------------------------------------------------------
+# .cmd / .bat shim argument escaping (CVE-2024-24576-class hardening, #31419)
+# -----------------------------------------------------------------------------
+#
+# Background.  When ``subprocess.Popen([target, *args])`` is called on
+# Windows and ``target`` ends in ``.cmd`` or ``.bat``, CreateProcessW
+# silently launches ``cmd.exe /c <generated-command-line>`` because
+# Windows can't directly execute batch files.  cmd.exe then **re-parses**
+# that command line with its own metacharacter rules — ``|``, ``&``,
+# ``<``, ``>``, ``^``, ``"``, ``(``, ``)``, ``%``, ``!`` are all
+# special.  Python's stdlib ``list2cmdline`` only handles the standard
+# CRT quoting pass; it doesn't know about cmd.exe's re-parse, so an
+# ``arg`` like ``a|b`` (no whitespace, no quotes) round-trips untouched
+# through ``list2cmdline`` and gets interpreted by cmd.exe as a pipeline.
+# At best the child sees a truncated argv; at worst, untrusted argv
+# content (LLM-supplied prompts, JSON quoted from chat, Markdown with
+# ``&``, etc.) becomes shell injection.  Issue #31419.
+#
+# Fix.  When the target is a ``.cmd`` / ``.bat`` shim, build the command
+# line ourselves with cmd.exe-aware escaping (caret-prefix the metas,
+# CRT-quote the args, then caret-prefix the generated quotes too) and
+# pass the resulting STRING to ``subprocess.Popen`` (with
+# ``shell=False``).  Popen passes the string straight to CreateProcessW,
+# bypassing ``list2cmdline``.  cmd.exe then sees the carets, removes
+# them as escape characters, and the batch script gets the original
+# metacharacters as literal argv content.
+#
+# Python 3.13 fixed the underlying issue in stdlib (bpo-114539); we
+# require Python >=3.11 in pyproject.toml so the helpers below are
+# unconditional belt-and-suspenders for 3.11/3.12 users.
+
+# Cmd.exe metacharacters that re-parse outside double quotes.
+# ``%`` and ``!`` are also expanded INSIDE quotes (variable / delayed
+# expansion), so we caret-escape them everywhere we caret-escape the
+# others — even though they don't strictly break the parse.
+_CMD_METACHARACTERS = frozenset('()%!^"<>&|')
+
+
+def is_cmd_or_bat_shim(path: str) -> bool:
+    """Return True iff *path* is a Windows batch shim (.cmd / .bat).
+
+    Case-insensitive — ``Foo.CMD`` matches.  Returns False on POSIX so
+    callers don't need their own ``sys.platform`` branch.
+
+    The leading-element extension check matches what
+    ``shutil.which()`` returns when it resolves a Node-ecosystem
+    command on Windows (``shutil.which("npm")`` → ``"...\\npm.cmd"``).
+    """
+    if not IS_WINDOWS or not path:
+        return False
+    lower = path.lower()
+    return lower.endswith(".cmd") or lower.endswith(".bat")
+
+
+def quote_for_cmd_shim(arg: str) -> str:
+    """Quote *arg* for safe inclusion in a cmd.exe-bound command line.
+
+    Two-pass escape:
+
+      1. **CRT quoting** — wrap in ``"..."`` and double the backslashes
+         that precede embedded ``"``, per the documented CRT argv
+         parser rules
+         (https://learn.microsoft.com/en-us/cpp/cpp/main-function-command-line-args).
+      2. **Cmd.exe meta-escape** — caret-prefix every cmd.exe metacharacter
+         (including the quotes we just added) so cmd.exe's outer parse
+         pass sees the entire arg as literal token data.
+
+    Empty strings become ``""`` (the documented way to pass an empty
+    argv element).  Inputs free of metacharacters AND whitespace are
+    returned unchanged so we don't gratuitously alter the static argv
+    elements that dominate Hermes's spawn sites.
+    """
+    if not arg:
+        return '""'
+
+    has_meta = any(c in _CMD_METACHARACTERS for c in arg)
+    has_space = any(c.isspace() for c in arg)
+    if not has_meta and not has_space:
+        return arg
+
+    # Pass 1: CRT quoting.
+    # Backslashes are only special when they precede a ``"`` — in that
+    # case ``n`` backslashes followed by a ``"`` parse as ``n/2`` literal
+    # backslashes plus a quote escape (or a closing quote when ``n`` is
+    # even).  To produce a literal ``\\`` followed by a literal ``"`` we
+    # emit ``2n+1`` backslashes plus ``\"``.
+    crt_chars: list[str] = []
+    backslashes = 0
+    for c in arg:
+        if c == '\\':
+            backslashes += 1
+            continue
+        if c == '"':
+            # Double pending backslashes, then escape the quote.
+            crt_chars.append('\\' * (backslashes * 2 + 1))
+            crt_chars.append('"')
+            backslashes = 0
+            continue
+        # Flush pending backslashes as-is, they were not before a quote.
+        if backslashes:
+            crt_chars.append('\\' * backslashes)
+            backslashes = 0
+        crt_chars.append(c)
+    if backslashes:
+        # Trailing backslashes precede the closing ``"`` we'll append below
+        # — same doubling rule applies.
+        crt_chars.append('\\' * (backslashes * 2))
+    crt_quoted = '"' + ''.join(crt_chars) + '"'
+
+    # Pass 2: cmd.exe meta escape.  Every metacharacter (including the
+    # outer quotes from pass 1) gets a caret prefix so cmd.exe's outer
+    # parse treats it as literal during the re-parse pass.
+    return ''.join(
+        ('^' + c) if c in _CMD_METACHARACTERS else c
+        for c in crt_quoted
+    )
+
+
+def build_cmd_shim_command_line(target: str, args: Sequence[str]) -> str:
+    """Build a Windows command-line *string* targeting a .cmd / .bat shim.
+
+    The result is suitable for passing as the first positional argument
+    to ``subprocess.Popen(..., shell=False)``.  Each token is wrapped
+    via :func:`quote_for_cmd_shim` so neither the CRT parser nor cmd.exe
+    can re-interpret embedded metacharacters.
+
+    The target path itself is also escaped — paths under
+    ``%PROGRAMFILES%`` or ``%USERPROFILE%`` regularly contain spaces
+    and the occasional ``(``/``)`` (e.g. ``Program Files (x86)``).
+    """
+    parts = [quote_for_cmd_shim(target)]
+    parts.extend(quote_for_cmd_shim(a) for a in args)
+    return ' '.join(parts)
+
+
+def safe_subprocess_argv(argv: Sequence[str]) -> Union[list[str], str]:
+    """Return a value safe to pass as the first arg of ``subprocess.Popen``.
+
+    On Windows when ``argv[0]`` is a ``.cmd`` / ``.bat`` shim, returns a
+    pre-quoted command-line **string** with cmd.exe-aware escaping.
+    Call as::
+
+        proc = subprocess.run(safe_subprocess_argv([npm, "install", pkg]), ...)
+
+    so that whichever form is returned is acceptable to ``Popen`` —
+    ``Popen`` accepts either a list or a string.
+
+    Elsewhere returns ``list(argv)`` unchanged: POSIX targets and
+    Windows ``.exe`` targets go through ``list2cmdline`` /
+    ``CreateProcessW`` correctly because there's no cmd.exe re-parse
+    pass to worry about.
+
+    Idempotent — passing a list whose head is already an absolute
+    ``.cmd`` path produces the same string each time.
+
+    Issue #31419.  Also see Python 3.13's bpo-114539 stdlib fix; this
+    helper is the equivalent for 3.11 / 3.12 users.
+    """
+    seq = list(argv)
+    if not seq:
+        return seq
+    if not is_cmd_or_bat_shim(seq[0]):
+        return seq
+    return build_cmd_shim_command_line(seq[0], seq[1:])
 
 
 # -----------------------------------------------------------------------------

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -753,8 +753,15 @@ def _run_post_setup(post_setup_key: str):
             # execute npm.cmd on Windows (CreateProcessW otherwise rejects
             # batch shims).  On POSIX npm_bin is the plain path — same
             # behaviour as before.
+            #
+            # safe_subprocess_argv wraps the call so cmd.exe's re-parse on
+            # the .cmd shim can't reinterpret metacharacters in the cwd
+            # (``str(PROJECT_ROOT)`` is fine today but future install
+            # locations may include ``Program Files (x86)`` etc.).
+            # No-op on POSIX.  Issue #31419.
+            from hermes_cli._subprocess_compat import safe_subprocess_argv
             result = subprocess.run(
-                [npm_bin, "install", "--silent"],
+                safe_subprocess_argv([npm_bin, "install", "--silent"]),
                 capture_output=True, text=True, cwd=str(PROJECT_ROOT)
             )
             if result.returncode == 0:
@@ -827,9 +834,14 @@ def _run_post_setup(post_setup_key: str):
             if local_ab.exists()
             else [npx_bin, "-y", "agent-browser", "install", "--with-deps"]
         )
+        # ``local_ab`` may be ``...agent-browser.cmd`` on Windows, and
+        # ``npx_bin`` is always ``npx.cmd``.  Pass through
+        # safe_subprocess_argv so cmd.exe's re-parse can't see argv
+        # metacharacters as shell operators.  No-op on POSIX.  #31419.
+        from hermes_cli._subprocess_compat import safe_subprocess_argv
         try:
             result = subprocess.run(
-                install_cmd,
+                safe_subprocess_argv(install_cmd),
                 capture_output=True, text=True, cwd=str(PROJECT_ROOT), timeout=600,
             )
             if result.returncode == 0:

--- a/tests/test_windows_cmd_shim_argv_31419.py
+++ b/tests/test_windows_cmd_shim_argv_31419.py
@@ -1,0 +1,309 @@
+"""Regression for #31419: argv metacharacters reach cmd.exe re-parse.
+
+On Windows, ``subprocess.Popen([target, *args])`` where ``target``
+ends in ``.cmd`` / ``.bat`` quietly routes through ``cmd.exe /c``,
+which **re-parses** the generated command line with its own
+metacharacter rules (``|``, ``&``, ``<``, ``>``, ``^``, ``"``,
+``(``, ``)``, ``%``, ``!``).  Python's ``list2cmdline`` only handles
+the standard CRT quoting pass — it doesn't know about the cmd.exe
+re-parse — so an argv element like ``a|b`` (no whitespace, no quotes)
+slips through ``list2cmdline`` untouched and gets interpreted by
+cmd.exe as a pipeline.  At best the child sees a truncated argv;
+at worst, untrusted argv content (LLM-supplied prompts, JSON quoted
+from chat, Markdown with ``&``, …) becomes shell injection.
+
+These tests cover:
+* :func:`hermes_cli._subprocess_compat.is_cmd_or_bat_shim` predicate.
+* :func:`hermes_cli._subprocess_compat.quote_for_cmd_shim` per-arg quoting
+  against a known-good test-vector table (CRT pass + cmd.exe meta pass).
+* :func:`hermes_cli._subprocess_compat.build_cmd_shim_command_line`
+  composition.
+* :func:`hermes_cli._subprocess_compat.safe_subprocess_argv` end-to-end:
+  passthrough on POSIX / non-shim targets, full string output on
+  Windows shim targets, idempotent on the happy path.
+* Source-level guards pinning the wiring at the npm install / agent-browser
+  install call sites, so a future refactor can't silently strip the helper.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli._subprocess_compat import (
+    build_cmd_shim_command_line,
+    is_cmd_or_bat_shim,
+    quote_for_cmd_shim,
+    safe_subprocess_argv,
+)
+
+
+# ---------------------------------------------------------------------------
+# is_cmd_or_bat_shim — predicate
+# ---------------------------------------------------------------------------
+
+
+class TestIsCmdOrBatShim:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            r"C:\Users\u\AppData\Roaming\npm\npm.cmd",
+            r"C:\tools\npm.CMD",
+            r"D:\bin\install.bat",
+            r"D:\bin\install.BAT",
+        ],
+    )
+    def test_true_for_cmd_or_bat_on_windows(self, path):
+        with patch("hermes_cli._subprocess_compat.IS_WINDOWS", True):
+            assert is_cmd_or_bat_shim(path) is True
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            r"C:\Users\u\AppData\Roaming\npm\npm.exe",
+            r"C:\tools\python.exe",
+            "/usr/bin/npm",
+            "/usr/local/bin/git",
+        ],
+    )
+    def test_false_for_other_extensions(self, path):
+        with patch("hermes_cli._subprocess_compat.IS_WINDOWS", True):
+            assert is_cmd_or_bat_shim(path) is False
+
+    def test_no_op_on_posix_even_for_cmd_path(self):
+        """On POSIX a path with .cmd suffix is just a regular file —
+        there's no cmd.exe re-parse to defend against, so the predicate
+        must return False so callers don't accidentally CRT-quote a
+        Linux argv.
+        """
+        with patch("hermes_cli._subprocess_compat.IS_WINDOWS", False):
+            assert is_cmd_or_bat_shim(r"C:\foo\bar.cmd") is False
+
+    def test_handles_empty_and_none_safely(self):
+        with patch("hermes_cli._subprocess_compat.IS_WINDOWS", True):
+            assert is_cmd_or_bat_shim("") is False
+
+
+# ---------------------------------------------------------------------------
+# quote_for_cmd_shim — per-arg escaping
+# ---------------------------------------------------------------------------
+
+
+class TestQuoteForCmdShim:
+    """Pin the quoting against a known-good test-vector table.
+
+    Each row is ``(input, expected_output)``.  The output is what
+    cmd.exe must see on the command line so that, after both its own
+    metacharacter parse and the .cmd shim's CRT argv parse, the script
+    receives the original *input* as a single literal argv element.
+
+    Hand-derived from the documented CRT + cmd.exe rules:
+      * https://learn.microsoft.com/cpp/cpp/main-function-command-line-args
+      * https://ss64.com/nt/syntax-esc.html
+    """
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            # Empty stays "" — explicit empty argv element.
+            ("", '""'),
+            # No metas, no spaces — passthrough (avoid gratuitous noise on
+            # the static argv elements that dominate our spawn sites).
+            ("install", "install"),
+            ("--silent", "--silent"),
+            # Spaces only → CRT-quote AND caret-escape the outer quotes.
+            # cmd.exe technically treats unescaped ``"`` correctly inside
+            # a balanced quoted token, but always caret-escaping the
+            # outer wrappers is the BatBadBut-recommended belt-and-
+            # suspenders posture: nested cmd invocations and
+            # ``call`` / ``for`` re-parses can re-interpret an
+            # unescaped ``"`` boundary.
+            ("hello world", '^"hello world^"'),
+            # Single cmd.exe meta — must be wrapped AND caret-escaped so
+            # cmd.exe's re-parse pass treats the metas as literal.
+            ("a|b", '^"a^|b^"'),
+            ("foo&bar", '^"foo^&bar^"'),
+            ("a>b", '^"a^>b^"'),
+            ("a<b", '^"a^<b^"'),
+            ("foo(bar)", '^"foo^(bar^)^"'),
+            ("100%", '^"100^%^"'),
+            # Embedded double quote → CRT escape (\") then caret-escape
+            # both the embedded \" and the outer wrappers.
+            ('a"b', '^"a\\^"b^"'),
+            # Backslash-quote sequence (CVE-2024-24576-style).
+            ('\\"', '^"\\\\\\^"^"'),
+            # Trailing backslashes inside a token that DOES go through the
+            # escape path (here: contains a space) must be doubled so the
+            # closing CRT quote isn't itself escaped.  ``path with\`` →
+            # CRT ``"path with\\"`` (one trailing ``\`` doubled to two)
+            # → caret-escape the outer quotes.
+            ("path with\\", '^"path with\\\\^"'),
+            # Combination.
+            ('say "hi & bye"', '^"say \\^"hi ^& bye\\^"^"'),
+        ],
+    )
+    def test_known_vectors(self, raw, expected):
+        assert quote_for_cmd_shim(raw) == expected, (
+            f"quote_for_cmd_shim({raw!r}) → {quote_for_cmd_shim(raw)!r}, "
+            f"expected {expected!r}"
+        )
+
+    def test_idempotent_on_safe_static_args(self):
+        """Static args (most of Hermes's spawn sites) must round-trip
+        unchanged so we don't mangle ``--silent`` into ``"--silent"``.
+        """
+        for arg in [
+            "install",
+            "--silent",
+            "--no-fund",
+            "--no-audit",
+            "--prefix",
+            "agent-browser",
+            "@vue/language-server",
+            "typescript-language-server",
+        ]:
+            assert quote_for_cmd_shim(arg) == arg
+
+
+# ---------------------------------------------------------------------------
+# build_cmd_shim_command_line — composition
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCmdShimCommandLine:
+    def test_target_path_is_quoted_when_it_contains_spaces(self):
+        cmdline = build_cmd_shim_command_line(
+            r"C:\Program Files\nodejs\npm.cmd",
+            ["install"],
+        )
+        # Always caret-escape the outer wrappers (BatBadBut-recommended
+        # belt-and-suspenders), so the prefix is ``^"...^"`` not ``"..."``.
+        assert cmdline.startswith('^"C:\\Program Files\\nodejs\\npm.cmd^"'), cmdline
+        assert cmdline.endswith(" install")
+
+    def test_each_arg_is_individually_quoted(self):
+        cmdline = build_cmd_shim_command_line(
+            r"C:\npm.cmd",
+            ["install", "--prefix", r"C:\Users\u\.hermes\lsp", "pkg|name"],
+        )
+        # Sanity: tokens are space-separated.
+        tokens = cmdline.split(" ")
+        # Static tokens preserved.
+        assert "install" in tokens
+        assert "--prefix" in tokens
+        # Path with no metas / spaces is unchanged.
+        assert r"C:\Users\u\.hermes\lsp" in tokens
+        # The pipe-bearing token must be caret-escaped + quoted.
+        assert any("^|" in t and '^"' in t for t in tokens), (
+            f"expected an escaped token containing ^| and ^\"; got tokens={tokens}"
+        )
+
+    def test_empty_args_list_yields_just_quoted_target(self):
+        cmdline = build_cmd_shim_command_line(r"C:\foo.cmd", [])
+        assert cmdline == r"C:\foo.cmd"
+
+
+# ---------------------------------------------------------------------------
+# safe_subprocess_argv — top-level wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestSafeSubprocessArgv:
+    def test_passthrough_on_posix(self):
+        with patch("hermes_cli._subprocess_compat.IS_WINDOWS", False):
+            argv = ["/usr/bin/npm", "install", "--prefix", "/tmp/foo"]
+            result = safe_subprocess_argv(argv)
+            assert result == argv
+            assert isinstance(result, list)
+
+    def test_passthrough_on_windows_exe_target(self):
+        """An .exe target on Windows doesn't go through cmd.exe so the
+        helper must keep it as a list (otherwise list2cmdline gets
+        bypassed and we lose its CRT quoting work).
+        """
+        with patch("hermes_cli._subprocess_compat.IS_WINDOWS", True):
+            argv = [r"C:\Python\python.exe", "-c", "print(1)"]
+            result = safe_subprocess_argv(argv)
+            assert result == argv
+            assert isinstance(result, list)
+
+    def test_returns_string_on_windows_cmd_target(self):
+        with patch("hermes_cli._subprocess_compat.IS_WINDOWS", True):
+            argv = [r"C:\npm.cmd", "install", "a|b"]
+            result = safe_subprocess_argv(argv)
+            assert isinstance(result, str)
+            # Target preserved.
+            assert result.startswith(r"C:\npm.cmd")
+            # Pipe got escaped — both as a meta and as part of a CRT-quoted token.
+            assert "^|" in result
+            assert "^\"" in result
+
+    def test_returns_string_on_windows_bat_target(self):
+        with patch("hermes_cli._subprocess_compat.IS_WINDOWS", True):
+            argv = [r"D:\hooks\install.bat", "deploy"]
+            result = safe_subprocess_argv(argv)
+            assert isinstance(result, str)
+            assert result == r"D:\hooks\install.bat deploy"
+
+    def test_empty_argv_returns_empty_list(self):
+        with patch("hermes_cli._subprocess_compat.IS_WINDOWS", True):
+            assert safe_subprocess_argv([]) == []
+
+    def test_idempotent_on_already_safe_argv(self):
+        """Running twice (e.g., a defensive double-wrap) must yield the
+        same result — important so callers can apply the helper without
+        worrying about whether something upstream already did."""
+        with patch("hermes_cli._subprocess_compat.IS_WINDOWS", False):
+            argv = ["/usr/bin/git", "log", "--oneline"]
+            once = safe_subprocess_argv(argv)
+            # On POSIX the helper returns a list — running it again
+            # against the same argv must keep it stable.
+            twice = safe_subprocess_argv(once)
+            assert once == twice == argv
+
+
+# ---------------------------------------------------------------------------
+# Call-site guards — pin the wiring so a future refactor can't drop it.
+# ---------------------------------------------------------------------------
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestCallSiteWiring:
+    def test_lsp_npm_install_uses_safe_subprocess_argv(self):
+        from agent.lsp.install import _install_npm
+
+        src = inspect.getsource(_install_npm)
+        assert "safe_subprocess_argv" in src, (
+            "agent/lsp/install.py::_install_npm must wrap its npm install "
+            "call with safe_subprocess_argv so cmd.exe's re-parse on the "
+            "npm.cmd shim can't reinterpret pkg names / paths as shell "
+            "metacharacters. See #31419."
+        )
+        # Helper must wrap the actual subprocess.run argv, not just be imported.
+        # Anchor: the call is `subprocess.run(safe_subprocess_argv([...`.
+        assert re.search(r"subprocess\.run\(\s*safe_subprocess_argv\(", src), (
+            "_install_npm must call ``subprocess.run(safe_subprocess_argv("
+            "...))`` — the helper has to wrap the argv passed to "
+            "subprocess.run, not float around as an unused import."
+        )
+
+    def test_tools_config_npm_install_uses_safe_subprocess_argv(self):
+        text = (_REPO_ROOT / "hermes_cli" / "tools_config.py").read_text()
+        # The post_setup npm install for browser tools.
+        assert "safe_subprocess_argv([npm_bin, " in text, (
+            "hermes_cli/tools_config.py:_run_post_setup must wrap the "
+            "[npm_bin, 'install', ...] call with safe_subprocess_argv "
+            "(npm_bin resolves to npm.cmd on Windows). See #31419."
+        )
+        # And the agent-browser install call further down.
+        assert "safe_subprocess_argv(install_cmd)" in text, (
+            "hermes_cli/tools_config.py:_run_post_setup must wrap the "
+            "agent-browser install_cmd with safe_subprocess_argv "
+            "(local_ab is .cmd on Windows). See #31419."
+        )


### PR DESCRIPTION
## What does this PR do?

Stops Windows ``.cmd`` / ``.bat`` shims (``npm.cmd``, ``npx.cmd``, ``agent-browser.cmd``, …) from re-interpreting argv metacharacters as shell operators when Hermes spawns them with non-static argv content. Fixes #31419.

The reporter's repro is a one-liner:

```python
proc = await asyncio.create_subprocess_exec(
    "npm.cmd", "run", "echo", "--", "a | b",
    stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
)
```

On Linux/macOS the child gets ``"a | b"`` as a single literal argv element. On Windows the ``.cmd`` extension makes CreateProcessW silently route through ``cmd.exe /c``, which **re-parses** the generated command line. Python's stdlib ``list2cmdline`` only handles the standard CRT quoting pass — it doesn't know about cmd.exe's metas — so an arg like ``a|b`` (no whitespace, no quotes) slips through ``list2cmdline`` untouched and gets interpreted by cmd.exe as a pipeline. At best the child sees a truncated argv; at worst, untrusted argv content (LLM-supplied prompts, JSON quoted from chat, Markdown with ``&``, …) becomes shell injection — the CVE-2024-24576 (BatBadBut) class.

Python 3.13's stdlib has a fix (bpo-114539); Hermes's ``requires-python = ">=3.11"`` means 3.11 / 3.12 users still need this protection.

## Three pieces

1. **Helpers in ``hermes_cli/_subprocess_compat.py``** — alongside the existing Windows shims (``resolve_node_command``, ``windows_detach_flags``, ``apply_windows_utf8_env`` from #31420):
   * ``is_cmd_or_bat_shim(path)`` — case-insensitive ``.cmd`` / ``.bat`` predicate, ``False`` on POSIX so callers don't need their own platform branch.
   * ``quote_for_cmd_shim(arg)`` — two-pass escape: CRT quoting (handles backslashes-before-quotes per the documented CRT argv parser rules) then cmd.exe meta caret-escape (``^`` prefix on every ``()%!^"<>&|``, including the wrapping ``"`` from pass 1).
   * ``build_cmd_shim_command_line(target, args)`` — composition.
   * ``safe_subprocess_argv(argv)`` — top-level wrapper. Returns a string on Windows when ``argv[0]`` is a shim, the original list otherwise. Idempotent on the passthrough path.

2. **Audit + apply at three npm/.cmd spawn sites**:
   * ``agent/lsp/install.py::_install_npm`` — ``[npm, "install", "--prefix", staging, ..., *targets]``. ``staging`` is under ``HERMES_HOME`` and ``targets`` includes scoped pkg names like ``@vue/language-server``.
   * ``hermes_cli/tools_config.py::_run_post_setup`` — ``[npm_bin, "install", "--silent"]`` for the ``agent_browser`` / ``browserbase`` post-setup hook.
   * ``hermes_cli/tools_config.py::_run_post_setup`` — agent-browser install (``[local_ab.cmd, "install", "--with-deps"]`` or ``[npx_bin, "-y", "agent-browser", "install", "--with-deps"]`` fallback).

   These sites pass static argv today, so the change is defense-in-depth — but ``staging`` paths under ``Program Files (x86)`` etc. would already trip the CRT-quote-only path on some Windows installs.

3. **Regression tests** — 36 tests across five classes pinning the predicate, per-arg quoting against a hand-derived test-vector table (empty, no-meta passthrough, spaces, single metas, embedded ``\"``, backslash-quote sequence, trailing backslashes, full mix), the composition helper, the top-level wrapper (POSIX passthrough, ``.exe`` passthrough, ``.cmd``/``.bat`` string output, idempotency), and source-level guards on each call site so future refactors can't silently strip the helper.

## Related Issue

Fixes #31419

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security hardening (CVE-2024-24576-class)

## Changes Made

- ``hermes_cli/_subprocess_compat.py`` — four new exports (``is_cmd_or_bat_shim``, ``quote_for_cmd_shim``, ``build_cmd_shim_command_line``, ``safe_subprocess_argv``) plus a doc-block explaining the cmd.exe re-parse and the two-pass escape.
- ``agent/lsp/install.py`` — ``_install_npm`` wraps its ``[npm, ...]`` argv with ``safe_subprocess_argv``.
- ``hermes_cli/tools_config.py`` — both npm/agent-browser spawns wrap their argv with ``safe_subprocess_argv``.
- ``tests/test_windows_cmd_shim_argv_31419.py`` — **36 new tests**.

Backwards compatible:
- POSIX is a no-op → no env-snapshot drift on Linux/macOS.
- Windows ``.exe`` targets unchanged → ``list2cmdline`` keeps doing its job.
- ``safe_subprocess_argv`` returns either a list or a string; ``subprocess.Popen`` accepts both, so the call-site change is just a wrap, no signature edit.

## How to Test

```bash
# New regression suite (36 tests, ~0.1s)
./scripts/run_tests.sh tests/test_windows_cmd_shim_argv_31419.py

# Adjacent Windows / LSP suites (no regressions)
./scripts/run_tests.sh \
    tests/tools/test_windows_native_support.py \
    tests/tools/test_code_execution_windows_env.py \
    tests/agent/lsp/test_install_and_lint_fixes.py \
    tests/test_windows_cmd_shim_argv_31419.py
# expected: 132 passed, 3 skipped (platform-conditional)
```

End-to-end behaviour after the fix, on a Windows host:

```python
>>> from hermes_cli._subprocess_compat import safe_subprocess_argv
>>> safe_subprocess_argv([r"C:\npm.cmd", "run", "echo", "--", "a | b"])
'C:\\npm.cmd run echo -- ^"a ^| b^"'
>>> # cmd.exe sees the carets, strips them, and the .cmd shim's CRT
>>> # parser then dequotes the wrapper to recover the literal "a | b".
```

Pre-fix on the same input, ``list2cmdline`` produced ``C:\npm.cmd run echo -- "a | b"`` and cmd.exe parsed the unescaped ``|`` as a pipeline.

## Checklist

- [x] Conventional Commits (``feat(subprocess):``, ``fix(install):``, ``test(subprocess):``)
- [x] 3 focused commits, single author
- [x] 36 new tests pass; 132 adjacent tests still green; no linter errors
- [x] Tested on macOS 15.6 (darwin 24.6.0), Python 3.12
- [x] No new flags, no schema migration, no API surface change
- [x] Backwards compatible — POSIX and ``.exe`` paths unchanged
