### PR TITLE
fix(tui): prefer OSC52 for copy in remote tmux sessions

### DIFF
--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -4,9 +4,13 @@ import { createSlashHandler } from '../app/createSlashHandler.js'
 import { getOverlayState, resetOverlayState } from '../app/overlayStore.js'
 import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
 import { TUI_SESSION_MODEL_FLAG } from '../domain/slash.js'
+import * as ClipboardModule from '../lib/clipboard.js'
+import * as Osc52Module from '../lib/osc52.js'
+import * as TerminalSetupModule from '../lib/terminalSetup.js'
 
 describe('createSlashHandler', () => {
   beforeEach(() => {
+    vi.restoreAllMocks()
     resetOverlayState()
     resetUiState()
   })
@@ -147,6 +151,51 @@ describe('createSlashHandler', () => {
       session_id: 'sid-abc',
       value: 'x-model --global'
     })
+  })
+
+  it('prefers OSC52 copy for remote sessions', async () => {
+    const writeClipboardText = vi.spyOn(ClipboardModule, 'writeClipboardText').mockResolvedValue(true)
+    const writeOsc52Clipboard = vi.spyOn(Osc52Module, 'writeOsc52Clipboard').mockReturnValue(true)
+    vi.spyOn(TerminalSetupModule, 'isRemoteShellSession').mockReturnValue(true)
+
+    const ctx = buildCtx({
+      local: {
+        ...buildLocal(),
+        getHistoryItems: vi.fn(() => [{ role: 'assistant', text: 'remote answer' }])
+      }
+    })
+
+    expect(createSlashHandler(ctx)('/copy')).toBe(true)
+    await vi.waitFor(() => {
+      expect(writeOsc52Clipboard).toHaveBeenCalledWith('remote answer')
+    })
+    expect(writeClipboardText).not.toHaveBeenCalled()
+    expect(ctx.transcript.sys).toHaveBeenCalledWith('sent OSC52 copy sequence (terminal support required)')
+  })
+
+  it('keeps native-first copy in local tmux sessions', async () => {
+    const tmuxBackup = process.env.TMUX
+    process.env.TMUX = '/tmp/tmux-123/default,1,0'
+
+    const writeClipboardText = vi.spyOn(ClipboardModule, 'writeClipboardText').mockResolvedValue(true)
+    const writeOsc52Clipboard = vi.spyOn(Osc52Module, 'writeOsc52Clipboard').mockReturnValue(true)
+    vi.spyOn(TerminalSetupModule, 'isRemoteShellSession').mockReturnValue(false)
+
+    const ctx = buildCtx({
+      local: {
+        ...buildLocal(),
+        getHistoryItems: vi.fn(() => [{ role: 'assistant', text: 'local answer' }])
+      }
+    })
+
+    expect(createSlashHandler(ctx)('/copy')).toBe(true)
+    await vi.waitFor(() => {
+      expect(writeClipboardText).toHaveBeenCalledWith('local answer')
+    })
+    expect(writeOsc52Clipboard).not.toHaveBeenCalled()
+    expect(ctx.transcript.sys).toHaveBeenCalledWith('copied to clipboard')
+
+    process.env.TMUX = tmuxBackup
   })
 
   it('applies /reasoning hide to the thinking section immediately', async () => {

--- a/ui-tui/src/__tests__/osc52.test.ts
+++ b/ui-tui/src/__tests__/osc52.test.ts
@@ -4,7 +4,8 @@ import {
   buildOsc52ClipboardQuery,
   OSC52_CLIPBOARD_QUERY,
   parseOsc52ClipboardData,
-  readOsc52Clipboard
+  readOsc52Clipboard,
+  writeOsc52Clipboard
 } from '../lib/osc52.js'
 
 const envBackup = { ...process.env }
@@ -63,5 +64,36 @@ describe('readOsc52Clipboard', () => {
     const send = vi.fn().mockResolvedValue(undefined)
     const flush = vi.fn().mockResolvedValue(undefined)
     await expect(readOsc52Clipboard({ flush, send })).resolves.toBeNull()
+  })
+})
+
+describe('writeOsc52Clipboard', () => {
+  it('wraps writes for tmux passthrough', () => {
+    process.env.TMUX = '/tmp/tmux-123/default,1,0'
+    delete process.env.STY
+
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true as any)
+    writeOsc52Clipboard('hello')
+
+    expect(write).toHaveBeenCalledTimes(1)
+    const seq = String(write.mock.calls[0]?.[0] ?? '')
+    expect(seq).toContain('\x1bPtmux;')
+    expect(seq).toContain(']52;c;')
+
+    write.mockRestore()
+  })
+
+  it('keeps raw OSC52 outside multiplexers', () => {
+    delete process.env.TMUX
+    delete process.env.STY
+
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true as any)
+    writeOsc52Clipboard('hello')
+
+    expect(write).toHaveBeenCalledTimes(1)
+    const seq = String(write.mock.calls[0]?.[0] ?? '')
+    expect(seq.startsWith('\x1b]52;c;')).toBe(true)
+
+    write.mockRestore()
   })
 })

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -15,7 +15,11 @@ import type {
 } from '../../../gatewayTypes.js'
 import { writeClipboardText } from '../../../lib/clipboard.js'
 import { writeOsc52Clipboard } from '../../../lib/osc52.js'
