### PR TITLE
fix(gateway): prevent third-sender message drop in queue-mode debounce

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2821,14 +2821,18 @@ class BasePlatformAdapter(ABC):
             await self._flush_text_debounce_now(session_key)
             state = store.get(session_key)
             if state is not None and not self._can_merge_text_debounce_events(state.event, event):
-                existing_pending = self._pending_messages.get(session_key)
-                if existing_pending is not None and self._can_merge_text_debounce_events(existing_pending, event):
-                    merge_pending_message_event(
-                        self._pending_messages,
-                        session_key,
-                        event,
-                        merge_text=True,
-                    )
+                # B's debounce state is stuck (timer fired but the pending slot
+                # belongs to a different sender). Rather than silently dropping
+                # the incoming event, fall back to a direct pending merge — the
+                # same safety net as the pre-debounce path that always queued
+                # follow-ups. Sender attribution is best-effort when 3+ senders
+                # collide simultaneously; losing the message entirely is worse.
+                merge_pending_message_event(
+                    self._pending_messages,
+                    session_key,
+                    event,
+                    merge_text=True,
+                )
                 return
 
         now = time.monotonic()

--- a/tests/gateway/test_active_session_text_merge.py
+++ b/tests/gateway/test_active_session_text_merge.py
@@ -375,3 +375,58 @@ def test_busy_text_mode_respects_env_var_override(monkeypatch):
     adapter = _make_initialized_adapter()
     assert adapter._busy_text_mode == "interrupt"
     assert not adapter._is_queue_text_debounce_candidate(_make_event("test"))
+
+
+@pytest.mark.asyncio
+async def test_third_sender_not_dropped_when_debounce_store_is_stuck():
+    """Regression: when B is stuck in the debounce store (task=None because
+    the timer fired but the pending slot belongs to sender A) and C arrives
+    from a third sender, C must not be silently dropped.
+
+    Pre-fix behaviour: the inner branch hit ``return`` without saving C
+    anywhere — no pending entry, no interrupt, no retry.
+    """
+    import time as _time
+
+    from gateway.platforms.base import TextDebounceState
+
+    adapter = _make_adapter()
+
+    event_a = _make_event("sender-a message", user_id="ua")
+    session_key = build_session_key(event_a.source)
+
+    adapter._active_sessions[session_key] = asyncio.Event()
+
+    # A's message is already in the pending slot (flushed from debounce
+    # by a previous timer).
+    adapter._pending_messages[session_key] = event_a
+
+    # B's debounce state is stuck: timer fired but couldn't flush because
+    # pending already has A (different sender). task=None means no retry
+    # is scheduled.
+    event_b = _make_event("sender-b message", user_id="ub")
+    _now = _time.monotonic()
+    adapter._text_debounce[session_key] = TextDebounceState(
+        event=event_b,
+        task=None,
+        first_ts=_now - 0.5,
+        last_ts=_now - 0.2,
+    )
+
+    # C arrives from a third sender.
+    event_c = _make_event("sender-c message", user_id="uc")
+    await adapter._queue_text_debounce(session_key, event_c)
+
+    # C must not be dropped — its text must appear in the pending slot.
+    pending = adapter._pending_messages.get(session_key)
+    assert pending is not None, "C was permanently dropped — pending slot is empty"
+    assert "sender-c message" in (pending.text or ""), (
+        f"C's text missing from pending; got: {pending.text!r}"
+    )
+
+    # B must still be in the debounce store — it will be flushed by
+    # _drain_pending_after_session_command when the active session completes.
+    assert session_key in adapter._text_debounce, (
+        "B's debounce state was unexpectedly removed"
+    )
+    assert "sender-b message" in (adapter._text_debounce[session_key].event.text or "")


### PR DESCRIPTION
## Summary

- **Bug**: In `busy_text_mode=queue` (the default), messages from a third sender in a group chat are permanently and silently dropped when two prior senders have created a debounce/pending collision.
- **Root cause**: `_queue_text_debounce` hit an early `return` without saving the incoming event anywhere when (a) sender B's debounce state is stuck in the store (`task=None`, timer fired but couldn't flush because pending belongs to sender A) and (b) the new message from sender C can't merge with B's stuck state OR with pending-A.
- **Fix**: Remove the `_can_merge(existing_pending, event)` guard from the inner conflict branch and unconditionally call `merge_pending_message_event` — C's text is appended to the pending slot (or placed there directly if empty), matching the pre-debounce behaviour that always queued follow-ups regardless of sender.

## Affected path

`gateway/platforms/base.py` → `_queue_text_debounce()`, the inner `if state is not None and not self._can_merge_text_debounce_events(state.event, event):` branch introduced in #31341.

## Reproduction scenario

1. Agent is processing a session (active session lock held).
2. Sender A's message is debounced, timer fires, flushed to `_pending_messages`.
3. Sender B's message is debounced; timer fires but `_flush_text_debounce_now` returns `False` because pending-A is a different sender → B stuck in store with `task=None`, no retry scheduled.
4. Sender C (third distinct sender) arrives → `_queue_text_debounce` tries to flush B, fails again → hits `return` → **C is never written to store, pending, or anywhere else**.

Only affects multi-user group chats (Matrix, Slack channels, Discord servers, WeChat groups) with 3+ participants messaging simultaneously during an active session.

## Changes

| File | Change |
|------|--------|
| `gateway/platforms/base.py` | Remove sender-check guard; always call `merge_pending_message_event` in the stuck-debounce fallback |
| `tests/gateway/test_active_session_text_merge.py` | Add `test_third_sender_not_dropped_when_debounce_store_is_stuck` regression test |

## Test plan

- [x] New regression test `test_third_sender_not_dropped_when_debounce_store_is_stuck` pins the exact 3-sender scenario (A in pending, B stuck in store with `task=None`, C from third sender → C survives in `_pending_messages`)
- [x] All 16 tests in `test_active_session_text_merge.py` pass
- [x] `test_busy_session_ack.py` (16 tests), `test_base_topic_sessions.py` (10 tests), `test_wecom.py` (44 tests) — all pass, no regressions