### PR TITLE
[codex] Add gateway runtime model note

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -564,6 +564,34 @@ def _wrap_current_message_with_observed_context(message: Any, observed_context: 
     return message
 
 
+def _build_runtime_model_note(model: str, runtime: Optional[Dict[str, Any]]) -> str:
+    """Build a short current-runtime note for gateway turns.
+
+    Long-lived gateway sessions can contain old assistant self-descriptions
+    ("I am running model X") after the user changes the global model.  The
+    actual API call uses the freshly resolved runtime, but the model may still
+    answer from historical transcript text.  Keep the correction in-band like
+    other gateway notes so it survives all providers without mutating history.
+    """
+    model_text = str(model or "").strip()
+    if not model_text:
+        return ""
+    runtime = runtime or {}
+    provider = str(runtime.get("provider") or "").strip()
+    base_url = str(runtime.get("base_url") or "").strip()
+    parts = [f"model={model_text}"]
+    if provider:
+        parts.append(f"provider={provider}")
+    if base_url:
+        parts.append(f"base_url={base_url}")
+    return (
+        "[System note: Current runtime for this turn is "
+        + ", ".join(parts)
+        + ". If earlier transcript messages mention a different model/provider, "
+        "treat them as historical, not current.]"
+    )
+
+
 def _last_transcript_timestamp(history: Optional[List[Dict[str, Any]]]) -> Any:
     """Return the ``timestamp`` of the last usable transcript row, if any.
 
@@ -16678,6 +16706,13 @@ class GatewayRunner:
             _msn = _pending_notes.pop(session_key, None) if session_key else None
             if _msn:
                 message = _msn + "\n\n" + message
+
+            _runtime_note = _build_runtime_model_note(
+                turn_route["model"],
+                turn_route.get("runtime"),
+            )
+            if _runtime_note:
+                message = _runtime_note + "\n\n" + message
 
             # Auto-continue: if the loaded history ends with a tool result,
             # the previous agent turn was interrupted mid-work (gateway

--- a/tests/gateway/test_runtime_model_note.py
+++ b/tests/gateway/test_runtime_model_note.py
@@ -1,0 +1,20 @@
+from gateway.run import _build_runtime_model_note
+
+
+def test_runtime_model_note_declares_current_model_and_provider():
+    note = _build_runtime_model_note(
+        "Qwen3.5-397B-A17B",
+        {
+            "provider": "custom",
+            "base_url": "http://10.128.58.20:8000/v1",
+        },
+    )
+
+    assert "model=Qwen3.5-397B-A17B" in note
+    assert "provider=custom" in note
+    assert "base_url=http://10.128.58.20:8000/v1" in note
+    assert "historical, not current" in note
+
+
+def test_runtime_model_note_omits_empty_model():
+    assert _build_runtime_model_note("", {"provider": "custom"}) == ""


### PR DESCRIPTION
## Summary

- add an in-band gateway runtime note before each agent turn with the resolved model/provider/base URL
- tell the model to treat older transcript self-identification as historical when it conflicts with the current runtime
- cover the note builder with focused gateway tests

## Why

Long-lived gateway sessions can preserve old transcript metadata or prior assistant self-descriptions after users switch models. The actual API call may already use the new model, but the assistant can still answer questions like "what model are you?" from stale conversation history.

This keeps existing sessions and history intact while giving every turn the current runtime fact close to the live user message.

## Validation

- `git diff --check -- gateway/run.py tests/gateway/test_runtime_model_note.py`
- `.venv/bin/python -m pytest tests/gateway/test_runtime_model_note.py tests/gateway/test_session_model_reset.py -q`