### PR TITLE
docs: replace invalid config get examples

### DIFF
--- a/website/docs/guides/migrate-from-openclaw.md
+++ b/website/docs/guides/migrate-from-openclaw.md
@@ -225,7 +225,7 @@ The migration resolves all three formats. For env templates and SecretRef object
 
 5. **Test messaging** — if you migrated platform tokens, restart the gateway: `systemctl --user restart hermes-gateway`
 
-6. **Check session policies** — verify `hermes config get session_reset` matches your expectations.
+6. **Check session policies** — verify the `session_reset` entry in `hermes config show` matches your expectations.
 
 7. **Re-pair WhatsApp** — WhatsApp uses QR code pairing (Baileys), not token migration. Run `hermes whatsapp` to pair.
 

--- a/website/docs/guides/work-with-skills.md
+++ b/website/docs/guides/work-with-skills.md
@@ -161,8 +161,8 @@ Manage skill config from the CLI:
 # Interactive config for a specific skill
 hermes skills config gif-search
 
-# View all skill config
-hermes config get skills.config
+# View all skill config under "Skill Settings"
+hermes config show
 ```
 
 ---

--- a/website/docs/user-guide/configuring-models.md
+++ b/website/docs/user-guide/configuring-models.md
@@ -196,7 +196,7 @@ hermes model            # Interactive provider + model picker (the canonical way
 
 `hermes model` walks you through picking a provider, authenticating (OAuth flows open a browser; API-key providers prompt for the key), and then choosing a specific model from that provider's curated catalog. The choice is written to `model.provider` and `model.model` in `~/.hermes/config.yaml`.
 
-To list providers/models without launching the picker, use the dashboard or the REST endpoints below. To inspect what the CLI will actually use right now: `hermes config get model` and `hermes status`.
+To list providers/models without launching the picker, use the dashboard or the REST endpoints below. To inspect what the CLI will actually use right now: `hermes config show` and `hermes status`.
 
 ### Direct config edit
 


### PR DESCRIPTION
## Summary
- replace the three documented `hermes config get <key>` examples with the supported `hermes config show` command
- clarify where skill settings and session/model values can be inspected from the CLI

Fixes #30195.

## Verification
- `rg -n "hermes config get" website/docs` returns no matches
- `git diff --check`