### PR TITLE
fix(bluebubbles): stop phantom typing indicator after agent turn completes

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -132,6 +132,9 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._private_api_enabled: Optional[bool] = None
         self._helper_connected: bool = False
         self._guid_cache: OrderedDict[str, str] = OrderedDict()
+        # Serializes send_typing / stop_typing per chat so a stale typing-start
+        # POST can't reorder past a typing-cancel DELETE on the wire (#31534).
+        self._typing_locks: Dict[str, asyncio.Lock] = {}
 
     # ------------------------------------------------------------------
     # API helpers
@@ -613,28 +616,61 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         if not self._private_api_enabled or not self._helper_connected or not self.client:
             return
-        try:
-            guid = await self._resolve_chat_guid(chat_id)
-            if guid:
-                encoded = quote(guid, safe="")
-                await self.client.post(
-                    self._api_url(f"/api/v1/chat/{encoded}/typing"), timeout=5
-                )
-        except Exception:
-            pass
+        lock = self._typing_locks.setdefault(chat_id, asyncio.Lock())
+        async with lock:
+            try:
+                guid = await self._resolve_chat_guid(chat_id)
+                if guid:
+                    encoded = quote(guid, safe="")
+                    await self.client.post(
+                        self._api_url(f"/api/v1/chat/{encoded}/typing"), timeout=5
+                    )
+            except Exception:
+                pass
 
     async def stop_typing(self, chat_id: str) -> None:
         if not self._private_api_enabled or not self._helper_connected or not self.client:
             return
-        try:
-            guid = await self._resolve_chat_guid(chat_id)
-            if guid:
-                encoded = quote(guid, safe="")
-                await self.client.delete(
-                    self._api_url(f"/api/v1/chat/{encoded}/typing"), timeout=5
-                )
-        except Exception:
-            pass
+        lock = self._typing_locks.setdefault(chat_id, asyncio.Lock())
+        # Acquire the lock so the cancel DELETE is serialized after any
+        # in-flight refresh POST. Without this, base.py's keep-typing loop
+        # can have a send_typing in-flight when the agent finishes; HTTP/1.1
+        # keepalive then makes the wire arrival order non-deterministic.
+        async with lock:
+            try:
+                guid = await self._resolve_chat_guid(chat_id)
+                if guid:
+                    encoded = quote(guid, safe="")
+                    await self.client.delete(
+                        self._api_url(f"/api/v1/chat/{encoded}/typing"), timeout=5
+                    )
+            except Exception:
+                pass
+            # IMCore's isIncomingTypingMessage / isCancelTypingMessage queue is
+            # not strictly ordered: a typing-start that BlueBubbles forwarded
+            # before the DELETE can still be surfaced to the iMessage UI after
+            # our cancel, leaving the bubble visible for ~10s until IMCore's
+            # own timeout clears it (#31534). Re-issue the cancel after a brief
+            # settle window so the stop is the last signal IMCore observes.
+            try:
+                await asyncio.sleep(0.5)
+            except asyncio.CancelledError:
+                return
+            if (
+                not self._private_api_enabled
+                or not self._helper_connected
+                or not self.client
+            ):
+                return
+            try:
+                guid = await self._resolve_chat_guid(chat_id)
+                if guid:
+                    encoded = quote(guid, safe="")
+                    await self.client.delete(
+                        self._api_url(f"/api/v1/chat/{encoded}/typing"), timeout=5
+                    )
+            except Exception:
+                pass
 
     # ------------------------------------------------------------------
     # Read receipts

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -698,3 +698,148 @@ class TestBlueBubblesWebhookRegistration:
             adapter._unregister_webhook()
         )
         assert ok is False
