### PR TITLE
fix(http): add loopback-safe urlopen that bypasses HTTP_PROXY for 127.0.0.1 / localhost

### DIFF
--- a/agent/process_bootstrap.py
+++ b/agent/process_bootstrap.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import os
 import sys
+import urllib.parse
 import urllib.request
 from typing import Optional
 
@@ -142,6 +143,61 @@ def _get_proxy_for_base_url(base_url: Optional[str]) -> Optional[str]:
     return proxy
 
 
+# ----------------------------------------------------------------------
+# Loopback-safe urlopen — bypasses HTTP_PROXY for 127.0.0.1 / localhost
+# ----------------------------------------------------------------------
+
+
+# Hostnames that should never be routed through HTTP_PROXY. ``::1`` covers
+# IPv6 loopback whether or not the URL wraps it in brackets — urllib
+# normalizes ``http://[::1]/`` to host ``::1``.
+_LOOPBACK_HOSTS: frozenset[str] = frozenset({"127.0.0.1", "localhost", "::1"})
+
+
+def is_loopback_url(url: str) -> bool:
+    """Return ``True`` if ``url`` targets a loopback address.
+
+    Detection is conservative: only the three canonical loopback hosts
+    (``127.0.0.1``, ``localhost``, ``::1``) are considered loopback. The
+    full 127.0.0.0/8 range is technically loopback too, but in practice
+    nothing in Hermes binds outside the canonical address; checking the
+    exact set keeps the false-positive rate at zero.
+    """
+    try:
+        host = urllib.parse.urlparse(url).hostname
+    except Exception:
+        return False
+    if not host:
+        return False
+    return host.lower() in _LOOPBACK_HOSTS
+
+
+def loopback_safe_urlopen(url, *args, **kwargs):
+    """Drop-in replacement for ``urllib.request.urlopen`` that bypasses
+    ``HTTP_PROXY`` / ``HTTPS_PROXY`` when the target is a loopback URL.
+
+    When the user's environment configures a local outbound proxy
+    (``HTTP_PROXY=http://127.0.0.1:10808`` is the standard setup for
+    v2ray / clash / corporate egress on Windows in particular), urllib
+    silently routes *loopback* requests through that proxy. The proxy
+    has no way to relay back to a local service on the same host, so it
+    returns 502 / 503 — leaving the user staring at a "service down"
+    error while the local service is in fact running fine.
+
+    Non-loopback URLs fall through to the normal ``urlopen`` path so
+    they continue to honor ``HTTP_PROXY`` / ``HTTPS_PROXY`` / ``NO_PROXY``
+    as configured.
+
+    See #31421 for the upstream context; complementary defensive layers
+    exist in :func:`_get_proxy_for_base_url` (for the OpenAI client) and
+    in ``gateway/platforms/base.py`` (for chat platforms).
+    """
+    if is_loopback_url(url):
+        opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+        return opener.open(url, *args, **kwargs)
+    return urllib.request.urlopen(url, *args, **kwargs)
+
+
 def _install_safe_stdio() -> None:
     """Wrap stdout/stderr so best-effort console output cannot crash the agent."""
     for stream_name in ("stdout", "stderr"):
@@ -164,4 +220,6 @@ __all__ = [
     "_install_safe_stdio",
     "_get_proxy_from_env",
     "_get_proxy_for_base_url",
+    "is_loopback_url",
+    "loopback_safe_urlopen",
 ]

