### PR TITLE
fix(agent): emit recovery-path final response through stream_delta_callback

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4357,6 +4357,21 @@ def run_conversation(
                             "as final response"
                         )
                         final_response = _recovered
+                        # Push the recovered text through the streaming
+                        # callback so SSE/TUI clients see it before the
+                        # finish chunk lands.  The recovered text wasn't
+                        # necessarily streamed in full this turn — the
+                        # current SSE writer drains an empty queue and
+                        # emits a finish chunk with zero content delta
+                        # otherwise, indistinguishable from a crash
+                        # (#31449, mirrors the guardrail-halt site in
+                        # #31448).
+                        if final_response and agent.stream_delta_callback:
+                            try:
+                                agent.stream_delta_callback(final_response)
+                                agent.stream_delta_callback(None)
+                            except Exception:
+                                pass
                         agent._response_was_previewed = True
                         break
 
@@ -4383,6 +4398,18 @@ def run_conversation(
                         # poisoned the conversation history.  Just use the
                         # fallback text as the final response and break.
                         final_response = agent._strip_think_blocks(fallback).strip()
+                        # Push the prior-turn content through the streaming
+                        # callback so SSE/TUI clients see it before the
+                        # finish chunk lands.  The text was streamed on the
+                        # *previous* SSE response, so the current SSE writer
+                        # drains an empty queue otherwise (#31449, mirrors
+                        # the guardrail-halt site in #31448).
+                        if final_response and agent.stream_delta_callback:
+                            try:
+                                agent.stream_delta_callback(final_response)
+                                agent.stream_delta_callback(None)
+                            except Exception:
+                                pass
                         agent._response_was_previewed = True
                         break
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -146,6 +146,41 @@ def _ollama_context_limit_error(agent: Any, request_tokens: int) -> Optional[str
     )
 
 
+def _flush_synthesized_final_to_stream(agent: Any, text: str) -> None:
+    """Push synthesized final text + close sentinel through ``stream_delta_callback``.
+
+    Used by recovery / fallback break sites where ``final_response`` was
+    assigned from text not (fully) streamed this turn (#31449).  Without this
+    flush the SSE writer drains an empty queue and emits a finish chunk with
+    zero content delta, indistinguishable from a crash for Open WebUI clients.
+
+    The close sentinel is best-effort and runs in a ``finally`` so it still
+    fires when ``callback(text)`` raises — guaranteeing the SSE writer can
+    drain.  Both emit and close are guarded individually so a single bad
+    callback can't break the surrounding turn-exit flow.
+    """
+    callback = getattr(agent, "stream_delta_callback", None)
+    if not callback or not text:
+        return
+    try:
+        try:
+            callback(text)
+        except Exception:
+            logger.debug(
+                "stream_delta_callback raised while emitting synthesized "
+                "final text",
+                exc_info=True,
+            )
+    finally:
+        try:
+            callback(None)
+        except Exception:
+            logger.debug(
+                "stream_delta_callback raised while closing stream",
+                exc_info=True,
+            )
+
+
 def _ra():
     """Lazy reference to ``run_agent`` so callers can patch
     ``run_agent.handle_function_call`` / ``run_agent._set_interrupt`` /
@@ -4359,19 +4394,9 @@ def run_conversation(
                         final_response = _recovered
                         # Push the recovered text through the streaming
                         # callback so SSE/TUI clients see it before the
-                        # finish chunk lands.  The recovered text wasn't
-                        # necessarily streamed in full this turn — the
-                        # current SSE writer drains an empty queue and
-                        # emits a finish chunk with zero content delta
-                        # otherwise, indistinguishable from a crash
-                        # (#31449, mirrors the guardrail-halt site in
-                        # #31448).
-                        if final_response and agent.stream_delta_callback:
-                            try:
-                                agent.stream_delta_callback(final_response)
-                                agent.stream_delta_callback(None)
-                            except Exception:
-                                pass
+                        # finish chunk lands (#31449, mirrors the
+                        # guardrail-halt site in #31448).
+                        _flush_synthesized_final_to_stream(agent, final_response)
                         agent._response_was_previewed = True
                         break
 
@@ -4400,16 +4425,9 @@ def run_conversation(
                         final_response = agent._strip_think_blocks(fallback).strip()
                         # Push the prior-turn content through the streaming
                         # callback so SSE/TUI clients see it before the
-                        # finish chunk lands.  The text was streamed on the
-                        # *previous* SSE response, so the current SSE writer
-                        # drains an empty queue otherwise (#31449, mirrors
-                        # the guardrail-halt site in #31448).
-                        if final_response and agent.stream_delta_callback:
-                            try:
-                                agent.stream_delta_callback(final_response)
-                                agent.stream_delta_callback(None)
-                            except Exception:
-                                pass
+                        # finish chunk lands (#31449, mirrors the
+                        # guardrail-halt site in #31448).
+                        _flush_synthesized_final_to_stream(agent, final_response)
                         agent._response_was_previewed = True
                         break
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4262,7 +4262,7 @@ class TestRunConversation:
         assert "Earlier user-visible answer." in text_deltas, (
             f"prior-turn text was never streamed; callback only saw {deltas!r}"
         )
-        assert deltas[-1] is None, (
+        assert deltas and deltas[-1] is None, (
             f"stream_delta_callback was not closed with None; deltas={deltas!r}"
         )
         assert result.get("response_previewed") is True

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4173,6 +4173,100 @@ class TestRunConversation:
         assert result["final_response"].startswith(INTERRUPT_WAITING_FOR_MODEL_PREFIX)
         assert result["messages"][-1]["role"] == "user"
 
+    def test_partial_stream_recovery_emits_final_response_through_stream_callback(self, agent):
+        """Regression for #31449: when the loop exits via partial_stream_recovery,
+        the recovered final_response must be pushed through stream_delta_callback
+        so SSE/TUI clients see content delta before the finish chunk lands.
+        Without this the current SSE writer drains an empty queue and emits a
+        finish chunk with zero content (indistinguishable from a crash for
+        Open WebUI and similar clients).  Mirrors the guardrail-halt site in
+        #31448.
+        """
+        self._setup_agent(agent)
+        empty_stub = _mock_response(content=None, finish_reason="stop")
+
+        def _fake_api_call(api_kwargs):
+            agent._current_streamed_assistant_text = "Recovered partial answer."
+            return empty_stub
+
+        deltas: list = []
+        agent.stream_delta_callback = lambda d: deltas.append(d)
+        # Force the non-streaming code path so the recovery branch is
+        # reached without engaging the real streaming machinery (the
+        # mocked client returns SimpleNamespace, not a stream iterator).
+        agent._disable_streaming = True
+
+        with (
+            patch.object(agent, "_interruptible_api_call", side_effect=_fake_api_call),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("ask me")
+
+        assert result["turn_exit_reason"] == "partial_stream_recovery"
+        assert result["final_response"] == "Recovered partial answer."
+        # The recovered text must have been pushed through the callback at
+        # least once.  Empty-queue SSE writers were the bug — clients saw no
+        # content delta before the finish chunk.
+        text_deltas = [d for d in deltas if isinstance(d, str)]
+        assert "Recovered partial answer." in text_deltas, (
+            f"recovered text was never streamed; callback only saw {deltas!r}"
+        )
+        # Callback should also have been closed so the SSE writer can drain.
+        assert deltas[-1] is None, (
+            f"stream_delta_callback was not closed with None; deltas={deltas!r}"
+        )
+        # response_previewed must be set so the gateway suppresses its own
+        # final send (avoid duplicate delivery).
+        assert result.get("response_previewed") is True
+
+    def test_fallback_prior_turn_content_emits_final_response_through_stream_callback(self, agent):
+        """Regression for #31449: when the loop exits via fallback_prior_turn_content,
+        the prior-turn final_response must be pushed through stream_delta_callback
+        so SSE/TUI clients see content delta before the finish chunk lands.
+        The text was streamed on the *previous* SSE response, so the current
+        SSE writer drains an empty queue without this push.  Mirrors the
+        guardrail-halt site in #31448.
+        """
+        self._setup_agent(agent)
+        empty_stub = _mock_response(content=None, finish_reason="stop")
+
+        def _fake_api_call(api_kwargs):
+            # run_conversation() resets _last_content_with_tools at turn
+            # start; re-seed it here so the empty response engages the
+            # fallback_prior_turn_content branch.  The text reaches
+            # final_response via _strip_think_blocks(fallback).strip().
+            agent._last_content_with_tools = "Earlier user-visible answer."
+            agent._last_content_tools_all_housekeeping = True
+            agent._current_streamed_assistant_text = ""
+            return empty_stub
+
+        deltas: list = []
+        agent.stream_delta_callback = lambda d: deltas.append(d)
+        # Force the non-streaming code path so the recovery branch is
+        # reached without engaging the real streaming machinery.
+        agent._disable_streaming = True
+
+        with (
+            patch.object(agent, "_interruptible_api_call", side_effect=_fake_api_call),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("ack")
+
+        assert result["turn_exit_reason"] == "fallback_prior_turn_content"
+        assert result["final_response"] == "Earlier user-visible answer."
+        text_deltas = [d for d in deltas if isinstance(d, str)]
+        assert "Earlier user-visible answer." in text_deltas, (
+            f"prior-turn text was never streamed; callback only saw {deltas!r}"
+        )
+        assert deltas[-1] is None, (
+            f"stream_delta_callback was not closed with None; deltas={deltas!r}"
+        )
+        assert result.get("response_previewed") is True
+
     def test_nous_401_refreshes_after_remint_and_retries(self, agent):
         self._setup_agent(agent)
         agent.provider = "nous"

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4214,7 +4214,7 @@ class TestRunConversation:
             f"recovered text was never streamed; callback only saw {deltas!r}"
         )
         # Callback should also have been closed so the SSE writer can drain.
-        assert deltas[-1] is None, (
+        assert deltas and deltas[-1] is None, (
             f"stream_delta_callback was not closed with None; deltas={deltas!r}"
         )
         # response_previewed must be set so the gateway suppresses its own


### PR DESCRIPTION
## What does this PR do?

Closes the same blank-stream gap teknium1 fixed at the guardrail-halt site in #31448, but at the two structurally-identical sibling sites in `agent/conversation_loop.py` that #31449 calls out:

- **`partial_stream_recovery`** (~L3566) — `final_response = _recovered` (text reconstructed from a partial stream). The recovered text wasn't necessarily streamed in full this turn.
- **`fallback_prior_turn_content`** (~L3593) — `final_response = agent._strip_think_blocks(fallback).strip()` where `fallback` is the previous turn's content. That text was streamed on the *previous* SSE response, so the current SSE writer drains an empty queue.

Both sites set `_response_was_previewed = True` (so the gateway suppresses its own final send) and then `break` — but never actually push the assembled text through `agent.stream_delta_callback`. SSE/TUI clients see a finish chunk with zero content delta, indistinguishable from a crash for Open WebUI and similar clients.

The fix mirrors teknium1's pattern from #31448: push `final_response` and then `None` through the callback inside a try/except, immediately before `break`. No `_safe_print` here — unlike the guardrail-halt site, the CLI has already seen the partial / prior-turn content on screen, and re-printing would look like a stray echo.

> Mirrors the post-execute pattern from `#31448`'s guardrail-halt site. Helper extraction (teknium1's optional follow-up suggestion in #31449) is intentionally left for a separate refactor pass so this PR doesn't conflict with #31448's still-open diff on the same file.

## Related Issue

Fixes #31449

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/conversation_loop.py` — at both `partial_stream_recovery` and `fallback_prior_turn_content` sites, push `final_response` and then `None` through `stream_delta_callback` before `break`. Mirrors the try/except pattern from #31448.
- `tests/run_agent/test_run_agent.py` — two new tests under `TestRunConversation`:
  - `test_partial_stream_recovery_emits_final_response_through_stream_callback`
  - `test_fallback_prior_turn_content_emits_final_response_through_stream_callback`

  Each asserts (a) the recovered text reaches the callback as a text delta, (b) the callback is closed with `None` so the SSE writer can drain, and (c) `response_previewed` remains `True` so the gateway suppresses its own final send.

## How to Test

1. Focused tests for the two new branches:
   ```
   uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest \
     tests/run_agent/test_run_agent.py::TestRunConversation::test_partial_stream_recovery_emits_final_response_through_stream_callback \
     tests/run_agent/test_run_agent.py::TestRunConversation::test_fallback_prior_turn_content_emits_final_response_through_stream_callback -v
   ```
2. Adjacent regression coverage (existing partial-stream / guardrail / fallback / streaming tests):
   ```
   uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest \
     tests/run_agent/test_run_agent.py \
     tests/run_agent/test_streaming.py \
     tests/run_agent/test_partial_stream_finish_reason.py \
     tests/run_agent/test_tool_call_guardrail_runtime.py -q
   ```
   341 + 54 = **395 tests pass locally**.
3. Gateway suppression coverage (the `response_previewed` consumer side):
   ```
   uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest \
     tests/gateway/test_duplicate_reply_suppression.py \
     tests/gateway/test_run_progress_topics.py -q
   ```
   **52 tests pass locally** — gateway's existing suppress-on-`response_previewed` logic still triggers, so this fix does not introduce duplicate delivery for streamed clients.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(agent): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (regression for both sibling sites)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing API change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure Python control-flow, no platform branches)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

This is the explicit follow-up issue teknium1 filed in #31449 to keep #31448 narrowly scoped to the reported guardrail-halt bug. The recovery-path sites have the same failure shape (blank Open WebUI bubble) but trigger less frequently, so they're worth a separate PR rather than bundling onto #31448.

> Audited siblings: enumerated every `break` site in `agent/conversation_loop.py` that re-assigns `final_response` to text not (fully) streamed this turn. The three sites that match are: the guardrail-halt site (handled by #31448), `partial_stream_recovery`, and `fallback_prior_turn_content`. The other `break` sites in the same loop either return the assistant message's own content (already streamed this turn) or set `final_response = "(empty)"` after exhausted retries (no real content to deliver). No widening needed beyond the two sites in this PR.