### PR TITLE
fix(hindsight): make legacy 'hindsight' import optional on Python 3.11+

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -92,7 +92,13 @@ def _check_local_runtime() -> tuple[bool, str | None]:
     a broken local memory backend.
     """
     try:
-        importlib.import_module("hindsight")
+        # "hindsight" package (<=0.1.7) fails to build on Python 3.11+
+        # due to use_2to3 deprecation. hindsight-embed is the replacement
+        # for local-embedded mode and ships daemon_embed_manager directly.
+        try:
+            importlib.import_module("hindsight")
+        except Exception:
+            pass  # Legacy package not required when hindsight-embed is present
         importlib.import_module("hindsight_embed.daemon_embed_manager")
         return True, None
     except Exception as exc:


### PR DESCRIPTION
## Problem

The `hindsight` package (`<=0.1.7`) uses `setup(use_2to3=...)` in its `setup.py`, which was deprecated in Python 3.10 and fully removed in Python 3.12. On Python 3.11+ systems this causes an install-time error:

```
error in hindsight setup command: use_2to3 is invalid
```

As a result, `_check_local_runtime()` raises an exception before reaching the `hindsight_embed` import, causing `is_available()` to return `False` even when the correct `hindsight-embed` package is installed.

## Root Cause

`_check_local_runtime()` calls `importlib.import_module("hindsight")` unconditionally. On Python 3.11+ where the legacy package cannot be installed, this always fails.

## Fix

Wrap the legacy `import hindsight` in an inner `try/except` so it is treated as optional. The outer `import hindsight_embed.daemon_embed_manager` remains mandatory — misconfigured environments still fail fast with a clear error.

```python
# Before
importlib.import_module("hindsight")
importlib.import_module("hindsight_embed.daemon_embed_manager")

# After
try:
    importlib.import_module("hindsight")
except Exception:
    pass  # Legacy package not required when hindsight-embed is present
importlib.import_module("hindsight_embed.daemon_embed_manager")
```

## Testing

Verified on Python 3.11.15 with `hindsight-embed==0.6.2` (without the legacy `hindsight` package installed):

```python
>>> from plugins.memory.hindsight import HindsightMemoryProvider
>>> p = HindsightMemoryProvider()
>>> p.is_available()
True
```

## Notes

- `hindsight-embed` is the official replacement for local embedded mode and ships `daemon_embed_manager` directly
- The legacy `hindsight` package is still supported when installed — no regression for Python <=3.10 users
- This is a one-line logic change with zero functional impact on working environments