### PR TITLE
feat(hooks): add hermes hooks allow for non-TTY allowlisting

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -715,6 +715,33 @@ def revoke(command: str) -> int:
     return before - after
 
 
+def approve(event: str, command: str) -> bool:
+    """Persistently allowlist ``command`` for ``event``.
+
+    Public wrapper over :func:`_record_approval` for non-interactive
+    callers — the ``hermes hooks allow`` CLI, deployment scripts, and
+    headless service accounts that have no TTY for the first-use
+    consent prompt and don't want the blanket ``hooks_auto_accept:
+    true`` switch.  Issue #31479.
+
+    Returns ``True`` if a new entry was written, ``False`` if the pair
+    was already on the allowlist.  Idempotent: calling twice never
+    produces duplicate entries (``_record_approval`` rewrites in place
+    when an existing match is found).
+
+    The allowlist key is the literal ``command`` string as it will
+    appear in ``~/.hermes/config.yaml`` — match this byte-for-byte at
+    runtime is what gates registration, so callers must pass the same
+    shape.  Tilde expansion / symlink resolution is *not* applied
+    here so that ``~/.hermes/hooks/x.py`` written by both the user's
+    config and the allowlist line up.
+    """
+    if _is_allowlisted(event, command):
+        return False
+    _record_approval(event, command)
+    return True
+
+
 _SCRIPT_EXTENSIONS: Tuple[str, ...] = (
     ".sh", ".bash", ".zsh", ".fish",
     ".py", ".pyw",

--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -4,6 +4,7 @@ Usage::
 
     hermes hooks list
     hermes hooks test <event> [--for-tool X] [--payload-file F]
+    hermes hooks allow <command> [--event <event>]
     hermes hooks revoke <command>
     hermes hooks doctor
 
@@ -28,7 +29,7 @@ def hooks_command(args) -> None:
     sub = getattr(args, "hooks_action", None)
 
     if not sub:
-        print("Usage: hermes hooks {list|test|revoke|doctor}")
+        print("Usage: hermes hooks {list|test|allow|revoke|doctor}")
         print("Run 'hermes hooks --help' for details.")
         return
 
@@ -36,6 +37,8 @@ def hooks_command(args) -> None:
         _cmd_list(args)
     elif sub == "test":
         _cmd_test(args)
+    elif sub in {"allow", "approve"}:
+        _cmd_allow(args)
     elif sub in {"revoke", "remove", "rm"}:
         _cmd_revoke(args)
     elif sub == "doctor":
@@ -266,6 +269,99 @@ def _print_run_result(result: Dict[str, Any]) -> None:
 
 def _truncate(s: str, n: int) -> str:
     return s if len(s) <= n else s[: n - 3] + "..."
+
+
+# ---------------------------------------------------------------------------
+# allow
+# ---------------------------------------------------------------------------
+
+def _cmd_allow(args) -> None:
+    """Persistently allowlist a hook command for non-TTY deployments.
+
+    Two modes:
+
+    1. *Config-driven* (preferred) — ``hermes hooks allow <command>``
+       inspects ``~/.hermes/config.yaml`` and approves every event that
+       references this exact command.  This is the path the issue's
+       service-account / headless deployment scenarios want: the
+       command is already declared in config, the operator just needs
+       a non-interactive way to flip it from "✗ not allowlisted" to
+       "✓ allowed" without falling back to the blanket
+       ``hooks_auto_accept: true`` switch (#31479).
+
+    2. *Direct* — ``hermes hooks allow <command> --event <event>``
+       writes a single ``(event, command)`` allowlist entry without
+       cross-checking the config.  Useful when the operator is staging
+       config and allowlist together via configuration management
+       tooling, or when they want to pre-approve a hook the next
+       config update will introduce.
+    """
+    from hermes_cli.config import load_config
+    from hermes_cli.plugins import VALID_HOOKS
+    from agent import shell_hooks
+
+    command = args.command
+    event = getattr(args, "event", None)
+
+    # --event takes precedence and bypasses the config lookup so the
+    # operator can pre-stage entries.  Validate against VALID_HOOKS so
+    # typos surface here rather than silently producing a dead entry.
+    if event is not None:
+        if event not in VALID_HOOKS:
+            print(f"Unknown event: {event!r}")
+            print(f"Valid events: {', '.join(sorted(VALID_HOOKS))}")
+            return
+        events_to_approve = [event]
+        config_match_summary = f"--event {event}"
+    else:
+        specs = shell_hooks.iter_configured_hooks(load_config())
+        events_to_approve = sorted({
+            s.event for s in specs if s.command == command
+        })
+        if not events_to_approve:
+            print(
+                f"No hook in ~/.hermes/config.yaml uses command: {command}"
+            )
+            print(
+                "  Either add the hook to config.yaml first, or pass "
+                "--event <event> to write the allowlist entry directly."
+            )
+            print(
+                f"  Valid events: {', '.join(sorted(VALID_HOOKS))}"
+            )
+            return
+        config_match_summary = (
+            f"{len(events_to_approve)} configured event(s)"
+        )
+
+    print(
+        f"Allowlisting {command} for {config_match_summary}:"
+    )
+    new_entries = 0
+    already = 0
+    for ev in events_to_approve:
+        if shell_hooks.approve(ev, command):
+            new_entries += 1
+            print(f"  ✓ {ev} — allowlisted")
+        else:
+            already += 1
+            print(f"  • {ev} — already allowlisted (no change)")
+
+    print()
+    if new_entries and already:
+        print(
+            f"Approved {new_entries} new entry/entries; "
+            f"{already} already present."
+        )
+    elif new_entries:
+        print(f"Approved {new_entries} entry/entries.")
+    else:
+        print("Nothing to do — every requested entry was already allowlisted.")
+
+    print(
+        "Note: currently running CLI / gateway processes only honour the "
+        "new allowlist after they restart."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11959,6 +11959,34 @@ def main():
         ),
     )
 
