### PR TITLE
feat(matrix): convert LaTeX math to data-mx-maths for KaTeX rendering

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -2685,6 +2685,44 @@ class MatrixAdapter(BasePlatformAdapter):
         parts = mxc_url[6:]  # strip mxc://
         return f"{self._homeserver}/_matrix/client/v1/media/download/{parts}"
 
+    @staticmethod
+    def _latex_to_math_spans(text: str, stash_fn) -> str:
+        """Replace $...$ and $$...$$ with stashed placeholders for Matrix math markup."""
+        import re as _re
+
+        # Protect code blocks and inline code from LaTeX processing.
+        _code_blocks: list = []
+
+        def _stash_code(m):
+            _code_blocks.append(m.group(0))
+            return f"\x00CODE{len(_code_blocks) - 1}\x00"
+
+        # Stash fenced code blocks and inline code.
+        text = _re.sub(r"```[\s\S]*?```", _stash_code, text)
+        text = _re.sub(r"`[^`]+`", _stash_code, text)
+
+        # Display math: $$...$$
+        def _display_math(m):
+            latex = m.group(1).strip()
+            html = f'<div data-mx-maths="{latex}"><code>{latex}</code></div>'
+            return stash_fn(html)
+
+        text = _re.sub(r"\$\$(.+?)\$\$", _display_math, text, flags=_re.DOTALL)
+
+        # Inline math: $...$
+        def _inline_math(m):
+            latex = m.group(1).strip()
+            html = f'<span data-mx-maths="{latex}"><code>{latex}</code></span>'
+            return stash_fn(html)
+
+        text = _re.sub(r"(?<!\$)\$(?!\$)(.+?)(?<!\$)\$(?!\$)", _inline_math, text)
+
+        # Restore code blocks.
+        for i, block in enumerate(_code_blocks):
+            text = text.replace(f"\x00CODE{i}\x00", block)
+
+        return text
+
     def _markdown_to_html(self, text: str) -> str:
         """Convert Markdown to Matrix-compatible HTML (org.matrix.custom.html).
 
@@ -2694,6 +2732,15 @@ class MatrixAdapter(BasePlatformAdapter):
         italic, strikethrough, links, blockquotes, lists, and horizontal
         rules — everything the Matrix HTML spec allows.
         """
+        # Convert LaTeX math ($...$, $$...$$) to Matrix math spans before markdown processing.
+        # We stash the HTML and restore after markdown to prevent mangling.
+        _math_stash: list = []
+        def _stash_math(html):
+            _math_stash.append(html)
+            return f"\x00MATH{len(_math_stash) - 1}\x00"
+
+        text = self._latex_to_math_spans(text, _stash_math)
+
         try:
             import markdown as _md
 
@@ -2708,11 +2755,17 @@ class MatrixAdapter(BasePlatformAdapter):
 
             if html.count("<p>") == 1:
                 html = html.replace("<p>", "").replace("</p>", "")
+            # Restore math spans.
+            for i, mhtml in enumerate(_math_stash):
+                html = html.replace(f"\x00MATH{i}\x00", mhtml)
             return html
         except ImportError:
             pass
 
-        return self._markdown_to_html_fallback(text)
+        result = self._markdown_to_html_fallback(text)
+        for i, mhtml in enumerate(_math_stash):
+            result = result.replace(f"\x00MATH{i}\x00", mhtml)
+        return result
 
     # ------------------------------------------------------------------
     # Regex-based Markdown -> HTML (no extra dependencies)

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -58,6 +58,7 @@ import logging
 import mimetypes
 import os
 import re
+import secrets
 import shutil
 import subprocess
 import sys
@@ -415,16 +416,21 @@ class _MatrixHtmlSanitizer(HTMLParser):
     """Allowlist sanitizer for Matrix-compatible formatted HTML."""
 
     _ALLOWED_TAGS = {
-        "a", "b", "blockquote", "br", "code", "del", "em", "h1", "h2", "h3",
-        "h4", "h5", "h6", "hr", "i", "li", "ol", "p", "pre", "s", "strike",
-        "strong", "table", "tbody", "td", "th", "thead", "tr", "ul",
+        "a", "b", "blockquote", "br", "code", "del", "div", "em", "h1", "h2",
+        "h3", "h4", "h5", "h6", "hr", "i", "li", "ol", "p", "pre", "s", "span",
+        "strike", "strong", "table", "tbody", "td", "th", "thead", "tr", "ul",
     }
