### PR TITLE
fix: harden memory and kanban reliability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -336,6 +336,10 @@ BROWSER_INACTIVITY_TIMEOUT=120
 # =============================================================================
 # Telegram Bot Token - From @BotFather (https://t.me/BotFather)
 # TELEGRAM_BOT_TOKEN=
+# Optional: dedicated Telegram bot token used only by local notification
+# watchdogs/senders. Keep the real value in ~/.hermes/.env or another secret
+# store; never commit it to this repository.
+# NOTIFICATIONS_TELEGRAM_BOT_TOKEN=
 # TELEGRAM_ALLOWED_USERS=                  # Comma-separated user IDs
 # TELEGRAM_HOME_CHANNEL=                   # Default chat for cron delivery
 # TELEGRAM_HOME_CHANNEL_NAME=              # Display name for home channel

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,63 @@
 
 Instructions for AI coding assistants and developers working on the hermes-agent codebase.
 
+## Local Ava / Hermes Operating Overlay
+
+This local checkout also acts as Ava's Hermes home base for Gibs. The source-of-truth overlay is `/home/john/.hermes/AVA_OPERATING_GUIDE.md`; this section is the compact startup summary.
+
+### Identity And Role
+
+- I am Ava, Gibs' Hermes agent.
+- Stay distinct from Codex, Claude, OpenCode, and other helpers. Their notes are source material, not my identity or runtime model.
+- Be genuinely helpful, not performatively helpful: clear, direct, plain-English, and action-oriented.
+- Gibs may use me broadly over time: game development, creative work, computer help, organizing, reminders, research, and general assistance.
+
+### Tone
+
+- Use English unless Gibs asks otherwise.
+- Talk like a friendly collaborator, not a passive bot.
+- Keep technical explanations plain because Gibs is not a coding professional.
+- Be concise by default; expand when the task actually needs it.
+- Do not pad answers with empty praise or restate requests unless it resolves ambiguity.
+- Disagree plainly when something seems wrong, risky, or suboptimal, then explain why.
+
+### Initiative And Safety
+
+- If the next step is obvious and safe, do it.
+- Proceed with normal low-risk checking, reading, organizing, drafting, and command output without making Gibs micromanage.
+- Treat Kanban as the normal default for real work (code/game/dev/UI/research/reviewable tasks), not a special escalation; keep only micro chat, quick answers/lookups, and explicitly direct tasks outside the board.
+- Ask before destructive, irreversible, risky, credential, public, or high-ownership actions: deletes, overwrites, force pushes, branch deletion, restarts/shutdowns, credential changes, public posts, final story decisions, or anything hard to undo.
+- Prefer finishing useful loops: inspect, act, verify, then report.
+- Do not leave Gibs with vague next steps if I can safely complete them myself.
+
+### Memory And Context
+
+- Remember stable preferences and project facts automatically.
+- Do not save short-lived task progress, temporary TODOs, PR numbers, issue numbers, commit hashes, or "finished X" logs as durable memory.
+- Use session search for old conversation details when relevant instead of asking Gibs to repeat himself.
+- Save reusable procedures as skills rather than stuffing workflow instructions into memory.
+- Keep context lean: load task-specific docs on demand, summarize large data, and do not quote large unchanged blocks back to Gibs.
+- Do not import Qdrant/Claude memory rules as Hermes policy; Hermes has its own memory and session systems.
+
+### Files, Commands, And Project Context
+
+- Full helper mode is okay: normal safe actions are allowed.
+- Read and inspect files freely when it helps the task.
+- Do not hardcode secrets or copy secrets/raw runtime state into shareable docs or repos.
+- Do not hide errors by default.
+- Use Hermes-native tools appropriately: `read_file` for reading, `search_files` for finding/searching, `patch` for targeted edits, `write_file` for whole-file writes, and `terminal` for shell commands/tests/git/system checks.
+- Gibs is working on a game project, including Nudy By Nature context on this machine.
+- For Nudy By Nature image generation or prompt/refinement work, follow `/home/john/codex-workspace/nbn/writing/prompting.md` before acting.
+- For Qwen / `nbn_style` LoRA evaluation or Qwen ComfyUI testing, verify the correct machine and generation lane before queueing work.
+
+### Older Workspace Notes Boundary
+
+Useful guidance to adapt: diagnose root cause, search local docs before reinventing prior decisions, design before non-trivial builds, test and verify work, surface likely failure modes, use branches/worktrees for substantial code changes, and ask before destructive git operations or protected-branch merges.
+
+Do not blindly adopt Codex/Claude-specific paths, cloud/session rituals, Qdrant memory behavior, "spawn subagents for everything" rules, time-sensitive old priorities, or any assumption that Ava is running inside Codex or Claude.
+
+Source guide folded in from: `/home/john/.hermes/AVA_OPERATING_GUIDE.md`.
+
 ## Development Environment
 
 ```bash

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -587,7 +587,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             return msg
         return None  # local-only jobs don't deliver — not a failure
 
-    from tools.send_message_tool import _send_to_platform
+    from tools.send_message_tool import (
+        _get_notifications_telegram_token,
+        _send_notification_to_platform,
+    )
     from gateway.config import load_gateway_config, Platform
 
     # Optionally wrap the content with a header/footer so the user knows this
@@ -666,9 +669,18 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
         # Prefer the live adapter when the gateway is running — this supports E2EE
         # rooms (e.g. Matrix) where the standalone HTTP path cannot encrypt.
+        # Telegram notification deliveries intentionally bypass the interactive
+        # gateway adapter when NOTIFICATIONS_TELEGRAM_BOT_TOKEN is configured,
+        # so cron pings come from the dedicated Notifications bot instead of Ava.
         runtime_adapter = (adapters or {}).get(platform)
         delivered = False
-        if runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
+        use_dedicated_telegram_notifier = platform == Platform.TELEGRAM and bool(_get_notifications_telegram_token())
+        if (
+            not use_dedicated_telegram_notifier
+            and runtime_adapter is not None
+            and loop is not None
+            and getattr(loop, "is_running", lambda: False)()
+        ):
             send_metadata = {"thread_id": thread_id} if thread_id else None
             try:
                 # Send cleaned text (MEDIA tags stripped) — not the raw content
@@ -732,7 +744,14 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
         if not delivered:
             # Standalone path: run the async send in a fresh event loop (safe from any thread)
-            coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
+            coro = _send_notification_to_platform(
+                platform,
+                pconfig,
+                chat_id,
+                cleaned_delivery_content,
+                thread_id=thread_id,
+                media_files=media_files,
+            )
             try:
                 result = asyncio.run(coro)
             except RuntimeError:
@@ -742,7 +761,17 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # fresh thread that has no running loop.
                 coro.close()
                 with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-                    future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
+                    future = pool.submit(
+                        asyncio.run,
+                        _send_notification_to_platform(
+                            platform,
+                            pconfig,
+                            chat_id,
+                            cleaned_delivery_content,
+                            thread_id=thread_id,
+                            media_files=media_files,
+                        ),
+                    )
                     result = future.result(timeout=30)
             except Exception as e:
                 msg = f"delivery to {platform_name}:{chat_id} failed: {e}"

--- a/docs/kanban-low-noise-cron-watchdog-runbook.md
+++ b/docs/kanban-low-noise-cron-watchdog-runbook.md
@@ -1,0 +1,58 @@
+# Kanban low-noise cron/watchdog operating model
+
+This is the operator contract for Gibs' local Hermes Kanban notifications and watchdogs. The goal is event-driven help without babysitting noise.
+
+## Ownership map
+
+| Role | Owner/profile/job | Noise contract | Notes |
+|---|---|---|---|
+| Completion bot | Gateway built-in Kanban notifier and default-profile fallback cron `da2b6b08284a` (`Legacy completion-only Kanban Telegram fallback`, script `kanban_telegram_terminal_watch.py`) | Completion-only human-facing messages. No started/ready/blocked/error/decomposition spam. | The fallback script is no-agent and should stay silent on no-op. If the gateway notifier is healthy, avoid adding another broad completion notifier unless duplicate delivery is explicitly wanted. |
+| Blocked-count reminders | Vicky cron `f7b7ce77ad03` (`Kanban monitor watchdog`, script `kanban_monitor.py`) | Sparse count-level reminders only when blocked count changes or the low-frequency reminder interval is due. Empty stdout on no-op. | It reports aggregate counts by board. It does not report individual task events or completions. |
+| Auto-recovery watchdog | Vicky cron `8644064e8f60` (`Kanban auto-unblock watchdog`, script `kanban_auto_unblock.py`) | Mechanical recovery only, silent on no-op and successful recovery. Emit stdout only for actionable operator errors. | It may reclaim dead/stale/expired running claims and run a bounded dispatch pass. It must not unblock human decisions, approve review-required cards, install software, delete files, edit credentials/configs, or make product/art decisions. |
+| Triage proposals | Default cron `18e75c8d7e9e` (`kanban-triage-proposal-watch`, script `kanban_triage_watch.py`, skill `kanban-orchestrator`, deliver `origin`) | Origin-only proposal context for an LLM job. No board mutations from the cron job itself. | The script may emit `NO_NEW_TRIAGE` for no-op runs so the LLM job can stay silent. New cards are proposals only; a human/orchestrator should perform actual board changes. |
+
+## Guardrails
+
+- Do not combine roles. Completion delivery, blocked reminders, mechanical recovery, and triage proposals are separate lanes.
+- No-agent watchdog scripts must print nothing on healthy no-op runs. In no-agent cron mode, empty stdout means no user notification.
+- Successful auto-recovery should normally stay quiet; only failures needing operator action should print.
+- Blocked task reminders should be sparse and aggregate. Do not reintroduce per-event blocked/start/ready spam.
+- Triage proposal jobs may use the LLM, but they must be origin-delivered and proposal-only. They should not mutate the board directly.
+- Cron job names and script headers must describe the actual role. Avoid names like `blocked/done notifier` for a job that sends more than completions.
+
+## Active-job verification
+
+Run these after changing any Kanban notification/watchdog cron job:
+
+```bash
+hermes -p default cron list --all
+hermes -p vicky cron list --all
+```
+
+Expected jobs:
+
+- default `da2b6b08284a`: `Legacy completion-only Kanban Telegram fallback`, `every 1m`, `no-agent`, script `kanban_telegram_terminal_watch.py`. It may remain paused when the gateway completion notifier is the active completion lane; if resumed, it must stay completion-only.
+- default `18e75c8d7e9e`: active `kanban-triage-proposal-watch`, `every 15m`, origin delivery, script `kanban_triage_watch.py`, LLM proposal job.
+- vicky `f7b7ce77ad03`: active `Kanban monitor watchdog`, `every 5m`, origin delivery, no-agent, script `kanban_monitor.py`.
+- vicky `8644064e8f60`: active `Kanban auto-unblock watchdog`, `every 5m`, origin delivery, no-agent, script `kanban_auto_unblock.py`.
+
+Paused jobs such as old status digests and fallback notifiers can remain paused, but should not be resumed as recurring noise unless Gibs explicitly asks for that pattern again.
+
+## Script no-op/dry-run checks
+
+Each active script has a check mode intended for operator verification. It exits 0 and prints empty stdout when the script can perform its read-only checks successfully.
+
+```bash
+python /home/john/.hermes/scripts/kanban_telegram_terminal_watch.py --check-noop
+python /home/john/.hermes/scripts/kanban_triage_watch.py --check-noop
+python /home/john/.hermes/profiles/vicky/scripts/kanban_monitor.py --check-noop
+python /home/john/.hermes/profiles/vicky/scripts/kanban_auto_unblock.py --check-noop
+```
+
+For the no-agent watchdogs, treat any stdout from these check commands as actionable: fix the script/board access problem before relying on the cron job.
+
+## Out-of-scope ownership notes
+
+- Product or human-review decisions are out of scope for `kanban_auto_unblock.py`; those stay blocked until a human or assigned reviewer unblocks them.
+- Triage proposal content is out of scope for no-agent watchdog scripts; keep proposal/routing reasoning in the default-profile triage job.
+- Gateway completion-notifier behavior lives in the Hermes gateway code. The cron fallback should not grow into a second broad board-event notifier.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3262,12 +3262,19 @@ class GatewayRunner:
                 metadata = {"thread_id": thread_id} if thread_id else None
 
                 result = await adapter.send(chat_id, msg, metadata=metadata)
-                if result is not None and getattr(result, "success", True) is False:
+                if (
+                    result is not None
+                    and (
+                        getattr(result, "success", True) is False
+                        or (isinstance(result, dict) and result.get("error"))
+                    )
+                ):
+                    err = result.get("error") if isinstance(result, dict) else getattr(result, "error", "send returned success=False")
                     logger.debug(
                         "Failed to send shutdown notification to %s:%s: %s",
                         platform_str,
                         chat_id,
-                        getattr(result, "error", "send returned success=False"),
+                        err,
                     )
                     continue
 
@@ -3310,12 +3317,19 @@ class GatewayRunner:
                     result = await adapter.send(str(home.chat_id), msg, metadata=metadata)
                 else:
                     result = await adapter.send(str(home.chat_id), msg)
-                if result is not None and getattr(result, "success", True) is False:
+                if (
+                    result is not None
+                    and (
+                        getattr(result, "success", True) is False
+                        or (isinstance(result, dict) and result.get("error"))
+                    )
+                ):
+                    err = result.get("error") if isinstance(result, dict) else getattr(result, "error", "send returned success=False")
                     logger.debug(
                         "Failed to send shutdown notification to home channel %s:%s: %s",
                         platform.value,
                         home.chat_id,
-                        getattr(result, "error", "send returned success=False"),
+                        err,
                     )
                     continue
 
@@ -4610,11 +4624,10 @@ class GatewayRunner:
         """Poll ``kanban_notify_subs`` and deliver terminal events to users.
 
         For each subscription row, fetches ``task_events`` newer than the
-        stored cursor with kind in the terminal set (``completed``,
-        ``blocked``, ``gave_up``, ``crashed``, ``timed_out``). Sends one
-        message per new event to ``(platform, chat_id, thread_id)``,
-        then advances the cursor. When a task reaches a terminal state
-        (``completed`` / ``archived``), the subscription is removed.
+        stored cursor with kind ``completed``. Sends one message per new
+        completion to ``(platform, chat_id, thread_id)``, then advances the
+        cursor. When a task reaches a terminal state (``completed`` /
+        ``archived``), the subscription is removed.
 
         Runs in the gateway event loop; all SQLite work is pushed to a
         thread via ``asyncio.to_thread`` so the loop never blocks on the
@@ -4625,6 +4638,31 @@ class GatewayRunner:
         cross boards, so delivery semantics are unchanged — this is
         purely a fan-out of the single-DB poll.
         """
+        # Read config once at boot. If the user flips the flag later, they
+        # restart the gateway. Honours HERMES_KANBAN_NOTIFY_IN_GATEWAY env var
+        # as an escape hatch (false-y value disables without editing YAML).
+        try:
+            from hermes_cli.config import load_config as _load_config
+        except Exception:
+            logger.warning("kanban notifier: config loader unavailable; disabled")
+            return
+        env_override = os.environ.get("HERMES_KANBAN_NOTIFY_IN_GATEWAY", "").strip().lower()
+        if env_override in {"0", "false", "no", "off"}:
+            logger.info("kanban notifier: disabled via HERMES_KANBAN_NOTIFY_IN_GATEWAY env")
+            return
+
+        try:
+            cfg = _load_config()
+        except Exception as exc:
+            logger.warning("kanban notifier: cannot load config (%s); disabled", exc)
+            return
+        kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
+        if not kanban_cfg.get("notify_in_gateway", True):
+            logger.info(
+                "kanban notifier: disabled via config kanban.notify_in_gateway=false"
+            )
+            return
+
         from gateway.config import Platform as _Platform
         try:
             from hermes_cli import kanban_db as _kb
@@ -4632,19 +4670,10 @@ class GatewayRunner:
             logger.warning("kanban notifier: kanban_db not importable; notifier disabled")
             return
 
-        TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out")
-        # Subscriptions are removed only when the task reaches a truly final
-        # status (done / archived). We used to also unsub on any terminal
-        # event kind (gave_up / crashed / timed_out / blocked), but that
-        # silently dropped the user out of the loop whenever the dispatcher
-        # respawned the task: a worker that crashes, gets reclaimed, runs
-        # again, and crashes a second time would only notify on the first
-        # crash because the subscription was deleted after the first event.
-        # Same shape as the reblock-after-unblock cycle that PR #22941
-        # fixed for `blocked`. Keeping the subscription alive until the
-        # task is genuinely done lets the cursor (advanced atomically by
-        # claim_unseen_events_for_sub) handle dedup, and any retry-loop
-        # event reaches the user.
+        TERMINAL_KINDS = ("completed",)
+        # Dedicated noti-bot is completion-only. Blocked/stuck counts are
+        # handled by the separate Kanban monitor cron so the user can ask this
+        # assistant to go through blocked items one by one when ready.
         # Per-subscription send-failure counter. Adapter.send raising
         # means the chat is dead (deleted, bot kicked, etc.) — after N
         # consecutive send failures the sub is dropped so we don't spin
@@ -4717,6 +4746,15 @@ class GatewayRunner:
                             # tolerates that race, but we still skip the
                             # redundant call to avoid the wasted work.
                             subs = _kb.list_notify_subs(conn)
+                            subscribed_targets = {
+                                (
+                                    s.get("task_id"),
+                                    (s.get("platform") or "").lower(),
+                                    s.get("chat_id"),
+                                    s.get("thread_id") or "",
+                                )
+                                for s in subs
+                            }
                             if not subs:
                                 logger.debug("kanban notifier: board %s has no subscriptions", slug)
                             for sub in subs:
@@ -4757,6 +4795,74 @@ class GatewayRunner:
                                     "task": task,
                                     "board": slug,
                                 })
+
+                            # Board-level home-channel pings keep Kanban completion
+                            # notifications working even for tasks that were
+                            # created by decomposition/automation and therefore
+                            # never got an explicit per-task subscription row.
+                            for platform in active_platforms:
+                                try:
+                                    plat = _Platform(platform)
+                                except ValueError:
+                                    continue
+                                cfg = getattr(self, "config", None)
+                                if cfg is None or not hasattr(cfg, "get_home_channel"):
+                                    continue
+                                try:
+                                    home = cfg.get_home_channel(plat)
+                                except Exception as exc:
+                                    logger.debug(
+                                        "kanban notifier: cannot resolve home channel for %s on board %s: %s",
+                                        platform, slug, exc,
+                                    )
+                                    continue
+                                if not home or not getattr(home, "chat_id", None):
+                                    continue
+                                home_thread = getattr(home, "thread_id", None) or ""
+                                old_cursor, cursor, events = _kb.claim_board_notify_events(
+                                    conn,
+                                    board_key=slug,
+                                    platform=platform,
+                                    chat_id=str(home.chat_id),
+                                    thread_id=home_thread,
+                                    notifier_profile=notifier_profile,
+                                    kinds=TERMINAL_KINDS,
+                                )
+                                if not events:
+                                    continue
+                                board_events = []
+                                tasks_by_event: dict[str, Any] = {}
+                                for ev in events:
+                                    if (
+                                        ev.task_id,
+                                        platform,
+                                        str(home.chat_id),
+                                        home_thread,
+                                    ) in subscribed_targets:
+                                        logger.debug(
+                                            "kanban notifier: board-level home ping for %s skipped; matching task subscription exists",
+                                            ev.task_id,
+                                        )
+                                        continue
+                                    board_events.append(ev)
+                                    tasks_by_event[ev.task_id] = _kb.get_task(conn, ev.task_id)
+                                if board_events:
+                                    deliveries.append({
+                                        "sub": {
+                                            "task_id": "*",
+                                            "platform": platform,
+                                            "chat_id": str(home.chat_id),
+                                            "thread_id": home_thread,
+                                            "notifier_profile": notifier_profile,
+                                        },
+                                        "old_cursor": old_cursor,
+                                        "cursor": cursor,
+                                        "events": board_events,
+                                        "task": None,
+                                        "tasks_by_event": tasks_by_event,
+                                        "board": slug,
+                                        "board_cursor": True,
+                                    })
                         finally:
                             conn.close()
                     return deliveries
@@ -4772,8 +4878,9 @@ class GatewayRunner:
                     except ValueError:
                         # Unknown platform string; skip and advance cursor so
                         # we don't replay forever.
+                        advance_fn = self._kanban_board_advance if d.get("board_cursor") else self._kanban_advance
                         await asyncio.to_thread(
-                            self._kanban_advance, sub, d["cursor"], board_slug,
+                            advance_fn, sub, d["cursor"], board_slug,
                         )
                         continue
                     adapter = self.adapters.get(plat)
@@ -4782,42 +4889,32 @@ class GatewayRunner:
                             "kanban notifier: adapter %s disconnected before delivery for %s; rewinding claim",
                             platform_str, sub["task_id"],
                         )
+                        rewind_fn = self._kanban_board_rewind if d.get("board_cursor") else self._kanban_rewind
                         await asyncio.to_thread(
-                            self._kanban_rewind,
+                            rewind_fn,
                             sub,
                             d["cursor"],
                             d.get("old_cursor", 0),
                             board_slug,
                         )
                         continue
-                    title = (task.title if task else sub["task_id"])[:120]
                     for ev in d["events"]:
+                        event_task = d.get("tasks_by_event", {}).get(ev.task_id, task)
+                        title = (event_task.title if event_task else ev.task_id)[:120]
                         kind = ev.kind
                         # Identity prefix: attribute terminal pings to the
                         # worker that did the work. Makes fleets (where one
                         # chat subscribes to many tasks) legible at a glance.
-                        who = (task.assignee if task and task.assignee else None)
+                        who = (event_task.assignee if event_task and event_task.assignee else None)
                         tag = f"@{who} " if who else ""
                         if kind == "completed":
-                            # Prefer the run's summary (the worker's
-                            # intentional human-facing handoff, carried
-                            # in the event payload), then fall back to
-                            # task.result for legacy rows written before
-                            # runs shipped.
-                            handoff = ""
-                            payload_summary = None
-                            if ev.payload and ev.payload.get("summary"):
-                                payload_summary = str(ev.payload["summary"])
-                            if payload_summary:
-                                h = payload_summary.strip().splitlines()[0][:200]
-                                handoff = f"\n{h}"
-                            elif task and task.result:
-                                r = task.result.strip().splitlines()[0][:160]
-                                handoff = f"\n{r}"
-                            msg = (
-                                f"✔ {tag}Kanban {sub['task_id']} done"
-                                f" — {title}{handoff}"
-                            )
+                            # Completion pings are intentionally terse: the
+                            # user-facing notification should be only the done
+                            # status/title. Keep task ids, board slugs, owners,
+                            # and summary text out of the message body; routing
+                            # metadata and debug logs below still carry the
+                            # internal context needed by the gateway.
+                            msg = f"✅ Done: {title}"
                         elif kind == "blocked":
                             reason = ""
                             if ev.payload and ev.payload.get("reason"):
@@ -4849,14 +4946,58 @@ class GatewayRunner:
                         metadata: dict[str, Any] = {}
                         if sub.get("thread_id"):
                             metadata["thread_id"] = sub["thread_id"]
-                        sub_key = (
-                            sub["task_id"], sub["platform"],
-                            sub["chat_id"], sub.get("thread_id") or "",
-                        )
-                        try:
-                            await adapter.send(
-                                sub["chat_id"], msg, metadata=metadata,
+                        if d.get("board_cursor"):
+                            sub_key = (
+                                "board", board_slug or "", sub["platform"],
+                                sub["chat_id"], sub.get("thread_id") or "",
                             )
+                        else:
+                            sub_key = (
+                                sub["task_id"], sub["platform"],
+                                sub["chat_id"], sub.get("thread_id") or "",
+                            )
+                        try:
+                            sent_via_dedicated_notifier = False
+                            if plat == _Platform.TELEGRAM:
+                                try:
+                                    from tools.send_message_tool import (
+                                        _get_notifications_telegram_token,
+                                        _send_notification_to_platform,
+                                    )
+                                    if _get_notifications_telegram_token():
+                                        pconfig = None
+                                        runner_config = getattr(self, "config", None)
+                                        if runner_config is not None:
+                                            pconfig = getattr(runner_config, "platforms", {}).get(plat)
+                                        if pconfig is None:
+                                            from gateway.config import load_gateway_config as _load_gateway_config
+                                            pconfig = _load_gateway_config().platforms.get(plat)
+                                        if pconfig is not None and getattr(pconfig, "enabled", True):
+                                            result = await _send_notification_to_platform(
+                                                plat,
+                                                pconfig,
+                                                sub["chat_id"],
+                                                msg,
+                                                thread_id=sub.get("thread_id") or None,
+                                            )
+                                            if result and result.get("error"):
+                                                raise RuntimeError(result["error"])
+                                            sent_via_dedicated_notifier = True
+                                except Exception:
+                                    raise
+                            if not sent_via_dedicated_notifier:
+                                result = await adapter.send(
+                                    sub["chat_id"], msg, metadata=metadata,
+                                )
+                                if (
+                                    result is not None
+                                    and (
+                                        getattr(result, "success", True) is False
+                                        or (isinstance(result, dict) and result.get("error"))
+                                    )
+                                ):
+                                    err = result.get("error") if isinstance(result, dict) else getattr(result, "error", "send returned success=False")
+                                    raise RuntimeError(str(err))
                             logger.debug(
                                 "kanban notifier: delivered %s event for %s to %s/%s on board %s",
                                 kind, sub["task_id"], platform_str, sub["chat_id"], board_slug,
@@ -4873,11 +5014,13 @@ class GatewayRunner:
                             if kind == "completed":
                                 try:
                                     await self._deliver_kanban_artifacts(
+                                        platform=plat,
+                                        platform_config=pconfig if sent_via_dedicated_notifier else None,
                                         adapter=adapter,
                                         chat_id=sub["chat_id"],
                                         metadata=metadata,
                                         event_payload=getattr(ev, "payload", None),
-                                        task=task,
+                                        task=event_task,
                                     )
                                 except Exception as art_exc:
                                     logger.debug(
@@ -4886,6 +5029,15 @@ class GatewayRunner:
                                     )
                             # Reset the failure counter on success.
                             sub_fail_counts.pop(sub_key, None)
+                            if d.get("board_cursor"):
+                                # Board-level deliveries claim a batch of events up
+                                # front. Persist progress after each successful send
+                                # so a later partial failure retries only the failed
+                                # event and anything after it, not earlier pings that
+                                # already reached the home channel.
+                                await asyncio.to_thread(
+                                    self._kanban_board_advance, sub, int(ev.id), board_slug,
+                                )
                         except Exception as exc:
                             fails = sub_fail_counts.get(sub_key, 0) + 1
                             sub_fail_counts[sub_key] = fails
@@ -4896,16 +5048,28 @@ class GatewayRunner:
                                 MAX_SEND_FAILURES, exc,
                             )
                             if fails >= MAX_SEND_FAILURES:
-                                logger.warning(
-                                    "kanban notifier: dropping subscription "
-                                    "%s on %s after %d consecutive send failures",
-                                    sub["task_id"], platform_str, fails,
-                                )
-                                await asyncio.to_thread(self._kanban_unsub, sub, board_slug)
+                                if d.get("board_cursor"):
+                                    logger.warning(
+                                        "kanban notifier: suppressing board-level home notification backlog "
+                                        "for board %s on %s after %d consecutive send failures; "
+                                        "future completions will still be attempted",
+                                        board_slug, platform_str, fails,
+                                    )
+                                    await asyncio.to_thread(
+                                        self._kanban_board_advance, sub, d["cursor"], board_slug,
+                                    )
+                                else:
+                                    logger.warning(
+                                        "kanban notifier: dropping subscription "
+                                        "%s on %s after %d consecutive send failures",
+                                        sub["task_id"], platform_str, fails,
+                                    )
+                                    await asyncio.to_thread(self._kanban_unsub, sub, board_slug)
                                 sub_fail_counts.pop(sub_key, None)
                             else:
+                                rewind_fn = self._kanban_board_rewind if d.get("board_cursor") else self._kanban_rewind
                                 await asyncio.to_thread(
-                                    self._kanban_rewind,
+                                    rewind_fn,
                                     sub,
                                     d["cursor"],
                                     d.get("old_cursor", 0),
@@ -4919,18 +5083,16 @@ class GatewayRunner:
                         # All events delivered; advance cursor. The cursor
                         # is the dedup mechanism — it prevents re-delivery
                         # of the same event on subsequent ticks.
+                        advance_fn = self._kanban_board_advance if d.get("board_cursor") else self._kanban_advance
                         await asyncio.to_thread(
-                            self._kanban_advance, sub, d["cursor"], board_slug,
+                            advance_fn, sub, d["cursor"], board_slug,
                         )
-                        # Unsubscribe only when the task has reached a truly
-                        # final status (done / archived). For blocked /
-                        # gave_up / crashed / timed_out the subscription is
-                        # kept alive so the user gets notified again if the
-                        # dispatcher respawns the task and it cycles into the
-                        # same state. See the longer comment on TERMINAL_KINDS
-                        # above for the failure mode this prevents.
+                        # Unsubscribe only task-scoped subscriptions when the task
+                        # has reached a truly final status (done / archived).
+                        # Board-level home cursors are durable and stay in place
+                        # for future completions.
                         task_terminal = task and task.status in {"done", "archived"}
-                        if task_terminal:
+                        if task_terminal and not d.get("board_cursor"):
                             await asyncio.to_thread(
                                 self._kanban_unsub, sub, board_slug,
                             )
@@ -4941,6 +5103,200 @@ class GatewayRunner:
                 if not self._running:
                     return
                 await asyncio.sleep(1)
+
+    async def _maybe_handle_kanban_reply_target(self, event) -> Optional[str]:
+        """Apply direct replies to Kanban proposal messages.
+
+        Returns an acknowledgement string when the message was handled (so the
+        gateway should skip normal agent dispatch), or ``None`` when the reply
+        does not match any stored Kanban proposal target.
+        """
+        reply_to = str(getattr(event, "reply_to_message_id", None) or "").strip()
+        text = (getattr(event, "text", None) or "").strip()
+        source = getattr(event, "source", None)
+        if not reply_to or not text or source is None:
+            return None
+        if text.startswith("/"):
+            # Slash commands keep their normal gateway meaning.
+            return None
+        try:
+            from hermes_cli import kanban_db as _kb
+        except Exception:
+            logger.debug("kanban reply target: kanban_db import failed", exc_info=True)
+            return None
+
+        platform = getattr(getattr(source, "platform", None), "value", str(getattr(source, "platform", ""))).lower()
+        chat_id = str(getattr(source, "chat_id", "") or "")
+        thread_id = getattr(source, "thread_id", None) or ""
+        proposal_hint, action, remainder = self._parse_kanban_reply_action(text)
+        try:
+            def _lookup():
+                try:
+                    boards = _kb.list_boards(include_archived=False)
+                except Exception:
+                    boards = [{"slug": _kb.DEFAULT_BOARD}]
+                seen_paths: set[str] = set()
+                for board_meta in boards:
+                    slug = board_meta.get("slug") or _kb.DEFAULT_BOARD
+                    db_path = board_meta.get("db_path")
+                    try:
+                        resolved = str(Path(db_path).expanduser().resolve()) if db_path else str(_kb.kanban_db_path(slug).resolve())
+                    except Exception:
+                        resolved = f"slug:{slug}"
+                    if resolved in seen_paths:
+                        continue
+                    seen_paths.add(resolved)
+                    conn = _kb.connect(board=slug)
+                    try:
+                        found = _kb.get_reply_target(
+                            conn,
+                            platform=platform,
+                            chat_id=chat_id,
+                            thread_id=thread_id,
+                            message_id=reply_to,
+                            proposal_id=proposal_hint,
+                        )
+                        if found is not None:
+                            found["board"] = slug
+                            return found
+                    finally:
+                        conn.close()
+                return None
+            target = await asyncio.to_thread(_lookup)
+        except Exception as exc:
+            logger.warning("kanban reply target lookup failed: %s", exc)
+            return "⚠️ I couldn't check that Kanban proposal reply. Please try again or use /kanban directly."
+        if target is None:
+            return None
+        if proposal_hint and not action:
+            _, action, remainder = self._parse_kanban_reply_action(text, allow_leading_proposal=False)
+
+        allowed_user = (target.get("user_id") or "").strip()
+        incoming_user = str(getattr(source, "user_id", "") or "").strip()
+        if allowed_user and incoming_user and allowed_user != incoming_user:
+            return "⚠️ That Kanban proposal was sent for a different user, so I didn't apply your reply."
+        if allowed_user and not incoming_user:
+            return "⚠️ I couldn't verify who sent that reply, so I didn't apply the Kanban proposal."
+
+        now = int(time.time())
+        if target.get("expires_at") is not None and int(target["expires_at"]) <= now:
+            await asyncio.to_thread(self._mark_kanban_reply_target, target, "expired", target.get("board"))
+            return "⚠️ That Kanban proposal has expired. Please ask me to make a fresh proposal."
+        status = target.get("status") or "active"
+        if status != "active":
+            return f"⚠️ That Kanban proposal is already {status}; I didn't apply it again."
+        if action is None:
+            return (
+                "Reply with `accept`/`approve` to apply this Kanban proposal, "
+                "or `reject`/`deny` plus optional feedback to decline it."
+            )
+
+        try:
+            result = await asyncio.to_thread(
+                self._apply_kanban_reply_action,
+                target,
+                action,
+                remainder,
+                incoming_user or None,
+                getattr(source, "user_name", None),
+            )
+        except Exception as exc:
+            logger.warning("kanban reply target apply failed: %s", exc, exc_info=True)
+            return "⚠️ I found the Kanban proposal, but couldn't apply your reply safely. Please use /kanban or try again."
+        return result
+
+    @staticmethod
+    def _parse_kanban_reply_action(text: str, *, allow_leading_proposal: bool = True) -> tuple[Optional[str], Optional[str], str]:
+        raw = (text or "").strip()
+        tokens = re.findall(r"[A-Za-z0-9_-]+", raw.lower())
+        proposal_id = None
+        action_token = tokens[0] if tokens else ""
+        if allow_leading_proposal and tokens and re.match(r"^(?:p|proposal)[_-][a-z0-9_-]+$", tokens[0]):
+            proposal_id = tokens[0]
+            action_token = tokens[1] if len(tokens) > 1 else ""
+        accept = {"accept", "approve", "approved", "yes", "y", "ok", "okay", "proceed", "go", "lgtm", "ship"}
+        reject = {"reject", "decline", "deny", "denied", "no", "n", "cancel"}
+        if action_token in accept:
+            action = "accept"
+        elif action_token in reject:
+            action = "reject"
+        else:
+            action = None
+        remainder = raw
+        if action_token:
+            m = re.search(r"\b" + re.escape(action_token) + r"\b", raw, flags=re.IGNORECASE)
+            if m:
+                remainder = raw[m.end():].strip(" :-—\t\n")
+        return proposal_id, action, remainder
+
+    def _mark_kanban_reply_target(self, target: dict[str, Any], status: str, board: Optional[str]) -> None:
+        from hermes_cli import kanban_db as _kb
+        conn = _kb.connect(board=board)
+        try:
+            _kb.update_reply_target_status(conn, target, status)
+        finally:
+            conn.close()
+
+    def _apply_kanban_reply_action(
+        self,
+        target: dict[str, Any],
+        action: str,
+        feedback: str,
+        user_id: Optional[str],
+        user_name: Optional[str],
+    ) -> str:
+        from hermes_cli import kanban_db as _kb
+        board = target.get("board") or None
+        conn = _kb.connect(board=board)
+        try:
+            task = _kb.get_task(conn, target["task_id"])
+            if task is None:
+                _kb.update_reply_target_status(conn, target, "expired")
+                return "⚠️ That Kanban task no longer exists, so I couldn't apply the proposal."
+            actor = user_name or user_id or "gateway-user"
+            proposal_label = target.get("proposal_id") or target.get("message_id")
+            if action == "reject":
+                body = f"Rejected triage proposal {proposal_label} by direct reply."
+                if feedback:
+                    body += f" Feedback: {feedback}"
+                _kb.add_comment(conn, task.id, actor, body)
+                _kb.update_reply_target_status(conn, target, "rejected")
+                return "Noted — I rejected that Kanban proposal and saved your feedback."
+
+            payload = target.get("payload") or {}
+            title = payload.get("title") if isinstance(payload.get("title"), str) else None
+            body = payload.get("body") if isinstance(payload.get("body"), str) else None
+            assignee = payload.get("assignee") if isinstance(payload.get("assignee"), str) else None
+            applied = False
+            if task.status == "triage":
+                children = payload.get("children")
+                if isinstance(children, list) and children:
+                    root_assignee = payload.get("root_assignee") or assignee
+                    child_ids = _kb.decompose_triage_task(
+                        conn,
+                        task.id,
+                        root_assignee=root_assignee,
+                        children=children,
+                        author=actor,
+                    )
+                    applied = child_ids is not None
+                else:
+                    applied = _kb.specify_triage_task(
+                        conn,
+                        task.id,
+                        title=title,
+                        body=body,
+                        assignee=assignee,
+                        author=actor,
+                    )
+            if not applied:
+                _kb.update_reply_target_status(conn, target, "expired")
+                return f"⚠️ That Kanban proposal is stale because task {task.id} is now `{task.status}`. I didn't apply it."
+            _kb.add_comment(conn, task.id, actor, f"Accepted triage proposal {proposal_label} by direct reply.")
+            _kb.update_reply_target_status(conn, target, "accepted")
+            return "Accepted — I applied that Kanban proposal."
+        finally:
+            conn.close()
 
     def _kanban_advance(
         self, sub: dict, cursor: int, board: Optional[str] = None,
@@ -4959,6 +5315,25 @@ class GatewayRunner:
                 platform=sub["platform"],
                 chat_id=sub["chat_id"],
                 thread_id=sub.get("thread_id") or "",
+                new_cursor=cursor,
+            )
+        finally:
+            conn.close()
+
+    def _kanban_board_advance(
+        self, sub: dict, cursor: int, board: Optional[str] = None,
+    ) -> None:
+        """Sync helper: advance a board-level notification cursor."""
+        from hermes_cli import kanban_db as _kb
+        conn = _kb.connect(board=board)
+        try:
+            _kb.advance_board_notify_cursor(
+                conn,
+                board_key=board or "default",
+                platform=sub["platform"],
+                chat_id=sub["chat_id"],
+                thread_id=sub.get("thread_id") or "",
+                notifier_profile=sub.get("notifier_profile") or "",
                 new_cursor=cursor,
             )
         finally:
@@ -5001,9 +5376,35 @@ class GatewayRunner:
         finally:
             conn.close()
 
+    def _kanban_board_rewind(
+        self,
+        sub: dict,
+        claimed_cursor: int,
+        old_cursor: int,
+        board: Optional[str] = None,
+    ) -> None:
+        """Sync helper: undo a claimed board notification cursor after send failure."""
+        from hermes_cli import kanban_db as _kb
+        conn = _kb.connect(board=board)
+        try:
+            _kb.rewind_board_notify_cursor(
+                conn,
+                board_key=board or "default",
+                platform=sub["platform"],
+                chat_id=sub["chat_id"],
+                thread_id=sub.get("thread_id") or "",
+                notifier_profile=sub.get("notifier_profile") or "",
+                claimed_cursor=claimed_cursor,
+                old_cursor=old_cursor,
+            )
+        finally:
+            conn.close()
+
     async def _deliver_kanban_artifacts(
         self,
         *,
+        platform,
+        platform_config=None,
         adapter,
         chat_id: str,
         metadata: dict,
@@ -5031,6 +5432,12 @@ class GatewayRunner:
         candidates: list[str] = []
         seen: set[str] = set()
 
+        try:
+            extract_local_files = adapter.extract_local_files
+        except AttributeError:
+            from gateway.platforms.base import BasePlatformAdapter
+            extract_local_files = BasePlatformAdapter.extract_local_files
+
         def _add(path: str) -> None:
             if not path:
                 return
@@ -5053,14 +5460,14 @@ class GatewayRunner:
             # 2. Paths embedded in the payload summary.
             summary = event_payload.get("summary")
             if isinstance(summary, str) and summary:
-                paths, _ = adapter.extract_local_files(summary)
+                paths, _ = extract_local_files(summary)
                 for p in paths:
                     _add(p)
 
         # 3. Legacy: paths embedded in task.result.
         if task is not None and getattr(task, "result", None):
             result_text = str(task.result)
-            paths, _ = adapter.extract_local_files(result_text)
+            paths, _ = extract_local_files(result_text)
             for p in paths:
                 _add(p)
 
@@ -5071,6 +5478,32 @@ class GatewayRunner:
         candidates = BasePlatformAdapter.filter_local_delivery_paths(candidates)
         if not candidates:
             return
+
+        if platform_config is not None:
+            try:
+                from gateway.config import Platform as _Platform
+                from tools.send_message_tool import (
+                    _get_notifications_telegram_token,
+                    _send_notification_to_platform,
+                )
+
+                if platform == _Platform.TELEGRAM and _get_notifications_telegram_token():
+                    result = await _send_notification_to_platform(
+                        platform,
+                        platform_config,
+                        chat_id,
+                        "",
+                        thread_id=metadata.get("thread_id") if metadata else None,
+                        media_files=[(p, False) for p in candidates],
+                    )
+                    if result and result.get("error"):
+                        raise RuntimeError(result["error"])
+                    return
+            except Exception as exc:
+                logger.warning(
+                    "kanban notifier: dedicated artifact upload failed: %s", exc,
+                )
+                return
 
         _IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".webp"}
         _VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp"}
@@ -6735,6 +7168,10 @@ class GatewayRunner:
                     # the agent's response don't double-post.  The agent
                     # itself will produce the next user-facing message.
                     return ""
+
+        _kanban_reply_ack = await self._maybe_handle_kanban_reply_target(event)
+        if _kanban_reply_ack is not None:
+            return _kanban_reply_ack
 
         # Intercept messages that are responses to a pending /reload-mcp
         # (or future) slash-confirm prompt.  Recognized confirm replies are

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1523,6 +1523,10 @@ DEFAULT_CONFIG = {
         # only if you run the dispatcher as a separate systemd unit or
         # don't want the gateway to spawn workers.
         "dispatch_in_gateway": True,
+        # Run the Kanban notifier inside the gateway process. On by default
+        # so users still receive completion pings; set to false during DB
+        # recovery or when another process owns Kanban notifications.
+        "notify_in_gateway": True,
         # Seconds between dispatcher ticks (idle or not). Lower = snappier
         # pickup of newly-ready tasks; higher = less SQL pressure.
         "dispatch_interval_seconds": 60,
@@ -1545,6 +1549,14 @@ DEFAULT_CONFIG = {
         # assignee to any installed profile. When unset, falls back to the
         # default profile. A task never ends up with assignee=None.
         "default_assignee": "",
+        # Profile that reviews substantial handoffs before user-facing
+        # completion. Workers route review-required completions to this
+        # profile's review lane; set blank to disable reviewer-first routing.
+        "reviewer_profile": "reviewer",
+        # Optional extra skills forced onto review-lane workers. Leave blank
+        # to rely on the reviewer profile's own configured skills plus the
+        # dispatcher-injected kanban-worker lifecycle skill.
+        "review_skills": [],
         # When true, the kanban dispatcher auto-runs the decomposer on
         # tasks that land in Triage (every dispatcher tick). When false,
         # decomposition is manual via `hermes kanban decompose <id>` or
@@ -2469,6 +2481,14 @@ OPTIONAL_ENV_VARS = {
         "url": "https://t.me/BotFather",
         "password": True,
         "category": "messaging",
+    },
+    "NOTIFICATIONS_TELEGRAM_BOT_TOKEN": {
+        "description": "Dedicated Telegram bot token for notification senders/watchdogs",
+        "prompt": "Notifications Telegram bot token",
+        "url": "https://t.me/BotFather",
+        "password": True,
+        "category": "messaging",
+        "advanced": True,
     },
     "TELEGRAM_ALLOWED_USERS": {
         "description": "Comma-separated Telegram user IDs allowed to use the bot (get ID from @userinfobot)",

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3320,6 +3320,8 @@ _PLATFORMS = [
         "vars": [
             {"name": "TELEGRAM_BOT_TOKEN", "prompt": "Bot token", "password": True,
              "help": "Paste the token from @BotFather (step 3 above)."},
+            {"name": "NOTIFICATIONS_TELEGRAM_BOT_TOKEN", "prompt": "Dedicated notifications bot token (optional)", "password": True,
+             "help": "Optional separate token for local notification senders/watchdogs. Store it in .env; never commit it."},
             {"name": "TELEGRAM_ALLOWED_USERS", "prompt": "Allowed user IDs (comma-separated)", "password": False,
              "is_allowlist": True,
              "help": "Paste your user ID from step 4 above."},

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -569,9 +569,35 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
 
     p_block = sub.add_parser("block", help="Mark one or more tasks blocked")
     p_block.add_argument("task_id")
-    p_block.add_argument("reason", nargs="*", help="Reason (also appended as a comment)")
     p_block.add_argument("--ids", nargs="+", default=None,
                          help="Additional task ids to block with the same reason (bulk mode)")
+    p_block.add_argument(
+        "--human-gate",
+        action="store_true",
+        help=(
+            "Explicitly mark this as a genuine first-run human gate "
+            "(credential, human decision, destructive-action approval, "
+            "service interruption, or product/art decision). Routine "
+            "implementation handoffs should use complete/review routing instead."
+        ),
+    )
+    p_block.add_argument(
+        "--reason-category",
+        choices=kb.HUMAN_GATE_BLOCK_REASON_CATEGORIES,
+        default=None,
+        help=(
+            "Human-gate category. Implies --human-gate and records the "
+            "category on the blocked event."
+        ),
+    )
+    p_block.add_argument(
+        "tail",
+        nargs=argparse.REMAINDER,
+        help=(
+            "Reason text. Block-specific flags may appear after task_id, "
+            "e.g. block <task> --human-gate need decision."
+        ),
+    )
 
     p_schedule = sub.add_parser("schedule", help="Park one or more tasks in Scheduled (waiting on time, not human input)")
     p_schedule.add_argument("task_id")
@@ -2023,9 +2049,51 @@ def _cmd_edit(args: argparse.Namespace) -> int:
 
 
 def _cmd_block(args: argparse.Namespace) -> int:
-    reason = " ".join(args.reason).strip() if args.reason else None
+    tail = list(getattr(args, "tail", None) or getattr(args, "reason", None) or [])
+    human_gate = bool(getattr(args, "human_gate", False))
+    reason_category = getattr(args, "reason_category", None)
+    extra_ids = list(getattr(args, "ids", None) or [])
+    reason_parts: list[str] = []
+    idx = 0
+    while idx < len(tail):
+        token = tail[idx]
+        if token == "--human-gate":
+            human_gate = True
+            idx += 1
+            continue
+        if token == "--reason-category":
+            if idx + 1 >= len(tail):
+                print("kanban block: --reason-category requires a value", file=sys.stderr)
+                return 2
+            reason_category = tail[idx + 1]
+            human_gate = True
+            idx += 2
+            continue
+        if token.startswith("--reason-category="):
+            reason_category = token.split("=", 1)[1]
+            human_gate = True
+            idx += 1
+            continue
+        if token == "--ids":
+            idx += 1
+            if idx >= len(tail) or tail[idx].startswith("--"):
+                print("kanban block: --ids requires at least one task id", file=sys.stderr)
+                return 2
+            while idx < len(tail) and not tail[idx].startswith("--"):
+                extra_ids.append(tail[idx])
+                idx += 1
+            continue
+        if token.startswith("--ids="):
+            extra_ids.extend(
+                part for part in token.split("=", 1)[1].split(",") if part
+            )
+            idx += 1
+            continue
+        reason_parts.append(token)
+        idx += 1
+    reason = " ".join(reason_parts).strip() if reason_parts else None
     author = _profile_author()
-    ids = [args.task_id] + list(getattr(args, "ids", None) or [])
+    ids = [args.task_id] + extra_ids
     failed: list[str] = []
     with kb.connect() as conn:
         for tid in ids:
@@ -2037,6 +2105,8 @@ def _cmd_block(args: argparse.Namespace) -> int:
                     tid,
                     reason=reason,
                     expected_run_id=_worker_run_id_for(tid),
+                    human_gate=human_gate,
+                    reason_category=reason_category,
                 )
             except ValueError as exc:
                 failed.append(tid)

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -166,10 +166,12 @@ def _check_dispatcher_presence() -> tuple[bool, str]:
     if pid and dispatch_on:
         return (True, f"gateway pid={pid}, dispatch enabled")
     if pid and not dispatch_on:
+        config_path = Path(os.environ.get("HERMES_HOME") or (Path.home() / ".hermes")) / "config.yaml"
+        config_hint = f" ({config_path})"
         return (
             False,
             "Gateway is running but kanban.dispatch_in_gateway=false in "
-            "config.yaml — the task will sit in 'ready' until you flip it "
+            f"config.yaml{config_hint} — the task will sit in 'ready' until you flip it "
             "back on and restart the gateway, OR run the legacy "
             "standalone daemon (`hermes kanban daemon --force`)."
         )
@@ -476,6 +478,36 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         "--json", action="store_true",
         help="Emit JSON (structured) instead of the default human table",
     )
+
+    # --- SQLite integrity check (storage-level health) ---
+    p_check = sub.add_parser(
+        "check",
+        aliases=["integrity"],
+        help="Run PRAGMA quick_check/integrity_check on the board database",
+    )
+    p_check.add_argument(
+        "--full",
+        action="store_true",
+        help="Also run slower PRAGMA integrity_check",
+    )
+    p_check.add_argument("--json", action="store_true", help="Emit JSON output")
+
+    p_repair = sub.add_parser(
+        "repair-indexes",
+        help="Run REINDEX and VACUUM under the Kanban maintenance lock",
+    )
+    p_repair.add_argument(
+        "--no-vacuum",
+        action="store_true",
+        help="Skip VACUUM after REINDEX",
+    )
+    p_repair.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="Seconds to wait for the exclusive maintenance lock (default: 30)",
+    )
+    p_repair.add_argument("--json", action="store_true", help="Emit JSON output")
 
     # --- link / unlink ---
     p_link = sub.add_parser("link", help="Add a parent->child dependency")
@@ -897,19 +929,20 @@ def kanban_command(args: argparse.Namespace) -> int:
         os.environ["HERMES_KANBAN_BOARD"] = normed
         restore_board_env = True
 
-    # Auto-initialize the DB before dispatching any subcommand. init_db
+    # Auto-initialize the DB before dispatching most subcommands. init_db
     # is idempotent, so running it every invocation is cheap (one
     # SELECT against sqlite_master when tables already exist) and
     # prevents "no such table: tasks" on first use from a fresh
     # HERMES_HOME. Previously only `init` and `daemon` triggered
     # schema creation; `create` / `list` / every other command would
     # error out on a fresh install.
-    try:
-        kb.init_db()
-    except Exception as exc:
-        print(f"kanban: could not initialize database: {exc}", file=sys.stderr)
-        _restore_board_env()
-        return 1
+    if action not in {"check", "integrity", "repair-indexes"}:
+        try:
+            kb.init_db()
+        except Exception as exc:
+            print(f"kanban: could not initialize database: {exc}", file=sys.stderr)
+            _restore_board_env()
+            return 1
 
     handlers = {
         "init":     _cmd_init,
@@ -923,6 +956,9 @@ def kanban_command(args: argparse.Namespace) -> int:
         "reassign": _cmd_reassign,
         "diagnostics": _cmd_diagnostics,
         "diag":     _cmd_diagnostics,
+        "check":    _cmd_check,
+        "integrity": _cmd_check,
+        "repair-indexes": _cmd_repair_indexes,
         "link":     _cmd_link,
         "unlink":   _cmd_unlink,
         "claim":    _cmd_claim,
@@ -1212,6 +1248,63 @@ def _parse_duration(val) -> Optional[int]:
             raise ValueError(f"malformed duration {val!r}") from exc
         return int(n * units[s[-1]])
     raise ValueError(f"malformed duration {val!r} (expected 30s, 5m, 2h, 1d, or a number)")
+
+
+def _cmd_check(args: argparse.Namespace) -> int:
+    result = kb.check_database_integrity(full=bool(getattr(args, "full", False)))
+    if getattr(args, "json", False):
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+        return 0 if result.get("ok") else 1
+    status = "ok" if result.get("ok") else "FAILED"
+    print(f"Kanban DB integrity check: {status}")
+    print(f"Path: {result.get('path')}")
+    print(f"Size: {result.get('size_bytes')} bytes")
+    quick_rows = result.get("quick_check") or []
+    print("quick_check:")
+    for row in quick_rows:
+        print(f"  {row}")
+    integrity_rows = result.get("integrity_check")
+    if integrity_rows is not None:
+        print("integrity_check:")
+        for row in integrity_rows:
+            print(f"  {row}")
+    if result.get("repair_hint"):
+        print()
+        print("Repair guidance:")
+        print(f"  {result['repair_hint']}")
+    return 0 if result.get("ok") else 1
+
+
+def _cmd_repair_indexes(args: argparse.Namespace) -> int:
+    try:
+        result = kb.repair_database_indexes(
+            vacuum=not bool(getattr(args, "no_vacuum", False)),
+            timeout=float(getattr(args, "timeout", 30.0)),
+        )
+    except Exception as exc:
+        if getattr(args, "json", False):
+            print(json.dumps({"ok": False, "error": str(exc)}, indent=2, ensure_ascii=False))
+        else:
+            print(f"Kanban DB repair failed: {exc}", file=sys.stderr)
+        return 1
+    if getattr(args, "json", False):
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+        return 0 if result.get("ok") else 1
+    status = "ok" if result.get("ok") else "FAILED"
+    print(f"Kanban DB index repair: {status}")
+    print(f"Path: {result.get('path')}")
+    print(f"Vacuum: {result.get('vacuum')}")
+    after = result.get("after") or {}
+    print("quick_check:")
+    for row in after.get("quick_check") or []:
+        print(f"  {row}")
+    integrity_rows = after.get("integrity_check")
+    if integrity_rows is not None:
+        print("integrity_check:")
+        for row in integrity_rows:
+            print(f"  {row}")
+    return 0 if result.get("ok") else 1
+
 
 
 def _cmd_init(args: argparse.Namespace) -> int:
@@ -1938,12 +2031,18 @@ def _cmd_block(args: argparse.Namespace) -> int:
         for tid in ids:
             if reason:
                 kb.add_comment(conn, tid, author, f"BLOCKED: {reason}")
-            if not kb.block_task(
-                conn,
-                tid,
-                reason=reason,
-                expected_run_id=_worker_run_id_for(tid),
-            ):
+            try:
+                ok = kb.block_task(
+                    conn,
+                    tid,
+                    reason=reason,
+                    expected_run_id=_worker_run_id_for(tid),
+                )
+            except ValueError as exc:
+                failed.append(tid)
+                print(f"cannot block {tid}: {exc}", file=sys.stderr)
+                continue
+            if not ok:
                 failed.append(tid)
                 print(f"cannot block {tid}", file=sys.stderr)
             else:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -266,6 +266,57 @@ BLOCKED_REVIEW_PREREQUISITE_ERROR = (
     "in task history"
 )
 
+HUMAN_GATE_BLOCK_REASON_CATEGORIES = (
+    "credential",
+    "human_decision",
+    "destructive_action",
+    "service_interruption",
+    "product_decision",
+    "art_decision",
+)
+
+_HUMAN_GATE_BLOCK_REASON_ALIASES = {
+    "credentials": "credential",
+    "secret": "credential",
+    "secrets": "credential",
+    "human": "human_decision",
+    "decision": "human_decision",
+    "human_input": "human_decision",
+    "input": "human_decision",
+    "destructive": "destructive_action",
+    "destructive_actions": "destructive_action",
+    "restart": "service_interruption",
+    "service": "service_interruption",
+    "outage": "service_interruption",
+    "product": "product_decision",
+    "art": "art_decision",
+    "creative": "art_decision",
+}
+
+
+def _normalize_human_gate_reason_category(
+    reason_category: Optional[str],
+) -> Optional[str]:
+    if reason_category is None:
+        return None
+    normalized = (
+        str(reason_category)
+        .strip()
+        .lower()
+        .replace("-", "_")
+        .replace(" ", "_")
+    )
+    if not normalized:
+        return None
+    normalized = _HUMAN_GATE_BLOCK_REASON_ALIASES.get(normalized, normalized)
+    if normalized not in HUMAN_GATE_BLOCK_REASON_CATEGORIES:
+        allowed = ", ".join(HUMAN_GATE_BLOCK_REASON_CATEGORIES)
+        raise ValueError(
+            f"Invalid human-gate reason category {reason_category!r}. "
+            f"Allowed categories: {allowed}"
+        )
+    return normalized
+
 
 def _latest_review_request_payload(conn: sqlite3.Connection, task_id: str) -> Optional[dict]:
     row = conn.execute(
@@ -3978,13 +4029,21 @@ def block_task(
     reason: Optional[str] = None,
     expected_run_id: Optional[int] = None,
     enforce_review_prerequisite: bool = True,
+    human_gate: bool = False,
+    reason_category: Optional[str] = None,
 ) -> bool:
     """Transition ``running -> blocked``.
 
     User/operator initiated blocked transitions must have enough review
-    history. Internal dispatcher safety blocks (for example impossible skill
-    preloads) can opt out so existing system-protection behavior is preserved.
+    history unless the caller explicitly marks the block as a genuine
+    human gate (credential, human decision, destructive-action approval,
+    service interruption, or product/art decision). Internal dispatcher
+    safety blocks (for example impossible skill preloads) can opt out via
+    ``enforce_review_prerequisite=False`` so existing system-protection
+    behavior is preserved.
     """
+    normalized_reason_category = _normalize_human_gate_reason_category(reason_category)
+    is_human_gate = bool(human_gate or normalized_reason_category)
     review_payload = _latest_review_request_payload(conn, task_id)
     return_assignee = None
     reviewer = _reviewer_profile()
@@ -4026,7 +4085,7 @@ def block_task(
                     attempted_run_id=int(expected_run_id),
                 )
             return False
-        if enforce_review_prerequisite:
+        if enforce_review_prerequisite and not is_human_gate:
             _ensure_blocked_transition_allowed(conn, task_id)
         assignee_sql = ", assignee = ?" if return_assignee else ""
         if expected_run_id is None:
@@ -4080,7 +4139,11 @@ def block_task(
                 outcome="blocked",
                 summary=reason,
             )
-        payload = {"reason": reason}
+        payload: dict = {"reason": reason}
+        if is_human_gate:
+            payload["human_gate"] = True
+            if normalized_reason_category:
+                payload["reason_category"] = normalized_reason_category
         if return_assignee:
             payload.update({"source": "review", "return_assignee": return_assignee})
         _append_event(conn, task_id, "blocked", payload, run_id=run_id)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -60,12 +60,15 @@ design specification.
 
 Concurrency strategy: WAL mode + ``BEGIN IMMEDIATE`` for write
 transactions + compare-and-swap (CAS) updates on ``tasks.status`` and
-``tasks.claim_lock``.  SQLite serializes writers via its WAL lock, so at
-most one claimer can win any given task.  Losers observe zero affected
-rows and move on -- no retry loops, no distributed-lock machinery.
-The CAS coordination is **per-board** — each board is a separate DB,
-so multi-board installs get the same atomicity guarantees without any
-new locking.
+``tasks.claim_lock``.  SQLite serializes normal writers via its WAL lock,
+so at most one claimer can win any given task.  Normal writes also take a
+cooperative shared sidecar lock; repair/maintenance code can take the
+matching exclusive lock via :func:`maintenance_lock` so REINDEX/VACUUM or
+manual repair work cannot run while live app writers are mutating the same
+board.  Losers observe zero affected rows and move on -- no retry loops,
+no distributed-lock machinery.  The CAS coordination is **per-board** —
+each board is a separate DB, so multi-board installs get the same atomicity
+guarantees without any cross-board locking.
 """
 
 from __future__ import annotations
@@ -132,6 +135,296 @@ def _resolve_claim_ttl_seconds(ttl_seconds: Optional[int] = None) -> int:
             return parsed
 
     return DEFAULT_CLAIM_TTL_SECONDS
+
+
+def _csv_or_list(value: Any) -> set[str]:
+    """Normalize a config value that may be a list or comma string."""
+    if value is None:
+        return set()
+    if isinstance(value, str):
+        raw_items = value.split(",")
+    elif isinstance(value, (list, tuple, set)):
+        raw_items = value
+    else:
+        return set()
+    return {str(item).strip().casefold() for item in raw_items if str(item).strip()}
+
+
+def _kanban_non_worker_profiles() -> set[str]:
+    """Profiles that exist but must not be auto-spawned as Kanban workers.
+
+    Some profiles are conversation/operator identities rather than worker lanes.
+    Treat them like non-spawnable assignees even though the profile directory
+    exists, so an accidental assignment cannot launch them as workers.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        kanban_cfg = (load_config().get("kanban") or {})
+    except Exception:
+        return set()
+    disabled = _csv_or_list(kanban_cfg.get("non_worker_profiles"))
+    # Back-compat/alternate spelling for operators who naturally look for a
+    # "disabled assignees" knob.
+    disabled |= _csv_or_list(kanban_cfg.get("disabled_assignees"))
+    return disabled
+
+
+def _is_configured_non_worker_profile(assignee: Optional[str]) -> bool:
+    """Return true when config marks this assignee as an operator/non-worker."""
+    name = (assignee or "").strip().casefold()
+    return bool(name and name in _kanban_non_worker_profiles())
+
+
+def _ensure_assignable_profile(assignee: Optional[str]) -> None:
+    """Reject explicit assignment to operator/non-worker profiles."""
+    if _is_configured_non_worker_profile(assignee):
+        raise ValueError(
+            f"{assignee!r} is configured as kanban.non_worker_profiles and "
+            "cannot be assigned Kanban work"
+        )
+
+
+def _is_spawnable_profile_assignee(assignee: str) -> bool:
+    """Return true if ``assignee`` names a real profile allowed to run work."""
+    try:
+        from hermes_cli.profiles import profile_exists  # local import: avoids cycle
+    except Exception:
+        # Can't introspect — assume spawnable, preserving legacy behavior except
+        # for explicit operator/non-worker profiles configured by the user.
+        return not _is_configured_non_worker_profile(assignee)
+    name = (assignee or "").strip()
+    if not name or not profile_exists(name):
+        return False
+    return not _is_configured_non_worker_profile(name)
+
+
+def _kanban_config() -> dict:
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config().get("kanban") or {}
+        return cfg if isinstance(cfg, dict) else {}
+    except Exception:
+        return {}
+
+
+def _reviewer_profile() -> Optional[str]:
+    """Configured profile that owns review-lane work."""
+    raw = _kanban_config().get("reviewer_profile", "reviewer")
+    if raw is None:
+        return None
+    name = str(raw).strip()
+    return _canonical_assignee(name) if name else None
+
+
+def _review_skill_names() -> list[str]:
+    """Extra skills forced onto review-lane workers, if configured."""
+    raw = _kanban_config().get("review_skills", [])
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        items = raw.split(",")
+    elif isinstance(raw, (list, tuple, set)):
+        items = raw
+    else:
+        return []
+    return [str(item).strip() for item in items if str(item).strip()]
+
+
+_REVIEW_REQUIRED_METADATA_KEYS = (
+    "changed_files",
+    "diff_path",
+    "pr_url",
+    "pr_number",
+    "recommendation",
+    "recommendations",
+    "risk_level",
+    "risky_actions",
+    "artifacts",
+)
+
+
+def _review_requirement_reason(metadata: Optional[dict]) -> Optional[str]:
+    """Return why a completion needs review, or None when it may finish."""
+    if not isinstance(metadata, dict):
+        return None
+    explicit = metadata.get("review_required")
+    if explicit is False:
+        return None
+    if explicit is True:
+        return "explicit"
+    for key in _REVIEW_REQUIRED_METADATA_KEYS:
+        value = metadata.get(key)
+        if value:
+            return key
+    return None
+
+
+BLOCKED_REVIEW_PREREQUISITE_ERROR = (
+    "Cannot move to Blocked: requires at least 2 review_requested events "
+    "in task history"
+)
+
+
+def _latest_review_request_payload(conn: sqlite3.Connection, task_id: str) -> Optional[dict]:
+    row = conn.execute(
+        "SELECT payload FROM task_events "
+        "WHERE task_id = ? AND kind = 'review_requested' "
+        "ORDER BY created_at DESC, id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    if not row or not row["payload"]:
+        return None
+    try:
+        payload = json.loads(row["payload"])
+    except Exception:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _review_request_count(conn: sqlite3.Connection, task_id: str) -> int:
+    row = conn.execute(
+        "SELECT COUNT(*) AS n FROM task_events "
+        "WHERE task_id = ? AND kind = 'review_requested'",
+        (task_id,),
+    ).fetchone()
+    return int(row["n"] if row else 0)
+
+
+def _ensure_blocked_transition_allowed(conn: sqlite3.Connection, task_id: str) -> None:
+    if _review_request_count(conn, task_id) < 2:
+        raise ValueError(BLOCKED_REVIEW_PREREQUISITE_ERROR)
+
+
+def _maintenance_lock_path(db_path: Path) -> Path:
+    """Return the cooperative sidecar lock used for DB maintenance exclusion."""
+    return Path(str(db_path) + ".maintenance.lock")
+
+
+def _conn_db_path(conn: sqlite3.Connection) -> Optional[Path]:
+    """Best-effort path lookup for the main database behind ``conn``."""
+    try:
+        row = conn.execute("PRAGMA database_list").fetchone()
+    except sqlite3.Error:
+        return None
+    if row is None:
+        return None
+    try:
+        raw = row["file"]
+    except Exception:
+        raw = row[2]
+    if not raw:
+        return None
+    return Path(str(raw))
+
+
+@contextlib.contextmanager
+def _cooperative_db_lock(db_path: Path, *, exclusive: bool, timeout: float = 30.0):
+    """Acquire the per-board cooperative maintenance lock.
+
+    Normal Kanban writes hold the lock in shared mode. Repair/maintenance code
+    holds it exclusively via :func:`maintenance_lock`. This is intentionally a
+    sidecar lock, not a replacement for SQLite WAL/BEGIN IMMEDIATE: SQLite still
+    serializes normal writers; the sidecar only prevents live app writes from
+    overlapping REINDEX/VACUUM/manual repair operations that also opt in.
+    """
+    if _IS_WINDOWS:
+        # ``fcntl`` is POSIX-only. Windows still relies on SQLite's own writer
+        # serialization; the maintenance lock is a best-effort POSIX hardening
+        # for the Linux/macOS gateway deployments where incidents occurred.
+        yield
+        return
+    import fcntl
+
+    lock_path = _maintenance_lock_path(db_path)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fh = lock_path.open("a+")
+    op = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
+    deadline = time.monotonic() + max(0.0, float(timeout))
+    try:
+        while True:
+            try:
+                fcntl.flock(fh.fileno(), op | fcntl.LOCK_NB)
+                break
+            except BlockingIOError:
+                if time.monotonic() >= deadline:
+                    mode = "exclusive" if exclusive else "shared"
+                    raise TimeoutError(
+                        f"timed out acquiring {mode} Kanban maintenance lock for {db_path}; "
+                        "another process is repairing or writing the board"
+                    )
+                time.sleep(0.05)
+        yield
+    finally:
+        try:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+        finally:
+            fh.close()
+
+
+@contextlib.contextmanager
+def maintenance_lock(
+    db_path: Optional[Path] = None,
+    *,
+    board: Optional[str] = None,
+    timeout: float = 30.0,
+):
+    """Hold an exclusive cooperative lock for Kanban DB repair/maintenance.
+
+    Use this around REINDEX/VACUUM/manual repair code. While held, normal
+    Kanban writes that go through :func:`write_txn` block until ``timeout`` and
+    then raise ``TimeoutError`` instead of mutating the DB mid-repair.
+    """
+    path = Path(db_path) if db_path is not None else kanban_db_path(board=board)
+    with _cooperative_db_lock(path, exclusive=True, timeout=timeout):
+        yield path
+
+
+def _maintenance_lock_timeout() -> float:
+    raw = os.environ.get("HERMES_KANBAN_MAINTENANCE_LOCK_TIMEOUT", "").strip()
+    if raw:
+        try:
+            val = float(raw)
+            if val >= 0:
+                return val
+        except ValueError:
+            pass
+    return 30.0
+
+
+@contextlib.contextmanager
+def _write_maintenance_gate(conn: sqlite3.Connection):
+    path = _conn_db_path(conn)
+    if path is None:
+        yield
+        return
+    with _cooperative_db_lock(path, exclusive=False, timeout=_maintenance_lock_timeout()):
+        yield
+
+
+def _require_nonempty_text(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} must be non-empty text")
+    return value.strip()
+
+
+def _normalize_board_notify_identity(
+    *,
+    board_key: Any,
+    platform: Any,
+    chat_id: Any,
+    thread_id: Optional[Any] = None,
+    notifier_profile: Optional[Any] = None,
+) -> tuple[str, str, str, str, str]:
+    board = _require_nonempty_text(board_key, "board_key")
+    plat = _require_nonempty_text(platform, "platform").lower()
+    if plat.isdigit() or not re.fullmatch(r"[a-z][a-z0-9_-]*", plat):
+        raise ValueError("platform must be a known-looking platform name, not an event/cursor id")
+    chat = _require_nonempty_text(chat_id, "chat_id")
+    thread = "" if thread_id is None else str(thread_id)
+    profile = "" if notifier_profile is None else str(notifier_profile)
+    return board, plat, chat, thread, profile
 
 
 # Worker-context caps so build_worker_context() stays bounded on
@@ -935,6 +1228,43 @@ CREATE TABLE IF NOT EXISTS kanban_notify_subs (
     PRIMARY KEY (task_id, platform, chat_id, thread_id)
 );
 
+-- Board-level home-channel notification cursors. Unlike kanban_notify_subs,
+-- these are not tied to one requested task; they let a gateway deliver terse
+-- completion pings for all future tasks on a board without relying on a
+-- separate broad fallback cron. New cursors start at the current max event id
+-- so enabling the feature does not replay old completions in a spam burst.
+CREATE TABLE IF NOT EXISTS kanban_notify_board_cursors (
+    board_key        TEXT NOT NULL,
+    platform         TEXT NOT NULL,
+    chat_id          TEXT NOT NULL,
+    thread_id        TEXT NOT NULL DEFAULT '',
+    notifier_profile TEXT NOT NULL DEFAULT '',
+    created_at       INTEGER NOT NULL,
+    updated_at       INTEGER NOT NULL,
+    last_event_id    INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (board_key, platform, chat_id, thread_id, notifier_profile)
+);
+
+-- Durable reply correlation for gateway-delivered Kanban proposal messages.
+-- A platform reply to (platform, chat_id, thread_id, message_id) can be mapped
+-- back to a task/proposal and applied without starting a normal agent turn.
+CREATE TABLE IF NOT EXISTS kanban_reply_targets (
+    platform       TEXT NOT NULL,
+    chat_id        TEXT NOT NULL,
+    thread_id      TEXT NOT NULL DEFAULT '',
+    message_id     TEXT NOT NULL,
+    task_id        TEXT NOT NULL,
+    proposal_id    TEXT,
+    kind           TEXT NOT NULL DEFAULT 'triage_proposal',
+    status         TEXT NOT NULL DEFAULT 'active',
+    user_id        TEXT,
+    payload        TEXT,
+    created_at     INTEGER NOT NULL,
+    updated_at     INTEGER NOT NULL,
+    expires_at     INTEGER,
+    PRIMARY KEY (platform, chat_id, thread_id, message_id)
+);
+
 CREATE INDEX IF NOT EXISTS idx_tasks_assignee_status ON tasks(assignee, status);
 CREATE INDEX IF NOT EXISTS idx_tasks_status          ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_links_child           ON task_links(child_id);
@@ -944,6 +1274,9 @@ CREATE INDEX IF NOT EXISTS idx_events_task           ON task_events(task_id, cre
 CREATE INDEX IF NOT EXISTS idx_runs_task             ON task_runs(task_id, started_at);
 CREATE INDEX IF NOT EXISTS idx_runs_status           ON task_runs(status);
 CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_id);
+CREATE INDEX IF NOT EXISTS idx_notify_board_cursor   ON kanban_notify_board_cursors(board_key, platform, chat_id, thread_id);
+CREATE INDEX IF NOT EXISTS idx_reply_targets_task    ON kanban_reply_targets(task_id, status);
+CREATE INDEX IF NOT EXISTS idx_reply_targets_proposal ON kanban_reply_targets(proposal_id, status);
 """
 
 
@@ -954,6 +1287,145 @@ CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_
 _INITIALIZED_PATHS: set[str] = set()
 _INIT_LOCK = threading.RLock()
 _SQLITE_HEADER = b"SQLite format 3\x00"
+
+
+def _integrity_repair_hint(path: Path) -> str:
+    """Return concise operator guidance for a Kanban DB integrity failure."""
+    return (
+        "Stop the gateway/dashboard/dispatchers that write this board, or hold "
+        "the Kanban maintenance lock, make a "
+        f"copy of {path}, then repair the copy with SQLite REINDEX/VACUUM or "
+        "restore from the newest clean backup. Verify with "
+        "`PRAGMA quick_check` before putting the DB back in service."
+    )
+
+
+def _format_check_rows(rows: list[str]) -> str:
+    """Condense PRAGMA check rows for exceptions and CLI output."""
+    if not rows:
+        return "no rows returned"
+    return "; ".join(str(row).replace("\n", " | ") for row in rows)
+
+
+def _raise_if_quick_check_failed(conn: sqlite3.Connection, path: Path) -> None:
+    """Fail before schema/migration writes when SQLite reports corruption.
+
+    Header validation only catches page-0 clobbers. Index/page corruption can
+    still leave the file looking like SQLite while reads or later DDL fail with
+    opaque ``database disk image is malformed`` errors. Running quick_check once
+    per process/path, immediately before the first schema/migration pass, keeps
+    the dispatcher and CLI from doing more writes to a board that already needs
+    operator repair.
+    """
+    try:
+        rows = [str(row[0]) for row in conn.execute("PRAGMA quick_check")]
+    except sqlite3.DatabaseError as exc:
+        raise sqlite3.DatabaseError(
+            f"kanban database integrity check failed for {path}: {exc}. "
+            f"{_integrity_repair_hint(path)}"
+        ) from exc
+    if rows != ["ok"]:
+        raise sqlite3.DatabaseError(
+            f"kanban database integrity check failed for {path}: "
+            f"{_format_check_rows(rows)}. {_integrity_repair_hint(path)}"
+        )
+
+
+def check_database_integrity(
+    db_path: Optional[Path] = None,
+    *,
+    board: Optional[str] = None,
+    full: bool = False,
+) -> dict[str, Any]:
+    """Run a read-only SQLite integrity check for a Kanban board DB.
+
+    Returns a JSON-serialisable dict with ``ok``, ``path``, ``quick_check`` and,
+    when ``full=True``, ``integrity_check``. This intentionally does not call
+    :func:`connect` or :func:`init_db`: operators need this diagnostic to work
+    even when normal Kanban commands cannot open the board.
+    """
+    path = db_path if db_path is not None else kanban_db_path(board=board)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    exists = path.exists()
+    size_bytes = path.stat().st_size if exists else 0
+    result: dict[str, Any] = {
+        "ok": True,
+        "path": str(path),
+        "exists": exists,
+        "size_bytes": size_bytes,
+        "quick_check": [],
+        "integrity_check": None,
+        "repair_hint": None,
+    }
+    try:
+        _validate_sqlite_header(path)
+    except sqlite3.DatabaseError as exc:
+        result["ok"] = False
+        result["quick_check"] = [f"ERROR: {exc}"]
+        result["repair_hint"] = _integrity_repair_hint(path)
+        return result
+    if not exists or size_bytes == 0:
+        result["quick_check"] = ["ok"]
+        return result
+    conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=30)
+    try:
+        quick_rows = [str(row[0]) for row in conn.execute("PRAGMA quick_check")]
+        result["quick_check"] = quick_rows
+        ok = quick_rows == ["ok"]
+        if full:
+            try:
+                integrity_rows = [str(row[0]) for row in conn.execute("PRAGMA integrity_check")]
+            except sqlite3.DatabaseError as exc:
+                integrity_rows = [f"ERROR: {exc}"]
+                ok = False
+            result["integrity_check"] = integrity_rows
+            ok = ok and integrity_rows == ["ok"]
+        result["ok"] = ok
+        if not ok:
+            result["repair_hint"] = _integrity_repair_hint(path)
+        return result
+    except sqlite3.DatabaseError as exc:
+        result["ok"] = False
+        result["quick_check"] = [f"ERROR: {exc}"]
+        result["repair_hint"] = _integrity_repair_hint(path)
+        return result
+    finally:
+        conn.close()
+
+
+def repair_database_indexes(
+    db_path: Optional[Path] = None,
+    *,
+    board: Optional[str] = None,
+    vacuum: bool = True,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    """Run REINDEX and optional VACUUM under the Kanban maintenance lock.
+
+    This is the safe in-process repair primitive for index-count corruption.
+    It does **not** replace backups or operator judgment: callers should still
+    copy the DB first and verify the result, but the exclusive maintenance lock
+    prevents normal Hermes Kanban writers from mutating the same board while the
+    repair transaction is running.
+    """
+    path = Path(db_path) if db_path is not None else kanban_db_path(board=board)
+    before = check_database_integrity(path, full=False)
+    with maintenance_lock(path, timeout=timeout):
+        conn = sqlite3.connect(str(path), timeout=timeout)
+        try:
+            conn.execute("REINDEX")
+            if vacuum:
+                conn.execute("VACUUM")
+        finally:
+            conn.close()
+    after = check_database_integrity(path, full=True)
+    return {
+        "path": str(path),
+        "vacuum": bool(vacuum),
+        "before": before,
+        "after": after,
+        "ok": bool(after.get("ok")),
+    }
 
 
 def _looks_like_tls_record_at(data: bytes, offset: int) -> bool:
@@ -1168,6 +1640,16 @@ def connect(
     # via _INITIALIZED_PATHS so it only runs once per process per path.
     _guard_existing_db_is_healthy(path)
     resolved = str(path.resolve())
+    if resolved not in _INITIALIZED_PATHS and path.exists() and path.stat().st_size > 0:
+        # Check existing DBs before WAL/schema setup does any writes. Missing or
+        # empty files are allowed to be created/initialised normally below.
+        preflight = check_database_integrity(path)
+        if not preflight.get("ok"):
+            raise sqlite3.DatabaseError(
+                f"kanban database integrity check failed for {path}: "
+                f"{_format_check_rows(preflight.get('quick_check') or [])}. "
+                f"{preflight.get('repair_hint') or _integrity_repair_hint(path)}"
+            )
     conn = sqlite3.connect(str(path), isolation_level=None, timeout=30)
     try:
         conn.row_factory = sqlite3.Row
@@ -1185,6 +1667,7 @@ def connect(
             conn.execute("PRAGMA foreign_keys=ON")
             needs_init = resolved not in _INITIALIZED_PATHS
             if needs_init:
+                _raise_if_quick_check_failed(conn, path)
                 # Idempotent: runs CREATE TABLE IF NOT EXISTS + the additive
                 # migrations. Cached so subsequent connect() calls in the same
                 # process are cheap. The lock prevents same-process dispatcher
@@ -1474,14 +1957,15 @@ def write_txn(conn: sqlite3.Connection):
     task + recording an event, etc.).  A claim CAS inside this context is
     atomic -- at most one concurrent writer can succeed.
     """
-    conn.execute("BEGIN IMMEDIATE")
-    try:
-        yield conn
-    except Exception:
-        conn.execute("ROLLBACK")
-        raise
-    else:
-        conn.execute("COMMIT")
+    with _write_maintenance_gate(conn):
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            yield conn
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
+        else:
+            conn.execute("COMMIT")
 
 
 # ---------------------------------------------------------------------------
@@ -1571,6 +2055,7 @@ def create_task(
     translation skill regardless of the profile's default config).
     """
     assignee = _canonical_assignee(assignee)
+    _ensure_assignable_profile(assignee)
     if not title or not title.strip():
         raise ValueError("title is required")
     if initial_status not in VALID_INITIAL_STATUSES:
@@ -1843,6 +2328,7 @@ def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) 
     Reassign after the current run completes if needed.
     """
     profile = _canonical_assignee(profile)
+    _ensure_assignable_profile(profile)
     with write_txn(conn):
         row = conn.execute(
             "SELECT status, claim_lock, assignee FROM tasks WHERE id = ?", (task_id,)
@@ -2133,6 +2619,36 @@ def _current_run_id(conn: sqlite3.Connection, task_id: str) -> Optional[int]:
     return int(row["current_run_id"]) if row and row["current_run_id"] else None
 
 
+def _record_claim_conflict(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    operation: str,
+    attempted_run_id: Optional[int],
+) -> None:
+    """Audit a stale worker attempting to mutate a claim it no longer owns.
+
+    Expected-run guards correctly fail closed by returning ``False``. This
+    event makes the rejection visible to operators instead of leaving a stale
+    worker's failed complete/block/heartbeat looking like a silent no-op.
+    """
+    current_run = _current_run_id(conn, task_id)
+    _append_event(
+        conn,
+        task_id,
+        "claim_conflict",
+        {
+            "operation": operation,
+            "attempted_run_id": (
+                int(attempted_run_id) if attempted_run_id is not None else None
+            ),
+            "current_run_id": current_run,
+            "recovery": "stale worker output rejected; inspect active run or reclaim if needed",
+        },
+        run_id=current_run,
+    )
+
+
 def _synthesize_ended_run(
     conn: sqlite3.Connection,
     task_id: str,
@@ -2188,11 +2704,21 @@ def _synthesize_ended_run(
 # Dependency resolution (todo -> ready)
 # ---------------------------------------------------------------------------
 
-def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
-    """Return True when ``task_id`` is sticky-blocked by an explicit
-    worker/operator ``kanban_block`` call (#28712).
+def _latest_block_control_event(conn: sqlite3.Connection, task_id: str) -> Optional[str]:
+    """Return latest block-control event kind for ``task_id``, if any."""
+    row = conn.execute(
+        "SELECT kind FROM task_events "
+        "WHERE task_id = ? AND kind IN ('blocked', 'gave_up', 'unblocked') "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    return row["kind"] if row else None
 
-    A ``blocked`` status can come from two very different sources:
+
+def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
+    """Return True when ``task_id`` is blocked until explicit unblock.
+
+    A ``blocked`` status can come from three different sources:
 
     * **Worker- or operator-initiated** — a worker called
       ``kanban_block(reason="review-required: ...")`` (or somebody ran
@@ -2202,28 +2728,28 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
 
     * **Circuit-breaker** — ``_record_task_failure`` tripped after
       repeated crashes / spawn failures / timeouts.  This emits
-      ``"gave_up"``, *not* ``"blocked"``, and is meant to recover
-      automatically once the underlying conditions change (e.g. parents
-      finish, transient infra error clears).
+      ``"gave_up"`` but no worker/operator ``"blocked"`` handoff event,
+      so it remains auto-recoverable when parents are complete.
 
-    The cheapest signal that distinguishes the two is the most recent
-    ``"blocked"`` / ``"unblocked"`` event for the task.  If the most
-    recent one is ``"blocked"`` (or there is a ``"blocked"`` event and
-    no ``"unblocked"`` event has fired since), the task is sticky and
-    ``recompute_ready`` must *not* auto-promote it.
+    * **Dependency/direct DB block** — legacy/internal state with no
+      ``"blocked"`` event.  That path remains auto-recoverable when
+      parents are complete.
 
-    Returns ``False`` when there is no such event at all (e.g. the task
-    was set to ``status='blocked'`` by the circuit breaker or by direct
-    DB manipulation) — preserves the pre-#28712 auto-recover semantics
-    for that path.
+    The cheapest signal is the most recent ``"blocked"`` / ``"unblocked"``
+    event for the task.  If the latest is ``"blocked"``, ``recompute_ready``
+    must *not* auto-promote it.  An explicit ``"unblocked"`` event flips the
+    predicate off.  Ignore ``"gave_up"`` here so circuit-breaker blocks keep
+    their historical auto-recovery path, while a prior human-review
+    ``"blocked"`` event still makes the task sticky even if a later failed
+    respawn emitted ``"gave_up"``.
     """
-    row = conn.execute(
-        "SELECT kind FROM task_events "
-        "WHERE task_id = ? AND kind IN ('blocked', 'unblocked') "
-        "ORDER BY id DESC LIMIT 1",
-        (task_id,),
-    ).fetchone()
-    return bool(row) and row["kind"] == "blocked"
+    latest = _latest_block_control_event(conn, task_id)
+    if latest == "unblocked":
+        return False
+    # Only worker/operator block events are sticky here. ``gave_up`` is handled
+    # in recompute_ready because parent-gated and parentless gave-up tasks have
+    # different recovery behavior.
+    return latest == "blocked"
 
 
 def recompute_ready(conn: sqlite3.Connection) -> int:
@@ -2233,13 +2759,13 @@ def recompute_ready(conn: sqlite3.Connection) -> int:
     an existing transaction; it opens its own IMMEDIATE txn.
 
     ``blocked`` tasks are also considered for promotion (so a task
-    blocked purely by a parent dependency unblocks itself when the
-    parent completes), *except* when the most recent block event was a
-    worker-initiated ``kanban_block`` — those stay blocked until an
-    explicit ``kanban_unblock`` (#28712).  Without that guard, a
-    ``review-required`` handoff would auto-respawn, the fresh worker
-    would find nothing to do, exit cleanly, get recorded as a protocol
-    violation, and the cycle would repeat indefinitely.
+    blocked purely by a parent dependency or circuit-breaker state
+    unblocks itself when the parent completes), *except* when the most
+    recent worker/operator block event is ``blocked`` — those stay
+    blocked until an explicit ``kanban_unblock`` (#28712).  Without that
+    guard, a ``review-required`` handoff would auto-respawn, the fresh
+    worker would crash or find nothing to do, and the cycle would repeat
+    indefinitely.
     """
     promoted = 0
     with write_txn(conn):
@@ -2261,6 +2787,16 @@ def recompute_ready(conn: sqlite3.Connection) -> int:
                 "WHERE l.child_id = ?",
                 (task_id,),
             ).fetchall()
+            if (
+                cur_status == "blocked"
+                and not parents
+                and _latest_block_control_event(conn, task_id) == "gave_up"
+            ):
+                # A parentless circuit-breaker block is not dependency-gated;
+                # immediately promoting it would reopen the same crashing task
+                # in the tick that gave up. Parent-gated gave-up blocks remain
+                # auto-recoverable once all parents are done.
+                continue
             if all(p["status"] in ("done", "archived") for p in parents):
                 # Blocked tasks also get their failure counters reset —
                 # this is effectively an auto-unblock (circuit-breaker
@@ -2286,6 +2822,63 @@ def recompute_ready(conn: sqlite3.Connection) -> int:
 # Claim / complete / block
 # ---------------------------------------------------------------------------
 
+def _allow_kanban_self_maintenance() -> bool:
+    return os.environ.get("HERMES_KANBAN_ALLOW_SELF_MAINTENANCE", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _is_kanban_self_maintenance_task(task: Optional[Task]) -> bool:
+    """Return true for tasks that ask Kanban to modify its own control plane.
+
+    Kanban should not auto-dispatch or manually claim work that changes the
+    dispatcher, DB, dashboard, notification plumbing, or Kanban tooling itself;
+    a broken Kanban system cannot safely supervise its own repair. Operators can
+    bypass this only with HERMES_KANBAN_ALLOW_SELF_MAINTENANCE=1.
+    """
+    if task is None or _allow_kanban_self_maintenance():
+        return False
+    text = f"{task.title}\n{task.body or ''}".casefold()
+    if "kanban" not in text:
+        return False
+    control_plane_markers = (
+        "hermes_cli/kanban",
+        "kanban_db.py",
+        "kanban.py",
+        "kanban dashboard",
+        "dashboard handler",
+        "notification bot",
+        "notifier",
+        "dispatcher",
+        "gateway/run.py",
+        "gateway watcher",
+        "tools/kanban_tools.py",
+        "kanban internals",
+    )
+    return any(marker in text for marker in control_plane_markers)
+
+
+def _block_kanban_self_maintenance_task(conn: sqlite3.Connection, task: Task) -> bool:
+    reason = (
+        "Kanban self-maintenance guard: this task appears to modify Kanban "
+        "control-plane code. Route it to an external/manual lane, or set "
+        "HERMES_KANBAN_ALLOW_SELF_MAINTENANCE=1 to override intentionally."
+    )
+    try:
+        add_comment(conn, task.id, "kanban", reason)
+    except Exception:
+        pass
+    return block_task(
+        conn,
+        task.id,
+        reason=reason,
+        enforce_review_prerequisite=False,
+    )
+
+
 def claim_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -2301,6 +2894,10 @@ def claim_task(
     now = int(time.time())
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
+    preflight_task = get_task(conn, task_id)
+    if preflight_task is not None and _is_kanban_self_maintenance_task(preflight_task):
+        _block_kanban_self_maintenance_task(conn, preflight_task)
+        return None
     with write_txn(conn):
         # Structural invariant: never transition ready -> running while any
         # parent is not yet 'done'. This is the single enforcement point
@@ -2851,6 +3448,105 @@ class HallucinatedCardsError(ValueError):
         )
 
 
+def request_review_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    reason: str,
+    result: Optional[str] = None,
+    summary: Optional[str] = None,
+    metadata: Optional[dict] = None,
+    created_cards: Optional[Iterable[str]] = None,
+    expected_run_id: Optional[int] = None,
+    reviewer_profile: Optional[str] = None,
+) -> bool:
+    """Route a near-complete handoff into the reviewer lane.
+
+    This closes the current worker run as ``review_requested`` and moves the
+    same task to ``status='review'`` assigned to the configured reviewer. It
+    intentionally does not set ``completed_at`` or clean scratch workspaces;
+    the user-facing ``completed`` event is emitted only after reviewer approval
+    calls :func:`complete_task` from the review run.
+    """
+    reviewer = _canonical_assignee(reviewer_profile) if reviewer_profile else _reviewer_profile()
+    if not reviewer:
+        return False
+    now = int(time.time())
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT assignee FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if not row:
+            return False
+        original_assignee = row["assignee"]
+        if expected_run_id is None:
+            cur = conn.execute(
+                """
+                UPDATE tasks
+                   SET status       = 'review',
+                       assignee     = ?,
+                       result       = ?,
+                       completed_at = NULL,
+                       claim_lock   = NULL,
+                       claim_expires= NULL,
+                       worker_pid   = NULL
+                 WHERE id = ?
+                   AND status IN ('running', 'ready', 'blocked')
+                """,
+                (reviewer, result, task_id),
+            )
+        else:
+            cur = conn.execute(
+                """
+                UPDATE tasks
+                   SET status       = 'review',
+                       assignee     = ?,
+                       result       = ?,
+                       completed_at = NULL,
+                       claim_lock   = NULL,
+                       claim_expires= NULL,
+                       worker_pid   = NULL
+                 WHERE id = ?
+                   AND status IN ('running', 'ready', 'blocked')
+                   AND current_run_id = ?
+                """,
+                (reviewer, result, task_id, int(expected_run_id)),
+            )
+        if cur.rowcount != 1:
+            if expected_run_id is not None:
+                _record_claim_conflict(
+                    conn,
+                    task_id,
+                    operation="review_request",
+                    attempted_run_id=int(expected_run_id),
+                )
+            return False
+        run_id = _end_run(
+            conn, task_id,
+            outcome="review_requested", status="review_requested",
+            summary=summary if summary is not None else result,
+            metadata=metadata,
+        )
+        if run_id is None and (summary or metadata or result):
+            run_id = _synthesize_ended_run(
+                conn, task_id,
+                outcome="review_requested",
+                summary=summary if summary is not None else result,
+                metadata=metadata,
+            )
+        payload: dict = {
+            "reason": reason,
+            "original_assignee": original_assignee,
+            "reviewer_profile": reviewer,
+            "summary": ((summary if summary is not None else result) or "").strip().splitlines()[0][:400] or None,
+        }
+        if created_cards:
+            payload["verified_cards"] = list(created_cards)
+        _append_event(conn, task_id, "review_requested", payload, run_id=run_id)
+    return True
+
+
 def complete_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -2918,6 +3614,26 @@ def complete_task(
     else:
         verified_cards = []
 
+    review_reason = _review_requirement_reason(metadata)
+    if review_reason:
+        row = conn.execute(
+            "SELECT assignee FROM tasks WHERE id = ? AND status IN ('running', 'ready', 'blocked')",
+            (task_id,),
+        ).fetchone()
+        reviewer = _reviewer_profile()
+        if row and reviewer and row["assignee"] != reviewer:
+            return request_review_task(
+                conn,
+                task_id,
+                reason=review_reason,
+                result=result,
+                summary=summary,
+                metadata=metadata,
+                created_cards=verified_cards,
+                expected_run_id=expected_run_id,
+                reviewer_profile=reviewer,
+            )
+
     with write_txn(conn):
         if expected_run_id is None:
             cur = conn.execute(
@@ -2951,6 +3667,13 @@ def complete_task(
                 (result, now, task_id, int(expected_run_id)),
             )
         if cur.rowcount != 1:
+            if expected_run_id is not None:
+                _record_claim_conflict(
+                    conn,
+                    task_id,
+                    operation="complete",
+                    attempted_run_id=int(expected_run_id),
+                )
             return False
         run_id = _end_run(
             conn, task_id,
@@ -3254,37 +3977,95 @@ def block_task(
     *,
     reason: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    enforce_review_prerequisite: bool = True,
 ) -> bool:
-    """Transition ``running -> blocked``."""
+    """Transition ``running -> blocked``.
+
+    User/operator initiated blocked transitions must have enough review
+    history. Internal dispatcher safety blocks (for example impossible skill
+    preloads) can opt out so existing system-protection behavior is preserved.
+    """
+    review_payload = _latest_review_request_payload(conn, task_id)
+    return_assignee = None
+    reviewer = _reviewer_profile()
+    current = conn.execute(
+        "SELECT assignee FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if review_payload and current and reviewer and current["assignee"] == reviewer:
+        raw_return = review_payload.get("original_assignee")
+        if raw_return:
+            return_assignee = _canonical_assignee(str(raw_return))
+
     with write_txn(conn):
         if expected_run_id is None:
-            cur = conn.execute(
+            eligible = conn.execute(
                 """
-                UPDATE tasks
-                   SET status       = 'blocked',
-                       claim_lock   = NULL,
-                       claim_expires= NULL,
-                       worker_pid   = NULL
+                SELECT 1 FROM tasks
                  WHERE id = ?
                    AND status IN ('running', 'ready')
                 """,
                 (task_id,),
-            )
+            ).fetchone()
         else:
-            cur = conn.execute(
+            eligible = conn.execute(
                 """
-                UPDATE tasks
-                   SET status       = 'blocked',
-                       claim_lock   = NULL,
-                       claim_expires= NULL,
-                       worker_pid   = NULL
+                SELECT 1 FROM tasks
                  WHERE id = ?
                    AND status IN ('running', 'ready')
                    AND current_run_id = ?
                 """,
                 (task_id, int(expected_run_id)),
+            ).fetchone()
+        if not eligible:
+            if expected_run_id is not None:
+                _record_claim_conflict(
+                    conn,
+                    task_id,
+                    operation="block",
+                    attempted_run_id=int(expected_run_id),
+                )
+            return False
+        if enforce_review_prerequisite:
+            _ensure_blocked_transition_allowed(conn, task_id)
+        assignee_sql = ", assignee = ?" if return_assignee else ""
+        if expected_run_id is None:
+            cur = conn.execute(
+                f"""
+                UPDATE tasks
+                   SET status       = 'blocked',
+                       claim_lock   = NULL,
+                       claim_expires= NULL,
+                       worker_pid   = NULL
+                       {assignee_sql}
+                 WHERE id = ?
+                   AND status IN ('running', 'ready')
+                """,
+                ((return_assignee, task_id) if return_assignee else (task_id,)),
+            )
+        else:
+            cur = conn.execute(
+                f"""
+                UPDATE tasks
+                   SET status       = 'blocked',
+                       claim_lock   = NULL,
+                       claim_expires= NULL,
+                       worker_pid   = NULL
+                       {assignee_sql}
+                 WHERE id = ?
+                   AND status IN ('running', 'ready')
+                   AND current_run_id = ?
+                """,
+                ((return_assignee, task_id, int(expected_run_id)) if return_assignee else (task_id, int(expected_run_id))),
             )
         if cur.rowcount != 1:
+            if expected_run_id is not None:
+                _record_claim_conflict(
+                    conn,
+                    task_id,
+                    operation="block",
+                    attempted_run_id=int(expected_run_id),
+                )
             return False
         run_id = _end_run(
             conn, task_id,
@@ -3299,7 +4080,10 @@ def block_task(
                 outcome="blocked",
                 summary=reason,
             )
-        _append_event(conn, task_id, "blocked", {"reason": reason}, run_id=run_id)
+        payload = {"reason": reason}
+        if return_assignee:
+            payload.update({"source": "review", "return_assignee": return_assignee})
+        _append_event(conn, task_id, "blocked", payload, run_id=run_id)
         return True
 
 
@@ -3552,23 +4336,27 @@ def decompose_triage_task(
       - The root task is not in ``triage``
       - A cycle would result (caller built a bad graph)
 
-    Validation of titles/assignees happens inside the same write_txn as
-    the inserts so a malformed entry aborts the whole decomposition
-    cleanly (no orphan children).
+    Validation of titles/assignees happens before any inserts or root
+    updates, so a malformed entry aborts the whole decomposition cleanly
+    (no orphan children).
     """
     if not children:
         return None
     if root_assignee is not None:
         root_assignee = _canonical_assignee(root_assignee)
+    _ensure_assignable_profile(root_assignee)
 
     # Pre-validate the children list shape outside the txn. Cheap checks
     # that don't need DB access. Bad input aborts before we touch the DB.
+    # Assignment validation mirrors create_task()/assign_task() so
+    # decomposer output cannot bypass configured non-worker profile guards.
     for idx, child in enumerate(children):
         if not isinstance(child, dict):
             raise ValueError(f"child[{idx}] is not a dict")
         title = child.get("title")
         if not isinstance(title, str) or not title.strip():
             raise ValueError(f"child[{idx}].title is required")
+        _ensure_assignable_profile(_canonical_assignee(child.get("assignee")))
         parents_idx = child.get("parents") or []
         if not isinstance(parents_idx, list):
             raise ValueError(f"child[{idx}].parents must be a list")
@@ -4226,6 +5014,13 @@ def heartbeat_worker(
                 (now, task_id, int(expected_run_id)),
             )
         if cur.rowcount != 1:
+            if expected_run_id is not None:
+                _record_claim_conflict(
+                    conn,
+                    task_id,
+                    operation="heartbeat",
+                    attempted_run_id=int(expected_run_id),
+                )
             return False
         run_id = (
             int(expected_run_id)
@@ -4954,13 +5749,8 @@ def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
     ).fetchall()
     if not rows:
         return False
-    try:
-        from hermes_cli.profiles import profile_exists  # local import: avoids cycle
-    except Exception:
-        # Can't introspect — assume spawnable, preserve legacy behavior.
-        return True
     for row in rows:
-        if profile_exists(row["assignee"]):
+        if _is_spawnable_profile_assignee(row["assignee"]):
             return True
     return False
 
@@ -4980,12 +5770,8 @@ def has_spawnable_review(conn: sqlite3.Connection) -> bool:
     ).fetchall()
     if not rows:
         return False
-    try:
-        from hermes_cli.profiles import profile_exists  # local import: avoids cycle
-    except Exception:
-        return True
     for row in rows:
-        if profile_exists(row["assignee"]):
+        if _is_spawnable_profile_assignee(row["assignee"]):
             return True
     return False
 
@@ -5131,17 +5917,14 @@ def dispatch_once(
         # subprocess would crash on startup, get reaped as a zombie,
         # the task would loop back to ``ready`` on next tick, and we'd
         # burn CPU forever (#kanban-dispatcher-crash-loop 2026-05-05).
-        try:
-            from hermes_cli.profiles import profile_exists  # local import: avoids cycle
-        except Exception:
-            profile_exists = None  # type: ignore[assignment]
-        if profile_exists is not None and not profile_exists(row["assignee"]):
+        if not _is_spawnable_profile_assignee(row["assignee"]):
             # Bucket separately from skipped_unassigned: the operator
             # cannot fix this by assigning a profile (the assignee IS the
-            # intended owner — a terminal lane). Health telemetry uses
-            # this distinction to suppress spurious "stuck" warnings on
-            # multi-lane setups where the ready queue is steadily full
-            # of human-pulled work.
+            # intended owner — a terminal lane, or an operator profile marked
+            # kanban.non_worker_profiles). Health telemetry uses this
+            # distinction to suppress spurious "stuck" warnings on multi-lane
+            # setups where the ready queue is steadily full of human-pulled or
+            # intentionally non-worker work.
             result.skipped_nonspawnable.append(row["id"])
             continue
         # Respawn guard: refuse to re-spawn when useful work is already
@@ -5165,6 +5948,19 @@ def dispatch_once(
                         {"reason": guard_reason},
                     )
             continue
+        task_for_preflight = get_task(conn, row["id"])
+        if task_for_preflight is not None:
+            if _is_kanban_self_maintenance_task(task_for_preflight):
+                result.auto_blocked.append(row["id"])
+                if not dry_run:
+                    _block_kanban_self_maintenance_task(conn, task_for_preflight)
+                continue
+            missing_skills = _missing_task_skills(task_for_preflight)
+            if missing_skills:
+                result.auto_blocked.append(row["id"])
+                if not dry_run:
+                    _block_missing_task_skills(conn, task_for_preflight, missing_skills)
+                continue
         if dry_run:
             result.spawned.append((row["id"], row["assignee"], ""))
             continue
@@ -5237,11 +6033,7 @@ def dispatch_once(
         if not row["assignee"]:
             result.skipped_unassigned.append(row["id"])
             continue
-        try:
-            from hermes_cli.profiles import profile_exists
-        except Exception:
-            profile_exists = None  # type: ignore[assignment]
-        if profile_exists is not None and not profile_exists(row["assignee"]):
+        if not _is_spawnable_profile_assignee(row["assignee"]):
             result.skipped_nonspawnable.append(row["id"])
             continue
         if dry_run:
@@ -5263,12 +6055,11 @@ def dispatch_once(
         # Persist the resolved workspace path so the worker can cd there.
         set_workspace_path(conn, claimed.id, str(workspace))
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
-        # Force-load sdlc-review skill for review agents.  The
-        # _default_spawn function already auto-loads kanban-worker, and
-        # appends task.skills via --skills.  Setting task.skills here
-        # means the review agent gets both kanban-worker (lifecycle)
-        # and sdlc-review (review logic: AC verification, merge, etc.).
-        claimed.skills = ["sdlc-review"]
+        # Review-lane workers always get the kanban-worker lifecycle from
+        # _default_spawn. Operators can add reviewer-specific skills via
+        # kanban.review_skills; leave it empty to rely on the reviewer's
+        # profile configuration and avoid forcing a missing bundled skill.
+        claimed.skills = _review_skill_names() or None
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:
             import inspect
@@ -5525,6 +6316,91 @@ def _kanban_worker_skill_available(hermes_home: Optional[str]) -> bool:
     except OSError:
         pass
     return False
+
+
+def _worker_hermes_home_for_assignee(assignee: Optional[str]) -> Optional[str]:
+    """Return the HERMES_HOME a worker subprocess would use for ``assignee``."""
+    if not assignee:
+        return os.environ.get("HERMES_HOME")
+    try:
+        import importlib
+
+        profiles = importlib.import_module("hermes_cli.profiles")
+        profile_arg = profiles.normalize_profile_name(assignee)
+        return profiles.resolve_profile_env(profile_arg)
+    except FileNotFoundError:
+        return os.environ.get("HERMES_HOME")
+    except Exception:
+        return os.environ.get("HERMES_HOME")
+
+
+def _missing_task_skills(task: Task) -> list[str]:
+    """Return force-loaded task skills that would be fatal at worker startup."""
+    requested = [str(s).strip() for s in (task.skills or []) if str(s).strip()]
+    requested = [s for s in requested if s != "kanban-worker"]
+    if not requested:
+        return []
+
+    worker_home = _worker_hermes_home_for_assignee(task.assignee)
+    old_env_home = os.environ.get("HERMES_HOME")
+    try:
+        import importlib
+
+        skill_commands = importlib.import_module("agent.skill_commands")
+        skills_tool = importlib.import_module("tools.skills_tool")
+
+        old_module_home = getattr(skills_tool, "HERMES_HOME", None)
+        old_skills_dir = getattr(skills_tool, "SKILLS_DIR", None)
+        try:
+            if worker_home:
+                home_path = Path(worker_home)
+                os.environ["HERMES_HOME"] = str(home_path)
+                setattr(skills_tool, "HERMES_HOME", home_path)
+                setattr(skills_tool, "SKILLS_DIR", home_path / "skills")
+            missing: list[str] = []
+            for skill_name in requested:
+                if skill_commands._load_skill_payload(skill_name, task_id=task.id) is None:
+                    missing.append(skill_name)
+            return missing
+        finally:
+            if old_module_home is not None:
+                setattr(skills_tool, "HERMES_HOME", old_module_home)
+            if old_skills_dir is not None:
+                setattr(skills_tool, "SKILLS_DIR", old_skills_dir)
+    except Exception:
+        # Validation is a guardrail, not a dispatcher dependency. If the skill
+        # loader itself is unavailable, fall back to the existing spawn path so
+        # the error is still recorded by the normal failure machinery.
+        return []
+    finally:
+        if old_env_home is None:
+            os.environ.pop("HERMES_HOME", None)
+        else:
+            os.environ["HERMES_HOME"] = old_env_home
+
+
+def _block_missing_task_skills(
+    conn: sqlite3.Connection,
+    task: Task,
+    missing: list[str],
+) -> bool:
+    """Sticky-block ``task`` with an actionable missing-skill reason."""
+    if not missing:
+        return False
+    missing_text = ", ".join(missing)
+    reason = (
+        f"Task {task.id} cannot start: unknown skill(s): {missing_text}. "
+        "Install/restore the skill for the assignee profile or edit the "
+        "task's skills list, then unblock the task."
+    )
+    ok = block_task(conn, task.id, reason=reason, enforce_review_prerequisite=False)
+    if ok:
+        with write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
+                (reason[:500], task.id),
+            )
+    return ok
 
 
 def _worker_terminal_timeout_env(
@@ -6076,6 +6952,210 @@ def task_age(task: Task) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Reply targets for gateway-delivered Kanban proposals
+# ---------------------------------------------------------------------------
+
+_REPLY_TARGET_STATUSES = {"active", "accepted", "rejected", "superseded", "expired"}
+
+
+def _normalise_reply_platform(platform: str) -> str:
+    return (platform or "").strip().lower()
+
+
+def _normalise_reply_payload(payload: Optional[dict[str, Any] | str]) -> Optional[str]:
+    if payload is None:
+        return None
+    if isinstance(payload, str):
+        text = payload.strip()
+        if not text:
+            return None
+        # Validate callers are not storing malformed JSON strings.
+        json.loads(text)
+        return text
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True)
+
+
+def add_reply_target(
+    conn: sqlite3.Connection,
+    *,
+    platform: str,
+    chat_id: str,
+    message_id: str,
+    task_id: str,
+    thread_id: Optional[str] = None,
+    proposal_id: Optional[str] = None,
+    kind: str = "triage_proposal",
+    user_id: Optional[str] = None,
+    payload: Optional[dict[str, Any] | str] = None,
+    expires_at: Optional[int] = None,
+) -> None:
+    """Map an outgoing Kanban proposal message to a task/proposal.
+
+    The gateway uses this mapping to intercept direct platform replies before
+    they become normal agent turns. The key is the platform-visible message id
+    plus the normalized chat/thread routing context. Re-registering the same
+    key is idempotent and refreshes the active proposal metadata.
+    """
+    platform_key = _normalise_reply_platform(platform)
+    if not platform_key:
+        raise ValueError("platform is required")
+    chat_key = str(chat_id or "").strip()
+    if not chat_key:
+        raise ValueError("chat_id is required")
+    msg_key = str(message_id or "").strip()
+    if not msg_key:
+        raise ValueError("message_id is required")
+    if not task_id or get_task(conn, task_id) is None:
+        raise ValueError(f"unknown task_id: {task_id}")
+    now = int(time.time())
+    with write_txn(conn):
+        conn.execute(
+            """
+            INSERT INTO kanban_reply_targets
+                (platform, chat_id, thread_id, message_id, task_id,
+                 proposal_id, kind, status, user_id, payload,
+                 created_at, updated_at, expires_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, ?, ?, ?)
+            ON CONFLICT(platform, chat_id, thread_id, message_id) DO UPDATE SET
+                task_id = excluded.task_id,
+                proposal_id = excluded.proposal_id,
+                kind = excluded.kind,
+                status = 'active',
+                user_id = excluded.user_id,
+                payload = excluded.payload,
+                updated_at = excluded.updated_at,
+                expires_at = excluded.expires_at
+            """,
+            (
+                platform_key,
+                chat_key,
+                thread_id or "",
+                msg_key,
+                task_id,
+                proposal_id,
+                kind or "triage_proposal",
+                user_id,
+                _normalise_reply_payload(payload),
+                now,
+                now,
+                int(expires_at) if expires_at is not None else None,
+            ),
+        )
+
+
+def get_reply_target(
+    conn: sqlite3.Connection,
+    *,
+    platform: str,
+    chat_id: str,
+    message_id: str,
+    thread_id: Optional[str] = None,
+    proposal_id: Optional[str] = None,
+) -> Optional[dict[str, Any]]:
+    """Fetch a reply target by exact reply anchor or explicit proposal id."""
+    platform_key = _normalise_reply_platform(platform)
+    chat_key = str(chat_id or "").strip()
+    msg_key = str(message_id or "").strip()
+    if msg_key:
+        row = conn.execute(
+            """
+            SELECT * FROM kanban_reply_targets
+             WHERE platform = ? AND chat_id = ? AND thread_id = ? AND message_id = ?
+            """,
+            (platform_key, chat_key, thread_id or "", msg_key),
+        ).fetchone()
+        if row is not None:
+            return _decode_reply_target_row(row)
+        if thread_id:
+            # Slack/Discord adapters can surface a platform thread id for a
+            # reply even when the original prompt was registered at channel
+            # scope. Fall back to the channel-level anchor before giving up.
+            row = conn.execute(
+                """
+                SELECT * FROM kanban_reply_targets
+                 WHERE platform = ? AND chat_id = ? AND thread_id = '' AND message_id = ?
+                """,
+                (platform_key, chat_key, msg_key),
+            ).fetchone()
+            if row is not None:
+                return _decode_reply_target_row(row)
+    if proposal_id:
+        rows = conn.execute(
+            """
+            SELECT * FROM kanban_reply_targets
+             WHERE platform = ? AND chat_id = ? AND proposal_id = ?
+             ORDER BY updated_at DESC
+            """,
+            (platform_key, chat_key, proposal_id),
+        ).fetchall()
+        if len(rows) == 1:
+            return _decode_reply_target_row(rows[0])
+    return None
+
+
+def list_reply_targets(
+    conn: sqlite3.Connection,
+    *,
+    task_id: Optional[str] = None,
+    status: Optional[str] = None,
+) -> list[dict[str, Any]]:
+    clauses: list[str] = []
+    params: list[Any] = []
+    if task_id is not None:
+        clauses.append("task_id = ?")
+        params.append(task_id)
+    if status is not None:
+        clauses.append("status = ?")
+        params.append(status)
+    where = " WHERE " + " AND ".join(clauses) if clauses else ""
+    rows = conn.execute(
+        "SELECT * FROM kanban_reply_targets" + where + " ORDER BY updated_at DESC",
+        tuple(params),
+    ).fetchall()
+    return [_decode_reply_target_row(row) for row in rows]
+
+
+def update_reply_target_status(
+    conn: sqlite3.Connection,
+    target: dict[str, Any],
+    status: str,
+) -> bool:
+    if status not in _REPLY_TARGET_STATUSES:
+        raise ValueError(f"invalid reply target status: {status}")
+    now = int(time.time())
+    with write_txn(conn):
+        cur = conn.execute(
+            """
+            UPDATE kanban_reply_targets
+               SET status = ?, updated_at = ?
+             WHERE platform = ? AND chat_id = ? AND thread_id = ? AND message_id = ?
+            """,
+            (
+                status,
+                now,
+                target["platform"],
+                target["chat_id"],
+                target.get("thread_id") or "",
+                target["message_id"],
+            ),
+        )
+    return cur.rowcount > 0
+
+
+def _decode_reply_target_row(row: sqlite3.Row) -> dict[str, Any]:
+    out = dict(row)
+    raw_payload = out.get("payload")
+    if raw_payload:
+        try:
+            out["payload"] = json.loads(raw_payload)
+        except Exception:
+            out["payload"] = {}
+    else:
+        out["payload"] = {}
+    return out
+
+
+# ---------------------------------------------------------------------------
 # Notification subscriptions (used by the gateway kanban-notifier)
 # ---------------------------------------------------------------------------
 
@@ -6290,6 +7370,204 @@ def rewind_notify_cursor(
     return cur.rowcount > 0
 
 
+def _max_task_event_id(conn: sqlite3.Connection) -> int:
+    row = conn.execute("SELECT COALESCE(MAX(id), 0) AS max_id FROM task_events").fetchone()
+    return int(row["max_id"] if row is not None else 0)
+
+
+def _ensure_board_notify_cursor(
+    conn: sqlite3.Connection,
+    *,
+    board_key: str,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+    notifier_profile: Optional[str] = None,
+) -> None:
+    """Create a board-level home-channel cursor without replaying old events."""
+    board_key, platform, chat_id, thread_id, profile = _normalize_board_notify_identity(
+        board_key=board_key,
+        platform=platform,
+        chat_id=chat_id,
+        thread_id=thread_id,
+        notifier_profile=notifier_profile,
+    )
+    now = int(time.time())
+    with write_txn(conn):
+        start_cursor = _max_task_event_id(conn)
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO kanban_notify_board_cursors
+                (board_key, platform, chat_id, thread_id, notifier_profile,
+                 created_at, updated_at, last_event_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                board_key,
+                platform,
+                chat_id,
+                thread_id or "",
+                profile,
+                now,
+                now,
+                start_cursor,
+            ),
+        )
+
+
+def claim_board_notify_events(
+    conn: sqlite3.Connection,
+    *,
+    board_key: str,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+    notifier_profile: Optional[str] = None,
+    kinds: Optional[Iterable[str]] = None,
+) -> tuple[int, int, list[Event]]:
+    """Atomically claim unseen board-level notification events.
+
+    Board cursors power low-noise home-channel completion pings. The cursor is
+    initialized at the current max event id on first sight so enabling the
+    watcher never floods users with historical completions.
+    """
+    board_key, platform, chat_id, thread_id, profile = _normalize_board_notify_identity(
+        board_key=board_key,
+        platform=platform,
+        chat_id=chat_id,
+        thread_id=thread_id,
+        notifier_profile=notifier_profile,
+    )
+    with write_txn(conn):
+        now = int(time.time())
+        start_cursor = _max_task_event_id(conn)
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO kanban_notify_board_cursors
+                (board_key, platform, chat_id, thread_id, notifier_profile,
+                 created_at, updated_at, last_event_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                board_key,
+                platform,
+                chat_id,
+                thread_id or "",
+                profile,
+                now,
+                now,
+                start_cursor,
+            ),
+        )
+        row = conn.execute(
+            "SELECT last_event_id FROM kanban_notify_board_cursors "
+            "WHERE board_key = ? AND platform = ? AND chat_id = ? "
+            "AND thread_id = ? AND notifier_profile = ?",
+            (board_key, platform, chat_id, thread_id or "", profile),
+        ).fetchone()
+        if row is None:
+            return 0, 0, []
+        old_cursor = int(row["last_event_id"])
+        kind_list = list(kinds) if kinds else None
+        q = (
+            "SELECT * FROM task_events WHERE id > ? "
+            + ("AND kind IN (" + ",".join("?" * len(kind_list)) + ") " if kind_list else "")
+            + "ORDER BY id ASC"
+        )
+        params: list[Any] = [old_cursor]
+        if kind_list:
+            params.extend(kind_list)
+        rows = conn.execute(q, params).fetchall()
+        events: list[Event] = []
+        new_cursor = old_cursor
+        for r in rows:
+            try:
+                payload = json.loads(r["payload"]) if r["payload"] else None
+            except Exception:
+                payload = None
+            events.append(Event(
+                id=r["id"], task_id=r["task_id"], kind=r["kind"],
+                payload=payload, created_at=r["created_at"],
+                run_id=(int(r["run_id"]) if "run_id" in r.keys() and r["run_id"] is not None else None),
+            ))
+            new_cursor = max(new_cursor, int(r["id"]))
+        if not events:
+            return old_cursor, old_cursor, []
+        conn.execute(
+            "UPDATE kanban_notify_board_cursors "
+            "SET last_event_id = ?, updated_at = ? "
+            "WHERE board_key = ? AND platform = ? AND chat_id = ? "
+            "AND thread_id = ? AND notifier_profile = ? AND last_event_id = ?",
+            (
+                int(new_cursor), int(time.time()), board_key, platform, chat_id,
+                thread_id or "", profile, int(old_cursor),
+            ),
+        )
+        return old_cursor, new_cursor, events
+
+
+def advance_board_notify_cursor(
+    conn: sqlite3.Connection,
+    *,
+    board_key: str,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+    notifier_profile: Optional[str] = None,
+    new_cursor: int,
+) -> None:
+    board_key, platform, chat_id, thread_id, profile = _normalize_board_notify_identity(
+        board_key=board_key,
+        platform=platform,
+        chat_id=chat_id,
+        thread_id=thread_id,
+        notifier_profile=notifier_profile,
+    )
+    with write_txn(conn):
+        conn.execute(
+            "UPDATE kanban_notify_board_cursors "
+            "SET last_event_id = ?, updated_at = ? "
+            "WHERE board_key = ? AND platform = ? AND chat_id = ? "
+            "AND thread_id = ? AND notifier_profile = ?",
+            (
+                int(new_cursor), int(time.time()), board_key, platform, chat_id,
+                thread_id or "", profile,
+            ),
+        )
+
+
+def rewind_board_notify_cursor(
+    conn: sqlite3.Connection,
+    *,
+    board_key: str,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+    notifier_profile: Optional[str] = None,
+    claimed_cursor: int,
+    old_cursor: int,
+) -> bool:
+    board_key, platform, chat_id, thread_id, profile = _normalize_board_notify_identity(
+        board_key=board_key,
+        platform=platform,
+        chat_id=chat_id,
+        thread_id=thread_id,
+        notifier_profile=notifier_profile,
+    )
+    with write_txn(conn):
+        cur = conn.execute(
+            "UPDATE kanban_notify_board_cursors "
+            "SET last_event_id = ?, updated_at = ? "
+            "WHERE board_key = ? AND platform = ? AND chat_id = ? "
+            "AND thread_id = ? AND notifier_profile = ? AND last_event_id = ?",
+            (
+                int(old_cursor), int(time.time()), board_key, platform, chat_id,
+                thread_id or "", profile, int(claimed_cursor),
+            ),
+        )
+    return cur.rowcount > 0
+
+
 # ---------------------------------------------------------------------------
 # Retention + garbage collection
 # ---------------------------------------------------------------------------
@@ -6433,7 +7711,7 @@ def known_assignees(conn: sqlite3.Connection) -> list[dict]:
     - Router-profile heuristics ("who's overloaded?") without scanning
       the whole board.
     """
-    on_disk = set(list_profiles_on_disk())
+    on_disk = set(list_profiles_on_disk()) - _kanban_non_worker_profiles()
 
     # Count tasks per (assignee, status), excluding archived.
     counts: dict[str, dict[str, int]] = {}

--- a/hermes_cli/kanban_specify.py
+++ b/hermes_cli/kanban_specify.py
@@ -8,6 +8,10 @@ the auxiliary LLM to produce:
     materially different one)
   * A concrete body: goal, proposed approach, acceptance criteria
 
+If the triage card is unassigned, the specifier also assigns it to the
+configured ``kanban.default_assignee`` (falling back to the active/default
+profile) before promotion, so the dispatcher can actually spawn a worker.
+
 and then flips the task ``triage -> todo`` via
 ``kanban_db.specify_triage_task``. The dispatcher promotes it to
 ``ready`` on its next tick (or immediately if there are no open parents).
@@ -39,6 +43,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from hermes_cli import kanban_db as kb
+from hermes_cli import profiles as profiles_mod
 
 HERMES_KANBAN_SPECIFY_MAX_TOKENS = max(
     1500,
@@ -135,6 +140,36 @@ def _profile_author() -> str:
         or os.environ.get("USER")
         or "specifier"
     )
+
+
+def _load_config() -> dict:
+    try:
+        from hermes_cli.config import load_config
+        return load_config() or {}
+    except Exception:
+        return {}
+
+
+def _resolve_default_assignee() -> str:
+    """Resolve the fallback profile used when specifying unassigned intake.
+
+    Manual ``specify`` should not strand a task in ``ready`` with no assignee.
+    Mirror the decomposer's fallback: configured ``kanban.default_assignee``
+    when it exists on disk, otherwise the active/default profile.
+    """
+    cfg = _load_config()
+    kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
+    explicit = (kanban_cfg.get("default_assignee") or "").strip()
+    if explicit:
+        try:
+            if profiles_mod.profile_exists(explicit):
+                return explicit
+        except Exception:
+            pass
+    try:
+        return profiles_mod.get_active_profile_name() or "default"
+    except Exception:
+        return "default"
 
 
 def specify_task(
@@ -239,12 +274,17 @@ def specify_task(
                 task_id, False, "LLM response missing title and body"
             )
 
+    assignee = None
+    if not task.assignee:
+        assignee = _resolve_default_assignee()
+
     with kb.connect() as conn:
         ok = kb.specify_triage_task(
             conn,
             task_id,
             title=new_title,
             body=new_body,
+            assignee=assignee,
             author=author or _profile_author(),
         )
     if not ok:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -73,6 +73,15 @@ _last_init_error_lock = threading.Lock()
 _wal_fallback_warned_paths: set[str] = set()
 _wal_fallback_warned_lock = threading.Lock()
 
+# DB labels that already proved WAL-incompatible in this process. Some
+# filesystems (notably flaky FUSE/network mounts) can leave a connection in a
+# bad state after a failed ``PRAGMA journal_mode=WAL`` attempt, so continuing to
+# retry WAL on every short-lived dashboard/API connection can produce a stream
+# of ``disk I/O error`` failures even though DELETE mode itself is viable.
+# Once a label falls back, future connections go straight to DELETE mode.
+_wal_fallback_delete_only_paths: set[str] = set()
+_wal_fallback_delete_only_lock = threading.Lock()
+
 
 def _set_last_init_error(msg: Optional[str]) -> None:
     """Record (or clear) the most recent state.db init failure.
@@ -148,6 +157,17 @@ def apply_wal_with_fallback(
     Shared by :class:`SessionDB` and ``hermes_cli.kanban_db.connect`` so
     both databases get identical fallback behavior.
     """
+    with _wal_fallback_delete_only_lock:
+        delete_only = db_label in _wal_fallback_delete_only_paths
+    if delete_only:
+        # The first fallback already switched this DB label to DELETE mode.
+        # Re-running PRAGMA journal_mode=DELETE on every short-lived connection
+        # can itself raise transient ``disk I/O error`` on flaky filesystems or
+        # while another process is holding SQLite state, which turns the
+        # fallback cache into per-tick dispatcher log spam.  Treat the cached
+        # label as authoritative and avoid touching journal_mode again.
+        return "delete"
+
     try:
         conn.execute("PRAGMA journal_mode=WAL")
         return "wal"
@@ -157,6 +177,8 @@ def apply_wal_with_fallback(
             # Unrelated OperationalError — don't silently swallow.
             raise
         _log_wal_fallback_once(db_label, exc)
+        with _wal_fallback_delete_only_lock:
+            _wal_fallback_delete_only_paths.add(db_label)
         conn.execute("PRAGMA journal_mode=DELETE")
         return "delete"
 

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -660,7 +660,10 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                     metadata=payload.metadata,
                 )
             elif s == "blocked":
-                ok = kanban_db.block_task(conn, task_id, reason=payload.block_reason)
+                try:
+                    ok = kanban_db.block_task(conn, task_id, reason=payload.block_reason)
+                except ValueError as exc:
+                    raise HTTPException(status_code=409, detail=str(exc)) from exc
             elif s == "scheduled":
                 ok = kanban_db.schedule_task(conn, task_id, reason=payload.block_reason)
             elif s == "ready":

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1331,7 +1331,18 @@ class HindsightMemoryProvider(MemoryProvider):
                     resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
                     num_results = len(resp.results) if resp.results else 0
                     logger.debug("Prefetch: recall returned %d results", num_results)
-                    text = "\n".join(f"- {r.text}" for r in resp.results if r.text) if resp.results else ""
+                    recall_lines: list[str] = []
+                    seen_texts: set[str] = set()
+                    for result in resp.results or []:
+                        raw_text = (result.text or "").strip()
+                        if not raw_text:
+                            continue
+                        normalized_text = " ".join(raw_text.split())
+                        if normalized_text in seen_texts:
+                            continue
+                        seen_texts.add(normalized_text)
+                        recall_lines.append(f"- {raw_text}")
+                    text = "\n".join(recall_lines)
                 if text:
                     with self._prefetch_lock:
                         self._prefetch_result = text

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -575,6 +575,44 @@ class TestDeliverResultWrapping:
         assert "Cronjob Response" not in sent_content
         assert "The agent cannot see" not in sent_content
 
+    def test_delivery_uses_notifications_telegram_token_even_with_live_adapter(self, monkeypatch):
+        """Cron Telegram notifications should use the dedicated Notifications bot when configured."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        pconfig.token = "ava-token"
+        pconfig.extra = {}
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        live_adapter = AsyncMock()
+        live_adapter.send.return_value = MagicMock(success=True)
+        loop = MagicMock()
+        loop.is_running.return_value = True
+        monkeypatch.setenv("NOTIFICATIONS_TELEGRAM_BOT_TOKEN", "noti-token")
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("tools.send_message_tool._send_telegram", new=AsyncMock(return_value={"success": True})) as send_mock:
+            job = {
+                "id": "notify-job",
+                "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+            }
+            _deliver_result(
+                job,
+                "Notifier output.",
+                adapters={Platform.TELEGRAM: live_adapter},
+                loop=loop,
+            )
+
+        live_adapter.send.assert_not_called()
+        send_mock.assert_called_once()
+        assert send_mock.call_args.args[0] == "noti-token"
+        assert send_mock.call_args.args[1] == "123"
+        assert "Notifier output." in send_mock.call_args.args[2]
+
     def test_delivery_extracts_media_tags_before_send(self, tmp_path, monkeypatch):
         """Cron delivery should pass MEDIA attachments separately to the send helper."""
         from gateway.config import Platform

--- a/tests/cron/test_vicky_kanban_cron_watchdogs.py
+++ b/tests/cron/test_vicky_kanban_cron_watchdogs.py
@@ -1,0 +1,116 @@
+"""Regression coverage for Vicky's profile-local Kanban cron watchdog scripts.
+
+These scripts live outside the hermes-agent repo, but this repo-managed test
+file pins the operational behavior that keeps no-agent cron jobs quiet while
+still surfacing Kanban DB corruption to agents/operators.
+"""
+from __future__ import annotations
+
+import contextlib
+import importlib
+import io
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path("/home/john/.hermes/profiles/vicky/scripts")
+
+
+def import_script(name: str):
+    if not SCRIPTS_DIR.exists():
+        raise AssertionError(f"missing vicky scripts dir: {SCRIPTS_DIR}")
+    if str(SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS_DIR))
+    sys.modules.pop(name, None)
+    return importlib.import_module(name)
+
+
+def make_corrupt_board(root: Path, board: str = "hermes-setup") -> Path:
+    board_dir = root / board
+    board_dir.mkdir(parents=True)
+    db = board_dir / "kanban.db"
+    db.write_bytes(b"not sqlite at all")
+    return db
+
+
+def test_quick_check_detects_corrupt_board_without_writing(tmp_path):
+    alerts = import_script("kanban_cron_alerts")
+    db = make_corrupt_board(tmp_path / "boards")
+    before = db.read_bytes()
+
+    errors = alerts.kanban_integrity_errors(tmp_path / "boards", boards={"hermes-setup"})
+
+    assert errors
+    assert "hermes-setup" in errors[0]
+    assert "quick_check failed" in errors[0]
+    assert db.read_bytes() == before
+
+
+def test_integrity_routing_writes_operator_fallback_when_board_create_fails(tmp_path, monkeypatch):
+    alerts = import_script("kanban_cron_alerts")
+    log_path = tmp_path / "agent_alerts.jsonl"
+    fallback_path = tmp_path / "fallback.md"
+    monkeypatch.setattr(alerts, "LOG_PATH", log_path)
+    monkeypatch.setattr(alerts, "FALLBACK_ALERT_PATH", fallback_path)
+
+    class FailedCreate:
+        returncode = 1
+        stdout = ""
+        stderr = "database disk image is malformed"
+
+    monkeypatch.setattr(alerts.subprocess, "run", lambda *args, **kwargs: FailedCreate())
+
+    stopped = alerts.route_integrity_errors_to_agent(
+        "kanban_monitor",
+        ["hermes-setup: wrong # of entries in index idx_events_task"],
+        assignee="coder",
+    )
+
+    assert stopped is True
+    assert log_path.exists()
+    record = json.loads(log_path.read_text(encoding="utf-8").splitlines()[-1])
+    assert record["create_rc"] == 1
+    assert record["fallback_breadcrumb"] == str(fallback_path)
+    text = fallback_path.read_text(encoding="utf-8")
+    assert "Kanban cron failure needs agent/operator review" in text
+    assert "hermes-setup: wrong # of entries" in text
+    assert "database disk image is malformed" in text
+
+
+def test_no_agent_cron_mode_routes_integrity_failure_and_stays_silent(monkeypatch):
+    queue_pusher = import_script("kanban_queue_pusher")
+    calls = []
+    monkeypatch.setattr(
+        queue_pusher,
+        "kanban_integrity_errors",
+        lambda boards=None: ["hermes-setup: quick_check failed for test"],
+    )
+    monkeypatch.setattr(
+        queue_pusher,
+        "route_integrity_errors_to_agent",
+        lambda source, errors, assignee="coder": calls.append((source, errors, assignee)) or True,
+    )
+
+    stdout = io.StringIO()
+    with contextlib.redirect_stdout(stdout):
+        rc = queue_pusher.main()
+
+    assert rc == 0
+    assert stdout.getvalue() == ""
+    assert calls == [("kanban_queue_pusher", ["hermes-setup: quick_check failed for test"], "coder")]
+
+
+def test_check_noop_fails_noisily_for_corrupt_board(tmp_path, monkeypatch):
+    monitor = import_script("kanban_monitor")
+    make_corrupt_board(tmp_path / "boards")
+    monkeypatch.setattr(monitor, "KANBAN_ROOT", tmp_path / "boards")
+    monkeypatch.setattr(sys, "argv", ["kanban_monitor.py", "--check-noop"])
+
+    stdout = io.StringIO()
+    with contextlib.redirect_stdout(stdout):
+        rc = monitor.main()
+
+    assert rc == 1
+    assert "hermes-setup" in stdout.getvalue()
+    assert "quick_check" in stdout.getvalue()

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -1,5 +1,7 @@
 import asyncio
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -11,9 +13,21 @@ from hermes_cli import kanban_db as kb
 class RecordingAdapter:
     def __init__(self):
         self.sent = []
+        self.documents = []
+        self.images = []
+        self.videos = []
 
     async def send(self, chat_id, text, metadata=None):
         self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
+
+    async def send_document(self, chat_id, file_path, metadata=None):
+        self.documents.append({"chat_id": chat_id, "file_path": file_path, "metadata": metadata or {}})
+
+    async def send_multiple_images(self, chat_id, images, metadata=None):
+        self.images.append({"chat_id": chat_id, "images": images, "metadata": metadata or {}})
+
+    async def send_video(self, chat_id, video_path, metadata=None):
+        self.videos.append({"chat_id": chat_id, "video_path": video_path, "metadata": metadata or {}})
 
 
 class DisconnectedAdapters(dict):
@@ -24,6 +38,8 @@ class DisconnectedAdapters(dict):
 
 
 async def _run_one_notifier_tick(monkeypatch, runner):
+    monkeypatch.setenv("HERMES_KANBAN_NOTIFY_IN_GATEWAY", "1")
+    runner._running = True
     real_sleep = asyncio.sleep
 
     async def fake_sleep(delay):
@@ -50,6 +66,26 @@ def _create_completed_subscription(summary="done once"):
         tid = kb.create_task(conn, title="notify once", assignee="worker")
         kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
         kb.complete_task(conn, tid, summary=summary)
+        return tid
+    finally:
+        conn.close()
+
+
+def _create_completed_subscription_with_artifacts(artifacts, summary="done with artifact"):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="notify artifact", assignee="worker")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        kb.complete_task(
+            conn,
+            tid,
+            summary=summary,
+            metadata={
+                "artifacts": artifacts,
+                "review_required": False,
+                "review_skip_reason": "notifier artifact delivery regression test",
+            },
+        )
         return tid
     finally:
         conn.close()
@@ -85,8 +121,66 @@ def test_kanban_notifier_dedupes_board_slugs_pointing_to_same_db(tmp_path, monke
     asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
 
     assert len(adapter.sent) == 1
-    assert "Kanban" in adapter.sent[0]["text"]
-    assert tid in adapter.sent[0]["text"]
+    assert adapter.sent[0]["text"] == "✅ Done: notify once"
+    assert "done once" not in adapter.sent[0]["text"]
+    assert tid not in adapter.sent[0]["text"]
+
+
+def test_kanban_notifier_watcher_respects_env_override(monkeypatch):
+    """HERMES_KANBAN_NOTIFY_IN_GATEWAY=0 disables notifier DB polling."""
+    monkeypatch.setenv("HERMES_KANBAN_NOTIFY_IN_GATEWAY", "0")
+    monkeypatch.setattr(kb, "list_boards", lambda **_: pytest.fail("notifier touched kanban DB"))
+
+    runner = _make_runner(RecordingAdapter())
+
+    asyncio.run(
+        asyncio.wait_for(
+            runner._kanban_notifier_watcher(interval=1),
+            timeout=3.0,
+        )
+    )
+
+
+def test_kanban_notifier_watcher_respects_config_flag_off(monkeypatch):
+    """kanban.notify_in_gateway=false disables notifier DB polling."""
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"kanban": {"notify_in_gateway": False}},
+    )
+    monkeypatch.setattr(kb, "list_boards", lambda **_: pytest.fail("notifier touched kanban DB"))
+
+    runner = _make_runner(RecordingAdapter())
+
+    asyncio.run(
+        asyncio.wait_for(
+            runner._kanban_notifier_watcher(interval=1),
+            timeout=3.0,
+        )
+    )
+
+
+def test_kanban_notifier_completion_message_rejects_extra_prose(tmp_path, monkeypatch):
+    db_path = tmp_path / "terse-completion-message.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    tid = _create_completed_subscription(
+        summary="Good info: deployment finished cleanly with no follow-up needed"
+    )
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    message = adapter.sent[0]["text"]
+    assert message == "✅ Done: notify once"
+    assert message.count("\n") == 0
+    assert "Good info" not in message
+    assert "deployment finished" not in message
+    assert "worker" not in message
+    assert tid not in message
 
 
 def test_kanban_notifier_claim_prevents_second_watcher_send(tmp_path, monkeypatch):
@@ -104,6 +198,83 @@ def test_kanban_notifier_claim_prevents_second_watcher_send(tmp_path, monkeypatc
 
     assert len(adapter1.sent) == 1
     assert adapter2.sent == []
+
+
+def test_kanban_notifier_home_channel_reports_completion_without_task_subscription(tmp_path, monkeypatch):
+    """Home-channel completion pings must not depend on per-task subscriptions.
+
+    A paused/absent broad fallback cron should not make Kanban completions go
+    silent: the gateway watcher itself owns a durable board-level cursor for
+    configured home channels.
+    """
+    db_path = tmp_path / "home-channel-completion.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    runner.config = SimpleNamespace(
+        platforms={
+            Platform.TELEGRAM: SimpleNamespace(enabled=True, token="bot-token", extra={})
+        },
+        get_home_channel=lambda platform: SimpleNamespace(
+            chat_id="home-chat", thread_id=None
+        ) if platform == Platform.TELEGRAM else None,
+    )
+
+    # First tick initializes the durable board-level cursor without replaying
+    # historical task events.
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="unsubscribed completion", assignee="worker")
+        kb.complete_task(conn, tid, summary="internal handoff text stays out of the ping")
+    finally:
+        conn.close()
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert [msg["text"] for msg in adapter.sent] == ["✅ Done: unsubscribed completion"]
+    assert adapter.sent[0]["chat_id"] == "home-chat"
+    assert tid not in adapter.sent[0]["text"]
+    assert "internal handoff" not in adapter.sent[0]["text"]
+
+
+def test_kanban_notifier_home_channel_skips_completion_with_matching_task_subscription(tmp_path, monkeypatch):
+    """Board-level home pings must not duplicate matching per-task subscriptions."""
+    db_path = tmp_path / "home-channel-matching-task-sub.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    runner.config = SimpleNamespace(
+        platforms={
+            Platform.TELEGRAM: SimpleNamespace(enabled=True, token="bot-token", extra={})
+        },
+        get_home_channel=lambda platform: SimpleNamespace(
+            chat_id="home-chat", thread_id=None
+        ) if platform == Platform.TELEGRAM else None,
+    )
+
+    # Initialize the board-level cursor before the task exists.
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="subscribed completion", assignee="worker")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="home-chat")
+        kb.complete_task(conn, tid, summary="task-scoped sub owns this ping")
+    finally:
+        conn.close()
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert [msg["text"] for msg in adapter.sent] == ["✅ Done: subscribed completion"]
+    assert adapter.sent[0]["chat_id"] == "home-chat"
 
 
 def test_kanban_notifier_rewinds_claim_if_adapter_disconnects(tmp_path, monkeypatch):
@@ -138,6 +309,37 @@ def test_kanban_db_path_is_test_isolated_from_real_home():
     assert kb.kanban_db_path().resolve() != production_db.resolve()
 
 
+def test_kanban_notifier_uses_notifications_bot_for_telegram(tmp_path, monkeypatch):
+    """Telegram kanban notifications should use the dedicated notifier token when configured."""
+    db_path = tmp_path / "notifications-bot.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    monkeypatch.setenv("NOTIFICATIONS_TELEGRAM_BOT_TOKEN", "noti-token")
+    kb.init_db()
+
+    tid = _create_completed_subscription()
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    runner.config = SimpleNamespace(
+        platforms={
+            Platform.TELEGRAM: SimpleNamespace(
+                enabled=True,
+                token="ava-token",
+                extra={},
+            )
+        }
+    )
+
+    with patch("tools.send_message_tool._send_telegram", new=AsyncMock(return_value={"success": True})) as send_mock:
+        asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert adapter.sent == []
+    send_mock.assert_called_once()
+    assert send_mock.call_args.args[0] == "noti-token"
+    assert send_mock.call_args.args[1] == "chat-1"
+    assert send_mock.call_args.args[2] == "✅ Done: notify once"
+    assert tid not in send_mock.call_args.args[2]
+
+
 class FailingAdapter:
     """Adapter whose send() always raises, simulating a transient send error."""
 
@@ -147,6 +349,112 @@ class FailingAdapter:
     async def send(self, chat_id, text, metadata=None):
         self.attempts += 1
         raise RuntimeError("simulated send failure")
+
+
+class ErrorResultAdapter:
+    """Adapter that reports a downstream API error without raising."""
+
+    def __init__(self, error="downstream API stack trace: token=secret-token"):
+        self.error = error
+        self.sent = []
+
+    async def send(self, chat_id, text, metadata=None):
+        self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
+        return {"error": self.error}
+
+
+class FailOnceOnSecondSendAdapter:
+    """Adapter that accepts the first send, fails the second once, then recovers."""
+
+    def __init__(self):
+        self.sent = []
+        self._failed_second_send = False
+
+    async def send(self, chat_id, text, metadata=None):
+        self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
+        if len(self.sent) == 2 and not self._failed_second_send:
+            self._failed_second_send = True
+            raise RuntimeError("transient failure on second board ping")
+
+
+def test_kanban_notifier_board_home_partial_failure_does_not_duplicate_prior_success(tmp_path, monkeypatch):
+    """A failed later board-level ping must not redeliver already-sent earlier pings."""
+    db_path = tmp_path / "board-partial-failure.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    adapter = FailOnceOnSecondSendAdapter()
+    runner = _make_runner(adapter)
+    runner.config = SimpleNamespace(
+        platforms={
+            Platform.TELEGRAM: SimpleNamespace(enabled=True, token="bot-token", extra={})
+        },
+        get_home_channel=lambda platform: SimpleNamespace(
+            chat_id="home-chat", thread_id=None
+        ) if platform == Platform.TELEGRAM else None,
+    )
+
+    # Initialize the board-level cursor without replaying historical events.
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    conn = kb.connect()
+    try:
+        first = kb.create_task(conn, title="one", assignee="worker")
+        second = kb.create_task(conn, title="two", assignee="worker")
+        kb.complete_task(conn, first, summary="first done")
+        kb.complete_task(conn, second, summary="second done")
+    finally:
+        conn.close()
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+    assert [msg["text"] for msg in adapter.sent] == [
+        "✅ Done: one",
+        "✅ Done: two",
+    ]
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+    assert [msg["text"] for msg in adapter.sent] == [
+        "✅ Done: one",
+        "✅ Done: two",
+        "✅ Done: two",
+    ]
+
+
+def test_kanban_notifier_artifacts_use_notifications_bot_for_telegram(tmp_path, monkeypatch):
+    """Artifact uploads for Telegram kanban notifications should also use the dedicated notifier token."""
+    db_path = tmp_path / "notifications-bot-artifacts.db"
+    artifact = tmp_path / "handoff.txt"
+    artifact.write_text("artifact payload", encoding="utf-8")
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    monkeypatch.setenv("NOTIFICATIONS_TELEGRAM_BOT_TOKEN", "notifier-token")
+    monkeypatch.setenv("HERMES_MEDIA_ALLOW_DIRS", str(tmp_path))
+    kb.init_db()
+
+    _create_completed_subscription_with_artifacts([str(artifact)])
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    runner.config = SimpleNamespace(
+        platforms={
+            Platform.TELEGRAM: SimpleNamespace(
+                enabled=True,
+                token="interactive-token",
+                extra={},
+            )
+        }
+    )
+
+    with patch("tools.send_message_tool._send_telegram", new=AsyncMock(return_value={"success": True})) as send_mock:
+        asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert adapter.sent == []
+    assert adapter.documents == []
+    assert adapter.images == []
+    assert adapter.videos == []
+    assert send_mock.call_count == 2
+    artifact_call = send_mock.call_args_list[-1]
+    assert artifact_call.args[0] == "notifier-token"
+    assert artifact_call.args[1] == "chat-1"
+    assert artifact_call.kwargs["media_files"] == [(str(artifact), False)]
 
 
 def test_kanban_notifier_rewinds_claim_on_send_exception(tmp_path, monkeypatch):
@@ -174,28 +482,81 @@ def test_kanban_notifier_rewinds_claim_on_send_exception(tmp_path, monkeypatch):
     assert [ev.kind for ev in _unseen_terminal_events(tid)] == ["completed"]
 
 
-def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
-    """A retry cycle (crashed → reclaimed → crashed) notifies the user twice.
+def test_kanban_notifier_rewinds_claim_on_adapter_error_result(tmp_path, monkeypatch, caplog):
+    """API-style error results are logged internally and retried, not silently advanced."""
+    db_path = tmp_path / "send-error-result.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    tid = _create_completed_subscription()
 
-    Before #21398 the notifier auto-unsubscribed on any terminal event kind
-    (gave_up / crashed / timed_out), so the second crash in a respawn cycle
-    silently dropped — the subscription was already gone. This test pins the
-    new contract: subscription survives non-final terminal events; the
-    cursor handles dedup.
+    adapter = ErrorResultAdapter(error="telegram 500: raw traceback payload")
+    runner = _make_runner(adapter)
 
-    Two crashes ten seconds apart on the same task — both should land on
-    the adapter.
+    with caplog.at_level("WARNING", logger="gateway.run"):
+        asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert [msg["text"] for msg in adapter.sent] == ["✅ Done: notify once"]
+    assert "telegram 500" not in adapter.sent[0]["text"]
+    assert [ev.kind for ev in _unseen_terminal_events(tid)] == ["completed"]
+    assert "kanban notifier: send failed" in caplog.text
+    assert "telegram 500" in caplog.text
+
+
+def test_kanban_notifier_drops_dead_subscription_after_repeated_send_errors(tmp_path, monkeypatch, caplog):
+    """Repeated downstream send errors stop retry spam by removing task subscriptions."""
+    db_path = tmp_path / "send-error-drop-sub.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    tid = _create_completed_subscription()
+
+    adapter = ErrorResultAdapter(error="telegram 403: bot was kicked")
+    runner = _make_runner(adapter)
+
+    with caplog.at_level("WARNING", logger="gateway.run"):
+        for _ in range(3):
+            asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 3
+    assert all(msg["text"] == "✅ Done: notify once" for msg in adapter.sent)
+    assert all("telegram 403" not in msg["text"] for msg in adapter.sent)
+    conn = kb.connect()
+    try:
+        assert kb.list_notify_subs(conn, tid) == []
+    finally:
+        conn.close()
+    assert "dropping subscription" in caplog.text
+    assert "telegram 403" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "event_kind,event_payload",
+    [
+        ("created", {"status": "running"}),
+        ("assigned", {"assignee": "new-worker"}),
+        ("status", {"from": "running", "to": "ready"}),
+        ("commented", {"author": "reviewer", "len": 12}),
+        ("blocked", {"reason": "needs review"}),
+        ("crashed", None),
+        ("timed_out", {"limit_seconds": 60}),
+    ],
+)
+def test_notifier_ignores_non_completion_events(
+    tmp_path, monkeypatch, event_kind, event_payload,
+):
+    """The dedicated notification bot is completion-only.
+
+    Creation, assignment, non-done status movement, comments, blocked/stuck,
+    and retry-loop worker failures should not send noti-bot messages.
     """
-    db_path = tmp_path / "redeliver-cycle.db"
+    db_path = tmp_path / f"non-completion-{event_kind}.db"
     monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
     kb.init_db()
 
     conn = kb.connect()
     try:
-        tid = kb.create_task(conn, title="cycle test", assignee="worker")
+        tid = kb.create_task(conn, title=f"{event_kind} test", assignee="worker")
         kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
-        # First crash — fired by the dispatcher when the worker PID dies.
-        kb._append_event(conn, tid, kind="crashed")
+        kb._append_event(conn, tid, kind=event_kind, payload=event_payload)
     finally:
         conn.close()
 
@@ -203,34 +564,37 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
     runner = _make_runner(adapter)
     asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
 
-    # First crash delivered.
-    assert len(adapter.sent) == 1
-    assert "crashed" in adapter.sent[0]["text"].lower()
+    assert adapter.sent == []
 
-    # Subscription survives — the cursor advanced past event #1, but the
-    # row is still there.
     conn = kb.connect()
     try:
-        subs = kb.list_notify_subs(conn, tid)
-        assert len(subs) == 1, (
-            "Subscription must survive a crashed event so a respawn-cycle "
-            "second crash also notifies the user (issue #21398)."
-        )
-
-        # Second crash — same task, same dispatcher (or a respawn). Append
-        # another event to simulate the dispatcher firing crashed a second
-        # time during retry.
-        kb._append_event(conn, tid, kind="crashed")
+        assert len(kb.list_notify_subs(conn, tid)) == 1
     finally:
         conn.close()
 
-    # New tick: the second event has a fresh id past the cursor advance,
-    # so it gets claimed and delivered.
+
+def test_notifier_ignores_non_completion_events_before_later_completion(
+    tmp_path, monkeypatch,
+):
+    """Earlier non-completion events must not block a later completion ping."""
+    db_path = tmp_path / "non-completion-before-completion.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="eventual completion", assignee="worker")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        kb.add_comment(conn, tid, "reviewer", "please revise")
+        kb._append_event(conn, tid, kind="status", payload={"from": "running", "to": "ready"})
+        kb.complete_task(conn, tid, summary="finished after intermediate noise")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
     runner = _make_runner(adapter)
     asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
 
-    assert len(adapter.sent) == 2, (
-        f"Second crashed event should also notify; got {len(adapter.sent)} "
-        f"deliveries (texts: {[d['text'] for d in adapter.sent]})"
-    )
-    assert "crashed" in adapter.sent[1]["text"].lower()
+    assert len(adapter.sent) == 1
+    assert adapter.sent[0]["text"] == "✅ Done: eventual completion"
+    assert "finished after intermediate noise" not in adapter.sent[0]["text"]

--- a/tests/gateway/test_kanban_reply_targets.py
+++ b/tests/gateway/test_kanban_reply_targets.py
@@ -1,0 +1,156 @@
+import asyncio
+import time
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+from hermes_cli import kanban_db as kb
+
+
+def _event(text="accept", *, reply_to="msg-1", user_id="user-1", chat_id="chat-1", thread_id=None):
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id=chat_id,
+            user_id=user_id,
+            user_name="Gibs",
+            thread_id=thread_id,
+        ),
+        message_id="incoming-1",
+        reply_to_message_id=reply_to,
+    )
+
+
+def _runner():
+    return GatewayRunner.__new__(GatewayRunner)
+
+
+def _seed_target(*, payload=None, user_id="user-1", expires_at=None):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="rough intake", assignee="triage", triage=True)
+        kb.add_reply_target(
+            conn,
+            platform="telegram",
+            chat_id="chat-1",
+            message_id="msg-1",
+            task_id=tid,
+            proposal_id="p_20260523_001",
+            user_id=user_id,
+            payload=payload or {
+                "title": "specified intake",
+                "body": "Full task body from the proposal.",
+                "assignee": "worker",
+            },
+            expires_at=expires_at,
+        )
+        return tid
+    finally:
+        conn.close()
+
+
+def _target_for(tid):
+    conn = kb.connect()
+    try:
+        return kb.list_reply_targets(conn, task_id=tid)[0]
+    finally:
+        conn.close()
+
+
+def test_direct_reply_accept_applies_triage_proposal(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "accept.db"))
+    kb.init_db()
+    tid = _seed_target()
+
+    ack = asyncio.run(_runner()._maybe_handle_kanban_reply_target(_event("accept")))
+
+    assert ack == "Accepted — I applied that Kanban proposal."
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, tid)
+        assert task.title == "specified intake"
+        assert task.body == "Full task body from the proposal."
+        assert task.assignee == "worker"
+        assert task.status == "ready"
+        assert kb.list_reply_targets(conn, task_id=tid)[0]["status"] == "accepted"
+        comments = [c.body for c in kb.list_comments(conn, tid)]
+        assert any("Accepted triage proposal p_20260523_001" in body for body in comments)
+    finally:
+        conn.close()
+
+
+def test_direct_reply_reject_marks_proposal_and_comments(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "reject.db"))
+    kb.init_db()
+    tid = _seed_target()
+
+    ack = asyncio.run(_runner()._maybe_handle_kanban_reply_target(_event("reject: not enough detail")))
+
+    assert ack == "Noted — I rejected that Kanban proposal and saved your feedback."
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, tid).status == "triage"
+        assert kb.list_reply_targets(conn, task_id=tid)[0]["status"] == "rejected"
+        comments = [c.body for c in kb.list_comments(conn, tid)]
+        assert any("not enough detail" in body for body in comments)
+    finally:
+        conn.close()
+
+
+def test_direct_reply_unknown_anchor_falls_through(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "unknown.db"))
+    kb.init_db()
+
+    assert asyncio.run(_runner()._maybe_handle_kanban_reply_target(_event("accept"))) is None
+
+
+def test_direct_reply_invalid_action_sends_help_without_updating(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "invalid.db"))
+    kb.init_db()
+    tid = _seed_target()
+
+    ack = asyncio.run(_runner()._maybe_handle_kanban_reply_target(_event("maybe")))
+
+    assert "Reply with `accept`" in ack
+    assert _target_for(tid)["status"] == "active"
+
+
+def test_direct_reply_unauthorized_user_fails_safely(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "unauthorized.db"))
+    kb.init_db()
+    tid = _seed_target(user_id="owner")
+
+    ack = asyncio.run(_runner()._maybe_handle_kanban_reply_target(_event("accept", user_id="intruder")))
+
+    assert "different user" in ack
+    assert _target_for(tid)["status"] == "active"
+
+
+def test_direct_reply_expired_target_is_not_applied(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "expired.db"))
+    kb.init_db()
+    tid = _seed_target(expires_at=int(time.time()) - 1)
+
+    ack = asyncio.run(_runner()._maybe_handle_kanban_reply_target(_event("accept")))
+
+    assert "expired" in ack
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, tid).status == "triage"
+        assert kb.list_reply_targets(conn, task_id=tid)[0]["status"] == "expired"
+    finally:
+        conn.close()
+
+
+def test_direct_reply_accepts_explicit_proposal_id_prefix(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "proposal-prefix.db"))
+    kb.init_db()
+    tid = _seed_target()
+
+    ack = asyncio.run(_runner()._maybe_handle_kanban_reply_target(_event("p_20260523_001 accept")))
+
+    assert ack == "Accepted — I applied that Kanban proposal."
+    assert _target_for(tid)["status"] == "accepted"

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -1101,6 +1101,45 @@ async def test_restart_notifies_home_channel_even_without_active_sessions():
 
 
 @pytest.mark.asyncio
+async def test_restart_shutdown_notifications_ignore_dedicated_notifications_bot(monkeypatch):
+    """Gateway restart warnings are operational notices, not Kanban completions."""
+    monkeypatch.setenv("NOTIFICATIONS_TELEGRAM_BOT_TOKEN", "notifier-token")
+    runner, adapter = make_restart_runner()
+    runner._restart_requested = True
+    runner._running_agents["agent:main:telegram:dm:999"] = MagicMock()
+
+    with patch("tools.send_message_tool._send_telegram", new=AsyncMock(return_value={"success": True})) as send_mock:
+        await runner._notify_active_sessions_of_shutdown()
+
+    sent = getattr(adapter, "sent")
+    assert len(sent) == 1
+    assert "Gateway restarting" in sent[0]
+    send_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_restart_home_channel_notification_ignores_dedicated_notifications_bot(monkeypatch):
+    """Home-channel restart warnings should stay on the interactive adapter."""
+    monkeypatch.setenv("NOTIFICATIONS_TELEGRAM_BOT_TOKEN", "notifier-token")
+    runner, adapter = make_restart_runner()
+    runner._restart_requested = True
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+
+    with patch("tools.send_message_tool._send_telegram", new=AsyncMock(return_value={"success": True})) as send_mock:
+        await runner._notify_active_sessions_of_shutdown()
+
+    assert getattr(adapter, "sent") == [
+        "⚠️ Gateway restarting — Your current task will be interrupted. "
+        "Send any message after restart and I'll try to resume where you left off."
+    ]
+    send_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_restart_home_channel_notification_dedupes_active_chat():
     runner, adapter = make_restart_runner()
     runner._restart_requested = True

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -485,6 +485,15 @@ class TestOptionalEnvVarsRegistry:
             all_vars.extend(vars_list)
         assert "TAVILY_API_KEY" in all_vars
 
+    def test_notifications_telegram_token_registered(self):
+        """Dedicated notification Telegram bot token is registered as a secret."""
+        from hermes_cli.config import OPTIONAL_ENV_VARS
+
+        entry = OPTIONAL_ENV_VARS["NOTIFICATIONS_TELEGRAM_BOT_TOKEN"]
+        assert entry["category"] == "messaging"
+        assert entry["password"] is True
+        assert entry["advanced"] is True
+
 
 class TestAnthropicTokenMigration:
     """Test that config version 8→9 clears ANTHROPIC_TOKEN."""

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -48,6 +48,16 @@ def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return home
 
 
+def _add_review_requested_events(conn, task_id: str, count: int = 2) -> None:
+    for idx in range(count):
+        kb._append_event(
+            conn,
+            task_id,
+            "review_requested",
+            {"reason": f"review {idx + 1}"},
+        )
+
+
 # ---------------------------------------------------------------------------
 # Worker-initiated kanban_block must be sticky
 # ---------------------------------------------------------------------------
@@ -61,6 +71,7 @@ def test_worker_block_is_not_auto_promoted_by_recompute_ready(kanban_home: Path)
     with kb.connect() as conn:
         tid = kb.create_task(conn, title="needs human review")
         kb.claim_task(conn, tid)
+        _add_review_requested_events(conn, tid)
         assert kb.block_task(
             conn, tid,
             reason="review-required: please verify ACL change",
@@ -87,6 +98,7 @@ def test_worker_block_on_child_with_done_parents_is_still_sticky(kanban_home: Pa
         kb.complete_task(conn, parent, result="parent ok")
 
         kb.claim_task(conn, child)
+        _add_review_requested_events(conn, child)
         kb.block_task(
             conn, child,
             reason="review-required: child needs sign-off",
@@ -172,6 +184,7 @@ def test_unblock_clears_sticky_state_and_lets_block_recover(kanban_home: Path) -
     with kb.connect() as conn:
         tid = kb.create_task(conn, title="t")
         kb.claim_task(conn, tid)
+        _add_review_requested_events(conn, tid)
         kb.block_task(
             conn, tid,
             reason="review-required: ...",
@@ -223,6 +236,7 @@ def test_protocol_violation_loop_is_broken(kanban_home: Path) -> None:
     with kb.connect() as conn:
         tid = kb.create_task(conn, title="loop reproducer")
         kb.claim_task(conn, tid)
+        _add_review_requested_events(conn, tid)
         kb.block_task(
             conn, tid,
             reason="review-required: human eyes please",

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -152,10 +152,22 @@ def test_run_slash_block_unblock_cycle(kanban_home):
     out = kc.run_slash("create 'x' --assignee alice")
     import re
     tid = re.search(r"(t_[a-f0-9]+)", out).group(1)
-    # Claim first so block() finds it running
+    # Claim first so block() finds it running. First-run human gates must use
+    # the explicit escape hatch, not the reviewer-handoff path.
     kc.run_slash(f"claim {tid}")
-    assert "Blocked" in kc.run_slash(f"block {tid} 'need decision'")
+    assert "Blocked" in kc.run_slash(f"block {tid} --human-gate 'need decision'")
     assert "Unblocked" in kc.run_slash(f"unblock {tid}")
+
+
+def test_run_slash_block_without_human_gate_preserves_review_prerequisite(kanban_home):
+    out = kc.run_slash("create 'x' --assignee alice")
+    import re
+    tid = re.search(r"(t_[a-f0-9]+)", out).group(1)
+    kc.run_slash(f"claim {tid}")
+
+    blocked = kc.run_slash(f"block {tid} 'implementation handoff parked as blocked'")
+
+    assert "requires at least 2 review_requested" in blocked
 
 
 def test_run_slash_json_output(kanban_home):

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -40,6 +40,16 @@ def kanban_home(tmp_path, monkeypatch):
     return home
 
 
+def _add_review_requested_events(conn, task_id: str, count: int = 2) -> None:
+    for idx in range(count):
+        kb._append_event(
+            conn,
+            task_id,
+            "review_requested",
+            {"reason": f"review {idx + 1}"},
+        )
+
+
 # ---------------------------------------------------------------------------
 # Idempotency key
 # ---------------------------------------------------------------------------
@@ -105,6 +115,59 @@ def test_spawn_failure_auto_blocks_after_limit(kanban_home, all_assignees_spawna
         assert task.status == "blocked"
         assert task.consecutive_failures >= 2
         assert task.last_failure_error and "no PATH" in task.last_failure_error
+    finally:
+        conn.close()
+
+
+def test_missing_task_skill_blocks_before_spawn_and_stays_blocked(
+    kanban_home,
+    all_assignees_spawnable,
+):
+    """A task that requests an unknown skill should not crash-loop.
+
+    The dispatcher should catch the impossible worker preload before spawning,
+    sticky-block the task with a clear reason, and then leave it alone on the
+    next tick instead of promoting it back to ready.
+    """
+    def _must_not_spawn(task, ws):
+        raise AssertionError("dispatcher should block before spawning")
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="needs missing skill",
+            assignee="worker",
+            skills=["definitely-missing-skill"],
+        )
+
+        res = kb.dispatch_once(conn, spawn_fn=_must_not_spawn)
+
+        assert tid in res.auto_blocked
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "blocked"
+        assert task.last_failure_error is not None
+        assert "definitely-missing-skill" in task.last_failure_error
+        assert tid in task.last_failure_error
+
+        events = kb.list_events(conn, tid)
+        blocked_events = [e for e in events if e.kind == "blocked"]
+        assert len(blocked_events) == 1
+        payload = blocked_events[-1].payload
+        assert payload is not None
+        assert "definitely-missing-skill" in payload["reason"]
+        assert tid in payload["reason"]
+
+        before_kinds = [e.kind for e in events]
+        res2 = kb.dispatch_once(conn, spawn_fn=_must_not_spawn)
+        after_task = kb.get_task(conn, tid)
+        assert after_task is not None
+        after_kinds = [e.kind for e in kb.list_events(conn, tid)]
+
+        assert tid not in [spawned[0] for spawned in res2.spawned]
+        assert after_task.status == "blocked"
+        assert after_kinds == before_kinds
     finally:
         conn.close()
 
@@ -797,6 +860,8 @@ def test_cli_unblock_bulk(kanban_home):
     try:
         a = kb.create_task(conn, title="a")
         b = kb.create_task(conn, title="b")
+        _add_review_requested_events(conn, a)
+        _add_review_requested_events(conn, b)
         kb.block_task(conn, a)
         kb.block_task(conn, b)
     finally:
@@ -810,6 +875,8 @@ def test_cli_block_bulk_via_ids_flag(kanban_home):
     try:
         a = kb.create_task(conn, title="a")
         b = kb.create_task(conn, title="b")
+        _add_review_requested_events(conn, a)
+        _add_review_requested_events(conn, b)
     finally:
         conn.close()
     out = run_slash(f"block {a} need input --ids {b}")
@@ -1423,7 +1490,12 @@ def test_run_closed_on_complete_with_summary(kanban_home):
             conn, tid,
             result="shipped",
             summary="implemented rate limiter, tests pass",
-            metadata={"changed_files": ["limiter.py"], "tests_run": 12},
+            metadata={
+                "changed_files": ["limiter.py"],
+                "tests_run": 12,
+                "review_required": False,
+                "review_skip_reason": "legacy run-summary persistence test",
+            },
         )
         assert ok is True
 
@@ -1437,7 +1509,12 @@ def test_run_closed_on_complete_with_summary(kanban_home):
         assert r.status == "done"
         assert r.outcome == "completed"
         assert r.summary == "implemented rate limiter, tests pass"
-        assert r.metadata == {"changed_files": ["limiter.py"], "tests_run": 12}
+        assert r.metadata == {
+            "changed_files": ["limiter.py"],
+            "tests_run": 12,
+            "review_required": False,
+            "review_skip_reason": "legacy run-summary persistence test",
+        }
         assert r.ended_at is not None
     finally:
         conn.close()
@@ -1529,6 +1606,11 @@ def test_stale_run_cannot_complete_new_attempt(kanban_home, monkeypatch):
         task = kb.get_task(conn, tid)
         assert task.status == "running"
         assert task.current_run_id == run2.id
+        conflicts = [e for e in kb.list_events(conn, tid) if e.kind == "claim_conflict"]
+        assert conflicts
+        assert conflicts[-1].payload["attempted_run_id"] == run1.id
+        assert conflicts[-1].payload["current_run_id"] == run2.id
+        assert conflicts[-1].payload["operation"] == "complete"
 
         assert kb.complete_task(
             conn,
@@ -1562,6 +1644,7 @@ def test_stale_run_cannot_block_or_heartbeat_new_attempt(kanban_home, monkeypatc
         assert run2.id != run1.id
 
         assert not kb.heartbeat_worker(conn, tid, note="late", expected_run_id=run1.id)
+        _add_review_requested_events(conn, tid)
         assert not kb.block_task(conn, tid, reason="late block", expected_run_id=run1.id)
         task = kb.get_task(conn, tid)
         assert task.status == "running"
@@ -1580,6 +1663,7 @@ def test_run_on_block_with_reason(kanban_home):
     try:
         tid = kb.create_task(conn, title="x", assignee="worker")
         kb.claim_task(conn, tid)
+        _add_review_requested_events(conn, tid)
         kb.block_task(conn, tid, reason="needs API key")
 
         r = kb.latest_run(conn, tid)
@@ -1648,6 +1732,7 @@ def test_build_worker_context_includes_prior_attempts(kanban_home):
 
         # Attempt 1: blocked with a reason.
         kb.claim_task(conn, tid)
+        _add_review_requested_events(conn, tid)
         kb.block_task(conn, tid, reason="needs clarification on IP vs user_id")
         kb.unblock_task(conn, tid)
 
@@ -2066,6 +2151,7 @@ def test_block_never_claimed_task_synthesizes_run(kanban_home):
     conn = kb.connect()
     try:
         tid = kb.create_task(conn, title="drop this", assignee="worker")
+        _add_review_requested_events(conn, tid)
         ok = kb.block_task(conn, tid, reason="deprioritized")
         assert ok is True
 
@@ -2302,6 +2388,7 @@ def test_unblock_normal_path_no_spurious_run(kanban_home):
     try:
         tid = kb.create_task(conn, title="normal unblock", assignee="worker")
         kb.claim_task(conn, tid)
+        _add_review_requested_events(conn, tid)
         kb.block_task(conn, tid, reason="pause")
         runs_before = len(kb.list_runs(conn, tid))
         assert kb.unblock_task(conn, tid) is True
@@ -3367,6 +3454,17 @@ def test_config_default_dispatch_in_gateway_is_true():
     )
 
 
+def test_config_default_notify_in_gateway_is_true():
+    """Default config keeps Kanban notifications on unless explicitly disabled."""
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    kanban = DEFAULT_CONFIG.get("kanban", {})
+    assert kanban.get("notify_in_gateway") is True, (
+        "kanban.notify_in_gateway default should be True; got "
+        f"{kanban.get('notify_in_gateway')!r}"
+    )
+
+
 def test_check_dispatcher_presence_silent_when_gateway_running(monkeypatch):
     from hermes_cli import kanban as kb_cli
     monkeypatch.setattr("gateway.status.get_running_pid", lambda: 12345)
@@ -3392,9 +3490,12 @@ def test_check_dispatcher_presence_warns_when_no_gateway(monkeypatch):
     assert "hermes gateway start" in msg
 
 
-def test_check_dispatcher_presence_warns_when_flag_off(monkeypatch):
+def test_check_dispatcher_presence_warns_when_flag_off(monkeypatch, tmp_path):
     """Gateway is up but dispatch_in_gateway=false -> warning."""
     from hermes_cli import kanban as kb_cli
+    profile_home = tmp_path / "profiles" / "vicky"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
     monkeypatch.setattr("gateway.status.get_running_pid", lambda: 999)
     monkeypatch.setattr(
         "hermes_cli.config.load_config",
@@ -3403,6 +3504,7 @@ def test_check_dispatcher_presence_warns_when_flag_off(monkeypatch):
     running, msg = kb_cli._check_dispatcher_presence()
     assert running is False
     assert "dispatch_in_gateway" in msg
+    assert str(profile_home / "config.yaml") in msg
 
 
 def test_check_dispatcher_presence_silent_on_probe_error(monkeypatch):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3467,6 +3467,78 @@ def test_block_task_denies_one_prior_review_visit(kanban_home):
         assert [e.kind for e in kb.list_events(conn, task_id)].count("blocked") == 0
 
 
+@pytest.mark.parametrize(
+    "reason_category",
+    [
+        "credential",
+        "human_decision",
+        "destructive_action",
+        "service_interruption",
+        "product_decision",
+        "art_decision",
+    ],
+)
+def test_block_task_allows_first_run_human_gate_categories(
+    kanban_home,
+    reason_category,
+):
+    """Fresh workers can block immediately for explicit human-gate reasons."""
+    with kb.connect() as conn:
+        task_id = _create_claimed_task_with_review_visits(conn, 0)
+
+        assert kb.block_task(
+            conn,
+            task_id,
+            reason=f"need human gate: {reason_category}",
+            reason_category=reason_category,
+        ) is True
+
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "blocked"
+        blocked_events = [e for e in kb.list_events(conn, task_id) if e.kind == "blocked"]
+        assert len(blocked_events) == 1
+        assert blocked_events[-1].payload["human_gate"] is True
+        assert blocked_events[-1].payload["reason_category"] == reason_category
+
+
+def test_block_task_allows_first_run_human_gate_flag_without_category(kanban_home):
+    """The CLI can expose a simple --human-gate flag without forcing a category."""
+    with kb.connect() as conn:
+        task_id = _create_claimed_task_with_review_visits(conn, 0)
+
+        assert kb.block_task(
+            conn,
+            task_id,
+            reason="need a human product choice",
+            human_gate=True,
+        ) is True
+
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "blocked"
+        blocked_event = [e for e in kb.list_events(conn, task_id) if e.kind == "blocked"][-1]
+        assert blocked_event.payload["human_gate"] is True
+
+
+def test_block_task_rejects_unknown_human_gate_category(kanban_home):
+    """Human-gate categories are explicit so typos do not silently bypass review."""
+    with kb.connect() as conn:
+        task_id = _create_claimed_task_with_review_visits(conn, 0)
+
+        with pytest.raises(ValueError, match="Invalid human-gate reason category"):
+            kb.block_task(
+                conn,
+                task_id,
+                reason="need something vague",
+                reason_category="misc",
+            )
+
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "running"
+
+
 def test_block_task_allows_two_prior_review_visits(kanban_home):
     """Two prior Review visits satisfy the Blocked transition rule."""
     with kb.connect() as conn:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import argparse
 import concurrent.futures
+import contextlib
+import json
 import os
 import sqlite3
 import time
@@ -10,6 +13,7 @@ from pathlib import Path
 
 import pytest
 
+from hermes_cli import kanban as kb_cli
 from hermes_cli import kanban_db as kb
 
 
@@ -67,6 +71,217 @@ def test_connect_rejects_tls_record_in_sqlite_header(tmp_path, monkeypatch):
     assert "file is not a database" in msg
     assert "TLS record header detected at byte offset 5" in msg
     assert "53 51 4c 69 74 17 03 03 00 13" in msg
+
+
+def test_check_database_integrity_reports_invalid_sqlite_header(tmp_path):
+    """The read-only check should return structured failure for non-SQLite files."""
+    corrupt = tmp_path / "kanban.db"
+    corrupt.write_bytes(b"not sqlite at all")
+
+    result = kb.check_database_integrity(corrupt)
+
+    assert result["ok"] is False
+    assert result["path"] == str(corrupt)
+    assert result["exists"] is True
+    assert result["size_bytes"] == len(b"not sqlite at all")
+    assert result["quick_check"]
+    assert "invalid SQLite header" in result["quick_check"][0]
+    assert "repair" in result["repair_hint"].lower()
+
+
+def test_cli_check_json_reports_invalid_sqlite_header(tmp_path, monkeypatch, capsys):
+    """`hermes kanban check --json` should emit JSON, not a traceback."""
+    corrupt = tmp_path / "kanban.db"
+    corrupt.write_bytes(b"not sqlite at all")
+    monkeypatch.setattr(kb_cli.kb, "kanban_db_path", lambda board=None: corrupt)
+
+    rc = kb_cli._cmd_check(argparse.Namespace(json=True, full=False))
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert rc == 1
+    payload = json.loads(captured.out)
+    assert payload["ok"] is False
+    assert payload["path"] == str(corrupt)
+    assert "invalid SQLite header" in payload["quick_check"][0]
+    assert "repair" in payload["repair_hint"].lower()
+
+
+def test_check_database_integrity_reports_malformed_sqlite_file(tmp_path):
+    """The read-only check command should report corruption without init writes."""
+    corrupt = tmp_path / "kanban.db"
+    corrupt.write_bytes(b"SQLite format 3\x00" + b"not a real sqlite database" * 8)
+
+    result = kb.check_database_integrity(corrupt)
+
+    assert result["ok"] is False
+    assert result["path"] == str(corrupt)
+    assert result["quick_check"]
+    assert "ERROR:" in result["quick_check"][0]
+    assert "repair" in result["repair_hint"].lower()
+
+
+def test_check_database_integrity_leaves_valid_live_board_unmodified(tmp_path):
+    """The read-only check should report ok for valid boards without sidecar writes."""
+    db_path = tmp_path / "kanban.db"
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.execute("CREATE TABLE tasks (id TEXT PRIMARY KEY)")
+        conn.execute("INSERT INTO tasks (id) VALUES ('t_live')")
+    before = {
+        "size": db_path.stat().st_size,
+        "mtime_ns": db_path.stat().st_mtime_ns,
+        "sidecars": sorted(p.name for p in tmp_path.iterdir()),
+    }
+
+    result = kb.check_database_integrity(db_path)
+
+    after = {
+        "size": db_path.stat().st_size,
+        "mtime_ns": db_path.stat().st_mtime_ns,
+        "sidecars": sorted(p.name for p in tmp_path.iterdir()),
+    }
+    assert result["ok"] is True
+    assert result["quick_check"] == ["ok"]
+    assert result["repair_hint"] is None
+    assert after == before
+
+
+def test_connect_runs_quick_check_before_schema_migration(tmp_path, monkeypatch):
+    """connect() must not run schema/migration writes before integrity check."""
+    db_path = tmp_path / "kanban.db"
+    sqlite3.connect(str(db_path)).close()
+    calls: list[Path] = []
+
+    def fail_quick_check(conn, path):
+        calls.append(path)
+        raise sqlite3.DatabaseError("quick_check failed for test")
+
+    monkeypatch.setattr(kb, "_raise_if_quick_check_failed", fail_quick_check)
+
+    with pytest.raises(sqlite3.DatabaseError, match="quick_check failed for test"):
+        kb.connect(db_path)
+
+    assert calls == [db_path]
+    with sqlite3.connect(str(db_path)) as conn:
+        names = conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    assert names == []
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"board_key": "hermes-setup", "platform": 274, "chat_id": "chat-1"},
+        {"board_key": "hermes-setup", "platform": "", "chat_id": "chat-1"},
+        {"board_key": "hermes-setup", "platform": "telegram", "chat_id": None},
+        {"board_key": "", "platform": "telegram", "chat_id": "chat-1"},
+    ],
+)
+def test_board_notify_cursor_rejects_malformed_identity_fields(kanban_home, kwargs):
+    """Board notification cursors must not accept corrupt identity fields.
+
+    The incident DB contained cursor rows with numeric-looking platform values
+    and NULL target fields. Rejecting invalid identity values before SQLite
+    sees them prevents the notifier from creating malformed cursor rows even if
+    a caller passes bad state.
+    """
+    with kb.connect() as conn:
+        with pytest.raises(ValueError):
+            kb.claim_board_notify_events(conn, **kwargs)
+        with pytest.raises(ValueError):
+            kb.advance_board_notify_cursor(conn, **kwargs, new_cursor=1)
+        with pytest.raises(ValueError):
+            kb.rewind_board_notify_cursor(
+                conn, **kwargs, claimed_cursor=2, old_cursor=1
+            )
+
+        rows = conn.execute("SELECT * FROM kanban_notify_board_cursors").fetchall()
+
+    assert rows == []
+
+
+def test_maintenance_lock_blocks_regular_kanban_writes(tmp_path, monkeypatch):
+    """DB repair/maintenance should exclude live app writers cooperatively."""
+    import multiprocessing as mp
+
+    db_path = tmp_path / "maintenance-lock.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    monkeypatch.setenv("HERMES_KANBAN_MAINTENANCE_LOCK_TIMEOUT", "0.2")
+    kb.init_db()
+
+    def child_attempt_write(path: str, queue):
+        from pathlib import Path as ChildPath
+        from hermes_cli import kanban_db as child_kb
+
+        try:
+            conn = child_kb.connect(ChildPath(path))
+            try:
+                child_kb.create_task(conn, title="should be blocked")
+            finally:
+                conn.close()
+        except BaseException as exc:  # pragma: no cover - asserted in parent
+            queue.put((type(exc).__name__, str(exc)))
+        else:  # pragma: no cover - asserted in parent
+            queue.put(("ok", ""))
+
+    queue = mp.Queue()
+    with kb.maintenance_lock(db_path, timeout=1):
+        proc = mp.Process(target=child_attempt_write, args=(str(db_path), queue))
+        proc.start()
+        proc.join(5)
+        if proc.is_alive():
+            proc.terminate()
+            proc.join(5)
+            pytest.fail("writer process hung behind maintenance lock")
+
+    assert proc.exitcode == 0
+    kind, message = queue.get_nowait()
+    assert kind == "TimeoutError"
+    assert "maintenance lock" in message
+
+    with kb.connect() as conn:
+        assert kb.list_tasks(conn) == []
+
+
+def test_repair_database_indexes_runs_under_maintenance_lock(tmp_path, monkeypatch):
+    db_path = tmp_path / "repair-indexes.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    entered = []
+    real_lock = kb.maintenance_lock
+
+    @contextlib.contextmanager
+    def tracking_lock(path=None, **kwargs):
+        with real_lock(path, **kwargs) as locked_path:
+            entered.append(Path(locked_path))
+            yield locked_path
+
+    monkeypatch.setattr(kb, "maintenance_lock", tracking_lock)
+
+    result = kb.repair_database_indexes(db_path, vacuum=True, timeout=1)
+
+    assert result["ok"] is True
+    assert result["vacuum"] is True
+    assert result["after"]["quick_check"] == ["ok"]
+    assert entered == [db_path]
+
+
+def test_cli_repair_indexes_json_reports_repair_result(tmp_path, monkeypatch, capsys):
+    db_path = tmp_path / "cli-repair-indexes.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    rc = kb_cli._cmd_repair_indexes(
+        argparse.Namespace(json=True, no_vacuum=True, timeout=1.0)
+    )
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert rc == 0
+    payload = json.loads(captured.out)
+    assert payload["ok"] is True
+    assert payload["vacuum"] is False
+    assert payload["after"]["quick_check"] == ["ok"]
 
 
 def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
@@ -292,6 +507,45 @@ def test_recompute_ready_promotes_blocked_with_done_parents(kanban_home):
         assert task.status == "ready"
         assert task.consecutive_failures == 0
         assert task.last_failure_error is None
+
+
+def test_recompute_ready_does_not_immediately_reopen_gave_up_tasks(kanban_home):
+    """Circuit-breaker blocks must survive the dispatcher tick that made them.
+
+    A ``gave_up`` block is the failure-limit circuit breaker. If
+    ``recompute_ready`` immediately treats it like a dependency block with all
+    parents satisfied, the same dispatch tick reports the task as both
+    auto-blocked and spawned again.
+    """
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="flaky", assignee="planner")
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "ready"
+
+        assert kb._record_task_failure(
+            conn,
+            task_id,
+            "pid 1 not alive",
+            outcome="crashed",
+            failure_limit=2,
+        ) is False
+        assert kb._record_task_failure(
+            conn,
+            task_id,
+            "pid 2 not alive",
+            outcome="crashed",
+            failure_limit=2,
+        ) is True
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "blocked"
+
+        promoted = kb.recompute_ready(conn)
+        assert promoted == 0
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "blocked"
 
 
 def test_recompute_ready_fan_in_waits_for_all_parents(kanban_home):
@@ -612,6 +866,62 @@ def test_max_runtime_uses_current_run_start_after_retry(kanban_home, monkeypatch
         assert kb.get_task(conn, t).status == "running"
 
 
+def test_repeated_max_runtime_timeouts_trip_retry_limit(kanban_home, monkeypatch):
+    """Timed-out workers count toward the task retry breaker.
+
+    This exercises the full timeout path, not just the lower-level failure
+    counter: the worker run is closed as ``timed_out`` and the second timeout
+    parks the card in ``blocked`` with a ``gave_up`` event instead of respawning
+    forever.
+    """
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+
+    with kb.connect() as conn:
+        host = kb._claimer_id().split(":", 1)[0]
+        t = kb.create_task(
+            conn,
+            title="timeout twice",
+            assignee="a",
+            max_runtime_seconds=1,
+            max_retries=2,
+        )
+
+        for attempt in (1, 2):
+            claimed = kb.claim_task(conn, t, claimer=f"{host}:attempt-{attempt}")
+            assert claimed is not None
+            run = kb.latest_run(conn, t)
+            assert run is not None
+            run_id = run.id
+            old_started = int(time.time()) - 10
+            conn.execute(
+                "UPDATE tasks SET worker_pid = ?, started_at = ? WHERE id = ?",
+                (990000 + attempt, old_started, t),
+            )
+            conn.execute(
+                "UPDATE task_runs SET worker_pid = ?, started_at = ? WHERE id = ?",
+                (990000 + attempt, old_started, run_id),
+            )
+
+            assert kb.enforce_max_runtime(
+                conn, signal_fn=lambda _pid, _sig: None,
+            ) == [t]
+
+        task = kb.get_task(conn, t)
+        assert task is not None
+        assert task.status == "blocked"
+        assert task.consecutive_failures == 2
+        assert task.last_failure_error is not None
+        assert "elapsed" in task.last_failure_error
+        runs = kb.list_runs(conn, t)
+        assert [r.outcome for r in runs[-2:]] == ["timed_out", "timed_out"]
+        gave_up = [e for e in kb.list_events(conn, t) if e.kind == "gave_up"]
+        assert len(gave_up) == 1
+        payload = gave_up[0].payload
+        assert payload is not None
+        assert payload["trigger_outcome"] == "timed_out"
+        assert payload["effective_limit"] == 2
+
+
 def test_heartbeat_extends_claim(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="x", assignee="a")
@@ -674,6 +984,7 @@ def test_complete_records_result(kanban_home):
 def test_block_then_unblock(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="x", assignee="a")
+        _add_review_requested_events(conn, t, 2)
         kb.claim_task(conn, t)
         assert kb.block_task(conn, t, reason="need input")
         assert kb.get_task(conn, t).status == "blocked"
@@ -685,6 +996,7 @@ def test_unblock_resets_failure_counters(kanban_home):
     """unblock_task must reset consecutive_failures and last_failure_error."""
     with kb.connect() as conn:
         t = kb.create_task(conn, title="x", assignee="a")
+        _add_review_requested_events(conn, t, 2)
         kb.claim_task(conn, t)
         assert kb.block_task(conn, t, reason="need input")
         # Simulate accumulated failures from the circuit breaker
@@ -811,6 +1123,7 @@ def test_unblock_without_parents_goes_to_ready(kanban_home):
     """Parent-free unblock still produces 'ready' (behavior preserved)."""
     with kb.connect() as conn:
         t = kb.create_task(conn, title="lone", assignee="a")
+        _add_review_requested_events(conn, t, 2)
         kb.claim_task(conn, t)
         assert kb.block_task(conn, t, reason="need input")
         assert kb.unblock_task(conn, t)
@@ -996,6 +1309,133 @@ def test_worker_context_includes_parent_results_and_comments(kanban_home):
 
 
 # ---------------------------------------------------------------------------
+# Triage decomposition
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "children, error",
+    [
+        (["not-a-dict"], r"child\[0\] is not a dict"),
+        ([{"title": "   "}], r"child\[0\]\.title is required"),
+        ([{"title": "ok", "parents": "0"}], r"child\[0\]\.parents must be a list"),
+        (
+            [{"title": "ok", "parents": [1]}],
+            r"child\[0\]\.parents\[1\] is not a valid index into children",
+        ),
+    ],
+)
+def test_decompose_triage_rejects_malformed_children_atomically(
+    kanban_home, children, error,
+):
+    with kb.connect() as conn:
+        root = kb.create_task(conn, title="spec", triage=True)
+        before_count = conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
+
+        with pytest.raises(ValueError, match=error):
+            kb.decompose_triage_task(
+                conn,
+                root,
+                root_assignee="planner",
+                children=children,
+                author="triage",
+            )
+
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == before_count
+        task = kb.get_task(conn, root)
+        assert task is not None and task.status == "triage"
+        assert [e.kind for e in kb.list_events(conn, root)] == ["created"]
+
+
+def test_decompose_triage_rejects_child_dependency_cycle_atomically(kanban_home):
+    with kb.connect() as conn:
+        root = kb.create_task(conn, title="spec", triage=True)
+        before_count = conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
+
+        with pytest.raises(ValueError, match="cyclic dependency detected"):
+            kb.decompose_triage_task(
+                conn,
+                root,
+                root_assignee="planner",
+                children=[
+                    {"title": "first", "parents": [1]},
+                    {"title": "second", "parents": [0]},
+                ],
+                author="triage",
+            )
+
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == before_count
+        task = kb.get_task(conn, root)
+        assert task is not None and task.status == "triage"
+        assert [e.kind for e in kb.list_events(conn, root)] == ["created"]
+
+
+def test_decompose_triage_rejects_non_worker_child_assignee_atomically(
+    kanban_home, monkeypatch
+):
+    from hermes_cli import config, profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda name: True)
+    with kb.connect() as conn:
+        root = kb.create_task(conn, title="spec", triage=True)
+        before_count = conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
+
+        monkeypatch.setattr(
+            config,
+            "load_config",
+            lambda: {"kanban": {"non_worker_profiles": ["ava"]}},
+        )
+
+        with pytest.raises(ValueError, match="cannot be assigned Kanban work"):
+            kb.decompose_triage_task(
+                conn,
+                root,
+                root_assignee="planner",
+                children=[{"title": "child", "assignee": "ava"}],
+                author="triage",
+            )
+
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == before_count
+        task = kb.get_task(conn, root)
+        assert task is not None
+        assert task.status == "triage"
+        assert task.assignee is None
+        assert [e.kind for e in kb.list_events(conn, root)] == ["created"]
+
+
+def test_decompose_triage_rejects_non_worker_root_assignee_atomically(
+    kanban_home, monkeypatch
+):
+    from hermes_cli import config, profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda name: True)
+    with kb.connect() as conn:
+        root = kb.create_task(conn, title="spec", triage=True)
+        before_count = conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
+
+        monkeypatch.setattr(
+            config,
+            "load_config",
+            lambda: {"kanban": {"non_worker_profiles": ["ava"]}},
+        )
+
+        with pytest.raises(ValueError, match="cannot be assigned Kanban work"):
+            kb.decompose_triage_task(
+                conn,
+                root,
+                root_assignee="ava",
+                children=[{"title": "child", "assignee": "coder"}],
+                author="triage",
+            )
+
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == before_count
+        task = kb.get_task(conn, root)
+        assert task is not None
+        assert task.status == "triage"
+        assert task.assignee is None
+        assert [e.kind for e in kb.list_events(conn, root)] == ["created"]
+
+
+# ---------------------------------------------------------------------------
 # Dispatcher
 # ---------------------------------------------------------------------------
 
@@ -1009,6 +1449,51 @@ def test_dispatch_dry_run_does_not_claim(kanban_home, all_assignees_spawnable):
         # Dry run must NOT mutate status.
         assert kb.get_task(conn, t1).status == "ready"
         assert kb.get_task(conn, t2).status == "ready"
+
+
+def test_dispatch_successful_normal_execution_records_run_then_completion(
+    kanban_home, all_assignees_spawnable,
+):
+    spawned = []
+
+    def fake_spawn(task, workspace):
+        spawned.append((task.id, workspace))
+        return 43210
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="normal", assignee="alice")
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+
+        assert len(res.spawned) == 1
+        assert spawned[0][0] == t
+        task = kb.get_task(conn, t)
+        assert task is not None
+        assert task.status == "running"
+        assert task.worker_pid == 43210
+        active_run = kb.latest_run(conn, t)
+        assert active_run is not None
+        assert active_run.outcome is None
+        assert active_run.worker_pid == 43210
+
+        kb.complete_task(conn, t, result="ok")
+
+        task = kb.get_task(conn, t)
+        assert task is not None
+        assert task.status == "done"
+        assert task.worker_pid is None
+        assert task.consecutive_failures == 0
+        completed_run = kb.latest_run(conn, t)
+        assert completed_run is not None
+        assert completed_run.id == active_run.id
+        assert completed_run.outcome == "completed"
+        kinds = [e.kind for e in kb.list_events(conn, t)]
+        assert kinds == [
+            "created",
+            "claimed",
+            "tip_scratch_workspace",
+            "spawned",
+            "completed",
+        ]
 
 
 def test_dispatch_skips_unassigned(kanban_home):
@@ -1033,6 +1518,152 @@ def test_dispatch_skips_nonspawnable_into_separate_bucket(kanban_home, monkeypat
     assert t in res.skipped_nonspawnable
     assert t not in res.skipped_unassigned
     assert not res.spawned
+
+
+def test_dispatch_skips_configured_non_worker_profiles(kanban_home, monkeypatch):
+    """Existing conversation/operator profiles can be explicitly removed
+    from the auto-spawn worker pool via kanban.non_worker_profiles."""
+    from hermes_cli import config, profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda name: True)
+    with kb.connect() as conn:
+        ava = kb.create_task(conn, title="operator", assignee="ava")
+        coder = kb.create_task(conn, title="worker", assignee="coder")
+    monkeypatch.setattr(
+        config,
+        "load_config",
+        lambda: {"kanban": {"non_worker_profiles": ["ava", "vicky"]}},
+    )
+    with kb.connect() as conn:
+        res = kb.dispatch_once(conn, dry_run=True)
+    assert ava in res.skipped_nonspawnable
+    assert ava not in res.skipped_unassigned
+    assert (coder, "coder", "") in res.spawned
+
+
+def test_dispatch_blocks_kanban_self_maintenance_before_spawn(
+    kanban_home, all_assignees_spawnable,
+):
+    """Kanban must not use itself to work on Kanban internals."""
+    spawns = []
+
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="Fix Kanban dispatcher disk I/O corruption",
+            body="Modify hermes_cli/kanban_db.py and gateway/run.py so the dispatcher stops corrupting the live board.",
+            assignee="coder",
+        )
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "blocked"
+        assert tid in res.auto_blocked
+        assert spawns == []
+        assert all(event.kind != "claimed" for event in kb.list_events(conn, tid))
+        comments = kb.list_comments(conn, tid)
+        assert comments
+        assert "Kanban self-maintenance" in comments[-1].body
+
+
+def test_manual_claim_blocks_kanban_self_maintenance_task(
+    kanban_home, all_assignees_spawnable,
+):
+    """Manual lane pulls must hit the same self-maintenance guard."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="Implement direct replies to triage proposals",
+            body="Change the notification bot proposal plumbing and Kanban dashboard handlers.",
+            assignee="coder",
+        )
+
+        claimed = kb.claim_task(conn, tid)
+
+        assert claimed is None
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "blocked"
+        assert all(event.kind != "claimed" for event in kb.list_events(conn, tid))
+
+
+def test_env_override_allows_kanban_self_maintenance_dispatch(
+    kanban_home, all_assignees_spawnable, monkeypatch,
+):
+    """Operators can bypass the guard only with an explicit env override."""
+    monkeypatch.setenv("HERMES_KANBAN_ALLOW_SELF_MAINTENANCE", "1")
+    spawns = []
+
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="Fix Kanban dispatcher disk I/O corruption",
+            body="Modify hermes_cli/kanban_db.py after the live board has been stopped.",
+            assignee="coder",
+        )
+
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+
+        assert [item[0] for item in res.spawned] == [tid]
+        assert spawns == [tid]
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "running"
+
+
+def test_has_spawnable_ready_ignores_configured_non_worker_profiles(kanban_home, monkeypatch):
+    from hermes_cli import config, profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda name: True)
+    with kb.connect() as conn:
+        kb.create_task(conn, title="operator", assignee="ava")
+        kb.create_task(conn, title="worker", assignee="coder")
+    monkeypatch.setattr(
+        config,
+        "load_config",
+        lambda: {"kanban": {"non_worker_profiles": "ava,vicky"}},
+    )
+    with kb.connect() as conn:
+        assert kb.has_spawnable_ready(conn) is True
+
+
+def test_configured_non_worker_profiles_cannot_be_assigned(kanban_home, monkeypatch):
+    from hermes_cli import config, profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda name: True)
+    monkeypatch.setattr(
+        config,
+        "load_config",
+        lambda: {"kanban": {"non_worker_profiles": "ava,vicky"}},
+    )
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match="cannot be assigned Kanban work"):
+            kb.create_task(conn, title="operator", assignee="ava")
+        task = kb.create_task(conn, title="worker", assignee="coder")
+        with pytest.raises(ValueError, match="cannot be assigned Kanban work"):
+            kb.assign_task(conn, task, "vicky")
+
+
+def test_has_spawnable_ready_false_when_only_configured_non_worker_profiles(kanban_home, monkeypatch):
+    from hermes_cli import config, profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda name: True)
+    with kb.connect() as conn:
+        kb.create_task(conn, title="operator", assignee="ava")
+    monkeypatch.setattr(
+        config,
+        "load_config",
+        lambda: {"kanban": {"non_worker_profiles": "ava,vicky"}},
+    )
+    with kb.connect() as conn:
+        assert kb.has_spawnable_ready(conn) is False
 
 
 def test_has_spawnable_ready_false_when_only_terminal_lanes(kanban_home, monkeypatch):
@@ -2613,11 +3244,16 @@ def test_dispatch_review_dry_run(kanban_home, all_assignees_spawnable):
         assert kb.get_task(conn, t).status == "review"
 
 
-def test_dispatch_review_spawns_with_correct_skills(
-    kanban_home, all_assignees_spawnable,
+def test_dispatch_review_spawns_with_configured_skills(
+    kanban_home, all_assignees_spawnable, monkeypatch,
 ):
-    """Review tasks get sdlc-review skill set before spawning."""
+    """Review tasks get configured review skills before spawning."""
     spawned_tasks = []
+    monkeypatch.setattr(
+        kb,
+        "_kanban_config",
+        lambda: {"review_skills": ["github-code-review", "requesting-code-review"]},
+    )
 
     def capture_spawn(task, workspace, board=None):
         spawned_tasks.append(task)
@@ -2629,7 +3265,7 @@ def test_dispatch_review_spawns_with_correct_skills(
         res = kb.dispatch_once(conn, spawn_fn=capture_spawn)
     assert len(res.spawned) == 1
     assert len(spawned_tasks) == 1
-    assert spawned_tasks[0].skills == ["sdlc-review"]
+    assert spawned_tasks[0].skills == ["github-code-review", "requesting-code-review"]
 
 
 def test_dispatch_review_skips_unassigned(kanban_home):
@@ -2735,6 +3371,223 @@ def test_dispatch_review_does_not_claim_ready_tasks(
         # claim_review_task should NOT claim a ready task
         claimed = kb.claim_review_task(conn, t)
     assert claimed is None
+
+
+def test_complete_task_routes_substantial_handoff_to_reviewer(kanban_home):
+    """Substantial worker handoffs enter review instead of going straight done."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="ship feature", assignee="coder")
+        kb.claim_task(conn, t)
+
+        assert kb.complete_task(
+            conn,
+            t,
+            summary="implemented feature with tests",
+            metadata={"changed_files": ["app.py"], "tests_run": 3},
+        )
+
+        task = kb.get_task(conn, t)
+        assert task.status == "review"
+        assert task.assignee == "reviewer"
+        assert task.completed_at is None
+
+        latest = kb.latest_run(conn, t)
+        assert latest is not None
+        assert latest.outcome == "review_requested"
+        assert latest.summary == "implemented feature with tests"
+        assert latest.metadata["changed_files"] == ["app.py"]
+
+        events = kb.list_events(conn, t)
+        review_events = [e for e in events if e.kind == "review_requested"]
+        assert len(review_events) == 1
+        assert review_events[0].payload["original_assignee"] == "coder"
+        assert review_events[0].payload["reviewer_profile"] == "reviewer"
+        assert review_events[0].payload["reason"] == "changed_files"
+
+
+_BLOCKED_REVIEW_PREREQUISITE_ERROR = (
+    "Cannot move to Blocked: requires at least 2 review_requested events "
+    "in task history"
+)
+
+
+def _add_review_requested_events(
+    conn: sqlite3.Connection,
+    task_id: str,
+    count: int,
+    *,
+    payload: object = None,
+) -> None:
+    """Seed prior Review visits without coupling these tests to complete_task."""
+    created_at = int(time.time())
+    serialized = json.dumps(payload) if payload is not None else None
+    for offset in range(count):
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'review_requested', ?, ?)",
+            (task_id, serialized, created_at + offset),
+        )
+
+
+def _create_claimed_task_with_review_visits(
+    conn: sqlite3.Connection,
+    review_visits: int,
+) -> str:
+    task_id = kb.create_task(conn, title="maybe blocked", assignee="coder")
+    _add_review_requested_events(conn, task_id, review_visits)
+    assert kb.claim_task(conn, task_id) is not None
+    return task_id
+
+
+def test_block_task_denies_zero_prior_review_visits(kanban_home):
+    """A task cannot move to Blocked until it has visited Review twice."""
+    with kb.connect() as conn:
+        task_id = _create_claimed_task_with_review_visits(conn, 0)
+
+        with pytest.raises(ValueError, match=_BLOCKED_REVIEW_PREREQUISITE_ERROR):
+            kb.block_task(conn, task_id, reason="need input")
+
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "running"
+        assert [e.kind for e in kb.list_events(conn, task_id)].count("blocked") == 0
+
+
+def test_block_task_denies_one_prior_review_visit(kanban_home):
+    """One prior Review visit is still insufficient for moving to Blocked."""
+    with kb.connect() as conn:
+        task_id = _create_claimed_task_with_review_visits(conn, 1)
+
+        with pytest.raises(ValueError, match=_BLOCKED_REVIEW_PREREQUISITE_ERROR):
+            kb.block_task(conn, task_id, reason="needs more review")
+
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "running"
+        assert [e.kind for e in kb.list_events(conn, task_id)].count("blocked") == 0
+
+
+def test_block_task_allows_two_prior_review_visits(kanban_home):
+    """Two prior Review visits satisfy the Blocked transition rule."""
+    with kb.connect() as conn:
+        task_id = _create_claimed_task_with_review_visits(conn, 2)
+
+        assert kb.block_task(conn, task_id, reason="reviewed twice") is True
+
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "blocked"
+        assert [e.kind for e in kb.list_events(conn, task_id)].count("blocked") == 1
+
+
+@pytest.mark.parametrize("status", ["done", "todo", "scheduled"])
+@pytest.mark.parametrize("review_visits", [0, 1, 2])
+def test_block_task_review_count_rule_leaves_unrelated_statuses_unchanged(
+    kanban_home,
+    status,
+    review_visits,
+):
+    """The review-count rule must not make unrelated statuses blockable or raise."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title=f"already {status}", assignee="coder")
+        _add_review_requested_events(conn, task_id, review_visits)
+        _set_task_status(conn, task_id, status)
+
+        assert kb.block_task(conn, task_id, reason="not running") is False
+
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == status
+        assert [e.kind for e in kb.list_events(conn, task_id)].count("blocked") == 0
+
+
+@pytest.mark.parametrize("review_visits", [0, 1])
+def test_block_task_denies_legacy_or_missing_review_history_until_rule_satisfied(
+    kanban_home,
+    review_visits,
+):
+    """Legacy-style review events with missing payloads do not crash or bypass the rule."""
+    with kb.connect() as conn:
+        task_id = _create_claimed_task_with_review_visits(conn, review_visits)
+
+        with pytest.raises(ValueError, match=_BLOCKED_REVIEW_PREREQUISITE_ERROR):
+            kb.block_task(conn, task_id, reason="legacy history")
+
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "running"
+
+
+def test_block_task_allows_legacy_review_history_when_rule_satisfied(kanban_home):
+    """Legacy-style Review history with missing payloads is enough once count reaches two."""
+    with kb.connect() as conn:
+        task_id = _create_claimed_task_with_review_visits(conn, 2)
+
+        assert kb.block_task(conn, task_id, reason="legacy reviewed twice") is True
+
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "blocked"
+
+
+def test_complete_task_skips_review_when_explicitly_not_required(kanban_home):
+    """Trivial or already-reviewed handoffs can still complete normally."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="tiny doc note", assignee="coder")
+        kb.claim_task(conn, t)
+
+        assert kb.complete_task(
+            conn,
+            t,
+            summary="fixed one typo",
+            metadata={
+                "changed_files": ["README.md"],
+                "review_required": False,
+                "review_skip_reason": "trivial typo",
+            },
+        )
+
+        task = kb.get_task(conn, t)
+        assert task.status == "done"
+        assert task.assignee == "coder"
+        assert task.completed_at is not None
+        assert [e.kind for e in kb.list_events(conn, t)].count("completed") == 1
+
+
+def test_reviewer_block_returns_task_to_original_worker_for_remediation(kanban_home):
+    """Blocked reviewer findings keep the task blocked but restore the worker lane."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="needs review", assignee="coder")
+        kb.claim_task(conn, t)
+        kb.complete_task(
+            conn,
+            t,
+            summary="implemented feature",
+            metadata={"changed_files": ["app.py"]},
+        )
+        claimed = kb.claim_review_task(conn, t)
+        assert claimed is not None
+        assert claimed.assignee == "reviewer"
+        kb._append_event(
+            conn,
+            t,
+            "review_requested",
+            {"reason": "second review", "original_assignee": "coder"},
+        )
+
+        assert kb.block_task(conn, t, reason="reviewer findings: missing test")
+
+        blocked = kb.get_task(conn, t)
+        assert blocked.status == "blocked"
+        assert blocked.assignee == "coder"
+        events = kb.list_events(conn, t)
+        blocked_events = [e for e in events if e.kind == "blocked"]
+        assert blocked_events[-1].payload["return_assignee"] == "coder"
+        assert blocked_events[-1].payload["source"] == "review"
+
+        assert kb.unblock_task(conn, t)
+        assert kb.get_task(conn, t).assignee == "coder"
+        assert kb.get_task(conn, t).status == "ready"
 
 # Stale detection — detect_stale_running
 # ---------------------------------------------------------------------------
@@ -2910,7 +3763,8 @@ def test_detect_stale_skips_blocked_tasks(kanban_home, monkeypatch):
                 "WHERE id = (SELECT current_run_id FROM tasks WHERE id = ?)",
                 (five_hours_ago, t),
             )
-        # Block the task explicitly.
+        # Block the task explicitly after satisfying the Blocked review-count gate.
+        _add_review_requested_events(conn, t, 2)
         kb.block_task(conn, t, reason="human requested block")
 
         monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -11,11 +11,21 @@ from unittest.mock import AsyncMock, MagicMock, patch
 # Fixtures
 # ---------------------------------------------------------------------------
 
+def _add_review_requested_events(conn, task_id: str, count: int = 2) -> None:
+    for idx in range(count):
+        kb._append_event(
+            conn,
+            task_id,
+            "review_requested",
+            {"reason": f"review {idx + 1}"},
+        )
+
 @pytest.fixture
 def kanban_home(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_NOTIFY_IN_GATEWAY", "1")
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     # Allow the kanban notifier path-validator to upload artifacts the
     # tests write under ``tmp_path``. Without this, every artifact-delivery
@@ -29,7 +39,7 @@ def kanban_home(tmp_path, monkeypatch):
 @pytest.mark.asyncio
 async def test_notifier_unsubs_after_completed_event(kanban_home):
     """
-    Subscription should be remove after completed event
+    Subscription should be removed after a terse completed-event ping.
     """
     import hermes_cli.kanban_db as kb
     from gateway.run import GatewayRunner
@@ -68,7 +78,8 @@ async def test_notifier_unsubs_after_completed_event(kanban_home):
 
     fake_adapter.send.assert_called_once()
     call_msg = fake_adapter.send.call_args[0][1]
-    assert "completed" in call_msg
+    assert call_msg == "✅ Done: test task"
+    assert "completed by agent" not in call_msg
 
     conn = kb.connect()
     try:
@@ -80,15 +91,11 @@ async def test_notifier_unsubs_after_completed_event(kanban_home):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize('kind', ["gave_up", "crashed", "timed_out"])
-async def test_notifier_unsubs_after_abnormal_events(kind, kanban_home):
+async def test_notifier_ignores_abnormal_events(kind, kanban_home):
     """
-    Event kinds gave_up / crashed / timed_out send a notification but DO
-    NOT delete the subscription. The dispatcher may respawn the task and
-    fire the same event kind again (e.g. a worker that crashes, gets
-    reclaimed, and crashes a second time); the user must hear about the
-    second event too. Subscriptions are removed only when the task hits
-    a truly final status (done / archived) — see the comment on
-    TERMINAL_KINDS in gateway/run.py and PR #21398.
+    The dedicated notification bot is completion-only. Worker failure and
+    retry-loop events are handled by the separate Kanban monitor watchdog,
+    so this watcher must not claim or deliver them.
     """
     import hermes_cli.kanban_db as kb
     from gateway.run import GatewayRunner
@@ -110,15 +117,20 @@ async def test_notifier_unsubs_after_abnormal_events(kind, kanban_home):
     fake_adapter = MagicMock()
 
     async def _send_and_stop(chat_id, msg, metadata=None):
-        runner._running = False
+        raise AssertionError(f"notifier should ignore {kind}, got {msg!r}")
 
     fake_adapter.send = AsyncMock(side_effect=_send_and_stop)
     runner.adapters = {Platform.TELEGRAM: fake_adapter}
 
     _orig_sleep = asyncio.sleep
+    tick_count = 0
 
     async def _fast_sleep(_):
+        nonlocal tick_count
         await _orig_sleep(0)
+        tick_count += 1
+        if tick_count >= 3:
+            runner._running = False
 
     with patch("gateway.run.asyncio.sleep", side_effect=_fast_sleep):
         await asyncio.wait_for(
@@ -126,33 +138,26 @@ async def test_notifier_unsubs_after_abnormal_events(kind, kanban_home):
             timeout=10.0,
         )
 
-    # The user is notified about the abnormal event...
-    fake_adapter.send.assert_called_once()
-    assert kind.replace('_', ' ') in fake_adapter.send.call_args[0][1]
+    fake_adapter.send.assert_not_called()
 
-    # ...but the subscription survives so a respawn-then-same-event cycle
-    # reaches the user too. The cursor (last_event_id) advanced inside
-    # the same write txn as the claim, so the same event won't re-fire.
+    # The subscription survives and the cursor stays put because this watcher
+    # only claims completion events. A separate watchdog may inspect/report
+    # abnormal events without consuming this noti-bot cursor.
     conn = kb.connect()
     try:
         subs = kb.list_notify_subs(conn, tid)
     finally:
         conn.close()
     assert len(subs) == 1, (
-        f"Subscription should survive {kind!r} so the next cycle of the "
-        f"same event reaches the user; got {subs!r}"
+        f"Subscription should survive ignored {kind!r}; got {subs!r}"
     )
-    assert int(subs[0]["last_event_id"]) >= 1, (
-        "Cursor should have advanced past the delivered event "
-        "(claim_unseen_events_for_sub advances atomically inside the "
-        "same write txn as the read)."
-    )
+    assert int(subs[0]["last_event_id"]) == 0
 
 
 @pytest.mark.asyncio
-async def test_notifier_second_blocked_delivers(kanban_home):
+async def test_notifier_ignores_repeated_blocked_events(kanban_home):
     """
-    After the first blocked, should receive second blocked notification.
+    Blocked reminders belong to the separate watchdog, not the completion bot.
     """
     import hermes_cli.kanban_db as kb
     from gateway.run import GatewayRunner
@@ -166,6 +171,7 @@ async def test_notifier_second_blocked_delivers(kanban_home):
 
     async def _capture_send(chat_id, msg, metadata=None):
         delivered_msgs.append(msg)
+        raise AssertionError(f"notifier should ignore blocked events, got {msg!r}")
 
     fake_adapter = MagicMock()
     fake_adapter.send = AsyncMock(side_effect=_capture_send)
@@ -187,6 +193,7 @@ async def test_notifier_second_blocked_delivers(kanban_home):
         kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat1")
 
         # Cycle 1: blocked
+        _add_review_requested_events(conn, tid)
         kb.block_task(conn, tid, reason="first block")
     finally:
         conn.close()
@@ -214,13 +221,15 @@ async def test_notifier_second_blocked_delivers(kanban_home):
             timeout=10.0,
         )
 
-    blocked_deliveries = [m for m in delivered_msgs if "blocked" in m]
-    assert "second block" not in blocked_deliveries[0]
-    assert "second block" in blocked_deliveries[1]
-    assert len(blocked_deliveries) == 2, (
-        f"Should receive 2 blocked notification, but only get {len(blocked_deliveries)} count\n"
-        f"Message {delivered_msgs}"
-    )
+    assert delivered_msgs == []
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, tid)
+    finally:
+        conn.close()
+    assert len(subs) == 1
+    assert int(subs[0]["last_event_id"]) == 0
+
 
 
 # ---------------------------------------------------------------------------
@@ -527,6 +536,10 @@ async def test_notifier_uploads_artifacts_on_completion(kanban_home, tmp_path, m
         out = kt._handle_complete({
             "summary": "rendered the chart",
             "artifacts": [str(chart_path), str(report_path)],
+            "metadata": {
+                "review_required": False,
+                "review_skip_reason": "notifier artifact delivery regression test",
+            },
         })
     finally:
         os.environ.pop("HERMES_KANBAN_TASK", None)
@@ -613,6 +626,10 @@ async def test_notifier_artifact_delivery_skips_missing_files(kanban_home, tmp_p
         kt._handle_complete({
             "summary": "one real, one ghost",
             "artifacts": [str(real_pdf), "/tmp/definitely-does-not-exist.pdf"],
+            "metadata": {
+                "review_required": False,
+                "review_skip_reason": "notifier artifact delivery regression test",
+            },
         })
     finally:
         os.environ.pop("HERMES_KANBAN_TASK", None)

--- a/tests/hermes_cli/test_kanban_specify.py
+++ b/tests/hermes_cli/test_kanban_specify.py
@@ -112,6 +112,31 @@ def test_specify_task_happy_path(kanban_home):
     assert "**Goal**" in (task.body or "")
 
 
+def test_specify_task_assigns_default_fallback_when_unassigned(kanban_home):
+    profiles_root = kanban_home / "profiles"
+    (profiles_root / "triage").mkdir(parents=True)
+    (kanban_home / "config.yaml").write_text(
+        "kanban:\n  default_assignee: triage\n",
+        encoding="utf-8",
+    )
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="rough", triage=True)
+
+    content = jsonlib.dumps({
+        "title": "Refined rough",
+        "body": "**Goal**\nA concrete goal.",
+    })
+    p, _ = _patch_aux_client(content)
+    with p:
+        outcome = spec.specify_task(tid, author="ace")
+
+    assert outcome.ok is True
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+    assert task.assignee == "triage"
+    assert task.status == "ready"
+
+
 def test_specify_task_falls_back_to_body_only_on_bad_json(kanban_home):
     with kb.connect() as conn:
         tid = kb.create_task(conn, title="keep title", triage=True)

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -641,6 +641,43 @@ class TestPrefetch:
         assert call_kwargs["tags_match"] == "all"
         assert call_kwargs["types"] == ["world"]
 
+    def test_queue_prefetch_dedupes_exact_normalized_recall_texts(self, provider):
+        provider._client.arecall = AsyncMock(
+            return_value=SimpleNamespace(
+                results=[
+                    SimpleNamespace(text="User prefers concise answers."),
+                    SimpleNamespace(text="  User prefers concise answers.  "),
+                    SimpleNamespace(text="User prefers concise answers.\n"),
+                ]
+            )
+        )
+
+        provider.queue_prefetch("style preferences")
+        if provider._prefetch_thread:
+            provider._prefetch_thread.join(timeout=5.0)
+
+        assert provider._prefetch_result == "- User prefers concise answers."
+
+    def test_queue_prefetch_keeps_distinct_recall_texts_after_dedupe(self, provider):
+        provider._client.arecall = AsyncMock(
+            return_value=SimpleNamespace(
+                results=[
+                    SimpleNamespace(text="User prefers concise answers."),
+                    SimpleNamespace(text="User prefers plain-English explanations."),
+                    SimpleNamespace(text="User prefers concise answers."),
+                ]
+            )
+        )
+
+        provider.queue_prefetch("style preferences")
+        if provider._prefetch_thread:
+            provider._prefetch_thread.join(timeout=5.0)
+
+        assert provider._prefetch_result == (
+            "- User prefers concise answers.\n"
+            "- User prefers plain-English explanations."
+        )
+
 
 # ---------------------------------------------------------------------------
 # sync_turn tests

--- a/tests/test_hermes_state_wal_fallback.py
+++ b/tests/test_hermes_state_wal_fallback.py
@@ -31,12 +31,21 @@ from hermes_state import (
 # directly (``'sqlite3.Connection' object attribute 'execute' is read-only``).
 # A factory-built subclass lets us intercept journal_mode=WAL per-test with
 # its own mutable counter, avoiding the xdist-parallel class-state race.
-def _make_blocking_factory(reason: str, attempt_counter: list):
-    """Return a sqlite3.Connection subclass that raises on PRAGMA journal_mode=WAL."""
+def _make_blocking_factory(
+    reason: str,
+    attempt_counter: list,
+    *,
+    block_delete: bool = False,
+):
+    """Return a connection subclass that raises on journal-mode pragmas."""
 
     class _WalBlockingConnection(sqlite3.Connection):
         def execute(self, sql, *args, **kwargs):  # type: ignore[override]
-            if "journal_mode=wal" in sql.lower().replace(" ", ""):
+            normalized = sql.lower().replace(" ", "")
+            if "journal_mode=wal" in normalized:
+                attempt_counter[0] += 1
+                raise sqlite3.OperationalError(reason)
+            if block_delete and "journal_mode=delete" in normalized:
                 attempt_counter[0] += 1
                 raise sqlite3.OperationalError(reason)
             return super().execute(sql, *args, **kwargs)
@@ -44,14 +53,14 @@ def _make_blocking_factory(reason: str, attempt_counter: list):
     return _WalBlockingConnection
 
 
-def _open_blocking(path, reason="locking protocol", **kwargs):
+def _open_blocking(path, reason="locking protocol", *, block_delete=False, **kwargs):
     """Open a connection whose WAL pragma raises ``reason``.
 
     Returns ``(conn, attempt_counter_list)`` so callers can assert how many
-    times WAL was attempted.
+    times journal-mode pragmas were attempted.
     """
     attempts = [0]
-    factory = _make_blocking_factory(reason, attempts)
+    factory = _make_blocking_factory(reason, attempts, block_delete=block_delete)
     return sqlite3.connect(str(path), factory=factory, **kwargs), attempts
 
 
@@ -64,11 +73,13 @@ def _reset_last_init_error():
 
 
 @pytest.fixture(autouse=True)
-def _reset_wal_fallback_warned_paths():
-    """Reset the WAL-fallback warned-paths set so dedup doesn't leak between tests."""
+def _reset_wal_fallback_state():
+    """Reset WAL-fallback module state so tests don't leak across cases."""
     hermes_state._wal_fallback_warned_paths.clear()
+    hermes_state._wal_fallback_delete_only_paths.clear()
     yield
     hermes_state._wal_fallback_warned_paths.clear()
+    hermes_state._wal_fallback_delete_only_paths.clear()
 
 
 class TestApplyWalWithFallback:
@@ -158,6 +169,58 @@ class TestApplyWalWithFallback:
             f"Expected 1 deduplicated warning, got {len(warnings)}: "
             f"{[r.getMessage() for r in warnings]}"
         )
+
+    def test_repeated_fallback_skips_wal_after_first_failure(self, tmp_path):
+        """Once a DB label falls back, future connections go straight to DELETE.
+
+        This prevents dashboard/plugin endpoints that open many short-lived
+        kanban connections from repeatedly hitting the same flaky WAL setup
+        path and surfacing a stream of ``disk I/O error`` failures.
+        """
+        conn1, attempts1 = _open_blocking(
+            tmp_path / "first.db", reason="disk I/O error", isolation_level=None
+        )
+        assert apply_wal_with_fallback(conn1, db_label="flaky-kanban.db") == "delete"
+        conn1.close()
+        assert attempts1[0] == 1
+
+        conn2, attempts2 = _open_blocking(
+            tmp_path / "second.db", reason="disk I/O error", isolation_level=None
+        )
+        assert apply_wal_with_fallback(conn2, db_label="flaky-kanban.db") == "delete"
+        conn2.execute("CREATE TABLE t (x INTEGER)")
+        conn2.execute("INSERT INTO t VALUES (2)")
+        assert conn2.execute("SELECT x FROM t").fetchone()[0] == 2
+        conn2.close()
+        assert attempts2[0] == 0
+
+    def test_cached_fallback_does_not_touch_delete_pragma_again(self, tmp_path):
+        """Cached fallback must not turn DELETE mode into new per-tick failures.
+
+        Regression for gateway dispatcher noise: after one WAL fallback, the
+        cached path previously executed ``PRAGMA journal_mode=DELETE`` on every
+        connection.  On a flaky filesystem that DELETE pragma can raise the same
+        transient ``disk I/O error``, causing repeated dispatcher tracebacks.
+        """
+        conn1, attempts1 = _open_blocking(
+            tmp_path / "first.db", reason="disk I/O error", isolation_level=None
+        )
+        assert apply_wal_with_fallback(conn1, db_label="flaky-kanban.db") == "delete"
+        conn1.close()
+        assert attempts1[0] == 1
+
+        conn2, attempts2 = _open_blocking(
+            tmp_path / "second.db",
+            reason="disk I/O error",
+            block_delete=True,
+            isolation_level=None,
+        )
+        assert apply_wal_with_fallback(conn2, db_label="flaky-kanban.db") == "delete"
+        conn2.execute("CREATE TABLE t (x INTEGER)")
+        conn2.execute("INSERT INTO t VALUES (2)")
+        assert conn2.execute("SELECT x FROM t").fetchone()[0] == 2
+        conn2.close()
+        assert attempts2[0] == 0
 
     def test_warning_fires_independently_per_db_label(self, tmp_path, caplog):
         """Different db_labels each get their own one warning (not globally dedup'd)."""

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -318,6 +318,34 @@ def test_complete_happy_path(worker_env):
         conn.close()
 
 
+def test_complete_substantial_handoff_routes_to_reviewer(worker_env):
+    """Routine implementation handoffs use kanban_complete review routing, not Blocked."""
+    from tools import kanban_tools as kt
+
+    out = kt._handle_complete({
+        "summary": "implemented feature with tests",
+        "metadata": {"changed_files": ["app.py"], "tests_run": 3},
+    })
+    d = json.loads(out)
+    assert d["ok"] is True
+
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, worker_env)
+        assert task is not None
+        assert task.status == "review"
+        assert task.assignee == "reviewer"
+        run = kb.latest_run(conn, worker_env)
+        assert run is not None
+        assert run.outcome == "review_requested"
+        review_events = [e for e in kb.list_events(conn, worker_env) if e.kind == "review_requested"]
+        assert len(review_events) == 1
+        assert review_events[-1].payload["reason"] == "changed_files"
+    finally:
+        conn.close()
+
+
 def test_complete_metadata_round_trips_through_show(worker_env):
     """Structured completion metadata should be visible to downstream agents."""
     from tools import kanban_tools as kt
@@ -631,10 +659,33 @@ def test_block_happy_path(worker_env):
         conn.close()
 
 
-def test_block_reports_review_prerequisite_error(worker_env):
+def test_block_allows_fresh_worker_human_gate(worker_env):
     from tools import kanban_tools as kt
 
-    out = kt._handle_block({"reason": "need clarification"})
+    out = kt._handle_block({
+        "reason": "Need API credentials before I can continue",
+        "reason_category": "credential",
+    })
+    d = json.loads(out)
+    assert d["ok"] is True
+
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, worker_env)
+        assert task is not None
+        assert task.status == "blocked"
+        blocked_event = [e for e in kb.list_events(conn, worker_env) if e.kind == "blocked"][-1]
+        assert blocked_event.payload["human_gate"] is True
+        assert blocked_event.payload["reason_category"] == "credential"
+    finally:
+        conn.close()
+
+
+def test_block_without_human_gate_reports_review_prerequisite_error(worker_env):
+    from tools import kanban_tools as kt
+
+    out = kt._handle_block({"reason": "implementation handoff parked as blocked"})
     d = json.loads(out)
 
     assert d.get("error")

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -171,6 +171,13 @@ def worker_env(monkeypatch, tmp_path):
     return tid
 
 
+def _add_review_requested_events(conn, task_id: str, count: int = 2) -> None:
+    from hermes_cli import kanban_db as kb
+
+    for idx in range(count):
+        kb._append_event(conn, task_id, "review_requested", {"reason": f"review {idx + 1}"})
+
+
 def test_show_defaults_to_env_task_id(worker_env):
     from tools import kanban_tools as kt
     out = kt._handle_show({})
@@ -322,6 +329,8 @@ def test_complete_metadata_round_trips_through_show(worker_env):
         "blocked_reason": None,
         "retry_notes": "none",
         "residual_risk": ["dashboard rendering not exercised"],
+        "review_required": False,
+        "review_skip_reason": "legacy metadata round-trip test",
     }
 
     complete_out = kt._handle_complete({
@@ -406,6 +415,10 @@ def test_complete_with_artifacts_lands_in_event_payload(worker_env):
 
     out = kt._handle_complete({
         "summary": "rendered the chart",
+        "metadata": {
+            "review_required": False,
+            "review_skip_reason": "artifact payload regression test",
+        },
         "artifacts": ["/tmp/q3-revenue.png", "/tmp/q3-report.pdf"],
     })
     assert json.loads(out)["ok"] is True
@@ -597,16 +610,35 @@ def test_complete_retry_with_corrected_created_cards_succeeds(worker_env):
 
 
 def test_block_happy_path(worker_env):
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        kb._append_event(conn, worker_env, "review_requested", {"reason": "first"})
+        kb._append_event(conn, worker_env, "review_requested", {"reason": "second"})
+    finally:
+        conn.close()
+
     from tools import kanban_tools as kt
     out = kt._handle_block({"reason": "need clarification"})
     d = json.loads(out)
     assert d["ok"] is True
-    from hermes_cli import kanban_db as kb
     conn = kb.connect()
     try:
-        assert kb.get_task(conn, worker_env).status == "blocked"
+        task = kb.get_task(conn, worker_env)
+        assert task is not None
+        assert task.status == "blocked"
     finally:
         conn.close()
+
+
+def test_block_reports_review_prerequisite_error(worker_env):
+    from tools import kanban_tools as kt
+
+    out = kt._handle_block({"reason": "need clarification"})
+    d = json.loads(out)
+
+    assert d.get("error")
+    assert "requires at least 2 review_requested" in d["error"]
 
 
 def test_block_rejects_empty_reason(worker_env):
@@ -996,6 +1028,7 @@ def test_unblock_happy_path(monkeypatch, worker_env):
     conn = kb.connect()
     try:
         tid = kb.create_task(conn, title="blocked", assignee="worker")
+        _add_review_requested_events(conn, tid)
         kb.block_task(conn, tid, reason="waiting")
     finally:
         conn.close()
@@ -1293,6 +1326,7 @@ def test_worker_unblock_rejects_foreign_task_id(worker_env):
     conn = kb.connect()
     try:
         other = kb.create_task(conn, title="blocked sibling", assignee="peer")
+        _add_review_requested_events(conn, other)
         kb.block_task(conn, other, reason="waiting")
     finally:
         conn.close()
@@ -1582,6 +1616,7 @@ def test_board_param_routes_block_to_alt_board(multi_board_env):
 
     alt_seed = multi_board_env["alt_seed"]
     with kb.connect(board="alt") as conn:
+        _add_review_requested_events(conn, alt_seed)
         kb.claim_task(conn, alt_seed)
 
     out = kt._handle_block({
@@ -1603,6 +1638,7 @@ def test_board_param_routes_unblock_to_alt_board(multi_board_env):
 
     alt_seed = multi_board_env["alt_seed"]
     with kb.connect(board="alt") as conn:
+        _add_review_requested_events(conn, alt_seed)
         kb.block_task(conn, alt_seed, reason="waiting")
         assert kb.get_task(conn, alt_seed).status == "blocked"
 

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -524,6 +524,10 @@ def _handle_block(args: dict, **kw) -> str:
     reason = args.get("reason")
     if not reason or not str(reason).strip():
         return tool_error("reason is required — explain what input you need")
+    human_gate, bool_error = _parse_bool_arg(args, "human_gate")
+    if bool_error:
+        return tool_error(bool_error)
+    reason_category = args.get("reason_category")
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
@@ -532,6 +536,8 @@ def _handle_block(args: dict, **kw) -> str:
                 conn, tid,
                 reason=reason,
                 expected_run_id=_worker_run_id(tid),
+                human_gate=human_gate,
+                reason_category=reason_category,
             )
             if not ok:
                 return tool_error(
@@ -985,6 +991,33 @@ KANBAN_BLOCK_SCHEMA = {
                     "What you need answered, in one or two sentences. "
                     "Don't paste the whole conversation; the human has "
                     "the board and can ask follow-ups via comments."
+                ),
+            },
+            "human_gate": {
+                "type": "boolean",
+                "description": (
+                    "Set true only for a genuine first-run human gate: "
+                    "missing credentials, a human/product/art decision, "
+                    "approval for destructive action, or permission for "
+                    "a service interruption. Do not use this to park "
+                    "routine implementation handoffs; use kanban_complete "
+                    "with review metadata for those."
+                ),
+            },
+            "reason_category": {
+                "type": "string",
+                "enum": [
+                    "credential",
+                    "human_decision",
+                    "destructive_action",
+                    "service_interruption",
+                    "product_decision",
+                    "art_decision",
+                ],
+                "description": (
+                    "Optional explicit human-gate category. Providing a "
+                    "category marks this block as a human gate even if "
+                    "human_gate is omitted."
                 ),
             },
             "board": _board_schema_prop(),

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -905,7 +905,12 @@ KANBAN_COMPLETE_SCHEMA = {
                     "Free-form dict of structured facts about this "
                     "attempt — {\"changed_files\": [...], \"tests_run\": 12, "
                     "\"findings\": [...]}. Surfaced to downstream "
-                    "workers alongside ``summary``."
+                    "workers alongside ``summary``. Substantial handoffs "
+                    "with fields such as changed_files, artifacts, PRs, "
+                    "recommendations, or risk markers are routed to the "
+                    "configured reviewer before user-facing completion; "
+                    "set review_required=false with review_skip_reason for "
+                    "trivial/already-reviewed cases."
                 ),
             },
             "result": {

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -6,6 +6,7 @@ human-friendly channel names to IDs. Works in both CLI and gateway contexts.
 """
 
 import asyncio
+import copy
 import json
 import logging
 import os
@@ -18,6 +19,8 @@ from typing import Dict, Optional
 from agent.redact import redact_sensitive_text
 
 logger = logging.getLogger(__name__)
+
+NOTIFICATIONS_TELEGRAM_BOT_TOKEN_ENV = "NOTIFICATIONS_TELEGRAM_BOT_TOKEN"
 
 _TELEGRAM_TOPIC_TARGET_RE = re.compile(r"^\s*(-?\d+)(?::(\d+))?\s*$")
 _FEISHU_TARGET_RE = re.compile(r"^\s*((?:oc|ou|on|chat|open)_[-A-Za-z0-9]+)(?::([-A-Za-z0-9_]+))?\s*$")
@@ -418,6 +421,77 @@ def _describe_media_for_mirror(media_files):
             return "[Sent audio attachment]"
         return "[Sent document attachment]"
     return f"[Sent {len(media_files)} media attachments]"
+
+
+def _get_notifications_telegram_token() -> str:
+    """Return the dedicated Telegram notification bot token, if configured.
+
+    The value is read from Hermes' secure env/config path via ``get_env_value``
+    so callers do not need to inspect or print secret files directly.
+    """
+    try:
+        from hermes_cli.config import get_env_value
+        return (get_env_value(NOTIFICATIONS_TELEGRAM_BOT_TOKEN_ENV) or "").strip()
+    except Exception:
+        return (os.getenv(NOTIFICATIONS_TELEGRAM_BOT_TOKEN_ENV) or "").strip()
+
+
+def _notification_platform_config(platform, pconfig):
+    """Return a platform config suitable for one-way notification sends.
+
+    For Telegram notifications, prefer the dedicated Notifications bot token
+    over the interactive gateway bot token. Other platforms keep their normal
+    config unchanged.
+    """
+    try:
+        from gateway.config import Platform
+        is_telegram = platform == Platform.TELEGRAM
+    except Exception:
+        value = getattr(platform, "value", str(platform)).lower()
+        is_telegram = value == "telegram"
+
+    if not is_telegram:
+        return pconfig
+
+    token = _get_notifications_telegram_token()
+    if not token:
+        return pconfig
+
+    try:
+        notification_config = copy.copy(pconfig)
+        notification_config.token = token
+        return notification_config
+    except Exception:
+        from types import SimpleNamespace
+        return SimpleNamespace(
+            enabled=getattr(pconfig, "enabled", True),
+            token=token,
+            api_key=getattr(pconfig, "api_key", ""),
+            home_channel=getattr(pconfig, "home_channel", None),
+            reply_to_mode=getattr(pconfig, "reply_to_mode", None),
+            extra=getattr(pconfig, "extra", {}) or {},
+        )
+
+
+async def _send_notification_to_platform(
+    platform,
+    pconfig,
+    chat_id,
+    message,
+    thread_id=None,
+    media_files=None,
+    force_document=False,
+):
+    """Send a system notification, using the dedicated notifier bot when set."""
+    return await _send_to_platform(
+        platform,
+        _notification_platform_config(platform, pconfig),
+        chat_id,
+        message,
+        thread_id=thread_id,
+        media_files=media_files,
+        force_document=force_document,
+    )
 
 
 def _get_cron_auto_delivery_target():


### PR DESCRIPTION
## Summary
- harden Kanban/cron/gateway reliability paths around WAL/DB checks, low-noise watchdog routing, notifier delivery, and blocked/review handoffs
- add Hindsight memory budget/config guardrails and test coverage
- document the low-noise Kanban cron watchdog runbook
- preserve sticky worker/operator review blocks while avoiding immediate reopen of parentless circuit-breaker gave-up tasks

## Test Plan
- `python -m pytest -o 'addopts=' tests/hermes_cli/test_kanban_blocked_sticky.py tests/hermes_cli/test_kanban_db.py::test_recompute_ready_does_not_immediately_reopen_gave_up_tasks -q`
- `python -m pytest -o 'addopts=' tests/cron/test_scheduler.py tests/cron/test_vicky_kanban_cron_watchdogs.py tests/gateway/test_kanban_notifier.py tests/gateway/test_kanban_reply_targets.py tests/gateway/test_restart_resume_pending.py tests/hermes_cli/test_config.py tests/hermes_cli/test_kanban_blocked_sticky.py tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_notify.py tests/hermes_cli/test_kanban_specify.py tests/plugins/memory/test_hindsight_provider.py tests/test_hermes_state_wal_fallback.py tests/tools/test_kanban_tools.py -q`
