### PR TITLE
feat(subprocess): detect cmd.exe metacharacters in argv targeting .cmd/.bat shims

### DIFF
--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -39,6 +39,9 @@ __all__ = [
     "windows_detach_flags",
     "windows_hide_flags",
     "windows_detach_popen_kwargs",
+    "is_windows_shim_target",
+    "arg_contains_cmd_metachars",
+    "CMD_METACHARS",
 ]
 
 
@@ -140,6 +143,72 @@ def windows_hide_flags() -> int:
     if not IS_WINDOWS:
         return 0
     return _CREATE_NO_WINDOW
+
+
+# -----------------------------------------------------------------------------
+# cmd.exe shim metacharacter detection (Windows .cmd / .bat re-parse hazard)
+# -----------------------------------------------------------------------------
+
+
+# Characters that cmd.exe treats specially when a .cmd / .bat shim
+# re-parses its argv.  Even if Python's subprocess module passes argv
+# correctly to ``CreateProcessW``, a ``.cmd`` / ``.bat`` target runs
+# inside ``cmd.exe /c``, which re-tokenizes its arguments and interprets
+# these as shell operators rather than literals:
+#
+#   |       pipe — splits the rest of the argv into a new command
+#   &       command sequencer (``a & b``) or background (``&``)
+#   <  >    file redirection (``> out.txt`` truncates a file)
+#   ^       cmd.exe's escape character — strips the next char
+#   "       quote — affects argv tokenization on the cmd.exe side
+#
+# Note: ``%`` is also a cmd.exe metacharacter (variable expansion) but
+# only inside batch files, not on the command line; we leave it off the
+# default set to keep the false-positive rate low.  Callers who care
+# about it can extend the constant.
+#
+# See #31419 for the upstream context and the recommended fix pattern
+# (route argument content via stdin or escape on the way in).
+CMD_METACHARS = frozenset("|&<>^\"")
+
+
+def is_windows_shim_target(target: Optional[str]) -> bool:
+    """Return ``True`` if ``target`` is a Windows .cmd / .bat shim.
+
+    Returns ``False`` on non-Windows.  Returns ``False`` if ``target``
+    is ``None`` or empty.  Detection is purely extension-based — a
+    correctly-named .cmd / .bat suffix.  The check is case-insensitive
+    because Windows paths often round-trip through different cases.
+    """
+    if not IS_WINDOWS or not target:
+        return False
+    lowered = target.lower()
+    return lowered.endswith(".cmd") or lowered.endswith(".bat")
+
+
+def arg_contains_cmd_metachars(arg: str, *, extra: str = "") -> bool:
+    """Return ``True`` if ``arg`` contains any cmd.exe metacharacter.
+
+    Use this to detect when an argv value about to be passed to a
+    ``.cmd`` / ``.bat`` shim would be re-parsed by ``cmd.exe`` and
+    risk wrong behavior (or, with attacker-controlled content,
+    command injection).
+
+    The check is platform-agnostic on purpose: callers who already
+    know they're targeting a .cmd shim (see
+    :func:`is_windows_shim_target`) can call this without first
+    branching on platform.  Returns ``False`` for an empty string.
+
+    Args:
+        arg: The argv value to inspect.
+        extra: Optional extra characters to treat as metacharacters
+            for this call (e.g. ``"%"`` if the caller is targeting
+            a batch file rather than a shim).
+    """
+    if not arg:
+        return False
+    metachars = CMD_METACHARS | set(extra)
+    return any(ch in metachars for ch in arg)
 
 
 def windows_detach_popen_kwargs() -> dict:

