### PR TITLE
fix: aggregate streaming responses in auxiliary client

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4568,6 +4568,100 @@ def _build_call_kwargs(
     return kwargs
 
 
+def _aggregate_stream_response(stream: Any, task: str = None) -> Any:
+    """Consume a streaming response and aggregate it into a completion object.
+
+    Some custom providers return SSE streams even when stream=False is not
+    honored. This function detects that case and aggregates the chunks into
+    a standard .choices[0].message shape so downstream code works unchanged.
+
+    Handles both OpenAI SDK Stream objects (iterable of ChatCompletionChunk)
+    and raw string/generator responses from non-compliant endpoints.
+    """
+    logger.info(
+        "Auxiliary %s: provider returned streaming response; aggregating into completion",
+        task or "call",
+    )
+
+    collected_content = []
+    collected_reasoning = []
+    finish_reason = None
+    chunk_id = ""
+    chunk_model = ""
+
+    try:
+        for chunk in stream:
+            # OpenAI SDK ChatCompletionChunk shape
+            if hasattr(chunk, "choices") and chunk.choices:
+                delta = chunk.choices[0].delta
+                if hasattr(delta, "content") and delta.content:
+                    collected_content.append(delta.content)
+                if hasattr(delta, "reasoning_content") and delta.reasoning_content:
+                    collected_reasoning.append(delta.reasoning_content)
+                if hasattr(chunk.choices[0], "finish_reason") and chunk.choices[0].finish_reason:
+                    finish_reason = chunk.choices[0].finish_reason
+                if hasattr(chunk, "id") and chunk.id:
+                    chunk_id = chunk.id
+                if hasattr(chunk, "model") and chunk.model:
+                    chunk_model = chunk.model
+            # Raw SSE string line (e.g. 'data: {...}')
+            elif isinstance(chunk, str):
+                line = chunk.strip()
+                if line.startswith("data: "):
+                    line = line[6:]
+                if line == "[DONE]":
+                    break
+                try:
+                    import json as _json
+                    data = _json.loads(line)
+                    choices = data.get("choices", [])
+                    if choices:
+                        delta = choices[0].get("delta", {})
+                        content = delta.get("content", "")
+                        reasoning = delta.get("reasoning_content", "")
+                        if content:
+                            collected_content.append(content)
+                        if reasoning:
+                            collected_reasoning.append(reasoning)
+                        fr = choices[0].get("finish_reason")
+                        if fr:
+                            finish_reason = fr
+                    if not chunk_id:
+                        chunk_id = data.get("id", "")
+                    if not chunk_model:
+                        chunk_model = data.get("model", "")
+                except (ValueError, KeyError):
+                    # Not valid JSON — accumulate as raw text
+                    collected_content.append(line)
+    except Exception as exc:
+        logger.warning(
+            "Auxiliary %s: error while aggregating stream response: %s",
+            task or "call", exc,
+        )
+
+    full_content = "".join(collected_content)
+    full_reasoning = "".join(collected_reasoning) or None
+
+    # Build a SimpleNamespace matching the expected .choices[0].message shape
+    message = SimpleNamespace(
+        role="assistant",
+        content=full_content,
+        reasoning=full_reasoning,
+        tool_calls=None,
+    )
+    choice = SimpleNamespace(
+        index=0,
+        message=message,
+        finish_reason=finish_reason or "stop",
+    )
+    return SimpleNamespace(
+        id=chunk_id or "aggregated-stream",
+        object="chat.completion",
+        model=chunk_model or "",
+        choices=[choice],
+    )
+
+
 def _validate_llm_response(response: Any, task: str = None) -> Any:
     """Validate that an LLM response has the expected .choices[0].message shape.
 
@@ -4575,12 +4669,34 @@ def _validate_llm_response(response: Any, task: str = None) -> Any:
     propagate to downstream consumers where they crash with misleading
     AttributeError (e.g. "'str' object has no attribute 'choices'").
 
+    If the response looks like a streaming iterator/generator (has __iter__
+    but no .choices), transparently aggregates it into a completion object.
+    This handles custom providers that ignore stream=False and return SSE
+    chunks regardless of the request parameter.
+
     See #7264.
     """
     if response is None:
         raise RuntimeError(
             f"Auxiliary {task or 'call'}: LLM returned None response"
         )
+
+    # Detect streaming responses: iterables without .choices are likely
+    # SSE generators from providers that don't honor stream=False.
+    # Exclude bytes and dict from stream detection.
+    # Strings ARE included — some custom providers return the entire SSE
+    # payload as a single raw string (type=str) instead of an iterator of
+    # chunks.  We detect this by checking for "data:" prefix which is the
+    # SSE wire format marker.
+    if isinstance(response, str) and "data:" in response:
+        response = _aggregate_stream_response(iter(response.splitlines()), task)
+    elif (
+        not isinstance(response, (str, bytes, dict))
+        and not hasattr(response, "choices")
+        and hasattr(response, "__iter__")
+    ):
+        response = _aggregate_stream_response(response, task)
+
     # Allow SimpleNamespace responses from adapters (CodexAuxiliaryClient,
     # AnthropicAuxiliaryClient) — they have .choices[0].message.
     try:

--- a/tests/agent/test_auxiliary_stream_aggregation.py
+++ b/tests/agent/test_auxiliary_stream_aggregation.py
@@ -1,0 +1,180 @@
+"""Tests for _aggregate_stream_response and streaming detection in _validate_llm_response.
+
+Covers the fix for custom providers that return SSE streams even when
+stream=False is not honored (e.g. title_generation returning raw SSE data).
+"""
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+def _make_chunk(content="", finish_reason=None, reasoning=""):
+    """Build a minimal ChatCompletionChunk-like object."""
+    delta = SimpleNamespace(content=content, reasoning_content=reasoning)
+    choice = SimpleNamespace(delta=delta, finish_reason=finish_reason)
+    return SimpleNamespace(
+        choices=[choice],
+        id="chatcmpl-test123",
+        model="test-model",
+    )
+
+
+class TestAggregateStreamResponse:
+    """Test _aggregate_stream_response aggregates chunks into completion shape."""
+
+    def test_aggregates_openai_sdk_chunks(self):
+        from agent.auxiliary_client import _aggregate_stream_response
+
+        chunks = [
+            _make_chunk(content="Hello"),
+            _make_chunk(content=" "),
+            _make_chunk(content="world"),
+            _make_chunk(content="", finish_reason="stop"),
+        ]
+        result = _aggregate_stream_response(iter(chunks), task="title_generation")
+
+        assert hasattr(result, "choices")
+        assert len(result.choices) == 1
+        msg = result.choices[0].message
+        assert msg.content == "Hello world"
+        assert msg.role == "assistant"
+        assert result.choices[0].finish_reason == "stop"
+
+    def test_aggregates_raw_sse_strings(self):
+        from agent.auxiliary_client import _aggregate_stream_response
+
+        lines = [
+            f'data: {json.dumps({"id": "cmpl-1", "model": "m", "choices": [{"delta": {"content": "Hi"}, "finish_reason": None}]})}',
+            f'data: {json.dumps({"id": "cmpl-1", "model": "m", "choices": [{"delta": {"content": " there"}, "finish_reason": None}]})}',
+            f'data: {json.dumps({"id": "cmpl-1", "model": "m", "choices": [{"delta": {}, "finish_reason": "stop"}]})}',
+            "data: [DONE]",
+        ]
+        result = _aggregate_stream_response(iter(lines), task="compression")
+
+        assert result.choices[0].message.content == "Hi there"
+        assert result.choices[0].finish_reason == "stop"
+        assert result.id == "cmpl-1"
+        assert result.model == "m"
+
+    def test_preserves_reasoning_content(self):
+        from agent.auxiliary_client import _aggregate_stream_response
+
+        chunks = [
+            _make_chunk(content="", reasoning="thinking..."),
+            _make_chunk(content="answer", reasoning=" more thought"),
+            _make_chunk(content="", finish_reason="stop"),
+        ]
+        result = _aggregate_stream_response(iter(chunks), task="vision")
+
+        assert result.choices[0].message.content == "answer"
+        assert result.choices[0].message.reasoning == "thinking... more thought"
+
+    def test_handles_empty_stream(self):
+        from agent.auxiliary_client import _aggregate_stream_response
+
+        result = _aggregate_stream_response(iter([]), task="test")
+
+        assert result.choices[0].message.content == ""
+        assert result.choices[0].finish_reason == "stop"
+
+    def test_handles_malformed_json_in_sse(self):
+        from agent.auxiliary_client import _aggregate_stream_response
+
+        lines = [
+            'data: {"choices": [{"delta": {"content": "ok"}}]}',
+            "data: not-valid-json",
+            "data: [DONE]",
+        ]
+        result = _aggregate_stream_response(iter(lines), task="test")
+
+        # Should accumulate what it can, including the raw fallback text
+        content = result.choices[0].message.content
+        assert "ok" in content
+
+    def test_handles_iteration_error_gracefully(self):
+        from agent.auxiliary_client import _aggregate_stream_response
+
+        def bad_stream():
+            yield _make_chunk(content="partial")
+            raise ConnectionError("connection dropped")
+
+        result = _aggregate_stream_response(bad_stream(), task="test")
+
+        # Should still return what was collected before the error
+        assert result.choices[0].message.content == "partial"
+
+
+class TestValidateLlmResponseStreamingDetection:
+    """Test that _validate_llm_response detects and aggregates streaming responses."""
+
+    def test_passes_normal_completion_through(self):
+        from agent.auxiliary_client import _validate_llm_response
+
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="hello"))]
+        )
+        result = _validate_llm_response(response, task="test")
+        assert result is response
+
+    def test_aggregates_generator_without_choices(self):
+        from agent.auxiliary_client import _validate_llm_response
+
+        chunks = [
+            _make_chunk(content="aggregated"),
+            _make_chunk(content="", finish_reason="stop"),
+        ]
+        result = _validate_llm_response(iter(chunks), task="title_generation")
+
+        assert hasattr(result, "choices")
+        assert result.choices[0].message.content == "aggregated"
+
+    def test_rejects_none(self):
+        from agent.auxiliary_client import _validate_llm_response
+
+        with pytest.raises(RuntimeError, match="None response"):
+            _validate_llm_response(None, task="test")
+
+    def test_rejects_plain_string_response(self):
+        from agent.auxiliary_client import _validate_llm_response
+
+        # Plain strings without "data:" are NOT treated as SSE streams
+        with pytest.raises(RuntimeError, match="invalid response"):
+            _validate_llm_response("raw string response", task="test")
+
+    def test_aggregates_sse_string_response(self):
+        from agent.auxiliary_client import _validate_llm_response
+
+        # Strings containing SSE "data:" lines ARE aggregated as streams.
+        # This is the exact case from the bug report: custom provider returns
+        # type=str with raw SSE content instead of a parsed completion object.
+        sse_blob = (
+            'data: {"id":"cmpl-1","model":"m","choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}\n'
+            'data: {"id":"cmpl-1","model":"m","choices":[{"delta":{"content":" world"},"finish_reason":"stop"}]}\n'
+            "data: [DONE]\n"
+        )
+        result = _validate_llm_response(sse_blob, task="title_generation")
+        assert hasattr(result, "choices")
+        assert result.choices[0].message.content == "Hello world"
+
+    def test_rejects_dict_without_choices_attr(self):
+        from agent.auxiliary_client import _validate_llm_response
+
+        # Dicts are excluded from stream detection
+        with pytest.raises(RuntimeError, match="invalid response"):
+            _validate_llm_response({"error": "something"}, task="test")
+
+    def test_rejects_empty_choices(self):
+        from agent.auxiliary_client import _validate_llm_response
+
+        response = SimpleNamespace(choices=[])
+        with pytest.raises(RuntimeError, match="invalid response"):
+            _validate_llm_response(response, task="test")
+
+    def test_rejects_choices_without_message(self):
+        from agent.auxiliary_client import _validate_llm_response
+
+        response = SimpleNamespace(choices=[SimpleNamespace(index=0)])
+        with pytest.raises(RuntimeError, match="invalid response"):
+            _validate_llm_response(response, task="test")


