### PR TITLE
feat(tools): add per-task routing to delegate_task

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5237,6 +5237,9 @@ class AIAgent:
             acp_args=function_args.get("acp_args"),
             role=function_args.get("role"),
             background=(not _is_subagent),
+            model=function_args.get("model"),
+            provider=function_args.get("provider"),
+            reasoning_effort=function_args.get("reasoning_effort"),
             parent_agent=self,
         )
 

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -16,6 +16,7 @@ import time
 import unittest
 from unittest.mock import MagicMock, patch
 
+from tools import delegate_tool as delegate_tool_module
 from tools.delegate_tool import (
     DELEGATE_BLOCKED_TOOLS,
     DELEGATE_TASK_SCHEMA,
@@ -74,6 +75,35 @@ class TestDelegateRequirements(unittest.TestCase):
         # predictable budgets.
         self.assertNotIn("max_iterations", props)
         self.assertNotIn("maxItems", props["tasks"])  # removed — limit is now runtime-configurable
+
+    def test_schema_exposes_per_task_routing_fields(self):
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        task_props = props["tasks"]["items"]["properties"]
+
+        for field in ("model", "provider", "reasoning_effort"):
+            self.assertIn(field, props)
+            self.assertIn(field, task_props)
+
+        expected_reasoning_enum = ["none", "minimal", "low", "medium", "high", "xhigh"]
+        self.assertEqual(props["reasoning_effort"]["enum"], expected_reasoning_enum)
+        self.assertEqual(task_props["reasoning_effort"]["enum"], expected_reasoning_enum)
+
+    def test_dynamic_schema_descriptions_explain_routing_scopes(self):
+        from tools.delegate_tool import _build_dynamic_schema_overrides
+
+        overrides = _build_dynamic_schema_overrides()
+        desc = overrides["description"]
+        tasks_desc = overrides["parameters"]["properties"]["tasks"]["description"]
+
+        self.assertIn(
+            "top-level model/provider/reasoning_effort apply only when you pass 'goal'",
+            desc,
+        )
+        self.assertIn(
+            "put model/provider/reasoning_effort inside each tasks[] item",
+            tasks_desc,
+        )
+        self.assertIn("Top-level routing fields are ignored in batch mode", tasks_desc)
 
     def test_schema_description_advertises_runtime_limits(self):
         """The model must see the user's actual concurrency / spawn-depth caps,
@@ -347,6 +377,54 @@ class TestDelegateTask(unittest.TestCase):
         result = json.loads(delegate_task(goal="Break things", parent_agent=parent))
         self.assertEqual(result["results"][0]["status"], "error")
         self.assertIn("Something broke", result["results"][0]["error"])
+
+    def test_batch_build_error_cleans_up_already_built_children(self):
+        parent = _make_mock_parent()
+        default_creds = {
+            "model": "delegate-model",
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "sk-delegate",
+            "api_mode": "chat_completions",
+        }
+        child = MagicMock()
+
+        with patch(
+            "tools.delegate_tool._load_config",
+            return_value={"max_iterations": 5},
+        ), patch(
+            "tools.delegate_tool._resolve_delegation_credentials",
+            return_value=default_creds,
+        ), patch(
+            "tools.delegate_tool._resolve_task_credentials",
+            side_effect=[
+                default_creds,
+                ValueError("Task 1 provider override is invalid."),
+            ],
+        ) as mock_task_creds, patch(
+            "tools.delegate_tool._unregister_subagent"
+        ) as mock_unregister, patch(
+            "run_agent.AIAgent",
+            return_value=child,
+        ) as mock_agent_cls:
+            result = json.loads(
+                delegate_task(
+                    tasks=[
+                        {"goal": "Task 0"},
+                        {"goal": "Task 1", "provider": "bad-provider"},
+                    ],
+                    parent_agent=parent,
+                )
+            )
+
+        self.assertIn("error", result)
+        self.assertEqual(result["error"], "Task 1 provider override is invalid.")
+        self.assertEqual(mock_task_creds.call_count, 2)
+        mock_agent_cls.assert_called_once()
+        self.assertEqual(parent._active_children, [])
+        child.close.assert_called_once_with()
+        self.assertIsInstance(child._subagent_id, str)
+        mock_unregister.assert_called_once_with(child._subagent_id)
 
     def test_depth_increments(self):
         """Verify child gets parent's depth + 1."""
@@ -1193,6 +1271,69 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertIsNone(creds["provider"])
 
 
+class TestPerTaskDelegationCredentialResolution(unittest.TestCase):
+    def test_reuses_default_credentials_when_task_has_no_model_or_provider(self):
+        parent = _make_mock_parent(depth=0)
+        default_creds = {
+            "model": "default-model",
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "sk-default",
+            "api_mode": "chat_completions",
+        }
+        cfg = {"model": "default-model", "provider": "openrouter"}
+
+        resolved = delegate_tool_module._resolve_task_credentials(
+            {"goal": "inherit defaults"},
+            default_creds,
+            cfg,
+            parent,
+        )
+
+        self.assertIs(resolved, default_creds)
+
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_provider_override_clears_base_url_before_resolution(self, mock_resolve):
+        parent = _make_mock_parent(depth=0)
+        default_creds = {
+            "model": "default-model",
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "sk-default",
+            "api_mode": "chat_completions",
+        }
+        cfg = {
+            "model": "default-model",
+            "provider": "openrouter",
+            "base_url": "https://sticky.example/v1",
+            "api_key": "sticky-key",
+        }
+        mock_resolve.return_value = {
+            "model": "nous-model",
+            "provider": "nous",
+            "base_url": "https://nous.example/v1",
+            "api_key": "sk-nous",
+            "api_mode": "chat_completions",
+            "command": "copilot",
+            "args": ["--acp", "--stdio"],
+        }
+
+        resolved = delegate_tool_module._resolve_task_credentials(
+            {"goal": "provider override", "provider": "nous", "model": "nous-model"},
+            default_creds,
+            cfg,
+            parent,
+        )
+
+        called_cfg = mock_resolve.call_args.args[0]
+        self.assertEqual(called_cfg["provider"], "nous")
+        self.assertEqual(called_cfg["model"], "nous-model")
+        self.assertIsNone(called_cfg.get("base_url"))
+        self.assertEqual(cfg["base_url"], "https://sticky.example/v1")
+        self.assertEqual(resolved["command"], "copilot")
+        self.assertEqual(resolved["args"], ["--acp", "--stdio"])
+
+
 class TestDelegationProviderIntegration(unittest.TestCase):
     """Integration tests: delegation config → _run_single_child → AIAgent construction."""
 
@@ -1499,6 +1640,222 @@ class TestDelegationProviderIntegration(unittest.TestCase):
             # But provider/base_url/api_key should inherit from parent
             self.assertEqual(kwargs["provider"], parent.provider)
             self.assertEqual(kwargs["base_url"], parent.base_url)
+
+
+class TestDelegateTaskPerTaskRouting(unittest.TestCase):
+    @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._build_child_agent")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._load_config")
+    def test_single_task_top_level_routing_reaches_child_build(
+        self,
+        mock_cfg,
+        mock_resolve,
+        mock_build,
+        mock_run,
+    ):
+        mock_cfg.return_value = {
+            "max_iterations": 50,
+            "model": "default-model",
+            "provider": "openrouter",
+        }
+        parent = _make_mock_parent(depth=0)
+        mock_build.return_value = MagicMock()
+        mock_run.return_value = {
+            "task_index": 0,
+            "status": "completed",
+            "summary": "done",
+            "api_calls": 1,
+            "duration_seconds": 0.1,
+        }
+        seen_cfgs = []
+
+        def _resolve(cfg, _parent_agent):
+            seen_cfgs.append(dict(cfg))
+            provider = cfg.get("provider")
+            model = cfg.get("model")
+            if provider == "nous":
+                return {
+                    "model": model,
+                    "provider": "nous",
+                    "base_url": "https://nous.example/v1",
+                    "api_key": "sk-nous",
+                    "api_mode": "chat_completions",
+                    "command": "copilot",
+                    "args": ["--acp", "--stdio"],
+                }
+            return {
+                "model": model,
+                "provider": "openrouter",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "sk-default",
+                "api_mode": "chat_completions",
+                "command": "default-acp",
+                "args": ["--default"],
+            }
+
+        mock_resolve.side_effect = _resolve
+
+        delegate_task(
+            goal="route this task",
+            model="single-task-model",
+            provider="nous",
+            reasoning_effort="high",
+            parent_agent=parent,
+        )
+
+        self.assertEqual(len(seen_cfgs), 2)
+        self.assertEqual(seen_cfgs[1]["model"], "single-task-model")
+        self.assertEqual(seen_cfgs[1]["provider"], "nous")
+
+        kwargs = mock_build.call_args.kwargs
+        self.assertEqual(kwargs["model"], "single-task-model")
+        self.assertEqual(kwargs["override_provider"], "nous")
+        self.assertEqual(kwargs["override_base_url"], "https://nous.example/v1")
+        self.assertEqual(kwargs["override_api_key"], "sk-nous")
+        self.assertEqual(kwargs["override_api_mode"], "chat_completions")
+        self.assertEqual(kwargs["override_acp_command"], "copilot")
+        self.assertEqual(kwargs["override_acp_args"], ["--acp", "--stdio"])
+        self.assertEqual(kwargs["reasoning_effort"], "high")
+
+    @patch("tools.delegate_tool._build_child_agent")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._load_config")
+    def test_single_task_override_credential_error_uses_tool_error_pattern(
+        self,
+        mock_cfg,
+        mock_resolve,
+        mock_build,
+    ):
+        mock_cfg.return_value = {
+            "max_iterations": 50,
+            "model": "default-model",
+            "provider": "openrouter",
+        }
+        parent = _make_mock_parent(depth=0)
+
+        def _resolve(cfg, _parent_agent):
+            if cfg.get("provider") == "bad-provider":
+                raise ValueError("Cannot resolve delegation provider 'bad-provider'")
+            return {
+                "model": cfg.get("model"),
+                "provider": "openrouter",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "sk-default",
+                "api_mode": "chat_completions",
+                "command": "default-acp",
+                "args": ["--default"],
+            }
+
+        mock_resolve.side_effect = _resolve
+
+        result = json.loads(
+            delegate_task(
+                goal="route this task",
+                provider="bad-provider",
+                parent_agent=parent,
+            )
+        )
+
+        self.assertIn("error", result)
+        self.assertIn("bad-provider", result["error"])
+        mock_build.assert_not_called()
+
+    @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._build_child_agent")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._load_config")
+    def test_batch_mode_uses_only_per_task_routing_overrides(
+        self,
+        mock_cfg,
+        mock_resolve,
+        mock_build,
+        mock_run,
+    ):
+        mock_cfg.return_value = {
+            "max_iterations": 50,
+            "max_concurrent_children": 4,
+            "model": "default-model",
+            "provider": "openrouter",
+        }
+        parent = _make_mock_parent(depth=0)
+        seen_cfgs = []
+
+        def _resolve(cfg, _parent_agent):
+            seen_cfgs.append(dict(cfg))
+            provider = cfg.get("provider")
+            model = cfg.get("model")
+            if provider == "nous":
+                return {
+                    "model": model,
+                    "provider": "nous",
+                    "base_url": "https://nous.example/v1",
+                    "api_key": "sk-nous",
+                    "api_mode": "chat_completions",
+                    "command": "nous-acp",
+                    "args": ["--nous"],
+                }
+            return {
+                "model": model,
+                "provider": "openrouter",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "sk-openrouter",
+                "api_mode": "chat_completions",
+                "command": "default-acp",
+                "args": ["--default"],
+            }
+
+        mock_resolve.side_effect = _resolve
+        mock_build.side_effect = lambda **kwargs: MagicMock()
+        mock_run.side_effect = lambda **kwargs: {
+            "task_index": kwargs["task_index"],
+            "status": "completed",
+            "summary": kwargs["goal"],
+            "api_calls": 1,
+            "duration_seconds": 0.1,
+        }
+
+        delegate_task(
+            tasks=[
+                {"goal": "inherit defaults"},
+                {"goal": "model only", "model": "task-model-only"},
+                {"goal": "provider+model", "provider": "nous", "model": "nous-model"},
+                {"goal": "reasoning only", "reasoning_effort": "minimal"},
+            ],
+            model="batch-top-model",
+            provider="batch-top-provider",
+            reasoning_effort="xhigh",
+            parent_agent=parent,
+        )
+
+        self.assertEqual(mock_resolve.call_count, 3)
+        self.assertEqual(seen_cfgs[0]["model"], "default-model")
+        self.assertEqual(seen_cfgs[0]["provider"], "openrouter")
+        self.assertEqual(seen_cfgs[1]["model"], "task-model-only")
+        self.assertEqual(seen_cfgs[1]["provider"], "openrouter")
+        self.assertEqual(seen_cfgs[2]["model"], "nous-model")
+        self.assertEqual(seen_cfgs[2]["provider"], "nous")
+        self.assertTrue(all(cfg.get("model") != "batch-top-model" for cfg in seen_cfgs))
+        self.assertTrue(all(cfg.get("provider") != "batch-top-provider" for cfg in seen_cfgs))
+
+        task0 = mock_build.call_args_list[0].kwargs
+        task1 = mock_build.call_args_list[1].kwargs
+        task2 = mock_build.call_args_list[2].kwargs
+        task3 = mock_build.call_args_list[3].kwargs
+
+        self.assertEqual(task0["model"], "default-model")
+        self.assertEqual(task0["override_provider"], "openrouter")
+        self.assertIsNone(task0["reasoning_effort"])
+
+        self.assertEqual(task1["model"], "task-model-only")
+        self.assertEqual(task1["override_provider"], "openrouter")
+
+        self.assertEqual(task2["model"], "nous-model")
+        self.assertEqual(task2["override_provider"], "nous")
+
+        self.assertEqual(task3["model"], "default-model")
+        self.assertEqual(task3["override_provider"], "openrouter")
+        self.assertEqual(task3["reasoning_effort"], "minimal")
 
 
 class TestChildCredentialPoolResolution(unittest.TestCase):
