### PR TITLE
fix(weixin): convert MSYS / Git-Bash drive paths to native Windows on send

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -872,8 +872,10 @@ def _path_is_within(path: Path, root: Path) -> bool:
 _MSYS_PATH_RE = re.compile(r"^/([A-Za-z])(/.*)$")
 # ``file:///c/Users/...`` (note: 3 slashes + lowercase drive letter, no
 # colon) is the MSYS / Git-Bash mistake; the canonical Windows file URL
-# is ``file:///C:/Users/...``.  We accept both shapes when stripping.
-_FILE_URL_PREFIX_RE = re.compile(r"^file://+")
+# is ``file:///C:/Users/...``.  Strip exactly the two-slash scheme
+# delimiter so the third slash — the actual path's leading ``/`` —
+# survives for the downstream MSYS rewrite to find.
+_FILE_URL_PREFIX_RE = re.compile(r"^file://")
 
 
 def normalize_msys_path(path: str) -> str:
@@ -938,10 +940,21 @@ def strip_file_url_prefix(url_or_path: str) -> str:
     stripped = _FILE_URL_PREFIX_RE.sub("", str(url_or_path), count=1)
     if stripped == url_or_path:
         return url_or_path
-    # ``file:///C:/Users/foo`` → ``C:/Users/foo`` after the strip; Windows
-    # Path() handles forward slashes fine so no further work needed.
-    # ``file:///c/Users/foo`` (MSYS) → ``/c/Users/foo`` after the strip;
-    # normalize_msys_path turns that into ``C:/Users/foo``.
+    # After ``^file://`` strips two slashes:
+    #   ``file:///c/Users/foo`` (MSYS)        → ``/c/Users/foo``
+    #   ``file:///C:/Users/foo`` (Windows)    → ``/C:/Users/foo``
+    # The leading ``/`` before a ``<drive>:`` segment is an artefact of
+    # the URL's third slash, not part of any real path on Windows; trim
+    # it so Path('/C:/...') doesn't surprise callers and so Path eats
+    # ``C:/...`` directly.  POSIX file URLs (``/srv/...``) are kept
+    # exactly as-is.
+    if (
+        len(stripped) >= 3
+        and stripped[0] == "/"
+        and stripped[1].isalpha()
+        and stripped[2] == ":"
+    ):
+        stripped = stripped[1:]
     return normalize_msys_path(stripped)
 
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -864,6 +864,87 @@ def _path_is_within(path: Path, root: Path) -> bool:
         return False
 
 
