### PR TITLE
test(config): cover live guard YAML line fallback

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1246,6 +1246,26 @@ def init_agent(
         _compression_cfg.get("abort_on_summary_failure", False)
     ).lower() in {"true", "1", "yes"}
 
+    def _cfg_bool(section: Any, key: str, default: bool) -> bool:
+        if isinstance(section, dict):
+            value = section.get(key, default)
+        else:
+            value = default
+        if isinstance(value, bool):
+            return value
+        return str(value).strip().lower() in {"true", "1", "yes", "on"}
+
+    _safe_retry_cfg = _compression_cfg.get("safe_retry", {}) if isinstance(_compression_cfg, dict) else {}
+    _chunked_cfg = _compression_cfg.get("chunked", {}) if isinstance(_compression_cfg, dict) else {}
+    _fallback_cfg = _compression_cfg.get("fallback", {}) if isinstance(_compression_cfg, dict) else {}
+    compression_safe_retry_enabled = _cfg_bool(_safe_retry_cfg, "enabled", True)
+    compression_chunked_summary_enabled = _cfg_bool(_chunked_cfg, "enabled", True)
+    compression_extractive_fallback_enabled = _cfg_bool(_fallback_cfg, "extractive_marker", True)
+    try:
+        compression_chunk_messages = max(1, int(_chunked_cfg.get("chunk_messages", 40))) if isinstance(_chunked_cfg, dict) else 40
+    except (TypeError, ValueError):
+        compression_chunk_messages = 40
+
     # Read optional explicit context_length override for the auxiliary
     # compression model. Custom endpoints often cannot report this via
     # /models, so the startup feasibility check needs the config hint.
@@ -1462,6 +1482,10 @@ def init_agent(
             provider=agent.provider,
             api_mode=agent.api_mode,
             abort_on_summary_failure=compression_abort_on_summary_failure,
+            safe_retry_enabled=compression_safe_retry_enabled,
+            chunked_summary_enabled=compression_chunked_summary_enabled,
+            chunk_summary_messages=compression_chunk_messages,
+            extractive_fallback_enabled=compression_extractive_fallback_enabled,
         )
     agent.compression_enabled = compression_enabled
 

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -322,6 +322,15 @@ def init_agent(
     else:
         agent.api_mode = "chat_completions"
 
+    if (
+        agent.provider == "custom"
+        and agent.api_mode == "chat_completions"
+        and "/codex" in agent._base_url_lower
+    ):
+        # Custom Codex proxies need Responses semantics even when the
+        # persisted/explicit api_mode is stale.
+        agent.api_mode = "codex_responses"
+
     # Eagerly warm the transport cache so import errors surface at init,
     # not mid-conversation.  Also validates the api_mode is registered.
     try:

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -734,6 +734,13 @@ def init_agent(
                 from hermes_cli.models import copilot_default_headers
 
                 client_kwargs["default_headers"] = copilot_default_headers()
+            elif (
+                base_url_host_matches(effective_base, "cpa.yumeapi.cn")
+                or base_url_host_matches(effective_base, "ai.yumeapi.cn")
+            ):
+                client_kwargs["default_headers"] = {
+                    "User-Agent": "curl/8.5.0",
+                }
             elif base_url_host_matches(effective_base, "api.kimi.com"):
                 client_kwargs["default_headers"] = {
                     "User-Agent": "claude-code/0.1.0",

--- a/agent/attribution_ledger.py
+++ b/agent/attribution_ledger.py
@@ -1,0 +1,348 @@
+"""Lightweight attribution/action ledger helpers.
+
+The ledger is intentionally smaller than a full transcript: it records
+redacted tool-action evidence that can answer "what did this agent do?" for
+one session lineage without treating git history, summaries, or broad search
+hits as attribution proof.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from datetime import datetime
+from typing import Any, Iterable, Mapping, Optional
+
+from agent.redact import redact_sensitive_text
+
+_READ_TOOLS = {
+    "read_file",
+    "search_files",
+    "browser_snapshot",
+    "browser_vision",
+    "browser_get_images",
+    "vision_analyze",
+    "session_search",
+    "skill_view",
+    "skills_list",
+}
+_WRITE_TOOLS = {
+    "write_file",
+    "patch",
+    "skill_manage",
+    "memory",
+    "todo",
+    "cronjob",
+}
+_MESSAGE_TOOLS = {"send_message", "text_to_speech"}
+_NETWORK_TOOLS = {
+    "browser_navigate",
+    "browser_click",
+    "browser_type",
+    "browser_press",
+    "browser_scroll",
+    "browser_console",
+    "image_generate",
+    "delegate_task",
+}
+_GIT_PREFIXES = ("git ", "gh ")
+_TERMINAL_WRITE_HINTS = (
+    " > ",
+    " >> ",
+    " tee ",
+    " rm ",
+    " mv ",
+    " cp ",
+    " chmod ",
+    " chown ",
+    " mkdir ",
+    " touch ",
+    " apply_patch",
+)
+_TERMINAL_NETWORK_HINTS = ("curl ", "wget ", "ssh ", "scp ", "rsync ")
+
+
+def _redact_text(value: str) -> str:
+    return redact_sensitive_text(str(value or ""), force=True)
+
+
+def _compact(value: str, limit: int = 360) -> str:
+    value = " ".join(str(value or "").split())
+    if len(value) <= limit:
+        return value
+    return value[: limit - 1] + "…"
+
+
+def _json_summary(value: Any, limit: int = 360) -> str:
+    try:
+        text = json.dumps(value, ensure_ascii=False, sort_keys=True, default=str)
+    except Exception:
+        text = str(value)
+    return _compact(_redact_text(text), limit=limit)
+
+
+def classify_side_effect(tool_name: str, args: Mapping[str, Any] | None = None) -> str:
+    """Return a coarse side-effect class for a tool call."""
+    name = str(tool_name or "")
+    args = args or {}
+    if name in _READ_TOOLS:
+        return "read"
+    if name in _WRITE_TOOLS:
+        return "write"
+    if name in _MESSAGE_TOOLS:
+        return "message"
+    if name in _NETWORK_TOOLS or name.startswith("browser_"):
+        return "network"
+    if name == "terminal":
+        command = str(args.get("command") or "").strip()
+        lowered = f" {command.lower()} "
+        if command.lower().startswith(_GIT_PREFIXES) or " gh " in lowered:
+            return "git"
+        if any(hint in lowered for hint in _TERMINAL_NETWORK_HINTS):
+            return "network"
+        if any(hint in lowered for hint in _TERMINAL_WRITE_HINTS):
+            return "write"
+        return "process"
+    if name == "execute_code":
+        return "process"
+    return "other"
+
+
+def summarize_tool_call(tool_name: str, args: Mapping[str, Any] | None = None) -> str:
+    """Return a short, secret-redacted human summary of the tool call."""
+    name = str(tool_name or "unknown")
+    args = args or {}
+    if name == "terminal":
+        command = _compact(_redact_text(str(args.get("command") or "")), 280)
+        workdir = args.get("workdir")
+        suffix = f" (workdir={_redact_text(workdir)})" if workdir else ""
+        return _compact(f"terminal: {command}{suffix}", 360)
+    if name == "execute_code":
+        code = _compact(_redact_text(str(args.get("code") or "")), 260)
+        return f"execute_code: {code}"
+    if name in {"read_file", "write_file"}:
+        path = _redact_text(str(args.get("path") or ""))
+        return _compact(f"{name}: {path}", 360)
+    if name == "patch":
+        mode = args.get("mode") or "replace"
+        path = _redact_text(str(args.get("path") or ""))
+        if not path and mode == "patch":
+            path = "multi-file patch"
+        return _compact(f"patch[{mode}]: {path}", 360)
+    if name == "search_files":
+        pattern = _redact_text(str(args.get("pattern") or ""))
+        path = _redact_text(str(args.get("path") or "."))
+        return _compact(f"search_files: {pattern} in {path}", 360)
+    if name == "send_message":
+        target = _redact_text(str(args.get("target") or ""))
+        action = args.get("action") or "send"
+        return _compact(f"send_message[{action}]: {target}", 360)
+    if name == "delegate_task":
+        tasks = args.get("tasks")
+        if isinstance(tasks, list) and tasks:
+            return f"delegate_task: {len(tasks)} task(s)"
+        goal = _redact_text(str(args.get("goal") or ""))
+        return _compact(f"delegate_task: {goal}", 360)
+    if name == "skill_manage":
+        action = args.get("action") or ""
+        skill = args.get("name") or ""
+        return _compact(f"skill_manage[{action}]: {skill}", 360)
+    return _compact(f"{name}: {_json_summary(args)}", 360)
+
+
+def output_digest(result: Any) -> str:
+    """Return a non-secret digest for a tool result."""
+    if result is None:
+        text = ""
+    elif isinstance(result, str):
+        text = result
+    else:
+        try:
+            text = json.dumps(result, ensure_ascii=False, sort_keys=True, default=str)
+        except Exception:
+            text = str(result)
+    redacted = _redact_text(text)
+    digest = hashlib.sha256(redacted.encode("utf-8", errors="replace")).hexdigest()[:16]
+    return f"sha256:{digest}; chars={len(redacted)}"
+
+
+def _error_preview(result: Any, limit: int = 240) -> Optional[str]:
+    if result is None:
+        return None
+    if isinstance(result, str):
+        text = result
+    else:
+        try:
+            text = json.dumps(result, ensure_ascii=False, default=str)
+        except Exception:
+            text = str(result)
+    return _compact(_redact_text(text), limit)
+
+
+def record_tool_event(
+    agent: Any,
+    tool_name: str,
+    args: Mapping[str, Any] | None,
+    *,
+    status: str,
+    tool_call_id: str | None = None,
+    started_at: float | None = None,
+    ended_at: float | None = None,
+    result: Any = None,
+) -> Optional[int]:
+    """Best-effort append of a redacted attribution event for a tool call."""
+    db = getattr(agent, "_session_db", None)
+    session_id = getattr(agent, "session_id", None)
+    if not db or not session_id:
+        return None
+    try:
+        ensure = getattr(agent, "_ensure_db_session", None)
+        if callable(ensure):
+            ensure()
+    except Exception:
+        pass
+    try:
+        now = time.time()
+        started = float(started_at) if started_at is not None else now
+        ended = float(ended_at) if ended_at is not None else (now if status != "started" else None)
+        duration_ms = None
+        if ended is not None and started is not None:
+            duration_ms = max(0, int((ended - started) * 1000))
+        failed_like = status in {"failed", "blocked", "cancelled"}
+        return db.append_attribution_event(
+            session_id=session_id,
+            source=getattr(agent, "platform", None),
+            user_id=getattr(agent, "_user_id", None),
+            chat_id=getattr(agent, "_chat_id", None),
+            thread_id=getattr(agent, "_thread_id", None),
+            platform_message_id=getattr(agent, "_turn_platform_message_id", None),
+            turn_id=getattr(agent, "_turn_id", None),
+            tool_call_id=tool_call_id,
+            tool_name=tool_name,
+            action_summary=summarize_tool_call(tool_name, args),
+            args_summary=_json_summary(args or {}),
+            side_effect_class=classify_side_effect(tool_name, args),
+            status=status,
+            started_at=started,
+            ended_at=ended,
+            duration_ms=duration_ms,
+            output_digest=output_digest(result) if result is not None else None,
+            error_preview=_error_preview(result) if failed_like else None,
+        )
+    except Exception:
+        return None
+
+
+def _fmt_time(ts: Any) -> str:
+    try:
+        return datetime.fromtimestamp(float(ts)).strftime("%H:%M:%S")
+    except Exception:
+        return "??:??:??"
+
+
+def _dedupe_started_events(events: Iterable[Mapping[str, Any]]) -> list[Mapping[str, Any]]:
+    events = list(events or [])
+    terminal_keys: set[str] = set()
+    for event in events:
+        status = str(event.get("status") or "")
+        key = str(event.get("tool_call_id") or event.get("id") or "")
+        if key and status in {"completed", "failed", "blocked", "cancelled"}:
+            terminal_keys.add(key)
+    result = []
+    for event in events:
+        key = str(event.get("tool_call_id") or event.get("id") or "")
+        if event.get("status") == "started" and key in terminal_keys:
+            continue
+        result.append(event)
+    return result
+
+
+def _line(event: Mapping[str, Any]) -> str:
+    eid = event.get("id", "?")
+    session_id = str(event.get("session_id") or "?")
+    sid_short = session_id[:18] + ("…" if len(session_id) > 18 else "")
+    side = event.get("side_effect_class") or "other"
+    tool = event.get("tool_name") or "tool"
+    summary = event.get("action_summary") or tool
+    when = _fmt_time(event.get("started_at"))
+    extra = ""
+    if event.get("error_preview"):
+        extra = f" — {event.get('error_preview')}"
+    return f"- {when} `{tool}` [{side}] {summary}（event#{eid}, session={sid_short}）{extra}"
+
+
+def format_attribution_report(
+    events: Iterable[Mapping[str, Any]],
+    *,
+    session_id: str,
+    lineage_id: str | None = None,
+    chat_id: str | None = None,
+    limit: int = 100,
+) -> str:
+    """Format a strict Chinese attribution report from ledger events."""
+    events = _dedupe_started_events(list(events or []))[:limit]
+    completed = [e for e in events if e.get("status") == "completed"]
+    failed = [e for e in events if e.get("status") in {"failed", "blocked", "cancelled"}]
+    started = [e for e in events if e.get("status") == "started"]
+
+    lines = [
+        "## 我做了什么（attribution ledger）",
+        f"当前 session: {session_id or 'unknown'}",
+        f"lineage: {lineage_id or session_id or 'unknown'}",
+    ]
+    if chat_id:
+        lines.append(f"chat: {chat_id}")
+    lines.append("")
+
+    if not events:
+        lines.append("未发现可归因证据：当前 session/lineage ledger 没有匹配工具事件。")
+        lines.append("")
+
+    lines.append("### 已确认完成")
+    lines.extend(_line(e) for e in completed) if completed else lines.append("- 无可确认项")
+    lines.append("")
+    lines.append("### 失败/被阻止")
+    lines.extend(_line(e) for e in failed) if failed else lines.append("- 无可确认项")
+    lines.append("")
+    lines.append("### 仅看到开始、无完成记录")
+    lines.extend(_line(e) for e in started) if started else lines.append("- 无可确认项")
+    lines.append("")
+    lines.append("不计入：git history、branch state、memory、session_search broad hits、compaction summary。")
+    return "\n".join(lines)
+
+
+def format_what_did_you_do_for_session(
+    db: Any,
+    *,
+    session_id: str,
+    chat_id: str | None = None,
+    source: str | None = None,
+    limit: int = 100,
+) -> str:
+    """Query the ledger for a session lineage and format the report."""
+    lineage_id = None
+    if db is not None and session_id:
+        try:
+            lineage_id = db.get_session_lineage_id(session_id)
+        except Exception:
+            lineage_id = session_id
+    events = []
+    if db is not None and session_id:
+        try:
+            events = db.get_attribution_events(
+                session_id=session_id,
+                include_lineage=True,
+                chat_id=chat_id,
+                source=source,
+                limit=limit,
+            )
+        except Exception:
+            events = []
+    return format_attribution_report(
+        events,
+        session_id=session_id,
+        lineage_id=lineage_id or session_id,
+        chat_id=chat_id,
+        limit=limit,
+    )

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -205,7 +205,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
     )
 
     _call_start = time.time()
-    agent._touch_activity("waiting for non-streaming API response")
+    agent._touch_activity("等待非流式 API 响应")
 
     t = threading.Thread(target=_call, daemon=True)
     t.start()
@@ -219,7 +219,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
         if _poll_count % 100 == 0:  # 100 × 0.3s = 30s
             _elapsed = time.time() - _call_start
             agent._touch_activity(
-                f"waiting for non-streaming response ({int(_elapsed)}s elapsed)"
+                f"等待非流式响应（已等待 {int(_elapsed)} 秒）"
             )
 
         # Stale-call detector: kill the connection if no response
@@ -234,9 +234,9 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 api_kwargs.get("model", "unknown"), f"{_est_ctx:,}",
             )
             agent._emit_status(
-                f"⚠️ No response from provider for {int(_elapsed)}s "
-                f"(non-streaming, model: {api_kwargs.get('model', 'unknown')}). "
-                f"Aborting call."
+                f"⚠️ Provider 已 {int(_elapsed)} 秒无响应"
+                f"（非流式，model: {api_kwargs.get('model', 'unknown')}）。"
+                f"正在中止本次调用。"
             )
             try:
                 if agent.api_mode == "anthropic_messages":
@@ -247,14 +247,14 @@ def interruptible_api_call(agent, api_kwargs: dict):
             except Exception:
                 pass
             agent._touch_activity(
-                f"stale non-streaming call killed after {int(_elapsed)}s"
+                f"非流式调用已因超时中止（已等待 {int(_elapsed)} 秒）"
             )
             # Wait briefly for the thread to notice the closed connection.
             t.join(timeout=2.0)
             if result["error"] is None and result["response"] is None:
                 result["error"] = TimeoutError(
-                    f"Non-streaming API call timed out after {int(_elapsed)}s "
-                    f"with no response (threshold: {int(_stale_timeout)}s)"
+                    f"非流式 API 调用超时：已等待 {int(_elapsed)} 秒仍无响应"
+                    f"（阈值：{int(_stale_timeout)} 秒）"
                 )
             break
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -332,6 +332,14 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             )
         )
         is_xai_responses = agent.provider in {"xai", "xai-oauth"} or agent._base_url_hostname == "api.x.ai"
+        uses_codex_transport_compat_headers = (
+            agent.provider == "custom"
+            and "/codex" in agent._base_url_lower
+            and not is_github_responses
+            and not is_xai_responses
+            and agent._base_url_hostname not in {"api.openai.com", "chatgpt.com"}
+        )
+        is_codex_backend = is_codex_backend or uses_codex_transport_compat_headers
         _msgs_for_codex = agent._prepare_messages_for_non_vision_model(api_messages)
 
         # xAI's /responses endpoint rejects ``pattern`` and ``format`` keywords
@@ -365,6 +373,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             request_overrides=agent.request_overrides,
             is_github_responses=is_github_responses,
             is_codex_backend=is_codex_backend,
+            use_codex_transport_compat_headers=uses_codex_transport_compat_headers,
             is_xai_responses=is_xai_responses,
             github_reasoning_extra=agent._github_models_reasoning_extra_body() if is_github_responses else None,
         )

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -475,6 +475,7 @@ class ContextCompressor(ContextEngine):
         self._last_summary_error = None
         self._last_summary_dropped_count = 0
         self._last_summary_fallback_used = False
+        self._last_summary_recovery_stage = None
         self._last_aux_model_failure_error = None
         self._last_aux_model_failure_model = None
         self._last_compression_savings_pct = 100.0
@@ -524,6 +525,10 @@ class ContextCompressor(ContextEngine):
         provider: str = "",
         api_mode: str = "",
         abort_on_summary_failure: bool = False,
+        safe_retry_enabled: bool = True,
+        chunked_summary_enabled: bool = True,
+        chunk_summary_messages: int = 40,
+        extractive_fallback_enabled: bool = True,
     ):
         self.model = model
         self.base_url = base_url
@@ -540,6 +545,13 @@ class ContextCompressor(ContextEngine):
         # When False (default = historical behavior), insert a static
         # "summary unavailable" placeholder and drop the middle window.
         self.abort_on_summary_failure = abort_on_summary_failure
+        self.safe_retry_enabled = bool(safe_retry_enabled)
+        self.chunked_summary_enabled = bool(chunked_summary_enabled)
+        try:
+            self.chunk_summary_messages = max(1, int(chunk_summary_messages))
+        except (TypeError, ValueError):
+            self.chunk_summary_messages = self._CHUNK_SUMMARY_MESSAGES
+        self.extractive_fallback_enabled = bool(extractive_fallback_enabled)
 
         self.context_length = get_model_context_length(
             model, base_url=base_url, api_key=api_key,
@@ -592,6 +604,7 @@ class ContextCompressor(ContextEngine):
         # (gateway hygiene, /compress) can surface a visible warning.
         self._last_summary_dropped_count: int = 0
         self._last_summary_fallback_used: bool = False
+        self._last_summary_recovery_stage: Optional[str] = None
         # When summary generation fails we now ABORT compression entirely
         # and return the original messages unchanged instead of dropping
         # the middle window with a static placeholder.  Callers inspect
@@ -828,8 +841,31 @@ class ContextCompressor(ContextEngine):
     _CONTENT_TAIL = 1500      # chars kept from the end
     _TOOL_ARGS_MAX = 1500     # tool call argument chars
     _TOOL_ARGS_HEAD = 1200    # kept from the start of tool args
+    _CHUNK_SUMMARY_MESSAGES = 40  # messages per chunk when safe retry is still blocked
 
-    def _serialize_for_summary(self, turns: List[Dict[str, Any]]) -> str:
+    @staticmethod
+    def _looks_filter_blocked_error(exc: Exception) -> bool:
+        """Return True when a summary failure looks like provider safety blocking."""
+        text = str(exc or "").lower()
+        return any(
+            marker in text
+            for marker in (
+                "request was blocked",
+                "content policy",
+                "content_filter",
+                "content filter",
+                "safety",
+                "blocked by",
+                "policy violation",
+            )
+        )
+
+    def _serialize_for_summary(
+        self,
+        turns: List[Dict[str, Any]],
+        *,
+        safe_mode: bool = False,
+    ) -> str:
         """Serialize conversation turns into labeled text for the summarizer.
 
         Includes tool call arguments and result content (up to
@@ -839,6 +875,10 @@ class ContextCompressor(ContextEngine):
         All content is redacted before serialization to prevent secrets
         (API keys, tokens, passwords) from leaking into the summary that
         gets sent to the auxiliary model and persisted across compactions.
+
+        ``safe_mode`` is used after a provider safety block.  It keeps the
+        timeline but strips high-risk raw material (tracebacks, huge tool
+        outputs, binary-ish blobs) before retrying the summary request.
         """
         parts = []
         for msg in turns:
@@ -848,7 +888,13 @@ class ContextCompressor(ContextEngine):
             # Tool results: keep enough content for the summarizer
             if role == "tool":
                 tool_id = msg.get("tool_call_id", "")
-                if len(content) > self._CONTENT_MAX:
+                if safe_mode:
+                    content = (
+                        f"[tool output summarized for safe compression retry] "
+                        f"tool_call_id={tool_id or '?'} chars={len(content):,} "
+                        f"lines={content.count(chr(10)) + 1 if content else 0}"
+                    )
+                elif len(content) > self._CONTENT_MAX:
                     content = content[:self._CONTENT_HEAD] + "\n...[truncated]...\n" + content[-self._CONTENT_TAIL:]
                 parts.append(f"[TOOL RESULT {tool_id}]: {content}")
                 continue
@@ -878,11 +924,225 @@ class ContextCompressor(ContextEngine):
                 continue
 
             # User and other roles
-            if len(content) > self._CONTENT_MAX:
+            if safe_mode and len(content) > 1200:
+                content = content[:900] + "\n...[safe retry truncated]...\n" + content[-200:]
+            elif len(content) > self._CONTENT_MAX:
                 content = content[:self._CONTENT_HEAD] + "\n...[truncated]...\n" + content[-self._CONTENT_TAIL:]
             parts.append(f"[{role.upper()}]: {content}")
 
         return "\n\n".join(parts)
+
+    def _call_summary_llm(self, prompt: str, summary_budget: int) -> str:
+        """Call the configured compression LLM and return redacted text content."""
+        call_kwargs = {
+            "task": "compression",
+            "main_runtime": {
+                "model": self.model,
+                "provider": self.provider,
+                "base_url": self.base_url,
+                "api_key": self.api_key,
+                "api_mode": self.api_mode,
+            },
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": int(summary_budget * 1.3),
+            # timeout resolved from auxiliary.compression.timeout config by call_llm
+        }
+        if self.summary_model:
+            call_kwargs["model"] = self.summary_model
+        response = call_llm(**call_kwargs)
+        content = response.choices[0].message.content
+        if not isinstance(content, str):
+            content = str(content) if content else ""
+        return redact_sensitive_text(content.strip())
+
+    def _generate_extractive_fallback_summary(
+        self,
+        turns: List[Dict[str, Any]],
+        *,
+        error: str = "summary unavailable",
+    ) -> str:
+        """Build a local no-LLM fallback summary after repeated summary failure.
+
+        This preserves key continuity facts without sending another request to
+        the provider.  It is intentionally extractive and conservative: recent
+        user asks, assistant/tool actions, file paths, commands and errors are
+        kept; large raw outputs and secrets are redacted/truncated.
+        """
+        last_user = "None."
+        user_asks: list[str] = []
+        actions: list[str] = []
+        blockers: list[str] = []
+        files: set[str] = set()
+
+        path_re = re.compile(r"(?:^|[\s`'\"])(/[\w./@+-]+|[\w.-]+/[\w./@+-]+)")
+        for msg in turns:
+            role = msg.get("role", "unknown")
+            raw = redact_sensitive_text(msg.get("content") or "")
+            text = _content_text_for_contains(raw).strip()
+            if len(text) > 500:
+                text = text[:360] + " ...[truncated]... " + text[-120:]
+            for match in path_re.findall(text):
+                if len(files) < 20 and not match.startswith("http"):
+                    files.add(match)
+            if role == "user" and text:
+                last_user = text
+                user_asks.append(text)
+            elif role == "assistant":
+                tool_names: list[str] = []
+                for tc in msg.get("tool_calls") or []:
+                    if isinstance(tc, dict):
+                        name = tc.get("function", {}).get("name")
+                        args = tc.get("function", {}).get("arguments", "")
+                        if name:
+                            tool_names.append(name)
+                        for match in path_re.findall(str(args)):
+                            if len(files) < 20 and not match.startswith("http"):
+                                files.add(match)
+                if tool_names:
+                    actions.append(f"Called tools: {', '.join(tool_names)}")
+                if text:
+                    actions.append(text)
+            elif role == "tool":
+                tool_id = msg.get("tool_call_id", "?")
+                raw_len = len(_content_text_for_contains(raw))
+                line_count = _content_text_for_contains(raw).count("\n") + 1 if raw else 0
+                tool_summary = (
+                    f"Tool result {tool_id}: [raw output omitted in extractive fallback] "
+                    f"chars={raw_len:,} lines={line_count}"
+                )
+                if "traceback" in text.lower() or "error" in text.lower() or "failed" in text.lower():
+                    blockers.append(tool_summary)
+                actions.append(tool_summary)
+
+        def _bullets(items: list[str], limit: int = 8) -> str:
+            kept = [i for i in items if i][:limit]
+            return "\n".join(f"{idx}. {item}" for idx, item in enumerate(kept, 1)) or "None."
+
+        body = f"""## Active Task
+User asked: {last_user!r}
+
+## Goal
+Continue the conversation after LLM context summarization failed.
+
+## Constraints & Preferences
+Preserve user language and avoid repeating completed work. Secrets are redacted.
+
+## Completed Actions
+{_bullets(actions)}
+
+## Active State
+Summary was generated locally without an LLM after provider summary failure: {redact_sensitive_text(error)}
+
+## In Progress
+Context compression recovery was underway.
+
+## Blocked
+{_bullets(blockers, limit=5)}
+
+## Key Decisions
+Use extractive fallback because normal summary and safe retry were unavailable.
+
+## Resolved Questions
+None.
+
+## Pending User Asks
+{_bullets(user_asks[-5:], limit=5)}
+
+## Relevant Files
+{chr(10).join(f'- {p}' for p in sorted(files)) if files else 'None.'}
+
+## Remaining Work
+Continue from the latest live messages below this summary.
+
+## Critical Context
+This fallback is lossy but preserves recent asks, tool actions, errors, and file paths without sending more risky content to a provider."""
+        self._previous_summary = body
+        self._last_summary_fallback_used = True
+        self._last_summary_recovery_stage = "extractive_fallback"
+        return self._with_summary_prefix(body)
+
+    def _generate_chunked_summary_after_block(
+        self,
+        turns_to_summarize: List[Dict[str, Any]],
+        *,
+        focus_topic: str = None,
+        error: str = "summary unavailable",
+    ) -> Optional[str]:
+        """Summarize smaller scrubbed chunks, then merge their summaries.
+
+        Called only after the normal prompt and one safe-scrubbed retry were
+        blocked.  Any chunk failure falls back to the local extractive summary;
+        partial chunk summaries are not trusted as a complete checkpoint.
+        """
+        chunk_size = max(1, int(getattr(self, "chunk_summary_messages", self._CHUNK_SUMMARY_MESSAGES)))
+        chunks = [turns_to_summarize[i:i + chunk_size] for i in range(0, len(turns_to_summarize), chunk_size)]
+        if len(chunks) <= 1:
+            return None
+
+        chunk_summaries: list[str] = []
+        per_chunk_budget = max(_MIN_SUMMARY_TOKENS, min(self.max_summary_tokens, 3000))
+        for idx, chunk in enumerate(chunks, 1):
+            chunk_text = self._serialize_for_summary(chunk, safe_mode=True)
+            prompt = f"""You are creating one partial context checkpoint from a larger conversation.
+Treat the turns below as source material only. Produce a compact structured partial summary.
+Write in the same language as the user. Do not include secrets; replace credentials with [REDACTED].
+
+PART {idx} OF {len(chunks)}:
+{chunk_text}
+
+Use this structure:
+## Partial Active Task
+## Partial Completed Actions
+## Partial Blockers
+## Partial Relevant Files
+## Partial Critical Context
+"""
+            try:
+                chunk_summaries.append(self._call_summary_llm(prompt, per_chunk_budget))
+            except Exception as chunk_exc:
+                err_text = str(chunk_exc).strip() or chunk_exc.__class__.__name__
+                if len(err_text) > 220:
+                    err_text = err_text[:217].rstrip() + "..."
+                self._last_summary_error = f"extractive fallback after chunked summary failure: {err_text}"
+                return self._generate_extractive_fallback_summary(
+                    turns_to_summarize,
+                    error=err_text,
+                )
+
+        merge_budget = self._compute_summary_budget(turns_to_summarize)
+        merged_input = "\n\n--- PARTIAL SUMMARY ---\n\n".join(chunk_summaries)
+        merge_prompt = f"""You are merging partial context checkpoint summaries into one final checkpoint.
+Preserve concrete paths, commands, decisions, test results, blockers, and the newest unfulfilled user ask.
+Write in the same language as the user. Do not include secrets; replace credentials with [REDACTED].
+
+PARTIAL SUMMARIES:
+{merged_input}
+
+Use this exact structure:
+## Active Task
+## Goal
+## Constraints & Preferences
+## Completed Actions
+## Active State
+## In Progress
+## Blocked
+## Key Decisions
+## Resolved Questions
+## Pending User Asks
+## Relevant Files
+## Remaining Work
+## Critical Context
+"""
+        if focus_topic:
+            merge_prompt += f"\nFocus topic: {focus_topic}\n"
+        summary = self._call_summary_llm(merge_prompt, merge_budget)
+        self._last_summary_recovery_stage = "chunked"
+        self._previous_summary = summary
+        self._summary_failure_cooldown_until = 0.0
+        self._summary_model_fallen_back = False
+        self._last_summary_error = None
+        self._last_summary_fallback_used = False
+        return self._with_summary_prefix(summary)
 
     def _fallback_to_main_for_compression(self, e: Exception, reason: str) -> None:
         """Switch from a separate ``summary_model`` back to the main model.
@@ -911,7 +1171,13 @@ class ContextCompressor(ContextEngine):
         self.summary_model = ""  # empty = use main model
         self._summary_failure_cooldown_until = 0.0  # no cooldown — retry immediately
 
-    def _generate_summary(self, turns_to_summarize: List[Dict[str, Any]], focus_topic: str = None) -> Optional[str]:
+    def _generate_summary(
+        self,
+        turns_to_summarize: List[Dict[str, Any]],
+        focus_topic: str = None,
+        *,
+        _safe_retry: bool = False,
+    ) -> Optional[str]:
         """Generate a structured summary of conversation turns.
 
         Uses a structured template (Goal, Progress, Decisions, Resolved/Pending
@@ -938,7 +1204,10 @@ class ContextCompressor(ContextEngine):
             return None
 
         summary_budget = self._compute_summary_budget(turns_to_summarize)
-        content_to_summarize = self._serialize_for_summary(turns_to_summarize)
+        content_to_summarize = self._serialize_for_summary(
+            turns_to_summarize,
+            safe_mode=_safe_retry,
+        )
 
         # Preamble shared by both first-compaction and iterative-update prompts.
         # Keep the wording deliberately plain: Azure/OpenAI-compatible content
@@ -1054,29 +1323,7 @@ FOCUS TOPIC: "{focus_topic}"
 The user has requested that this compaction PRIORITISE preserving all information related to the focus topic above. For content related to "{focus_topic}", include full detail — exact values, file paths, command outputs, error messages, and decisions. For content NOT related to the focus topic, summarise more aggressively (brief one-liners or omit if truly irrelevant). The focus topic sections should receive roughly 60-70% of the summary token budget. Even for the focus topic, NEVER preserve API keys, tokens, passwords, or credentials — use [REDACTED]."""
 
         try:
-            call_kwargs = {
-                "task": "compression",
-                "main_runtime": {
-                    "model": self.model,
-                    "provider": self.provider,
-                    "base_url": self.base_url,
-                    "api_key": self.api_key,
-                    "api_mode": self.api_mode,
-                },
-                "messages": [{"role": "user", "content": prompt}],
-                "max_tokens": int(summary_budget * 1.3),
-                # timeout resolved from auxiliary.compression.timeout config by call_llm
-            }
-            if self.summary_model:
-                call_kwargs["model"] = self.summary_model
-            response = call_llm(**call_kwargs)
-            content = response.choices[0].message.content
-            # Handle cases where content is not a string (e.g., dict from llama.cpp)
-            if not isinstance(content, str):
-                content = str(content) if content else ""
-            # Redact the summary output as well — the summarizer LLM may
-            # ignore prompt instructions and echo back secrets verbatim.
-            summary = redact_sensitive_text(content.strip())
+            summary = self._call_summary_llm(prompt, summary_budget)
             # Store for iterative updates on next compaction
             self._previous_summary = summary
             self._summary_failure_cooldown_until = 0.0
@@ -1174,14 +1421,60 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 self._fallback_to_main_for_compression(e, "failed")
                 return self._generate_summary(turns_to_summarize, focus_topic=focus_topic)
 
+            err_text = str(e).strip() or e.__class__.__name__
+            if len(err_text) > 220:
+                err_text = err_text[:217].rstrip() + "..."
+
+            # Provider safety blocks are often caused by one raw log/tool blob
+            # inside the summary prompt. Retry once with high-risk content
+            # scrubbed. If even the scrubbed prompt is blocked, return a local
+            # extractive summary instead of inserting a useless marker.
+            if self._looks_filter_blocked_error(e):
+                if not _safe_retry and getattr(self, "safe_retry_enabled", True):
+                    self._last_summary_recovery_stage = "safe_retry"
+                    logging.warning(
+                        "Context summary was blocked; retrying once with safe-scrubbed input."
+                    )
+                    return self._generate_summary(
+                        turns_to_summarize,
+                        focus_topic=focus_topic,
+                        _safe_retry=True,
+                    )
+                if _safe_retry and getattr(self, "chunked_summary_enabled", True):
+                    self._last_summary_recovery_stage = "chunked"
+                    logging.warning(
+                        "Context summary safe retry was blocked; attempting chunked summary."
+                    )
+                    chunked = self._generate_chunked_summary_after_block(
+                        turns_to_summarize,
+                        focus_topic=focus_topic,
+                        error=err_text,
+                    )
+                    if chunked:
+                        return chunked
+                self._summary_failure_cooldown_until = time.monotonic() + 30
+                if getattr(self, "extractive_fallback_enabled", True):
+                    self._last_summary_recovery_stage = "extractive_fallback"
+                    self._last_summary_error = f"extractive fallback after summary failure: {err_text}"
+                    logging.warning(
+                        "Context chunked summary unavailable; using local extractive fallback."
+                    )
+                    return self._generate_extractive_fallback_summary(
+                        turns_to_summarize,
+                        error=err_text,
+                    )
+                self._last_summary_error = err_text
+                logging.warning(
+                    "Context summary blocked and recovery fallbacks are disabled: %s",
+                    err_text,
+                )
+                return None
+
             # Transient errors (timeout, rate limit, network, JSON decode,
             # streaming premature-close) — shorter cooldown for JSON decode and
             # streaming-closed since those conditions can self-resolve quickly.
             _transient_cooldown = 30 if (_is_json_decode or _is_streaming_closed) else 60
             self._summary_failure_cooldown_until = time.monotonic() + _transient_cooldown
-            err_text = str(e).strip() or e.__class__.__name__
-            if len(err_text) > 220:
-                err_text = err_text[:217].rstrip() + "..."
             self._last_summary_error = err_text
             logger.warning(
                 "Failed to generate context summary: %s. "

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -302,7 +302,7 @@ def compress_context(
         focus_topic,
     )
     agent._emit_status(
-        "🗜️ Compacting context — summarizing earlier conversation so I can continue..."
+        "🗜️ 正在压缩 context：总结前面的对话，方便继续。"
     )
 
     # Notify external memory provider before compression discards context
@@ -329,9 +329,9 @@ def compress_context(
         if getattr(agent, "_last_compression_summary_warning", None) != _err:
             agent._last_compression_summary_warning = _err
             agent._emit_warning(
-                f"⚠ Compression aborted: {_err}. "
-                "No messages were dropped — conversation continues unchanged. "
-                "Run /compress to retry, or /new to start a fresh session."
+                f"⚠ context 压缩已中止：{_err}。"
+                "没有丢弃任何消息，对话会保持原样继续。"
+                "可发送 /compress 重试，或 /new 开新会话。"
             )
         _existing_sp = getattr(agent, "_cached_system_prompt", None)
         if not _existing_sp:
@@ -339,12 +339,28 @@ def compress_context(
         return messages, _existing_sp
 
     summary_error = getattr(agent.context_compressor, "_last_summary_error", None)
-    if summary_error:
+    summary_recovery_stage = getattr(agent.context_compressor, "_last_summary_recovery_stage", None)
+    if summary_recovery_stage == "chunked":
+        _stage_key = "chunked"
+        if getattr(agent, "_last_compression_summary_warning", None) != _stage_key:
+            agent._last_compression_summary_warning = _stage_key
+            agent._emit_warning(
+                "ℹ context 常规压缩被 provider 拦截；已通过分块压缩恢复上下文。"
+            )
+    elif summary_recovery_stage == "extractive_fallback":
+        _stage_key = summary_error or "extractive_fallback"
+        if getattr(agent, "_last_compression_summary_warning", None) != _stage_key:
+            agent._last_compression_summary_warning = _stage_key
+            agent._emit_warning(
+                f"⚠ context summary 失败：{summary_error or 'unknown error'}。"
+                "已使用本地提取式 fallback 保留最近关键上下文。"
+            )
+    elif summary_error:
         if getattr(agent, "_last_compression_summary_warning", None) != summary_error:
             agent._last_compression_summary_warning = summary_error
             agent._emit_warning(
-                f"⚠ Compression summary failed: {summary_error}. "
-                "Inserted a fallback context marker."
+                f"⚠ context summary 失败：{summary_error}。"
+                "已插入 fallback context marker。"
             )
     else:
         # No hard failure — but did the configured aux model error out
@@ -359,9 +375,9 @@ def compress_context(
             if getattr(agent, "_last_aux_fallback_warning_key", None) != _aux_key:
                 agent._last_aux_fallback_warning_key = _aux_key
                 agent._emit_warning(
-                    f"ℹ Configured compression model '{_aux_fail_model}' failed "
-                    f"({_aux_fail_err or 'unknown error'}). Recovered using main model — "
-                    "check auxiliary.compression.model in config.yaml."
+                    f"ℹ 配置的 compression model '{_aux_fail_model}' 失败"
+                    f"（{_aux_fail_err or 'unknown error'}）。已改用 main model 恢复 — "
+                    "请检查 auxiliary.compression.model in config.yaml。"
                 )
 
     todo_snapshot = agent._todo_store.format_for_injection()
@@ -446,8 +462,8 @@ def compress_context(
     _cc = agent.context_compressor.compression_count
     if _cc >= 2:
         agent._vprint(
-            f"{agent.log_prefix}⚠️  Session compressed {_cc} times — "
-            f"accuracy may degrade. Consider /new to start fresh.",
+            f"{agent.log_prefix}⚠️  Session 已压缩 {_cc} 次 — "
+            f"准确性可能下降。建议发送 /new 开新会话。",
             force=True,
         )
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -409,6 +409,7 @@ def compress_context(
                 source=agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
                 model=agent.model,
                 model_config=agent._session_init_model_config,
+                user_id=getattr(agent, "_user_id", None),
                 parent_session_id=old_session_id,
             )
             agent._session_db_created = True

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -493,9 +493,9 @@ def run_conversation(
                 f"{agent.context_compressor.context_length:,}",
             )
             agent._emit_status(
-                f"📦 Preflight compression: ~{_preflight_tokens:,} tokens "
-                f">= {agent.context_compressor.threshold_tokens:,} threshold. "
-                "This may take a moment."
+                f"📦 预先压缩 context：约 {_preflight_tokens:,} tokens "
+                f">= {agent.context_compressor.threshold_tokens:,} threshold，"
+                "可能需要一点时间。"
             )
             # May need multiple passes for very large sessions with small
             # context windows (each pass summarises the middle N turns).
@@ -1359,7 +1359,7 @@ def run_conversation(
                             agent._persist_session(messages, conversation_history)
                             agent.clear_interrupt()
                             return {
-                                "final_response": f"Operation interrupted during retry ({_failure_hint}, attempt {retry_count}/{max_retries}).",
+                                "final_response": f"操作已中断：正在重试等待（{_failure_hint}，第 {retry_count}/{max_retries} 次尝试）。",
                                 "messages": messages,
                                 "api_calls": api_call_count,
                                 "completed": False,
@@ -1780,7 +1780,7 @@ def run_conversation(
                 agent._vprint(f"{agent.log_prefix}⚡ Interrupted during API call.", force=True)
                 agent._persist_session(messages, conversation_history)
                 interrupted = True
-                final_response = f"Operation interrupted: waiting for model response ({api_elapsed:.1f}s elapsed)."
+                final_response = f"操作已中断：正在等待模型响应（已等待 {api_elapsed:.1f} 秒）。"
                 break
 
             except Exception as api_error:
@@ -2374,7 +2374,7 @@ def run_conversation(
                     agent._persist_session(messages, conversation_history)
                     agent.clear_interrupt()
                     return {
-                        "final_response": f"Operation interrupted: handling API error ({error_type}: {agent._clean_error_message(str(api_error))}).",
+                        "final_response": f"操作已中断：正在处理 API 错误（{error_type}: {agent._clean_error_message(str(api_error))}）。",
                         "messages": messages,
                         "api_calls": api_call_count,
                         "completed": False,
@@ -3002,7 +3002,7 @@ def run_conversation(
                         agent._persist_session(messages, conversation_history)
                         agent.clear_interrupt()
                         return {
-                            "final_response": f"Operation interrupted: retrying API call after error (retry {retry_count}/{max_retries}).",
+                            "final_response": f"操作已中断：API 错误后正在重试（第 {retry_count}/{max_retries} 次）。",
                             "messages": messages,
                             "api_calls": api_call_count,
                             "completed": False,

--- a/agent/live_config_guard.py
+++ b/agent/live_config_guard.py
@@ -1,0 +1,284 @@
+"""Guards for writes to the active Hermes config and secret files.
+
+The file tools normally block credential files outright.  Active Hermes
+``config.yaml`` / ``.env`` need a narrower path: allow intentional safe edits
+while refusing the dangerous class of agent mistakes that wipe real secrets by
+replacing them with placeholders, nulls, empties, or by deleting credential
+fields entirely.
+"""
+
+from __future__ import annotations
+
+import difflib
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+
+@dataclass(frozen=True)
+class LiveConfigGuardResult:
+    guarded: bool = False
+    redacted_diff: str = ""
+    error: Optional[str] = None
+
+
+_CREDENTIAL_NAME_RE = re.compile(
+    r"(?:api[_-]?key|token|secret|password|credential|private[_-]?key|"
+    r"access[_-]?key|auth[_-]?token|oauth)",
+    re.IGNORECASE,
+)
+_PLACEHOLDER_RE = re.compile(
+    r"^(?:"
+    r"|none|null|nil|undefined|false|0"
+    r"|changeme|change[_-]?me|replace[_-]?me|todo|tbd"
+    r"|placeholder|dummy|example|sample"
+    r"|your(?:[_-]?[a-z0-9]+)*[_-]?(?:key|token|secret|password)(?:[_-]?here)?"
+    r"|<[^>]*(?:key|token|secret|password)[^>]*>"
+    r"|\[[^\]]*(?:redacted|key|token|secret|password)[^\]]*\]"
+    r"|\*+|x{3,}|\.\.\."
+    r")$",
+    re.IGNORECASE,
+)
+_ENV_ASSIGNMENT_RE = re.compile(
+    r"^(?P<prefix>\s*(?:export\s+)?(?P<key>[A-Za-z_][A-Za-z0-9_]*)\s*=)(?P<value>.*)$"
+)
+_YAML_SECRET_LINE_RE = re.compile(
+    r"^(?P<prefix>\s*[^#\n:]*?(?:api[_-]?key|token|secret|password|credential|"
+    r"private[_-]?key|access[_-]?key|auth[_-]?token|oauth)[^:\n]*:\s*)(?P<value>.*)$",
+    re.IGNORECASE,
+)
+_REDACTED = "[REDACTED]"
+
+
+def classify_live_config_path(path: str | os.PathLike[str]) -> Optional[str]:
+    """Return ``config``/``env`` for active Hermes config files, else None."""
+    try:
+        resolved = Path(path).expanduser().resolve()
+        from hermes_constants import get_default_hermes_root, get_hermes_home
+
+        hermes_home = get_hermes_home().expanduser().resolve()
+        hermes_root = get_default_hermes_root().expanduser().resolve()
+    except Exception:
+        return None
+
+    if resolved == hermes_home / "config.yaml":
+        return "config"
+    # Active profile .env plus top-level root .env are both credential stores.
+    if resolved in {hermes_home / ".env", hermes_root / ".env"}:
+        return "env"
+    return None
+
+
+def is_live_config_path(path: str | os.PathLike[str]) -> bool:
+    return classify_live_config_path(path) is not None
+
+
+def validate_live_config_write(
+    path: str | os.PathLike[str],
+    *,
+    old_content: Optional[str],
+    new_content: str,
+) -> LiveConfigGuardResult:
+    """Validate a prospective write to a live Hermes config/secrets file.
+
+    Existing real credential values may not be removed or replaced with null,
+    empty, redacted, or placeholder-looking values.  The returned diff is always
+    redacted when the path is guarded.
+    """
+    kind = classify_live_config_path(path)
+    if kind is None:
+        return LiveConfigGuardResult(guarded=False)
+
+    before = old_content or ""
+    redacted_diff = _redacted_unified_diff(before, new_content, str(path), kind)
+    try:
+        old_credentials = _collect_credentials(kind, before, label="existing", path=str(path))
+        new_credentials = _collect_credentials(kind, new_content, label="new", path=str(path))
+    except ValueError as exc:
+        return LiveConfigGuardResult(
+            guarded=True,
+            redacted_diff=redacted_diff,
+            error=f"Refusing to write live Hermes config/secrets file: {exc}",
+        )
+
+    violations: list[str] = []
+    for name, old_value in sorted(old_credentials.items()):
+        if not _is_real_secret(old_value):
+            continue
+        if name not in new_credentials:
+            violations.append(f"would remove existing credential field {name}")
+            continue
+        new_value = new_credentials[name]
+        if _is_placeholder_value(new_value):
+            violations.append(f"would replace existing credential field {name} with a placeholder/null/empty value")
+
+    if violations:
+        return LiveConfigGuardResult(
+            guarded=True,
+            redacted_diff=redacted_diff,
+            error=(
+                "Refusing to write live Hermes config/secrets file: "
+                + "; ".join(violations)
+                + ". Preserve the existing secret value or update it with a real credential."
+            ),
+        )
+
+    return LiveConfigGuardResult(guarded=True, redacted_diff=redacted_diff)
+
+
+def _collect_credentials(kind: str, content: str, *, label: str, path: str) -> dict[str, Any]:
+    if kind == "env":
+        return _collect_env_credentials(content)
+    return _collect_yaml_credentials(content, label=label, path=path)
+
+
+def _collect_env_credentials(content: str) -> dict[str, str]:
+    credentials: dict[str, str] = {}
+    for raw_line in content.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        match = _ENV_ASSIGNMENT_RE.match(raw_line)
+        if not match:
+            continue
+        key = match.group("key")
+        if not _is_credential_name(key):
+            continue
+        credentials[key] = _strip_env_value(match.group("value"))
+    return credentials
+
+
+def _strip_env_value(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+        return value[1:-1]
+    return value
+
+
+def _collect_yaml_credentials(content: str, *, label: str, path: str) -> dict[str, Any]:
+    if not content.strip():
+        return {}
+    try:
+        import yaml
+    except ImportError:
+        # PyYAML is optional elsewhere, but Hermes config safety needs a
+        # conservative fallback: regex line extraction still catches the common
+        # ``api_key: value`` shape without pretending nested YAML was parsed.
+        return _collect_yaml_credentials_by_line(content)
+
+    try:
+        data = yaml.safe_load(content)
+    except Exception as exc:
+        raise ValueError(
+            f"Cannot parse {label} live Hermes config {path!r} for credential safety: {exc}"
+        ) from exc
+
+    credentials: dict[str, Any] = {}
+    _walk_yaml(data, (), credentials)
+    return credentials
+
+
+def _collect_yaml_credentials_by_line(content: str) -> dict[str, str]:
+    credentials: dict[str, str] = {}
+    for index, line in enumerate(content.splitlines(), start=1):
+        match = _YAML_SECRET_LINE_RE.match(line)
+        if match:
+            credentials[f"line:{index}"] = match.group("value").strip().strip('"\'')
+    return credentials
+
+
+def _walk_yaml(value: Any, path: tuple[str, ...], out: dict[str, Any]) -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            child_path = path + (str(key),)
+            if _is_credential_name(str(key)):
+                out[".".join(child_path)] = child
+            _walk_yaml(child, child_path, out)
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            _walk_yaml(child, path + (str(index),), out)
+
+
+def _is_credential_name(name: str) -> bool:
+    return bool(_CREDENTIAL_NAME_RE.search(name))
+
+
+def _is_real_secret(value: Any) -> bool:
+    return not _is_placeholder_value(value)
+
+
+def _is_placeholder_value(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, bool):
+        return value is False
+    if isinstance(value, (int, float)):
+        return value == 0
+    text = str(value).strip().strip('"\'')
+    if not text:
+        return True
+    if _PLACEHOLDER_RE.match(text):
+        return True
+    return False
+
+
+def _redacted_unified_diff(old: str, new: str, path: str, kind: str) -> str:
+    old_redacted = _redact_content(kind, old).splitlines(keepends=True)
+    new_redacted = _redact_content(kind, new).splitlines(keepends=True)
+    return "".join(
+        difflib.unified_diff(
+            old_redacted,
+            new_redacted,
+            fromfile=f"{path} (before, secrets redacted)",
+            tofile=f"{path} (after, secrets redacted)",
+        )
+    )
+
+
+def _redact_content(kind: str, content: str) -> str:
+    if kind == "env":
+        redacted = [_redact_env_line(line) for line in content.splitlines()]
+    else:
+        redacted = _redact_yaml_lines(content.splitlines())
+    return "\n".join(redacted) + ("\n" if content.endswith("\n") else "")
+
+
+def _redact_env_line(line: str) -> str:
+    match = _ENV_ASSIGNMENT_RE.match(line)
+    if match and _is_credential_name(match.group("key")):
+        return f"{match.group('prefix')}{_REDACTED}"
+    return line
+
+
+def _redact_yaml_lines(lines: list[str]) -> list[str]:
+    """Redact YAML credential values, including literal/folded blocks."""
+    redacted: list[str] = []
+    block_secret_indent: Optional[int] = None
+    block_placeholder_emitted = False
+
+    for line in lines:
+        indent = len(line) - len(line.lstrip(" "))
+        stripped = line.strip()
+        if block_secret_indent is not None:
+            if stripped and indent > block_secret_indent:
+                if not block_placeholder_emitted:
+                    redacted.append(" " * (block_secret_indent + 2) + _REDACTED)
+                    block_placeholder_emitted = True
+                continue
+            block_secret_indent = None
+            block_placeholder_emitted = False
+
+        match = _YAML_SECRET_LINE_RE.match(line)
+        if match:
+            value = match.group("value").strip()
+            redacted.append(f"{match.group('prefix')}{_REDACTED}")
+            if value in {"|", ">", "|-", "|+", ">-", ">+"}:
+                block_secret_indent = indent
+                block_placeholder_emitted = False
+            continue
+
+        redacted.append(line)
+
+    return redacted

--- a/agent/live_config_guard.py
+++ b/agent/live_config_guard.py
@@ -29,8 +29,9 @@ class LiveConfigGuardResult:
 
 _CREDENTIAL_NAME_RE = re.compile(
     r"(?:api[_-]?key|secret|password|credential|private[_-]?key|"
-    r"access[_-]?key|access[_-]?token|auth[_-]?token|oauth[_-]?token|oauth|"
-    r"(?<![A-Za-z0-9])token(?![A-Za-z0-9_-]))",
+    r"access[_-]?key|access[_-]?token|auth[_-]?token|oauth[_-]?token|"
+    r"bot[_-]?token|app[_-]?token|refresh[_-]?token|session[_-]?token|"
+    r"bearer[_-]?token|oauth|(?<![A-Za-z0-9])token(?![A-Za-z0-9_-]))",
     re.IGNORECASE,
 )
 _PLACEHOLDER_RE = re.compile(

--- a/agent/live_config_guard.py
+++ b/agent/live_config_guard.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import difflib
 import os
 import re
+import shutil
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
@@ -22,11 +24,13 @@ class LiveConfigGuardResult:
     guarded: bool = False
     redacted_diff: str = ""
     error: Optional[str] = None
+    backup_path: Optional[str] = None
 
 
 _CREDENTIAL_NAME_RE = re.compile(
-    r"(?:api[_-]?key|token|secret|password|credential|private[_-]?key|"
-    r"access[_-]?key|auth[_-]?token|oauth)",
+    r"(?:api[_-]?key|secret|password|credential|private[_-]?key|"
+    r"access[_-]?key|access[_-]?token|auth[_-]?token|oauth[_-]?token|oauth|"
+    r"(?<![A-Za-z0-9])token(?![A-Za-z0-9_-]))",
     re.IGNORECASE,
 )
 _PLACEHOLDER_RE = re.compile(
@@ -45,8 +49,9 @@ _ENV_ASSIGNMENT_RE = re.compile(
     r"^(?P<prefix>\s*(?:export\s+)?(?P<key>[A-Za-z_][A-Za-z0-9_]*)\s*=)(?P<value>.*)$"
 )
 _YAML_SECRET_LINE_RE = re.compile(
-    r"^(?P<prefix>\s*[^#\n:]*?(?:api[_-]?key|token|secret|password|credential|"
-    r"private[_-]?key|access[_-]?key|auth[_-]?token|oauth)[^:\n]*:\s*)(?P<value>.*)$",
+    r"^(?P<prefix>\s*[^#\n:]*?(?:api[_-]?key|secret|password|credential|"
+    r"private[_-]?key|access[_-]?key|access[_-]?token|auth[_-]?token|"
+    r"oauth[_-]?token|oauth|token\b)[^:\n]*:\s*)(?P<value>.*)$",
     re.IGNORECASE,
 )
 _REDACTED = "[REDACTED]"
@@ -80,6 +85,7 @@ def validate_live_config_write(
     *,
     old_content: Optional[str],
     new_content: str,
+    allow_destructive_secret_change: bool = False,
 ) -> LiveConfigGuardResult:
     """Validate a prospective write to a live Hermes config/secrets file.
 
@@ -104,10 +110,20 @@ def validate_live_config_write(
         )
 
     violations: list[str] = []
+    newly_added_real_values = {
+        str(value).strip().strip('"\'')
+        for name, value in new_credentials.items()
+        if name not in old_credentials and _is_real_secret(value)
+    }
     for name, old_value in sorted(old_credentials.items()):
         if not _is_real_secret(old_value):
             continue
+        if allow_destructive_secret_change:
+            continue
+        old_text = str(old_value).strip().strip('"\'')
         if name not in new_credentials:
+            if old_text in newly_added_real_values:
+                continue
             violations.append(f"would remove existing credential field {name}")
             continue
         new_value = new_credentials[name]
@@ -126,6 +142,60 @@ def validate_live_config_write(
         )
 
     return LiveConfigGuardResult(guarded=True, redacted_diff=redacted_diff)
+
+
+def validate_and_backup_live_config_write(
+    path: str | os.PathLike[str],
+    *,
+    new_content: str,
+    old_content: Optional[str] = None,
+    create_backup: bool = True,
+    allow_destructive_secret_change: bool = False,
+) -> LiveConfigGuardResult:
+    """Validate a live config/secrets write and create a pre-write backup."""
+    kind = classify_live_config_path(path)
+    if kind is None:
+        return LiveConfigGuardResult(guarded=False)
+
+    target = Path(path).expanduser().resolve()
+    before = old_content
+    if before is None:
+        try:
+            before = target.read_text(encoding="utf-8") if target.exists() else ""
+        except OSError as exc:
+            return LiveConfigGuardResult(
+                guarded=True,
+                error=f"Refusing to write live Hermes config/secrets file: cannot read existing file: {exc}",
+            )
+
+    result = validate_live_config_write(
+        target,
+        old_content=before,
+        new_content=new_content,
+        allow_destructive_secret_change=allow_destructive_secret_change,
+    )
+    if result.error or not result.guarded:
+        return result
+
+    backup_path: Optional[str] = None
+    if create_backup and target.exists():
+        stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+        backup = target.with_name(f"{target.name}.bak.{stamp}.{os.getpid()}")
+        try:
+            shutil.copy2(target, backup)
+            backup_path = str(backup)
+        except OSError as exc:
+            return LiveConfigGuardResult(
+                guarded=True,
+                redacted_diff=result.redacted_diff,
+                error=f"Failed to back up live Hermes config before write: {exc}",
+            )
+
+    return LiveConfigGuardResult(
+        guarded=True,
+        redacted_diff=result.redacted_diff,
+        backup_path=backup_path,
+    )
 
 
 def _collect_credentials(kind: str, content: str, *, label: str, path: str) -> dict[str, Any]:
@@ -240,9 +310,40 @@ def _redacted_unified_diff(old: str, new: str, path: str, kind: str) -> str:
 def _redact_content(kind: str, content: str) -> str:
     if kind == "env":
         redacted = [_redact_env_line(line) for line in content.splitlines()]
+        text = "\n".join(redacted)
     else:
         redacted = _redact_yaml_lines(content.splitlines())
-    return "\n".join(redacted) + ("\n" if content.endswith("\n") else "")
+        text = _redact_yaml_scalar_secret_values(content, "\n".join(redacted))
+    return text + ("\n" if content.endswith("\n") else "")
+
+
+def _redact_yaml_scalar_secret_values(original: str, redacted_text: str) -> str:
+    """Redact parsed YAML credential scalar values missed by line regexes."""
+    try:
+        import yaml
+
+        data = yaml.safe_load(original)
+    except Exception:
+        return redacted_text
+
+    values: list[str] = []
+
+    def walk(value: Any) -> None:
+        if isinstance(value, dict):
+            for key, child in value.items():
+                if _is_credential_name(str(key)) and child is not None:
+                    scalar = str(child).strip()
+                    if scalar:
+                        values.append(scalar)
+                walk(child)
+        elif isinstance(value, list):
+            for child in value:
+                walk(child)
+
+    walk(data)
+    for value in sorted(set(values), key=len, reverse=True):
+        redacted_text = redacted_text.replace(value, _REDACTED)
+    return redacted_text
 
 
 def _redact_env_line(line: str) -> str:

--- a/agent/onboarding.py
+++ b/agent/onboarding.py
@@ -40,22 +40,22 @@ def busy_input_hint_gateway(mode: str) -> str:
     """
     if mode == "queue":
         return (
-            "💡 First-time tip — I queued your message instead of interrupting. "
-            "Send `/busy interrupt` to make new messages stop the current task "
-            "immediately, or `/busy status` to check. This notice won't appear again."
+            "💡 首次提示：我已把你的消息排队，没有中断当前任务。"
+            "发送 `/busy interrupt` 可改为新消息立即中断当前任务，"
+            "或发送 `/busy status` 查看状态。此提示不会再出现。"
         )
     if mode == "steer":
         return (
-            "💡 First-time tip — I steered your message into the current run; "
-            "it will arrive after the next tool call instead of interrupting. "
-            "Send `/busy interrupt` or `/busy queue` to change this, or "
-            "`/busy status` to check. This notice won't appear again."
+            "💡 首次提示：我已把你的消息插入当前任务；"
+            "它会在下一个工具调用后进入，不会中断任务。"
+            "发送 `/busy interrupt` 或 `/busy queue` 可切换模式，"
+            "或发送 `/busy status` 查看状态。此提示不会再出现。"
         )
     return (
-        "💡 First-time tip — I just interrupted my current task to answer you. "
-        "Send `/busy queue` to queue follow-ups for after the current task instead, "
-        "`/busy steer` to inject them mid-run without interrupting, or "
-        "`/busy status` to check. This notice won't appear again."
+        "💡 首次提示：我刚刚中断当前任务来回复你。"
+        "发送 `/busy queue` 可让后续消息排队到当前任务之后，"
+        "发送 `/busy steer` 可在不中断的情况下插入当前任务，"
+        "或发送 `/busy status` 查看状态。此提示不会再出现。"
     )
 
 
@@ -82,9 +82,9 @@ def busy_input_hint_cli(mode: str) -> str:
 
 def tool_progress_hint_gateway() -> str:
     return (
-        "💡 First-time tip — that tool took a while and I'm streaming every step. "
-        "If the progress messages feel noisy, send `/verbose` to cycle modes "
-        "(all → new → off). This notice won't appear again."
+        "💡 首次提示：这个工具运行较久，我正在流式显示每一步。"
+        "如果觉得进度消息太多，发送 `/verbose` 可切换显示模式"
+        "（all → new → off）。此提示不会再出现。"
     )
 
 

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -30,6 +30,7 @@ from agent.display import (
     _detect_tool_failure,
 )
 from agent.tool_guardrails import ToolGuardrailDecision
+from agent.attribution_ledger import record_tool_event
 from agent.tool_dispatch_helpers import (
     _is_destructive_command,
     _is_multimodal_tool_result,
@@ -233,6 +234,14 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             except Exception:
                 pass
         start = time.time()
+        record_tool_event(
+            agent,
+            function_name,
+            function_args,
+            status="started",
+            tool_call_id=tool_call.id,
+            started_at=start,
+        )
         try:
             result = agent._invoke_tool(
                 function_name,
@@ -245,8 +254,19 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         except Exception as tool_error:
             result = f"Error executing tool '{function_name}': {tool_error}"
             logger.error("_invoke_tool raised for %s: %s", function_name, tool_error, exc_info=True)
-        duration = time.time() - start
+        ended = time.time()
+        duration = ended - start
         is_error, _ = _detect_tool_failure(function_name, result)
+        record_tool_event(
+            agent,
+            function_name,
+            function_args,
+            status="failed" if is_error else "completed",
+            tool_call_id=tool_call.id,
+            started_at=start,
+            ended_at=ended,
+            result=result,
+        )
         if is_error:
             logger.info("tool %s failed (%.2fs): %s", function_name, duration, result[:200])
         else:
@@ -349,15 +369,37 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     for i, (tc, name, args, block_result, blocked_by_guardrail) in enumerate(parsed_calls):
         r = results[i]
         blocked = False
+        function_name = name
+        function_args = args
+        is_error = True
         if r is None:
             # Tool was cancelled (interrupt) or thread didn't return
             if agent._interrupt_requested:
                 function_result = f"[Tool execution cancelled — {name} was skipped due to user interrupt]"
+                event_status = "cancelled"
             else:
                 function_result = f"Error executing tool '{name}': thread did not return a result"
+                event_status = "failed"
             tool_duration = 0.0
+            record_tool_event(
+                agent,
+                name,
+                args,
+                status=event_status,
+                tool_call_id=tc.id,
+                result=function_result,
+            )
         else:
             function_name, function_args, function_result, tool_duration, is_error, blocked = r
+            if blocked:
+                record_tool_event(
+                    agent,
+                    function_name,
+                    function_args,
+                    status="blocked",
+                    tool_call_id=tc.id,
+                    result=function_result,
+                )
 
             if not blocked:
                 function_result = agent._append_guardrail_observation(
@@ -478,6 +520,14 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 agent._vprint(f"{agent.log_prefix}⚡ Interrupt: skipping {len(remaining_calls)} tool call(s)", force=True)
             for skipped_tc in remaining_calls:
                 skipped_name = skipped_tc.function.name
+                record_tool_event(
+                    agent,
+                    skipped_name,
+                    {},
+                    status="cancelled",
+                    tool_call_id=skipped_tc.id,
+                    result=f"[Tool execution cancelled — {skipped_name} was skipped due to user interrupt]",
+                )
                 skip_msg = {
                     "role": "tool",
                     "name": skipped_name,
@@ -586,6 +636,15 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 pass  # never block tool execution
 
         tool_start_time = time.time()
+        if not _execution_blocked:
+            record_tool_event(
+                agent,
+                function_name,
+                function_args,
+                status="started",
+                tool_call_id=tool_call.id,
+                started_at=tool_start_time,
+            )
 
         if _block_msg is not None:
             # Tool blocked by plugin policy — return error without executing.
@@ -801,6 +860,16 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             result_preview = function_result if agent.verbose_logging else (
                 function_result[:200] if len(function_result) > 200 else function_result
             )
+        record_tool_event(
+            agent,
+            function_name,
+            function_args,
+            status="blocked" if _execution_blocked else ("failed" if _is_error_result else "completed"),
+            tool_call_id=tool_call.id,
+            started_at=tool_start_time,
+            ended_at=tool_start_time + tool_duration,
+            result=function_result,
+        )
         if _is_error_result:
             logger.warning("Tool %s returned error (%.2fs): %s", function_name, tool_duration, result_preview)
         else:
@@ -882,6 +951,14 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             agent._vprint(f"{agent.log_prefix}⚡ Interrupt: skipping {remaining} remaining tool call(s)", force=True)
             for skipped_tc in assistant_message.tool_calls[i:]:
                 skipped_name = skipped_tc.function.name
+                record_tool_event(
+                    agent,
+                    skipped_name,
+                    {},
+                    status="cancelled",
+                    tool_call_id=skipped_tc.id,
+                    result=f"[Tool execution skipped — {skipped_name} was not started. User sent a new message]",
+                )
                 messages.append(make_tool_result_message(
                     skipped_name,
                     f"[Tool execution skipped — {skipped_name} was not started. User sent a new message]",

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -5,6 +5,8 @@ This transport owns format conversion and normalization — NOT client lifecycle
 streaming, or the _run_codex_stream() call path.
 """
 
+import json
+import uuid
 from typing import Any, Dict, List, Optional
 
 from agent.transports.base import ProviderTransport
@@ -56,6 +58,7 @@ class ResponsesApiTransport(ProviderTransport):
             base_url_hostname: str | None — hostname for backend detection
             is_github_responses: bool — Copilot/GitHub models backend
             is_codex_backend: bool — chatgpt.com/backend-api/codex
+            use_codex_transport_compat_headers: bool — custom /codex proxy cache headers
             is_xai_responses: bool — xAI/Grok backend
             github_reasoning_extra: dict | None — Copilot reasoning params
         """
@@ -77,6 +80,7 @@ class ResponsesApiTransport(ProviderTransport):
 
         is_github_responses = params.get("is_github_responses", False)
         is_codex_backend = params.get("is_codex_backend", False)
+        use_codex_transport_compat_headers = params.get("use_codex_transport_compat_headers", False)
         is_xai_responses = params.get("is_xai_responses", False)
 
         # Resolve reasoning effort
@@ -159,6 +163,27 @@ class ResponsesApiTransport(ProviderTransport):
                     )
                 merged_extra_headers["session_id"] = cache_scope_id
                 merged_extra_headers["x-client-request-id"] = cache_scope_id
+                if use_codex_transport_compat_headers:
+                    window_id = f"{cache_scope_id}:0"
+                    merged_extra_headers["x-codex-window-id"] = window_id
+                    merged_extra_headers.setdefault("originator", "codex_exec")
+                    merged_extra_headers.setdefault(
+                        "User-Agent",
+                        "codex_exec/0.120.0 (Hermes Agent)",
+                    )
+                    merged_extra_headers.setdefault(
+                        "x-codex-turn-metadata",
+                        json.dumps(
+                            {
+                                "session_id": cache_scope_id,
+                                "turn_id": str(uuid.uuid4()),
+                                "window_id": window_id,
+                                "sandbox": "none",
+                            },
+                            separators=(",", ":"),
+                            sort_keys=True,
+                        ),
+                    )
                 kwargs["extra_headers"] = merged_extra_headers
 
         max_tokens = params.get("max_tokens")

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -74,6 +74,26 @@ def _normalize_notice_delivery(value: Any, default: str = "public") -> str:
     return default
 
 
+def _qq_indexed_credential_indexes() -> list[int]:
+    """Return numeric suffixes for QQ_APP_ID_N / QQ_CLIENT_SECRET_N env pairs."""
+    indexes: set[int] = set()
+    for key in os.environ:
+        for prefix in ("QQ_APP_ID_", "QQ_CLIENT_SECRET_"):
+            if key.startswith(prefix):
+                suffix = key[len(prefix):]
+                if suffix.isdigit():
+                    indexes.add(int(suffix))
+    return sorted(indexes)
+
+
+def _qq_indexed_credentials_present() -> bool:
+    """True if at least one complete indexed QQ credential pair is present."""
+    for idx in _qq_indexed_credential_indexes():
+        if os.getenv(f"QQ_APP_ID_{idx}") and os.getenv(f"QQ_CLIENT_SECRET_{idx}"):
+            return True
+    return False
+
+
 def _ensure_platform_extra_dict(platforms_data: dict, name: str) -> tuple[dict, dict]:
     """Get-or-create ``platforms_data[name]`` and its nested ``extra`` dict.
 
@@ -436,7 +456,9 @@ _PLATFORM_CONNECTED_CHECKERS: dict[Platform, Callable[[PlatformConfig], bool]] =
         cfg.extra.get("server_url") and cfg.extra.get("password")
     ),
     Platform.QQBOT: lambda cfg: bool(
-        cfg.extra.get("app_id") and cfg.extra.get("client_secret")
+        (cfg.extra.get("app_id") and cfg.extra.get("client_secret"))
+        or (os.getenv("QQ_APP_ID") and os.getenv("QQ_CLIENT_SECRET"))
+        or _qq_indexed_credentials_present()
     ),
     Platform.YUANBAO: lambda cfg: bool(
         cfg.extra.get("app_id") and cfg.extra.get("app_secret")
@@ -1709,7 +1731,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # QQ (Official Bot API v2)
     qq_app_id = os.getenv("QQ_APP_ID")
     qq_client_secret = os.getenv("QQ_CLIENT_SECRET")
-    if qq_app_id or qq_client_secret:
+    qq_indexed_present = _qq_indexed_credentials_present()
+    if qq_app_id or qq_client_secret or qq_indexed_present:
         if Platform.QQBOT not in config.platforms:
             config.platforms[Platform.QQBOT] = PlatformConfig()
         config.platforms[Platform.QQBOT].enabled = True

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2309,28 +2309,50 @@ class BasePlatformAdapter(ABC):
 
         # Check for [[audio_as_voice]] directive
         has_voice_tag = "[[audio_as_voice]]" in content
-        cleaned = cleaned.replace("[[audio_as_voice]]", "")
         # Strip [[as_document]] directive — callers inspect the original
         # ``content`` for it (so they can still react to it); here we just
         # keep it out of the user-visible cleaned text.
-        cleaned = cleaned.replace("[[as_document]]", "")
+        has_as_document_tag = "[[as_document]]" in content
         
-        # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
-        # and quoted/backticked paths for LLM-formatted outputs.
+        # Extract only top-level, standalone MEDIA:<path> directive lines.
+        # MEDIA strings in prose, quotes, inline code, fenced code, logs, or
+        # history snippets are evidence text, not attachment controls.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''^[ \t]*MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/).+?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa))[ \t]*$''',
+            re.MULTILINE,
         )
+
+        code_spans: list[tuple[int, int]] = []
+        for m in re.finditer(r'```[^\n]*\n.*?```', content, re.DOTALL):
+            code_spans.append((m.start(), m.end()))
+        for m in re.finditer(r'`[^`\n]+`', content):
+            code_spans.append((m.start(), m.end()))
+
+        def _in_code(pos: int) -> bool:
+            return any(start <= pos < end for start, end in code_spans)
+
+        media_spans = set()
         for match in media_pattern.finditer(content):
+            if _in_code(match.start()):
+                continue
             path = match.group("path").strip()
             if len(path) >= 2 and path[0] == path[-1] and path[0] in "`\"'":
                 path = path[1:-1].strip()
             path = path.lstrip("`\"'").rstrip("`\"',.;:)}]")
             if path:
                 media.append((os.path.expanduser(path), has_voice_tag))
+                media_spans.add((match.start(), match.end()))
 
-        # Remove MEDIA tags from content (including surrounding quote/backtick wrappers)
+        # Remove only directive lines that were accepted as attachments.
         if media:
-            cleaned = media_pattern.sub('', cleaned)
+            cleaned = media_pattern.sub(
+                lambda m: '' if (m.start(), m.end()) in media_spans else m.group(0),
+                content,
+            )
+
+        cleaned = cleaned.replace("[[audio_as_voice]]", "")
+        cleaned = cleaned.replace("[[as_document]]", "")
+        if media or has_voice_tag or has_as_document_tag:
             cleaned = re.sub(r'\n{3,}', '\n\n', cleaned).strip()
         
         return media, cleaned

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1029,6 +1029,20 @@ class ProcessingOutcome(Enum):
 
 
 @dataclass
+class MessageAttachment:
+    """Structured metadata for a platform attachment cached for an inbound message."""
+
+    kind: str
+    local_path: Optional[str] = None
+    filename: Optional[str] = None
+    content_type: Optional[str] = None
+    size: Optional[int] = None
+    message_id: Optional[str] = None
+    source_url: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
 class MessageEvent:
     """
     Incoming message from a platform.
@@ -1059,6 +1073,7 @@ class MessageEvent:
     # media_urls: local file paths (for vision tool access)
     media_urls: List[str] = field(default_factory=list)
     media_types: List[str] = field(default_factory=list)
+    attachments: List[MessageAttachment] = field(default_factory=list)
     
     # Reply context
     reply_to_message_id: Optional[str] = None
@@ -1241,14 +1256,19 @@ def merge_pending_message_event(
         if existing_is_photo and incoming_is_photo:
             existing.media_urls.extend(event.media_urls)
             existing.media_types.extend(event.media_types)
+            existing.attachments.extend(getattr(event, "attachments", []) or [])
             if event.text:
                 existing.text = BasePlatformAdapter._merge_caption(existing.text, event.text)
             return
 
-        if existing_has_media or incoming_has_media:
+        incoming_has_attachments = bool(getattr(event, "attachments", None))
+        existing_has_attachments = bool(getattr(existing, "attachments", None))
+        if existing_has_media or incoming_has_media or existing_has_attachments or incoming_has_attachments:
             if incoming_has_media:
                 existing.media_urls.extend(event.media_urls)
                 existing.media_types.extend(event.media_types)
+            if incoming_has_attachments:
+                existing.attachments.extend(event.attachments)
             if event.text:
                 if existing.text:
                     existing.text = BasePlatformAdapter._merge_caption(existing.text, event.text)

--- a/gateway/platforms/qqbot/__init__.py
+++ b/gateway/platforms/qqbot/__init__.py
@@ -22,6 +22,11 @@ from .adapter import (  # noqa: F401
     _coerce_list,
     _ssrf_redirect_guard,
 )
+from .multi_adapter import (  # noqa: F401
+    QQMultiAdapter,
+    collect_qq_credentials,
+    has_any_qq_credentials,
+)
 
 # -- Onboard (QR-code scan-to-configure) -----------------------------------
 from .onboard import (  # noqa: F401
@@ -58,6 +63,9 @@ from .keyboards import (  # noqa: F401
 __all__ = [
     # adapter
     "QQAdapter",
+    "QQMultiAdapter",
+    "collect_qq_credentials",
+    "has_any_qq_credentials",
     "QQCloseError",
     "check_qq_requirements",
     "_coerce_list",

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -33,12 +33,17 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import html as html_lib
+import io
 import json
 import logging
 import mimetypes
 import os
+import re
 import time
 import uuid
+import zipfile
+from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
@@ -63,16 +68,105 @@ except ImportError:
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
+    MessageAttachment,
     MessageEvent,
     MessageType,
     SendResult,
+    _looks_like_image,
     _ssrf_redirect_guard,
     cache_document_from_bytes,
     cache_image_from_bytes,
+    get_document_cache_dir,
 )
 from gateway.platforms.helpers import strip_markdown
 
 logger = logging.getLogger(__name__)
+
+
+_MB = 1024 * 1024
+
+
+@dataclass(frozen=True)
+class QQInboundAttachmentRule:
+    """Inbound QQ file policy for non-image attachments."""
+
+    kind: str
+    max_bytes: int
+    preview_bytes: int = 0
+    extract_max_total_bytes: int = 0
+    extract_max_files: int = 0
+    extract_max_single_file_bytes: int = 0
+    extract_max_depth: int = 0
+
+
+class QQInboundAttachmentPolicy:
+    """Classify inbound QQ files and expose safe size limits."""
+
+    _BLOCKED_EXTENSIONS = {
+        ".exe", ".dll", ".so", ".bin", ".app", ".apk", ".dmg", ".msi",
+        ".bat", ".cmd", ".scr", ".com", ".pif",
+        ".env", ".pem", ".key", ".p12", ".pfx",
+    }
+    _TEXT_EXTENSIONS = {
+        ".txt", ".md", ".markdown", ".log", ".csv", ".tsv", ".json",
+        ".yaml", ".yml", ".xml", ".toml", ".ini", ".cfg", ".sql",
+        ".py", ".js", ".ts", ".jsx", ".tsx", ".css", ".sh", ".bash",
+        ".zsh", ".java", ".kt", ".go", ".rs", ".c", ".cpp", ".h", ".hpp",
+        ".cs", ".php", ".rb", ".lua", ".dockerfile",
+    }
+    _HTML_EXTENSIONS = {".html", ".htm"}
+    _DOCUMENT_EXTENSIONS = {".pdf", ".docx", ".doc", ".pptx", ".ppt", ".xlsx", ".xls"}
+    _ARCHIVE_EXTENSIONS = {".zip", ".tar", ".gz", ".tgz", ".7z", ".rar"}
+    _AUDIO_EXTENSIONS = {".mp3", ".wav", ".m4a", ".ogg", ".flac"}
+    _VIDEO_EXTENSIONS = {".mp4", ".mov", ".mkv", ".webm", ".avi"}
+
+    REGULAR = QQInboundAttachmentRule("file", 20 * _MB, preview_bytes=64 * 1024)
+    IMAGE = QQInboundAttachmentRule("image", 25 * _MB)
+    DOCUMENT = QQInboundAttachmentRule("document", 50 * _MB, preview_bytes=64 * 1024)
+    ARCHIVE = QQInboundAttachmentRule(
+        "archive",
+        200 * _MB,
+        extract_max_total_bytes=1024 * _MB,
+        extract_max_files=10000,
+        extract_max_single_file_bytes=100 * _MB,
+        extract_max_depth=10,
+    )
+    MEDIA = QQInboundAttachmentRule("media", 100 * _MB)
+
+    def is_blocked_filename(self, filename: str) -> bool:
+        name = Path(filename or "").name.strip()
+        lower = name.lower()
+        suffix = Path(lower).suffix
+        return lower in {".env", "env"} or suffix in self._BLOCKED_EXTENSIONS
+
+    def classify(self, filename: str, content_type: str) -> Optional[QQInboundAttachmentRule]:
+        name = Path(filename or "").name.strip()
+        lower = name.lower()
+        suffix = Path(lower).suffix
+        if self.is_blocked_filename(name):
+            return None
+        if lower == "dockerfile":
+            return self.REGULAR
+        if content_type.startswith("image/"):
+            return self.IMAGE
+        if suffix in self._TEXT_EXTENSIONS:
+            return self.REGULAR
+        if suffix in self._HTML_EXTENSIONS:
+            return self.REGULAR
+        if suffix in self._DOCUMENT_EXTENSIONS:
+            return self.DOCUMENT
+        if suffix in self._ARCHIVE_EXTENSIONS or lower.endswith(".tar.gz"):
+            return self.ARCHIVE
+        if suffix in self._AUDIO_EXTENSIONS or suffix in self._VIDEO_EXTENSIONS:
+            return self.MEDIA
+        if content_type in {"text/plain", "text/markdown", "text/csv", "text/html"}:
+            return self.REGULAR
+        if content_type in {"application/pdf", "application/zip"}:
+            return self.DOCUMENT if content_type == "application/pdf" else self.ARCHIVE
+        return None
+
+
+QQ_INBOUND_ATTACHMENT_POLICY = QQInboundAttachmentPolicy()
 
 
 class QQCloseError(Exception):
@@ -1233,11 +1327,12 @@ class QQAdapter(BasePlatformAdapter):
                     )
 
         # Process all attachments uniformly (images, voice, files)
-        att_result = await self._process_attachments(attachments_raw)
+        att_result = await self._process_attachments(attachments_raw, message_id=msg_id)
         image_urls = att_result["image_urls"]
         image_media_types = att_result["image_media_types"]
         voice_transcripts = att_result["voice_transcripts"]
         attachment_info = att_result["attachment_info"]
+        structured_attachments = att_result.get("attachments") or []
 
         # Append voice transcripts to the text body
         if voice_transcripts:
@@ -1283,6 +1378,7 @@ class QQAdapter(BasePlatformAdapter):
             message_id=msg_id,
             media_urls=image_urls,
             media_types=image_media_types,
+            attachments=structured_attachments,
             timestamp=self._parse_qq_timestamp(timestamp),
         )
         await self.handle_message(event)
@@ -1306,11 +1402,12 @@ class QQAdapter(BasePlatformAdapter):
 
         # Strip the @bot mention prefix from content
         text = self._strip_at_mention(content)
-        att_result = await self._process_attachments(d.get("attachments"))
+        att_result = await self._process_attachments(d.get("attachments"), message_id=msg_id)
         image_urls = att_result["image_urls"]
         image_media_types = att_result["image_media_types"]
         voice_transcripts = att_result["voice_transcripts"]
         attachment_info = att_result["attachment_info"]
+        structured_attachments = att_result.get("attachments") or []
 
         # Append voice transcripts
         if voice_transcripts:
@@ -1348,6 +1445,7 @@ class QQAdapter(BasePlatformAdapter):
             message_id=msg_id,
             media_urls=image_urls,
             media_types=image_media_types,
+            attachments=structured_attachments,
             timestamp=self._parse_qq_timestamp(timestamp),
         )
         await self.handle_message(event)
@@ -1381,11 +1479,12 @@ class QQAdapter(BasePlatformAdapter):
         nick = str(member.get("nick", "")) or str(author.get("username", ""))
 
         text = content
-        att_result = await self._process_attachments(d.get("attachments"))
+        att_result = await self._process_attachments(d.get("attachments"), message_id=msg_id)
         image_urls = att_result["image_urls"]
         image_media_types = att_result["image_media_types"]
         voice_transcripts = att_result["voice_transcripts"]
         attachment_info = att_result["attachment_info"]
+        structured_attachments = att_result.get("attachments") or []
 
         if voice_transcripts:
             voice_block = "\n".join(voice_transcripts)
@@ -1423,6 +1522,7 @@ class QQAdapter(BasePlatformAdapter):
             message_id=msg_id,
             media_urls=image_urls,
             media_types=image_media_types,
+            attachments=structured_attachments,
             timestamp=self._parse_qq_timestamp(timestamp),
         )
         await self.handle_message(event)
@@ -1452,11 +1552,12 @@ class QQAdapter(BasePlatformAdapter):
             return
 
         text = content
-        att_result = await self._process_attachments(d.get("attachments"))
+        att_result = await self._process_attachments(d.get("attachments"), message_id=msg_id)
         image_urls = att_result["image_urls"]
         image_media_types = att_result["image_media_types"]
         voice_transcripts = att_result["voice_transcripts"]
         attachment_info = att_result["attachment_info"]
+        structured_attachments = att_result.get("attachments") or []
 
         if voice_transcripts:
             voice_block = "\n".join(voice_transcripts)
@@ -1493,6 +1594,7 @@ class QQAdapter(BasePlatformAdapter):
             message_id=msg_id,
             media_urls=image_urls,
             media_types=image_media_types,
+            attachments=structured_attachments,
             timestamp=self._parse_qq_timestamp(timestamp),
         )
         await self.handle_message(event)
@@ -1628,9 +1730,130 @@ class QQAdapter(BasePlatformAdapter):
         )
         return MessageType.TEXT
 
+    @staticmethod
+    def _safe_cache_component(value: Optional[str], default: str) -> str:
+        raw = str(value or "").replace("\x00", "").strip()
+        raw = Path(raw).name if raw else ""
+        safe = re.sub(r"[^A-Za-z0-9._-]+", "_", raw).strip("._-")
+        return safe[:120] or default
+
+    @classmethod
+    def _inbound_message_cache_dir(cls, message_id: Optional[str]) -> Path:
+        safe_id = cls._safe_cache_component(message_id, f"unknown_{uuid.uuid4().hex[:12]}")
+        cache_dir = get_document_cache_dir() / "qqbot" / safe_id
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        return cache_dir
+
+    @classmethod
+    def _cache_inbound_attachment(
+            cls,
+            *,
+            data: bytes,
+            filename: str,
+            content_type: str,
+            kind: str,
+            message_id: Optional[str],
+            source_url: str,
+            index: int,
+    ) -> MessageAttachment:
+        cache_dir = cls._inbound_message_cache_dir(message_id)
+        safe_name = cls._safe_cache_component(filename, f"attachment_{index}")
+        candidate = cache_dir / f"{index:02d}_{safe_name}"
+        if candidate.exists():
+            candidate = cache_dir / f"{index:02d}_{uuid.uuid4().hex[:8]}_{safe_name}"
+        if not candidate.resolve().is_relative_to(cache_dir.resolve()):
+            raise ValueError(f"Path traversal rejected: {filename!r}")
+        candidate.write_bytes(data)
+        return MessageAttachment(
+            kind=kind,
+            local_path=str(candidate),
+            filename=safe_name,
+            content_type=content_type or None,
+            size=len(data),
+            message_id=message_id,
+            source_url=source_url or None,
+        )
+
+    @staticmethod
+    def _write_inbound_meta(
+            cache_dir: Path,
+            message_id: Optional[str],
+            attachments: List[MessageAttachment],
+    ) -> None:
+        if not attachments:
+            return
+        payload = {
+            "platform": "qqbot",
+            "message_id": message_id,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "attachments": [asdict(att) for att in attachments],
+        }
+        (cache_dir / "meta.json").write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+    @classmethod
+    def extract_archive_to_isolated_dir(
+            cls,
+            archive_path: str,
+            *,
+            message_id: Optional[str] = None,
+    ) -> Path:
+        """Extract a saved QQ ZIP attachment into an isolated per-message directory."""
+        archive = Path(archive_path).expanduser().resolve()
+        if archive.suffix.lower() != ".zip":
+            raise ValueError("Only ZIP archive extraction is supported")
+        if not archive.exists() or not archive.is_file():
+            raise FileNotFoundError(f"Archive not found: {archive}")
+
+        rule = QQ_INBOUND_ATTACHMENT_POLICY.ARCHIVE
+        base_dir = archive.parent if archive.parent.exists() else cls._inbound_message_cache_dir(message_id)
+        dest = base_dir / f"extracted_{uuid.uuid4().hex[:12]}"
+        dest.mkdir(parents=True, exist_ok=False)
+        dest_resolved = dest.resolve()
+
+        with zipfile.ZipFile(archive) as zf:
+            infos = zf.infolist()
+            if len(infos) > rule.extract_max_files:
+                raise ValueError(f"Archive exceeds file count limit: {rule.extract_max_files}")
+            total = 0
+            for info in infos:
+                name = info.filename.replace("\\", "/")
+                parts = [part for part in name.split("/") if part]
+                if name.startswith("/") or ".." in parts:
+                    raise ValueError(f"Unsafe archive path: {info.filename}")
+                if len(parts) > rule.extract_max_depth:
+                    raise ValueError(f"Archive exceeds directory depth limit: {rule.extract_max_depth}")
+                if (info.external_attr >> 16) & 0o170000 == 0o120000:
+                    raise ValueError(f"Unsafe archive symlink: {info.filename}")
+                total += int(info.file_size or 0)
+                if info.file_size > rule.extract_max_single_file_bytes:
+                    raise ValueError(
+                        f"Archive member exceeds single-file limit: {info.filename}"
+                    )
+                if total > rule.extract_max_total_bytes:
+                    raise ValueError(
+                        f"Archive exceeds total extracted size limit: {cls._format_bytes(rule.extract_max_total_bytes)}"
+                    )
+
+            for info in infos:
+                if info.is_dir():
+                    continue
+                target = dest / info.filename
+                target_resolved = target.resolve()
+                if not target_resolved.is_relative_to(dest_resolved):
+                    raise ValueError(f"Unsafe archive path: {info.filename}")
+                target.parent.mkdir(parents=True, exist_ok=True)
+                with zf.open(info) as src, open(target, "wb") as out:
+                    out.write(src.read())
+        return dest
+
     async def _process_attachments(
             self,
             attachments: Any,
+            *,
+            message_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Process inbound attachments (all message types).
 
@@ -1649,20 +1872,24 @@ class QQAdapter(BasePlatformAdapter):
                 "image_media_types": [],
                 "voice_transcripts": [],
                 "attachment_info": "",
+                "attachments": [],
             }
 
+        effective_message_id = message_id or f"unknown_{uuid.uuid4().hex[:12]}"
         image_urls: List[str] = []
         image_media_types: List[str] = []
         voice_transcripts: List[str] = []
         other_attachments: List[str] = []
+        structured_attachments: List[MessageAttachment] = []
 
-        for att in attachments:
+        for index, att in enumerate(attachments):
             if not isinstance(att, dict):
                 continue
 
             ct = str(att.get("content_type", "")).strip().lower()
             url_raw = str(att.get("url", "")).strip()
             filename = str(att.get("filename", ""))
+            display_name = Path(filename or Path(urlparse(url_raw).path).name or f"attachment_{index}").name
             if url_raw.startswith("//"):
                 url = f"https:{url_raw}"
             elif url_raw:
@@ -1679,76 +1906,292 @@ class QQAdapter(BasePlatformAdapter):
                 filename,
             )
 
-            if self._is_voice_content_type(ct, filename):
-                # Voice: use QQ's asr_refer_text first, then voice_wav_url, then STT.
+            if self._is_voice_message_attachment(att, ct, filename):
                 asr_refer = (
                     str(att.get("asr_refer_text", "")).strip()
                     if isinstance(att.get("asr_refer_text"), str)
                     else ""
                 )
+                if asr_refer:
+                    voice_transcripts.append(f"[Voice] {asr_refer}")
+                    structured_attachments.append(
+                        MessageAttachment(
+                            kind="voice",
+                            filename=display_name,
+                            content_type=ct or None,
+                            size=0,
+                            message_id=effective_message_id,
+                            source_url=url,
+                            metadata={"transcript_source": "asr_refer_text"},
+                        )
+                    )
+                    continue
+
                 voice_wav_url = (
                     str(att.get("voice_wav_url", "")).strip()
                     if isinstance(att.get("voice_wav_url"), str)
                     else ""
                 )
+                is_pre_wav = False
+                download_url = url
+                if voice_wav_url:
+                    download_url = f"https:{voice_wav_url}" if voice_wav_url.startswith("//") else voice_wav_url
+                    is_pre_wav = True
+                    display_name = Path(display_name).with_suffix(".wav").name
 
-                transcript = await self._stt_voice_attachment(
-                    url,
-                    ct,
-                    filename,
-                    asr_refer_text=asr_refer or None,
-                    voice_wav_url=voice_wav_url or None,
+                data = await self._download_attachment_bytes(
+                    download_url,
+                    QQ_INBOUND_ATTACHMENT_POLICY.MEDIA.max_bytes,
+                    follow_redirects=True,
                 )
+                if data is None:
+                    voice_transcripts.append("[Voice] [语音识别失败]")
+                    other_attachments.append(
+                        f"[Voice: {display_name}] 语音超过大小限制 ({self._format_bytes(QQ_INBOUND_ATTACHMENT_POLICY.MEDIA.max_bytes)})，未下载识别。"
+                    )
+                    continue
+
+                att_obj = self._cache_inbound_attachment(
+                    data=data,
+                    filename=display_name,
+                    content_type=ct or "voice",
+                    kind="voice",
+                    message_id=effective_message_id,
+                    source_url=download_url,
+                    index=index,
+                )
+                structured_attachments.append(att_obj)
+                transcript = await self._stt_audio_bytes(data, display_name, is_pre_wav=is_pre_wav)
                 if transcript:
                     voice_transcripts.append(f"[Voice] {transcript}")
                     logger.debug("[%s] Voice transcript: %s", self._log_tag, transcript)
                 else:
-                    logger.warning("[%s] Voice STT failed for %s", self._log_tag, url[:60])
+                    logger.warning("[%s] Voice STT failed for %s", self._log_tag, download_url[:60])
                     voice_transcripts.append("[Voice] [语音识别失败]")
             elif ct.startswith("image/"):
-                # Image: download and cache locally.
                 try:
-                    cached_path = await self._download_and_cache(url, ct, filename)
-                    if cached_path and os.path.isfile(cached_path):
-                        image_urls.append(cached_path)
-                        image_media_types.append(ct or "image/jpeg")
-                    elif cached_path:
-                        logger.warning(
-                            "[%s] Cached image path does not exist: %s",
-                            self._log_tag,
-                            cached_path,
+                    data = await self._download_attachment_bytes(url, QQ_INBOUND_ATTACHMENT_POLICY.IMAGE.max_bytes)
+                    if data is None:
+                        other_attachments.append(
+                            f"[图片: {display_name}] 下载失败或超过大小限制 ({self._format_bytes(QQ_INBOUND_ATTACHMENT_POLICY.IMAGE.max_bytes)})。"
                         )
+                        continue
+                    if not _looks_like_image(data):
+                        other_attachments.append(f"[图片: {display_name}] 下载失败：内容不是有效图片。")
+                        continue
+                    ext = Path(display_name).suffix or mimetypes.guess_extension(ct) or ".jpg"
+                    image_name = display_name if Path(display_name).suffix else f"{display_name}{ext}"
+                    att_obj = self._cache_inbound_attachment(
+                        data=data,
+                        filename=image_name,
+                        content_type=ct,
+                        kind="image",
+                        message_id=effective_message_id,
+                        source_url=url,
+                        index=index,
+                    )
+                    structured_attachments.append(att_obj)
+                    if att_obj.local_path and os.path.isfile(att_obj.local_path):
+                        image_urls.append(att_obj.local_path)
+                        image_media_types.append(ct or "image/jpeg")
                 except Exception as exc:
                     logger.debug("[%s] Failed to cache image: %s", self._log_tag, exc)
             else:
-                # Other attachments (video, file, etc.): download and record with path.
                 try:
-                    cached_path = await self._download_and_cache(url, ct, filename)
-                    if cached_path:
-                        name = filename or ct
-                        if ct.startswith("video/"):
-                            other_attachments.append(f"[video: {name} ({cached_path})]")
-                        else:
-                            other_attachments.append(f"[file: {name} ({cached_path})]")
+                    info, att_obj = await self._download_and_describe_file_attachment(
+                        url=url,
+                        content_type=ct,
+                        filename=filename,
+                        message_id=effective_message_id,
+                        index=index,
+                    )
+                    if att_obj:
+                        structured_attachments.append(att_obj)
+                    if info:
+                        other_attachments.append(info)
                 except Exception as exc:
                     logger.debug("[%s] Failed to cache attachment: %s", self._log_tag, exc)
 
+        if structured_attachments:
+            self._write_inbound_meta(
+                self._inbound_message_cache_dir(effective_message_id),
+                effective_message_id,
+                structured_attachments,
+            )
         attachment_info = "\n".join(other_attachments) if other_attachments else ""
         return {
             "image_urls": image_urls,
             "image_media_types": image_media_types,
             "voice_transcripts": voice_transcripts,
             "attachment_info": attachment_info,
+            "attachments": structured_attachments,
         }
 
-    async def _download_and_cache(
-            self, url: str, content_type: str, original_name: str = "",
-    ) -> Optional[str]:
-        """Download a URL and cache it locally.
+    async def _download_and_describe_file_attachment(
+            self,
+            *,
+            url: str,
+            content_type: str,
+            filename: str,
+            message_id: Optional[str],
+            index: int,
+    ) -> Tuple[str, Optional[MessageAttachment]]:
+        """Download a supported non-image QQ attachment and return agent-visible info."""
+        display_name = Path(filename or Path(urlparse(url).path).name or "qq_attachment").name
+        rule = QQ_INBOUND_ATTACHMENT_POLICY.classify(display_name, content_type)
+        if rule is None:
+            return f"[文件: {display_name}] 不支持或敏感类型，未下载。", None
 
-        :param original_name: Preferred filename from attachment metadata.
-            Falls back to the URL path basename if empty.
-        """
+        data = await self._download_attachment_bytes(url, rule.max_bytes)
+        if data is None:
+            return f"[文件: {display_name}] 下载失败或超过大小限制 ({self._format_bytes(rule.max_bytes)})。", None
+
+        att_obj = self._cache_inbound_attachment(
+            data=data,
+            filename=display_name,
+            content_type=content_type,
+            kind=rule.kind,
+            message_id=message_id,
+            source_url=url,
+            index=index,
+        )
+        cached_path = att_obj.local_path or ""
+
+        lines = [
+            f"[文件: {display_name}]",
+            f"类型: {content_type or 'unknown'}",
+            f"大小: {self._format_bytes(len(data))}",
+            f"本地路径: {cached_path}",
+        ]
+
+        lower = display_name.lower()
+        if lower.endswith(('.html', '.htm')) or content_type == "text/html":
+            preview = self._html_text_preview(data, rule.preview_bytes)
+            if preview:
+                lines.append("HTML 文本预览:\n" + preview)
+        elif rule.kind == "archive":
+            lines.extend(self._archive_summary_lines(display_name, data, rule))
+        elif self._is_previewable_text(display_name, content_type):
+            preview = self._text_preview(data, rule.preview_bytes)
+            if preview:
+                lines.append("文本预览:\n" + preview)
+        elif lower.endswith(".pdf"):
+            lines.append("PDF 已保存。需要内容时可用文档/OCR 工具读取。")
+        elif lower.endswith((".docx", ".doc", ".pptx", ".ppt", ".xlsx", ".xls")):
+            lines.append("Office 文档已保存。需要内容时可用文档工具转换/读取。")
+        elif rule.kind == "media":
+            lines.append("媒体文件已保存，不按语音消息自动转写。")
+        return "\n".join(lines), att_obj
+
+    async def _download_attachment_bytes(
+            self,
+            url: str,
+            max_bytes: int,
+            *,
+            follow_redirects: bool = False,
+    ) -> Optional[bytes]:
+        """Download attachment bytes with SSRF and size guards."""
+        from tools.url_safety import is_safe_url
+
+        if not is_safe_url(url):
+            raise ValueError(f"Blocked unsafe URL: {url[:80]}")
+        if not self._http_client:
+            return None
+        resp = await self._http_client.get(
+            url,
+            timeout=30.0,
+            headers=self._qq_media_headers(),
+            follow_redirects=follow_redirects,
+        )
+        resp.raise_for_status()
+        content_length = None
+        try:
+            content_length = int(resp.headers.get("content-length", "") or 0)
+        except Exception:
+            content_length = None
+        if content_length and content_length > max_bytes:
+            return None
+        data = resp.content
+        if len(data) > max_bytes:
+            return None
+        return data
+
+    @staticmethod
+    def _format_bytes(size: int) -> str:
+        if size >= _MB:
+            return f"{size / _MB:.0f}MB"
+        if size >= 1024:
+            return f"{size / 1024:.0f}KB"
+        return f"{size}B"
+
+    @staticmethod
+    def _is_previewable_text(filename: str, content_type: str) -> bool:
+        suffix = Path(filename.lower()).suffix
+        return content_type.startswith("text/") or suffix in QQInboundAttachmentPolicy._TEXT_EXTENSIONS
+
+    @staticmethod
+    def _decode_text_bytes(data: bytes, limit: int) -> str:
+        sample = data[:limit]
+        for encoding in ("utf-8", "utf-8-sig", "gb18030", "latin-1"):
+            try:
+                return sample.decode(encoding, errors="replace")
+            except Exception:
+                continue
+        return sample.decode("utf-8", errors="replace")
+
+    @classmethod
+    def _text_preview(cls, data: bytes, limit: int) -> str:
+        text = cls._decode_text_bytes(data, limit).replace("\x00", "")
+        if len(data) > limit:
+            text += "\n...[已截断预览]"
+        return text.strip()
+
+    @classmethod
+    def _html_text_preview(cls, data: bytes, limit: int) -> str:
+        raw = cls._decode_text_bytes(data, limit)
+        raw = re.sub(r"(?is)<(script|style)[^>]*>.*?</\1>", " ", raw)
+        raw = re.sub(r"(?s)<!--.*?-->", " ", raw)
+        raw = re.sub(r"(?s)<[^>]+>", " ", raw)
+        text = html_lib.unescape(raw)
+        text = re.sub(r"[ \t\r\f\v]+", " ", text)
+        text = re.sub(r"\n\s*\n+", "\n", text)
+        if len(data) > limit:
+            text += "\n...[已截断预览]"
+        return text.strip()
+
+    @staticmethod
+    def _archive_summary_lines(filename: str, data: bytes, rule: QQInboundAttachmentRule) -> List[str]:
+        lines = ["压缩包已保存，未自动解压。"]
+        lower = filename.lower()
+        if lower.endswith(".zip"):
+            try:
+                total = 0
+                max_depth = 0
+                with zipfile.ZipFile(io.BytesIO(data)) as zf:
+                    infos = zf.infolist()
+                    for info in infos:
+                        name = info.filename.replace("\\", "/")
+                        if name.startswith("/") or ".." in Path(name).parts:
+                            lines.append("警告: 检测到不安全路径，解压时会拒绝。")
+                            break
+                        max_depth = max(max_depth, len([p for p in name.split("/") if p]))
+                        total += int(info.file_size or 0)
+                    lines.append(f"文件数: {len(infos)}")
+                    lines.append(f"解压后估算: {QQAdapter._format_bytes(total)}")
+                    if len(infos) > rule.extract_max_files:
+                        lines.append(f"警告: 超过文件数限制 {rule.extract_max_files}")
+                    if total > rule.extract_max_total_bytes:
+                        lines.append(f"警告: 超过解压总大小限制 {QQAdapter._format_bytes(rule.extract_max_total_bytes)}")
+                    if max_depth > rule.extract_max_depth:
+                        lines.append(f"警告: 超过目录深度限制 {rule.extract_max_depth}")
+            except zipfile.BadZipFile:
+                lines.append("警告: ZIP 结构无法读取。")
+        else:
+            lines.append("需要你明确说“解压看看”才会进入隔离目录解压。")
+        return lines
+
+    async def _download_and_cache(self, url: str, content_type: str) -> Optional[str]:
+        """Download a URL and cache it locally."""
         from tools.url_safety import is_safe_url
 
         if not is_safe_url(url):
@@ -1779,34 +2222,30 @@ class QQAdapter(BasePlatformAdapter):
             # Convert to .wav using ffmpeg so STT engines can process it.
             return await self._convert_audio_to_wav(data, url)
         else:
-            filename = (
-                original_name
-                or Path(urlparse(url).path).name
-                or "qq_attachment"
-            )
+            filename = Path(urlparse(url).path).name or "qq_attachment"
             return cache_document_from_bytes(data, filename)
 
     @staticmethod
     def _is_voice_content_type(content_type: str, filename: str) -> bool:
-        """Check if an attachment is a voice/audio message."""
+        """Return true for QQ voice-message formats, not ordinary audio files."""
         ct = content_type.strip().lower()
         fn = filename.strip().lower()
-        if ct == "voice" or ct.startswith("audio/"):
+        if ct == "voice" or ct.startswith("voice/"):
             return True
-        _VOICE_EXTENSIONS = (
-            ".silk",
-            ".amr",
-            ".mp3",
-            ".wav",
-            ".ogg",
-            ".m4a",
-            ".aac",
-            ".speex",
-            ".flac",
-        )
-        if any(fn.endswith(ext) for ext in _VOICE_EXTENSIONS):
+        if "silk" in ct or ct in {"audio/amr", "audio/x-amr", "audio/speex"}:
             return True
-        return False
+        return fn.endswith((".silk", ".amr", ".speex"))
+
+    @classmethod
+    def _is_voice_message_attachment(
+            cls,
+            attachment: Dict[str, Any],
+            content_type: str,
+            filename: str,
+    ) -> bool:
+        if attachment.get("asr_refer_text") or attachment.get("voice_wav_url"):
+            return True
+        return cls._is_voice_content_type(content_type, filename)
 
     def _qq_media_headers(self) -> Dict[str, str]:
         """Return Authorization headers for QQ multimedia CDN downloads.
@@ -1828,66 +2267,54 @@ class QQAdapter(BasePlatformAdapter):
             asr_refer_text: Optional[str] = None,
             voice_wav_url: Optional[str] = None,
     ) -> Optional[str]:
-        """Download a voice attachment, convert to wav, and transcribe.
-
-        Priority:
-        1. QQ's built-in ``asr_refer_text`` (Tencent's own ASR — free, no API call).
-        2. Self-hosted STT on ``voice_wav_url`` (pre-converted WAV from QQ, avoids SILK decoding).
-        3. Self-hosted STT on the original attachment URL (requires SILK→WAV conversion).
-
-        Returns the transcript text, or None on failure.
-        """
-        # 1. Use QQ's built-in ASR text if available
+        """Download a voice attachment with hard size limits, then transcribe it."""
+        del content_type
         if asr_refer_text:
             logger.debug(
                 "[%s] STT: using QQ asr_refer_text: %r", self._log_tag, asr_refer_text[:100]
             )
             return asr_refer_text
 
-        # Determine which URL to download (prefer voice_wav_url — already WAV)
         download_url = url
         is_pre_wav = False
         if voice_wav_url:
-            if voice_wav_url.startswith("//"):
-                voice_wav_url = f"https:{voice_wav_url}"
-            download_url = voice_wav_url
+            download_url = f"https:{voice_wav_url}" if voice_wav_url.startswith("//") else voice_wav_url
             is_pre_wav = True
             logger.debug("[%s] STT: using voice_wav_url (pre-converted WAV)", self._log_tag)
 
-        from tools.url_safety import is_safe_url
-        if not is_safe_url(download_url):
-            logger.warning("[QQ] STT blocked unsafe URL: %s", download_url[:80])
-            return None
-
         try:
-            # 2. Download audio (QQ CDN requires Authorization header)
-            if not self._http_client:
-                logger.warning("[%s] STT: no HTTP client", self._log_tag)
-                return None
-
-            download_headers = self._qq_media_headers()
-            logger.debug(
-                "[%s] STT: downloading voice from %s (pre_wav=%s, headers=%s)",
-                self._log_tag,
-                download_url[:80],
-                is_pre_wav,
-                bool(download_headers),
-            )
-            resp = await self._http_client.get(
+            audio_data = await self._download_attachment_bytes(
                 download_url,
-                timeout=30.0,
-                headers=download_headers,
+                QQ_INBOUND_ATTACHMENT_POLICY.MEDIA.max_bytes,
                 follow_redirects=True,
             )
-            resp.raise_for_status()
-            audio_data = resp.content
-            logger.debug(
-                "[%s] STT: downloaded %d bytes, content_type=%s",
+            if audio_data is None:
+                logger.warning(
+                    "[%s] STT: voice download failed or exceeded %s",
+                    self._log_tag,
+                    self._format_bytes(QQ_INBOUND_ATTACHMENT_POLICY.MEDIA.max_bytes),
+                )
+                return None
+            return await self._stt_audio_bytes(audio_data, filename, is_pre_wav=is_pre_wav)
+        except (httpx.HTTPStatusError, httpx.TransportError, IOError, ValueError) as exc:
+            logger.warning(
+                "[%s] STT failed for voice attachment: %s: %s",
                 self._log_tag,
-                len(audio_data),
-                resp.headers.get("content-type", "unknown"),
+                type(exc).__name__,
+                exc,
             )
+            return None
 
+    async def _stt_audio_bytes(
+            self,
+            audio_data: bytes,
+            filename: str,
+            *,
+            is_pre_wav: bool = False,
+    ) -> Optional[str]:
+        """Convert already-downloaded voice bytes to WAV and call the configured STT provider."""
+        try:
+            logger.debug("[%s] STT: downloaded %d bytes", self._log_tag, len(audio_data))
             if len(audio_data) < 10:
                 logger.warning(
                     "[%s] STT: downloaded data too small (%d bytes), skipping",
@@ -1896,7 +2323,6 @@ class QQAdapter(BasePlatformAdapter):
                 )
                 return None
 
-            # 3. Convert to wav (skip if we already have a pre-converted WAV)
             if is_pre_wav:
                 import tempfile
 
@@ -1915,15 +2341,13 @@ class QQAdapter(BasePlatformAdapter):
                 wav_path = await self._convert_audio_to_wav_file(audio_data, filename)
                 if not wav_path or not Path(wav_path).exists():
                     logger.warning(
-                        "[%s] STT: ffmpeg conversion produced no output", self._log_tag
+                        "[%s] STT: conversion produced no output", self._log_tag
                     )
                     return None
 
-            # 4. Call STT API
             logger.debug("[%s] STT: calling ASR on %s", self._log_tag, wav_path)
             transcript = await self._call_stt(wav_path)
 
-            # 5. Cleanup temp file
             try:
                 os.unlink(wav_path)
             except OSError:
@@ -1936,7 +2360,7 @@ class QQAdapter(BasePlatformAdapter):
             return transcript
         except (httpx.HTTPStatusError, httpx.TransportError, IOError) as exc:
             logger.warning(
-                "[%s] STT failed for voice attachment: %s: %s",
+                "[%s] STT failed for voice bytes: %s: %s",
                 self._log_tag,
                 type(exc).__name__,
                 exc,
@@ -2817,6 +3241,13 @@ class QQAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send a file/document natively."""
         del kwargs
+        display_name = file_name or Path(urlparse(file_path).path if self._is_url(file_path) else file_path).name
+        if QQ_INBOUND_ATTACHMENT_POLICY.is_blocked_filename(display_name):
+            return SendResult(
+                success=False,
+                error=f"危险扩展或敏感文件名，已在本地拦截: {display_name}",
+                retryable=False,
+            )
         return await self._send_media(
             chat_id,
             file_path,

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -159,6 +159,8 @@ class QQInboundAttachmentPolicy:
             return self.ARCHIVE
         if suffix in self._AUDIO_EXTENSIONS or suffix in self._VIDEO_EXTENSIONS:
             return self.MEDIA
+        if content_type.startswith("audio/") or content_type.startswith("video/"):
+            return self.MEDIA
         if content_type in {"text/plain", "text/markdown", "text/csv", "text/html"}:
             return self.REGULAR
         if content_type in {"application/pdf", "application/zip"}:

--- a/gateway/platforms/qqbot/multi_adapter.py
+++ b/gateway/platforms/qqbot/multi_adapter.py
@@ -1,0 +1,395 @@
+"""Multi-account QQBot adapter.
+
+Runs multiple official QQ Bot connections under one Hermes ``qqbot`` platform.
+Each child connection owns one app_id/client_secret pair; the parent keeps the
+normal gateway/session semantics and routes outbound messages back through the
+child that received the inbound chat.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from collections.abc import Iterable
+from dataclasses import replace
+from typing import Any, Dict, Optional, Tuple
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, SendResult
+
+from .adapter import QQAdapter
+
+logger = logging.getLogger(__name__)
+
+Credential = Tuple[str, str, str]
+
+
+def _strip(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _indexed_qq_credential_indexes(env: Optional[dict[str, str]] = None) -> list[int]:
+    """Return sorted numeric suffixes for QQ_APP_ID_N / QQ_CLIENT_SECRET_N."""
+    environ = env if env is not None else os.environ
+    indexes: set[int] = set()
+    prefixes = ("QQ_APP_ID_", "QQ_CLIENT_SECRET_")
+    for key in environ:
+        for prefix in prefixes:
+            if key.startswith(prefix):
+                suffix = key[len(prefix):]
+                if suffix.isdigit():
+                    indexes.add(int(suffix))
+    return sorted(indexes)
+
+
+def collect_qq_credentials(config: PlatformConfig) -> list[Credential]:
+    """Collect QQ credentials from config, legacy env, and indexed env pairs.
+
+    Returns ``[(label, app_id, client_secret), ...]``. Secrets are never logged.
+    Duplicate app IDs are skipped; the first occurrence wins.
+    """
+    extra = config.extra or {}
+    credentials: list[Credential] = []
+    seen_app_ids: set[str] = set()
+
+    def add(label: str, app_id: Any, client_secret: Any) -> None:
+        app = _strip(app_id)
+        secret = _strip(client_secret)
+        if not app and not secret:
+            return
+        if not app or not secret:
+            missing = "app_id" if not app else "client_secret"
+            logger.warning("QQBot %s credential ignored: missing %s", label, missing)
+            return
+        if app in seen_app_ids:
+            logger.info("QQBot %s credential ignored: duplicate app_id %s", label, app)
+            return
+        seen_app_ids.add(app)
+        credentials.append((label, app, secret))
+
+    # Config / legacy single-bot env.  Keep first so existing deployments keep
+    # their default outbound route when QQ_APP_ID and QQ_APP_ID_0 both exist.
+    add(
+        "primary",
+        extra.get("app_id") or os.getenv("QQ_APP_ID"),
+        extra.get("client_secret") or os.getenv("QQ_CLIENT_SECRET"),
+    )
+
+    # Optional config-native account lists for future use:
+    # platforms.qqbot.extra.accounts: [{app_id, client_secret, name?}, ...]
+    accounts = extra.get("accounts") or extra.get("bots") or []
+    if isinstance(accounts, Iterable) and not isinstance(accounts, (str, bytes, dict)):
+        for idx, account in enumerate(accounts):
+            if not isinstance(account, dict):
+                continue
+            add(
+                _strip(account.get("name")) or f"config:{idx}",
+                account.get("app_id") or account.get("appId"),
+                account.get("client_secret") or account.get("clientSecret"),
+            )
+
+    # Indexed env pairs: QQ_APP_ID_0 / QQ_CLIENT_SECRET_0, etc.
+    for idx in _indexed_qq_credential_indexes():
+        add(
+            f"env:{idx}",
+            os.getenv(f"QQ_APP_ID_{idx}"),
+            os.getenv(f"QQ_CLIENT_SECRET_{idx}"),
+        )
+
+    return credentials
+
+
+def has_any_qq_credentials(config: PlatformConfig) -> bool:
+    """True when at least one complete QQ credential pair is available."""
+    return bool(collect_qq_credentials(config))
+
+
+def _child_config(base: PlatformConfig, app_id: str, client_secret: str) -> PlatformConfig:
+    extra = dict(base.extra or {})
+    extra["app_id"] = app_id
+    extra["client_secret"] = client_secret
+    return replace(base, extra=extra)
+
+
+class _QQChildAdapter(QQAdapter):
+    """QQAdapter child that forwards normalized inbound events to the parent."""
+
+    def __init__(self, config: PlatformConfig, parent: "QQMultiAdapter", label: str):
+        self._multi_parent = parent
+        self._multi_label = label
+        super().__init__(config)
+
+    @property
+    def name(self) -> str:
+        return f"QQBot[{self._multi_label}]"
+
+    async def handle_message(self, event: MessageEvent) -> None:
+        await self._multi_parent.handle_child_message(self, event)
+
+    def _write_runtime_status_safe(self, context: str, **kwargs) -> None:
+        # Parent owns the aggregate qqbot runtime status.  Child status writes
+        # would race each other on the same platform key and make a partial
+        # failure look like the whole qqbot platform died.
+        del context, kwargs
+
+
+class QQMultiAdapter(BasePlatformAdapter):
+    """One Hermes qqbot adapter backed by multiple QQ bot credentials."""
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, Platform.QQBOT)
+        self._credentials = collect_qq_credentials(config)
+        self._children: list[_QQChildAdapter] = [
+            _QQChildAdapter(_child_config(config, app_id, secret), self, label)
+            for label, app_id, secret in self._credentials
+        ]
+        self._connected_children: list[_QQChildAdapter] = []
+        self._chat_routes: Dict[str, _QQChildAdapter] = {}
+        self._app_routes: Dict[str, _QQChildAdapter] = {
+            _strip(getattr(child, "_app_id", "")): child for child in self._children
+        }
+
+    @property
+    def name(self) -> str:
+        return "QQBotMulti"
+
+    @property
+    def is_connected(self) -> bool:
+        return any(child.is_connected for child in self._children)
+
+    def _default_child(self) -> Optional[_QQChildAdapter]:
+        for child in self._connected_children:
+            if child.is_connected:
+                return child
+        for child in self._children:
+            if child.is_connected:
+                return child
+        return self._children[0] if self._children else None
+
+    def _resolve_child(
+        self,
+        chat_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[_QQChildAdapter]:
+        meta = metadata or {}
+        app_id = _strip(meta.get("qq_app_id") or meta.get("app_id"))
+        if app_id and app_id in self._app_routes:
+            return self._app_routes[app_id]
+        child = self._chat_routes.get(str(chat_id))
+        if child is not None:
+            return child
+        return self._default_child()
+
+    def _remember_route(self, child: _QQChildAdapter, event: MessageEvent) -> None:
+        source = event.source
+        if not source:
+            return
+        if source.chat_id:
+            self._chat_routes[str(source.chat_id)] = child
+        child._chat_type_map[str(source.chat_id)] = self._qq_chat_type_for_source(event)
+        if event.message_id:
+            child._last_msg_id[str(source.chat_id)] = str(event.message_id)
+
+    @staticmethod
+    def _qq_chat_type_for_source(event: MessageEvent) -> str:
+        source = event.source
+        if not source:
+            return "c2c"
+        raw = event.raw_message if isinstance(event.raw_message, dict) else {}
+        if source.chat_type == "group":
+            return "guild" if raw.get("channel_id") else "group"
+        if source.chat_type == "dm" and raw.get("guild_id"):
+            return "dm"
+        return "c2c"
+
+    async def handle_child_message(self, child: _QQChildAdapter, event: MessageEvent) -> None:
+        self._remember_route(child, event)
+        await self.handle_message(event)
+
+    async def connect(self) -> bool:
+        if not self._children:
+            message = (
+                "QQ startup failed: QQ_APP_ID/QQ_CLIENT_SECRET or "
+                "QQ_APP_ID_N/QQ_CLIENT_SECRET_N are required"
+            )
+            self._set_fatal_error("qq_missing_credentials", message, retryable=True)
+            logger.warning("[%s] %s", self.name, message)
+            return False
+
+        self._connected_children.clear()
+        results = await asyncio.gather(
+            *(child.connect() for child in self._children),
+            return_exceptions=True,
+        )
+        failures: list[str] = []
+        for child, result in zip(self._children, results):
+            if result is True and child.is_connected:
+                self._connected_children.append(child)
+                continue
+            if isinstance(result, Exception):
+                failures.append(f"{child.name}: {result}")
+                logger.error("[%s] connect raised: %s", child.name, result, exc_info=True)
+            else:
+                failures.append(
+                    f"{child.name}: {child.fatal_error_message or 'failed to connect'}"
+                )
+
+        if self._connected_children:
+            self._mark_connected()
+            if failures:
+                logger.warning(
+                    "[%s] connected %d/%d QQ bots; failures: %s",
+                    self.name,
+                    len(self._connected_children),
+                    len(self._children),
+                    "; ".join(failures),
+                )
+            else:
+                logger.info("[%s] connected %d QQ bots", self.name, len(self._connected_children))
+            return True
+
+        message = "; ".join(failures) or "no QQ bot connected"
+        retryable = any(child.fatal_error_retryable for child in self._children)
+        self._set_fatal_error("qq_connect_error", message, retryable=retryable)
+        logger.error("[%s] %s", self.name, message)
+        return False
+
+    async def disconnect(self) -> None:
+        self._running = False
+        await self.cancel_background_tasks()
+        await asyncio.gather(
+            *(child.disconnect() for child in self._children),
+            return_exceptions=True,
+        )
+        self._connected_children.clear()
+        self._chat_routes.clear()
+        self._mark_disconnected()
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        child = self._resolve_child(chat_id, metadata)
+        if child is None:
+            return SendResult(success=False, error="No QQ bot credentials configured", retryable=True)
+        return await child.send(chat_id, content, reply_to=reply_to, metadata=metadata)
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        child = self._resolve_child(chat_id, metadata)
+        if child is not None and hasattr(child, "send_typing"):
+            await child.send_typing(chat_id, metadata=metadata)
+
+    async def send_image(
+        self,
+        chat_id: str,
+        image_url: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        child = self._resolve_child(chat_id, metadata)
+        if child is None:
+            return SendResult(success=False, error="No QQ bot credentials configured", retryable=True)
+        return await child.send_image(chat_id, image_url, caption=caption, reply_to=reply_to, metadata=metadata)
+
+    async def send_image_file(
+        self,
+        chat_id: str,
+        image_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        child = self._resolve_child(chat_id, kwargs.get("metadata"))
+        if child is None:
+            return SendResult(success=False, error="No QQ bot credentials configured", retryable=True)
+        return await child.send_image_file(chat_id, image_path, caption=caption, reply_to=reply_to, **kwargs)
+
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        child = self._resolve_child(chat_id, kwargs.get("metadata"))
+        if child is None:
+            return SendResult(success=False, error="No QQ bot credentials configured", retryable=True)
+        return await child.send_voice(chat_id, audio_path, caption=caption, reply_to=reply_to, **kwargs)
+
+    async def send_video(
+        self,
+        chat_id: str,
+        video_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        child = self._resolve_child(chat_id, kwargs.get("metadata"))
+        if child is None:
+            return SendResult(success=False, error="No QQ bot credentials configured", retryable=True)
+        return await child.send_video(chat_id, video_path, caption=caption, reply_to=reply_to, **kwargs)
+
+    async def send_document(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        child = self._resolve_child(chat_id, kwargs.get("metadata"))
+        if child is None:
+            return SendResult(success=False, error="No QQ bot credentials configured", retryable=True)
+        return await child.send_document(
+            chat_id,
+            file_path,
+            caption=caption,
+            file_name=file_name,
+            reply_to=reply_to,
+            **kwargs,
+        )
+
+    async def send_exec_approval(
+        self,
+        chat_id: str,
+        command: str,
+        session_key: str,
+        description: str = "dangerous command",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        child = self._resolve_child(chat_id, metadata)
+        if child is None:
+            return SendResult(success=False, error="No QQ bot credentials configured", retryable=True)
+        return await child.send_exec_approval(chat_id, command, session_key, description, metadata=metadata)
+
+    async def send_update_prompt(
+        self,
+        chat_id: str,
+        prompt: str,
+        default: str = "",
+        session_key: str = "",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        child = self._resolve_child(chat_id, metadata)
+        if child is None:
+            return SendResult(success=False, error="No QQ bot credentials configured", retryable=True)
+        return await child.send_update_prompt(chat_id, prompt, default, session_key, metadata=metadata)
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        child = self._resolve_child(chat_id)
+        if child is None:
+            return {"name": chat_id, "type": "dm"}
+        return await child.get_chat_info(chat_id)
+
+    def format_message(self, content: str) -> str:
+        child = self._default_child()
+        if child is None:
+            return content
+        return child.format_message(content)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1210,23 +1210,9 @@ class TelegramAdapter(BasePlatformAdapter):
                         break
 
             if changed:
-                fd, tmp_path = tempfile.mkstemp(
-                    dir=str(config_path.parent),
-                    suffix=".tmp",
-                    prefix=".config_",
-                )
-                try:
-                    with os.fdopen(fd, "w", encoding="utf-8") as f:
-                        _yaml.dump(config, f, default_flow_style=False, sort_keys=False)
-                        f.flush()
-                        os.fsync(f.fileno())
-                    atomic_replace(tmp_path, config_path)
-                except BaseException:
-                    try:
-                        os.unlink(tmp_path)
-                    except OSError:
-                        pass
-                    raise
+                from utils import atomic_yaml_write
+
+                atomic_yaml_write(config_path, config, sort_keys=False)
                 logger.info(
                     "[%s] Persisted thread_id=%s for topic '%s' in config.yaml",
                     self.name, thread_id, topic_name,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -139,6 +139,251 @@ def _gateway_platform_value(platform: Any) -> str:
     return str(getattr(platform, "value", platform) or "").strip().lower()
 
 
+def _gateway_prefers_chinese(platform: Any) -> bool:
+    """Return True for chat platforms whose Hermes system copy should be Chinese."""
+    return _gateway_platform_value(platform) == "qqbot"
+
+
+def _localize_gateway_error_detail_zh(text: str) -> str:
+    """Translate known Hermes-owned error detail fragments for QQ.
+
+    Keep API/function names intact, but localize the English runtime prose so
+    QQ users do not see raw Hermes status copy for common failures.
+    """
+    body = str(text or "").strip()
+    body = re.sub(
+        r"Responses create\(stream=True\) fallback did not emit a terminal response\.?",
+        "Responses create(stream=True) fallback 未产生终止响应。",
+        body,
+        flags=re.IGNORECASE,
+    )
+    return body
+
+
+def _localize_stream_stalled_tool_call_zh(text: str) -> Optional[str]:
+    """Localize the Hermes dropped tool-call warning for Chinese-first chats."""
+    body = str(text or "").strip()
+    match = re.match(
+        r"^⚠\s*Stream stalled mid tool-call \((?P<tool>[^)]+)\); "
+        r"the action was not executed\. Ask me to retry if you want to continue\.?$",
+        body,
+        re.IGNORECASE,
+    )
+    if not match:
+        return None
+    return f"⚠ 流式响应在工具调用中途停住（{match.group('tool')}）；操作未执行。需要继续的话，请让我重试。"
+
+
+def _localize_gateway_status_zh(text: str) -> str:
+    """Translate common Hermes runtime status chatter for Chinese-first chats.
+
+    This intentionally handles static Hermes status envelopes only. Provider
+    names, commands, paths, and raw error identifiers remain untouched.
+    """
+    body = str(text or "").strip()
+
+    retry_match = re.match(
+        r"^⏳\s*Retrying in (?P<wait>\d+(?:\.\d+)?)s "
+        r"\(attempt (?P<attempt>\d+)/(?:\s*)?(?P<max>\d+)\)\.\.\.$",
+        body,
+        re.IGNORECASE,
+    )
+    if retry_match:
+        return (
+            f"⏳ {retry_match.group('wait')} 秒后重试"
+            f"（第 {retry_match.group('attempt')}/{retry_match.group('max')} 次）..."
+        )
+
+    rate_limit_match = re.match(
+        r"^⏱️\s*Rate limited\. Waiting (?P<wait>\d+(?:\.\d+)?)s "
+        r"\(attempt (?P<attempt>\d+)/(?:\s*)?(?P<max>\d+)\)\.\.\.$",
+        body,
+        re.IGNORECASE,
+    )
+    if rate_limit_match:
+        return (
+            f"⏱️ 被限流，{rate_limit_match.group('wait')} 秒后重试"
+            f"（第 {rate_limit_match.group('attempt')}/{rate_limit_match.group('max')} 次）..."
+        )
+
+    max_retry_match = re.match(
+        r"^⚠️\s*Max retries \((?P<count>\d+)\) "
+        r"(?P<tail>exhausted|for invalid responses) — trying fallback\.\.\.$",
+        body,
+        re.IGNORECASE,
+    )
+    if max_retry_match:
+        count = max_retry_match.group("count")
+        if "invalid" in max_retry_match.group("tail").lower():
+            return f"⚠️ 无效响应已重试 {count} 次，正在尝试备用模型..."
+        return f"⚠️ 已重试 {count} 次仍失败，正在尝试备用模型..."
+
+    max_retry_exceeded = re.match(
+        r"^❌\s*Max retries \((?P<count>\d+)\) exceeded for invalid responses\. Giving up\.$",
+        body,
+        re.IGNORECASE,
+    )
+    if max_retry_exceeded:
+        return f"❌ 无效响应已重试 {max_retry_exceeded.group('count')} 次，停止尝试。"
+
+    static_map = {
+        "⚠️ Empty/malformed response — switching to fallback...": "⚠️ 模型返回空或格式异常，正在切换到备用模型...",
+        "⚠️ Rate limited — switching to fallback provider...": "⚠️ 已被限流，正在切换到备用提供商...",
+        "↻ Stream interrupted — using delivered content as final response": "↻ 流式响应中断，改用已发送内容作为最终回复",
+        "↻ Empty response after tool calls — using earlier content as final answer": "↻ 工具调用后模型返回空内容，改用较早内容作为最终回复",
+        "⚠️ Model returned empty after tool calls — nudging to continue": "⚠️ 工具调用后模型返回空内容，正在提示模型继续",
+        "⚠️ Model returning empty responses — switching to fallback provider...": "⚠️ 模型持续返回空内容，正在切换到备用提供商...",
+        "⚠️ Model produced reasoning but no visible response after all retries. Returning empty.": "⚠️ 模型多次重试后仍只返回思考内容，没有可见回复。将返回空结果。",
+        "❌ Model returned no content after all retries. No fallback providers configured.": "❌ 多次重试后模型仍无内容，且未配置备用提供商。",
+        "❌ Model returned no content after all retries and fallback attempts.": "❌ 多次重试和备用模型尝试后，模型仍无内容。",
+    }
+    if body in static_map:
+        return static_map[body]
+
+    auxiliary_match = re.match(
+        r"^⚠\s*Auxiliary (?P<task>.+?) failed: (?P<detail>.*)$",
+        body,
+        re.IGNORECASE,
+    )
+    if auxiliary_match:
+        return f"⚠ 辅助任务 {auxiliary_match.group('task')} 失败：{auxiliary_match.group('detail')}"
+
+    payload_match = re.match(
+        r"^⚠️\s*Request payload too large \(413\) — compression attempt "
+        r"(?P<attempt>\d+)/(?:\s*)?(?P<max>\d+)\.\.\.$",
+        body,
+        re.IGNORECASE,
+    )
+    if payload_match:
+        return (
+            "⚠️ 请求内容过大 (413)，正在压缩"
+            f"（第 {payload_match.group('attempt')}/{payload_match.group('max')} 次）..."
+        )
+
+    context_large_match = re.match(
+        r"^🗜️\s*Context too large \(~(?P<tokens>[\d,]+) tokens\) — compressing "
+        r"\((?P<attempt>\d+)/(?:\s*)?(?P<max>\d+)\)\.\.\.$",
+        body,
+        re.IGNORECASE,
+    )
+    if context_large_match:
+        return (
+            f"🗜️ 上下文过大（约 {context_large_match.group('tokens')} tokens），正在压缩"
+            f"（第 {context_large_match.group('attempt')}/{context_large_match.group('max')} 次）..."
+        )
+
+    context_reduced_match = re.match(
+        r"^🗜️\s*Context reduced to (?P<new>[\d,]+) tokens "
+        r"\(was (?P<old>[\d,]+)\), retrying\.\.\.$",
+        body,
+        re.IGNORECASE,
+    )
+    if context_reduced_match:
+        return (
+            f"🗜️ 上下文已降到 {context_reduced_match.group('new')} tokens"
+            f"（原 {context_reduced_match.group('old')}），正在重试..."
+        )
+
+    compressed_match = re.match(
+        r"^🗜️\s*Compressed (?P<old>\d+) → (?P<new>\d+) messages, retrying\.\.\.$",
+        body,
+        re.IGNORECASE,
+    )
+    if compressed_match:
+        return (
+            f"🗜️ 已压缩 {compressed_match.group('old')} → "
+            f"{compressed_match.group('new')} 条消息，正在重试..."
+        )
+
+    non_retryable_fallback_match = re.match(
+        r"^⚠️\s*Non-retryable error \(HTTP (?P<code>[^)]+)\) — trying fallback\.\.\.$",
+        body,
+        re.IGNORECASE,
+    )
+    if non_retryable_fallback_match:
+        return f"⚠️ 不可重试错误 (HTTP {non_retryable_fallback_match.group('code')})，正在尝试备用模型..."
+
+    non_retryable_final_match = re.match(
+        r"^❌\s*Non-retryable error \(HTTP (?P<code>[^)]+)\): (?P<detail>.+)$",
+        body,
+        re.IGNORECASE,
+    )
+    if non_retryable_final_match:
+        return f"❌ 不可重试错误 (HTTP {non_retryable_final_match.group('code')})：{non_retryable_final_match.group('detail')}"
+
+    rate_limit_final_match = re.match(
+        r"^❌\s*Rate limited after (?P<count>\d+) retries — (?P<detail>.+)$",
+        body,
+        re.IGNORECASE,
+    )
+    if rate_limit_final_match:
+        detail = _localize_gateway_error_detail_zh(rate_limit_final_match.group("detail"))
+        return f"❌ 重试 {rate_limit_final_match.group('count')} 次后仍被限流 — {detail}"
+
+    api_failed_final_match = re.match(
+        r"^❌\s*API failed after (?P<count>\d+) retries — (?P<detail>.+)$",
+        body,
+        re.IGNORECASE,
+    )
+    if api_failed_final_match:
+        detail = _localize_gateway_error_detail_zh(api_failed_final_match.group("detail"))
+        return f"❌ API 重试 {api_failed_final_match.group('count')} 次后仍失败 — {detail}"
+
+    thinking_prefill_match = re.match(
+        r"^↻\s*Thinking-only response — prefilling to continue "
+        r"\((?P<attempt>\d+)/(?:\s*)?(?P<max>\d+)\)$",
+        body,
+        re.IGNORECASE,
+    )
+    if thinking_prefill_match:
+        return (
+            "↻ 模型只返回思考内容，正在预填继续"
+            f"（第 {thinking_prefill_match.group('attempt')}/{thinking_prefill_match.group('max')} 次）"
+        )
+
+    empty_retry_match = re.match(
+        r"^⚠️\s*Empty response from model — retrying "
+        r"\((?P<attempt>\d+)/(?:\s*)?(?P<max>\d+)\)$",
+        body,
+        re.IGNORECASE,
+    )
+    if empty_retry_match:
+        return (
+            "⚠️ 模型返回空内容，正在重试"
+            f"（第 {empty_retry_match.group('attempt')}/{empty_retry_match.group('max')} 次）"
+        )
+
+    fallback_switch_match = re.match(
+        r"^↻\s*Switched to fallback: (?P<model>.+)$",
+        body,
+        re.IGNORECASE,
+    )
+    if fallback_switch_match:
+        return f"↻ 已切换到备用模型：{fallback_switch_match.group('model')}"
+
+    iteration_budget_match = re.match(
+        r"^⚠️\s*Iteration budget exhausted \((?P<used>\d+)/(?:\s*)?(?P<max>\d+)\) "
+        r"— asking model to summarise$",
+        body,
+        re.IGNORECASE,
+    )
+    if iteration_budget_match:
+        return (
+            f"⚠️ 轮次预算已用尽（{iteration_budget_match.group('used')}/"
+            f"{iteration_budget_match.group('max')}），正在请求模型总结"
+        )
+
+    guardrail_match = re.match(
+        r"^⚠️\s*Tool guardrail halted (?P<tool>[^:]+): (?P<code>.+)$",
+        body,
+        re.IGNORECASE,
+    )
+    if guardrail_match:
+        return f"⚠️ 工具保护规则已暂停 {guardrail_match.group('tool')}：{guardrail_match.group('code')}"
+
+    return body
+
+
 def _redact_gateway_user_facing_secrets(text: str) -> str:
     """Best-effort secret redaction before text can leave the gateway."""
     redacted = str(text or "")
@@ -147,8 +392,17 @@ def _redact_gateway_user_facing_secrets(text: str) -> str:
     return redacted
 
 
-def _gateway_provider_error_reply(text: str) -> str:
-    """Map raw provider/API errors to a short user-safe Telegram reply."""
+def _gateway_provider_error_reply(text: str, *, lang: str = "en") -> str:
+    """Map raw provider/API errors to a short user-safe gateway reply."""
+    if lang == "zh":
+        if _GATEWAY_AUTH_ERROR_RE.search(text):
+            return "⚠️ 模型凭证认证失败。请检查已配置的凭证；原始提供商细节已写入 gateway logs。"
+        if _GATEWAY_PROVIDER_POLICY_RE.search(text):
+            return "⚠️ 模型提供商拒绝了这次请求。原始错误未发送到聊天；可查看 gateway logs 或换种说法重试。"
+        if _GATEWAY_RATE_LIMIT_RE.search(text):
+            return "⏱️ 模型提供商正在限流。请稍等再试。"
+        return "⚠️ 模型提供商多次重试后仍失败。原始细节未发送到聊天；可查看 gateway logs。"
+
     if _GATEWAY_AUTH_ERROR_RE.search(text):
         return (
             "⚠️ Provider authentication failed. Check the configured credentials; "
@@ -208,16 +462,31 @@ def _looks_like_gateway_provider_error(text: str) -> bool:
 def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
     """Sanitize final gateway replies before sending them to high-noise chats.
 
-    Telegram is Bob's mobile inbox, so it should receive concise, safe provider
-    failure categories instead of raw HTTP bodies, request IDs, or policy text.
-    Other platforms keep the existing behaviour for now.
+    Telegram keeps the existing English safety copy. QQ gets the same safety
+    shielding but localized to Chinese for Hermes-owned system messages.
     """
     if not text:
         return text
-    if _gateway_platform_value(platform) != "telegram":
+    platform_value = _gateway_platform_value(platform)
+    if platform_value not in {"telegram", "qqbot"}:
         return text
 
     redacted = _redact_gateway_user_facing_secrets(str(text))
+    if _gateway_prefers_chinese(platform):
+        empty_model_reply = (
+            "⚠️ The model returned no response after processing tool "
+            "results. This can happen with some models — try again or "
+            "rephrase your question."
+        )
+        if redacted == empty_model_reply:
+            return "⚠️ 模型处理完工具结果后没有返回内容。部分模型会这样；请重试或换种说法。"
+        stream_stalled = _localize_stream_stalled_tool_call_zh(redacted)
+        if stream_stalled:
+            return stream_stalled
+        if _looks_like_gateway_provider_error(redacted):
+            return _gateway_provider_error_reply(redacted, lang="zh")
+        return redacted
+
     if _looks_like_gateway_provider_error(redacted):
         return _gateway_provider_error_reply(redacted)
     return redacted
@@ -228,6 +497,15 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
     text = str(message or "").strip()
     if not text:
         return None
+    if _gateway_prefers_chinese(platform):
+        text = _redact_gateway_user_facing_secrets(text)
+        stream_stalled = _localize_stream_stalled_tool_call_zh(text)
+        if stream_stalled:
+            return stream_stalled
+        text = _localize_gateway_status_zh(text)
+        if _looks_like_gateway_provider_error(text):
+            return _gateway_provider_error_reply(text, lang="zh")
+        return text
     if _gateway_platform_value(platform) != "telegram":
         return text
 
@@ -2467,6 +2745,12 @@ class GatewayRunner:
     def _status_action_gerund(self) -> str:
         return "restarting" if self._restart_requested else "shutting down"
 
+    def _status_action_zh(self) -> str:
+        return "重启" if self._restart_requested else "关闭"
+
+    def _status_action_gerund_zh(self) -> str:
+        return "重启中" if self._restart_requested else "关闭中"
+
     def _queue_during_drain_enabled(self) -> bool:
         # Both "queue" and "steer" modes imply the user doesn't want messages
         # to be lost during restart — queue them for the newly-spawned gateway
@@ -2988,9 +3272,9 @@ class GatewayRunner:
             thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
             if self._queue_during_drain_enabled():
                 self._queue_or_replace_pending_event(session_key, event)
-                message = f"⏳ Gateway {self._status_action_gerund()} — queued for the next turn after it comes back."
+                message = f"⏳ Gateway 正在{self._status_action_zh()}，已排队到恢复后的下一轮。"
             else:
-                message = f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
+                message = f"⏳ Gateway 正在{self._status_action_zh()}，暂时不接受新的任务。"
 
             await adapter._send_with_retry(
                 chat_id=event.source.chat_id,
@@ -3099,29 +3383,29 @@ class GatewayRunner:
                 if start_ts:
                     elapsed_min = int((now - start_ts) / 60)
                     if elapsed_min > 0:
-                        status_parts.append(f"{elapsed_min} min elapsed")
+                        status_parts.append(f"已运行 {elapsed_min} 分钟")
                 if max_iter:
-                    status_parts.append(f"iteration {iteration}/{max_iter}")
+                    status_parts.append(f"轮次 {iteration}/{max_iter}")
                 if current_tool:
-                    status_parts.append(f"running: {current_tool}")
+                    status_parts.append(f"正在运行：{current_tool}")
             except Exception:
                 pass
 
-        status_detail = f" ({', '.join(status_parts)})" if status_parts else ""
+        status_detail = f"（{'，'.join(status_parts)}）" if status_parts else ""
         if is_steer_mode:
             message = (
-                f"⏩ Steered into current run{status_detail}. "
-                f"Your message arrives after the next tool call."
+                f"⏩ 已插入当前任务{status_detail}。"
+                f"你的消息会在下一个工具调用后进入。"
             )
         elif is_queue_mode:
             message = (
-                f"⏳ Queued for the next turn{status_detail}. "
-                f"I'll respond once the current task finishes."
+                f"⏳ 已排队到下一轮{status_detail}。"
+                f"当前任务结束后我会回复。"
             )
         else:
             message = (
-                f"⚡ Interrupting current task{status_detail}. "
-                f"I'll respond to your message shortly."
+                f"⚡ 正在中断当前任务{status_detail}。"
+                f"马上处理你的消息。"
             )
 
         # First-touch onboarding: the very first time a user sends a message
@@ -3220,14 +3504,13 @@ class GatewayRunner:
         """
         active = self._snapshot_running_agents()
 
-        action = "restarting" if self._restart_requested else "shutting down"
+        action = "重启" if self._restart_requested else "关闭"
         hint = (
-            "Your current task will be interrupted. "
-            "Send any message after restart and I'll try to resume where you left off."
+            "当前任务会被中断。重启后发任意消息，我会尽量从断点继续。"
             if self._restart_requested
-            else "Your current task will be interrupted."
+            else "当前任务会被中断。"
         )
-        msg = f"⚠️ Gateway {action} — {hint}"
+        msg = f"⚠️ Gateway 正在{action} — {hint}"
 
         notified: set[tuple[str, str, Optional[str]]] = set()
         for session_key in active:
@@ -6966,7 +7249,7 @@ class GatewayRunner:
             if event.get_command() in {"queue", "q"}:
                 queued_text = event.get_command_args().strip()
                 if not queued_text:
-                    return "Usage: /queue <prompt>"
+                    return "用法：/queue <prompt>"
                 adapter = self.adapters.get(source.platform)
                 if adapter:
                     queued_event = MessageEvent(
@@ -6979,8 +7262,8 @@ class GatewayRunner:
                     self._enqueue_fifo(_quick_key, queued_event, adapter)
                 depth = self._queue_depth(_quick_key, adapter=self.adapters.get(source.platform))
                 if depth <= 1:
-                    return "Queued for the next turn."
-                return f"Queued for the next turn. ({depth} queued)"
+                    return "已排队到下一轮。"
+                return f"已排队到下一轮。（当前队列 {depth} 条）"
 
             # /steer <prompt> — inject mid-run after the next tool call.
             # Unlike /queue (turn boundary), /steer lands BETWEEN tool-call
@@ -6990,7 +7273,7 @@ class GatewayRunner:
             if _cmd_def_inner and _cmd_def_inner.name == "steer":
                 steer_text = event.get_command_args().strip()
                 if not steer_text:
-                    return "Usage: /steer <prompt>"
+                    return "用法：/steer <prompt>"
                 running_agent = self._running_agents.get(_quick_key)
                 if running_agent is _AGENT_PENDING_SENTINEL:
                     # Agent hasn't started yet — queue as turn-boundary fallback.
@@ -7004,17 +7287,17 @@ class GatewayRunner:
                             channel_prompt=event.channel_prompt,
                         )
                         adapter._pending_messages[_quick_key] = queued_event
-                    return "Agent still starting — /steer queued for the next turn."
+                    return "任务仍在启动中，/steer 已改为排队到下一轮。"
                 if running_agent and hasattr(running_agent, "steer"):
                     try:
                         accepted = running_agent.steer(steer_text)
                     except Exception as exc:
                         logger.warning("Steer failed for session %s: %s", _quick_key, exc)
-                        return f"⚠️ Steer failed: {exc}"
+                        return f"⚠️ /steer 失败：{exc}"
                     if accepted:
                         preview = steer_text[:60] + ("..." if len(steer_text) > 60 else "")
-                        return f"⏩ Steer queued — arrives after the next tool call: '{preview}'"
-                    return "Steer rejected (empty payload)."
+                        return f"⏩ 已插入当前任务：会在下一个工具调用后进入：'{preview}'"
+                    return "/steer 被拒绝：内容为空。"
                 # Running agent is missing or lacks steer() — fall back to queue.
                 adapter = self.adapters.get(source.platform)
                 if adapter:
@@ -7026,17 +7309,16 @@ class GatewayRunner:
                         channel_prompt=event.channel_prompt,
                     )
                     adapter._pending_messages[_quick_key] = queued_event
-                return "No active agent — /steer queued for the next turn."
+                return "没有活跃任务，/steer 已改为排队到下一轮。"
 
             # /model must not be used while the agent is running.
             if _cmd_def_inner and _cmd_def_inner.name == "model":
-                return "Agent is running — wait or /stop first, then switch models."
+                return "任务正在运行。请等待完成，或先发送 /stop，再切换模型。"
 
             # /codex-runtime must not be used while the agent is running.
             # Switching mid-turn would split a turn across two transports.
             if _cmd_def_inner and _cmd_def_inner.name == "codex-runtime":
-                return ("Agent is running — wait or /stop first, then "
-                        "change runtime.")
+                return "任务正在运行。请等待完成，或先发送 /stop，再切换 runtime。"
 
             # /approve and /deny must bypass the running-agent interrupt path.
             # The agent thread is blocked on a threading.Event inside
@@ -7075,7 +7357,7 @@ class GatewayRunner:
                 _goal_arg = (event.get_command_args() or "").strip().lower()
                 if not _goal_arg or _goal_arg in {"status", "pause", "resume", "clear", "stop", "done"}:
                     return await self._handle_goal_command(event)
-                return "Agent is running — use /goal status / pause / clear mid-run, or /stop before setting a new goal."
+                return "任务正在运行。可用 /goal status / pause / clear 在任务中途查看或控制；设置新目标前请先 /stop。"
 
             # /subgoal is safe mid-run — it only modifies the goal's
             # subgoals list, which the judge reads at the next turn
@@ -7122,8 +7404,8 @@ class GatewayRunner:
             # producing a zero-char response. See #5057, #6252, #10370.
             if _cmd_def_inner:
                 return (
-                    f"⏳ Agent is running — `/{_cmd_def_inner.name}` can't run "
-                    f"mid-turn. Wait for the current response or `/stop` first."
+                    f"⏳ 任务正在运行，`/{_cmd_def_inner.name}` 不能中途执行。"
+                    f"请等当前回复完成，或先发送 `/stop`。"
                 )
 
             if event.message_type == MessageType.PHOTO:
@@ -7166,7 +7448,7 @@ class GatewayRunner:
                     # Force-clean the sentinel so the session is unlocked.
                     self._release_running_agent_state(_quick_key)
                     logger.info("HARD STOP (pending) for session %s — sentinel cleared", _quick_key)
-                    return EphemeralReply("⚡ Force-stopped. The agent was still starting — session unlocked.")
+                    return EphemeralReply("⚡ 已强制停止。任务仍在启动中，当前会话已解锁。")
                 # Queue the message so it will be picked up after the
                 # agent starts.
                 adapter = self.adapters.get(source.platform)
@@ -7182,9 +7464,9 @@ class GatewayRunner:
                 if self._queue_during_drain_enabled():
                     self._queue_or_replace_pending_event(_quick_key, event)
                 return (
-                    f"⏳ Gateway {self._status_action_gerund()} — queued for the next turn after it comes back."
+                    f"⏳ Gateway 正在{self._status_action_zh()}，已排队到恢复后的下一轮。"
                     if self._queue_during_drain_enabled()
-                    else f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
+                    else f"⏳ Gateway 正在{self._status_action_zh()}，暂时不接受新的任务。"
                 )
             if self._busy_input_mode == "queue":
                 logger.debug("PRIORITY queue follow-up for session %s", _quick_key)
@@ -7327,8 +7609,7 @@ class GatewayRunner:
                 command="new",
                 title="/new",
                 detail=(
-                    "This starts a fresh session and discards the current "
-                    "conversation history."
+                    "这会开始一个新会话，并丢弃当前 conversation history。"
                 ),
                 execute=_do_reset,
             )
@@ -7477,7 +7758,7 @@ class GatewayRunner:
             return await self._handle_voice_command(event)
 
         if self._draining:
-            return f"⏳ Gateway is {self._status_action_gerund()} and is not accepting new work right now."
+            return f"⏳ Gateway 正在{self._status_action_zh()}，暂时不接受新的任务。"
 
         # User-defined quick commands (bypass agent loop, no LLM call)
         if command:
@@ -13412,9 +13693,9 @@ class GatewayRunner:
             result = await execute()
             if choice == "always":
                 note = (
-                    "\n\nℹ️ Future /clear, /new, /reset, and /undo will run "
-                    "without confirmation. Re-enable via "
-                    "`approvals.destructive_slash_confirm: true` in config.yaml."
+                    "\n\nℹ️ 今后 /clear、/new、/reset、/undo 将不再确认。"
+                    "要重新启用，请在 config.yaml 设置 "
+                    "`approvals.destructive_slash_confirm: true`。"
                 )
                 if isinstance(result, str):
                     return result + note
@@ -13425,13 +13706,13 @@ class GatewayRunner:
             return result
 
         prompt_message = (
-            f"⚠️ **Confirm /{command}**\n\n"
+            f"⚠️ **确认 /{command}**\n\n"
             f"{detail}\n\n"
-            "Choose:\n"
-            "• **Approve Once** — proceed this time only\n"
-            "• **Always Approve** — proceed and silence this prompt permanently\n"
-            "• **Cancel** — keep current conversation\n\n"
-            "_Text fallback: reply `/approve`, `/always`, or `/cancel`._"
+            "请选择：\n"
+            "• **批准一次** — 仅本次继续\n"
+            "• **始终批准** — 继续，并永久关闭此确认提示\n"
+            "• **取消** — 保留当前会话\n\n"
+            "_文本备用：回复 `/approve`、`/always` 或 `/cancel`。_"
         )
         return await self._request_slash_confirm(
             event=event,
@@ -16802,27 +17083,24 @@ class GatewayRunner:
             if _is_resume_pending:
                 _reason = getattr(_resume_entry, "resume_reason", None) or "restart_timeout"
                 _reason_phrase = (
-                    "a gateway restart"
+                    "Gateway 重启"
                     if _reason == "restart_timeout"
-                    else "a gateway shutdown"
+                    else "Gateway 关闭"
                     if _reason == "shutdown_timeout"
-                    else "a gateway interruption"
+                    else "Gateway 中断"
                 )
                 message = (
-                    f"[System note: Your previous turn in this session was interrupted "
-                    f"by {_reason_phrase}. The conversation history below is intact. "
-                    f"If it contains unfinished tool result(s), process them first and "
-                    f"summarize what was accomplished, then address the user's new "
-                    f"message below.]\n\n"
+                    f"[系统提示：本会话上一轮被 {_reason_phrase} 中断。"
+                    f"下面的 conversation history 保持完整。"
+                    f"如果里面有未完成的 tool result(s)，请先处理并总结已完成内容，"
+                    f"再处理下面用户的新消息。]\n\n"
                     + message
                 )
             elif _has_fresh_tool_tail:
                 message = (
-                    "[System note: Your previous turn was interrupted before you could "
-                    "process the last tool result(s). The conversation history contains "
-                    "tool outputs you haven't responded to yet. Please finish processing "
-                    "those results and summarize what was accomplished, then address the "
-                    "user's new message below.]\n\n"
+                    "[系统提示：上一轮在处理最后的 tool result(s) 前被中断。"
+                    "conversation history 里还有尚未回复的 tool outputs。"
+                    "请先处理这些结果并总结已完成内容，再处理下面用户的新消息。]\n\n"
                     + message
                 )
 
@@ -17219,18 +17497,27 @@ class GatewayRunner:
                 if _agent_ref and hasattr(_agent_ref, "get_activity_summary"):
                     try:
                         _a = _agent_ref.get_activity_summary()
-                        _parts = [f"iteration {_a['api_call_count']}/{_a['max_iterations']}"]
+                        _parts = [f"第 {_a['api_call_count']}/{_a['max_iterations']} 轮"]
                         if _a.get("current_tool"):
-                            _parts.append(f"running: {_a['current_tool']}")
+                            _parts.append(f"正在运行: {_a['current_tool']}")
                         else:
-                            _parts.append(_a.get("last_activity_desc", ""))
+                            _desc = _a.get("last_activity_desc", "")
+                            if _desc == "waiting for non-streaming API response":
+                                _desc = "等待非流式 API 响应"
+                            elif _desc.startswith("waiting for non-streaming response"):
+                                _desc = _desc.replace(
+                                    "waiting for non-streaming response",
+                                    "等待非流式响应",
+                                    1,
+                                ).replace("elapsed", "已等待")
+                            _parts.append(_desc)
                         _status_detail = " — " + ", ".join(_parts)
                     except Exception:
                         pass
                 try:
                     _notify_res = await _notify_adapter.send(
                         source.chat_id,
-                        f"⏳ Still working... ({_elapsed_mins} min elapsed{_status_detail})",
+                        f"⏳ 还在处理...（已等待 {_elapsed_mins} 分钟{_status_detail}）",
                         metadata=_status_thread_metadata,
                     )
                     if (
@@ -17327,10 +17614,9 @@ class GatewayRunner:
                             try:
                                 await _warn_adapter.send(
                                     source.chat_id,
-                                    f"⚠️ No activity for {_elapsed_warn} min. "
-                                    f"If the agent does not respond soon, it will "
-                                    f"be timed out in {_remaining_mins} min. "
-                                    f"You can continue waiting or use /reset.",
+                                    f"⚠️ 已 {_elapsed_warn} 分钟无活动。"
+                                    f"如果 Agent 很快仍无响应，将在 {_remaining_mins} 分钟后超时。"
+                                    f"你可以继续等待，或使用 /reset。",
                                     metadata=_status_thread_metadata,
                                 )
                             except Exception as _warn_err:
@@ -17389,25 +17675,27 @@ class GatewayRunner:
 
                 # Construct a user-facing message with diagnostic context.
                 _diag_lines = [
-                    f"⏱️ Agent inactive for {_timeout_mins} min — no tool calls "
-                    f"or API responses."
+                    f"⏱️ Agent 已连续 {_timeout_mins} 分钟无活动："
+                    f"没有 tool call 或 API 响应。"
                 ]
                 if _cur_tool:
                     _diag_lines.append(
-                        f"The agent appears stuck on tool `{_cur_tool}` "
-                        f"({_secs_ago:.0f}s since last activity, "
-                        f"iteration {_iter_n}/{_iter_max})."
+                        f"看起来卡在工具 `{_cur_tool}` 上"
+                        f"（距上次活动 {_secs_ago:.0f} 秒，"
+                        f"第 {_iter_n}/{_iter_max} 轮）。"
                     )
                 else:
+                    if _last_desc == "waiting for non-streaming API response":
+                        _last_desc = "等待非流式 API 响应"
                     _diag_lines.append(
-                        f"Last activity: {_last_desc} ({_secs_ago:.0f}s ago, "
-                        f"iteration {_iter_n}/{_iter_max}). "
-                        "The agent may have been waiting on an API response."
+                        f"上次活动：{_last_desc}（{_secs_ago:.0f} 秒前，"
+                        f"第 {_iter_n}/{_iter_max} 轮）。"
+                        "可能仍在等待 API 响应。"
                     )
                 _diag_lines.append(
-                    "To increase the limit, set agent.gateway_timeout in config.yaml "
-                    "(value in seconds, 0 = no limit) and restart the gateway.\n"
-                    "Try again, or use /reset to start fresh."
+                    "如需调高限制，请在 config.yaml 设置 agent.gateway_timeout "
+                    "（单位秒，0 表示不限），然后重启 Gateway。\n"
+                    "可以重试，或用 /reset 开始新会话。"
                 )
 
                 response = {

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1386,6 +1386,31 @@ def _resolve_hermes_bin() -> Optional[list[str]]:
     return None
 
 
+def _is_webui_embedded_runtime() -> bool:
+    """Return True when the gateway is hosted by Hermes WebUI.
+
+    WebUI itself commonly runs inside a Docker container, but the gateway is
+    a child of the WebUI server process rather than the container's PID 1 or a
+    system service. In that mode, exiting with the service-restart code leaves
+    the gateway down until WebUI starts it again, so /restart must use the
+    detached manual relaunch helper instead.
+    """
+    return bool(
+        os.environ.get("HERMES_WEBUI_STATE_DIR")
+        or os.environ.get("HERMES_WEBUI_PORT")
+        or os.environ.get("HERMES_SESSION_PLATFORM") == "webui"
+    )
+
+
+def _should_restart_via_service_manager() -> bool:
+    """Choose whether /restart should rely on an external supervisor."""
+    if _is_webui_embedded_runtime():
+        return False
+    under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
+    in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
+    return under_service or in_container
+
+
 def _parse_session_key(session_key: str) -> "dict | None":
     """Parse a session key into its component parts.
 
@@ -9850,15 +9875,13 @@ class GatewayRunner:
             logger.debug("Failed to write restart dedup marker: %s", e)
 
         active_agents = self._running_agent_count()
-        # When running under a service manager (systemd/launchd) or inside a
-        # Docker/Podman container, use the service restart path: exit with
-        # code 75 so the service manager / container restart policy restarts
-        # us.  The detached subprocess approach (setsid + bash) doesn't work
-        # under systemd (KillMode=mixed kills the cgroup) or Docker (tini
-        # exits when the gateway dies, taking the detached helper with it).
-        _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
-        _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
-        if _under_service or _in_container:
+        # When running under a service manager (systemd/launchd) or as a
+        # container main process, use the service restart path: exit with code
+        # 75 so the external supervisor restarts us.  WebUI is a special case:
+        # it often runs inside Docker too, but the gateway is just a child of
+        # the WebUI server, so there is no container restart policy watching the
+        # gateway PID.  In that embedded mode, use the detached helper.
+        if _should_restart_via_service_manager():
             self.request_restart(detached=False, via_service=True)
         else:
             self.request_restart(detached=True, via_service=False)
@@ -18171,7 +18194,8 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         asyncio.create_task(runner.stop())
 
     def restart_signal_handler():
-        runner.request_restart(detached=False, via_service=True)
+        via_service = _should_restart_via_service_manager()
+        runner.request_restart(detached=not via_service, via_service=via_service)
     
     loop = asyncio.get_running_loop()
     if threading.current_thread() is threading.main_thread():

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3500,14 +3500,14 @@ class GatewayRunner:
 
         # On Windows there's no bash/setsid chain — spawn a tiny Python
         # watcher directly via sys.executable instead.  The watcher polls
-        # current_pid, waits for our exit, then runs `hermes gateway
-        # restart` with detach flags so the respawn survives the CLI
+        # current_pid, waits for our exit, then runs `hermes gateway run
+        # --replace` with detach flags so the respawn survives the CLI
         # that triggered the /restart command closing its console.
         if sys.platform == "win32":
             import textwrap
             from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
 
-            cmd_argv = [*hermes_cmd, "gateway", "restart"]
+            cmd_argv = [*hermes_cmd, "gateway", "run", "--replace"]
             watcher = textwrap.dedent(
                 """
                 import os, subprocess, sys, time
@@ -3565,10 +3565,41 @@ class GatewayRunner:
             )
             return
 
+        expected_starttime = ""
+        try:
+            stat_text = Path(f"/proc/{current_pid}/stat").read_text(
+                encoding="utf-8", errors="ignore"
+            )
+            # /proc/<pid>/stat field 2 (comm) is parenthesized and may contain
+            # spaces, so split after the final ") " before indexing fields.
+            stat_fields_after_comm = stat_text.rsplit(") ", 1)[1].split()
+            # After comm, field 3 (state) is index 0 and field 22 (starttime)
+            # is index 19.  Capturing starttime avoids waiting on PID reuse.
+            if len(stat_fields_after_comm) >= 20:
+                expected_starttime = stat_fields_after_comm[19]
+        except Exception:
+            expected_starttime = ""
+
         cmd = " ".join(shlex.quote(part) for part in hermes_cmd)
         shell_cmd = (
-            f"while kill -0 {current_pid} 2>/dev/null; do sleep 0.2; done; "
-            f"{cmd} gateway restart"
+            f"deadline=$((SECONDS + 120)); "
+            f"expected_start={shlex.quote(expected_starttime)}; "
+            f"stat_path=/proc/{current_pid}/stat; "
+            f"while kill -0 {current_pid} 2>/dev/null; do "
+            f"if [[ -r \"$stat_path\" ]]; then "
+            f"stat_line=$(<\"$stat_path\") || stat_line=''; "
+            f"if [[ -n \"$stat_line\" ]]; then "
+            f"stat_tail=${{stat_line##*) }}; "
+            f"set -- $stat_tail; "
+            f"state=$1; starttime=${{20:-}}; "
+            f"if [[ \"$state\" == 'Z' ]]; then break; fi; "
+            f"if [[ -n \"$expected_start\" && -n \"$starttime\" && \"$starttime\" != \"$expected_start\" ]]; then break; fi; "
+            f"fi; "
+            f"fi; "
+            f"if [[ $SECONDS -ge $deadline ]]; then break; fi; "
+            f"sleep 0.2; "
+            f"done; "
+            f"{cmd} gateway run --replace"
         )
         setsid_bin = shutil.which("setsid")
         if setsid_bin:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1247,6 +1247,13 @@ _GATEWAY_TRUSTED_MEDIA_TOOL_NAMES = frozenset({
     "video_generate",
 })
 
+# MCP tool names are dynamic (mcp_<server>_<tool>).  Do not trust arbitrary
+# MEDIA-looking text from all MCP outputs; only trust the wrapper's explicit
+# metadata key, which is populated when an MCP ImageContent block is cached by
+# tools/mcp_tool.py.
+_GATEWAY_EXPLICIT_MEDIA_TOOL_PREFIXES = ("mcp_",)
+_GATEWAY_EXPLICIT_MEDIA_TAGS_KEY = "_hermes_media_tags"
+
 _GATEWAY_TOOL_MEDIA_RE = re.compile(
     r'MEDIA:\s*((?:/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
     r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
@@ -1288,6 +1295,47 @@ def _gateway_tool_result_name(msg: dict, tool_call_names: dict) -> str:
     return ""
 
 
+def _extract_explicit_gateway_media_tags(
+    content: Any,
+    history_media_paths: set[str],
+) -> list[str]:
+    """Read wrapper-marked MEDIA tags from a tool result payload.
+
+    Used for dynamic tool names such as MCP tools.  This intentionally does
+    not regex-scan arbitrary tool text: only top-level explicit metadata
+    written by Hermes wrapper code is considered a current-turn attachment
+    directive.
+    """
+    if isinstance(content, str):
+        try:
+            payload = json.loads(content)
+        except Exception:
+            return []
+    else:
+        payload = content
+    if not isinstance(payload, dict):
+        return []
+
+    raw_tags = payload.get(_GATEWAY_EXPLICIT_MEDIA_TAGS_KEY)
+    if isinstance(raw_tags, str):
+        raw_tags = [raw_tags]
+    if not isinstance(raw_tags, list):
+        return []
+
+    media_tags: list[str] = []
+    for raw_tag in raw_tags:
+        if not isinstance(raw_tag, str):
+            continue
+        match = _GATEWAY_TOOL_MEDIA_RE.fullmatch(raw_tag.strip())
+        if not match:
+            continue
+        raw_path = match.group(1).strip().rstrip('\",}')
+        path = os.path.expanduser(raw_path)
+        if raw_path and path not in history_media_paths:
+            media_tags.append(f"MEDIA:{raw_path}")
+    return media_tags
+
+
 def _extract_trusted_tool_media_tags(
     result_messages: list,
     *,
@@ -1320,10 +1368,17 @@ def _extract_trusted_tool_media_tags(
         if msg.get("role") not in {"tool", "function"}:
             continue
         tool_name = _gateway_tool_result_name(msg, tool_call_names)
+        content = msg.get("content", "")
         if tool_name not in _GATEWAY_TRUSTED_MEDIA_TOOL_NAMES:
+            if tool_name.startswith(_GATEWAY_EXPLICIT_MEDIA_TOOL_PREFIXES):
+                media_tags.extend(
+                    _extract_explicit_gateway_media_tags(
+                        content,
+                        history_media_paths,
+                    )
+                )
             continue
 
-        content = msg.get("content", "")
         if not isinstance(content, str):
             try:
                 content = json.dumps(content, ensure_ascii=False)
@@ -11995,6 +12050,8 @@ class GatewayRunner:
                     session_db=self._session_db,
                     fallback_model=self._fallback_model,
                 )
+                agent._turn_platform_message_id = event_message_id
+                agent._turn_id = task_id
                 try:
                     return agent.run_conversation(
                         user_message=enriched_prompt,
@@ -16876,6 +16933,8 @@ class GatewayRunner:
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides") or {}
+            agent._turn_platform_message_id = event_message_id or getattr(source, "message_id", None)
+            agent._turn_id = f"{session_id}:{run_generation}" if run_generation is not None else session_id
 
             _bg_review_release = threading.Event()
             _bg_review_pending: list[str] = []

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1238,6 +1238,112 @@ logger = logging.getLogger(__name__)
 # between the guard check and actual agent creation.
 _AGENT_PENDING_SENTINEL = object()
 
+_GATEWAY_TRUSTED_MEDIA_TOOL_NAMES = frozenset({
+    # Tools whose current-turn result is itself an attachment directive.
+    # Other tools can mention MEDIA: as logs, history, code, or evidence and
+    # must not trigger native uploads just because the string appears there.
+    "text_to_speech",
+    "image_generate",
+    "video_generate",
+})
+
+_GATEWAY_TOOL_MEDIA_RE = re.compile(
+    r'MEDIA:\s*((?:/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
+    r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
+    r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
+    r'txt|csv|apk|ipa))',
+    re.IGNORECASE,
+)
+
+
+def _mapping_get(value: Any, key: str, default: Any = None) -> Any:
+    """Read *key* from either a dict-like object or SDK object."""
+    if isinstance(value, dict):
+        return value.get(key, default)
+    return getattr(value, key, default)
+
+
+def _gateway_tool_call_name(tool_call: Any) -> str:
+    """Return a normalized tool/function name from an assistant tool_call."""
+    function = _mapping_get(tool_call, "function", {}) or {}
+    name = _mapping_get(function, "name") or _mapping_get(tool_call, "name")
+    return str(name or "").strip()
+
+
+def _gateway_tool_result_name(msg: dict, tool_call_names: dict) -> str:
+    """Resolve the producing tool name for a tool/function result message."""
+    for key in ("name", "tool_name"):
+        value = msg.get(key)
+        if value:
+            return str(value).strip()
+    metadata = msg.get("metadata")
+    if isinstance(metadata, dict):
+        for key in ("name", "tool_name"):
+            value = metadata.get(key)
+            if value:
+                return str(value).strip()
+    tool_call_id = msg.get("tool_call_id")
+    if tool_call_id is not None:
+        return str(tool_call_names.get(tool_call_id, "")).strip()
+    return ""
+
+
+def _extract_trusted_tool_media_tags(
+    result_messages: list,
+    *,
+    history_media_paths: set | None = None,
+) -> tuple[list[str], bool]:
+    """Extract MEDIA tags only from trusted current media tool results.
+
+    Generic tool output is plain evidence text.  In particular, session_search,
+    terminal, log readers, and file readers may include historical ``MEDIA:``
+    strings; those must never be promoted into current native attachments.
+    """
+    history_media_paths = {
+        os.path.expanduser(str(path)) for path in (history_media_paths or set())
+    }
+    tool_call_names: dict[str, str] = {}
+    media_tags: list[str] = []
+    has_voice_directive = False
+
+    for msg in result_messages or []:
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("role") == "assistant":
+            for tool_call in msg.get("tool_calls") or []:
+                tool_call_id = _mapping_get(tool_call, "id")
+                tool_name = _gateway_tool_call_name(tool_call)
+                if tool_call_id and tool_name:
+                    tool_call_names[str(tool_call_id)] = tool_name
+            continue
+
+        if msg.get("role") not in {"tool", "function"}:
+            continue
+        tool_name = _gateway_tool_result_name(msg, tool_call_names)
+        if tool_name not in _GATEWAY_TRUSTED_MEDIA_TOOL_NAMES:
+            continue
+
+        content = msg.get("content", "")
+        if not isinstance(content, str):
+            try:
+                content = json.dumps(content, ensure_ascii=False)
+            except Exception:
+                content = str(content)
+        if "media:" not in content.lower():
+            continue
+
+        found_for_message = False
+        for match in _GATEWAY_TOOL_MEDIA_RE.finditer(content):
+            raw_path = match.group(1).strip().rstrip('",}')
+            path = os.path.expanduser(raw_path)
+            if raw_path and path not in history_media_paths:
+                media_tags.append(f"MEDIA:{raw_path}")
+                found_for_message = True
+        if found_for_message and "[[audio_as_voice]]" in content:
+            has_voice_directive = True
+
+    return media_tags, has_voice_directive
+
 
 def _resolve_runtime_agent_kwargs() -> dict:
     """Resolve provider credentials for gateway-created AIAgent instances.
@@ -16929,18 +17035,16 @@ class GatewayRunner:
             for _hm in agent_history:
                 if _hm.get("role") in {"tool", "function"}:
                     _hc = _hm.get("content", "")
-                    if "MEDIA:" in _hc:
-                        _TOOL_MEDIA_RE = re.compile(
-                            r'MEDIA:((?:/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
-                            r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
-                            r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
-                            r'txt|csv|apk|ipa))',
-                            re.IGNORECASE
-                        )
-                        for _match in _TOOL_MEDIA_RE.finditer(_hc):
+                    if not isinstance(_hc, str):
+                        try:
+                            _hc = json.dumps(_hc, ensure_ascii=False)
+                        except Exception:
+                            _hc = str(_hc)
+                    if "media:" in _hc.lower():
+                        for _match in _GATEWAY_TOOL_MEDIA_RE.finditer(_hc):
                             _p = _match.group(1).strip().rstrip('",}')
                             if _p:
-                                _history_media_paths.add(_p)
+                                _history_media_paths.add(os.path.expanduser(_p))
             
             # Register per-session gateway approval callback so dangerous
             # command approval blocks the agent thread (mirrors CLI input()).
@@ -17216,48 +17320,38 @@ class GatewayRunner:
                     "context_length": _context_length,
                 }
             
-            # Scan tool results for MEDIA:<path> tags that need to be delivered
-            # as native audio/file attachments.  The TTS tool embeds MEDIA: tags
-            # in its JSON response, but the model's final text reply usually
-            # doesn't include them.  We collect unique tags from tool results and
-            # append any that aren't already present in the final response, so the
-            # adapter's extract_media() can find and deliver the files exactly once.
+            # Scan trusted media tool results for MEDIA:<path> tags that need
+            # to be delivered as native attachments. Generic tool output is not
+            # a control channel: session_search, terminal, logs, and file reads
+            # may contain historical MEDIA strings and must not re-send them.
             #
             # Uses path-based deduplication against _history_media_paths (collected
             # before run_conversation) instead of index slicing. This is safe even
             # when context compression shrinks the message list. (Fixes #160)
-            if "MEDIA:" not in final_response:
-                media_tags = []
-                has_voice_directive = False
-                for msg in result.get("messages", []):
-                    if msg.get("role") in {"tool", "function"}:
-                        content = msg.get("content", "")
-                        if "MEDIA:" in content:
-                            _TOOL_MEDIA_RE = re.compile(
-                                r'MEDIA:((?:/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
-                                r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
-                                r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
-                                r'txt|csv|apk|ipa))',
-                                re.IGNORECASE
-                            )
-                            for match in _TOOL_MEDIA_RE.finditer(content):
-                                path = match.group(1).strip().rstrip('",}')
-                                if path and path not in _history_media_paths:
-                                    media_tags.append(f"MEDIA:{path}")
-                            if "[[audio_as_voice]]" in content:
-                                has_voice_directive = True
-                
-                if media_tags:
-                    seen = set()
-                    unique_tags = []
-                    for tag in media_tags:
-                        if tag not in seen:
-                            seen.add(tag)
-                            unique_tags.append(tag)
+            media_tags, has_voice_directive = _extract_trusted_tool_media_tags(
+                result.get("messages", []),
+                history_media_paths=_history_media_paths,
+            )
+            if media_tags:
+                try:
+                    existing_response_paths = {
+                        path for path, _is_voice in BasePlatformAdapter.extract_media(final_response)[0]
+                    }
+                except Exception:
+                    existing_response_paths = set()
+                seen_paths = set()
+                unique_tags = []
+                for tag in media_tags:
+                    tag_path = os.path.expanduser(tag[len("MEDIA:"):])
+                    if tag_path in seen_paths or tag_path in existing_response_paths:
+                        continue
+                    seen_paths.add(tag_path)
+                    unique_tags.append(tag)
+                if unique_tags:
                     if has_voice_directive:
                         unique_tags.insert(0, "[[audio_as_voice]]")
                     final_response = final_response + "\n" + "\n".join(unique_tags)
-            
+
             # Sync session_id: the agent may have created a new session during
             # mid-run context compression (_compress_context splits sessions).
             # If so, update the session store entry so the NEXT message loads

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6191,11 +6191,14 @@ class GatewayRunner:
             return BlueBubblesAdapter(config)
 
         elif platform == Platform.QQBOT:
-            from gateway.platforms.qqbot import QQAdapter, check_qq_requirements
+            from gateway.platforms.qqbot import QQMultiAdapter, check_qq_requirements, has_any_qq_credentials
             if not check_qq_requirements():
-                logger.warning("QQBot: aiohttp/httpx missing or QQ_APP_ID/QQ_CLIENT_SECRET not configured")
+                logger.warning("QQBot: aiohttp/httpx missing")
                 return None
-            return QQAdapter(config)
+            if not has_any_qq_credentials(config):
+                logger.warning("QQBot: QQ_APP_ID/QQ_CLIENT_SECRET or QQ_APP_ID_N/QQ_CLIENT_SECRET_N not configured")
+                return None
+            return QQMultiAdapter(config)
 
         elif platform == Platform.YUANBAO:
             from gateway.platforms.yuanbao import YuanbaoAdapter, WEBSOCKETS_AVAILABLE

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -66,6 +66,21 @@ _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
+_WHAT_DID_YOU_DO_TRIGGERS = frozenset(
+    {
+        "你做了什么",
+        "刚才你干嘛了",
+        "你到底改了啥",
+        "哪些是你做的",
+    }
+)
+
+
+def _is_what_did_you_do_trigger(text: str | None) -> bool:
+    """Return True for Chinese plain-text aliases of /what-did-you-do."""
+    normalized = re.sub(r"[\s，。！？!?、,.`'\"“”‘’：:；;（）()【】\[\]]+", "", str(text or ""))
+    return normalized in _WHAT_DID_YOU_DO_TRIGGERS
+
 
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"("  # transient/auxiliary status that should stay in logs, not Telegram chat
@@ -7141,6 +7156,8 @@ class GatewayRunner:
         # Otherwise control/session commands like /new or /help get silently
         # consumed as update answers instead of being dispatched normally.
         _quick_key = self._session_key_for_source(source)
+        if _is_what_did_you_do_trigger(event.text):
+            event = dataclasses.replace(event, text="/what-did-you-do")
         _update_prompts = getattr(self, "_update_prompt_pending", {})
         if _update_prompts.get(_quick_key):
             raw = (event.text or "").strip()
@@ -7553,6 +7570,8 @@ class GatewayRunner:
                     return await self._handle_profile_command(event)
                 if _cmd_def_inner.name == "update":
                     return await self._handle_update_command(event)
+                if _cmd_def_inner.name == "what-did-you-do":
+                    return await self._handle_what_did_you_do_command(event)
 
             # Catch-all: any other recognized slash command reached the
             # running-agent guard. Reject gracefully rather than falling
@@ -7792,6 +7811,9 @@ class GatewayRunner:
 
         if canonical == "status":
             return await self._handle_status_command(event)
+
+        if canonical == "what-did-you-do":
+            return await self._handle_what_did_you_do_command(event)
 
         if canonical == "agents":
             return await self._handle_agents_command(event)
@@ -9947,6 +9969,55 @@ class GatewayRunner:
         if len(output) > 3800:
             output = output[:3800] + "\n" + t("gateway.kanban.truncated_suffix")
         return output or t("gateway.kanban.no_output")
+
+    async def _handle_what_did_you_do_command(self, event: MessageEvent) -> str:
+        """Handle /what-did-you-do — show this session lineage's tool ledger."""
+        source = event.source
+        session_id = None
+        session_store = getattr(self, "session_store", None)
+        if session_store is not None and source is not None:
+            session_key = None
+            try:
+                session_key = session_store._generate_session_key(source)
+            except Exception:
+                try:
+                    session_key = self._session_key_for_source(source)
+                except Exception:
+                    session_key = None
+            if session_key:
+                try:
+                    entries = getattr(session_store, "_entries", {}) or {}
+                    entry = entries.get(session_key)
+                    session_id = getattr(entry, "session_id", None) if entry else None
+                except Exception:
+                    session_id = None
+            if not session_id:
+                try:
+                    entry = session_store.get_or_create_session(source)
+                    session_id = getattr(entry, "session_id", None)
+                except Exception:
+                    session_id = None
+
+        if not session_id:
+            return "未找到当前 session_id，不能归因。"
+
+        db = getattr(self, "_session_db", None)
+        if db is None:
+            return "未连接 SessionDB，不能读取 attribution ledger。"
+
+        try:
+            from agent.attribution_ledger import format_what_did_you_do_for_session
+
+            return format_what_did_you_do_for_session(
+                db,
+                session_id=session_id,
+                chat_id=getattr(source, "chat_id", None),
+                source=_gateway_platform_value(getattr(source, "platform", None)),
+                limit=100,
+            )
+        except Exception as exc:
+            logger.warning("/what-did-you-do failed for session %s: %s", session_id, exc)
+            return f"读取 attribution ledger 失败：{exc}"
 
     async def _handle_status_command(self, event: MessageEvent) -> str:
         """Handle /status command."""

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -108,6 +108,15 @@ def _get_scope_lock_path(scope: str, identity: str) -> Path:
     return _get_lock_dir() / f"{scope}-{_scope_hash(identity)}.lock"
 
 
+def _proc_status_path(pid: int) -> Path:
+    """Return the Linux proc status path for a process.
+
+    Kept as a helper so tests can simulate process states without touching
+    the real /proc filesystem.
+    """
+    return Path(f"/proc/{pid}/status")
+
+
 def _get_process_start_time(pid: int) -> Optional[int]:
     """Return the kernel start time for a process when available."""
     stat_path = Path(f"/proc/{pid}/stat")
@@ -639,17 +648,17 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
                     live_cmdline = _read_process_cmdline(existing_pid)
                     if live_cmdline is not None or not _record_looks_like_gateway(existing):
                         stale = True
-                # Check if process is stopped (Ctrl+Z / SIGTSTP) — stopped
-                # processes still appear alive to _pid_exists but are not
-                # actually running. Treat them as stale so --replace works.
+                # Check if process is stopped (Ctrl+Z / SIGTSTP) or zombie.
+                # These states still appear alive to _pid_exists but cannot
+                # operate the gateway. Treat them as stale so --replace works.
                 if not stale:
                     try:
-                        _proc_status = Path(f"/proc/{existing_pid}/status")
+                        _proc_status = _proc_status_path(existing_pid)
                         if _proc_status.exists():
                             for _line in _proc_status.read_text(encoding="utf-8").splitlines():
                                 if _line.startswith("State:"):
                                     _state = _line.split()[1]
-                                    if _state in {"T", "t"}:  # stopped or tracing stop
+                                    if _state in {"T", "t", "Z", "z"}:  # stopped/tracing stop/zombie
                                         stale = True
                                     break
                     except (OSError, PermissionError):

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -5961,7 +5961,12 @@ def _update_config_for_provider(
 
     config["model"] = model_cfg
 
-    atomic_yaml_write(config_path, config, sort_keys=False)
+    atomic_yaml_write(
+        config_path,
+        config,
+        sort_keys=False,
+        allow_destructive_secret_change=True,
+    )
     return config_path
 
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -107,6 +107,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("subgoal", "Add or manage extra criteria on the active goal", "Session",
                args_hint="[text | remove N | clear]"),
     CommandDef("status", "Show session info", "Session"),
+    CommandDef("what-did-you-do", "Show strict attribution ledger for this session", "Info",
+               gateway_only=True, aliases=("whatdidyoudo", "wdyd")),
     CommandDef("whoami", "Show your slash command access (admin / user)", "Info"),
     CommandDef("profile", "Show active profile name and home directory", "Info"),
     CommandDef("sethome", "Set this chat as the home channel", "Session",
@@ -346,6 +348,7 @@ ACTIVE_SESSION_BYPASS_COMMANDS: frozenset[str] = frozenset(
         "steer",
         "stop",
         "update",
+        "what-did-you-do",
     }
 )
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3642,7 +3642,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
         try:
             old_token = get_env_value("ANTHROPIC_TOKEN")
             if old_token:
-                save_env_value("ANTHROPIC_TOKEN", "")
+                save_env_value("ANTHROPIC_TOKEN", "", allow_destructive_secret_change=True)
                 if not quiet:
                     print("  ✓ Cleared ANTHROPIC_TOKEN from .env (no longer used)")
         except Exception:
@@ -4697,6 +4697,34 @@ def invalidate_env_cache() -> None:
     _env_cache = None
 
 
+def _guard_live_env_write(
+    env_path: Path,
+    old_lines: list[str],
+    new_lines: list[str],
+    *,
+    allow_destructive_secret_change: bool = False,
+) -> None:
+    """Validate and back up active .env before replacing it."""
+    from agent.live_config_guard import validate_and_backup_live_config_write
+
+    old_content = "".join(old_lines)
+    new_content = "".join(new_lines)
+    guard_result = validate_and_backup_live_config_write(
+        env_path,
+        old_content=old_content,
+        new_content=new_content,
+        allow_destructive_secret_change=allow_destructive_secret_change,
+    )
+    if guard_result.error:
+        raise ValueError(guard_result.error)
+    if guard_result.guarded and guard_result.redacted_diff:
+        logger.info(
+            "Live Hermes .env write approved for %s; redacted diff:\n%s",
+            env_path,
+            guard_result.redacted_diff,
+        )
+
+
 def _sanitize_env_lines(lines: list) -> list:
     """Fix corrupted .env lines before reading or writing.
 
@@ -4785,6 +4813,8 @@ def sanitize_env_file() -> int:
         fixes = sum(1 for a, b in zip(original_lines, sanitized) if a != b)
         fixes += abs(len(sanitized) - len(original_lines))
 
+    _guard_live_env_write(env_path, original_lines, sanitized)
+
     fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix=".tmp", prefix=".env_")
     try:
         with os.fdopen(fd, "w", **write_kw) as f:
@@ -4843,7 +4873,7 @@ def _check_non_ascii_credential(key: str, value: str) -> str:
     return sanitized
 
 
-def save_env_value(key: str, value: str):
+def save_env_value(key: str, value: str, *, allow_destructive_secret_change: bool = False):
     """Save or update a value in ~/.hermes/.env."""
     if is_managed():
         managed_error(f"set {key}")
@@ -4867,6 +4897,7 @@ def save_env_value(key: str, value: str):
             lines = f.readlines()
         # Sanitize on every read: split concatenated keys, drop stale placeholders
         lines = _sanitize_env_lines(lines)
+    old_lines = list(lines)
 
     # Find and update or append
     found = False
@@ -4881,6 +4912,13 @@ def save_env_value(key: str, value: str):
         if lines and not lines[-1].endswith("\n"):
             lines[-1] += "\n"
         lines.append(f"{key}={value}\n")
+
+    _guard_live_env_write(
+        env_path,
+        old_lines,
+        lines,
+        allow_destructive_secret_change=allow_destructive_secret_change,
+    )
     
     fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix='.tmp', prefix='.env_')
     # Preserve original permissions so Docker volume mounts aren't clobbered.
@@ -4940,6 +4978,7 @@ def remove_env_value(key: str) -> bool:
     found = len(new_lines) < len(lines)
 
     if found:
+        _guard_live_env_write(env_path, lines, new_lines)
         fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix='.tmp', prefix='.env_')
         # Preserve original permissions so Docker volume mounts aren't clobbered.
         original_mode = None
@@ -4971,25 +5010,36 @@ def remove_env_value(key: str) -> bool:
     return found
 
 
+def _call_env_writer(writer, key: str, value: str, *, allow_destructive_secret_change: bool = False) -> None:
+    if allow_destructive_secret_change:
+        try:
+            writer(key, value, allow_destructive_secret_change=True)
+            return
+        except TypeError:
+            # Tests and embedding code may pass a two-argument fake writer.
+            pass
+    writer(key, value)
+
+
 def save_anthropic_oauth_token(value: str, save_fn=None):
     """Persist an Anthropic OAuth/setup token and clear the API-key slot."""
     writer = save_fn or save_env_value
-    writer("ANTHROPIC_TOKEN", value)
-    writer("ANTHROPIC_API_KEY", "")
+    _call_env_writer(writer, "ANTHROPIC_TOKEN", value)
+    _call_env_writer(writer, "ANTHROPIC_API_KEY", "", allow_destructive_secret_change=True)
 
 
 def use_anthropic_claude_code_credentials(save_fn=None):
     """Use Claude Code's own credential files instead of persisting env tokens."""
     writer = save_fn or save_env_value
-    writer("ANTHROPIC_TOKEN", "")
-    writer("ANTHROPIC_API_KEY", "")
+    _call_env_writer(writer, "ANTHROPIC_TOKEN", "", allow_destructive_secret_change=True)
+    _call_env_writer(writer, "ANTHROPIC_API_KEY", "", allow_destructive_secret_change=True)
 
 
 def save_anthropic_api_key(value: str, save_fn=None):
     """Persist an Anthropic API key and clear the OAuth/setup-token slot."""
     writer = save_fn or save_env_value
-    writer("ANTHROPIC_API_KEY", value)
-    writer("ANTHROPIC_TOKEN", "")
+    _call_env_writer(writer, "ANTHROPIC_API_KEY", value)
+    _call_env_writer(writer, "ANTHROPIC_TOKEN", "", allow_destructive_secret_change=True)
 
 
 def save_env_value_secure(key: str, value: str) -> Dict[str, Any]:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3040,6 +3040,7 @@ def _normalize_custom_provider_entry(
         "apiKey": "api_key",
         "baseUrl": "base_url",
         "apiMode": "api_mode",
+        "defaultHeaders": "default_headers",
         "keyEnv": "key_env",
         "apiKeyEnv": "key_env",  # alias — OpenClaw-compatible + docs variant
         "defaultModel": "default_model",
@@ -3056,7 +3057,7 @@ def _normalize_custom_provider_entry(
         "api_mode", "transport", "model", "default_model", "models",
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
-        "discover_models", "extra_body",
+        "discover_models", "extra_body", "default_headers",
     }
     for camel, snake in _CAMEL_ALIASES.items():
         if camel in entry and snake not in entry:
@@ -3154,6 +3155,19 @@ def _normalize_custom_provider_entry(
     extra_body = entry.get("extra_body")
     if isinstance(extra_body, dict):
         normalized["extra_body"] = dict(extra_body)
+
+    default_headers = entry.get("default_headers")
+    if isinstance(default_headers, dict):
+        headers: Dict[str, str] = {}
+        for key, value in default_headers.items():
+            header_name = str(key or "").strip()
+            if not header_name or value is None:
+                continue
+            header_value = str(value).strip()
+            if header_value:
+                headers[header_name] = header_value
+        if headers:
+            normalized["default_headers"] = headers
 
     return normalized
 
@@ -3315,7 +3329,7 @@ _KNOWN_ROOT_KEYS = {
 # Valid fields inside a custom_providers list entry
 _VALID_CUSTOM_PROVIDER_FIELDS = {
     "name", "base_url", "api_key", "api_mode", "model", "models",
-    "context_length", "rate_limit_delay", "extra_body",
+    "context_length", "rate_limit_delay", "extra_body", "default_headers",
     # key_env is read at runtime by runtime_provider.py and auxiliary_client.py
     # — include it here so the set accurately describes the supported schema.
     "key_env",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -814,6 +814,20 @@ DEFAULT_CONFIG = {
                                       # Default False matches historical behavior; set to
                                       # True if you'd rather pause than silently lose
                                       # context turns when your aux model is flaky.
+        "safe_retry": {
+            "enabled": True,         # on provider safety/content-filter blocks,
+                                      # retry once with high-risk raw tool output
+                                      # scrubbed before giving up.
+        },
+        "chunked": {
+            "enabled": True,         # after normal + safe retry are blocked,
+                                      # summarize scrubbed message chunks then merge.
+            "chunk_messages": 40,    # messages per chunk for chunked recovery.
+        },
+        "fallback": {
+            "extractive_marker": True,  # final no-LLM local fallback that preserves
+                                         # recent asks/actions/files without raw logs.
+        },
     },
 
     # Anthropic prompt caching (Claude via OpenRouter or native Anthropic API).

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -37,6 +37,10 @@ _MCP_PRESETS: Dict[str, Dict[str, Any]] = {
         "command": "codex",
         "args": ["mcp-server"],
     },
+    "codegraph": {
+        "command": "codegraph",
+        "args": ["serve", "--mcp"],
+    },
 }
 
 

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -358,33 +358,11 @@ def cmd_setup(args) -> None:
 
 def _write_env_vars(env_path: Path, env_writes: dict) -> None:
     """Append or update env vars in .env file."""
+    from hermes_cli.config import save_env_value
+
     env_path.parent.mkdir(parents=True, exist_ok=True)
-
-    existing_lines = []
-    if env_path.exists():
-        existing_lines = env_path.read_text(encoding="utf-8").splitlines()
-
-    updated_keys = set()
-    new_lines = []
-    for line in existing_lines:
-        key_match = line.split("=", 1)[0].strip() if "=" in line else ""
-        if key_match in env_writes:
-            new_lines.append(f"{key_match}={env_writes[key_match]}")
-            updated_keys.add(key_match)
-        else:
-            new_lines.append(line)
-
     for key, val in env_writes.items():
-        if key not in updated_keys:
-            new_lines.append(f"{key}={val}")
-
-    env_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
-    # Restrict permissions — .env holds API keys and tokens.
-    try:
-        import stat
-        env_path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0600
-    except OSError:
-        pass  # Windows or read-only FS
+        save_env_value(str(key), str(val))
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -93,11 +93,33 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
         return "codex_responses"
     if hostname == "api.openai.com":
         return "codex_responses"
+    if "/codex" in normalized:
+        return "codex_responses"
     if normalized.endswith("/anthropic"):
         return "anthropic_messages"
     if hostname == "api.kimi.com" and "/coding" in normalized:
         return "anthropic_messages"
     return None
+
+
+def _custom_api_mode_for_url(
+    base_url: str,
+    configured_mode: Optional[str] = None,
+) -> str:
+    """Resolve api_mode for custom endpoints, preferring /codex when present.
+
+    Custom Codex-compatible proxies rely on Responses semantics and
+    transport-compatible cache headers even when an older config still says
+    ``chat_completions``. Treat a ``/codex`` URL path as authoritative so
+    stale config does not silently route GPT-5 Codex traffic through the
+    wrong adapter.
+    """
+    normalized = (base_url or "").strip().lower().rstrip("/")
+    if "/codex" in normalized:
+        return "codex_responses"
+    if configured_mode:
+        return configured_mode
+    return _detect_api_mode_for_url(base_url) or "chat_completions"
 
 
 def _host_derived_api_key(base_url: str) -> str:
@@ -464,7 +486,7 @@ def _try_resolve_from_custom_pool(
             return None
         return {
             "provider": provider_label,
-            "api_mode": api_mode_override or _detect_api_mode_for_url(base_url) or "chat_completions",
+            "api_mode": _custom_api_mode_for_url(base_url, api_mode_override),
             "base_url": base_url,
             "api_key": pool_api_key,
             "source": f"pool:{pool_key}",
@@ -673,7 +695,7 @@ def _resolve_named_custom_runtime(
         ) or "no-key-required"
         return {
             "provider": "custom",
-            "api_mode": _detect_api_mode_for_url(base_url) or "chat_completions",
+            "api_mode": _custom_api_mode_for_url(base_url),
             "base_url": base_url,
             "api_key": api_key,
             "source": "direct-alias",
@@ -725,9 +747,10 @@ def _resolve_named_custom_runtime(
 
     result = {
         "provider": "custom",
-        "api_mode": custom_provider.get("api_mode")
-        or _detect_api_mode_for_url(base_url)
-        or "chat_completions",
+        "api_mode": _custom_api_mode_for_url(
+            base_url,
+            _parse_api_mode(custom_provider.get("api_mode")),
+        ),
         "base_url": base_url,
         "api_key": api_key or "no-key-required",
         "source": f"custom_provider:{custom_provider.get('name', requested_provider)}",
@@ -873,9 +896,10 @@ def _resolve_openrouter_runtime(
 
     return {
         "provider": effective_provider,
-        "api_mode": _parse_api_mode(model_cfg.get("api_mode"))
-        or _detect_api_mode_for_url(base_url)
-        or "chat_completions",
+        "api_mode": _custom_api_mode_for_url(
+            base_url,
+            _parse_api_mode(model_cfg.get("api_mode")),
+        ),
         "base_url": base_url,
         "api_key": api_key,
         "source": source,

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -553,6 +553,9 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                     extra_body = entry.get("extra_body")
                     if isinstance(extra_body, dict):
                         result["extra_body"] = dict(extra_body)
+                    default_headers = entry.get("default_headers")
+                    if isinstance(default_headers, dict):
+                        result["default_headers"] = dict(default_headers)
                     # The v11→v12 migration writes the API mode under the new
                     # ``transport`` field, but hand-edited configs may still
                     # use the legacy ``api_mode`` spelling.  Accept both —
@@ -581,6 +584,9 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                         extra_body = entry.get("extra_body")
                         if isinstance(extra_body, dict):
                             result["extra_body"] = dict(extra_body)
+                        default_headers = entry.get("default_headers")
+                        if isinstance(default_headers, dict):
+                            result["default_headers"] = dict(default_headers)
                         api_mode = _parse_api_mode(entry.get("api_mode") or entry.get("transport"))
                         if api_mode:
                             result["api_mode"] = api_mode
@@ -627,6 +633,9 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
         extra_body = entry.get("extra_body")
         if isinstance(extra_body, dict):
             result["extra_body"] = dict(extra_body)
+        default_headers = entry.get("default_headers")
+        if isinstance(default_headers, dict):
+            result["default_headers"] = dict(default_headers)
         api_mode = _parse_api_mode(entry.get("api_mode"))
         if api_mode:
             result["api_mode"] = api_mode
@@ -639,10 +648,23 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
 
 
 def _custom_provider_request_overrides(custom_provider: Dict[str, Any]) -> Dict[str, Any]:
+    request_overrides: Dict[str, Any] = {}
     extra_body = custom_provider.get("extra_body")
-    if not isinstance(extra_body, dict) or not extra_body:
-        return {}
-    return {"extra_body": dict(extra_body)}
+    if isinstance(extra_body, dict) and extra_body:
+        request_overrides["extra_body"] = dict(extra_body)
+    default_headers = custom_provider.get("default_headers")
+    if isinstance(default_headers, dict) and default_headers:
+        headers: Dict[str, str] = {}
+        for key, value in default_headers.items():
+            header_name = str(key or "").strip()
+            if not header_name or value is None:
+                continue
+            header_value = str(value).strip()
+            if header_value:
+                headers[header_name] = header_value
+        if headers:
+            request_overrides["extra_headers"] = headers
+    return request_overrides
 
 
 def _resolve_named_custom_runtime(

--- a/hermes_cli/xai_retirement.py
+++ b/hermes_cli/xai_retirement.py
@@ -242,8 +242,40 @@ def apply_migration(
         )
         shutil.copy2(config_path, backup_path)
 
-    with config_path.open("w", encoding="utf-8") as fh:
-        yaml.dump(doc, fh)
+    from io import StringIO
+    import os
+    import tempfile
+    from agent.live_config_guard import validate_and_backup_live_config_write
+    from utils import atomic_replace
+
+    payload_io = StringIO()
+    yaml.dump(doc, payload_io)
+    payload = payload_io.getvalue()
+    guard_result = validate_and_backup_live_config_write(
+        config_path,
+        new_content=payload,
+        create_backup=False,
+    )
+    if guard_result.error:
+        raise ValueError(guard_result.error)
+
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(config_path.parent),
+        suffix=".tmp",
+        prefix=f".{config_path.stem}_",
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(payload)
+            fh.flush()
+            os.fsync(fh.fileno())
+        atomic_replace(tmp_path, config_path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
     return ApplyResult(
         file_path=config_path,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -33,7 +33,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 13
+SCHEMA_VERSION = 14
 
 # ---------------------------------------------------------------------------
 # WAL-compatibility fallback
@@ -197,6 +197,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     prompt_cache_key TEXT,
     prompt_cache_supported INTEGER,
     parent_session_id TEXT,
+    lineage_id TEXT,
     started_at REAL NOT NULL,
     ended_at REAL,
     end_reason TEXT,
@@ -243,6 +244,29 @@ CREATE TABLE IF NOT EXISTS messages (
     observed INTEGER DEFAULT 0
 );
 
+CREATE TABLE IF NOT EXISTS attribution_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL REFERENCES sessions(id),
+    lineage_id TEXT NOT NULL,
+    source TEXT,
+    user_id TEXT,
+    chat_id TEXT,
+    thread_id TEXT,
+    platform_message_id TEXT,
+    turn_id TEXT,
+    tool_call_id TEXT,
+    tool_name TEXT NOT NULL,
+    action_summary TEXT,
+    args_summary TEXT,
+    side_effect_class TEXT,
+    status TEXT NOT NULL,
+    started_at REAL NOT NULL,
+    ended_at REAL,
+    duration_ms INTEGER,
+    output_digest TEXT,
+    error_preview TEXT
+);
+
 CREATE TABLE IF NOT EXISTS state_meta (
     key TEXT PRIMARY KEY,
     value TEXT
@@ -252,6 +276,9 @@ CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp);
+CREATE INDEX IF NOT EXISTS idx_attribution_lineage ON attribution_events(lineage_id, started_at, id);
+CREATE INDEX IF NOT EXISTS idx_attribution_session ON attribution_events(session_id, started_at, id);
+CREATE INDEX IF NOT EXISTS idx_attribution_chat_lineage ON attribution_events(chat_id, lineage_id, started_at, id);
 """
 
 FTS_SQL = """
@@ -587,6 +614,13 @@ class SessionDB:
             )
         except sqlite3.OperationalError as exc:
             logger.debug("idx_messages_platform_msg_id create skipped: %s", exc)
+        try:
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_sessions_lineage "
+                "ON sessions(lineage_id)"
+            )
+        except sqlite3.OperationalError as exc:
+            logger.debug("idx_sessions_lineage create skipped: %s", exc)
 
         # ── Schema version bookkeeping ─────────────────────────────────
         # Bump to current so future data migrations (if any) can gate on
@@ -698,6 +732,50 @@ class SessionDB:
     # Session lifecycle
     # =========================================================================
 
+    def get_session_lineage_id(self, session_id: str) -> Optional[str]:
+        """Return the stable lineage id for *session_id*.
+
+        New sessions store ``lineage_id`` directly.  Older rows may not have it,
+        so fall back to walking ``parent_session_id`` to the root.
+        """
+        if not session_id:
+            return None
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT id, parent_session_id, lineage_id FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            if row is None:
+                return None
+            lineage = row["lineage_id"] if hasattr(row, "keys") else row[2]
+            if lineage:
+                return lineage
+
+            current = session_id
+            root = session_id
+            seen = set()
+            for _ in range(100):
+                if not current or current in seen:
+                    break
+                seen.add(current)
+                parent_row = self._conn.execute(
+                    "SELECT parent_session_id FROM sessions WHERE id = ?",
+                    (current,),
+                ).fetchone()
+                if parent_row is None:
+                    break
+                parent = parent_row["parent_session_id"] if hasattr(parent_row, "keys") else parent_row[0]
+                if not parent:
+                    break
+                root = parent
+                current = parent
+            return root
+
+    def _lineage_id_for_new_session(self, session_id: str, parent_session_id: str = None) -> str:
+        if parent_session_id:
+            return self.get_session_lineage_id(parent_session_id) or parent_session_id
+        return session_id
+
     def _insert_session_row(
         self,
         session_id: str,
@@ -709,14 +787,18 @@ class SessionDB:
         prompt_cache_supported: Optional[bool] = None,
         user_id: str = None,
         parent_session_id: str = None,
+        lineage_id: str = None,
     ) -> None:
         """Shared INSERT OR IGNORE for session rows."""
+        if not lineage_id:
+            lineage_id = self._lineage_id_for_new_session(session_id, parent_session_id)
+
         def _do(conn):
             conn.execute(
                 """INSERT OR IGNORE INTO sessions (id, source, user_id, model, model_config,
                    system_prompt, prompt_cache_key, prompt_cache_supported,
-                   parent_session_id, started_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   parent_session_id, lineage_id, started_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     source,
@@ -727,6 +809,7 @@ class SessionDB:
                     prompt_cache_key,
                     None if prompt_cache_supported is None else int(bool(prompt_cache_supported)),
                     parent_session_id,
+                    lineage_id,
                     time.time(),
                 ),
             )
@@ -1595,6 +1678,116 @@ class SessionDB:
             return msg_id
 
         return self._execute_write(_do)
+
+    def append_attribution_event(
+        self,
+        session_id: str,
+        tool_name: str,
+        status: str,
+        action_summary: str = None,
+        args_summary: str = None,
+        side_effect_class: str = None,
+        source: str = None,
+        user_id: str = None,
+        chat_id: str = None,
+        thread_id: str = None,
+        platform_message_id: str = None,
+        turn_id: str = None,
+        tool_call_id: str = None,
+        lineage_id: str = None,
+        started_at: float = None,
+        ended_at: float = None,
+        duration_ms: int = None,
+        output_digest: str = None,
+        error_preview: str = None,
+    ) -> int:
+        """Append one redacted attribution/action-ledger event."""
+        lineage_id = lineage_id or self.get_session_lineage_id(session_id) or session_id
+        if source is None:
+            try:
+                session = self.get_session(session_id)
+                if session:
+                    source = session.get("source")
+                    if user_id is None:
+                        user_id = session.get("user_id")
+            except Exception:
+                pass
+        started_at = time.time() if started_at is None else float(started_at)
+
+        def _do(conn):
+            cursor = conn.execute(
+                """INSERT INTO attribution_events (
+                   session_id, lineage_id, source, user_id, chat_id, thread_id,
+                   platform_message_id, turn_id, tool_call_id, tool_name,
+                   action_summary, args_summary, side_effect_class, status,
+                   started_at, ended_at, duration_ms, output_digest, error_preview)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    session_id,
+                    lineage_id,
+                    source,
+                    user_id,
+                    chat_id,
+                    thread_id,
+                    platform_message_id,
+                    turn_id,
+                    tool_call_id,
+                    tool_name,
+                    action_summary,
+                    args_summary,
+                    side_effect_class,
+                    status,
+                    started_at,
+                    ended_at,
+                    duration_ms,
+                    output_digest,
+                    error_preview,
+                ),
+            )
+            return cursor.lastrowid
+
+        return self._execute_write(_do)
+
+    def get_attribution_events(
+        self,
+        session_id: str = None,
+        lineage_id: str = None,
+        include_lineage: bool = True,
+        source: str = None,
+        chat_id: str = None,
+        limit: int = 100,
+    ) -> List[Dict[str, Any]]:
+        """Return attribution events for a session or lineage."""
+        where = []
+        params: list[Any] = []
+        if session_id:
+            if include_lineage:
+                lineage_id = lineage_id or self.get_session_lineage_id(session_id) or session_id
+                where.append("lineage_id = ?")
+                params.append(lineage_id)
+            else:
+                where.append("session_id = ?")
+                params.append(session_id)
+        elif lineage_id:
+            where.append("lineage_id = ?")
+            params.append(lineage_id)
+        if source:
+            where.append("source = ?")
+            params.append(source)
+        if chat_id:
+            where.append("chat_id = ?")
+            params.append(chat_id)
+        where_sql = " WHERE " + " AND ".join(where) if where else ""
+        try:
+            limit_int = max(1, min(int(limit), 500))
+        except Exception:
+            limit_int = 100
+        with self._lock:
+            rows = self._conn.execute(
+                f"SELECT * FROM attribution_events{where_sql} ORDER BY started_at ASC, id ASC LIMIT ?",
+                (*params, limit_int),
+            ).fetchall()
+        return [dict(row) for row in rows]
 
     def replace_messages(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
         """Atomically replace every message for a session.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -194,6 +194,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     model TEXT,
     model_config TEXT,
     system_prompt TEXT,
+    prompt_cache_key TEXT,
+    prompt_cache_supported INTEGER,
     parent_session_id TEXT,
     started_at REAL NOT NULL,
     ended_at REAL,
@@ -703,6 +705,8 @@ class SessionDB:
         model: str = None,
         model_config: Dict[str, Any] = None,
         system_prompt: str = None,
+        prompt_cache_key: str = None,
+        prompt_cache_supported: Optional[bool] = None,
         user_id: str = None,
         parent_session_id: str = None,
     ) -> None:
@@ -710,8 +714,9 @@ class SessionDB:
         def _do(conn):
             conn.execute(
                 """INSERT OR IGNORE INTO sessions (id, source, user_id, model, model_config,
-                   system_prompt, parent_session_id, started_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                   system_prompt, prompt_cache_key, prompt_cache_supported,
+                   parent_session_id, started_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     source,
@@ -719,6 +724,8 @@ class SessionDB:
                     model,
                     json.dumps(model_config) if model_config else None,
                     system_prompt,
+                    prompt_cache_key,
+                    None if prompt_cache_supported is None else int(bool(prompt_cache_supported)),
                     parent_session_id,
                     time.time(),
                 ),
@@ -764,6 +771,53 @@ class SessionDB:
                 (system_prompt, session_id),
             )
         self._execute_write(_do)
+
+    def update_prompt_cache_state(
+        self,
+        session_id: str,
+        *,
+        prompt_cache_key: Optional[str] = None,
+        prompt_cache_supported: Optional[bool] = None,
+    ) -> bool:
+        """Persist prompt-cache metadata for a session.
+
+        Returns True when a row was updated, False when the session does not
+        exist.
+        """
+        def _do(conn):
+            cur = conn.execute(
+                "UPDATE sessions SET prompt_cache_key = ?, prompt_cache_supported = ? WHERE id = ?",
+                (
+                    prompt_cache_key,
+                    None if prompt_cache_supported is None else int(bool(prompt_cache_supported)),
+                    session_id,
+                ),
+            )
+            return cur.rowcount > 0
+
+        return bool(self._execute_write(_do))
+
+    def get_prompt_cache_state(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """Return prompt-cache metadata for a session, if any."""
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT prompt_cache_key, prompt_cache_supported FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        prompt_cache_key = row["prompt_cache_key"] if isinstance(row, sqlite3.Row) else row[0]
+        prompt_cache_supported = row["prompt_cache_supported"] if isinstance(row, sqlite3.Row) else row[1]
+        if prompt_cache_key is None and prompt_cache_supported is None:
+            return None
+        if prompt_cache_supported is None:
+            supported_value = None
+        else:
+            supported_value = bool(prompt_cache_supported)
+        return {
+            "prompt_cache_key": prompt_cache_key,
+            "prompt_cache_supported": supported_value,
+        }
 
     def update_token_counts(
         self,

--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -1,30 +1,17 @@
-"""OpenAI image generation backend.
+"""OpenAI-compatible image generation backend.
 
 Exposes OpenAI's ``gpt-image-2`` model at three quality tiers as an
-:class:`ImageGenProvider` implementation. The tiers are implemented as
-three virtual model IDs so the ``hermes tools`` model picker and the
-``image_gen.model`` config key behave like any other multi-model backend:
-
-    gpt-image-2-low     ~15s   fastest, good for iteration
-    gpt-image-2-medium  ~40s   default — balanced
-    gpt-image-2-high    ~2min  slowest, highest fidelity
-
-All three hit the same underlying API model (``gpt-image-2``) with a
-different ``quality`` parameter. Output is base64 JSON → saved under
-``$HERMES_HOME/cache/images/``.
-
-Selection precedence (first hit wins):
-
-1. ``OPENAI_IMAGE_MODEL`` env var (escape hatch for scripts / tests)
-2. ``image_gen.openai.model`` in ``config.yaml``
-3. ``image_gen.model`` in ``config.yaml`` (when it's one of our tier IDs)
-4. :data:`DEFAULT_MODEL` — ``gpt-image-2-medium``
+:class:`ImageGenProvider` implementation. The same provider class is also used
+for named ``custom:<name>`` providers that expose the OpenAI-compatible
+``/images/generations`` and ``/images/edits`` endpoints. It does not use the
+Responses API.
 """
 
 from __future__ import annotations
 
 import logging
 import os
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from agent.image_gen_provider import (
@@ -79,6 +66,11 @@ _SIZES = {
 }
 
 
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
 def _load_openai_config() -> Dict[str, Any]:
     """Read ``image_gen`` from config.yaml (returns {} on any failure)."""
     try:
@@ -116,24 +108,81 @@ def _resolve_model() -> Tuple[str, Dict[str, Any]]:
     return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
 
 
+def _clean_str(value: Any) -> Optional[str]:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _resolve_effective_model(requested: Optional[str]) -> Tuple[str, str, Dict[str, Any]]:
+    """Return ``(reported_model, api_model, meta)`` for a tier or raw model id."""
+    requested = (requested or "").strip()
+    if requested:
+        if requested in _MODELS:
+            return requested, API_MODEL, _MODELS[requested]
+        return requested, requested, {}
+    tier_id, meta = _resolve_model()
+    return tier_id, API_MODEL, meta
+
+
+def _open_file_input(value: Any, *, field: str) -> Tuple[Any, List[Any]]:
+    """Open local image file path(s) for OpenAI's multipart images.edit API."""
+    handles: List[Any] = []
+
+    def _open_one(item: Any) -> Any:
+        if hasattr(item, "read"):
+            return item
+        path_text = str(item or "").strip()
+        if not path_text:
+            raise ValueError(f"{field} must be a non-empty local file path")
+        path = Path(path_text).expanduser()
+        if not path.is_file():
+            raise ValueError(f"{field} must be a local file path; not found: {path_text}")
+        handle = path.open("rb")
+        handles.append(handle)
+        return handle
+
+    if isinstance(value, (list, tuple)):
+        opened = [_open_one(item) for item in value if item]
+        if not opened:
+            raise ValueError(f"{field} must include at least one local file path")
+        return opened, handles
+    return _open_one(value), handles
+
+
 # ---------------------------------------------------------------------------
 # Provider
 # ---------------------------------------------------------------------------
 
 
 class OpenAIImageGenProvider(ImageGenProvider):
-    """OpenAI ``images.generate`` backend — gpt-image-2 at low/medium/high."""
+    """OpenAI ``images.generate`` / ``images.edit`` backend."""
+
+    def __init__(
+        self,
+        *,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        provider_name: str = "openai",
+        default_model: Optional[str] = None,
+    ) -> None:
+        self._api_key = (api_key or "").strip() or None
+        self._base_url = (base_url or "").strip().rstrip("/") or None
+        self._provider_name = (provider_name or "openai").strip() or "openai"
+        self._default_model = (default_model or "").strip() or None
 
     @property
     def name(self) -> str:
-        return "openai"
+        return self._provider_name
 
     @property
     def display_name(self) -> str:
-        return "OpenAI"
+        if self._provider_name == "openai":
+            return "OpenAI"
+        return self._provider_name
 
     def is_available(self) -> bool:
-        if not os.environ.get("OPENAI_API_KEY"):
+        if not (self._api_key or os.environ.get("OPENAI_API_KEY")):
             return False
         try:
             import openai  # noqa: F401
@@ -170,6 +219,14 @@ class OpenAIImageGenProvider(ImageGenProvider):
             ],
         }
 
+    def _client_kwargs(self) -> Dict[str, Any]:
+        kwargs: Dict[str, Any] = {}
+        if self._api_key:
+            kwargs["api_key"] = self._api_key
+        if self._base_url:
+            kwargs["base_url"] = self._base_url
+        return kwargs
+
     def generate(
         self,
         prompt: str,
@@ -183,11 +240,11 @@ class OpenAIImageGenProvider(ImageGenProvider):
             return error_response(
                 error="Prompt is required and must be a non-empty string",
                 error_type="invalid_argument",
-                provider="openai",
+                provider=self.name,
                 aspect_ratio=aspect,
             )
 
-        if not os.environ.get("OPENAI_API_KEY"):
+        if not (self._api_key or os.environ.get("OPENAI_API_KEY")):
             return error_response(
                 error=(
                     "OPENAI_API_KEY not set. Run `hermes tools` → Image "
@@ -195,7 +252,7 @@ class OpenAIImageGenProvider(ImageGenProvider):
                     "to add the key."
                 ),
                 error_type="auth_required",
-                provider="openai",
+                provider=self.name,
                 aspect_ratio=aspect,
             )
 
@@ -205,43 +262,84 @@ class OpenAIImageGenProvider(ImageGenProvider):
             return error_response(
                 error="openai Python package not installed (pip install openai)",
                 error_type="missing_dependency",
-                provider="openai",
+                provider=self.name,
                 aspect_ratio=aspect,
             )
 
-        tier_id, meta = _resolve_model()
-        size = _SIZES.get(aspect, _SIZES["square"])
+        tier_id, api_model, meta = _resolve_effective_model(
+            _clean_str(kwargs.get("model")) or self._default_model
+        )
+        size = _clean_str(kwargs.get("size")) or _SIZES.get(aspect, _SIZES["square"])
+        quality = _clean_str(kwargs.get("quality")) or meta.get("quality")
+        output_format = _clean_str(kwargs.get("output_format"))
+        n = kwargs.get("n", kwargs.get("num_images", 1))
+        operation = "edit" if kwargs.get("image") is not None else "generate"
 
-        # gpt-image-2 returns b64_json unconditionally and REJECTS
-        # ``response_format`` as an unknown parameter. Don't send it.
-        payload: Dict[str, Any] = {
-            "model": API_MODEL,
+        common_payload: Dict[str, Any] = {
+            "model": api_model,
             "prompt": prompt,
             "size": size,
-            "n": 1,
-            "quality": meta["quality"],
+            "n": n,
         }
+        if quality:
+            common_payload["quality"] = quality
+        for key in ("background", "output_compression", "output_format", "user"):
+            if kwargs.get(key) is not None:
+                common_payload[key] = kwargs[key]
 
+        handles: List[Any] = []
         try:
-            client = openai.OpenAI()
-            response = client.images.generate(**payload)
+            client = openai.OpenAI(**self._client_kwargs())
+            if operation == "edit":
+                image_value, image_handles = _open_file_input(kwargs.get("image"), field="image")
+                handles.extend(image_handles)
+                payload = dict(common_payload)
+                payload["image"] = image_value
+                if kwargs.get("mask") is not None:
+                    mask_value, mask_handles = _open_file_input(kwargs.get("mask"), field="mask")
+                    handles.extend(mask_handles)
+                    payload["mask"] = mask_value
+                if kwargs.get("input_fidelity") is not None:
+                    payload["input_fidelity"] = kwargs["input_fidelity"]
+                response = client.images.edit(**payload)
+            else:
+                payload = dict(common_payload)
+                for key in ("moderation", "style"):
+                    if kwargs.get(key) is not None:
+                        payload[key] = kwargs[key]
+                response = client.images.generate(**payload)
+        except ValueError as exc:
+            return error_response(
+                error=str(exc),
+                error_type="invalid_argument",
+                provider=self.name,
+                model=tier_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
         except Exception as exc:
             logger.debug("OpenAI image generation failed", exc_info=True)
             return error_response(
                 error=f"OpenAI image generation failed: {exc}",
                 error_type="api_error",
-                provider="openai",
+                provider=self.name,
                 model=tier_id,
                 prompt=prompt,
                 aspect_ratio=aspect,
             )
+        finally:
+            for handle in handles:
+                try:
+                    handle.close()
+                except Exception:
+                    pass
 
         data = getattr(response, "data", None) or []
         if not data:
             return error_response(
                 error="OpenAI returned no image data",
                 error_type="empty_response",
-                provider="openai",
+                provider=self.name,
                 model=tier_id,
                 prompt=prompt,
                 aspect_ratio=aspect,
@@ -254,32 +352,35 @@ class OpenAIImageGenProvider(ImageGenProvider):
 
         if b64:
             try:
-                saved_path = save_b64_image(b64, prefix=f"openai_{tier_id}")
+                extension = output_format if output_format in {"png", "jpeg", "webp"} else "png"
+                saved_path = save_b64_image(b64, prefix=f"openai_{tier_id}", extension=extension)
             except Exception as exc:
                 return error_response(
                     error=f"Could not save image to cache: {exc}",
                     error_type="io_error",
-                    provider="openai",
+                    provider=self.name,
                     model=tier_id,
                     prompt=prompt,
                     aspect_ratio=aspect,
                 )
             image_ref = str(saved_path)
         elif url:
-            # Defensive — gpt-image-2 returns b64 today, but fall back
-            # gracefully if the API ever changes.
             image_ref = url
         else:
             return error_response(
                 error="OpenAI response contained neither b64_json nor URL",
                 error_type="empty_response",
-                provider="openai",
+                provider=self.name,
                 model=tier_id,
                 prompt=prompt,
                 aspect_ratio=aspect,
             )
 
-        extra: Dict[str, Any] = {"size": size, "quality": meta["quality"]}
+        extra: Dict[str, Any] = {"size": size, "operation": operation}
+        if quality:
+            extra["quality"] = quality
+        if output_format:
+            extra["output_format"] = output_format
         if revised_prompt:
             extra["revised_prompt"] = revised_prompt
 
@@ -288,7 +389,7 @@ class OpenAIImageGenProvider(ImageGenProvider):
             model=tier_id,
             prompt=prompt,
             aspect_ratio=aspect,
-            provider="openai",
+            provider=self.name,
             extra=extra,
         )
 

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -587,9 +587,12 @@ def build_postback_button_message(
 # cache for these so they reach the user as visible bubbles instead of
 # being silently swallowed. From PR #18153.
 _SYSTEM_BYPASS_PREFIXES: Tuple[str, ...] = (
-    "⚡ Interrupting",
-    "⏳ Queued",
-    "⏩ Steered",
+    "⚡ 正在中断",
+    "⏳ 已排队",
+    "⏩ 已插入",
+    "⚡ Interrupting",  # legacy English busy ack
+    "⏳ Queued",        # legacy English busy ack
+    "⏩ Steered",       # legacy English busy ack
     "💾",  # background-review summary
 )
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -2860,6 +2860,11 @@ class AIAgent:
             self._client_kwargs["default_headers"] = copilot_default_headers()
         elif base_url_host_matches(base_url, "api.kimi.com"):
             self._client_kwargs["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
+        elif (
+            base_url_host_matches(base_url, "cpa.yumeapi.cn")
+            or base_url_host_matches(base_url, "ai.yumeapi.cn")
+        ):
+            self._client_kwargs["default_headers"] = {"User-Agent": "curl/8.5.0"}
         elif base_url_host_matches(base_url, "portal.qwen.ai"):
             self._client_kwargs["default_headers"] = _qwen_portal_headers()
         elif base_url_host_matches(base_url, "chatgpt.com"):

--- a/run_agent.py
+++ b/run_agent.py
@@ -513,7 +513,7 @@ class AIAgent:
                 model=self.model,
                 model_config=self._session_init_model_config,
                 system_prompt=self._cached_system_prompt,
-                user_id=None,
+                user_id=self._user_id,
                 parent_session_id=self._parent_session_id,
             )
             self._session_db_created = True

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1942,3 +1942,145 @@ class TestTruncateToolCallArgsJson:
         parsed = _json.loads(shrunk)
         assert parsed["path"] == "~/.hermes/skills/shopping/browser-setup-notes.md"
         assert parsed["content"].endswith("...[truncated]")
+
+
+class TestSummarySafeRetryAndExtractiveFallback:
+    def _mock_summary(self, text):
+        resp = MagicMock()
+        resp.choices = [MagicMock()]
+        resp.choices[0].message.content = text
+        return resp
+
+    def _messages_with_risky_tool_output(self):
+        return [
+            {"role": "user", "content": "请修复 context 压缩失败"},
+            {"role": "assistant", "content": "我会检查压缩代码", "tool_calls": [
+                {"id": "call_1", "function": {"name": "terminal", "arguments": "{\"command\": \"pytest\"}"}}
+            ]},
+            {"role": "tool", "tool_call_id": "call_1", "content": "Traceback (most recent call last):\n" + "blocked scary output\n" * 2000},
+            {"role": "assistant", "content": "发现 summary 被 provider 拦截"},
+            {"role": "user", "content": "长期方案怎么设计"},
+        ]
+
+    def test_blocked_summary_retries_with_scrubbed_prompt(self):
+        err = Exception("Your request was blocked.")
+        ok = self._mock_summary("## Active Task\nUser asked: '长期方案怎么设计'\n\n## Completed Actions\n1. Checked compression failure.")
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="main-model", quiet_mode=True)
+
+        with patch("agent.context_compressor.call_llm", side_effect=[err, ok]) as mock_call:
+            result = c._generate_summary(self._messages_with_risky_tool_output())
+
+        assert mock_call.call_count == 2
+        first_prompt = mock_call.call_args_list[0].kwargs["messages"][0]["content"]
+        second_prompt = mock_call.call_args_list[1].kwargs["messages"][0]["content"]
+        assert "Traceback (most recent call last)" in first_prompt
+        assert "Traceback (most recent call last)" not in second_prompt
+        assert "blocked scary output" not in second_prompt
+        assert "[tool output summarized for safe compression retry]" in second_prompt
+        assert result is not None
+        assert result.startswith(SUMMARY_PREFIX)
+        assert "长期方案怎么设计" in result
+        assert c._last_summary_error is None
+
+    def test_blocked_summary_uses_extractive_fallback_after_safe_retry_fails(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="main-model", quiet_mode=True)
+
+        with patch("agent.context_compressor.call_llm", side_effect=Exception("Your request was blocked.")) as mock_call:
+            result = c._generate_summary(self._messages_with_risky_tool_output())
+
+        assert mock_call.call_count == 2
+        assert result is not None
+        assert result.startswith(SUMMARY_PREFIX)
+        assert "## Active Task" in result
+        assert "长期方案怎么设计" in result
+        assert "## Completed Actions" in result
+        assert "terminal" in result
+        assert "blocked scary output" not in result
+        assert c._last_summary_fallback_used is True
+        assert c._last_summary_error == "extractive fallback after summary failure: Your request was blocked."
+
+    def test_safe_retry_can_be_disabled(self):
+        err = Exception("Your request was blocked.")
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="main-model", quiet_mode=True, safe_retry_enabled=False)
+
+        with patch("agent.context_compressor.call_llm", side_effect=[err]) as mock_call:
+            result = c._generate_summary(self._messages_with_risky_tool_output())
+
+        assert mock_call.call_count == 1
+        assert result is not None
+        assert "extractive fallback" in c._last_summary_error
+
+    def test_chunked_summary_can_be_disabled(self):
+        err = Exception("Your request was blocked.")
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="main-model", quiet_mode=True, chunked_summary_enabled=False)
+
+        with patch("agent.context_compressor.call_llm", side_effect=[err, err]) as mock_call:
+            result = c._generate_summary(self._messages_with_risky_tool_output())
+
+        assert mock_call.call_count == 2
+        assert result is not None
+        assert "extractive fallback" in c._last_summary_error
+
+    def test_extractive_fallback_can_be_disabled(self):
+        err = Exception("Your request was blocked.")
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="main-model", quiet_mode=True, extractive_fallback_enabled=False)
+
+        with patch("agent.context_compressor.call_llm", side_effect=[err, err]) as mock_call:
+            result = c._generate_summary(self._messages_with_risky_tool_output())
+
+        assert mock_call.call_count == 2
+        assert result is None
+        assert c._last_summary_error == "Your request was blocked."
+
+    def test_chunk_message_count_is_configurable(self):
+        err = Exception("Your request was blocked.")
+        chunk1 = self._mock_summary("chunk one")
+        chunk2 = self._mock_summary("chunk two")
+        merged = self._mock_summary("merged")
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="main-model", quiet_mode=True, chunk_summary_messages=3)
+
+        with patch("agent.context_compressor.call_llm", side_effect=[err, err, chunk1, chunk2, merged]) as mock_call:
+            result = c._generate_summary(self._messages_with_risky_tool_output())
+
+        assert mock_call.call_count == 5
+        assert result.startswith(SUMMARY_PREFIX)
+
+    def test_blocked_safe_retry_then_chunked_summary_succeeds(self):
+        err = Exception("Your request was blocked.")
+        chunk1 = self._mock_summary("## Active Task\npart one\n\n## Completed Actions\n1. chunk one summarized")
+        chunk2 = self._mock_summary("## Active Task\npart two\n\n## Completed Actions\n1. chunk two summarized")
+        chunk3 = self._mock_summary("## Active Task\npart three\n\n## Completed Actions\n1. chunk three summarized")
+        merged = self._mock_summary("## Active Task\nUser asked: '长期方案怎么设计'\n\n## Completed Actions\n1. chunk one summarized\n2. chunk two summarized\n3. chunk three summarized")
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="main-model", quiet_mode=True, chunk_summary_messages=2)
+
+        with patch("agent.context_compressor.call_llm", side_effect=[err, err, chunk1, chunk2, chunk3, merged]) as mock_call:
+            result = c._generate_summary(self._messages_with_risky_tool_output())
+
+        assert mock_call.call_count == 6
+        assert result is not None
+        assert result.startswith(SUMMARY_PREFIX)
+        assert "chunk one summarized" in result
+        assert "chunk two summarized" in result
+        assert c._last_summary_fallback_used is False
+
+    def test_chunked_summary_falls_back_extractively_when_one_chunk_blocked(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="main-model", quiet_mode=True, chunk_summary_messages=2)
+
+        with patch("agent.context_compressor.call_llm", side_effect=Exception("Your request was blocked.")) as mock_call:
+            result = c._generate_summary(self._messages_with_risky_tool_output())
+
+        # normal + safe retry + first chunk attempt, then local fallback
+        assert mock_call.call_count == 3
+        assert result is not None
+        assert result.startswith(SUMMARY_PREFIX)
+        assert "## Active Task" in result
+        assert "长期方案怎么设计" in result
+        assert c._last_summary_fallback_used is True

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -155,6 +155,47 @@ class TestCodexBuildKwargs:
         )
         assert "max_output_tokens" not in kw
 
+    def test_custom_codex_proxy_adds_transport_compat_headers(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=[],
+            session_id="custom-codex-session",
+            max_tokens=4096,
+            is_codex_backend=True,
+            use_codex_transport_compat_headers=True,
+        )
+        headers = kw.get("extra_headers", {})
+        assert "max_output_tokens" not in kw
+        assert headers["session_id"] == "custom-codex-session"
+        assert headers["x-client-request-id"] == "custom-codex-session"
+        assert headers["x-codex-window-id"] == "custom-codex-session:0"
+        assert headers["originator"] == "codex_exec"
+        assert "codex_exec/0.120.0" in headers["User-Agent"]
+        metadata = json.loads(headers["x-codex-turn-metadata"])
+        assert metadata["session_id"] == "custom-codex-session"
+        assert metadata["window_id"] == "custom-codex-session:0"
+        assert metadata["sandbox"] == "none"
+        assert isinstance(metadata["turn_id"], str) and metadata["turn_id"]
+
+    def test_codex_backend_without_proxy_flag_omits_transport_compat_headers(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=[],
+            session_id="official-codex-session",
+            is_codex_backend=True,
+        )
+        headers = kw.get("extra_headers", {})
+        assert headers["session_id"] == "official-codex-session"
+        assert headers["x-client-request-id"] == "official-codex-session"
+        assert "x-codex-window-id" not in headers
+        assert "originator" not in headers
+        assert "User-Agent" not in headers
+        assert "x-codex-turn-metadata" not in headers
+
     def test_xai_headers(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(

--- a/tests/e2e/test_platform_commands.py
+++ b/tests/e2e/test_platform_commands.py
@@ -88,6 +88,9 @@ class TestSlashCommands:
         if platform != Platform.TELEGRAM:
             pytest.skip("Plaintext restart shortcut is intentionally DM/Telegram-focused")
 
+        monkeypatch.delenv("HERMES_WEBUI_STATE_DIR", raising=False)
+        monkeypatch.delenv("HERMES_WEBUI_PORT", raising=False)
+        monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
         monkeypatch.setenv("INVOCATION_ID", "e2e-systemd")
         runner.request_restart = MagicMock(return_value=True)
 
@@ -103,6 +106,9 @@ class TestSlashCommands:
         if platform != Platform.TELEGRAM:
             pytest.skip("Shortcut scope is only verified for Telegram here")
 
+        monkeypatch.delenv("HERMES_WEBUI_STATE_DIR", raising=False)
+        monkeypatch.delenv("HERMES_WEBUI_PORT", raising=False)
+        monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
         monkeypatch.setenv("INVOCATION_ID", "e2e-systemd")
         runner.request_restart = MagicMock(return_value=True)
         runner._handle_message_with_agent = AsyncMock(return_value="agent-handled")

--- a/tests/gateway/test_auto_continue.py
+++ b/tests/gateway/test_auto_continue.py
@@ -19,11 +19,9 @@ def _simulate_auto_continue(agent_history: list, user_message: str) -> str:
     message = user_message
     if agent_history and agent_history[-1].get("role") == "tool":
         message = (
-            "[System note: Your previous turn was interrupted before you could "
-            "process the last tool result(s). The conversation history contains "
-            "tool outputs you haven't responded to yet. Please finish processing "
-            "those results and summarize what was accomplished, then address the "
-            "user's new message below.]\n\n"
+            "[系统提示：上一轮在处理最后的 tool result(s) 前被中断。"
+            "conversation history 里还有尚未回复的 tool outputs。"
+            "请先处理这些结果并总结已完成内容，再处理下面用户的新消息。]\n\n"
             + message
         )
     return message
@@ -41,8 +39,8 @@ class TestAutoDetection:
             {"role": "tool", "tool_call_id": "call_1", "content": "deployed successfully"},
         ]
         result = _simulate_auto_continue(history, "what happened?")
-        assert "[System note:" in result
-        assert "interrupted" in result
+        assert "[系统提示：" in result
+        assert "被中断" in result
         assert "what happened?" in result
 
     def test_trailing_assistant_message_no_note(self):
@@ -51,7 +49,7 @@ class TestAutoDetection:
             {"role": "assistant", "content": "Hi there!"},
         ]
         result = _simulate_auto_continue(history, "how are you?")
-        assert "[System note:" not in result
+        assert "[系统提示：" not in result
         assert result == "how are you?"
 
     def test_empty_history_no_note(self):
@@ -78,7 +76,7 @@ class TestAutoDetection:
             {"role": "tool", "tool_call_id": "call_2", "content": "file content here"},
         ]
         result = _simulate_auto_continue(history, "continue")
-        assert "[System note:" in result
+        assert "[系统提示：" in result
 
     def test_original_message_preserved_after_note(self):
         """The user's actual message must appear after the system note."""

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -155,7 +155,7 @@ class TestBusySessionAck:
         if not content and call_kwargs.args:
             # positional args
             content = str(call_kwargs)
-        assert "Interrupting" in content or "respond" in content
+        assert "正在中断" in content or "马上处理" in content
         assert "/stop" not in content  # no need — we ARE interrupting
 
         # Verify agent interrupt was called
@@ -185,9 +185,9 @@ class TestBusySessionAck:
         adapter._send_with_retry.assert_called_once()
         call_kwargs = adapter._send_with_retry.call_args
         content = call_kwargs.kwargs.get("content") or call_kwargs[1].get("content", "")
-        assert "Queued for the next turn" in content
-        assert "respond once the current task finishes" in content
-        assert "Interrupting" not in content
+        assert "已排队到下一轮" in content
+        assert "当前任务结束后我会回复" in content
+        assert "正在中断" not in content
 
     @pytest.mark.asyncio
     async def test_busy_text_mode_queue_delegates_to_adapter_handle_message(self):
@@ -244,8 +244,8 @@ class TestBusySessionAck:
         adapter._send_with_retry.assert_called_once()
         call_kwargs = adapter._send_with_retry.call_args
         content = call_kwargs.kwargs.get("content") or call_kwargs[1].get("content", "")
-        assert "Steered" in content or "steer" in content.lower()
-        assert "Interrupting" not in content
+        assert "已插入当前任务" in content or "下一个工具调用" in content
+        assert "正在中断" not in content
 
     @pytest.mark.asyncio
     async def test_steer_mode_falls_back_to_queue_when_agent_rejects(self):
@@ -273,8 +273,8 @@ class TestBusySessionAck:
         # Ack uses queue-mode wording (not steer, not interrupt)
         call_kwargs = adapter._send_with_retry.call_args
         content = call_kwargs.kwargs.get("content") or call_kwargs[1].get("content", "")
-        assert "Queued for the next turn" in content
-        assert "Steered" not in content
+        assert "已排队到下一轮" in content
+        assert "已插入当前任务" not in content
 
     @pytest.mark.asyncio
     async def test_steer_mode_falls_back_to_queue_when_agent_pending(self):
@@ -298,7 +298,7 @@ class TestBusySessionAck:
 
         call_kwargs = adapter._send_with_retry.call_args
         content = call_kwargs.kwargs.get("content") or call_kwargs[1].get("content", "")
-        assert "Queued for the next turn" in content
+        assert "已排队到下一轮" in content
 
     @pytest.mark.asyncio
     async def test_debounce_suppresses_rapid_acks(self):
@@ -404,9 +404,9 @@ class TestBusySessionAck:
 
         call_kwargs = adapter._send_with_retry.call_args
         content = call_kwargs.kwargs.get("content", "")
-        assert "21/60" in content  # iteration
+        assert "轮次 21/60" in content  # iteration
         assert "terminal" in content  # current tool
-        assert "10 min" in content  # elapsed
+        assert "10 分钟" in content  # elapsed
 
     @pytest.mark.asyncio
     async def test_draining_still_works(self):
@@ -422,14 +422,14 @@ class TestBusySessionAck:
 
         # Mock the drain-specific methods
         runner._queue_during_drain_enabled = lambda: False
-        runner._status_action_gerund = lambda: "restarting"
+        runner._status_action_zh = lambda: "重启"
 
         result = await runner._handle_active_session_busy_message(event, sk)
         assert result is True
 
         call_kwargs = adapter._send_with_retry.call_args
         content = call_kwargs.kwargs.get("content", "")
-        assert "restarting" in content
+        assert "正在重启" in content
 
     @pytest.mark.asyncio
     async def test_pending_sentinel_no_interrupt(self):
@@ -501,9 +501,9 @@ class TestBusySessionOnboardingHint:
         content = call_kwargs.kwargs.get("content", "")
 
         # Normal ack body
-        assert "Interrupting" in content
+        assert "正在中断" in content
         # First-touch hint appended
-        assert "First-time tip" in content
+        assert "首次提示" in content
         assert "/busy queue" in content
 
         # The flag is now persisted to tmp_path/config.yaml
@@ -549,8 +549,8 @@ class TestBusySessionOnboardingHint:
         call_kwargs = adapter._send_with_retry.call_args
         content = call_kwargs.kwargs.get("content", "")
 
-        assert "Interrupting" in content
-        assert "First-time tip" not in content
+        assert "正在中断" in content
+        assert "首次提示" not in content
         assert "/busy queue" not in content
 
     @pytest.mark.asyncio
@@ -576,8 +576,8 @@ class TestBusySessionOnboardingHint:
             await runner._handle_active_session_busy_message(event, sk)
 
         content = adapter._send_with_retry.call_args.kwargs.get("content", "")
-        assert "Queued for the next turn" in content
-        assert "First-time tip" in content
+        assert "已排队到下一轮" in content
+        assert "首次提示" in content
         assert "/busy interrupt" in content
         # Must NOT tell the user to /busy queue when they're already on queue.
         assert "/busy queue" not in content

--- a/tests/gateway/test_destructive_slash_confirm.py
+++ b/tests/gateway/test_destructive_slash_confirm.py
@@ -120,9 +120,12 @@ async def test_gate_on_text_fallback_returns_prompt_without_executing(monkeypatc
 
     execute.assert_not_awaited()
     assert isinstance(result, str)
-    assert "Confirm /new" in result
-    assert "Approve Once" in result
-    assert "Cancel" in result
+    assert "确认 /new" in result
+    assert "批准一次" in result
+    assert "取消" in result
+    assert "Confirm /new" not in result
+    assert "Approve Once" not in result
+    assert "Cancel" not in result
 
 
 @pytest.mark.asyncio
@@ -235,8 +238,11 @@ async def test_resolve_always_persists_opt_out_and_runs_execute(monkeypatch):
         saved[path] = value
         return True
 
-    import cli as cli_mod
-    monkeypatch.setattr(cli_mod, "save_config_value", _fake_save)
+    import sys
+    import types
+
+    cli_mod = types.SimpleNamespace(save_config_value=_fake_save)
+    monkeypatch.setitem(sys.modules, "cli", cli_mod)
 
     execute = AsyncMock(return_value="✨ fresh")
 

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -319,6 +319,9 @@ class TestSendRouting:
         return ad
 
     def test_system_bypass_recognized(self):
+        assert _is_system_bypass("⚡ 正在中断当前任务")
+        assert _is_system_bypass("⏳ 已排队到下一轮")
+        assert _is_system_bypass("⏩ 已插入当前任务")
         assert _is_system_bypass("⚡ Interrupting current run")
         assert _is_system_bypass("⏳ Queued — agent is busy")
         assert _is_system_bypass("⏩ Steered toward new task")
@@ -372,7 +375,7 @@ class TestSendRouting:
         # Even with a pending button, system busy-acks must surface visibly.
         rid = adapter._cache.register_pending("Uchat")
         adapter._pending_buttons["Uchat"] = rid
-        result = asyncio.run(adapter.send("Uchat", "⚡ Interrupting current run"))
+        result = asyncio.run(adapter.send("Uchat", "⚡ 正在中断当前任务"))
         assert result.success
         # Bypass goes through push (no reply token stored)
         adapter._client.push.assert_called_once()

--- a/tests/gateway/test_media_extraction.py
+++ b/tests/gateway/test_media_extraction.py
@@ -10,6 +10,8 @@ times per reply. (Regression test for #160)
 import pytest
 import re
 
+from gateway.run import _extract_trusted_tool_media_tags
+
 
 def extract_media_tags_fixed(result_messages, history_len):
     """
@@ -67,6 +69,113 @@ def extract_media_tags_broken(result_messages):
 
 class TestMediaExtraction:
     """Tests for MEDIA tag extraction from tool results."""
+
+    def test_session_search_media_tags_are_not_extracted_from_current_turn(self, tmp_path):
+        """Historical MEDIA strings returned by session_search are evidence, not attachments."""
+        old_image = tmp_path / "old.png"
+        old_image.write_bytes(b"fake png bytes")
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "call_search", "function": {"name": "session_search"}},
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_search",
+                "content": f"Past transcript said MEDIA:{old_image}",
+            },
+        ]
+
+        tags, voice_directive = _extract_trusted_tool_media_tags(
+            messages,
+            history_media_paths=set(),
+        )
+
+        assert tags == []
+        assert voice_directive is False
+
+    def test_terminal_media_tags_are_not_extracted_from_current_turn(self, tmp_path):
+        """Command output can print MEDIA-looking text without requesting upload."""
+        artifact = tmp_path / "artifact.png"
+        artifact.write_bytes(b"fake png bytes")
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "call_terminal", "function": {"name": "terminal"}},
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_terminal",
+                "content": f"stdout: MEDIA:{artifact}",
+            },
+        ]
+
+        tags, voice_directive = _extract_trusted_tool_media_tags(
+            messages,
+            history_media_paths=set(),
+        )
+
+        assert tags == []
+        assert voice_directive is False
+
+    def test_text_to_speech_media_tags_are_extracted_from_current_turn(self, tmp_path):
+        """Trusted media tools still auto-append generated media for delivery."""
+        audio = tmp_path / "speech.ogg"
+        audio.write_bytes(b"fake audio bytes")
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "call_tts", "function": {"name": "text_to_speech"}},
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_tts",
+                "content": f'{{"media_tag": "[[audio_as_voice]]\\nMEDIA:{audio}"}}',
+            },
+        ]
+
+        tags, voice_directive = _extract_trusted_tool_media_tags(
+            messages,
+            history_media_paths=set(),
+        )
+
+        assert tags == [f"MEDIA:{audio}"]
+        assert voice_directive is True
+
+    def test_history_media_paths_are_compared_after_expanding_user(self, tmp_path, monkeypatch):
+        """A trusted tool must not resend a ~/ path already present as an absolute history path."""
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        audio = home / "speech.ogg"
+        audio.write_bytes(b"fake audio bytes")
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "call_tts", "function": {"name": "text_to_speech"}},
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_tts",
+                "content": "MEDIA:~/speech.ogg",
+            },
+        ]
+
+        tags, voice_directive = _extract_trusted_tool_media_tags(
+            messages,
+            history_media_paths={str(audio)},
+        )
+
+        assert tags == []
+        assert voice_directive is False
     
     def test_media_tags_not_extracted_from_history(self):
         """MEDIA tags from previous turns should NOT be extracted again."""

--- a/tests/gateway/test_media_extraction.py
+++ b/tests/gateway/test_media_extraction.py
@@ -7,6 +7,7 @@ This prevents voice messages from accumulating and being sent multiple
 times per reply. (Regression test for #160)
 """
 
+import json
 import pytest
 import re
 
@@ -147,6 +148,65 @@ class TestMediaExtraction:
 
         assert tags == [f"MEDIA:{audio}"]
         assert voice_directive is True
+
+    def test_mcp_explicit_media_tags_are_extracted_from_current_turn(self, tmp_path):
+        """MCP ImageContent blocks carry explicit media metadata for gateway delivery."""
+        image = tmp_path / "screenshot.png"
+        image.write_bytes(b"fake png bytes")
+        tag = f"MEDIA:{image}"
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "call_mcp", "function": {"name": "mcp_playwright_screenshot"}},
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_mcp",
+                "content": json.dumps(
+                    {"result": tag, "_hermes_media_tags": [tag]},
+                    ensure_ascii=False,
+                ),
+            },
+        ]
+
+        tags, voice_directive = _extract_trusted_tool_media_tags(
+            messages,
+            history_media_paths=set(),
+        )
+
+        assert tags == [tag]
+        assert voice_directive is False
+
+    def test_mcp_plain_result_media_tags_are_not_extracted_without_metadata(self, tmp_path):
+        """MCP text evidence mentioning MEDIA must not become an attachment directive."""
+        image = tmp_path / "historical.png"
+        image.write_bytes(b"fake png bytes")
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "call_mcp", "function": {"name": "mcp_filesystem_read_file"}},
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_mcp",
+                "content": json.dumps(
+                    {"result": f"A log line said MEDIA:{image}"},
+                    ensure_ascii=False,
+                ),
+            },
+        ]
+
+        tags, voice_directive = _extract_trusted_tool_media_tags(
+            messages,
+            history_media_paths=set(),
+        )
+
+        assert tags == []
+        assert voice_directive is False
 
     def test_history_media_paths_are_compared_after_expanding_user(self, tmp_path, monkeypatch):
         """A trusted tool must not resend a ~/ path already present as an absolute history path."""

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -329,6 +329,30 @@ class TestExtractMedia:
         assert media == [("/tmp/Jane Doe/speech.flac", False)]
         assert cleaned == ""
 
+    def test_media_tag_in_inline_code_is_not_an_attachment(self):
+        content = "历史记录里出现了 `MEDIA:/tmp/old.png`，不要发送它。"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == []
+        assert cleaned == content
+
+    def test_media_tag_in_fenced_code_is_not_an_attachment(self):
+        content = "```text\nMEDIA:/tmp/old.png\n```"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == []
+        assert cleaned == content
+
+    def test_media_tag_in_quote_is_not_an_attachment(self):
+        content = "> MEDIA:/tmp/old.png"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == []
+        assert cleaned == content
+
+    def test_media_tag_mid_sentence_is_not_an_attachment(self):
+        content = "session_search returned MEDIA:/tmp/old.png yesterday"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == []
+        assert cleaned == content
+
     def test_as_document_directive_stripped_from_cleaned_text(self):
         """[[as_document]] is a routing directive — strip it from
         user-visible text just like [[audio_as_voice]]. Callers detect the

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -138,8 +138,8 @@ class TestIsVoiceContentType:
     def test_voice_content_type(self):
         assert self._fn("voice", "msg.silk") is True
 
-    def test_audio_content_type(self):
-        assert self._fn("audio/mp3", "file.mp3") is True
+    def test_plain_audio_file_is_not_voice_message(self):
+        assert self._fn("audio/mp3", "file.mp3") is False
 
     def test_voice_extension(self):
         assert self._fn("", "file.silk") is True

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1894,11 +1894,10 @@ class TestProcessAttachmentsPathExposure:
     async def test_video_attachment_includes_path(self):
         adapter = self._make_adapter()
 
-        # Mock _download_and_cache to return a known path
-        async def fake_download(url, ct, original_name=""):
-            return "/tmp/cache/video_abc123.mp4"
+        async def fake_download(url, max_bytes, *, follow_redirects=False):
+            return b"fake video bytes"
 
-        adapter._download_and_cache = fake_download  # type: ignore[assignment]
+        adapter._download_attachment_bytes = fake_download  # type: ignore[assignment]
 
         attachments = [
             {
@@ -1912,18 +1911,20 @@ class TestProcessAttachmentsPathExposure:
         assert result["image_urls"] == []
         assert result["voice_transcripts"] == []
         info = result["attachment_info"]
-        assert "[video:" in info
+        assert "[文件: my_video.mp4]" in info
+        assert "本地路径:" in info
         assert "my_video.mp4" in info
-        assert "/tmp/cache/video_abc123.mp4" in info
+        assert result["attachments"][0].kind == "media"
+        assert result["attachments"][0].local_path.endswith("my_video.mp4")
 
     @pytest.mark.asyncio
     async def test_file_attachment_includes_path(self):
         adapter = self._make_adapter()
 
-        async def fake_download(url, ct, original_name=""):
-            return "/tmp/cache/doc_abc123_report.pdf"
+        async def fake_download(url, max_bytes, *, follow_redirects=False):
+            return b"%PDF-1.4 fake pdf bytes"
 
-        adapter._download_and_cache = fake_download  # type: ignore[assignment]
+        adapter._download_attachment_bytes = fake_download  # type: ignore[assignment]
 
         attachments = [
             {
@@ -1935,18 +1936,20 @@ class TestProcessAttachmentsPathExposure:
         result = await adapter._process_attachments(attachments)
 
         info = result["attachment_info"]
-        assert "[file:" in info
-        assert "report.pdf" in info
-        assert "/tmp/cache/doc_abc123_report.pdf" in info
+        assert "[文件: report.pdf]" in info
+        assert "本地路径:" in info
+        assert "PDF 已保存" in info
+        assert result["attachments"][0].kind == "document"
+        assert result["attachments"][0].local_path.endswith("report.pdf")
 
     @pytest.mark.asyncio
-    async def test_video_without_filename_falls_back_to_content_type(self):
+    async def test_video_without_filename_falls_back_to_url_name(self):
         adapter = self._make_adapter()
 
-        async def fake_download(url, ct, original_name=""):
-            return "/tmp/cache/video_xyz.mp4"
+        async def fake_download(url, max_bytes, *, follow_redirects=False):
+            return b"fake video bytes"
 
-        adapter._download_and_cache = fake_download  # type: ignore[assignment]
+        adapter._download_attachment_bytes = fake_download  # type: ignore[assignment]
 
         attachments = [
             {
@@ -1958,17 +1961,19 @@ class TestProcessAttachmentsPathExposure:
         result = await adapter._process_attachments(attachments)
 
         info = result["attachment_info"]
-        assert "[video: video/mp4" in info
-        assert "/tmp/cache/video_xyz.mp4" in info
+        assert "[文件: vid]" in info
+        assert "本地路径:" in info
+        assert result["attachments"][0].kind == "media"
+        assert result["attachments"][0].local_path.endswith("vid")
 
     @pytest.mark.asyncio
-    async def test_download_failure_produces_no_attachment_info(self):
+    async def test_download_failure_produces_attachment_info(self):
         adapter = self._make_adapter()
 
-        async def fake_download(url, ct, original_name=""):
+        async def fake_download(url, max_bytes, *, follow_redirects=False):
             return None
 
-        adapter._download_and_cache = fake_download  # type: ignore[assignment]
+        adapter._download_attachment_bytes = fake_download  # type: ignore[assignment]
 
         attachments = [
             {
@@ -1978,7 +1983,7 @@ class TestProcessAttachmentsPathExposure:
             }
         ]
         result = await adapter._process_attachments(attachments)
-        assert result["attachment_info"] == ""
+        assert "下载失败或超过大小限制" in result["attachment_info"]
 
     @pytest.mark.asyncio
     async def test_quoted_video_includes_path_in_quote_block(self):

--- a/tests/gateway/test_qqbot_file_attachments.py
+++ b/tests/gateway/test_qqbot_file_attachments.py
@@ -1,0 +1,327 @@
+"""Tests for QQ Bot non-image file attachment handling."""
+
+import asyncio
+import io
+import json
+import zipfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.qqbot import QQAdapter
+
+
+def _make_adapter() -> QQAdapter:
+    adapter = QQAdapter(PlatformConfig(enabled=True, extra={"app_id": "a", "client_secret": "b"}))
+    adapter._http_client = mock.AsyncMock()
+    return adapter
+
+
+class TestQQAttachmentPolicy:
+    def test_txt_html_pdf_zip_are_allowed(self):
+        from gateway.platforms.qqbot.adapter import QQ_INBOUND_ATTACHMENT_POLICY
+
+        for filename in ("note.txt", "page.html", "report.pdf", "src.zip"):
+            assert QQ_INBOUND_ATTACHMENT_POLICY.classify(filename, "") is not None
+
+    def test_executable_and_secret_key_files_are_rejected(self):
+        from gateway.platforms.qqbot.adapter import QQ_INBOUND_ATTACHMENT_POLICY
+
+        for filename in ("run.exe", "lib.so", ".env", "id_rsa.key", "cert.pem"):
+            assert QQ_INBOUND_ATTACHMENT_POLICY.classify(filename, "") is None
+
+    def test_archive_limits_are_larger_than_regular_files(self):
+        from gateway.platforms.qqbot.adapter import QQ_INBOUND_ATTACHMENT_POLICY
+
+        regular = QQ_INBOUND_ATTACHMENT_POLICY.classify("note.txt", "text/plain")
+        archive = QQ_INBOUND_ATTACHMENT_POLICY.classify("project.zip", "application/zip")
+
+        assert regular.max_bytes == 20 * 1024 * 1024
+        assert archive.max_bytes == 200 * 1024 * 1024
+        assert archive.extract_max_total_bytes == 1024 * 1024 * 1024
+        assert archive.extract_max_files == 10000
+
+
+class TestQQDownloadedFileDescriptions:
+    @pytest.mark.asyncio
+    async def test_text_file_is_cached_and_previewed(self, tmp_path, monkeypatch):
+        adapter = _make_adapter()
+        payload = b"hello\nworld\n"
+        adapter._http_client.get = mock.AsyncMock(
+            return_value=SimpleNamespace(
+                content=payload,
+                headers={"content-length": str(len(payload))},
+                raise_for_status=lambda: None,
+            )
+        )
+        monkeypatch.setattr("gateway.platforms.qqbot.adapter.cache_document_from_bytes", lambda data, name: str(tmp_path / name))
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda url: True)
+        monkeypatch.setattr(Path, "write_bytes", lambda self, data: len(data), raising=False)
+
+        result = await adapter._process_attachments([
+            {"content_type": "text/plain", "url": "https://qq.example/note.txt", "filename": "note.txt"}
+        ])
+
+        assert "note.txt" in result["attachment_info"]
+        assert "本地路径" in result["attachment_info"]
+        assert "hello" in result["attachment_info"]
+        assert "world" in result["attachment_info"]
+
+    @pytest.mark.asyncio
+    async def test_html_file_gets_text_preview_without_raw_tags(self, tmp_path, monkeypatch):
+        adapter = _make_adapter()
+        payload = b"<html><body><h1>Title</h1><script>bad()</script><p>Hello HTML</p></body></html>"
+        adapter._http_client.get = mock.AsyncMock(
+            return_value=SimpleNamespace(
+                content=payload,
+                headers={"content-length": str(len(payload))},
+                raise_for_status=lambda: None,
+            )
+        )
+        monkeypatch.setattr("gateway.platforms.qqbot.adapter.cache_document_from_bytes", lambda data, name: str(tmp_path / name))
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda url: True)
+        monkeypatch.setattr(Path, "write_bytes", lambda self, data: len(data), raising=False)
+
+        result = await adapter._process_attachments([
+            {"content_type": "text/html", "url": "https://qq.example/page.html", "filename": "page.html"}
+        ])
+
+        info = result["attachment_info"]
+        assert "page.html" in info
+        assert "Title" in info
+        assert "Hello HTML" in info
+        assert "<h1>" not in info
+        assert "bad()" not in info
+
+    @pytest.mark.asyncio
+    async def test_zip_file_is_cached_but_not_auto_extracted(self, tmp_path, monkeypatch):
+        adapter = _make_adapter()
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("README.md", "hello")
+        payload = buf.getvalue()
+        adapter._http_client.get = mock.AsyncMock(
+            return_value=SimpleNamespace(
+                content=payload,
+                headers={"content-length": str(len(payload))},
+                raise_for_status=lambda: None,
+            )
+        )
+        monkeypatch.setattr("gateway.platforms.qqbot.adapter.cache_document_from_bytes", lambda data, name: str(tmp_path / name))
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda url: True)
+        monkeypatch.setattr(Path, "write_bytes", lambda self, data: len(data), raising=False)
+
+        result = await adapter._process_attachments([
+            {"content_type": "application/zip", "url": "https://qq.example/project.zip", "filename": "project.zip"}
+        ])
+
+        info = result["attachment_info"]
+        assert "project.zip" in info
+        assert "未自动解压" in info
+        assert "文件数: 1" in info
+
+    @pytest.mark.asyncio
+    async def test_oversized_archive_is_rejected_before_cache(self, monkeypatch):
+        adapter = _make_adapter()
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda url: True)
+        too_large = 200 * 1024 * 1024 + 1
+        adapter._http_client.get = mock.AsyncMock(
+            return_value=SimpleNamespace(
+                content=b"x",
+                headers={"content-length": str(too_large)},
+                raise_for_status=lambda: None,
+            )
+        )
+
+        with mock.patch("gateway.platforms.qqbot.adapter.cache_document_from_bytes") as cache_doc:
+            result = await adapter._process_attachments([
+                {"content_type": "application/zip", "url": "https://qq.example/big.zip", "filename": "big.zip"}
+            ])
+
+        cache_doc.assert_not_called()
+        assert "超过大小限制" in result["attachment_info"]
+
+    @pytest.mark.asyncio
+    async def test_blocked_extension_is_reported_not_downloaded(self):
+        adapter = _make_adapter()
+
+        result = await adapter._process_attachments([
+            {"content_type": "application/octet-stream", "url": "https://qq.example/run.exe", "filename": "run.exe"}
+        ])
+
+        adapter._http_client.get.assert_not_called()
+        assert "不支持或敏感类型" in result["attachment_info"]
+
+    @pytest.mark.asyncio
+    async def test_oversized_image_is_rejected_before_cache(self, monkeypatch):
+        adapter = _make_adapter()
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda url: True)
+        too_large = 25 * 1024 * 1024 + 1
+        adapter._http_client.get = mock.AsyncMock(
+            return_value=SimpleNamespace(
+                content=b"\x89PNG\r\n\x1a\nsmall",
+                headers={"content-length": str(too_large)},
+                raise_for_status=lambda: None,
+            )
+        )
+
+        with mock.patch("gateway.platforms.qqbot.adapter.cache_image_from_bytes") as cache_img:
+            result = await adapter._process_attachments([
+                {"content_type": "image/png", "url": "https://qq.example/big.png", "filename": "big.png"}
+            ], message_id="msg-img")
+
+        cache_img.assert_not_called()
+        assert result["image_urls"] == []
+        assert "图片" in result["attachment_info"]
+        assert "超过大小限制" in result["attachment_info"]
+
+    @pytest.mark.asyncio
+    async def test_oversized_voice_is_rejected_before_stt(self, tmp_path, monkeypatch):
+        adapter = _make_adapter()
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda url: True)
+        too_large = 100 * 1024 * 1024 + 1
+        adapter._http_client.get = mock.AsyncMock(
+            return_value=SimpleNamespace(
+                content=b"0123456789abcdef",
+                headers={"content-length": str(too_large)},
+                raise_for_status=lambda: None,
+            )
+        )
+        wav = tmp_path / "voice.wav"
+        wav.write_bytes(b"RIFFxxxx")
+        adapter._convert_audio_to_wav_file = mock.AsyncMock(return_value=str(wav))
+        adapter._call_stt = mock.AsyncMock(return_value="should-not-run")
+
+        result = await adapter._process_attachments([
+            {"content_type": "voice", "url": "https://qq.example/voice.silk", "filename": "voice.silk"}
+        ], message_id="msg-voice")
+
+        adapter._call_stt.assert_not_called()
+        assert result["voice_transcripts"] == ["[Voice] [语音识别失败]"]
+        assert "语音超过大小限制" in result["attachment_info"]
+
+    @pytest.mark.asyncio
+    async def test_regular_audio_file_is_structured_media_not_voice_stt(self, tmp_path, monkeypatch):
+        adapter = _make_adapter()
+        payload = b"ID3 audio payload"
+        adapter._http_client.get = mock.AsyncMock(
+            return_value=SimpleNamespace(
+                content=payload,
+                headers={"content-length": str(len(payload))},
+                raise_for_status=lambda: None,
+            )
+        )
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda url: True)
+        monkeypatch.setattr("gateway.platforms.qqbot.adapter.get_document_cache_dir", lambda: tmp_path)
+        adapter._stt_voice_attachment = mock.AsyncMock(return_value="wrong")
+
+        result = await adapter._process_attachments([
+            {"content_type": "audio/mpeg", "url": "https://qq.example/song.mp3", "filename": "song.mp3"}
+        ], message_id="msg-audio")
+
+        adapter._stt_voice_attachment.assert_not_called()
+        assert result["voice_transcripts"] == []
+        assert "song.mp3" in result["attachment_info"]
+        assert result["attachments"][0].kind == "media"
+        assert result["attachments"][0].filename == "song.mp3"
+
+    @pytest.mark.asyncio
+    async def test_inbound_cache_uses_message_id_directory_and_meta_json(self, tmp_path, monkeypatch):
+        adapter = _make_adapter()
+        payload = b"hello\n"
+        adapter._http_client.get = mock.AsyncMock(
+            return_value=SimpleNamespace(
+                content=payload,
+                headers={"content-length": str(len(payload))},
+                raise_for_status=lambda: None,
+            )
+        )
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda url: True)
+        monkeypatch.setattr("gateway.platforms.qqbot.adapter.get_document_cache_dir", lambda: tmp_path)
+
+        result = await adapter._process_attachments([
+            {"content_type": "text/plain", "url": "https://qq.example/note.txt", "filename": "note.txt"}
+        ], message_id="msg-123")
+
+        attachment = result["attachments"][0]
+        local_path = Path(attachment.local_path)
+        assert local_path.parent == tmp_path / "qqbot" / "msg-123"
+        assert local_path.read_bytes() == payload
+        meta = json.loads((local_path.parent / "meta.json").read_text(encoding="utf-8"))
+        assert meta["platform"] == "qqbot"
+        assert meta["message_id"] == "msg-123"
+        assert meta["attachments"][0]["filename"] == "note.txt"
+        assert meta["attachments"][0]["local_path"] == str(local_path)
+
+    def test_zip_extracts_to_isolated_directory_and_blocks_traversal(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("gateway.platforms.qqbot.adapter.get_document_cache_dir", lambda: tmp_path)
+        archive = tmp_path / "qqbot" / "msg-zip" / "archive.zip"
+        archive.parent.mkdir(parents=True)
+        with zipfile.ZipFile(archive, "w") as zf:
+            zf.writestr("dir/file.txt", "ok")
+
+        extracted = QQAdapter.extract_archive_to_isolated_dir(str(archive), message_id="msg-zip")
+
+        assert extracted.parent == archive.parent
+        assert (extracted / "dir" / "file.txt").read_text(encoding="utf-8") == "ok"
+
+        unsafe = archive.parent / "unsafe.zip"
+        with zipfile.ZipFile(unsafe, "w") as zf:
+            zf.writestr("../escape.txt", "no")
+
+        with pytest.raises(ValueError, match="Unsafe archive path"):
+            QQAdapter.extract_archive_to_isolated_dir(str(unsafe), message_id="msg-zip")
+
+    @pytest.mark.asyncio
+    async def test_c2c_message_event_includes_structured_non_image_attachment(self, tmp_path, monkeypatch):
+        adapter = _make_adapter()
+        payload = b"hello from file\n"
+        adapter._http_client.get = mock.AsyncMock(
+            return_value=SimpleNamespace(
+                content=payload,
+                headers={"content-length": str(len(payload))},
+                raise_for_status=lambda: None,
+            )
+        )
+        adapter.handle_message = mock.AsyncMock()
+        monkeypatch.setattr("tools.url_safety.is_safe_url", lambda url: True)
+        monkeypatch.setattr("gateway.platforms.qqbot.adapter.get_document_cache_dir", lambda: tmp_path)
+
+        await adapter._handle_c2c_message(
+            {
+                "attachments": [
+                    {
+                        "content_type": "text/plain",
+                        "url": "https://qq.example/note.txt",
+                        "filename": "note.txt",
+                    }
+                ]
+            },
+            "msg-event",
+            "see attached",
+            {"user_openid": "user-1"},
+            "",
+        )
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        assert "本地路径" in event.text
+        assert len(event.attachments) == 1
+        assert event.attachments[0].filename == "note.txt"
+        assert event.attachments[0].message_id == "msg-event"
+        assert Path(event.attachments[0].local_path).parent == tmp_path / "qqbot" / "msg-event"
+
+    @pytest.mark.asyncio
+    async def test_send_document_blocks_dangerous_extensions_locally(self):
+        adapter = _make_adapter()
+        adapter._send_media = mock.AsyncMock()
+
+        result = await adapter.send_document("chat", "/tmp/run.exe")
+
+        adapter._send_media.assert_not_called()
+        assert result.success is False
+        assert result.retryable is False
+        assert "危险扩展" in result.error

--- a/tests/gateway/test_qqbot_multi_adapter.py
+++ b/tests/gateway/test_qqbot_multi_adapter.py
@@ -1,0 +1,111 @@
+"""Tests for multi-account QQBot adapter support."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, SendResult
+from gateway.session import SessionSource
+from gateway.platforms.qqbot import QQMultiAdapter, collect_qq_credentials
+
+
+_QQ_ENV_PREFIXES = ("QQ_APP_ID", "QQ_CLIENT_SECRET")
+
+
+def _clear_qq_env(monkeypatch):
+    import os
+
+    for key in list(os.environ):
+        if key == "QQ_APP_ID" or key == "QQ_CLIENT_SECRET":
+            monkeypatch.delenv(key, raising=False)
+        elif key.startswith("QQ_APP_ID_") or key.startswith("QQ_CLIENT_SECRET_"):
+            monkeypatch.delenv(key, raising=False)
+
+
+def test_collect_qq_credentials_reads_indexed_env_pairs(monkeypatch):
+    _clear_qq_env(monkeypatch)
+    monkeypatch.setenv("QQ_APP_ID_1", "app-one")
+    monkeypatch.setenv("QQ_CLIENT_SECRET_1", "secret-one")
+    monkeypatch.setenv("QQ_APP_ID_0", "app-zero")
+    monkeypatch.setenv("QQ_CLIENT_SECRET_0", "secret-zero")
+    monkeypatch.setenv("QQ_APP_ID_2", "incomplete")
+
+    creds = collect_qq_credentials(PlatformConfig(enabled=True))
+
+    assert [(label, app_id) for label, app_id, _secret in creds] == [
+        ("env:0", "app-zero"),
+        ("env:1", "app-one"),
+    ]
+
+
+def test_gateway_connected_platforms_accepts_indexed_qq_env(monkeypatch):
+    _clear_qq_env(monkeypatch)
+    monkeypatch.setenv("QQ_APP_ID_0", "app-zero")
+    monkeypatch.setenv("QQ_CLIENT_SECRET_0", "secret-zero")
+
+    cfg = GatewayConfig(platforms={Platform.QQBOT: PlatformConfig(enabled=True)})
+
+    assert Platform.QQBOT in cfg.get_connected_platforms()
+
+
+def test_multi_adapter_routes_reply_through_child_that_received_chat(monkeypatch):
+    _clear_qq_env(monkeypatch)
+    monkeypatch.setenv("QQ_APP_ID_0", "app-zero")
+    monkeypatch.setenv("QQ_CLIENT_SECRET_0", "secret-zero")
+    monkeypatch.setenv("QQ_APP_ID_1", "app-one")
+    monkeypatch.setenv("QQ_CLIENT_SECRET_1", "secret-one")
+
+    adapter = QQMultiAdapter(PlatformConfig(enabled=True))
+    assert len(adapter._children) == 2
+    child0, child1 = adapter._children
+    child0.send = AsyncMock(return_value=SendResult(success=True, message_id="m0"))
+    child1.send = AsyncMock(return_value=SendResult(success=True, message_id="m1"))
+
+    event = MessageEvent(
+        text="hello",
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.QQBOT,
+            chat_id="chat-a",
+            chat_type="dm",
+            user_id="user-a",
+        ),
+        raw_message={"id": "raw"},
+        message_id="msg-a",
+    )
+
+    awaitable = adapter.handle_child_message(child1, event)
+    import asyncio
+
+    asyncio.run(awaitable)
+    result = asyncio.run(adapter.send("chat-a", "reply"))
+
+    assert result.message_id == "m1"
+    child1.send.assert_awaited_once()
+    child0.send.assert_not_awaited()
+
+
+def test_gateway_runner_uses_multi_adapter_for_qqbot(monkeypatch):
+    _clear_qq_env(monkeypatch)
+    monkeypatch.setenv("QQ_APP_ID_0", "app-zero")
+    monkeypatch.setenv("QQ_CLIENT_SECRET_0", "secret-zero")
+
+    from gateway import platforms as _unused  # noqa: F401 - ensure package import path exists
+    import gateway.platforms.qqbot as qqbot_pkg
+    from gateway.run import GatewayRunner
+
+    monkeypatch.setattr(qqbot_pkg, "check_qq_requirements", lambda: True)
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig()
+
+    adapter = GatewayRunner._create_adapter(
+        runner,
+        Platform.QQBOT,
+        PlatformConfig(enabled=True),
+    )
+
+    assert isinstance(adapter, QQMultiAdapter)
+    assert len(adapter._children) == 1

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -68,7 +68,7 @@ async def test_drain_queue_mode_queues_follow_up_without_interrupt():
     assert session_key in adapter._pending_messages
     assert adapter._pending_messages[session_key].text == "follow up"
     assert not adapter._active_sessions[session_key].is_set()
-    assert any("queued for the next turn" in message for message in adapter.sent)
+    assert any("已排队" in message and "下一轮" in message for message in adapter.sent)
 
 
 @pytest.mark.asyncio
@@ -86,7 +86,7 @@ async def test_draining_rejects_new_session_messages():
 
     result = await runner._handle_message(event)
 
-    assert result == "⏳ Gateway is restarting and is not accepting new work right now."
+    assert result == "⏳ Gateway 正在重启，暂时不接受新的任务。"
 
 
 def test_load_busy_input_mode_prefers_env_then_config_then_default(tmp_path, monkeypatch):
@@ -245,8 +245,8 @@ async def test_shutdown_notification_sent_to_active_sessions():
     await runner._notify_active_sessions_of_shutdown()
 
     assert len(adapter.sent) == 1
-    assert "shutting down" in adapter.sent[0]
-    assert "interrupted" in adapter.sent[0]
+    assert "正在关闭" in adapter.sent[0]
+    assert "当前任务会被中断" in adapter.sent[0]
 
 
 @pytest.mark.asyncio
@@ -260,8 +260,8 @@ async def test_shutdown_notification_says_restarting_when_restart_requested():
     await runner._notify_active_sessions_of_shutdown()
 
     assert len(adapter.sent) == 1
-    assert "restarting" in adapter.sent[0]
-    assert "resume" in adapter.sent[0]
+    assert "正在重启" in adapter.sent[0]
+    assert "尽量从断点继续" in adapter.sent[0]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -197,11 +197,38 @@ async def test_launch_detached_restart_command_uses_setsid(monkeypatch):
     assert len(popen_calls) == 1
     cmd, kwargs = popen_calls[0]
     assert cmd[:2] == ["/usr/bin/setsid", "bash"]
-    assert "gateway restart" in cmd[-1]
+    assert "gateway run --replace" in cmd[-1]
+    assert "gateway restart" not in cmd[-1]
     assert "kill -0 321" in cmd[-1]
     assert kwargs["start_new_session"] is True
     assert kwargs["stdout"] is subprocess.DEVNULL
     assert kwargs["stderr"] is subprocess.DEVNULL
+
+
+@pytest.mark.asyncio
+async def test_launch_detached_restart_command_waiter_does_not_hang_on_zombie_pid(monkeypatch):
+    """The POSIX watcher must not wait forever when the old PID is a zombie."""
+    runner, _adapter = make_restart_runner()
+    popen_calls = []
+
+    monkeypatch.setattr(gateway_run, "_resolve_hermes_bin", lambda: ["/usr/bin/hermes"])
+    monkeypatch.setattr(gateway_run.os, "getpid", lambda: 321)
+    monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/bin/setsid" if cmd == "setsid" else None)
+
+    def fake_popen(cmd, **kwargs):
+        popen_calls.append((cmd, kwargs))
+        return MagicMock()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    await runner._launch_detached_restart_command()
+
+    assert len(popen_calls) == 1
+    shell_cmd = popen_calls[0][0][-1]
+    assert "/proc/321/stat" in shell_cmd
+    assert "'Z'" in shell_cmd or '"Z"' in shell_cmd
+    assert "120" in shell_cmd
+    assert "gateway run --replace" in shell_cmd
 
 
 # ── Shutdown notification tests ──────────────────────────────────────

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -673,6 +673,6 @@ async def test_shutdown_notifications_use_cached_live_thread_source_when_origin_
 
     adapter.send.assert_awaited_once_with(
         "parent-42",
-        "⚠️ Gateway shutting down — Your current task will be interrupted.",
+        "⚠️ Gateway 正在关闭 — 当前任务会被中断。",
         metadata={"thread_id": "topic-7"},
     )

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -36,6 +36,23 @@ def test_restart_notification_pending_true_with_marker(tmp_path, monkeypatch):
 # ── _handle_restart_command writes .restart_notify.json ──────────────────
 
 
+def _clear_webui_restart_env(monkeypatch):
+    monkeypatch.delenv("HERMES_WEBUI_STATE_DIR", raising=False)
+    monkeypatch.delenv("HERMES_WEBUI_PORT", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+
+
+def _pretend_not_container(monkeypatch):
+    real_exists = gateway_run.os.path.exists
+
+    def fake_exists(path):
+        if path in {"/.dockerenv", "/run/.containerenv"}:
+            return False
+        return real_exists(path)
+
+    monkeypatch.setattr(gateway_run.os.path, "exists", fake_exists)
+
+
 @pytest.mark.asyncio
 async def test_restart_command_writes_notify_file(tmp_path, monkeypatch):
     """When /restart fires, the requester's routing info is persisted to disk."""
@@ -67,6 +84,7 @@ async def test_restart_command_writes_notify_file(tmp_path, monkeypatch):
 async def test_restart_command_uses_service_restart_under_systemd(tmp_path, monkeypatch):
     """Under systemd (INVOCATION_ID set), /restart uses via_service=True."""
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    _clear_webui_restart_env(monkeypatch)
     monkeypatch.setenv("INVOCATION_ID", "abc123")
 
     runner, _adapter = make_restart_runner()
@@ -86,9 +104,44 @@ async def test_restart_command_uses_service_restart_under_systemd(tmp_path, monk
 
 @pytest.mark.asyncio
 async def test_restart_command_uses_detached_without_systemd(tmp_path, monkeypatch):
-    """Without systemd, /restart uses the detached subprocess approach."""
+    """Without systemd/container supervision, /restart uses detached subprocess."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    _clear_webui_restart_env(monkeypatch)
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    _pretend_not_container(monkeypatch)
+
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+
+    source = make_restart_source(chat_id="42")
+    event = MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="m1",
+    )
+
+    await runner._handle_restart_command(event)
+    runner.request_restart.assert_called_once_with(detached=True, via_service=False)
+
+
+@pytest.mark.asyncio
+async def test_restart_command_uses_detached_inside_webui_container(tmp_path, monkeypatch):
+    """WebUI-hosted gateways are not supervised by Docker's restart policy."""
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.setenv("HERMES_WEBUI_STATE_DIR", str(tmp_path / "webui"))
+
+    real_exists = gateway_run.os.path.exists
+
+    def fake_exists(path):
+        if path == "/.dockerenv":
+            return True
+        if path == "/run/.containerenv":
+            return False
+        return real_exists(path)
+
+    monkeypatch.setattr(gateway_run.os.path, "exists", fake_exists)
 
     runner, _adapter = make_restart_runner()
     runner.request_restart = MagicMock(return_value=True)

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -4,7 +4,7 @@ Covers the behaviour introduced to fix the ``Gateway shutting down ...
 task will be interrupted`` follow-up bug (spec: PR #11852, builds on
 PRs #9850, #9934, #7536):
 
-1. When a gateway restart drain times out and agents are force-interrupted,
+1. When a Gateway 重启 drain times out and agents are force-interrupted,
    the affected sessions are flagged ``resume_pending=True`` — not
    ``suspended`` — so the next user message on the same session_key
    auto-resumes from the existing transcript instead of getting routed
@@ -56,7 +56,7 @@ from tests.gateway.restart_test_helpers import (
 def test_resume_pending_is_cleared_only_after_successful_turn():
     """Interrupted/failed drain results must keep the restart recovery marker.
 
-    Regression for dogfood failure: during gateway restart the interrupted run
+    Regression for dogfood failure: during Gateway 重启 the interrupted run
     returned an empty final response and was normalized into a user-facing
     fallback, but the gateway cleared ``resume_pending`` before startup could
     auto-resume it.
@@ -146,27 +146,24 @@ def _simulate_note_injection(
     if is_resume_pending:
         reason = getattr(resume_entry, "resume_reason", None) or "restart_timeout"
         reason_phrase = (
-            "a gateway restart"
+            "Gateway 重启"
             if reason == "restart_timeout"
-            else "a gateway shutdown"
+            else "Gateway 关闭"
             if reason == "shutdown_timeout"
-            else "a gateway interruption"
+            else "Gateway 中断"
         )
         message = (
-            f"[System note: Your previous turn in this session was interrupted "
-            f"by {reason_phrase}. The conversation history below is intact. "
-            f"If it contains unfinished tool result(s), process them first and "
-            f"summarize what was accomplished, then address the user's new "
-            f"message below.]\n\n"
+            f"[系统提示：本会话上一轮被 {reason_phrase} 中断。"
+            f"下面的 conversation history 保持完整。"
+            f"如果里面有未完成的 tool result(s)，请先处理并总结已完成内容，"
+            f"再处理下面用户的新消息。]\n\n"
             + message
         )
     elif has_fresh_tool_tail:
         message = (
-            "[System note: Your previous turn was interrupted before you could "
-            "process the last tool result(s). The conversation history contains "
-            "tool outputs you haven't responded to yet. Please finish processing "
-            "those results and summarize what was accomplished, then address the "
-            "user's new message below.]\n\n"
+            "[系统提示：上一轮在处理最后的 tool result(s) 前被中断。"
+            "conversation history 里还有尚未回复的 tool outputs。"
+            "请先处理这些结果并总结已完成内容，再处理下面用户的新消息。]\n\n"
             + message
         )
     return message
@@ -439,8 +436,8 @@ class TestResumePendingSystemNote:
             user_message="what happened?",
             resume_entry=entry,
         )
-        assert "[System note:" in result
-        assert "gateway restart" in result
+        assert "[系统提示：" in result
+        assert "Gateway 重启" in result
         assert "what happened?" in result
 
     def test_resume_pending_shutdown_note_mentions_shutdown(self):
@@ -452,7 +449,7 @@ class TestResumePendingSystemNote:
             user_message="ping",
             resume_entry=entry,
         )
-        assert "gateway shutdown" in result
+        assert "Gateway 关闭" in result
 
     def test_resume_pending_fires_without_tool_tail(self):
         """Key improvement over PR #9934: the restart-resume note fires
@@ -463,8 +460,8 @@ class TestResumePendingSystemNote:
             {"role": "assistant", "content": "ok, starting...", "timestamp": time.time()},
         ]
         result = _simulate_note_injection(history, "ping", resume_entry=entry)
-        assert "[System note:" in result
-        assert "gateway restart" in result
+        assert "[系统提示：" in result
+        assert "Gateway 重启" in result
 
     def test_resume_pending_subsumes_tool_tail_note(self):
         """When BOTH conditions are true, the restart-resume note wins —
@@ -478,10 +475,10 @@ class TestResumePendingSystemNote:
              "timestamp": time.time()},
         ]
         result = _simulate_note_injection(history, "ping", resume_entry=entry)
-        assert result.count("[System note:") == 1
-        assert "gateway restart" in result
+        assert result.count("[系统提示：") == 1
+        assert "Gateway 重启" in result
         # Old tool-tail wording absent
-        assert "haven't responded to yet" not in result
+        assert "尚未回复" not in result
 
     def test_no_resume_pending_preserves_tool_tail_note(self):
         """Regression: the old PR #9934 tool-tail behaviour is unchanged."""
@@ -493,7 +490,7 @@ class TestResumePendingSystemNote:
              "timestamp": time.time()},
         ]
         result = _simulate_note_injection(history, "ping", resume_entry=None)
-        assert "[System note:" in result
+        assert "[系统提示：" in result
         assert "tool result" in result
 
     def test_stale_resume_pending_does_not_inject_restart_note(self):
@@ -531,7 +528,7 @@ class TestResumePendingSystemNote:
             },
         ]
         result = _simulate_note_injection(history, "ping", resume_entry=None)
-        assert "[System note:" in result
+        assert "[系统提示：" in result
         assert "tool result" in result
 
     def test_stale_tool_tail_does_not_inject_auto_continue_note(self):
@@ -622,7 +619,7 @@ class TestResumePendingSystemNote:
         result = _simulate_note_injection(
             history, "ping", resume_entry=None, window_secs=0,
         )
-        assert "[System note:" in result
+        assert "[系统提示：" in result
         assert "tool result" in result
 
     def test_legacy_history_without_timestamps_still_injects(self):
@@ -635,7 +632,7 @@ class TestResumePendingSystemNote:
             {"role": "tool", "tool_call_id": "c1", "content": "result"},
         ]
         result = _simulate_note_injection(history, "ping", resume_entry=None)
-        assert "[System note:" in result
+        assert "[系统提示：" in result
         assert "tool result" in result
 
     def test_no_note_when_nothing_to_resume(self):
@@ -1078,8 +1075,8 @@ async def test_restart_banner_uses_try_to_resume_wording():
 
     assert len(adapter.sent) == 1
     msg = adapter.sent[0]
-    assert "restarting" in msg
-    assert "try to resume" in msg
+    assert "正在重启" in msg
+    assert "尽量从断点继续" in msg
 
 
 @pytest.mark.asyncio
@@ -1095,8 +1092,7 @@ async def test_restart_notifies_home_channel_even_without_active_sessions():
     await runner._notify_active_sessions_of_shutdown()
 
     assert adapter.sent == [
-        "⚠️ Gateway restarting — Your current task will be interrupted. "
-        "Send any message after restart and I'll try to resume where you left off."
+        "⚠️ Gateway 正在重启 — 当前任务会被中断。重启后发任意消息，我会尽量从断点继续。"
     ]
 
 

--- a/tests/gateway/test_run_cleanup_progress.py
+++ b/tests/gateway/test_run_cleanup_progress.py
@@ -131,6 +131,27 @@ class FailingAgent:
         }
 
 
+class SlowStatusAgent:
+    """Runs long enough for a gateway still-working notice to fire."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def get_activity_summary(self):
+        return {
+            "api_call_count": 19,
+            "max_iterations": 90,
+            "current_tool": None,
+            "last_activity_desc": "waiting for non-streaming API response",
+            "seconds_since_activity": 30.0,
+        }
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        time.sleep(0.4)
+        return {"final_response": "done", "messages": [], "api_calls": 19}
+
+
 def _make_runner(adapter):
     gateway_run = importlib.import_module("gateway.run")
     GatewayRunner = gateway_run.GatewayRunner
@@ -365,3 +386,33 @@ async def test_cleanup_chains_with_existing_callback(monkeypatch, tmp_path):
     # deletes at least one progress bubble.
     assert pre_existing_fired == [True]
     assert len(adapter.deleted) >= 1
+
+
+@pytest.mark.asyncio
+async def test_long_running_notice_is_chinese(monkeypatch, tmp_path):
+    """Gateway wait notices are user-facing and must be localized."""
+    adapter = CleanupCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = _install_fakes(monkeypatch, SlowStatusAgent, cleanup_on=False)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setenv("HERMES_AGENT_NOTIFY_INTERVAL", "0.05")
+
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="-1001")
+    session_key = "agent:main:telegram:group:-1001"
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-1",
+        session_key=session_key,
+    )
+
+    assert result["final_response"] == "done"
+    notices = [entry["content"] for entry in adapter.sent if "还在处理" in entry["content"]]
+    assert notices
+    assert all("Still working" not in notice for notice in notices)
+    assert all("iteration" not in notice for notice in notices)
+    assert all("waiting for non-streaming API response" not in notice for notice in notices)
+    assert any("等待非流式 API 响应" in notice for notice in notices), notices

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -551,6 +551,32 @@ class TestScopedLocks:
         assert payload["pid"] == os.getpid()
         assert payload["metadata"]["platform"] == "telegram"
 
+    def test_acquire_scoped_lock_replaces_zombie_owner(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        proc_root = tmp_path / "proc"
+        zombie_status = proc_root / "24120" / "status"
+        zombie_status.parent.mkdir(parents=True)
+        zombie_status.write_text("Name:\tpython3\nState:\tZ (zombie)\n", encoding="utf-8")
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": 24120,
+            "start_time": 123,
+            "kind": "hermes-gateway",
+            "argv": ["python3", "-m", "hermes_cli.main", "gateway", "run"],
+        }))
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
+        monkeypatch.setattr(status, "_proc_status_path", lambda pid: proc_root / str(pid) / "status")
+
+        acquired, existing = status.acquire_scoped_lock("telegram-bot-token", "secret", metadata={"platform": "telegram"})
+
+        assert acquired is True
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+        assert payload["metadata"]["platform"] == "telegram"
+
     def test_acquire_scoped_lock_recovers_empty_lock_file(self, tmp_path, monkeypatch):
         """Empty lock file (0 bytes) left by a crashed process should be treated as stale."""
         monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -11,7 +11,7 @@ def test_telegram_status_suppresses_auxiliary_and_retry_noise():
     """Auxiliary failures and retry backoff chatter should not hit Telegram."""
     noisy_messages = [
         "⚠ Auxiliary title generation failed: HTTP 400: Operation contains cybersecurity risk",
-        "⚠ Compression summary failed: upstream error. Inserted a fallback context marker.",
+        "⚠ context summary 失败：upstream error。已插入 fallback context marker。",
         "ℹ Configured compression model 'small-model' failed (timeout). Recovered using main model — check auxiliary.compression.model in config.yaml.",
         "⏳ Retrying in 4.2s (attempt 1/3)...",
         "⏱️ Rate limited. Waiting 30.0s (attempt 2/3)...",
@@ -22,12 +22,88 @@ def test_telegram_status_suppresses_auxiliary_and_retry_noise():
         assert _prepare_gateway_status_message(Platform.TELEGRAM, "warn", message) is None
 
 
-def test_non_telegram_status_is_unchanged():
-    """The Telegram quieting policy must not hide CLI/Discord diagnostics."""
+def test_non_chatty_status_is_unchanged():
+    """The chat-specific policy must not hide CLI/Discord diagnostics."""
     message = "⏳ Retrying in 4.2s (attempt 1/3)..."
 
     assert _prepare_gateway_status_message(Platform.DISCORD, "lifecycle", message) == message
     assert _prepare_gateway_status_message("local", "lifecycle", message) == message
+
+
+def test_qqbot_status_localizes_retry_backoff():
+    """QQ should see Chinese gateway retry status, not English chatter."""
+    message = "⏳ Retrying in 4.2s (attempt 1/3)..."
+
+    localized = _prepare_gateway_status_message(Platform.QQBOT, "lifecycle", message)
+
+    assert localized == "⏳ 4.2 秒后重试（第 1/3 次）..."
+    assert "Retrying" not in localized
+    assert "attempt" not in localized
+
+
+def test_qqbot_status_localizes_common_runtime_statuses():
+    """QQ gets Chinese Hermes runtime envelopes while preserving technical tokens."""
+    cases = {
+        "⚠️ Empty/malformed response — switching to fallback...": "⚠️ 模型返回空或格式异常，正在切换到备用模型...",
+        "⚠️ Rate limited — switching to fallback provider...": "⚠️ 已被限流，正在切换到备用提供商...",
+        "⚠️  Request payload too large (413) — compression attempt 1/3...": "⚠️ 请求内容过大 (413)，正在压缩（第 1/3 次）...",
+        "🗜️ Context too large (~12,345 tokens) — compressing (1/3)...": "🗜️ 上下文过大（约 12,345 tokens），正在压缩（第 1/3 次）...",
+        "🗜️ Compressed 99 → 10 messages, retrying...": "🗜️ 已压缩 99 → 10 条消息，正在重试...",
+        "⚠️ Non-retryable error (HTTP 400) — trying fallback...": "⚠️ 不可重试错误 (HTTP 400)，正在尝试备用模型...",
+        "❌ Rate limited after 3 retries — HTTP 429 too many": "❌ 重试 3 次后仍被限流 — HTTP 429 too many",
+        "❌ API failed after 3 retries — timeout": "❌ API 重试 3 次后仍失败 — timeout",
+        "❌ API failed after 3 retries — Responses create(stream=True) fallback did not emit a terminal response.": "❌ API 重试 3 次后仍失败 — Responses create(stream=True) fallback 未产生终止响应。",
+        "↻ Empty response after tool calls — using earlier content as final answer": "↻ 工具调用后模型返回空内容，改用较早内容作为最终回复",
+        "⚠️ Model returned empty after tool calls — nudging to continue": "⚠️ 工具调用后模型返回空内容，正在提示模型继续",
+        "↻ Thinking-only response — prefilling to continue (1/2)": "↻ 模型只返回思考内容，正在预填继续（第 1/2 次）",
+        "⚠️ Empty response from model — retrying (1/3)": "⚠️ 模型返回空内容，正在重试（第 1/3 次）",
+        "⚠️ Model returning empty responses — switching to fallback provider...": "⚠️ 模型持续返回空内容，正在切换到备用提供商...",
+        "↻ Switched to fallback: gpt-4 (openai)": "↻ 已切换到备用模型：gpt-4 (openai)",
+        "⚠️ Iteration budget exhausted (90/90) — asking model to summarise": "⚠️ 轮次预算已用尽（90/90），正在请求模型总结",
+    }
+
+    for original, expected in cases.items():
+        localized = _prepare_gateway_status_message(Platform.QQBOT, "lifecycle", original)
+        assert localized == expected
+        assert "retrying" not in localized.lower()
+        assert "switching" not in localized.lower()
+        assert "fallback provider" not in localized.lower()
+        assert "empty response" not in localized.lower()
+        assert "model returned" not in localized.lower()
+
+
+def test_qqbot_final_response_localizes_provider_failure_envelope():
+    """QQ final replies should hide English provider failure envelopes."""
+    raw = (
+        "API call failed after 3 retries: Responses create(stream=True) "
+        "fallback did not emit a terminal response."
+    )
+
+    sanitized = _sanitize_gateway_final_response(Platform.QQBOT, raw)
+
+    assert sanitized == "⚠️ 模型提供商多次重试后仍失败。原始细节未发送到聊天；可查看 gateway logs。"
+    assert "API call failed" not in sanitized
+    assert "did not emit" not in sanitized
+
+
+def test_qqbot_localizes_stream_stalled_tool_call_warning():
+    """QQ should not receive the English dropped tool-call warning envelope."""
+    raw = (
+        "⚠ Stream stalled mid tool-call (write_file); the action was not "
+        "executed. Ask me to retry if you want to continue."
+    )
+
+    expected = "⚠ 流式响应在工具调用中途停住（write_file）；操作未执行。需要继续的话，请让我重试。"
+
+    status = _prepare_gateway_status_message(Platform.QQBOT, "lifecycle", raw)
+    final = _sanitize_gateway_final_response(Platform.QQBOT, raw)
+
+    assert status == expected
+    assert final == expected
+    for localized in (status, final):
+        assert "Stream stalled" not in localized
+        assert "action was not executed" not in localized
+        assert "Ask me to retry" not in localized
 
 
 def test_telegram_status_sanitizes_raw_provider_security_errors():

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -332,6 +332,36 @@ class TestMcpAdd:
         out = capsys.readouterr().out
         assert "only supported for stdio MCP servers" in out
 
+    def test_add_codegraph_preset_fills_transport(self, tmp_path, capsys, monkeypatch):
+        """The built-in codegraph preset starts the local CodeGraph MCP server."""
+        fake_tools = [FakeTool("codegraph_context", "Build context for a task")]
+
+        def mock_probe(name, config, **kw):
+            assert name == "codegraph"
+            assert config["command"] == "codegraph"
+            assert config["args"] == ["serve", "--mcp"]
+            assert "env" not in config
+            return [(t.name, t.description) for t in fake_tools]
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", mock_probe
+        )
+        monkeypatch.setattr("builtins.input", lambda _: "")
+
+        from hermes_cli.mcp_config import cmd_mcp_add
+        from hermes_cli.config import read_raw_config
+
+        cmd_mcp_add(_make_args(name="codegraph", preset="codegraph"))
+        out = capsys.readouterr().out
+        assert "Saved" in out
+
+        config = read_raw_config()
+        srv = config["mcp_servers"]["codegraph"]
+        assert srv["command"] == "codegraph"
+        assert srv["args"] == ["serve", "--mcp"]
+        assert srv["enabled"] is True
+        assert "env" not in srv
+
     def test_add_preset_fills_transport(self, tmp_path, capsys, monkeypatch):
         """A preset fills in command/args when no explicit transport given."""
         monkeypatch.setattr(

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1689,6 +1689,32 @@ def test_named_custom_runtime_propagates_extra_body_direct_path(monkeypatch):
     }
 
 
+def test_named_custom_runtime_propagates_default_headers_direct_path(monkeypatch):
+    """Custom provider default_headers should become per-request extra_headers."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "my-proxy")
+    monkeypatch.setattr(
+        rp, "_get_named_custom_provider",
+        lambda p: {
+            "name": "my-proxy",
+            "base_url": "https://proxy.example.com/v1",
+            "api_key": "test-key",
+            "default_headers": {
+                "User-Agent": "Mozilla/5.0 Hermes",
+                "X-Route": "custom",
+            },
+        },
+    )
+    monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *a, **k: None)
+
+    resolved = rp.resolve_runtime_provider(requested="my-proxy")
+    assert resolved["request_overrides"] == {
+        "extra_headers": {
+            "User-Agent": "Mozilla/5.0 Hermes",
+            "X-Route": "custom",
+        }
+    }
+
+
 def test_named_custom_runtime_propagates_model_pool_path(monkeypatch):
     """Model should propagate even when credential pool handles credentials."""
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "my-server")
@@ -1747,6 +1773,35 @@ def test_named_custom_runtime_propagates_extra_body_pool_path(monkeypatch):
     resolved = rp.resolve_runtime_provider(requested="my-gemma")
     assert resolved["request_overrides"] == {
         "extra_body": {"enable_thinking": True}
+    }
+
+
+def test_named_custom_runtime_propagates_default_headers_pool_path(monkeypatch):
+    """Custom provider headers should survive credential-pool resolution."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "my-proxy")
+    monkeypatch.setattr(
+        rp, "_get_named_custom_provider",
+        lambda p: {
+            "name": "my-proxy",
+            "base_url": "https://proxy.example.com/v1",
+            "api_key": "test-key",
+            "default_headers": {"User-Agent": "Mozilla/5.0 Hermes"},
+        },
+    )
+    monkeypatch.setattr(
+        rp, "_try_resolve_from_custom_pool",
+        lambda *a, **k: {
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "base_url": "https://proxy.example.com/v1",
+            "api_key": "pool-key",
+            "source": "pool:custom:my-proxy",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="my-proxy")
+    assert resolved["request_overrides"] == {
+        "extra_headers": {"User-Agent": "Mozilla/5.0 Hermes"}
     }
 
 
@@ -2256,6 +2311,24 @@ class TestProviderEntryApiKeyEnvAlias:
         assert normalized is not None
         assert "extra_body" in _VALID_CUSTOM_PROVIDER_FIELDS
         assert normalized["extra_body"] == entry["extra_body"]
+
+    def test_default_headers_is_supported_schema(self):
+        from hermes_cli.config import (
+            _VALID_CUSTOM_PROVIDER_FIELDS,
+            _normalize_custom_provider_entry,
+        )
+        entry = {
+            "name": "vendor",
+            "base_url": "https://api.vendor.example.com/v1",
+            "default_headers": {
+                "User-Agent": "Mozilla/5.0 Hermes",
+                "X-Route": "custom",
+            },
+        }
+        normalized = _normalize_custom_provider_entry(dict(entry), provider_key="vendor")
+        assert normalized is not None
+        assert "default_headers" in _VALID_CUSTOM_PROVIDER_FIELDS
+        assert normalized["default_headers"] == entry["default_headers"]
 # =============================================================================
 # Tencent TokenHub — API-key provider runtime resolution
 # =============================================================================

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -632,6 +632,37 @@ def test_custom_endpoint_uses_config_api_field_when_no_api_key(monkeypatch):
     assert resolved["api_key"] == "config-api-field"
 
 
+def test_custom_codex_endpoint_without_api_mode_auto_detects_codex_responses(monkeypatch):
+    """Custom proxy URLs ending in /codex must use Codex Responses semantics.
+
+    Users may configure a Codex-compatible cache/proxy as provider=custom with
+    only base_url/api_key.  A stale or missing api_mode must not silently route
+    GPT-5 Codex traffic through chat_completions.
+    """
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "custom",
+            "base_url": "https://right.codes/codex/v1",
+            "api_key": "proxy-token",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="custom")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["base_url"] == "https://right.codes/codex/v1"
+    assert resolved["api_key"] == "proxy-token"
+    assert resolved["api_mode"] == "codex_responses"
+
+
 def test_custom_endpoint_explicit_custom_prefers_config_key(monkeypatch):
     """Explicit 'custom' provider with config base_url+api_key should use them.
 

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -438,7 +438,7 @@ class TestPreflightCompression:
         assert compressed == [{"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious conversation"}]
         assert new_system_prompt == "new system prompt"
         assert events[0][0] == "lifecycle"
-        assert "Compacting context" in events[0][1]
+        assert "正在压缩 context" in events[0][1]
         assert events[1] == ("compress", "started")
 
     def test_preflight_compresses_oversized_history(self, agent):
@@ -489,7 +489,7 @@ class TestPreflightCompression:
         assert result["completed"] is True
         assert result["final_response"] == "After preflight"
         assert any(
-            ev == "lifecycle" and "Preflight compression" in msg
+            ev == "lifecycle" and "预先压缩 context" in msg
             for ev, msg in status_messages
         )
 

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -202,3 +202,65 @@ class TestGatewayHistoryOffsetAfterSplit:
         assert len(new_messages) == 0, (
             "Expected 0 messages with stale offset=200 (demonstrates the bug)"
         )
+
+def test_compress_context_warns_chunked_recovery_without_fallback_marker():
+    from agent.conversation_compression import compress_context
+
+    agent = MagicMock()
+    agent.session_id = "sid"
+    agent.model = "model"
+    agent.platform = "qqbot"
+    agent.tools = []
+    agent.status_callback = None
+    agent._memory_manager = None
+    agent._compression_feasibility_checked = True
+    agent._last_compression_summary_warning = None
+    agent._last_aux_fallback_warning_key = None
+    agent._cached_system_prompt = "system"
+    agent._build_system_prompt.return_value = "system"
+    agent._todo_store.format_for_injection.return_value = ""
+    agent.context_compressor.compress.return_value = [{"role": "user", "content": "kept"}]
+    agent.context_compressor._last_compress_aborted = False
+    agent.context_compressor._last_summary_error = None
+    agent.context_compressor._last_summary_recovery_stage = "chunked"
+    agent.context_compressor._last_aux_model_failure_model = None
+    agent.context_compressor.compression_count = 1
+
+    compressed, _ = compress_context(agent, [{"role": "user", "content": "old"}], "system")
+
+    assert compressed == [{"role": "user", "content": "kept"}]
+    warnings = [call.args[0] for call in agent._emit_warning.call_args_list]
+    assert any("分块压缩恢复" in msg for msg in warnings)
+    assert all("fallback context marker" not in msg for msg in warnings)
+
+
+def test_compress_context_warns_extractive_fallback_without_fallback_marker():
+    from agent.conversation_compression import compress_context
+
+    agent = MagicMock()
+    agent.session_id = "sid"
+    agent.model = "model"
+    agent.platform = "qqbot"
+    agent.tools = []
+    agent.status_callback = None
+    agent._memory_manager = None
+    agent._compression_feasibility_checked = True
+    agent._last_compression_summary_warning = None
+    agent._last_aux_fallback_warning_key = None
+    agent._cached_system_prompt = "system"
+    agent._build_system_prompt.return_value = "system"
+    agent._todo_store.format_for_injection.return_value = ""
+    agent.context_compressor.compress.return_value = [{"role": "user", "content": "kept"}]
+    agent.context_compressor._last_compress_aborted = False
+    agent.context_compressor._last_summary_error = "extractive fallback after summary failure: Your request was blocked."
+    agent.context_compressor._last_summary_recovery_stage = "extractive_fallback"
+    agent.context_compressor._last_aux_model_failure_model = None
+    agent.context_compressor.compression_count = 1
+
+    compressed, _ = compress_context(agent, [{"role": "user", "content": "old"}], "system")
+
+    assert compressed == [{"role": "user", "content": "kept"}]
+    warnings = [call.args[0] for call in agent._emit_warning.call_args_list]
+    assert any("本地提取式 fallback" in msg for msg in warnings)
+    assert all("fallback context marker" not in msg for msg in warnings)
+

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2755,6 +2755,9 @@ class TestRunConversation:
         ):
             result = agent.run_conversation("hello")
         assert result["interrupted"] is True
+        assert "操作已中断" in result["final_response"]
+        assert "Operation interrupted" not in result["final_response"]
+        assert "waiting for model response" not in result["final_response"]
 
     def test_invalid_tool_name_retry(self, agent):
         """Model hallucinates an invalid tool name, agent retries and succeeds."""

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1,3 +1,4 @@
+import json
 import sys
 import types
 from types import SimpleNamespace
@@ -71,6 +72,27 @@ def _build_copilot_agent(monkeypatch, *, model="gpt-5.4"):
         skip_context_files=True,
         skip_memory=True,
     )
+    agent._cleanup_task_resources = lambda task_id: None
+    agent._persist_session = lambda messages, history=None: None
+    agent._save_trajectory = lambda messages, user_message, completed: None
+    return agent
+
+
+def _build_custom_codex_agent(monkeypatch):
+    _patch_agent_bootstrap(monkeypatch)
+
+    agent = run_agent.AIAgent(
+        model="gpt-5-codex",
+        provider="custom",
+        api_mode="chat_completions",
+        base_url="https://right.codes/codex/v1",
+        api_key="proxy-token",
+        quiet_mode=True,
+        max_iterations=4,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent.session_id = "custom-codex-session"
     agent._cleanup_task_resources = lambda task_id: None
     agent._persist_session = lambda messages, history=None: None
     agent._save_trajectory = lambda messages, user_message, completed: None
@@ -309,6 +331,31 @@ def test_build_api_kwargs_codex(monkeypatch):
     assert "timeout" not in kwargs
     assert "max_tokens" not in kwargs
     assert "extra_body" not in kwargs
+
+
+def test_build_api_kwargs_custom_codex_proxy_injects_codex_transport_headers(monkeypatch):
+    agent = _build_custom_codex_agent(monkeypatch)
+
+    kwargs = agent._build_api_kwargs(
+        [
+            {"role": "system", "content": "You are Hermes."},
+            {"role": "user", "content": "Ping"},
+        ]
+    )
+
+    assert kwargs["prompt_cache_key"] == "custom-codex-session"
+    headers = kwargs["extra_headers"]
+    assert headers["session_id"] == "custom-codex-session"
+    assert headers["x-client-request-id"] == "custom-codex-session"
+    assert headers["x-codex-window-id"] == "custom-codex-session:0"
+    assert headers["originator"] == "codex_exec"
+    assert "codex_exec/0.120.0" in headers["User-Agent"]
+
+    turn_metadata = json.loads(headers["x-codex-turn-metadata"])
+    assert turn_metadata["session_id"] == "custom-codex-session"
+    assert turn_metadata["sandbox"] == "none"
+    assert isinstance(turn_metadata.get("turn_id"), str)
+    assert turn_metadata["turn_id"]
 
 
 def test_build_api_kwargs_codex_clamps_minimal_effort(monkeypatch):

--- a/tests/test_attribution_ledger.py
+++ b/tests/test_attribution_ledger.py
@@ -1,0 +1,155 @@
+"""Tests for the lightweight attribution/action ledger."""
+
+import asyncio
+from types import SimpleNamespace
+
+from agent.attribution_ledger import (
+    classify_side_effect,
+    format_attribution_report,
+    summarize_tool_call,
+)
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.run import GatewayRunner, _is_what_did_you_do_trigger
+from gateway.session import SessionSource
+from hermes_cli.commands import ACTIVE_SESSION_BYPASS_COMMANDS, resolve_command
+from hermes_state import SessionDB
+
+
+class TestAttributionLedgerFormatting:
+    def test_summarize_tool_call_redacts_secret_arguments(self):
+        token = "sk-proj-abcdefghijklmnopqrstuvwxyz123456"
+
+        summary = summarize_tool_call(
+            "terminal",
+            {"command": f"curl -H 'Authorization: Bearer {token}' https://example.test"},
+        )
+
+        assert token not in summary
+        assert "terminal" in summary
+        assert "curl" in summary
+
+    def test_classify_side_effect_for_core_tools(self):
+        assert classify_side_effect("read_file", {}) == "read"
+        assert classify_side_effect("patch", {}) == "write"
+        assert classify_side_effect("send_message", {}) == "message"
+        assert classify_side_effect("terminal", {"command": "git status"}) == "git"
+        assert classify_side_effect("terminal", {"command": "python build.py"}) == "process"
+
+    def test_format_report_keeps_empty_buckets_visible(self):
+        report = format_attribution_report(
+            [], session_id="s1", lineage_id="s1", chat_id="chat-1"
+        )
+
+        assert "无可确认项" in report
+        assert "未发现可归因证据" in report
+        assert "git history" in report
+
+    def test_format_report_groups_completed_failed_and_started(self):
+        report = format_attribution_report(
+            [
+                {
+                    "id": 1,
+                    "session_id": "s1",
+                    "tool_name": "read_file",
+                    "status": "completed",
+                    "action_summary": "read README.md",
+                    "side_effect_class": "read",
+                    "started_at": 100.0,
+                },
+                {
+                    "id": 2,
+                    "session_id": "s1",
+                    "tool_name": "patch",
+                    "status": "failed",
+                    "action_summary": "patch SKILL.md",
+                    "side_effect_class": "write",
+                    "started_at": 101.0,
+                    "error_preview": "old_string not found",
+                },
+                {
+                    "id": 3,
+                    "session_id": "s1",
+                    "tool_name": "terminal",
+                    "status": "started",
+                    "action_summary": "terminal: sleep 999",
+                    "side_effect_class": "process",
+                    "started_at": 102.0,
+                },
+            ],
+            session_id="s1",
+            lineage_id="s1",
+            chat_id="chat-1",
+        )
+
+        assert "已确认完成" in report
+        assert "失败/被阻止" in report
+        assert "仅看到开始" in report
+        assert "event#1" in report
+        assert "event#2" in report
+        assert "event#3" in report
+
+
+class TestGatewayWhatDidYouDoCommand:
+    def test_chinese_plain_text_triggers_command(self):
+        assert _is_what_did_you_do_trigger("你做了什么")
+        assert _is_what_did_you_do_trigger("刚才你干嘛了？")
+        assert _is_what_did_you_do_trigger("你到底改了啥")
+        assert _is_what_did_you_do_trigger("哪些是你做的")
+        assert not _is_what_did_you_do_trigger("你接着做吧")
+
+    def test_command_aliases_resolve_and_bypass_running_agent(self):
+        assert resolve_command("whatdidyoudo").name == "what-did-you-do"
+        assert resolve_command("wdyd").name == "what-did-you-do"
+        assert "what-did-you-do" in ACTIVE_SESSION_BYPASS_COMMANDS
+
+    def test_gateway_handler_reports_current_lineage_events(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            db.create_session(session_id="parent", source="qqbot")
+            db.create_session(session_id="child", source="qqbot", parent_session_id="parent")
+            db.append_attribution_event(
+                session_id="parent",
+                tool_name="read_file",
+                status="completed",
+                action_summary="read AGENTS.md",
+                side_effect_class="read",
+                source="qqbot",
+                chat_id="chat-1",
+                platform_message_id="msg-1",
+            )
+            db.append_attribution_event(
+                session_id="child",
+                tool_name="patch",
+                status="completed",
+                action_summary="patch what-did-you-do skill",
+                side_effect_class="write",
+                source="qqbot",
+                chat_id="chat-1",
+                platform_message_id="msg-2",
+            )
+
+            source = SessionSource(
+                platform=Platform.QQBOT,
+                chat_id="chat-1",
+                chat_type="dm",
+                user_id="user-1",
+            )
+            event = MessageEvent(text="/what-did-you-do", source=source, message_id="msg-3")
+
+            runner = object.__new__(GatewayRunner)
+            runner._session_db = db
+            runner.session_store = SimpleNamespace(
+                _entries={"qqbot:dm:chat-1": SimpleNamespace(session_id="child")},
+                _generate_session_key=lambda src: "qqbot:dm:chat-1",
+            )
+
+            response = asyncio.run(runner._handle_what_did_you_do_command(event))
+
+            assert "当前 session: child" in response
+            assert "lineage: parent" in response
+            assert "read AGENTS.md" in response
+            assert "patch what-did-you-do skill" in response
+            assert "event#" in response
+        finally:
+            db.close()

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -85,6 +85,22 @@ class TestSessionLifecycle:
         session = db.get_session("s1")
         assert session["system_prompt"] == "You are a helpful assistant."
 
+    def test_update_and_get_prompt_cache_state(self, db):
+        db.create_session(session_id="s1", source="cli")
+
+        assert db.get_prompt_cache_state("s1") is None
+        assert db.update_prompt_cache_state(
+            "s1",
+            prompt_cache_key="custom-codex-session",
+            prompt_cache_supported=True,
+        ) is True
+
+        cache_state = db.get_prompt_cache_state("s1")
+        assert cache_state == {
+            "prompt_cache_key": "custom-codex-session",
+            "prompt_cache_supported": True,
+        }
+
     def test_update_token_counts(self, db):
         db.create_session(session_id="s1", source="cli")
         db.update_token_counts("s1", input_tokens=200, output_tokens=100)

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1,5 +1,6 @@
 """Tests for hermes_state.py — SessionDB SQLite CRUD, FTS5 search, export."""
 
+import sqlite3
 import time
 import pytest
 from pathlib import Path
@@ -151,6 +152,116 @@ class TestSessionLifecycle:
 
         child = db.get_session("child")
         assert child["parent_session_id"] == "parent"
+
+    def test_lineage_id_inherits_from_parent_session(self, db):
+        db.create_session(session_id="parent", source="qqbot")
+        db.create_session(session_id="child", source="qqbot", parent_session_id="parent")
+
+        parent = db.get_session("parent")
+        child = db.get_session("child")
+
+        assert parent["lineage_id"] == "parent"
+        assert child["lineage_id"] == "parent"
+        assert db.get_session_lineage_id("child") == "parent"
+
+    def test_existing_database_without_lineage_column_is_reconciled(self, tmp_path):
+        db_path = tmp_path / "legacy_state.db"
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.executescript(
+                """
+                CREATE TABLE schema_version (version INTEGER NOT NULL);
+                INSERT INTO schema_version (version) VALUES (13);
+                CREATE TABLE sessions (
+                    id TEXT PRIMARY KEY,
+                    source TEXT NOT NULL,
+                    user_id TEXT,
+                    parent_session_id TEXT,
+                    started_at REAL NOT NULL
+                );
+                INSERT INTO sessions (id, source, user_id, parent_session_id, started_at)
+                VALUES ('legacy-parent', 'qqbot', 'user-1', NULL, 1.0);
+                """
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        migrated = SessionDB(db_path=db_path)
+        try:
+            session = migrated.get_session("legacy-parent")
+            assert session["lineage_id"] is None
+            assert migrated.get_session_lineage_id("legacy-parent") == "legacy-parent"
+
+            migrated.create_session(
+                session_id="legacy-child",
+                source="qqbot",
+                parent_session_id="legacy-parent",
+            )
+            assert migrated.get_session("legacy-child")["lineage_id"] == "legacy-parent"
+        finally:
+            migrated.close()
+
+
+# =========================================================================
+# Attribution ledger
+# =========================================================================
+
+class TestAttributionLedger:
+    def test_append_and_query_attribution_events_by_lineage(self, db):
+        db.create_session(session_id="parent", source="qqbot")
+        db.create_session(session_id="child", source="qqbot", parent_session_id="parent")
+        db.create_session(session_id="other", source="qqbot")
+
+        parent_event = db.append_attribution_event(
+            session_id="parent",
+            tool_name="read_file",
+            status="completed",
+            action_summary="read README.md",
+            side_effect_class="read",
+            chat_id="chat-1",
+            platform_message_id="msg-1",
+        )
+        child_event = db.append_attribution_event(
+            session_id="child",
+            tool_name="patch",
+            status="completed",
+            action_summary="patched SKILL.md",
+            side_effect_class="write",
+            chat_id="chat-1",
+            platform_message_id="msg-2",
+        )
+        db.append_attribution_event(
+            session_id="other",
+            tool_name="terminal",
+            status="completed",
+            action_summary="git status",
+            side_effect_class="process",
+            chat_id="chat-1",
+        )
+
+        events = db.get_attribution_events(session_id="child", include_lineage=True)
+
+        assert [e["id"] for e in events] == [parent_event, child_event]
+        assert {e["lineage_id"] for e in events} == {"parent"}
+        assert events[1]["platform_message_id"] == "msg-2"
+
+    def test_attribution_events_can_be_filtered_to_current_chat(self, db):
+        db.create_session(session_id="s1", source="qqbot")
+        keep = db.append_attribution_event(
+            session_id="s1", tool_name="read_file", status="completed",
+            action_summary="read local file", chat_id="chat-keep",
+        )
+        db.append_attribution_event(
+            session_id="s1", tool_name="terminal", status="completed",
+            action_summary="other chat command", chat_id="chat-other",
+        )
+
+        events = db.get_attribution_events(
+            session_id="s1", include_lineage=True, chat_id="chat-keep"
+        )
+
+        assert [e["id"] for e in events] == [keep]
 
 
 # =========================================================================

--- a/tests/tools/test_image_generation.py
+++ b/tests/tools/test_image_generation.py
@@ -9,6 +9,7 @@ tests/tools/test_managed_media_gateways.py.
 
 from __future__ import annotations
 
+import json
 from unittest.mock import patch
 
 import pytest
@@ -338,6 +339,55 @@ class TestModelResolution:
         assert mid == "fal-ai/nano-banana-pro"
 
 
+class TestFalToolResponseEnvelope:
+    def test_success_response_includes_message_and_actual_parameters(self, image_tool, monkeypatch):
+        class FakeHandler:
+            def get(self):
+                return {
+                    "images": [
+                        {
+                            "url": "https://cdn.example/image.png",
+                            "width": 1024,
+                            "height": 1024,
+                        }
+                    ]
+                }
+
+        submitted = {}
+
+        def fake_submit(model, arguments):
+            submitted["model"] = model
+            submitted["arguments"] = arguments
+            return FakeHandler()
+
+        monkeypatch.setattr(image_tool, "fal_" + "key_is_configured", lambda: True)
+        monkeypatch.setattr(image_tool, "_resolve_managed_fal_gateway", lambda: None)
+        monkeypatch.setattr(image_tool, "_submit_fal_request", fake_submit)
+
+        payload = image_tool.image_generate_tool(
+            prompt="draw a dog",
+            aspect_ratio="square",
+            num_images=2,
+            output_format="png",
+            seed=7,
+        )
+
+        result = json.loads(payload)
+        assert result["success"] is True
+        assert result["message"] == "Image generation completed"
+        assert result["provider"] == "fal"
+        assert result["model"] == "fal-ai/flux-2/klein/9b"
+        assert result["parameters"] == {
+            "prompt": "draw a dog",
+            "aspect_ratio": "square",
+            "num_images": 2,
+            "output_format": "png",
+            "seed": 7,
+        }
+        assert result["provider_request"] == submitted["arguments"]
+        assert result["provider_request"]["image_size"] == "square_hd"
+
+
 # ---------------------------------------------------------------------------
 # Aspect ratio handling
 # ---------------------------------------------------------------------------
@@ -363,11 +413,26 @@ class TestAspectRatioNormalization:
 
 class TestRegistryIntegration:
 
-    def test_schema_exposes_only_prompt_and_aspect_ratio_to_agent(self, image_tool):
-        """The agent-facing schema must stay tight — model selection is a
-        user-level config choice, not an agent-level arg."""
+    def test_schema_exposes_generation_and_edit_controls_to_agent(self, image_tool):
+        """The agent-facing schema exposes image controls but still keeps
+        model/provider selection as user-level config."""
         props = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]
-        assert set(props.keys()) == {"prompt", "aspect_ratio"}
+        assert set(props.keys()) == {
+            "prompt",
+            "aspect_ratio",
+            "size",
+            "quality",
+            "n",
+            "background",
+            "output_format",
+            "output_compression",
+            "moderation",
+            "seed",
+            "image",
+            "mask",
+            "input_fidelity",
+        }
+        assert "model" not in props
 
     def test_aspect_ratio_enum_is_three_values(self, image_tool):
         enum = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]["aspect_ratio"]["enum"]

--- a/tests/tools/test_image_generation_plugin_dispatch.py
+++ b/tests/tools/test_image_generation_plugin_dispatch.py
@@ -54,6 +54,28 @@ class _RecordingProvider(ImageGenProvider):
         }
 
 
+class _ScriptedProvider(ImageGenProvider):
+    def __init__(self, outcomes):
+        self.outcomes = list(outcomes)
+        self.calls = []
+
+    @property
+    def name(self) -> str:
+        return "scripted"
+
+    def generate(self, prompt, aspect_ratio="landscape", **kwargs):
+        self.calls.append({
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "kwargs": dict(kwargs),
+        })
+        index = min(len(self.calls) - 1, len(self.outcomes) - 1)
+        outcome = self.outcomes[index]
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return dict(outcome)
+
+
 class TestPluginDispatch:
 
     def test_dispatch_routes_to_codex_provider(self, monkeypatch, tmp_path):
@@ -229,3 +251,122 @@ class TestPluginDispatch:
                 "input_fidelity": "high",
             },
         }]
+
+    def test_dispatch_retries_upstream_eof_with_identical_parameters_five_times(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from hermes_cli import plugins as plugins_module
+        from agent import image_gen_registry as registry_module
+
+        provider = _ScriptedProvider([
+            {
+                "success": False,
+                "image": None,
+                "provider": "scripted",
+                "model": "gpt-image-2",
+                "prompt": "draw cat",
+                "aspect_ratio": "square",
+                "error": "OpenAI image generation failed: EOF while reading upstream response",
+                "error_type": "api_error",
+            }
+        ])
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(image_generation_tool, "_read_configured_image_provider", lambda: "scripted")
+        monkeypatch.setattr(image_generation_tool, "_read_configured_image_model", lambda: "gpt-image-2")
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda force=False: None)
+        monkeypatch.setattr(registry_module, "get_provider", lambda name: provider if name == "scripted" else None)
+
+        payload = json.loads(image_generation_tool._dispatch_to_plugin_provider(
+            "draw cat",
+            "square",
+            {"size": "1024x1024", "quality": "high", "output_format": "png"},
+        ))
+
+        expected_call = {
+            "prompt": "draw cat",
+            "aspect_ratio": "square",
+            "kwargs": {
+                "size": "1024x1024",
+                "quality": "high",
+                "output_format": "png",
+                "model": "gpt-image-2",
+            },
+        }
+        assert provider.calls == [expected_call] * 5
+        assert payload["success"] is False
+        assert payload["error_type"] == "upstream_transport_error"
+        assert "5 identical attempts" in payload["error"]
+        assert payload["retry_policy"] == {"max_attempts": 5, "same_parameters": True}
+        assert len(payload["retry_attempts"]) == 5
+        assert payload["parameters"] == {
+            "prompt": "draw cat",
+            "aspect_ratio": "square",
+            "size": "1024x1024",
+            "quality": "high",
+            "output_format": "png",
+            "model": "gpt-image-2",
+        }
+
+    def test_dispatch_stops_retrying_after_transient_error_then_success(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from hermes_cli import plugins as plugins_module
+        from agent import image_gen_registry as registry_module
+
+        provider = _ScriptedProvider([
+            ConnectionError("Connection reset by peer"),
+            {
+                "success": True,
+                "image": "/tmp/recovered.png",
+                "provider": "scripted",
+                "model": "gpt-image-2",
+                "prompt": "draw cat",
+                "aspect_ratio": "square",
+            },
+        ])
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(image_generation_tool, "_read_configured_image_provider", lambda: "scripted")
+        monkeypatch.setattr(image_generation_tool, "_read_configured_image_model", lambda: "gpt-image-2")
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda force=False: None)
+        monkeypatch.setattr(registry_module, "get_provider", lambda name: provider if name == "scripted" else None)
+
+        payload = json.loads(image_generation_tool._dispatch_to_plugin_provider(
+            "draw cat",
+            "square",
+            {"size": "1024x1024", "quality": "high"},
+        ))
+
+        assert len(provider.calls) == 2
+        assert provider.calls[0] == provider.calls[1]
+        assert payload["success"] is True
+        assert payload["image"] == "/tmp/recovered.png"
+        assert payload["retry_policy"] == {"max_attempts": 5, "same_parameters": True}
+        assert len(payload["retry_attempts"]) == 1
+
+    def test_dispatch_does_not_retry_non_transport_provider_errors(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from hermes_cli import plugins as plugins_module
+        from agent import image_gen_registry as registry_module
+
+        provider = _ScriptedProvider([
+            {
+                "success": False,
+                "image": None,
+                "provider": "scripted",
+                "model": "gpt-image-2",
+                "prompt": "draw cat",
+                "aspect_ratio": "square",
+                "error": "Invalid size parameter",
+                "error_type": "invalid_argument",
+            }
+        ])
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(image_generation_tool, "_read_configured_image_provider", lambda: "scripted")
+        monkeypatch.setattr(image_generation_tool, "_read_configured_image_model", lambda: "gpt-image-2")
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda force=False: None)
+        monkeypatch.setattr(registry_module, "get_provider", lambda name: provider if name == "scripted" else None)
+
+        payload = json.loads(image_generation_tool._dispatch_to_plugin_provider("draw cat", "square"))
+
+        assert len(provider.calls) == 1
+        assert payload["success"] is False
+        assert payload["error_type"] == "invalid_argument"
+        assert "retry_attempts" not in payload

--- a/tests/tools/test_image_generation_plugin_dispatch.py
+++ b/tests/tools/test_image_generation_plugin_dispatch.py
@@ -30,7 +30,32 @@ class _FakeCodexProvider(ImageGenProvider):
         }
 
 
+class _RecordingProvider(ImageGenProvider):
+    def __init__(self):
+        self.calls = []
+
+    @property
+    def name(self) -> str:
+        return "recording"
+
+    def generate(self, prompt, aspect_ratio="landscape", **kwargs):
+        self.calls.append({
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "kwargs": dict(kwargs),
+        })
+        return {
+            "success": True,
+            "image": "/tmp/recording-test.png",
+            "model": kwargs.get("model", "test-model"),
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "provider": "recording",
+        }
+
+
 class TestPluginDispatch:
+
     def test_dispatch_routes_to_codex_provider(self, monkeypatch, tmp_path):
         from tools import image_generation_tool
         from agent import image_gen_registry as registry_module
@@ -97,3 +122,110 @@ class TestPluginDispatch:
         assert payload["success"] is True
         assert payload["provider"] == "codex"
         assert payload["aspect_ratio"] == "portrait"
+
+    def test_handle_forwards_generation_and_edit_parameters_to_provider(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from hermes_cli import plugins as plugins_module
+        from agent import image_gen_registry as registry_module
+
+        provider = _RecordingProvider()
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(image_generation_tool, "_read_configured_image_provider", lambda: "recording")
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda force=False: None)
+        monkeypatch.setattr(registry_module, "get_provider", lambda name: provider if name == "recording" else None)
+
+        args = {
+            "prompt": "change the jacket to red",
+            "aspect_ratio": "portrait",
+            "size": "1536x1024",
+            "quality": "high",
+            "n": 2,
+            "background": "opaque",
+            "output_format": "webp",
+            "output_compression": 82,
+            "moderation": "low",
+            "seed": 123,
+            "image": "/tmp/input.png",
+            "mask": "/tmp/mask.png",
+            "input_fidelity": "high",
+        }
+
+        payload = json.loads(image_generation_tool._handle_image_generate(args))
+
+        assert payload["success"] is True
+        assert provider.calls == [{
+            "prompt": "change the jacket to red",
+            "aspect_ratio": "portrait",
+            "kwargs": {
+                "size": "1536x1024",
+                "quality": "high",
+                "n": 2,
+                "background": "opaque",
+                "output_format": "webp",
+                "output_compression": 82,
+                "moderation": "low",
+                "seed": 123,
+                "image": "/tmp/input.png",
+                "mask": "/tmp/mask.png",
+                "input_fidelity": "high",
+            },
+        }]
+
+    def test_handle_drops_edit_parameters_for_text_to_image(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from hermes_cli import plugins as plugins_module
+        from agent import image_gen_registry as registry_module
+
+        provider = _RecordingProvider()
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(image_generation_tool, "_read_configured_image_provider", lambda: "recording")
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda force=False: None)
+        monkeypatch.setattr(registry_module, "get_provider", lambda name: provider if name == "recording" else None)
+
+        args = {
+            "prompt": "draw a cat",
+            "aspect_ratio": "square",
+            "image": "",
+            "mask": "",
+            "input_fidelity": "low",
+        }
+
+        payload = json.loads(image_generation_tool._handle_image_generate(args))
+
+        assert payload["success"] is True
+        assert provider.calls == [{
+            "prompt": "draw a cat",
+            "aspect_ratio": "square",
+            "kwargs": {},
+        }]
+
+    def test_handle_drops_empty_mask_for_image_to_image(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from hermes_cli import plugins as plugins_module
+        from agent import image_gen_registry as registry_module
+
+        provider = _RecordingProvider()
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(image_generation_tool, "_read_configured_image_provider", lambda: "recording")
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda force=False: None)
+        monkeypatch.setattr(registry_module, "get_provider", lambda name: provider if name == "recording" else None)
+
+        args = {
+            "prompt": "make it cyberpunk",
+            "aspect_ratio": "square",
+            "image": "/tmp/input.png",
+            "mask": "",
+            "input_fidelity": "high",
+        }
+
+        payload = json.loads(image_generation_tool._handle_image_generate(args))
+
+        assert payload["success"] is True
+        assert provider.calls == [{
+            "prompt": "make it cyberpunk",
+            "aspect_ratio": "square",
+            "kwargs": {
+                "image": "/tmp/input.png",
+                "input_fidelity": "high",
+            },
+        }]

--- a/tests/tools/test_live_config_guard.py
+++ b/tests/tools/test_live_config_guard.py
@@ -1,0 +1,172 @@
+"""Regression tests for guarded writes to live Hermes config/secrets files."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from tools.file_operations import ShellFileOperations
+
+
+class _LocalShellEnv:
+    def __init__(self, cwd: Path):
+        self.cwd = str(cwd)
+
+    def execute(self, command: str, cwd: str | None = None, timeout: int | None = None,
+                stdin_data: str | None = None):
+        completed = subprocess.run(
+            command,
+            shell=True,
+            cwd=cwd or self.cwd,
+            input=stdin_data,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+        return {
+            "output": completed.stdout + completed.stderr,
+            "returncode": completed.returncode,
+        }
+
+
+@pytest.fixture()
+def hermes_home(tmp_path: Path):
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    token = set_hermes_home_override(home)
+    try:
+        yield home
+    finally:
+        reset_hermes_home_override(token)
+
+
+@pytest.fixture()
+def file_ops(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    ops = ShellFileOperations(_LocalShellEnv(tmp_path))
+    monkeypatch.setattr(ops, "_snapshot_lsp_baseline", lambda path: None)
+    monkeypatch.setattr(ops, "_maybe_lsp_diagnostics", lambda *args, **kwargs: "")
+    return ops
+
+
+def test_config_write_allows_safe_edit_with_backup_and_redacted_diff(
+    hermes_home: Path,
+    file_ops: ShellFileOperations,
+):
+    config_path = hermes_home / "config.yaml"
+    old = "model:\n  api_key: sk-live-secret\n  default: old-model\n"
+    new = "model:\n  api_key: sk-live-secret\n  default: new-model\n"
+    config_path.write_text(old)
+
+    result = file_ops.write_file(str(config_path), new)
+
+    assert result.error is None
+    assert config_path.read_text() == new
+    assert result.backup_path
+    assert Path(result.backup_path).read_text() == old
+    assert result.redacted_diff
+    assert "default: new-model" in result.redacted_diff
+    assert "sk-live-secret" not in result.redacted_diff
+    assert "[REDACTED]" in result.redacted_diff
+
+
+def test_config_write_redacts_multiline_private_key_blocks(
+    hermes_home: Path,
+    file_ops: ShellFileOperations,
+):
+    config_path = hermes_home / "config.yaml"
+    old = """ssh:
+  private_key: |
+    -----BEGIN PRIVATE KEY-----
+    live-secret-key-material
+    -----END PRIVATE KEY-----
+  host: old.example.test
+"""
+    new = old.replace("host: old.example.test", "host: new.example.test")
+    config_path.write_text(old)
+
+    result = file_ops.write_file(str(config_path), new)
+
+    assert result.error is None
+    assert result.redacted_diff
+    assert "host: new.example.test" in result.redacted_diff
+    assert "BEGIN PRIVATE KEY" not in result.redacted_diff
+    assert "live-secret-key-material" not in result.redacted_diff
+    assert "END PRIVATE KEY" not in result.redacted_diff
+
+
+def test_config_write_refuses_deleting_existing_api_key(
+    hermes_home: Path,
+    file_ops: ShellFileOperations,
+):
+    config_path = hermes_home / "config.yaml"
+    old = "custom_providers:\n  yuna:\n    api_key: sk-provider-secret\n    base_url: https://example.test/v1\n"
+    new = "custom_providers:\n  yuna:\n    base_url: https://example.test/v1\n"
+    config_path.write_text(old)
+
+    result = file_ops.write_file(str(config_path), new)
+
+    assert result.error
+    assert "credential" in result.error.lower()
+    assert config_path.read_text() == old
+    assert not result.backup_path
+    assert result.redacted_diff
+    assert "sk-provider-secret" not in result.redacted_diff
+
+
+def test_env_write_allows_non_secret_edit_with_backup(
+    hermes_home: Path,
+    file_ops: ShellFileOperations,
+):
+    env_path = hermes_home / ".env"
+    old = "OPENAI_API_KEY=sk-env-secret\nLOG_LEVEL=info\n"
+    new = "OPENAI_API_KEY=sk-env-secret\nLOG_LEVEL=debug\n"
+    env_path.write_text(old)
+
+    result = file_ops.write_file(str(env_path), new)
+
+    assert result.error is None
+    assert env_path.read_text() == new
+    assert result.backup_path
+    assert Path(result.backup_path).read_text() == old
+    assert result.redacted_diff
+    assert "LOG_LEVEL=debug" in result.redacted_diff
+    assert "sk-env-secret" not in result.redacted_diff
+
+
+def test_env_write_refuses_replacing_real_secret_with_placeholder(
+    hermes_home: Path,
+    file_ops: ShellFileOperations,
+):
+    env_path = hermes_home / ".env"
+    old = "OPENAI_API_KEY=sk-env-secret\nLOG_LEVEL=info\n"
+    new = "OPENAI_API_KEY=YOUR_API_KEY_HERE\nLOG_LEVEL=info\n"
+    env_path.write_text(old)
+
+    result = file_ops.write_file(str(env_path), new)
+
+    assert result.error
+    assert "placeholder" in result.error.lower()
+    assert env_path.read_text() == old
+    assert "sk-env-secret" not in result.redacted_diff
+    assert "YOUR_API_KEY_HERE" not in result.redacted_diff
+
+
+def test_patch_replace_on_env_uses_live_config_guard(
+    hermes_home: Path,
+    file_ops: ShellFileOperations,
+):
+    env_path = hermes_home / ".env"
+    old = "OPENAI_API_KEY=sk-env-secret\nLOG_LEVEL=info\n"
+    env_path.write_text(old)
+
+    result = file_ops.patch_replace(str(env_path), "LOG_LEVEL=info", "LOG_LEVEL=debug")
+
+    assert result.success is True
+    assert env_path.read_text() == "OPENAI_API_KEY=sk-env-secret\nLOG_LEVEL=debug\n"
+    assert result.backup_path
+    assert result.redacted_diff
+    assert "sk-env-secret" not in result.redacted_diff

--- a/tests/tools/test_live_config_guard.py
+++ b/tests/tools/test_live_config_guard.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 import subprocess
 from pathlib import Path
 
@@ -311,6 +312,36 @@ def test_live_config_guard_treats_camelcase_token_fields_as_secrets(
     assert "channels.session.refreshToken" in result.error
     assert "channels.session.sessionToken" in result.error
     assert config_path.read_text() == old
+
+
+def test_live_config_guard_line_fallback_treats_camelcase_token_fields_as_secrets(
+    hermes_home: Path,
+    file_ops: ShellFileOperations,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    config_path = hermes_home / "config.yaml"
+    old = """channels:
+  telegram:
+    botToken: REALBOTTOKEN123
+model:
+  maxTokens: 4096
+  promptTokenCount: 128
+"""
+    new = """channels:
+  telegram: {}
+model: {}
+"""
+    config_path.write_text(old)
+    monkeypatch.setitem(sys.modules, "yaml", None)
+
+    result = file_ops.write_file(str(config_path), new)
+
+    assert result.error
+    assert "line:3" in result.error
+    assert "line:5" not in result.error
+    assert "line:6" not in result.error
+    assert config_path.read_text() == old
+    assert "REALBOTTOKEN123" not in result.redacted_diff
 
 
 def test_live_config_guard_refuses_deleting_duplicate_secret_even_if_value_remains(

--- a/tests/tools/test_live_config_guard.py
+++ b/tests/tools/test_live_config_guard.py
@@ -258,6 +258,61 @@ def test_live_config_guard_does_not_treat_token_count_fields_as_secrets(
     assert yaml.safe_load(config_path.read_text()) == {"model": {"default": "new-model"}}
 
 
+def test_live_config_guard_does_not_treat_camelcase_token_count_fields_as_secrets(
+    hermes_home: Path,
+):
+    from utils import atomic_yaml_write
+
+    config_path = hermes_home / "config.yaml"
+    config_path.write_text(
+        "model:\n"
+        "  default: old-model\n"
+        "  maxTokens: 4096\n"
+        "  contextTokens: 8192\n"
+        "  promptTokenCount: 128\n"
+        "  completionTokens: 256\n"
+    )
+
+    atomic_yaml_write(
+        config_path,
+        {"model": {"default": "new-model"}},
+        sort_keys=False,
+    )
+
+    assert yaml.safe_load(config_path.read_text()) == {"model": {"default": "new-model"}}
+
+
+def test_live_config_guard_treats_camelcase_token_fields_as_secrets(
+    hermes_home: Path,
+    file_ops: ShellFileOperations,
+):
+    config_path = hermes_home / "config.yaml"
+    old = """channels:
+  telegram:
+    botToken: REALBOTTOKEN123
+  slack:
+    appToken: REALAPPTOKEN123
+  session:
+    refreshToken: REALREFRESHTOKEN123
+    sessionToken: REALSESSIONTOKEN123
+"""
+    new = """channels:
+  telegram: {}
+  slack: {}
+  session: {}
+"""
+    config_path.write_text(old)
+
+    result = file_ops.write_file(str(config_path), new)
+
+    assert result.error
+    assert "channels.telegram.botToken" in result.error
+    assert "channels.slack.appToken" in result.error
+    assert "channels.session.refreshToken" in result.error
+    assert "channels.session.sessionToken" in result.error
+    assert config_path.read_text() == old
+
+
 def test_live_config_guard_refuses_deleting_duplicate_secret_even_if_value_remains(
     hermes_home: Path,
     file_ops: ShellFileOperations,

--- a/tests/tools/test_live_config_guard.py
+++ b/tests/tools/test_live_config_guard.py
@@ -6,6 +6,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+import yaml
 
 from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 from tools.file_operations import ShellFileOperations
@@ -160,13 +161,191 @@ def test_patch_replace_on_env_uses_live_config_guard(
     file_ops: ShellFileOperations,
 ):
     env_path = hermes_home / ".env"
-    old = "OPENAI_API_KEY=sk-env-secret\nLOG_LEVEL=info\n"
+    old = "OPENAI_API_KEY=***\nLOG_LEVEL=info\n"
     env_path.write_text(old)
 
     result = file_ops.patch_replace(str(env_path), "LOG_LEVEL=info", "LOG_LEVEL=debug")
 
     assert result.success is True
-    assert env_path.read_text() == "OPENAI_API_KEY=sk-env-secret\nLOG_LEVEL=debug\n"
+    assert env_path.read_text() == "OPENAI_API_KEY=***\nLOG_LEVEL=debug\n"
     assert result.backup_path
     assert result.redacted_diff
-    assert "sk-env-secret" not in result.redacted_diff
+    assert "***" not in result.redacted_diff
+
+
+def test_config_write_redacts_flow_style_secret_values(
+    hermes_home: Path,
+    file_ops: ShellFileOperations,
+):
+    config_path = hermes_home / "config.yaml"
+    old = "model: {api_key: FLOWVALUE12345, default: old}\n"
+    new = "model: {api_key: FLOWVALUE12345, default: new}\n"
+    config_path.write_text(old)
+
+    result = file_ops.write_file(str(config_path), new)
+
+    assert result.error is None
+    assert result.backup_path
+    assert result.redacted_diff
+    assert "default: new" in result.redacted_diff
+    assert "FLOWVALUE12345" not in result.redacted_diff
+    assert "[REDACTED]" in result.redacted_diff
+
+
+def test_patch_v4a_on_env_uses_live_config_guard(
+    hermes_home: Path,
+    file_ops: ShellFileOperations,
+):
+    env_path = hermes_home / ".env"
+    old = "OPENAI_API_KEY=LIVEVALUE12345\nLOG_LEVEL=info\n"
+    env_path.write_text(old)
+    patch = f"""*** Begin Patch
+*** Update File: {env_path}
+@@ LOG_LEVEL=info @@
+ OPENAI_API_KEY=LIVEVALUE12345
+-LOG_LEVEL=info
++LOG_LEVEL=debug
+*** End Patch
+"""
+
+    result = file_ops.patch_v4a(patch)
+
+    assert result.success is True
+    assert env_path.read_text() == "OPENAI_API_KEY=LIVEVALUE12345\nLOG_LEVEL=debug\n"
+    assert result.backup_path
+    assert Path(result.backup_path).read_text() == old
+    assert result.redacted_diff
+    assert "LIVEVALUE12345" not in result.diff
+    assert "LIVEVALUE12345" not in result.redacted_diff
+
+
+def test_atomic_yaml_write_refuses_live_config_secret_deletion(
+    hermes_home: Path,
+):
+    from utils import atomic_yaml_write
+
+    config_path = hermes_home / "config.yaml"
+    old = "custom_providers:\n  yuna:\n    api_key: sk-live-value\n    base_url: https://example.test/v1\n"
+    config_path.write_text(old)
+
+    with pytest.raises(ValueError, match="credential"):
+        atomic_yaml_write(
+            config_path,
+            {"custom_providers": {"yuna": {"base_url": "https://example.test/v1"}}},
+            sort_keys=False,
+        )
+
+    assert config_path.read_text() == old
+    assert list(hermes_home.glob("config.yaml.bak.*")) == []
+
+
+def test_live_config_guard_does_not_treat_token_count_fields_as_secrets(
+    hermes_home: Path,
+):
+    from utils import atomic_yaml_write
+
+    config_path = hermes_home / "config.yaml"
+    config_path.write_text(
+        "model:\n  default: old-model\n  max_tokens: 4096\n  tokenizer: cl100k_base\n"
+    )
+
+    atomic_yaml_write(
+        config_path,
+        {"model": {"default": "new-model"}},
+        sort_keys=False,
+    )
+
+    assert yaml.safe_load(config_path.read_text()) == {"model": {"default": "new-model"}}
+
+
+def test_live_config_guard_refuses_deleting_duplicate_secret_even_if_value_remains(
+    hermes_home: Path,
+    file_ops: ShellFileOperations,
+):
+    config_path = hermes_home / "config.yaml"
+    old = """providers:
+  one:
+    api_key: SHAREDREALVALUE123
+  two:
+    api_key: SHAREDREALVALUE123
+"""
+    new = """providers:
+  two:
+    api_key: SHAREDREALVALUE123
+"""
+    config_path.write_text(old)
+
+    result = file_ops.write_file(str(config_path), new)
+
+    assert result.error
+    assert "providers.one.api_key" in result.error
+    assert config_path.read_text() == old
+
+
+def test_atomic_yaml_write_backs_up_live_config_safe_edit(
+    hermes_home: Path,
+):
+    from utils import atomic_yaml_write
+
+    config_path = hermes_home / "config.yaml"
+    old_data = {"model": {"api_key": "sk-live-value", "default": "old-model"}}
+    config_path.write_text(yaml.safe_dump(old_data, sort_keys=False))
+
+    atomic_yaml_write(
+        config_path,
+        {"model": {"api_key": "sk-live-value", "default": "new-model"}},
+        sort_keys=False,
+    )
+
+    assert yaml.safe_load(config_path.read_text())["model"]["default"] == "new-model"
+    backups = list(hermes_home.glob("config.yaml.bak.*"))
+    assert len(backups) == 1
+    assert yaml.safe_load(backups[0].read_text()) == old_data
+
+
+def test_save_env_value_refuses_overwriting_real_secret_with_placeholder(
+    hermes_home: Path,
+):
+    from hermes_cli.config import save_env_value
+
+    env_path = hermes_home / ".env"
+    old = "OPENAI_API_KEY=sk-live-value\nLOG_LEVEL=info\n"
+    env_path.write_text(old)
+
+    with pytest.raises(ValueError, match="placeholder"):
+        save_env_value("OPENAI_API_KEY", "YOUR_API_KEY_HERE")
+
+    assert env_path.read_text() == old
+    assert list(hermes_home.glob(".env.bak.*")) == []
+
+
+def test_save_env_value_backs_up_live_env_safe_edit(
+    hermes_home: Path,
+):
+    from hermes_cli.config import save_env_value
+
+    env_path = hermes_home / ".env"
+    old = "OPENAI_API_KEY=sk-live-value\nLOG_LEVEL=info\n"
+    env_path.write_text(old)
+
+    save_env_value("LOG_LEVEL", "debug")
+
+    assert env_path.read_text() == "OPENAI_API_KEY=sk-live-value\nLOG_LEVEL=debug\n"
+    backups = list(hermes_home.glob(".env.bak.*"))
+    assert len(backups) == 1
+    assert backups[0].read_text() == old
+
+
+def test_remove_env_value_refuses_deleting_real_secret(
+    hermes_home: Path,
+):
+    from hermes_cli.config import remove_env_value
+
+    env_path = hermes_home / ".env"
+    old = "OPENAI_API_KEY=sk-live-value\nLOG_LEVEL=info\n"
+    env_path.write_text(old)
+
+    with pytest.raises(ValueError, match="remove existing credential"):
+        remove_env_value("OPENAI_API_KEY")
+
+    assert env_path.read_text() == old

--- a/tests/tools/test_mcp_image_content.py
+++ b/tests/tools/test_mcp_image_content.py
@@ -17,6 +17,8 @@ images natively.
 from __future__ import annotations
 
 import base64
+import asyncio
+import json
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -136,3 +138,53 @@ class TestCacheMcpImageBlock:
         tag = _cache_mcp_image_block(block)
         assert tag.startswith("MEDIA:")
         assert tag.endswith(".jpg"), f"expected .jpg extension, got {tag!r}"
+
+
+class TestMcpToolImageResultPayload:
+    def test_image_content_tags_are_marked_as_explicit_gateway_media(self, tmp_path, monkeypatch):
+        """Gateway extraction trusts MCP image tags only when the wrapper marks them explicit."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        import tools.mcp_tool as mcp_tool
+
+        class AsyncNullLock:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        class FakeSession:
+            async def call_tool(self, tool_name, arguments):
+                assert tool_name == "screenshot"
+                assert arguments == {"full_page": True}
+                return SimpleNamespace(
+                    isError=False,
+                    content=[
+                        SimpleNamespace(text="Screenshot captured"),
+                        SimpleNamespace(
+                            data=base64.b64encode(_png_bytes()).decode("ascii"),
+                            mimeType="image/png",
+                        ),
+                    ],
+                    structuredContent=None,
+                )
+
+        fake_server = SimpleNamespace(
+            session=FakeSession(),
+            _rpc_lock=AsyncNullLock(),
+        )
+        monkeypatch.setitem(mcp_tool._servers, "playwright", fake_server)
+
+        def run_sync(coro_factory, timeout):
+            return asyncio.run(coro_factory())
+
+        monkeypatch.setattr(mcp_tool, "_run_on_mcp_loop", run_sync)
+
+        handler = mcp_tool._make_tool_handler("playwright", "screenshot", 120)
+        payload = json.loads(handler({"full_page": True}))
+
+        assert "MEDIA:" in payload["result"]
+        assert payload["_hermes_media_tags"] == [
+            line for line in payload["result"].splitlines() if line.startswith("MEDIA:")
+        ]

--- a/tests/tools/test_openai_image_generation_provider.py
+++ b/tests/tools/test_openai_image_generation_provider.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import json
+import sys
+from types import SimpleNamespace
+
+
+class _FakeImages:
+    def __init__(self):
+        self.generate_kwargs = None
+        self.edit_kwargs = None
+
+    def generate(self, **kwargs):
+        self.generate_kwargs = kwargs
+        return SimpleNamespace(data=[SimpleNamespace(b64_json="aGVsbG8=", revised_prompt="revised")])
+
+    def edit(self, **kwargs):
+        self.edit_kwargs = kwargs
+        return SimpleNamespace(data=[SimpleNamespace(b64_json="aGVsbG8=", revised_prompt=None)])
+
+
+def _install_fake_openai(monkeypatch, images):
+    created = []
+
+    class FakeOpenAI:
+        def __init__(self, **kwargs):
+            created.append(kwargs)
+            self.images = images
+
+    monkeypatch.setitem(sys.modules, "openai", SimpleNamespace(OpenAI=FakeOpenAI))
+    return created
+
+
+def test_openai_provider_forwards_generate_parameters(monkeypatch, tmp_path):
+    from plugins.image_gen import openai as openai_image
+
+    images = _FakeImages()
+    created = _install_fake_openai(monkeypatch, images)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setattr(openai_image, "_resolve_model", lambda: ("gpt-image-2-medium", {"quality": "medium"}))
+    monkeypatch.setattr(openai_image, "save_b64_image", lambda *a, **k: tmp_path / "out.webp")
+
+    result = openai_image.OpenAIImageGenProvider().generate(
+        "draw a cat",
+        "landscape",
+        size="2560x1440",
+        quality="high",
+        n=2,
+        background="opaque",
+        output_format="webp",
+        output_compression=72,
+        moderation="low",
+        seed=123,
+    )
+
+    assert created == [{}]
+    assert images.generate_kwargs == {
+        "model": "gpt-image-2",
+        "prompt": "draw a cat",
+        "size": "2560x1440",
+        "n": 2,
+        "quality": "high",
+        "background": "opaque",
+        "output_format": "webp",
+        "output_compression": 72,
+        "moderation": "low",
+    }
+    assert result["success"] is True
+    assert result["size"] == "2560x1440"
+    assert result["quality"] == "high"
+    assert result["output_format"] == "webp"
+    assert result["revised_prompt"] == "revised"
+
+
+def test_openai_provider_uses_edit_when_image_is_supplied(monkeypatch, tmp_path):
+    from plugins.image_gen import openai as openai_image
+
+    source = tmp_path / "input.png"
+    source.write_bytes(b"fake image")
+    mask = tmp_path / "mask.png"
+    mask.write_bytes(b"fake mask")
+
+    images = _FakeImages()
+    _install_fake_openai(monkeypatch, images)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setattr(openai_image, "_resolve_model", lambda: ("gpt-image-2-medium", {"quality": "medium"}))
+    monkeypatch.setattr(openai_image, "save_b64_image", lambda *a, **k: tmp_path / "edited.png")
+
+    result = openai_image.OpenAIImageGenProvider().generate(
+        "make the jacket red",
+        "square",
+        image=str(source),
+        mask=str(mask),
+        input_fidelity="high",
+        size="1024x1024",
+        quality="high",
+        n=1,
+        background="opaque",
+        output_format="png",
+        output_compression=90,
+    )
+
+    assert images.generate_kwargs is None
+    assert images.edit_kwargs["model"] == "gpt-image-2"
+    assert images.edit_kwargs["prompt"] == "make the jacket red"
+    assert images.edit_kwargs["image"].name == str(source)
+    assert images.edit_kwargs["image"].closed is True
+    assert images.edit_kwargs["mask"].name == str(mask)
+    assert images.edit_kwargs["mask"].closed is True
+    assert images.edit_kwargs["input_fidelity"] == "high"
+    assert images.edit_kwargs["size"] == "1024x1024"
+    assert images.edit_kwargs["quality"] == "high"
+    assert images.edit_kwargs["background"] == "opaque"
+    assert result["operation"] == "edit"
+
+
+def test_custom_provider_uses_openai_compatible_images_api(monkeypatch, tmp_path):
+    from tools import image_generation_tool
+    import hermes_cli.runtime_provider as runtime_provider
+
+    images = _FakeImages()
+    created = _install_fake_openai(monkeypatch, images)
+    monkeypatch.setattr(image_generation_tool, "_read_configured_image_provider", lambda: "custom:yuna")
+    monkeypatch.setattr(image_generation_tool, "_read_configured_image_model", lambda: "gpt-image-2")
+
+    def fake_named_custom(name):
+        assert name == "custom:yuna"
+        return {
+            "name": "yuna",
+            "base_url": "https://yuna.example/v1",
+            "api_key": "sk-yuna",
+        }
+
+    monkeypatch.setattr(runtime_provider, "_get_named_custom_provider", fake_named_custom)
+    monkeypatch.setattr(image_generation_tool, "save_b64_image", lambda *a, **k: tmp_path / "custom.png", raising=False)
+
+    payload = image_generation_tool._dispatch_to_plugin_provider(
+        "draw a cat",
+        "square",
+        {"size": "1024x1024", "quality": "high", "output_format": "png"},
+    )
+
+    result = json.loads(payload)
+    assert result["success"] is True
+    assert result["message"] == "Image generation completed"
+    assert result["parameters"] == {
+        "prompt": "draw a cat",
+        "aspect_ratio": "square",
+        "size": "1024x1024",
+        "quality": "high",
+        "output_format": "png",
+        "model": "gpt-image-2",
+    }
+    assert result["provider"] == "custom:yuna"
+    assert created == [{"api_key": "sk-yuna", "base_url": "https://yuna.example/v1"}]
+    assert images.generate_kwargs["model"] == "gpt-image-2"
+    assert images.generate_kwargs["prompt"] == "draw a cat"
+    assert images.generate_kwargs["size"] == "1024x1024"
+    assert images.generate_kwargs["quality"] == "high"

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -27,6 +27,7 @@ Usage:
 
 import os
 import re
+import time
 import difflib
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -39,6 +40,11 @@ from agent.file_safety import (
     build_write_denied_prefixes,
     get_safe_write_root as _shared_get_safe_write_root,
     is_write_denied as _shared_is_write_denied,
+)
+from agent.live_config_guard import (
+    classify_live_config_path,
+    is_live_config_path,
+    validate_live_config_write,
 )
 
 
@@ -90,6 +96,31 @@ def _is_write_denied(path: str) -> bool:
     return _shared_is_write_denied(path)
 
 
+def _is_outside_safe_write_root(path: str) -> bool:
+    """Return True when HERMES_WRITE_SAFE_ROOT blocks this path."""
+    safe_root = _get_safe_write_root()
+    if not safe_root:
+        return False
+    try:
+        resolved = os.path.realpath(os.path.expanduser(str(path)))
+    except Exception:
+        return True
+    return not (resolved == safe_root or resolved.startswith(safe_root + os.sep))
+
+
+def _is_write_denied_for_modify(path: str) -> bool:
+    """Write-deny check for content-preserving writes.
+
+    Active Hermes config.yaml/.env files are still protected, but by the
+    stronger live-config guard below so safe edits can preserve existing
+    credentials, emit a redacted diff, and create a backup.  The opt-in
+    HERMES_WRITE_SAFE_ROOT sandbox remains authoritative.
+    """
+    if is_live_config_path(path) and not _is_outside_safe_write_root(path):
+        return False
+    return _is_write_denied(path)
+
+
 # =============================================================================
 # Result Data Classes
 # =============================================================================
@@ -127,6 +158,8 @@ class WriteResult:
     # isn't in a git workspace, or when no diagnostics were introduced
     # by this edit.
     lsp_diagnostics: Optional[str] = None
+    backup_path: Optional[str] = None
+    redacted_diff: Optional[str] = None
     error: Optional[str] = None
     warning: Optional[str] = None
 
@@ -145,6 +178,8 @@ class PatchResult:
     lint: Optional[Dict[str, Any]] = None
     # See :class:`WriteResult.lsp_diagnostics`.
     lsp_diagnostics: Optional[str] = None
+    backup_path: Optional[str] = None
+    redacted_diff: Optional[str] = None
     error: Optional[str] = None
     
     def to_dict(self) -> dict:
@@ -161,6 +196,10 @@ class PatchResult:
             result["lint"] = self.lint
         if self.lsp_diagnostics:
             result["lsp_diagnostics"] = self.lsp_diagnostics
+        if self.backup_path:
+            result["backup_path"] = self.backup_path
+        if self.redacted_diff:
+            result["redacted_diff"] = self.redacted_diff
         if self.error:
             result["error"] = self.error
         return result
@@ -943,37 +982,54 @@ class ShellFileOperations(FileOperations):
         # Expand ~ and other shell paths
         path = self._expand_path(path)
 
-        # Block writes to sensitive paths
-        if _is_write_denied(path):
+        # Block writes to sensitive paths.  Live Hermes config/.env files use
+        # a stronger content-aware guard below instead of a blanket deny.
+        if _is_write_denied_for_modify(path):
             return WriteResult(error=f"Write denied: '{path}' is a protected system/credential file.")
 
-        # Capture pre-write content.  Two consumers want it:
+        live_guarded = classify_live_config_path(path)
+
+        # Capture pre-write content.  Three consumers want it:
         #
-        #   1. The lint-delta layer (for in-process linters like ast.parse
+        #   1. The live-config guard needs old vs new credential fields to
+        #      refuse placeholder/null/deleted secret writes before touching
+        #      disk and to generate a force-redacted diff.
+        #   2. The lint-delta layer (for in-process linters like ast.parse
         #      and json.loads) needs the previous content to compute the
         #      set of NEW lint errors introduced by this write.
-        #   2. The LSP layer needs pre/post content to build a line-shift
+        #   3. The LSP layer needs pre/post content to build a line-shift
         #      map — pre-existing diagnostics below the edit point shift
         #      when lines are added/removed, and the shift map remaps
         #      baseline diagnostics into post-edit coordinates so the
         #      strict (range-aware) delta key matches.
         #
         # The set of extensions we capture pre_content for is therefore
-        # the UNION of in-process lint coverage and LSP coverage.  For
-        # extensions outside both sets (binaries, opaque formats),
-        # skipping the read keeps the hot path fast.
+        # the UNION of live-config coverage, in-process lint coverage, and
+        # LSP coverage.  For extensions outside all sets (binaries, opaque
+        # formats), skipping the read keeps the hot path fast.
         ext = os.path.splitext(path)[1].lower()
         pre_content: Optional[str] = None
-        want_pre = ext in LINTERS_INPROC or self._lsp_handles_extension(ext)
+        want_pre = live_guarded is not None or ext in LINTERS_INPROC or self._lsp_handles_extension(ext)
         if want_pre:
             # Best-effort read; failure (file missing, permission) leaves
-            # pre_content as None which makes both downstream consumers
-            # degrade gracefully (lint reports all errors; LSP skips the
-            # shift map).
+            # pre_content as None which makes downstream consumers degrade
+            # gracefully (guard treats it as a new file, lint reports all
+            # errors, LSP skips the shift map).
             read_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
             read_result = self._exec(read_cmd)
-            if read_result.exit_code == 0 and read_result.stdout:
+            if read_result.exit_code == 0:
                 pre_content = read_result.stdout
+
+        guard_result = validate_live_config_write(
+            path,
+            old_content=pre_content,
+            new_content=content,
+        )
+        if guard_result.error:
+            return WriteResult(
+                error=guard_result.error,
+                redacted_diff=guard_result.redacted_diff,
+            )
 
         # Snapshot LSP diagnostics for this file (best-effort) so the
         # post-write LSP layer can return only diagnostics introduced
@@ -991,6 +1047,21 @@ class ShellFileOperations(FileOperations):
             mkdir_result = self._exec(mkdir_cmd)
             if mkdir_result.exit_code == 0:
                 dirs_created = True
+
+        backup_path: Optional[str] = None
+        if guard_result.guarded and pre_content is not None:
+            stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+            backup_path = f"{path}.bak.{stamp}.{os.getpid()}"
+            backup_cmd = (
+                f"cp -p {self._escape_shell_arg(path)} "
+                f"{self._escape_shell_arg(backup_path)}"
+            )
+            backup_result = self._exec(backup_cmd)
+            if backup_result.exit_code != 0:
+                return WriteResult(
+                    error=f"Failed to back up live Hermes config before write: {backup_result.stdout}",
+                    redacted_diff=guard_result.redacted_diff,
+                )
 
         # Write via stdin pipe — content bypasses shell arg parsing entirely,
         # so there's no ARG_MAX limit regardless of file size.
@@ -1031,6 +1102,8 @@ class ShellFileOperations(FileOperations):
             dirs_created=dirs_created,
             lint=lint_result.to_dict() if lint_result else None,
             lsp_diagnostics=lsp_diagnostics,
+            backup_path=backup_path,
+            redacted_diff=guard_result.redacted_diff,
         )
     
     # =========================================================================
@@ -1054,8 +1127,9 @@ class ShellFileOperations(FileOperations):
         # Expand ~ and other shell paths
         path = self._expand_path(path)
 
-        # Block writes to sensitive paths
-        if _is_write_denied(path):
+        # Block writes to sensitive paths.  Live Hermes config/.env files are
+        # checked by write_file's content-aware live-config guard.
+        if _is_write_denied_for_modify(path):
             return PatchResult(error=f"Write denied: '{path}' is a protected system/credential file.")
 
         # Read current content
@@ -1085,7 +1159,10 @@ class ShellFileOperations(FileOperations):
         # Write back
         write_result = self.write_file(path, new_content)
         if write_result.error:
-            return PatchResult(error=f"Failed to write changes: {write_result.error}")
+            return PatchResult(
+                error=f"Failed to write changes: {write_result.error}",
+                redacted_diff=write_result.redacted_diff,
+            )
 
         # Post-write verification — re-read the file and confirm the bytes we
         # intended to write actually landed. Catches silent persistence
@@ -1114,8 +1191,9 @@ class ShellFileOperations(FileOperations):
                 "The patch did not persist. Re-read the file and try again."
             ))
 
-        # Generate diff
-        diff = self._unified_diff(content, new_content, path)
+        # Generate diff.  For live config/secrets files, never return an
+        # unredacted diff because unchanged context lines may contain keys.
+        diff = write_result.redacted_diff or self._unified_diff(content, new_content, path)
 
         # Auto-lint with delta refinement: only surface errors introduced
         # by this patch, filtering out pre-existing lint failures so the
@@ -1134,6 +1212,8 @@ class ShellFileOperations(FileOperations):
             # the patch as a whole.  Keep the field separate from the
             # syntax-check ``lint`` so the agent can read both signals.
             lsp_diagnostics=write_result.lsp_diagnostics,
+            backup_path=write_result.backup_path,
+            redacted_diff=write_result.redacted_diff,
         )
     
     def patch_v4a(self, patch_content: str) -> PatchResult:

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -27,7 +27,6 @@ Usage:
 
 import os
 import re
-import time
 import difflib
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -44,7 +43,7 @@ from agent.file_safety import (
 from agent.live_config_guard import (
     classify_live_config_path,
     is_live_config_path,
-    validate_live_config_write,
+    validate_and_backup_live_config_write,
 )
 
 
@@ -1020,7 +1019,7 @@ class ShellFileOperations(FileOperations):
             if read_result.exit_code == 0:
                 pre_content = read_result.stdout
 
-        guard_result = validate_live_config_write(
+        guard_result = validate_and_backup_live_config_write(
             path,
             old_content=pre_content,
             new_content=content,
@@ -1048,20 +1047,7 @@ class ShellFileOperations(FileOperations):
             if mkdir_result.exit_code == 0:
                 dirs_created = True
 
-        backup_path: Optional[str] = None
-        if guard_result.guarded and pre_content is not None:
-            stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
-            backup_path = f"{path}.bak.{stamp}.{os.getpid()}"
-            backup_cmd = (
-                f"cp -p {self._escape_shell_arg(path)} "
-                f"{self._escape_shell_arg(backup_path)}"
-            )
-            backup_result = self._exec(backup_cmd)
-            if backup_result.exit_code != 0:
-                return WriteResult(
-                    error=f"Failed to back up live Hermes config before write: {backup_result.stdout}",
-                    redacted_diff=guard_result.redacted_diff,
-                )
+        backup_path = guard_result.backup_path
 
         # Write via stdin pipe — content bypasses shell arg parsing entirely,
         # so there's no ARG_MAX limit regardless of file size.

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -495,6 +495,46 @@ def _build_fal_payload(
     return {k: v for k, v in payload.items() if k in supports}
 
 
+def _json_safe(value: Any) -> Any:
+    """Return a JSON-serializable copy of public tool metadata."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(v) for v in value]
+    return str(value)
+
+
+def _clean_response_parameters(parameters: Dict[str, Any]) -> Dict[str, Any]:
+    """Drop absent optional tool parameters before echoing them back."""
+    cleaned: Dict[str, Any] = {}
+    for key, value in parameters.items():
+        if value is None:
+            continue
+        if isinstance(value, str) and not value.strip():
+            continue
+        cleaned[key] = _json_safe(value)
+    return cleaned
+
+
+def _attach_response_envelope(
+    response_data: Dict[str, Any],
+    *,
+    parameters: Dict[str, Any],
+    provider_request: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Add a user-facing completion notice and actual public parameters."""
+    if response_data.get("success") is True:
+        response_data.setdefault("message", "Image generation completed")
+    elif response_data.get("success") is False:
+        response_data.setdefault("message", "Image generation failed")
+    response_data.setdefault("parameters", _clean_response_parameters(parameters))
+    if provider_request is not None:
+        response_data.setdefault("provider_request", _json_safe(provider_request))
+    return response_data
+
+
 # ---------------------------------------------------------------------------
 # Upscaler
 # ---------------------------------------------------------------------------
@@ -586,9 +626,20 @@ def image_generate_tool(
     }
 
     start_time = datetime.datetime.now()
+    prompt_text = prompt.strip() if isinstance(prompt, str) else ""
+    effective_aspect_ratio = DEFAULT_ASPECT_RATIO
+    response_parameters: Dict[str, Any] = {
+        "prompt": prompt_text,
+        "aspect_ratio": effective_aspect_ratio,
+        "num_inference_steps": num_inference_steps,
+        "guidance_scale": guidance_scale,
+        "num_images": num_images,
+        "output_format": output_format,
+        "seed": seed,
+    }
 
     try:
-        if not prompt or not isinstance(prompt, str) or len(prompt.strip()) == 0:
+        if not prompt_text:
             raise ValueError("Prompt is required and must be a non-empty string")
 
         if not (fal_key_is_configured() or _resolve_managed_fal_gateway()):
@@ -601,6 +652,8 @@ def image_generate_tool(
                 aspect_ratio, DEFAULT_ASPECT_RATIO,
             )
             aspect_lc = DEFAULT_ASPECT_RATIO
+        effective_aspect_ratio = aspect_lc
+        response_parameters["aspect_ratio"] = effective_aspect_ratio
 
         overrides: Dict[str, Any] = {}
         if num_inference_steps is not None:
@@ -613,12 +666,12 @@ def image_generate_tool(
             overrides["output_format"] = output_format
 
         arguments = _build_fal_payload(
-            model_id, prompt, aspect_lc, seed=seed, overrides=overrides,
+            model_id, prompt_text, aspect_lc, seed=seed, overrides=overrides,
         )
 
         logger.info(
             "Generating image with %s (%s) — prompt: %s",
-            meta.get("display", model_id), model_id, prompt[:80],
+            meta.get("display", model_id), model_id, prompt_text[:80],
         )
 
         handler = _submit_fal_request(model_id, arguments=arguments)
@@ -646,7 +699,7 @@ def image_generate_tool(
             }
 
             if should_upscale:
-                upscaled_image = _upscale_image(img["url"], prompt.strip())
+                upscaled_image = _upscale_image(img["url"], prompt_text)
                 if upscaled_image:
                     formatted_images.append(upscaled_image)
                     continue
@@ -667,7 +720,19 @@ def image_generate_tool(
         response_data = {
             "success": True,
             "image": formatted_images[0]["url"] if formatted_images else None,
+            "images": formatted_images,
+            "provider": "fal",
+            "model": model_id,
+            "operation": "generate",
+            "prompt": prompt_text,
+            "aspect_ratio": effective_aspect_ratio,
+            "generation_time": generation_time,
         }
+        _attach_response_envelope(
+            response_data,
+            parameters=response_parameters,
+            provider_request=arguments,
+        )
 
         debug_call_data["success"] = True
         debug_call_data["images_generated"] = len(formatted_images)
@@ -687,7 +752,13 @@ def image_generate_tool(
             "image": None,
             "error": str(e),
             "error_type": type(e).__name__,
+            "provider": "fal",
+            "model": model_id,
+            "operation": "generate",
+            "prompt": prompt_text,
+            "aspect_ratio": effective_aspect_ratio,
         }
+        _attach_response_envelope(response_data, parameters=response_parameters)
 
         debug_call_data["error"] = error_msg
         debug_call_data["generation_time"] = generation_time
@@ -826,21 +897,75 @@ IMAGE_GENERATE_SCHEMA = {
         "Generate high-quality images from text prompts. The underlying "
         "backend (FAL, OpenAI, etc.) and model are user-configured and not "
         "selectable by the agent. Returns either a URL or an absolute file "
-        "path in the `image` field; display it with markdown "
-        "![description](url-or-path) and the gateway will deliver it."
+        "path in the `image` field plus `message` and `parameters` fields "
+        "that echo the actual public inputs used; display the image with "
+        "markdown ![description](url-or-path) and the gateway will deliver it."
     ),
     "parameters": {
         "type": "object",
         "properties": {
             "prompt": {
                 "type": "string",
-                "description": "The text prompt describing the desired image. Be detailed and descriptive.",
+                "description": "The text prompt describing the desired image or edit. Be detailed and descriptive.",
             },
             "aspect_ratio": {
                 "type": "string",
                 "enum": list(VALID_ASPECT_RATIOS),
-                "description": "The aspect ratio of the generated image. 'landscape' is 16:9 wide, 'portrait' is 16:9 tall, 'square' is 1:1.",
+                "description": "Fallback aspect ratio when `size` is omitted. 'landscape' is wide, 'portrait' is tall, 'square' is 1:1.",
                 "default": DEFAULT_ASPECT_RATIO,
+            },
+            "size": {
+                "type": "string",
+                "description": "Optional output size, e.g. 1024x1024, 1536x1024, 1024x1536, 2560x1440, or auto when supported by the provider.",
+            },
+            "quality": {
+                "type": "string",
+                "enum": ["low", "medium", "high", "auto", "standard", "hd"],
+                "description": "Optional output quality. OpenAI-compatible GPT image models support low/medium/high/auto.",
+            },
+            "n": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 10,
+                "description": "Number of images to generate or edit when the provider supports it.",
+            },
+            "background": {
+                "type": "string",
+                "enum": ["transparent", "opaque", "auto"],
+                "description": "Optional background mode for providers/models that support it.",
+            },
+            "output_format": {
+                "type": "string",
+                "enum": ["png", "jpeg", "webp"],
+                "description": "Optional output image format.",
+            },
+            "output_compression": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 100,
+                "description": "Optional compression level for jpeg/webp output when supported.",
+            },
+            "moderation": {
+                "type": "string",
+                "enum": ["low", "auto"],
+                "description": "Optional moderation level for OpenAI-compatible image generation.",
+            },
+            "seed": {
+                "type": "integer",
+                "description": "Optional deterministic seed for providers that support seeded generation.",
+            },
+            "image": {
+                "type": "string",
+                "description": "Image-to-image/edit mode only: a non-empty local image file path. Omit for text-to-image; never pass an empty string.",
+            },
+            "mask": {
+                "type": "string",
+                "description": "Image editing only: optional non-empty local PNG mask path; transparent areas indicate edit regions. Omit for text-to-image and omit when no real mask exists.",
+            },
+            "input_fidelity": {
+                "type": "string",
+                "enum": ["high", "low"],
+                "description": "Image-to-image/edit mode only, and only for models that support it. Omit for text-to-image; never pass an empty string.",
             },
         },
         "required": ["prompt"],
@@ -887,7 +1012,7 @@ def _read_configured_image_provider():
     return None
 
 
-def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
+def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str, options: Optional[Dict[str, Any]] = None):
     """Route the call to a plugin-registered provider when one is selected.
 
     Returns a JSON string on dispatch, or ``None`` to fall through to the
@@ -903,66 +1028,113 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
     if not configured:
         return None
 
+    options = dict(options or {})
+    response_parameters: Dict[str, Any] = {
+        "prompt": prompt,
+        "aspect_ratio": aspect_ratio,
+        **options,
+    }
     # Also read configured model so we can pass it to the plugin
     configured_model = _read_configured_image_model()
 
+    provider = None
     try:
-        # Import locally so plugin discovery isn't triggered just by
-        # importing this module (tests rely on that).
-        from agent.image_gen_registry import get_provider
-        from hermes_cli.plugins import _ensure_plugins_discovered
+        # Named custom providers expose OpenAI-compatible image endpoints but
+        # are not plugin-registered under every custom:<name> key. Build the
+        # provider directly from the saved custom-provider runtime config.
+        if configured.startswith("custom:"):
+            from hermes_cli.runtime_provider import _get_named_custom_provider
+            from plugins.image_gen.openai import OpenAIImageGenProvider
 
-        _ensure_plugins_discovered()
-        provider = get_provider(configured)
+            custom = _get_named_custom_provider(configured)
+            if custom:
+                provider = OpenAIImageGenProvider(
+                    api_key=str(custom.get("api_key") or "").strip() or None,
+                    base_url=str(custom.get("base_url") or "").strip() or None,
+                    provider_name=configured,
+                    default_model=configured_model or str(custom.get("model") or "").strip() or None,
+                )
     except Exception as exc:
-        logger.debug("image_gen plugin dispatch skipped: %s", exc)
-        return None
+        logger.debug("image_gen custom provider dispatch skipped: %s", exc)
 
     if provider is None:
         try:
-            # Long-lived sessions may have discovered plugins before a bundled
-            # backend was patched in or before config changed. Retry once with
-            # a forced refresh before surfacing a missing-provider error.
-            _ensure_plugins_discovered(force=True)
+            # Import locally so plugin discovery isn't triggered just by
+            # importing this module (tests rely on that).
+            from agent.image_gen_registry import get_provider
+            from hermes_cli.plugins import _ensure_plugins_discovered
+
+            _ensure_plugins_discovered()
             provider = get_provider(configured)
         except Exception as exc:
-            logger.debug("image_gen plugin force-refresh skipped: %s", exc)
+            logger.debug("image_gen plugin dispatch skipped: %s", exc)
+            return None
+
+        if provider is None:
+            try:
+                # Long-lived sessions may have discovered plugins before a bundled
+                # backend was patched in or before config changed. Retry once with
+                # a forced refresh before surfacing a missing-provider error.
+                _ensure_plugins_discovered(force=True)
+                provider = get_provider(configured)
+            except Exception as exc:
+                logger.debug("image_gen plugin force-refresh skipped: %s", exc)
 
     if provider is None:
-        return json.dumps({
+        response_data = {
             "success": False,
             "image": None,
+            "provider": configured,
+            "model": configured_model or "",
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
             "error": (
                 f"image_gen.provider='{configured}' is set but no plugin "
                 f"registered that name. Run `hermes plugins list` to see "
                 f"available image gen backends."
             ),
             "error_type": "provider_not_registered",
-        })
+        }
+        _attach_response_envelope(response_data, parameters=response_parameters)
+        return json.dumps(response_data)
 
     try:
-        kwargs = {"prompt": prompt, "aspect_ratio": aspect_ratio}
-        if configured_model:
+        kwargs = {"prompt": prompt, "aspect_ratio": aspect_ratio, **options}
+        if configured_model and "model" not in kwargs:
             kwargs["model"] = configured_model
+        response_parameters = dict(kwargs)
         result = provider.generate(**kwargs)
     except Exception as exc:
         logger.warning(
             "Image gen provider '%s' raised: %s",
             getattr(provider, "name", "?"), exc,
         )
-        return json.dumps({
+        response_data = {
             "success": False,
             "image": None,
+            "provider": getattr(provider, "name", configured),
+            "model": configured_model or "",
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
             "error": f"Provider '{getattr(provider, 'name', '?')}' error: {exc}",
             "error_type": "provider_exception",
-        })
+        }
+        _attach_response_envelope(response_data, parameters=response_parameters)
+        return json.dumps(response_data)
     if not isinstance(result, dict):
-        return json.dumps({
+        response_data = {
             "success": False,
             "image": None,
+            "provider": getattr(provider, "name", configured),
+            "model": configured_model or "",
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
             "error": "Provider returned a non-dict result",
             "error_type": "provider_contract",
-        })
+        }
+        _attach_response_envelope(response_data, parameters=response_parameters)
+        return json.dumps(response_data)
+    _attach_response_envelope(result, parameters=response_parameters)
     return json.dumps(result)
 
 
@@ -971,10 +1143,40 @@ def _handle_image_generate(args, **kw):
     if not prompt:
         return tool_error("prompt is required for image generation")
     aspect_ratio = args.get("aspect_ratio", DEFAULT_ASPECT_RATIO)
+    option_keys = (
+        "size",
+        "quality",
+        "n",
+        "background",
+        "output_format",
+        "output_compression",
+        "moderation",
+        "seed",
+        "image",
+        "mask",
+        "input_fidelity",
+    )
+    options = {key: args[key] for key in option_keys if args.get(key) is not None}
+
+    image_path = options.get("image")
+    has_input_image = isinstance(image_path, str) and bool(image_path.strip())
+    if not has_input_image:
+        # Text-to-image mode: edit-only options must be absent, not empty.
+        # Some providers switch to image-edit mode just because these keys
+        # exist, causing errors such as "image must be a non-empty local file path".
+        for key in ("image", "mask", "input_fidelity"):
+            options.pop(key, None)
+    else:
+        # Image-to-image mode: keep the real input image, but omit optional
+        # edit fields when the model supplied an empty placeholder.
+        for key in ("mask", "input_fidelity"):
+            value = options.get(key)
+            if isinstance(value, str) and not value.strip():
+                options.pop(key, None)
 
     # Route to a plugin-registered provider if one is active (and it's
     # not the in-tree FAL path).
-    dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio)
+    dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio, options)
     if dispatched is not None:
         return dispatched
 

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -23,6 +23,7 @@ update when it's noticed.
 import json
 import logging
 import os
+import re
 import datetime
 import threading
 import uuid
@@ -70,6 +71,8 @@ from tools.tool_backend_helpers import (
 )
 
 logger = logging.getLogger(__name__)
+
+IMAGE_GEN_UPSTREAM_RETRY_ATTEMPTS = 5
 
 
 # ---------------------------------------------------------------------------
@@ -532,6 +535,138 @@ def _attach_response_envelope(
     response_data.setdefault("parameters", _clean_response_parameters(parameters))
     if provider_request is not None:
         response_data.setdefault("provider_request", _json_safe(provider_request))
+    return response_data
+
+
+_SECRET_PATTERNS = (
+    re.compile(r"(?i)(authorization\s*[:=]\s*bearer\s+)[^\s,;]+"),
+    re.compile(r"(?i)((?:api[_-]?key|token|password|secret)\s*[:=]\s*)[^\s,;]+"),
+    re.compile(r"sk-[A-Za-z0-9_-]{12,}"),
+)
+
+_UPSTREAM_TRANSPORT_ERROR_MARKERS = (
+    "eof",
+    "end of file",
+    "connection reset",
+    "connection refused",
+    "connection aborted",
+    "connection error",
+    "connect error",
+    "connection failed",
+    "failed to connect",
+    "cannot connect",
+    "can't connect",
+    "network unreachable",
+    "network is unreachable",
+    "temporary failure in name resolution",
+    "name or service not known",
+    "timed out",
+    "timeout",
+    "read timeout",
+    "connect timeout",
+    "remote disconnected",
+    "server disconnected",
+    "server disconnected without sending a response",
+    "remote end closed connection",
+    "peer closed connection",
+    "broken pipe",
+    "incomplete read",
+    "protocol error",
+    "upstream request timeout",
+    "upstream prematurely closed",
+)
+
+_UPSTREAM_TRANSPORT_EXCEPTION_NAMES = (
+    "APIConnectionError",
+    "APITimeoutError",
+    "ConnectError",
+    "ConnectTimeout",
+    "ConnectionError",
+    "ConnectionResetError",
+    "NetworkError",
+    "ReadError",
+    "ReadTimeout",
+    "RemoteProtocolError",
+    "ServerDisconnectedError",
+    "TimeoutError",
+    "TimeoutException",
+)
+
+
+def _sanitize_error_message(value: Any) -> str:
+    """Return a compact, user-safe error string without credential material."""
+    text = str(value or "")
+    for pattern in _SECRET_PATTERNS:
+        text = pattern.sub(lambda match: f"{match.group(1)}[REDACTED]" if match.groups() else "[REDACTED]", text)
+    return text[:1000]
+
+
+def _is_upstream_transport_error(value: Any, *, error_type: str = "") -> bool:
+    """True for EOF/connection/timeout style upstream transport failures."""
+    class_name = value.__class__.__name__ if isinstance(value, BaseException) else ""
+    if isinstance(value, (ConnectionError, TimeoutError, BrokenPipeError, ConnectionResetError)):
+        return True
+    if class_name in _UPSTREAM_TRANSPORT_EXCEPTION_NAMES:
+        return True
+    lowered = f"{class_name} {error_type} {_sanitize_error_message(value)}".lower()
+    return any(marker in lowered for marker in _UPSTREAM_TRANSPORT_ERROR_MARKERS)
+
+
+def _result_is_upstream_transport_error(result: Dict[str, Any]) -> bool:
+    if result.get("success") is not False:
+        return False
+    return _is_upstream_transport_error(
+        result.get("error") or result.get("message") or "",
+        error_type=str(result.get("error_type") or ""),
+    )
+
+
+def _retry_attempt_summary(attempt: int, source: Any, *, error_type: str = "") -> Dict[str, Any]:
+    if isinstance(source, dict):
+        source_error_type = str(source.get("error_type") or error_type or "provider_error")
+        source_error = source.get("error") or source.get("message") or ""
+    else:
+        source_error_type = error_type or source.__class__.__name__
+        source_error = source
+    return {
+        "attempt": attempt,
+        "error_type": source_error_type,
+        "error": _sanitize_error_message(source_error),
+    }
+
+
+def _build_upstream_retry_exhausted_response(
+    *,
+    provider: Any,
+    configured: str,
+    configured_model: str,
+    prompt: str,
+    aspect_ratio: str,
+    parameters: Dict[str, Any],
+    attempts: list,
+) -> Dict[str, Any]:
+    provider_name = getattr(provider, "name", configured)
+    last_error = attempts[-1]["error"] if attempts else "unknown upstream transport error"
+    response_data = {
+        "success": False,
+        "image": None,
+        "provider": provider_name,
+        "model": configured_model or "",
+        "prompt": prompt,
+        "aspect_ratio": aspect_ratio,
+        "error": (
+            "Upstream image provider transport error after "
+            f"{IMAGE_GEN_UPSTREAM_RETRY_ATTEMPTS} identical attempts; "
+            f"stopped without changing parameters. Last error: {last_error}"
+        ),
+        "error_type": "upstream_transport_error",
+        "retry_policy": {
+            "max_attempts": IMAGE_GEN_UPSTREAM_RETRY_ATTEMPTS,
+            "same_parameters": True,
+        },
+        "retry_attempts": attempts,
+    }
+    _attach_response_envelope(response_data, parameters=parameters)
     return response_data
 
 
@@ -1098,29 +1233,87 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str, options: Option
         _attach_response_envelope(response_data, parameters=response_parameters)
         return json.dumps(response_data)
 
-    try:
-        kwargs = {"prompt": prompt, "aspect_ratio": aspect_ratio, **options}
-        if configured_model and "model" not in kwargs:
-            kwargs["model"] = configured_model
-        response_parameters = dict(kwargs)
-        result = provider.generate(**kwargs)
-    except Exception as exc:
-        logger.warning(
-            "Image gen provider '%s' raised: %s",
-            getattr(provider, "name", "?"), exc,
-        )
-        response_data = {
-            "success": False,
-            "image": None,
-            "provider": getattr(provider, "name", configured),
-            "model": configured_model or "",
-            "prompt": prompt,
-            "aspect_ratio": aspect_ratio,
-            "error": f"Provider '{getattr(provider, 'name', '?')}' error: {exc}",
-            "error_type": "provider_exception",
-        }
-        _attach_response_envelope(response_data, parameters=response_parameters)
-        return json.dumps(response_data)
+    kwargs = {"prompt": prompt, "aspect_ratio": aspect_ratio, **options}
+    if configured_model and "model" not in kwargs:
+        kwargs["model"] = configured_model
+    response_parameters = dict(kwargs)
+    retry_attempts = []
+    result: Any = None
+
+    for attempt in range(1, IMAGE_GEN_UPSTREAM_RETRY_ATTEMPTS + 1):
+        try:
+            result = provider.generate(**kwargs)
+        except Exception as exc:
+            if _is_upstream_transport_error(exc):
+                retry_attempts.append(_retry_attempt_summary(attempt, exc))
+                logger.warning(
+                    "Image gen provider '%s' upstream transport error on attempt %s/%s: %s",
+                    getattr(provider, "name", "?"),
+                    attempt,
+                    IMAGE_GEN_UPSTREAM_RETRY_ATTEMPTS,
+                    _sanitize_error_message(exc),
+                )
+                if attempt < IMAGE_GEN_UPSTREAM_RETRY_ATTEMPTS:
+                    continue
+                response_data = _build_upstream_retry_exhausted_response(
+                    provider=provider,
+                    configured=configured,
+                    configured_model=configured_model or "",
+                    prompt=prompt,
+                    aspect_ratio=aspect_ratio,
+                    parameters=response_parameters,
+                    attempts=retry_attempts,
+                )
+                return json.dumps(response_data)
+
+            logger.warning(
+                "Image gen provider '%s' raised: %s",
+                getattr(provider, "name", "?"),
+                _sanitize_error_message(exc),
+            )
+            response_data = {
+                "success": False,
+                "image": None,
+                "provider": getattr(provider, "name", configured),
+                "model": configured_model or "",
+                "prompt": prompt,
+                "aspect_ratio": aspect_ratio,
+                "error": f"Provider '{getattr(provider, 'name', '?')}' error: {_sanitize_error_message(exc)}",
+                "error_type": "provider_exception",
+            }
+            _attach_response_envelope(response_data, parameters=response_parameters)
+            return json.dumps(response_data)
+
+        if isinstance(result, dict) and _result_is_upstream_transport_error(result):
+            retry_attempts.append(_retry_attempt_summary(attempt, result))
+            logger.warning(
+                "Image gen provider '%s' returned upstream transport error on attempt %s/%s: %s",
+                getattr(provider, "name", "?"),
+                attempt,
+                IMAGE_GEN_UPSTREAM_RETRY_ATTEMPTS,
+                retry_attempts[-1]["error"],
+            )
+            if attempt < IMAGE_GEN_UPSTREAM_RETRY_ATTEMPTS:
+                continue
+            response_data = _build_upstream_retry_exhausted_response(
+                provider=provider,
+                configured=configured,
+                configured_model=configured_model or "",
+                prompt=prompt,
+                aspect_ratio=aspect_ratio,
+                parameters=response_parameters,
+                attempts=retry_attempts,
+            )
+            return json.dumps(response_data)
+
+        if retry_attempts and isinstance(result, dict):
+            result.setdefault("retry_policy", {
+                "max_attempts": IMAGE_GEN_UPSTREAM_RETRY_ATTEMPTS,
+                "same_parameters": True,
+            })
+            result.setdefault("retry_attempts", retry_attempts)
+        break
+
     if not isinstance(result, dict):
         response_data = {
             "success": False,

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -439,6 +439,8 @@ def _resolve_stdio_command(command: str, env: dict) -> tuple[str, dict]:
 # MCP ImageContent block → Hermes MEDIA tag
 # ---------------------------------------------------------------------------
 
+_HERMES_MEDIA_TAGS_RESULT_KEY = "_hermes_media_tags"
+
 
 def _mcp_image_extension_for_mime_type(mime_type: str) -> str:
     """Return a reasonable file extension for an MCP image MIME type."""
@@ -2365,6 +2367,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             # Hermes' MEDIA tag + cache_image_from_bytes) was the cleaner of
             # the two — plugs into existing infrastructure.
             parts: List[str] = []
+            media_tags: List[str] = []
             for block in (result.content or []):
                 if hasattr(block, "text") and block.text:
                     parts.append(block.text)
@@ -2372,6 +2375,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 image_tag = _cache_mcp_image_block(block)
                 if image_tag:
                     parts.append(image_tag)
+                    media_tags.append(image_tag)
             text_result = "\n".join(parts) if parts else ""
 
             # Combine content + structuredContent when both are present.
@@ -2381,12 +2385,21 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             structured = getattr(result, "structuredContent", None)
             if structured is not None:
                 if text_result:
-                    return json.dumps({
+                    payload = {
                         "result": text_result,
                         "structuredContent": structured,
-                    }, ensure_ascii=False)
-                return json.dumps({"result": structured}, ensure_ascii=False)
-            return json.dumps({"result": text_result}, ensure_ascii=False)
+                    }
+                else:
+                    payload = {"result": structured}
+            else:
+                payload = {"result": text_result}
+            if media_tags:
+                # Gateway media extraction deliberately ignores arbitrary MCP
+                # text output.  Mark only tags produced from ImageContent blocks
+                # so dynamic mcp_<server>_<tool> results can still render their
+                # fresh screenshots/images as native attachments.
+                payload[_HERMES_MEDIA_TAGS_RESULT_KEY] = media_tags
+            return json.dumps(payload, ensure_ascii=False)
 
         def _call_once():
             return _run_on_mcp_loop(_call, timeout=tool_timeout)

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -369,6 +369,8 @@ def apply_v4a_operations(operations: List[PatchOperation],
     # the LSP tier's output gets silently dropped — see
     # ``PatchResult.lsp_diagnostics`` aggregation below.
     lsp_blocks: List[str] = []
+    backup_path: Optional[str] = None
+    redacted_diffs: List[str] = []
     errors = []
 
     for op in operations:
@@ -380,6 +382,10 @@ def apply_v4a_operations(operations: List[PatchOperation],
                     all_diffs.append(result[1])
                     if result[2]:
                         lsp_blocks.append(result[2])
+                    if len(result) > 3 and result[3] and not backup_path:
+                        backup_path = result[3]
+                    if len(result) > 4 and result[4]:
+                        redacted_diffs.append(result[4])
                 else:
                     errors.append(f"Failed to add {op.file_path}: {result[1]}")
 
@@ -406,6 +412,10 @@ def apply_v4a_operations(operations: List[PatchOperation],
                     all_diffs.append(result[1])
                     if result[2]:
                         lsp_blocks.append(result[2])
+                    if len(result) > 3 and result[3] and not backup_path:
+                        backup_path = result[3]
+                    if len(result) > 4 and result[4]:
+                        redacted_diffs.append(result[4])
                 else:
                     errors.append(f"Failed to update {op.file_path}: {result[1]}")
 
@@ -437,6 +447,8 @@ def apply_v4a_operations(operations: List[PatchOperation],
             files_deleted=files_deleted,
             lint=lint_results if lint_results else None,
             lsp_diagnostics=combined_lsp,
+            backup_path=backup_path,
+            redacted_diff="\n".join(redacted_diffs) if redacted_diffs else None,
             error="Apply phase failed (state may be inconsistent — run `git diff` to assess):\n"
                   + "\n".join(f"  • {e}" for e in errors),
         )
@@ -449,6 +461,8 @@ def apply_v4a_operations(operations: List[PatchOperation],
         files_deleted=files_deleted,
         lint=lint_results if lint_results else None,
         lsp_diagnostics=combined_lsp,
+        backup_path=backup_path,
+        redacted_diff="\n".join(redacted_diffs) if redacted_diffs else None,
     )
 
 
@@ -472,12 +486,20 @@ def _apply_add(op: PatchOperation, file_ops: Any) -> Tuple[bool, str, Optional[s
     
     result = file_ops.write_file(op.file_path, content)
     if result.error:
-        return False, result.error, None
+        return False, result.error, None, None, None
     
-    diff = f"--- /dev/null\n+++ b/{op.file_path}\n"
-    diff += '\n'.join(f"+{line}" for line in content_lines)
+    diff = getattr(result, "redacted_diff", None)
+    if not diff:
+        diff = f"--- /dev/null\n+++ b/{op.file_path}\n"
+        diff += '\n'.join(f"+{line}" for line in content_lines)
     
-    return True, diff, getattr(result, "lsp_diagnostics", None)
+    return (
+        True,
+        diff,
+        getattr(result, "lsp_diagnostics", None),
+        getattr(result, "backup_path", None),
+        getattr(result, "redacted_diff", None),
+    )
 
 
 def _apply_delete(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
@@ -608,15 +630,22 @@ def _apply_update(op: PatchOperation, file_ops: Any) -> Tuple[bool, str, Optiona
     # Write new content
     write_result = file_ops.write_file(op.file_path, new_content)
     if write_result.error:
-        return False, write_result.error, None
+        return False, write_result.error, None, None, None
     
-    # Generate diff
-    diff_lines = difflib.unified_diff(
-        current_content.splitlines(keepends=True),
-        new_content.splitlines(keepends=True),
-        fromfile=f"a/{op.file_path}",
-        tofile=f"b/{op.file_path}"
+    diff = getattr(write_result, "redacted_diff", None)
+    if not diff:
+        diff_lines = difflib.unified_diff(
+            current_content.splitlines(keepends=True),
+            new_content.splitlines(keepends=True),
+            fromfile=f"a/{op.file_path}",
+            tofile=f"b/{op.file_path}"
+        )
+        diff = ''.join(diff_lines)
+    
+    return (
+        True,
+        diff,
+        getattr(write_result, "lsp_diagnostics", None),
+        getattr(write_result, "backup_path", None),
+        getattr(write_result, "redacted_diff", None),
     )
-    diff = ''.join(diff_lines)
-    
-    return True, diff, getattr(write_result, "lsp_diagnostics", None)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -680,11 +680,11 @@ def _load_cfg() -> dict:
 
 def _save_cfg(cfg: dict):
     global _cfg_cache, _cfg_mtime, _cfg_path
-    import yaml
 
     path = _hermes_home / "config.yaml"
-    with open(path, "w", encoding="utf-8") as f:
-        yaml.safe_dump(cfg, f)
+    from utils import atomic_yaml_write
+
+    atomic_yaml_write(path, cfg)
     with _cfg_lock:
         _cfg_cache = copy.deepcopy(cfg)
         _cfg_path = path

--- a/utils.py
+++ b/utils.py
@@ -5,6 +5,7 @@ import logging
 import os
 import stat
 import tempfile
+from io import StringIO
 from pathlib import Path
 from typing import Any, Union
 from urllib.parse import urlparse
@@ -143,6 +144,7 @@ def atomic_yaml_write(
     default_flow_style: bool = False,
     sort_keys: bool = False,
     extra_content: str | None = None,
+    allow_destructive_secret_change: bool = False,
 ) -> None:
     """Write YAML data to a file atomically.
 
@@ -161,6 +163,28 @@ def atomic_yaml_write(
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
 
+    payload_io = StringIO()
+    yaml.dump(data, payload_io, default_flow_style=default_flow_style, sort_keys=sort_keys)
+    if extra_content:
+        payload_io.write(extra_content)
+    payload = payload_io.getvalue()
+
+    from agent.live_config_guard import validate_and_backup_live_config_write
+
+    guard_result = validate_and_backup_live_config_write(
+        path,
+        new_content=payload,
+        allow_destructive_secret_change=allow_destructive_secret_change,
+    )
+    if guard_result.error:
+        raise ValueError(guard_result.error)
+    if guard_result.guarded and guard_result.redacted_diff:
+        logger.info(
+            "Live Hermes config write approved for %s; redacted diff:\n%s",
+            path,
+            guard_result.redacted_diff,
+        )
+
     original_mode = _preserve_file_mode(path)
 
     fd, tmp_path = tempfile.mkstemp(
@@ -170,9 +194,7 @@ def atomic_yaml_write(
     )
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
-            yaml.dump(data, f, default_flow_style=default_flow_style, sort_keys=sort_keys)
-            if extra_content:
-                f.write(extra_content)
+            f.write(payload)
             f.flush()
             os.fsync(f.fileno())
         # Preserve symlinks — swap in-place on the real file (GitHub #16743).
@@ -192,6 +214,8 @@ def atomic_roundtrip_yaml_update(
     path: Union[str, Path],
     key_path: str,
     value: Any,
+    *,
+    allow_destructive_secret_change: bool = False,
 ) -> None:
     """Update one dotted YAML key while preserving comments and readable text.
 
@@ -232,6 +256,26 @@ def atomic_roundtrip_yaml_update(
     current[keys[-1]] = value
 
     original_mode = _preserve_file_mode(path)
+    payload_io = StringIO()
+    yaml_rt.dump(config, payload_io)
+    payload = payload_io.getvalue()
+
+    from agent.live_config_guard import validate_and_backup_live_config_write
+
+    guard_result = validate_and_backup_live_config_write(
+        path,
+        new_content=payload,
+        allow_destructive_secret_change=allow_destructive_secret_change,
+    )
+    if guard_result.error:
+        raise ValueError(guard_result.error)
+    if guard_result.guarded and guard_result.redacted_diff:
+        logger.info(
+            "Live Hermes config write approved for %s; redacted diff:\n%s",
+            path,
+            guard_result.redacted_diff,
+        )
+
     fd, tmp_path = tempfile.mkstemp(
         dir=str(path.parent),
         prefix=f".{path.stem}_",
@@ -239,7 +283,7 @@ def atomic_roundtrip_yaml_update(
     )
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
-            yaml_rt.dump(config, f)
+            f.write(payload)
             f.flush()
             os.fsync(f.fileno())
         real_path = atomic_replace(tmp_path, path)

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -196,6 +196,7 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 | `/new` | Start a new conversation. |
 | `/reset` | Reset conversation history. |
 | `/status` | Show session info, followed by a local **Session recap** block (recent turn counts, top tools used, files touched, latest prompt + reply). |
+| `/what-did-you-do` (aliases: `/whatdidyoudo`, `/wdyd`) | Show the strict attribution ledger for the current messaging session lineage. This reports this agent's own recorded tool actions only; branch state, git history, memory, and compaction summaries are not treated as proof of work. |
 | `/stop` | Kill all running background processes and interrupt the running agent. |
 | `/model [provider:model]` | Show or change the model. Supports provider switches (`/model zai:glm-5`), custom endpoints (`/model custom:model`), named custom providers (`/model custom:local:qwen`), auto-detect (`/model custom`), and user-defined aliases (`/model fav`, `/model grok` — see [Custom model aliases](#custom-model-aliases)). Use `--global` to persist the change to config.yaml. **Note:** `/model` can only switch between already-configured providers. To add a new provider or set up API keys, use `hermes model` from your terminal (outside the chat session). |
 | `/codex-runtime [auto\|codex_app_server\|on\|off]` | Toggle the optional [Codex app-server runtime](../user-guide/features/codex-app-server-runtime). Persists to `model.openai_runtime` in config.yaml and evicts the cached agent so the next message picks up the new runtime. Effective on next session. |
@@ -235,7 +236,7 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 
 - `/skin`, `/snapshot`, `/gquota`, `/reload`, `/tools`, `/toolsets`, `/browser`, `/config`, `/cron`, `/skills`, `/platforms`, `/paste`, `/image`, `/statusbar`, `/plugins`, `/busy`, `/indicator`, `/redraw`, `/clear`, `/history`, `/save`, `/copy`, `/handoff`, and `/quit` are **CLI-only** commands.
 - `/verbose` is **CLI-only by default**, but can be enabled for messaging platforms by setting `display.tool_progress_command: true` in `config.yaml`. When enabled, it cycles the `display.tool_progress` mode and saves to config.
-- `/sethome`, `/update`, `/restart`, `/approve`, `/deny`, `/topic`, and `/commands` are **messaging-only** commands.
+- `/sethome`, `/update`, `/restart`, `/approve`, `/deny`, `/topic`, `/commands`, and `/what-did-you-do` are **messaging-only** commands.
 - `/status`, `/background`, `/queue`, `/steer`, `/voice`, `/reload-mcp`, `/reload-skills`, `/rollback`, `/debug`, `/fast`, `/footer`, `/curator`, `/kanban`, `/sessions`, and `/yolo` work in **both** the CLI and the messaging gateway.
 - `/voice join`, `/voice channel`, and `/voice leave` are only meaningful on Discord.
 

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -134,10 +134,14 @@ For well-known MCP servers, `hermes mcp add` accepts a `--preset` flag that fill
 | Preset | What it wires up |
 |---|---|
 | `codex` | The Codex CLI's MCP server (`codex mcp-server` over stdio). Requires the `codex` CLI on PATH. |
+| `codegraph` | The CodeGraph local code-intelligence MCP server (`codegraph serve --mcp` over stdio). Requires the `codegraph` CLI on PATH. |
 
 ```bash
 # Add Codex CLI as an MCP server in one line
 hermes mcp add codex --preset codex
+
+# Add CodeGraph code-intelligence tools in one line
+hermes mcp add codegraph --preset codegraph
 ```
 
 That writes the equivalent of:
@@ -147,6 +151,9 @@ mcp_servers:
   codex:
     command: "codex"
     args: ["mcp-server"]
+  codegraph:
+    command: "codegraph"
+    args: ["serve", "--mcp"]
 ```
 
 You can pick any local name (`hermes mcp add my-codex --preset codex` is fine); the preset only provides the `command`/`args` defaults.


### PR DESCRIPTION
## Summary
- Add regression coverage for the live config guard YAML line-regex fallback when PyYAML is unavailable.
- Verify camelCase token keys such as `botToken` are still treated as secrets in the fallback path.
- Confirm camelCase token counter fields such as `maxTokens` and `promptTokenCount` are not reported as credentials.

## Test Plan
- `python -m pytest -q -o addopts='' tests/tools/test_live_config_guard.py -k 'line_fallback or camelcase_token or token_count_fields or duplicate_secret'`
- `python -m pytest -q -o addopts='' tests/tools/test_live_config_guard.py tests/hermes_cli/test_set_config_value.py tests/hermes_cli/test_config.py tests/hermes_cli/test_update_config_clears_custom_fields.py tests/tools/test_write_deny.py`
- `python -m py_compile agent/live_config_guard.py tools/file_operations.py tools/patch_parser.py utils.py hermes_cli/config.py hermes_cli/auth.py hermes_cli/memory_setup.py tui_gateway/server.py gateway/platforms/telegram.py hermes_cli/xai_retirement.py`
- `git diff --check`