@@ -2028,6 +2385,70 @@ class TestDelegationReasoningEffort(unittest.TestCase):
         call_kwargs = MockAgent.call_args[1]
         self.assertEqual(call_kwargs["reasoning_config"], {"enabled": True, "effort": "medium"})
 
+    @patch("tools.delegate_tool._load_config")
+    @patch("run_agent.AIAgent")
+    def test_task_reasoning_effort_overrides_config_and_parent(self, MockAgent, mock_cfg):
+        mock_cfg.return_value = {"max_iterations": 50, "reasoning_effort": "low"}
+        MockAgent.return_value = MagicMock()
+        parent = _make_mock_parent()
+        parent.reasoning_config = {"enabled": True, "effort": "xhigh"}
+
+        _build_child_agent(
+            task_index=0, goal="test", context=None, toolsets=None,
+            model=None, max_iterations=50, parent_agent=parent,
+            task_count=1, reasoning_effort="high",
+        )
+        call_kwargs = MockAgent.call_args[1]
+        self.assertEqual(call_kwargs["reasoning_config"], {"enabled": True, "effort": "high"})
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("run_agent.AIAgent")
+    def test_task_reasoning_effort_none_disables(self, MockAgent, mock_cfg):
+        mock_cfg.return_value = {"max_iterations": 50, "reasoning_effort": "low"}
+        MockAgent.return_value = MagicMock()
+        parent = _make_mock_parent()
+        parent.reasoning_config = {"enabled": True, "effort": "xhigh"}
+
+        _build_child_agent(
+            task_index=0, goal="test", context=None, toolsets=None,
+            model=None, max_iterations=50, parent_agent=parent,
+            task_count=1, reasoning_effort="none",
+        )
+        call_kwargs = MockAgent.call_args[1]
+        self.assertEqual(call_kwargs["reasoning_config"], {"enabled": False})
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("run_agent.AIAgent")
+    def test_invalid_task_reasoning_effort_falls_back_to_config(self, MockAgent, mock_cfg):
+        mock_cfg.return_value = {"max_iterations": 50, "reasoning_effort": "low"}
+        MockAgent.return_value = MagicMock()
+        parent = _make_mock_parent()
+        parent.reasoning_config = {"enabled": True, "effort": "xhigh"}
+
+        _build_child_agent(
+            task_index=0, goal="test", context=None, toolsets=None,
+            model=None, max_iterations=50, parent_agent=parent,
+            task_count=1, reasoning_effort="banana",
+        )
+        call_kwargs = MockAgent.call_args[1]
+        self.assertEqual(call_kwargs["reasoning_config"], {"enabled": True, "effort": "low"})
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("run_agent.AIAgent")
+    def test_invalid_task_reasoning_effort_falls_back_to_parent_when_config_invalid(self, MockAgent, mock_cfg):
+        mock_cfg.return_value = {"max_iterations": 50, "reasoning_effort": "banana"}
+        MockAgent.return_value = MagicMock()
+        parent = _make_mock_parent()
+        parent.reasoning_config = {"enabled": True, "effort": "medium"}
+
+        _build_child_agent(
+            task_index=0, goal="test", context=None, toolsets=None,
+            model=None, max_iterations=50, parent_agent=parent,
+            task_count=1, reasoning_effort="banana",
+        )
+        call_kwargs = MockAgent.call_args[1]
+        self.assertEqual(call_kwargs["reasoning_config"], {"enabled": True, "effort": "medium"})
+
 
 # =========================================================================
 # Dispatch helper, progress events, concurrency
