### PR TITLE
fix(run_agent): clamp _last_flushed_db_idx after scaffolding drop (#31507)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1174,6 +1174,13 @@ class AIAgent:
         Ensures conversations are never lost, even on errors or early returns.
         """
         self._drop_trailing_empty_response_scaffolding(messages)
+        # Scaffolding drop can pop messages already counted in
+        # _last_flushed_db_idx. Clamp so the next flush's
+        # ``messages[flush_from:]`` slice isn't empty and silently skip every
+        # newly-appended message (e.g. the final assistant response). See
+        # #31507.
+        if self._last_flushed_db_idx > len(messages):
+            self._last_flushed_db_idx = len(messages)
         self._apply_persist_user_message_override(messages)
         self._session_messages = messages
         self._save_session_log(messages)

--- a/tests/run_agent/test_empty_response_recovery_persistence.py
+++ b/tests/run_agent/test_empty_response_recovery_persistence.py
@@ -9,6 +9,7 @@ def _agent_with_stubbed_persistence():
     agent._persist_user_message_override = None
     agent._session_db = None
     agent._session_messages = []
+    agent._last_flushed_db_idx = 0
     agent.flushed_session_db_messages = []
     agent._flush_messages_to_session_db = lambda messages, conversation_history=None: (
         agent.flushed_session_db_messages.append([m.copy() for m in messages])
@@ -92,3 +93,88 @@ def test_persist_session_strips_marked_terminal_empty_sentinel():
     assert messages == [{"role": "user", "content": "continue"}]
     assert agent.flushed_session_db_messages[-1] == messages
     assert all(not msg.get("_empty_terminal_sentinel") for msg in messages)
+
+
+def test_persist_session_clamps_flush_idx_after_scaffolding_drop():
+    """Regression for #31507.
+
+    An intermediate _persist_session that flushed while scaffolding was still
+    present in ``messages`` leaves ``_last_flushed_db_idx`` at the pre-drop
+    length. A later call drops the scaffolding (shrinking the list) and then
+    must still flush newly-appended messages — without the clamp,
+    ``messages[flush_from:]`` is empty and the final assistant response is
+    silently lost.
+    """
+    agent = _agent_with_stubbed_persistence()
+
+    # Simulate the previous flush that wrote the user + scaffolding tail
+    # (4 messages total). The flush index was advanced to that length.
+    agent._last_flushed_db_idx = 4
+
+    # After the scaffolding got dropped and a new assistant turn was appended,
+    # the list is now shorter than _last_flushed_db_idx.
+    messages = [
+        {"role": "user", "content": "run the task"},
+        {"role": "assistant", "content": "final response"},
+    ]
+
+    AIAgent._persist_session(agent, messages, conversation_history=[])
+
+    # The clamp must have happened so the next flush observes the real length.
+    assert agent._last_flushed_db_idx <= len(messages)
+    # And the final assistant must have reached the flush path.
+    assert agent.flushed_session_db_messages[-1] == messages
+
+
+def test_persist_session_flushes_new_assistant_after_scaffolding_drop_integration():
+    """End-to-end regression for #31507 using a real SessionDB.
+
+    Mirrors the production trigger: an intermediate flush writes a scaffolded
+    tail; a later _persist_session drops the scaffolding and appends a real
+    assistant response; that response must land in the DB.
+    """
+    import os
+    import tempfile
+    from pathlib import Path
+    from unittest.mock import patch
+
+    from hermes_state import SessionDB
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db = SessionDB(db_path=Path(tmpdir) / "test.db")
+
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+            agent = AIAgent(
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+                model="test/model",
+                quiet_mode=True,
+                session_db=db,
+                session_id="test-31507",
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        agent._ensure_db_session()
+
+        # Intermediate persist with scaffolding still in messages — gets flushed.
+        messages = [
+            {"role": "user", "content": "run the task"},
+            {
+                "role": "assistant",
+                "content": "(empty)",
+                "_empty_terminal_sentinel": True,
+            },
+        ]
+        agent._flush_messages_to_session_db(messages, conversation_history=[])
+        assert agent._last_flushed_db_idx == 2
+
+        # A later turn appends the real assistant response. _persist_session
+        # drops the sentinel then must still flush the new assistant.
+        messages.append({"role": "assistant", "content": "real response"})
+        agent._persist_session(messages, conversation_history=[])
+
+        rows = db.get_messages(agent.session_id)
+        contents = [r["content"] for r in rows]
+        assert "real response" in contents, (
+            f"final assistant lost (regression of #31507): got {contents}"
+        )


### PR DESCRIPTION
## Summary

`_persist_session` runs `_drop_trailing_empty_response_scaffolding` before `_flush_messages_to_session_db`. If an earlier intermediate flush advanced `_last_flushed_db_idx` to a length that included the scaffolding tail, the drop leaves the index strictly greater than `len(messages)`. The next flush computes `flush_from = max(start_idx, _last_flushed_db_idx) >= len(messages)`, slices `messages[flush_from:]` to empty, and silently writes nothing — including any final assistant response appended after the drop. CLI sessions that reuse the same `AIAgent` across turns are the common trigger, which is why state.db loses assistant rows while the WebUI mirror keeps the full transcript.

## Fix

Resetting `flush_from` to `start_idx` (as the report suggested) would re-flush messages already persisted, so instead clamp `_last_flushed_db_idx` down to `len(messages)` right after the scaffolding drop. New messages appended on the next turn are then flushed exactly once — preserving the #860 dedup invariant.

- `run_agent.py`: clamp `_last_flushed_db_idx` after `_drop_trailing_empty_response_scaffolding`
- `tests/run_agent/test_empty_response_recovery_persistence.py`: two new regression tests (one direct, one end-to-end against a real `SessionDB`); existing stub fixture updated to seed the new attribute it now reads

## Test plan

- [x] `pytest tests/run_agent/test_empty_response_recovery_persistence.py` — 5 passed (2 existing + 3 new)
- [x] `pytest tests/run_agent/test_860_dedup.py tests/run_agent/test_compression_persistence.py tests/run_agent/test_message_sequence_repair.py tests/run_agent/test_413_compression.py` — 40 passed (dedup / compression / repair invariants unchanged)
- [x] `pytest tests/cli/test_branch_command.py tests/cli/test_cli_new_session.py` — 23 passed (other `_last_flushed_db_idx` consumers unaffected)

Fixes #31507