### PR TITLE
fix(gateway): recognize markdown media attachments

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2298,7 +2298,8 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|html?|zip|rar|7z|docx?|xlsx?|pptx?|txt|md|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?''',
+            re.IGNORECASE,
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -329,6 +329,35 @@ class TestExtractMedia:
         assert media == [("/tmp/Jane Doe/speech.flac", False)]
         assert cleaned == ""
 
+    def test_media_tag_supports_html_documents(self):
+        content = "File attached:\nMEDIA:/home/hermes/report.html"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [("/home/hermes/report.html", False)]
+        assert "MEDIA:" not in cleaned
+        assert "File attached" in cleaned
+
+    def test_media_tag_supports_htm_documents(self):
+        content = "MEDIA:/home/hermes/report.htm"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [("/home/hermes/report.htm", False)]
+        assert cleaned == ""
+
+    def test_media_tag_supports_markdown_documents(self):
+        content = "Here is the file again:\nMEDIA:/home/hermes/notes.md"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [("/home/hermes/notes.md", False)]
+        assert "MEDIA:" not in cleaned
+        assert "Here is the file again" in cleaned
+
+    def test_media_tag_supports_uppercase_document_extensions(self):
+        content = "MEDIA:/home/hermes/NOTES.MD\nMEDIA:/home/hermes/report.HTML"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [
+            ("/home/hermes/NOTES.MD", False),
+            ("/home/hermes/report.HTML", False),
+        ]
+        assert cleaned == ""
+
     def test_as_document_directive_stripped_from_cleaned_text(self):
         """[[as_document]] is a routing directive — strip it from
         user-visible text just like [[audio_as_voice]]. Callers detect the


### PR DESCRIPTION
## Summary

- Teach the shared gateway `MEDIA:` extractor to recognize markdown and HTML document attachments.
- Make `MEDIA:` extraction case-insensitive so uppercase document extensions like `.MD` are handled.
- Add focused regression coverage for `.md`, `.MD`, `.html`, and `.htm` media tags.

Fixes #31560

## Test plan

- `python -m pytest tests/gateway/test_platform_base.py -q -o 'addopts='`
- `git diff --check`
- Lightweight added-line secret/private scan over the touched files
