### PR TITLE
[codex] Fix docs image base URLs

### DIFF
--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -4,6 +4,8 @@ title: "CLI Interface"
 description: "Master the Hermes Agent terminal interface — commands, keybindings, personalities, and more"
 ---
 
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
 # CLI Interface
 
 Hermes Agent's CLI is a full terminal user interface (TUI) — not a web UI. It features multiline editing, slash-command autocomplete, conversation history, interrupt-and-redirect, and streaming tool output. Built for people who live in the terminal.
@@ -49,7 +51,7 @@ hermes -w -q "Fix issue #123"     # Single query in worktree
 
 ## Interface Layout
 
-<img className="docs-terminal-figure" src="/img/docs/cli-layout.svg" alt="Stylized preview of the Hermes CLI layout showing the banner, conversation area, and fixed input prompt." />
+<img className="docs-terminal-figure" src={useBaseUrl('/img/docs/cli-layout.svg')} alt="Stylized preview of the Hermes CLI layout showing the banner, conversation area, and fixed input prompt." />
 <p className="docs-figure-caption">The Hermes CLI banner, conversation stream, and fixed input prompt rendered as a stable docs figure instead of fragile text art.</p>
 
 The welcome banner shows your model, terminal backend, working directory, available tools, and installed skills at a glance.

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -4,6 +4,8 @@ title: "Sessions"
 description: "Session persistence, resume, search, management, and per-platform session tracking"
 ---
 
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
 # Sessions
 
 Hermes Agent automatically saves every conversation as a session. Sessions enable conversation resume, cross-session search, and full conversation history management.
@@ -144,7 +146,7 @@ Session IDs are shown when you exit a CLI session, and can be found with `hermes
 
 When you resume a session, Hermes displays a compact recap of the previous conversation in a styled panel before the input prompt:
 
-<img className="docs-terminal-figure" src="/img/docs/session-recap.svg" alt="Stylized preview of the Previous Conversation recap panel shown when resuming a Hermes session." />
+<img className="docs-terminal-figure" src={useBaseUrl('/img/docs/session-recap.svg')} alt="Stylized preview of the Previous Conversation recap panel shown when resuming a Hermes session." />
 <p className="docs-figure-caption">Resume mode shows a compact recap panel with recent user and assistant turns before returning you to the live prompt.</p>
 
 The recap:


### PR DESCRIPTION
## Summary

- Use Docusaurus `useBaseUrl()` for raw HTML docs figures so static image paths include the `/docs` base URL.
- Fix the session recap figure from #24809 and the adjacent CLI layout figure with the same root-path pattern.

## Root cause

The docs site is configured with `baseUrl: "/docs/"`, but raw HTML `<img>` tags kept absolute `/img/docs/...` paths. In production those resolve outside the docs base path and can 404 even though the static asset exists.

Fixes #24809

## Validation

- `npm run build` from `website/` completed with exit code 0. Existing Docusaurus broken-link/broken-anchor warnings remain unrelated.
- Verified generated HTML includes `/docs/img/docs/session-recap.svg` and `/docs/img/docs/cli-layout.svg`, with no remaining root `/img/docs/...` path for those figures.
