### PR TITLE
feat(creative): add codex-vision skill for image analysis and generation via Codex CLI

### DIFF
--- a/skills/creative/codex-vision/SKILL.md
+++ b/skills/creative/codex-vision/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: codex-vision
+description: "Use Codex CLI for image analysis and generation — vision tasks that the Hermes vision_analyze tool can't handle. Covers MCP setup, exec workflow, image generation with the built-in image_gen tool, and iCloud File Provider placeholder pitfalls."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags:
+      - codex
+      - vision
+      - image-generation
+      - gpt-image
+      - creative
+      - generative-ai
+      - mcp
+    related_skills: [codex, comfyui, stable-diffusion-image-generation]
+    category: creative
+---
+
+# Codex Vision — Image Analysis and Generation via Codex CLI
+
+## Overview
+
+Use the Codex CLI (`codex exec`) for vision tasks: analyzing images that the Hermes `vision_analyze` tool can't handle, and generating new images via Codex's built-in `image_gen` tool (GPT-image-2).
+
+This skill goes beyond basic vision analysis. It covers:
+
+- **Image analysis** — Detailed descriptions, QA, and understanding of local images
+- **Image generation** — Generate new images using Codex's built-in `image_gen` tool
+- **Identity-preserve generation** — Use reference images to maintain consistent identity across generated portraits
+- **MCP server setup** — Register Codex as an MCP server in Hermes for code tasks
+- **Hermes integration** — Proper handling of `codex exec` from non-TTY Hermes terminal sessions
+
+**Auth is ChatGPT OAuth, not API key.** Codex uses ChatGPT Plus OAuth tokens stored in `~/.codex/auth.json` with `"auth_mode": "chatgpt"` and `"OPENAI_API_KEY": null`. This means you must have an active ChatGPT Plus subscription and run `codex auth login` at least once.
+
+---
+
+## When to Use
+
+- Analyzing an image in detail (who/what, style, mood, colors, composition)
+- Generating a new image from a text prompt
+- Generating an image with identity preservation from a reference photo
+- Generating portraits, editorial characters, maps, or scene illustrations
+- QA of previously generated images for identity consistency or artifacts
+
+**Don't use for:**
+- Quick image lookups (use `vision_analyze` if the image is a URL)
+- Image generation that doesn't need Codex's built-in tool (use `image_generate` / FAL for style-diverse generation)
+- Video or multi-frame content
+
+---
+
+## Prerequisites
+
+| Requirement | Details |
+|---|---|
+| **Codex CLI** | `npm install -g @openai/codex` |
+| **ChatGPT Plus** | Required for image generation (OAuth, not API key) |
+| **Auth** | `codex auth login` completed — valid `~/.codex/auth.json` |
+| **macOS `sips`** | For format conversion on macOS. On Linux, use `convert` from ImageMagick |
+| **Hermes Agent** | The skill is designed for the Hermes agent framework |
+
+---
+
+## MCP Setup (Code Tasks)
+
+Add Codex as an MCP server to Hermes so its code tools are available natively:
+
+```bash
+hermes mcp add codex --command codex --args mcp-server
+```
+
+**What you get:** `codex` (run a coding session) and `codex-reply` (continue a thread).
+
+**Important:** The MCP server does **NOT** expose image generation. Use `codex exec` for all vision and image work.
+
+**Auth:** If tokens are invalidated, re-auth with `codex auth login`.
+
+---
+
+## Image Analysis
+
+### Quick Analysis
+
+```bash
+cd /path/to/images && codex exec \
+  "Describe this image in detail — who/what is depicted, style, mood, colors, composition" \
+  --image <filename.jpg> \
+  --skip-git-repo-check
+```
+
+- `--skip-git-repo-check` is required when the working directory is not a git repo
+- Codex auto-selects the configured model (typically GPT-4o or higher for vision)
+
+### Cross-Directory Analysis
+
+```bash
+codex exec \
+  "Describe this image in detail" \
+  --image /full/path/to/image.jpg \
+  --skip-git-repo-check
+```
+
+### Auth Failures
+
+```
+401 Unauthorized
+Your access token could not be refreshed because your refresh token was already used.
+```
+
+→ User needs to re-authenticate: `codex auth login`
+
+**MCP is not a bypass:** `mcp_codex_codex` uses the same auth path. When CLI OAuth is invalidated, MCP sessions fail with the same error.
+
+---
+
+## Image Generation
+
+### Critical: Writable Sandbox Required
+
+Codex runs in a read-only sandbox by default. For image generation (which writes to `$CODEX_HOME/generated_images/`), you **must** use `-s workspace-write`:
+
+```bash
+codex exec --skip-git-repo-check -s workspace-write --add-dir /target/dir \
+  "Generate a portrait. Save to /target/dir/output.jpg"
+```
+
+If the target output directory differs from the workdir, include it via `--add-dir`.
+
+### Basic Generation
+
+```bash
+cd /target/directory
+
+codex exec --skip-git-repo-check -s workspace-write \
+  --add-dir /target/directory \
+  "Generate a photorealistic portrait of a woman in a Pacific Northwest forest at dawn. Save to /target/directory/output.jpg"
+```
+
+### Non-TTY Prompt Handling (Hermes Terminal)
+
+In Hermes terminal sessions (non-TTY), `codex exec` may silently drop a positional prompt. **Always pipe via stdin** for reliable delivery:
+
+```bash
+printf '%s' "Generate a portrait. Save to /target/output.jpg" | \
+  codex exec --skip-git-repo-check -s workspace-write \
+    --add-dir /target/directory \
+    -
+```
+
+This is critical for image generation runs triggered from Telegram, Discord, or other non-interactive Hermes channels.
+
+### Output Path Resolution
+
+Codex writes generated images to `$CODEX_HOME/generated_images/<session_id>/ig_XXXX.png` first, then you copy/convert to the desired final path:
+
+```bash
+# 1. Generate
+codex exec --skip-git-repo-check -s workspace-write --add-dir /target/dir \
+  "Generate a portrait. Save to /target/dir/output.jpg"
+
+# 2. Find the latest session's output
+SESSION=$(ls -lt "$HOME/.codex/generated_images/" | head -1 | awk '{print $NF}')
+
+# 3. Convert (macOS sips)
+sips -s format jpeg "$HOME/.codex/generated_images/$SESSION/ig_*.png" --out /target/dir/output.jpg
+```
+
+**Timeout:** Image generation takes 2–5 minutes. Use `timeout=300` in Hermes terminal calls.
+
+---
+
+## Identity-Preserve Generation
+
+Use a reference image to guide identity (face, build, style) in generated output. The `image_gen` tool treats references as style/identity guidance — there is no explicit face-locking parameter, so results are non-deterministic.
+
+### Verbose Prompt (Quality, Slow)
+
+```bash
+codex exec --skip-git-repo-check -s workspace-write \
+  --add-dir /path/to/references \
+  -i reference.jpg \
+  --add-dir /path/to/output \
+  "Use case: identity-preserve
+Asset type: portrait
+Primary request: A portrait of a woman with long curly hair on a cabin deck at dawn. Soft morning light, mist, mountains in the background.
+Input images: Image 1: canonical reference — preserve exact face, face shape, hair, build, skin tone
+Style: photorealistic, natural morning light, warm tones
+Constraints: lock face identity from reference. Change only scene and clothing. No text, no watermark.
+Output: save to /path/to/output/result.jpg"
+```
+
+### Brief Prompt (Fast, Iterative)
+
+```bash
+codex exec --skip-git-repo-check -s workspace-write \
+  --add-dir /path/to/references \
+  -i reference.jpg \
+  --add-dir /path/to/output \
+  "Generate a portrait: woman, curly hair, slim, on a morning deck with coffee, natural light. Reference: reference.jpg. Save to /path/to/output/result.jpg"
+```
+
+### Key Flags Reference
+
+| Flag | Purpose |
+|---|---|
+| `--add-dir <path>` | Whitelist a directory for read/write access in the sandbox |
+| `-i <file>` or `--image <file>` | Attach a reference image (must be in an `--add-dir` directory) |
+| `-s workspace-write` | Enable writable sandbox (required for image generation) |
+| `--skip-git-repo-check` | Skip git repo validation (required outside git repos) |
+| `-` | Read prompt from stdin (required in non-TTY sessions) |
+
+### Prompt Style Guide
+
+| Use case | Prompt style | Expected time |
+|---|---|---|
+| Iterative exploration, pose variety | Brief single-line | ~60s |
+| Final canonical portraits | Verbose structured | 2–3 min |
+| Time-critical generation | Brief only | ~60s |
+| Multi-person generation | Verbose or brief (test both) | Varies |
+
+**Rule:** Start with brief prompts for iteration. Use verbose structured for final assets. If a verbose prompt times out (300s), retry with a condensed version.
+
+---
+
+## Time-Aware Scene Generation
+
+Match the scene to actual local time for authentic lighting:
+
+```bash
+date '+%Y-%m-%d %H:%M %Z'
+```
+
+| Time of Day | Lighting & Scene Context |
+|---|---|
+| Morning (6–11 AM) | Soft sun, mist, golden/cream light, warm drinks, waking scenes |
+| Midday (11 AM–5 PM) | Clear light, warm indoor sun, afternoon clarity |
+| Evening (5–8 PM) | Golden hour, sunset, last warm light, shadows |
+| Night (8 PM–6 AM) | Stars, darkness, candlelight, rain at night, artificial light |
+
+Include the actual local time in the prompt for Codex to generate appropriate lighting and atmosphere.
+
+---
+
+## Messenger Delivery Workflow
+
+For images requested over Telegram, Discord, or other messaging platforms:
+
+1. Generate via `codex exec` with reference attached (if identity-preserve)
+2. Copy/convert the output PNG to a stable project path
+3. Verify with `file` / `ls -lh`
+4. Run a quick `vision_analyze` QA pass for identity consistency, scene match, artifacts
+5. Deliver with `MEDIA:/absolute/path/to/file` in the final response
+
+Keep the reply concise: one grounded sentence about the scene + the `MEDIA:` line + any major QA caveat only if one exists.
+
+---
+
+## Common Pitfalls
+
+1. **Verbose prompts timeout (300s).** Use brief prompts for iteration. Condense verbose prompts if timeout occurs.
+2. **iCloud placeholders.** Files synced to iCloud may be "dataless" — correct file size but no readable pixel data. Always verify with `file <path>`.
+3. **Forgot writable sandbox.** Default read-only sandbox prevents Codex from writing generated images. Always use `-s workspace-write`.
+4. **Forgot `--add-dir`.** Without `--add-dir /target/dir`, Codex cannot write output to that directory.
+5. **Auth token expiry.** `401 Unauthorized` means re-auth via `codex auth login`.
+6. **`keep` database error.** Non-fatal. Codex proceeds without the reflection step. Ignore.
+7. **Forgot `--skip-git-repo-check`.** Always include when outside a git repo.
+8. **Non-TTY prompt dropped.** Pipe via `printf '...' | codex exec -` for reliable delivery in Hermes terminal sessions.
+9. **Output in wrong directory.** Codex writes to `$CODEX_HOME/generated_images/<session_id>/` first, not the target directory. Copy/convert afterward.
+10. **`vision_analyze` not available.** If Hermes `vision_analyze` returns errors on image input, use `codex exec` with `--image` flag for vision QA instead.
+
+---
+
+## Verification Checklist
+
+- [ ] Codex CLI is installed and `codex auth login` has been run
+- [ ] ChatGPT Plus subscription is active (required for image generation)
+- [ ] Reference images are local files, not iCloud placeholders (verify with `file <path>`)
+- [ ] All output directories are whitelisted with `--add-dir`
+- [ ] `-s workspace-write` is set for any generation task
+- [ ] `--skip-git-repo-check` is included when outside a git repo
+- [ ] Prompts are piped via `printf '...' | codex exec -` in non-TTY sessions
+- [ ] `timeout=300` is set for image generation terminal calls
+- [ ] Output was copied from `$CODEX_HOME/generated_images/<session_id>/` to the final destination
+- [ ] Generated image passes identity/scene QA before delivery

