### PR TITLE
feat: add simple credential broker

### DIFF
--- a/agent/credential_broker.py
+++ b/agent/credential_broker.py
@@ -1,0 +1,202 @@
+"""Small policy-gated credential broker for tool subprocesses.
+
+This module is intentionally narrow: it lets tools request named credentials
+from existing Hermes sources without teaching tools to read ~/.hermes/.env or
+other secret stores directly. The first supported source is ``env`` so the
+feature can be adopted incrementally without introducing a new secret backend.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shlex
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any, Iterator, Mapping, Sequence
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class BrokeredCredential:
+    """A resolved credential value plus non-secret metadata."""
+
+    name: str
+    value: str
+    env_name: str
+    source: str = "env"
+
+    @property
+    def forced_env_name(self) -> str:
+        """Return the internal env override name used by terminal backends."""
+
+        return f"_HERMES_FORCE_{self.env_name}"
+
+
+def _load_config() -> dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        return load_config() or {}
+    except Exception:
+        logger.debug("credential broker: failed to load config", exc_info=True)
+        return {}
+
+
+def _broker_config(config: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    cfg = dict(config or _load_config())
+    credentials = cfg.get("credentials") or {}
+    if not isinstance(credentials, Mapping):
+        return {}
+    broker = credentials.get("broker") or {}
+    return dict(broker) if isinstance(broker, Mapping) else {}
+
+
+def is_enabled(config: Mapping[str, Any] | None = None) -> bool:
+    """Return whether the optional credential broker is enabled."""
+
+    broker = _broker_config(config)
+    return bool(broker.get("enabled", False))
+
+
+def _requested_executable(command: str | None) -> str:
+    if not command:
+        return ""
+    try:
+        parts = shlex.split(command, posix=(os.name != "nt"))
+    except ValueError:
+        return ""
+    if not parts:
+        return ""
+    return os.path.basename(parts[0])
+
+
+def _as_str_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        return [str(item) for item in value if item]
+    return []
+
+
+def _is_allowed(secret_cfg: Mapping[str, Any], *, requester: str, command: str | None) -> bool:
+    allow = secret_cfg.get("allow") or {}
+    if not isinstance(allow, Mapping) or not allow:
+        return False
+
+    tools = set(_as_str_list(allow.get("tools")))
+    commands = set(_as_str_list(allow.get("commands")))
+    if not tools and not commands:
+        return False
+
+    if tools and requester not in tools:
+        return False
+
+    if commands:
+        executable = _requested_executable(command)
+        if executable not in commands:
+            return False
+
+    return True
+
+
+class CredentialBrokerError(RuntimeError):
+    """Raised when brokered credential resolution is denied or unavailable."""
+
+
+def resolve(
+    name: str,
+    *,
+    requester: str,
+    command: str | None = None,
+    config: Mapping[str, Any] | None = None,
+) -> BrokeredCredential:
+    """Resolve one named credential if broker config and policy allow it.
+
+    Supported config shape::
+
+        credentials:
+          broker:
+            enabled: true
+            secrets:
+              github_token:
+                source: env
+                name: GITHUB_TOKEN
+                allow:
+                  tools: [terminal]
+                  commands: [gh]
+    """
+
+    broker = _broker_config(config)
+    if not broker.get("enabled", False):
+        raise CredentialBrokerError("credential broker is disabled")
+
+    secrets = broker.get("secrets") or {}
+    if not isinstance(secrets, Mapping) or name not in secrets:
+        raise CredentialBrokerError(f"credential {name!r} is not configured")
+
+    secret_cfg = secrets[name]
+    if not isinstance(secret_cfg, Mapping):
+        raise CredentialBrokerError(f"credential {name!r} has invalid configuration")
+
+    source = str(secret_cfg.get("source") or "env")
+    if source != "env":
+        raise CredentialBrokerError(
+            f"credential {name!r} uses unsupported source {source!r}; only 'env' is supported"
+        )
+
+    env_name = str(secret_cfg.get("name") or "").strip()
+    if not env_name:
+        raise CredentialBrokerError(f"credential {name!r} is missing env variable name")
+
+    if not _is_allowed(secret_cfg, requester=requester, command=command):
+        raise CredentialBrokerError(f"credential {name!r} is not allowed for {requester}")
+
+    try:
+        from hermes_cli.config import get_env_value
+
+        value = get_env_value(env_name)
+    except Exception:
+        value = os.environ.get(env_name)
+    if not value:
+        raise CredentialBrokerError(f"credential {name!r} source env:{env_name} is not set")
+
+    return BrokeredCredential(name=name, value=value, env_name=env_name, source=source)
+
+
+def resolve_env_overrides(
+    names: Sequence[str] | None,
+    *,
+    requester: str,
+    command: str | None = None,
+    config: Mapping[str, Any] | None = None,
+) -> dict[str, str]:
+    """Resolve names into internal one-command environment overrides."""
+
+    overrides: dict[str, str] = {}
+    for name in names or []:
+        credential = resolve(str(name), requester=requester, command=command, config=config)
+        overrides[credential.forced_env_name] = credential.value
+    return overrides
+
+
+@contextmanager
+def scoped_env_overrides(env: dict[str, str], overrides: Mapping[str, str]) -> Iterator[None]:
+    """Temporarily add brokered env overrides to an environment object."""
+
+    if not overrides:
+        yield
+        return
+
+    sentinel = object()
+    previous: dict[str, str | object] = {key: env.get(key, sentinel) for key in overrides}
+    env.update({str(key): str(value) for key, value in overrides.items()})
+    try:
+        yield
+    finally:
+        for key, old_value in previous.items():
+            if old_value is sentinel:
+                env.pop(key, None)
+            else:
+                env[key] = str(old_value)

--- a/agent/credential_broker.py
+++ b/agent/credential_broker.py
@@ -10,10 +10,10 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import shlex
-from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Iterator, Mapping, Sequence
+from typing import Any, Mapping, Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -26,12 +26,6 @@ class BrokeredCredential:
     value: str
     env_name: str
     source: str = "env"
-
-    @property
-    def forced_env_name(self) -> str:
-        """Return the internal env override name used by terminal backends."""
-
-        return f"_HERMES_FORCE_{self.env_name}"
 
 
 def _load_config() -> dict[str, Any]:
@@ -60,16 +54,67 @@ def is_enabled(config: Mapping[str, Any] | None = None) -> bool:
     return bool(broker.get("enabled", False))
 
 
-def _requested_executable(command: str | None) -> str:
-    if not command:
-        return ""
+_SHELL_OPERATOR_CHARS = frozenset("();<>|&")
+
+
+def _contains_shell_execution_syntax(command: str) -> bool:
+    """Return whether *command* contains active Bash execution syntax."""
+
+    quote: str | None = None
+    escaped = False
+    for index, char in enumerate(command):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\" and quote != "'":
+            escaped = True
+            continue
+        if quote == "'":
+            if char == "'":
+                quote = None
+            continue
+        if char == '"':
+            quote = None if quote == '"' else '"'
+            continue
+        if quote == '"':
+            if char == "`" or (char == "$" and command[index : index + 2] == "$("):
+                return True
+            continue
+        if char == "'":
+            quote = "'"
+            continue
+        if char in _SHELL_OPERATOR_CHARS or char == "`":
+            return True
+        if char == "$" and command[index : index + 2] == "$(":
+            return True
+    return False
+
+
+def _parse_simple_command(command: str | None) -> list[str]:
+    """Parse one simple Bash command, rejecting active shell syntax.
+
+    Brokered credentials are inherited by the whole shell.  An allow rule for
+    ``gh`` therefore cannot safely authorize ``gh ...; other-command`` (or an
+    equivalent pipe/background/command-substitution form).
+    """
+    if not command or "\n" in command or "\r" in command:
+        return []
+    if _contains_shell_execution_syntax(command):
+        return []
     try:
-        parts = shlex.split(command, posix=(os.name != "nt"))
+        parts = shlex.split(command, posix=True, comments=False)
     except ValueError:
-        return ""
+        return []
+    return parts
+
+
+def canonicalize_command(command: str | None) -> str:
+    """Return a shell-safe canonical form of an accepted simple command."""
+
+    parts = _parse_simple_command(command)
     if not parts:
-        return ""
-    return os.path.basename(parts[0])
+        raise CredentialBrokerError("brokered credentials require one simple command")
+    return shlex.join(parts)
 
 
 def _as_str_list(value: Any) -> list[str]:
@@ -80,7 +125,9 @@ def _as_str_list(value: Any) -> list[str]:
     return []
 
 
-def _is_allowed(secret_cfg: Mapping[str, Any], *, requester: str, command: str | None) -> bool:
+def _is_allowed(
+    secret_cfg: Mapping[str, Any], *, requester: str, command: str | None
+) -> bool:
     allow = secret_cfg.get("allow") or {}
     if not isinstance(allow, Mapping) or not allow:
         return False
@@ -94,7 +141,8 @@ def _is_allowed(secret_cfg: Mapping[str, Any], *, requester: str, command: str |
         return False
 
     if commands:
-        executable = _requested_executable(command)
+        parts = _parse_simple_command(command)
+        executable = parts[0] if parts else ""
         if executable not in commands:
             return False
 
@@ -149,9 +197,15 @@ def resolve(
     env_name = str(secret_cfg.get("name") or "").strip()
     if not env_name:
         raise CredentialBrokerError(f"credential {name!r} is missing env variable name")
+    if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", env_name):
+        raise CredentialBrokerError(
+            f"credential {name!r} has invalid env variable name"
+        )
 
     if not _is_allowed(secret_cfg, requester=requester, command=command):
-        raise CredentialBrokerError(f"credential {name!r} is not allowed for {requester}")
+        raise CredentialBrokerError(
+            f"credential {name!r} is not allowed for {requester}"
+        )
 
     try:
         from hermes_cli.config import get_env_value
@@ -160,7 +214,9 @@ def resolve(
     except Exception:
         value = os.environ.get(env_name)
     if not value:
-        raise CredentialBrokerError(f"credential {name!r} source env:{env_name} is not set")
+        raise CredentialBrokerError(
+            f"credential {name!r} source env:{env_name} is not set"
+        )
 
     return BrokeredCredential(name=name, value=value, env_name=env_name, source=source)
 
@@ -172,31 +228,12 @@ def resolve_env_overrides(
     command: str | None = None,
     config: Mapping[str, Any] | None = None,
 ) -> dict[str, str]:
-    """Resolve names into internal one-command environment overrides."""
+    """Resolve names into one-command environment overrides."""
 
     overrides: dict[str, str] = {}
     for name in names or []:
-        credential = resolve(str(name), requester=requester, command=command, config=config)
-        overrides[credential.forced_env_name] = credential.value
+        credential = resolve(
+            str(name), requester=requester, command=command, config=config
+        )
+        overrides[credential.env_name] = credential.value
     return overrides
-
-
-@contextmanager
-def scoped_env_overrides(env: dict[str, str], overrides: Mapping[str, str]) -> Iterator[None]:
-    """Temporarily add brokered env overrides to an environment object."""
-
-    if not overrides:
-        yield
-        return
-
-    sentinel = object()
-    previous: dict[str, str | object] = {key: env.get(key, sentinel) for key in overrides}
-    env.update({str(key): str(value) for key, value in overrides.items()})
-    try:
-        yield
-    finally:
-        for key, old_value in previous.items():
-            if old_value is sentinel:
-                env.pop(key, None)
-            else:
-                env[key] = str(old_value)

--- a/agent/credential_broker.py
+++ b/agent/credential_broker.py
@@ -108,12 +108,29 @@ def _parse_simple_command(command: str | None) -> list[str]:
     return parts
 
 
-def canonicalize_command(command: str | None) -> str:
+def requested_executable(command: str | None) -> str:
+    """Return argv[0] for an accepted simple command."""
+
+    parts = _parse_simple_command(command)
+    if not parts:
+        raise CredentialBrokerError("brokered credentials require one simple command")
+    return parts[0]
+
+
+def canonicalize_command(
+    command: str | None,
+    *,
+    executable_path: str | None = None,
+) -> str:
     """Return a shell-safe canonical form of an accepted simple command."""
 
     parts = _parse_simple_command(command)
     if not parts:
         raise CredentialBrokerError("brokered credentials require one simple command")
+    if executable_path is not None:
+        if not executable_path.startswith("/"):
+            raise CredentialBrokerError("resolved executable path is not absolute")
+        parts[0] = executable_path
     return shlex.join(parts)
 
 

--- a/tests/agent/test_credential_broker.py
+++ b/tests/agent/test_credential_broker.py
@@ -1,0 +1,146 @@
+import json
+
+import pytest
+
+from agent import credential_broker
+import tools.terminal_tool as terminal_tool
+
+
+BROKER_CONFIG = {
+    "credentials": {
+        "broker": {
+            "enabled": True,
+            "secrets": {
+                "github_token": {
+                    "source": "env",
+                    "name": "GITHUB_TOKEN",
+                    "allow": {
+                        "tools": ["terminal"],
+                        "commands": ["gh"],
+                    },
+                }
+            },
+        }
+    }
+}
+
+
+def test_resolve_env_credential_when_tool_and_command_allowed(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
+
+    credential = credential_broker.resolve(
+        "github_token",
+        requester="terminal",
+        command="gh pr list",
+        config=BROKER_CONFIG,
+    )
+
+    assert credential.env_name == "GITHUB_TOKEN"
+    assert credential.value == "ghp_test"
+    assert credential.forced_env_name == "_HERMES_FORCE_GITHUB_TOKEN"
+
+
+def test_resolve_env_credential_denies_unlisted_command(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
+
+    with pytest.raises(credential_broker.CredentialBrokerError, match="not allowed"):
+        credential_broker.resolve(
+            "github_token",
+            requester="terminal",
+            command="python script.py",
+            config=BROKER_CONFIG,
+        )
+
+
+def test_resolve_env_credential_denies_secret_without_allow_rule(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
+    config = {
+        "credentials": {
+            "broker": {
+                "enabled": True,
+                "secrets": {
+                    "github_token": {
+                        "source": "env",
+                        "name": "GITHUB_TOKEN",
+                    }
+                },
+            }
+        }
+    }
+
+    with pytest.raises(credential_broker.CredentialBrokerError, match="not allowed"):
+        credential_broker.resolve(
+            "github_token",
+            requester="terminal",
+            command="gh pr list",
+            config=config,
+        )
+
+
+def test_scoped_env_overrides_restore_original_environment():
+    env = {"KEEP": "1", "_HERMES_FORCE_GITHUB_TOKEN": "old"}
+
+    with credential_broker.scoped_env_overrides(
+        env,
+        {"_HERMES_FORCE_GITHUB_TOKEN": "new", "_HERMES_FORCE_OTHER": "value"},
+    ):
+        assert env["_HERMES_FORCE_GITHUB_TOKEN"] == "new"
+        assert env["_HERMES_FORCE_OTHER"] == "value"
+
+    assert env == {"KEEP": "1", "_HERMES_FORCE_GITHUB_TOKEN": "old"}
+
+
+def test_terminal_tool_injects_brokered_credential_for_one_command(monkeypatch, tmp_path):
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
+    monkeypatch.setattr(credential_broker, "_load_config", lambda: BROKER_CONFIG)
+
+    terminal_tool._active_environments.clear()
+    terminal_tool._last_activity.clear()
+
+    captured = {}
+
+    class FakeEnv:
+        def __init__(self):
+            self.env = {}
+
+        def execute(self, command, **kwargs):
+            captured["command"] = command
+            captured["env_during_execute"] = dict(self.env)
+            return {"output": "ok", "returncode": 0}
+
+    fake_env = FakeEnv()
+
+    monkeypatch.setattr(
+        terminal_tool,
+        "_get_env_config",
+        lambda: {
+            "env_type": "local",
+            "docker_image": "",
+            "singularity_image": "",
+            "modal_image": "",
+            "daytona_image": "",
+            "cwd": str(tmp_path),
+            "host_cwd": str(tmp_path),
+            "timeout": 30,
+            "container_cpu": 1,
+            "container_memory": 512,
+            "container_disk": 1024,
+            "container_persistent": False,
+            "local_persistent": False,
+        },
+    )
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(terminal_tool, "_create_environment", lambda **kwargs: fake_env)
+    monkeypatch.setattr(terminal_tool, "_check_all_guards", lambda command, env_type: {"approved": True})
+
+    result = json.loads(
+        terminal_tool.terminal_tool(
+            "gh pr list",
+            credentials=["github_token"],
+            workdir=str(tmp_path),
+        )
+    )
+
+    assert result["exit_code"] == 0
+    assert captured["env_during_execute"] == {"_HERMES_FORCE_GITHUB_TOKEN": "ghp_test"}
+    assert fake_env.env == {}

--- a/tests/agent/test_credential_broker.py
+++ b/tests/agent/test_credential_broker.py
@@ -37,7 +37,6 @@ def test_resolve_env_credential_when_tool_and_command_allowed(monkeypatch):
 
     assert credential.env_name == "GITHUB_TOKEN"
     assert credential.value == "ghp_test"
-    assert credential.forced_env_name == "_HERMES_FORCE_GITHUB_TOKEN"
 
 
 def test_resolve_env_credential_denies_unlisted_command(monkeypatch):
@@ -77,20 +76,113 @@ def test_resolve_env_credential_denies_secret_without_allow_rule(monkeypatch):
         )
 
 
-def test_scoped_env_overrides_restore_original_environment():
-    env = {"KEEP": "1", "_HERMES_FORCE_GITHUB_TOKEN": "old"}
+@pytest.mark.parametrize(
+    "command",
+    [
+        "gh pr list; env",
+        "gh pr list && env",
+        "gh pr list || env",
+        "gh pr list | env",
+        "gh pr list & env",
+        "gh pr list\nenv",
+        "gh pr list $(env)",
+        "gh pr list `env`",
+        "gh pr list < input",
+        "gh pr list > output",
+        "gh pr list <(env)",
+        "gh pr list >(env)",
+        "gh pr list (env)",
+    ],
+)
+def test_resolve_env_credential_denies_compound_command(monkeypatch, command):
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
 
-    with credential_broker.scoped_env_overrides(
-        env,
-        {"_HERMES_FORCE_GITHUB_TOKEN": "new", "_HERMES_FORCE_OTHER": "value"},
-    ):
-        assert env["_HERMES_FORCE_GITHUB_TOKEN"] == "new"
-        assert env["_HERMES_FORCE_OTHER"] == "value"
+    with pytest.raises(credential_broker.CredentialBrokerError, match="not allowed"):
+        credential_broker.resolve(
+            "github_token",
+            requester="terminal",
+            command=command,
+            config=BROKER_CONFIG,
+        )
 
-    assert env == {"KEEP": "1", "_HERMES_FORCE_GITHUB_TOKEN": "old"}
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "gh search issues 'parser; bug'",
+        "gh api --jq ';'",
+        "gh api --jq '|'",
+        r"gh search issues parser\;bug",
+    ],
+)
+def test_resolve_env_credential_allows_inert_shell_metacharacters(monkeypatch, command):
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
+
+    credential = credential_broker.resolve(
+        "github_token",
+        requester="terminal",
+        command=command,
+        config=BROKER_CONFIG,
+    )
+
+    assert credential.value == "ghp_test"
 
 
-def test_terminal_tool_injects_brokered_credential_for_one_command(monkeypatch, tmp_path):
+def test_resolve_env_credential_requires_exact_executable(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
+
+    with pytest.raises(credential_broker.CredentialBrokerError, match="not allowed"):
+        credential_broker.resolve(
+            "github_token",
+            requester="terminal",
+            command="/tmp/gh pr list",
+            config=BROKER_CONFIG,
+        )
+
+
+def test_canonicalize_command_preserves_arguments_as_data():
+    assert (
+        credential_broker.canonicalize_command("gh search issues 'parser; bug'")
+        == "gh search issues 'parser; bug'"
+    )
+
+
+def test_resolve_rejects_invalid_environment_name():
+    config = {
+        "credentials": {
+            "broker": {
+                "enabled": True,
+                "secrets": {
+                    "bad": {
+                        "source": "env",
+                        "name": "BAD-NAME",
+                        "allow": {"tools": ["terminal"], "commands": ["gh"]},
+                    }
+                },
+            }
+        }
+    }
+
+    with pytest.raises(credential_broker.CredentialBrokerError, match="invalid env"):
+        credential_broker.resolve(
+            "bad", requester="terminal", command="gh pr list", config=config
+        )
+
+
+def test_resolve_env_overrides_uses_target_environment_name(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
+
+    assert credential_broker.resolve_env_overrides(
+        ["github_token"],
+        requester="terminal",
+        command="gh pr list",
+        config=BROKER_CONFIG,
+    ) == {"GITHUB_TOKEN": "ghp_test"}
+
+
+def test_terminal_tool_injects_brokered_credential_for_one_command(
+    monkeypatch, tmp_path
+):
     monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
     monkeypatch.setattr(credential_broker, "_load_config", lambda: BROKER_CONFIG)
 
@@ -104,8 +196,9 @@ def test_terminal_tool_injects_brokered_credential_for_one_command(monkeypatch, 
             self.env = {}
 
         def execute(self, command, **kwargs):
+            captured.setdefault("calls", []).append((command, kwargs))
             captured["command"] = command
-            captured["env_during_execute"] = dict(self.env)
+            captured["kwargs"] = kwargs
             return {"output": "ok", "returncode": 0}
 
     fake_env = FakeEnv()
@@ -131,7 +224,11 @@ def test_terminal_tool_injects_brokered_credential_for_one_command(monkeypatch, 
     )
     monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
     monkeypatch.setattr(terminal_tool, "_create_environment", lambda **kwargs: fake_env)
-    monkeypatch.setattr(terminal_tool, "_check_all_guards", lambda command, env_type: {"approved": True})
+    monkeypatch.setattr(
+        terminal_tool,
+        "_check_all_guards",
+        lambda command, env_type, **kwargs: {"approved": True},
+    )
 
     result = json.loads(
         terminal_tool.terminal_tool(
@@ -142,5 +239,19 @@ def test_terminal_tool_injects_brokered_credential_for_one_command(monkeypatch, 
     )
 
     assert result["exit_code"] == 0
-    assert captured["env_during_execute"] == {"_HERMES_FORCE_GITHUB_TOKEN": "ghp_test"}
+    assert captured["command"] == "gh pr list"
+    assert captured["kwargs"]["env_overrides"] == {"GITHUB_TOKEN": "ghp_test"}
     assert fake_env.env == {}
+
+    sentinel = tmp_path / "credential-bypass-sentinel"
+    blocked = json.loads(
+        terminal_tool.terminal_tool(
+            f"gh pr list; touch {sentinel}",
+            credentials=["github_token"],
+            workdir=str(tmp_path),
+        )
+    )
+
+    assert blocked["status"] == "blocked"
+    assert len(captured["calls"]) == 1
+    assert not sentinel.exists()

--- a/tests/agent/test_credential_broker.py
+++ b/tests/agent/test_credential_broker.py
@@ -195,6 +195,10 @@ def test_terminal_tool_injects_brokered_credential_for_one_command(
         def __init__(self):
             self.env = {}
 
+        def resolve_executable(self, executable):
+            assert executable == "gh"
+            return "/usr/bin/gh"
+
         def execute(self, command, **kwargs):
             captured.setdefault("calls", []).append((command, kwargs))
             captured["command"] = command
@@ -239,7 +243,7 @@ def test_terminal_tool_injects_brokered_credential_for_one_command(
     )
 
     assert result["exit_code"] == 0
-    assert captured["command"] == "gh pr list"
+    assert captured["command"] == "/usr/bin/gh pr list"
     assert captured["kwargs"]["env_overrides"] == {"GITHUB_TOKEN": "ghp_test"}
     assert fake_env.env == {}
 

--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -52,7 +52,7 @@ class TestWrapCommand:
 
         assert "source" not in wrapped
 
-    def test_invocation_env_is_unset_before_snapshot_refresh(self):
+    def test_invocation_env_is_applied_after_source_and_restored_before_snapshot(self):
         env = _TestableEnv()
         env._snapshot_ready = True
 
@@ -62,8 +62,19 @@ class TestWrapCommand:
             ("GITHUB_TOKEN",),
         )
 
-        assert wrapped.index("eval ") < wrapped.index("unset GITHUB_TOKEN")
-        assert wrapped.index("unset GITHUB_TOKEN") < wrapped.index("export -p >")
+        assert wrapped.index("__hermes_override_value_0=") < wrapped.index("source ")
+        assert wrapped.index("source ") < wrapped.index(
+            'export GITHUB_TOKEN="$__hermes_override_value_0"'
+        )
+        assert wrapped.index(
+            'export GITHUB_TOKEN="$__hermes_override_value_0"'
+        ) < wrapped.index("eval ")
+        assert wrapped.index("eval ") < wrapped.index(
+            'export GITHUB_TOKEN="$__hermes_override_previous_0"'
+        )
+        assert wrapped.index(
+            'export GITHUB_TOKEN="$__hermes_override_previous_0"'
+        ) < wrapped.index("export -p >")
 
     def test_single_quote_escaping(self):
         env = _TestableEnv()
@@ -470,3 +481,52 @@ class TestCwdMarker:
         env1 = _TestableEnv()
         env2 = _TestableEnv()
         assert env1._cwd_marker != env2._cwd_marker
+
+
+def test_execute_without_overrides_supports_legacy_run_bash_signature():
+    env = _TestableEnv()
+    env._snapshot_ready = False
+    calls = []
+
+    def legacy_run_bash(cmd, *, login=False, timeout=120, stdin_data=None):
+        calls.append(cmd)
+        proc = MagicMock()
+        proc.poll.return_value = 0
+        proc.returncode = 0
+        proc.stdout = iter([])
+        return proc
+
+    setattr(env, "_run_bash", legacy_run_bash)
+    result = env.execute("echo compatible")
+
+    assert result["returncode"] == 0
+    assert len(calls) == 1
+
+
+def test_local_override_wins_then_restores_and_path_resolution_ignores_snapshot(tmp_path):
+    import shlex
+
+    from tools.environments.local import LocalEnvironment
+
+    fake_bash = tmp_path / "bash"
+    fake_bash.write_text("#!/bin/sh\nexit 99\n")
+    fake_bash.chmod(0o755)
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=10)
+    try:
+        env.execute(f"export PATH={shlex.quote(str(tmp_path))}:$PATH")
+        snapshot_resolution = env.execute("command -v bash")
+        trusted_resolution = env.resolve_executable("bash")
+
+        env.execute("export BROKER_COLLIDE=old")
+        overridden = env.execute(
+            "printf '%s' \"$BROKER_COLLIDE\"",
+            env_overrides={"BROKER_COLLIDE": "new"},
+        )
+        restored = env.execute("printf '%s' \"$BROKER_COLLIDE\"")
+    finally:
+        env.cleanup()
+
+    assert snapshot_resolution["output"].strip() == str(fake_bash)
+    assert trusted_resolution != str(fake_bash)
+    assert overridden["output"] == "new"
+    assert restored["output"] == "old"

--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -15,7 +15,15 @@ class _TestableEnv(BaseEnvironment):
     def __init__(self, cwd="/tmp", timeout=10):
         super().__init__(cwd=cwd, timeout=timeout)
 
-    def _run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None):
+    def _run_bash(
+        self,
+        cmd_string,
+        *,
+        login=False,
+        timeout=120,
+        stdin_data=None,
+        env_overrides=None,
+    ):
         raise NotImplementedError("Use mock")
 
     def cleanup(self):
@@ -43,6 +51,19 @@ class TestWrapCommand:
         wrapped = env._wrap_command("echo hello", "/tmp")
 
         assert "source" not in wrapped
+
+    def test_invocation_env_is_unset_before_snapshot_refresh(self):
+        env = _TestableEnv()
+        env._snapshot_ready = True
+
+        wrapped = env._wrap_command(
+            "python -c 'print(1)'",
+            "/tmp",
+            ("GITHUB_TOKEN",),
+        )
+
+        assert wrapped.index("eval ") < wrapped.index("unset GITHUB_TOKEN")
+        assert wrapped.index("unset GITHUB_TOKEN") < wrapped.index("export -p >")
 
     def test_single_quote_escaping(self):
         env = _TestableEnv()
@@ -297,7 +318,7 @@ class TestSnapshotFileModes:
             def get_temp_dir(self):
                 return self._temp_dir
 
-            def _run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None):
+            def _run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None, env_overrides=None):
                 proc = subprocess.Popen(
                     ["/bin/bash", "-lc", cmd_string],
                     stdout=subprocess.PIPE,
@@ -422,7 +443,9 @@ class TestInitSessionFailure:
         env._snapshot_ready = False
 
         calls = []
-        def mock_run_bash(cmd, *, login=False, timeout=120, stdin_data=None):
+        def mock_run_bash(
+            cmd, *, login=False, timeout=120, stdin_data=None, env_overrides=None
+        ):
             calls.append({"login": login})
             # Return a mock process handle
             mock = MagicMock()

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -1,4 +1,6 @@
 import logging
+import os
+import shutil
 from io import StringIO
 import subprocess
 
@@ -1840,3 +1842,93 @@ def test_execute_does_not_recover_on_ordinary_failure(monkeypatch):
     result = env.execute("badcmd")
     assert result.get("returncode") == 127
     assert "command not found" in result.get("output", "")
+
+
+def test_run_bash_applies_environment_overrides_to_one_docker_exec(monkeypatch):
+    env = object.__new__(docker_env.DockerEnvironment)
+    env._container_id = "container-id"
+    env._docker_exe = "/usr/bin/docker"
+    env._init_env_args = ["-e", "BASE=value"]
+    calls = []
+
+    def fake_popen(cmd, stdin_data):
+        calls.append((cmd, stdin_data))
+        return StringIO()
+
+    monkeypatch.setattr(docker_env, "_popen_bash", fake_popen)
+
+    env._run_bash(
+        "env",
+        env_overrides={"GITHUB_TOKEN": "brokered-token"},
+    )
+    env._run_bash("env")
+
+    assert calls[0][0][:5] == [
+        "/usr/bin/docker",
+        "exec",
+        "-e",
+        "GITHUB_TOKEN=brokered-token",
+        "container-id",
+    ]
+    assert "GITHUB_TOKEN=brokered-token" not in calls[1][0]
+    assert env._init_env_args == ["-e", "BASE=value"]
+
+
+def test_real_docker_override_is_scoped_for_foreground_and_background():
+    docker = shutil.which("docker")
+    image = os.environ.get("HERMES_DOCKER_TEST_IMAGE", "python:3.11")
+    if not docker:
+        pytest.skip("Docker CLI is unavailable")
+    if subprocess.run(
+        [docker, "info"], capture_output=True, text=True, timeout=15
+    ).returncode:
+        pytest.skip("Docker daemon is unavailable")
+    if subprocess.run(
+        [docker, "image", "inspect", image],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    ).returncode:
+        pytest.skip(f"Docker test image is not present locally: {image}")
+
+    from tools.process_registry import ProcessRegistry
+
+    env = docker_env.DockerEnvironment(
+        image=image,
+        cwd="/root",
+        timeout=60,
+        cpu=0,
+        memory=0,
+        disk=0,
+        persistent_filesystem=False,
+        task_id="credential-broker-real-docker",
+        volumes=[],
+        network=True,
+        auto_mount_cwd=False,
+        persist_across_processes=False,
+    )
+    registry = ProcessRegistry()
+    command = "python -c 'import os; print(os.getenv(\"BROKER_TEST\", \"missing\"))'"
+    try:
+        foreground = env.execute(
+            command,
+            env_overrides={"BROKER_TEST": "foreground-value"},
+        )
+        foreground_after = env.execute(command)
+
+        session = registry.spawn_via_env(
+            env,
+            command,
+            env_overrides={"BROKER_TEST": "background-value"},
+        )
+        background = registry.wait(session.id, timeout=30)
+        background_after = env.execute(command)
+    finally:
+        env.cleanup()
+
+    assert foreground["returncode"] == 0
+    assert foreground["output"].strip() == "foreground-value"
+    assert foreground_after["output"].strip() == "missing"
+    assert background["exit_code"] == 0
+    assert background["output"].strip() == "background-value"
+    assert background_after["output"].strip() == "missing"

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -1910,6 +1910,7 @@ def test_real_docker_override_is_scoped_for_foreground_and_background():
     registry = ProcessRegistry()
     command = "python -c 'import os; print(os.getenv(\"BROKER_TEST\", \"missing\"))'"
     try:
+        baseline = env.execute("export BROKER_TEST=old-value")
         foreground = env.execute(
             command,
             env_overrides={"BROKER_TEST": "foreground-value"},
@@ -1926,9 +1927,10 @@ def test_real_docker_override_is_scoped_for_foreground_and_background():
     finally:
         env.cleanup()
 
+    assert baseline["returncode"] == 0
     assert foreground["returncode"] == 0
     assert foreground["output"].strip() == "foreground-value"
-    assert foreground_after["output"].strip() == "missing"
+    assert foreground_after["output"].strip() == "old-value"
     assert background["exit_code"] == 0
     assert background["output"].strip() == "background-value"
-    assert background_after["output"].strip() == "missing"
+    assert background_after["output"].strip() == "old-value"

--- a/tests/tools/test_init_session_cwd_respect.py
+++ b/tests/tools/test_init_session_cwd_respect.py
@@ -25,7 +25,7 @@ class _TestableEnv(BaseEnvironment):
     def __init__(self, cwd="/tmp", timeout=10):
         super().__init__(cwd=cwd, timeout=timeout)
 
-    def _run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None):
+    def _run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None, env_overrides=None):
         raise NotImplementedError("Use mock")
 
     def cleanup(self):

--- a/tests/tools/test_managed_modal_environment.py
+++ b/tests/tools/test_managed_modal_environment.py
@@ -145,6 +145,35 @@ def test_managed_modal_execute_polls_until_completed(monkeypatch):
     assert any(call[0] == "POST" and call[1].endswith("/execs") for call in calls)
 
 
+def test_managed_modal_fails_closed_for_invocation_environment(monkeypatch):
+    _install_fake_tools_package()
+    managed_modal = _load_tool_module(
+        "tools.environments.managed_modal", "environments/managed_modal.py"
+    )
+    calls = []
+
+    def fake_request(method, url, headers=None, json=None, timeout=None):
+        calls.append((method, url, json, timeout))
+        if method == "POST" and url.endswith("/v1/sandboxes"):
+            return _FakeResponse(200, {"id": "sandbox-1"})
+        if method == "POST" and url.endswith("/terminate"):
+            return _FakeResponse(200, {"status": "terminated"})
+        raise AssertionError(f"Unexpected request: {method} {url}")
+
+    monkeypatch.setattr(managed_modal.requests, "request", fake_request)
+
+    env = managed_modal.ManagedModalEnvironment(image="python:3.11")
+    result = env.execute(
+        "echo hello",
+        env_overrides={"GITHUB_TOKEN": "brokered-token"},
+    )
+    env.cleanup()
+
+    assert result["returncode"] == 1
+    assert "does not support" in result["output"]
+    assert not any(call[1].endswith("/execs") for call in calls)
+
+
 def test_managed_modal_create_sends_a_stable_idempotency_key(monkeypatch):
     _install_fake_tools_package()
     managed_modal = _load_tool_module("tools.environments.managed_modal", "environments/managed_modal.py")

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -699,6 +699,30 @@ class TestSpawnEnvSanitization:
         assert f"{_HERMES_PROVIDER_ENV_FORCE_PREFIX}TELEGRAM_BOT_TOKEN" not in env
         assert env["PYTHONUNBUFFERED"] == "1"
 
+    def test_spawn_local_applies_brokered_override_after_sanitization(self, registry):
+        captured = {}
+
+        def fake_popen(cmd, **kwargs):
+            captured["env"] = kwargs["env"]
+            proc = MagicMock()
+            proc.pid = 4321
+            proc.stdout = iter([])
+            proc.poll.return_value = None
+            return proc
+
+        with patch("tools.process_registry._find_shell", return_value="/bin/bash"), \
+            patch("subprocess.Popen", side_effect=fake_popen), \
+            patch("threading.Thread", return_value=MagicMock()), \
+            patch.object(registry, "_write_checkpoint"):
+            registry.spawn_local(
+                "gh pr list",
+                cwd="/tmp",
+                env_overrides={"GITHUB_TOKEN": "brokered-token"},
+            )
+
+        assert captured["env"]["GITHUB_TOKEN"] == "brokered-token"
+        assert not any(key.startswith("_HERMES_FORCE_") for key in captured["env"])
+
     def test_spawn_via_env_uses_backend_temp_dir_for_artifacts(self, registry):
         class FakeEnv:
             def __init__(self):
@@ -716,7 +740,11 @@ class TestSpawnEnvSanitization:
 
         with patch("tools.process_registry.threading.Thread", return_value=fake_thread), \
             patch.object(registry, "_write_checkpoint"):
-            session = registry.spawn_via_env(env, "echo hello")
+            session = registry.spawn_via_env(
+                env,
+                "echo hello",
+                env_overrides={"GITHUB_TOKEN": "brokered-token"},
+            )
 
         bg_command = env.commands[0][0]
         assert session.pid == 4321
@@ -725,6 +753,9 @@ class TestSpawnEnvSanitization:
         assert "rc=$?;" in bg_command
         assert " > /tmp/hermes_bg_" not in bg_command
         assert "cat /tmp/hermes_bg_" not in bg_command
+        assert env.commands[0][1]["env_overrides"] == {
+            "GITHUB_TOKEN": "brokered-token"
+        }
         fake_thread.start.assert_called_once()
 
     def test_spawn_via_env_checks_returncode_when_wrapper_fails(self, registry):
@@ -805,6 +836,7 @@ class TestSpawnEnvSanitization:
         assert env.commands[0][0] == "cat '/path with spaces/hermes_bg.log' 2>/dev/null"
         assert env.commands[1][0] == "kill -0 \"$(cat '/path with spaces/hermes_bg.pid' 2>/dev/null)\" 2>/dev/null; echo $?"
         assert env.commands[2][0] == "cat '/path with spaces/hermes_bg.exit' 2>/dev/null"
+        assert all("env_overrides" not in kwargs for _, kwargs in env.commands)
 
 
 # =========================================================================

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -259,9 +259,9 @@ _TOOL_STUBS = {
     ),
     "terminal": (
         "terminal",
-        "command: str, timeout: int = None, workdir: str = None",
+        "command: str, timeout: int = None, workdir: str = None, credentials: list = None",
         '"""Run a shell command (foreground only). Returns dict with "output" and "exit_code"."""',
-        '{"command": command, "timeout": timeout, "workdir": workdir}',
+        '{"command": command, "timeout": timeout, "workdir": workdir, "credentials": credentials}',
     ),
 }
 
@@ -481,7 +481,13 @@ def _call(tool_name, args):
 # ---------------------------------------------------------------------------
 
 # Terminal parameters that must not be used from ephemeral sandbox scripts
-_TERMINAL_BLOCKED_PARAMS = {"background", "pty", "notify_on_complete", "watch_patterns"}
+_TERMINAL_BLOCKED_PARAMS = {
+    "background",
+    "pty",
+    "notify_on_complete",
+    "watch_patterns",
+    "credentials",
+}
 
 
 def _rpc_server_loop(

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -18,7 +18,7 @@ import time
 import uuid
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import IO, Callable, Protocol
+from typing import IO, Callable, Mapping, Protocol, Sequence
 
 from hermes_constants import get_hermes_home
 from hermes_cli._subprocess_compat import windows_hide_flags
@@ -333,6 +333,7 @@ class BaseEnvironment(ABC):
         login: bool = False,
         timeout: int = 120,
         stdin_data: str | None = None,
+        env_overrides: Mapping[str, str] | None = None,
     ) -> ProcessHandle:
         """Spawn a bash process to run *cmd_string*.
 
