### PR TITLE
feat(env): load Nexus vault bootstrap secrets

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -234,11 +234,14 @@ def _load_nexus_bootstrap_env() -> bool:
     try:
         with urlopen(req, timeout=15) as resp:
             payload = json.loads(resp.read().decode("utf-8"))
-    except (HTTPError, URLError, TimeoutError, OSError, json.JSONDecodeError):
+    except (HTTPError, URLError, TimeoutError, OSError, UnicodeDecodeError, json.JSONDecodeError):
         print(
             "  Nexus vault bootstrap: configured but unavailable; using local fallback.",
             file=sys.stderr,
         )
+        return False
+
+    if not isinstance(payload, dict):
         return False
 
     secrets = payload.get("secrets")
@@ -254,7 +257,10 @@ def _load_nexus_bootstrap_env() -> bool:
         name = key.strip()
         if not any(name.endswith(suffix) for suffix in _CREDENTIAL_SUFFIXES):
             continue
-        os.environ[name] = value
+        try:
+            os.environ[name] = value
+        except ValueError:
+            continue
         _SECRET_SOURCES[name] = "Nexus vault"
         loaded.append(name)
 
@@ -304,7 +310,10 @@ def load_hermes_dotenv(
         _load_dotenv_with_fallback(project_env_path, override=not loaded)
         loaded.append(project_env_path)
 
-    _load_nexus_bootstrap_env()
+    try:
+        _load_nexus_bootstrap_env()
+    except Exception:  # noqa: BLE001 — Nexus bootstrap must not block startup
+        pass
     _apply_external_secret_sources(home_path)
 
     return loaded

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -19,6 +19,8 @@ from utils import atomic_replace
 # alter arbitrary user env vars, but credentials are known to require
 # pure ASCII (they become HTTP header values).
 _CREDENTIAL_SUFFIXES = ("_API_KEY", "_TOKEN", "_SECRET", "_KEY")
+_NEXUS_BOOTSTRAP_MAX_BYTES = 1_048_576
+_NEXUS_BOOTSTRAP_MAX_SECRETS = 128
 
 # Names we've already warned about during this process, so repeated
 # load_hermes_dotenv() calls (user env + project env, gateway hot-reload,
@@ -200,8 +202,10 @@ def _load_nexus_bootstrap_env() -> bool:
     - NEXUS_SERVICE_TOKEN or NEXUS_TOKEN
 
     When present, Nexus values override stale shell or dotenv values so the
-    central vault becomes the authority during cutover. Failures are swallowed:
-    bootstrap secret loading must not block Hermes startup or leak secret values.
+    central vault becomes the authority during cutover. External secret
+    sources that run later may still apply according to their own override
+    policy. Failures are swallowed: bootstrap secret loading must not block
+    Hermes startup or leak secret values.
     """
     enabled = os.getenv("HERMES_NEXUS_BOOTSTRAP_ENABLED", "1").strip().lower()
     if enabled in {"0", "false", "no", "off"}:
@@ -233,7 +237,14 @@ def _load_nexus_bootstrap_env() -> bool:
     )
     try:
         with urlopen(req, timeout=15) as resp:
-            payload = json.loads(resp.read().decode("utf-8"))
+            raw_body = resp.read(_NEXUS_BOOTSTRAP_MAX_BYTES + 1)
+            if len(raw_body) > _NEXUS_BOOTSTRAP_MAX_BYTES:
+                print(
+                    "  Nexus vault bootstrap: response too large; using local fallback.",
+                    file=sys.stderr,
+                )
+                return False
+            payload = json.loads(raw_body.decode("utf-8"))
     except (HTTPError, URLError, TimeoutError, OSError, UnicodeDecodeError, json.JSONDecodeError):
         print(
             "  Nexus vault bootstrap: configured but unavailable; using local fallback.",
@@ -263,6 +274,8 @@ def _load_nexus_bootstrap_env() -> bool:
             continue
         _SECRET_SOURCES[name] = "Nexus vault"
         loaded.append(name)
+        if len(loaded) >= _NEXUS_BOOTSTRAP_MAX_SECRETS:
+            break
 
     if not loaded:
         return False

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import json
 import os
 import sys
 from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urlparse
+from urllib.request import Request, urlopen
 
 from dotenv import load_dotenv
 from utils import atomic_replace
@@ -187,6 +191,86 @@ def _sanitize_env_file_if_needed(path: Path) -> None:
         pass  # best-effort — don't block gateway startup
 
 
+def _load_nexus_bootstrap_env() -> bool:
+    """Load runtime secrets from Nexus vault bootstrap when configured.
+
+    Opt-in env vars:
+    - HERMES_NEXUS_BOOTSTRAP_URL
+    - HERMES_NEXUS_BOOTSTRAP_INTEGRATION_ID
+    - NEXUS_SERVICE_TOKEN or NEXUS_TOKEN
+
+    When present, Nexus values override stale shell or dotenv values so the
+    central vault becomes the authority during cutover. Failures are swallowed:
+    bootstrap secret loading must not block Hermes startup or leak secret values.
+    """
+    enabled = os.getenv("HERMES_NEXUS_BOOTSTRAP_ENABLED", "1").strip().lower()
+    if enabled in {"0", "false", "no", "off"}:
+        return False
+
+    base_url = os.getenv("HERMES_NEXUS_BOOTSTRAP_URL", "").strip()
+    integration_id = os.getenv("HERMES_NEXUS_BOOTSTRAP_INTEGRATION_ID", "").strip()
+    token = (os.getenv("NEXUS_SERVICE_TOKEN") or os.getenv("NEXUS_TOKEN") or "").strip()
+    if not (base_url and integration_id and token):
+        return False
+
+    parsed = urlparse(base_url)
+    if parsed.scheme != "https":
+        print(
+            "  Nexus vault bootstrap: configured URL must use https; skipping.",
+            file=sys.stderr,
+        )
+        return False
+
+    safe_integration_id = quote(integration_id, safe="")
+    url = f"{base_url.rstrip('/')}/api/v1/vault/bootstrap/{safe_integration_id}"
+    req = Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+            "User-Agent": "HermesAgent/1.0",
+        },
+    )
+    try:
+        with urlopen(req, timeout=15) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except (HTTPError, URLError, TimeoutError, OSError, json.JSONDecodeError):
+        print(
+            "  Nexus vault bootstrap: configured but unavailable; using local fallback.",
+            file=sys.stderr,
+        )
+        return False
+
+    secrets = payload.get("secrets")
+    if not isinstance(secrets, dict):
+        return False
+
+    loaded: list[str] = []
+    for key, value in secrets.items():
+        if not isinstance(key, str) or not key.strip() or not isinstance(value, str):
+            continue
+        if not value.strip():
+            continue
+        name = key.strip()
+        if not any(name.endswith(suffix) for suffix in _CREDENTIAL_SUFFIXES):
+            continue
+        os.environ[name] = value
+        _SECRET_SOURCES[name] = "Nexus vault"
+        loaded.append(name)
+
+    if not loaded:
+        return False
+
+    _sanitize_loaded_credentials()
+    print(
+        f"  Nexus vault bootstrap: applied {len(loaded)} "
+        f"secret{'s' if len(loaded) != 1 else ''} "
+        f"({', '.join(sorted(loaded))})",
+        file=sys.stderr,
+    )
+    return True
+
+
 def load_hermes_dotenv(
     *,
     hermes_home: str | os.PathLike | None = None,
@@ -220,6 +304,7 @@ def load_hermes_dotenv(
         _load_dotenv_with_fallback(project_env_path, override=not loaded)
         loaded.append(project_env_path)
 
+    _load_nexus_bootstrap_env()
     _apply_external_secret_sources(home_path)
 
     return loaded

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -262,3 +262,87 @@ def test_nexus_bootstrap_url_encodes_integration_id_and_uses_timeout(tmp_path, m
     req = mock_urlopen.call_args.args[0]
     assert req.full_url == "https://nexus.example/api/v1/vault/bootstrap/athena%2Fprod"
     assert mock_urlopen.call_args.kwargs["timeout"] == 15
+
+
+def test_nexus_bootstrap_non_dict_json_body_falls_back(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / ".env").write_text("TELEGRAM_BOT_TOKEN=local-token\n", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_NEXUS_BOOTSTRAP_URL", "https://nexus.example")
+    monkeypatch.setenv("HERMES_NEXUS_BOOTSTRAP_INTEGRATION_ID", "athena")
+    monkeypatch.setenv("NEXUS_SERVICE_TOKEN", "x" * 64)
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return b"[]"
+
+    with patch("hermes_cli.env_loader.urlopen", return_value=_Resp()):
+        load_hermes_dotenv(hermes_home=home)
+
+    assert os.getenv("TELEGRAM_BOT_TOKEN") == "local-token"
+
+
+def test_nexus_bootstrap_non_utf8_body_falls_back(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / ".env").write_text("TELEGRAM_BOT_TOKEN=local-token\n", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_NEXUS_BOOTSTRAP_URL", "https://nexus.example")
+    monkeypatch.setenv("HERMES_NEXUS_BOOTSTRAP_INTEGRATION_ID", "athena")
+    monkeypatch.setenv("NEXUS_SERVICE_TOKEN", "x" * 64)
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return b"\xff\xfe\x00"
+
+    with patch("hermes_cli.env_loader.urlopen", return_value=_Resp()):
+        load_hermes_dotenv(hermes_home=home)
+
+    assert os.getenv("TELEGRAM_BOT_TOKEN") == "local-token"
+
+
+def test_nexus_bootstrap_invalid_env_value_is_skipped(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+
+    monkeypatch.setenv("HERMES_NEXUS_BOOTSTRAP_URL", "https://nexus.example")
+    monkeypatch.setenv("HERMES_NEXUS_BOOTSTRAP_INTEGRATION_ID", "athena")
+    monkeypatch.setenv("NEXUS_SERVICE_TOKEN", "x" * 64)
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return json.dumps(
+                {
+                    "secrets": {
+                        "TELEGRAM_BOT_TOKEN": "vault-token\x00invalid",
+                        "OPENAI_API_KEY": "valid-key",
+                    }
+                }
+            ).encode("utf-8")
+
+    with patch("hermes_cli.env_loader.urlopen", return_value=_Resp()):
+        load_hermes_dotenv(hermes_home=home)
+
+    assert os.getenv("TELEGRAM_BOT_TOKEN") is None
+    assert os.getenv("OPENAI_API_KEY") == "valid-key"

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -5,6 +5,7 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import hermes_cli.env_loader as env_loader
 from hermes_cli.env_loader import get_secret_source, load_hermes_dotenv
 
 
@@ -124,7 +125,7 @@ def test_nexus_bootstrap_overrides_local_dotenv_secret(tmp_path, monkeypatch, ca
         def __exit__(self, exc_type, exc, tb):
             return False
 
-        def read(self):
+        def read(self, *_args):
             return json.dumps({"secrets": {"TELEGRAM_BOT_TOKEN": "vault-token"}}).encode("utf-8")
 
     with patch("hermes_cli.env_loader.urlopen", return_value=_Resp()) as mock_urlopen:
@@ -174,7 +175,7 @@ def test_nexus_bootstrap_ignores_empty_or_non_string_secrets(tmp_path, monkeypat
         def __exit__(self, exc_type, exc, tb):
             return False
 
-        def read(self):
+        def read(self, *_args):
             return json.dumps(
                 {
                     "secrets": {
@@ -253,7 +254,7 @@ def test_nexus_bootstrap_url_encodes_integration_id_and_uses_timeout(tmp_path, m
         def __exit__(self, exc_type, exc, tb):
             return False
 
-        def read(self):
+        def read(self, *_args):
             return json.dumps({"secrets": {"TELEGRAM_BOT_TOKEN": "vault-token"}}).encode("utf-8")
 
     with patch("hermes_cli.env_loader.urlopen", return_value=_Resp()) as mock_urlopen:
@@ -280,7 +281,7 @@ def test_nexus_bootstrap_non_dict_json_body_falls_back(tmp_path, monkeypatch):
         def __exit__(self, exc_type, exc, tb):
             return False
 
-        def read(self):
+        def read(self, *_args):
             return b"[]"
 
     with patch("hermes_cli.env_loader.urlopen", return_value=_Resp()):
@@ -305,7 +306,7 @@ def test_nexus_bootstrap_empty_secrets_response_falls_back(tmp_path, monkeypatch
         def __exit__(self, exc_type, exc, tb):
             return False
 
-        def read(self):
+        def read(self, *_args):
             return json.dumps({"secrets": {}}).encode("utf-8")
 
     with patch("hermes_cli.env_loader.urlopen", return_value=_Resp()):
@@ -330,13 +331,70 @@ def test_nexus_bootstrap_non_utf8_body_falls_back(tmp_path, monkeypatch):
         def __exit__(self, exc_type, exc, tb):
             return False
 
-        def read(self):
+        def read(self, *_args):
             return b"\xff\xfe\x00"
 
     with patch("hermes_cli.env_loader.urlopen", return_value=_Resp()):
         load_hermes_dotenv(hermes_home=home)
 
     assert os.getenv("TELEGRAM_BOT_TOKEN") == "local-token"
+
+
+def test_nexus_bootstrap_oversized_response_falls_back(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / ".env").write_text("TELEGRAM_BOT_TOKEN=local-token\n", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_NEXUS_BOOTSTRAP_URL", "https://nexus.example")
+    monkeypatch.setenv("HERMES_NEXUS_BOOTSTRAP_INTEGRATION_ID", "athena")
+    monkeypatch.setenv("NEXUS_SERVICE_TOKEN", "x" * 64)
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self, size=-1):
+            assert size == getattr(env_loader, "_NEXUS_BOOTSTRAP_MAX_BYTES") + 1
+            return b"{" + (b" " * getattr(env_loader, "_NEXUS_BOOTSTRAP_MAX_BYTES")) + b"}"
+
+    with patch("hermes_cli.env_loader.urlopen", return_value=_Resp()):
+        load_hermes_dotenv(hermes_home=home)
+
+    assert os.getenv("TELEGRAM_BOT_TOKEN") == "local-token"
+    assert "response too large" in capsys.readouterr().err
+
+
+def test_nexus_bootstrap_limits_applied_secrets(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+
+    monkeypatch.setenv("HERMES_NEXUS_BOOTSTRAP_URL", "https://nexus.example")
+    monkeypatch.setenv("HERMES_NEXUS_BOOTSTRAP_INTEGRATION_ID", "athena")
+    monkeypatch.setenv("NEXUS_SERVICE_TOKEN", "x" * 64)
+
+    secrets = {
+        f"NEXUS_TEST_{idx}_TOKEN": f"value-{idx}"
+        for idx in range(getattr(env_loader, "_NEXUS_BOOTSTRAP_MAX_SECRETS") + 1)
+    }
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self, *_args):
+            return json.dumps({"secrets": secrets}).encode("utf-8")
+
+    with patch("hermes_cli.env_loader.urlopen", return_value=_Resp()):
+        load_hermes_dotenv(hermes_home=home)
+
+    loaded = [key for key in secrets if os.getenv(key) is not None]
+    assert len(loaded) == getattr(env_loader, "_NEXUS_BOOTSTRAP_MAX_SECRETS")
 
 
 def test_nexus_bootstrap_invalid_env_value_is_skipped(tmp_path, monkeypatch):
@@ -356,7 +414,7 @@ def test_nexus_bootstrap_invalid_env_value_is_skipped(tmp_path, monkeypatch):
         def __exit__(self, exc_type, exc, tb):
             return False
 
-        def read(self):
+        def read(self, *_args):
             return json.dumps(
                 {
                     "secrets": {

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -227,15 +227,15 @@ def test_nexus_bootstrap_kill_switch_skips_fetch(tmp_path, monkeypatch):
     home = tmp_path / "hermes"
     home.mkdir()
 
-    monkeypatch.setenv("HERMES_NEXUS_BOOTSTRAP_ENABLED", "0")
     monkeypatch.setenv("HERMES_NEXUS_BOOTSTRAP_URL", "https://nexus.example")
     monkeypatch.setenv("HERMES_NEXUS_BOOTSTRAP_INTEGRATION_ID", "athena")
     monkeypatch.setenv("NEXUS_SERVICE_TOKEN", "x" * 64)
 
-    with patch("hermes_cli.env_loader.urlopen") as mock_urlopen:
-        load_hermes_dotenv(hermes_home=home)
-
-    mock_urlopen.assert_not_called()
+    for disabled_value in ("0", "false", "no", "off"):
+        monkeypatch.setenv("HERMES_NEXUS_BOOTSTRAP_ENABLED", disabled_value)
+        with patch("hermes_cli.env_loader.urlopen") as mock_urlopen:
+            load_hermes_dotenv(hermes_home=home)
+        mock_urlopen.assert_not_called()
 
 
 def test_nexus_bootstrap_url_encodes_integration_id_and_uses_timeout(tmp_path, monkeypatch):
@@ -282,6 +282,31 @@ def test_nexus_bootstrap_non_dict_json_body_falls_back(tmp_path, monkeypatch):
 
         def read(self):
             return b"[]"
+
+    with patch("hermes_cli.env_loader.urlopen", return_value=_Resp()):
+        load_hermes_dotenv(hermes_home=home)
+
+    assert os.getenv("TELEGRAM_BOT_TOKEN") == "local-token"
+
+
+def test_nexus_bootstrap_empty_secrets_response_falls_back(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / ".env").write_text("TELEGRAM_BOT_TOKEN=local-token\n", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_NEXUS_BOOTSTRAP_URL", "https://nexus.example")
+    monkeypatch.setenv("HERMES_NEXUS_BOOTSTRAP_INTEGRATION_ID", "athena")
+    monkeypatch.setenv("NEXUS_SERVICE_TOKEN", "x" * 64)
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return json.dumps({"secrets": {}}).encode("utf-8")
 
     with patch("hermes_cli.env_loader.urlopen", return_value=_Resp()):
         load_hermes_dotenv(hermes_home=home)

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -1,9 +1,11 @@
 import importlib
+import json
 import os
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
-from hermes_cli.env_loader import load_hermes_dotenv
+from hermes_cli.env_loader import get_secret_source, load_hermes_dotenv
 
 
 def test_user_env_overrides_stale_shell_values(tmp_path, monkeypatch):
@@ -104,3 +106,159 @@ def test_main_import_applies_user_env_over_shell_values(tmp_path, monkeypatch):
 
     assert os.getenv("OPENAI_BASE_URL") == "https://new.example/v1"
     assert os.getenv("HERMES_INFERENCE_PROVIDER") == "custom"
+
+
+def test_nexus_bootstrap_overrides_local_dotenv_secret(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / ".env").write_text("TELEGRAM_BOT_TOKEN=local-token\n", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_NEXUS_BOOTSTRAP_URL", "https://nexus.example")
+    monkeypatch.setenv("HERMES_NEXUS_BOOTSTRAP_INTEGRATION_ID", "athena")
+    monkeypatch.setenv("NEXUS_SERVICE_TOKEN", "x" * 64)
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return json.dumps({"secrets": {"TELEGRAM_BOT_TOKEN": "vault-token"}}).encode("utf-8")
+
+    with patch("hermes_cli.env_loader.urlopen", return_value=_Resp()) as mock_urlopen:
+        loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == [home / ".env"]
+    assert os.getenv("TELEGRAM_BOT_TOKEN") == "vault-token"
+    assert get_secret_source("TELEGRAM_BOT_TOKEN") == "Nexus vault"
+    req = mock_urlopen.call_args.args[0]
+    assert req.full_url == "https://nexus.example/api/v1/vault/bootstrap/athena"
+    assert req.headers["Authorization"] == f"Bearer {'x' * 64}"
+    stderr = capsys.readouterr().err
+    assert "TELEGRAM_BOT_TOKEN" in stderr
+    assert "local-token" not in stderr
+    assert "vault-token" not in stderr
+
+
+def test_nexus_bootstrap_is_skipped_without_required_env(monkeypatch, tmp_path):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    monkeypatch.delenv("HERMES_NEXUS_BOOTSTRAP_URL", raising=False)
+    monkeypatch.delenv("HERMES_NEXUS_BOOTSTRAP_INTEGRATION_ID", raising=False)
+    monkeypatch.delenv("NEXUS_SERVICE_TOKEN", raising=False)
+    monkeypatch.delenv("NEXUS_TOKEN", raising=False)
+
+    with patch("hermes_cli.env_loader.urlopen") as mock_urlopen:
+        loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == []
+    mock_urlopen.assert_not_called()
+
+
+def test_nexus_bootstrap_ignores_empty_or_non_string_secrets(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+
+    monkeypatch.setenv("HERMES_NEXUS_BOOTSTRAP_URL", "https://nexus.example/")
+    monkeypatch.setenv("HERMES_NEXUS_BOOTSTRAP_INTEGRATION_ID", "athena")
+    monkeypatch.setenv("NEXUS_TOKEN", "nexus-token")
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    original_path = os.getenv("PATH")
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return json.dumps(
+                {
+                    "secrets": {
+                        "TELEGRAM_BOT_TOKEN": "   ",
+                        "OPENAI_API_KEY": 123,
+                        "PATH": "/tmp/malicious",
+                    }
+                }
+            ).encode("utf-8")
+
+    with patch("hermes_cli.env_loader.urlopen", return_value=_Resp()):
+        load_hermes_dotenv(hermes_home=home)
+
+    assert os.getenv("TELEGRAM_BOT_TOKEN") is None
+    assert os.getenv("OPENAI_API_KEY") is None
+    assert os.getenv("PATH") == original_path
+
+
+def test_nexus_bootstrap_failure_does_not_override_local_secret(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / ".env").write_text("TELEGRAM_BOT_TOKEN=local-token\n", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_NEXUS_BOOTSTRAP_URL", "https://nexus.example")
+    monkeypatch.setenv("HERMES_NEXUS_BOOTSTRAP_INTEGRATION_ID", "athena")
+    monkeypatch.setenv("NEXUS_SERVICE_TOKEN", "x" * 64)
+
+    with patch("hermes_cli.env_loader.urlopen", side_effect=OSError("network down")):
+        load_hermes_dotenv(hermes_home=home)
+
+    assert os.getenv("TELEGRAM_BOT_TOKEN") == "local-token"
+
+
+def test_nexus_bootstrap_rejects_non_https_url(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "hermes"
+    home.mkdir()
+
+    monkeypatch.setenv("HERMES_NEXUS_BOOTSTRAP_URL", "http://nexus.example")
+    monkeypatch.setenv("HERMES_NEXUS_BOOTSTRAP_INTEGRATION_ID", "athena")
+    monkeypatch.setenv("NEXUS_SERVICE_TOKEN", "x" * 64)
+
+    with patch("hermes_cli.env_loader.urlopen") as mock_urlopen:
+        load_hermes_dotenv(hermes_home=home)
+
+    mock_urlopen.assert_not_called()
+    assert "must use https" in capsys.readouterr().err
+
+
+def test_nexus_bootstrap_kill_switch_skips_fetch(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+
+    monkeypatch.setenv("HERMES_NEXUS_BOOTSTRAP_ENABLED", "0")
+    monkeypatch.setenv("HERMES_NEXUS_BOOTSTRAP_URL", "https://nexus.example")
+    monkeypatch.setenv("HERMES_NEXUS_BOOTSTRAP_INTEGRATION_ID", "athena")
+    monkeypatch.setenv("NEXUS_SERVICE_TOKEN", "x" * 64)
+
+    with patch("hermes_cli.env_loader.urlopen") as mock_urlopen:
+        load_hermes_dotenv(hermes_home=home)
+
+    mock_urlopen.assert_not_called()
+
+
+def test_nexus_bootstrap_url_encodes_integration_id_and_uses_timeout(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+
+    monkeypatch.setenv("HERMES_NEXUS_BOOTSTRAP_URL", "https://nexus.example")
+    monkeypatch.setenv("HERMES_NEXUS_BOOTSTRAP_INTEGRATION_ID", "athena/prod")
+    monkeypatch.setenv("NEXUS_SERVICE_TOKEN", "x" * 64)
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return json.dumps({"secrets": {"TELEGRAM_BOT_TOKEN": "vault-token"}}).encode("utf-8")
+
+    with patch("hermes_cli.env_loader.urlopen", return_value=_Resp()) as mock_urlopen:
+        load_hermes_dotenv(hermes_home=home)
+
+    req = mock_urlopen.call_args.args[0]
+    assert req.full_url == "https://nexus.example/api/v1/vault/bootstrap/athena%2Fprod"
+    assert mock_urlopen.call_args.kwargs["timeout"] == 15


### PR DESCRIPTION
## Summary
- add opt-in Nexus vault bootstrap loading during `load_hermes_dotenv()`
- apply only string, non-empty credential-like keys from the Nexus response to `os.environ`
- enforce HTTPS, URL-encode integration IDs, add a kill switch, bounded timeout, and safe fallback warnings
- label Nexus-sourced credentials through `_SECRET_SOURCES` without logging secret values

Closes #31489

## Validation
- `python3 -m pytest tests/hermes_cli/test_env_loader.py -q` → 13 passed
- `python3 -m pytest tests/hermes_cli/test_env_loader.py tests/test_env_loader_secret_sources.py -q` → 20 passed
- Gemini CLI validation: PASS; noted timeout/logging checks, which are covered/added
- Claude Opus interactive CLI validation: CONCERNS; addressed main findings with HTTPS enforcement, URL encoding, env-key guard, kill switch, timeout assertion, and no-secret logging test

## Notes
- Nexus bootstrap currently runs after dotenv and before Bitwarden external secret sources, preserving the existing Bitwarden override semantics while allowing Nexus to replace stale local dotenv/shell values.
- No secret values are included in this PR body or tests.
