### PR TITLE
fix(mcp): raise ImportError instead of NameError when stdio SDK missing

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1462,6 +1462,27 @@ class TestHTTPConfig:
 
         asyncio.run(_test())
 
+    def test_stdio_unavailable_raises_importerror_not_nameerror(self):
+        """Regression test for #30904.
+
+        When the mcp SDK isn't installed, ``_run_stdio`` previously leaked a
+        bare ``NameError: name 'StdioServerParameters' is not defined``. The
+        gate now raises a clear ``ImportError`` with install instructions,
+        mirroring ``_run_http``'s behaviour when the HTTP transport is
+        unavailable.
+        """
+        from tools.mcp_tool import MCPServerTask
+
+        server = MCPServerTask("local")
+        config = {"command": "python3", "args": ["/tmp/echo.py"]}
+
+        async def _test():
+            with patch("tools.mcp_tool._MCP_AVAILABLE", False):
+                with pytest.raises(ImportError, match=r"mcp.*SDK"):
+                    await server._run_stdio(config)
+
+        asyncio.run(_test())
+
     def test_http_seeds_initial_protocol_header(self):
         from tools.mcp_tool import LATEST_PROTOCOL_VERSION, MCPServerTask
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1255,6 +1255,15 @@ class MCPServerTask:
 
     async def _run_stdio(self, config: dict):
         """Run the server using stdio transport."""
+        if not _MCP_AVAILABLE:
+            raise ImportError(
+                f"MCP server '{self.name}' requires the 'mcp' Python SDK, but "
+                "it is not installed. Install with:\n"
+                "  pip install 'hermes-agent[mcp]'\n"
+                "or (full install):\n"
+                "  pip install 'hermes-agent[all]'"
+            )
+
         command = config.get("command")
         args = config.get("args", [])
         user_env = config.get("env")


### PR DESCRIPTION
Fixes #30904.

When the `mcp` Python SDK isn't installed, `_run_stdio` leaked a bare `NameError: name 'StdioServerParameters' is not defined` instead of telling the user how to install it. `_run_http` already had the parallel gate; `_run_stdio` was missing it.

## Changes
- `tools/mcp_tool.py`: gate `_run_stdio` on `_MCP_AVAILABLE` and raise `ImportError` with install instructions, mirroring `_run_http`'s `_MCP_HTTP_AVAILABLE` check.
- `tests/tools/test_mcp_tool.py`: regression test parallel to `test_http_unavailable_raises`.

## Validation

| | Before | After |
|---|---|---|
| `hermes mcp test` with mcp uninstalled | `✗ Connection failed: name 'StdioServerParameters' is not defined` | `✗ Connection failed: MCP server 'echo-test' requires the 'mcp' Python SDK, but it is not installed. Install with: pip install 'hermes-agent[mcp]' ...` |
| `hermes mcp test` with mcp installed | ✓ Connected | ✓ Connected (unchanged) |
| Targeted pytest | 1 test | 2 passed |


## Infographic

![fix-mcp-nameerror-importerror](https://v3b.fal.media/files/b/0a9b7d4a/V96KsojF3trnmKx7g_cST_gxbe1Eh0.png)
