### PR TITLE
feat(gateway): add Discord and Telegram quick action palettes

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -107,6 +107,12 @@ _TELEGRAM_IMAGE_EXT_TO_MIME = {
 
 MAX_COMMANDS_PER_SCOPE = 30
 
+TELEGRAM_QUICK_ACTIONS: tuple[str, ...] = (
+    "status", "usage", "help", "model", "agents", "personality", "whoami", "insights",
+    "new", "retry", "undo", "stop", "compress", "fast", "yolo",
+)
+TELEGRAM_QUICK_CONFIRM = {"stop", "yolo"}
+
 
 def check_telegram_requirements() -> bool:
     """Check if Telegram dependencies are available.
@@ -451,6 +457,9 @@ class TelegramAdapter(BasePlatformAdapter):
         )
         # Interactive model picker state per chat
         self._model_picker_state: Dict[str, dict] = {}
+        # Quick-action personality state keyed by chat/message so callback_data
+        # stays short while dispatching the selected full personality name.
+        self._palette_personality_state: Dict[str, Dict[str, str]] = {}
         # Approval button state: message_id → session_key
         self._approval_state: Dict[int, str] = {}
         # Slash-confirm button state: confirm_id → session_key (for /reload-mcp
@@ -2619,6 +2628,141 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.warning("[%s] send_clarify failed: %s", self.name, e)
             return SendResult(success=False, error=str(e))
 
+    async def send_palette(
+        self, chat_id: str, metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Render Telegram quick-action buttons."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+        try:
+            buttons = [InlineKeyboardButton({"whoami": "Who Am I", "yolo": "YOLO"}.get(c, c.title()), callback_data=f"qa:{c}") for c in TELEGRAM_QUICK_ACTIONS]
+            thread_id = self._metadata_thread_id(metadata)
+            reply_to_id = self._reply_to_message_id_for_send(None, metadata, reply_to_mode=self._reply_to_mode)
+            msg = await self._send_message_with_thread_fallback(
+                chat_id=int(chat_id),
+                text="Hermes Quick Actions\n\nChoose a button below. Sensitive actions ask for confirmation first.",
+                reply_markup=InlineKeyboardMarkup([buttons[i:i + 3] for i in range(0, len(buttons), 3)]),
+                reply_to_message_id=reply_to_id,
+                **self._thread_kwargs_for_send(chat_id, thread_id, metadata, reply_to_message_id=reply_to_id, reply_to_mode=self._reply_to_mode),
+                **self._link_preview_kwargs(),
+            )
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            logger.warning("[%s] send_palette failed: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
+    def _build_fast_palette_keyboard(self):
+        return InlineKeyboardMarkup([[InlineKeyboardButton(label, callback_data=f"qaf:{value}")] for label, value in (
+            ("Show current mode", "status"), ("Fast / priority", "fast"), ("Normal", "normal"),
+        )])
+
+    def _palette_message_state_key(self, msg) -> Optional[str]:
+        chat_id = getattr(msg, "chat_id", None)
+        message_id = getattr(msg, "message_id", None)
+        if chat_id is None or message_id is None:
+            return None
+        return f"{chat_id}:{message_id}"
+
+    def _build_personality_palette_keyboard(self, *, state_key: Optional[str] = None):
+        try:
+            from hermes_cli.config import cfg_get, load_config
+            personalities = cfg_get(load_config(), "agent", "personalities", default={})
+        except Exception:
+            personalities = {}
+        names = ["none", *(personalities.keys() if isinstance(personalities, dict) else [])]
+        rows = []
+        state: Dict[str, str] = {}
+        for index, raw_name in enumerate(names[:25]):
+            name = str(raw_name)
+            token = str(index)
+            state[token] = name
+            rows.append([
+                InlineKeyboardButton(
+                    "None / default" if name == "none" else name[:64],
+                    callback_data=f"qap:{token}",
+                )
+            ])
+        if state_key is not None:
+            self._palette_personality_state[state_key] = state
+        return InlineKeyboardMarkup(rows)
+
+    async def _dispatch_palette_command(self, query, command_text: str) -> None:
+        event = self._build_message_event(query.message, MessageType.COMMAND)
+        event.text = command_text
+        caller = query.from_user
+        event.source.user_id = str(getattr(caller, "id", "")) or event.source.user_id
+        event.source.user_name = getattr(caller, "full_name", None) or getattr(caller, "first_name", None) or event.source.user_name
+        await self.handle_message(event)
+
+    async def _handle_palette_callback(self, query, data: str) -> None:
+        msg = getattr(query, "message", None)
+        chat_id = getattr(msg, "chat_id", None)
+        chat = getattr(msg, "chat", None)
+        state_key = self._palette_message_state_key(msg)
+        caller = getattr(query, "from_user", None)
+        if not self._is_callback_user_authorized(
+            str(getattr(caller, "id", "")),
+            chat_id=chat_id,
+            chat_type=str(getattr(chat, "type", "")) if chat is not None else None,
+            thread_id=str(getattr(msg, "message_thread_id", "")) if getattr(msg, "message_thread_id", None) is not None else None,
+            user_name=getattr(caller, "first_name", None),
+        ):
+            await query.answer(text="⛔ You are not authorized to use this action.")
+            return
+
+        async def run(command_text: str, *, label: str = "Quick action sent"):
+            await query.edit_message_text(text=f"{label}: {command_text}", reply_markup=None)
+            await query.answer()
+            await self._dispatch_palette_command(query, command_text)
+
+        if data.startswith("qa:"):
+            command_name = data[3:]
+            if command_name in TELEGRAM_QUICK_CONFIRM:
+                await query.edit_message_text(text=f"Run /{command_name}?", reply_markup=InlineKeyboardMarkup([[
+                    InlineKeyboardButton("Confirm", callback_data=f"qac:confirm:{command_name}"),
+                    InlineKeyboardButton("Cancel", callback_data=f"qac:cancel:{command_name}"),
+                ]]))
+                await query.answer()
+            elif command_name == "fast":
+                await query.edit_message_text(text="Choose a fast-mode action:", reply_markup=self._build_fast_palette_keyboard())
+                await query.answer()
+            elif command_name == "personality":
+                await query.edit_message_text(
+                    text="Choose a personality:",
+                    reply_markup=self._build_personality_palette_keyboard(state_key=state_key),
+                )
+                await query.answer()
+            else:
+                await run(f"/{command_name}")
+            return
+
+        if data.startswith("qaf:"):
+            await run(f"/fast {data[4:]}", label="Fast mode action sent")
+            return
+        if data.startswith("qap:"):
+            token = data[4:] or "0"
+            state = self._palette_personality_state.get(state_key) if state_key is not None else None
+            if state is not None:
+                if token not in state:
+                    await query.answer(text="This personality choice is no longer available. Open /palette again.")
+                    return
+                choice = state[token]
+                self._palette_personality_state.pop(state_key, None)
+            elif token.isdigit():
+                await query.answer(text="This personality choice expired. Open /palette again.")
+                return
+            else:
+                choice = token or "none"
+            await run(f"/personality {choice}", label="Personality action sent")
+            return
+        if data.startswith("qac:"):
+            _, choice, command_name = data.split(":", 2)
+            if choice == "cancel":
+                await query.edit_message_text(text="Quick action cancelled.", reply_markup=None)
+                await query.answer()
+            else:
+                await run(f"/{command_name}")
+
     async def send_model_picker(
         self,
         chat_id: str,
@@ -2945,6 +3089,11 @@ class TelegramAdapter(BasePlatformAdapter):
         query_chat_type = getattr(query_chat, "type", None)
         query_thread_id = getattr(query_message, "message_thread_id", None)
         query_user_name = getattr(query.from_user, "first_name", None)
+
+        # --- Quick-action palette callbacks ---
+        if data.startswith(("qa:", "qaf:", "qap:", "qac:")):
+            await self._handle_palette_callback(query, data)
+            return
 
         # --- Model picker callbacks ---
         if data.startswith(("mp:", "mm:", "mb", "mx", "mg:")):
@@ -4819,6 +4968,14 @@ class TelegramAdapter(BasePlatformAdapter):
         event = self._build_message_event(msg, MessageType.COMMAND, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)
         event = self._apply_telegram_group_observe_attribution(event)
+        if event.get_command() == "palette":
+            from gateway.platforms.base import _reply_anchor_for_event, _thread_metadata_for_source
+
+            await self.send_palette(
+                event.source.chat_id,
+                metadata=_thread_metadata_for_source(event.source, _reply_anchor_for_event(event)),
+            )
+            return
         await self.handle_message(event)
 
     async def _handle_location_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -68,6 +68,72 @@ from gateway.platforms.base import (
 from tools.url_safety import is_safe_url
 
 
+DISCORD_QUICK_ACTION_COMMANDS: tuple[str, ...] = (
+    "status", "usage", "help",
+    "model", "agents", "personality",
+    "whoami", "insights", "new",
+    "retry", "undo", "stop",
+    "compress", "fast", "yolo",
+)
+DISCORD_QUICK_ACTION_CONFIRM_COMMANDS: frozenset[str] = frozenset({"stop", "yolo"})
+DISCORD_QUICK_ACTION_PRIMARY_COMMANDS: frozenset[str] = frozenset({
+    "model", "personality", "retry", "compress", "fast",
+})
+def _quick_action_row(command_name: str) -> int:
+    try:
+        return min(DISCORD_QUICK_ACTION_COMMANDS.index(command_name) // 3, 4)
+    except ValueError:
+        return 0
+
+
+def _quick_action_prompt(command_name: str) -> str:
+    prompts = {
+        "new": "Start a fresh Hermes session for this Discord thread?",
+        "undo": "Undo the last user/assistant exchange in this Discord thread?",
+        "stop": "Stop the active Hermes response in this Discord thread?",
+        "yolo": "Enable YOLO mode for this session and skip dangerous-command approvals?",
+    }
+    return prompts.get(command_name, f"Run /{command_name}?")
+
+
+def _load_quick_action_personalities() -> dict[str, Any]:
+    try:
+        from hermes_cli.config import cfg_get, load_config
+
+        personalities = cfg_get(load_config(), "agent", "personalities", default={})
+    except Exception:
+        return {}
+    return personalities if isinstance(personalities, dict) else {}
+
+
+def _quick_action_personality_preview(value: Any) -> str:
+    if isinstance(value, dict):
+        preview = value.get("description") or value.get("system_prompt", "")
+    else:
+        preview = str(value)
+    preview = " ".join(preview.split())
+    return preview[:97] + "..." if len(preview) > 100 else preview
+
+
+async def _dispatch_quick_action_slash(
+    platform: "DiscordAdapter",
+    interaction: discord.Interaction,
+    command_text: str,
+    *,
+    cleanup_response: bool = False,
+) -> None:
+    if not await platform._check_slash_authorization(interaction, command_text):
+        return
+    await interaction.response.defer(ephemeral=True)
+    event = platform._build_slash_event(interaction, command_text)
+    await platform.handle_message(event)
+    if cleanup_response:
+        try:
+            await interaction.delete_original_response()
+        except Exception as e:
+            logger.debug("Discord quick-action cleanup failed: %s", e)
+
+
 def _clean_discord_id(entry: str) -> str:
     """Strip common prefixes from a Discord user ID or username entry.
 
@@ -2960,6 +3026,19 @@ class DiscordAdapter(BasePlatformAdapter):
         async def slash_retry(interaction: discord.Interaction):
             await self._run_simple_slash(interaction, "/retry", "Retrying~")
 
+        @tree.command(name="palette", description="Show Discord quick action palette")
+        async def slash_palette(interaction: discord.Interaction):
+            if not await self._check_slash_authorization(interaction, "/palette"):
+                return
+            await interaction.response.defer(ephemeral=False)
+            await interaction.edit_original_response(
+                content=(
+                    "Hermes Quick Actions\n\n"
+                    "Choose a button below. Sensitive actions ask for confirmation first."
+                ),
+                view=CommandQuickActionsView(self),
+            )
+
         @tree.command(name="undo", description="Remove the last exchange")
         async def slash_undo(interaction: discord.Interaction):
             await self._run_simple_slash(interaction, "/undo")
@@ -5002,6 +5081,206 @@ def _define_discord_view_classes() -> None:
     undefined, causing NameError on the first button interaction.
     """
     global ExecApprovalView, SlashConfirmView, UpdatePromptView, ModelPickerView, ClarifyChoiceView
+    global CommandQuickActionButton, CommandQuickActionsView, QuickActionConfirmView
+    global FastQuickActionView, PersonalityQuickActionView
+
+    def _quick_action_style(command_name: str):
+        if command_name in DISCORD_QUICK_ACTION_CONFIRM_COMMANDS:
+            return discord.ButtonStyle.red
+        if command_name in DISCORD_QUICK_ACTION_PRIMARY_COMMANDS:
+            return discord.ButtonStyle.primary
+        return discord.ButtonStyle.secondary
+
+    class QuickActionConfirmView(discord.ui.View):
+        def __init__(self, platform: "DiscordAdapter", command_name: str):
+            super().__init__(timeout=300)
+            self.platform = platform
+            self.command_name = command_name
+            self.allowed_user_ids = platform._allowed_user_ids
+            self.allowed_role_ids = platform._allowed_role_ids
+            self.resolved = False
+
+        def _check_auth(self, interaction: discord.Interaction) -> bool:
+            return _component_check_auth(interaction, self.allowed_user_ids, self.allowed_role_ids)
+
+        @discord.ui.button(label="Confirm", style=discord.ButtonStyle.red)
+        async def confirm(self, interaction: discord.Interaction, button: discord.ui.Button):
+            if self.resolved:
+                await interaction.response.send_message("This prompt has already been resolved~", ephemeral=True)
+                return
+            if not self._check_auth(interaction):
+                await interaction.response.send_message("You're not authorized to use this action~", ephemeral=True)
+                return
+            self.resolved = True
+            for child in self.children:
+                child.disabled = True
+            await _dispatch_quick_action_slash(
+                self.platform,
+                interaction,
+                f"/{self.command_name}",
+                cleanup_response=True,
+            )
+
+        @discord.ui.button(label="Cancel", style=discord.ButtonStyle.secondary)
+        async def cancel(self, interaction: discord.Interaction, button: discord.ui.Button):
+            if self.resolved:
+                await interaction.response.send_message("This prompt has already been resolved~", ephemeral=True)
+                return
+            if not self._check_auth(interaction):
+                await interaction.response.send_message("You're not authorized to use this action~", ephemeral=True)
+                return
+            self.resolved = True
+            for child in self.children:
+                child.disabled = True
+            await interaction.response.edit_message(content="Quick action cancelled.", view=self)
+
+    class FastQuickActionView(discord.ui.View):
+        def __init__(self, platform: "DiscordAdapter"):
+            super().__init__(timeout=120)
+            self.platform = platform
+            self.allowed_user_ids = platform._allowed_user_ids
+            self.allowed_role_ids = platform._allowed_role_ids
+            select = discord.ui.Select(
+                placeholder="Choose fast mode...",
+                options=[
+                    discord.SelectOption(label="Show current mode", value="status"),
+                    discord.SelectOption(label="Fast / priority", value="fast"),
+                    discord.SelectOption(label="Normal", value="normal"),
+                ],
+                custom_id="hermes:quick-action:fast:select",
+            )
+            select.callback = self._on_selected
+            self.add_item(select)
+
+        def _check_auth(self, interaction: discord.Interaction) -> bool:
+            return _component_check_auth(interaction, self.allowed_user_ids, self.allowed_role_ids)
+
+        async def _on_selected(self, interaction: discord.Interaction):
+            if not self._check_auth(interaction):
+                await interaction.response.send_message("You're not authorized to use this action~", ephemeral=True)
+                return
+            choice = interaction.data["values"][0]
+            await _dispatch_quick_action_slash(
+                self.platform,
+                interaction,
+                f"/fast {choice}",
+                cleanup_response=False,
+            )
+            self.clear_items()
+            await interaction.edit_original_response(
+                content=f"Fast mode action sent: `/fast {choice}`",
+                view=self,
+            )
+
+    class PersonalityQuickActionView(discord.ui.View):
+        def __init__(self, platform: "DiscordAdapter", personalities: Optional[dict[str, Any]] = None):
+            super().__init__(timeout=120)
+            self.platform = platform
+            self.allowed_user_ids = platform._allowed_user_ids
+            self.allowed_role_ids = platform._allowed_role_ids
+            self.personalities = personalities if personalities is not None else _load_quick_action_personalities()
+            options = [
+                discord.SelectOption(
+                    label="None / default",
+                    value="none",
+                    description="Clear the current personality",
+                )
+            ]
+            for name, prompt in list(self.personalities.items())[:24]:
+                options.append(
+                    discord.SelectOption(
+                        label=str(name)[:100],
+                        value=str(name)[:100],
+                        description=_quick_action_personality_preview(prompt) or None,
+                    )
+                )
+            select = discord.ui.Select(
+                placeholder="Choose personality...",
+                options=options,
+                custom_id="hermes:quick-action:personality:select",
+            )
+            select.callback = self._on_selected
+            self.add_item(select)
+
+        def _check_auth(self, interaction: discord.Interaction) -> bool:
+            return _component_check_auth(interaction, self.allowed_user_ids, self.allowed_role_ids)
+
+        async def _on_selected(self, interaction: discord.Interaction):
+            if not self._check_auth(interaction):
+                await interaction.response.send_message("You're not authorized to use this action~", ephemeral=True)
+                return
+            choice = interaction.data["values"][0]
+            await _dispatch_quick_action_slash(
+                self.platform,
+                interaction,
+                f"/personality {choice}",
+                cleanup_response=False,
+            )
+            self.clear_items()
+            await interaction.edit_original_response(
+                content=f"Personality action sent: `/personality {choice}`",
+                view=self,
+            )
+
+    class CommandQuickActionButton(discord.ui.Button):
+        def __init__(self, command_name: str):
+            super().__init__(
+                label=command_name,
+                style=_quick_action_style(command_name),
+                custom_id=f"hermes:quick-action:{command_name}",
+                row=_quick_action_row(command_name),
+            )
+            self.command_name = command_name
+
+        async def callback(self, interaction: discord.Interaction):
+            platform = getattr(self.view, "platform", None)
+            if platform is None:
+                await interaction.response.send_message("Quick actions are unavailable right now.", ephemeral=True)
+                return
+            if self.command_name in DISCORD_QUICK_ACTION_CONFIRM_COMMANDS:
+                await interaction.response.send_message(
+                    _quick_action_prompt(self.command_name),
+                    view=QuickActionConfirmView(platform, self.command_name),
+                    ephemeral=True,
+                )
+                return
+            if self.command_name == "model":
+                await _dispatch_quick_action_slash(
+                    platform,
+                    interaction,
+                    "/model",
+                    cleanup_response=False,
+                )
+                return
+            if self.command_name == "fast":
+                await interaction.response.send_message(
+                    "Choose a fast-mode action:",
+                    view=FastQuickActionView(platform),
+                    ephemeral=True,
+                )
+                return
+            if self.command_name == "personality":
+                if not await platform._check_slash_authorization(interaction, "/personality"):
+                    return
+                await interaction.response.send_message(
+                    "Choose a personality:",
+                    view=PersonalityQuickActionView(platform),
+                    ephemeral=True,
+                )
+                return
+            await _dispatch_quick_action_slash(
+                platform,
+                interaction,
+                f"/{self.command_name}",
+                cleanup_response=False,
+            )
+
+    class CommandQuickActionsView(discord.ui.View):
+        def __init__(self, platform: "DiscordAdapter"):
+            super().__init__(timeout=300)
+            self.platform = platform
+            for command_name in DISCORD_QUICK_ACTION_COMMANDS:
+                self.add_item(CommandQuickActionButton(command_name))
 
     class ExecApprovalView(discord.ui.View):
         """

--- a/tests/gateway/test_discord_quick_actions.py
+++ b/tests/gateway/test_discord_quick_actions.py
@@ -1,0 +1,253 @@
+"""Focused tests for the Discord quick-action palette."""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from gateway.config import PlatformConfig
+import plugins.platforms.discord.adapter as discord_platform
+from plugins.platforms.discord.adapter import (
+    DISCORD_QUICK_ACTION_COMMANDS,
+    DISCORD_QUICK_ACTION_CONFIRM_COMMANDS,
+    DISCORD_QUICK_ACTION_PRIMARY_COMMANDS,
+    _quick_action_prompt,
+    _quick_action_row,
+)
+
+
+EXPECTED_COMMANDS = (
+    "status", "usage", "help",
+    "model", "agents", "personality",
+    "whoami", "insights", "new",
+    "retry", "undo", "stop",
+    "compress", "fast", "yolo",
+)
+
+
+def test_quick_action_metadata_is_fixed_and_compact():
+    assert DISCORD_QUICK_ACTION_COMMANDS == EXPECTED_COMMANDS
+    assert DISCORD_QUICK_ACTION_CONFIRM_COMMANDS == frozenset({"stop", "yolo"})
+    assert DISCORD_QUICK_ACTION_PRIMARY_COMMANDS == frozenset({
+        "model", "personality", "retry", "compress", "fast",
+    })
+
+
+def test_quick_action_layout_fits_discord_button_rows():
+    rows = {command: _quick_action_row(command) for command in DISCORD_QUICK_ACTION_COMMANDS}
+    assert max(rows.values()) <= 4
+    assert [command for command, row in rows.items() if row == 0] == ["status", "usage", "help"]
+    assert [command for command, row in rows.items() if row == 4] == ["compress", "fast", "yolo"]
+
+
+def test_quick_action_confirmation_prompts_are_specific():
+    assert _quick_action_prompt("stop") == "Stop the active Hermes response in this Discord thread?"
+    assert _quick_action_prompt("yolo") == (
+        "Enable YOLO mode for this session and skip dangerous-command approvals?"
+    )
+
+
+def _view_or_skip():
+    if not hasattr(discord_platform, "CommandQuickActionsView"):
+        pytest.skip("discord.py UI classes are not available")
+    adapter = discord_platform.DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    return adapter, discord_platform.CommandQuickActionsView(adapter)
+
+
+def _button_for(view, command_name: str):
+    button = next(child for child in view.children if child.command_name == command_name)
+    # The lightweight discord.py test double does not attach item.view like
+    # real discord.py does, so set it explicitly for direct callback tests.
+    button.view = view
+    return button
+
+
+async def _click_quick_button(button, interaction):
+    callback = getattr(type(button), "callback", None)
+    if not callable(callback):
+        pytest.skip("discord.py Button callback binding is not available")
+    await callback(button, interaction)
+
+
+def test_quick_action_button_styles_use_semantic_groups():
+    _adapter, view = _view_or_skip()
+    buttons = {child.command_name: child for child in view.children}
+    for command in DISCORD_QUICK_ACTION_CONFIRM_COMMANDS:
+        assert buttons[command].style == discord_platform.discord.ButtonStyle.red
+    for command in DISCORD_QUICK_ACTION_PRIMARY_COMMANDS:
+        assert buttons[command].style == discord_platform.discord.ButtonStyle.primary
+
+
+@pytest.mark.asyncio
+async def test_quick_action_button_dispatches_through_slash_pipeline(monkeypatch):
+    adapter, view = _view_or_skip()
+    dispatch = AsyncMock()
+    monkeypatch.setattr(discord_platform, "_dispatch_quick_action_slash", dispatch)
+    status_button = _button_for(view, "status")
+
+    interaction = object()
+    await _click_quick_button(status_button, interaction)
+
+    dispatch.assert_awaited_once_with(
+        adapter,
+        interaction,
+        "/status",
+        cleanup_response=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_model_quick_action_opens_existing_interactive_picker_flow_without_deleting_palette(monkeypatch):
+    adapter, view = _view_or_skip()
+    dispatch = AsyncMock()
+    monkeypatch.setattr(discord_platform, "_dispatch_quick_action_slash", dispatch)
+    model_button = _button_for(view, "model")
+
+    interaction = object()
+    await _click_quick_button(model_button, interaction)
+
+    dispatch.assert_awaited_once_with(
+        adapter,
+        interaction,
+        "/model",
+        cleanup_response=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_fast_quick_action_opens_select_menu():
+    adapter, view = _view_or_skip()
+    adapter._run_simple_slash = AsyncMock()
+    fast_button = _button_for(view, "fast")
+
+    response = type("ResponseStub", (), {})()
+    response.send_message = AsyncMock()
+    interaction = type("InteractionStub", (), {"response": response})()
+    await _click_quick_button(fast_button, interaction)
+
+    adapter._run_simple_slash.assert_not_awaited()
+    response.send_message.assert_awaited_once()
+    kwargs = response.send_message.await_args.kwargs
+    assert kwargs["ephemeral"] is True
+    assert isinstance(kwargs["view"], discord_platform.FastQuickActionView)
+    select = kwargs["view"].children[0]
+    assert [option.value for option in select.options] == ["status", "fast", "normal"]
+
+
+@pytest.mark.asyncio
+async def test_personality_quick_action_opens_select_menu(monkeypatch):
+    adapter, view = _view_or_skip()
+    adapter._run_simple_slash = AsyncMock()
+    monkeypatch.setattr(
+        discord_platform,
+        "_load_quick_action_personalities",
+        lambda: {"friendly": "warm", "concise": {"description": "short"}},
+        raising=False,
+    )
+    personality_button = _button_for(view, "personality")
+
+    response = type("ResponseStub", (), {})()
+    response.send_message = AsyncMock()
+    interaction = type("InteractionStub", (), {"response": response})()
+    await _click_quick_button(personality_button, interaction)
+
+    adapter._run_simple_slash.assert_not_awaited()
+    response.send_message.assert_awaited_once()
+    kwargs = response.send_message.await_args.kwargs
+    assert kwargs["ephemeral"] is True
+    assert isinstance(kwargs["view"], discord_platform.PersonalityQuickActionView)
+    select = kwargs["view"].children[0]
+    assert [option.value for option in select.options] == ["none", "friendly", "concise"]
+
+
+@pytest.mark.asyncio
+async def test_personality_quick_action_rejects_unauthorized_before_loading_config(monkeypatch):
+    adapter, view = _view_or_skip()
+    adapter._allowed_user_ids = {"111"}
+    adapter._notify_unauthorized_slash = AsyncMock()
+    load_personalities = Mock(return_value={"secret": {"description": "do not leak"}})
+    monkeypatch.setattr(
+        discord_platform,
+        "_load_quick_action_personalities",
+        load_personalities,
+        raising=False,
+    )
+    personality_button = _button_for(view, "personality")
+    response = type("ResponseStub", (), {})()
+    response.send_message = AsyncMock()
+    user = type("UserStub", (), {"id": 222, "name": "outsider"})()
+    interaction = type(
+        "InteractionStub",
+        (),
+        {
+            "response": response,
+            "user": user,
+            "channel": None,
+            "channel_id": 333,
+            "guild": None,
+            "guild_id": 444,
+        },
+    )()
+
+    await _click_quick_button(personality_button, interaction)
+
+    load_personalities.assert_not_called()
+    response.send_message.assert_awaited_once_with(
+        "You're not authorized to use this command.",
+        ephemeral=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_quick_action_selects_dispatch_existing_commands(monkeypatch):
+    if not hasattr(discord_platform, "FastQuickActionView"):
+        pytest.skip("discord.py UI classes are not available")
+    adapter = discord_platform.DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    dispatch = AsyncMock()
+    monkeypatch.setattr(discord_platform, "_dispatch_quick_action_slash", dispatch)
+    view = discord_platform.FastQuickActionView(adapter)
+    interaction = type(
+        "InteractionStub",
+        (),
+        {
+            "data": {"values": ["normal"]},
+            "response": type("ResponseStub", (), {"send_message": AsyncMock()})(),
+            "edit_original_response": AsyncMock(),
+        },
+    )()
+
+    await view._on_selected(interaction)
+
+    dispatch.assert_awaited_once_with(
+        adapter,
+        interaction,
+        "/fast normal",
+        cleanup_response=False,
+    )
+    interaction.edit_original_response.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_confirmed_quick_action_dispatches_after_component_confirmation(monkeypatch):
+    if not hasattr(discord_platform, "QuickActionConfirmView"):
+        pytest.skip("discord.py UI classes are not available")
+    adapter = discord_platform.DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    dispatch = AsyncMock()
+    monkeypatch.setattr(discord_platform, "_dispatch_quick_action_slash", dispatch)
+    view = discord_platform.QuickActionConfirmView(adapter, "stop")
+    interaction = type("InteractionStub", (), {"response": type("ResponseStub", (), {})()})()
+    interaction.response.send_message = AsyncMock()
+
+    confirm_button = next(
+        (child for child in view.children if getattr(child, "label", None) == "Confirm"),
+        None,
+    )
+    if confirm_button is None or not callable(getattr(confirm_button, "callback", None)):
+        pytest.skip("discord.py Button callback binding is not available")
+    await confirm_button.callback(interaction)
+
+    dispatch.assert_awaited_once_with(
+        adapter,
+        interaction,
+        "/stop",
+        cleanup_response=True,
+    )

--- a/tests/gateway/test_telegram_palette.py
+++ b/tests/gateway/test_telegram_palette.py
@@ -1,0 +1,146 @@
+"""Telegram quick-action palette behavior."""
+
+from types import SimpleNamespace as NS
+from unittest.mock import AsyncMock, MagicMock
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms import telegram as tg
+from gateway.platforms.telegram import TelegramAdapter
+
+
+class Btn:
+    def __init__(self, text, callback_data=None): self.text, self.callback_data = text, callback_data
+
+
+class Markup:
+    def __init__(self, inline_keyboard): self.inline_keyboard = inline_keyboard
+
+
+@pytest.fixture(autouse=True)
+def fake_keyboard(monkeypatch):
+    monkeypatch.setattr(tg, "InlineKeyboardButton", Btn)
+    monkeypatch.setattr(tg, "InlineKeyboardMarkup", Markup)
+
+
+def adapter():
+    a = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    a._bot = AsyncMock()
+    a._send_message_with_thread_fallback = AsyncMock(return_value=NS(message_id=77))
+    a.handle_message = AsyncMock()
+    return a
+
+
+def cb(data):
+    user = NS(id=123, first_name="Merlin", full_name="Merlin")
+    chat = NS(id=456, type="private", title=None, full_name="Merlin", is_forum=False)
+    msg = NS(chat_id=456, chat=chat, from_user=user, message_id=88, message_thread_id=None,
+             is_topic_message=False, text="", caption=None, reply_to_message=None, date=None)
+    q = NS(data=data, message=msg, from_user=user, answer=AsyncMock(), edit_message_text=AsyncMock())
+    return NS(callback_query=q), q
+
+
+def cbs(markup):
+    return [b.callback_data for row in markup.inline_keyboard for b in row]
+
+
+async def open_personality_palette(adapter):
+    update, query = cb("qa:personality")
+    await adapter._handle_callback_query(update, MagicMock())
+    return cbs(query.edit_message_text.call_args.kwargs["reply_markup"])
+
+
+@pytest.mark.asyncio
+async def test_send_palette_renders_discord_matching_actions():
+    a = adapter()
+    assert (await a.send_palette("456")).success is True
+    assert cbs(a._send_message_with_thread_fallback.call_args.kwargs["reply_markup"]) == [
+        "qa:status", "qa:usage", "qa:help", "qa:model", "qa:agents", "qa:personality",
+        "qa:whoami", "qa:insights", "qa:new", "qa:retry", "qa:undo", "qa:stop",
+        "qa:compress", "qa:fast", "qa:yolo",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("data", "expected"), [
+    ("qa:model", "/model"), ("qaf:normal", "/fast normal"), ("qap:coder", "/personality coder"),
+])
+async def test_palette_callbacks_dispatch_existing_command_paths(monkeypatch, data, expected):
+    monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+    a = adapter()
+    await a._handle_callback_query(cb(data)[0], MagicMock())
+    assert a.handle_message.call_args.args[0].text == expected
+
+
+@pytest.mark.asyncio
+async def test_palette_config_buttons_open_menus(monkeypatch):
+    monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    monkeypatch.setattr("hermes_cli.config.cfg_get", lambda _cfg, *_path, default=None: {"cat": {}, "coder": {}})
+    a = adapter()
+    for data, expected in [("qa:fast", ["qaf:status", "qaf:fast", "qaf:normal"]),
+                           ("qa:personality", ["qap:0", "qap:1", "qap:2"]),
+                           ("qa:stop", ["qac:confirm:stop", "qac:cancel:stop"] )]:
+        update, query = cb(data)
+        await a._handle_callback_query(update, MagicMock())
+        assert cbs(query.edit_message_text.call_args.kwargs["reply_markup"]) == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("name", ["x" * 90, "猫" * 40])
+async def test_personality_palette_dispatches_long_and_multibyte_names(monkeypatch, name):
+    monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    monkeypatch.setattr("hermes_cli.config.cfg_get", lambda _cfg, *_path, default=None: {name: {}})
+    a = adapter()
+
+    callbacks = await open_personality_palette(a)
+
+    assert callbacks == ["qap:0", "qap:1"]
+    assert all(len(data.encode("utf-8")) <= 64 for data in callbacks)
+    a.handle_message.reset_mock()
+    await a._handle_callback_query(cb("qap:1")[0], MagicMock())
+    assert a.handle_message.call_args.args[0].text == f"/personality {name}"
+
+
+@pytest.mark.asyncio
+async def test_personality_palette_disambiguates_names_with_same_long_prefix(monkeypatch):
+    monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+    first = ("shared-prefix-" * 5) + "first"
+    second = ("shared-prefix-" * 5) + "second"
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    monkeypatch.setattr("hermes_cli.config.cfg_get", lambda _cfg, *_path, default=None: {
+        first: {},
+        second: {},
+    })
+    a = adapter()
+
+    callbacks = await open_personality_palette(a)
+
+    assert callbacks == ["qap:0", "qap:1", "qap:2"]
+    assert len(set(callbacks)) == len(callbacks)
+    a.handle_message.reset_mock()
+    await a._handle_callback_query(cb("qap:2")[0], MagicMock())
+    assert a.handle_message.call_args.args[0].text == f"/personality {second}"
+
+
+@pytest.mark.asyncio
+async def test_palette_confirm_and_command_path(monkeypatch):
+    monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+    a = adapter()
+    await a._handle_callback_query(cb("qac:confirm:stop")[0], MagicMock())
+    assert a.handle_message.call_args.args[0].text == "/stop"
+    assert not hasattr(a.handle_message.call_args.args[0], "preconfirmed_destructive")
+    a.handle_message.reset_mock()
+    a._should_process_message = MagicMock(return_value=True)
+    a._ensure_forum_commands = AsyncMock()
+    a._clean_bot_trigger_text = lambda text: text
+    a._apply_telegram_group_observe_attribution = lambda event: event
+    a.send_palette = AsyncMock()
+    user = NS(id=123, first_name="Merlin", full_name="Merlin")
+    chat = NS(id=456, type="private", title=None, full_name="Merlin", is_forum=False)
+    msg = NS(text="/palette", chat=chat, from_user=user, message_id=99, message_thread_id=None,
+             is_topic_message=False, caption=None, reply_to_message=None, date=None)
+    await a._handle_command(NS(update_id=100, message=msg, edited_message=None, channel_post=None, edited_channel_post=None), MagicMock())
+    a.send_palette.assert_awaited_once()
+    a.handle_message.assert_not_awaited()


### PR DESCRIPTION
Fixes # New feature, not a fix

Makes common Hermes gateway actions easier to discover and faster to run from Discord and Telegram, especially on mobile where typing slash commands is slower. The palette keeps users on the existing command paths while adding guided buttons and confirmation for sensitive actions, so it improves usability without introducing a separate behavior model.

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

- Add a Discord `/palette` command that renders a quick-action button view for common Hermes gateway commands.
- Add a Telegram `/palette` command that renders matching inline quick-action buttons.
- Route model, fast-mode, and personality actions through existing command paths, with selection menus where needed.
- Keep sensitive quick actions such as `/stop` and `/yolo` behind an explicit confirmation step.
- Add focused Discord and Telegram gateway tests for button metadata, dispatch behavior, auth handling, confirmation flows, and long personality names.

1. Run the focused gateway coverage:
   `scripts/run_tests.sh tests/gateway/test_discord_quick_actions.py tests/gateway/test_telegram_palette.py`
2. In Discord, run `/palette` and verify the quick-action buttons appear.
3. Click normal actions such as `status`, `usage`, `model`, `fast`, and `personality`, and verify they dispatch through the existing slash command flows.
4. Click sensitive actions such as `stop` or `yolo` and verify confirmation is required before dispatch.
5. In Telegram, send `/palette` and verify the inline keyboard mirrors the Discord action set and dispatches through existing command handling.

Preview
<img width="1002" height="994" alt="image" src="https://github.com/user-attachments/assets/d0ff6809-bc1a-48b8-b51c-d7e44150e41d" />

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 Linux; focused gateway tests passed

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-adapter UI only; no OS-specific process, terminal, or file-path handling changed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

Test evidence:
- `scripts/run_tests.sh tests/gateway/test_discord_quick_actions.py tests/gateway/test_telegram_palette.py`
- Result: 2 files, 19 tests passed, 0 failed