### PR TITLE
fix: route telegram notification replies to origin

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -126,6 +126,50 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
 
 from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run
 
+
+def _register_notification_route_from_send_result(
+    *,
+    platform_name: str,
+    chat_id: str,
+    thread_id: Optional[str],
+    send_result,
+    job: dict,
+    origin: dict,
+) -> None:
+    """Record cron notification message ids so Telegram replies route to origin."""
+    if not send_result or not getattr(send_result, "success", True):
+        return
+    message_ids = []
+    message_id = getattr(send_result, "message_id", None)
+    if message_id is not None:
+        message_ids.append(str(message_id))
+    raw = getattr(send_result, "raw_response", None)
+    if isinstance(raw, dict):
+        for mid in raw.get("message_ids") or []:
+            if mid is not None:
+                message_ids.append(str(mid))
+    if not message_ids:
+        return
+    try:
+        from gateway.notification_routes import register_outbound_notification
+
+        route = {
+            "kind": "cron_delivery",
+            "job_id": job.get("id"),
+            "state": "delivered",
+            "source": origin,
+        }
+        register_outbound_notification(
+            platform=platform_name,
+            chat_id=chat_id,
+            thread_id=thread_id,
+            message_ids=message_ids,
+            route=route,
+        )
+    except Exception as exc:
+        logger.debug("Job '%s': failed to register notification route: %s", job.get("id", "?"), exc)
+
+
 # Sentinel: when a cron agent has nothing new to report, it can start its
 # response with this marker to suppress delivery.  Output is still saved
 # locally for audit.
@@ -695,7 +739,16 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                                 job["id"], platform_name, chat_id, err,
                             )
                             adapter_ok = False  # fall through to standalone path
