### PR TITLE
docs(skills): document media path allowlist requirement

### DIFF
--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -113,6 +113,40 @@ When a skill response (or any agent response) includes a bare absolute path to a
 
 For audio specifically, the `[[audio_as_voice]]` directive promotes audio files to native voice-message bubbles on platforms that support them (Telegram, WhatsApp).
 
+### Understanding the media path allowlist
+
+By default, the gateway only delivers media files that live inside Hermes-managed cache directories:
+
+```
+~/.hermes/audio_cache/
+~/.hermes/image_cache/
+~/.hermes/video_cache/
+~/.hermes/document_cache/
+~/.hermes/cache/audio/
+~/.hermes/cache/images/
+~/.hermes/browser_screenshots/
+```
+
+Files placed anywhere else — for example `~/my-audio.wav` or `/tmp/screenshot.png` — are silently dropped during delivery. The visible text still goes through, but the attachment disappears with only a debug-level logger warning to show for it.
+
+This restriction exists as a security measure. `MEDIA:` tags in LLM output are untrusted text; without a path allowlist, a malicious prompt could inject `MEDIA:/etc/passwd` and cause Hermes to exfiltrate arbitrary system files.
+
+**Two ways to use a custom output path:**
+
+**Option A — Output directly to a Hermes cache directory:**
+```
+--output ~/.hermes/audio_cache/my-clip.wav
+```
+Send with `MEDIA:~/.hermes/audio_cache/my-clip.wav`. No extra configuration needed.
+
+**Option B — Authorize a custom directory** by setting an environment variable:
+```
+HERMES_MEDIA_ALLOW_DIRS=/path/to/your/dir
+```
+Add it to `~/.hermes/.env` and restart the gateway. Multiple directories can be listed separated by commas (or `;` on Windows).
+
+**Always verify delivery** by sending a test message with the file before assuming it worked.
+
 ### Forcing document-style delivery: `[[as_document]]`
 
 Sometimes you want the **opposite** of inline preview: you want the file delivered as a downloadable attachment, not a re-compressed image bubble. The classic example is a high-resolution screenshot or chart — Telegram's `sendPhoto` recompresses it to ~200 KB at 1280 px, destroying readability. A 1-2 MB PNG sent via `sendDocument` keeps the original bytes intact.


### PR DESCRIPTION
## Summary

Clarifies that `MEDIA:` directive paths must live inside Hermes-managed cache directories or be explicitly allowlisted via `HERMES_MEDIA_ALLOW_DIRS`. Files outside the allowlist are silently dropped during delivery.

## Problem

Skills and agents that generate media files to arbitrary paths (e.g. `~/my-audio.wav`, `/tmp/screenshot.png`) appear to succeed — the text response goes through, but the attachment never arrives. There is no visible error, only a debug-level logger warning.

This is a documentation gap following the security fix in [PR #30432](https://github.com/NousResearch/hermes-agent/pull/30432) / [GHSA-jmf9-9729-7pp8](https://github.com/NousResearch/hermes-agent/security/advisories/GHSA-jmf9-9729-7pp8) (merged 2026-05-22), which introduced `validate_media_delivery_path()` to block arbitrary file read via `MEDIA:` tag path traversal. The security logic is correct but user-facing docs never documented the allowlist behaviour.

## Related issues

- [GHSA-jmf9-9729-7pp8](https://github.com/NousResearch/hermes-agent/security/advisories/GHSA-jmf9-9729-7pp8) / [#29150](https://github.com/NousResearch/hermes-agent/issues/29150) — Security advisory: arbitrary file read via unsanitized MEDIA tag path. Root cause of the silent-drop behaviour.
- [#6249](https://github.com/NousResearch/hermes-agent/issues/6249) — Telegram MEDIA image delivery echoes local file path as text instead of uploading attachment. User-visible symptom of the same root cause.
- [#16720](https://github.com/NousResearch/hermes-agent/issues/16720) — Gateway auto-appends MEDIA tags from arbitrary tool results. Related extraction-over-matching concern in the same MEDIA path handling area.

## What changed

Added a new subsection **Understanding the media path allowlist** to `website/docs/user-guide/features/skills.md` covering:

- Default safe roots (Hermes cache dirs)
- The security rationale (preventing `MEDIA:/etc/passwd` injection)
- Option A: output directly to a Hermes cache directory
- Option B: set `HERMES_MEDIA_ALLOW_DIRS` in `.env`
- Verification tip (always send a test message after generating)