### PR TITLE
feat(gateway): per-chat display setting overrides

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -1,22 +1,29 @@
 """Per-platform display/verbosity configuration resolver.
 
 Provides ``resolve_display_setting()`` — the single entry-point for reading
-display settings with platform-specific overrides and sensible defaults.
+display settings with platform-specific (and optional per-chat) overrides
+and sensible defaults.
 
 Resolution order (first non-None wins):
-    1. ``display.platforms.<platform>.<key>``  — explicit per-platform user override
-    2. ``display.<key>``                       — global user setting
-    3. ``_PLATFORM_DEFAULTS[<platform>][<key>]``  — built-in sensible default
-    4. ``_GLOBAL_DEFAULTS[<key>]``              — built-in global default
+    1. ``display.platforms.<platform>.chats.<chat_id>:<thread_id>.<key>``  — most specific
+    2. ``display.platforms.<platform>.chats.<chat_id>.<key>``
+    3. ``display.platforms.<platform>.<key>``  — platform-wide user override
+    4. ``display.<key>``                       — global user setting
+    5. ``_PLATFORM_DEFAULTS[<platform>][<key>]``  — built-in sensible default
+    6. ``_GLOBAL_DEFAULTS[<key>]``              — built-in global default
 
-Exception: ``display.streaming`` is CLI-only.  Gateway streaming follows the
-top-level ``streaming`` config unless ``display.platforms.<platform>.streaming``
+The per-chat layer (rungs 1–2) is opt-in: callers must pass ``chat_id``
+(and optionally ``thread_id``).  Existing callers that don't pass those
+arguments see identical behaviour — the new lookup is simply skipped.
+
+Exception: ``display.streaming`` is CLI-only.  Gateway streaming follows
+the top-level ``streaming`` config unless ``display.platforms.<platform>``
 sets an explicit per-platform override.
 
-Backward compatibility: ``display.tool_progress_overrides`` is still read as a
-fallback for ``tool_progress`` when no ``display.platforms`` entry exists.  A
-config migration (version bump) automatically moves the old format into the new
-``display.platforms`` structure.
+Backward compatibility: ``display.tool_progress_overrides`` is still read
+as a fallback for ``tool_progress`` when no ``display.platforms`` entry
+exists.  A config migration (version bump) automatically moves the old
+format into the new ``display.platforms`` structure.
 """
 
 from __future__ import annotations
@@ -118,8 +125,11 @@ def resolve_display_setting(
     platform_key: str,
     setting: str,
     fallback: Any = None,
+    *,
+    chat_id: str | int | None = None,
+    thread_id: str | int | None = None,
 ) -> Any:
-    """Resolve a display setting with per-platform override support.
+    """Resolve a display setting with per-platform and per-chat override support.
 
     Parameters
     ----------
