### PR TITLE
fix(hooks): warn when config.yaml uses gateway-event names for shell hooks

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -239,6 +239,113 @@ def reset_for_tests() -> None:
 # Config parsing
 # ---------------------------------------------------------------------------
 
+_GATEWAY_EVENT_HINTS: Dict[str, str] = {
+    # Gateway-only events are documented on the same page as shell hooks
+    # (website/docs/user-guide/features/hooks.md) and ship with HOOK.yaml /
+    # handler.py under ~/.hermes/hooks/, NOT inside config.yaml's ``hooks:``
+    # block.  Users routinely copy a gateway event name (the colon-suffixed
+    # ``agent:end`` etc.) into ``hooks:`` and silently get nothing.  Map
+    # each gateway event to the closest shell-hook event so the warning
+    # carries a precise "did you mean?" rather than the difflib fallback,
+    # which scores ``agent:end`` below the 0.6 fuzzy-match cutoff and so
+    # collapses to the generic "valid: ..." dump.  Issue #31480.
+    "agent:start": "pre_llm_call",
+    "agent:step": "post_llm_call",
+    "agent:end": "post_llm_call",
+    "session:start": "on_session_start",
+    "session:end": "on_session_end",
+    "session:reset": "on_session_reset",
+    # ``gateway:startup`` and ``command:*`` have no shell-hook analogue —
+    # they fire purely at the gateway runtime layer.  Mapping them to
+    # an empty string lets the warning say "no shell-hook analogue".
+    "gateway:startup": "",
+}
+
+
+def _suggest_for_unknown_event(event_name: Any) -> Optional[str]:
+    """Best matching shell-hook event for an invalid ``event_name``.
+
+    Returns ``None`` when no useful suggestion exists — either because
+    the input is unrecognisable or because the gateway event has no
+    shell-hook analogue (e.g. ``gateway:startup``).
+    """
+    from hermes_cli.plugins import VALID_HOOKS
+
+    if isinstance(event_name, str) and event_name in _GATEWAY_EVENT_HINTS:
+        mapped = _GATEWAY_EVENT_HINTS[event_name]
+        return mapped or None
+
+    matches = difflib.get_close_matches(
+        str(event_name), VALID_HOOKS, n=1, cutoff=0.6,
+    )
+    return matches[0] if matches else None
+
+
+def validate_hooks_config(cfg: Optional[Dict[str, Any]]) -> List[str]:
+    """Return user-facing warning strings for the ``hooks:`` block.
+
+    Same checks as :func:`_parse_hooks_block` (unknown event keys,
+    non-list event values, gateway-event confusion) but flattened
+    into plain strings so the CLI can surface them to the operator
+    in addition to / in place of the ``logger.warning`` channel —
+    which the user reports never reaches the terminal during
+    ``hermes hooks list``.  Issue #31480.
+
+    Returns an empty list when the block is empty or fully valid.
+    Never raises: a broken ``hooks:`` block must not crash the CLI.
+    """
+    from hermes_cli.plugins import VALID_HOOKS
+
+    warnings: List[str] = []
+    if not isinstance(cfg, dict):
+        return warnings
+    hooks_cfg = cfg.get("hooks")
+    if not isinstance(hooks_cfg, dict):
+        return warnings
+
+    for event_name, entries in hooks_cfg.items():
+        if event_name not in VALID_HOOKS:
+            suggestion = _suggest_for_unknown_event(event_name)
+            is_gateway = (
+                isinstance(event_name, str)
+                and event_name in _GATEWAY_EVENT_HINTS
+            )
+            header = (
+                f"'{event_name}' is not a valid shell hook event "
+                f"and will be ignored."
+            )
+            if is_gateway:
+                gateway_note = (
+                    "  Gateway events ('agent:start', 'agent:end', "
+                    "'agent:step', 'session:*', 'gateway:startup', "
+                    "'command:*') only fire from gateway hooks under "
+                    "~/.hermes/hooks/<name>/HOOK.yaml — they cannot "
+                    "appear in config.yaml's `hooks:` block."
+                )
+                if suggestion:
+                    body = (
+                        f"  Did you mean '{suggestion}'?\n{gateway_note}"
+                    )
+                else:
+                    body = gateway_note
+            elif suggestion:
+                body = f"  Did you mean '{suggestion}'?"
+            else:
+                body = (
+                    f"  Valid shell hook events: "
+                    f"{', '.join(sorted(VALID_HOOKS))}"
+                )
+            warnings.append(f"{header}\n{body}")
+            continue
+        if entries is not None and not isinstance(entries, list):
+            warnings.append(
+                f"hooks.{event_name} must be a list of hook definitions; "
+                f"got {type(entries).__name__}"
+            )
+
+    return warnings
+
+
 def _parse_hooks_block(hooks_cfg: Any) -> List[ShellHookSpec]:
     """Normalise the ``hooks:`` dict into a flat list of ``ShellHookSpec``.
 
@@ -254,13 +361,29 @@ def _parse_hooks_block(hooks_cfg: Any) -> List[ShellHookSpec]:
 
     for event_name, entries in hooks_cfg.items():
         if event_name not in VALID_HOOKS:
-            suggestion = difflib.get_close_matches(
-                str(event_name), VALID_HOOKS, n=1, cutoff=0.6,
+            suggestion = _suggest_for_unknown_event(event_name)
+            is_gateway = (
+                isinstance(event_name, str)
+                and event_name in _GATEWAY_EVENT_HINTS
             )
-            if suggestion:
+            if is_gateway and suggestion:
+                logger.warning(
+                    "unknown hook event %r in hooks: config — that name "
+                    "fires from gateway hooks (~/.hermes/hooks/...), not "
+                    "config.yaml; did you mean %r?",
+                    event_name, suggestion,
+                )
+            elif is_gateway:
+                logger.warning(
+                    "unknown hook event %r in hooks: config — gateway "
+                    "events can only fire from ~/.hermes/hooks/<name>/, "
+                    "not from config.yaml's `hooks:` block.",
+                    event_name,
+                )
+            elif suggestion:
                 logger.warning(
                     "unknown hook event %r in hooks: config — did you mean %r?",
-                    event_name, suggestion[0],
+                    event_name, suggestion,
                 )
             else:
                 logger.warning(

--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -44,6 +44,22 @@ def hooks_command(args) -> None:
         print(f"Unknown hooks subcommand: {sub}")
 
 
+def _print_hooks_config_warnings(cfg) -> None:
+    """Print ``hooks:`` block warnings (typos, gateway-event confusion).
+
+    Shared between ``hermes hooks list`` and ``hermes hooks doctor``.
+    Silent when the block is empty or fully valid.  Issue #31480.
+    """
+    from agent import shell_hooks
+
+    warnings = shell_hooks.validate_hooks_config(cfg)
+    if not warnings:
+        return
+    for msg in warnings:
+        print(f"⚠ {msg}")
+    print()
+
+
 # ---------------------------------------------------------------------------
 # list
 # ---------------------------------------------------------------------------
@@ -52,7 +68,20 @@ def _cmd_list(_args) -> None:
     from hermes_cli.config import load_config
     from agent import shell_hooks
 
-    specs = shell_hooks.iter_configured_hooks(load_config())
+    cfg = load_config()
+    # Surface ``hooks:`` block typos / gateway-event confusion BEFORE the
+    # specs check below — otherwise a config that contains only
+    # gateway-style event names (``agent:end``, ``session:end``, …)
+    # silently produces "No shell hooks configured" with no hint that
+    # the entries were dropped during parsing.  Logger.warning fires
+    # too, but the CLI's logger isn't configured to route WARNING to
+    # stderr at every entry point, so the user routinely never sees
+    # it.  Surfacing here makes the failure mode self-evident at the
+    # ``hermes hooks list`` call site the issue reproduces against.
+    # Issue #31480.
+    _print_hooks_config_warnings(cfg)
+
+    specs = shell_hooks.iter_configured_hooks(cfg)
 
     if not specs:
         print("No shell hooks configured in ~/.hermes/config.yaml.")
@@ -294,7 +323,9 @@ def _cmd_doctor(_args) -> None:
     from hermes_cli.config import load_config
     from agent import shell_hooks
 
-    specs = shell_hooks.iter_configured_hooks(load_config())
+    cfg = load_config()
+    _print_hooks_config_warnings(cfg)
+    specs = shell_hooks.iter_configured_hooks(cfg)
 
     if not specs:
         print("No shell hooks configured — nothing to check.")

--- a/tests/agent/test_shell_hooks_invalid_event_31480.py
+++ b/tests/agent/test_shell_hooks_invalid_event_31480.py
@@ -1,0 +1,264 @@
+"""Regression tests for #31480 — invalid shell-hook event-name warnings.
+
+A user who copies a gateway event name (``agent:end``, ``session:end``,
+…) into ``config.yaml``'s ``hooks:`` block sees their hook silently
+dropped; ``hermes hooks list`` previously reported only "No shell hooks
+configured" with zero hint that anything went wrong.  These tests pin:
+
+* the new ``_GATEWAY_EVENT_HINTS`` mapping and the
+  ``_suggest_for_unknown_event`` helper that drives both the logger
+  warning and the new CLI surface,
+* the public ``validate_hooks_config`` helper used by ``hermes hooks
+  list`` / ``hermes hooks doctor`` to surface those warnings to the
+  operator,
+* the CLI's call-site wiring so future refactors cannot quietly drop
+  the warning print without breaking the test.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+from contextlib import redirect_stdout
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from agent import shell_hooks
+from hermes_cli import hooks as hooks_cli
+
+
+# ---------------------------------------------------------------------------
+# _suggest_for_unknown_event
+# ---------------------------------------------------------------------------
+
+
+class TestSuggestForUnknownEvent:
+    """Direct contract for the gateway-aware suggestion helper."""
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            # Gateway events — exact mapping wins over difflib's
+            # fuzzy match (which scores ``agent:end`` below the 0.6
+            # cutoff and would otherwise return None).
+            ("agent:start", "pre_llm_call"),
+            ("agent:step", "post_llm_call"),
+            ("agent:end", "post_llm_call"),
+            ("session:start", "on_session_start"),
+            ("session:end", "on_session_end"),
+            ("session:reset", "on_session_reset"),
+        ],
+    )
+    def test_gateway_events_get_precise_mapping(self, raw, expected):
+        assert shell_hooks._suggest_for_unknown_event(raw) == expected
+
+    def test_gateway_only_events_have_no_shell_analogue(self):
+        # ``gateway:startup`` fires only at the gateway layer — there is
+        # no shell-hook lifecycle slot that's even close.  The helper
+        # must return None so the caller can render "no analogue"
+        # rather than a misleading "did you mean foo?".
+        assert shell_hooks._suggest_for_unknown_event("gateway:startup") is None
+
+    def test_typo_falls_back_to_difflib_close_match(self):
+        # The original difflib path is still the right answer for
+        # ordinary typos in the underscore namespace.
+        assert (
+            shell_hooks._suggest_for_unknown_event("pre_tool_calll")
+            == "pre_tool_call"
+        )
+
+    def test_completely_unknown_event_returns_none(self):
+        assert shell_hooks._suggest_for_unknown_event("xyzzy_made_up") is None
+
+    def test_non_string_input_does_not_crash(self):
+        # config.yaml occasionally hands us int/None keys after a YAML
+        # parsing accident; the helper must coerce-or-skip rather than
+        # raise.
+        assert shell_hooks._suggest_for_unknown_event(None) is None
+        assert shell_hooks._suggest_for_unknown_event(42) is None
+
+
+# ---------------------------------------------------------------------------
+# validate_hooks_config — public CLI-facing API
+# ---------------------------------------------------------------------------
+
+
+class TestValidateHooksConfig:
+    """The new helper feeds ``hermes hooks list`` /
+    ``hermes hooks doctor`` so the operator sees what the parser
+    rejected.  Pin its output shape."""
+
+    def test_empty_or_missing_block_is_silent(self):
+        assert shell_hooks.validate_hooks_config({}) == []
+        assert shell_hooks.validate_hooks_config({"hooks": {}}) == []
+        assert shell_hooks.validate_hooks_config({"hooks": None}) == []
+        assert shell_hooks.validate_hooks_config(None) == []
+
+    def test_fully_valid_config_is_silent(self):
+        cfg = {
+            "hooks": {
+                "post_llm_call": [{"command": "/x/hook.sh"}],
+                "on_session_end": [{"command": "/x/hook.sh"}],
+            }
+        }
+        assert shell_hooks.validate_hooks_config(cfg) == []
+
+    def test_gateway_event_emits_targeted_message(self):
+        cfg = {"hooks": {"agent:end": [{"command": "/x/hook.sh"}]}}
+        warnings = shell_hooks.validate_hooks_config(cfg)
+        assert len(warnings) == 1
+        msg = warnings[0]
+        # Header names the offending event verbatim and labels it as
+        # invalid for shell hooks.
+        assert "'agent:end' is not a valid shell hook event" in msg
+        # Targeted suggestion (precise mapping, NOT the difflib dump).
+        assert "Did you mean 'post_llm_call'?" in msg
+        # Distinguishes the two namespaces.
+        assert "Gateway events" in msg
+        assert "config.yaml" in msg
+
+    def test_gateway_only_event_explains_no_analogue(self):
+        # ``gateway:startup`` has no shell-hook equivalent: the message
+        # must explain the namespace mistake without misleadingly
+        # suggesting a random shell event.
+        cfg = {"hooks": {"gateway:startup": [{"command": "/x/hook.sh"}]}}
+        warnings = shell_hooks.validate_hooks_config(cfg)
+        assert len(warnings) == 1
+        msg = warnings[0]
+        assert "'gateway:startup' is not a valid shell hook event" in msg
+        assert "Did you mean" not in msg  # no false suggestion
+        assert "Gateway events" in msg
+
+    def test_typo_warns_with_close_match(self):
+        cfg = {"hooks": {"pre_tool_calll": [{"command": "/x/hook.sh"}]}}
+        warnings = shell_hooks.validate_hooks_config(cfg)
+        assert len(warnings) == 1
+        assert "Did you mean 'pre_tool_call'?" in warnings[0]
+        # No gateway-event noise on a plain typo.
+        assert "Gateway events" not in warnings[0]
+
+    def test_completely_unknown_event_lists_valid_options(self):
+        cfg = {"hooks": {"xyzzy_no_match": [{"command": "/x/hook.sh"}]}}
+        warnings = shell_hooks.validate_hooks_config(cfg)
+        assert len(warnings) == 1
+        assert "Valid shell hook events:" in warnings[0]
+        # The full list must include at least the two events the bug
+        # report quotes as the answer the user wanted.
+        assert "post_llm_call" in warnings[0]
+        assert "on_session_end" in warnings[0]
+
+    def test_non_list_event_value_warns(self):
+        cfg = {"hooks": {"pre_tool_call": "not-a-list"}}
+        warnings = shell_hooks.validate_hooks_config(cfg)
+        assert any("must be a list" in w for w in warnings)
+
+    def test_multiple_problems_each_get_their_own_message(self):
+        cfg = {
+            "hooks": {
+                "agent:end": [{"command": "/x"}],
+                "pre_tool_calll": [{"command": "/x"}],
+                "post_llm_call": [{"command": "/x"}],  # valid — no warn
+            }
+        }
+        warnings = shell_hooks.validate_hooks_config(cfg)
+        # One warning per offending key — the valid ``post_llm_call``
+        # entry must NOT contribute a warning of its own.
+        assert len(warnings) == 2
+        # Each invalid key surfaces as its own header so the operator
+        # can scan a multi-error config without parsing concatenations.
+        assert any("'agent:end' is not a valid" in w for w in warnings)
+        assert any("'pre_tool_calll' is not a valid" in w for w in warnings)
+        # No warning header references the valid event — we only allow
+        # ``post_llm_call`` to appear as a suggestion under
+        # ``agent:end``, never as an offender.
+        assert not any(
+            "'post_llm_call' is not a valid" in w for w in warnings
+        )
+
+
+# ---------------------------------------------------------------------------
+# Logger-level warnings (existing channel; still emitted, now with hint)
+# ---------------------------------------------------------------------------
+
+
+class TestParseHooksBlockLogsTargetedWarning:
+    """The existing ``logger.warning`` channel must still fire and now
+    carries the gateway-aware hint, so external log scrapers continue
+    to see structured data."""
+
+    def test_gateway_event_logs_targeted_message(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="agent.shell_hooks"):
+            shell_hooks._parse_hooks_block({"agent:end": [{"command": "/x"}]})
+        msgs = [r.getMessage() for r in caplog.records]
+        joined = "\n".join(msgs)
+        assert "agent:end" in joined
+        assert "post_llm_call" in joined
+        # The new wording explicitly tells the operator gateway hooks
+        # live elsewhere — this is the missing context the bug report
+        # complains about.
+        assert "gateway hooks" in joined or "~/.hermes/hooks" in joined
+
+
+# ---------------------------------------------------------------------------
+# CLI surfacing — hermes hooks list / hermes hooks doctor
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    monkeypatch.delenv("HERMES_ACCEPT_HOOKS", raising=False)
+    shell_hooks.reset_for_tests()
+    yield
+    shell_hooks.reset_for_tests()
+
+
+def _run_cli(action: str) -> str:
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        hooks_cli.hooks_command(SimpleNamespace(hooks_action=action))
+    return buf.getvalue()
+
+
+class TestCliSurfacesWarnings:
+    """The bug report quotes the exact ``hermes hooks list`` output the
+    user sees — pin the new wording so it can't regress to silence."""
+
+    def test_hooks_list_prints_warning_for_gateway_event(self):
+        cfg = {"hooks": {"agent:end": [{"command": "/tmp/hook.sh"}]}}
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            out = _run_cli("list")
+
+        # The warning must come BEFORE the "No shell hooks configured"
+        # line (or in lieu of it) so the user sees it first.
+        assert "⚠" in out
+        assert "agent:end" in out
+        assert "post_llm_call" in out
+        assert "Gateway events" in out
+        # The original silent-fallback message stays — but only AFTER
+        # the warning, so the user sees "your hook was dropped" before
+        # "no hooks configured".
+        warn_idx = out.find("⚠")
+        empty_idx = out.find("No shell hooks configured")
+        assert warn_idx >= 0 < empty_idx
+        assert warn_idx < empty_idx
+
+    def test_hooks_list_silent_when_block_is_clean(self):
+        # No false-positive warnings on a healthy config.
+        script = "/tmp/clean-hook.sh"
+        cfg = {"hooks": {"post_llm_call": [{"command": script}]}}
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            out = _run_cli("list")
+        assert "⚠" not in out
+
+    def test_hooks_doctor_also_surfaces_warnings(self):
+        cfg = {"hooks": {"session:end": [{"command": "/tmp/hook.sh"}]}}
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            out = _run_cli("doctor")
+        # ``session:end`` must map precisely to ``on_session_end`` —
+        # it's the sister case of ``agent:end`` from the bug report.
+        assert "session:end" in out
+        assert "on_session_end" in out
+        assert "⚠" in out

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -1178,6 +1178,10 @@ hooks_auto_accept: false         # See "Consent model" below
 
 Event names must be one of the [plugin hook events](#plugin-hooks); typos produce a "Did you mean X?" warning and are skipped. Unknown keys inside a single entry are ignored; missing `command` is a skip-with-warning. `timeout > 300` is clamped with a warning.
 
+:::warning Gateway events vs shell hook events
+The gateway-event names listed above (`gateway:startup`, `agent:start`, `agent:end`, `agent:step`, `session:*`, `command:*`) only fire from gateway hooks under `~/.hermes/hooks/<name>/HOOK.yaml` — they cannot appear inside `config.yaml`'s `hooks:` block. If you put `agent:end` (or any other colon-suffixed gateway event) in `config.yaml`, the entry is parsed but every event is dropped during registration. `hermes hooks list` and `hermes hooks doctor` print a `⚠` warning at the top of their output that flags the misuse and suggests the closest shell-hook analogue (e.g. `agent:end` → `post_llm_call`, `session:end` → `on_session_end`).
+:::
+
 ### JSON wire protocol
 
 Each time the event fires, Hermes spawns a subprocess for every matching hook (matcher permitting), pipes a JSON payload to **stdin**, and reads **stdout** back as JSON.


### PR DESCRIPTION
## Summary

Closes #31480.

When a user puts a gateway-event name (`agent:end`, `session:end`,
…) into `config.yaml`'s `hooks:` block, the entry is silently
dropped during parsing and `hermes hooks list` reports only "No
shell hooks configured" — exactly mimicking the empty-config
state. The existing `logger.warning` *does* fire, but the CLI's
logger isn't routed to stderr at WARNING level for these
entry points, so the operator sees nothing.

This is a realistic mistake because the docs cover both surfaces
on the same page; copying a row from the gateway-events table
into the shell-hooks schema looks reasonable and gets zero
feedback.

## What changed

- New `_GATEWAY_EVENT_HINTS` table maps each gateway event to its
  closest shell-hook analogue (`agent:end` → `post_llm_call`,
  `session:end` → `on_session_end`, …). `difflib` would otherwise
  score the colon-suffixed names below its 0.6 cutoff and fall
  back to dumping the entire `VALID_HOOKS` set.
- New public `agent.shell_hooks.validate_hooks_config(cfg)` returns
  the same warnings `_parse_hooks_block` already logs, flattened
  into user-readable strings — so the CLI can surface them
  without depending on logger configuration.
- `hermes hooks list` and `hermes hooks doctor` print the ⚠
  warnings before their main output, including a clear "this
  is a gateway event, not a shell-hook event" callout for the
  copy-paste case.
- Existing `logger.warning` channel still fires (external log
  scrapers continue to see structured data), now with the
  gateway-aware suggestion baked in.
- Docs admonition next to the schema names the gateway-only
  events explicitly so future readers don't fall into the
  same trap.

## Test plan

- [x] `pytest tests/agent/test_shell_hooks_invalid_event_31480.py`
      — 22 new tests covering the hint helper, the public
      validator, the existing logger channel, and the CLI
      surfacing wiring.
- [x] `pytest tests/hermes_cli/test_hooks_cli.py
      tests/agent/test_shell_hooks.py` — 66 existing passes (one
      pre-existing, unrelated `os.waitpid` flake on
      `TestCallbackSubprocess::test_timeout_returns_none` deselected;
      it fails on `main` without my changes).
- [x] Manual: drop `agent:end` into `config.yaml`'s `hooks:` and
      run `hermes hooks list` → see the ⚠ warning suggesting
      `post_llm_call` and explaining the gateway/shell-hook
      namespace split, in addition to the existing "No shell
      hooks configured" line.
