### PR TITLE
fix(dashboard): add capture-phase wheel listener for reliable chat sc…

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -427,6 +427,21 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
 
     term.open(host);
 
+    // Capture-phase wheel listener on the host div as a fallback.
+    // In browser/dashboard layouts, parent layers or renderer/host event
+    // ordering can consume or bypass wheel events before xterm's own
+    // attachCustomWheelEventHandler fires. This non-passive capture listener
+    // ensures the scroll always reaches the terminal.
+    const wheelHandler = (ev: WheelEvent) => {
+      const delta = ev.deltaY;
+      if (!delta) return;
+      const step = Math.max(1, Math.round(Math.abs(delta) / 50));
+      term.scrollLines(delta > 0 ? step : -step);
+      ev.preventDefault();
+      ev.stopPropagation();
+    };
+    host.addEventListener("wheel", wheelHandler, { capture: true, passive: false });
+
     // WebGL draws from a texture atlas sized with device pixels. On phones and
     // in DevTools device mode that often produces *visually* much larger cells
     // than `fontSize` suggests — users see "huge" text even at 7–9px settings.
@@ -640,6 +655,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       if (hostSyncRaf) cancelAnimationFrame(hostSyncRaf);
       if (settleRaf1) cancelAnimationFrame(settleRaf1);
       if (settleRaf2) cancelAnimationFrame(settleRaf2);
+      host.removeEventListener("wheel", wheelHandler, { capture: true });
       ws.close();
       wsRef.current = null;
       term.dispose();


### PR DESCRIPTION
## Summary

In browser/dashboard layouts, parent layers or renderer/host event ordering can consume or bypass wheel events before xterm.js own `attachCustomWheelEventHandler` fires. This causes mouse-wheel scrolling to fail in Dashboard Chat even though keyboard scrollback works.

Fix: adds a non-passive capture-phase wheel listener directly on the terminal host div that calls the same `term.scrollLines()` helper as the existing xterm custom wheel handler. This ensures wheel events always reach the terminal regardless of event ordering.

The listener is properly cleaned up in the `useEffect` return function.

## Changes

- `web/src/pages/ChatPage.tsx`: capture-phase wheel listener for reliable chat scroll

Fixes #30008

---

*Replaces #31439 — rebased cleanly onto current main to remove unintended diff pollution.*