### PR TITLE
docs: add MCP registry metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # Hermes Agent ☤
 
+<!-- mcp-name: io.github.NousResearch/hermes-agent -->
+
 <p align="center">
   <a href="https://hermes-agent.nousresearch.com/docs/"><img src="https://img.shields.io/badge/Docs-hermes--agent.nousresearch.com-FFD700?style=for-the-badge" alt="Documentation"></a>
   <a href="https://discord.gg/NousResearch"><img src="https://img.shields.io/badge/Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>

--- a/server.json
+++ b/server.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.NousResearch/hermes-agent",
+  "title": "Hermes Agent",
+  "description": "Bridge MCP clients to Hermes conversations, messaging targets, events, and approvals.",
+  "version": "0.14.0",
+  "websiteUrl": "https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp#running-hermes-as-an-mcp-server",
+  "repository": {
+    "source": "github",
+    "url": "https://github.com/NousResearch/hermes-agent"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "hermes-agent",
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp"
+        },
+        {
+          "type": "positional",
+          "value": "serve"
+        }
+      ],
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -524,6 +524,8 @@ hermes mcp serve
 
 This starts a stdio MCP server. The MCP client (not you) manages the process lifecycle.
 
+Hermes also ships a root-level [`server.json`](https://github.com/NousResearch/hermes-agent/blob/main/server.json) metadata file for MCP registries. Clients that understand MCP registry metadata can install the PyPI package and run it with the fixed `mcp serve` arguments.
+
 ### MCP client configuration
 
 Add Hermes to your MCP client config. For example, in Claude Code's `~/.claude/claude_desktop_config.json`:


### PR DESCRIPTION
## Summary
- Add root `server.json` MCP registry metadata for Hermes Agent's stdio MCP server
- Add the PyPI README ownership verification marker matching `server.json.name`
- Document that registry-aware MCP clients can install the PyPI package and run `mcp serve`

## Validation
- `mcp-publisher validate`
- `git diff --check`
- Subagent review: Spec Compliance PASS; Quality/Safety APPROVED
- Follow-up subagent re-review after removing package-level version: PASS / APPROVED

## Notes
- This prepares Hermes for MCP registry/directory submission but does not claim the listing is already published.
- `server.json` intentionally omits the optional package-level version so registry clients can resolve a PyPI release that contains the README ownership marker after this lands.
