### PR TITLE
fix(feishu): honor explicit gateway disable

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1575,10 +1575,12 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # Feishu / Lark
     feishu_app_id = os.getenv("FEISHU_APP_ID")
     feishu_app_secret = os.getenv("FEISHU_APP_SECRET")
+    feishu_gateway_enabled = _coerce_bool(os.getenv("FEISHU_GATEWAY_ENABLED"), default=True)
     if feishu_app_id and feishu_app_secret:
         if Platform.FEISHU not in config.platforms:
-            config.platforms[Platform.FEISHU] = PlatformConfig()
-        config.platforms[Platform.FEISHU].enabled = True
+            config.platforms[Platform.FEISHU] = PlatformConfig(enabled=feishu_gateway_enabled)
+        elif not feishu_gateway_enabled:
+            config.platforms[Platform.FEISHU].enabled = False
         config.platforms[Platform.FEISHU].extra.update({
             "app_id": feishu_app_id,
             "app_secret": feishu_app_secret,

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -3,6 +3,8 @@
 import os
 from unittest.mock import patch
 
+import pytest
+
 from gateway.config import (
     GatewayConfig,
     HomeChannel,
@@ -504,6 +506,86 @@ class TestLoadGatewayConfig:
         load_gateway_config()
 
         assert os.environ.get("FEISHU_ALLOW_BOTS") == "none"
+
+    def test_feishu_env_creds_auto_enable_gateway_by_default(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("FEISHU_APP_ID", "app_123")
+        monkeypatch.setenv("FEISHU_APP_SECRET", "secret_123")
+        monkeypatch.delenv("FEISHU_GATEWAY_ENABLED", raising=False)
+
+        config = load_gateway_config()
+
+        feishu_cfg = config.platforms[Platform.FEISHU]
+        assert feishu_cfg.enabled is True
+        assert feishu_cfg.extra["app_id"] == "app_123"
+        assert feishu_cfg.extra["app_secret"] == "secret_123"
+
+    @pytest.mark.parametrize("disabled_value", ["false", "0", "off", "no"])
+    def test_feishu_gateway_enabled_false_prevents_env_auto_enable(
+        self, tmp_path, monkeypatch, disabled_value
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("FEISHU_APP_ID", "app_123")
+        monkeypatch.setenv("FEISHU_APP_SECRET", "secret_123")
+        monkeypatch.setenv("FEISHU_GATEWAY_ENABLED", disabled_value)
+
+        config = load_gateway_config()
+
+        feishu_cfg = config.platforms[Platform.FEISHU]
+        assert feishu_cfg.enabled is False
+        assert feishu_cfg.extra["app_id"] == "app_123"
+        assert feishu_cfg.extra["app_secret"] == "secret_123"
+
+    def test_feishu_explicit_enabled_config_stays_enabled_with_env_creds(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text("feishu:\n  enabled: true\n", encoding="utf-8")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("FEISHU_APP_ID", "app_123")
+        monkeypatch.setenv("FEISHU_APP_SECRET", "secret_123")
+        monkeypatch.delenv("FEISHU_GATEWAY_ENABLED", raising=False)
+
+        config = load_gateway_config()
+
+        feishu_cfg = config.platforms[Platform.FEISHU]
+        assert feishu_cfg.enabled is True
+        assert feishu_cfg.extra["app_id"] == "app_123"
+        assert feishu_cfg.extra["app_secret"] == "secret_123"
+
+    def test_feishu_explicit_disabled_config_is_not_overridden_by_env_creds(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "feishu:\n"
+            "  enabled: false\n"
+            "  extra:\n"
+            "    connection_mode: websocket\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("FEISHU_APP_ID", "app_123")
+        monkeypatch.setenv("FEISHU_APP_SECRET", "secret_123")
+
+        config = load_gateway_config()
+
+        feishu_cfg = config.platforms[Platform.FEISHU]
+        assert feishu_cfg.enabled is False
+        assert feishu_cfg.extra["app_id"] == "app_123"
+        assert feishu_cfg.extra["app_secret"] == "secret_123"
 
     def test_invalid_quick_commands_in_config_yaml_are_ignored(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"


### PR DESCRIPTION
## Summary

This PR makes Feishu/Lark gateway startup respect an explicit disable even when Feishu credentials are present in the environment.

Concretely, it:

- Keeps the existing default behavior where `FEISHU_APP_ID` and `FEISHU_APP_SECRET` auto-configure and enable the Feishu gateway when no disable is requested.
- Adds support for `FEISHU_GATEWAY_ENABLED=false` style values (`false`, `0`, `off`, `no`) to keep the gateway listener disabled while still loading Feishu credentials into the platform config metadata.
- Preserves `feishu.enabled: false` from `config.yaml` instead of flipping the platform back on during env override processing.
- Adds regression coverage for the default auto-enable path, env-level disable, explicit enabled config, and explicit disabled config.

## Motivation

Some deployments need Feishu/Lark credentials available to Hermes for API/tool usage, but do not want a given gateway process to open the Feishu websocket. This is especially important in multi-profile or service-managed setups where only one process should own the Feishu gateway connection.

Before this change, the env override path could re-enable Feishu whenever `FEISHU_APP_ID` and `FEISHU_APP_SECRET` existed, even if the operator had explicitly disabled Feishu gateway startup. The result was surprising gateway startup behavior and possible duplicate Feishu websocket ownership.

This keeps credentials and gateway listener enablement separate: credentials can exist, while the gateway remains disabled when explicitly requested.

## Tests

```bash
python -m py_compile gateway/config.py tests/gateway/test_config.py
python -m pytest -o addopts='' tests/gateway/test_config.py -q
```