+# MSYS / Git Bash path detector — leading slash, single-letter drive, then
+# ``/`` and the rest of the path: ``/c/Users/foo`` ↔ ``C:\Users\foo``.
+# Anchored so we don't mis-fire on legitimate POSIX paths like ``/c`` (a
+# directory named ``c`` at the filesystem root) — the trailing ``/...`` is
+# required.  Issue #31457.
+_MSYS_PATH_RE = re.compile(r"^/([A-Za-z])(/.*)$")
+# ``file:///c/Users/...`` (note: 3 slashes + lowercase drive letter, no
+# colon) is the MSYS / Git-Bash mistake; the canonical Windows file URL
+# is ``file:///C:/Users/...``.  We accept both shapes when stripping.
+_FILE_URL_PREFIX_RE = re.compile(r"^file://+")
+
+
+def normalize_msys_path(path: str) -> str:
+    """Convert a Git-Bash / MSYS path to its native Windows equivalent.
+
+    On Windows the agent's terminal often runs under Git Bash, which
+    surfaces drive letters as ``/c/Users/...`` (and equivalents
+    ``/cygdrive/c/...``).  Native Windows Python's ``pathlib.Path`` does
+    not understand that shape — it treats ``/c/Users/foo`` as
+    "directory ``c`` at the root of the current drive", which doesn't
+    exist, so ``Path.resolve(strict=True)`` raises ``FileNotFoundError``
+    and ``Path.read_bytes()`` reports ``[Errno 2] No such file or
+    directory``.  See #31457.
+
+    Behaviour:
+      * On non-Windows hosts the input is returned unchanged — POSIX
+        paths like ``/c`` are legitimate filesystem paths and we must
+        not silently corrupt them.
+      * On Windows, ``/<drive>/...`` and ``/cygdrive/<drive>/...`` are
+        rewritten to ``<DRIVE>:\\...``.  Forward slashes are kept (Path
+        on Windows accepts them) so the result reads naturally in
+        log messages.
+      * Anything else — including already-native ``C:\\foo``, drive-
+        relative ``foo\\bar``, or pure POSIX-only paths — is returned
+        unchanged.
+    """
+    if not path or sys.platform != "win32":
+        return path
+
+    candidate = str(path)
+
+    # ``/cygdrive/c/...`` — emitted by Cygwin and very-old Git Bash.
+    if candidate.startswith("/cygdrive/") and len(candidate) >= 12 and candidate[11] == "/":
+        drive = candidate[10]
+        if drive.isalpha():
+            return f"{drive.upper()}:{candidate[11:]}"
+
+    match = _MSYS_PATH_RE.match(candidate)
+    if match:
+        drive, rest = match.groups()
+        return f"{drive.upper()}:{rest}"
+
+    return candidate
+
+
+def strip_file_url_prefix(url_or_path: str) -> str:
+    """Strip a ``file://`` / ``file:///`` prefix and return the local path.
+
+    Handles the documented two-slash-plus-host (``file://host/path``,
+    rare in our codebase) and the canonical three-slash-no-host
+    (``file:///path``) forms uniformly.  Returns the input unchanged
+    when no ``file://`` prefix is present so callers can chain the
+    helper around already-bare paths safely.
+
+    On Windows, applies :func:`normalize_msys_path` to the result so
+    ``file:///c/Users/...`` (the MSYS-produced URL the agent sometimes
+    emits — note the lowercase drive letter and missing ``:``)
+    survives the round-trip back to ``C:\\Users\\...``.  Issue #31457.
+    """
+    if not url_or_path:
+        return url_or_path
+    stripped = _FILE_URL_PREFIX_RE.sub("", str(url_or_path), count=1)
+    if stripped == url_or_path:
+        return url_or_path
+    # ``file:///C:/Users/foo`` → ``C:/Users/foo`` after the strip; Windows
+    # Path() handles forward slashes fine so no further work needed.
+    # ``file:///c/Users/foo`` (MSYS) → ``/c/Users/foo`` after the strip;
+    # normalize_msys_path turns that into ``C:/Users/foo``.
+    return normalize_msys_path(stripped)
+
+
 def validate_media_delivery_path(path: str) -> Optional[str]:
     """Return a safe absolute file path for native media delivery, else None.
 
@@ -871,6 +952,11 @@ def validate_media_delivery_path(path: str) -> Optional[str]:
     existing regular files under Hermes-managed media caches, or roots the
     operator explicitly allowlists, may be uploaded as native attachments.
     Symlinks are resolved before the containment check.
+
+    On Windows, MSYS / Git-Bash style paths (``/c/Users/...``,
+    ``/cygdrive/c/...``) are normalized to native ``C:\\Users\\...``
+    before validation so MEDIA directives emitted by an agent running
+    under Git Bash actually resolve.  Issue #31457.
     """
     if not path:
         return None
@@ -882,6 +968,7 @@ def validate_media_delivery_path(path: str) -> Optional[str]:
     if not candidate:
         return None
 
+    candidate = normalize_msys_path(candidate)
     expanded = Path(os.path.expanduser(candidate))
     if not expanded.is_absolute():
         return None
@@ -2383,7 +2470,13 @@ class BasePlatformAdapter(ABC):
             if _in_code(match.start()):
                 continue
             raw = match.group(0)
-            expanded = os.path.expanduser(raw)
+            # Normalize MSYS/Git-Bash drive paths so ``/c/Users/...``
+            # emitted by an agent running under Git Bash on Windows gets
+            # rewritten to ``C:\Users\...`` before the existence check —
+            # otherwise ``os.path.isfile`` consults the literal path
+            # ``C:\c\Users\...``, finds nothing, and the bare-path
+            # delivery silently degrades to text-only.  Issue #31457.
+            expanded = os.path.expanduser(normalize_msys_path(raw))
             if os.path.isfile(expanded):
                 found.append((raw, expanded))
 

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -65,6 +65,8 @@ from gateway.platforms.base import (
     cache_audio_from_bytes,
     cache_document_from_bytes,
     cache_image_from_bytes,
+    normalize_msys_path,
+    strip_file_url_prefix,
 )
 from hermes_constants import get_hermes_home
 from utils import atomic_json_write
