### PR TITLE
fix(agent): emit guardrail-halt message to client before closing stream

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3470,6 +3470,19 @@ def run_conversation(
                         f"⚠️ Tool guardrail halted {decision.tool_name}: {decision.code}"
                     )
                     messages.append({"role": "assistant", "content": final_response})
+                    # Emit the halt message to the client so it's not
+                    # indistinguishable from a crash.  The stream display
+                    # was flushed (callback(None)) before tool execution,
+                    # but the callback is still alive — fire the text
+                    # through it so SSE/TUI clients see the explanation.
+                    if final_response:
+                        agent._safe_print(f"\n{final_response}\n")
+                        if agent.stream_delta_callback:
+                            try:
+                                agent.stream_delta_callback(final_response)
+                                agent.stream_delta_callback(None)
+                            except Exception:
+                                pass
                     break
 
                 # Reset per-turn retry counters after successful tool

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -304,3 +304,52 @@ def test_config_enabled_hard_stop_run_conversation_returns_controlled_guardrail_
         call_ids = [tc["id"] for tc in assistant_msg["tool_calls"]]
         following_results = [m for m in result["messages"] if m.get("role") == "tool" and m.get("tool_call_id") in call_ids]
         assert len(following_results) == len(call_ids)
+
+
+def test_guardrail_halt_emits_final_response_through_stream_delta_callback():
+    """Regression for #30770: when the guardrail halts the loop, the
+    synthesized halt message must be pushed through ``stream_delta_callback``
+    so SSE/TUI clients see why the agent stopped instead of a silent stream
+    close.  Without this the chat-completions SSE writer drains an empty
+    queue and emits a finish chunk with zero content (indistinguishable
+    from a crash for Open WebUI and similar clients).
+    """
+    agent = _make_agent("web_search", max_iterations=10, config=_hard_stop_config())
+    same_args = {"query": "same"}
+    responses = [
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call("web_search", json.dumps(same_args), f"c{i}")],
+        )
+        for i in range(1, 10)
+    ]
+    agent.client.chat.completions.create.side_effect = responses
+
+    deltas: list = []
+    agent.stream_delta_callback = lambda d: deltas.append(d)
+    # The mocked client returns SimpleNamespace responses which aren't
+    # iterable as streaming chunks; force the non-streaming code path so
+    # the guardrail-halt branch is reached without engaging the real
+    # streaming machinery.
+    agent._disable_streaming = True
+
+    with (
+        patch("run_agent.handle_function_call", return_value=json.dumps({"error": "boom"})),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("search repeatedly")
+
+    assert result["turn_exit_reason"] == "guardrail_halt"
+    halt_text = result["final_response"]
+    assert "stopped retrying" in halt_text
+
+    # The halt message must have been pushed through the callback at least
+    # once.  Empty-queue SSE writers were the bug — clients saw no content
+    # delta before the finish chunk.
+    text_deltas = [d for d in deltas if isinstance(d, str)]
+    assert halt_text in text_deltas, (
+        f"halt message was never streamed; callback only saw {deltas!r}"
+    )


### PR DESCRIPTION
## Summary
Guardrail halts now deliver the synthesized halt message to SSE/TUI clients instead of closing the stream silently. Fixes #30770.

## Root cause
In `agent/conversation_loop.py` the guardrail-halt branch (~L3431) synthesizes `final_response` from a static template (`_toolguard_controlled_halt_response`) — it was never produced by the model and never streamed. The display callback was already flushed with `None` at L3423 before tool execution, so the SSE writer (`gateway/platforms/api_server.py:_write_sse_chat_completion`) drains an empty queue and emits a finish chunk with zero content. Open WebUI and similar clients render a blank bubble — indistinguishable from a crash.

The model-generated `text_response` path doesn't have this gap because its deltas were already streamed during the API call.

## Changes
- `agent/conversation_loop.py` — after the halt response is generated, push it through `_safe_print` (CLI/TUI) and `stream_delta_callback` (SSE) before breaking. Trailing `None` is filtered by the SSE writer (`_on_delta` at api_server.py:L1153) so it doesn't prematurely close the stream. (+13 LOC, salvaged from PR #30807 by @annguyenNous)
- `tests/run_agent/test_tool_call_guardrail_runtime.py` — regression test asserting the halt message reaches `stream_delta_callback`. Verified to fail when the production fix is reverted.

## Validation
| | Before | After |
|---|---|---|
| SSE client (Open WebUI) | empty stream, then finish chunk | content delta with halt explanation, then finish chunk |
| Targeted suite | 8 passing | 9 passing (regression test added) |

`scripts/run_tests.sh tests/run_agent/test_tool_call_guardrail_runtime.py` → 9/9 pass.

## Follow-up
Filing a separate issue for the two sibling sites with the same shape — `partial_stream_recovery` (~L3556) and `fallback_prior_turn_content` (~L3582) — where `final_response` is synthesized from non-streamed text. Lower-impact than the guardrail case (those paths only trigger on partial/empty-response recovery) but the gap is structurally the same.

Closes #30770
Salvages #30807


## Infographic

![guardrail-halt-no-more-silent-streams](https://v3b.fal.media/files/b/0a9b815b/mUBcUGc3Z1fGOlkOfTA7i_bIXoHYqL.png)