@@ -132,22 +142,53 @@ def resolve_display_setting(
         Display setting name (e.g. ``"tool_progress"``, ``"show_reasoning"``).
     fallback : Any
         Fallback value when the setting isn't found anywhere.
+    chat_id : str | int | None
+        Optional chat id for per-chat overrides.  When provided, the
+        resolver also inspects
+        ``display.platforms.<platform>.chats.<chat_id>.<setting>`` and, if
+        ``thread_id`` is also provided,
+        ``display.platforms.<platform>.chats.<chat_id>:<thread_id>.<setting>``
+        before falling back to the platform-wide override.  Pass ``None``
+        (default) when the call site doesn't know the chat — behaviour is
+        then identical to the pre-1.0 resolver.
+    thread_id : str | int | None
+        Optional thread / topic id, used together with ``chat_id`` to look
+        up an override scoped to a specific Telegram forum topic, Discord
+        thread, or Slack thread within a parent chat.
 
     Returns
     -------
     The resolved value, or *fallback* if nothing is configured.
     """
     display_cfg = user_config.get("display") or {}
-
-    # 1. Explicit per-platform override (display.platforms.<platform>.<key>)
     platforms = display_cfg.get("platforms") or {}
     plat_overrides = platforms.get(platform_key)
-    if isinstance(plat_overrides, dict):
-        val = plat_overrides.get(setting)
+    plat_overrides_dict = plat_overrides if isinstance(plat_overrides, dict) else None
+
+    # 1. Per-chat override under display.platforms.<plat>.chats.<chat_key>.<setting>.
+    # Prefer the most specific key (chat_id:thread_id) over the chat-wide one.
+    if chat_id is not None and plat_overrides_dict is not None:
+        chats_cfg = plat_overrides_dict.get("chats")
+        if isinstance(chats_cfg, dict):
+            chat_id_s = str(chat_id)
+            candidates: list[str] = []
+            if thread_id is not None and thread_id != "":
+                candidates.append(f"{chat_id_s}:{thread_id}")
+            candidates.append(chat_id_s)
+            for key in candidates:
+                entry = chats_cfg.get(key)
+                if isinstance(entry, dict):
+                    val = entry.get(setting)
+                    if val is not None:
+                        return _normalise(setting, val)
+
+    # 2. Platform-wide override (display.platforms.<platform>.<key>)
+    if plat_overrides_dict is not None:
+        val = plat_overrides_dict.get(setting)
         if val is not None:
             return _normalise(setting, val)
 
-    # 1b. Backward compat: display.tool_progress_overrides.<platform>
+    # 2b. Backward compat: display.tool_progress_overrides.<platform>
     if setting == "tool_progress":
         legacy = display_cfg.get("tool_progress_overrides")
         if isinstance(legacy, dict):
@@ -155,7 +196,7 @@ def resolve_display_setting(
             if val is not None:
                 return _normalise(setting, val)
 
-    # 2. Global user setting (display.<key>).  Skip display.streaming because
+    # 3. Global user setting (display.<key>).  Skip display.streaming because
     # that key controls only CLI terminal streaming; gateway token streaming is
     # governed by the top-level streaming config plus per-platform overrides.
     if setting != "streaming":
@@ -163,14 +204,14 @@ def resolve_display_setting(
         if val is not None:
             return _normalise(setting, val)
 
-    # 3. Built-in platform default
+    # 4. Built-in platform default
     plat_defaults = _PLATFORM_DEFAULTS.get(platform_key)
     if plat_defaults:
         val = plat_defaults.get(setting)
         if val is not None:
             return val
 
-    # 4. Built-in global default
+    # 5. Built-in global default
     val = _GLOBAL_DEFAULTS.get(setting)
     if val is not None:
         return val

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15207,7 +15207,9 @@ class GatewayRunner:
         user_config = _load_gateway_config()
         from gateway.display_config import resolve_display_setting
         _plat_streaming = resolve_display_setting(
-            user_config, platform_key, "streaming"
+            user_config, platform_key, "streaming",
+            chat_id=getattr(source, "chat_id", None),
+            thread_id=getattr(source, "thread_id", None),
         )
         _streaming_enabled = (
             _scfg.enabled and _scfg.transport != "off"
@@ -15462,18 +15464,45 @@ class GatewayRunner:
         # Apply tool preview length config (0 = no limit)
         try:
             from agent.display import set_tool_preview_max_len
-            _tpl = resolve_display_setting(user_config, platform_key, "tool_preview_length", 0)
+            _tpl = resolve_display_setting(
+                user_config, platform_key, "tool_preview_length", 0,
+                chat_id=getattr(source, "chat_id", None),
+                thread_id=getattr(source, "thread_id", None),
+            )
             set_tool_preview_max_len(int(_tpl) if _tpl else 0)
         except Exception:
             pass
 
         # Tool progress mode — resolved per-platform with env var fallback
-        _resolved_tp = resolve_display_setting(user_config, platform_key, "tool_progress")
+        _resolved_tp = resolve_display_setting(
+            user_config, platform_key, "tool_progress",
+            chat_id=getattr(source, "chat_id", None),
+            thread_id=getattr(source, "thread_id", None),
+        )
         _env_tp = os.getenv("HERMES_TOOL_PROGRESS_MODE")
         _display_cfg = display_config if isinstance(display_config, dict) else {}
         _platforms_cfg = _display_cfg.get("platforms") or {}
         _platform_cfg = _platforms_cfg.get(platform_key) or {}
         _legacy_tp_overrides = _display_cfg.get("tool_progress_overrides") or {}
+
+        def _per_chat_tp_configured() -> bool:
+            if not isinstance(_platform_cfg, dict):
+                return False
+            chats_cfg = _platform_cfg.get("chats")
+            if not isinstance(chats_cfg, dict):
+                return False
+            cid = getattr(source, "chat_id", None)
+            if cid is None:
+                return False
+            tid = getattr(source, "thread_id", None)
+            cid_s = str(cid)
+            keys = [f"{cid_s}:{tid}", cid_s] if tid not in (None, "") else [cid_s]
+            for k in keys:
+                entry = chats_cfg.get(k)
+                if isinstance(entry, dict) and "tool_progress" in entry:
+                    return True
+            return False
+
         _tool_progress_configured = (
             "tool_progress" in _display_cfg
             or (
@@ -15484,6 +15513,7 @@ class GatewayRunner:
                 isinstance(_legacy_tp_overrides, dict)
                 and platform_key in _legacy_tp_overrides
             )
+            or _per_chat_tp_configured()
         )
         progress_mode = (
             _env_tp
@@ -15518,7 +15548,11 @@ class GatewayRunner:
         # are collected here and deleted after the final response lands.
         # Failed runs skip cleanup so the bubbles remain as breadcrumbs.
         _cleanup_progress = bool(
-            resolve_display_setting(user_config, platform_key, "cleanup_progress")
+            resolve_display_setting(
+                user_config, platform_key, "cleanup_progress",
+                chat_id=getattr(source, "chat_id", None),
+                thread_id=getattr(source, "thread_id", None),
+            )
         )
         _cleanup_adapter = self.adapters.get(source.platform) if _cleanup_progress else None
         if _cleanup_adapter is not None and (
@@ -16158,7 +16192,9 @@ class GatewayRunner:
             # can disable streaming for specific platforms even when the global
             # streaming config is enabled.
             _plat_streaming = resolve_display_setting(
-                user_config, platform_key, "streaming"
+                user_config, platform_key, "streaming",
+                chat_id=getattr(source, "chat_id", None),
+                thread_id=getattr(source, "thread_id", None),
             )
             # None = no per-platform override → follow global config
             _streaming_enabled = (

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -81,6 +81,195 @@ class TestResolveDisplaySetting:
 
 
 # ---------------------------------------------------------------------------
+# Per-chat overrides (display.platforms.<plat>.chats.<chat_id>[:<thread_id>])
+# ---------------------------------------------------------------------------
+
+class TestPerChatOverrides:
+    """``chat_id`` (+ optional ``thread_id``) selects narrower overrides."""
+
+    def test_per_chat_override_wins_over_platform(self):
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "platforms": {
+                    "telegram": {
+                        "tool_progress": "all",
+                        "chats": {
+                            "-100123": {"tool_progress": "off"},
+                        },
+                    }
+                }
+            }
+        }
+        # No chat_id → platform-wide value.
+        assert resolve_display_setting(config, "telegram", "tool_progress") == "all"
+        # Matching chat_id → per-chat value.
+        assert (
+            resolve_display_setting(
+                config, "telegram", "tool_progress", chat_id="-100123"
+            )
+            == "off"
+        )
+        # Different chat_id → platform-wide value.
+        assert (
+            resolve_display_setting(
+                config, "telegram", "tool_progress", chat_id="-100999"
+            )
+            == "all"
+        )
+
+    def test_thread_specific_override_wins_over_chat_wide(self):
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "platforms": {
+                    "telegram": {
+                        "tool_progress": "all",
+                        "chats": {
+                            "-100123": {"tool_progress": "off"},
+                            "-100123:65": {"tool_progress": "verbose"},
+                        },
+                    }
+                }
+            }
+        }
+        assert (
+            resolve_display_setting(
+                config, "telegram", "tool_progress",
+                chat_id="-100123", thread_id=65,
+            )
+            == "verbose"
+        )
+        assert (
+            resolve_display_setting(
+                config, "telegram", "tool_progress",
+                chat_id="-100123", thread_id=99,
+            )
+            == "off"
+        )
+
+    def test_per_chat_falls_through_to_global_when_no_setting(self):
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "tool_progress": "all",
+                "platforms": {
+                    "telegram": {
+                        "chats": {
+                            "-100123": {"show_reasoning": True},
+                        },
+                    }
+                },
+            }
+        }
+        assert (
+            resolve_display_setting(
+                config, "telegram", "tool_progress", chat_id="-100123"
+            )
+            == "all"
+        )
+        assert (
+            resolve_display_setting(
+                config, "telegram", "show_reasoning", chat_id="-100123"
+            )
+            is True
+        )
+
+    def test_int_and_str_chat_ids_both_match(self):
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "platforms": {
+                    "telegram": {
+                        "chats": {"-100123": {"tool_progress": "off"}},
+                    }
+                }
+            }
+        }
+        for cid in ("-100123", -100123):
+            assert (
+                resolve_display_setting(
+                    config, "telegram", "tool_progress", chat_id=cid
+                )
+                == "off"
+            )
+
+    def test_thread_id_zero_matches_explicit_key(self):
+        """thread_id=0 looks up the ``<chat>:0`` key before the chat-wide one."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "platforms": {
+                    "telegram": {
+                        "tool_progress": "new",
+                        "chats": {
+                            "-100123:0": {"tool_progress": "verbose"},
+                            "-100123": {"tool_progress": "off"},
+                        },
+                    }
+                }
+            }
+        }
+        assert (
+            resolve_display_setting(
+                config, "telegram", "tool_progress",
+                chat_id="-100123", thread_id=0,
+            )
+            == "verbose"
+        )
+        # thread_id="" is treated as "no thread".
+        assert (
+            resolve_display_setting(
+                config, "telegram", "tool_progress",
+                chat_id="-100123", thread_id="",
+            )
+            == "off"
+        )
+
+    def test_per_chat_normalises_yaml_values(self):
+        from gateway.display_config import resolve_display_setting
+
+        # YAML's bare ``off`` parses as False.
+        config = {
+            "display": {
+                "platforms": {
+                    "telegram": {
+                        "chats": {"-100123": {"tool_progress": False}},
+                    }
+                }
+            }
+        }
+        assert (
+            resolve_display_setting(
+                config, "telegram", "tool_progress", chat_id="-100123"
+            )
+            == "off"
+        )
+
+    def test_no_chats_section_falls_through_silently(self):
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "platforms": {
+                    "telegram": {"tool_progress": "off"},
+                }
+            }
+        }
+        assert (
+            resolve_display_setting(
+                config, "telegram", "tool_progress", chat_id="-100123"
+            )
+            == "off"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Backward compatibility: tool_progress_overrides
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Add an optional `chats:` map under `display.platforms.<platform>` so individual chats (and Telegram forum topics / Discord threads / Slack threads) can override display verbosity without touching the platform default.

```yaml
display:
  tool_progress: all
  platforms:
    telegram:
      chats:
        "-1001234567890":     {tool_progress: off}        # whole group
        "-1001234567890:65":  {tool_progress: verbose}    # specific topic
```

Concrete motivating use case: a user-facing Telegram group used for product surfaces (cron deliveries, scheduled briefings, scripted services) where tool-progress chatter is noise, while keeping full tool-progress visibility in DMs and dev chats on the same Telegram bot.

## How

- `resolve_display_setting()` gains keyword-only `chat_id` / `thread_id` args.
- New resolution rungs (most-specific first):
  1. `display.platforms.<plat>.chats.<chat_id>:<thread_id>.<key>`
  2. `display.platforms.<plat>.chats.<chat_id>.<key>`
  3. existing platform-wide override
  4. existing global setting
  5. existing built-in defaults
- All existing call sites that don't pass `chat_id` behave identically — the new lookup is simply skipped.
- `gateway/run.py` threads `source.chat_id` / `source.thread_id` through the four runtime call-sites (`tool_progress`, `tool_preview_length`, two `streaming` sites, `cleanup_progress`).
- The `HERMES_TOOL_PROGRESS_MODE` env-var fallback guard recognises a per-chat `tool_progress` entry as 'configured' so an env-var doesn't silently override it.
- The `/verbose` slash-command toggle (cli) is intentionally left as a platform-wide toggle.

Per-chat overrides honour the same set as platform overrides: `tool_progress`, `show_reasoning`, `tool_preview_length`, `streaming`, `cleanup_progress`. YAML quirks (bare `off` → False, etc.) flow through the existing `_normalise()` helper unchanged.

## Tests

- 7 new tests in `TestPerChatOverrides` covering: per-chat precedence over platform; thread-specific precedence over chat-wide; passthrough when no override; int / str chat_id parity; explicit `<chat>:0` thread key; YAML normalisation; silent passthrough when `chats:` absent.
- Full suite: `pytest tests/gateway/ -k 'display or whatsapp_formatting'` → 89 passed, 1 skipped.

## Backward compatibility

100%. All existing callers omit the new kwargs, and the resolver behaves exactly as before when `chat_id is None`. Existing per-platform configs work unchanged; the new `chats:` map is purely additive.