### PR TITLE
fix(webhook): fail closed for routes without HMAC secret (salvage #29629)

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -391,7 +391,7 @@ class WebhookAdapter(BasePlatformAdapter):
             )
             return web.json_response(
                 {"error": "Webhook route is missing an HMAC secret"},
-                status=500,
+                status=403,
             )
         if secret != _INSECURE_NO_AUTH:
             if not self._validate_signature(request, raw_body, secret):

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -379,9 +379,21 @@ class WebhookAdapter(BasePlatformAdapter):
             logger.error("[webhook] Failed to read body: %s", e)
             return web.json_response({"error": "Bad request"}, status=400)
 
-        # Validate HMAC signature FIRST (skip for INSECURE_NO_AUTH testing mode)
+        # Validate HMAC signature FIRST (skip only for the explicit local-test
+        # INSECURE_NO_AUTH mode). Missing/empty secrets must fail closed here,
+        # not only during connect(), so direct handler reuse cannot turn a
+        # network webhook route into an unauthenticated agent-dispatch surface.
         secret = route_config.get("secret", self._global_secret)
-        if secret and secret != _INSECURE_NO_AUTH:
+        if not secret:
+            logger.error(
+                "[webhook] Route %s has no HMAC secret; refusing request",
+                route_name,
+            )
+            return web.json_response(
+                {"error": "Webhook route is missing an HMAC secret"},
+                status=500,
+            )
+        if secret != _INSECURE_NO_AUTH:
             if not self._validate_signature(request, raw_body, secret):
                 logger.warning(
                     "[webhook] Invalid signature for route %s", route_name

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -72,6 +72,7 @@ AUTHOR_MAP = {
     "70629228+shaun0927@users.noreply.github.com": "shaun0927",
     "98262967+Bihruze@users.noreply.github.com": "Bihruze",
     "189280367+Lempkey@users.noreply.github.com": "Lempkey",
+    "34853915+m0n3r0@users.noreply.github.com": "m0n3r0",
     "leovillalbajr@gmail.com": "Lempkey",
     "nidhi2894@gmail.com": "nidhi-singh02",
     "30312689+aashizpoudel@users.noreply.github.com": "aashizpoudel",

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -508,7 +508,7 @@ class TestHTTPHandling:
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
             resp = await cli.post("/webhooks/test", json={"data": "value"})
-            assert resp.status == 500
+            assert resp.status == 403
             data = await resp.json()
             assert data["error"] == "Webhook route is missing an HMAC secret"
 

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -499,6 +499,22 @@ class TestHTTPHandling:
             assert data["route"] == "test"
 
     @pytest.mark.asyncio
+    async def test_route_without_secret_rejects_unsigned_request(self):
+        """Missing HMAC secret must fail closed even if connect() was bypassed."""
+        routes = {"test": {"prompt": "hi"}}
+        adapter = _make_adapter(routes=routes, secret="")
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/webhooks/test", json={"data": "value"})
+            assert resp.status == 500
+            data = await resp.json()
+            assert data["error"] == "Webhook route is missing an HMAC secret"
+
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_health_endpoint(self):
         """GET /health returns 200 with status=ok."""
         adapter = _make_adapter()


### PR DESCRIPTION
Salvage of #29629 by @m0n3r0 onto current main.

## Summary
`_handle_webhook` now refuses requests when a route has no effective HMAC secret, returning **403** instead of silently accepting unsigned payloads. Defense-in-depth against any code path that adds routes to `self._routes` without going through `_reload_dynamic_routes` (which already validates secret presence).

## Changes
- `gateway/platforms/webhook.py`: per-request secret-presence check before signature validation
- `tests/gateway/test_webhook_adapter.py`: regression test for the direct-handler path

## Salvage tweak on top of the contributor PR
The original PR returned **500**. Operator misconfiguration is a 4xx (client/setup error), not a 5xx (internal exception) — 500 would trigger incident alerting on monitoring and conflate config drift with real bugs. Adjusted to 403 "forbidden," matching test updated.

## Test plan
```
pytest tests/gateway/test_webhook_adapter.py        # 65 passed
pytest tests/gateway/test_webhook_dynamic_routes.py # 13 passed
```

Co-authored-by: m0n3r0 <34853915+m0n3r0@users.noreply.github.com>

Closes #29629