### PR TITLE
fix(agent): normalize empty assistant content to None when tool_calls present

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1753,6 +1753,36 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             "Pre-call sanitizer: added %d stub tool result(s)",
             len(missing_results),
         )
+
+    # [empty-content-with-tool-calls patch v1]
+    # 3. Normalize assistant messages where content is empty AND tool_calls
+    #    are present. Some OpenAI-compatible upstreams (notably Anthropic-
+    #    compatible shims and certain proxy gateways) hard-reject this with
+    #    400 "messages: text content blocks must be non-empty".
+    #    Both OpenAI and Anthropic accept content=None when tool_calls
+    #    carry the assistant turn, so coerce empty -> None.
+    _empty_fixed = 0
+    for _m in messages:
+        if _m.get("role") != "assistant":
+            continue
+        if not _m.get("tool_calls"):
+            continue
+        _c = _m.get("content")
+        if _c == "" or _c == [] or (isinstance(_c, list) and not any(
+            isinstance(_b, dict) and (
+                (_b.get("type") in ("text", "input_text", "output_text") and _b.get("text"))
+                or _b.get("type") not in (None, "text", "input_text", "output_text")
+            )
+            for _b in _c
+        )):
+            _m["content"] = None
+            _empty_fixed += 1
+    if _empty_fixed:
+        _ra().logger.debug(
+            "Pre-call sanitizer: coerced %d empty assistant content(s) -> None (tool_calls preserved)",
+            _empty_fixed,
+        )
+
     return messages
 
 

--- a/tests/run_agent/test_agent_guardrails.py
+++ b/tests/run_agent/test_agent_guardrails.py
@@ -294,3 +294,126 @@ class TestGetToolCallNameStatic:
     def test_object_without_function_attr(self):
         tc = types.SimpleNamespace(id="call_1")
         assert AIAgent._get_tool_call_name_static(tc) == ""