@@ -469,7 +470,12 @@ class BaseEnvironment(ABC):
         """
         return shlex.quote(path)
 
-    def _wrap_command(self, command: str, cwd: str) -> str:
+    def _wrap_command(
+        self,
+        command: str,
+        cwd: str,
+        env_override_names: Sequence[str] = (),
+    ) -> str:
         """Build the full bash script that sources snapshot, cd's, runs command,
         re-dumps env vars, and emits CWD markers."""
         escaped = command.replace("'", "'\\''")
@@ -512,6 +518,11 @@ class BaseEnvironment(ABC):
         # Restrict Hermes metadata files without changing the user's command
         # umask. Snapshot files may contain env-carried secrets.
         parts.append("umask 077")
+
+        # Per-invocation values arrive through the backend's process environment.
+        # Remove them before refreshing the persistent shell snapshot.
+        if env_override_names:
+            parts.append("unset " + " ".join(env_override_names))
 
         # Re-dump env vars to snapshot (atomic replacement to avoid races).
         # Chain mv on the export succeeding so a failed/partial dump never
@@ -904,8 +915,9 @@ class BaseEnvironment(ABC):
         timeout: int | None = None,
         stdin_data: str | None = None,
         rewrite_compound_background: bool = True,
+        env_overrides: Mapping[str, str] | None = None,
     ) -> dict:
-        """Execute a command, return {"output": str, "returncode": int}."""
+        """Execute a command with optional invocation-scoped environment values."""
         self._before_execute()
 
         exec_command, sudo_stdin = self._prepare_command(command)
@@ -931,13 +943,28 @@ class BaseEnvironment(ABC):
             exec_command = self._embed_stdin_heredoc(exec_command, effective_stdin)
             effective_stdin = None
 
-        wrapped = self._wrap_command(exec_command, effective_cwd)
+        invocation_env = {
+            str(key): str(value) for key, value in (env_overrides or {}).items()
+        }
+        for key in invocation_env:
+            if not key.isidentifier() or not key.isascii():
+                raise ValueError(f"Invalid environment override name: {key!r}")
+
+        wrapped = self._wrap_command(
+            exec_command,
+            effective_cwd,
+            tuple(invocation_env),
+        )
 
         # Use login shell if snapshot failed (so user's profile still loads)
         login = not self._snapshot_ready
 
         proc = self._run_bash(
-            wrapped, login=login, timeout=effective_timeout, stdin_data=effective_stdin
+            wrapped,
+            login=login,
+            timeout=effective_timeout,
+            stdin_data=effective_stdin,
+            env_overrides=invocation_env,
         )
         result = self._wait_for_process(proc, timeout=effective_timeout)
         self._update_cwd(result)

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -342,6 +342,28 @@ class BaseEnvironment(ABC):
         """
         raise NotImplementedError(f"{type(self).__name__} must implement _run_bash()")
 