@@ -1780,7 +1782,14 @@ class WeixinAdapter(BasePlatformAdapter):
             file_path = await self._download_remote_media(image_url)
             cleanup = True
         else:
-            file_path = image_url.replace("file://", "")
+            # ``image_url`` may arrive as ``file:///C:/Users/...`` (canonical),
+            # ``file:///c/Users/...`` (MSYS / Git-Bash quirk #31457), or a
+            # bare path emitted by the agent.  ``strip_file_url_prefix``
+            # handles all three: it removes any ``file://`` prefix and, on
+            # Windows, rewrites MSYS drive paths to ``C:\Users\...`` so the
+            # downstream ``Path(...).read_bytes()`` actually finds the file
+            # rather than failing with ``[Errno 2]``.
+            file_path = strip_file_url_prefix(image_url)
             if not os.path.isabs(file_path):
                 file_path = os.path.abspath(file_path)
             cleanup = False
@@ -1901,6 +1910,11 @@ class WeixinAdapter(BasePlatformAdapter):
         force_file_attachment: bool = False,
     ) -> str:
         assert self._send_session is not None and self._token is not None
+        # Defense in depth — even when an upstream caller forgot to run
+        # the path through validate_media_delivery_path / strip_file_url_prefix,
+        # rewrite Git-Bash drive paths here so the read survives on
+        # Windows.  See #31457.
+        path = normalize_msys_path(path)
         plaintext = Path(path).read_bytes()
         media_type, item_builder = self._outbound_media_builder(path, force_file_attachment=force_file_attachment)
         filekey = secrets.token_hex(16)

