### PR TITLE
fix(agent): skip Ollama /api/show probe for known non-Ollama providers

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1675,16 +1675,25 @@ def get_model_context_length(
         ctx = _resolve_endpoint_context_length(model, base_url, api_key=api_key)
         if ctx is not None:
             return ctx
-    # 5e. Ollama native /api/show probe — runs for ANY provider with a
-    # base_url, not just ollama-cloud.  Ollama-compatible servers expose
+    # 5e. Ollama native /api/show probe — runs only when the effective
+    # provider is unknown or Ollama-class.  Ollama-compatible servers expose
     # this endpoint regardless of hostname (local Ollama, Ollama Cloud,
-    # custom Ollama hosting).  The OpenAI-compat /v1/models endpoint
+    # custom Ollama hosting); the OpenAI-compat /v1/models endpoint
     # correctly omits context_length per the OpenAI schema, but /api/show
     # returns the authoritative GGUF model_info.context_length.
-    # For non-Ollama servers (OpenAI, Anthropic, etc.), the POST returns
-    # 404/405 quickly.  Results are cached, so the hit is per-model+URL,
-    # once per hour.
-    if base_url:
+    # For known non-Ollama providers (OpenAI, Anthropic, OpenRouter, etc.)
+    # the POST does return 404/405 — but the per-call latency cost on a
+    # cold cache is real (~1.7s for OpenRouter SSL handshake + server
+    # round-trip).  That cost is paid on every cold start because the
+    # negative result is only cached per-process via `_RECENT_PROBES`.
+    # Custom-endpoint Ollama servers are already covered by step 2b above,
+    # so this branch is only needed for the "no explicit provider" case
+    # where _infer_provider_from_url returned nothing.  Refs #31555.
+    should_probe_ollama = (
+        not effective_provider
+        or effective_provider in {"ollama", "ollama-cloud"}
+    )
+    if base_url and should_probe_ollama:
         ctx = _query_ollama_api_show(model, base_url, api_key=api_key)
         if ctx is not None:
             save_context_length(model, base_url, ctx)

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -12,6 +12,7 @@ Coverage levels:
 
 import time
 
+import pytest
 import yaml
 from unittest.mock import patch, MagicMock
 
@@ -1247,3 +1248,155 @@ class TestContextLengthCache:
         with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
             save_context_length(model, url, 200000)
             assert get_cached_context_length(model, url) == 200000
+
+
+class TestOllamaProbeGate:
+    """Step 5e of ``get_model_context_length`` runs the Ollama
+    ``/api/show`` probe.  On a cold cache that probe blocks ~1.7s on
+    OpenRouter and similar non-Ollama hosts (full SSL handshake + server
+    round-trip to confirm a 404).  Skip it for any provider that is
+    known not to speak the Ollama protocol — only run when the resolved
+    provider is unknown, ``ollama``, or ``ollama-cloud``.  Refs #31555."""
+
+    def _patch_skip_other_branches(self):
+        """Force the resolver down to step 5e by neutralising every
+        higher-precedence branch.  Returns the patch context managers as
+        a list the caller can stack with ``contextlib.ExitStack``."""
+        return [
+            patch("agent.model_metadata.get_cached_context_length", return_value=None),
+            patch("agent.model_metadata.fetch_model_metadata", return_value={}),
+            patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}),
+            patch("agent.model_metadata._query_anthropic_context_length", return_value=None),
+            patch("agent.model_metadata._resolve_endpoint_context_length", return_value=None),
+            patch("agent.models_dev.lookup_models_dev_context", return_value=None),
+            patch("agent.models_dev.fetch_models_dev", return_value={}),
+        ]
+
+    @pytest.mark.parametrize("provider,base_url", [
+        ("openai", "https://api.openai.com/v1"),
+        ("anthropic", "https://api.anthropic.com"),
+        ("openrouter", "https://openrouter.ai/api/v1"),
+        ("gemini", "https://generativelanguage.googleapis.com"),
+        ("deepseek", "https://api.deepseek.com"),
+        ("xai", "https://api.x.ai/v1"),
+        ("zai", "https://api.z.ai"),
+        ("fireworks", "https://api.fireworks.ai"),
+    ])
+    def test_known_non_ollama_provider_skips_probe(self, provider, base_url):
+        """The probe must not run for known non-Ollama providers — the
+        latency cost on a cold cache is real (~1.7s for OpenRouter)."""
+        import contextlib
+        from agent.model_metadata import get_model_context_length
+
+        with contextlib.ExitStack() as stack:
+            for ctx_mgr in self._patch_skip_other_branches():
+                stack.enter_context(ctx_mgr)
+            mock_probe = stack.enter_context(
+                patch("agent.model_metadata._query_ollama_api_show")
+            )
+
+            get_model_context_length(
+                "some-unknown-model-not-in-defaults",
+                provider=provider,
+                base_url=base_url,
+            )
+
+            assert mock_probe.call_count == 0, (
+                f"_query_ollama_api_show ran for known-non-Ollama provider "
+                f"{provider!r}; this re-introduces the #31555 startup-latency bug"
+            )
+
+    @pytest.mark.parametrize("provider", ["ollama", "ollama-cloud"])
+    def test_ollama_class_provider_still_probes(self, provider):
+        """Real Ollama users must keep getting the authoritative
+        ``/api/show`` context length."""
+        import contextlib
+        from agent.model_metadata import get_model_context_length
+
+        with contextlib.ExitStack() as stack:
+            for ctx_mgr in self._patch_skip_other_branches():
+                stack.enter_context(ctx_mgr)
+            mock_probe = stack.enter_context(
+                patch("agent.model_metadata._query_ollama_api_show", return_value=131072)
+            )
+            # Block the local-server fallback step 9 — only step 5e should
+            # ever see this call.
+            stack.enter_context(
+                patch("agent.model_metadata._query_local_context_length", return_value=None)
+            )
+            stack.enter_context(
+                patch("agent.model_metadata.save_context_length")
+            )
+
+            ctx = get_model_context_length(
+                "qwen3-coder",
+                provider=provider,
+                base_url="https://ollama.example.com/v1",
+            )
+
+            assert mock_probe.call_count >= 1, (
+                f"_query_ollama_api_show was skipped for {provider!r}; "
+                "Ollama users would silently lose context detection"
+            )
+            assert ctx == 131072
+
+    def test_empty_provider_still_probes(self):
+        """When provider is unknown, the probe is the only signal we
+        have for context length — must still run."""
+        import contextlib
+        from agent.model_metadata import get_model_context_length
+
+        with contextlib.ExitStack() as stack:
+            for ctx_mgr in self._patch_skip_other_branches():
+                stack.enter_context(ctx_mgr)
+            # Step 2b also runs the probe for unknown-custom endpoints.
+            # We use a base_url that is a known-provider host so step 2b
+            # doesn't fire, but we leave ``provider`` empty so step 5
+            # can't infer it via URL match (we'd hit ``openai`` and skip
+            # the probe).  Use a synthetic non-mapped host instead.
+            mock_probe = stack.enter_context(
+                patch("agent.model_metadata._query_ollama_api_show", return_value=None)
+            )
+            stack.enter_context(
+                patch("agent.model_metadata._is_custom_endpoint", return_value=False)
+            )
+            stack.enter_context(
+                patch("agent.model_metadata._infer_provider_from_url", return_value=None)
+            )
+
+            get_model_context_length(
+                "completely-novel-model-name",
+                provider="",
+                base_url="https://internal.example.com/v1",
+            )
+
+            assert mock_probe.call_count >= 1, (
+                "Unknown-provider path skipped the Ollama probe — the "
+                "fallback would never reach authoritative context length"
+            )
+
+    def test_known_provider_via_url_inference_skips_probe(self):
+        """Even when provider is empty, an inferred known provider
+        (via ``_infer_provider_from_url``) must skip the probe.  This is
+        the OpenRouter-via-``provider: custom`` case from #31555."""
+        import contextlib
+        from agent.model_metadata import get_model_context_length
+
+        with contextlib.ExitStack() as stack:
+            for ctx_mgr in self._patch_skip_other_branches():
+                stack.enter_context(ctx_mgr)
+            mock_probe = stack.enter_context(
+                patch("agent.model_metadata._query_ollama_api_show")
+            )
+
+            # provider="openrouter" is in the {"openrouter","custom"}
+            # set that triggers inference at step 5; the URL maps back
+            # to "openrouter" so effective_provider becomes "openrouter"
+            # — known non-Ollama, probe must skip.
+            get_model_context_length(
+                "novel-model-no-default",
+                provider="openrouter",
+                base_url="https://openrouter.ai/api/v1",
+            )
+
+            assert mock_probe.call_count == 0


