### PR TITLE
fix(transport): strip Hermes-internal scaffolding keys + classify 5xx validation errors (salvage #26054)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -240,6 +240,24 @@ _MODEL_NOT_FOUND_PATTERNS = [
     "unsupported model",
 ]
 
+# Request-validation patterns — the request is malformed and will fail
+# identically on every retry. Some OpenAI-compatible gateways (notably
+# codex.nekos.me) return these as 5xx instead of the standard 4xx, which
+# makes the generic "5xx → retryable server_error" rule misfire: the retry
+# loop hammers the same deterministic rejection 3+ times, then the
+# transport-recovery path resets the counter and does it again, producing
+# a request flood. When a 5xx body carries one of these unambiguous
+# request-validation signals, classify as a non-retryable format_error so
+# the loop fails fast and falls back instead of looping.
+_REQUEST_VALIDATION_PATTERNS = [
+    "unknown parameter",
+    "unsupported parameter",
+    "unrecognized request argument",
+    "invalid_request_error",
+    "unknown_parameter",
+    "unsupported_parameter",
+]
+
 # OpenRouter aggregator policy-block patterns.
 #
 # When a user's OpenRouter account privacy setting (or a per-request
@@ -745,6 +763,23 @@ def _classify_by_status(
         )
 
     if status_code in {500, 502}:
+        # Some OpenAI-compatible gateways return request-validation errors
+        # with a 5xx status (codex.nekos.me returns 502 for unknown/
+        # unsupported parameters). These are deterministic — every retry
+        # gets the identical rejection — so the generic "5xx → retryable
+        # server_error" rule turns one bad request into a retry flood.
+        # Detect the unambiguous request-validation signals (in either the
+        # message text or the structured error code) and fail fast.
+        if (
+            any(p in error_msg for p in _REQUEST_VALIDATION_PATTERNS)
+            or error_code.lower() in {"invalid_request_error", "unknown_parameter",
+                                      "unsupported_parameter"}
+        ):
+            return result_fn(
+                FailoverReason.format_error,
+                retryable=False,
+                should_fallback=True,
+            )
         return result_fn(FailoverReason.server_error, retryable=True)
 
     if status_code in {503, 529}:

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -113,9 +113,8 @@ class ChatCompletionsTransport(ProviderTransport):
         self, messages: list[dict[str, Any]], **kwargs
     ) -> list[dict[str, Any]]:
         """Messages are already in OpenAI format — strip internal fields
-        that strict chat-completions providers reject with HTTP 400/422.
-
-        Strips:
+        that strict chat-completions providers reject with HTTP 400/422
+        (or, in the case of some OpenAI-compatible gateways, 5xx):
 
         - Codex Responses API fields: ``codex_reasoning_items`` /
           ``codex_message_items`` on the message, ``call_id`` /
@@ -127,6 +126,16 @@ class ChatCompletionsTransport(ProviderTransport):
           ``Extra inputs are not permitted, field: 'messages[N].tool_name'``.
           Permissive providers (OpenRouter, MiniMax) silently ignore the
           field, which masked the bug for months.
+        - Hermes-internal scaffolding markers — any top-level message key
+          starting with ``_`` (e.g. ``_empty_recovery_synthetic``,
+          ``_empty_terminal_sentinel``, ``_thinking_prefill``). These are
+          bookkeeping flags the agent loop attaches to messages so the
+          persistence layer can later strip its own scaffolding; they must
+          never reach the wire. Permissive providers (real OpenAI,
+          Anthropic) silently drop unknown message keys, but strict
+          gateways (e.g. opencode-go, codex.nekos.me) reject with
+          ``Extra inputs are not permitted, field: 'messages[N]._empty_recovery_synthetic'``,
+          which then poisons every subsequent request in the session.
         """
         needs_sanitize = False
         for msg in messages:
@@ -137,6 +146,9 @@ class ChatCompletionsTransport(ProviderTransport):
                 or "codex_message_items" in msg
                 or "tool_name" in msg
             ):
+                needs_sanitize = True
+                break
+            if any(isinstance(k, str) and k.startswith("_") for k in msg):
                 needs_sanitize = True
                 break
             tool_calls = msg.get("tool_calls")