+    def resolve_executable(self, executable: str) -> str:
+        """Resolve via the backend's baseline PATH, bypassing its shell snapshot."""
+
+        timeout = min(self.timeout, 30)
+        proc = self._run_bash(
+            f"command -v -- {shlex.quote(executable)}",
+            login=False,
+            timeout=timeout,
+            stdin_data=None,
+        )
+        result = self._wait_for_process(proc, timeout=timeout)
+        resolved = str(result.get("output", "")).strip()
+        if result.get("returncode") != 0 or not resolved.startswith("/"):
+            raise RuntimeError(
+                f"credential broker could not resolve trusted executable {executable!r}"
+            )
+        if "\n" in resolved or "\r" in resolved:
+            raise RuntimeError(
+                f"credential broker received ambiguous executable path for {executable!r}"
+            )
+        return resolved
+
     @abstractmethod
     def cleanup(self):
         """Release backend resources (container, instance, connection)."""
@@ -495,6 +517,13 @@ class BaseEnvironment(ABC):
 
         parts = []
 
+        # Backends provide override values through the process environment. Save
+        # them before sourcing the persistent snapshot, which may contain older
+        # values for the same names.
+        for index, name in enumerate(env_override_names):
+            parts.append(f"__hermes_override_value_{index}=\"${{{name}-}}\"")
+            parts.append(f"unset {name}")
+
         # Source snapshot (env vars from previous commands).
         # Redirect stdout to /dev/null: on macOS (bash 3.2 and certain
         # Homebrew bash builds) sourcing a file containing ``declare -x``