### PR DESCRIPTION
## What does this PR do?

Step 5e of `get_model_context_length` runs `_query_ollama_api_show` for any `base_url`, including known non-Ollama providers (OpenAI, Anthropic, OpenRouter, Gemini, etc.). The probe correctly returns 404/405 for those servers, but the per-call latency cost on a cold cache is real — ~1.7s for OpenRouter (full SSL handshake + server round-trip), paid on every cold start because the negative result is only cached per-process via `_RECENT_PROBES`.

Gate step 5e by `effective_provider`: only probe when the resolver hasn't identified a provider, or when the provider is Ollama-class (`ollama`, `ollama-cloud`). Step 2b (line 1565-1576) continues to cover custom-endpoint Ollama servers where the URL host isn't in `_URL_TO_PROVIDER` — that branch is untouched, so real Ollama users on custom hosting still get authoritative GGUF context lengths.

Mirrors the existing provider classification in `agent/model_metadata.py`: `effective_provider` is already set/inferred earlier at lines 1607-1612 via `_infer_provider_from_url`, so this fix piggybacks on the same precedence and doesn't introduce a new resolver path.

## Related Issue

Fixes #31555

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/model_metadata.py` — add `should_probe_ollama` gate on step 5e so the probe only runs when `effective_provider` is empty/None or Ollama-class. Comment updated to reference the latency cost and #31555.
- `tests/agent/test_model_metadata.py` — add `TestOllamaProbeGate` (12 tests): parametrised across 8 known non-Ollama providers asserting `_query_ollama_api_show` is never called; both Ollama-class providers asserting the probe still runs and the returned context is consumed; an empty-provider case asserting the probe still runs (last-resort signal); the OpenRouter-via-`provider: custom` path asserting that URL-inferred known providers also skip.

## How to Test

1. Reproduce the issue with no fix: run `hermes /model` against an OpenRouter-backed config and observe the ~1.7s `_query_ollama_api_show` call in cProfile output (`agent/model_metadata.py:1665` pre-fix).
2. Apply the patch and re-run; the probe is skipped and startup latency drops by ~1.7s.
3. Focused test run:

   ```bash
   uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest \
     tests/agent/test_model_metadata.py::TestOllamaProbeGate -v
   ```

   Expected: 12 passed.
4. Full module regression: `pytest tests/agent/test_model_metadata.py tests/agent/test_models_dev.py -q` → 146 passed locally.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline comment updated to match)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — change is platform-agnostic
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

- #27331 (Tranquil-Flow, open) addresses #26489 by adding a guard at **step 2b** for the `provider: custom` + LiteLLM-fronting-Ollama case (OpenAI-shape catalog + `detect_local_server_type` says non-Ollama). That fix is complementary: it covers the "unknown provider, server isn't actually Ollama" path. This PR covers the orthogonal **step 5e** path: "provider IS known and isn't Ollama, skip the probe entirely." Both fixes can land together without conflict — they touch different branches of the same function and different code blocks.
- Audited siblings: confirmed `agent/model_metadata.py:1573` (step 2b) is already gated by `_is_custom_endpoint(base_url) and not _is_known_provider_base_url(base_url)` so it won't fire for OpenAI/Anthropic/OpenRouter; `agent/model_metadata.py:1717` (step 9 `_query_local_context_length`) is already gated by `is_local_endpoint(base_url)` so it won't fire for cloud providers. No widening needed.