+    # Tags that may carry Element's KaTeX attribute (MSC2191 `data-mx-maths`).
+    _MATHS_TAGS = {"div", "span"}
     _VOID_TAGS = {"br", "hr"}
 
     def __init__(self) -> None:
         super().__init__(convert_charrefs=False)
         self._parts: list[str] = []
         self._skip_depth = 0
+        # Depth counters for span/div, which are allowed ONLY as math carriers.
+        self._maths_open: dict[str, int] = {}
+        self._dropped: dict[str, int] = {}
 
     @staticmethod
     def _safe_url(value: str) -> str:
@@ -449,6 +455,16 @@ class _MatrixHtmlSanitizer(HTMLParser):
             elif tag == "code" and attr == "class":
                 if re.fullmatch(r"language-[A-Za-z0-9_+.-]{1,64}", raw_value):
                     safe.append(f' class="{_html_escape(raw_value, quote=True)}"')
+            elif tag in self._MATHS_TAGS and attr == "data-mx-maths":
+                # Element renders this attribute with KaTeX. The value is
+                # plain LaTeX, never markup: escape it and drop control
+                # characters so it cannot break out of the attribute. LaTeX
+                # commands that could navigate (`\href`) are inert under
+                # KaTeX's default `trust: false`, which Element does not
+                # override; we deliberately do not attempt to parse LaTeX here.
+                latex = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]+", "", raw_value)
+                if latex:
+                    safe.append(f' data-mx-maths="{_html_escape(latex, quote=True)}"')
         return "".join(safe)
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
@@ -463,7 +479,17 @@ class _MatrixHtmlSanitizer(HTMLParser):
         if tag in self._VOID_TAGS:
             self._parts.append(f"<{tag}>")
             return
-        self._parts.append(f"<{tag}{self._safe_attrs(tag, attrs)}>")
+        safe_attrs = self._safe_attrs(tag, attrs)
+        if tag in self._MATHS_TAGS:
+            # span/div exist in the allowlist purely to carry `data-mx-maths`.
+            # A bare one (raw HTML in model output) is dropped, tag only, so
+            # widening the allowlist for math does not also let arbitrary
+            # layout markup through.
+            if "data-mx-maths=" not in safe_attrs:
+                self._dropped[tag] = self._dropped.get(tag, 0) + 1
+                return
+            self._maths_open[tag] = self._maths_open.get(tag, 0) + 1
+        self._parts.append(f"<{tag}{safe_attrs}>")
 
     def handle_endtag(self, tag: str) -> None:
         tag = tag.lower()
@@ -472,6 +498,13 @@ class _MatrixHtmlSanitizer(HTMLParser):
             return
         if self._skip_depth or tag not in self._ALLOWED_TAGS or tag in self._VOID_TAGS:
             return
+        if tag in self._MATHS_TAGS:
+            if self._dropped.get(tag):
+                self._dropped[tag] -= 1
+                return
+            if not self._maths_open.get(tag):
+                return
+            self._maths_open[tag] -= 1
         self._parts.append(f"</{tag}>")
 
     def handle_data(self, data: str) -> None:
@@ -974,6 +1007,106 @@ def _pre_sanitize_matrix_markdown(text: str) -> str:
         "",
         result,
     )
