### PR TITLE
fix(conversation-loop): bail on preflight compression cascade saturation

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -499,6 +499,7 @@ def run_conversation(
             )
             # May need multiple passes for very large sessions with small
             # context windows (each pass summarises the middle N turns).
+            _preflight_saturated = False
             for _pass in range(3):
                 _orig_len = len(messages)
                 messages, active_system_prompt = agent._compress_context(
@@ -506,7 +507,13 @@ def run_conversation(
                     task_id=effective_task_id,
                 )
                 if len(messages) >= _orig_len:
-                    break  # Cannot compress further
+                    # Compression returned the same (or more) messages —
+                    # we entered the block because tokens >= threshold AND
+                    # this pass didn't help, so we're still over threshold
+                    # with no path forward. Mark saturated so the
+                    # post-loop bailout fires.
+                    _preflight_saturated = True
+                    break
                 # Compression created a new session — clear the history
                 # reference so _flush_messages_to_session_db writes ALL
                 # compressed messages to the new session's SQLite, not
@@ -531,6 +538,57 @@ def run_conversation(
                 )
                 if _preflight_tokens < agent.context_compressor.threshold_tokens:
                     break  # Under threshold
+            else:
+                # ``for…else`` runs only when the loop completes without
+                # break. That means three full compression passes ran AND
+                # the under-threshold break never fired on the last pass —
+                # tokens are still ≥ threshold after the maximum cascade.
+                _preflight_saturated = True
+
+            # Cascade-saturation bailout: when preflight cannot get under
+            # threshold within the 3-pass cap, the first API call in the
+            # main loop is structurally doomed — the model server will
+            # return context-overflow, the post-API recovery chain will
+            # also saturate, and run_conversation will eventually return
+            # ``compression_exhausted=True`` after wasting 4+ seconds of
+            # doomed work + spawning more transient compression-only
+            # sessions in the chain. Return the same structured error
+            # immediately so callers (oneshot, gateway, kanban) see a
+            # clean failure result at session start instead.
+            if _preflight_saturated:
+                logger.warning(
+                    "Preflight compression saturated: %d-pass cascade "
+                    "could not get under %s threshold (final estimate ~%s tokens). "
+                    "Bailing before doomed first API call.",
+                    _pass + 1,
+                    f"{agent.context_compressor.threshold_tokens:,}",
+                    f"{_preflight_tokens:,}",
+                )
+                agent._emit_warning(
+                    f"⚠ Preflight compression saturated — context is "
+                    f"~{_preflight_tokens:,} tokens after "
+                    f"{_pass + 1} compression pass(es), still over the "
+                    f"{agent.context_compressor.threshold_tokens:,}-token "
+                    "threshold. Cannot fit this conversation into the "
+                    "current model's window. Try /new to start fresh, "
+                    "a longer-context model, or a smaller prompt."
+                )
+                agent._persist_session(messages, conversation_history)
+                return {
+                    "messages": messages,
+                    "completed": False,
+                    "api_calls": 0,
+                    "error": (
+                        f"Preflight compression saturated: ~{_preflight_tokens:,} "
+                        f"tokens still exceeds "
+                        f"{agent.context_compressor.threshold_tokens:,}-token "
+                        f"threshold after {_pass + 1} compression pass(es). "
+                        "Conversation cannot fit in this model's context window."
+                    ),
+                    "partial": True,
+                    "failed": True,
+                    "compression_exhausted": True,
+                }
 
     # Plugin hook: pre_llm_call
     # Fired once per turn before the tool-calling loop.  Plugins can

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -444,10 +444,19 @@ class TestPreflightCompression:
     def test_preflight_compresses_oversized_history(self, agent):
         """When loaded history exceeds the model's context threshold, compress before API call."""
         agent.compression_enabled = True
-        # Set a small context so the history is "oversized", but large enough
-        # that the compressed result (2 short messages) fits in a single pass.
+        # Set a small context so the history is "oversized", but the
+        # threshold must be high enough that the post-compression
+        # estimate (~257 tokens with tool schemas + 2 short messages)
+        # genuinely lands under it. Otherwise the new cascade-saturation
+        # bailout (test_preflight_cascade_saturation.py) fires instead
+        # of the under-threshold break, and preflight returns a
+        # structured failed result before any API call happens. The
+        # original 200-token threshold was implicitly relying on
+        # Hermes attempting a doomed API call past the still-oversized
+        # post-compression tape; that scenario is now the bailout, not
+        # this success path.
         agent.context_compressor.context_length = 2000
-        agent.context_compressor.threshold_tokens = 200
+        agent.context_compressor.threshold_tokens = 500
 
         # Build a history that will be large enough to trigger preflight
         # (each message ~50 chars ≈ 13 tokens, 40 messages ≈ 520 tokens > 200 threshold)

--- a/tests/run_agent/test_preflight_cascade_saturation.py
+++ b/tests/run_agent/test_preflight_cascade_saturation.py
@@ -1,0 +1,314 @@
+"""Pin the cascade-saturation bailout in preflight compression.
+
+When a session's pre-API-call token estimate exceeds the compression
+threshold AND the 3-pass preflight cascade can't get back under,
+``run_conversation`` used to silently continue into the main while loop
+— at which point the first API call would return context-overflow,
+the post-API recovery chain would also saturate, the function would
+return ``compression_exhausted=True`` after wasting 4+ seconds of
+doomed work, and (per oneshot.py's bug A) wrappers would never see the
+error.
+
+Audit of one user's ``~/.hermes/state.db`` found 103 incidents in 20
+days (76 in the last 24h) with this exact fingerprint on the
+qwen3.6-35b-a3b model: compression chain depth = exactly 3 (the
+``range(3)`` cap), parent session ``api_call_count = 0`` AND
+``message_count = 0`` (a transient compression-only stub), then a
+child session with messages bulk-loaded and the process dying before
+any new API call.
+
+After this fix, the preflight loop sets a ``_preflight_saturated``
+flag in two cases:
+
+1. ``len(messages) >= _orig_len`` after a ``_compress_context`` call —
+   compression made no progress, we know we're still over threshold
+   (we entered the block precisely because we were).
+2. The 3-pass ``for`` loop completes without ever hitting the
+   under-threshold break (``for ... else`` clause).
+
+When the flag is set, ``run_conversation`` returns a structured
+failed-result dict immediately (same shape as the existing
+post-API-call compression-exhausted return paths) so callers see a
+clean failure at session start instead of after the doomed first API
+call.
+"""
+
+import pytest
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from agent.context_compressor import SUMMARY_PREFIX
+from run_agent import AIAgent
+import run_agent
+
+
+@pytest.fixture(autouse=True)
+def _no_compression_sleep(monkeypatch):
+    """Short-circuit the 2s ``time.sleep`` between compression retries
+    so tests don't burn real wall-time."""
+    import time as _time
+    monkeypatch.setattr(_time, "sleep", lambda *_a, **_k: None)
+    monkeypatch.setattr(run_agent, "jittered_backoff", lambda *a, **k: 0.0)
+
+
+def _make_tool_defs(*names):
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": n,
+                "description": f"{n} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for n in names
+    ]
+
+
+@pytest.fixture()
+def agent():
+    """AIAgent fixture mirrors test_413_compression.py's setup so the
+    preflight code path runs through the same code without any real
+    network or DB hits."""
+    with (
+        patch("run_agent.get_tool_definitions",
+              return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        a.client = MagicMock()
+        a._cached_system_prompt = "You are helpful."
+        a._use_prompt_caching = False
+        a.tool_delay = 0
+        a.compression_enabled = True
+        a.save_trajectories = False
+        # Set a small context so a moderately-sized history triggers
+        # preflight, and a generous threshold so 3 passes are needed
+        # to exhaust the cap.
+        a.context_compressor.context_length = 2000
+        a.context_compressor.threshold_tokens = 200
+        return a
+
+
+def _make_big_history():
+    """40 messages large enough to push estimate over 200-token threshold."""
+    h = []
+    for i in range(20):
+        h.append({"role": "user",
+                   "content": f"Message number {i} with extra text padding"})
+        h.append({"role": "assistant",
+                   "content": f"Response number {i} with extra text padding"})
+    return h
+
+
+class TestPreflightCascadeSaturation:
+    """Bug B (this PR): preflight must bail with a structured
+    failed-result dict when 3 passes can't get under threshold."""
+
+    def test_compression_no_progress_triggers_bailout(self, agent):
+        """When ``_compress_context`` returns the same (or more)
+        messages, preflight should bail immediately on the first
+        pass rather than continuing into the main loop.
+        """
+        big_history = _make_big_history()
+
+        with (
+            # side_effect returns the INPUT messages unchanged so
+            # ``len(messages) >= _orig_len`` triggers the no-progress
+            # break on the very first pass. (Setting return_value to a
+            # fixed list of length 40 doesn't fire the break because
+            # the caller passes in 41 messages — history + the new
+            # user message.)
+            patch.object(
+                agent, "_compress_context",
+                side_effect=lambda msgs, sysm, **kw: (
+                    list(msgs), "still long system prompt",
+                ),
+            ) as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation(
+                "hello", conversation_history=big_history,
+            )
+
+        # Only one compress attempt should fire — the no-progress
+        # check breaks immediately.
+        assert mock_compress.call_count == 1, (
+            f"expected 1 compress attempt (no-progress break), "
+            f"got {mock_compress.call_count}"
+        )
+        # The API call must NEVER happen — the bailout returns before
+        # the main while loop.
+        agent.client.chat.completions.create.assert_not_called()
+        # Structured failed-result dict.
+        assert result["failed"] is True
+        assert result["partial"] is True
+        assert result["compression_exhausted"] is True
+        assert result["api_calls"] == 0
+        assert "Preflight compression saturated" in result["error"]
+        assert "1 compression pass" in result["error"]
+
+    def test_three_pass_exhaustion_triggers_bailout(self, agent):
+        """When all 3 passes reduce messages by a tiny amount but
+        never get under threshold, preflight should bail after the
+        third pass.
+        """
+        big_history = _make_big_history()
+
+        # Each compression pass shrinks by exactly 2 messages.
+        # 40 → 38 → 36 → 34, but the threshold logic is driven by the
+        # token estimate, which our patched estimate keeps "over" the
+        # threshold for all three passes.
+        compress_call_counter = {"n": 0}
+
+        def fake_compress(messages, system_message, **kwargs):
+            compress_call_counter["n"] += 1
+            return (messages[2:], "compressed prompt")
+
+        with (
+            patch.object(agent, "_compress_context",
+                          side_effect=fake_compress) as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            # Pin the post-compression estimate ABOVE the threshold so
+            # the under-threshold break never fires.
+            patch(
+                "agent.conversation_loop.estimate_request_tokens_rough",
+                return_value=300,  # > 200 threshold
+            ),
+        ):
+            result = agent.run_conversation(
+                "hello", conversation_history=big_history,
+            )
+
+        # All 3 passes should have run before the for-else bailout.
+        assert compress_call_counter["n"] == 3, (
+            f"expected exactly 3 compress attempts (for-else bailout), "
+            f"got {compress_call_counter['n']}"
+        )
+        # API call still never happens.
+        agent.client.chat.completions.create.assert_not_called()
+        assert result["failed"] is True
+        assert result["compression_exhausted"] is True
+        assert "3 compression pass" in result["error"]
+
+    def test_under_threshold_after_one_pass_does_not_bail(self, agent):
+        """Sanity: if the first pass gets under threshold, preflight
+        must NOT bail — the main while loop continues normally."""
+        big_history = _make_big_history()
+
+        from tests.run_agent.test_413_compression import _mock_response
+        agent.client.chat.completions.create.side_effect = [
+            _mock_response(content="OK", finish_reason="stop"),
+        ]
+
+        # Patch estimate_request_tokens_rough so the pre-compression
+        # estimate is over threshold (enters the preflight block) but
+        # the post-compression estimate is under threshold (the
+        # under-threshold break fires after exactly one pass). Without
+        # the patch, the tool-schema tokens push every estimate above
+        # 200, and saturation would fire instead.
+        estimate_calls = {"n": 0}
+
+        def fake_estimate(messages, **kwargs):
+            estimate_calls["n"] += 1
+            return 800 if estimate_calls["n"] == 1 else 50
+
+        with (
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch(
+                "agent.conversation_loop.estimate_request_tokens_rough",
+                side_effect=fake_estimate,
+            ),
+        ):
+            # Compress to a tiny tape (any length < input is enough,
+            # estimate patch decides the under-threshold break).
+            mock_compress.return_value = (
+                [
+                    {"role": "user",
+                      "content": f"{SUMMARY_PREFIX}\nPrior turn"},
+                    {"role": "user", "content": "hi"},
+                ],
+                "compressed prompt",
+            )
+            result = agent.run_conversation(
+                "hello", conversation_history=big_history,
+            )
+
+        # One compress call (under-threshold break fires immediately).
+        assert mock_compress.call_count == 1
+        # API call DOES happen.
+        agent.client.chat.completions.create.assert_called_once()
+        assert result["completed"] is True
+        assert result["final_response"] == "OK"
+        assert not result.get("compression_exhausted")
+
+    def test_bailout_persists_session_before_returning(self, agent):
+        """The bailout must call ``_persist_session`` so the partial
+        compressed-message tape isn't lost — same as the existing
+        post-API-call exhaustion return paths.
+        """
+        big_history = _make_big_history()
+
+        with (
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session") as mock_persist,
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            mock_compress.return_value = (
+                list(big_history), "no-progress prompt",
+            )
+            result = agent.run_conversation(
+                "hello", conversation_history=big_history,
+            )
+
+        # Must have persisted before the bailout return.
+        mock_persist.assert_called()
+        assert result["compression_exhausted"] is True
+
+    def test_bailout_emits_warning_to_status_callback(self, agent):
+        """The bailout must surface a human-readable warning via
+        ``agent._emit_warning`` so the gateway/CLI shows the operator
+        a real reason instead of an opaque failure.
+        """
+        big_history = _make_big_history()
+        warnings = []
+
+        # _emit_warning routes through emit_warning_callback, which
+        # falls back to printing if no callback set. Patch the agent's
+        # _emit_warning directly to capture.
+        with (
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(
+                agent, "_emit_warning",
+                side_effect=lambda msg: warnings.append(msg),
+            ),
+        ):
+            mock_compress.return_value = (
+                list(big_history), "still long",
+            )
+            agent.run_conversation(
+                "hello", conversation_history=big_history,
+            )
+
+        assert any(
+            "Preflight compression saturated" in w for w in warnings
+        ), f"expected a saturation warning, got {warnings!r}"


### PR DESCRIPTION
## Summary

When preflight compression's 3-pass cap can't get under threshold,
`run_conversation` used to continue into the main while loop and
attempt a doomed first API call — wasting 4+ seconds on
context-overflow → post-API compression-recovery → re-saturation, and
spawning 2-3 more transient compression-only session rows along the
way before eventually returning `compression_exhausted=True`.

Audit of one user's `~/.hermes/state.db` found **103 incidents** of
this fingerprint over 20 days (**76 in the last 24h**), all on
qwen3.6-35b-a3b at **compression-chain depth = exactly 3** — the
`range(3)` cap of the preflight loop. Recurring pattern:

```
session A (parent): api_call_count=0, message_count=0,
                    end_reason=compression  ← transient cascade-pass stub
session B (child) : api_call_count=0, message_count=11,
                    started ~2s after parent, process dies ~4s later
```

These are 100+ silent-exit incidents that the new
`hermes_silent_exit_no_stderr` classifier (paired with the upstream
oneshot stderr fix in #31505) now surfaces, but the underlying
saturation pathology was still firing every dispatch.

## Changes

- `agent/conversation_loop.py`:
  - Add `_preflight_saturated` flag set to True when:
    1. `_compress_context` returns `len(messages) >= _orig_len` —
       compression made no progress, but we entered the block
       precisely because tokens were over threshold, so we're still
       over with no way forward (the existing "Cannot compress
       further" break path).
    2. The `for ... else` clause runs — all 3 passes completed
       without the under-threshold break ever firing.
  - When saturated, emit a `_emit_warning` for the operator,
    `_persist_session` to preserve the partial compressed-message
    tape, and return a structured failed-result dict
    (`failed=True, partial=True, compression_exhausted=True`, plus a
    descriptive `error` string) — same shape as the existing
    post-API-call `compression_exhausted` returns at lines
    2583/2614/2667/2741/2774.
  - The doomed first API call never happens; the cascade chain stops
    at the first failure instead of growing 2-3 more transient
    session rows.

- `tests/run_agent/test_preflight_cascade_saturation.py` (new, 5
  tests):
  - `test_compression_no_progress_triggers_bailout` — first-pass
    no-progress break sets the flag, bailout fires.
  - `test_three_pass_exhaustion_triggers_bailout` — three passes,
    each shrinking by 2 messages, never under threshold, `for…else`
    fires.
  - `test_under_threshold_after_one_pass_does_not_bail` — sanity:
    successful compression still proceeds to API call.
  - `test_bailout_persists_session_before_returning` — partial tape
    is flushed to SQLite before the bailout return.
  - `test_bailout_emits_warning_to_status_callback` — operator-
    visible warning fires.

- `tests/run_agent/test_413_compression.py`:
  - Update `test_preflight_compresses_oversized_history` to set
    `threshold_tokens = 500` (was 200). The original 200-token
    threshold was implicitly relying on the post-compression
    tool-schema estimate (~257 tokens) still being "over" — which
    the new code correctly identifies as saturation. The success
    path needs the threshold high enough that compressed tokens
    genuinely land under it.

## Test plan

```
pytest tests/run_agent/test_preflight_cascade_saturation.py   # 5 passed
pytest tests/run_agent/test_413_compression.py \
       tests/run_agent/test_1630_context_overflow_loop.py     # 36 passed
pytest tests/run_agent/ -q                                    # 648/651
                                                              # (1 pre-existing
                                                              # test-order failure
                                                              # in test_provider_parity,
                                                              # unrelated)
```

## Companion PR

Pairs with #31505 (`fix(oneshot): surface structured agent failures
to stderr with rc=1`). With both landed:

1. This PR stops the cascade-saturation from happening in the first
   place — first-pass no-progress or 3-pass exhaustion both bail
   immediately with a structured error.
2. #31505 makes that structured error visible to wrappers (oneshot
   mode currently swallows it).

Together they convert the 100+ silent-rc=1-empty-stderr incidents
into clean exit-1-with-clear-stderr signals AND avoid the 4+ seconds
of doomed work that produced the transient compression-only session
rows in the first place.
