### PR TITLE
fix(messaging): add API gateway root landing page

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -881,6 +881,52 @@ class APIServerAdapter(BasePlatformAdapter):
     # HTTP Handlers
     # ------------------------------------------------------------------
 
+    async def _handle_root(self, request: "web.Request") -> "web.Response":
+        """GET / — browser-friendly landing page for the API server."""
+        html = """<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Hermes API Gateway</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.5;
+    }
+    body {
+      max-width: 760px;
+      margin: 48px auto;
+      padding: 0 24px;
+      background: Canvas;
+      color: CanvasText;
+    }
+    h1 { margin-bottom: 0.25rem; }
+    code {
+      padding: 0.125rem 0.25rem;
+      border-radius: 4px;
+      background: color-mix(in srgb, CanvasText 10%, Canvas);
+    }
+    a { color: LinkText; }
+    ul { padding-left: 1.25rem; }
+  </style>
+</head>
+<body>
+  <h1>Hermes API Gateway</h1>
+  <p>Status: <strong>running</strong></p>
+  <p>This port serves the OpenAI-compatible Hermes API. Use <code>/v1</code> as the API base URL.</p>
+  <ul>
+    <li><a href="/health">Health</a></li>
+    <li><a href="/health/detailed">Detailed health</a></li>
+    <li><a href="/v1/models">Models</a> (requires API key when configured)</li>
+    <li><a href="/v1/capabilities">Capabilities</a> (requires API key when configured)</li>
+  </ul>
+  <p>Dashboard UI: run <code>hermes dashboard</code>, then open <code>http://127.0.0.1:9119/</code>.</p>
+</body>
+</html>"""
+        return web.Response(text=html, content_type="text/html")
+
     async def _handle_health(self, request: "web.Request") -> "web.Response":
         """GET /health — simple health check."""
         return web.json_response({"status": "ok", "platform": "hermes-agent"})
@@ -3360,6 +3406,7 @@ class APIServerAdapter(BasePlatformAdapter):
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
             self._app = web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)
             self._app["api_server_adapter"] = self
+            self._app.router.add_get("/", self._handle_root)
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/health/detailed", self._handle_health_detailed)
             self._app.router.add_get("/v1/health", self._handle_health)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -375,6 +375,7 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
     app = web.Application(middlewares=mws)
     app["api_server_adapter"] = adapter
+    app.router.add_get("/", adapter._handle_root)
     app.router.add_get("/health", adapter._handle_health)
     app.router.add_get("/health/detailed", adapter._handle_health_detailed)
     app.router.add_get("/v1/health", adapter._handle_health)
@@ -438,6 +439,19 @@ class TestAgentExecution:
 
 
 class TestHealthEndpoint:
+    @pytest.mark.asyncio
+    async def test_root_returns_browser_landing_page(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/")
+            assert resp.status == 200
+            assert resp.content_type == "text/html"
+            text = await resp.text()
+            assert "Hermes API Gateway" in text
+            assert "/health" in text
+            assert "/v1" in text
+            assert "{{" not in text
+
     @pytest.mark.asyncio
     async def test_security_headers_present(self, adapter):
         """Responses should include basic security headers."""


### PR DESCRIPTION
## What does this PR do?

Adds a browser-friendly landing page for the Hermes API gateway root route. The gateway was healthy on `127.0.0.1:8642`, but opening `/` in a browser showed aiohttp's default `404: Not Found`, which made the local service look broken even though `/health` and `/v1` were working.

## Related Issue

N/A - reported from local browser smoke testing of `http://127.0.0.1:8642/`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/api_server.py`: add `GET /` handler returning a small HTML status/landing page with links to `/health`, `/health/detailed`, `/v1/models`, and `/v1/capabilities`.
- `gateway/platforms/api_server.py`: register the root handler in the aiohttp API server.
- `tests/gateway/test_api_server.py`: add coverage for the root landing page and guard against escaped template braces leaking into the HTML.

## How to Test

1. Run `pytest tests/gateway/test_api_server.py -q`.
2. Restart the gateway service: `python -m hermes_cli.main gateway restart`.
3. Open or curl `http://127.0.0.1:8642/` and confirm it returns `200 OK` HTML with `Hermes API Gateway` and `Status: running`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, local launchd gateway on `127.0.0.1:8642`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A - this PR does not add or change a skill.

## Screenshots / Logs

Focused tests:

```text
pytest tests/gateway/test_api_server.py -q
147 passed, 96 warnings in 6.04s
```

Live local verification after restarting the gateway:

```text
curl -i http://127.0.0.1:8642/
HTTP/1.1 200 OK
Content-Type: text/html; charset=utf-8

Hermes API Gateway
Status: running
```
