### PR TITLE
fix(oneshot): surface structured agent failures to stderr with rc=1

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -174,11 +174,12 @@ def run_oneshot(
     # Redirect stderr AND stdout to devnull for the entire call tree.
     # We'll print the final response to the real stdout at the end.
     real_stdout = sys.stdout
+    real_stderr = sys.stderr
     devnull = open(os.devnull, "w", encoding="utf-8")
 
     try:
         with redirect_stdout(devnull), redirect_stderr(devnull):
-            response = _run_agent(
+            result = _run_agent(
                 prompt,
                 model=model,
                 provider=provider,
@@ -191,11 +192,51 @@ def run_oneshot(
         except Exception:
             pass
 
+    # ``_run_agent`` now returns the structured ``run_conversation`` result
+    # dict instead of just the final-response string, so oneshot can
+    # distinguish "agent produced no text but ran fine" from
+    # "agent failed mid-turn (e.g. compression-exhausted, rate limit,
+    # invalid model slug)". The previous code returned 0 with empty stdout
+    # in both cases, so callers like the MeshBoard launcher saw a silent
+    # rc=0 exit on hard failures — pure stdout/stderr capture gave them
+    # no signal at all. Surface every structured failure to real_stderr
+    # and exit non-zero so wrappers can classify.
+    if isinstance(result, dict):
+        response = str(result.get("final_response") or "")
+        failed = bool(result.get("failed") or result.get("partial"))
+        error_detail = str(result.get("error") or "")
+    else:
+        # Defensive: if some path returns a bare string, treat it as the
+        # response. This preserves backwards-compat for any caller still
+        # exercising the old shape.
+        response = str(result or "")
+        failed = False
+        error_detail = ""
+
     if response:
         real_stdout.write(response)
         if not response.endswith("\n"):
             real_stdout.write("\n")
         real_stdout.flush()
+
+    if failed:
+        # Always emit *something* to stderr — even if the agent already
+        # produced a partial response. Wrappers need a reliable signal
+        # to classify the outcome; a non-empty stdout + empty stderr
+        # currently looks identical to a clean run.
+        message = error_detail or "hermes -z: agent reported failure with no error detail"
+        real_stderr.write(f"hermes -z: {message}\n")
+        if result.get("compression_exhausted"):
+            real_stderr.write(
+                "hermes -z: context compression exhausted — the model's "
+                "context window cannot fit the conversation after the "
+                "configured max compression attempts. Consider /new in "
+                "an interactive session, a longer-context model, or a "
+                "smaller prompt.\n"
+            )
+        real_stderr.flush()
+        return 1
+
     return 0
 
 
@@ -221,9 +262,58 @@ def _run_agent(
     provider: Optional[str] = None,
     toolsets: object = None,
     use_config_toolsets: bool = True,
-) -> str:
+) -> dict:
     """Build an AIAgent exactly like a normal CLI chat turn would, then
-    run a single conversation.  Returns the final response string."""
+    run a single conversation.  Returns the structured ``run_conversation``
+    result dict (with ``final_response``, ``failed``, ``error``,
+    ``compression_exhausted``, etc.).
+
+    Previously returned only the final-response string, which meant
+    oneshot mode could not distinguish a successful empty response from
+    a hard failure. Wrappers like the MeshBoard launcher need the
+    failure flags to classify a non-zero exit; returning the full result
+    lets ``run_oneshot`` surface the error to real_stderr and exit
+    non-zero on failure.
+    """
+    try:
+        return _run_agent_inner(
+            prompt,
+            model=model,
+            provider=provider,
+            toolsets=toolsets,
+            use_config_toolsets=use_config_toolsets,
+        )
+    except Exception as exc:
+        # Catch anything (agent init, config loading, conversation_loop
+        # raises) and synthesise a failed-result dict. Without this, an
+        # exception would propagate past run_oneshot's redirect_stderr
+        # block, then Python's default handler would print a traceback
+        # to real_stderr — useful for humans but it bypasses the
+        # uniform "hermes -z: <error>" surface that wrappers parse.
+        # The synthetic dict preserves the exception class + message so
+        # the line is still diagnostically useful.
+        logging.debug(
+            "oneshot _run_agent: agent path raised", exc_info=True,
+        )
+        return {
+            "final_response": "",
+            "failed": True,
+            "error": f"{type(exc).__name__}: {exc}"[:500],
+            "messages": [],
+            "api_calls": 0,
+        }
+
+
+def _run_agent_inner(
+    prompt: str,
+    model: Optional[str] = None,
+    provider: Optional[str] = None,
+    toolsets: object = None,
+    use_config_toolsets: bool = True,
+) -> dict:
+    """The actual agent-construction-and-run path. Separated from
+    ``_run_agent`` so the outer wrapper can convert any raise into a
+    structured failed-result dict without obscuring the real flow."""
     # Imports are local so they don't run when hermes is invoked for
     # other commands (keeps top-level CLI startup cheap).
     from hermes_cli.config import load_config
@@ -337,7 +427,16 @@ def _run_agent(
     agent.stream_delta_callback = None
     agent.tool_gen_callback = None
 
-    return agent.chat(prompt) or ""
+    # Use run_conversation directly (not agent.chat) so the caller can see
+    # the structured result including failed/error/compression_exhausted.
+    # agent.chat discards everything except final_response.
+    result = agent.run_conversation(prompt)
+    if isinstance(result, dict):
+        return result
+    # AIAgent.run_conversation should always return a dict, but defend
+    # against a string fallback in case a future code path narrows the
+    # return type. Wrap so the oneshot caller's contract stays stable.
+    return {"final_response": str(result or ""), "failed": False}
 
 
 def _oneshot_clarify_callback(question: str, choices=None) -> str:

--- a/tests/hermes_cli/test_oneshot_failure_to_stderr.py
+++ b/tests/hermes_cli/test_oneshot_failure_to_stderr.py
@@ -1,0 +1,223 @@
+"""Pin the contract that ``hermes -z`` (oneshot mode) surfaces structured
+agent failures to stderr and exits with rc=1.
+
+Prior to this fix ``run_oneshot`` always returned 0 and only printed
+``response`` to stdout. When the agent's ``run_conversation`` returned a
+``failed=True`` / ``compression_exhausted=True`` result (e.g. the
+context-overflow recovery chain exhausted its retries on a local model),
+the caller saw an exit-0 process with empty stdout and empty stderr —
+indistinguishable from a clean run that happened to produce no text.
+
+Wrappers like the MeshBoard launcher classify silent rc=1 differently
+from a structured error; the fingerprint of the 2026-05-23 incident
+(103 incidents in 20 days, 76 in the last 24h, all chain_depth=3 on
+qwen3.6-35b-a3b) was driven by exactly this gap. After the fix:
+
+* A failed result writes ``hermes -z: <error>`` to real_stderr and the
+  process exits 1.
+* A ``compression_exhausted=True`` result writes an additional
+  diagnostic line explaining the recovery hint.
+* Successful results still print response to stdout and exit 0 unchanged.
+* Exceptions inside ``agent.run_conversation`` are captured as
+  synthetic failed-result dicts so the stderr formatter produces a
+  uniform line instead of a Python traceback.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+
+def _stub_run_agent(result):
+    """Patch hermes_cli.oneshot._run_agent to return ``result``."""
+    return patch("hermes_cli.oneshot._run_agent", return_value=result)
+
+
+# ``capfd`` captures at the file-descriptor level so it sees writes that
+# went through ``sys.__stdout__`` / ``sys.__stderr__`` as well as
+# ``sys.stdout`` / ``sys.stderr``. ``run_oneshot`` captures
+# ``sys.stdout`` / ``sys.stderr`` at function entry — capfd sees the
+# eventual fd-level write either way, which matches how the MeshBoard
+# launcher actually observes Hermes's output (subprocess pipes).
+
+
+def test_compression_exhausted_writes_stderr_and_exits_1(capfd):
+    """The 2026-05-23 incident shape: failed + compression_exhausted +
+    error="Context length exceeded..." must produce stderr output and
+    rc=1, not a silent rc=0."""
+    from hermes_cli.oneshot import run_oneshot
+
+    failed_result = {
+        "final_response": "",
+        "failed": True,
+        "compression_exhausted": True,
+        "error": (
+            "Context length exceeded (50000 tokens). "
+            "Cannot compress further."
+        ),
+        "messages": [],
+        "api_calls": 0,
+    }
+    with _stub_run_agent(failed_result):
+        rc = run_oneshot("any prompt", model=None, provider=None)
+    captured = capfd.readouterr()
+    assert rc == 1
+    assert captured.out == ""
+    assert "hermes -z:" in captured.err
+    assert "Context length exceeded" in captured.err
+    # Compression-exhausted-specific diagnostic line.
+    assert "context compression exhausted" in captured.err.lower()
+
+
+def test_failed_without_compression_exhausted_writes_stderr(capfd):
+    """Generic ``failed=True`` (e.g. invalid model slug, provider 4xx)
+    still surfaces to stderr with rc=1, just without the
+    compression-specific hint."""
+    from hermes_cli.oneshot import run_oneshot
+
+    failed_result = {
+        "final_response": "",
+        "failed": True,
+        "error": "Invalid model 'bogus-model'",
+        "messages": [],
+        "api_calls": 0,
+    }
+    with _stub_run_agent(failed_result):
+        rc = run_oneshot("any prompt", model=None, provider=None)
+    captured = capfd.readouterr()
+    assert rc == 1
+    assert "hermes -z: Invalid model 'bogus-model'" in captured.err
+    assert "context compression exhausted" not in captured.err.lower()
+
+
+def test_partial_with_error_also_writes_stderr(capfd):
+    """``partial=True`` (truncated output) is treated the same as
+    ``failed=True`` for stderr-surfacing purposes — both indicate the
+    agent did not produce a clean response."""
+    from hermes_cli.oneshot import run_oneshot
+
+    partial_result = {
+        "final_response": "",
+        "partial": True,
+        "error": "Stream truncated mid-response",
+        "messages": [],
+        "api_calls": 1,
+    }
+    with _stub_run_agent(partial_result):
+        rc = run_oneshot("any prompt", model=None, provider=None)
+    captured = capfd.readouterr()
+    assert rc == 1
+    assert "Stream truncated mid-response" in captured.err
+
+
+def test_failed_with_response_text_still_writes_stderr_and_returns_1(capfd):
+    """Even when the agent produced SOME response text alongside a
+    failure flag, the stderr signal must still fire so wrappers can
+    distinguish a partial-success from a clean run."""
+    from hermes_cli.oneshot import run_oneshot
+
+    failed_with_partial_response = {
+        "final_response": "Here is what I got before the error...",
+        "failed": True,
+        "error": "Provider timeout after 60s",
+        "messages": [],
+        "api_calls": 1,
+    }
+    with _stub_run_agent(failed_with_partial_response):
+        rc = run_oneshot("any prompt", model=None, provider=None)
+    captured = capfd.readouterr()
+    # Response goes to stdout (it's real partial content).
+    assert "Here is what I got before the error" in captured.out
+    # Error still surfaces to stderr.
+    assert "Provider timeout after 60s" in captured.err
+    # And the exit code reflects failure.
+    assert rc == 1
+
+
+def test_successful_result_unchanged(capfd):
+    """The happy path must remain identical to the previous behaviour:
+    write response to stdout, no stderr, rc=0."""
+    from hermes_cli.oneshot import run_oneshot
+
+    ok_result = {
+        "final_response": "The answer is 42.",
+        "messages": [],
+        "api_calls": 1,
+    }
+    with _stub_run_agent(ok_result):
+        rc = run_oneshot("any prompt", model=None, provider=None)
+    captured = capfd.readouterr()
+    assert rc == 0
+    assert captured.out.rstrip("\n") == "The answer is 42."
+    assert captured.err == ""
+
+
+def test_response_without_trailing_newline_gets_one_appended(capfd):
+    """Pre-existing behaviour: response without a trailing newline gets
+    one appended so terminal display lines up. Pin it here so the new
+    structured-result path doesn't accidentally regress."""
+    from hermes_cli.oneshot import run_oneshot
+
+    ok_result = {"final_response": "no newline"}
+    with _stub_run_agent(ok_result):
+        run_oneshot("any prompt", model=None, provider=None)
+    captured = capfd.readouterr()
+    assert captured.out == "no newline\n"
+
+
+def test_exception_in_run_agent_becomes_failed_result(monkeypatch):
+    """``_run_agent`` swallows exceptions and converts them to a
+    synthetic failed-result dict so the stderr formatter can produce a
+    uniform line. Without this, an unhandled exception would propagate
+    past ``run_oneshot`` and Python's default handler would print a
+    traceback to real stderr — useful, but it bypasses the structured
+    error reporting path."""
+    from hermes_cli import oneshot as oneshot_mod
+
+    # Make AIAgent constructor raise the moment _run_agent tries to
+    # build the agent. The exception must be captured into a synthetic
+    # failed-result dict, not propagated.
+    def _exploding_agent(*args, **kwargs):
+        raise RuntimeError("boom in agent init")
+
+    monkeypatch.setattr("run_agent.AIAgent", _exploding_agent)
+    # Stub the upstream config/runtime resolution so _run_agent gets as
+    # far as the AIAgent(...) call without running the real auth path.
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kw: {"provider": "none", "base_url": "", "api_key": "",
+                       "api_mode": "openai_chat", "credential_pool": None},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_platform_tools",
+        lambda cfg, plat: [],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.fallback_config.get_fallback_chain", lambda cfg: [],
+    )
+
+    result = oneshot_mod._run_agent(
+        "any prompt", model=None, provider=None,
+        toolsets=None, use_config_toolsets=False,
+    )
+    assert isinstance(result, dict)
+    assert result.get("failed") is True
+    assert "RuntimeError" in result.get("error", "")
+    assert "boom in agent init" in result.get("error", "")
+    assert result.get("final_response") == ""
+
+
+def test_bare_string_return_from_run_agent_treated_as_response(capfd):
+    """Defensive backwards-compat: if some path returns a bare string,
+    treat it as the response (no failure)."""
+    from hermes_cli.oneshot import run_oneshot
+
+    with _stub_run_agent("just a string"):
+        rc = run_oneshot("any prompt", model=None, provider=None)
+    captured = capfd.readouterr()
+    assert rc == 0
+    assert "just a string" in captured.out
+    assert captured.err == ""

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -752,9 +752,12 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
             self.stream_delta_callback = object()
             self.tool_gen_callback = object()
 
-        def chat(self, prompt):
+        def run_conversation(self, prompt):
+            # _run_agent now calls run_conversation directly (not chat)
+            # so the caller can see the structured result including
+            # failed/error/compression_exhausted flags.
             captured["prompt"] = prompt
-            return "ok"
+            return {"final_response": "ok"}
 
     class FakeSessionDB:
         def __new__(cls):
@@ -798,7 +801,9 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
         mod("hermes_cli.tools_config", _get_platform_tools=lambda *_args, **_kwargs: {"session_search"}),
     )
 
-    assert _run_agent("recall this") == "ok"
+    result = _run_agent("recall this")
+    assert isinstance(result, dict)
+    assert result.get("final_response") == "ok"
     assert captured["session_db"] is sentinel_db
     assert captured["enabled_toolsets"] == ["session_search"]
     assert captured["prompt"] == "recall this"


### PR DESCRIPTION
## Summary

`hermes -z` (oneshot mode) was returning rc=0 with empty stdout AND
empty stderr on structured agent failures — wrappers couldn't tell a
hard failure (compression-exhausted, invalid model, provider 4xx)
from a clean run that happened to produce no text.

Audit of one user's `~/.hermes/state.db` found **103 incidents** of
this fingerprint over 20 days (**76 in the last 24h**), all at
compression-chain depth 3 on qwen3.6-35b-a3b. Every one is the same
shape:

- preflight compression runs all 3 passes
- main loop attempts first API call
- model server returns context-overflow
- recovery chain saturates
- `run_conversation` returns
  `{failed: True, compression_exhausted: True, error: "Context length exceeded (..) Cannot compress further."}`
- `cli.py`-interactive path would have printed that error; the
  oneshot path discarded it because `run_oneshot` only used
  `agent.chat(prompt)` (which throws away every field except
  `final_response`).

Result: kanban-style dispatchers see exit-0 + empty stdout + empty
stderr, can't classify, retry forever or count it as success.

## Changes

- `hermes_cli/oneshot.py`:
  - `_run_agent` now returns the structured `run_conversation` dict
    instead of the bare response string, so the caller can see
    `failed` / `error` / `compression_exhausted` flags.
  - New outer `_run_agent` wrapper catches any exception in agent
    construction or the conversation loop and converts it to a
    synthetic failed-result dict — preserves the prior "always produce
    some signal" guarantee without bypassing the new structured
    surface.
  - `run_oneshot` captures `sys.stderr` alongside `sys.stdout` before
    the `redirect_stderr` block, writes `hermes -z: <error>` to it
    when `failed` / `partial`, and adds a one-line
    compression-exhausted hint suggesting `/new`, a longer-context
    model, or a smaller prompt.
  - Failed results now return rc=1. Happy path unchanged: response →
    stdout, rc=0, no stderr.

- `tests/hermes_cli/test_oneshot_failure_to_stderr.py` (new): 8 tests
  pinning the new contract: compression-exhausted, generic-failed,
  partial, failed-with-partial-response, happy path, trailing
  newline, exception capture, bare-string fallback.

- `tests/hermes_cli/test_tui_resume_flow.py`: update the existing
  `test_oneshot_wires_session_db_for_recall` fixture's `FakeAgent`
  to use `run_conversation` returning a dict (the new contract)
  instead of `chat` returning a string.

## Test plan

```
pytest tests/hermes_cli/test_oneshot_failure_to_stderr.py        # 8 passed
pytest tests/hermes_cli/test_tui_resume_flow.py                  # 41 passed
pytest tests/tools/test_voice_cli_integration.py \
       tests/run_agent/test_partial_stream_finish_reason.py      # 89 passed
```

## Follow-up

This PR makes the failure mode *visible* but doesn't fix the
underlying cause (compression cascade saturating on
qwen3.6-35b-a3b — likely a mismatch between Hermes's configured
context_length and what the model server actually accepts). A
separate PR will add a structured bailout when preflight uses all 3
passes AND tokens still > threshold, so the doomed first API call
doesn't have to happen.
