### PR TITLE
fix: accept provider type alias

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3053,7 +3053,7 @@ def _normalize_custom_provider_entry(
         entry["key_env"] = entry["api_key_env"]
     _KNOWN_KEYS = {
         "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
-        "api_mode", "transport", "model", "default_model", "models",
+        "api_mode", "transport", "type", "model", "default_model", "models",
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
         "discover_models", "extra_body",
@@ -3119,7 +3119,11 @@ def _normalize_custom_provider_entry(
     if isinstance(key_env, str) and key_env.strip():
         normalized["key_env"] = key_env.strip()
 
-    api_mode = entry.get("api_mode") or entry.get("transport")
+    # ``type: openai`` is the shape used by many OpenAI-compatible provider
+    # examples (including Ollama snippets).  Treat it as a transport alias so
+    # hand-written configs don't emit noisy "unknown key" warnings on every
+    # load.
+    api_mode = entry.get("api_mode") or entry.get("transport") or entry.get("type")
     if isinstance(api_mode, str) and api_mode.strip():
         normalized["api_mode"] = api_mode.strip()
 

--- a/tests/hermes_cli/test_provider_config_validation.py
+++ b/tests/hermes_cli/test_provider_config_validation.py
@@ -104,6 +104,43 @@ class TestNormalizeCustomProviderEntry:
         assert result is not None
         assert not any("unknown config keys" in r.message.lower() for r in caplog.records)
 
+    def test_type_alias_sets_api_mode_without_unknown_key_warning(self, caplog):
+        """type: openai should be accepted as an api_mode/transport alias."""
+        entry = {
+            "base_url": "http://localhost:11434/v1",
+            "type": "openai",
+            "model": "qwen2.5:7b",
+            "api_key": "***",
+        }
+        with caplog.at_level(logging.WARNING):
+            result = _normalize_custom_provider_entry(entry, provider_key="ollama-local")
+        assert result is not None
+        assert result["api_mode"] == "openai"
+        assert not any("unknown config keys" in r.message.lower() for r in caplog.records)
+
+    def test_api_mode_precedence_over_transport_and_type(self):
+        """Explicit api_mode should keep precedence over transport and type aliases."""
+        entry = {
+            "base_url": "https://api.example.com/v1",
+            "api_mode": "explicit",
+            "transport": "transport-alias",
+            "type": "type-alias",
+        }
+        result = _normalize_custom_provider_entry(entry, provider_key="test")
+        assert result is not None
+        assert result["api_mode"] == "explicit"
+
+    def test_transport_precedence_over_type(self):
+        """transport should keep precedence over the more generic type alias."""
+        entry = {
+            "base_url": "https://api.example.com/v1",
+            "transport": "transport-alias",
+            "type": "type-alias",
+        }
+        result = _normalize_custom_provider_entry(entry, provider_key="test")
+        assert result is not None
+        assert result["api_mode"] == "transport-alias"
+
     def test_camel_case_warning_logged(self, caplog):
         """camelCase alias mapping should produce a warning."""
         entry = {


### PR DESCRIPTION
## Summary
- Accept `type` as a known provider config key for OpenAI-compatible custom providers.
- Treat `type` as the lowest-precedence `api_mode` alias after explicit `api_mode` and `transport`.
- Add regression coverage for warning suppression and alias precedence.

## Test plan
- `python -m pytest tests/hermes_cli/test_provider_config_validation.py -q -o 'addopts='`
