### PR TITLE
fix(kanban): preflight Codex worker auth readiness

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -893,6 +893,7 @@ def _auth_lock_path() -> Path:
 
 
 _auth_lock_holder = threading.local()
+_global_auth_lock_holder = threading.local()
 
 
 @contextmanager
@@ -986,6 +987,62 @@ def _auth_store_lock(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
         yield
 
 
+@contextmanager
+def _global_auth_store_lock(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
+    """Cross-process advisory lock for the global-root auth.json fallback."""
+    global_path = _global_auth_file_path()
+    if global_path is None:
+        # Classic/non-profile mode has no separate global fallback. Use the
+        # normal auth lock so callers can stay source-agnostic.
+        with _auth_store_lock(timeout_seconds=timeout_seconds):
+            yield
+        return
+    with _file_lock(
+        global_path.with_suffix(".lock"),
+        _global_auth_lock_holder,
+        timeout_seconds,
+        "Timed out waiting for global auth store lock",
+    ):
+        yield
+
+
+@contextmanager
+def _auth_store_lock_for_path(
+    auth_file: Path,
+    timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS,
+):
+    """Lock the auth store that owns ``auth_file``."""
+    is_local = False
+    try:
+        is_local = auth_file.resolve(strict=False) == _auth_file_path().resolve(strict=False)
+    except Exception:
+        is_local = False
+    if is_local:
+        with _auth_store_lock(timeout_seconds=timeout_seconds):
+            yield
+        return
+
+    global_path = _global_auth_file_path()
+    is_global = False
+    if global_path is not None:
+        try:
+            is_global = auth_file.resolve(strict=False) == global_path.resolve(strict=False)
+        except Exception:
+            is_global = False
+    if is_global:
+        with _global_auth_store_lock(timeout_seconds=timeout_seconds):
+            yield
+        return
+
+    with _file_lock(
+        auth_file.with_suffix(".lock"),
+        _global_auth_lock_holder,
+        timeout_seconds,
+        "Timed out waiting for auth store lock",
+    ):
+        yield
+
+
 def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
     auth_file = auth_file or _auth_file_path()
     if not auth_file.exists():
@@ -1026,8 +1083,8 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
     return {"version": AUTH_STORE_VERSION, "providers": {}}
 
 
-def _save_auth_store(auth_store: Dict[str, Any]) -> Path:
-    auth_file = _auth_file_path()
+def _save_auth_store(auth_store: Dict[str, Any], auth_file: Optional[Path] = None) -> Path:
+    auth_file = auth_file or _auth_file_path()
     auth_file.parent.mkdir(parents=True, exist_ok=True)
     # Tighten parent dir to 0o700 so siblings can't traverse to creds.
     # No-op on Windows (POSIX mode bits not enforced); ignore failures.
@@ -3127,20 +3184,9 @@ def _print_loopback_ssh_hint(redirect_uri: str, *, docs_url: str | None = None) 
 # where one app's refresh invalidates the other's session.
 # =============================================================================
 
-def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
-    """Read Codex OAuth tokens from Hermes auth store (~/.hermes/auth.json).
-    
-    Returns dict with 'tokens' (access_token, refresh_token) and 'last_refresh'.
-    Raises AuthError if no Codex tokens are stored.
-    """
-    if _lock:
-        with _auth_store_lock():
-            auth_store = _load_auth_store()
-    else:
-        auth_store = _load_auth_store()
-    state = _load_provider_state(auth_store, "openai-codex")
+def _codex_state_error(state: Optional[Dict[str, Any]]) -> Optional[AuthError]:
     if not state:
-        raise AuthError(
+        return AuthError(
             "No Codex credentials stored. Run `hermes auth` to authenticate.",
             provider="openai-codex",
             code="codex_auth_missing",
@@ -3148,7 +3194,7 @@ def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
         )
     tokens = state.get("tokens")
     if not isinstance(tokens, dict):
-        raise AuthError(
+        return AuthError(
             "Codex auth state is missing tokens. Run `hermes auth` to re-authenticate.",
             provider="openai-codex",
             code="codex_auth_invalid_shape",
@@ -3157,37 +3203,108 @@ def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     access_token = tokens.get("access_token")
     refresh_token = tokens.get("refresh_token")
     if not isinstance(access_token, str) or not access_token.strip():
-        raise AuthError(
+        return AuthError(
             "Codex auth is missing access_token. Run `hermes auth` to re-authenticate.",
             provider="openai-codex",
             code="codex_auth_missing_access_token",
             relogin_required=True,
         )
     if not isinstance(refresh_token, str) or not refresh_token.strip():
-        raise AuthError(
+        return AuthError(
             "Codex auth is missing refresh_token. Run `hermes auth` to re-authenticate.",
             provider="openai-codex",
             code="codex_auth_missing_refresh_token",
             relogin_required=True,
         )
+    return None
+
+
+def _codex_tokens_payload(
+    state: Dict[str, Any],
+    *,
+    auth_file: Path,
+    auth_source: str,
+) -> Dict[str, Any]:
     return {
-        "tokens": tokens,
+        "tokens": state["tokens"],
         "last_refresh": state.get("last_refresh"),
+        "auth_file": auth_file,
+        "auth_source": auth_source,
     }
 
 
-def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None) -> None:
+def _read_codex_tokens_from_path(auth_file: Path, *, auth_source: str) -> Dict[str, Any]:
+    auth_store = _load_auth_store(auth_file)
+    state = _load_provider_state(auth_store, "openai-codex")
+    err = _codex_state_error(state)
+    if err is not None:
+        raise err
+    return _codex_tokens_payload(state or {}, auth_file=auth_file, auth_source=auth_source)
+
+
+def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
+    """Read Codex OAuth tokens from Hermes auth store (~/.hermes/auth.json).
+
+    Profile processes may inherit a valid global-root Codex login when their
+    local profile state is missing or stale/broken.  A valid local profile state
+    still wins; a broken local state falls back only if the global-root state is
+    usable.  Refresh writes are later persisted back to the source auth file, so
+    single-use Codex refresh tokens are not copied into profile-local stores.
+    """
+    local_auth_file = _auth_file_path()
+    if _lock:
+        with _auth_store_lock():
+            auth_store = _load_auth_store(local_auth_file)
+    else:
+        auth_store = _load_auth_store(local_auth_file)
+
+    state = _load_provider_state(auth_store, "openai-codex")
+    local_error = _codex_state_error(state)
+    if local_error is None:
+        return _codex_tokens_payload(
+            state or {},
+            auth_file=local_auth_file,
+            auth_source="profile-auth-store",
+        )
+
+    global_auth_file = _global_auth_file_path()
+    if global_auth_file is not None:
+        global_store = _load_global_auth_store()
+        global_state = _load_provider_state(global_store, "openai-codex") if global_store else None
+        global_error = _codex_state_error(global_state)
+        if global_error is None:
+            logger.debug(
+                "Codex auth: using global-root fallback because profile state is invalid (%s).",
+                getattr(local_error, "code", "unknown"),
+            )
+            return _codex_tokens_payload(
+                global_state or {},
+                auth_file=global_auth_file,
+                auth_source="global-auth-store-fallback",
+            )
+
+    raise local_error
+
+
+def _save_codex_tokens(
+    tokens: Dict[str, str],
+    last_refresh: Optional[str] = None,
+    *,
+    auth_file: Optional[Path] = None,
+    set_active: bool = True,
+) -> None:
     """Save Codex OAuth tokens to Hermes auth store (~/.hermes/auth.json)."""
     if last_refresh is None:
         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-    with _auth_store_lock():
-        auth_store = _load_auth_store()
+    target_auth_file = auth_file or _auth_file_path()
+    with _auth_store_lock_for_path(target_auth_file):
+        auth_store = _load_auth_store(target_auth_file)
         state = _load_provider_state(auth_store, "openai-codex") or {}
         state["tokens"] = tokens
         state["last_refresh"] = last_refresh
         state["auth_mode"] = "chatgpt"
-        _save_provider_state(auth_store, "openai-codex", state)
-        _save_auth_store(auth_store)
+        _store_provider_state(auth_store, "openai-codex", state, set_active=set_active)
+        _save_auth_store(auth_store, target_auth_file)
 
 
 def refresh_codex_oauth_pure(
@@ -3297,10 +3414,12 @@ def refresh_codex_oauth_pure(
 def _refresh_codex_auth_tokens(
     tokens: Dict[str, str],
     timeout_seconds: float,
+    *,
+    auth_file: Optional[Path] = None,
 ) -> Dict[str, str]:
     """Refresh Codex access token using the refresh token.
     
-    Saves the new tokens to Hermes auth store automatically.
+    Saves the new tokens to the source Hermes auth store automatically.
     """
     refreshed = refresh_codex_oauth_pure(
         str(tokens.get("access_token", "") or ""),
@@ -3311,7 +3430,7 @@ def _refresh_codex_auth_tokens(
     updated_tokens["access_token"] = refreshed["access_token"]
     updated_tokens["refresh_token"] = refreshed["refresh_token"]
 
-    _save_codex_tokens(updated_tokens)
+    _save_codex_tokens(updated_tokens, auth_file=auth_file, set_active=False)
     return updated_tokens
 
 
@@ -3349,6 +3468,7 @@ def _import_codex_cli_tokens() -> Optional[Dict[str, str]]:
         return None
 
 
+
 def resolve_codex_runtime_credentials(
     *,
     force_refresh: bool = False,
@@ -3365,9 +3485,17 @@ def resolve_codex_runtime_credentials(
     if (not should_refresh) and refresh_if_expiring:
         should_refresh = _codex_access_token_is_expiring(access_token, refresh_skew_seconds)
     if should_refresh:
-        # Re-read under lock to avoid racing with other Hermes processes
-        with _auth_store_lock(timeout_seconds=max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0)):
-            data = _read_codex_tokens(_lock=False)
+        # Re-read under the lock for the auth store that supplied the tokens.
+        # Profile fallback must lock/write the global-root store, not the broken
+        # profile-local store, otherwise Codex's single-use refresh token can be
+        # consumed by one profile and left stale for every other worker.
+        auth_file = data.get("auth_file")
+        if not isinstance(auth_file, Path):
+            auth_file = _auth_file_path()
+        auth_source = str(data.get("auth_source") or "hermes-auth-store")
+        lock_timeout = max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0)
+        with _auth_store_lock_for_path(auth_file, timeout_seconds=lock_timeout):
+            data = _read_codex_tokens_from_path(auth_file, auth_source=auth_source)
             tokens = dict(data["tokens"])
             access_token = str(tokens.get("access_token", "") or "").strip()
 
@@ -3376,7 +3504,11 @@ def resolve_codex_runtime_credentials(
                 should_refresh = _codex_access_token_is_expiring(access_token, refresh_skew_seconds)
 
             if should_refresh:
-                tokens = _refresh_codex_auth_tokens(tokens, refresh_timeout_seconds)
+                tokens = _refresh_codex_auth_tokens(
+                    tokens,
+                    refresh_timeout_seconds,
+                    auth_file=auth_file,
+                )
                 access_token = str(tokens.get("access_token", "") or "").strip()
 
     base_url = (
@@ -3388,7 +3520,11 @@ def resolve_codex_runtime_credentials(
         "provider": "openai-codex",
         "base_url": base_url,
         "api_key": access_token,
-        "source": "hermes-auth-store",
+        "source": (
+            "hermes-auth-store"
+            if data.get("auth_source") == "profile-auth-store"
+            else data.get("auth_source") or "hermes-auth-store"
+        ),
         "last_refresh": data.get("last_refresh"),
         "auth_mode": "chatgpt",
     }

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4001,6 +4001,14 @@ class DispatchResult:
     Reasons: ``"blocker_auth"`` (quota/auth error — also auto-blocked),
     ``"recent_success"`` (completed run within guard window),
     ``"active_pr"`` (GitHub PR URL in a recent comment)."""
+    readiness_blocked: list[tuple[str, str]] = field(default_factory=list)
+    """Tasks blocked by pre-spawn worker readiness checks.
+
+    Each pair is ``(task_id, reason_code)``. These are deterministic
+    capability failures discovered before launching the worker subprocess
+    (for example provider auth missing for the assigned profile), so the
+    dispatcher can stop a crash-loop before ``Popen``.
+    """
 
 
 # Bounded registry of recently-reaped worker child exits, populated by the
@@ -4659,6 +4667,7 @@ def _record_task_failure(
     release_claim: bool = False,
     end_run: bool = False,
     event_payload_extra: Optional[dict] = None,
+    force_failure_limit: bool = False,
 ) -> bool:
     """Record a non-success outcome (spawn_failed / crashed / timed_out)
     and maybe trip the circuit breaker.
@@ -4689,10 +4698,12 @@ def _record_task_failure(
     context (e.g. pid on crash, elapsed on timeout).
 
     Resolution order for the effective threshold:
-      1. per-task ``max_retries`` if set (nothing else overrides)
-      2. caller-supplied ``failure_limit`` (gateway passes the config
+      1. caller-supplied ``failure_limit`` when ``force_failure_limit`` is true
+         (used for deterministic pre-spawn readiness failures)
+      2. per-task ``max_retries`` if set (normal failure paths)
+      3. caller-supplied ``failure_limit`` (gateway passes the config
          value from ``kanban.failure_limit``; tests pass fixed values)
-      3. ``DEFAULT_FAILURE_LIMIT``
+      4. ``DEFAULT_FAILURE_LIMIT``
     """
     if failure_limit is None:
         failure_limit = DEFAULT_FAILURE_LIMIT
@@ -4708,11 +4719,16 @@ def _record_task_failure(
         cur_status = row["status"]
 
         # Per-task override wins over both caller-supplied and default
-        # thresholds. None (the common case) falls through.
+        # thresholds for normal failures. Deterministic readiness failures can
+        # force the caller-supplied limit so they block in one tick instead of
+        # honoring retry counts that cannot repair missing provider capability.
         task_override = (
             row["max_retries"] if "max_retries" in row.keys() else None
         )
-        if task_override is not None:
+        if force_failure_limit:
+            effective_limit = int(failure_limit)
+            limit_source = "forced"
+        elif task_override is not None:
             effective_limit = int(task_override)
             limit_source = "task"
         else:
@@ -4811,6 +4827,7 @@ def _record_spawn_failure(
     error: str,
     *,
     failure_limit: int = None,
+    force_failure_limit: bool = False,
 ) -> bool:
     return _record_task_failure(
         conn, task_id, error,
@@ -4818,7 +4835,175 @@ def _record_spawn_failure(
         failure_limit=failure_limit,
         release_claim=True,
         end_run=True,
+        force_failure_limit=force_failure_limit,
     )
+
+
+def _worker_readiness_reason_code(message: str) -> str:
+    """Return a stable low-cardinality reason code for readiness telemetry."""
+    text = (message or "").lower()
+    if "openai-codex" in text and "auth" in text:
+        return "openai-codex_auth_unavailable"
+    if "profile" in text and "unavailable" in text:
+        return "profile_unavailable"
+    return "worker_readiness_failed"
+
+
+def _worker_fallback_chain_can_resolve(cfg: dict) -> Optional[bool]:
+    """Return whether a configured fallback provider can resolve for runtime.
+
+    ``None`` means the fallback probe itself hit an unexpected error; callers
+    should fail open because the worker runtime owns the full fallback path.
+    """
+    try:
+        from hermes_cli.fallback_config import get_fallback_chain
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+        from utils import base_url_host_matches
+    except Exception:
+        return None
+
+    chain = get_fallback_chain(cfg if isinstance(cfg, dict) else {})
+    if not chain:
+        return False
+
+    saw_fallback = False
+    for entry in chain:
+        provider = str(entry.get("provider") or "").strip()
+        model = str(entry.get("model") or "").strip()
+        if not provider or not model:
+            continue
+        saw_fallback = True
+        base_url = str(entry.get("base_url") or "").strip() or None
+        try:
+            runtime = resolve_runtime_provider(
+                requested=provider,
+                explicit_base_url=base_url,
+                target_model=model,
+            )
+        except Exception:
+            continue
+        runtime_base_url = runtime.get("base_url")
+        runtime_api_key = runtime.get("api_key")
+        if runtime_api_key:
+            return True
+        if (
+            isinstance(runtime_base_url, str)
+            and runtime_base_url
+            and not base_url_host_matches(runtime_base_url, "openrouter.ai")
+        ):
+            # Mirrors CLI runtime startup: local/custom endpoints can run with
+            # the placeholder "no-key-required" key.
+            return True
+    return False if saw_fallback else False
+
+
+def _record_worker_readiness_failure(
+    conn: sqlite3.Connection,
+    result: DispatchResult,
+    task_id: str,
+    message: str,
+) -> None:
+    """Block a deterministic pre-spawn capability failure immediately.
+
+    Readiness failures happen before ``Popen`` and are known-fatal for the
+    assigned profile (for example provider auth is unavailable). Retrying the
+    same task on every dispatcher tick would only create a crash loop, so this
+    path trips the existing failure circuit breaker in one step while preserving
+    the normal run/event audit trail.
+    """
+    code = _worker_readiness_reason_code(message)
+    result.readiness_blocked.append((task_id, code))
+    auto = _record_spawn_failure(
+        conn,
+        task_id,
+        message,
+        failure_limit=1,
+        force_failure_limit=True,
+    )
+    if auto:
+        result.auto_blocked.append(task_id)
+
+
+def _worker_readiness_failure(profile_name: str) -> Optional[str]:
+    """Return a redacted fatal readiness error for ``profile_name``, if any.
+
+    The dispatcher uses this as a fast preflight immediately before default
+    worker spawn. It is deliberately narrow and fail-open: only deterministic
+    provider capability failures should block a task. Unexpected probe bugs are
+    logged and the worker is allowed to spawn so this guard cannot become a new
+    single point of failure.
+    """
+    profile = (profile_name or "").strip()
+    if not profile:
+        return "Worker readiness failed: assigned profile is unavailable"
+
+    try:
+        from hermes_cli.profiles import resolve_profile_env
+
+        profile_home = resolve_profile_env(profile)
+    except Exception as exc:
+        return f"Worker readiness failed: profile {profile!r} unavailable: {exc}"
+
+    token = None
+    reset_home_override = None
+    try:
+        from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+        from hermes_cli.auth import AuthError, format_auth_error, resolve_provider
+        from hermes_cli.config import load_config
+
+        reset_home_override = reset_hermes_home_override
+        token = set_hermes_home_override(profile_home)
+        cfg = load_config()
+        model_cfg = cfg.get("model")
+        requested_provider = ""
+        if isinstance(model_cfg, dict):
+            requested_provider = str(model_cfg.get("provider") or "").strip()
+        elif isinstance(model_cfg, str):
+            # Root-level model strings carry model ids, not provider ids, so do
+            # not infer a provider from them here.
+            requested_provider = ""
+
+        if not requested_provider:
+            return None
+
+        try:
+            provider = resolve_provider(requested_provider)
+        except AuthError as exc:
+            return f"Worker readiness failed: provider {requested_provider!r} invalid for profile {profile}: {format_auth_error(exc)}"
+
+        if provider == "openai-codex":
+            try:
+                from hermes_cli.auth import resolve_codex_runtime_credentials
+
+                resolve_codex_runtime_credentials(refresh_if_expiring=False)
+            except AuthError as exc:
+                fallback_ready = _worker_fallback_chain_can_resolve(cfg)
+                if fallback_ready is True:
+                    _log.debug(
+                        "kanban worker readiness: allowing %s to spawn because a fallback provider resolved",
+                        profile,
+                    )
+                    return None
+                if fallback_ready is None:
+                    _log.debug(
+                        "kanban worker readiness: skipping %s because fallback probe was inconclusive",
+                        profile,
+                    )
+                    return None
+                return (
+                    "Worker readiness failed: openai-codex auth unavailable "
+                    f"for profile {profile}: {format_auth_error(exc)}"
+                )
+        return None
+    except Exception as exc:
+        _log.debug("kanban worker readiness probe skipped for %s: %s", profile, exc, exc_info=True)
+        return None
+    finally:
+        if token is not None and reset_home_override is not None:
+            try:
+                reset_home_override(token)
+            except Exception:
+                pass
 
 
 def _set_worker_pid(conn: sqlite3.Connection, task_id: str, pid: int) -> None:
@@ -5171,6 +5356,13 @@ def dispatch_once(
         claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
             continue
+        if spawn_fn is None:
+            readiness_error = _worker_readiness_failure(claimed.assignee or "")
+            if readiness_error:
+                _record_worker_readiness_failure(
+                    conn, result, claimed.id, readiness_error,
+                )
+                continue
         try:
             workspace = resolve_workspace(claimed, board=board)
         except Exception as exc:
@@ -5250,6 +5442,13 @@ def dispatch_once(
         claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
             continue
+        if spawn_fn is None:
+            readiness_error = _worker_readiness_failure(claimed.assignee or "")
+            if readiness_error:
+                _record_worker_readiness_failure(
+                    conn, result, claimed.id, readiness_error,
+                )
+                continue
         try:
             workspace = resolve_workspace(claimed, board=board)
         except Exception as exc:
@@ -5527,6 +5726,25 @@ def _kanban_worker_skill_available(hermes_home: Optional[str]) -> bool:
     return False
 
 
+def _canonical_home_from_profile_hermes_home(hermes_home: Optional[str]) -> Optional[str]:
+    """Return the real Unix home for profile-local HERMES_HOME layouts."""
+    if not hermes_home:
+        return None
+    try:
+        path = os.path.abspath(os.path.expanduser(str(hermes_home)))
+    except Exception:
+        return None
+    marker = f"{os.sep}.hermes{os.sep}profiles{os.sep}"
+    if marker in path:
+        prefix = path.split(marker, 1)[0]
+        if prefix and os.path.isabs(prefix):
+            return prefix
+    parts = path.rstrip(os.sep).split(os.sep)
+    if len(parts) >= 3 and parts[-2] == "profiles" and os.path.isabs(path):
+        return os.sep.join(parts[:-2]) or os.sep
+    return None
+
+
 def _worker_terminal_timeout_env(
     max_runtime_seconds: Optional[int],
     current_timeout: Optional[str],
@@ -5604,6 +5822,23 @@ def _default_spawn(
         # This only happens in test fixtures where the isolated
         # HERMES_HOME never had profiles created.
         pass
+    canonical_home = _canonical_home_from_profile_hermes_home(env.get("HERMES_HOME"))
+    acpx_guard_keys = (
+        "ACPX_GUARD_REAL_HOME",
+        "ACPX_GUARD_HOME",
+        "ACPX_GUARD_LOG_DIR",
+        "ACPX_GUARD_USAGE_HOME",
+        "ACPX_GUARD_AGENT_HOME",
+    )
+    if canonical_home:
+        env["ACPX_GUARD_REAL_HOME"] = canonical_home
+        env["ACPX_GUARD_HOME"] = os.path.join(canonical_home, ".hermes", "acpx")
+        env["ACPX_GUARD_LOG_DIR"] = os.path.join(canonical_home, ".hermes", "logs", "acpx")
+        env["ACPX_GUARD_USAGE_HOME"] = canonical_home
+        env["ACPX_GUARD_AGENT_HOME"] = canonical_home
+    else:
+        for key in acpx_guard_keys:
+            env.pop(key, None)
     if task.tenant:
         env["HERMES_TENANT"] = task.tenant
     env["HERMES_KANBAN_TASK"] = task.id

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -25,12 +25,18 @@ from hermes_cli.auth import (
 )
 
 
-def _setup_hermes_auth(hermes_home: Path, *, access_token: str = "access", refresh_token: str = "refresh"):
+def _setup_hermes_auth(
+    hermes_home: Path,
+    *,
+    access_token: str = "access",
+    refresh_token: str = "refresh",
+    active_provider: str = "openai-codex",
+):
     """Write Codex tokens into the Hermes auth store."""
     hermes_home.mkdir(parents=True, exist_ok=True)
     auth_store = {
         "version": 1,
-        "active_provider": "openai-codex",
+        "active_provider": active_provider,
         "providers": {
             "openai-codex": {
                 "tokens": {
@@ -51,6 +57,34 @@ def _jwt_with_exp(exp_epoch: int) -> str:
     payload = {"exp": exp_epoch}
     encoded = base64.urlsafe_b64encode(json.dumps(payload).encode("utf-8")).rstrip(b"=").decode("utf-8")
     return f"h.{encoded}.s"
+
+
+def _setup_profile_with_global_codex_auth(tmp_path: Path, monkeypatch):
+    """Mirror ~/.hermes + ~/.hermes/profiles/worker profile mode."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    global_root = tmp_path / ".hermes"
+    profile_home = global_root / "profiles" / "worker"
+    global_root.mkdir(parents=True, exist_ok=True)
+    profile_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    return global_root, profile_home
+
+
+def _write_broken_profile_codex_state(profile_home: Path) -> None:
+    profile_home.mkdir(parents=True, exist_ok=True)
+    (profile_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "active_provider": "openai-codex",
+        "providers": {
+            "openai-codex": {
+                "tokens": {},
+                "last_auth_error": {
+                    "code": "refresh_token_reused",
+                    "message": "redacted",
+                },
+            },
+        },
+    }, indent=2))
 
 
 def test_read_codex_tokens_success(tmp_path, monkeypatch):
@@ -86,6 +120,50 @@ def test_resolve_codex_runtime_credentials_missing_access_token(tmp_path, monkey
     assert exc.value.relogin_required is True
 
 
+def test_profile_broken_codex_state_falls_back_to_global_auth(tmp_path, monkeypatch):
+    global_root, profile_home = _setup_profile_with_global_codex_auth(tmp_path, monkeypatch)
+    _setup_hermes_auth(global_root, access_token="global-access", refresh_token="global-refresh")
+    _write_broken_profile_codex_state(profile_home)
+
+    data = _read_codex_tokens()
+    assert data["tokens"]["access_token"] == "global-access"
+    assert data["auth_source"] == "global-auth-store-fallback"
+
+    creds = resolve_codex_runtime_credentials(refresh_if_expiring=False)
+    assert creds["api_key"] == "global-access"
+    assert creds["source"] == "global-auth-store-fallback"
+
+
+def test_profile_global_codex_fallback_refresh_updates_global_not_profile(tmp_path, monkeypatch):
+    global_root, profile_home = _setup_profile_with_global_codex_auth(tmp_path, monkeypatch)
+    expiring_token = _jwt_with_exp(int(time.time()) - 10)
+    _setup_hermes_auth(
+        global_root,
+        access_token=expiring_token,
+        refresh_token="global-refresh-old",
+        active_provider="nous",
+    )
+    _write_broken_profile_codex_state(profile_home)
+
+    def _fake_refresh(access_token, refresh_token, *, timeout_seconds):
+        assert access_token == expiring_token
+        assert refresh_token == "global-refresh-old"
+        return {"access_token": "global-access-new", "refresh_token": "global-refresh-new"}
+
+    monkeypatch.setattr("hermes_cli.auth.refresh_codex_oauth_pure", _fake_refresh)
+
+    creds = resolve_codex_runtime_credentials()
+    assert creds["api_key"] == "global-access-new"
+    assert creds["source"] == "global-auth-store-fallback"
+
+    global_auth = json.loads((global_root / "auth.json").read_text())
+    profile_auth = json.loads((profile_home / "auth.json").read_text())
+    assert global_auth["active_provider"] == "nous"
+    assert global_auth["providers"]["openai-codex"]["tokens"]["access_token"] == "global-access-new"
+    assert global_auth["providers"]["openai-codex"]["tokens"]["refresh_token"] == "global-refresh-new"
+    assert profile_auth["providers"]["openai-codex"]["tokens"] == {}
+
+
 def test_resolve_codex_runtime_credentials_refreshes_expiring_token(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes"
     expiring_token = _jwt_with_exp(int(time.time()) - 10)
@@ -94,7 +172,7 @@ def test_resolve_codex_runtime_credentials_refreshes_expiring_token(tmp_path, mo
 
     called = {"count": 0}
 
-    def _fake_refresh(tokens, timeout_seconds):
+    def _fake_refresh(tokens, timeout_seconds, **kwargs):
         called["count"] += 1
         return {"access_token": "access-new", "refresh_token": "refresh-new"}
 
@@ -113,7 +191,7 @@ def test_resolve_codex_runtime_credentials_force_refresh(tmp_path, monkeypatch):
 
     called = {"count": 0}
 
-    def _fake_refresh(tokens, timeout_seconds):
+    def _fake_refresh(tokens, timeout_seconds, **kwargs):
         called["count"] += 1
         return {"access_token": "access-forced", "refresh_token": "refresh-new"}
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1100,6 +1100,127 @@ def test_dispatch_spawn_failure_releases_claim(kanban_home, all_assignees_spawna
         assert kb.get_task(conn, t).claim_lock is None
 
 
+def test_dispatch_readiness_gate_ignores_task_max_retries(
+    kanban_home, all_assignees_spawnable, monkeypatch,
+):
+    """Deterministic readiness failures block immediately, even with retries."""
+    default_spawn_called = []
+
+    def should_not_spawn(task, workspace, *, board=None):
+        default_spawn_called.append(task.id)
+        raise AssertionError("default spawn should not be reached")
+
+    monkeypatch.setattr(kb, "_default_spawn", should_not_spawn)
+    monkeypatch.setattr(
+        kb,
+        "_worker_readiness_failure",
+        lambda profile: "Worker readiness failed: openai-codex auth unavailable for profile alice",
+        raising=False,
+    )
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="needs-auth", assignee="alice", max_retries=5)
+        res = kb.dispatch_once(conn, failure_limit=3)
+        task = kb.get_task(conn, t)
+        run = kb.latest_run(conn, t)
+
+    assert default_spawn_called == []
+    assert task is not None
+    assert task.status == "blocked"
+    assert task.claim_lock is None
+    assert t in res.auto_blocked
+    assert res.readiness_blocked == [(t, "openai-codex_auth_unavailable")]
+    assert run is not None
+    assert run.outcome == "gave_up"
+
+
+def test_worker_readiness_allows_configured_runtime_fallback(tmp_path, monkeypatch):
+    """Primary Codex auth failure should not block workers with a valid fallback."""
+    profile_home = tmp_path / ".hermes" / "profiles" / "alice"
+    profile_home.mkdir(parents=True)
+    (profile_home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: openai-codex\n"
+        "  default: gpt-5.5\n"
+        "fallback_providers:\n"
+        "  - provider: openrouter\n"
+        "    model: openai/gpt-5-mini\n",
+        encoding="utf-8",
+    )
+
+    from hermes_cli.auth import AuthError
+
+    monkeypatch.setattr(
+        "hermes_cli.profiles.resolve_profile_env",
+        lambda profile: str(profile_home),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_codex_runtime_credentials",
+        lambda **kwargs: (_ for _ in ()).throw(AuthError("missing access_token")),
+    )
+
+    seen = {}
+
+    def fake_resolve_runtime_provider(**kwargs):
+        seen.update(kwargs)
+        return {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "fallback-test-key",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        fake_resolve_runtime_provider,
+    )
+
+    assert kb._worker_readiness_failure("alice") is None
+    assert seen["requested"] == "openrouter"
+    assert seen["target_model"] == "openai/gpt-5-mini"
+
+
+def test_dispatch_readiness_gate_blocks_before_default_spawn(
+    kanban_home, all_assignees_spawnable, monkeypatch,
+):
+    """Known-fatal worker readiness failures should block before Popen.
+
+    This catches profile/provider auth failures (for example Codex auth missing
+    access_token) before the dispatcher crash-loops a worker subprocess.
+    """
+    default_spawn_called = []
+
+    def should_not_spawn(task, workspace, *, board=None):
+        default_spawn_called.append(task.id)
+        raise AssertionError("default spawn should not be reached")
+
+    monkeypatch.setattr(kb, "_default_spawn", should_not_spawn)
+    monkeypatch.setattr(
+        kb,
+        "_worker_readiness_failure",
+        lambda profile: "Worker readiness failed: openai-codex auth unavailable for profile alice",
+        raising=False,
+    )
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="needs-auth", assignee="alice")
+        res = kb.dispatch_once(conn, failure_limit=3)
+        task = kb.get_task(conn, t)
+        run = kb.latest_run(conn, t)
+
+    assert default_spawn_called == []
+    assert task is not None
+    assert task.status == "blocked"
+    assert task.claim_lock is None
+    assert task.worker_pid is None
+    assert t in res.auto_blocked
+    assert res.readiness_blocked == [(t, "openai-codex_auth_unavailable")]
+    assert task.last_failure_error is not None
+    assert "Worker readiness failed" in task.last_failure_error
+    assert run is not None
+    assert run.outcome == "gave_up"
+
+
 def test_dispatch_max_spawn_counts_existing_running_tasks(
     kanban_home, all_assignees_spawnable
 ):
@@ -1881,6 +2002,67 @@ class TestSharedBoardPaths:
         )
         assert env["HERMES_KANBAN_TASK"] == "t_dispatch_env"
         assert env["HERMES_KANBAN_BRANCH"] == "wt/t_dispatch_env"
+
+    def test_dispatcher_spawn_sets_acpx_canonical_home_for_profile_workers(
+        self, tmp_path, monkeypatch
+    ):
+        default_home = tmp_path / ".hermes"
+        profile_home = default_home / "profiles" / "coder"
+        profile_home.mkdir(parents=True)
+        self._set_home(monkeypatch, tmp_path, default_home)
+        monkeypatch.setattr(
+            "hermes_cli.profiles.resolve_profile_env",
+            lambda _profile: str(profile_home),
+        )
+        monkeypatch.setenv("ACPX_GUARD_REAL_HOME", "/tmp/stale-real")
+        monkeypatch.setenv("ACPX_GUARD_HOME", "/tmp/stale-home")
+        monkeypatch.setenv("ACPX_GUARD_LOG_DIR", "/tmp/stale-log")
+        monkeypatch.setenv("ACPX_GUARD_USAGE_HOME", "/tmp/stale-usage")
+        monkeypatch.setenv("ACPX_GUARD_AGENT_HOME", "/tmp/stale-agent")
+
+        captured = {}
+
+        class _FakePopen:
+            def __init__(self, cmd, **kwargs):
+                captured["cmd"] = cmd
+                captured["env"] = kwargs.get("env", {})
+                self.pid = 4242
+
+        monkeypatch.setattr("subprocess.Popen", _FakePopen)
+
+        task = kb.Task(
+            id="t_acpx_env",
+            title="x",
+            body=None,
+            assignee="coder",
+            status="ready",
+            priority=0,
+            created_by=None,
+            created_at=0,
+            started_at=None,
+            completed_at=None,
+            workspace_kind="scratch",
+            workspace_path=None,
+            claim_lock=None,
+            claim_expires=None,
+            tenant=None,
+            branch_name=None,
+        )
+        kb._default_spawn(task, str(tmp_path / "ws"))
+
+        env = captured["env"]
+        assert env["HERMES_HOME"] == str(profile_home)
+        assert env["ACPX_GUARD_REAL_HOME"] == str(tmp_path)
+        assert env["ACPX_GUARD_HOME"] == str(tmp_path / ".hermes" / "acpx")
+        assert env["ACPX_GUARD_LOG_DIR"] == str(tmp_path / ".hermes" / "logs" / "acpx")
+        assert env["ACPX_GUARD_USAGE_HOME"] == str(tmp_path)
+        assert env["ACPX_GUARD_AGENT_HOME"] == str(tmp_path)
+
+    def test_acpx_canonical_home_supports_generic_profile_layout(self):
+        assert kb._canonical_home_from_profile_hermes_home("/opt/hermes/profiles/coder") == "/opt/hermes"
+
+    def test_acpx_canonical_home_returns_none_for_non_profile_layout(self):
+        assert kb._canonical_home_from_profile_hermes_home("/opt/hermes/coder") is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- let profile-local broken Codex auth fall back to valid root/global Hermes auth without copying refresh tokens into worker profiles
- add a narrow Kanban pre-spawn readiness gate for deterministic Codex auth failures, including immediate block for no-fallback auth failures
- preserve configured runtime fallback providers and ACPX canonical-home routing for profile workers

## Test plan
- `python -m py_compile hermes_cli/auth.py hermes_cli/kanban_db.py`
- `scripts/run_tests.sh tests/hermes_cli/test_auth_codex_provider.py tests/hermes_cli/test_auth_profile_fallback.py tests/hermes_cli/test_kanban_db.py`

## Notes
- The readiness probe uses `refresh_if_expiring=False` so it does not consume Codex refresh tokens during preflight.
- Refreshes sourced from the global auth store write back to that source store, not to profile-local auth files.