--- a/skills/creative/codex-vision/references/identity-constants-template.md
+++ b/skills/creative/codex-vision/references/identity-constants-template.md
@@ -1,0 +1,80 @@
+# Identity Constants Reference Template
+
+Use this template to document entity identity constants for image generation prompts. Copy and customize it for each entity you generate images for.
+
+## Physical Identity
+
+```
+- Gender/Age: [description]
+- Build: [height, frame, posture]
+- Hair: [color, length, style, texture]
+- Face: [shape, distinguishing features, expression tendency]
+- Skin tone: [description]
+- Signature details: [glasses, jewelry, tattoos, scars, etc.]
+```
+
+## Reference Image Guidelines
+
+Store canonical reference images in a stable directory:
+
+```
+/path/to/references/<entity>-primary.jpg     # Primary: well-lit, identity-forward
+/path/to/references/<entity>-alt-1.jpg       # Alternate angle or context
+```
+
+Choose reference images that are:
+- **Local, not iCloud placeholders** — verify with `file <path>` (look for `dataless`)
+- **Well-lit and clear** — blurry/dark references produce poor outputs
+- **Identity-forward** — clearly shows the face and build to preserve
+- **Single-entity** — avoid group photos as identity references
+
+## Prompt Patterns
+
+### Brief (Fast, Iterative)
+
+```
+Generate a [scene]: [identity constants], [scene context with time of day]. Reference: ref.jpg. Save to output.jpg
+```
+Expected time: ~60s
+
+### Verbose (Quality, Final)
+
+```
+Use case: identity-preserve
+Asset type: portrait
+Primary request: [full scene description with time of day]
+Input images: Image 1: reference — preserve exact face, hair, build, skin tone
+Style: photorealistic, [lighting description]
+Constraints: lock identity from reference. Change only scene and clothing. No text, no watermark.
+Output: save to output.jpg
+```
+Expected time: 2–3 min. May timeout at 300s — if so, condense.
+
+## Time-Aware Scene Library
+
+Document your entity's common scenes matched to time of day:
+
+| Time of Day | Scene | Location | Props | Mood |
+|---|---|---|---|---|
+| Morning (6–11 AM) | | | | |
+| Midday (11 AM–5 PM) | | | | |
+| Evening (5–8 PM) | | | | |
+| Night (8 PM–6 AM) | | | | |
+
+## Multi-Entity Generation
+
+When generating images with multiple entities in the same scene:
+
+- Describe each entity's **distinctive visual markers** in the prompt
+- Specify **relative positions** and **interactions**
+- Note shared context (lighting, location, time of day)
+- Use brief prompts first; escalate to verbose if quality is insufficient
+
+## Success Tracking
+
+Keep a log of what works:
+
+- Which prompt styles produce the best identity preservation
+- Which scenes yield the most naturalistic results
+- Which reference images produce the strongest identity match
+- Recurring artifacts or failure modes to avoid