-                        elif (
+                        else:
+                            _register_notification_route_from_send_result(
+                                platform_name=platform_name,
+                                chat_id=chat_id,
+                                thread_id=thread_id,
+                                send_result=send_result,
+                                job=job,
+                                origin=origin,
+                            )
+                        if (
                             send_result
                             and thread_id
                             and getattr(send_result, "raw_response", None)

--- a/gateway/notification_routes.py
+++ b/gateway/notification_routes.py
@@ -1,0 +1,310 @@
+"""Durable routing index for replies to outbound gateway notifications.
+
+Notifications from cron/background/watchers are delivered into a platform chat,
+but user replies should often continue the originating session/process rather
+than create a new delivery-chat workflow.  This module stores only routing-safe
+metadata under HERMES_HOME; it intentionally does not persist notification body
+text or secrets.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import time
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping, Optional
+from urllib.parse import quote
+
+from hermes_constants import get_hermes_home
+
+from .config import Platform
+from .session import SessionSource
+
+_DEFAULT_TTL_SECONDS = 30 * 60
+_CONTEXTUAL_PREFIXES = (
+    "ok",
+    "okay",
+    "ок",
+    "окей",
+    "да",
+    "yes",
+    "yep",
+    "продолж",
+    "continue",
+    "go on",
+    "проверь",
+    "check",
+    "останов",
+    "stop",
+    "отмени",
+    "cancel",
+    "сделай",
+    "do it",
+    "запусти",
+    "run",
+)
+
+
+def _hermes_home() -> Path:
+    return Path(get_hermes_home())
+
+
+def _routes_path() -> Path:
+    return _hermes_home() / "gateway" / "notification_routes.json"
+
+
+def _detect_server_ip() -> Optional[str]:
+    """Best-effort externally usable server IP for WebUI link fallback."""
+    try:
+        candidates = socket.gethostbyname_ex(socket.gethostname())[2]
+    except OSError:
+        candidates = []
+    for ip in candidates:
+        if not ip.startswith("127.") and not ip.startswith("169.254."):
+            return ip
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            sock.connect(("8.8.8.8", 80))
+            ip = sock.getsockname()[0]
+            if ip and not ip.startswith("127."):
+                return ip
+    except OSError:
+        return None
+    return None
+
+
+def build_webui_session_url(session_id: Optional[str] = None) -> Optional[str]:
+    """Build a direct WebUI chat/session URL when enough runtime data exists.
+
+    Priority:
+    1. Explicit public/base URL: HERMES_WEBUI_PUBLIC_URL or HERMES_WEBUI_BASE_URL.
+    2. Runtime fallback: detected server IP + HERMES_WEBUI_PORT.
+
+    Returns None instead of inventing a link when session id, host, or port is
+    unavailable.
+    """
+    sid = (session_id or os.getenv("HERMES_SESSION_ID") or "").strip()
+    if not sid:
+        return None
+    encoded = quote(sid, safe="")
+    base = (
+        os.getenv("HERMES_WEBUI_PUBLIC_URL")
+        or os.getenv("HERMES_WEBUI_BASE_URL")
+        or os.getenv("WEBUI_PUBLIC_URL")
+        or ""
+    ).strip()
+    if base:
+        return f"{base.rstrip('/')}/session/{encoded}"
+    port = (os.getenv("HERMES_WEBUI_PORT") or "").strip()
+    if not port:
+        return None
+    host = _detect_server_ip()
+    if not host:
+        return None
+    return f"http://{host}:{port}/session/{encoded}"
+
+
+def _load_state() -> Dict[str, Any]:
+    path = _routes_path()
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except FileNotFoundError:
+        return {"messages": {}, "latest_by_scope": {}}
+    except (OSError, json.JSONDecodeError):
+        return {"messages": {}, "latest_by_scope": {}}
+    if not isinstance(data, dict):
+        return {"messages": {}, "latest_by_scope": {}}
+    data.setdefault("messages", {})
+    data.setdefault("latest_by_scope", {})
+    return data
+
+
+def _save_state(state: Mapping[str, Any]) -> None:
+    path = _routes_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as fh:
+        json.dump(state, fh, ensure_ascii=False, sort_keys=True, indent=2)
+    tmp.replace(path)
+
+
+def _norm(value: Any) -> str:
+    return "" if value is None else str(value)
+
+
+def _message_key(platform: str, chat_id: Any, message_id: Any, thread_id: Any = None) -> str:
+    return f"{_norm(platform)}:{_norm(chat_id)}:{_norm(thread_id)}:{_norm(message_id)}"
+
+
+def _scope_key(platform: str, chat_id: Any, thread_id: Any = None) -> str:
+    return f"{_norm(platform)}:{_norm(chat_id)}:{_norm(thread_id)}"
+
+
+def _source_from_route(route: Mapping[str, Any]) -> Optional[SessionSource]:
+    raw = route.get("source")
+    if not isinstance(raw, Mapping):
+        return None
+    data = dict(raw)
+    if "platform" in data and not isinstance(data["platform"], Platform):
+        data["platform"] = str(data["platform"])
+    try:
+        return SessionSource.from_dict(data)
+    except Exception:
+        return None
+
+
+def _sanitize_route(route: Mapping[str, Any]) -> Dict[str, Any]:
+    clean: Dict[str, Any] = {}
+    for key in ("kind", "session_key", "session_id", "job_id", "process_id", "repo", "branch", "issue", "pr", "state"):
+        value = route.get(key)
+        if value is not None:
+            clean[key] = str(value)
+    source = route.get("source")
+    if isinstance(source, SessionSource):
+        clean["source"] = source.to_dict()
+    elif isinstance(source, Mapping):
+        allowed = {
+            "platform",
+            "chat_id",
+            "chat_name",
+            "chat_type",
+            "user_id",
+            "user_name",
+            "thread_id",
+            "chat_topic",
+            "user_id_alt",
+            "chat_id_alt",
+            "guild_id",
+            "parent_chat_id",
+        }
+        clean["source"] = {k: v for k, v in source.items() if k in allowed and v is not None}
+    return clean
+
+
+def register_outbound_notification(
+    *,
+    platform: str,
+    chat_id: Any,
+    message_ids: Iterable[Any],
+    route: Mapping[str, Any],
+    thread_id: Any = None,
+    ttl_seconds: int = _DEFAULT_TTL_SECONDS,
+    now: Optional[float] = None,
+) -> None:
+    """Register routing metadata for an actionable outbound notification."""
+    created_at = time.time() if now is None else float(now)
+    expires_at = created_at + max(1, int(ttl_seconds))
+    clean = _sanitize_route(route)
+    clean.update({"created_at": created_at, "expires_at": expires_at})
+
+    state = _load_state()
+    messages = state.setdefault("messages", {})
+    latest = state.setdefault("latest_by_scope", {})
+
+    first_key: Optional[str] = None
+    for message_id in message_ids:
+        if message_id is None:
+            continue
+        key = _message_key(platform, chat_id, message_id, thread_id)
+        messages[key] = dict(clean)
+        if first_key is None:
+            first_key = key
+    if first_key is not None:
+        latest[_scope_key(platform, chat_id, thread_id)] = first_key
+    _save_state(state)
+
+
+def _route_if_fresh(route: Mapping[str, Any], *, now: Optional[float] = None) -> Optional[Dict[str, Any]]:
+    current = time.time() if now is None else float(now)
+    try:
+        expires_at = float(route.get("expires_at", 0))
+    except (TypeError, ValueError):
+        return None
+    if expires_at < current:
+        return None
+    source = _source_from_route(route)
+    if source is None:
+        return None
+    return {"source": source, "route": dict(route)}
+
+
+def resolve_exact_reply(
+    *,
+    platform: str,
+    chat_id: Any,
+    reply_to_message_id: Any,
+    thread_id: Any = None,
+    now: Optional[float] = None,
+) -> Optional[Dict[str, Any]]:
+    if reply_to_message_id is None:
+        return None
+    state = _load_state()
+    messages = state.get("messages", {})
+    route = messages.get(_message_key(platform, chat_id, reply_to_message_id, thread_id))
+    if route is None and thread_id is not None:
+        route = messages.get(_message_key(platform, chat_id, reply_to_message_id, None))
+    if not isinstance(route, Mapping):
+        return None
+    return _route_if_fresh(route, now=now)
+
+
+def _looks_like_continuation(text: str) -> bool:
+    stripped = (text or "").strip().lower()
+    if not stripped or stripped.startswith("/"):
+        return False
+    return any(stripped.startswith(prefix) for prefix in _CONTEXTUAL_PREFIXES)
+
+
+def resolve_latest_followup(
+    *,
+    platform: str,
+    chat_id: Any,
+    text: str,
+    thread_id: Any = None,
+    now: Optional[float] = None,
+) -> Optional[Dict[str, Any]]:
+    if not _looks_like_continuation(text):
+        return None
+    state = _load_state()
+    latest = state.get("latest_by_scope", {})
+    messages = state.get("messages", {})
+    route_key = latest.get(_scope_key(platform, chat_id, thread_id))
+    if route_key is None and thread_id is not None:
+        route_key = latest.get(_scope_key(platform, chat_id, None))
+    if not route_key:
+        return None
+    route = messages.get(route_key)
+    if not isinstance(route, Mapping):
+        return None
+    return _route_if_fresh(route, now=now)
+
+
+def resolve_notification_route_for_message(
+    *,
+    platform: str,
+    chat_id: Any,
+    text: str,
+    reply_to_message_id: Any = None,
+    thread_id: Any = None,
+    now: Optional[float] = None,
+) -> Optional[Dict[str, Any]]:
+    """Resolve an inbound platform message to a notification origin if safe."""
+    exact = resolve_exact_reply(
+        platform=platform,
+        chat_id=chat_id,
+        reply_to_message_id=reply_to_message_id,
+        thread_id=thread_id,
+        now=now,
+    )
+    if exact is not None:
+        return exact
+    return resolve_latest_followup(
+        platform=platform,
+        chat_id=chat_id,
+        text=text,
+        thread_id=thread_id,
+        now=now,
+    )

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5597,6 +5597,23 @@ class TelegramAdapter(BasePlatformAdapter):
                     or None
                 )
 
+        try:
+            from gateway.notification_routes import resolve_notification_route_for_message
+
+            notification_route = resolve_notification_route_for_message(
+                platform="telegram",
+                chat_id=str(chat.id),
+                text=message.text or message.caption or "",
+                reply_to_message_id=reply_to_id,
+                thread_id=thread_id_str,
+            )
+            if notification_route is not None:
+                routed_source = notification_route.get("source")
+                if routed_source is not None:
+                    source = routed_source
+        except Exception as exc:
+            logger.debug("[%s] notification route resolution skipped: %s", self.name, exc)
+
         # Per-channel/topic ephemeral prompt
         from gateway.platforms.base import resolve_channel_prompt
         _chat_id_str = str(chat.id)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -788,6 +788,66 @@ class TestDeliverResultWrapping:
         assert "MEDIA:" not in text_sent
         assert "Report" in text_sent
 
+    def test_live_adapter_registers_notification_reply_route(self, tmp_path, monkeypatch):
+        """Cron live-adapter deliveries should register message_id -> origin routes."""
+        from concurrent.futures import Future
+        from gateway.config import Platform
+        import gateway.notification_routes as routes_mod
+        from gateway.notification_routes import resolve_exact_reply
+
+        monkeypatch.setattr(routes_mod, "_hermes_home", lambda: tmp_path)
+
+        adapter = AsyncMock()
+        adapter.send.return_value = MagicMock(success=True, message_id="700", raw_response={})
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        def fake_run_coro(coro, _loop):
+            future = Future()
+            future.set_result(MagicMock(success=True, message_id="700", raw_response={}))
+            coro.close()
+            return future
+
+        job = {
+            "id": "route-job",
+            "name": "route job",
+            "deliver": "origin",
+            "origin": {
+                "platform": "telegram",
+                "chat_id": "123",
+                "chat_type": "dm",
+                "thread_id": "24296",
+                "user_id": "456",
+                "user_name": "Alice",
+            },
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+            assert _deliver_result(
+                job,
+                "done",
+                adapters={Platform.TELEGRAM: adapter},
+                loop=loop,
+            ) is None
+
+        resolved = resolve_exact_reply(
+            platform="telegram",
+            chat_id="123",
+            reply_to_message_id="700",
+            thread_id="24296",
+        )
+        assert resolved is not None
+        assert resolved["source"].chat_id == "123"
+        assert resolved["source"].thread_id == "24296"
+
     def test_no_mirror_to_session_call(self):
         """Cron deliveries should NOT mirror into the gateway session."""
         from gateway.config import Platform

--- a/tests/gateway/test_notification_routes.py
+++ b/tests/gateway/test_notification_routes.py
@@ -1,0 +1,106 @@
+"""Tests for outbound notification reply routing metadata."""
+
+import time
+
+import gateway.notification_routes as routes
+from gateway.notification_routes import (
+    build_webui_session_url,
+    register_outbound_notification,
+    resolve_latest_followup,
+)
+
+
+def _route():
+    return {
+        "kind": "background_process",
+        "session_key": "agent:main:telegram:dm:123:24296",
+        "source": {
+            "platform": "telegram",
+            "chat_id": "123",
+            "chat_type": "dm",
+            "thread_id": "24296",
+            "user_id": "456",
+            "user_name": "Alice",
+        },
+    }
+
+
+def test_latest_followup_expires(monkeypatch, tmp_path):
+    monkeypatch.setattr(routes, "_hermes_home", lambda: tmp_path)
+    register_outbound_notification(
+        platform="telegram",
+        chat_id="999",
+        message_ids=["700"],
+        route=_route(),
+        ttl_seconds=10,
+        now=1_000,
+    )
+
+    assert resolve_latest_followup(
+        platform="telegram",
+        chat_id="999",
+        text="ок, продолжай",
+        now=1_020,
+    ) is None
+
+
+def test_latest_followup_does_not_hijack_slash_commands(monkeypatch, tmp_path):
+    monkeypatch.setattr(routes, "_hermes_home", lambda: tmp_path)
+    register_outbound_notification(
+        platform="telegram",
+        chat_id="999",
+        message_ids=["700"],
+        route=_route(),
+        ttl_seconds=1800,
+        now=time.time(),
+    )
+
+    assert resolve_latest_followup(
+        platform="telegram",
+        chat_id="999",
+        text="/new unrelated task",
+    ) is None
+
+
+def test_latest_followup_does_not_hijack_short_new_tasks(monkeypatch, tmp_path):
+    monkeypatch.setattr(routes, "_hermes_home", lambda: tmp_path)
+    register_outbound_notification(
+        platform="telegram",
+        chat_id="999",
+        message_ids=["700"],
+        route=_route(),
+        ttl_seconds=1800,
+        now=time.time(),
+    )
+
+    assert resolve_latest_followup(
+        platform="telegram",
+        chat_id="999",
+        text="создай новый отчет",
+    ) is None
+
+
+def test_webui_session_url_prefers_explicit_public_url(monkeypatch):
+    monkeypatch.setenv("HERMES_WEBUI_PUBLIC_URL", "https://hermes.example.com/base/")
+    monkeypatch.setenv("HERMES_WEBUI_PORT", "8788")
+
+    assert build_webui_session_url("abc123") == "https://hermes.example.com/base/session/abc123"
+
+
+def test_webui_session_url_falls_back_to_server_ip_and_port(monkeypatch):
+    monkeypatch.delenv("HERMES_WEBUI_PUBLIC_URL", raising=False)
+    monkeypatch.delenv("HERMES_WEBUI_BASE_URL", raising=False)
+    monkeypatch.setenv("HERMES_WEBUI_PORT", "8788")
+    monkeypatch.setattr(routes, "_detect_server_ip", lambda: "70.34.246.102")
+
+    assert build_webui_session_url("00cd34bde02b") == "http://70.34.246.102:8788/session/00cd34bde02b"
+
+
+def test_webui_session_url_unavailable_without_session_or_host(monkeypatch):
+    monkeypatch.delenv("HERMES_WEBUI_PUBLIC_URL", raising=False)
+    monkeypatch.delenv("HERMES_WEBUI_BASE_URL", raising=False)
+    monkeypatch.setenv("HERMES_WEBUI_PORT", "8788")
+    monkeypatch.setattr(routes, "_detect_server_ip", lambda: None)
+
+    assert build_webui_session_url("") is None
+    assert build_webui_session_url("abc123") is None

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -168,6 +168,107 @@ def test_non_forum_group_reply_thread_id_does_not_fork_session_key():
     assert build_session_key(event.source) == "agent:main:telegram:group:-100123:456"
 
 
+def test_reply_to_registered_notification_reroutes_to_origin_session(monkeypatch, tmp_path):
+    """Replying to a Hermes notification should use the recorded origin route.
+
+    Regression for tradebotint/hermes-agent#4: a reply in the delivery/home chat
+    must not create a fresh workflow keyed by the delivery chat when the outbound
+    notification message id is known to belong to a different origin session.
+    """
+    from gateway.platforms import telegram as telegram_mod
+    import gateway.notification_routes as routes_mod
+    from gateway.notification_routes import register_outbound_notification
+
+    monkeypatch.setattr(routes_mod, "_hermes_home", lambda: tmp_path)
+    register_outbound_notification(
+        platform="telegram",
+        chat_id="999",
+        message_ids=["700"],
+        route={
+            "kind": "background_process",
+            "session_key": "agent:main:telegram:dm:123:24296",
+            "source": {
+                "platform": "telegram",
+                "chat_id": "123",
+                "chat_type": "dm",
+                "thread_id": "24296",
+                "user_id": "456",
+                "user_name": "Alice",
+            },
+        },
+    )
+
+    adapter = _make_adapter()
+    message = SimpleNamespace(
+        text="continue there",
+        caption=None,
+        chat=SimpleNamespace(id=999, type=telegram_mod.ChatType.PRIVATE, title=None, full_name="Alice"),
+        from_user=SimpleNamespace(id=456, full_name="Alice"),
+        message_thread_id=None,
+        is_topic_message=False,
+        reply_to_message=SimpleNamespace(message_id=700, text="Background process completed", caption=None),
+        message_id=701,
+        date=None,
+    )
+
+    event = adapter._build_message_event(message, msg_type=MessageType.TEXT)
+
+    assert event.reply_to_message_id == "700"
+    assert event.source.chat_id == "123"
+    assert event.source.chat_type == "dm"
+    assert event.source.thread_id == "24296"
+    assert event.source.user_id == "456"
+    assert build_session_key(event.source) == "agent:main:telegram:dm:123:24296"
+
+
+def test_recent_registered_notification_followup_reroutes_without_native_reply(monkeypatch, tmp_path):
+    """Fresh semantic follow-ups should continue the latest actionable origin."""
+    from gateway.platforms import telegram as telegram_mod
+    import gateway.notification_routes as routes_mod
+    from gateway.notification_routes import register_outbound_notification
+
+    monkeypatch.setattr(routes_mod, "_hermes_home", lambda: tmp_path)
+    register_outbound_notification(
+        platform="telegram",
+        chat_id="999",
+        message_ids=["700"],
+        route={
+            "kind": "background_process",
+            "session_key": "agent:main:telegram:dm:123:24296",
+            "source": {
+                "platform": "telegram",
+                "chat_id": "123",
+                "chat_type": "dm",
+                "thread_id": "24296",
+                "user_id": "456",
+                "user_name": "Alice",
+            },
+        },
+        ttl_seconds=1800,
+    )
+
+    adapter = _make_adapter()
+    message = SimpleNamespace(
+        text="ок, продолжай",
+        caption=None,
+        chat=SimpleNamespace(id=999, type=telegram_mod.ChatType.PRIVATE, title=None, full_name="Alice"),
+        from_user=SimpleNamespace(id=456, full_name="Alice"),
+        message_thread_id=None,
+        is_topic_message=False,
+        reply_to_message=None,
+        message_id=702,
+        date=None,
+    )
+
+    event = adapter._build_message_event(message, msg_type=MessageType.TEXT)
+
+    assert event.reply_to_message_id is None
+    assert event.source.chat_id == "123"
+    assert event.source.chat_type == "dm"
+    assert event.source.thread_id == "24296"
+    assert build_session_key(event.source) == "agent:main:telegram:dm:123:24296"
+
+
 def test_forum_group_topic_message_preserves_thread_session_key():
     """Real Telegram forum-topic messages should still route by topic id."""
     from gateway.platforms import telegram as telegram_mod


### PR DESCRIPTION
## Summary
- Add a profile-safe notification route index for actionable outbound gateway notifications.
- Register cron live-adapter Telegram deliveries so native replies and short semantic follow-ups can resume the originating session/process instead of creating/continuing the wrong chat.
- Add WebUI session link builder with explicit public URL support and best-effort server-IP fallback.

## Why
Telegram notification replies should be handled by the originating process/session. Without a durable route from outbound notification message IDs back to the source session, follow-up replies from Telegram can be misrouted as unrelated inbound chat messages.

## Safety / routing rules
- Exact route: `platform + chat_id + thread_id + outbound_message_id -> origin`.
- Latest actionable route: `platform + chat_id + thread_id -> origin` for short semantic continuation replies.
- Slash commands are never hijacked.
- Short new-task phrasing is not hijacked.
- Routes expire by TTL.
- Cron deliveries are not mirrored into the target gateway session history, preserving role alternation.

## Tests
```bash
python3 -m py_compile gateway/notification_routes.py cron/scheduler.py gateway/platforms/telegram.py
python3 -m pytest tests/gateway/test_notification_routes.py tests/gateway/test_telegram_thread_fallback.py tests/gateway/test_delivery.py tests/cron/test_scheduler.py::TestDeliverResultWrapping -q -o 'addopts='
# 76 passed
python3 -m pytest tests/cron/test_scheduler.py -q -o 'addopts='
# 128 passed
```
