### PR TITLE
fix(gateway): skip edit_message when stream consumer carries __no_edit__ sentinel

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17696,7 +17696,7 @@ class GatewayRunner:
                 # Plugin hooks transformed the response after streaming — edit the
                 # existing streamed message instead of sending a duplicate.
                 _sc_msg_id = _sc.message_id
-                if _sc_msg_id:
+                if _sc_msg_id and _sc_msg_id != "__no_edit__":
                     try:
                         await _sc.adapter.edit_message(
                             chat_id=source.chat_id,


### PR DESCRIPTION
## Summary

When a platform accepts a streamed message but does not return an editable message id (e.g. platforms without edit support), `StreamConsumer` sets `self._message_id = "__no_edit__"` as a sentinel.

The `response_transformed` delivery gate in `run_sync` checked the message id for truthiness only — `"__no_edit__"` is a non-empty string, so it passed the guard. `edit_message` was then called with the literal string `"__no_edit__"` as the message id:

- **Telegram**: tries `int("__no_edit__")` → `ValueError`
- Other platforms: reject the unknown id with their own error

The exception is caught and logged, but `already_sent` is **never set** on the except path. The delivery gate therefore falls through to the normal send, producing a **duplicate message** for every plugin-transformed reply on any platform that doesn't support message editing.

## Root cause

```python
# run.py — before fix
_sc_msg_id = _sc.message_id        # == "__no_edit__"  (truthy!)
if _sc_msg_id:                      # passes — BUG
    await _sc.adapter.edit_message(
        message_id=_sc_msg_id,      # "__no_edit__" reaches the platform
        ...
    )
    response["already_sent"] = True # only reached on success
# except path does NOT set already_sent → normal send runs → duplicate
```

## Fix

```python
if _sc_msg_id and _sc_msg_id != "__no_edit__":
```

One-line change: filter the sentinel before attempting the edit. When the sentinel is present the `elif` branch is skipped entirely, `already_sent` stays unset, and the normal final-response send runs exactly once — no duplicate.

## Test plan

- [x] `tests/gateway/` suite: 313 passed, 1 skipped
- [x] `tests/gateway/test_active_session_text_merge.py`: 16/16 passed
- [x] `grep -n "__no_edit__" gateway/run.py` — sentinel guard present only at the patched line; no other callers