-import { configureDetectedTerminalKeybindings, configureTerminalKeybindings } from '../../../lib/terminalSetup.js'
+import {
+  configureDetectedTerminalKeybindings,
+  configureTerminalKeybindings,
+  isRemoteShellSession
+} from '../../../lib/terminalSetup.js'
 import type { Msg, PanelSection } from '../../../types.js'
 import type { StatusBarMode } from '../../interfaces.js'
 import { patchOverlayState } from '../../overlayStore.js'
@@ -371,6 +375,13 @@ export const coreCommands: SlashCommand[] = [
 
       if (!target) {
         return sys('nothing to copy — start a conversation first')
+      }
+
+      const shouldUseTerminalClipboard = process.env['TMUX'] || process.env['STY'] || isRemoteShellSession(process.env)
+
+      if (shouldUseTerminalClipboard) {
+        writeOsc52Clipboard(target.text)
+        return sys('sent OSC52 copy sequence (terminal support required)')
       }
 
       void writeClipboardText(target.text)

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -377,7 +377,7 @@ export const coreCommands: SlashCommand[] = [
         return sys('nothing to copy — start a conversation first')
       }
 
-      const shouldUseTerminalClipboard = process.env['TMUX'] || process.env['STY'] || isRemoteShellSession(process.env)
+      const shouldUseTerminalClipboard = isRemoteShellSession(process.env)
 
       if (shouldUseTerminalClipboard) {
         writeOsc52Clipboard(target.text)

--- a/ui-tui/src/lib/osc52.ts
+++ b/ui-tui/src/lib/osc52.ts
@@ -69,5 +69,8 @@ export async function readOsc52Clipboard(querier: null | OscQuerier, timeoutMs =
   return response ? parseOsc52ClipboardData(response.data) : null
 }
 
-export const writeOsc52Clipboard = (s: string) =>
-  process.stdout.write(`\x1b]52;c;${Buffer.from(s, 'utf8').toString('base64')}\x07`)
+export const writeOsc52Clipboard = (s: string) => {
+  const sequence = `${ESC}]52;c;${Buffer.from(s, 'utf8').toString('base64')}${BEL}`
+
+  return process.stdout.write(wrapForMultiplexer(sequence))
+}


### PR DESCRIPTION
## Summary

- prefer terminal OSC52 for assistant-message `/copy` in SSH/tmux/screen sessions
- wrap OSC52 clipboard writes for tmux/screen using the existing multiplexer helper
- keep native clipboard backends for local non-remote sessions

Closes #31528

## Why

In remote terminal chains such as:

```text
local iTerm2 → ssh → tmux → sudo/su to another user → hermes --tui
```

`/copy` should update the user's local terminal clipboard. Native clipboard commands like `pbcopy` run on the remote host/user and may report success while leaving the local clipboard unchanged.

In the tested setup, raw OSC52 through tmux did not reach iTerm2, while DCS passthrough OSC52 did. `buildOsc52ClipboardQuery()` already used `wrapForMultiplexer()` for reads; this PR applies the same wrapping to writes.

## Test plan

- `npm --prefix ui-tui test -- osc52`
- `npm --prefix ui-tui run build`
- manual verification in `Air iTerm2 → ssh serpo@studio → tmux → sudo -u shag with TMUX/SSH env preserved → hermes --tui`: `/copy 1` updates the Air clipboard with clean assistant text

## Related

Related: #15664 / #15856.

This PR addresses the same `/copy` clipboard area, but for the TUI path rather than the legacy Python CLI path. #15856 adds native clipboard fallback for terminals that do not support OSC52, while this PR fixes the opposite remote/tmux case where native clipboard helpers run on the remote host and can report success without updating the user's local clipboard. Both fixes are complementary.

