### PR TITLE
fix(discord): use effective_channel for backfill, not message.channel

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4786,7 +4786,7 @@ class DiscordAdapter(BasePlatformAdapter):
             _backfill_enabled = self._discord_history_backfill()
             if _needed_mention and _backfill_enabled:
                 _backfill_text = await self._fetch_channel_context(
-                    message.channel, before=message,
+                    effective_channel, before=message,
                 )
                 if _backfill_text:
                     _channel_context = _backfill_text


### PR DESCRIPTION
## Bug

When auto-threading creates a new thread, `_fetch_channel_context` was querying `message.channel` (the parent text channel) instead of the thread. This leaked unrelated conversation context from the parent channel into thread sessions.

## Fix

Replaced `message.channel` with `effective_channel` at the backfill call site. `effective_channel` already correctly points to the thread when auto-threading fires (used everywhere else for session routing).

## Bonus

Fixes a secondary cache-miss: `_last_self_message_id` is keyed by `thread_id` when the bot responds in a thread, but the old code looked up `message.channel.id` (parent channel) — so the `after=` optimization in `channel.history()` never hit for auto-threaded conversations. Now the cache key matches.

Closes #31467