### PR TITLE
fix(state): proactively skip WAL journal mode on BTRFS filesystems (#30846)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -349,7 +349,7 @@ class ResponseStore:
         # issue addressed for state.db/kanban.db — see
         # hermes_state._WAL_INCOMPAT_MARKERS).
         from hermes_state import apply_wal_with_fallback
-        apply_wal_with_fallback(self._conn, db_label="response_store.db")
+        apply_wal_with_fallback(self._conn, db_label="response_store.db", db_path=self._db_path)
         self._conn.execute(
             """CREATE TABLE IF NOT EXISTS responses (
                 response_id TEXT PRIMARY KEY,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1180,7 +1180,7 @@ def connect(
             # falls back to DELETE with one WARNING so kanban stays usable there.
             # See hermes_state._WAL_INCOMPAT_MARKERS for detection logic.
             from hermes_state import apply_wal_with_fallback
-            apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
+            apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})", db_path=str(resolved))
             conn.execute("PRAGMA synchronous=NORMAL")
             conn.execute("PRAGMA foreign_keys=ON")
             needs_init = resolved not in _INITIALIZED_PATHS

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -57,6 +57,55 @@ _WAL_INCOMPAT_MARKERS = (
     "disk i/o error",         # Flaky network FS during WAL setup
 )
 
+# Filesystem types known to have WAL incompatibility beyond the exception-
+# based markers above.  BTRFS Copy-on-Write can modify disk blocks after
+# WAL records them, producing silent corruption.  We detect these ahead of
+# time rather than waiting for an OperationalError that arrives too late.
+_WAL_FS_BLOCKLIST: frozenset[str] = frozenset({"btrfs"})
+
+
+def _decode_mountinfo_path(value: str) -> str:
+    """Decode octal escapes used by Linux mountinfo paths."""
+    return re.sub(r"\\([0-7]{3})", lambda m: chr(int(m.group(1), 8)), value)
+
+
+def _is_on_btrfs(db_path: str) -> bool:
+    """Return True if *db_path* resides on a BTRFS filesystem.
+
+    Reads ``/proc/self/mountinfo`` (Linux only).  Returns ``False`` on
+    any non-Linux platform or when the mountinfo cannot be parsed.
+    """
+    import os as _os
+
+    if not _os.path.exists("/proc/self/mountinfo"):
+        return False
+    try:
+        db_real = _os.path.realpath(db_path)
+    except OSError:
+        return False
+    best_match = ""
+    try:
+        with open("/proc/self/mountinfo", "r", encoding="utf-8") as f:
+            for line in f:
+                parts = line.split()
+                try:
+                    sep = parts.index("-")
+                except ValueError:
+                    continue
+                if sep + 1 >= len(parts) or parts[sep + 1] not in _WAL_FS_BLOCKLIST:
+                    continue
+                mount_point = _os.path.realpath(_decode_mountinfo_path(parts[4]))
+                try:
+                    common = _os.path.commonpath([db_real, mount_point])
+                except ValueError:
+                    continue
+                if common == mount_point and len(mount_point) > len(best_match):
+                    best_match = mount_point
+    except OSError:
+        pass
+    return bool(best_match)
+
+
 # Last SessionDB() init error, per-process.  Surfaced in /resume and
 # related slash-command error strings so users know WHY the DB is
 # unavailable instead of getting a bare "Session database not available."
@@ -129,15 +178,21 @@ def apply_wal_with_fallback(
     conn: sqlite3.Connection,
     *,
     db_label: str = "state.db",
+    db_path: Optional[str] = None,
 ) -> str:
     """Set ``journal_mode=WAL`` on ``conn``, falling back to DELETE on failure.
 
     Returns the journal mode actually set (``"wal"`` or ``"delete"``).
 
-    On WAL-incompatible filesystems (NFS, SMB, some FUSE), SQLite raises
-    ``OperationalError("locking protocol")`` when setting WAL.  We fall
-    back to DELETE mode — the pre-WAL default, which works on NFS — and
-    log one WARNING explaining why.
+    On WAL-incompatible filesystems (NFS, SMB, some FUSE, BTRFS), SQLite
+    may raise ``OperationalError(...)`` when setting WAL.  We fall back
+    to DELETE mode — the pre-WAL default, which works on NFS — and log
+    one WARNING explaining why.
+
+    BTRFS detection is **proactive**: if *db_path* is provided and resides
+    on a BTRFS filesystem, WAL is skipped entirely (before any pragma).
+    This avoids the exception-based fallback path, which would be too late
+    for BTRFS COW-induced corruption (data already written by that point).
 
     The WARNING is deduplicated per ``db_label``: repeated connections
     to the same underlying DB (e.g. kanban_db.connect() which is called
@@ -148,6 +203,22 @@ def apply_wal_with_fallback(
     Shared by :class:`SessionDB` and ``hermes_cli.kanban_db.connect`` so
     both databases get identical fallback behavior.
     """
+    # Proactive BTRFS detection: avoid WAL entirely on COW filesystems.
+    if db_path and _is_on_btrfs(db_path):
+        with _wal_fallback_warned_lock:
+            should_log = db_label not in _wal_fallback_warned_paths
+            _wal_fallback_warned_paths.add(db_label)
+        if should_log:
+            logging.getLogger("hermes").warning(
+                "WAL disabled for %s: database resides on BTRFS (Copy-on-Write "
+                "filesystem incompatible with WAL journal mode). Falling back "
+                "to DELETE journal mode. To re-enable WAL on BTRFS, run "
+                "'chattr +C' on the Hermes data directory before creating the database.",
+                db_label,
+            )
+        conn.execute("PRAGMA journal_mode=DELETE")
+        return "delete"
+
     try:
         conn.execute("PRAGMA journal_mode=WAL")
         return "wal"
@@ -352,7 +423,7 @@ class SessionDB:
                 isolation_level=None,
             )
             self._conn.row_factory = sqlite3.Row
-            apply_wal_with_fallback(self._conn, db_label="state.db")
+            apply_wal_with_fallback(self._conn, db_label="state.db", db_path=str(self.db_path))
             self._conn.execute("PRAGMA foreign_keys=ON")
 
             self._init_schema()

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -131,7 +131,7 @@ class MemoryStore:
         # gracefully on NFS/SMB/FUSE-mounted HERMES_HOME (same issue as
         # state.db / kanban.db — see hermes_state._WAL_INCOMPAT_MARKERS).
         from hermes_state import apply_wal_with_fallback
-        apply_wal_with_fallback(self._conn, db_label="memory_store.db (holographic)")
+        apply_wal_with_fallback(self._conn, db_label="memory_store.db (holographic)", db_path=str(self.db_path))
         self._conn.executescript(_SCHEMA)
         # Migrate: add hrr_vector column if missing (safe for existing databases)
         columns = {row[1] for row in self._conn.execute("PRAGMA table_info(facts)").fetchall()}

--- a/tests/test_hermes_state_wal_fallback.py
+++ b/tests/test_hermes_state_wal_fallback.py
@@ -14,7 +14,7 @@ filesystem".
 """
 
 import sqlite3
-from unittest.mock import patch
+from unittest.mock import mock_open, patch
 
 import pytest
 
@@ -303,3 +303,107 @@ class TestSessionDbUsesWalFallback:
             assert get_last_init_error() is None
         finally:
             db.close()
+
+
+class TestIsOnBtrfs:
+    """Tests for ``_is_on_btrfs`` — proactive BTRFS COW detection."""
+
+    def test_detection_contract_accepts_path_and_returns_bool(self, tmp_path):
+        """_is_on_btrfs accepts a path string and returns a boolean."""
+        result = hermes_state._is_on_btrfs(str(tmp_path / "test.db"))
+        assert isinstance(result, bool)
+
+    def test_false_when_mountinfo_absent(self):
+        """Non-Linux platforms have no mountinfo and should be a no-op."""
+        with patch("os.path.exists", return_value=False):
+            assert hermes_state._is_on_btrfs("/some/path.db") is False
+
+    def test_detects_btrfs_mountinfo_entry(self):
+        """Parse the real mountinfo shape: fs type follows the '-' separator."""
+        data = "\n".join([
+            "36 25 0:32 / / rw,relatime - ext4 /dev/sda1 rw",
+            "48 36 0:45 /subvol /home rw,relatime shared:1 - btrfs /dev/nvme0n1p2 rw,compress=zstd",
+        ])
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("os.path.realpath", side_effect=lambda p: p),
+            patch("builtins.open", mock_open(read_data=data)),
+        ):
+            assert hermes_state._is_on_btrfs("/home/evi/.hermes/state.db") is True
+
+    def test_uses_path_boundaries_not_prefixes(self):
+        """A DB under /homebrew must not match a /home BTRFS mount."""
+        data = "48 36 0:45 / /home rw,relatime - btrfs /dev/nvme0n1p2 rw\n"
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("os.path.realpath", side_effect=lambda p: p),
+            patch("builtins.open", mock_open(read_data=data)),
+        ):
+            assert hermes_state._is_on_btrfs("/homebrew/state.db") is False
+
+    def test_decodes_mountinfo_octal_escapes(self):
+        """Mount points with spaces are escaped as octal in mountinfo."""
+        data = "48 36 0:45 / /mnt/Hermes\\040Data rw,relatime - btrfs /dev/nvme0n1p2 rw\n"
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("os.path.realpath", side_effect=lambda p: p),
+            patch("builtins.open", mock_open(read_data=data)),
+        ):
+            assert hermes_state._is_on_btrfs("/mnt/Hermes Data/state.db") is True
+
+
+class TestBtrfsProactiveSkip:
+    """E2E: ``apply_wal_with_fallback`` skips WAL proactively on BTRFS."""
+
+    def test_skips_wal_when_path_on_btrfs(self, tmp_path, caplog, monkeypatch):
+        """When db_path is on BTRFS, WAL is skipped without trying the pragma."""
+        db = tmp_path / "btrfs.db"
+        monkeypatch.setattr(hermes_state, "_is_on_btrfs", lambda p: True)
+        conn = sqlite3.connect(str(db), isolation_level=None)
+        try:
+            with caplog.at_level("WARNING", logger="hermes"):
+                mode = apply_wal_with_fallback(conn, db_label="test.db", db_path=str(db))
+            assert mode == "delete"
+            # Verify DELETE was actually set
+            cur = conn.execute("PRAGMA journal_mode")
+            assert cur.fetchone()[0].lower() == "delete"
+            # Warning logged about BTRFS
+            assert any("BTRFS" in r.getMessage() for r in caplog.records)
+        finally:
+            conn.close()
+
+    def test_btrfs_warning_deduplicated_per_db_label(self, tmp_path, caplog, monkeypatch):
+        """Repeated BTRFS connections warn once per DB label, matching fallback path."""
+        monkeypatch.setattr(hermes_state, "_is_on_btrfs", lambda p: True)
+        with caplog.at_level("WARNING", logger="hermes"):
+            for i in range(3):
+                conn = sqlite3.connect(str(tmp_path / f"btrfs_{i}.db"), isolation_level=None)
+                try:
+                    apply_wal_with_fallback(conn, db_label="shared-btrfs.db", db_path=str(tmp_path / f"btrfs_{i}.db"))
+                finally:
+                    conn.close()
+        warnings = [r for r in caplog.records if "shared-btrfs.db" in r.getMessage()]
+        assert len(warnings) == 1
+
+    def test_db_path_none_never_triggers_btrfs_check(self, tmp_path):
+        """When db_path is None (backward compat), WAL proceeds normally."""
+        conn = sqlite3.connect(str(tmp_path / "ok.db"), isolation_level=None)
+        try:
+            mode = apply_wal_with_fallback(conn, db_label="test.db", db_path=None)
+            assert mode == "wal"
+        finally:
+            conn.close()
+
+    def test_btrfs_skip_writeable_after_fallback(self, tmp_path, monkeypatch):
+        """After BTRFS skip to DELETE, the DB is still fully usable."""
+        db = tmp_path / "btrfs_writable.db"
+        monkeypatch.setattr(hermes_state, "_is_on_btrfs", lambda p: True)
+        conn = sqlite3.connect(str(db), isolation_level=None)
+        try:
+            mode = apply_wal_with_fallback(conn, db_label="test.db", db_path=str(db))
+            assert mode == "delete"
+            conn.execute("CREATE TABLE t (x INTEGER)")
+            conn.execute("INSERT INTO t VALUES (42)")
+            assert list(conn.execute("SELECT x FROM t"))[0][0] == 42
+        finally:
+            conn.close()


### PR DESCRIPTION
## What

SQLite WAL journal mode is incompatible with BTRFS Copy-on-Write. The existing exception-based fallback (catching `OperationalError`) is too late — by the time SQLite raises, COW may have already corrupted WAL records. Users on BTRFS get persistent `disk I/O error` without understanding the root cause.

## Fix

Proactive BTRFS detection via `/proc/self/mountinfo` (Linux only). `apply_wal_with_fallback()` now accepts an optional `db_path` parameter. If the path resides on BTRFS, WAL is skipped entirely — before any pragma is executed — with a clear warning directing users to `chattr +C`.

- `hermes_state.py` — +81: `_is_on_btrfs()`, `_decode_mountinfo_path()`, proactive skip in `apply_wal_with_fallback()`
- Callers just add `db_path=` argument (2 chars each): `gateway/platforms/api_server.py`, `hermes_cli/kanban_db.py`, `plugins/memory/holographic/store.py`
- `db_path=None` preserves full backward compatibility

### Mountinfo parsing handles edge cases
- Locates filesystem type after the `-` separator (not fixed field index)
- Decodes octal escapes (`\040` → space) for mount points with spaces
- Uses `os.path.commonpath()` not raw `startswith()` — `/homebrew` won't match `/home`

## Tests

```
python3 -m pytest tests/test_hermes_state_wal_fallback.py -q -o addopts=
189 passed (9 new BTRFS tests)
```

9 regression tests: mountinfo parser shape, path boundary guard, octal escape decoding, proactive WAL skip, warning deduplication, backward-compatible `db_path=None`, post-fallback DB writability, non-Linux no-op, API contract.

Fail-without-fix: reverting to upstream `hermes_state.py` → 9/9 BTRFS tests fail.

## Competitor check

Adjacent WAL PRs (#30700, #30823, #31294, #31014, #30654, #31130) address related SQLite/WAL issues but none implements proactive BTRFS filesystem detection for #30846.

Closes #30846