### PR TITLE
feat(prompt): add SHARED.md for cross-profile identity rules

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1310,8 +1310,51 @@ def _truncate_content(content: str, filename: str, max_chars: int = CONTEXT_FILE
     return head + marker + tail
 
 
+def load_shared_soul_md() -> Optional[str]:
+    """Load SHARED.md (cross-profile shared identity) from the default Hermes root.
+
+    SHARED.md provides rules and identity context common to all profiles on
+    this machine.  When present, it is prepended to each profile's SOUL.md
+    in the agent identity slot, so a single rule (e.g. "user's wiki lives
+    at ~/wiki, consult it before saying you don't know") can apply to every
+    profile without being duplicated in each ``profiles/<name>/SOUL.md``.
+
+    Path resolution:
+      * ``HERMES_SHARED_SOUL`` env var if set (absolute or user-expandable path).
+      * Otherwise ``~/.hermes/SHARED.md`` — the default Hermes root, regardless
+        of the current profile's ``HERMES_HOME``.
+
+    Returns ``None`` if the file does not exist, is empty, or cannot be read.
+    """
+    override = os.environ.get("HERMES_SHARED_SOUL", "").strip()
+    if override:
+        shared_path = Path(os.path.expanduser(override))
+    else:
+        # Always read from the default Hermes root (~/.hermes), not the
+        # current profile's HERMES_HOME — that's the whole point of SHARED.
+        shared_path = Path.home() / ".hermes" / "SHARED.md"
+
+    if not shared_path.exists():
+        return None
+    try:
+        content = shared_path.read_text(encoding="utf-8").strip()
+        if not content:
+            return None
+        content = _scan_context_content(content, "SHARED.md")
+        content = _truncate_content(content, "SHARED.md")
+        return content
+    except Exception as e:
+        logger.debug("Could not read SHARED.md from %s: %s", shared_path, e)
+        return None
+
+
 def load_soul_md() -> Optional[str]:
     """Load SOUL.md from HERMES_HOME and return its content, or None.
+
+    If ``~/.hermes/SHARED.md`` (or the path in ``HERMES_SHARED_SOUL``) exists,
+    its content is prepended to the profile SOUL with a ``\\n\\n---\\n\\n``
+    separator.  This lets cross-profile rules apply to every agent without
+    duplication.  See :func:`load_shared_soul_md`.
 
     Used as the agent identity (slot #1 in the system prompt).  When this
     returns content, ``build_context_files_prompt`` should be called with
@@ -1324,18 +1367,21 @@ def load_soul_md() -> Optional[str]:
         logger.debug("Could not ensure HERMES_HOME before loading SOUL.md: %s", e)
 
     soul_path = get_hermes_home() / "SOUL.md"
-    if not soul_path.exists():
-        return None
-    try:
-        content = soul_path.read_text(encoding="utf-8").strip()
-        if not content:
-            return None
-        content = _scan_context_content(content, "SOUL.md")
-        content = _truncate_content(content, "SOUL.md")
-        return content
-    except Exception as e:
-        logger.debug("Could not read SOUL.md from %s: %s", soul_path, e)
-        return None
+    profile_soul: Optional[str] = None
+    if soul_path.exists():
+        try:
+            content = soul_path.read_text(encoding="utf-8").strip()
+            if content:
+                content = _scan_context_content(content, "SOUL.md")
+                profile_soul = _truncate_content(content, "SOUL.md")
+        except Exception as e:
+            logger.debug("Could not read SOUL.md from %s: %s", soul_path, e)
+
+    shared_soul = load_shared_soul_md()
+
+    if shared_soul and profile_soul:
+        return f"{shared_soul}\n\n---\n\n{profile_soul}"
+    return shared_soul or profile_soul
 
 
 def _load_hermes_md(cwd_path: Path) -> str:

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1194,4 +1194,118 @@ class TestOpenAIModelExecutionGuidance:
 # =========================================================================
 
 
+# =========================================================================
+# SHARED.md — cross-profile shared identity
+# =========================================================================
+
+
+class TestLoadSharedSoulMd:
+    """``load_shared_soul_md`` reads ~/.hermes/SHARED.md (or env-overridden path)."""
+
+    def test_returns_none_when_file_does_not_exist(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_SHARED_SOUL", str(tmp_path / "missing.md"))
+        from agent.prompt_builder import load_shared_soul_md
+        assert load_shared_soul_md() is None
+
+    def test_returns_none_when_file_is_empty(self, tmp_path, monkeypatch):
+        shared = tmp_path / "SHARED.md"
+        shared.write_text("\n\n   \n", encoding="utf-8")
+        monkeypatch.setenv("HERMES_SHARED_SOUL", str(shared))
+        from agent.prompt_builder import load_shared_soul_md
+        assert load_shared_soul_md() is None
+
+    def test_loads_via_env_var_override(self, tmp_path, monkeypatch):
+        shared = tmp_path / "custom-shared.md"
+        shared.write_text("Cross-profile rule: be honest.", encoding="utf-8")
+        monkeypatch.setenv("HERMES_SHARED_SOUL", str(shared))
+        from agent.prompt_builder import load_shared_soul_md
+        assert load_shared_soul_md() == "Cross-profile rule: be honest."
+
+    def test_loads_from_default_root_when_no_env(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("HERMES_SHARED_SOUL", raising=False)
+        fake_home = tmp_path / "home"
+        (fake_home / ".hermes").mkdir(parents=True)
+        (fake_home / ".hermes" / "SHARED.md").write_text(
+            "Default location works.", encoding="utf-8"
+        )
+        monkeypatch.setattr("pathlib.Path.home", lambda: fake_home)
+        from agent.prompt_builder import load_shared_soul_md
+        assert load_shared_soul_md() == "Default location works."
+
+    def test_default_root_ignores_hermes_home(self, tmp_path, monkeypatch):
+        """SHARED.md is read from ~/.hermes regardless of the profile's HERMES_HOME."""
+        monkeypatch.delenv("HERMES_SHARED_SOUL", raising=False)
+        fake_home = tmp_path / "home"
+        (fake_home / ".hermes").mkdir(parents=True)
+        (fake_home / ".hermes" / "SHARED.md").write_text("Root SHARED.", encoding="utf-8")
+        # A profile HERMES_HOME with its own SHARED.md should be ignored.
+        profile_home = tmp_path / "profile_x"
+        profile_home.mkdir()
+        (profile_home / "SHARED.md").write_text(
+            "Profile-local SHARED must be ignored.", encoding="utf-8"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        monkeypatch.setattr("pathlib.Path.home", lambda: fake_home)
+        from agent.prompt_builder import load_shared_soul_md
+        result = load_shared_soul_md()
+        assert result == "Root SHARED."
+        assert "Profile-local" not in (result or "")
+
+    def test_env_var_supports_tilde_expansion(self, tmp_path, monkeypatch):
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        (fake_home / "myshared.md").write_text("Tilde works.", encoding="utf-8")
+        monkeypatch.setattr("os.path.expanduser", lambda p: p.replace("~", str(fake_home)))
+        monkeypatch.setenv("HERMES_SHARED_SOUL", "~/myshared.md")
+        from agent.prompt_builder import load_shared_soul_md
+        assert load_shared_soul_md() == "Tilde works."
+
+
+class TestLoadSoulMdWithShared:
+    """``load_soul_md`` concatenates SHARED.md before the profile SOUL.md."""
+
+    def test_shared_prepended_to_profile_soul(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        (hermes_home / "SOUL.md").write_text("Profile identity.", encoding="utf-8")
+        shared = tmp_path / "SHARED.md"
+        shared.write_text("Cross-profile rule.", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HERMES_SHARED_SOUL", str(shared))
+        from agent.prompt_builder import load_soul_md
+        result = load_soul_md()
+        assert result == "Cross-profile rule.\n\n---\n\nProfile identity."
+
+    def test_shared_only_when_profile_soul_empty(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        # Empty profile SOUL.md — blocks the auto-seed too.
+        (hermes_home / "SOUL.md").write_text("", encoding="utf-8")
+        shared = tmp_path / "SHARED.md"
+        shared.write_text("Just shared.", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HERMES_SHARED_SOUL", str(shared))
+        from agent.prompt_builder import load_soul_md
+        assert load_soul_md() == "Just shared."
+
+    def test_profile_only_when_no_shared(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        (hermes_home / "SOUL.md").write_text("Profile only.", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HERMES_SHARED_SOUL", str(tmp_path / "no-shared.md"))
+        from agent.prompt_builder import load_soul_md
+        assert load_soul_md() == "Profile only."
+
+    def test_separator_format_is_stable(self, tmp_path, monkeypatch):
+        """The separator between SHARED and profile SOUL is ``\\n\\n---\\n\\n``."""
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        (hermes_home / "SOUL.md").write_text("PROFILE", encoding="utf-8")
+        shared = tmp_path / "SHARED.md"
+        shared.write_text("SHARED", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HERMES_SHARED_SOUL", str(shared))
+        from agent.prompt_builder import load_soul_md
+        assert load_soul_md() == "SHARED\n\n---\n\nPROFILE"
 

--- a/website/docs/guides/use-soul-with-hermes.md
+++ b/website/docs/guides/use-soul-with-hermes.md
@@ -71,6 +71,28 @@ If SOUL.md is missing, empty, or cannot be loaded, Hermes falls back to a built-
 
 No wrapper language is added around the file. The content itself matters — write the way you want your agent to think and speak.
 
+## Sharing rules across profiles with SHARED.md
+
+If you run multiple profiles on the same machine (e.g. `default`, plus `profiles/work/`, `profiles/personal/`), each profile has its own `SOUL.md`. Rules that should apply to **every** profile — for example "user's wiki lives at `~/wiki`, consult it before saying you don't know" — used to require editing every profile's SOUL one by one.
+
+`SHARED.md` solves that. When Hermes loads the identity slot, it also checks for a shared file and prepends it to the profile SOUL with a `\n\n---\n\n` separator. The same shared rules then apply to every profile without duplication.
+
+```text
+~/.hermes/SHARED.md
+```
+
+Override the path with the `HERMES_SHARED_SOUL` environment variable if you want it elsewhere (tilde expansion supported).
+
+How the slot is built:
+
+- `SHARED.md` exists, profile `SOUL.md` exists → `SHARED + \n\n---\n\n + SOUL`
+- `SHARED.md` exists, profile `SOUL.md` missing/empty → `SHARED` alone becomes the identity
+- `SHARED.md` missing → behavior is unchanged from earlier versions; only the profile SOUL is loaded
+
+`SHARED.md` always reads from the **default Hermes root** (`~/.hermes`), regardless of the current profile's `HERMES_HOME`. This is intentional: each profile's `HERMES_HOME` points at its own directory, so reading SHARED from there would defeat the purpose. The shared rules live at one well-known spot.
+
+Use SHARED for things like infrastructure facts ("the team's vector DB is at `db.internal:6333`"), shared safety rules ("never call destructive scripts without a dry-run first"), or anything you'd otherwise be tempted to copy-paste into multiple SOUL files.
+
 ## A good first edit
 
 If you do nothing else, open the file and change just a few lines so it feels like you.


### PR DESCRIPTION
## What does this PR do?

Adds `SHARED.md` — a cross-profile identity file that is prepended to each profile's `SOUL.md` when the agent identity slot is assembled.

**The problem.** Users running multiple profiles on the same machine (e.g. one default Hermione plus `profiles/sophie/`, `profiles/maya/`, `profiles/hephaistos/`) currently have to duplicate every cross-cutting rule in every profile's `SOUL.md`. Want all your agents to know "the team wiki lives at `~/wiki` — consult it before saying you don't know"? You edit 4+ files. Forget one and that agent silently violates the rule.

**The change.** If `~/.hermes/SHARED.md` (or `$HERMES_SHARED_SOUL`) exists, its content is prepended to the profile SOUL with a `\n\n---\n\n` separator inside `load_soul_md()`. The same shared rules then apply to every profile without duplication. Behavior is fully backward compatible: with no `SHARED.md`, `load_soul_md()` behaves exactly as before.

`SHARED.md` always reads from the **default Hermes root** (`~/.hermes`), regardless of the current profile's `HERMES_HOME` — reading it from the profile-specific home would defeat the point.

## Related Issue

No existing issue (I searched open issues and PRs for "shared SOUL", "cross-profile SOUL", "global SOUL" before opening this). Happy to file one first if you'd prefer.

Fixes #

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/prompt_builder.py` — new function `load_shared_soul_md()` (same `_scan_context_content` + `_truncate_content` pipeline as `load_soul_md()`); `load_soul_md()` now merges shared + profile SOUL with `\n\n---\n\n` separator. +58 / −12.
- `tests/agent/test_prompt_builder.py` — two new test classes (`TestLoadSharedSoulMd`, `TestLoadSoulMdWithShared`), 10 tests covering: missing file, empty file, env-var override path, default-root location, `HERMES_HOME` is ignored for SHARED, tilde expansion, prepend behavior, shared-only fallback, profile-only fallback, separator format. +114.
- `website/docs/guides/use-soul-with-hermes.md` — new section "Sharing rules across profiles with SHARED.md" between "How Hermes uses it" and "A good first edit". +22.

## How to Test

1. With **no** `SHARED.md`: `pytest tests/agent/test_prompt_builder.py` → all 134 tests pass (124 existing + 10 new).
2. With `~/.hermes/SHARED.md` populated:
   ```bash
   echo "Cross-profile rule: always confirm destructive ops." > ~/.hermes/SHARED.md
   hermes -q "What rules apply to you?"
   ```
   The identity slot will contain the SHARED content prepended to the profile SOUL.
3. With `HERMES_SHARED_SOUL` pointing elsewhere:
   ```bash
   HERMES_SHARED_SOUL=/tmp/my-shared.md hermes ...
   ```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(prompt): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature (no unrelated commits)
- [x] I've run `pytest tests/agent/test_prompt_builder.py` and all 134 tests pass
- [x] I've added tests for my changes (10 unit tests)
- [x] I've tested on my platform: Ubuntu 24.04 (Mercure server, Python 3.11.15)
- [x] Ruff: `ruff check agent/prompt_builder.py tests/agent/test_prompt_builder.py` → All checks passed

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/guides/use-soul-with-hermes.md`)
- [x] N/A — no new config keys for `cli-config.yaml.example` (`HERMES_SHARED_SOUL` is an env var, like `HERMES_HOME`)
- [x] N/A — no architecture change requiring `CONTRIBUTING.md` / `AGENTS.md` updates
- [x] Cross-platform: uses `Path.home()` + `os.path.expanduser()` — works on Windows/macOS/Linux
- [x] N/A — no tool descriptions/schemas changed

## Why this is the right approach

- **Minimal surface area.** One new function, one function modified, one doc section. Reuses the existing `_scan_context_content` / `_truncate_content` pipeline so injection scanning and length capping behave identically to `SOUL.md`.
- **No breaking change.** Without `SHARED.md`, the function returns the same value it always did. Existing test suite passes unchanged.
- **Discoverable.** Symmetric naming (`SHARED.md` alongside `SOUL.md`), env var follows the same `HERMES_*` convention, and doc section sits next to "Where it lives".
- **Honest about scope.** SHARED is read from the **default root**, not the profile home — documented and tested explicitly. A user running with `HERMES_HOME=/somewhere/weird` still gets `~/.hermes/SHARED.md`, which is the desired behavior for "shared across profiles".

Open to renaming (`COMMON.md`, `GLOBAL_SOUL.md`, …) or alternative placement if the maintainers prefer a different convention. Happy to iterate.
