### PR TITLE
feat(gateway,cli): exclude cron sessions from default session lists

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6283,7 +6283,7 @@ class HermesCLI:
         try:
             sessions = self._session_db.list_sessions_rich(
                 source="cli",
-                exclude_sources=["tool"],
+                exclude_sources=["tool", "cron"],
                 limit=limit,
             )
         except Exception:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12872,7 +12872,10 @@ class GatewayRunner:
 
         def _list_titled_sessions() -> list[dict]:
             user_source = source.platform.value if source.platform else None
-            sessions = self._session_db.list_sessions_rich(source=user_source, limit=10)
+            sessions = self._session_db.list_sessions_rich(
+                source=user_source, limit=10,
+                exclude_sources=["cron"],
+            )
             return [s for s in sessions if s.get("title")][:10]
 
         if not name:


### PR DESCRIPTION
## Summary

Cron sessions (source=cron) are now excluded by default when listing sessions in both the gateway and CLI views.

## Changes

- gateway/run.py: add exclude_sources=["cron"] to list_sessions_rich() call in _handle_resume_command
- cli.py: add "cron" to existing exclude_sources in _list_recent_sessions

## Rationale

Cron sessions cluttered the user-facing session browser. They remain accessible via direct session ID or by explicitly filtering for source=cron.

## Tests

80 existing gateway tests pass. No new tests needed (behavior change is a single parameter addition).