@@ -504,6 +533,20 @@ class BaseEnvironment(ABC):
         if self._snapshot_ready:
             parts.append(
                 f"source {_quoted_snap} >/dev/null 2>&1 || true"
+            )
+
+        # Save snapshot state, then apply the invocation value after sourcing.
+        for index, name in enumerate(env_override_names):
+            parts.extend(
+                [
+                    f"if [[ ${{{name}+x}} ]]; then",
+                    f"  __hermes_override_was_set_{index}=1",
+                    f"  __hermes_override_previous_{index}=\"${{{name}}}\"",
+                    "else",
+                    f"  __hermes_override_was_set_{index}=0",
+                    "fi",
+                    f"export {name}=\"$__hermes_override_value_{index}\"",
+                ]
             )
 
         # Preserve bare ``~`` expansion, but rewrite ``~/...`` through
@@ -519,10 +562,21 @@ class BaseEnvironment(ABC):
         # umask. Snapshot files may contain env-carried secrets.
         parts.append("umask 077")
 
-        # Per-invocation values arrive through the backend's process environment.
-        # Remove them before refreshing the persistent shell snapshot.
-        if env_override_names:
-            parts.append("unset " + " ".join(env_override_names))
+        # Restore snapshot state before refreshing it, so an override neither
+        # persists nor deletes a pre-existing value with the same name.
+        for index, name in enumerate(env_override_names):
+            parts.extend(
+                [
+                    f"if [[ $__hermes_override_was_set_{index} == 1 ]]; then",
+                    f"  export {name}=\"$__hermes_override_previous_{index}\"",
+                    "else",
+                    f"  unset {name}",
+                    "fi",
+                    f"unset __hermes_override_value_{index}",
+                    f"unset __hermes_override_was_set_{index}",
+                    f"unset __hermes_override_previous_{index}",
+                ]
+            )
 
         # Re-dump env vars to snapshot (atomic replacement to avoid races).
         # Chain mv on the export succeeding so a failed/partial dump never
