### PR TITLE
fix(qqbot): authorize approval clicks for dm session keys

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1082,7 +1082,7 @@ class QQAdapter(BasePlatformAdapter):
 
         chat_type = parsed.get("chat_type", "")
         chat_id = parsed.get("chat_id", "")
-        if chat_type == "c2c":
+        if chat_type in {"c2c", "dm"}:
             return bool(chat_id) and operator == chat_id
 
         if chat_type in {"group", "guild"}:

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1654,6 +1654,33 @@ class TestDefaultInteractionDispatch:
         assert resolve_calls == []
 
     @pytest.mark.asyncio
+    async def test_approval_click_dm_session_authorizes_owner(self):
+        """dm-typed session key with matching operator should be authorized."""
+        adapter = self._make_adapter()
+        resolve_calls = []
+
+        def fake_resolve(session_key, choice, resolve_all=False):
+            resolve_calls.append((session_key, choice, resolve_all))
+            return 1
+
+        import tools.approval
+        orig = tools.approval.resolve_gateway_approval
+        tools.approval.resolve_gateway_approval = fake_resolve
+        try:
+            from gateway.platforms.qqbot.keyboards import parse_interaction_event
+            event = parse_interaction_event({
+                "id": "i",
+                "chat_type": 2,
+                "user_openid": "u-42",
+                "data": {"resolved": {"button_data": "approve:agent:main:qqbot:dm:u-42:allow-once"}},
+            })
+            await adapter._default_interaction_dispatch(event)
+        finally:
+            tools.approval.resolve_gateway_approval = orig
+
+        assert resolve_calls == [("agent:main:qqbot:dm:u-42", "once", False)]
+
+    @pytest.mark.asyncio
     async def test_update_prompt_click_writes_response_file(self, tmp_path, monkeypatch):
         """update_prompt:y click writes 'y' to ~/.hermes/.update_response."""
         adapter = self._make_adapter()


### PR DESCRIPTION
## Problem

PR #30737 added authorization checks for approval button clicks in QQBot, but the check hardcodes `chat_type == "c2c"` while C2C sessions are actually created with `chat_type="dm"` (`build_source` at L1278, L1488). This causes all DM approval buttons to be rejected as unauthorized:

```
WARNING [QQBot] Rejected unauthorized approval click for session agent:main:qqbot:dm:<user_id> (operator=<user_id>)
```

The agent waits for approval that never resolves, then times out after 300s.

## Root Cause

The codebase has two parallel chat_type systems:
- **Routing layer** (`_chat_type_map` / `_guess_chat_type`): uses `"c2c"` for QQ C2C
- **Session layer** (`build_source(chat_type=...)`): uses `"dm"` for all direct messages

The session key is built from the session layer, so it becomes `agent:main:qqbot:dm:<id>`. The authorization check used the routing layer semantics instead.

## Fix

`_is_authorized_interaction_for_session` now accepts both `"c2c"` and `"dm"` for direct-message session keys, matching the actual chat_type used when creating C2C sessions.

## Testing

Added `test_approval_click_dm_session_authorizes_owner` — verifies that a `dm`-typed session key with matching operator is accepted.

Existing tests still pass (they use `c2c` in button_data which remains valid).