--- a/tests/agent/test_loopback_safe_urlopen.py
+++ b/tests/agent/test_loopback_safe_urlopen.py
@@ -1,0 +1,146 @@
+"""Tests for the loopback-safe urlopen helper added under #31421.
+
+Verifies that ``loopback_safe_urlopen`` bypasses any configured
+``HTTP_PROXY`` for loopback URLs while still honoring it for everything
+else.
+"""
+from __future__ import annotations
+
+import asyncio
+import http.server
+import socket
+import threading
+import time
+from contextlib import closing
+from unittest.mock import patch
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+from agent.process_bootstrap import is_loopback_url, loopback_safe_urlopen
+
+
+# ----------------------------------------------------------------------
+# is_loopback_url
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1:8765/health",
+        "http://127.0.0.1/health",
+        "http://localhost:8765/health",
+        "http://localhost/health",
+        "https://127.0.0.1:8765/health",
+        "http://LocalHost/health",          # case-insensitive
+        "http://[::1]:8765/health",         # IPv6 loopback
+        "http://[::1]/health",
+    ],
+)
+def test_is_loopback_url_detects_loopback(url):
+    assert is_loopback_url(url), f"missed loopback URL: {url!r}"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://api.example.com/health",
+        "https://github.com",
+        "http://192.168.1.10/local-lan",    # private LAN, not loopback
+        "http://10.0.0.1/",
+        "http://0.0.0.0/",                  # wildcard bind, not loopback
+        "",                                 # empty falls through to False
+        "not-a-url",
+    ],
+)
+def test_is_loopback_url_does_not_flag_remote(url):
+    assert not is_loopback_url(url), f"false positive: {url!r}"
+
+
+# ----------------------------------------------------------------------
+# loopback_safe_urlopen — proxy bypass behavior (mocked HTTP_PROXY)
+# ----------------------------------------------------------------------
+
+
+def _free_port() -> int:
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class _OKHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802 (stdlib signature)
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.end_headers()
+        self.wfile.write(b"ok")
+
+    def log_message(self, *_args, **_kwargs):
+        # Silence the default stderr per-request log.
+        return
+
+
+@pytest.fixture
+def local_http_server():
+    """Start a tiny HTTP server on 127.0.0.1:<random-port> for the test."""
+    port = _free_port()
+    server = http.server.HTTPServer(("127.0.0.1", port), _OKHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        # Wait until the listener is actually accepting.
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            try:
+                with closing(socket.create_connection(("127.0.0.1", port), 0.2)):
+                    break
+            except OSError:
+                time.sleep(0.02)
+        yield port
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_loopback_safe_urlopen_succeeds_even_with_bogus_http_proxy(
+    local_http_server, monkeypatch
+):
+    """End-to-end: with HTTP_PROXY pointing at a definitely-dead address,
+    ``urllib.request.urlopen`` raises (because it routes through the
+    proxy that doesn't exist). ``loopback_safe_urlopen`` succeeds because
+    it bypasses the proxy for loopback URLs.
+    """
+    # Set HTTP_PROXY to an address nothing is listening on. Any plain
+    # urlopen call that honors HTTP_PROXY will fail with a connection
+    # error — the bypass is the only way through.
+    monkeypatch.setenv("HTTP_PROXY", "http://127.0.0.1:1")
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:1")
+
+    port = local_http_server
+    url = f"http://127.0.0.1:{port}/anything"
+
+    # Sanity: plain urlopen routes through the bogus proxy and fails.
+    import urllib.request as _urlreq
+    with pytest.raises((URLError, ConnectionRefusedError, HTTPError, OSError)):
+        _urlreq.urlopen(url, timeout=1.0).close()
+
+    # The helper bypasses the proxy and succeeds.
+    with loopback_safe_urlopen(url, timeout=2.0) as r:
+        assert r.status == 200
+        assert r.read() == b"ok"
+
+
+def test_loopback_safe_urlopen_uses_normal_path_for_remote_urls():
+    """Non-loopback URLs go through the normal ``urlopen`` path, where
+    HTTP_PROXY (if set) would still apply. Verified by patching
+    ``urllib.request.urlopen`` and asserting it gets called with the
+    remote URL.
+    """
+    remote_url = "http://example.com/anything"
+
+    with patch("agent.process_bootstrap.urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.return_value = "sentinel"
+        result = loopback_safe_urlopen(remote_url, timeout=2.0)
+        assert result == "sentinel"
+        mock_urlopen.assert_called_once_with(remote_url, timeout=2.0)


### PR DESCRIPTION
## What does this PR do?

Adds `loopback_safe_urlopen()` + `is_loopback_url()` helpers in `agent/process_bootstrap.py` (alongside the existing `_get_proxy_for_base_url`) so any internal Hermes code that hits `127.0.0.1` / `localhost` / `::1` via `urllib.request` can be one-liner-protected from the "local outbound proxy" footgun described in #31421.

**This PR does NOT auto-route every existing `urlopen` call.** It adds the helper and leaves call sites alone so the broader audit can land at its own pace. Two reasons:

1. `agent/process_bootstrap.py` already centralizes proxy resolution for the OpenAI client (`_get_proxy_for_base_url`), and `gateway/platforms/base.py` already does NO_PROXY checks for chat platforms — the missing piece is a generic helper for the *bare* `urllib.request.urlopen` callers (e.g., `scripts/benchmark_browser_eval.py:49`)
2. A blanket "every `urlopen` call goes through this wrapper" sweep is a maintainer policy decision — landing the primitive first lets that decision be made in isolation

## Related Issue

Addresses #31421 (urllib path). Sibling httpx path tracked in #25319.

## Type of Change

- [x] 🐛 Bug fix (defensive layer against silent loopback-via-proxy failures)

## Changes Made

- `agent/process_bootstrap.py`:
  - new `_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})`
  - new `is_loopback_url(url)` — conservative detection, case-insensitive
  - new `loopback_safe_urlopen(url, *args, **kwargs)` — drop-in replacement that builds a `ProxyHandler({})` opener for loopback URLs; falls through to plain `urlopen` for everything else
  - `__all__` extended; added `import urllib.parse` (was previously implicit-via-`urllib.request`)
- `tests/agent/test_loopback_safe_urlopen.py` (new): 17 cases — 8 loopback positive (IPv4 / IPv6 / case-insensitive), 7 non-loopback negative (remote / LAN / wildcard / empty), end-to-end with a real `http.server` and bogus `HTTP_PROXY` (the helper succeeds; plain `urlopen` fails), and a mock-verified pass-through for remote URLs

## How to Test

```bash
PYTHONPATH=. python -m pytest tests/agent/test_loopback_safe_urlopen.py -v
# 17 passed (includes a real http.server end-to-end + HTTP_PROXY bypass verification)
```

Tested on Windows 11 + Python 3.13.

## Why this matters in practice

`HTTP_PROXY=http://127.0.0.1:10808` is the standard outbound setup for v2ray / clash / many corporate egress configurations. With that env set, this fails:

```python
import urllib.request
urllib.request.urlopen("http://127.0.0.1:8765/health")
# urllib.error.HTTPError: HTTP Error 502: Bad Gateway
# (the local proxy can't relay back to a local service)
```

The user's local service is fine; the framework is silently routing loopback through the proxy. The error message is "502", not "your HTTP_PROXY is misconfigured for loopback", so it's easy to misdiagnose as a service-startup problem.

`loopback_safe_urlopen()` lets call sites opt into the bypass with a single-character-rename diff:

```diff
-    with urllib.request.urlopen(f"http://127.0.0.1:{port}/json/version", timeout=1) as r:
+    with loopback_safe_urlopen(f"http://127.0.0.1:{port}/json/version", timeout=1) as r:
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(http):`)
- [x] I searched existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/agent/test_loopback_safe_urlopen.py -v` and all 17 cases pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 + Python 3.13

### Documentation & Housekeeping

- [x] Documentation — N/A (rationale lives in the helper docstrings inline)
- [x] `cli-config.yaml.example` — N/A (no config key added)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture change)
- [x] Cross-platform — fix applies identically on Linux / macOS / Windows; uses `urllib.parse.urlparse` (platform-agnostic)
- [x] Tool descriptions/schemas — N/A

## Related work

- #14451 (closed) — keepalive client `NO_PROXY` fix (different transport, same class of bug)
- #25319 — sibling httpx auxiliary-client variant (P2, OPEN)
- #31417 / #31454 — `StreamReader` 64 KiB sibling subprocess fix
- #31464 — `.cmd` shim metacharacter detection sibling Windows hardening
