### PR TITLE
fix(tui): add missing setVoiceTts to SlashHandlerContext + enforce tsc in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -200,3 +200,25 @@ jobs:
 
       - name: Run footgun checker
         run: python scripts/check-windows-footguns.py --all
+
+  tui-type-check:
+    # Enforce zero TS errors in the TUI frontend. Catches missing props,
+    # wrong types, and interface mismatches — like the voice context bug
+    # where setVoiceTts was added to the interface but missed in one of
+    # three construction sites.
+    name: TUI type check (blocking)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: ui-tui/package-lock.json
+
+      - name: Install deps + type-check
+        run: cd ui-tui && npm ci && npm run type-check

--- a/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.ts
+++ b/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process'
+import { spawn, type StdioOptions } from 'child_process'
 type ExecFileOptions = {
   input?: string
   timeout?: number
@@ -32,9 +32,9 @@ export function execFileNoThrow(
     // doesn't inherit those pipe FDs — prevents handle leaks that can
     // keep the parent process alive. No output data is collected in
     // this mode; both stdout and stderr will be empty strings.
-    const stdioConfig = options.resolveOnExit
-      ? ['pipe', 'ignore', 'ignore'] as const
-      : 'pipe' as const
+    const stdioConfig: StdioOptions = options.resolveOnExit
+      ? ['pipe', 'ignore', 'ignore']
+      : ['pipe', 'pipe', 'pipe']
 
     const child = spawn(file, args, {
       cwd: options.useCwd ? process.cwd() : undefined,

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -796,7 +796,8 @@ const buildTranscript = () => ({
 
 const buildVoice = () => ({
   setVoiceEnabled: vi.fn(),
-  setVoiceRecordKey: vi.fn()
+  setVoiceRecordKey: vi.fn(),
+  setVoiceTts: vi.fn()
 })
 
 interface Ctx {

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -676,7 +676,7 @@ export function useMainApp(gw: GatewayClient) {
         },
         slashFlightRef,
         transcript: { page, panel, send, setHistoryItems, sys, trimLastExchange: session.trimLastExchange },
-        voice: { setVoiceEnabled, setVoiceRecordKey }
+        voice: { setVoiceEnabled, setVoiceRecordKey, setVoiceTts }
       }),
     [
       catalog,


### PR DESCRIPTION
## Summary

PR #7de8cd4c added `setVoiceTts` to three voice context interfaces in `interfaces.ts`, but `useMainApp.ts` constructs those contexts in three separate object literals — only two were updated, and the `SlashHandlerContext` construction was missed.

TypeScript caught the error (`TS2741: Property "setVoiceTts" is missing`), but CI had no `type-check` step to enforce it.

## Changes

**Bug fix:**
- Add `setVoiceTts` to the `SlashHandlerContext` voice construction in `useMainApp.ts`
- Add `setVoiceTts` to the `buildVoice()` test helper (fixes 4 failing tests)

**Prevention:**
- Add `tui-type-check` blocking job to `lint.yml` — explicit `setup-node` (Node 22), npm cache, runs `cd ui-tui && npm ci && npm run type-check`

**Pre-existing cleanup:**
- Fix 18 TS errors in `execFileNoThrow.ts` — the `stdio` union type (`"pipe" | readonly [...]`) caused TS to infer `never` for the child process type. Replaced with an explicit `StdioOptions` annotation using `["pipe", "pipe", "pipe"]` instead of the shorthand `"pipe"` (semantically identical, type-consistent).