--- a/skills/creative/codex-vision/scripts/analyze_image.sh
+++ b/skills/creative/codex-vision/scripts/analyze_image.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+#
+# analyze_image.sh
+# Analyze an image via Codex CLI vision.
+#
+# Usage:
+#   ./analyze_image.sh <image_path> ["question"]
+#
+# Example:
+#   ./analyze_image.sh /path/to/photo.jpg
+#   ./analyze_image.sh /path/to/photo.jpg "Who is in this photo? Describe the scene."
+#
+
+IMAGE="$1"
+QUESTION="${2:-Describe this image in detail — who/what is depicted, style, mood, colors, composition}"
+
+if [[ ! -f "$IMAGE" ]]; then
+  echo "ERROR: Image not found: $IMAGE" >&2
+  exit 1
+fi
+
+IMGDIR="$(dirname "$IMAGE")"
+IMGFILE="$(basename "$IMAGE")"
+
+cd "$IMGDIR"
+codex exec "$QUESTION" --image "$IMGFILE" --skip-git-repo-check

--- a/skills/creative/codex-vision/scripts/batch_generate.sh
+++ b/skills/creative/codex-vision/scripts/batch_generate.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+#
+# batch_generate.sh
+# Generate multiple images from a prompt file, each with a shared reference image.
+#
+# Usage:
+#   ./batch_generate.sh <reference_image> <output_dir> <prompt_file>
+#
+# prompt_file format: one prompt per line. Lines starting with # are skipped.
+# Output files: output_dir/001.png, output_dir/002.png, ...
+#
+# Example:
+#   ./batch_generate.sh ~/references/primary.jpg ~/output/prompts.txt
+#
+
+REFERENCE="$1"
+OUTPUT_DIR="$2"
+PROMPT_FILE="$3"
+
+mkdir -p "$OUTPUT_DIR"
+
+COUNTER=0
+while IFS= read -r line; do
+  [[ "$line" =~ ^#.*$ || -z "$line" ]] && continue
+
+  COUNTER=$((COUNTER + 1))
+  PADDED=$(printf '%03d' "$COUNTER")
+  OUT_FILE="$OUTPUT_DIR/${PADDED}.png"
+
+  echo "=== Generating #$COUNTER: $line ==="
+
+  REFERENCE_DIR="$(dirname "$REFERENCE")"
+  REFERENCE_FILE="$(basename "$REFERENCE")"
+
+  cd "$OUTPUT_DIR"
+  printf '%s' "$line" | \
+    codex exec --skip-git-repo-check -s workspace-write \
+      --add-dir "$REFERENCE_DIR" \
+      -i "$REFERENCE_FILE" \
+      --add-dir "$OUTPUT_DIR" \
+      -
+
+  SESSION=$(ls -lt "$HOME/.codex/generated_images/" 2>/dev/null | head -1 | awk '{print $NF}')
+  if [[ -n "$SESSION" ]]; then
+    LATEST=$(find "$HOME/.codex/generated_images/$SESSION" -name '*.png' -type f 2>/dev/null | sort | tail -1)
+    if [[ -n "$LATEST" ]]; then
+      cp "$LATEST" "$OUT_FILE"
+      echo "  → Saved: $OUT_FILE"
+    fi
+  fi
+
+  echo "---"
+done < "$PROMPT_FILE"
+
+echo "BATCH DONE: $COUNTER images generated in $OUTPUT_DIR"

--- a/skills/creative/codex-vision/scripts/generate_with_reference.sh
+++ b/skills/creative/codex-vision/scripts/generate_with_reference.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+#
+# generate_with_reference.sh
+# Generate an image via Codex CLI with a reference image for identity preservation.
+#
+# Usage:
+#   ./generate_with_reference.sh <reference_image> <output_path> <prompt>
+#
+# Example:
+#   ./generate_with_reference.sh \
+#     ~/references/primary.jpg \
+#     ~/output/portrait.jpg \
+#     "Generate a portrait: woman, morning light on deck, natural, warm tones"
+#
+# Requirements:
+#   - codex CLI installed and authenticated (codex auth login)
+#   - ChatGPT Plus subscription (for image generation)
+#   - macOS with sips (for format conversion). On Linux, install ImageMagick.
+#
+
+REFERENCE="$1"
+OUTPUT="$2"
+PROMPT="$3"
+OUTDIR="$(dirname "$OUTPUT")"
+
+if [[ ! -f "$REFERENCE" ]]; then
+  echo "ERROR: Reference image not found: $REFERENCE" >&2
+  exit 1
+fi
+
+# Check for iCloud placeholder
+if file "$REFERENCE" | grep -qi "dataless\|placeholder"; then
+  echo "ERROR: Reference image appears to be an iCloud placeholder (dataless). Use a local copy." >&2
+  exit 1
+fi
+
+mkdir -p "$OUTDIR"
+
+NOW=$(date '+%Y-%m-%d %H:%M %Z')
+FULL_PROMPT="$PROMPT [Generated at $NOW. Match lighting and atmosphere to the time of day.]"
+
+REFERENCE_DIR="$(dirname "$REFERENCE")"
+REFERENCE_FILE="$(basename "$REFERENCE")"
+
+cd "$OUTDIR"
+printf '%s' "$FULL_PROMPT" | \
+  codex exec --skip-git-repo-check -s workspace-write \
+    --add-dir "$REFERENCE_DIR" \
+    -i "$REFERENCE_FILE" \
+    --add-dir "$OUTDIR" \
+    -
+
+SESSION=$(ls -lt "$HOME/.codex/generated_images/" 2>/dev/null | head -1 | awk '{print $NF}')
+if [[ -n "$SESSION" ]]; then
+  LATEST_PNG=$(find "$HOME/.codex/generated_images/$SESSION" -name '*.png' -type f 2>/dev/null | sort | tail -1)
+  if [[ -n "$LATEST_PNG" ]]; then
+    case "$OUTPUT" in
+      *.png) cp "$LATEST_PNG" "$OUTPUT" ;;
+      *.jpg|*.jpeg) sips -s format jpeg "$LATEST_PNG" --out "$OUTPUT" >/dev/null 2>&1 || \
+                    convert "$LATEST_PNG" "$OUTPUT" ;;
+      *) cp "$LATEST_PNG" "$OUTPUT.png" ;;
+    esac
+    echo "Generated: $OUTPUT"
+    file "$OUTPUT"
+    exit 0
+  fi
+fi
+
+echo "Codex completed but no generated image was found." >&2
+exit 3


