### PR TITLE
fix: extend gateway interaction timeouts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13501,7 +13501,7 @@ class GatewayRunner:
     # /approve & /deny — explicit dangerous-command approval
     # ------------------------------------------------------------------
 
-    _APPROVAL_TIMEOUT_SECONDS = 300  # 5 minutes
+    _APPROVAL_TIMEOUT_SECONDS = 3600  # 1 hour
 
     async def _handle_approve_command(self, event: MessageEvent) -> Optional[str]:
         """Handle /approve command — unblock waiting agent thread(s).

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -30,6 +30,7 @@ _DISCORD_COMMAND_SYNC_STATE_SUBDIR = "gateway"
 _DISCORD_COMMAND_SYNC_STATE_FILENAME = "discord_command_sync_state.json"
 _DISCORD_COMMAND_SYNC_MUTATION_INTERVAL_SECONDS = 4.5
 _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS = 30.0
+DISCORD_INTERACTIVE_VIEW_TIMEOUT_SECONDS = 3600
 
 try:
     import discord
@@ -83,6 +84,11 @@ def _clean_discord_id(entry: str) -> str:
     if entry.lower().startswith("user:"):
         entry = entry[5:]
     return entry.strip()
+
+
+def _discord_interactive_view_timeout() -> int:
+    """Return the default lifetime for Discord component views."""
+    return DISCORD_INTERACTIVE_VIEW_TIMEOUT_SECONDS
 
 
 def check_discord_requirements() -> bool:
@@ -5010,7 +5016,7 @@ def _define_discord_view_classes() -> None:
         Shows four buttons: Allow Once, Allow Session, Always Allow, Deny.
         Clicking a button calls ``resolve_gateway_approval()`` to unblock the
         waiting agent thread — the same mechanism as the text ``/approve`` flow.
-        Only users in the allowed list can click.  Times out after 5 minutes.
+        Only users in the allowed list can click.  Times out after 1 hour.
         """
 
         def __init__(
@@ -5019,7 +5025,7 @@ def _define_discord_view_classes() -> None:
             allowed_user_ids: set,
             allowed_role_ids: Optional[set] = None,
         ):
-            super().__init__(timeout=300)  # 5-minute timeout
+            super().__init__(timeout=_discord_interactive_view_timeout())
             self.session_key = session_key
             self.allowed_user_ids = allowed_user_ids
             self.allowed_role_ids = allowed_role_ids or set()
@@ -5118,7 +5124,7 @@ def _define_discord_view_classes() -> None:
         ``tools.slash_confirm.resolve(session_key, confirm_id, choice)``
         which runs the handler the runner stored for this ``session_key``.
         Only users in the adapter's allowlist can click.  Times out after
