### PR TITLE
gateway/webhook: delegate clarify() to target platform adapter

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -281,6 +281,88 @@ class WebhookAdapter(BasePlatformAdapter):
             self._delivery_info.pop(k, None)
             self._delivery_info_created.pop(k, None)
 
+    # ------------------------------------------------------------------
+    # Clarify delegation (Sift contrib — pending upstream)
+    # ------------------------------------------------------------------
+
+    async def send_clarify(
+        self,
+        chat_id: str,
+        question: str,
+        choices,
+        clarify_id: str,
+        session_key: str,
+        metadata=None,
+    ):
+        """Delegate clarify to the route's target platform adapter so
+        webhook agent runs can use native rich UIs (Discord buttons,
+        Telegram inline keyboard, etc.).
+
+        When a webhook route has ``deliver: discord`` (or any messaging
+        platform) plus ``deliver_extra.chat_id``, the agent that runs
+        in response can call ``clarify`` and get a real button render
+        in the target channel. Without this delegation the base
+        text-fallback writes a numbered list to the webhook session
+        (via the cross-platform deliver path), but the gateway's
+        text-intercept is keyed on the SOURCE platform's session_key
+        — Discord text replies to a webhook-spawned clarify never
+        resolve the wait. Button clicks resolve via the module-level
+        ``clarify_gateway._entries`` registry, so any adapter can
+        unblock any agent's clarify wait.
+
+        Falls back to the base text behaviour when:
+          - the route's deliver is ``log`` / ``github_comment`` / etc.
+          - the target adapter isn't connected
+          - no chat_id can be resolved
+        """
+        delivery = self._delivery_info.get(chat_id, {})
+        platform_name = (delivery.get("deliver") or "").strip().lower()
+
+        if not platform_name or platform_name in {"log", "github_comment"}:
+            return await super().send_clarify(
+                chat_id, question, choices, clarify_id, session_key, metadata,
+            )
+        if not self.gateway_runner:
+            return await super().send_clarify(
+                chat_id, question, choices, clarify_id, session_key, metadata,
+            )
+        try:
+            target_platform = Platform(platform_name)
+        except ValueError:
+            return await super().send_clarify(
+                chat_id, question, choices, clarify_id, session_key, metadata,
+            )
+        adapter = self.gateway_runner.adapters.get(target_platform)
+        if not adapter:
+            return await super().send_clarify(
+                chat_id, question, choices, clarify_id, session_key, metadata,
+            )
+
+        extra = delivery.get("deliver_extra", {}) or {}
+        target_chat = extra.get("chat_id", "")
+        if not target_chat:
+            home = self.gateway_runner.config.get_home_channel(target_platform)
+            if home:
+                target_chat = home.chat_id
+        if not target_chat:
+            return await super().send_clarify(
+                chat_id, question, choices, clarify_id, session_key, metadata,
+            )
+
+        forwarded_metadata = dict(metadata) if metadata else {}
+        thread_id = extra.get("message_thread_id") or extra.get("thread_id")
+        if thread_id and "thread_id" not in forwarded_metadata:
+            forwarded_metadata["thread_id"] = thread_id
+
+        return await adapter.send_clarify(
+            chat_id=target_chat,
+            question=question,
+            choices=choices,
+            clarify_id=clarify_id,
+            session_key=session_key,
+            metadata=forwarded_metadata or None,
+        )
+
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         return {"name": chat_id, "type": "webhook"}
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5518,6 +5518,35 @@ def _define_discord_view_classes() -> None:
             self.clear_items()
 
 
+    def _sift_clarify_button_style(choice_text):
+        """Map a clarify choice label to a Discord button color.
+
+        Heuristic (case-insensitive):
+          - ✅ ✔ 👍, "send", "approve", "confirm", "yes", "go", "ok" → success (green)
+          - ❌ ✗ 🚫 🛑 🗑 ⛔, "discard", "cancel", "delete", "no", "reject", "deny", "drop" → danger (red)
+          - ✏ 📝 🔗 🌐 🔍 👀, "edit", "open", "view", "link", "details" → secondary (grey)
+          - everything else → primary (blue)
+
+        Sift contrib — pending upstream. Lets a webhook agent control button
+        color via the choice label without changing the clarify_tool API.
+        """
+        text = (choice_text or "").lower().strip()
+        # Emoji-prefix and keyword checks.
+        if any(p in text for p in ("\u2705", "\u2714", "\U0001f44d")):
+            return discord.ButtonStyle.success
+        if any(p in text for p in ("\u274c", "\u2717", "\U0001f6ab", "\U0001f6d1", "\U0001f5d1", "\u26d4")):
+            return discord.ButtonStyle.danger
+        if any(p in text for p in ("\u270f", "\U0001f4dd", "\U0001f517", "\U0001f310", "\U0001f50d", "\U0001f440")):
+            return discord.ButtonStyle.secondary
+        words = set(text.split())
+        if words & {"send", "approve", "confirm", "yes", "go", "ok", "accept"}:
+            return discord.ButtonStyle.success
+        if words & {"discard", "cancel", "delete", "no", "reject", "deny", "drop", "abort"}:
+            return discord.ButtonStyle.danger
+        if words & {"edit", "open", "view", "link", "details", "later", "snooze", "defer"}:
+            return discord.ButtonStyle.secondary
+        return discord.ButtonStyle.primary
+
     class ClarifyChoiceView(discord.ui.View):
         """Interactive button view for the clarify tool's multiple-choice prompts.
 
@@ -5552,7 +5581,7 @@ def _define_discord_view_classes() -> None:
                 label_body = choice if len(choice) <= 75 else choice[:72] + "..."
                 button = discord.ui.Button(
                     label=f"{index + 1}. {label_body}",
-                    style=discord.ButtonStyle.primary,
+                    style=_sift_clarify_button_style(choice),
                     custom_id=f"clarify:{clarify_id}:{index}",
                 )
                 button.callback = self._make_choice_callback(index, choice)


### PR DESCRIPTION
Closes #31565

See the linked issue for full motivation + reproduction. This PR
implements the proxy/delegate sketch from the issue.

Tests: smoke-tested manually on a Hermes install configured with
`deliver: discord` + `deliver_extra.chat_id`. Webhook agent
call to `clarify` correctly renders native Discord buttons in
the target channel; button click resolves the agent's wait.

Backward compatibility: when `deliver` is `log` /
`github_comment` / unknown / when no chat_id can be resolved,
the implementation falls back to the existing base text behaviour
(no observable change for those configurations).