+    return result
+
+
+_MATRIX_MATH_MAX_LEN = 4096
+
+# Regions where a ``$`` must never be read as math. Order matters: fenced
+# blocks first, then indented code, inline code, and Markdown link/image
+# destinations (a placeholder landing inside `href=` would corrupt the anchor).
+_MATRIX_MATH_PROTECTED = (
+    re.compile(r"(?m)^[ \t]*```[\s\S]*?^[ \t]*```[^\n]*$"),
+    re.compile(r"(?m)^[ \t]*~~~[\s\S]*?^[ \t]*~~~[^\n]*$"),
+    re.compile(r"(?m)(?:\A|(?<=\n\n))(?:(?:[ ]{4}|\t)[^\n]*\n?)+"),
+    re.compile(r"`+[^`\n]+`+"),
+    re.compile(r"!?\[[^\]\n]*\]\([^)\n]*\)"),
+)
+
+# Display and inline math are matched in ONE pass, so a placeholder emitted by
+# the display branch can never be re-consumed by the inline branch.
+_MATRIX_MATH_RE = re.compile(
+    r"(?<![\$\w\\])\$\$(?!\s)((?:(?!\n[ \t]*\n).)+?)(?<!\s)\$\$(?![\$\w])"
+    r"|(?<![\$\w\\])\$(?!\s)([^\$\n]+?)(?<!\s)\$(?![\$\w])",
+    re.DOTALL,
+)
+
+
+class _NotMath(Exception):
+    """Internal signal that a ``$...$`` span should be left as literal text."""
+
+
+def _extract_matrix_math(text: str) -> tuple[str, list[tuple[str, str]]]:
+    """Replace ``$...$`` / ``$$...$$`` with placeholders holding math HTML.
+
+    Returns ``(text_with_placeholders, replacements)`` where each replacement is
+    a ``(placeholder, html)`` pair for :func:`_restore_matrix_math`.
+
+    Code (fenced, indented, and inline) and Markdown link/image destinations are
+    stashed first, so shell snippets like ``` `echo $HOME and $PATH` ``` and
+    URLs are never rewritten. ``\\$`` is an explicit escape hatch for a literal
+    dollar sign.
+
+    Placeholders are alphanumeric and carry a per-call random token: Markdown
+    leaves them untouched, and a hostile message cannot forge one to smuggle
+    markup past the conversion step.
+    """
+    if "$" not in (text or ""):
+        return text or "", []
+
+    token = secrets.token_hex(8)
+    replacements: list[tuple[str, str]] = []
+    literals: list[str] = []
+
+    def _stash_literal(value: str) -> str:
+        literals.append(value)
+        return f"hermesraw{token}x{len(literals) - 1}x"
+
+    work = text
+    for pattern in _MATRIX_MATH_PROTECTED:
+        work = pattern.sub(lambda m: _stash_literal(m.group(0)), work)
+    # Escape hatch: ``\$`` is a literal dollar and never starts an equation.
+    work = re.sub(r"\\\$", lambda _m: _stash_literal("$"), work)
+
+    def _make(latex: str, tag: str) -> str:
+        latex = latex.strip()
+        if not latex or len(latex) > _MATRIX_MATH_MAX_LEN:
+            raise _NotMath
+        placeholder = f"hermesmath{token}x{len(replacements)}x"
+        replacements.append(
+            (
+                placeholder,
+                f'<{tag} data-mx-maths="{_html_escape(latex, quote=True)}">'
+                f"<code>{_html_escape(latex)}</code></{tag}>",
+            )
+        )
+        return placeholder
+
+    def _convert(match: re.Match[str]) -> str:
+        display, inline = match.group(1), match.group(2)
+        try:
+            if display is not None:
+                return _make(display, "div")
+            return _make(inline or "", "span")
+        except _NotMath:
+            return match.group(0)
+
+    work = _MATRIX_MATH_RE.sub(_convert, work)
+
+    for index, literal in enumerate(literals):
+        work = work.replace(f"hermesraw{token}x{index}x", literal)
+    return work, replacements
+
+
+def _restore_matrix_math(html: str, replacements: list[tuple[str, str]]) -> str:
+    """Substitute math placeholders back into converted HTML.
+
+    Runs BEFORE :func:`_sanitize_matrix_html`, so the allowlist remains the
+    single boundary that decides which tags and attributes are emitted.
+    """
+    result = html or ""
+    for placeholder, math_html in replacements:
+        result = result.replace(placeholder, math_html)
     return result
 
 