### PR DESCRIPTION
## What does this PR do?

Adds a new bundled skill `codex-vision` under `skills/creative/` that enables image analysis and image generation via the OpenAI Codex CLI.

The skill covers:
- **Image analysis** — describe, QA, and understand local images via `codex exec --image`
- **Image generation** — generate new images using Codex's built-in `image_gen` tool (GPT-image-2)
- **Identity-preserve generation** — use reference images to maintain consistent identity across generated portraits
- **MCP server setup** — register Codex as an MCP server for code delegation tasks
- **Hermes terminal integration** — proper non-TTY prompt piping, writable sandbox flags, iCloud placeholder detection
- **Time-aware scene generation** — match prompts to actual local time for authentic lighting

Companion scripts: `generate_with_reference.sh`, `analyze_image.sh`, `batch_generate.sh`.

## Type of Change

- [x] 🎯 New skill (bundled or hub)

## Changes Made

- `skills/creative/codex-vision/SKILL.md` — full skill documentation with Hermes-standard frontmatter
- `skills/creative/codex-vision/references/identity-constants-template.md` — customizable template for entity identity specs
- `skills/creative/codex-vision/scripts/generate_with_reference.sh` — single image generation with reference
- `skills/creative/codex-vision/scripts/analyze_image.sh` — image analysis via Codex vision
- `skills/creative/codex-vision/scripts/batch_generate.sh` — batch generation from prompt file

## How to Test

1. Ensure `codex` CLI is installed and authenticated (`codex auth login`)
2. Analyze an image: `./scripts/analyze_image.sh /path/to/photo.jpg`
3. Generate with reference: `./scripts/generate_with_reference.sh /path/to/ref.jpg /path/to/output.jpg "Generate a portrait"`
4. Load the skill in a Hermes session: `skill_view(name="codex-vision")` — verify frontmatter validates and content loads
5. Verify YAML frontmatter passes the repo skill validator: `name`, `description` (≤1024 chars), body present, total ≤100k chars

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(creative):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've considered cross-platform impact — scripts note macOS `sips` vs Linux `convert` fallback; `codex` CLI is cross-platform

## For New Skills

- [x] This skill is **broadly useful** to most users
- [x] SKILL.md follows the standard format (frontmatter, trigger conditions, steps, pitfalls)
- [x] No external dependencies that aren't already available (requires `codex` CLI + ChatGPT Plus, which are user-provided; scripts use bash/stdlib only)
- [x] Tested end-to-end locally via `skill_view` — frontmatter validates, content loads correctly