### PR TITLE
Fix Telegram album photo batching

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -404,6 +404,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self._pending_photo_batch_tasks: Dict[str, asyncio.Task] = {}
         self._media_group_events: Dict[str, MessageEvent] = {}
         self._media_group_tasks: Dict[str, asyncio.Task] = {}
+        self._media_group_inflight: Dict[str, int] = {}
         # Buffer rapid text messages so Telegram client-side splits of long
         # messages are aggregated into a single MessageEvent.  Lower defaults
         # (0.3s / 1.0s instead of 0.6s / 2.0s) let short replies stream
@@ -1629,6 +1630,7 @@ class TelegramAdapter(BasePlatformAdapter):
             await asyncio.gather(*pending_media_group_tasks, return_exceptions=True)
         self._media_group_tasks.clear()
         self._media_group_events.clear()
+        self._media_group_inflight.clear()
 
         if self._app:
             try:
@@ -5058,6 +5060,13 @@ class TelegramAdapter(BasePlatformAdapter):
         # Download photo to local image cache so the vision tool can access it
         # even after Telegram's ephemeral file URLs expire (~1 hour).
         if msg.photo:
+            media_group_key = (
+                self._photo_batch_key(event, msg)
+                if getattr(msg, "media_group_id", None)
+                else None
+            )
+            if media_group_key:
+                self._begin_media_group_item(media_group_key)
             try:
                 # msg.photo is a list of PhotoSize sorted by size; take the largest
                 photo = msg.photo[-1]
@@ -5076,9 +5085,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 event.media_urls = [cached_path]
                 event.media_types = [f"image/{ext.lstrip('.')}" ]
                 logger.info("[Telegram] Cached user photo at %s", cached_path)
-                media_group_id = getattr(msg, "media_group_id", None)
-                if media_group_id:
-                    await self._queue_media_group_event(str(media_group_id), event)
+                if media_group_key:
+                    await self._queue_media_group_event(media_group_key, event)
                 else:
                     batch_key = self._photo_batch_key(event, msg)
                     self._enqueue_photo_event(batch_key, event)
@@ -5086,6 +5094,9 @@ class TelegramAdapter(BasePlatformAdapter):
 
             except Exception as e:
                 logger.warning("[Telegram] Failed to cache photo: %s", e, exc_info=True)
+            finally:
+                if media_group_key:
+                    self._finish_media_group_item(media_group_key)
 
         # Download voice/audio messages to cache for STT transcription
         if msg.voice:
@@ -5164,32 +5175,50 @@ class TelegramAdapter(BasePlatformAdapter):
                 # payload is actually an image, route it through the image cache
                 # and batching path instead of rejecting it as a document.
                 if ext in _TELEGRAM_IMAGE_EXTENSIONS or doc_mime.startswith("image/"):
-                    file_obj = await doc.get_file()
-                    image_bytes = await file_obj.download_as_bytearray()
-                    image_ext = ext if ext in _TELEGRAM_IMAGE_EXTENSIONS else _TELEGRAM_IMAGE_MIME_TO_EXT.get(doc_mime, ".jpg")
+                    media_group_key = (
+                        self._photo_batch_key(event, msg)
+                        if getattr(msg, "media_group_id", None)
+                        else None
+                    )
+                    if media_group_key:
+                        self._begin_media_group_item(media_group_key)
                     try:
-                        cached_path = cache_image_from_bytes(bytes(image_bytes), ext=image_ext)
-                    except ValueError as e:
-                        logger.warning("[Telegram] Failed to cache image document: %s", e, exc_info=True)
-                        event.text = (
-                            f"Image document '{original_filename or doc_mime or ext or 'unknown'}' "
-                            "could not be read as an image."
+                        file_obj = await doc.get_file()
+                        image_bytes = await file_obj.download_as_bytearray()
+                        image_ext = (
+                            ext
+                            if ext in _TELEGRAM_IMAGE_EXTENSIONS
+                            else _TELEGRAM_IMAGE_MIME_TO_EXT.get(doc_mime, ".jpg")
                         )
-                        await self.handle_message(event)
+                        try:
+                            cached_path = cache_image_from_bytes(bytes(image_bytes), ext=image_ext)
+                        except ValueError as e:
+                            logger.warning("[Telegram] Failed to cache image document: %s", e, exc_info=True)
+                            event.text = (
+                                f"Image document '{original_filename or doc_mime or ext or 'unknown'}' "
+                                "could not be read as an image."
+                            )
+                            await self.handle_message(event)
+                            return
+
+                        event.message_type = MessageType.PHOTO
+                        event.media_urls = [cached_path]
+                        event.media_types = [
+                            doc_mime
+                            if doc_mime.startswith("image/")
+                            else _TELEGRAM_IMAGE_EXT_TO_MIME.get(image_ext, "image/jpeg")
+                        ]
+                        logger.info("[Telegram] Cached user image-document at %s", cached_path)
+
+                        if media_group_key:
+                            await self._queue_media_group_event(media_group_key, event)
+                        else:
+                            batch_key = self._photo_batch_key(event, msg)
+                            self._enqueue_photo_event(batch_key, event)
                         return
-
-                    event.message_type = MessageType.PHOTO
-                    event.media_urls = [cached_path]
-                    event.media_types = [doc_mime if doc_mime.startswith("image/") else _TELEGRAM_IMAGE_EXT_TO_MIME.get(image_ext, "image/jpeg")]
-                    logger.info("[Telegram] Cached user image-document at %s", cached_path)
-
-                    media_group_id = getattr(msg, "media_group_id", None)
-                    if media_group_id:
-                        await self._queue_media_group_event(str(media_group_id), event)
-                    else:
-                        batch_key = self._photo_batch_key(event, msg)
-                        self._enqueue_photo_event(batch_key, event)
-                    return
+                    finally:
+                        if media_group_key:
+                            self._finish_media_group_item(media_group_key)
 
                 if not ext and doc.mime_type:
                     video_mime_to_ext = {v: k for k, v in SUPPORTED_VIDEO_TYPES.items()}
@@ -5264,12 +5293,38 @@ class TelegramAdapter(BasePlatformAdapter):
 
         media_group_id = getattr(msg, "media_group_id", None)
         if media_group_id:
-            await self._queue_media_group_event(str(media_group_id), event)
+            await self._queue_media_group_event(self._photo_batch_key(event, msg), event)
             return
 
         await self.handle_message(event)
 
-    async def _queue_media_group_event(self, media_group_id: str, event: MessageEvent) -> None:
+    def _schedule_media_group_flush(self, media_group_key: str) -> None:
+        prior_task = self._media_group_tasks.get(media_group_key)
+        if prior_task:
+            prior_task.cancel()
+
+        self._media_group_tasks[media_group_key] = asyncio.create_task(
+            self._flush_media_group_event(media_group_key)
+        )
+
+    def _begin_media_group_item(self, media_group_key: str) -> None:
+        self._media_group_inflight[media_group_key] = (
+            self._media_group_inflight.get(media_group_key, 0) + 1
+        )
+        prior_task = self._media_group_tasks.get(media_group_key)
+        if prior_task:
+            prior_task.cancel()
+
+    def _finish_media_group_item(self, media_group_key: str) -> None:
+        remaining = max(0, self._media_group_inflight.get(media_group_key, 0) - 1)
+        if remaining:
+            self._media_group_inflight[media_group_key] = remaining
+            return
+        self._media_group_inflight.pop(media_group_key, None)
+        if media_group_key in self._media_group_events:
+            self._schedule_media_group_flush(media_group_key)
+
+    async def _queue_media_group_event(self, media_group_key: str, event: MessageEvent) -> None:
         """Buffer Telegram media-group items so albums arrive as one logical event.
 
         Telegram delivers albums as multiple updates with a shared media_group_id.
@@ -5277,33 +5332,33 @@ class TelegramAdapter(BasePlatformAdapter):
         new user message and interrupts the first. We debounce briefly and merge the
         attachments into a single MessageEvent.
         """
-        existing = self._media_group_events.get(media_group_id)
+        existing = self._media_group_events.get(media_group_key)
         if existing is None:
-            self._media_group_events[media_group_id] = event
+            self._media_group_events[media_group_key] = event
         else:
             existing.media_urls.extend(event.media_urls)
             existing.media_types.extend(event.media_types)
             if event.text:
                 existing.text = self._merge_caption(existing.text, event.text)
 
-        prior_task = self._media_group_tasks.get(media_group_id)
-        if prior_task:
-            prior_task.cancel()
+        if self._media_group_inflight.get(media_group_key, 0) <= 0:
+            self._schedule_media_group_flush(media_group_key)
 
-        self._media_group_tasks[media_group_id] = asyncio.create_task(
-            self._flush_media_group_event(media_group_id)
-        )
-
-    async def _flush_media_group_event(self, media_group_id: str) -> None:
+    async def _flush_media_group_event(self, media_group_key: str) -> None:
+        current_task = asyncio.current_task()
         try:
-            await asyncio.sleep(self.MEDIA_GROUP_WAIT_SECONDS)
-            event = self._media_group_events.pop(media_group_id, None)
+            await asyncio.sleep(self._media_batch_delay_seconds)
+            if self._media_group_inflight.get(media_group_key, 0) > 0:
+                self._schedule_media_group_flush(media_group_key)
+                return
+            event = self._media_group_events.pop(media_group_key, None)
             if event is not None:
                 await self.handle_message(event)
         except asyncio.CancelledError:
             return
         finally:
-            self._media_group_tasks.pop(media_group_id, None)
+            if self._media_group_tasks.get(media_group_key) is current_task:
+                self._media_group_tasks.pop(media_group_key, None)
 
     async def _handle_sticker(self, msg: Message, event: "MessageEvent") -> None:
         """

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2986,6 +2986,12 @@ class GatewayRunner:
         if not adapter:
             return False  # let default path handle it
 
+        if event.message_type == MessageType.PHOTO:
+            # Photo albums/bursts are adapter-owned: BasePlatformAdapter queues
+            # them without setting the interrupt event so late Telegram album
+            # items don't produce a misleading "Interrupting current task" ack.
+            return False
+
         running_agent = self._running_agents.get(session_key)
 
         effective_mode = self._busy_input_mode

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -216,6 +216,35 @@ class TestBusySessionAck:
         adapter._send_with_retry.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_photo_followup_delegates_to_adapter_without_busy_ack(self):
+        """Photo follow-ups must use the adapter photo queue, not interrupt mode."""
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+
+        base = _make_event(text="caption")
+        event = MessageEvent(
+            text="caption",
+            message_type=MessageType.PHOTO,
+            source=base.source,
+            message_id="photo1",
+            media_urls=["/tmp/photo.jpg"],
+            media_types=["image/jpeg"],
+        )
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+        runner.adapters[event.source.platform] = adapter
+
+        result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is False
+        assert sk not in adapter._pending_messages
+        agent.interrupt.assert_not_called()
+        adapter._send_with_retry.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_steer_mode_calls_agent_steer_no_interrupt_no_queue(self):
         """busy_input_mode='steer' injects via agent.steer() and skips queueing."""
         runner, sentinel = _make_runner()

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -68,6 +68,19 @@ def _make_file_obj(data: bytes = b"hello"):
     return f
 
 
+def _make_delayed_file_obj(data: bytes = b"hello", delay: float = 0.0):
+    """Create a mock Telegram File whose download completes after delay."""
+    f = AsyncMock()
+
+    async def _download():
+        await asyncio.sleep(delay)
+        return bytearray(data)
+
+    f.download_as_bytearray = AsyncMock(side_effect=_download)
+    f.file_path = "photos/file.jpg"
+    return f
+
+
 def _make_document(
     file_name="report.pdf",
     mime_type="application/pdf",
@@ -477,6 +490,35 @@ class TestMediaGroups:
         assert len(event.media_types) == 2
 
     @pytest.mark.asyncio
+    async def test_photo_album_waits_for_slow_uncaptioned_item(self, adapter):
+        """A slow second album download must reset the flush before first dispatch."""
+        adapter._media_batch_delay_seconds = 0.05
+        first_photo = _make_photo(_make_delayed_file_obj(b"first", delay=0.0))
+        second_photo = _make_photo(_make_delayed_file_obj(b"second", delay=0.12))
+
+        msg1 = _make_message(caption="two images", media_group_id="album-slow", photo=[first_photo])
+        msg2 = _make_message(media_group_id="album-slow", photo=[second_photo])
+
+        with patch(
+            "gateway.platforms.telegram.cache_image_from_bytes",
+            side_effect=["/tmp/slow-one.jpg", "/tmp/slow-two.jpg"],
+        ):
+            task1 = asyncio.create_task(adapter._handle_media_message(_make_update(msg1), MagicMock()))
+            await asyncio.sleep(0.01)
+            task2 = asyncio.create_task(adapter._handle_media_message(_make_update(msg2), MagicMock()))
+
+            await asyncio.sleep(0.08)
+            assert adapter.handle_message.await_count == 0
+
+            await asyncio.gather(task1, task2)
+            await asyncio.sleep(0.08)
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        assert event.text == "two images"
+        assert event.media_urls == ["/tmp/slow-one.jpg", "/tmp/slow-two.jpg"]
+
+    @pytest.mark.asyncio
     async def test_disconnect_cancels_pending_media_group_flush(self, adapter):
         first_photo = _make_photo(_make_file_obj(b"first"))
         msg = _make_message(caption="two images", media_group_id="album-2", photo=[first_photo])
@@ -484,8 +526,8 @@ class TestMediaGroups:
         with patch("gateway.platforms.telegram.cache_image_from_bytes", return_value="/tmp/one.jpg"):
             await adapter._handle_media_message(_make_update(msg), MagicMock())
 
-        assert "album-2" in adapter._media_group_events
-        assert "album-2" in adapter._media_group_tasks
+        assert any(key.endswith(":album:album-2") for key in adapter._media_group_events)
+        assert any(key.endswith(":album:album-2") for key in adapter._media_group_tasks)
 
         await adapter.disconnect()
         await asyncio.sleep(adapter.MEDIA_GROUP_WAIT_SECONDS + 0.05)


### PR DESCRIPTION
## Summary
- keep Telegram media-group flushes open while album items are still downloading/caching
- scope media-group buffers by session to avoid cross-chat album collisions
- bypass busy interrupt acknowledgements for photo follow-ups so albums queue as one turn

## Tests
- python3 -m py_compile gateway/platforms/telegram.py gateway/run.py
- uv run --extra dev ruff check gateway/platforms/telegram.py gateway/run.py tests/gateway/test_telegram_documents.py tests/gateway/test_busy_session_ack.py
- uv run --extra dev python -m pytest tests/gateway/test_telegram_documents.py tests/gateway/test_busy_session_ack.py tests/gateway/test_interrupt_key_match.py tests/gateway/test_active_session_text_merge.py -q