@@ -5012,6 +5145,11 @@ class MatrixAdapter(BasePlatformAdapter):
         Matrix HTML spec allows.
         """
         text = _pre_sanitize_matrix_markdown(text)
+        # LaTeX is stashed as placeholders so the Markdown converter cannot
+        # mangle it (``$a_1$`` would otherwise become emphasis). Math HTML is
+        # restored BEFORE `_sanitize_matrix_html`, so the allowlist still gets
+        # the final say over every tag and attribute we emit.
+        text, math_stash = _extract_matrix_math(text)
         try:
             import markdown as _md
 
@@ -5026,11 +5164,13 @@ class MatrixAdapter(BasePlatformAdapter):
 
             if html.count("<p>") == 1:
                 html = html.replace("<p>", "").replace("</p>", "")
-            return _sanitize_matrix_html(html)
+            return _sanitize_matrix_html(_restore_matrix_math(html, math_stash))
         except ImportError:
             pass
 
-        return _sanitize_matrix_html(self._markdown_to_html_fallback(text))
+        return _sanitize_matrix_html(
+            _restore_matrix_math(self._markdown_to_html_fallback(text), math_stash)
+        )
 
     # ------------------------------------------------------------------
     # Regex-based Markdown -> HTML (no extra dependencies)

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1,5 +1,6 @@
 """Tests for Matrix platform adapter (mautrix-python backend)."""
 import asyncio
+import builtins
 import re
 import stat
 import sys
@@ -718,6 +719,182 @@ class TestMatrixMarkdownToHtml:
         assert "<tbody>" in result
         assert "<th>Item</th>" in result
         assert "<td>Apples</td>" in result
+
+
+class TestMatrixLatexMath:
+    """`$...$` / `$$...$$` -> Element's `data-mx-maths` (MSC2191)."""
+
+    def setup_method(self):
+        self.adapter = _make_adapter()
+
+    def test_inline_math_emits_span_with_attribute(self):
+        result = self.adapter._markdown_to_html(r"Energy is $E = mc^2$ exactly.")
+        assert 'data-mx-maths="E = mc^2"' in result
+        assert "<span" in result
+        # Non-supporting clients fall back to the <code> body.
+        assert "<code>E = mc^2</code>" in result
+
+    def test_display_math_emits_div(self):
+        result = self.adapter._markdown_to_html("$$\\int_0^1 x\\,dx$$")
+        assert "<div" in result
+        assert "data-mx-maths=" in result
+        assert "int_0^1" in result
+
+    def test_subscripts_survive_markdown_emphasis(self):
+        """`$a_1 + b_1$` must not be mangled into <em> by the converter."""
+        result = self.adapter._markdown_to_html("$a_1 + b_1$")
+        assert "<em>" not in result
+        assert "a_1 + b_1" in result
+
+    def test_inline_code_is_not_treated_as_math(self):
+        result = self.adapter._markdown_to_html("Run `echo $HOME and $USER` now")
+        assert "data-mx-maths" not in result
+        assert "$HOME" in result
+
+    def test_fenced_code_block_is_not_treated_as_math(self):
+        text = "```sh\ncost=$5\necho $PATH\n```"
+        result = self.adapter._markdown_to_html(text)
+        assert "data-mx-maths" not in result
+
+    def test_currency_prose_is_not_treated_as_math(self):
+        result = self.adapter._markdown_to_html("It costs $5 or maybe $10 total.")
+        assert "data-mx-maths" not in result
+
+    def test_hostile_latex_cannot_break_out_of_attribute(self):
+        """A payload that DOES become math must be fully escaped in the attr."""
+        result = self.adapter._markdown_to_html('$x"><img src=q>$')
+        assert 'data-mx-maths="x&quot;&gt;&lt;img src=q&gt;"' in result
+        assert "<img" not in result
+
+    def test_hostile_latex_cannot_inject_tags(self):
+        """`<script>` is removed upstream; other tags are escaped inside math."""
+        stripped = self.adapter._markdown_to_html("$<script>alert(1)</script>$")
+        assert "script" not in stripped.lower()
+        assert "alert(1)" not in stripped
+
+        result = self.adapter._markdown_to_html("$<img src=x onerror=y>$")
+        assert "<img" not in result
+        assert "onerror" not in result.lower()
+        assert "&lt;img src=x" in result
+
+    def test_display_math_currency_is_not_math(self):
+        result = self.adapter._markdown_to_html("Costs $$5 for A and $$10 for B.")
+        assert "data-mx-maths" not in result
+        assert "10 for B" in result
+
+    def test_display_math_does_not_span_paragraphs(self):
+        result = self.adapter._markdown_to_html("$$a\n\nb$$")
+        assert "data-mx-maths" not in result
+
+    def test_indented_code_block_is_not_treated_as_math(self):
+        result = self.adapter._markdown_to_html("    echo $x + y$")
+        assert "data-mx-maths" not in result
+        assert "<pre>" in result
+
+    def test_tilde_fence_is_not_treated_as_math(self):
+        result = self.adapter._markdown_to_html("~~~\ncost=$5 and $9\n~~~")
+        assert "data-mx-maths" not in result
+
+    def test_link_destination_is_not_corrupted(self):
+        result = self.adapter._markdown_to_html("[link]($x$)")
+        assert "data-mx-maths" not in result
+        assert ">link</a>" in result
+
+    def test_placeholder_cannot_leak_into_a_later_equation(self):
+        """Display and inline math are one pass — no re-matching placeholders."""
+        result = self.adapter._markdown_to_html("$x$$x$$x$")
+        assert "hermesmath" not in result
+
+    def test_backslash_dollar_is_an_escape_hatch(self):
+        result = self.adapter._markdown_to_html(r"Pay \$5 and \$9 today")
+        assert "data-mx-maths" not in result
+        assert "$5" in result and "$9" in result
+
+    def test_overlong_equation_is_left_as_text(self):
+        result = self.adapter._markdown_to_html("$" + "x" * 5000 + "$")
+        assert "data-mx-maths" not in result
+
+    def test_math_output_survives_the_sanitizer_allowlist(self):
+        """The emitted markup must be what the allowlist actually passes."""
+        from plugins.platforms.matrix.adapter import _sanitize_matrix_html
+
+        html = self.adapter._markdown_to_html("$E=mc^2$")
+        assert _sanitize_matrix_html(html) == html
+
+    def test_sanitizer_still_strips_unrelated_span_attributes(self):
+        from plugins.platforms.matrix.adapter import _sanitize_matrix_html
+
+        cleaned = _sanitize_matrix_html(
+            '<span style="color:red" onclick="x()" data-mx-maths="y">z</span>'
+        )
+        assert "style" not in cleaned
+        assert "onclick" not in cleaned
+        assert 'data-mx-maths="y"' in cleaned
+
+    def test_sanitizer_rejects_maths_attribute_on_other_tags(self):
+        from plugins.platforms.matrix.adapter import _sanitize_matrix_html
+
+        cleaned = _sanitize_matrix_html('<code data-mx-maths="x">x</code>')
+        assert "data-mx-maths" not in cleaned
+
+    def test_bare_span_and_div_are_still_dropped(self):
+        """Allowing span/div for math must not admit arbitrary layout markup."""
+        from plugins.platforms.matrix.adapter import _sanitize_matrix_html
+
+        cleaned = _sanitize_matrix_html("raw <span>hi</span> and <div>d</div>")
+        assert "<span" not in cleaned and "<div" not in cleaned
+        assert "hi" in cleaned and "d" in cleaned
+
+    def test_plain_message_without_math_is_unchanged(self):
+        result = self.adapter._markdown_to_html("**bold** and `code`")
+        assert "data-mx-maths" not in result
+        assert "<strong>bold</strong>" in result
+
+
+class TestMatrixLatexMathFallbackPath:
+    """Same contracts on the no-`markdown`-library regex fallback branch."""
+
+    def setup_method(self):
+        self.adapter = _make_adapter()
+
+    def _convert(self, text):
+        real_import = builtins.__import__
+
+        def _blocked(name, *args, **kwargs):
+            if name == "markdown":
+                raise ImportError("blocked for test")
+            return real_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", _blocked):
+            return self.adapter._markdown_to_html(text)
+
+    def test_fallback_path_is_actually_exercised(self):
+        """Guard the guard: the patch must really force the fallback branch."""
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        with patch.object(
+            MatrixAdapter, "_markdown_to_html_fallback", return_value="SENTINEL"
+        ):
+            assert self._convert("plain") == "SENTINEL"
+
+    def test_fallback_renders_inline_math(self):
+        result = self._convert("Energy is $E = mc^2$ exactly.")
+        assert 'data-mx-maths="E = mc^2"' in result
+        assert "<span" in result
+
+    def test_fallback_renders_display_math(self):
+        result = self._convert("$$E=mc^2$$")
+        assert "<div" in result
+        assert 'data-mx-maths="E=mc^2"' in result
+
+    def test_fallback_excludes_inline_code(self):
+        result = self._convert("Run `echo $HOME and $USER` now")
+        assert "data-mx-maths" not in result
+
+    def test_fallback_escapes_hostile_latex(self):
+        result = self._convert('$x"><img src=q>$')
+        assert "<img" not in result
+        assert "&quot;&gt;&lt;img" in result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Convert `$...$` (inline) and `$$...$$` (display) LaTeX notation in outgoing Matrix messages to Element's `data-mx-maths` HTML attribute format, enabling KaTeX rendering in Element clients.

## Format

- Inline: `<span data-mx-maths="LATEX"><code>LATEX</code></span>`
- Display: `<div data-mx-maths="LATEX"><code>LATEX</code></div>`

## Details

- Detects LaTeX delimiters in outgoing messages during the markdown→HTML conversion step
- Stashes the math HTML before markdown processing to prevent mangling of custom attributes
- Protects code blocks and inline code from false-positive LaTeX detection
- The `<code>` fallback inside ensures non-Element clients still display the raw LaTeX legibly
- No new dependencies required
- No configuration needed — works automatically when users have Element's "Render LaTeX maths" Labs feature enabled

## Testing

Tested live on Element Web — inline and display equations render correctly via KaTeX.