--- a/tests/gateway/test_msys_path_normalization_31457.py
+++ b/tests/gateway/test_msys_path_normalization_31457.py
@@ -1,0 +1,222 @@
+"""Regression tests for #31457 — Windows MSYS path normalization.
+
+The agent, when run under Git Bash on Windows, emits paths in the
+shape ``/c/Users/...`` (and very-old Cygwin shells produce
+``/cygdrive/c/...``).  Native Windows Python's :class:`pathlib.Path`
+treats the leading slash as the current drive's root, so
+``Path('/c/Users/foo').resolve(strict=True)`` raises
+``FileNotFoundError`` and ``read_bytes()`` reports
+``[Errno 2] No such file or directory`` — even when the file exists
+at ``C:\\Users\\foo``.
+
+The helpers ``normalize_msys_path`` and ``strip_file_url_prefix``
+rewrite those shapes before they reach :class:`pathlib.Path`.  These
+tests pin the helpers' contract and the call-site wiring inside
+``validate_media_delivery_path`` and the Weixin adapter.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from gateway.platforms import base as base_module
+
+
+# ---------------------------------------------------------------------------
+# normalize_msys_path
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeMsysPath:
+    """Helper contract: rewrite MSYS drive paths only on Windows."""
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("/c/Users/foo/bar.jpg", "C:/Users/foo/bar.jpg"),
+            ("/d/data/file.bin", "D:/data/file.bin"),
+            # Single-letter drive must be at position 1; the trailing
+            # slash and rest are required (so we don't rewrite ``/c``
+            # alone, which on a real POSIX disk could be a directory).
+            ("/cygdrive/c/Users/foo.png", "C:/Users/foo.png"),
+            # Drive letter is uppercased to match Windows convention.
+            ("/x/games/save.dat", "X:/games/save.dat"),
+        ],
+    )
+    def test_windows_rewrite(self, raw, expected):
+        with patch.object(base_module, "sys") as fake_sys:
+            fake_sys.platform = "win32"
+            assert base_module.normalize_msys_path(raw) == expected
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            # Already native: unchanged.
+            r"C:\Users\foo\bar.jpg",
+            "C:/Users/foo/bar.jpg",
+            # Drive-relative: unchanged (Windows resolves against drive cwd).
+            r"foo\bar.jpg",
+            # Two-character first segment is not a drive — leave alone.
+            "/cd/foo.jpg",
+            # Bare drive root with no rest must NOT be rewritten,
+            # otherwise ``/c`` (a hypothetical literal directory)
+            # gets corrupted to ``C:`` which is a totally different
+            # location.
+            "/c",
+            "/cygdrive",
+            "/cygdrive/",
+            # Empty string is a no-op.
+            "",
+        ],
+    )
+    def test_windows_unchanged(self, raw):
+        with patch.object(base_module, "sys") as fake_sys:
+            fake_sys.platform = "win32"
+            assert base_module.normalize_msys_path(raw) == raw
+
+    @pytest.mark.parametrize("plat", ["linux", "darwin", "freebsd"])
+    def test_non_windows_is_passthrough(self, plat):
+        # On real POSIX systems ``/c`` is a legitimate filesystem path.
+        # We must never rewrite it.
+        with patch.object(base_module, "sys") as fake_sys:
+            fake_sys.platform = plat
+            for raw in ("/c/Users/foo", "/cygdrive/c/foo", "/usr/bin/python"):
+                assert base_module.normalize_msys_path(raw) == raw
+
+
+# ---------------------------------------------------------------------------
+# strip_file_url_prefix
+# ---------------------------------------------------------------------------
+
+
+class TestStripFileUrlPrefix:
+    def test_canonical_windows_file_url(self):
+        with patch.object(base_module, "sys") as fake_sys:
+            fake_sys.platform = "win32"
+            # ``file:///C:/Users/foo`` is the canonical Windows file URL.
+            assert (
+                base_module.strip_file_url_prefix("file:///C:/Users/foo.jpg")
+                == "C:/Users/foo.jpg"
+            )
+
+    def test_msys_file_url_on_windows(self):
+        # The exact bug shape from #31457: agent emits
+        # ``file:///c/Users/.../file.jpg`` (lowercase drive, no colon).
+        with patch.object(base_module, "sys") as fake_sys:
+            fake_sys.platform = "win32"
+            assert (
+                base_module.strip_file_url_prefix(
+                    "file:///c/Users/qhttttt/cache/file.jpg"
+                )
+                == "C:/Users/qhttttt/cache/file.jpg"
+            )
+
+    def test_no_prefix_is_passthrough(self):
+        assert base_module.strip_file_url_prefix("/already/bare") == "/already/bare"
+        assert base_module.strip_file_url_prefix("") == ""
+
+    def test_posix_file_url_keeps_leading_slash(self):
+        # POSIX-style ``file:///srv/...`` is the common shape on Linux
+        # and macOS — the leading ``/`` after the prefix is the actual
+        # path root and must survive.
+        with patch.object(base_module, "sys") as fake_sys:
+            fake_sys.platform = "linux"
+            assert (
+                base_module.strip_file_url_prefix("file:///srv/data/x.png")
+                == "/srv/data/x.png"
+            )
+
+    def test_strips_synthetic_slash_before_windows_drive(self):
+        # ``file:///C:/foo`` is the canonical Windows file URL; the
+        # leading slash before ``C:`` is a URL artefact, not a path
+        # component.  Trim it so callers get a clean ``C:/foo``.
+        with patch.object(base_module, "sys") as fake_sys:
+            fake_sys.platform = "win32"
+            assert (
+                base_module.strip_file_url_prefix("file:///D:/games/save.dat")
+                == "D:/games/save.dat"
+            )
+
+
+# ---------------------------------------------------------------------------
+# validate_media_delivery_path call-site wiring
+# ---------------------------------------------------------------------------
+
+
+class TestValidateMediaDeliveryPathCallsNormalize:
+    """Source-level guard — fast and platform-independent."""
+
+    def test_validator_invokes_normalize_msys_path(self):
+        src = inspect.getsource(base_module.validate_media_delivery_path)
+        assert "normalize_msys_path" in src, (
+            "validate_media_delivery_path must normalize MSYS paths before "
+            "Path() consumes them; otherwise Windows Git-Bash MEDIA: "
+            "directives silently fail validation (#31457)."
+        )
+
+    def test_extract_local_files_invokes_normalize_msys_path(self):
+        src = inspect.getsource(base_module.BasePlatformAdapter.extract_local_files)
+        assert "normalize_msys_path" in src, (
+            "extract_local_files must rewrite MSYS drive paths before "
+            "os.path.isfile, otherwise bare local paths emitted by an "
+            "agent under Git Bash on Windows are silently dropped (#31457)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Behavioural integration via validate_media_delivery_path
+# ---------------------------------------------------------------------------
+
+
+class TestValidateMediaDeliveryPathBehaviour:
+    """Run on POSIX hosts via simulated MSYS prefix that points at a real file."""
+
+    def test_real_posix_path_under_allowlist_still_validates(self, tmp_path):
+        # The non-Windows branch must still accept ordinary absolute
+        # paths that live under an allowlisted root — i.e. our shim
+        # is not interfering with the existing happy path.
+        target = tmp_path / "cache.png"
+        target.write_bytes(b"x")
+        with patch.object(
+            base_module,
+            "_media_delivery_allowed_roots",
+            return_value=[tmp_path],
+        ):
+            resolved = base_module.validate_media_delivery_path(str(target))
+        assert resolved is not None
+        assert Path(resolved).resolve() == target.resolve()
+
+
+# ---------------------------------------------------------------------------
+# Weixin adapter wiring
+# ---------------------------------------------------------------------------
+
+
+class TestWeixinSendImageWiring:
+    """The naive ``replace('file://', '')`` was the visible bug; assert
+    the adapter now routes file URLs through ``strip_file_url_prefix``."""
+
+    def test_send_image_no_longer_uses_naive_replace(self):
+        from gateway.platforms import weixin as weixin_module
+
+        src = inspect.getsource(weixin_module.WeixinAdapter.send_image)
+        # The fragile pattern that broke on Windows MSYS.
+        assert 'replace("file://"' not in src, (
+            "send_image must use strip_file_url_prefix; the naive "
+            "replace() loses MSYS drive normalization (#31457)."
+        )
+        assert "strip_file_url_prefix" in src
+
+    def test_send_file_invokes_normalize_msys_path(self):
+        from gateway.platforms import weixin as weixin_module
+
+        src = inspect.getsource(weixin_module.WeixinAdapter._send_file)
+        assert "normalize_msys_path" in src, (
+            "_send_file must defensively normalize MSYS drive paths "
+            "before Path(path).read_bytes() to survive any caller that "
+            "bypasses the validator (#31457)."
+        )


### PR DESCRIPTION
## Summary

Closes #31457.

On Windows, when the agent runs under Git Bash / MSYS the gateway
sees MEDIA paths like `/c/Users/.../cache/file.jpg` (and the matching
`file:///c/Users/...` URL).  Native Windows Python's `pathlib.Path`
does not understand that drive shape — it joins the leading `/` to
the current drive's root, so the canonical example resolves to a
non-existent `C:\c\Users\...` and `Path(path).read_bytes()` reports
`[Errno 2] No such file or directory`.  The Weixin adapter therefore
silently drops every native attachment, even though Telegram and
Discord deliver the exact same path fine because they upload bytes
through a different code path that doesn't hit the MSYS quirk.

## Approach

Two small, well-tested helpers in `gateway/platforms/base.py`:

- `normalize_msys_path(path)` — Windows-only rewrite of
  `/c/Users/...` and the legacy `/cygdrive/c/...` shape to
  `C:/Users/...`, drive letter ASCII-uppercased, no-op on POSIX so a
  real `/c` filesystem path is never corrupted.
- `strip_file_url_prefix(url)` — strip exactly the `file://`
  scheme delimiter, drop the synthetic third slash before a
  `<drive>:` segment so callers get `C:/foo` instead of `/C:/foo`,
  and route the remainder through `normalize_msys_path` so the
  `file:///c/Users/...` shape (lowercase drive, no colon) survives.

Wired in at the validation seam (`validate_media_delivery_path`),
the bare-path scanner (`extract_local_files`) and the Weixin
adapter's two file-touching call sites (`send_image`'s old naive
`replace("file://", "")` and `_send_file`'s `Path(path).read_bytes()`).

## Test plan

- [x] `pytest tests/gateway/test_msys_path_normalization_31457.py` —
      25 new tests covering both helpers, source-level guards on
      the four wired call sites, and a behavioural smoke test that
      the existing happy-path validation still works.
- [x] `pytest tests/gateway/test_platform_base.py
      tests/gateway/test_media_extraction.py
      tests/gateway/test_weixin.py` — 153 passed, 2 skipped (no
      regressions in the surrounding adapters).
- [ ] Manual: agent emits `MEDIA:/c/Users/.../cache/x.jpg` under
      Git Bash on Windows 11 → image is delivered natively to WeChat
      (matching Telegram/Discord behaviour).


Made with [Cursor](https://cursor.com)