### PR TITLE
fix(cli): cache load_config() during /model picker discovery

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -59,6 +59,14 @@ def cached_config_loads() -> Iterator[None]:
     (issue #31556). Wrapping the discovery body in this context manager makes
     ``_load_config_safe()`` reuse the first successful load until the context
     exits.
+
+    READ-ONLY CONTRACT: callers inside the block share a single ``dict``
+    instance. Mutating the returned config (in-place writes, ``.pop()``,
+    ``.update()``, etc.) is forbidden — the mutation would be visible to
+    every subsequent ``_load_config_safe()`` caller in the same block. Use
+    only ``.get()`` / membership checks on the result. All three current
+    call sites in this module honour this (``_iter_custom_providers``,
+    ``get_pool_strategy``, the ``load_pool`` ``model_config`` seed path).
     """
     token = _cached_config_safe.set(None)
     try:
@@ -72,7 +80,10 @@ def _load_config_safe() -> Optional[dict]:
 
     Inside a :func:`cached_config_loads` block, the first successful load is
     memoized and returned on subsequent calls so YAML parsing and the
-    associated deepcopy don't repeat.
+    associated deepcopy don't repeat. The cached value is the *same instance*
+    on every call within the block — see :func:`cached_config_loads` for the
+    read-only contract. Outside a block this returns the fresh deepcopy that
+    :func:`load_config` provides, identical to pre-#31556 behaviour.
     """
     cached = _cached_config_safe.get()
     if cached is not _CONFIG_CACHE_UNSET and cached is not None:

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextvars
 import logging
 import os
 import random
@@ -9,9 +10,10 @@ import threading
 import time
 import uuid
 import re
+from contextlib import contextmanager
 from dataclasses import dataclass, fields, replace
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Set, Tuple
 
 from hermes_constants import OPENROUTER_BASE_URL
 from hermes_cli.config import load_env
@@ -40,14 +42,52 @@ from hermes_cli.auth import (
 logger = logging.getLogger(__name__)
 
 
+_CONFIG_CACHE_UNSET: Any = object()
+_cached_config_safe: contextvars.ContextVar[Any] = contextvars.ContextVar(
+    "_cached_config_safe", default=_CONFIG_CACHE_UNSET
+)
+
+
+@contextmanager
+def cached_config_loads() -> Iterator[None]:
+    """Reuse a single ``load_config()`` result across nested calls.
+
+    ``list_authenticated_providers()`` instantiates a ``CredentialPool``
+    for every provider candidate; each constructor calls ``get_pool_strategy``
+    which in turn calls ``_load_config_safe`` → ``load_config()``. Without a
+    cache the /model picker re-parses config.yaml ~69 times per invocation
+    (issue #31556). Wrapping the discovery body in this context manager makes
+    ``_load_config_safe()`` reuse the first successful load until the context
+    exits.
+    """
+    token = _cached_config_safe.set(None)
+    try:
+        yield
+    finally:
+        _cached_config_safe.reset(token)
+
+
 def _load_config_safe() -> Optional[dict]:
-    """Load config.yaml, returning None on any error."""
+    """Load config.yaml, returning None on any error.
+
+    Inside a :func:`cached_config_loads` block, the first successful load is
+    memoized and returned on subsequent calls so YAML parsing and the
+    associated deepcopy don't repeat.
+    """
+    cached = _cached_config_safe.get()
+    if cached is not _CONFIG_CACHE_UNSET and cached is not None:
+        return cached
     try:
         from hermes_cli.config import load_config
 
-        return load_config()
+        config = load_config()
     except Exception:
         return None
+    if cached is None and config is not None:
+        # ``cached is None`` (and not ``_CONFIG_CACHE_UNSET``) means we are
+        # inside a ``cached_config_loads`` block but have not memoized yet.
+        _cached_config_safe.set(config)
+    return config
 
 
 # --- Status and type constants ---

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1082,7 +1082,7 @@ def list_authenticated_providers(
 def _list_authenticated_providers_impl(
     current_provider: str = "",
     current_base_url: str = "",
-    user_providers: dict = None,
+    user_providers: dict | None = None,
     custom_providers: list | None = None,
     max_models: int = 8,
     current_model: str = "",

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1063,6 +1063,33 @@ def list_authenticated_providers(
 
     Only includes providers that have API keys set or are user-defined endpoints.
     """
+    # Reuse a single load_config() result across every CredentialPool
+    # construction in this discovery pass. Without this the /model picker
+    # parses config.yaml ~69 times per invocation (#31556).
+    from agent.credential_pool import cached_config_loads
+
+    with cached_config_loads():
+        return _list_authenticated_providers_impl(
+            current_provider=current_provider,
+            current_base_url=current_base_url,
+            user_providers=user_providers,
+            custom_providers=custom_providers,
+            max_models=max_models,
+            current_model=current_model,
+        )
+
+
+def _list_authenticated_providers_impl(
+    current_provider: str = "",
+    current_base_url: str = "",
+    user_providers: dict = None,
+    custom_providers: list | None = None,
+    max_models: int = 8,
+    current_model: str = "",
+) -> List[dict]:
+    """Body of :func:`list_authenticated_providers`. Extracted so the public
+    function can wrap it in :func:`cached_config_loads` without re-indenting
+    the entire ~700-line implementation."""
     import os
     from agent.models_dev import (
         PROVIDER_TO_MODELS_DEV,

--- a/tests/agent/test_credential_pool_config_cache.py
+++ b/tests/agent/test_credential_pool_config_cache.py
@@ -1,0 +1,184 @@
+"""Regression coverage for the ``cached_config_loads`` context manager
+introduced in #31556 to keep ``list_authenticated_providers()`` from
+re-parsing ``config.yaml`` once per CredentialPool construction."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from agent.credential_pool import (
+    CredentialPool,
+    PooledCredential,
+    _load_config_safe,
+    cached_config_loads,
+    get_pool_strategy,
+)
+
+
+def _make_entry(provider: str = "openai") -> PooledCredential:
+    return PooledCredential(
+        provider=provider,
+        id="cred-1",
+        label="key-1",
+        auth_type="api_key",
+        priority=0,
+        source="manual",
+        access_token="sk-test",
+    )
+
+
+def test_load_config_safe_called_each_time_outside_context():
+    call_count = 0
+
+    def _load() -> dict:
+        nonlocal call_count
+        call_count += 1
+        return {"credential_pool_strategies": {"openai": "round_robin"}}
+
+    with patch("hermes_cli.config.load_config", side_effect=_load):
+        for _ in range(3):
+            _load_config_safe()
+
+    assert call_count == 3
+
+
+def test_load_config_safe_memoized_within_context():
+    call_count = 0
+
+    def _load() -> dict:
+        nonlocal call_count
+        call_count += 1
+        return {"credential_pool_strategies": {"openai": "round_robin"}}
+
+    with patch("hermes_cli.config.load_config", side_effect=_load):
+        with cached_config_loads():
+            for _ in range(5):
+                config = _load_config_safe()
+                assert config == {"credential_pool_strategies": {"openai": "round_robin"}}
+
+    assert call_count == 1
+
+
+def test_cache_cleared_after_context_exits():
+    call_count = 0
+
+    def _load() -> dict:
+        nonlocal call_count
+        call_count += 1
+        return {"credential_pool_strategies": {}}
+
+    with patch("hermes_cli.config.load_config", side_effect=_load):
+        with cached_config_loads():
+            _load_config_safe()
+            _load_config_safe()
+        # Outside the context the cache is gone and every call re-loads.
+        _load_config_safe()
+        _load_config_safe()
+
+    assert call_count == 3  # 1 inside the context + 2 outside
+
+
+def test_nested_contexts_restore_outer_value():
+    """The outer context's memoized config must survive an inner context."""
+
+    loads: list[str] = []
+
+    def _load() -> dict:
+        loads.append("outer-or-inner")
+        return {"_marker": len(loads)}
+
+    with patch("hermes_cli.config.load_config", side_effect=_load):
+        with cached_config_loads():
+            outer = _load_config_safe()
+            assert outer["_marker"] == 1
+            with cached_config_loads():
+                # Inner context starts fresh — first call inside re-loads.
+                inner = _load_config_safe()
+                assert inner["_marker"] == 2
+                # ...and is then memoized for the rest of the inner scope.
+                assert _load_config_safe() is inner
+            # Back in the outer context: the original memoized value
+            # is restored, no additional load.
+            assert _load_config_safe() is outer
+
+    assert len(loads) == 2
+
+
+def test_failed_load_does_not_poison_cache():
+    """A None / raising load_config must not freeze the cache at None."""
+
+    sequence: list = [None, {"credential_pool_strategies": {"openai": "least_used"}}]
+
+    def _load():
+        return sequence.pop(0)
+
+    with patch("hermes_cli.config.load_config", side_effect=_load):
+        with cached_config_loads():
+            assert _load_config_safe() is None  # first attempt returns None
+            # Second attempt should retry, and now succeeds + memoizes.
+            second = _load_config_safe()
+            assert second == {"credential_pool_strategies": {"openai": "least_used"}}
+            # Third call hits the memoized value, no further loads.
+            assert _load_config_safe() is second
+
+    assert sequence == []  # both staged returns consumed, no third load
+
+
+def test_credential_pool_construction_loads_config_once_in_context():
+    """Regression for #31556: building many CredentialPools in one
+    discovery pass must parse config.yaml exactly once."""
+
+    call_count = 0
+
+    def _load() -> dict:
+        nonlocal call_count
+        call_count += 1
+        return {"credential_pool_strategies": {"openai": "round_robin"}}
+
+    with patch("hermes_cli.config.load_config", side_effect=_load):
+        with cached_config_loads():
+            pools = [
+                CredentialPool("openai", [_make_entry("openai")])
+                for _ in range(20)
+            ]
+
+    assert len(pools) == 20
+    assert all(p._strategy == "round_robin" for p in pools)
+    assert call_count == 1
+
+
+def test_credential_pool_construction_outside_context_loads_each_time():
+    """Without the context, every CredentialPool reparses config.yaml —
+    this is the pre-fix behavior that #31556 documents."""
+
+    call_count = 0
+
+    def _load() -> dict:
+        nonlocal call_count
+        call_count += 1
+        return {"credential_pool_strategies": {}}
+
+    with patch("hermes_cli.config.load_config", side_effect=_load):
+        for _ in range(5):
+            CredentialPool("openai", [_make_entry("openai")])
+
+    assert call_count == 5
+
+
+def test_get_pool_strategy_uses_cached_config():
+    """``get_pool_strategy`` is the call site that actually compounds in
+    the picker — verify it observes the cache."""
+
+    call_count = 0
+
+    def _load() -> dict:
+        nonlocal call_count
+        call_count += 1
+        return {"credential_pool_strategies": {"openai": "random"}}
+
+    with patch("hermes_cli.config.load_config", side_effect=_load):
+        with cached_config_loads():
+            for _ in range(10):
+                assert get_pool_strategy("openai") == "random"
+
+    assert call_count == 1


### PR DESCRIPTION
## What does this PR do?

`list_authenticated_providers()` instantiates a `CredentialPool` for every candidate provider during `/model` picker discovery. Each `CredentialPool.__init__` calls `get_pool_strategy()` → `_load_config_safe()` → `load_config()`, which re-parses `config.yaml` and deep-copies the dict tree. On a typical setup the picker triggers ~69 such loads per invocation (the issue reporter measured ~0.4s and ~82k deepcopies attributable to this alone).

This PR adds a `contextvars`-scoped cache in `agent/credential_pool.py` — `cached_config_loads()` opens a block during which `_load_config_safe()` memoizes the first successful `load_config()` return value, and `list_authenticated_providers()` wraps its discovery body in that block. The cache is per-discovery-pass, not process-wide, so long-running gateways still pick up config edits made between picker invocations.

## Related Issue

Fixes #31556

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/credential_pool.py` — add `cached_config_loads()` context manager backed by a `ContextVar` sentinel, and teach `_load_config_safe()` to return the memoized value while the block is open. Failed loads (`None` or raising) deliberately do not poison the cache.
- `hermes_cli/model_switch.py` — split `list_authenticated_providers` into a thin public wrapper that opens `cached_config_loads()` and a renamed private `_list_authenticated_providers_impl` containing the existing ~700-line body. The wrapper-and-rename keeps the diff small instead of re-indenting the implementation.
- `tests/agent/test_credential_pool_config_cache.py` — eight tests covering: outside-context no-caching, inside-context memoization, post-context invalidation, nested-context restore, failed-load not poisoning the cache, direct verification that 20 `CredentialPool` constructions inside the block parse `config.yaml` exactly once (regression for the 69×-load symptom), and `get_pool_strategy()` honouring the cache.

## How to Test

1. Reproduce the symptom on `main` (pre-fix): the test `test_credential_pool_construction_outside_context_loads_each_time` asserts 5 `CredentialPool` constructions trigger 5 `load_config` calls — this is the documented status quo.
2. With the fix applied: `test_credential_pool_construction_loads_config_once_in_context` asserts 20 `CredentialPool` constructions inside `cached_config_loads()` trigger exactly 1 `load_config` call.
3. Run focused tests:
   ```
   uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest \
     tests/agent/test_credential_pool_config_cache.py \
     tests/agent/test_credential_pool.py \
     tests/agent/test_credential_pool_routing.py \
     tests/hermes_cli/test_model_switch_custom_providers.py \
     tests/hermes_cli/test_inventory.py \
     tests/hermes_cli/test_model_picker_viewport.py -v
   ```
   222 tests pass locally (8 new + 62 + 87 + 43 + 22 existing).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (new symbol carries its own docstring; no user-facing API change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `contextvars` is stdlib on all supported Python versions
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

The issue body reports `cProfile` cumulative timings of `0.388s` across 69 `load_config` calls (`yaml.safe_load x7`, `deepcopy x81939`). With this PR that collapses to a single load per picker invocation.

---

> Sibling code paths the issue mentions but that I intentionally left out of this PR's scope to keep the diff focused on the `load_config` ask:
> - `agent.credential_pool.load_pool()` is called ~65× per picker (`0.585s`). Same caching pattern would apply — likely a follow-up using a similar provider-keyed contextvar.
> - `shutil.which()` is called ~64× for Copilot `gh` CLI detection (`0.251s`) inside the discovery loop. Independent fix — a single check at the top of `list_authenticated_providers()` would suffice.
> - `posix.stat` x4486 (`0.298s`) is the cumulative cost of the above plus auth-store / external-creds-file probes. Will shrink naturally once `load_pool` is cached. Happy to widen this PR or open follow-ups, whichever is preferred.