@@ -160,6 +172,11 @@ class ChatCompletionsTransport(ProviderTransport):
             msg.pop("codex_reasoning_items", None)
             msg.pop("codex_message_items", None)
             msg.pop("tool_name", None)
+            # Drop all Hermes-internal scaffolding markers (``_``-prefixed).
+            # OpenAI's message schema has no ``_``-prefixed fields, so this
+            # is safe and future-proofs against new markers being added.
+            for key in [k for k in msg if isinstance(k, str) and k.startswith("_")]:
+                msg.pop(key, None)
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):
                 for tc in tool_calls:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -70,6 +70,8 @@ AUTHOR_MAP = {
     "qiyin.zuo@pcitc.com": "qiyin-code",
     "mr.aashiz@gmail.com": "aashizpoudel",
     "70629228+shaun0927@users.noreply.github.com": "shaun0927",
+    "soju06@users.noreply.github.com": "Soju06",
+    "34199905+Soju06@users.noreply.github.com": "Soju06",
     "98262967+Bihruze@users.noreply.github.com": "Bihruze",
     "189280367+Lempkey@users.noreply.github.com": "Lempkey",
     "34853915+m0n3r0@users.noreply.github.com": "m0n3r0",

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -293,6 +293,64 @@ class TestClassifyApiError:
         result = classify_api_error(e)
         assert result.reason == FailoverReason.overloaded
 
+    # ── 5xx that are actually request-validation errors ──
+    # Some OpenAI-compatible gateways (e.g. codex.nekos.me) return
+    # request-validation failures with a 5xx status. These are
+    # deterministic, so they must NOT be retried — otherwise the retry
+    # loop hammers the identical bad request into a flood.
+
+    def test_502_with_unknown_parameter_is_non_retryable(self):
+        e = MockAPIError(
+            "Unknown parameter: 'input[617]._empty_recovery_synthetic'",
+            status_code=502,
+            body={
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": (
+                        "[ObjectParam] [input[617]._empty_recovery_synthetic] "
+                        "[unknown_parameter] Unknown parameter: "
+                        "'input[617]._empty_recovery_synthetic'."
+                    ),
+                }
+            },
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+        assert result.should_fallback is True
+
+    def test_502_with_unsupported_parameter_is_non_retryable(self):
+        e = MockAPIError(
+            "Unsupported parameter: logprobs",
+            status_code=502,
+            body={
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": "Unsupported parameter: logprobs",
+                }
+            },
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+
+    def test_500_with_invalid_request_error_type_is_non_retryable(self):
+        e = MockAPIError(
+            "bad request",
+            status_code=500,
+            body={"error": {"type": "invalid_request_error", "message": "bad request"}},
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+
+    def test_502_plain_bad_gateway_still_retryable(self):
+        """A genuine 502 with no request-validation signal stays retryable."""
+        e = MockAPIError("Bad Gateway", status_code=502)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.server_error
+        assert result.retryable is True
+
     # ── Model not found ──
 
     def test_404_model_not_found(self):

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -66,6 +66,38 @@ class TestChatCompletionsBasic:
         # Original list untouched (deepcopy-on-demand)
         assert msgs[2]["tool_name"] == "execute_code"
 
+    def test_convert_messages_strips_internal_scaffolding_markers(self, transport):
+        """Hermes-internal ``_``-prefixed markers must never reach the wire.
+
+        The empty-response recovery path appends synthetic messages tagged
+        with ``_empty_recovery_synthetic``; permissive providers ignore the
+        unknown key, but strict gateways (opencode-go, codex.nekos.me)
+        reject the request, poisoning every later turn in the session.
+        """
+        msgs = [
+            {"role": "user", "content": "run the task"},
+            {"role": "assistant", "content": "(empty)", "_empty_recovery_synthetic": True},
+            {"role": "user", "content": "continue", "_empty_recovery_synthetic": True},
+            {"role": "assistant", "content": "done", "_thinking_prefill": True,
+             "_empty_terminal_sentinel": True},
+        ]
+        result = transport.convert_messages(msgs)
+        for m in result:
+            assert not any(k.startswith("_") for k in m), m
+        # Visible content preserved
+        assert result[1]["content"] == "(empty)"
+        assert result[2]["content"] == "continue"
+        # Original list untouched (deepcopy-on-demand)
+        assert msgs[1]["_empty_recovery_synthetic"] is True
+
+    def test_convert_messages_clean_list_is_identity(self, transport):
+        """A list with no internal/codex keys is returned as-is (no copy)."""
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        assert transport.convert_messages(msgs) is msgs
+
 
 class TestChatCompletionsBuildKwargs:
 


### PR DESCRIPTION
## Summary
Hermes-internal scaffolding fields (`_empty_recovery_synthetic`, `_empty_terminal_sentinel`, `_thinking_prefill`) no longer reach the wire on the chat_completions transport. Once they entered a session's history, strict OpenAI-compatible providers (opencode-go in #30959, codex.nekos.me earlier) rejected every subsequent request with `Extra inputs are not permitted` — the session became unusable until restarted.

Salvages #26054 (closed, never reviewed) onto current `main`. Closes #30959.

## Changes
- `agent/transports/chat_completions.py` — `convert_messages()` now strips any top-level message key starting with `_` (single chokepoint at the transport, future-proof against new internal markers). OpenAI Chat Completions schema reserves no `_`-prefixed fields, so stripping is lossless. Anthropic/Codex/Bedrock transports unaffected — they rebuild the wire schema from scratch and never passthrough unknowns.
- `agent/error_classifier.py` — 5xx responses carrying request-validation signals (`unknown parameter`, `invalid_request_error`, `unsupported parameter`, etc. in the body OR `unknown_parameter`/`unsupported_parameter`/`invalid_request_error` as the structured error code) classified as non-retryable `format_error` instead of retryable `server_error`. Standard OpenAI returns these as 4xx; some compatible gateways return them as 5xx, which made the retry loop hammer the same deterministic rejection. Genuine `502 Bad Gateway` with no such signal stays retryable.
- Tests covering both the `_`-prefix strip (visible content preserved, original list untouched, clean lists returned by identity) and the new 5xx classification path.

## Why a single chokepoint at the transport (not 3 strip-at-source sites)
The issue proposes stripping in `conversation_loop.py`, `chat_completion_helpers.py`, AND the transport. The transport-only fix is strictly better: one place to maintain, future-proof against new internal markers (any new `_`-prefixed field is auto-stripped), and the messages list keeps the markers in-memory so `_drop_trailing_empty_response_scaffolding` and the message-sequence repair code can still recognize their own scaffolding when persisting to the SQLite store.

## Scope check — not "global"
opencode-go routes per-model: anthropic-flavored models → `anthropic_messages` transport, openai-flavored → `chat_completions` transport. This fix touches only `chat_completions::convert_messages`. The anthropic transport rebuilds the schema from scratch (system+messages tuple, content blocks) — unknown top-level keys can't survive that conversion, so it doesn't need the strip and isn't touched. codex_responses and bedrock_converse transports also unchanged.

## Validation
| | Before | After |
|---|---|---|
| `_empty_recovery_synthetic` in payload on opencode-go | HTTP 400, session poisoned | Stripped at transport, payload clean |
| Permissive providers (OpenAI, OpenRouter, Anthropic) | Silently ignored field server-side | Field never sent (identical model input/output) |
| `502 + "unknown parameter"` | retryable `server_error` → retry flood | non-retryable `format_error` → fail fast |
| `502 Bad Gateway` (genuine) | retryable `server_error` | retryable `server_error` (unchanged) |
| Original messages list | n/a | Untouched (deepcopy-on-demand) |
| Clean lists | n/a | Returned by identity, no copy |

Targeted suites: 336/336 pass (`tests/agent/transports/`, `tests/run_agent/test_empty_response_recovery_persistence.py`, `tests/run_agent/test_message_sequence_repair.py`, `tests/providers/test_transport_parity.py`).

E2E with real imports + a synthetic poisoned message list (system+user+tool_call+tool_result+2 recovery synthetics+thinking_prefill+terminal_sentinel) confirmed: all `_`-prefixed keys stripped, `tool_name` stripped, content preserved, original list untouched.

## Credit
Cherry-picked from #26054 by @Soju06 (PR self-closed without review). Both commits preserve original authorship via cherry-pick + rebase merge.


## Infographic

![strip-internal-scaffolding](https://v3b.fal.media/files/b/0a9b8c13/fcpyLf7jNSuDGHymV0KPI_KwtgyiM2.png)
