### PR TITLE
fix(gateway): stream synthesized recovery finals

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -127,6 +127,22 @@ def _ra():
     return run_agent
 
 
+def _emit_synthesized_final_delta(agent: Any, final_response: str) -> None:
+    """Stream final text synthesized outside the normal model delta path.
+
+    A few recovery paths assign ``final_response`` from already-available
+    text and then break out of the loop without another model stream event.
+    Gateway/SSE clients only see streamed deltas, so emit that synthesized
+    final answer before the loop closes.
+    """
+    if not final_response or not getattr(agent, "stream_delta_callback", None):
+        return
+    try:
+        agent.stream_delta_callback(final_response)
+    except Exception:
+        pass
+
+
 def _restore_or_build_system_prompt(agent, system_message, conversation_history):
     """Restore the cached system prompt from the session DB or build it fresh.
 
@@ -3470,6 +3486,7 @@ def run_conversation(
                         f"⚠️ Tool guardrail halted {decision.tool_name}: {decision.code}"
                     )
                     messages.append({"role": "assistant", "content": final_response})
+                    _emit_synthesized_final_delta(agent, final_response)
                     break
 
                 # Reset per-turn retry counters after successful tool
@@ -3576,6 +3593,7 @@ def run_conversation(
                         )
                         final_response = _recovered
                         agent._response_was_previewed = True
+                        _emit_synthesized_final_delta(agent, final_response)
                         break
 
                     # If the previous turn already delivered real content alongside
@@ -3602,6 +3620,7 @@ def run_conversation(
                         # fallback text as the final response and break.
                         final_response = agent._strip_think_blocks(fallback).strip()
                         agent._response_was_previewed = True
+                        _emit_synthesized_final_delta(agent, final_response)
                         break
 
                     # ── Post-tool-call empty response nudge ───────────

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3033,11 +3033,14 @@ class TestRunConversation:
             return empty_stub
 
         status_messages = []
+        stream_deltas = []
+        agent.stream_delta_callback = stream_deltas.append
 
         def _capture_status(msg):
             status_messages.append(msg)
 
         with (
+            patch.object(agent, "_has_stream_consumers", return_value=False),
             patch.object(agent, "_interruptible_api_call", side_effect=_fake_api_call),
             patch.object(agent, "_persist_session"),
             patch.object(agent, "_save_trajectory"),
@@ -3049,6 +3052,7 @@ class TestRunConversation:
         assert result["completed"] is True
         assert result["final_response"] == "The answer to your question is that"
         assert result["api_calls"] == 1  # No wasted retries
+        assert "The answer to your question is that" in stream_deltas
         # Should emit the stream-interrupted status, NOT the empty-retry status
         recovery_msgs = [m for m in status_messages if "stream interrupted" in m.lower()]
         assert len(recovery_msgs) >= 1, f"Expected stream recovery status, got: {status_messages}"
@@ -3079,6 +3083,33 @@ class TestRunConversation:
         # Should use the streamed content, not the old prior-turn fallback
         assert result["final_response"] == "Fresh partial content from this turn"
         assert result["api_calls"] == 1
+
+    def test_prior_turn_fallback_emits_stream_delta(self, agent):
+        """SSE clients receive fallback text synthesized from the previous turn."""
+        self._setup_agent(agent)
+        tool_call = _mock_tool_call(name="memory", arguments='{"action":"add","text":"ok"}', call_id="mem1")
+        tool_resp = _mock_response(
+            content="Earlier housekeeping answer",
+            finish_reason="tool_calls",
+            tool_calls=[tool_call],
+        )
+        empty_stub = _mock_response(content="", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [tool_resp, empty_stub]
+        agent.valid_tool_names.add("memory")
+        stream_deltas = []
+        agent.stream_delta_callback = stream_deltas.append
+
+        with (
+            patch.object(agent, "_has_stream_consumers", return_value=False),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("thanks")
+
+        assert result["final_response"] == "Earlier housekeeping answer"
+        assert result["api_calls"] == 2
+        assert "Earlier housekeeping answer" in stream_deltas
 
     def test_nous_401_refreshes_after_remint_and_retries(self, agent):
         self._setup_agent(agent)


### PR DESCRIPTION
## Summary
- Emits synthesized final text through `stream_delta_callback` before recovery/guardrail branches close the turn.
- Refs #31449.

## Why
- `partial_stream_recovery` and `fallback_prior_turn_content` assign `final_response` from local recovery text and then break without another model delta.
- SSE/Open WebUI-style clients can otherwise receive only a finish chunk and render a blank bubble even though Hermes has a final answer.

## Changes
- `agent/conversation_loop.py`: adds a small helper for synthesized final deltas and uses it for guardrail halt, partial stream recovery, and prior-turn fallback finals.
- `tests/run_agent/test_run_agent.py`: asserts partial-stream recovery and prior-turn fallback text is emitted to stream consumers.

## Validation
- `python -m ruff check agent/conversation_loop.py tests/run_agent/test_run_agent.py`
- `python -m pytest tests/run_agent/test_tool_call_guardrail_runtime.py tests/run_agent/test_run_agent.py::TestRunConversation::test_partial_stream_recovery_on_empty_stub tests/run_agent/test_run_agent.py::TestRunConversation::test_prior_turn_fallback_emits_stream_delta -o 'addopts=' -q`

## Scope
- In scope: final text synthesized by recovery/guardrail paths that would otherwise bypass stream deltas.
- Out of scope: changing retry policy, recovery selection, or the broader SSE protocol.