### PR TITLE
fix(gateway): respect explicit plugin platform disable

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1816,13 +1816,20 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         discover_plugins()  # idempotent
         from gateway.platform_registry import platform_registry
         for entry in platform_registry.plugin_entries():
+            platform = Platform(entry.name)
+            existing_config = config.platforms.get(platform)
+            if existing_config is not None and existing_config.enabled is False:
+                # Respect an explicit YAML/config disable. A plugin check_fn only
+                # proves dependencies are installed, not that the platform should
+                # be started. This keeps unused bundled integrations from
+                # reconnect-spamming logs when the user disabled them intentionally.
+                continue
             try:
                 if not entry.check_fn():
                     continue
             except Exception as e:
                 logger.debug("check_fn for %s raised: %s", entry.name, e)
                 continue
-            platform = Platform(entry.name)
             if platform not in config.platforms:
                 config.platforms[platform] = PlatformConfig()
             config.platforms[platform].enabled = True

--- a/tests/gateway/test_plugin_platform_explicit_disable.py
+++ b/tests/gateway/test_plugin_platform_explicit_disable.py
@@ -1,0 +1,40 @@
+from gateway.config import GatewayConfig, Platform, PlatformConfig, _apply_env_overrides
+from gateway.platform_registry import PlatformEntry, platform_registry
+
+
+def _register_test_plugin(name: str, *, check_fn=None, env_enablement_fn=None) -> None:
+    platform_registry.register(
+        PlatformEntry(
+            name=name,
+            label=name.title(),
+            adapter_factory=lambda cfg: object(),
+            check_fn=check_fn or (lambda: True),
+            env_enablement_fn=env_enablement_fn,
+            source="plugin",
+            plugin_name="test-plugin",
+        )
+    )
+
+
+def test_plugin_platform_auto_enable_respects_explicit_false(monkeypatch):
+    monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda: None)
+    name = "test-explicit-disabled"
+    _register_test_plugin(name)
+    platform = Platform(name)
+    config = GatewayConfig(platforms={platform: PlatformConfig(enabled=False)})
+
+    _apply_env_overrides(config)
+
+    assert config.platforms[platform].enabled is False
+
+
+def test_plugin_platform_auto_enable_still_enables_when_not_explicitly_disabled(monkeypatch):
+    monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda: None)
+    name = "test-auto-enabled"
+    _register_test_plugin(name)
+    platform = Platform(name)
+    config = GatewayConfig()
+
+    _apply_env_overrides(config)
+
+    assert config.platforms[platform].enabled is True


### PR DESCRIPTION
## What does this PR do?

Fixes registry-driven gateway plugin platform activation so an explicit `enabled: false` configuration is respected even when plugin auto-detection would otherwise enable the platform.

## Related Issue

Fixes #31049

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Test update

## Changes Made

- Respect explicit `enabled: false` for registry-driven plugin platforms during gateway env overrides.
- Preserve auto-enable behavior when a plugin platform has no explicit disable and its `check_fn()` passes.
- Add regression coverage for both explicit-disable and default auto-enable paths.

## How to Test

- [x] `scripts/run_tests.sh tests/gateway/test_plugin_platform_explicit_disable.py` — 2 passed
- [x] `python -m pytest tests/gateway/test_bluebubbles.py tests/gateway/test_whatsapp_group_gating.py tests/gateway/test_plugin_platform_explicit_disable.py -q -o 'addopts='` — 77 passed

## Tested Platforms

- Linux / Hermes VM

## Reviewer Notes

Pre-PR review was run through Hermes review-agent and OpenCode reviewers. No blocking findings remained; draft PR opened to let upstream CI and maintainers review.

## Checklist

- [x] I have read the contributing guidelines
- [x] My commits follow the Conventional Commits format
- [x] I have added tests for the bug fix
- [x] I have run the relevant tests locally
- [x] This PR focuses on one logical change