### PR DESCRIPTION
## Summary

Some custom providers return SSE streams even when `stream=False` is not honored. This caused `title_generation` and other auxiliary tasks to fail with errors like:

```
Auxiliary title_generation: LLM returned invalid response (type=str): 
'data: {"id": "chatcmpl-1b5552757d54", "object": "chat.completion.chunk"...'
Expected object with .choices[0].message
```

## Changes

- Add `_aggregate_stream_response()` — consumes SSE chunks into a standard `.choices[0].message` completion object
- Detect streaming responses in `_validate_llm_response()`:
  - Raw SSE strings containing `data:` prefix
  - Iterable objects without `.choices` attribute
- Support OpenAI SDK `ChatCompletionChunk` objects and raw SSE text lines
- Preserve `reasoning_content` from thinking models (e.g. Qwen, DeepSeek)
- Add comprehensive test suite (13 tests)

## How it works

When a custom provider ignores `stream=False` and returns SSE data:
1. `_validate_llm_response` detects the response is a stream (string with `data:` or iterable without `.choices`)
2. Transparently calls `_aggregate_stream_response` to consume all chunks
3. Returns a `SimpleNamespace` matching the expected `.choices[0].message` shape
4. Downstream code works unchanged

## Test Plan
- [x] Unit tests pass (13/13)
- [x] Verified with custom provider that returns SSE by default
- [x] title_generation now succeeds instead of failing

Fixes #7264