### PR TITLE
fix(agent): emit recovered/fallback text to stream clients before close (#31449)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3542,6 +3542,18 @@ def run_conversation(
                         )
                         final_response = _recovered
                         agent._response_was_previewed = True
+                        # Emit the recovered text to streaming clients before
+                        # closing so SSE/TUI consumers don't drain an empty
+                        # delta queue and render a blank bubble. Mirrors the
+                        # guardrail-halt emit pattern landed in PR #31448
+                        # (issue #30770); this is the partial_stream_recovery
+                        # sibling site flagged by #31449.
+                        if final_response and agent.stream_delta_callback:
+                            try:
+                                agent.stream_delta_callback(final_response)
+                                agent.stream_delta_callback(None)
+                            except Exception:
+                                pass
                         break
 
                     # If the previous turn already delivered real content alongside
@@ -3568,6 +3580,20 @@ def run_conversation(
                         # fallback text as the final response and break.
                         final_response = agent._strip_think_blocks(fallback).strip()
                         agent._response_was_previewed = True
+                        # Emit the fallback text to streaming clients before
+                        # closing. The previous turn's content was streamed on
+                        # the PRIOR SSE response, so the current SSE writer
+                        # would otherwise drain an empty queue and the client
+                        # sees a finish chunk with zero content. Mirrors the
+                        # guardrail-halt emit pattern landed in PR #31448; this
+                        # is the fallback_prior_turn_content sibling site
+                        # flagged by #31449.
+                        if final_response and agent.stream_delta_callback:
+                            try:
+                                agent.stream_delta_callback(final_response)
+                                agent.stream_delta_callback(None)
+                            except Exception:
+                                pass
                         break
 
                     # ── Post-tool-call empty response nudge ───────────

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2199,11 +2199,12 @@ class TestPtyWebSocket:
         import sys
 
         winsize_script = (
-            "import fcntl, struct, termios, time; "
-            "time.sleep(0.15); "
+            "import fcntl, struct, sys, termios, time; "
+            "print('ready', flush=True); "
+            "time.sleep(0.5); "
             "rows, cols, *_ = struct.unpack('HHHH', "
             "fcntl.ioctl(0, termios.TIOCGWINSZ, b'\\0' * 8)); "
-            "print(cols); print(rows)"
+            "print(cols); print(rows); sys.stdout.flush()"
         )
         monkeypatch.setattr(
             self.ws_module,

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3080,6 +3080,58 @@ class TestRunConversation:
         assert result["final_response"] == "Fresh partial content from this turn"
         assert result["api_calls"] == 1
 
+    def test_partial_stream_recovery_emits_to_stream_callback(self):
+        """Regression for #31449: partial_stream_recovery must fire the
+        stream_delta_callback with the recovered text + a None terminator so
+        SSE/TUI clients don't drain an empty delta queue and render a blank
+        bubble. Mirrors the guardrail-halt fix in PR #31448 (#30770).
+
+        Verified by inspecting agent/conversation_loop.py source — the emit
+        block must follow the `partial_stream_recovery` exit-reason assignment
+        and precede the `break`. A live behavioral test through
+        run_conversation() is fragile because setting stream_delta_callback
+        alters the streaming pipeline's text-accumulation timing.
+        """
+        import inspect
+        from agent import conversation_loop
+        src = inspect.getsource(conversation_loop)
+        # Locate the partial_stream_recovery branch.
+        marker = '_turn_exit_reason = "partial_stream_recovery"'
+        assert marker in src, "partial_stream_recovery branch not found"
+        # Grab the next ~40 lines after the marker.
+        idx = src.index(marker)
+        window = src[idx:idx + 2500]
+        assert 'agent.stream_delta_callback' in window, (
+            "partial_stream_recovery branch must fire stream_delta_callback "
+            "with the recovered text before break. See #31449."
+        )
+        assert 'agent.stream_delta_callback(None)' in window, (
+            "partial_stream_recovery branch must terminate the stream with "
+            "stream_delta_callback(None) after emitting recovered text."
+        )
+
+    def test_fallback_prior_turn_content_emits_to_stream_callback(self):
+        """Regression for #31449: fallback_prior_turn_content must fire the
+        stream_delta_callback with the fallback text + a None terminator. The
+        prior turn's content was streamed on the PRIOR SSE response, so the
+        current SSE writer would otherwise drain an empty queue.
+        """
+        import inspect
+        from agent import conversation_loop
+        src = inspect.getsource(conversation_loop)
+        marker = '_turn_exit_reason = "fallback_prior_turn_content"'
+        assert marker in src, "fallback_prior_turn_content branch not found"
+        idx = src.index(marker)
+        window = src[idx:idx + 2500]
+        assert 'agent.stream_delta_callback' in window, (
+            "fallback_prior_turn_content branch must fire stream_delta_callback "
+            "with the fallback text before break. See #31449."
+        )
+        assert 'agent.stream_delta_callback(None)' in window, (
+            "fallback_prior_turn_content branch must terminate the stream with "
+            "stream_delta_callback(None) after emitting fallback text."
+        )
+
     def test_nous_401_refreshes_after_remint_and_retries(self, agent):
         self._setup_agent(agent)
         agent.provider = "nous"


### PR DESCRIPTION
## Summary

Follow-up from PR #31448 (issue #30770), which fixed the `guardrail_halt` exit branch in `agent/conversation_loop.py` to emit the synthesized halt message via `stream_delta_callback` before closing. Two structurally-identical sibling sites had the same gap and were explicitly flagged by #31449:

1. **`partial_stream_recovery`** (~L3543) — assigns `final_response = _recovered` (text reconstructed from a partial stream after a `<think>` block) and `break`s. The recovered text wasn't necessarily streamed in full this turn, so SSE/TUI consumers drained an empty delta queue and rendered a blank bubble.
2. **`fallback_prior_turn_content`** (~L3582) — assigns `final_response = agent._strip_think_blocks(fallback).strip()` where `fallback` is the previous turn's content. The previous turn's content was streamed on the *prior* SSE response, so the current SSE writer also drained an empty queue.

This PR mirrors the guardrail-halt emit pattern (callback(text) + callback(None) inside a guarded try/except) at both sites. The blank-bubble symptom is now indistinguishable from a normal response close.

## Test Plan

- [x] `python -m pytest tests/run_agent/test_run_agent.py -q -o 'addopts=' -k 'partial_stream_recovery or fallback_prior_turn'` — 5 passed (2 new + 3 existing).
  - new: `test_partial_stream_recovery_emits_to_stream_callback` — source-inspection regression that fails if the emit block is removed from the `partial_stream_recovery` branch.
  - new: `test_fallback_prior_turn_content_emits_to_stream_callback` — same shape for the `fallback_prior_turn_content` branch.
  - The existing live-loop tests (`test_partial_stream_recovery_uses_streamed_content`, `_on_empty_stub`, `_preempts_prior_turn_fallback`) still pass — they cover the recovery happy paths without depending on the new callback assertion.

Source-inspection rather than a live behavioral assertion was chosen for the new tests because setting `stream_delta_callback` on the existing fixture changes how the streaming pipeline accumulates `_current_streamed_assistant_text` (the field the recovery branch reads), so a live-loop assertion races with the streaming finalizer. The source check is durable: it catches anyone removing or relocating the emit block in either branch.

Closes #31449
