### PR TITLE
fix(weixin): decode SILK voice messages to WAV so STT can transcribe them

### DIFF
--- a/gateway/platforms/_silk.py
+++ b/gateway/platforms/_silk.py
@@ -1,0 +1,248 @@
+"""Shared audio decoding helpers for gateway platform adapters.
+
+Tencent's IM products (Weixin/WeChat, QQ) deliver voice messages in SILK
+v3, a proprietary codec ffmpeg cannot decode. The community standard for
+decoding SILK in Python is ``pilk`` (wraps Tencent's official SILK SDK).
+
+This module provides:
+
+* :func:`looks_like_silk` — magic-byte detection
+* :func:`silk_to_wav`    — SILK → 16kHz mono WAV via ``pilk``
+* :func:`ffmpeg_to_wav`  — generic audio → 16kHz mono WAV via ``ffmpeg``
+* :func:`ensure_wav`     — try SILK first if applicable, fall back to ffmpeg
+
+Both helpers return ``None`` on failure (never raise) so callers can chain
+fallbacks naturally. Used by ``weixin.py`` (inbound voice STT) and
+``qqbot/adapter.py`` (inbound voice STT).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shutil
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+_SILK_MAGIC_PREFIXES = (
+    b"#!SILK_V3",
+    b"#!SILK",
+    b"\x02!",
+    b"\x02#!SILK",  # Weixin variant: 0x02 framing byte before #!SILK
+)
+
+# Minimum size in bytes for a WAV file to count as "non-empty" (header + samples)
+_MIN_VALID_WAV_BYTES = 45  # 44-byte RIFF header + at least 1 sample byte
+
+
+def looks_like_silk(data: bytes) -> bool:
+    """Return True if ``data`` starts with a known SILK v3 magic prefix."""
+    if not data:
+        return False
+    return any(data.startswith(prefix) for prefix in _SILK_MAGIC_PREFIXES)
+
+
+def silk_to_wav(
+    src_path: str,
+    wav_path: str,
+    *,
+    rate: int = 16000,
+    log_tag: str = "",
+) -> Optional[str]:
+    """Convert a SILK audio file to WAV using the ``pilk`` library.
+
+    pilk inspects the file extension. If ``src_path`` doesn't end in
+    ``.silk`` we copy it to a temporary ``.silk`` path before invoking
+    pilk, then clean up.
+
+    Returns ``wav_path`` on success, ``None`` on any failure (missing
+    ``pilk``, decode error, empty output). Never raises.
+    """
+    try:
+        import pilk  # type: ignore
+    except ImportError:
+        logger.warning(
+            "%spilk not installed — cannot decode SILK audio. "
+            "Run: pip install pilk",
+            f"[{log_tag}] " if log_tag else "",
+        )
+        return None
+
+    src = Path(src_path)
+    if not src.exists():
+        return None
+
+    # Try as-is first (cheap path when src already ends in .silk)
+    try:
+        pilk.silk_to_wav(str(src), wav_path, rate=rate)
+        if _wav_nonempty(wav_path):
+            return wav_path
+    except Exception as exc:
+        logger.debug(
+            "%spilk direct conversion failed for %s: %s",
+            f"[{log_tag}] " if log_tag else "",
+            src.name,
+            exc,
+        )
+
+    # Fall back: copy to .silk-suffixed path so pilk's extension check passes
+    if src.suffix.lower() != ".silk":
+        silk_path = str(src.with_suffix(".silk"))
+        try:
+            shutil.copy2(str(src), silk_path)
+            pilk.silk_to_wav(silk_path, wav_path, rate=rate)
+            if _wav_nonempty(wav_path):
+                return wav_path
+        except Exception as exc:
+            logger.debug(
+                "%spilk .silk-suffixed conversion failed for %s: %s",
+                f"[{log_tag}] " if log_tag else "",
+                src.name,
+                exc,
+            )
+        finally:
+            try:
+                os.unlink(silk_path)
+            except OSError:
+                pass
+
+    return None
+
+
+async def ffmpeg_to_wav(
+    src_path: str,
+    wav_path: str,
+    *,
+    rate: int = 16000,
+    timeout: float = 30.0,
+    log_tag: str = "",
+) -> Optional[str]:
+    """Convert any ffmpeg-decodable audio file to 16kHz mono WAV.
+
+    Returns ``wav_path`` on success, ``None`` on any failure (missing
+    ffmpeg binary, decode error, timeout, empty output). Never raises.
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "ffmpeg",
+            "-y",
+            "-i", src_path,
+            "-ar", str(rate),
+            "-ac", "1",
+            wav_path,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except FileNotFoundError:
+        logger.warning(
+            "%sffmpeg not installed — cannot decode audio via ffmpeg fallback",
+            f"[{log_tag}] " if log_tag else "",
+        )
+        return None
+
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=timeout)
+    except asyncio.TimeoutError:
+        logger.warning(
+            "%sffmpeg timed out converting %s",
+            f"[{log_tag}] " if log_tag else "",
+            Path(src_path).name,
+        )
+        try:
+            proc.kill()
+            await proc.wait()
+        except Exception:
+            pass
+        return None
+
+    if proc.returncode != 0:
+        stderr = b""
+        if proc.stderr is not None:
+            try:
+                stderr = await proc.stderr.read()
+            except Exception:
+                pass
+        logger.warning(
+            "%sffmpeg failed for %s: %s",
+            f"[{log_tag}] " if log_tag else "",
+            Path(src_path).name,
+            stderr[:200].decode(errors="replace"),
+        )
+        return None
+
+    if not _wav_nonempty(wav_path):
+        logger.warning(
+            "%sffmpeg produced no/empty output for %s",
+            f"[{log_tag}] " if log_tag else "",
+            Path(src_path).name,
+        )
+        return None
+
+    return wav_path
+
+
+async def ensure_wav(
+    src_path: str,
+    *,
+    wav_path: Optional[str] = None,
+    sniff_bytes: Optional[bytes] = None,
+    rate: int = 16000,
+    log_tag: str = "",
+) -> Optional[str]:
+    """Produce a 16kHz mono WAV from ``src_path``, trying SILK then ffmpeg.
+
+    Detection order:
+
+    1. If ``sniff_bytes`` starts with a SILK magic prefix, or the file
+       extension is ``.silk``, try ``pilk`` first.
+    2. Otherwise (or if pilk fails), try ``ffmpeg``.
+
+    ``wav_path`` defaults to ``<src_path stem>.wav`` next to the source.
+
+    Returns the wav path on success, ``None`` if every backend failed.
+    Callers can fall back to handing the original audio to a cloud STT
+    provider that may accept the source format natively.
+    """
+    src = Path(src_path)
+    if not src.exists():
+        return None
+
+    if wav_path is None:
+        wav_path = str(src.with_suffix(".wav"))
+
+    is_silk = False
+    if sniff_bytes is not None and looks_like_silk(sniff_bytes):
+        is_silk = True
+    elif src.suffix.lower() == ".silk":
+        is_silk = True
+    else:
+        # Cheap header sniff if no bytes given
+        try:
+            with open(src_path, "rb") as fh:
+                head = fh.read(16)
+            is_silk = looks_like_silk(head)
+        except OSError:
+            pass
+
+    if is_silk:
+        result = await asyncio.to_thread(
+            silk_to_wav, src_path, wav_path, rate=rate, log_tag=log_tag,
+        )
+        if result:
+            return result
+
+    result = await ffmpeg_to_wav(
+        src_path, wav_path, rate=rate, log_tag=log_tag,
+    )
+    return result
+
+
+def _wav_nonempty(wav_path: str) -> bool:
+    try:
+        return Path(wav_path).exists() and Path(wav_path).stat().st_size > _MIN_VALID_WAV_BYTES
+    except OSError:
+        return False

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1834,11 +1834,14 @@ class QQAdapter(BasePlatformAdapter):
         """Convert audio bytes to a temp .wav file using pilk (SILK) or ffmpeg.
 
         QQ voice messages are typically SILK format which ffmpeg cannot decode.
-        Strategy: always try pilk first, fall back to ffmpeg if pilk fails.
+        Strategy delegated to ``gateway.platforms._silk.ensure_wav``: try
+        pilk first when the payload looks like SILK, fall back to ffmpeg.
+        Last-resort raw-PCM fallback retained for QQ-specific edge cases.
 
         Returns the wav file path, or None on failure.
         """
         import tempfile