+
+
+class TestBlueBubblesTypingIndicator:
+    """Phantom-typing regression coverage (#31534).
+
+    `_keep_typing` in base.py refreshes typing every ~2s; if its last
+    `send_typing` POST is still in flight when the agent finishes, BlueBubbles'
+    server can forward the typing-start to IMCore *after* our typing-cancel
+    DELETE, leaving the bubble lingering for ~10s. The adapter must serialize
+    the two requests on the wire and re-issue the cancel after IMCore settles.
+    """
+
+    @staticmethod
+    def _wire_adapter(monkeypatch, calls):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = True
+
+        async def fake_resolve(chat_id):
+            return f"iMessage;-;{chat_id}"
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve)
+
+        class _Resp:
+            def raise_for_status(self):
+                pass
+
+        class _MockClient:
+            async def post(self, url, **kwargs):
+                calls.append(("POST", url))
+                return _Resp()
+
+            async def delete(self, url, **kwargs):
+                calls.append(("DELETE", url))
+                return _Resp()
+
+        adapter.client = _MockClient()
+        return adapter
+
+    @staticmethod
+    def _patch_settle_sleep(monkeypatch):
+        """Bypass the 0.5s settle delay in stop_typing without touching the
+        global asyncio.sleep (which would recurse if tests also await it)."""
+        import asyncio as _asyncio
+        sleeps = []
+        real_sleep = _asyncio.sleep
+
+        async def fast_sleep(seconds):
+            sleeps.append(seconds)
+            await real_sleep(0)
+
+        # asyncio is imported as a module attribute on the bluebubbles module;
+        # patching that attribute keeps the production code calling our fake
+        # while leaving the test's own _asyncio.sleep untouched.
+        import gateway.platforms.bluebubbles as bb
+        fake_module = type("FakeAsyncio", (), {"sleep": fast_sleep,
+                                                "Lock": _asyncio.Lock,
+                                                "CancelledError": _asyncio.CancelledError,
+                                                "Event": _asyncio.Event,
+                                                "create_task": _asyncio.create_task})
+        # Only override .sleep so the rest of asyncio (Lock, CancelledError,
+        # Event, create_task) keeps resolving to the real module — that's
+        # what the production code already uses for its lock setup.
+        monkeypatch.setattr(bb.asyncio, "sleep", fast_sleep)
+        return sleeps
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_issues_two_deletes_for_imcore_settle(
+        self, monkeypatch
+    ):
+        calls = []
+        adapter = self._wire_adapter(monkeypatch, calls)
+        sleeps = self._patch_settle_sleep(monkeypatch)
+
+        await adapter.stop_typing("user@example.com")
+
+        delete_count = sum(1 for verb, _ in calls if verb == "DELETE")
+        assert delete_count == 2, (
+            f"Expected two DELETEs (immediate + post-settle); got {calls}"
+        )
+        assert 0.5 in sleeps, (
+            "Settle delay between the two DELETEs must be ~0.5s"
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_and_stop_typing_serialized_via_lock(self, monkeypatch):
+        """An in-flight send_typing POST must complete on the wire before the
+        cancel DELETE goes out — otherwise HTTP/1.1 keepalive can reorder them
+        and BlueBubbles forwards the stale start to IMCore after the cancel."""
+        import asyncio as _asyncio
+        calls = []
+        adapter = self._wire_adapter(monkeypatch, calls)
+        self._patch_settle_sleep(monkeypatch)
+
+        # Block the send POST until we explicitly release it, so the stop
+        # call must wait on the lock — without serialization, the stop's
+        # DELETE would beat the still-pending POST.
+        post_release = _asyncio.Event()
+        original_client = adapter.client
+
+        class _SlowPostClient:
+            async def post(self_inner, url, **kwargs):
+                await post_release.wait()
+                return await original_client.post(url, **kwargs)
+
+            async def delete(self_inner, url, **kwargs):
+                return await original_client.delete(url, **kwargs)
+
+        adapter.client = _SlowPostClient()
+
+        send_task = _asyncio.create_task(adapter.send_typing("user@example.com"))
+        # Yield so send_task starts the POST coroutine and acquires the lock.
+        await _asyncio.sleep(0)
+        stop_task = _asyncio.create_task(adapter.stop_typing("user@example.com"))
+        await _asyncio.sleep(0)
+
+        # send_typing is parked inside slow_post; stop_typing should be
+        # blocked on the per-chat lock, so no DELETE has gone out yet.
+        assert all(verb != "DELETE" for verb, _ in calls), (
+            f"DELETE leaked while send_typing POST was still in flight: {calls}"
+        )
+
+        post_release.set()
+        await send_task
+        await stop_task
+
+        ordering = [verb for verb, _ in calls]
+        assert ordering[0] == "POST", (
+            f"send_typing POST must land on the wire first; got {ordering}"
+        )
+        # Two DELETEs from stop_typing's IMCore-settle pattern; both after POST.
+        assert ordering.count("DELETE") == 2
+        first_delete_idx = ordering.index("DELETE")
+        assert first_delete_idx > 0 and ordering[:first_delete_idx] == ["POST"]
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_noop_when_private_api_disabled(self, monkeypatch):
+        calls = []
+        adapter = self._wire_adapter(monkeypatch, calls)
+        adapter._private_api_enabled = False
+
+        await adapter.stop_typing("user@example.com")
+
+        assert calls == [], (
+            "stop_typing must not issue any HTTP when private API is unavailable"
+        )


### PR DESCRIPTION
## What does this PR do?

`base.py`'s `_keep_typing` loop refreshes the typing indicator every ~2s while the agent runs. When the turn finishes, the loop is cancelled and `stop_typing()` is called, but the loop's last `send_typing` POST can still be in flight on the underlying httpx client. HTTP/1.1 keepalive then makes the wire-arrival order of the trailing POST and the cancel DELETE non-deterministic, and BlueBubbles forwards both to IMCore. IMCore itself does not strictly order `isIncomingTypingMessage` / `isCancelTypingMessage` events, so a stale start can be surfaced in the iMessage UI after our cancel — the typing bubble then lingers for ~10s until IMCore's own timeout clears it.

This is the BlueBubbles analog of the Discord `_keep_typing` after-turn race that was fixed in PR #3003.

Mirrors the existing post-stop reinforcement pattern in `gateway/platforms/base.py:3793-3801` (the `# Also cancel any platform-level persistent typing tasks (e.g. Discord)…` block): same goal, but adapted to BlueBubbles' constraint that the race is also IMCore-internal, not just wire-order.

The fix is local to `gateway/platforms/bluebubbles.py`:

1. Per-chat `asyncio.Lock` around `send_typing` and `stop_typing` so the cancel DELETE is serialized after any in-flight refresh POST on the wire.
2. Re-issue the cancel DELETE 0.5s after the first one, so even if IMCore reorders the first cancel past a stale start, the second cancel is the last typing signal it observes.

## Related Issue

Fixes #31534

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/bluebubbles.py` — add per-chat `_typing_locks` dict in `__init__`; wrap `send_typing` and `stop_typing` with the lock; re-issue the cancel DELETE after a 0.5s settle window inside the same lock so it's still serialized against any new refresh POST.
- `tests/gateway/test_bluebubbles.py` — new `TestBlueBubblesTypingIndicator` class with three regression tests:
  - `test_stop_typing_issues_two_deletes_for_imcore_settle` — confirms the second DELETE fires after the ~0.5s settle window.
  - `test_send_and_stop_typing_serialized_via_lock` — confirms a stop call cannot leak a DELETE to the wire while a refresh POST is still pending; both DELETEs land after the POST completes.
  - `test_stop_typing_noop_when_private_api_disabled` — preserves the existing guard behaviour when the Private API helper is unavailable.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/gateway/test_bluebubbles.py -v` — all 52 tests should pass.
2. Regression-guard: revert `gateway/platforms/bluebubbles.py` only, rerun — the two new ordering tests fail with `DELETE leaked while send_typing POST was still in flight` and `Expected two DELETEs (immediate + post-settle); got [single DELETE]`. Restore the fix and they pass.
3. Manual repro (requires a BlueBubbles + Private API setup): send a message to a BlueBubbles DM, watch the typing indicator after the reply lands — it should disappear with the message rather than linger ~10s.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; the new behaviour is captured by inline comments at the lock + settle-window sites.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no new config.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A.
- [x] I've considered cross-platform impact (Windows, macOS) — the fix is BlueBubbles-only and BlueBubbles itself is macOS-only.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A.

> Audited siblings: every other adapter that overrides `stop_typing` (`gateway/platforms/matrix.py`, `gateway/platforms/signal.py`, `gateway/platforms/slack.py`, `gateway/platforms/weixin.py`, `gateway/platforms/yuanbao.py`) either talks to a transport that authoritatively orders the stop signal (Slack `assistant_threads_setStatus`, Signal's typing-stop via signal-cli) or already has platform-specific stop tracking. No widening needed.