+
+
+# ---------------------------------------------------------------------------
+# sanitize_api_messages — empty-content-with-tool-calls normalization
+# ---------------------------------------------------------------------------
+#
+# Some OpenAI-compatible upstreams (Anthropic-compatible shims, certain proxy
+# gateways) hard-reject an assistant message that carries BOTH tool_calls and
+# an empty string content with:
+#     400 "messages: text content blocks must be non-empty"
+#
+# Both OpenAI and Anthropic accept ``content=None`` when tool_calls carry the
+# assistant turn, so sanitize_api_messages() coerces empty content to None at
+# the last moment before the request is sent.
+
+
+class TestEmptyContentWithToolCalls:
+
+    @staticmethod
+    def _tc(call_id: str = "c1", name: str = "ping", arguments: str = "{}") -> dict:
+        return {
+            "id": call_id,
+            "type": "function",
+            "function": {"name": name, "arguments": arguments},
+        }
+
+    def test_normalizes_empty_string_content_when_tool_calls_present(self):
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "", "tool_calls": [self._tc()]},
+            {"role": "tool", "tool_call_id": "c1", "content": "pong"},
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert out[1]["content"] is None
+        assert len(out[1]["tool_calls"]) == 1
+        # tool_calls payload preserved verbatim
+        assert out[1]["tool_calls"][0]["function"]["name"] == "ping"
+
+    def test_normalizes_empty_list_content_when_tool_calls_present(self):
+        msgs = [
+            {"role": "assistant", "content": [], "tool_calls": [self._tc()]},
+            {"role": "tool", "tool_call_id": "c1", "content": "pong"},
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert out[0]["content"] is None
+
+    def test_normalizes_list_of_empty_text_blocks(self):
+        msgs = [
+            {
+                "role": "assistant",
+                "content": [{"type": "text", "text": ""}],
+                "tool_calls": [self._tc()],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": "pong"},
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert out[0]["content"] is None
+
+    def test_keeps_assistant_text_when_present(self):
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "thinking...",
+                "tool_calls": [self._tc()],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": "pong"},
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert out[0]["content"] == "thinking..."
+
+    def test_keeps_non_empty_text_block_list(self):
+        msgs = [
+            {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "hi"}],
+                "tool_calls": [self._tc()],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": "pong"},
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert out[0]["content"] == [{"type": "text", "text": "hi"}]
+
+    def test_keeps_non_text_content_blocks(self):
+        # Image/other non-text blocks must not be coerced — they carry payload
+        # the model needs even without an accompanying text block.
+        image_block = [
+            {"type": "image_url", "image_url": {"url": "https://example/x.png"}}
+        ]
+        msgs = [
+            {
+                "role": "assistant",
+                "content": image_block,
+                "tool_calls": [self._tc()],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": "pong"},
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert out[0]["content"] == image_block
+
+    def test_does_not_touch_assistant_without_tool_calls(self):
+        # Assistant with empty content but NO tool_calls is left alone — could
+        # be a legitimate "model wants to stay silent" turn handled elsewhere.
+        msgs = [{"role": "assistant", "content": ""}]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert out[0]["content"] == ""
+
+    def test_does_not_touch_user_or_system_messages(self):
+        msgs = [
+            {"role": "system", "content": ""},
+            {"role": "user", "content": ""},
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert out[0]["content"] == ""
+        assert out[1]["content"] == ""
+
+    def test_preserves_existing_none_content(self):
+        msgs = [
+            {"role": "assistant", "content": None, "tool_calls": [self._tc()]},
+            {"role": "tool", "tool_call_id": "c1", "content": "pong"},
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert out[0]["content"] is None
+        assert len(out[0]["tool_calls"]) == 1


### PR DESCRIPTION
Fixes #31583

     1|## TL;DR
     2|
     3|Some OpenAI-compatible upstreams (Anthropic-compatible shims, certain proxy gateways) reject `assistant` messages that carry both `tool_calls` **and** `content=""` with:
     4|
     5|```
     6|HTTP 400: messages: text content blocks must be non-empty
     7|```
     8|
     9|Both OpenAI and Anthropic accept `content=null` in this case. This PR normalizes empty content to `None` inside `sanitize_api_messages()` — the single chokepoint every outgoing messages list passes through.
    10|
    11|## Symptom
    12|
    13|On gateway platforms (Telegram / WeChat / Discord), users see a chain of:
    14|
    15|> ⚠️ The model provider failed after retries.
    16|
    17|with `errors.log` showing:
    18|
    19|```
    20|Non-retryable client error: Error code: 400 -
    21|{'error': {'message': 'messages: text content blocks must be non-empty',
    22|           'type': 'invalid_request_error', ...}}
    23|```
    24|
    25|Once the bad message lands in history, every retry sends the same payload, so failure is **deterministic, not flaky**.
    26|
    27|## Root Cause
    28|
    29|`build_assistant_message()` always writes a string into `content` (`content or ""`, never `None`). When the model decides on a pure tool-call turn with no chain-of-thought text, the resulting message looks like:
    30|
    31|```json
    32|{
    33|  "role": "assistant",
    34|  "content": "",
    35|  "tool_calls": [ { ... "function": { "name": "write_file", ... } } ]
    36|}
    37|```
    38|
    39|The empty string is then replayed to the upstream API on subsequent turns. Strict OpenAI-compat shims read this as a zero-length text content block and reject it.
    40|
    41|Reproduced from a real request dump (`~/.hermes/sessions/request_dump_<sid>_<ts>.json`) — 14 messages, the offending one was index 12:
    42|
    43|| # | role | content | tool_calls |
    44||---|------|---------|------------|
    45|| 10 | assistant | str(len=158) | terminal |
    46|| 11 | tool | result | |
    47|| **12** | **assistant** | **`""` ⚠️** | **write_file** |
    48|| 13 | tool | result | |
    49|
    50|## Fix
    51|
    52|Add a third pass inside `sanitize_api_messages()` (after the existing orphan tool-pair repair). Coerce `content` to `None` **only when**:
    53|
    54|- `role == "assistant"` AND
    55|- `tool_calls` is present AND
    56|- `content` is one of: `""`, `[]`, or a list containing only empty/missing text blocks
    57|
    58|| content                                              | hits? | action  |
    59||------------------------------------------------------|-------|---------|
    60|| `""`                                                 | ✅    | → `None` |
    61|| `[]`                                                 | ✅    | → `None` |
    62|| `[{"type":"text","text":""}]`                        | ✅    | → `None` |
    63|| `[{"type":"text","text":"hi"}]`                      | ❌    | kept     |
    64|| `[{"type":"image_url","image_url":{...}}]`           | ❌    | kept     |
    65|| `"hi"`                                               | ❌    | kept     |
    66|| `None`                                               | ❌    | kept (already valid) |
    67|
    68|### Why `sanitize_api_messages` and not `build_assistant_message`?
    69|
    70|`sanitize_api_messages` is called from exactly the two places that send messages to the LLM:
    71|
    72|- `agent/chat_completion_helpers.py:1001` (fallback summary call)
    73|- `agent/conversation_loop.py:878` (main loop, every API call)
    74|
    75|`build_assistant_message`, by contrast, writes the same dict into 5 different consumers — persistent history (`state.db`), UI rendering, compression, the `reasoning_content` trailing-merge logic, and the API replay path. Only the API replay path needs `None`. Putting the normalization at the outgoing-API boundary is the minimum-risk surface.
    76|
    77|## Verification
    78|
    79|### 1. Unit-level — feed the actual failing dump
    80|
    81|```python
    82|from agent.agent_runtime_helpers import sanitize_api_messages
    83|msgs = json.load(open("request_dump_..._b49e98ee_....json"))["request"]["body"]["messages"]
    84|cleaned = sanitize_api_messages(copy.deepcopy(msgs))
    85|# Before: msgs[12]["content"] == ""
    86|# After:  cleaned[12]["content"] is None,  tool_calls preserved
    87|```
    88|
    89|### 2. Integration-level — replay against upstream
    90|
    91|Same dump body, POSTed via the patched sanitizer:
    92|- **Before:** `HTTP 400 messages: text content blocks must be non-empty`
    93|- **After:** `HTTP 401 invalid token` (the token in the dump expired) — i.e. structure now accepted
    94|
    95|### 3. End-to-end — real tool-calling conversations
    96|
    97|```
    98|hermes -z "Use terminal: date, hostname, uptime — summarize." --yolo  # OK
    99|hermes -z "Create /tmp/hermes_patch_test.txt with timestamp, cat to verify." --yolo  # OK
   100|```
   101|
   102|Zero new entries in `~/.hermes/logs/errors.log` during the runs.
   103|
   104|### 4. Unit tests added
   105|
   106|`tests/run_agent/test_agent_guardrails.py::TestEmptyContentWithToolCalls` — 9 cases covering every branch of the detection rule:
   107|
   108|- `test_normalizes_empty_string_content_when_tool_calls_present`
   109|- `test_normalizes_empty_list_content_when_tool_calls_present`
   110|- `test_normalizes_list_of_empty_text_blocks`
   111|- `test_keeps_assistant_text_when_present`
   112|- `test_keeps_non_empty_text_block_list`
   113|- `test_keeps_non_text_content_blocks` (image blocks must pass through)
   114|- `test_does_not_touch_assistant_without_tool_calls`
   115|- `test_does_not_touch_user_or_system_messages`
   116|- `test_preserves_existing_none_content`
   117|
   118|All 44 tests in the file pass (35 existing + 9 new).
   119|
   120|## Regression Risk
   121|
   122|Confined to a narrow branch (`role=='assistant' AND tool_calls AND content empty`):
   123|
   124|- Plain-text turns: untouched
   125|- Assistant without tool_calls: untouched
   126|- Any non-empty text or non-text content block: untouched
   127|- Worst case if some other bug accidentally clears `content`: request **succeeds** instead of failing — degrades to "model called a tool without chain-of-thought text," which is already a normal mode
   128|
   129|## Compatibility
   130|
   131|- **OpenAI chat/completions path:** this is the path the patch fixes
   132|- **Anthropic Messages API path:** uses `anthropic_adapter.py` which has its own `result_content = "(no output)" if not content else json.dumps(content)` fallback — unaffected
   133|- **reasoning_content padding (DeepSeek-v4 / Kimi):** sits on `reasoning_content`, not `content` — orthogonal, no conflict
   134|
   135|## Files
   136|
   137|- `agent/agent_runtime_helpers.py` — **+30 / -0** (the patch)
   138|- `tests/run_agent/test_agent_guardrails.py` — **+123 / -0** (new test class)
   139|
   140|## Related Issues
   141|
   142|None — surfaced from private deployment. Similar symptoms have been reported against several OpenAI-compatible proxies (new-api / one-api / openrouter shims) and Anthropic-compatible bridges that enforce strict text-block validation.
   143|