@@ -959,13 +1013,21 @@ class BaseEnvironment(ABC):
         # Use login shell if snapshot failed (so user's profile still loads)
         login = not self._snapshot_ready
 
-        proc = self._run_bash(
-            wrapped,
-            login=login,
-            timeout=effective_timeout,
-            stdin_data=effective_stdin,
-            env_overrides=invocation_env,
-        )
+        if invocation_env:
+            proc = self._run_bash(
+                wrapped,
+                login=login,
+                timeout=effective_timeout,
+                stdin_data=effective_stdin,
+                env_overrides=invocation_env,
+            )
+        else:
+            proc = self._run_bash(
+                wrapped,
+                login=login,
+                timeout=effective_timeout,
+                stdin_data=effective_stdin,
+            )
         result = self._wait_for_process(proc, timeout=effective_timeout)
         self._update_cwd(result)
 

--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -10,6 +10,7 @@ import math
 import os
 import shlex
 import threading
+from collections.abc import Mapping
 from pathlib import Path
 
 from tools.environments.base import (
@@ -218,7 +219,8 @@ class DaytonaEnvironment(BaseEnvironment):
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
-                  stdin_data: str | None = None):
+                  stdin_data: str | None = None,
+                  env_overrides: Mapping[str, str] | None = None):
         """Return a _ThreadedProcessHandle wrapping a blocking Daytona SDK call."""
         sandbox = self._sandbox
         lock = self._lock
