### PR TITLE
fix(discord): fetch and inject reply context for incoming messages

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4810,6 +4810,20 @@ class DiscordAdapter(BasePlatformAdapter):
             reply_to_id = str(message.reference.message_id)
             if message.reference.resolved:
                 reply_to_text = getattr(message.reference.resolved, "content", None) or None
+            # When Discord doesn't provide the resolved message inline
+            # (common in high-traffic servers or for older messages),
+            # fetch it from the API so the agent has reply context.
+            if reply_to_text is None and reply_to_id:
+                try:
+                    ref_msg = await message.channel.fetch_message(int(reply_to_id))
+                    reply_to_text = getattr(ref_msg, "content", None) or None
+                except Exception:
+                    logger.debug("Could not fetch reply-to message %s", reply_to_id)
+        # Prepend reply context to the message text so the agent can
+        # understand what the user is responding to.
+        if reply_to_text:
+            reply_context = f'[Replying to: "{reply_to_text[:200]}"]\n' if len(reply_to_text) <= 200 else f'[Replying to: "{reply_to_text[:200]}..."]\n'
+            event_text = reply_context + event_text
 
         event = MessageEvent(
             text=event_text,


### PR DESCRIPTION
## Summary

When a Discord message references another message as a reply, Discord sometimes omits the resolved message content (common in high-traffic servers or for older messages). This causes the agent to receive a reply without knowing what it is replying to.

This fix:
1. Detects when `reply_to_text` is `None` but `reply_to_id` exists
2. Fetches the referenced message from the Discord API via `channel.fetch_message()`
3. Injects the reply context as `[Replying to: "<text>"][:200]` before the message text

The text is capped at 200 characters to avoid bloating the context.

## Changes

- `plugins/platforms/discord/adapter.py`: fetch reply-to message when Discord does not provide resolved content inline

---

*Replaces #31447 — rebased cleanly onto current main to remove unintended diff pollution.*