### PR TITLE
fix(patch): hard-fail when V4A patch contains no file-operation markers

### DIFF
--- a/tests/tools/test_patch_parser.py
+++ b/tests/tools/test_patch_parser.py
@@ -647,3 +647,82 @@ class TestV4ALspDiagnosticsPropagation:
         assert result.lsp_diagnostics is not None
         assert per_file["a.ts"] in result.lsp_diagnostics
         assert per_file["b.ts"] in result.lsp_diagnostics
+
+
+class TestEmptyOperationsRejected:
+    """Regression: a patch body with no V4A file-operation markers must
+    return ``PatchResult(success=False, ...)`` instead of silently
+    succeeding with zero modifications.
+
+    Pre-fix, ``apply_v4a_operations([])`` returned
+    ``PatchResult(success=True, files_modified=[])`` — the empty
+    operations list slipped past the validator and the apply loop ran
+    zero times.  The agent saw ``{"success": true}`` and moved on
+    without realizing nothing had been written.  This was the root
+    cause of multiple wiki-edit silent-failure incidents observed in
+    real agent traffic (the ``path`` tool argument is ignored in
+    ``patch`` mode, so callers who supplied a bare unified diff body
+    plus ``path=...`` got silent no-ops).
+    """
+
+    def _file_ops(self):
+        class FakeFileOps:
+            def __init__(self):
+                self.write_calls = 0
+
+            def read_file_raw(self, path):
+                return SimpleNamespace(content="anything", error=None)
+
+            def write_file(self, path, content):
+                self.write_calls += 1
+                return SimpleNamespace(error=None)
+
+        return FakeFileOps()
+
+    def test_empty_operations_returns_failure(self):
+        file_ops = self._file_ops()
+        result = apply_v4a_operations([], file_ops)
+        assert result.success is False, (
+            "empty ops must NOT report success — pre-fix this returned "
+            "success=True and silently wrote nothing"
+        )
+        assert file_ops.write_calls == 0, (
+            "empty ops must not invoke write_file"
+        )
+        assert "no operations" in result.error.lower()
+
+    def test_empty_operations_error_mentions_markers(self):
+        """Error message must teach the caller what shape the patch needs."""
+        file_ops = self._file_ops()
+        result = apply_v4a_operations([], file_ops)
+        msg = result.error
+        # Each of the four V4A file markers should be named so the agent
+        # can self-correct without re-reading the schema.
+        assert "*** Update File:" in msg
+        assert "*** Add File:" in msg
+        assert "*** Delete File:" in msg
+        assert "*** Move File:" in msg
+
+    def test_empty_operations_error_redirects_to_replace_mode(self):
+        """The most common cause is callers reaching for ``patch`` when
+        ``replace`` is the right tool; the error nudges them there."""
+        file_ops = self._file_ops()
+        result = apply_v4a_operations([], file_ops)
+        assert "replace" in result.error.lower()
+
+    def test_parse_then_apply_bare_diff_returns_failure(self):
+        """End-to-end: a unified-diff body with no V4A markers parses to
+        zero operations and then apply must hard-fail rather than
+        silently succeed.  This matches what the agent does when it
+        builds a patch as ``@@\n-old\n+new`` with no envelope."""
+        bare_diff = "@@\n-old line\n+new line\n"
+        operations, err = parse_v4a_patch(bare_diff)
+        assert operations == []
+        # parse_v4a_patch treats empty as not-an-error by design
+        assert err is None
+        # ...but apply MUST reject it loudly.
+        file_ops = self._file_ops()
+        result = apply_v4a_operations(operations, file_ops)
+        assert result.success is False
+        assert file_ops.write_calls == 0
+

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -349,6 +349,43 @@ def apply_v4a_operations(operations: List[PatchOperation],
     # Import here to avoid circular imports
     from tools.file_operations import PatchResult
 
+    # ---- Phase 0: reject empty operations list ----
+    # An empty operations list reaches here when the patch body has no
+    # ``*** Update File: <path>`` / ``*** Add File: <path>`` /
+    # ``*** Delete File: <path>`` / ``*** Move File: <src> -> <dst>``
+    # markers — for example, when the caller supplied a bare unified-diff
+    # body (``@@`` hunks + ``-``/``+`` lines) and assumed the ``path``
+    # tool argument would be honored.  In V4A the file path lives inside
+    # the patch body via the ``*** Update File:`` marker, and the
+    # ``path`` argument is ignored in ``patch`` mode.
+    #
+    # Pre-fix behavior: ``parse_v4a_patch`` returned ``([], None)``
+    # (empty patch is not a parse error per the docstring), the Phase 1
+    # validator had nothing to check, the Phase 2 loop ran zero times,
+    # and we returned ``PatchResult(success=True, files_modified=[])`` —
+    # a silent success with no filesystem change.  The agent saw
+    # ``{"success": true}`` and moved on.  This was the root cause of
+    # multiple wiki-edit silent-failure incidents.
+    #
+    # Now we hard-fail with an actionable message naming the expected
+    # markers and pointing at the right tool for the common case.
+    if not operations:
+        return PatchResult(
+            success=False,
+            error=(
+                "Patch contained no operations (no files modified).\n"
+                "V4A patch bodies must include at least one file-operation marker:\n"
+                "  *** Update File: <path>\n"
+                "  *** Add File: <path>\n"
+                "  *** Delete File: <path>\n"
+                "  *** Move File: <src> -> <dst>\n"
+                "The 'path' tool argument is ignored in 'patch' mode — the path "
+                "must be inside the patch body.\n"
+                "For simple string replacement, prefer mode='replace' with "
+                "old_string + new_string + path."
+            ),
+        )
+
     # ---- Phase 1: validate ----
     validation_errors = _validate_operations(operations, file_ops)
     if validation_errors:


### PR DESCRIPTION
## What does this PR do?

`apply_v4a_operations()` in `tools/patch_parser.py` previously returned `PatchResult(success=True, files_modified=[])` when the parsed operations list was empty. This silently succeeded with zero filesystem changes — the agent saw `{"success": true}`, no warning, no error, and moved on.

The empty-operations case is reached when the patch body has no `*** Update File:` / `*** Add File:` / `*** Delete File:` / `*** Move File:` markers. The most common cause in real agent traffic is callers building a bare unified-diff body (`@@\n-old\n+new`) and assuming the `path` tool argument would be honored — but `path` is ignored in `patch` mode; the file path must live inside the patch body via `*** Update File:`.

### Pre-fix flow

```
parse_v4a_patch(bare_diff) -> ([], None)   # docstring: empty is not a parse error
_validate_operations([])    -> []          # nothing to validate
apply loop                  -> runs 0x     # no errors collected
return PatchResult(success=True, files_modified=[])  # silent success
```

This was the root cause of multiple wiki-edit silent-failure incidents in production agent traffic — the agent reported successful edits and the user later discovered nothing had been written.

### Post-fix

Reject early in `apply_v4a_operations` with an actionable error that names every accepted marker and points at `mode='replace'` for the common simple-replace case. Phase 1 validation and Phase 2 apply are unchanged. No correctly-formatted V4A patches are affected.

## Related Issue

No prior issue — bug was discovered in production agent traffic. Full repro and pre/post-fix evidence is in the test plan below.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/patch_parser.py` — added a Phase 0 early-return in `apply_v4a_operations` that hard-fails when `operations == []`, with an error message listing every accepted V4A marker and pointing callers at `mode='replace'` for simple replacement.
- `tests/tools/test_patch_parser.py` — added `TestEmptyOperationsRejected` with 4 regression tests covering the empty-ops case end-to-end.

## How to Test

### Unit tests

```bash
source venv/bin/activate
python -m pytest tests/tools/test_patch_parser.py tests/tools/test_file_tools.py -q
# 58 passed
```

### Pre-fix verification (proves the bug exists)

Temporarily strip the Phase 0 block and re-run the new tests — all 4 fail with the exact buggy behavior:

```
FAILED tests/tools/test_patch_parser.py::TestEmptyOperationsRejected::test_empty_operations_returns_failure
FAILED tests/tools/test_patch_parser.py::TestEmptyOperationsRejected::test_empty_operations_error_mentions_markers
FAILED tests/tools/test_patch_parser.py::TestEmptyOperationsRejected::test_empty_operations_error_redirects_to_replace_mode
FAILED tests/tools/test_patch_parser.py::TestEmptyOperationsRejected::test_parse_then_apply_bare_diff_returns_failure

E   assert True is False
E    +  where True = PatchResult(success=True, diff='', files_modified=[], ...).success
```

### End-to-end manual test (through the real `patch_tool` dispatch)

Confirmed the fix surfaces correctly through the actual tool the agent calls:

```python
from tools.file_tools import patch_tool

# Bug shape — bare diff, no V4A markers, path passed as arg
result = patch_tool(mode="patch", path="/tmp/page.md",
                    patch="@@\n-Line B\n+Line B updated\n")
# Pre-fix:  {"success": true, "files_modified": []}  ← silent failure
# Post-fix: {"success": false, "error": "Patch contained no operations
#            (no files modified). V4A patch bodies must include at least
#            one file-operation marker: *** Update File: <path> ..."}
```

Other scenarios verified through the same dispatch path:
- **Well-formed V4A patch** (`*** Begin Patch / *** Update File: <path> / *** End Patch`) — still succeeds, file written, diff returned.
- **`mode='replace'`** (the recommended alternative for simple cases) — unchanged, still succeeds.
- **Empty patch string** — still rejected at the existing `"patch content required"` guard.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit message follows [Conventional Commits](https://www.conventionalcommits.org/) — `fix(patch): hard-fail when V4A patch contains no file-operation markers`
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — no duplicate found
- [x] My PR contains **only** changes related to this fix (Phase 0 block + regression tests, nothing else)
- [x] I've run the test suite and all tests pass (29/29 patch_parser, 58/58 patch + file_tools)
- [x] I've added tests for my changes — `TestEmptyOperationsRejected`, 4 regression tests
- [x] I've tested on my platform: Ubuntu 24.04 (kernel 6.8)

### Documentation & Housekeeping

- [x] No documentation changes needed — error message itself is the user-facing change and is self-explanatory
- [x] No config keys changed — N/A
- [x] No architecture/workflow changes — N/A
- [x] Cross-platform impact considered — pure Python logic, no OS-specific paths, signals, or syscalls; behavior is identical on macOS / Linux / Windows
- [x] No tool description/schema changes — the bug is in apply behavior, not tool surface

## Behavior change note for reviewers

Callers that were previously getting silent `success=True` with empty `files_modified` now get `success=False` with the new error message. The pre-fix behavior was already broken (no files written), so this surfaces an existing bug rather than introducing new failures. Any caller relying on the silent-success was already shipping a no-op.