@@ -236,7 +238,12 @@ class DaytonaEnvironment(BaseEnvironment):
             shell_cmd = f"bash -c {shlex.quote(cmd_string)}"
 
         def exec_fn() -> tuple[str, int]:
-            response = sandbox.process.exec(shell_cmd, timeout=timeout)
+            if env_overrides:
+                response = sandbox.process.exec(
+                    shell_cmd, env=dict(env_overrides), timeout=timeout
+                )
+            else:
+                response = sandbox.process.exec(shell_cmd, timeout=timeout)
             return (response.result or "", response.exit_code)
 
         return _ThreadedProcessHandle(exec_fn, cancel_fn=cancel)

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -14,7 +14,7 @@ import subprocess
 import sys
 import uuid
 from pathlib import Path
-from typing import Optional
+from typing import Mapping, Optional
 
 from tools.environments.base import BaseEnvironment, _popen_bash
 from tools.environments.local import (
@@ -1056,7 +1056,8 @@ class DockerEnvironment(BaseEnvironment):
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
-                  stdin_data: str | None = None) -> subprocess.Popen:
+                  stdin_data: str | None = None,
+                  env_overrides: Mapping[str, str] | None = None) -> subprocess.Popen:
         """Spawn a bash process inside the Docker container."""
         assert self._container_id, "Container not started"
         cmd = [self._docker_exe, "exec"]
@@ -1067,6 +1068,8 @@ class DockerEnvironment(BaseEnvironment):
         # Subsequent commands get env vars from the snapshot.
         if login:
             cmd.extend(self._init_env_args)
+        for key, value in (env_overrides or {}).items():
+            cmd.extend(["-e", f"{key}={value}"])
 
         cmd.extend([self._container_id])
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import tempfile
 import time
+from collections.abc import Mapping
 from pathlib import Path
 
 from tools.environments.base import BaseEnvironment, _pipe_stdin
@@ -1029,7 +1030,8 @@ class LocalEnvironment(BaseEnvironment):
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
-                  stdin_data: str | None = None) -> subprocess.Popen:
+                  stdin_data: str | None = None,
+                  env_overrides: Mapping[str, str] | None = None) -> subprocess.Popen:
         bash = _find_bash()
         # For login-shell invocations (used by init_session to build the
         # environment snapshot), prepend sources for the user's bashrc /
@@ -1043,6 +1045,7 @@ class LocalEnvironment(BaseEnvironment):
                 cmd_string = _prepend_shell_init(cmd_string, init_files)
         args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
         run_env = _make_run_env(self.env)
+        run_env.update(env_overrides or {})
 
         # Recover when the cwd has been deleted out from under us — usually by
         # a previous tool call that ran ``rm -rf`` on its own working dir

--- a/tools/environments/modal.py
+++ b/tools/environments/modal.py
@@ -12,7 +12,7 @@ import shlex
 import tarfile
 import threading
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Mapping, Optional
 
 from hermes_constants import get_hermes_home
 from tools.environments.base import (
@@ -407,7 +407,8 @@ class ModalEnvironment(BaseEnvironment):
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
-                  stdin_data: str | None = None):
+                  stdin_data: str | None = None,
+                  env_overrides: Mapping[str, str] | None = None):
         """Return a _ThreadedProcessHandle wrapping an async Modal sandbox exec."""
         sandbox = self._sandbox
         worker = self._worker
@@ -417,7 +418,13 @@ class ModalEnvironment(BaseEnvironment):
 
         def exec_fn() -> tuple[str, int]:
             async def _do():
-                args = ["bash"]
+                args = []
+                if env_overrides:
+                    args.append("env")
+                    args.extend(
+                        f"{key}={value}" for key, value in env_overrides.items()
+                    )
+                args.append("bash")
                 if login:
                     args.extend(["-l", "-c", cmd_string])
                 else:

--- a/tools/environments/modal_utils.py
+++ b/tools/environments/modal_utils.py
@@ -18,7 +18,7 @@ import time
 import uuid
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Mapping
 
 from tools.environments.base import BaseEnvironment
 from tools.interrupt import is_interrupted
@@ -80,11 +80,16 @@ class BaseModalExecutionEnvironment(BaseEnvironment):
         timeout: int | None = None,
         stdin_data: str | None = None,
         rewrite_compound_background: bool = True,
+        env_overrides: Mapping[str, str] | None = None,
     ) -> dict:
         # Managed/remote modal transports execute commands via explicit transport
         # and do not rely on shell background rewriters. Keep parameter for
         # compatibility with BaseEnvironment callers.
         _ = rewrite_compound_background
+        if env_overrides:
+            return self._error_result(
+                "Managed Modal does not support invocation-scoped environment overrides"
+            )
         self._before_execute()
         prepared = self._prepare_modal_exec(
             command,

--- a/tools/environments/singularity.py
+++ b/tools/environments/singularity.py
@@ -12,7 +12,7 @@ import subprocess
 import threading
 import uuid
 from pathlib import Path
-from typing import Optional
+from typing import Mapping, Optional
 
 from hermes_constants import get_hermes_home
 from tools.environments.base import (
@@ -231,13 +231,16 @@ class SingularityEnvironment(BaseEnvironment):
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
-                  stdin_data: str | None = None) -> subprocess.Popen:
+                  stdin_data: str | None = None,
+                  env_overrides: Mapping[str, str] | None = None) -> subprocess.Popen:
         """Spawn a bash process inside the Singularity instance."""
         if not self._instance_started:
             raise RuntimeError("Singularity instance not started")
 
-        cmd = [self.executable, "exec",
-               f"instance://{self.instance_id}"]
+        cmd = [self.executable, "exec"]
+        for key, value in (env_overrides or {}).items():
+            cmd.extend(["--env", f"{key}={value}"])
+        cmd.append(f"instance://{self.instance_id}")
         if login:
             cmd.extend(["bash", "-l", "-c", cmd_string])
         else:

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -7,6 +7,7 @@ import shlex
 import shutil
 import subprocess
 import tempfile
+from collections.abc import Mapping
 from pathlib import Path
 
 from tools.environments.base import BaseEnvironment, _popen_bash
@@ -342,9 +343,16 @@ class SSHEnvironment(BaseEnvironment):
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
-                  stdin_data: str | None = None) -> subprocess.Popen:
+                  stdin_data: str | None = None,
+                  env_overrides: Mapping[str, str] | None = None) -> subprocess.Popen:
         """Spawn an SSH process that runs bash on the remote host."""
         cmd = self._build_ssh_command()
+        if env_overrides:
+            cmd.append("env")
+            cmd.extend(
+                f"{key}={shlex.quote(value)}"
+                for key, value in env_overrides.items()
+            )
         if login:
             cmd.extend(["bash", "-l", "-c", shlex.quote(cmd_string)])
         else:

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -881,12 +881,19 @@ class ProcessRegistry:
         )
 
         try:
-            result = env.execute(
-                bg_command,
-                timeout=timeout,
-                rewrite_compound_background=False,
-                env_overrides=invocation_env,
-            )
+            if invocation_env:
+                result = env.execute(
+                    bg_command,
+                    timeout=timeout,
+                    rewrite_compound_background=False,
+                    env_overrides=invocation_env,
+                )
+            else:
+                result = env.execute(
+                    bg_command,
+                    timeout=timeout,
+                    rewrite_compound_background=False,
+                )
             output = result.get("output", "").strip()
             # Try to extract the PID from the output
             for line in output.splitlines():

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -51,6 +51,14 @@ from hermes_cli.config import get_hermes_home
 logger = logging.getLogger(__name__)
 
 
+def _copy_env_overrides(overrides: dict[str, str] | None) -> dict[str, str]:
+    copied = {str(key): str(value) for key, value in (overrides or {}).items()}
+    for key in copied:
+        if not key.isidentifier() or not key.isascii():
+            raise ValueError(f"Invalid environment override name: {key!r}")
+    return copied
+
+
 # Checkpoint file for crash recovery (gateway only)
 CHECKPOINT_PATH = get_hermes_home() / "processes.json"
 
@@ -686,6 +694,7 @@ class ProcessRegistry:
         task_id: str = "",
         session_key: str = "",
         env_vars: dict = None,
+        env_overrides: dict[str, str] | None = None,
         use_pty: bool = False,
     ) -> ProcessSession:
         """
@@ -698,6 +707,7 @@ class ProcessRegistry:
                      CLI tools (Codex, Claude Code, Python REPL). Falls back to
                      subprocess.Popen if ptyprocess is not installed.
         """