-        5 minutes (matches the gateway primitive's timeout).
+        1 hour (matches the gateway primitive's timeout).
         """
 
         def __init__(
@@ -5128,7 +5134,7 @@ def _define_discord_view_classes() -> None:
             allowed_user_ids: set,
             allowed_role_ids: Optional[set] = None,
         ):
-            super().__init__(timeout=300)
+            super().__init__(timeout=_discord_interactive_view_timeout())
             self.session_key = session_key
             self.confirm_id = confirm_id
             self.allowed_user_ids = allowed_user_ids
@@ -5212,8 +5218,7 @@ def _define_discord_view_classes() -> None:
 
         Clicking a button writes the answer to ``.update_response`` so the
         detached update process can pick it up.  Only authorized users can
-        click.  Times out after 5 minutes (the update process also has a
-        5-minute timeout on its side).
+        click.  Times out after 1 hour.
         """
 
         def __init__(
@@ -5222,7 +5227,7 @@ def _define_discord_view_classes() -> None:
             allowed_user_ids: set,
             allowed_role_ids: Optional[set] = None,
         ):
-            super().__init__(timeout=300)
+            super().__init__(timeout=_discord_interactive_view_timeout())
             self.session_key = session_key
             self.allowed_user_ids = allowed_user_ids
             self.allowed_role_ids = allowed_role_ids or set()
@@ -5297,7 +5302,7 @@ def _define_discord_view_classes() -> None:
 
         Two-step drill-down: provider dropdown → model dropdown.
         Edits the original message in-place as the user navigates.
-        Times out after 2 minutes.
+        Times out after 1 hour.
         """
 
         def __init__(
@@ -5310,7 +5315,7 @@ def _define_discord_view_classes() -> None:
             allowed_user_ids: set,
             allowed_role_ids: Optional[set] = None,
         ):
-            super().__init__(timeout=120)
+            super().__init__(timeout=_discord_interactive_view_timeout())
             self.providers = providers
             self.current_model = current_model
             self.current_provider = current_provider
@@ -5540,7 +5545,7 @@ def _define_discord_view_classes() -> None:
             allowed_user_ids: set,
             allowed_role_ids: Optional[set] = None,
         ):
-            super().__init__(timeout=300)  # 5-minute timeout
+            super().__init__(timeout=_discord_interactive_view_timeout())
             self.choices = list(choices)[:24]
             self.clarify_id = clarify_id
             self.allowed_user_ids = allowed_user_ids

--- a/tests/gateway/test_discord_component_auth.py
+++ b/tests/gateway/test_discord_component_auth.py
@@ -19,6 +19,8 @@ import pytest
 # Trigger the shared discord mock from tests/gateway/conftest.py before
 # importing the production module.
 from plugins.platforms.discord.adapter import (  # noqa: E402
+    DISCORD_INTERACTIVE_VIEW_TIMEOUT_SECONDS,
+    ClarifyChoiceView,
     ExecApprovalView,
     ModelPickerView,
     SlashConfirmView,
@@ -228,3 +230,30 @@ def test_model_picker_view_empty_allowlists_allow_everyone():
     )
     assert view.allowed_role_ids == set()
     assert view._check_auth(_interaction(99999)) is True
+
+
+def test_discord_interactive_views_default_to_one_hour_timeout():
+    async def _noop(*_a, **_k):
+        return ""
+
+    views = [
+        ExecApprovalView(session_key="s", allowed_user_ids=set()),
+        SlashConfirmView(session_key="s", confirm_id="c", allowed_user_ids=set()),
+        UpdatePromptView(session_key="s", allowed_user_ids=set()),
+        ModelPickerView(
+            providers=[],
+            current_model="m",
+            current_provider="p",
+            session_key="s",
+            on_model_selected=_noop,
+            allowed_user_ids=set(),
+        ),
+        ClarifyChoiceView(
+            choices=["a"],
+            clarify_id="clarify-1",
+            allowed_user_ids=set(),
+        ),
+    ]
+
+    assert DISCORD_INTERACTIVE_VIEW_TIMEOUT_SECONDS == 3600
+    assert {view.timeout for view in views} == {DISCORD_INTERACTIVE_VIEW_TIMEOUT_SECONDS}

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1334,6 +1334,12 @@ class TestApprovalTimeoutIsNotConsent:
 
     SESSION_KEY = "test-no-consent-session"
 
+    def test_default_gateway_approval_timeout_is_one_hour(self):
+        from tools import approval as mod
+
+        assert mod.DEFAULT_GATEWAY_APPROVAL_TIMEOUT_SECONDS == 3600
+
+
     def setup_method(self):
         """Reset module state and force tight gateway_timeout for fast tests."""
         from tools import approval as mod

--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -167,15 +167,25 @@ class TestClarifyPrimitive:
         assert a is not None and a.clarify_id == "idA"
         assert b is not None and b.clarify_id == "idB"
 
-    def test_clarify_timeout_config_default(self):
-        """get_clarify_timeout returns 600 by default."""
+    def test_clarify_timeout_config_default(self, monkeypatch):
+        """get_clarify_timeout returns 3600 by default."""
         from tools import clarify_gateway as cm
 
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+
         timeout = cm.get_clarify_timeout()
-        # Default 600s OR whatever is in the user's loaded config.
-        # Floor check: must be a positive int, not crashed.
-        assert isinstance(timeout, int)
-        assert timeout > 0
+        assert timeout == cm.DEFAULT_CLARIFY_TIMEOUT_SECONDS == 3600
+
+    def test_clarify_timeout_config_override_preserved(self, monkeypatch):
+        """agent.clarify_timeout still overrides the one-hour default."""
+        from tools import clarify_gateway as cm
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"agent": {"clarify_timeout": 42}},
+        )
+
+        assert cm.get_clarify_timeout() == 42
 
 
 class TestGatewayTextIntercept:

--- a/tests/tools/test_slash_confirm.py
+++ b/tests/tools/test_slash_confirm.py
@@ -21,6 +21,9 @@ def _clean_pending():
 
 
 class TestRegisterAndGetPending:
+    def test_default_timeout_is_one_hour(self):
+        assert slash_confirm.DEFAULT_TIMEOUT_SECONDS == 3600
+
     def test_register_stores_entry(self):
         async def handler(choice):
             return f"got {choice}"

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -22,6 +22,7 @@ from hermes_cli.config import cfg_get
 from utils import env_var_enabled, is_truthy_value
 
 logger = logging.getLogger(__name__)
+DEFAULT_GATEWAY_APPROVAL_TIMEOUT_SECONDS = 3600
 
 # Per-thread/per-task gateway session identity.
 # Gateway runs agent turns concurrently in executor threads, so reading a
@@ -1233,7 +1234,7 @@ def check_all_command_guards(command: str, env_type: str,
                     "description": combined_desc,
                 }
 
-            # Block until the user responds or timeout (default 5 min).
+            # Block until the user responds or timeout (default 1 hour).
             # Poll in short slices so we can fire activity heartbeats every
             # ~10s to the agent's inactivity tracker.  Without this, the
             # blocking event.wait() never touches activity, and the
@@ -1241,11 +1242,13 @@ def check_all_command_guards(command: str, env_type: str,
             # 1800s) kills the agent while the user is still responding to
             # the approval prompt.  Mirrors the _wait_for_process() cadence
             # in tools/environments/base.py.
-            timeout = _get_approval_config().get("gateway_timeout", 300)
+            timeout = _get_approval_config().get(
+                "gateway_timeout", DEFAULT_GATEWAY_APPROVAL_TIMEOUT_SECONDS
+            )
             try:
                 timeout = int(timeout)
             except (ValueError, TypeError):
-                timeout = 300
+                timeout = DEFAULT_GATEWAY_APPROVAL_TIMEOUT_SECONDS
 
             try:
                 from tools.environments.base import touch_activity_if_due

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -38,6 +38,7 @@ from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+DEFAULT_CLARIFY_TIMEOUT_SECONDS = 3600
 
 
 # =========================================================================
@@ -231,7 +232,7 @@ def clear_session(session_key: str) -> int:
 def get_clarify_timeout() -> int:
     """Read the clarify response timeout (seconds) from config.
 
-    Defaults to 600 (10 minutes) — long enough for the user to type a
+    Defaults to 3600 (1 hour) — long enough for the user to type a
     thoughtful response, short enough that an abandoned prompt eventually
     unblocks the agent thread instead of pinning the running-agent guard
     forever.
@@ -242,9 +243,9 @@ def get_clarify_timeout() -> int:
         from hermes_cli.config import load_config
         cfg = load_config() or {}
         agent_cfg = cfg.get("agent", {}) or {}
-        return int(agent_cfg.get("clarify_timeout", 600))
+        return int(agent_cfg.get("clarify_timeout", DEFAULT_CLARIFY_TIMEOUT_SECONDS))
     except Exception:
-        return 600
+        return DEFAULT_CLARIFY_TIMEOUT_SECONDS
 
 
 # =========================================================================

--- a/tools/slash_confirm.py
+++ b/tools/slash_confirm.py
@@ -45,7 +45,7 @@ _lock = threading.RLock()
 # the next message arrives for the same session.  Buttons work up until
 # the adapter drops the callback_data (Telegram: ~48h; Discord: ephemeral;
 # Slack: 3s ack + long-lived actions).
-DEFAULT_TIMEOUT_SECONDS = 300
+DEFAULT_TIMEOUT_SECONDS = 3600
 
 
 def register(


### PR DESCRIPTION
## Summary

- Extend Discord interactive component views to a one-hour timeout via a shared `DISCORD_INTERACTIVE_VIEW_TIMEOUT_SECONDS` helper.
- Align related gateway-side server state defaults so buttons/prompts do not appear usable after backend state expires:
  - gateway approval timeout default/fallback
  - slash-confirm pending expiry
  - clarify default/fallback timeout while preserving `agent.clarify_timeout` overrides
- Update stale 2-minute / 5-minute comments and add regression coverage for the one-hour defaults.

## Tests

```bash
./scripts/run_tests.sh tests/gateway/test_discord_component_auth.py tests/gateway/test_discord_model_picker.py tests/gateway/test_discord_clarify_buttons.py tests/tools/test_clarify_gateway.py tests/tools/test_slash_confirm.py tests/gateway/test_approve_deny_commands.py tests/tools/test_approval.py
```

Result: 278 passed.