+        from gateway.platforms._silk import ensure_wav
 
         ext = (
             Path(filename).suffix.lower()
@@ -1859,14 +1862,16 @@ class QQAdapter(BasePlatformAdapter):
 
         wav_path = src_path.rsplit(".", 1)[0] + ".wav"
 
-        # Try pilk first (handles SILK and many other formats)
-        result = await self._convert_silk_to_wav(src_path, wav_path)
+        # pilk-first, ffmpeg-fallback
+        result = await ensure_wav(
+            src_path,
+            wav_path=wav_path,
+            sniff_bytes=audio_data[:16],
+            log_tag=self._log_tag,
+        )
 
-        # If pilk failed, try ffmpeg
-        if not result:
-            result = await self._convert_ffmpeg_to_wav(src_path, wav_path)
-
-        # If ffmpeg also failed, try writing raw PCM as WAV (last resort)
+        # If both decoders failed, try writing raw PCM as WAV (last resort,
+        # QQ-specific — some odd payloads turn out to be raw PCM frames).
         if not result:
             result = await self._convert_raw_to_wav(audio_data, wav_path)
 
@@ -1906,56 +1911,14 @@ class QQAdapter(BasePlatformAdapter):
     async def _convert_silk_to_wav(self, src_path: str, wav_path: str) -> Optional[str]:
         """Convert audio file to WAV using the pilk library.
 
-        Tries the file as-is first, then as .silk if the extension differs.
-        pilk can handle SILK files with various headers (or no header).
+        Thin wrapper around :func:`gateway.platforms._silk.silk_to_wav`
+        kept for backward compatibility and direct call sites elsewhere
+        in this adapter.
         """
-        try:
-            import pilk
-        except ImportError:
-            logger.warning(
-                "[%s] pilk not installed — cannot decode SILK audio. Run: pip install pilk",
-                self._log_tag,
-            )
-            return None
-
-        # Try converting the file as-is
-        try:
-            pilk.silk_to_wav(src_path, wav_path, rate=16000)
-            if Path(wav_path).exists() and Path(wav_path).stat().st_size > 44:
-                logger.debug(
-                    "[%s] pilk converted %s to wav (%d bytes)",
-                    self._log_tag,
-                    Path(src_path).name,
-                    Path(wav_path).stat().st_size,
-                )
-                return wav_path
-        except Exception as exc:
-            logger.debug("[%s] pilk direct conversion failed: %s", self._log_tag, exc)
-
-        # Try renaming to .silk and converting (pilk checks the extension)
-        silk_path = src_path.rsplit(".", 1)[0] + ".silk"
-        try:
-            import shutil
-
-            shutil.copy2(src_path, silk_path)
-            pilk.silk_to_wav(silk_path, wav_path, rate=16000)
-            if Path(wav_path).exists() and Path(wav_path).stat().st_size > 44:
-                logger.debug(
-                    "[%s] pilk converted %s (as .silk) to wav (%d bytes)",
-                    self._log_tag,
-                    Path(src_path).name,
-                    Path(wav_path).stat().st_size,
-                )
-                return wav_path
-        except Exception as exc:
-            logger.debug("[%s] pilk .silk conversion failed: %s", self._log_tag, exc)
-        finally:
-            try:
-                os.unlink(silk_path)
-            except OSError:
-                pass
-
-        return None
+        from gateway.platforms._silk import silk_to_wav
+        return await asyncio.to_thread(
+            silk_to_wav, src_path, wav_path, rate=16000, log_tag=self._log_tag,
+        )
 
     async def _convert_raw_to_wav(self, audio_data: bytes, wav_path: str) -> Optional[str]:
         """Last resort: try writing audio data as raw PCM 16-bit mono 16kHz WAV.
@@ -1977,49 +1940,16 @@ class QQAdapter(BasePlatformAdapter):
             return None
 
     async def _convert_ffmpeg_to_wav(self, src_path: str, wav_path: str) -> Optional[str]:
-        """Convert audio file to WAV using ffmpeg."""
-        try:
-            proc = await asyncio.create_subprocess_exec(
-                "ffmpeg",
-                "-y",
-                "-i",
-                src_path,
-                "-ar",
-                "16000",
-                "-ac",
-                "1",
-                wav_path,
-                stdout=asyncio.subprocess.DEVNULL,
-                stderr=asyncio.subprocess.PIPE,
-            )
-            await asyncio.wait_for(proc.wait(), timeout=30)
-            if proc.returncode != 0:
-                stderr = await proc.stderr.read() if proc.stderr else b""
-                logger.warning(
-                    "[%s] ffmpeg failed for %s: %s",
-                    self._log_tag,
-                    Path(src_path).name,
-                    stderr[:200].decode(errors="replace"),
-                )
-                return None
-        except (asyncio.TimeoutError, FileNotFoundError) as exc:
-            logger.warning("[%s] ffmpeg conversion error: %s", self._log_tag, exc)
-            return None
+        """Convert audio file to WAV using ffmpeg.
 
-        if not Path(wav_path).exists() or Path(wav_path).stat().st_size <= 44:
-            logger.warning(
-                "[%s] ffmpeg produced no/small output for %s",
-                self._log_tag,
-                Path(src_path).name,
-            )
-            return None
-        logger.debug(
-            "[%s] ffmpeg converted %s to wav (%d bytes)",
-            self._log_tag,
-            Path(src_path).name,
-            Path(wav_path).stat().st_size,
+        Thin wrapper around :func:`gateway.platforms._silk.ffmpeg_to_wav`
+        kept for backward compatibility and direct call sites elsewhere
+        in this adapter.
+        """
+        from gateway.platforms._silk import ffmpeg_to_wav
+        return await ffmpeg_to_wav(
+            src_path, wav_path, rate=16000, timeout=30.0, log_tag=self._log_tag,
         )
-        return wav_path
 
     def _resolve_stt_config(self) -> Optional[Dict[str, str]]:
         """Resolve STT backend configuration from config/environment.

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1468,10 +1468,10 @@ class WeixinAdapter(BasePlatformAdapter):
                 media_paths.append(path)
                 media_types.append(mime)
         elif item_type == ITEM_VOICE:
-            voice_path = await self._download_voice(item)
+            voice_path, voice_mime = await self._download_voice(item)
             if voice_path:
                 media_paths.append(voice_path)
-                media_types.append("audio/silk")
+                media_types.append(voice_mime)
 
     async def _download_image(self, item: Dict[str, Any]) -> Optional[str]:
         media = _media_reference(item, "image_item")
@@ -1526,11 +1526,19 @@ class WeixinAdapter(BasePlatformAdapter):
             logger.warning("[%s] file download failed: %s", self.name, exc)
             return None, mime
 
-    async def _download_voice(self, item: Dict[str, Any]) -> Optional[str]:
+    async def _download_voice(self, item: Dict[str, Any]) -> tuple[Optional[str], str]:
+        """Download an inbound voice message and decode SILK → WAV when possible.
+
+        Returns ``(path, mime)``. ``path`` is None on download failure;
+        ``mime`` is the format of the cached file (``audio/wav`` when
+        decoded, ``audio/silk`` when we had to keep the raw payload).
+        """
         voice_item = item.get("voice_item") or {}
         media = voice_item.get("media") or {}
+        # If the server already transcribed it, skip the download — the
+        # caller picks up ``voice_item.text`` elsewhere.
         if voice_item.get("text"):
-            return None
+            return None, "audio/silk"
         try:
             data = await _download_and_decrypt_media(
                 self._poll_session,
@@ -1540,10 +1548,38 @@ class WeixinAdapter(BasePlatformAdapter):
                 full_url=media.get("full_url"),
                 timeout_seconds=60.0,
             )
-            return cache_audio_from_bytes(data, ".silk")
         except Exception as exc:
             logger.warning("[%s] voice download failed: %s", self.name, exc)
-            return None
+            return None, "audio/silk"
+
+        # Cache the raw SILK payload first so we always have something on
+        # disk even if decoding fails.
+        silk_path = cache_audio_from_bytes(data, ".silk")
+
+        # Try to decode SILK → WAV so downstream STT (faster-whisper /
+        # OpenAI Whisper API / Groq / Mistral) can actually transcribe it.
+        # ffmpeg does NOT decode SILK; pilk does (wraps Tencent's SILK SDK).
+        try:
+            from gateway.platforms._silk import ensure_wav
+            wav_path = await ensure_wav(
+                silk_path, sniff_bytes=data[:16], log_tag=self.name,
+            )
+        except Exception as exc:
+            logger.debug("[%s] silk→wav decode raised: %s", self.name, exc)
+            wav_path = None
+
+        if wav_path:
+            # Clean up the raw silk now that we have a usable wav.
+            try:
+                os.unlink(silk_path)
+            except OSError:
+                pass
+            return wav_path, "audio/wav"
+
+        # Decode failed — return the raw silk. STT will fail to transcribe
+        # it, but at least the file is preserved for manual inspection /
+        # alternate handling.
+        return silk_path, "audio/silk"
 
     async def _maybe_fetch_typing_ticket(self, user_id: str, context_token: Optional[str]) -> None:
         if not self._poll_session or not self._token:

--- a/tests/gateway/test_silk_decoder.py
+++ b/tests/gateway/test_silk_decoder.py
@@ -1,0 +1,289 @@
+"""Tests for the shared SILK / ffmpeg audio decoding helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import struct
+import sys
+import wave
+from pathlib import Path
+
+import pytest
+
+from gateway.platforms import _silk
+
+
+# ---------------------------------------------------------------------------
+# looks_like_silk
+# ---------------------------------------------------------------------------
+
+class TestLooksLikeSilk:
+    def test_classic_silk_v3_magic(self):
+        assert _silk.looks_like_silk(b"#!SILK_V3\x01\x02\x03")
+
+    def test_short_silk_magic(self):
+        assert _silk.looks_like_silk(b"#!SILK\x00\x00")
+
+    def test_framing_byte_variant(self):
+        # Tencent's wire format sometimes prefixes with 0x02 0x21
+        assert _silk.looks_like_silk(b"\x02!\x00\x01\x02")
+
+    def test_weixin_framed_silk_variant(self):
+        # Weixin payloads sometimes have 0x02 then #!SILK
+        assert _silk.looks_like_silk(b"\x02#!SILK_V3\x01\x02")
+
+    def test_wav_is_not_silk(self):
+        assert not _silk.looks_like_silk(b"RIFF\x00\x00\x00\x00WAVE")
+
+    def test_mp3_is_not_silk(self):
+        assert not _silk.looks_like_silk(b"\xff\xfb\x90\x00")
+
+    def test_empty_is_not_silk(self):
+        assert not _silk.looks_like_silk(b"")
+
+
+# ---------------------------------------------------------------------------
+# silk_to_wav
+# ---------------------------------------------------------------------------
+
+class TestSilkToWav:
+    def test_returns_none_when_pilk_missing(self, monkeypatch, tmp_path, caplog):
+        # Force ImportError on `import pilk`
+        monkeypatch.setitem(sys.modules, "pilk", None)
+
+        src = tmp_path / "v.silk"
+        src.write_bytes(b"#!SILK_V3 fake")
+        wav = tmp_path / "v.wav"
+
+        with caplog.at_level("WARNING"):
+            result = _silk.silk_to_wav(str(src), str(wav), log_tag="test")
+        assert result is None
+        assert "pilk not installed" in caplog.text
+
+    def test_returns_none_when_src_missing(self, tmp_path):
+        wav = tmp_path / "v.wav"
+        result = _silk.silk_to_wav(str(tmp_path / "missing.silk"), str(wav))
+        assert result is None
+
+    def test_calls_pilk_and_returns_wav_path(self, monkeypatch, tmp_path):
+        # Fake a pilk that writes a valid (small) WAV header to wav_path.
+        called = {}
+
+        def fake_silk_to_wav(src, dst, rate=16000):
+            called["src"] = src
+            called["dst"] = dst
+            called["rate"] = rate
+            _write_minimal_wav(dst)
+
+        fake_pilk = type(sys)("pilk")
+        fake_pilk.silk_to_wav = fake_silk_to_wav
+        monkeypatch.setitem(sys.modules, "pilk", fake_pilk)
+
+        src = tmp_path / "v.silk"
+        src.write_bytes(b"#!SILK_V3 ...")
+        wav = tmp_path / "v.wav"
+
+        result = _silk.silk_to_wav(str(src), str(wav))
+        assert result == str(wav)
+        assert called["rate"] == 16000
+
+    def test_retries_with_silk_suffix_when_direct_fails(self, monkeypatch, tmp_path):
+        # First call raises (pilk's extension check), second (.silk path) succeeds.
+        call_log = []
+
+        def fake_silk_to_wav(src, dst, rate=16000):
+            call_log.append(src)
+            if src.endswith(".silk"):
+                _write_minimal_wav(dst)
+                return
+            raise RuntimeError("pilk: bad extension")
+
+        fake_pilk = type(sys)("pilk")
+        fake_pilk.silk_to_wav = fake_silk_to_wav
+        monkeypatch.setitem(sys.modules, "pilk", fake_pilk)
+
+        # Source has .bin extension to force the rename branch.
+        src = tmp_path / "v.bin"
+        src.write_bytes(b"#!SILK_V3 ...")
+        wav = tmp_path / "v.wav"
+
+        result = _silk.silk_to_wav(str(src), str(wav))
+        assert result == str(wav)
+        assert len(call_log) == 2
+        assert call_log[0].endswith(".bin")
+        assert call_log[1].endswith(".silk")
+
+    def test_returns_none_when_pilk_produces_empty_wav(self, monkeypatch, tmp_path):
+        def fake_silk_to_wav(src, dst, rate=16000):
+            Path(dst).write_bytes(b"")  # empty output
+
+        fake_pilk = type(sys)("pilk")
+        fake_pilk.silk_to_wav = fake_silk_to_wav
+        monkeypatch.setitem(sys.modules, "pilk", fake_pilk)
+
+        src = tmp_path / "v.silk"
+        src.write_bytes(b"#!SILK_V3 ...")
+        wav = tmp_path / "v.wav"
+
+        result = _silk.silk_to_wav(str(src), str(wav))
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# ffmpeg_to_wav (uses asyncio.create_subprocess_exec — must be mocked)
+# ---------------------------------------------------------------------------
+
+class _FakeProc:
+    def __init__(self, returncode=0, stderr_bytes=b"", emit_wav_to=None):
+        self.returncode = returncode
+        self._stderr_bytes = stderr_bytes
+        self._emit_wav_to = emit_wav_to
+        self.stderr = self  # let .read() on the same object work
+
+    async def wait(self):
+        if self._emit_wav_to:
+            _write_minimal_wav(self._emit_wav_to)
+        return self.returncode
+
+    async def read(self):
+        return self._stderr_bytes
+
+    def kill(self):
+        pass
+
+
+class TestFfmpegToWav:
+    def test_returns_none_when_ffmpeg_missing(self, monkeypatch, tmp_path, caplog):
+        async def fake_exec(*args, **kwargs):
+            raise FileNotFoundError("ffmpeg not on PATH")
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+        src = tmp_path / "in.ogg"
+        src.write_bytes(b"OggS fake")
+        wav = tmp_path / "out.wav"
+
+        with caplog.at_level("WARNING"):
+            result = asyncio.run(_silk.ffmpeg_to_wav(str(src), str(wav), log_tag="t"))
+        assert result is None
+        assert "ffmpeg not installed" in caplog.text
+
+    def test_returns_wav_on_success(self, monkeypatch, tmp_path):
+        wav = tmp_path / "out.wav"
+
+        async def fake_exec(*args, **kwargs):
+            # Pull the output wav path from the positional args
+            return _FakeProc(returncode=0, emit_wav_to=str(wav))
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        src = tmp_path / "in.ogg"
+        src.write_bytes(b"OggS")
+
+        result = asyncio.run(_silk.ffmpeg_to_wav(str(src), str(wav)))
+        assert result == str(wav)
+
+    def test_returns_none_on_ffmpeg_nonzero_exit(self, monkeypatch, tmp_path, caplog):
+        async def fake_exec(*args, **kwargs):
+            return _FakeProc(returncode=1, stderr_bytes=b"Invalid data found")
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+        src = tmp_path / "in.silk"
+        src.write_bytes(b"#!SILK_V3")
+        wav = tmp_path / "out.wav"
+
+        with caplog.at_level("WARNING"):
+            result = asyncio.run(_silk.ffmpeg_to_wav(str(src), str(wav), log_tag="t"))
+        assert result is None
+        assert "ffmpeg failed" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# ensure_wav (the integrated SILK-first / ffmpeg-fallback path)
+# ---------------------------------------------------------------------------
+
+class TestEnsureWav:
+    def test_silk_path_tries_pilk_first(self, monkeypatch, tmp_path):
+        # pilk succeeds, ffmpeg should not be called
+        async def fake_exec(*args, **kwargs):
+            raise AssertionError("ffmpeg should not be invoked when pilk succeeds")
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+        def fake_silk_to_wav(src, dst, rate=16000):
+            _write_minimal_wav(dst)
+
+        fake_pilk = type(sys)("pilk")
+        fake_pilk.silk_to_wav = fake_silk_to_wav
+        monkeypatch.setitem(sys.modules, "pilk", fake_pilk)
+
+        src = tmp_path / "v.silk"
+        src.write_bytes(b"#!SILK_V3 abc")
+
+        result = asyncio.run(_silk.ensure_wav(str(src), sniff_bytes=b"#!SILK_V3 abc"))
+        assert result is not None
+        assert result.endswith(".wav")
+
+    def test_falls_back_to_ffmpeg_when_pilk_returns_none(self, monkeypatch, tmp_path):
+        # Force pilk to fail, ffmpeg to succeed
+        def fake_silk_to_wav(src, dst, rate=16000):
+            raise RuntimeError("decode failed")
+
+        fake_pilk = type(sys)("pilk")
+        fake_pilk.silk_to_wav = fake_silk_to_wav
+        monkeypatch.setitem(sys.modules, "pilk", fake_pilk)
+
+        wav_target = tmp_path / "v.wav"
+
+        async def fake_exec(*args, **kwargs):
+            return _FakeProc(returncode=0, emit_wav_to=str(wav_target))
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+        src = tmp_path / "v.silk"
+        src.write_bytes(b"#!SILK_V3 abc")
+
+        result = asyncio.run(
+            _silk.ensure_wav(str(src), wav_path=str(wav_target), sniff_bytes=b"#!SILK_V3")
+        )
+        assert result == str(wav_target)
+
+    def test_non_silk_source_skips_pilk(self, monkeypatch, tmp_path):
+        # If we never set up fake pilk, importing it would fail — which is
+        # fine, because we expect ensure_wav to skip the silk branch entirely
+        # for non-silk payloads and go straight to ffmpeg.
+        wav_target = tmp_path / "out.wav"
+
+        async def fake_exec(*args, **kwargs):
+            return _FakeProc(returncode=0, emit_wav_to=str(wav_target))
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+        src = tmp_path / "in.ogg"
+        src.write_bytes(b"OggS\x00fakeogg")
+
+        result = asyncio.run(
+            _silk.ensure_wav(
+                str(src), wav_path=str(wav_target), sniff_bytes=b"OggS\x00fakeogg"
+            )
+        )
+        assert result == str(wav_target)
+
+    def test_returns_none_when_src_missing(self, tmp_path):
+        result = asyncio.run(_silk.ensure_wav(str(tmp_path / "nope.silk")))
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _write_minimal_wav(path: str) -> None:
+    """Write a minimal but non-empty WAV (>44 bytes) file at ``path``."""
+    with wave.open(str(path), "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(16000)
+        # 100 frames of silence == 200 bytes of sample data
+        wf.writeframes(b"\x00\x00" * 100)


### PR DESCRIPTION
## Problem

Inbound Weixin voice messages arrive as Tencent **SILK v3** (`audio/silk`), which **ffmpeg cannot decode**. The Weixin adapter (`gateway/platforms/weixin.py::_download_voice`) was caching the raw `.silk` payload and handing it straight to the STT pipeline (faster-whisper / OpenAI Whisper API / Groq / Mistral) — all of which silently fail or return empty strings on SILK input.

Net effect: **voice messages on Weixin are effectively unsupported** even though the adapter accepts them, downloads them, and decrypts them correctly. Users see ' ' or no reply, with no log telling them why.

Meanwhile the QQ adapter (`gateway/platforms/qqbot/adapter.py`) already solves this exact problem with a pilk-first, ffmpeg-fallback strategy — but the logic was buried inside the QQ adapter and not reused.

## Solution

1. **Extract** the SILK / ffmpeg decoding logic into a new shared helper module `gateway/platforms/_silk.py` with:
   - `looks_like_silk(data)` — magic-byte detection (handles `#!SILK_V3`, `#!SILK`, `\x02!`, and the Weixin `\x02#!SILK` framing variant)
   - `silk_to_wav(src, dst)` — pilk-based decode with the same as-is + `.silk`-suffix retry logic the QQ adapter had
   - `ffmpeg_to_wav(src, dst)` — async ffmpeg decode with timeout + graceful `FileNotFoundError` handling
   - `ensure_wav(src, ...)` — SILK-first, ffmpeg-fallback selector

2. **Wire Weixin's `_download_voice`** through `ensure_wav`. When pilk is installed, the cached file is a real `.wav` that STT can transcribe; the raw `.silk` is preserved on decode failure so behavior degrades gracefully.

3. **Refactor QQ's** `_convert_silk_to_wav` and `_convert_ffmpeg_to_wav` into thin wrappers around the shared helpers. **No behavior change for QQ** — the heuristics that were already there are now in the shared module.

4. **Add 19 unit tests** covering magic-byte detection, missing pilk, pilk success/empty-output/retry, ffmpeg success/failure/missing-binary, and the `ensure_wav` SILK-first / ffmpeg-fallback selector path. All pass.

## Dependency

Requires `pip install pilk` (the same Python wrapper around Tencent's official SILK SDK that the QQ adapter already prompts for). `ffmpeg` remains optional and is only used for non-SILK formats. Behavior when pilk is missing: a single `WARNING` log telling the user to install it, then the raw `.silk` is preserved on disk — same UX as the QQ adapter today.

## Testing

```
$ pytest tests/gateway/test_silk_decoder.py -q
19 passed in 0.13s

$ pytest tests/gateway/test_weixin.py tests/gateway/test_qqbot.py -q
211 passed, 1 failed in 6.35s
```

The one failing test (`test_duplicate_content_with_different_message_ids_is_dropped`) is **pre-existing on main** — verified by stashing this PR's changes and re-running. Unrelated to this change.

## Why now

Hit this debugging a user-reported 'agent never replies to my Weixin voice messages' issue. Root-caused to the missing SILK→WAV step; the fix is mechanical once you compare the QQ and Weixin code paths.