+        invocation_env = _copy_env_overrides(env_overrides)
         session = ProcessSession(
             id=f"proc_{uuid.uuid4().hex[:12]}",
             command=command,
@@ -716,6 +726,7 @@ class ProcessRegistry:
                     from ptyprocess import PtyProcess as _PtyProcessCls
                 user_shell = _find_shell()
                 pty_env = _sanitize_subprocess_env(os.environ, env_vars)
+                pty_env.update(invocation_env)
                 pty_env["PYTHONUNBUFFERED"] = "1"
                 pty_proc = _PtyProcessCls.spawn(
                     [user_shell, "-lic", f"set +m; {command}"],
@@ -758,6 +769,7 @@ class ProcessRegistry:
         # during background execution (libraries like tqdm/datasets buffer when
         # stdout is a pipe, hiding output from process(action="poll")).
         bg_env = _sanitize_subprocess_env(os.environ, env_vars)
+        bg_env.update(invocation_env)
         bg_env["PYTHONUNBUFFERED"] = "1"
         _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
 
@@ -826,6 +838,7 @@ class ProcessRegistry:
         task_id: str = "",
         session_key: str = "",
         timeout: int = 10,
+        env_overrides: dict[str, str] | None = None,
     ) -> ProcessSession:
         """
         Spawn a background process through a non-local environment backend.
@@ -838,6 +851,7 @@ class ProcessRegistry:
         This is less capable than local spawn (no live stdout pipe, no stdin),
         but it ensures the command runs in the correct sandbox context.
         """
+        invocation_env = _copy_env_overrides(env_overrides)
         session = ProcessSession(
             id=f"proc_{uuid.uuid4().hex[:12]}",
             command=command,
@@ -871,6 +885,7 @@ class ProcessRegistry:
                 bg_command,
                 timeout=timeout,
                 rewrite_compound_background=False,
+                env_overrides=invocation_env,
             )
             output = result.get("output", "").strip()
             # Try to extract the PID from the output

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2145,6 +2145,7 @@ def terminal_tool(
         _start_cleanup_thread()
 
         # Get or create environment.
+        env = None
         # Use a per-task creation lock so concurrent tool calls for the same
         # task_id wait for the first one to finish creating the sandbox,
         # instead of each creating their own (wasting Modal resources).
@@ -2248,6 +2249,8 @@ def terminal_tool(
                         _last_activity[effective_task_id] = time.time()
                         env = new_env
                     logger.info("%s environment ready for task %s", env_type, effective_task_id[:8])
+
+        assert env is not None, "terminal environment was not initialized"
 
         # Hard-block: gateway lifecycle commands (systemctl/launchctl/hermes
         # restart|stop targeting hermes-gateway) must never run inside the
@@ -2366,14 +2369,25 @@ def terminal_tool(
             try:
                 from agent.credential_broker import (
                     canonicalize_command,
+                    requested_executable,
                     resolve_env_overrides,
                 )
 
+                executable = requested_executable(command)
                 command = canonicalize_command(command)
                 brokered_env_overrides = resolve_env_overrides(
                     credentials,
                     requester="terminal",
                     command=command,
+                )
+                resolver = getattr(env, "resolve_executable", None)
+                if not callable(resolver):
+                    raise RuntimeError(
+                        "terminal backend does not support trusted executable resolution"
+                    )
+                command = canonicalize_command(
+                    command,
+                    executable_path=resolver(executable),
                 )
             except Exception as e:
                 return json.dumps({
@@ -2397,14 +2411,33 @@ def terminal_tool(
             try:
                 if env_type == "local":
                     local_env_vars = dict(env.env) if hasattr(env, "env") else {}
-                    proc_session = process_registry.spawn_local(
+                    if brokered_env_overrides:
+                        proc_session = process_registry.spawn_local(
+                            command=command,
+                            cwd=effective_cwd,
+                            task_id=effective_task_id,
+                            session_key=session_key,
+                            env_vars=local_env_vars,
+                            env_overrides=brokered_env_overrides,
+                            use_pty=effective_pty,
+                        )
+                    else:
+                        proc_session = process_registry.spawn_local(
+                            command=command,
+                            cwd=effective_cwd,
+                            task_id=effective_task_id,
+                            session_key=session_key,
+                            env_vars=local_env_vars,
+                            use_pty=effective_pty,
+                        )
+                elif brokered_env_overrides:
+                    proc_session = process_registry.spawn_via_env(
+                        env=env,
                         command=command,
                         cwd=effective_cwd,
                         task_id=effective_task_id,
                         session_key=session_key,
-                        env_vars=local_env_vars,
                         env_overrides=brokered_env_overrides,
-                        use_pty=effective_pty,
                     )
                 else:
                     proc_session = process_registry.spawn_via_env(
@@ -2413,7 +2446,6 @@ def terminal_tool(
                         cwd=effective_cwd,
                         task_id=effective_task_id,
                         session_key=session_key,
-                        env_overrides=brokered_env_overrides,
                     )
 
                 result_data = {
@@ -2657,12 +2689,19 @@ def terminal_tool(
                         env=env,
                         default_cwd=cwd,
                     )
-                    execute_kwargs = {
-                        "timeout": effective_timeout,
-                        "cwd": command_cwd,
-                        "env_overrides": brokered_env_overrides,
-                    }
-                    result = env.execute(command, **execute_kwargs)
+                    if brokered_env_overrides:
+                        result = env.execute(
+                            command,
+                            timeout=effective_timeout,
+                            cwd=command_cwd,
+                            env_overrides=brokered_env_overrides,
+                        )
+                    else:
+                        result = env.execute(
+                            command,
+                            timeout=effective_timeout,
+                            cwd=command_cwd,
+                        )
                 except Exception as e:
                     error_str = str(e).lower()
                     if "timeout" in error_str:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2346,7 +2346,13 @@ def terminal_tool(
                 "EOF."
             )
 
-        # Claim the shared terminal environment for this session.
+        # Claim the (shared "default") terminal env for the session driving this
+        # command. File tools read env.cwd_owner to decide whether the env's live
+        # cwd is THIS session's `cd` or a different worktree session's — without
+        # it, two open worktree sessions sharing the env route each other's edits
+        # to the wrong checkout. get_current_session_key()'s contextvar doesn't
+        # cross tool-worker threads, so fall back to the raw task_id (which IS the
+        # session_key for the top-level agent) — a stable, thread-safe anchor.
         from tools.approval import get_current_session_key
 
         session_key = get_current_session_key(default="") or (task_id or "")

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2018,6 +2018,7 @@ def terminal_tool(
     pty: bool = False,
     notify_on_complete: bool = False,
     watch_patterns: Optional[List[str]] = None,
+    credentials: Optional[List[str]] = None,
 ) -> str:
     """
     Execute a command in the configured terminal environment.
@@ -2033,6 +2034,7 @@ def terminal_tool(
         pty: If True, use pseudo-terminal for interactive CLI tools (local backend only)
         notify_on_complete: If True and background=True, you'll be notified exactly once when the process exits. The right choice for almost every long task. MUTUALLY EXCLUSIVE with watch_patterns.
         watch_patterns: List of strings to watch for in background output. HARD rate limit: 1 notification per 15s per process. After 3 strike windows in a row, watch_patterns is disabled and the session is auto-promoted to notify_on_complete. Use ONLY for rare, one-shot mid-process signals on long-lived processes (server readiness, migration-done markers). NEVER use in loops/batch jobs — error patterns there will hit the strike limit and get disabled. MUTUALLY EXCLUSIVE with notify_on_complete — set one, not both.
+        credentials: Optional names from credentials.broker.secrets to inject for this one command when the broker policy allows terminal access.
 
     Returns:
         str: JSON string with output, exit_code, and error fields
@@ -2344,13 +2346,7 @@ def terminal_tool(
                 "EOF."
             )
 
-        # Claim the (shared "default") terminal env for the session driving this
-        # command. File tools read env.cwd_owner to decide whether the env's live
-        # cwd is THIS session's `cd` or a different worktree session's — without
-        # it, two open worktree sessions sharing the env route each other's edits
-        # to the wrong checkout. get_current_session_key()'s contextvar doesn't
-        # cross tool-worker threads, so fall back to the raw task_id (which IS the
-        # session_key for the top-level agent) — a stable, thread-safe anchor.
+        # Claim the shared terminal environment for this session.
         from tools.approval import get_current_session_key
 
         session_key = get_current_session_key(default="") or (task_id or "")
@@ -2358,6 +2354,28 @@ def terminal_tool(
             env.cwd_owner = session_key
         except Exception:
             pass
+
+        brokered_env_overrides = {}
+        if credentials:
+            try:
+                from agent.credential_broker import (
+                    canonicalize_command,
+                    resolve_env_overrides,
+                )
+
+                command = canonicalize_command(command)
+                brokered_env_overrides = resolve_env_overrides(
+                    credentials,
+                    requester="terminal",
+                    command=command,
+                )
+            except Exception as e:
+                return json.dumps({
+                    "output": "",
+                    "exit_code": -1,
+                    "error": f"Credential broker denied request: {e}",
+                    "status": "blocked",
+                }, ensure_ascii=False)
 
         if background:
             # Spawn a tracked background process via the process registry.
@@ -2372,12 +2390,14 @@ def terminal_tool(
             )
             try:
                 if env_type == "local":
+                    local_env_vars = dict(env.env) if hasattr(env, "env") else {}
                     proc_session = process_registry.spawn_local(
                         command=command,
                         cwd=effective_cwd,
                         task_id=effective_task_id,
                         session_key=session_key,
-                        env_vars=env.env if hasattr(env, 'env') else None,
+                        env_vars=local_env_vars,
+                        env_overrides=brokered_env_overrides,
                         use_pty=effective_pty,
                     )
                 else:
@@ -2387,6 +2407,7 @@ def terminal_tool(
                         cwd=effective_cwd,
                         task_id=effective_task_id,
                         session_key=session_key,
+                        env_overrides=brokered_env_overrides,
                     )
 
                 result_data = {
@@ -2633,6 +2654,7 @@ def terminal_tool(
                     execute_kwargs = {
                         "timeout": effective_timeout,
                         "cwd": command_cwd,
+                        "env_overrides": brokered_env_overrides,
                     }
                     result = env.execute(command, **execute_kwargs)
                 except Exception as e:
@@ -2999,6 +3021,11 @@ TERMINAL_SCHEMA = {
                 "type": "array",
                 "items": {"type": "string"},
                 "description": "Strings to watch for in background process output. HARD RATE LIMIT: at most 1 notification per 15 seconds per process — matches arriving inside the cooldown are dropped. After 3 consecutive 15-second windows with dropped matches, watch_patterns is automatically disabled for that process and promoted to notify_on_complete behavior (one notification on exit, no more mid-process spam). USE ONLY for truly rare, one-shot mid-process signals on LONG-LIVED processes that will never exit on their own — e.g. ['Application startup complete'] on a server so you know when to hit its endpoint, or ['migration done'] on a daemon. DO NOT use for: (1) end-of-run markers like 'DONE'/'PASS' — use notify_on_complete instead; (2) error patterns like 'ERROR'/'Traceback' in loops or multi-item batch jobs — they fire on every iteration and you'll hit the strike limit fast; (3) anything you'd ever combine with notify_on_complete. When in doubt, choose notify_on_complete. MUTUALLY EXCLUSIVE with notify_on_complete — set one, not both."
+            },
+            "credentials": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional credential broker secret names to inject only for this command. Credentialed terminal calls must be one simple command; shell chaining, pipelines, substitutions, grouping, background operators, and redirections are rejected. Requires credentials.broker.enabled=true and an allow rule for tool 'terminal' and, when configured, the exact command executable. Managed Modal does not currently support brokered credentials."
             }
         },
         "required": ["command"]
@@ -3017,6 +3044,7 @@ def _handle_terminal(args, **kw):
         pty=args.get("pty", False),
         notify_on_complete=args.get("notify_on_complete", False),
         watch_patterns=args.get("watch_patterns"),
+        credentials=args.get("credentials"),
     )
 
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -100,7 +100,9 @@ credentials:
           commands: [gh]
 ```
 
-Then a terminal tool call can request `credentials: ["github_token"]`; Hermes injects the secret only for that command. This is intentionally a lightweight local broker, not a Vault/KMS replacement.
+Then a terminal tool call can request `credentials: ["github_token"]`; Hermes injects the secret only for that invocation. Credentialed terminal calls must be one simple command. Hermes rejects shell chaining, pipelines, command/process substitution, grouping, background operators, and redirections so an allow rule for `gh` cannot authorize a second process. Allowlisted executables are matched exactly, so an entry for `gh` does not authorize `/tmp/gh`.
+
+Invocation-scoped credentials are supported by the local, Docker, SSH, direct Modal, Daytona, and Singularity backends, including their background launch paths. Managed Modal fails closed because its gateway does not currently expose a per-execution environment channel. This is intentionally a lightweight local broker, not a Vault/KMS replacement.
 
 ### Provider Timeouts
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -83,6 +83,25 @@ Multiple references in a single value work: `url: "${HOST}:${PORT}"`. If a refer
 
 For AI provider setup (OpenRouter, Anthropic, Copilot, custom endpoints, self-hosted LLMs, fallback models, etc.), see [AI Providers](/integrations/providers).
 
+## Optional Credential Broker
+
+Hermes keeps secrets in `.env` by default. For commands that need one of those secrets without broadly forwarding it to every terminal call, you can opt into the small credential broker. The broker is disabled unless `credentials.broker.enabled` is `true`, supports env-backed secrets, and only injects a named secret when the requesting tool and command match an explicit allow rule.
+
+```yaml
+credentials:
+  broker:
+    enabled: true
+    secrets:
+      github_token:
+        source: env
+        name: GITHUB_TOKEN
+        allow:
+          tools: [terminal]
+          commands: [gh]
+```
+
+Then a terminal tool call can request `credentials: ["github_token"]`; Hermes injects the secret only for that command. This is intentionally a lightweight local broker, not a Vault/KMS replacement.
+
 ### Provider Timeouts
 
 You can set `providers.<id>.request_timeout_seconds` for a provider-wide request timeout, plus `providers.<id>.models.<model>.timeout_seconds` for a model-specific override. Applies to the primary turn client on every transport (OpenAI-wire, native Anthropic, Anthropic-compatible), the fallback chain, rebuilds after credential rotation, and (for OpenAI-wire) the per-request timeout kwarg — so the configured value wins over the legacy `HERMES_API_TIMEOUT` env var.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -100,7 +100,7 @@ credentials:
           commands: [gh]
 ```
 
-Then a terminal tool call can request `credentials: ["github_token"]`; Hermes injects the secret only for that invocation. Credentialed terminal calls must be one simple command. Hermes rejects shell chaining, pipelines, command/process substitution, grouping, background operators, and redirections so an allow rule for `gh` cannot authorize a second process. Allowlisted executables are matched exactly, so an entry for `gh` does not authorize `/tmp/gh`.
+Then a terminal tool call can request `credentials: ["github_token"]`; Hermes injects the secret only for that invocation. Credentialed terminal calls must be one simple command. Hermes rejects shell chaining, pipelines, command/process substitution, grouping, background operators, and redirections so an allow rule for `gh` cannot authorize a second process. Allowlisted executables are matched exactly, so an entry for `gh` does not authorize `/tmp/gh`. Before injecting credentials, Hermes resolves that executable against the backend's baseline process `PATH` and executes the resulting absolute path, preventing a prior terminal command from shadowing an allowlisted name through the persistent shell snapshot.
 
 Invocation-scoped credentials are supported by the local, Docker, SSH, direct Modal, Daytona, and Singularity backends, including their background launch paths. Managed Modal fails closed because its gateway does not currently expose a per-execution environment channel. This is intentionally a lightweight local broker, not a Vault/KMS replacement.
 


### PR DESCRIPTION
## Summary

- Adds a small optional credential broker for named env-backed secrets.
- Lets the terminal tool request configured credential names for a single command.
- Keeps the scope intentionally narrow: disabled by default, env-backed only, terminal-only integration, and explicit tool/command allow rules.
- Documents the minimal `credentials.broker` config shape.

## Why

This provides a simple middle ground between broad env forwarding and a full external secrets system. Tools can request a named credential without reading `.env` directly, while existing terminal env sanitization remains the default behavior unless the broker explicitly injects a one-command override.

## Test plan

- `python -m pytest tests/agent/test_credential_broker.py tests/tools/test_terminal_tool.py tests/tools/test_terminal_tool_requirements.py -q -o 'addopts='`
- `python -m compileall -q agent/credential_broker.py tools/terminal_tool.py`
- `python -m ruff check agent/credential_broker.py tools/terminal_tool.py tests/agent/test_credential_broker.py`
- `git diff --check`