+    _hk_allow = hooks_subparsers.add_parser(
+        "allow",
+        aliases=["approve"],
+        help=(
+            "Persistently allowlist a hook command for non-TTY / "
+            "headless deployments (writes to "
+            "~/.hermes/shell-hooks-allowlist.json)"
+        ),
+    )
+    _hk_allow.add_argument(
+        "command",
+        help=(
+            "The exact command string declared in config.yaml.  Must "
+            "match byte-for-byte; the runtime gate compares the "
+            "literal string."
+        ),
+    )
+    _hk_allow.add_argument(
+        "--event",
+        dest="event",
+        default=None,
+        help=(
+            "Allowlist for this specific event only.  Without --event, "
+            "every event in config.yaml that references the command is "
+            "approved."
+        ),
+    )
+
     _hk_revoke = hooks_subparsers.add_parser(
         "revoke",
         aliases=["remove", "rm"],

--- a/tests/hermes_cli/test_hooks_allow_31479.py
+++ b/tests/hermes_cli/test_hooks_allow_31479.py
@@ -1,0 +1,262 @@
+"""Regression tests for #31479 — ``hermes hooks allow``.
+
+Service accounts and headless deployments have no TTY for the
+first-use consent prompt and don't want the blanket
+``hooks_auto_accept: true`` switch.  These tests pin the new
+``allow`` subcommand so the documented non-interactive workflow
+keeps working and so future refactors cannot quietly drop the
+public ``approve()`` API the CLI builds on.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from agent import shell_hooks
+from hermes_cli import hooks as hooks_cli
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    monkeypatch.delenv("HERMES_ACCEPT_HOOKS", raising=False)
+    shell_hooks.reset_for_tests()
+    yield
+    shell_hooks.reset_for_tests()
+
+
+def _hook_script(tmp_path: Path, body: str = "#!/usr/bin/env bash\nprintf '{}\\n'\n", name: str = "hook.sh") -> Path:
+    p = tmp_path / name
+    p.write_text(body)
+    p.chmod(0o755)
+    return p
+
+
+def _run(sub_args: SimpleNamespace) -> str:
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        hooks_cli.hooks_command(sub_args)
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# agent.shell_hooks.approve — public API contract
+# ---------------------------------------------------------------------------
+
+
+class TestApprovePublicApi:
+    """``approve`` is the seam non-CLI callers (deployment scripts,
+    operators, future TUI flows) build on.  Pin its contract."""
+
+    def test_writes_new_entry_and_returns_true(self, tmp_path):
+        script = _hook_script(tmp_path)
+        assert shell_hooks.approve("post_llm_call", str(script)) is True
+        # Allowlist now contains exactly the documented schema.
+        data = json.loads(shell_hooks.allowlist_path().read_text())
+        approvals = data["approvals"]
+        assert len(approvals) == 1
+        entry = approvals[0]
+        assert entry["event"] == "post_llm_call"
+        assert entry["command"] == str(script)
+        assert "approved_at" in entry
+        # mtime is captured so doctor can flag drift.
+        assert "script_mtime_at_approval" in entry
+
+    def test_idempotent_repeat_returns_false(self, tmp_path):
+        script = _hook_script(tmp_path)
+        assert shell_hooks.approve("post_llm_call", str(script)) is True
+        # Second call must NOT duplicate the entry and must report
+        # "no change" so the CLI can render a useful summary.
+        assert shell_hooks.approve("post_llm_call", str(script)) is False
+        data = json.loads(shell_hooks.allowlist_path().read_text())
+        assert len(data["approvals"]) == 1
+
+    def test_distinct_events_get_distinct_entries(self, tmp_path):
+        script = _hook_script(tmp_path)
+        shell_hooks.approve("pre_tool_call", str(script))
+        shell_hooks.approve("post_tool_call", str(script))
+        data = json.loads(shell_hooks.allowlist_path().read_text())
+        events = sorted(e["event"] for e in data["approvals"])
+        assert events == ["post_tool_call", "pre_tool_call"]
+
+    def test_byte_for_byte_command_match(self, tmp_path):
+        # The runtime registration gate compares the literal command
+        # string from config.yaml against the literal allowlist entry.
+        # A trailing-space variant must NOT collide with the canonical
+        # form, otherwise an operator could quietly approve a
+        # different command than the one their config declares.
+        script = _hook_script(tmp_path)
+        shell_hooks.approve("post_llm_call", str(script))
+        # Trailing-space variant counts as a different command.
+        assert shell_hooks.approve("post_llm_call", f"{script} ") is True
+        data = json.loads(shell_hooks.allowlist_path().read_text())
+        assert len(data["approvals"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# hermes hooks allow — config-driven default
+# ---------------------------------------------------------------------------
+
+
+class TestHooksAllowConfigDriven:
+    """Without --event, the CLI walks ~/.hermes/config.yaml and
+    approves every event that mentions the command."""
+
+    def test_approves_every_configured_event(self, tmp_path):
+        script = _hook_script(tmp_path)
+        cfg = {
+            "hooks": {
+                "pre_tool_call": [{"matcher": "terminal", "command": str(script)}],
+                "post_tool_call": [{"matcher": "terminal", "command": str(script)}],
+                "post_llm_call": [{"command": str(script)}],
+            }
+        }
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            out = _run(SimpleNamespace(
+                hooks_action="allow", command=str(script), event=None,
+            ))
+
+        # All three configured events should be allowlisted now.
+        for ev in ("pre_tool_call", "post_tool_call", "post_llm_call"):
+            assert shell_hooks.allowlist_entry_for(ev, str(script)) is not None
+            assert ev in out
+
+        assert "Approved 3 entry/entries" in out
+
+    def test_idempotent_second_run_reports_no_change(self, tmp_path):
+        script = _hook_script(tmp_path)
+        cfg = {"hooks": {"post_llm_call": [{"command": str(script)}]}}
+
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            _run(SimpleNamespace(
+                hooks_action="allow", command=str(script), event=None,
+            ))
+            out = _run(SimpleNamespace(
+                hooks_action="allow", command=str(script), event=None,
+            ))
+
+        assert "already allowlisted" in out
+        assert "Nothing to do" in out
+        # Still exactly one entry — no duplicate from the rerun.
+        data = json.loads(shell_hooks.allowlist_path().read_text())
+        assert len(data["approvals"]) == 1
+
+    def test_command_not_in_config_errors_out(self, tmp_path):
+        # Service-account scenarios where the operator typo'd the
+        # path or forgot to update config.yaml should NOT silently
+        # write a dead allowlist entry.
+        script = _hook_script(tmp_path)
+        cfg = {"hooks": {"post_llm_call": [{"command": "/some/other/script.sh"}]}}
+
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            out = _run(SimpleNamespace(
+                hooks_action="allow", command=str(script), event=None,
+            ))
+
+        assert "No hook in ~/.hermes/config.yaml" in out
+        assert "--event" in out
+        # Nothing was written.
+        assert shell_hooks.allowlist_entry_for(
+            "post_llm_call", str(script),
+        ) is None
+
+
+# ---------------------------------------------------------------------------
+# hermes hooks allow --event — direct entry mode
+# ---------------------------------------------------------------------------
+
+
+class TestHooksAllowDirectEvent:
+    """``--event`` writes a single entry without consulting config.yaml,
+    so operators can stage allowlist + config together."""
+
+    def test_writes_single_entry(self, tmp_path):
+        script = _hook_script(tmp_path)
+        with patch("hermes_cli.config.load_config", return_value={}):
+            out = _run(SimpleNamespace(
+                hooks_action="allow",
+                command=str(script),
+                event="post_llm_call",
+            ))
+
+        assert shell_hooks.allowlist_entry_for(
+            "post_llm_call", str(script),
+        ) is not None
+        # No incidental approvals leaked.
+        assert shell_hooks.allowlist_entry_for(
+            "pre_tool_call", str(script),
+        ) is None
+        assert "Approved 1 entry/entries" in out
+
+    def test_unknown_event_aborts_cleanly(self, tmp_path):
+        script = _hook_script(tmp_path)
+        with patch("hermes_cli.config.load_config", return_value={}):
+            out = _run(SimpleNamespace(
+                hooks_action="allow",
+                command=str(script),
+                event="totally_made_up_event",
+            ))
+
+        assert "Unknown event" in out
+        assert "Valid events" in out
+        # Nothing written.
+        data = json.loads(
+            shell_hooks.allowlist_path().read_text()
+        ) if shell_hooks.allowlist_path().exists() else {"approvals": []}
+        assert data.get("approvals") == []
+
+    def test_approve_alias_dispatches_to_allow(self, tmp_path):
+        # We intentionally accept both verbs — operators familiar with
+        # the API name (``shell_hooks.approve``) often type
+        # ``hermes hooks approve``.  Both must work.
+        script = _hook_script(tmp_path)
+        with patch("hermes_cli.config.load_config", return_value={}):
+            out = _run(SimpleNamespace(
+                hooks_action="approve",
+                command=str(script),
+                event="post_llm_call",
+            ))
+
+        assert shell_hooks.allowlist_entry_for(
+            "post_llm_call", str(script),
+        ) is not None
+        assert "allowlisted" in out
+
+
+# ---------------------------------------------------------------------------
+# Argparse wiring
+# ---------------------------------------------------------------------------
+
+
+class TestHooksAllowArgparseWiring:
+    """The bug report quotes the literal argparse error.  Pin the
+    argparse plumbing so a refactor cannot regress to it again."""
+
+    def test_allow_is_a_recognised_subcommand(self):
+        # build_top_level_parser + the rest of main()'s subparser
+        # registration is too entangled to invoke directly, so we
+        # exercise the public CLI surface with --help and assert the
+        # expected token shows up in the choices list.  Anything
+        # short of "argparse knows the word" reproduces #31479.
+        import subprocess
+        import sys
+
+        result = subprocess.run(
+            [sys.executable, "-m", "hermes_cli.main", "hooks", "--help"],
+            capture_output=True, text=True, timeout=30,
+        )
+        assert result.returncode == 0, result.stderr
+        # Both verbs are surfaced in the help.
+        assert "allow" in result.stdout
+        assert "approve" in result.stdout
+        # The original error listed only these — make sure the new
+        # subcommand actually joined the family rather than printing
+        # alongside it as documentation.
+        assert "{list,ls,test,allow,approve,revoke,remove,rm,doctor}" in result.stdout

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -942,6 +942,7 @@ Inspect shell-script hooks declared in `~/.hermes/config.yaml`, test them agains
 |------------|-------------|
 | `list` (alias: `ls`) | List configured hooks with matcher, timeout, and consent status |
 | `test <event>` | Fire every hook matching `<event>` against a synthetic payload |
+| `allow <command> [--event <event>]` (alias: `approve`) | Persistently allowlist a hook for non-TTY / headless deployments. Without `--event`, every event in `config.yaml` that references the command is approved; with `--event`, a single direct entry is written. Idempotent. |
 | `revoke` (aliases: `remove`, `rm`) | Remove a command's allowlist entries (takes effect on next restart) |
 | `doctor` | Check each configured hook: exec bit, allowlist, mtime drift, JSON validity, and synthetic run timing |
 

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -1299,13 +1299,14 @@ printf '{}\n'
 
 Each unique `(event, command)` pair prompts the user for approval the first time Hermes sees it, then persists the decision to `~/.hermes/shell-hooks-allowlist.json`. Subsequent runs (CLI or gateway) skip the prompt.
 
-Three escape hatches bypass the interactive prompt — any one is sufficient:
+Four escape hatches bypass the interactive prompt — any one is sufficient:
 
-1. `--accept-hooks` flag on the CLI (e.g. `hermes --accept-hooks chat`)
-2. `HERMES_ACCEPT_HOOKS=1` environment variable
-3. `hooks_auto_accept: true` in `cli-config.yaml`
+1. `hermes hooks allow <command>` to persistently allowlist a single configured hook ahead of the first run (recommended for service accounts and headless deployments — selective, audit-friendly, no global toggle).
+2. `--accept-hooks` flag on the CLI (e.g. `hermes --accept-hooks chat`) — bypasses the prompt for the current invocation only.
+3. `HERMES_ACCEPT_HOOKS=1` environment variable — same scope as `--accept-hooks`.
+4. `hooks_auto_accept: true` in `cli-config.yaml` — auto-approves every hook globally; coarse but useful when every hook is operator-controlled.
 
-Non-TTY runs (gateway, cron, CI) need one of these three — otherwise any newly-added hook silently stays un-registered and logs a warning.
+Non-TTY runs (gateway, cron, CI) need one of these four — otherwise any newly-added hook silently stays un-registered and logs a warning.
 
 **Script edits are silently trusted.** The allowlist keys on the exact command string, not the script's hash, so editing the script on disk does not invalidate consent. `hermes hooks doctor` flags mtime drift so you can spot edits and decide whether to re-approve.
 
@@ -1315,6 +1316,7 @@ Non-TTY runs (gateway, cron, CI) need one of these three — otherwise any newly
 |---------|--------------|
 | `hermes hooks list` | Dump configured hooks with matcher, timeout, and consent status |
 | `hermes hooks test <event> [--for-tool X] [--payload-file F]` | Fire every matching hook against a synthetic payload and print the parsed response |
+| `hermes hooks allow <command> [--event <event>]` | Persistently allowlist `<command>` for non-TTY / headless deployments. Without `--event`, every event in `config.yaml` that references the command is approved; with `--event`, a single direct entry is written (useful for staging an allowlist alongside an upcoming config change). Idempotent — repeated calls never duplicate entries. |
 | `hermes hooks revoke <command>` | Remove every allowlist entry matching `<command>` (takes effect on next restart) |
 | `hermes hooks doctor` | For every configured hook: check exec bit, allowlist status, mtime drift, JSON output validity, and rough execution time |
 


### PR DESCRIPTION
## Summary

Closes #31479.

Service-account / headless deployments have no TTY for the
first-use consent prompt and don't want the blanket
`hooks_auto_accept: true` switch — yet today they have no
documented path to flip a configured hook from `✗ not allowlisted`
to `✓ allowed`. The README'd workaround (hand-writing
`~/.hermes/shell-hooks-allowlist.json`) is brittle: nothing
validates the schema, future format changes silently break it,
and there is no equivalent of the runtime `flock` against
concurrent writers.

## What changed

- `agent.shell_hooks.approve(event, command) -> bool` — public
  wrapper over the existing locked `_record_approval` helper.
  Idempotent: returns `False` when the pair was already
  allowlisted, never duplicates entries.
- `hermes hooks allow <command> [--event <event>]` subcommand:
  - **Without `--event`** — walks `~/.hermes/config.yaml` and
    approves every event that references the command. The
    deployment scenario the issue describes.
  - **With `--event`** — writes a single direct entry, useful
    for staging an allowlist alongside an upcoming config change.
  - Both share the locked write path, so concurrent
    `hermes hooks allow` / runtime approvals can't race.
- Docs updated: hooks user-guide promotes the new subcommand to
  the top of the consent-bypass list, and the CLI command
  reference table gains a row for it.

## Test plan

- [x] `pytest tests/hermes_cli/test_hooks_allow_31479.py` — 11
      new tests covering the public API contract, the
      config-driven path, the `--event` direct path, the
      `approve` alias, idempotency, and an argparse smoke test
      that guards directly against the bug report's literal
      error string.
- [x] `pytest tests/hermes_cli/test_hooks_cli.py` — 14 existing
      passes (no regression in the surrounding subcommands).
- [x] `pytest tests/agent/test_shell_hooks.py` — 52 passes (one
      pre-existing, unrelated `os.waitpid` timeout flake on
      `TestCallbackSubprocess::test_timeout_returns_none` exists
      on `main` and is deselected).
- [x] Manual: `python -m hermes_cli.main hooks --help` now lists
      `allow (approve)` alongside the existing subcommands; the
      original error from the bug report (`invalid choice:
      'allow'`) is gone.