--- a/tests/hermes_cli/test_cmd_shim_metacharacter.py
+++ b/tests/hermes_cli/test_cmd_shim_metacharacter.py
@@ -1,0 +1,123 @@
+"""Tests for the cmd.exe shim metacharacter detection helpers added
+under #31419 (Windows ``.cmd`` / ``.bat`` argv re-parse hazard).
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli._subprocess_compat import (
+    CMD_METACHARS,
+    arg_contains_cmd_metachars,
+    is_windows_shim_target,
+)
+
+
+# ----------------------------------------------------------------------
+# CMD_METACHARS
+# ----------------------------------------------------------------------
+
+
+def test_cmd_metachars_includes_core_shell_operators():
+    """The default set must cover the operators that re-tokenize argv
+    inside ``cmd.exe /c``. Without these, a .cmd shim mis-parses any
+    argument containing them.
+    """
+    for ch in '|&<>^"':
+        assert ch in CMD_METACHARS, f"missing metachar in default set: {ch!r}"
+
+
+def test_cmd_metachars_is_immutable():
+    """``CMD_METACHARS`` is a frozenset so callers can't accidentally
+    mutate the shared default and leak state across modules.
+    """
+    assert isinstance(CMD_METACHARS, frozenset)
+
+
+# ----------------------------------------------------------------------
+# is_windows_shim_target
+# ----------------------------------------------------------------------
+
+
+def test_is_windows_shim_target_returns_false_off_windows():
+    """Detection is a no-op on POSIX — there are no .cmd / .bat shims
+    to worry about, and we don't want callers branching on platform.
+    """
+    with patch("hermes_cli._subprocess_compat.IS_WINDOWS", False):
+        assert not is_windows_shim_target(r"C:\path\to\npm.cmd")
+        assert not is_windows_shim_target(r"C:\path\to\foo.bat")
+        assert not is_windows_shim_target("/usr/bin/npm")
+
+
+def test_is_windows_shim_target_detects_cmd_and_bat_case_insensitive():
+    """On Windows, both ``.cmd`` and ``.bat`` shims need protection,
+    and the check is case-insensitive because paths round-trip through
+    different cases regularly.
+    """
+    with patch("hermes_cli._subprocess_compat.IS_WINDOWS", True):
+        assert is_windows_shim_target(r"C:\path\to\npm.cmd")
+        assert is_windows_shim_target(r"C:\PATH\TO\NPM.CMD")
+        assert is_windows_shim_target(r"foo.bat")
+        assert is_windows_shim_target(r"FOO.Bat")
+        # Negatives — .exe is not a shim
+        assert not is_windows_shim_target(r"C:\path\to\python.exe")
+        assert not is_windows_shim_target(r"C:\path\to\npm")
+        assert not is_windows_shim_target("")
+        assert not is_windows_shim_target(None)
+
+
+# ----------------------------------------------------------------------
+# arg_contains_cmd_metachars
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "arg",
+    [
+        "echo a | echo b",            # pipe — re-tokenizes argv
+        "foo > out.txt",              # redirect — truncates a file
+        "foo < in.txt",               # input redirect
+        "a & b",                      # command sequencer
+        "say \"hello\"",              # quote — affects cmd.exe tokenization
+        "^echo",                      # cmd.exe escape character
+        "mixed | content > here",
+    ],
+)
+def test_arg_contains_cmd_metachars_detects_hazardous_argv(arg):
+    """Any argv containing a default metacharacter is flagged. These are
+    exactly the inputs that would be silently mis-parsed when passed
+    through a ``.cmd`` / ``.bat`` shim.
+    """
+    assert arg_contains_cmd_metachars(arg), f"missed hazard: {arg!r}"
+
+
+@pytest.mark.parametrize(
+    "arg",
+    [
+        "",                           # empty — no hazard
+        "plain-string-no-shell-ops",
+        "a-b-c.d_e:f/g+h",            # punctuation that is NOT a cmd op
+        "中文 emoji 🎉",                # non-ASCII passes through cleanly
+        "/path/to/file.txt",
+        "--flag=value",
+    ],
+)
+def test_arg_contains_cmd_metachars_does_not_flag_safe_argv(arg):
+    """The default character set is small and prefix-anchored to keep
+    the false-positive rate low — common argv values must not trip.
+    """
+    assert not arg_contains_cmd_metachars(arg), f"false positive: {arg!r}"
+
+
+def test_arg_contains_cmd_metachars_extra_extends_default_set():
+    """Callers targeting a batch file (where ``%`` is also metachar)
+    can extend the detected set per call.
+    """
+    arg = "echo %PATH%"
+    assert not arg_contains_cmd_metachars(arg)  # % is NOT in default set
+    assert arg_contains_cmd_metachars(arg, extra="%")  # explicit opt-in
+
+
+def test_arg_contains_cmd_metachars_returns_false_for_empty_string():
+    assert not arg_contains_cmd_metachars("")


### PR DESCRIPTION
## What does this PR do?

Adds two detection helpers in `hermes_cli/_subprocess_compat.py` for the Windows `.cmd` / `.bat` shim metacharacter re-parse hazard described in #31419:

- `is_windows_shim_target(path)` — extension-based, no-op on POSIX, case-insensitive
- `arg_contains_cmd_metachars(arg, *, extra="")` — scans an argv value for `|`, `&`, `<`, `>`, `^`, `"` (with optional `extra` set for batch-file `%`)
- `CMD_METACHARS` — the prefix-anchored default frozenset, documented inline

**This PR does NOT change any existing call site.** The helpers are opt-in. The broader audit (every `.cmd`-target spawn site detecting + escaping or stdin-routing hazardous argv) is still tracked in #31419 and can land as a separate sweep if maintainers prefer.

The point of this PR is to make the detection primitive available with a clear name + rationale so when the sweep happens (whoever picks it up — me, you, or someone else), the per-site change is one helper call instead of re-deriving the metachar set N times.

## Related Issue

Adds detection layer for #31419 (does not fully close it — full closure needs the sweep).

## Type of Change

- [x] 🔒 Security fix (detection layer for a command-injection hazard)
- [x] ✨ New feature (helpers for downstream sweep)

## Changes Made

- `hermes_cli/_subprocess_compat.py`:
  - New constant `CMD_METACHARS = frozenset("|&<>^\"")` with docstring explaining each operator's cmd.exe re-parse effect
  - New function `is_windows_shim_target(target)` — case-insensitive `.cmd` / `.bat` detection, no-op on POSIX
  - New function `arg_contains_cmd_metachars(arg, *, extra="")` — argv scan with opt-in extra set
  - `__all__` extended
- `tests/hermes_cli/test_cmd_shim_metacharacter.py` (new):
  - 19 cases via parametrize: operator hazard detection (pipe / redirect / sequencer / quote / escape), non-hazard pass-through (plain strings, non-ASCII, common argv), case-insensitive `.cmd` / `.BAT` / `.Bat`, off-Windows no-op, `extra=` opt-in for batch `%`

## How to Test

```bash
PYTHONPATH=. python -m pytest tests/hermes_cli/test_cmd_shim_metacharacter.py -v
# 19 passed
```

Run on Windows + Python 3.13. Tests are platform-aware via `patch("hermes_cli._subprocess_compat.IS_WINDOWS", ...)` so they pass identically on Linux / macOS CI runners without skip markers.

## Why this matters in practice

`subprocess.Popen` on Windows correctly hands argv to `CreateProcessW`. When the target is a `.cmd` / `.bat` shim, the OS routes through `cmd.exe /c <script> arg1 arg2 ...`, which re-tokenizes those argv values. So this:

```python
# Looks safe — Python's subprocess module handles argv correctly.
subprocess.run(["claude.cmd", "-p", "answer 'a | b'"])
```

…silently turns into a pipeline as soon as `cmd.exe` sees the `|`. With attacker-influenced argv (LLM-quoted text, user-supplied prompts, chat content), this is a real command-injection surface even though Python's argv handling is correct.

`hermes_cli/_subprocess_compat.py` already centralizes the related Windows footgun for `.cmd` resolution (`resolve_node_command` — WinError 193 fix). This PR adds the metacharacter axis to the same module so future Windows-safety hardening lives in one place.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(subprocess):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/hermes_cli/test_cmd_shim_metacharacter.py -v` and all 19 cases pass on Windows + Python 3.13
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 + Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (rationale lives in the module / function docstrings inline)
- [x] I've updated `cli-config.yaml.example` — N/A (no config key added)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A (no architecture change)
- [x] I've considered cross-platform impact — helpers are no-op on POSIX; tests patch `IS_WINDOWS` so they're identical across OSes
- [x] I've updated tool descriptions/schemas — N/A

## Related work

- #31417 / #31454 — sibling `StreamReader` 64 KiB limit fix (LSP path)
- `hermes_cli/_subprocess_compat.py:resolve_node_command` — the existing `.cmd` resolution helper this complements
