### PR TITLE
docs: clarify Codex OAuth auth checks

### DIFF
--- a/website/docs/developer-guide/provider-runtime.md
+++ b/website/docs/developer-guide/provider-runtime.md
@@ -137,6 +137,15 @@ Codex uses a separate Responses API path:
 - `api_mode = codex_responses`
 - dedicated credential resolution and auth store support
 
+The `openai-codex` provider is OAuth-backed, not an `OPENAI_API_KEY` check.
+Hermes reads Codex tokens from its own provider auth state in
+`~/.hermes/auth.json` after `hermes auth add openai-codex` or `hermes model`
+selects OpenAI Codex. During setup it can also import an existing Codex CLI
+session from `${CODEX_HOME:-~/.codex}/auth.json`, then stores the imported
+tokens in Hermes' auth store. Diagnostics for this provider should check the
+Hermes auth state, and optionally the Codex CLI auth file as an import source,
+before reporting missing OpenAI credentials.
+
 ## Auxiliary model routing
 
 Auxiliary tasks such as:

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -18,7 +18,7 @@ Hermes reads environment variables from the process environment and, for user-ma
 | `HERMES_OPENROUTER_CACHE_TTL` | Cache TTL in seconds (1-86400). Overrides `openrouter.response_cache_ttl` in config.yaml. |
 | `NOUS_BASE_URL` | Override Nous Portal base URL (rarely needed; development/testing only) |
 | `NOUS_INFERENCE_BASE_URL` | Override Nous inference endpoint directly |
-| `OPENAI_API_KEY` | API key for custom OpenAI-compatible endpoints (used with `OPENAI_BASE_URL`) |
+| `OPENAI_API_KEY` | API key for custom OpenAI-compatible endpoints (used with `OPENAI_BASE_URL`). Not required for the `openai-codex` provider, which uses OAuth-backed auth state instead. |
 | `OPENAI_BASE_URL` | Base URL for custom endpoint (VLLM, SGLang, etc.) |
 | `LM_API_KEY` | API key for LM Studio (`lmstudio` provider). Often a placeholder for local servers |
 | `LM_BASE_URL` | LM Studio base URL (default: `http://localhost:1234/v1`) |
@@ -112,6 +112,12 @@ Hermes reads environment variables from the process environment and, for user-ma
 ## Provider Auth (OAuth)
 
 For native Anthropic auth, Hermes prefers Claude Code's own credential files when they exist because those credentials can refresh automatically. **OAuth against Anthropic requires a Claude Max plan with purchased extra usage credits** — Hermes routes as Claude Code, which only draws from the Max plan's extra/overage credits, not the base Max allowance, and does not work on Claude Pro. Without Max + extra credits, use an API key instead. Environment variables such as `ANTHROPIC_TOKEN` remain useful as manual overrides, but they are no longer the preferred path for Claude Max login.
+
+For OpenAI Codex, Hermes stores OAuth tokens under `~/.hermes/auth.json` when
+you run `hermes auth add openai-codex` or select OpenAI Codex in
+`hermes model`. If the Codex CLI is already logged in, Hermes can import tokens
+from `${CODEX_HOME:-~/.codex}/auth.json`; a missing `OPENAI_API_KEY` by itself
+does not mean Codex OAuth credentials are missing.
 
 | Variable | Description |
 |----------|-------------|


### PR DESCRIPTION
## Summary
- document that `openai-codex` auth is OAuth-backed through Hermes' auth store, not an `OPENAI_API_KEY` check
- call out Codex CLI auth import from `${CODEX_HOME:-~/.codex}/auth.json`
- clarify the environment variable reference so missing `OPENAI_API_KEY` is not treated as missing Codex OAuth credentials

Fixes #17038.

## Testing
- Docs-only change; verified the rendered Markdown snippets and PR diff locally.