@@ -2067,6 +2488,48 @@ class TestDispatchDelegateTask(unittest.TestCase):
             _, kwargs = mock_build.call_args
             self.assertEqual(kwargs["override_acp_command"], "claude")
             self.assertEqual(kwargs["override_acp_args"], ["--acp", "--stdio"])
+
+    def test_registry_handler_forwards_routing_fields(self):
+        from tools.registry import registry
+
+        parent = _make_mock_parent(depth=0)
+        with patch("tools.delegate_tool.delegate_task") as mock_delegate:
+            registry.get_entry("delegate_task").handler(
+                {
+                    "goal": "test",
+                    "model": "task-model",
+                    "provider": "nous",
+                    "reasoning_effort": "high",
+                },
+                parent_agent=parent,
+            )
+
+        kwargs = mock_delegate.call_args.kwargs
+        self.assertEqual(kwargs["model"], "task-model")
+        self.assertEqual(kwargs["provider"], "nous")
+        self.assertEqual(kwargs["reasoning_effort"], "high")
+        self.assertIs(kwargs["parent_agent"], parent)
+
+    def test_run_agent_dispatch_forwards_routing_fields(self):
+        from run_agent import AIAgent
+
+        parent = MagicMock()
+        with patch("tools.delegate_tool.delegate_task") as mock_delegate:
+            AIAgent._dispatch_delegate_task(
+                parent,
+                {
+                    "goal": "test",
+                    "model": "task-model",
+                    "provider": "nous",
+                    "reasoning_effort": "minimal",
+                },
+            )
+
+        kwargs = mock_delegate.call_args.kwargs
+        self.assertEqual(kwargs["model"], "task-model")
+        self.assertEqual(kwargs["provider"], "nous")
+        self.assertEqual(kwargs["reasoning_effort"], "minimal")
+        self.assertIs(kwargs["parent_agent"], parent)
 
 class TestDelegateEventEnum(unittest.TestCase):
     """Tests for DelegateEvent enum and back-compat aliases."""

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -194,6 +194,36 @@ def _unregister_subagent(subagent_id: str) -> None:
         _active_subagents.pop(subagent_id, None)
 
 
+def _cleanup_built_child(child: Any, parent_agent) -> None:
+    """Undo build-time child registration and close child resources.
+
+    Shared by delegate_task() build-stage error handling and
+    _run_single_child().finally. Lease release and tool-name restoration stay
+    with the caller because only the run path has that context.
+    """
+    _raw_sid = getattr(child, "_subagent_id", None)
+    _subagent_id = _raw_sid if isinstance(_raw_sid, str) else None
+    if _subagent_id:
+        _unregister_subagent(_subagent_id)
+
+    if hasattr(parent_agent, "_active_children"):
+        try:
+            lock = getattr(parent_agent, "_active_children_lock", None)
+            if lock:
+                with lock:
+                    parent_agent._active_children.remove(child)
+            else:
+                parent_agent._active_children.remove(child)
+        except (ValueError, UnboundLocalError) as exc:
+            logger.debug("Could not remove child from active_children: %s", exc)
+
+    try:
+        if hasattr(child, "close"):
+            child.close()
+    except Exception:
+        logger.debug("Failed to close child agent after delegation")
+
+
 def interrupt_subagent(subagent_id: str) -> bool:
     """Request that a single running subagent stop at its next iteration boundary.
 
@@ -1005,6 +1035,8 @@ def _build_child_agent(
     # ACP transport overrides — lets a non-ACP parent spawn ACP child agents
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
+    # Optional per-task reasoning override. Precedence: task > delegation config > parent.
+    reasoning_effort: Optional[str] = None,
     # Per-call role controlling whether the child can further delegate.
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
@@ -1180,22 +1212,42 @@ def _build_child_agent(
         effective_provider = "copilot-acp"
         effective_api_mode = "chat_completions"
 
-    # Resolve reasoning config: delegation override > parent inherit
+    # Resolve reasoning config: task override > delegation override > parent inherit
     parent_reasoning = getattr(parent_agent, "reasoning_config", None)
     child_reasoning = parent_reasoning
     try:
-        delegation_effort = str(delegation_cfg.get("reasoning_effort") or "").strip()
-        if delegation_effort:
-            from hermes_constants import parse_reasoning_effort
+        from hermes_constants import parse_reasoning_effort
 
+        delegation_effort = str(delegation_cfg.get("reasoning_effort") or "").strip()
+        config_reasoning = None
+        if delegation_effort:
             parsed = parse_reasoning_effort(delegation_effort)
             if parsed is not None:
+                config_reasoning = parsed
                 child_reasoning = parsed
             else:
                 logger.warning(
                     "Unknown delegation.reasoning_effort '%s', inheriting parent level",
                     delegation_effort,
                 )
+
+        task_effort = str(reasoning_effort or "").strip()
+        if task_effort:
+            parsed_task = parse_reasoning_effort(task_effort)
+            if parsed_task is not None:
+                child_reasoning = parsed_task
+            elif config_reasoning is not None:
+                logger.warning(
+                    "Unknown delegate_task reasoning_effort '%s', using delegation.reasoning_effort fallback",
+                    task_effort,
+                )
+                child_reasoning = config_reasoning
+            else:
+                logger.warning(
+                    "Unknown delegate_task reasoning_effort '%s', inheriting parent level",
+                    task_effort,
+                )
+                child_reasoning = parent_reasoning
     except Exception as exc:
         logger.debug("Could not load delegation reasoning_effort: %s", exc)
 
@@ -2017,9 +2069,6 @@ def _run_single_child(
 
         # Drop the TUI-facing registry entry.  Safe to call even if the
         # child was never registered (e.g. ID missing on test doubles).
-        if _subagent_id:
-            _unregister_subagent(_subagent_id)
-
         if child_pool is not None and leased_cred_id is not None:
             try:
                 child_pool.release_lease(leased_cred_id)
@@ -2034,28 +2083,7 @@ def _run_single_child(
         if isinstance(saved_tool_names, list):
             model_tools._last_resolved_tool_names = list(saved_tool_names)
 
-        # Remove child from active tracking
-
-        # Unregister child from interrupt propagation
-        if hasattr(parent_agent, "_active_children"):
-            try:
-                lock = getattr(parent_agent, "_active_children_lock", None)
-                if lock:
-                    with lock:
-                        parent_agent._active_children.remove(child)
-                else:
-                    parent_agent._active_children.remove(child)
-            except (ValueError, UnboundLocalError) as e:
-                logger.debug("Could not remove child from active_children: %s", e)
-
-        # Close tool resources (terminal sandboxes, browser daemons,
-        # background processes, httpx clients) so subagent subprocesses
-        # don't outlive the delegation.
-        try:
-            if hasattr(child, "close"):
-                child.close()
-        except Exception:
-            logger.debug("Failed to close child agent after delegation")
+        _cleanup_built_child(child, parent_agent)
 
 
 def _recover_tasks_from_json_string(
@@ -2081,6 +2109,35 @@ def _recover_tasks_from_json_string(
     return parsed, None
 
 
+def _resolve_task_credentials(
+    task: Dict[str, Any],
+    default_creds: dict,
+    cfg: dict,
+    parent_agent,
+) -> dict:
+    """Resolve per-task routing overrides against delegation config.
+
+    Tasks without a model/provider override reuse ``default_creds`` unchanged.
+    When a provider override is present we must clear ``base_url`` from the
+    copied config before calling ``_resolve_delegation_credentials()``,
+    otherwise the configured direct endpoint silently wins over the provider.
+    """
+    task_provider = str(task.get("provider") or "").strip() or None
+    task_model = str(task.get("model") or "").strip() or None
+
+    if not task_provider and not task_model:
+        return default_creds
+
+    task_cfg = dict(cfg or {})
+    if task_provider:
+        task_cfg["provider"] = task_provider
+        task_cfg["base_url"] = None
+    if task_model:
+        task_cfg["model"] = task_model
+
+    return _resolve_delegation_credentials(task_cfg, parent_agent)
+
+
 def delegate_task(
     goal: Optional[str] = None,
     context: Optional[str] = None,
@@ -2091,14 +2148,22 @@ def delegate_task(
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
     background: Optional[bool] = None,
+    model: Optional[str] = None,
+    provider: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
     Spawn one or more child agents to handle delegated tasks.
 
     Supports two modes:
-      - Single: provide goal (+ optional context, toolsets, role)
-      - Batch:  provide tasks array [{goal, context, toolsets, role}, ...]
+      - Single: provide goal (+ optional context, toolsets, role, routing)
+      - Batch:  provide tasks array [{goal, context, toolsets, role, routing}, ...]
+
+    Routing fields (model, provider, reasoning_effort) are optional.
+    In single-task mode they can be supplied at the top level. In batch mode
+    routing is per-task only; top-level routing fields do not default across
+    tasks.
 
     The 'role' parameter controls whether a child can further delegate:
     'leaf' (default) cannot; 'orchestrator' retains the delegation
@@ -2192,7 +2257,15 @@ def delegate_task(
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
         task_list = [
-            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role}
+            {
+                "goal": goal,
+                "context": context,
+                "toolsets": toolsets,
+                "role": top_role,
+                "model": model,
+                "provider": provider,
+                "reasoning_effort": reasoning_effort,
+            }
         ]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
@@ -2228,37 +2301,46 @@ def delegate_task(
     # child build raises (otherwise _last_resolved_tool_names stays corrupted).
     children = []
     try:
-        for i, t in enumerate(task_list):
-            task_acp_args = t.get("acp_args") if "acp_args" in t else None
-            # Per-task role beats top-level; normalise again so unknown
-            # per-task values warn and degrade to leaf uniformly.
-            effective_role = _normalize_role(t.get("role") or top_role)
-            child = _build_child_agent(
-                task_index=i,
-                goal=t["goal"],
-                context=t.get("context"),
-                toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
-                max_iterations=effective_max_iter,
-                task_count=n_tasks,
-                parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
-                override_acp_command=t.get("acp_command")
-                or acp_command
-                or creds.get("command"),
-                override_acp_args=(
-                    task_acp_args
-                    if task_acp_args is not None
-                    else (acp_args if acp_args is not None else creds.get("args"))
-                ),
-                role=effective_role,
-            )
-            # Override with correct parent tool names (before child construction mutated global)
-            child._delegate_saved_tool_names = _parent_tool_names
-            children.append((i, t, child))
+        try:
+            for i, t in enumerate(task_list):
+                task_acp_args = t.get("acp_args") if "acp_args" in t else None
+                task_creds = _resolve_task_credentials(t, creds, cfg, parent_agent)
+                # Per-task role beats top-level; normalise again so unknown
+                # per-task values warn and degrade to leaf uniformly.
+                effective_role = _normalize_role(t.get("role") or top_role)
+                child = _build_child_agent(
+                    task_index=i,
+                    goal=t["goal"],
+                    context=t.get("context"),
+                    toolsets=t.get("toolsets") or toolsets,
+                    model=task_creds["model"],
+                    max_iterations=effective_max_iter,
+                    task_count=n_tasks,
+                    parent_agent=parent_agent,
+                    override_provider=task_creds["provider"],
+                    override_base_url=task_creds["base_url"],
+                    override_api_key=task_creds["api_key"],
+                    override_api_mode=task_creds["api_mode"],
+                    override_acp_command=t.get("acp_command")
+                    or acp_command
+                    or task_creds.get("command"),
+                    override_acp_args=(
+                        task_acp_args
+                        if task_acp_args is not None
+                        else (acp_args if acp_args is not None else task_creds.get("args"))
+                    ),
+                    reasoning_effort=t.get("reasoning_effort"),
+                    role=effective_role,
+                )
+                # Override with correct parent tool names (before child construction mutated global)
+                child._delegate_saved_tool_names = _parent_tool_names
+                children.append((i, t, child))
+        except Exception as exc:
+            for _, _, built_child in children:
+                _cleanup_built_child(built_child, parent_agent)
+            if isinstance(exc, ValueError):
+                return tool_error(str(exc))
+            raise
     finally:
         # Authoritative restore: reset global to parent's tool names after all children built
         _model_tools._last_resolved_tool_names = _parent_tool_names
@@ -2899,6 +2981,8 @@ def _build_top_level_description() -> str:
         "never enter your context window.\n\n"
         "TWO MODES (one of 'goal' or 'tasks' is required):\n"
         "1. Single task: provide 'goal' (+ optional context, toolsets).\n"
+        "   Optional routing in single-task mode: top-level "
+        "model/provider/reasoning_effort apply only when you pass 'goal'.\n"
         f"2. Batch (parallel): provide 'tasks' array with up to {max_children} "
         f"items concurrently for this user (configured via "
         f"delegation.max_concurrent_children in config.yaml). {nesting_clause}\n\n"
@@ -2961,7 +3045,9 @@ def _build_tasks_param_description() -> str:
         f"Batch mode: tasks to run in parallel (up to {max_children} for this "
         f"user, set via delegation.max_concurrent_children). Each gets "
         "its own subagent with isolated context and terminal session. "
-        "When provided, top-level goal/context/toolsets are ignored."
+        "When provided, top-level goal/context/toolsets are ignored. "
+        "put model/provider/reasoning_effort inside each tasks[] item for "
+        "batch routing. Top-level routing fields are ignored in batch mode."
     )
 
 
@@ -3024,6 +3110,9 @@ def _build_dynamic_schema_overrides() -> dict:
     }
 
 
+_REASONING_EFFORT_ENUM = ["none", "minimal", "low", "medium", "high", "xhigh"]
+
+
 DELEGATE_TASK_SCHEMA = {
     "name": "delegate_task",
     # NOTE: description / tasks.description / role.description are placeholder
@@ -3070,6 +3159,30 @@ DELEGATE_TASK_SCHEMA = {
                     "['terminal', 'file', 'web'] for full-stack tasks."
                 ),
             },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Optional routing override for single-task mode only. "
+                    "Applies only when you pass top-level goal; batch mode routing "
+                    "must be set inside each tasks[] item."
+                ),
+            },
+            "provider": {
+                "type": "string",
+                "description": (
+                    "Optional provider routing override for single-task mode only. "
+                    "Ignored in batch mode unless set per-task inside tasks[]."
+                ),
+            },
+            "reasoning_effort": {
+                "type": "string",
+                "enum": _REASONING_EFFORT_ENUM,
+                "description": (
+                    "Optional reasoning override for single-task mode only. "
+                    "Use 'none' to disable reasoning. Ignored in batch mode unless "
+                    "set per-task inside tasks[]."
+                ),
+            },
             "tasks": {
                 "type": "array",
                 "items": {
@@ -3084,6 +3197,19 @@ DELEGATE_TASK_SCHEMA = {
                             "type": "array",
                             "items": {"type": "string"},
                             "description": f"Toolsets for this specific task. Available: {_TOOLSET_LIST_STR}. Use 'web' for network access, 'terminal' for shell, 'browser' for web interaction.",
+                        },
+                        "model": {
+                            "type": "string",
+                            "description": "Optional per-task model routing override for batch mode.",
+                        },
+                        "provider": {
+                            "type": "string",
+                            "description": "Optional per-task provider routing override for batch mode.",
+                        },
+                        "reasoning_effort": {
+                            "type": "string",
+                            "enum": _REASONING_EFFORT_ENUM,
+                            "description": "Optional per-task reasoning override for batch mode. Use 'none' to disable reasoning for that task.",
                         },
                         "acp_command": {
                             "type": "string",
@@ -3190,6 +3316,9 @@ registry.register(
         acp_args=args.get("acp_args"),
         role=args.get("role"),
         background=_model_background_value(args, kw.get("parent_agent")),
+        model=args.get("model"),
+        provider=args.get("provider"),
+        reasoning_effort=args.get("reasoning_effort"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,


### PR DESCRIPTION
## Summary
- Add per-task `model`, `provider`, and `reasoning_effort` routing fields to `delegate_task` batch items.
- Preserve backwards compatibility for existing single-task and batch callers, including keeping top-level batch routing fields from becoming implicit per-item defaults.
- Forward routing fields through `run_agent` dispatch and clean up partially built child agents when build-stage failures occur.

## Test plan
- [x] `scripts/run_tests.sh tests/tools/test_delegate.py tests/agent/test_subagent_stop_hook.py tests/run_agent/test_interrupt_propagation.py tests/run_agent/test_real_interrupt_subagent.py` — 164 passed.
- [x] `scripts/run_tests.sh tests/acp/test_auth.py` — 10 passed after bootstrapping the wrapper-supported `[all,dev]` venv.
- [x] `scripts/run_tests.sh tests/run_agent/test_streaming.py tests/run_agent/test_stream_drop_logging.py tests/run_agent/test_session_id_env.py tests/tools/test_discord_tool.py` — 143 passed after installing browser assets in the same hermetic `HOME` used by `scripts/run_tests.sh`.
- [ ] `scripts/run_tests.sh` full suite was attempted locally. It still fails outside this change area in this container/profile environment, including Docker install-method detection, missing `systemctl`/user-systemd assumptions, and tests that monkeypatch `HERMES_HOME` to temp dirs and then hit browser lazy-install timeouts. The changed/adjacent delegate tests above are green; CI should be the source of truth for the full matrix.
