### PR TITLE
feat: add Grok voice dispatch

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2154,6 +2154,28 @@ DEFAULT_CONFIG = {
         "beep_enabled": True,         # Play record start/stop beeps in CLI voice mode
         "silence_threshold": 200,     # RMS below this = silence (0-32767)
         "silence_duration": 3.0,      # Seconds of silence before auto-stop
+        "realtime": {
+            "enabled": False,          # Browser/phone realtime voice dispatch (off by default)
+            "provider": "xai",
+            "model": "grok-voice-latest",
+            "voice": "eve",           # Built-ins: eve, ara, rex, sal, leo; custom voice IDs also work
+            "ephemeral_token_ttl_seconds": 300,
+            "turn_detection": {
+                "type": "server_vad",
+                "threshold": 0.85,
+                "silence_duration_ms": 900,
+                "prefix_padding_ms": 333,
+            },
+            "audio": {
+                "input_rate": 24000,
+                "output_rate": 24000,
+            },
+            "dispatch": {
+                "max_active_delegates": 1,
+                "default_toolsets": [],
+                "summarize_events_for_voice": True,
+            },
+        },
     },
     
     "human_delay": {

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -3,10 +3,12 @@ Interactive setup wizard for Hermes Agent.
 
 Modular wizard with independently-runnable sections:
   1. Model & Provider — choose your AI provider and model
-  2. Terminal Backend — where your agent runs commands
-  3. Agent Settings — iterations, compression, session reset
+  2. Text-to-Speech — configure spoken responses
+  3. Terminal Backend — where your agent runs commands
   4. Messaging Platforms — connect Telegram, Discord, etc.
-  5. Tools — configure TTS, web search, image generation, etc.
+  5. Tools — configure web search, image generation, browser, etc.
+  6. Grok Voice Dispatch — realtime voice control for Hermes delegates
+  7. Agent Settings — iterations, compression, session reset
 
 Config files are stored in ~/.hermes/ for easy access.
 """
@@ -556,6 +558,15 @@ def _print_setup_summary(config: dict, hermes_home):
     elif managed_nous_tools_enabled() and subscription_features.nous_auth_present:
         tool_status.append(("Modal Execution (optional via Nous subscription)", True, None))
 
+    # Grok Voice Dispatch — dashboard realtime voice controller for delegates.
+    voice_realtime_enabled = bool(cfg_get(config, "voice", "realtime", "enabled", default=False))
+    if voice_realtime_enabled and get_env_value("XAI_API_KEY"):
+        tool_status.append(("Grok Voice Dispatch (xAI realtime)", True, None))
+    elif voice_realtime_enabled:
+        tool_status.append(("Grok Voice Dispatch", False, "XAI_API_KEY"))
+    else:
+        tool_status.append(("Grok Voice Dispatch (disabled by default)", True, None))
+
     # Home Assistant
     if get_env_value("HASS_TOKEN"):
         tool_status.append(("Smart Home (Home Assistant)", True, None))
@@ -649,6 +660,7 @@ def _print_setup_summary(config: dict, hermes_home):
     print(f"   {color('hermes setup terminal', Colors.GREEN)} Change terminal backend")
     print(f"   {color('hermes setup gateway', Colors.GREEN)}  Configure messaging")
     print(f"   {color('hermes setup tools', Colors.GREEN)}    Configure tool providers")
+    print(f"   {color('hermes setup voice', Colors.GREEN)}    Configure Grok Voice Dispatch")
     print()
     print(f"   {color('hermes config', Colors.GREEN)}         View current settings")
     print(
@@ -2199,6 +2211,92 @@ def setup_tools(config: dict, first_install: bool = False):
 
 
 # =============================================================================
+# Section 6: Grok Voice Dispatch
+# =============================================================================
+
+
+def _voice_realtime_config(config: dict) -> Dict[str, Any]:
+    """Return the mutable voice.realtime config dict, repairing shape if needed."""
+    voice_cfg = config.get("voice")
+    if not isinstance(voice_cfg, dict):
+        voice_cfg = {}
+        config["voice"] = voice_cfg
+    realtime_cfg = voice_cfg.get("realtime")
+    if not isinstance(realtime_cfg, dict):
+        realtime_cfg = {}
+        voice_cfg["realtime"] = realtime_cfg
+    return realtime_cfg
+
+
+def setup_voice_dispatch(config: dict):
+    """Configure dashboard Grok Voice Dispatch.
+
+    Voice Dispatch is intentionally disabled by default. The browser receives
+    only short-lived xAI realtime credentials from the Hermes dashboard; the
+    long-lived XAI_API_KEY stays in the Hermes .env file.
+    """
+    print_header("Grok Voice Dispatch")
+    print_info("Grok Voice Dispatch adds a /voice dashboard page for realtime voice control.")
+    print_info("Grok Voice listens and speaks; Hermes delegates do the actual work.")
+    print_info("It is disabled by default and must be explicitly enabled here.")
+    print_info("Secrets are stored in .env; config values are stored in config.yaml.")
+    print()
+
+    realtime = _voice_realtime_config(config)
+    currently_enabled = bool(realtime.get("enabled", False))
+    if not prompt_yes_no("Enable Grok Voice Dispatch?", default=currently_enabled):
+        realtime["enabled"] = False
+        realtime.setdefault("provider", "xai")
+        realtime.setdefault("model", "grok-voice-latest")
+        realtime.setdefault("voice", "eve")
+        try:
+            ttl = int(realtime.get("ephemeral_token_ttl_seconds") or 300)
+        except (TypeError, ValueError):
+            ttl = 300
+        realtime["ephemeral_token_ttl_seconds"] = max(1, min(ttl, 300))
+        save_config(config)
+        print_info("Grok Voice Dispatch remains disabled by default.")
+        return
+
+    realtime["enabled"] = True
+    realtime["provider"] = "xai"
+
+    current_model = str(realtime.get("model") or "grok-voice-latest")
+    current_voice = str(realtime.get("voice") or "eve")
+    realtime["model"] = prompt("Realtime voice model", current_model) or current_model
+    realtime["voice"] = prompt("Realtime voice", current_voice) or current_voice
+
+    try:
+        ttl = int(realtime.get("ephemeral_token_ttl_seconds") or 300)
+    except (TypeError, ValueError):
+        ttl = 300
+    realtime["ephemeral_token_ttl_seconds"] = max(1, min(ttl, 300))
+
+    existing_key = get_env_value("XAI_API_KEY")
+    if existing_key:
+        print_info(f"XAI_API_KEY is already configured in {get_env_path()}.")
+        replace_key = prompt_yes_no("Replace existing XAI_API_KEY?", default=False)
+    else:
+        replace_key = True
+
+    if replace_key:
+        api_key = prompt("XAI_API_KEY", password=True)
+        if api_key:
+            save_env_value("XAI_API_KEY", api_key)
+            print_success("XAI_API_KEY saved")
+        else:
+            print_warning(
+                "No XAI_API_KEY saved. Voice Dispatch will stay configured, "
+                "but the dashboard cannot mint xAI realtime credentials until the key is set."
+            )
+
+    save_config(config)
+    print_success(
+        f"Grok Voice Dispatch enabled ({realtime['model']} / voice {realtime['voice']})"
+    )
+
+
+# =============================================================================
 # Post-Migration Section Skip Logic
 # =============================================================================
 
@@ -2321,6 +2419,15 @@ def _get_section_config_summary(config: dict, section_key: str) -> Optional[str]
             tools.append("Firecrawl")
         if tools:
             return ", ".join(tools)
+        return None
+
+    elif section_key == "voice":
+        if bool(cfg_get(config, "voice", "realtime", "enabled", default=False)):
+            model = cfg_get(config, "voice", "realtime", "model", default="grok-voice-latest")
+            voice = cfg_get(config, "voice", "realtime", "voice", default="eve")
+            return f"enabled: {model} / {voice}"
+        if get_env_value("XAI_API_KEY"):
+            return "XAI_API_KEY configured; disabled"
         return None
 
     return None
@@ -2606,6 +2713,7 @@ SETUP_SECTIONS = [
     ("terminal", "Terminal Backend", setup_terminal_backend),
     ("gateway", "Messaging Platforms (Gateway)", setup_gateway),
     ("tools", "Tools", setup_tools),
+    ("voice", "Grok Voice Dispatch", setup_voice_dispatch),
     ("agent", "Agent Settings", setup_agent_settings),
 ]
 
@@ -2846,8 +2954,8 @@ def run_setup_wizard(args):
         print_info("Running the full wizard — each prompt shows your current value.")
         print_info("Press Enter to keep it, or type a new value to change it.")
         print_info("")
-        print_info("Tip: jump straight to a section with 'hermes setup model|terminal|")
-        print_info("     gateway|tools|agent', or fill only missing items with --quick.")
+        print_info("Tip: jump straight to a section with 'hermes setup model|tts|terminal|")
+        print_info("     gateway|tools|voice|agent', or fill only missing items with --quick.")
         # Fall through to the "Full Setup — run all sections" block below.
         # --reconfigure is now the default on existing installs; the flag
         # is preserved for backwards compatibility but is a no-op here.
@@ -2919,6 +3027,10 @@ def run_setup_wizard(args):
     # Section 5: Tools
     if not (migration_ran and _skip_configured_section(config, "tools", "Tools")):
         setup_tools(config, first_install=not is_existing)
+
+    # Section 6: Grok Voice Dispatch — remains disabled unless explicitly enabled.
+    if not (migration_ran and _skip_configured_section(config, "voice", "Grok Voice Dispatch")):
+        setup_voice_dispatch(config)
 
     # Save and show summary
     save_config(config)

--- a/hermes_cli/subcommands/setup.py
+++ b/hermes_cli/subcommands/setup.py
@@ -18,12 +18,12 @@ def build_setup_parser(subparsers, *, cmd_setup: Callable) -> None:
         "setup",
         help="Interactive setup wizard",
         description="Configure Hermes Agent with an interactive wizard. "
-        "Run a specific section: hermes setup model|tts|terminal|gateway|tools|agent",
+        "Run a specific section: hermes setup model|tts|terminal|gateway|tools|voice|agent",
     )
     setup_parser.add_argument(
         "section",
         nargs="?",
-        choices=["model", "tts", "terminal", "gateway", "tools", "agent"],
+        choices=["model", "tts", "terminal", "gateway", "tools", "voice", "agent"],
         default=None,
         help="Run a specific setup section instead of the full wizard",
     )

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -31,12 +31,14 @@ import re
 import secrets
 import shlex
 import shutil
+import sqlite3
 import stat
 import subprocess
 import sys
 import tempfile
 import threading
 import time
+import uuid
 import urllib.error
 import urllib.parse
 import zipfile
@@ -63,6 +65,7 @@ from hermes_cli.config import (
     get_hermes_home,
     load_config,
     load_env,
+    get_env_value,
     read_raw_config,
     save_config,
     save_env_value,
@@ -603,6 +606,1003 @@ async def _token_auth_seam(request: Request, call_next):
     """
     from hermes_cli.dashboard_auth.token_auth import token_auth_middleware
     return await token_auth_middleware(request, call_next)
+
+
+# ---------------------------------------------------------------------------
+# Realtime voice dispatch support (dashboard-local, xAI token broker only)
+# ---------------------------------------------------------------------------
+_XAI_REALTIME_CLIENT_SECRETS_URL = "https://api.x.ai/v1/realtime/client_secrets"
+_VOICE_TERMINAL_STATUSES = {"completed", "failed", "cancelled", "stopped"}
+_VOICE_APPROVAL_CHOICES: Tuple[str, ...] = ("once", "session", "deny")
+_VOICE_RUN_STATUSES: Dict[str, Dict[str, Any]] = {}
+_VOICE_ACTIVE_RUN_AGENTS: Dict[str, Any] = {}
+_VOICE_ACTIVE_RUN_TASKS: Dict[str, asyncio.Task] = {}
+_VOICE_RUN_APPROVAL_SESSIONS: Dict[str, str] = {}
+_VOICE_STOP_REQUESTED: set[str] = set()
+_VOICE_DELEGATE_LEDGER_LOCK = threading.RLock()
+_VOICE_MAX_INPUT_CHARS = 65_536
+_VOICE_LEDGER_SENSITIVE_KEY_RE = re.compile(r"(^|[_-])(api[_-]?key|authorization|bearer|client[_-]?secret|credential|password|secret|token)([_-]|$)", re.I)
+_VOICE_LEDGER_SECRET_VALUE_RES = (
+    re.compile(r"(?i)(Bearer\s+)[A-Za-z0-9._\-]{12,}"),
+    re.compile(r"(?i)\b(sk|xai|ghp|github_pat|glpat|sk-or|sk-ant|AIza)[A-Za-z0-9._\-]{8,}\b"),
+    re.compile(r"(?i)((?:api[_-]?key|authorization|client[_-]?secret|password|secret|token)\s*[:=]\s*)[^\s,;\]})]+"),
+)
+
+
+class VoiceRunCreate(BaseModel):
+    input: Optional[str] = None
+    objective: Optional[str] = None
+    instructions: Optional[str] = None
+    session_id: Optional[str] = None
+
+
+class VoiceRunApproval(BaseModel):
+    choice: str
+    resolve_all: bool = False
+
+
+_VOICE_REALTIME_TOOLS: Tuple[Dict[str, Any], ...] = (
+    {
+        "type": "function",
+        "name": "start_delegate",
+        "description": "Start an isolated Hermes delegate run from a spoken user objective.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "input": {
+                    "type": "string",
+                    "description": "The user's complete objective for the Hermes delegate to execute.",
+                }
+            },
+            "required": ["input"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "type": "function",
+        "name": "get_delegate_status",
+        "description": "Read a Hermes voice delegate status, output, and recent event trail. Defaults to the active delegate when delegate_id is omitted.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "delegate_id": {
+                    "type": "string",
+                    "description": "Optional delegate ID to inspect when more than one delegate exists.",
+                }
+            },
+            "additionalProperties": False,
+        },
+    },
+    {
+        "type": "function",
+        "name": "stop_delegate",
+        "description": "Interrupt a Hermes voice delegate run. Defaults to the active delegate when delegate_id is omitted.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "delegate_id": {
+                    "type": "string",
+                    "description": "Optional delegate ID to stop when more than one delegate exists.",
+                }
+            },
+            "additionalProperties": False,
+        },
+    },
+)
+
+def _voice_realtime_config() -> Dict[str, Any]:
+    """Return voice.realtime config merged with safe defaults.
+
+    Older config files will not contain ``voice.realtime`` yet.  Keep the
+    feature disabled and default-shaped instead of raising, so upgraded
+    dashboards remain safe until the user explicitly enables realtime voice.
+    """
+    base = json.loads(json.dumps(DEFAULT_CONFIG.get("voice", {}).get("realtime", {})))
+    cfg = load_config()
+    voice = cfg.get("voice") if isinstance(cfg, dict) else None
+    realtime = voice.get("realtime") if isinstance(voice, dict) else None
+    if isinstance(realtime, dict):
+        for key, value in realtime.items():
+            if key in {"turn_detection", "audio", "dispatch"} and isinstance(value, dict):
+                nested = base.get(key)
+                if not isinstance(nested, dict):
+                    nested = {}
+                nested.update(value)
+                base[key] = nested
+            else:
+                base[key] = value
+    return base
+
+
+def _voice_realtime_ttl_seconds(cfg: Dict[str, Any]) -> int:
+    try:
+        raw = int(cfg.get("ephemeral_token_ttl_seconds", 300))
+    except (TypeError, ValueError):
+        raw = 300
+    return max(30, min(raw, 300))
+
+
+def _voice_realtime_payload(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    turn_detection = cfg.get("turn_detection") if isinstance(cfg.get("turn_detection"), dict) else {}
+    audio = cfg.get("audio") if isinstance(cfg.get("audio"), dict) else {}
+    return {
+        "enabled": bool(cfg.get("enabled", False)),
+        "provider": str(cfg.get("provider") or "xai"),
+        "model": str(cfg.get("model") or "grok-voice-latest"),
+        "voice": str(cfg.get("voice") or "eve"),
+        "turn_detection": {
+            "type": str(turn_detection.get("type") or "server_vad"),
+            "threshold": float(turn_detection.get("threshold", 0.85)),
+            "silence_duration_ms": int(turn_detection.get("silence_duration_ms", 900)),
+            "prefix_padding_ms": int(turn_detection.get("prefix_padding_ms", 333)),
+        },
+        "audio": {
+            "input_rate": int(audio.get("input_rate", 24000)),
+            "output_rate": int(audio.get("output_rate", 24000)),
+        },
+        "tools": list(_VOICE_REALTIME_TOOLS),
+    }
+
+
+def _voice_normalize_profile(profile: Optional[str]) -> str:
+    """Canonical management-profile key used for in-memory isolation."""
+    return str(profile or "").strip()
+
+
+def _voice_status_matches_profile(status: Optional[Dict[str, Any]], profile: Optional[str]) -> bool:
+    if status is None:
+        return False
+    return _voice_normalize_profile(status.get("profile")) == _voice_normalize_profile(profile)
+
+
+def _mint_xai_realtime_client_secret(api_key: str, ttl_seconds: int) -> Dict[str, Any]:
+    """Blocking xAI client-secret request — always call via asyncio.to_thread."""
+    body = json.dumps({"expires_after": {"seconds": int(ttl_seconds)}}).encode("utf-8")
+    req = urllib.request.Request(
+        _XAI_REALTIME_CLIENT_SECRETS_URL,
+        data=body,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            raw = resp.read().decode("utf-8")
+            return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as exc:
+        detail = "xAI rejected the realtime client secret request"
+        try:
+            upstream = exc.read().decode("utf-8", errors="ignore")[:300]
+            if upstream:
+                detail = f"{detail}: {upstream}"
+        except Exception:
+            pass
+        raise HTTPException(status_code=502, detail=detail) from exc
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Unable to reach xAI realtime token service: {type(exc).__name__}",
+        ) from exc
+
+
+@app.get("/api/voice/realtime/config")
+async def get_voice_realtime_config(profile: Optional[str] = None):
+    """Return sanitized realtime voice configuration for the dashboard client."""
+    with _profile_scope(profile):
+        return _voice_realtime_payload(_voice_realtime_config())
+
+
+@app.post("/api/voice/realtime/xai-client-secret")
+async def create_xai_realtime_client_secret(profile: Optional[str] = None):
+    """Mint a short-lived xAI realtime client secret for browser voice mode.
+
+    The dashboard session token middleware gates this endpoint.  The long-lived
+    ``XAI_API_KEY`` remains server-side; the browser receives only xAI's
+    ephemeral client secret. Config/env lookup is scoped to the selected
+    dashboard management profile. The upstream HTTP call is offloaded so the
+    FastAPI event loop is not blocked for the full request timeout.
+    """
+    # Resolve profile-scoped config/env under the scope lock, then release
+    # before awaiting the network call (``_profile_scope`` must not span await).
+    with _profile_scope(profile):
+        cfg = _voice_realtime_config()
+        if not bool(cfg.get("enabled", False)):
+            raise HTTPException(status_code=400, detail="Realtime voice dispatch is disabled")
+        if str(cfg.get("provider") or "xai").lower() != "xai":
+            raise HTTPException(status_code=400, detail="Only provider 'xai' is supported for realtime voice")
+
+        api_key = str(get_env_value("XAI_API_KEY") or "").strip()
+        if not api_key:
+            raise HTTPException(status_code=400, detail="XAI_API_KEY is required for realtime voice")
+        ttl_seconds = _voice_realtime_ttl_seconds(cfg)
+        payload = _voice_realtime_payload(cfg)
+
+    data = await asyncio.to_thread(_mint_xai_realtime_client_secret, api_key, ttl_seconds)
+
+    value = data.get("value") or data.get("client_secret") or data.get("secret")
+    expires_at = data.get("expires_at")
+    if not value or expires_at is None:
+        raise HTTPException(status_code=502, detail="xAI client secret response was missing required fields")
+
+    return {
+        "client_secret": {"value": value, "expires_at": expires_at},
+        "model": payload["model"],
+        "voice": payload["voice"],
+        "profile": _voice_normalize_profile(profile) or None,
+    }
+
+
+def _voice_active_run_count(profile: Optional[str] = None) -> int:
+    return sum(
+        1
+        for status in _VOICE_RUN_STATUSES.values()
+        if status.get("status") not in _VOICE_TERMINAL_STATUSES
+        and _voice_status_matches_profile(status, profile)
+    )
+
+
+def _voice_max_active_runs(cfg: Dict[str, Any]) -> int:
+    dispatch = cfg.get("dispatch") if isinstance(cfg.get("dispatch"), dict) else {}
+    raw_value = dispatch.get("max_active_delegates", cfg.get("max_active_runs", 1))
+    try:
+        raw = int(raw_value)
+    except (TypeError, ValueError):
+        raw = 1
+    return max(1, min(raw, 5))
+
+
+def _voice_trim_text(value: Any, max_chars: int = _VOICE_MAX_INPUT_CHARS) -> str:
+    text = str(value or "").strip()
+    return text[:max_chars]
+
+
+def _voice_run_input(body: VoiceRunCreate) -> str:
+    return _voice_trim_text(body.input if body.input is not None else body.objective)
+
+
+def _voice_delegate_db_path() -> Path:
+    return get_hermes_home() / "voice_dispatch.db"
+
+
+def _voice_delegate_connect() -> sqlite3.Connection:
+    path = _voice_delegate_db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    try:
+        from hermes_state import apply_wal_with_fallback
+        apply_wal_with_fallback(conn, db_label="voice_dispatch.db")
+    except Exception:
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+        except Exception:
+            pass
+    conn.execute("PRAGMA foreign_keys=ON")
+    _voice_delegate_init_db(conn)
+    return conn
+
+
+def _voice_delegate_init_db(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS voice_delegate_runs (
+            delegate_id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            status TEXT NOT NULL,
+            input_preview TEXT,
+            output TEXT,
+            error TEXT,
+            usage_json TEXT,
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL,
+            last_event TEXT
+        );
+
+        CREATE TABLE IF NOT EXISTS voice_delegate_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            delegate_id TEXT NOT NULL,
+            event_name TEXT,
+            timestamp REAL NOT NULL,
+            event_json TEXT NOT NULL,
+            FOREIGN KEY (delegate_id) REFERENCES voice_delegate_runs(delegate_id) ON DELETE CASCADE
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_voice_delegate_runs_updated
+            ON voice_delegate_runs(updated_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_voice_delegate_events_delegate
+            ON voice_delegate_events(delegate_id, id);
+        """
+    )
+    conn.commit()
+
+
+def _voice_redact_ledger_string(value: str) -> str:
+    redacted = value
+    for pattern in _VOICE_LEDGER_SECRET_VALUE_RES:
+        if pattern.pattern.startswith("(?i)(Bearer"):
+            redacted = pattern.sub(r"\1[redacted]", redacted)
+        elif "api[_-]?key" in pattern.pattern and "[:=]" in pattern.pattern:
+            redacted = pattern.sub(r"\1[redacted]", redacted)
+        else:
+            redacted = pattern.sub("[redacted]", redacted)
+    return redacted
+
+
+def _voice_sanitize_for_ledger(value: Any) -> Any:
+    if isinstance(value, dict):
+        sanitized: Dict[str, Any] = {}
+        for key, item in value.items():
+            key_text = str(key)
+            if _VOICE_LEDGER_SENSITIVE_KEY_RE.search(key_text):
+                sanitized[key_text] = "[redacted]"
+            else:
+                sanitized[key_text] = _voice_sanitize_for_ledger(item)
+        return sanitized
+    if isinstance(value, list):
+        return [_voice_sanitize_for_ledger(item) for item in value]
+    if isinstance(value, tuple):
+        return [_voice_sanitize_for_ledger(item) for item in value]
+    if isinstance(value, str):
+        return _voice_redact_ledger_string(value)
+    return value
+
+
+def _voice_approval_choices(raw_choices: Any = None) -> List[str]:
+    choices: List[str] = []
+    candidates = raw_choices if isinstance(raw_choices, list) else list(_VOICE_APPROVAL_CHOICES)
+    for choice in candidates:
+        normalized = str(choice or "").strip().lower()
+        if normalized in _VOICE_APPROVAL_CHOICES and normalized not in choices:
+            choices.append(normalized)
+    return choices or list(_VOICE_APPROVAL_CHOICES)
+
+
+def _voice_approval_request_from_status(status: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if status.get("status") != "waiting_for_approval":
+        return None
+    approval_event: Optional[Dict[str, Any]] = None
+    for event in reversed(status.get("events") or []):
+        if isinstance(event, dict) and event.get("event") == "approval.request":
+            approval_event = event
+            break
+    if approval_event is None:
+        return None
+
+    details: Dict[str, Any] = {}
+    for key in (
+        "command",
+        "description",
+        "pattern_key",
+        "pattern_keys",
+        "tool",
+        "action",
+        "preview",
+        "timestamp",
+        "delegate_id",
+        "run_id",
+    ):
+        if key in approval_event and approval_event.get(key) is not None:
+            details[key] = approval_event.get(key)
+    details["choices"] = _voice_approval_choices(approval_event.get("choices"))
+    return _voice_sanitize_for_ledger(details)
+
+
+def _voice_status_payload(delegate_id: str, status: Dict[str, Any]) -> Dict[str, Any]:
+    payload = dict(status)
+    payload["object"] = "hermes.voice.delegate"
+    payload["delegate_id"] = delegate_id
+    payload["run_id"] = delegate_id  # backwards-compatible dashboard/run alias
+    payload.setdefault("events", [])
+    approval_request = _voice_approval_request_from_status(payload)
+    if approval_request is not None:
+        payload["approval_request"] = approval_request
+    else:
+        payload.pop("approval_request", None)
+    return payload
+
+
+def _persist_voice_run_status(status: Dict[str, Any]) -> None:
+    delegate_id = str(status.get("delegate_id") or status.get("run_id") or "").strip()
+    if not delegate_id:
+        return
+    status = _voice_sanitize_for_ledger(status)
+    usage = status.get("usage")
+    profile = status.get("profile")
+    with _VOICE_DELEGATE_LEDGER_LOCK:
+        try:
+            with _profile_scope(profile):
+                with _voice_delegate_connect() as conn:
+                    conn.execute(
+                        """
+                        INSERT INTO voice_delegate_runs (
+                            delegate_id, session_id, status, input_preview, output, error,
+                            usage_json, created_at, updated_at, last_event
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        ON CONFLICT(delegate_id) DO UPDATE SET
+                            session_id=excluded.session_id,
+                            status=excluded.status,
+                            input_preview=excluded.input_preview,
+                            output=excluded.output,
+                            error=excluded.error,
+                            usage_json=excluded.usage_json,
+                            created_at=excluded.created_at,
+                            updated_at=excluded.updated_at,
+                            last_event=excluded.last_event
+                        """,
+                        (
+                            delegate_id,
+                            str(status.get("session_id") or delegate_id),
+                            str(status.get("status") or "unknown"),
+                            status.get("input_preview"),
+                            status.get("output"),
+                            status.get("error"),
+                            json.dumps(usage) if usage is not None else None,
+                            float(status.get("created_at") or time.time()),
+                            float(status.get("updated_at") or time.time()),
+                            status.get("last_event"),
+                        ),
+                    )
+                    conn.commit()
+        except Exception:
+            _log.debug("Unable to persist voice delegate status", exc_info=True)
+
+
+def _persist_voice_run_event(delegate_id: str, event: Dict[str, Any], profile: Optional[str] = None) -> None:
+    if not delegate_id:
+        return
+    event = dict(event)
+    event.setdefault("delegate_id", delegate_id)
+    event.setdefault("run_id", delegate_id)
+    if profile is not None:
+        event.setdefault("profile", _voice_normalize_profile(profile) or None)
+    timestamp = float(event.get("timestamp") or time.time())
+    event_name = str(event.get("event") or "")
+    with _VOICE_DELEGATE_LEDGER_LOCK:
+        try:
+            with _profile_scope(event.get("profile") if profile is None else profile):
+                with _voice_delegate_connect() as conn:
+                    conn.execute(
+                        """
+                        INSERT INTO voice_delegate_events (delegate_id, event_name, timestamp, event_json)
+                        VALUES (?, ?, ?, ?)
+                        """,
+                        (delegate_id, event_name, timestamp, json.dumps(event)),
+                    )
+                    conn.commit()
+        except Exception:
+            _log.debug("Unable to persist voice delegate event", exc_info=True)
+
+
+def _load_voice_run_events(delegate_id: str, limit: int = 20, profile: Optional[str] = None) -> List[Dict[str, Any]]:
+    with _VOICE_DELEGATE_LEDGER_LOCK:
+        try:
+            with _profile_scope(profile):
+                with _voice_delegate_connect() as conn:
+                    rows = conn.execute(
+                        """
+                        SELECT event_json FROM voice_delegate_events
+                        WHERE delegate_id = ?
+                        ORDER BY id DESC
+                        LIMIT ?
+                        """,
+                        (delegate_id, max(1, min(int(limit), 200))),
+                    ).fetchall()
+        except Exception:
+            return []
+    events: List[Dict[str, Any]] = []
+    for row in reversed(rows):
+        try:
+            events.append(json.loads(row["event_json"]))
+        except Exception:
+            continue
+    return events
+
+
+def _load_voice_run_status(delegate_id: str, profile: Optional[str] = None) -> Optional[Dict[str, Any]]:
+    with _VOICE_DELEGATE_LEDGER_LOCK:
+        try:
+            with _profile_scope(profile):
+                with _voice_delegate_connect() as conn:
+                    row = conn.execute(
+                        "SELECT * FROM voice_delegate_runs WHERE delegate_id = ?",
+                        (delegate_id,),
+                    ).fetchone()
+        except Exception:
+            return None
+    if row is None:
+        return None
+    usage = None
+    if row["usage_json"]:
+        try:
+            usage = json.loads(row["usage_json"])
+        except Exception:
+            usage = None
+    status: Dict[str, Any] = {
+        "object": "hermes.voice.delegate",
+        "delegate_id": row["delegate_id"],
+        "run_id": row["delegate_id"],
+        "session_id": row["session_id"],
+        "status": row["status"],
+        "created_at": row["created_at"],
+        "updated_at": row["updated_at"],
+        "input_preview": row["input_preview"],
+        "last_event": row["last_event"],
+        "profile": _voice_normalize_profile(profile) or None,
+        "events": _load_voice_run_events(row["delegate_id"], profile=profile),
+    }
+    if row["output"] is not None:
+        status["output"] = row["output"]
+    if row["error"] is not None:
+        status["error"] = row["error"]
+    if usage is not None:
+        status["usage"] = usage
+    return status
+
+
+def _get_voice_run_status(delegate_id: str, profile: Optional[str] = None) -> Optional[Dict[str, Any]]:
+    status = _VOICE_RUN_STATUSES.get(delegate_id)
+    loaded_from_ledger = False
+    if status is not None and not _voice_status_matches_profile(status, profile):
+        status = None
+    if status is None:
+        status = _load_voice_run_status(delegate_id, profile=profile)
+        if status is not None:
+            _VOICE_RUN_STATUSES[delegate_id] = status
+            loaded_from_ledger = True
+    if status is None:
+        return None
+    if (
+        status.get("status") not in _VOICE_TERMINAL_STATUSES
+        and (status.get("status") != "waiting_for_approval" or loaded_from_ledger)
+        and delegate_id not in _VOICE_ACTIVE_RUN_TASKS
+        and delegate_id not in _VOICE_ACTIVE_RUN_AGENTS
+    ):
+        status = _set_voice_run_status(
+            delegate_id,
+            "stopped",
+            error="Delegate is no longer active; dashboard process restarted.",
+            last_event="run.stopped",
+        )
+        _append_voice_run_event(
+            delegate_id,
+            {"event": "run.stopped", "delegate_id": delegate_id, "run_id": delegate_id, "timestamp": time.time()},
+        )
+    return status
+
+
+def _set_voice_run_status(run_id: str, status: str, **fields: Any) -> Dict[str, Any]:
+    now = time.time()
+    current = dict(_VOICE_RUN_STATUSES.get(run_id, {}))
+    current.update({
+        "object": "hermes.voice.delegate",
+        "delegate_id": run_id,
+        "run_id": run_id,
+        "status": status,
+        "updated_at": now,
+    })
+    current.setdefault("created_at", fields.pop("created_at", now))
+    if "profile" in fields:
+        current["profile"] = _voice_normalize_profile(fields.pop("profile")) or None
+    else:
+        current.setdefault("profile", None)
+    current.update(_voice_sanitize_for_ledger(fields))
+    current = _voice_status_payload(run_id, _voice_sanitize_for_ledger(current))
+    _VOICE_RUN_STATUSES[run_id] = current
+    _persist_voice_run_status(current)
+    return current
+
+
+def _append_voice_run_event(run_id: str, event: Dict[str, Any]) -> None:
+    status = _VOICE_RUN_STATUSES.get(run_id)
+    if status is None:
+        # Unknown profile until we find an in-memory entry; callers always
+        # create status before appending events, so this is a last resort.
+        status = _load_voice_run_status(run_id, profile=event.get("profile") if isinstance(event, dict) else None)
+    if status is None:
+        return
+    event = _voice_sanitize_for_ledger(dict(event))
+    event.setdefault("delegate_id", run_id)
+    event.setdefault("run_id", run_id)
+    event.setdefault("profile", status.get("profile"))
+    events = list(status.get("events") or [])
+    events.append(event)
+    status["events"] = events[-20:]
+    status["last_event"] = event.get("event")
+    status["updated_at"] = time.time()
+    status = _voice_status_payload(run_id, status)
+    _VOICE_RUN_STATUSES[run_id] = status
+    _persist_voice_run_status(status)
+    _persist_voice_run_event(run_id, event, profile=status.get("profile"))
+
+
+def _create_voice_dispatch_agent(
+    *,
+    ephemeral_system_prompt: Optional[str] = None,
+    session_id: Optional[str] = None,
+    stream_delta_callback=None,
+    tool_progress_callback=None,
+    gateway_session_key: Optional[str] = None,
+) -> Any:
+    """Create the Hermes worker used by dashboard voice dispatch.
+
+    Grok Voice never receives local tools directly.  It can only call the
+    dashboard bridge, and this worker then runs through normal Hermes agent
+    construction, toolsets, and approval handling.
+    """
+    from run_agent import AIAgent
+    from gateway.run import (
+        GatewayRunner,
+        _load_gateway_config,
+        _resolve_gateway_model,
+        _resolve_runtime_agent_kwargs,
+    )
+    from hermes_cli.tools_config import _get_platform_tools
+
+    runtime_kwargs = _resolve_runtime_agent_kwargs()
+    reasoning_config = GatewayRunner._load_reasoning_config()
+    model = _resolve_gateway_model()
+    user_config = _load_gateway_config()
+
+    dispatch_cfg = _voice_realtime_config().get("dispatch")
+    configured_toolsets = None
+    if isinstance(dispatch_cfg, dict) and isinstance(dispatch_cfg.get("default_toolsets"), list):
+        configured_toolsets = [str(item) for item in dispatch_cfg.get("default_toolsets") if str(item).strip()]
+    enabled_toolsets = configured_toolsets or sorted(_get_platform_tools(user_config, "api_server"))
+
+    try:
+        max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+    except (TypeError, ValueError):
+        max_iterations = 90
+
+    return AIAgent(
+        model=model,
+        **runtime_kwargs,
+        max_iterations=max_iterations,
+        quiet_mode=True,
+        verbose_logging=False,
+        ephemeral_system_prompt=ephemeral_system_prompt or None,
+        enabled_toolsets=enabled_toolsets,
+        session_id=session_id,
+        platform="dashboard_voice",
+        stream_delta_callback=stream_delta_callback,
+        tool_progress_callback=tool_progress_callback,
+        fallback_model=GatewayRunner._load_fallback_model(),
+        reasoning_config=reasoning_config,
+        gateway_session_key=gateway_session_key,
+    )
+
+
+async def _run_voice_dispatch(run_id: str, body: VoiceRunCreate, profile: Optional[str] = None) -> None:
+    user_message = _voice_run_input(body)
+    session_id = _voice_trim_text(body.session_id, 256) or run_id
+    approval_session_key = _VOICE_RUN_APPROVAL_SESSIONS.get(run_id, f"voice:{session_id}")
+    loop = asyncio.get_running_loop()
+    output_chunks: List[str] = []
+    profile_key = _voice_normalize_profile(profile) or None
+
+    def _push(event: Dict[str, Any]) -> None:
+        _append_voice_run_event(run_id, event)
+
+    def _stream_delta(delta: Optional[str]) -> None:
+        if delta is None:
+            return
+        text = str(delta)
+        output_chunks.append(text)
+        try:
+            loop.call_soon_threadsafe(
+                _push,
+                {"event": "message.delta", "run_id": run_id, "timestamp": time.time(), "delta": text},
+            )
+        except Exception:
+            pass
+
+    def _tool_progress(event_type: str, tool_name: str = None, preview: str = None, args=None, **kwargs) -> None:
+        if event_type not in {"tool.started", "tool.completed", "reasoning.available"}:
+            return
+        event: Dict[str, Any] = {
+            "event": event_type,
+            "run_id": run_id,
+            "timestamp": time.time(),
+        }
+        if tool_name:
+            event["tool"] = tool_name
+        if preview:
+            event["preview"] = preview
+        if "duration" in kwargs:
+            event["duration"] = kwargs.get("duration")
+        if "is_error" in kwargs:
+            event["error"] = bool(kwargs.get("is_error"))
+        try:
+            loop.call_soon_threadsafe(_push, event)
+        except Exception:
+            pass
+
+    def _approval_notify(approval_data: Dict[str, Any]) -> None:
+        event = dict(approval_data or {})
+        event.update({
+            "event": "approval.request",
+            "run_id": run_id,
+            "timestamp": time.time(),
+            "choices": list(_VOICE_APPROVAL_CHOICES),
+        })
+        _set_voice_run_status(run_id, "waiting_for_approval", last_event="approval.request")
+        try:
+            loop.call_soon_threadsafe(_push, event)
+        except Exception:
+            pass
+
+    def _run_sync() -> tuple[Dict[str, Any], Dict[str, int]]:
+        from gateway.session_context import clear_session_vars, set_session_vars
+        from tools.approval import (
+            register_gateway_notify,
+            reset_current_session_key,
+            set_current_session_key,
+            unregister_gateway_notify,
+        )
+
+        # Agent construction + execution must see the selected profile's
+        # config/env/home. Scope stays inside this worker thread only.
+        with _profile_scope(profile):
+            agent = _create_voice_dispatch_agent(
+                ephemeral_system_prompt=body.instructions,
+                session_id=session_id,
+                stream_delta_callback=_stream_delta,
+                tool_progress_callback=_tool_progress,
+                gateway_session_key=approval_session_key,
+            )
+            _VOICE_ACTIVE_RUN_AGENTS[run_id] = agent
+            if run_id in _VOICE_STOP_REQUESTED:
+                try:
+                    agent.interrupt("Stop requested via voice dispatch")
+                except Exception:
+                    pass
+            approval_token = None
+            session_tokens = []
+            try:
+                approval_token = set_current_session_key(approval_session_key)
+                session_tokens = set_session_vars(platform="dashboard_voice_delegate", session_key=approval_session_key)
+                register_gateway_notify(approval_session_key, _approval_notify)
+                result = agent.run_conversation(
+                    user_message=user_message,
+                    conversation_history=[],
+                    task_id=f"voice_delegate:{session_id}",
+                )
+            finally:
+                try:
+                    unregister_gateway_notify(approval_session_key)
+                finally:
+                    if approval_token is not None:
+                        try:
+                            reset_current_session_key(approval_token)
+                        except Exception:
+                            pass
+                    if session_tokens:
+                        try:
+                            clear_session_vars(session_tokens)
+                        except Exception:
+                            pass
+            usage = {
+                "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
+                "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
+                "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
+            }
+            return result if isinstance(result, dict) else {}, usage
+
+    try:
+        if run_id in _VOICE_STOP_REQUESTED:
+            _set_voice_run_status(run_id, "stopped", last_event="run.stopped")
+            _push({"event": "run.stopped", "run_id": run_id, "timestamp": time.time()})
+            return
+        _set_voice_run_status(run_id, "running")
+        if run_id in _VOICE_STOP_REQUESTED:
+            _set_voice_run_status(run_id, "stopped", last_event="run.stopped")
+            _push({"event": "run.stopped", "run_id": run_id, "timestamp": time.time()})
+            return
+        result, usage = await loop.run_in_executor(None, _run_sync)
+        if result.get("failed"):
+            error = result.get("error") or "agent run failed"
+            _set_voice_run_status(run_id, "failed", error=error, usage=usage, last_event="run.failed")
+            _push({"event": "run.failed", "run_id": run_id, "timestamp": time.time(), "error": error})
+        else:
+            output = result.get("final_response") or "".join(output_chunks)
+            _set_voice_run_status(run_id, "completed", output=output, usage=usage, last_event="run.completed")
+            _push({"event": "run.completed", "run_id": run_id, "timestamp": time.time(), "output": output, "usage": usage})
+    except asyncio.CancelledError:
+        _set_voice_run_status(run_id, "cancelled", last_event="run.cancelled")
+        _push({"event": "run.cancelled", "run_id": run_id, "timestamp": time.time()})
+        raise
+    except Exception as exc:
+        _log.exception("Voice dispatch run %s failed", run_id)
+        _set_voice_run_status(run_id, "failed", error=str(exc), last_event="run.failed")
+        _push({"event": "run.failed", "run_id": run_id, "timestamp": time.time(), "error": str(exc)})
+    finally:
+        try:
+            from tools.approval import unregister_gateway_notify
+            unregister_gateway_notify(approval_session_key)
+        except Exception:
+            pass
+        _VOICE_ACTIVE_RUN_AGENTS.pop(run_id, None)
+        _VOICE_ACTIVE_RUN_TASKS.pop(run_id, None)
+        _VOICE_RUN_APPROVAL_SESSIONS.pop(run_id, None)
+        _VOICE_STOP_REQUESTED.discard(run_id)
+
+
+async def _start_voice_delegate(body: VoiceRunCreate, profile: Optional[str] = None):
+    with _profile_scope(profile):
+        cfg = _voice_realtime_config()
+        if not bool(cfg.get("enabled", False)):
+            raise HTTPException(status_code=400, detail="Realtime voice dispatch is disabled")
+        max_active = _voice_max_active_runs(cfg)
+
+    user_message = _voice_run_input(body)
+    if not user_message:
+        raise HTTPException(status_code=400, detail="Missing voice delegate input")
+
+    if _voice_active_run_count(profile) >= max_active:
+        raise HTTPException(status_code=429, detail=f"Too many active voice delegates (max {max_active})")
+
+    delegate_id = f"voice_delegate_{uuid.uuid4().hex}"
+    session_id = _voice_trim_text(body.session_id, 256) or delegate_id
+    approval_session_key = f"voice:{delegate_id}"
+    profile_key = _voice_normalize_profile(profile) or None
+    _VOICE_RUN_APPROVAL_SESSIONS[delegate_id] = approval_session_key
+    _set_voice_run_status(
+        delegate_id,
+        "queued",
+        created_at=time.time(),
+        session_id=session_id,
+        input_preview=user_message[:300],
+        profile=profile_key,
+    )
+    _append_voice_run_event(
+        delegate_id,
+        {
+            "event": "delegate.queued",
+            "delegate_id": delegate_id,
+            "run_id": delegate_id,
+            "timestamp": time.time(),
+            "profile": profile_key,
+        },
+    )
+    task = asyncio.create_task(_run_voice_dispatch(delegate_id, body, profile=profile))
+    _VOICE_ACTIVE_RUN_TASKS[delegate_id] = task
+    return JSONResponse(
+        status_code=202,
+        content={
+            "object": "hermes.voice.delegate",
+            "delegate_id": delegate_id,
+            "run_id": delegate_id,
+            "status": "started",
+            "profile": profile_key,
+        },
+    )
+
+
+@app.post("/api/voice/delegates")
+async def start_voice_delegate(body: VoiceRunCreate, profile: Optional[str] = None):
+    return await _start_voice_delegate(body, profile=profile)
+
+
+@app.post("/api/voice/runs")
+async def start_voice_run(body: VoiceRunCreate, profile: Optional[str] = None):
+    """Backward-compatible alias for the delegate launcher."""
+    return await _start_voice_delegate(body, profile=profile)
+
+
+async def _get_voice_delegate_or_404(delegate_id: str, profile: Optional[str] = None) -> Dict[str, Any]:
+    status = _get_voice_run_status(delegate_id, profile=profile)
+    if status is None:
+        raise HTTPException(status_code=404, detail=f"Voice delegate not found: {delegate_id}")
+    return status
+
+
+@app.get("/api/voice/delegates/{delegate_id}")
+async def get_voice_delegate(delegate_id: str, profile: Optional[str] = None):
+    return await _get_voice_delegate_or_404(delegate_id, profile=profile)
+
+
+@app.get("/api/voice/delegates/{delegate_id}/events")
+async def get_voice_delegate_events(delegate_id: str, profile: Optional[str] = None):
+    status = await _get_voice_delegate_or_404(delegate_id, profile=profile)
+    return {"object": "hermes.voice.delegate.events", "delegate_id": delegate_id, "run_id": delegate_id, "events": status.get("events") or []}
+
+
+@app.get("/api/voice/runs/{run_id}/events")
+async def get_voice_run_events(run_id: str, profile: Optional[str] = None):
+    """Backward-compatible alias for delegate event history."""
+    status = await _get_voice_delegate_or_404(run_id, profile=profile)
+    return {"object": "hermes.voice.delegate.events", "delegate_id": run_id, "run_id": run_id, "events": status.get("events") or []}
+
+
+@app.get("/api/voice/runs/{run_id}")
+async def get_voice_run(run_id: str, profile: Optional[str] = None):
+    """Backward-compatible alias for delegate status."""
+    return await _get_voice_delegate_or_404(run_id, profile=profile)
+
+
+async def _approve_voice_delegate(delegate_id: str, body: VoiceRunApproval, profile: Optional[str] = None):
+    if _get_voice_run_status(delegate_id, profile=profile) is None:
+        raise HTTPException(status_code=404, detail=f"Voice delegate not found: {delegate_id}")
+
+    raw_choice = str(body.choice or "").strip().lower()
+    choice = {"approve": "once", "approved": "once", "allow": "once"}.get(raw_choice, raw_choice)
+    if choice not in _VOICE_APPROVAL_CHOICES:
+        expected = ", ".join(_VOICE_APPROVAL_CHOICES)
+        raise HTTPException(status_code=400, detail=f"Approval choice '{choice}' is not allowed for voice dispatch; expected {expected}")
+
+    approval_session_key = _VOICE_RUN_APPROVAL_SESSIONS.get(delegate_id)
+    if not approval_session_key:
+        raise HTTPException(status_code=409, detail=f"Voice delegate has no active approval session: {delegate_id}")
+
+    try:
+        from tools.approval import resolve_gateway_approval
+        resolved = resolve_gateway_approval(approval_session_key, choice, resolve_all=bool(body.resolve_all))
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    if resolved <= 0:
+        raise HTTPException(status_code=409, detail=f"Voice delegate has no pending approval: {delegate_id}")
+
+    _set_voice_run_status(delegate_id, "running", last_event="approval.responded")
+    _append_voice_run_event(
+        delegate_id,
+        {"event": "approval.responded", "delegate_id": delegate_id, "run_id": delegate_id, "timestamp": time.time(), "choice": choice, "resolved": resolved},
+    )
+    return {"object": "hermes.voice.delegate.approval_response", "delegate_id": delegate_id, "run_id": delegate_id, "choice": choice, "resolved": resolved}
+
+
+@app.post("/api/voice/delegates/{delegate_id}/approval")
+async def approve_voice_delegate(delegate_id: str, body: VoiceRunApproval, profile: Optional[str] = None):
+    return await _approve_voice_delegate(delegate_id, body, profile=profile)
+
+
+@app.post("/api/voice/runs/{run_id}/approval")
+async def approve_voice_run(run_id: str, body: VoiceRunApproval, profile: Optional[str] = None):
+    """Backward-compatible alias for delegate approval."""
+    return await _approve_voice_delegate(run_id, body, profile=profile)
+
+
+async def _stop_voice_delegate(delegate_id: str, profile: Optional[str] = None):
+    status = _get_voice_run_status(delegate_id, profile=profile)
+    agent = _VOICE_ACTIVE_RUN_AGENTS.get(delegate_id)
+    task = _VOICE_ACTIVE_RUN_TASKS.get(delegate_id)
+    if status is None:
+        # Reject cross-profile active-task leakage when status is missing.
+        agent = None
+        task = None
+    if status is None and agent is None and task is None:
+        raise HTTPException(status_code=404, detail=f"Voice delegate not found: {delegate_id}")
+
+    if status is not None and status.get("status") in _VOICE_TERMINAL_STATUSES:
+        return status
+
+    _VOICE_STOP_REQUESTED.add(delegate_id)
+    _set_voice_run_status(delegate_id, "stopping", last_event="delegate.stopping")
+    _append_voice_run_event(
+        delegate_id,
+        {"event": "delegate.stopping", "delegate_id": delegate_id, "run_id": delegate_id, "timestamp": time.time()},
+    )
+    if agent is not None:
+        try:
+            agent.interrupt("Stop requested via voice dispatch")
+        except Exception:
+            pass
+    return {"object": "hermes.voice.delegate", "delegate_id": delegate_id, "run_id": delegate_id, "status": "stopping"}
+
+
+@app.post("/api/voice/delegates/{delegate_id}/stop")
+async def stop_voice_delegate(delegate_id: str, profile: Optional[str] = None):
+    return await _stop_voice_delegate(delegate_id, profile=profile)
+
+
+@app.post("/api/voice/runs/{run_id}/stop")
+async def stop_voice_run(run_id: str, profile: Optional[str] = None):
+    """Backward-compatible alias for delegate stop."""
+    return await _stop_voice_delegate(run_id, profile=profile)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -1,6 +1,7 @@
 """Tests for setup.py configuration flows."""
 import sys
 import types
+from pathlib import Path
 
 
 from hermes_cli.config import load_config, save_config
@@ -48,6 +49,147 @@ def _write_model_config(tmp_path, provider, base_url="", model_name="test-model"
     if model_name:
         m["default"] = model_name
     save_config(cfg)
+
+
+def test_setup_voice_dispatch_decline_keeps_realtime_disabled(tmp_path, monkeypatch, capsys):
+    """Voice Dispatch stays disabled unless the user explicitly opts in."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = load_config()
+    saved_env = {}
+
+    monkeypatch.setattr(setup_mod, "get_env_value", lambda key: "")
+    monkeypatch.setattr(setup_mod, "save_env_value", lambda key, value: saved_env.update({key: value}))
+    monkeypatch.setattr(setup_mod, "prompt_yes_no", lambda question, default=True: False)
+
+    setup_mod.setup_voice_dispatch(config)
+
+    assert config["voice"]["realtime"]["enabled"] is False
+    assert saved_env == {}
+    out = capsys.readouterr().out
+    assert "disabled by default" in out.lower()
+
+
+def test_setup_voice_dispatch_opt_in_saves_xai_key_without_printing_secret(
+    tmp_path, monkeypatch, capsys
+):
+    """Opting in enables config and stores XAI_API_KEY through Hermes env helpers."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = load_config()
+    saved_env = {}
+    secret = "xai-test-secret-value"
+
+    monkeypatch.setattr(setup_mod, "get_env_value", lambda key: "")
+    monkeypatch.setattr(setup_mod, "save_env_value", lambda key, value: saved_env.update({key: value}))
+    monkeypatch.setattr(setup_mod, "prompt_yes_no", lambda question, default=True: True)
+
+    def fake_prompt(question, default=None, password=False):
+        if "model" in question.lower():
+            return default
+        if "voice" in question.lower():
+            return default
+        assert password is True
+        assert "XAI" in question or "xAI" in question
+        return secret
+
+    monkeypatch.setattr(setup_mod, "prompt", fake_prompt)
+
+    setup_mod.setup_voice_dispatch(config)
+
+    realtime = config["voice"]["realtime"]
+    assert realtime["enabled"] is True
+    assert realtime["provider"] == "xai"
+    assert realtime["model"] == "grok-voice-latest"
+    assert realtime["voice"] == "eve"
+    assert realtime["ephemeral_token_ttl_seconds"] <= 300
+    assert saved_env == {"XAI_API_KEY": secret}
+    assert secret not in capsys.readouterr().out
+
+
+def test_setup_voice_dispatch_existing_key_is_not_reprinted_or_replaced_by_default(
+    tmp_path, monkeypatch, capsys
+):
+    """Existing xAI credentials are detected without echoing or replacing them."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = load_config()
+    saved_env = {}
+    existing_secret = "xai-existing-secret-value"
+
+    monkeypatch.setattr(
+        setup_mod,
+        "get_env_value",
+        lambda key: existing_secret if key == "XAI_API_KEY" else "",
+    )
+    monkeypatch.setattr(setup_mod, "save_env_value", lambda key, value: saved_env.update({key: value}))
+
+    def fake_yes_no(question, default=True):
+        if "Enable Grok Voice Dispatch" in question:
+            return True
+        if "Replace existing XAI_API_KEY" in question:
+            return False
+        raise AssertionError(f"Unexpected prompt_yes_no call: {question}")
+
+    monkeypatch.setattr(setup_mod, "prompt_yes_no", fake_yes_no)
+    monkeypatch.setattr(setup_mod, "prompt", lambda question, default=None, **kwargs: default)
+
+    setup_mod.setup_voice_dispatch(config)
+
+    assert config["voice"]["realtime"]["enabled"] is True
+    assert saved_env == {}
+    out = capsys.readouterr().out
+    assert "XAI_API_KEY is already configured" in out
+    assert existing_secret not in out
+
+
+def test_setup_sections_include_voice_dispatch():
+    sections = {name: (label, func) for name, label, func in setup_mod.SETUP_SECTIONS}
+
+    assert "voice" in sections
+    label, func = sections["voice"]
+    assert label == "Grok Voice Dispatch"
+    assert func is setup_mod.setup_voice_dispatch
+
+
+def test_setup_cli_parser_accepts_voice_section():
+    repo_root = Path(__file__).resolve().parents[2]
+    setup_parser_source = (repo_root / "hermes_cli" / "subcommands" / "setup.py").read_text(encoding="utf-8")
+
+    assert "hermes setup model|tts|terminal|gateway|tools|voice|agent" in setup_parser_source
+    assert '"voice"' in setup_parser_source
+
+
+def test_full_setup_runs_voice_dispatch_section(tmp_path, monkeypatch):
+    """The full setup path includes the disabled-by-default voice section."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _clear_provider_env(monkeypatch)
+    calls = []
+
+    monkeypatch.setattr(setup_mod, "is_interactive_stdin", lambda: True)
+    monkeypatch.setattr(setup_mod, "_offer_openclaw_migration", lambda hermes_home: False)
+    monkeypatch.setattr(setup_mod, "_print_setup_summary", lambda config, hermes_home: None)
+    monkeypatch.setattr("hermes_cli.auth.get_active_provider", lambda: None)
+    monkeypatch.setattr(setup_mod, "prompt_choice", lambda question, choices, default=0: 1)
+    monkeypatch.setattr(setup_mod, "setup_model_provider", lambda config, *args, **kwargs: calls.append("model"))
+    monkeypatch.setattr(setup_mod, "setup_terminal_backend", lambda config, *args, **kwargs: calls.append("terminal"))
+    monkeypatch.setattr(setup_mod, "setup_agent_settings", lambda config, *args, **kwargs: calls.append("agent"))
+    monkeypatch.setattr(setup_mod, "setup_gateway", lambda config, *args, **kwargs: calls.append("gateway"))
+    monkeypatch.setattr(setup_mod, "setup_tools", lambda config, *args, **kwargs: calls.append("tools"))
+    monkeypatch.setattr(setup_mod, "setup_voice_dispatch", lambda config, *args, **kwargs: calls.append("voice"))
+
+    setup_mod.run_setup_wizard(
+        types.SimpleNamespace(
+            reset=False,
+            reconfigure=False,
+            quick=False,
+            non_interactive=False,
+            portal=False,
+            section=None,
+        )
+    )
+
+    # Agent settings are applied as silent defaults on first install; the
+    # interactive section path is model → terminal → gateway → tools → voice.
+    assert calls == ["model", "terminal", "gateway", "tools", "voice"]
+    assert "voice" in calls
 
 
 def test_setup_delegates_to_select_provider_and_model(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_voice_realtime.py
+++ b/tests/hermes_cli/test_voice_realtime.py
@@ -1,0 +1,702 @@
+"""Tests for dashboard Grok realtime voice dispatch support."""
+
+import asyncio
+from contextlib import contextmanager
+import json
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.config import DEFAULT_CONFIG
+
+
+class _FakeHTTPResponse:
+    def __init__(self, payload: dict, status: int = 200):
+        self._payload = payload
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return json.dumps(self._payload).encode("utf-8")
+
+
+def test_voice_realtime_defaults_are_safe():
+    """Behavioral invariants for safe-by-default realtime voice config.
+
+    Avoid snapshotting mutable model/voice literals; assert the contracts
+    that keep the feature off and the surface narrow until explicit setup.
+    """
+    import hermes_cli.web_server as web_server
+
+    realtime = DEFAULT_CONFIG["voice"]["realtime"]
+    assert realtime["enabled"] is False
+
+    payload = web_server._voice_realtime_payload(realtime)
+    serialized = json.dumps(payload).lower()
+    assert payload["enabled"] is False
+    assert "api_key" not in serialized
+    assert "client_secret" not in serialized
+    assert "authorization" not in serialized
+    assert "xai_api_key" not in serialized
+
+    tools_by_name = {tool["name"]: tool for tool in payload["tools"]}
+    assert set(tools_by_name) == {
+        "start_delegate",
+        "get_delegate_status",
+        "stop_delegate",
+    }
+    assert "start_hermes_run" not in tools_by_name
+    assert "approve_delegate_action" not in tools_by_name
+
+    assert web_server._voice_realtime_ttl_seconds({"ephemeral_token_ttl_seconds": 10}) == 30
+    assert web_server._voice_realtime_ttl_seconds({"ephemeral_token_ttl_seconds": 900}) == 300
+    assert web_server._voice_realtime_ttl_seconds({"ephemeral_token_ttl_seconds": "nope"}) == 300
+
+
+class TestVoiceRealtimeEndpoints:
+    @pytest.fixture(autouse=True)
+    def _client(self, monkeypatch, _isolate_hermes_home):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+
+        import hermes_cli.web_server as web_server
+
+        self.web_server = web_server
+        for name in (
+            "_VOICE_RUN_STATUSES",
+            "_VOICE_ACTIVE_RUN_AGENTS",
+            "_VOICE_ACTIVE_RUN_TASKS",
+            "_VOICE_RUN_APPROVAL_SESSIONS",
+            "_VOICE_STOP_REQUESTED",
+        ):
+            store = getattr(web_server, name, None)
+            if hasattr(store, "clear"):
+                store.clear()
+        self.client = TestClient(web_server.app)
+        self.client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+
+    def _enable_voice_config(self, monkeypatch, **overrides):
+        import hermes_cli.web_server as web_server
+
+        cfg = json.loads(json.dumps(DEFAULT_CONFIG))
+        cfg["voice"]["realtime"]["enabled"] = True
+        cfg["voice"]["realtime"].update(overrides)
+        monkeypatch.setattr(web_server, "load_config", lambda: cfg)
+        return cfg
+
+    def test_config_endpoint_requires_dashboard_token(self):
+        client = self.client
+        client.headers.pop(self.web_server._SESSION_HEADER_NAME, None)
+
+        resp = client.get("/api/voice/realtime/config")
+
+        assert resp.status_code == 401
+
+    def test_client_secret_endpoint_requires_dashboard_token(self):
+        client = self.client
+        client.headers.pop(self.web_server._SESSION_HEADER_NAME, None)
+
+        resp = client.post("/api/voice/realtime/xai-client-secret")
+
+        assert resp.status_code == 401
+
+    def test_config_endpoint_returns_sanitized_realtime_config(self, monkeypatch):
+        self._enable_voice_config(monkeypatch, voice="rex")
+
+        resp = self.client.get("/api/voice/realtime/config")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is True
+        assert data["provider"] == "xai"
+        assert data["model"] == "grok-voice-latest"
+        assert data["voice"] == "rex"
+        assert "api_key" not in json.dumps(data).lower()
+        tools_by_name = {tool["name"]: tool for tool in data["tools"]}
+        assert set(tools_by_name) == {
+            "start_delegate",
+            "get_delegate_status",
+            "stop_delegate",
+        }
+        serialized = json.dumps(data)
+        assert "start_hermes_run" not in serialized
+        assert "approve_delegate_action" not in serialized
+        assert "approve_hermes_action" not in serialized
+        for name in ("get_delegate_status", "stop_delegate"):
+            assert "delegate_id" in tools_by_name[name]["parameters"]["properties"]
+
+    def test_client_secret_rejects_when_disabled(self, monkeypatch):
+        cfg = json.loads(json.dumps(DEFAULT_CONFIG))
+        monkeypatch.setattr(self.web_server, "load_config", lambda: cfg)
+
+        resp = self.client.post("/api/voice/realtime/xai-client-secret")
+
+        assert resp.status_code == 400
+        assert "disabled" in resp.text.lower()
+
+    def test_client_secret_requires_xai_api_key(self, monkeypatch):
+        self._enable_voice_config(monkeypatch)
+        monkeypatch.delenv("XAI_API_KEY", raising=False)
+        monkeypatch.setattr(self.web_server, "get_env_value", lambda key: None)
+
+        resp = self.client.post("/api/voice/realtime/xai-client-secret")
+
+        assert resp.status_code == 400
+        assert "XAI_API_KEY" in resp.text
+
+    def test_client_secret_uses_hermes_env_value(self, monkeypatch):
+        self._enable_voice_config(monkeypatch)
+        monkeypatch.delenv("XAI_API_KEY", raising=False)
+        monkeypatch.setattr(
+            self.web_server,
+            "get_env_value",
+            lambda key: "xai-dotenv-secret" if key == "XAI_API_KEY" else None,
+        )
+        captured = {}
+
+        def fake_urlopen(req, timeout=0):
+            captured["headers"] = dict(req.header_items())
+            return _FakeHTTPResponse({"value": "ephemeral-secret", "expires_at": 1893456000})
+
+        with patch("urllib.request.urlopen", fake_urlopen):
+            resp = self.client.post("/api/voice/realtime/xai-client-secret")
+
+        assert resp.status_code == 200
+        assert captured["headers"]["Authorization"] == "Bearer xai-dotenv-secret"
+        assert "xai-dotenv-secret" not in resp.text
+
+    def test_client_secret_mints_ephemeral_token_without_leaking_api_key(self, monkeypatch):
+        self._enable_voice_config(monkeypatch, ephemeral_token_ttl_seconds=9999)
+        monkeypatch.setenv("XAI_API_KEY", "xai-real-secret")
+        captured = {}
+
+        def fake_urlopen(req, timeout=0):
+            captured["url"] = req.full_url
+            captured["headers"] = dict(req.header_items())
+            captured["body"] = json.loads(req.data.decode("utf-8"))
+            return _FakeHTTPResponse({"value": "ephemeral-secret", "expires_at": 1893456000})
+
+        with patch("urllib.request.urlopen", fake_urlopen):
+            resp = self.client.post("/api/voice/realtime/xai-client-secret")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["client_secret"] == {"value": "ephemeral-secret", "expires_at": 1893456000}
+        assert data["model"]
+        assert data["voice"]
+        assert data.get("profile") in (None, "")
+        assert "api_key" not in json.dumps(data).lower()
+        assert captured["url"] == "https://api.x.ai/v1/realtime/client_secrets"
+        assert captured["body"] == {"expires_after": {"seconds": 300}}
+        assert captured["headers"]["Authorization"] == "Bearer xai-real-secret"
+        assert "xai-real-secret" not in resp.text
+
+    def test_voice_run_rejects_when_realtime_disabled(self, monkeypatch):
+        cfg = json.loads(json.dumps(DEFAULT_CONFIG))
+        monkeypatch.setattr(self.web_server, "load_config", lambda: cfg)
+
+        resp = self.client.post("/api/voice/runs", json={"input": "Check the current time"})
+
+        assert resp.status_code == 400
+        assert "disabled" in resp.text.lower()
+
+    def test_voice_run_starts_and_gets_completed_status(self, monkeypatch):
+        self._enable_voice_config(monkeypatch)
+        captured_coroutines = []
+
+        class FakeTask:
+            def __init__(self, coro):
+                self.coro = coro
+
+            def done(self):
+                return False
+
+            def cancel(self):
+                return None
+
+        class FakeAgent:
+            def __init__(self):
+                self.interrupted = False
+                self.session_prompt_tokens = 1
+                self.session_completion_tokens = 2
+                self.session_total_tokens = 3
+
+            def run_conversation(self, user_message, conversation_history=None, task_id=None):
+                assert user_message == "Check the current time"
+                assert task_id.startswith("voice_delegate:")
+                return {"final_response": "It is handled.", "completed": True}
+
+            def interrupt(self, reason):
+                self.interrupted = True
+
+        def fake_create_task(coro):
+            captured_coroutines.append(coro)
+            return FakeTask(coro)
+
+        monkeypatch.setattr(self.web_server, "_create_voice_dispatch_agent", lambda **kwargs: FakeAgent())
+        monkeypatch.setattr(self.web_server.asyncio, "create_task", fake_create_task)
+
+        resp = self.client.post("/api/voice/runs", json={"input": "Check the current time"})
+
+        assert resp.status_code == 202
+        run_id = resp.json()["run_id"]
+        assert run_id.startswith("voice_delegate_")
+        assert captured_coroutines
+
+        queued = self.client.get(f"/api/voice/runs/{run_id}")
+        assert queued.status_code == 200
+        assert queued.json()["status"] == "queued"
+
+        asyncio.run(captured_coroutines[0])
+
+        completed = self.client.get(f"/api/voice/runs/{run_id}")
+        assert completed.status_code == 200
+        data = completed.json()
+        assert data["status"] == "completed"
+        assert data["output"] == "It is handled."
+        assert data["usage"] == {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3}
+
+
+    def test_delegate_endpoint_starts_isolated_delegate_and_persists_to_sqlite(self, monkeypatch):
+        self._enable_voice_config(monkeypatch)
+        captured_coroutines = []
+        created_agents = []
+
+        class FakeTask:
+            def __init__(self, coro):
+                self.coro = coro
+
+            def done(self):
+                return False
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                created_agents.append(kwargs)
+                self.session_prompt_tokens = 10
+                self.session_completion_tokens = 20
+                self.session_total_tokens = 30
+
+            def run_conversation(self, user_message, conversation_history=None, task_id=None):
+                assert user_message == "Audit the repo"
+                assert task_id.startswith("voice_delegate:")
+                return {"final_response": "Delegate complete.", "completed": True}
+
+            def interrupt(self, reason):
+                raise AssertionError("delegate should not be interrupted")
+
+        def fake_create_task(coro):
+            captured_coroutines.append(coro)
+            return FakeTask(coro)
+
+        monkeypatch.setattr(self.web_server, "_create_voice_dispatch_agent", lambda **kwargs: FakeAgent(**kwargs))
+        monkeypatch.setattr(self.web_server.asyncio, "create_task", fake_create_task)
+
+        resp = self.client.post("/api/voice/delegates", json={"input": "Audit the repo"})
+
+        assert resp.status_code == 202
+        started = resp.json()
+        delegate_id = started["delegate_id"]
+        assert delegate_id.startswith("voice_delegate_")
+        assert started["run_id"] == delegate_id
+        assert started["object"] == "hermes.voice.delegate"
+        assert captured_coroutines
+
+        asyncio.run(captured_coroutines[0])
+
+        assert created_agents
+        assert created_agents[0]["session_id"] == delegate_id
+        assert created_agents[0]["gateway_session_key"] == f"voice:{delegate_id}"
+
+        # Simulate a dashboard process restart: in-memory state is gone, but
+        # the local SQLite delegate ledger still has the run and event trail.
+        self.web_server._VOICE_RUN_STATUSES.clear()
+        self.web_server._VOICE_ACTIVE_RUN_AGENTS.clear()
+        self.web_server._VOICE_ACTIVE_RUN_TASKS.clear()
+        self.web_server._VOICE_RUN_APPROVAL_SESSIONS.clear()
+
+        completed = self.client.get(f"/api/voice/delegates/{delegate_id}")
+        assert completed.status_code == 200
+        data = completed.json()
+        assert data["object"] == "hermes.voice.delegate"
+        assert data["delegate_id"] == delegate_id
+        assert data["status"] == "completed"
+        assert data["output"] == "Delegate complete."
+        assert data["usage"] == {"input_tokens": 10, "output_tokens": 20, "total_tokens": 30}
+        assert any(event["event"] == "run.completed" for event in data["events"])
+
+        events = self.client.get(f"/api/voice/delegates/{delegate_id}/events")
+        assert events.status_code == 200
+        assert events.json()["events"][-1]["event"] == "run.completed"
+        legacy_events = self.client.get(f"/api/voice/runs/{delegate_id}/events")
+        assert legacy_events.status_code == 200
+        assert legacy_events.json()["events"][-1]["event"] == "run.completed"
+
+    def test_legacy_run_endpoints_alias_delegate_ledger(self, monkeypatch):
+        self._enable_voice_config(monkeypatch)
+        captured_coroutines = []
+
+        class FakeTask:
+            def __init__(self, coro):
+                self.coro = coro
+
+            def done(self):
+                return False
+
+        class FakeAgent:
+            session_prompt_tokens = 0
+            session_completion_tokens = 0
+            session_total_tokens = 0
+
+            def run_conversation(self, user_message, conversation_history=None, task_id=None):
+                return {"final_response": "legacy ok", "completed": True}
+
+            def interrupt(self, reason):
+                pass
+
+        monkeypatch.setattr(self.web_server, "_create_voice_dispatch_agent", lambda **kwargs: FakeAgent())
+        monkeypatch.setattr(self.web_server.asyncio, "create_task", lambda coro: captured_coroutines.append(coro) or FakeTask(coro))
+
+        resp = self.client.post("/api/voice/runs", json={"input": "Legacy call"})
+
+        assert resp.status_code == 202
+        run_id = resp.json()["run_id"]
+        assert run_id.startswith("voice_delegate_")
+        asyncio.run(captured_coroutines[0])
+        assert self.client.get(f"/api/voice/runs/{run_id}").json()["delegate_id"] == run_id
+
+
+    def test_delegate_ledger_redacts_secret_shaped_status_and_events(self):
+        secret = "Authorization: Bearer sk-test-secret-value-1234567890"
+        self.web_server._set_voice_run_status(
+            "voice_delegate_secret",
+            "completed",
+            session_id="voice_delegate_secret",
+            input_preview=f"use api_key={secret}",
+            output=f"finished with {secret}",
+            error=f"token={secret}",
+            usage={"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+        )
+        self.web_server._append_voice_run_event(
+            "voice_delegate_secret",
+            {"event": "tool.completed", "timestamp": 123.0, "preview": f"secret={secret}", "api_key": secret},
+        )
+
+        resp = self.client.get("/api/voice/delegates/voice_delegate_secret")
+
+        assert resp.status_code == 200
+        payload = json.dumps(resp.json())
+        assert "sk-test-secret-value" not in payload
+        assert "api_key=Authorization" not in payload
+        assert "[redacted]" in payload
+
+    def test_delegate_approval_sessions_are_unique_even_with_same_client_session_id(self, monkeypatch):
+        self._enable_voice_config(monkeypatch, dispatch={"max_active_delegates": 2, "default_toolsets": []})
+        captured_coroutines = []
+
+        class FakeTask:
+            def __init__(self, coro):
+                self.coro = coro
+
+            def done(self):
+                return False
+
+        def fake_create_task(coro):
+            captured_coroutines.append(coro)
+            return FakeTask(coro)
+
+        monkeypatch.setattr(self.web_server.asyncio, "create_task", fake_create_task)
+
+        first = self.client.post("/api/voice/delegates", json={"input": "first", "session_id": "shared"}).json()["delegate_id"]
+        second = self.client.post("/api/voice/delegates", json={"input": "second", "session_id": "shared"}).json()["delegate_id"]
+
+        assert first != second
+        assert self.web_server._VOICE_RUN_APPROVAL_SESSIONS[first] == f"voice:{first}"
+        assert self.web_server._VOICE_RUN_APPROVAL_SESSIONS[second] == f"voice:{second}"
+        for coro in captured_coroutines:
+            coro.close()
+
+    def test_voice_approval_endpoint_rejects_always_choice_for_human_ui_path(self, monkeypatch):
+        self.web_server._set_voice_run_status(
+            "voice_delegate_approval",
+            "waiting_for_approval",
+            session_id="voice_delegate_approval",
+            last_event="approval.request",
+        )
+        self.web_server._VOICE_RUN_APPROVAL_SESSIONS["voice_delegate_approval"] = "voice:voice_delegate_approval"
+
+        from tools import approval as approval_module
+
+        resolved_choices = []
+
+        def fake_resolve_gateway_approval(session_key, choice, resolve_all=False):
+            resolved_choices.append((session_key, choice, resolve_all))
+            return 1
+
+        monkeypatch.setattr(approval_module, "resolve_gateway_approval", fake_resolve_gateway_approval)
+
+        resp = self.client.post("/api/voice/delegates/voice_delegate_approval/approval", json={"choice": "always"})
+
+        assert resp.status_code == 400
+        assert "always" in resp.text.lower()
+        assert resolved_choices == []
+
+    def test_waiting_delegate_status_exposes_approval_request_details_for_human_ui(self):
+        delegate_id = "voice_delegate_approval_detail"
+        self.web_server._set_voice_run_status(
+            delegate_id,
+            "waiting_for_approval",
+            session_id=delegate_id,
+            last_event="approval.request",
+        )
+        self.web_server._append_voice_run_event(
+            delegate_id,
+            {
+                "event": "approval.request",
+                "timestamp": 123.0,
+                "command": "python deploy.py --prod",
+                "description": "Run a production deployment command from the delegate.",
+                "pattern_key": "shell_command",
+                "pattern_keys": ["shell_command", "network_send"],
+                "choices": ["once", "session", "deny"],
+            },
+        )
+
+        resp = self.client.get(f"/api/voice/delegates/{delegate_id}")
+
+        assert resp.status_code == 200
+        approval = resp.json().get("approval_request")
+        assert isinstance(approval, dict)
+        assert approval["command"] == "python deploy.py --prod"
+        assert approval["description"] == "Run a production deployment command from the delegate."
+        assert approval["pattern_key"] == "shell_command"
+        assert approval["pattern_keys"] == ["shell_command", "network_send"]
+        assert approval["choices"] == ["once", "session", "deny"]
+        assert "always" not in approval["choices"]
+        assert approval["timestamp"] == 123.0
+
+    def test_waiting_approval_loaded_from_ledger_is_stopped_after_restart(self):
+        delegate_id = "voice_delegate_restart_waiting"
+        self.web_server._set_voice_run_status(
+            delegate_id,
+            "waiting_for_approval",
+            session_id=delegate_id,
+            last_event="approval.request",
+        )
+        self.web_server._append_voice_run_event(
+            delegate_id,
+            {
+                "event": "approval.request",
+                "timestamp": 123.0,
+                "command": "python deploy.py --prod",
+                "choices": ["once", "session", "deny"],
+            },
+        )
+        self.web_server._VOICE_RUN_STATUSES.clear()
+        self.web_server._VOICE_ACTIVE_RUN_TASKS.clear()
+        self.web_server._VOICE_ACTIVE_RUN_AGENTS.clear()
+        self.web_server._VOICE_RUN_APPROVAL_SESSIONS.clear()
+
+        resp = self.client.get(f"/api/voice/delegates/{delegate_id}")
+
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["status"] == "stopped"
+        assert "dashboard process restarted" in payload["error"]
+        assert payload.get("approval_request") is None
+
+    def test_voice_run_stop_interrupts_active_agent_without_cancelling_executor_task(self):
+        class FakeAgent:
+            def __init__(self):
+                self.reason = None
+
+            def interrupt(self, reason):
+                self.reason = reason
+
+        class FakeTask:
+            def __init__(self):
+                self.cancelled = False
+
+            def done(self):
+                return False
+
+            def cancel(self):
+                self.cancelled = True
+
+        agent = FakeAgent()
+        task = FakeTask()
+        self.web_server._VOICE_RUN_STATUSES["voice_run_test"] = {"run_id": "voice_run_test", "status": "running"}
+        self.web_server._VOICE_ACTIVE_RUN_AGENTS["voice_run_test"] = agent
+        self.web_server._VOICE_ACTIVE_RUN_TASKS["voice_run_test"] = task
+
+        resp = self.client.post("/api/voice/runs/voice_run_test/stop")
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "stopping"
+        assert agent.reason == "Stop requested via voice dispatch"
+        assert task.cancelled is False
+
+    def test_voice_run_stop_does_not_reopen_terminal_run(self):
+        self.web_server._VOICE_RUN_STATUSES["voice_run_done"] = {
+            "object": "hermes.voice.run",
+            "run_id": "voice_run_done",
+            "status": "completed",
+            "output": "done",
+        }
+
+        resp = self.client.post("/api/voice/runs/voice_run_done/stop")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "completed"
+        assert data["output"] == "done"
+        assert self.web_server._voice_active_run_count() == 0
+
+    def test_voice_run_stop_before_agent_registration_prevents_execution(self, monkeypatch):
+        self._enable_voice_config(monkeypatch)
+        captured_coroutines = []
+        created_agents = []
+
+        class FakeTask:
+            def done(self):
+                return False
+
+        def fake_create_task(coro):
+            captured_coroutines.append(coro)
+            return FakeTask()
+
+        def fail_if_created(**kwargs):
+            created_agents.append(kwargs)
+            raise AssertionError("agent should not be created after queued stop")
+
+        monkeypatch.setattr(self.web_server.asyncio, "create_task", fake_create_task)
+        monkeypatch.setattr(self.web_server, "_create_voice_dispatch_agent", fail_if_created)
+
+        started = self.client.post("/api/voice/runs", json={"input": "Do not run this"})
+        run_id = started.json()["run_id"]
+        stopped = self.client.post(f"/api/voice/runs/{run_id}/stop")
+
+        assert stopped.status_code == 200
+        assert stopped.json()["status"] == "stopping"
+
+        asyncio.run(captured_coroutines[0])
+
+        status = self.client.get(f"/api/voice/runs/{run_id}").json()
+        assert status["status"] == "stopped"
+        assert created_agents == []
+        assert self.web_server._voice_active_run_count() == 0
+
+
+class TestVoiceProfileAndAsyncSafety:
+    @pytest.fixture(autouse=True)
+    def _client(self, monkeypatch, _isolate_hermes_home):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+
+        import hermes_cli.web_server as web_server
+
+        self.web_server = web_server
+        for name in (
+            "_VOICE_RUN_STATUSES",
+            "_VOICE_ACTIVE_RUN_AGENTS",
+            "_VOICE_ACTIVE_RUN_TASKS",
+            "_VOICE_RUN_APPROVAL_SESSIONS",
+            "_VOICE_STOP_REQUESTED",
+        ):
+            store = getattr(web_server, name, None)
+            if hasattr(store, "clear"):
+                store.clear()
+        self.client = TestClient(web_server.app)
+        self.client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+
+    def _enable_voice_config(self, monkeypatch, **overrides):
+        import hermes_cli.web_server as web_server
+
+        cfg = json.loads(json.dumps(DEFAULT_CONFIG))
+        cfg["voice"]["realtime"]["enabled"] = True
+        cfg["voice"]["realtime"].update(overrides)
+        monkeypatch.setattr(web_server, "load_config", lambda: cfg)
+        return cfg
+
+    def test_client_secret_offloads_blocking_http(self, monkeypatch):
+        """xAI mint must not run urlopen on the event loop."""
+        self._enable_voice_config(monkeypatch)
+        monkeypatch.setattr(self.web_server, "get_env_value", lambda key: "xai-test-key" if key == "XAI_API_KEY" else None)
+
+        calls = {"to_thread": 0}
+
+        async def fake_to_thread(fn, *args, **kwargs):
+            calls["to_thread"] += 1
+            assert fn is self.web_server._mint_xai_realtime_client_secret
+            return {"value": "ephemeral-secret", "expires_at": 123}
+
+        monkeypatch.setattr(self.web_server.asyncio, "to_thread", fake_to_thread)
+
+        resp = self.client.post("/api/voice/realtime/xai-client-secret")
+        assert resp.status_code == 200
+        assert calls["to_thread"] == 1
+        data = resp.json()
+        assert data["client_secret"]["value"] == "ephemeral-secret"
+        assert "xai-test-key" not in json.dumps(data)
+
+    def test_voice_operations_use_selected_profile_scope(self, monkeypatch, tmp_path):
+        """Config/env/ledger/agent paths should honor ?profile=."""
+        import hermes_cli.web_server as web_server
+
+        self._enable_voice_config(monkeypatch, voice="rex")
+        seen = {"profiles": []}
+        homes = {"current": tmp_path / "default"}
+        homes["current"].mkdir(parents=True, exist_ok=True)
+
+        @contextmanager
+        def fake_scope(profile):
+            seen["profiles"].append(profile)
+            home = tmp_path / str(profile or "default")
+            home.mkdir(parents=True, exist_ok=True)
+            previous = homes["current"]
+            homes["current"] = home
+            try:
+                yield home
+            finally:
+                homes["current"] = previous
+
+        monkeypatch.setattr(web_server, "_profile_scope", fake_scope)
+        monkeypatch.setattr(web_server, "get_hermes_home", lambda: homes["current"])
+        monkeypatch.setattr(web_server, "get_env_value", lambda key: "xai-test-key" if key == "XAI_API_KEY" else None)
+
+        async def fake_to_thread(fn, *args, **kwargs):
+            return {"value": "ephemeral-secret", "expires_at": 999}
+
+        monkeypatch.setattr(web_server.asyncio, "to_thread", fake_to_thread)
+
+        cfg_resp = self.client.get("/api/voice/realtime/config?profile=work")
+        assert cfg_resp.status_code == 200
+        assert "work" in seen["profiles"]
+
+        secret_resp = self.client.post("/api/voice/realtime/xai-client-secret?profile=work")
+        assert secret_resp.status_code == 200
+        assert seen["profiles"].count("work") >= 2
+
+        # Seed a delegate under profile A and ensure profile B cannot read it.
+        run = web_server._set_voice_run_status(
+            "voice_delegate_profile_a",
+            "completed",
+            profile="alpha",
+            session_id="s1",
+            input_preview="alpha work",
+            output="done",
+        )
+        assert run["profile"] == "alpha"
+        missing = self.client.get("/api/voice/delegates/voice_delegate_profile_a?profile=beta")
+        assert missing.status_code == 404
+        found = self.client.get("/api/voice/delegates/voice_delegate_profile_a?profile=alpha")
+        assert found.status_code == 200
+        assert found.json()["profile"] == "alpha"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -35,6 +35,7 @@ import {
   KeyRound,
   Menu,
   MessageSquare,
+  Mic,
   Package,
   PanelLeftClose,
   PanelLeftOpen,
@@ -91,6 +92,7 @@ import ChannelsPage from "@/pages/ChannelsPage";
 import WebhooksPage from "@/pages/WebhooksPage";
 import SystemPage from "@/pages/SystemPage";
 import ChatPage from "@/pages/ChatPage";
+import VoiceDispatchPage from "@/pages/VoiceDispatchPage";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { ThemeSwitcher } from "@/components/ThemeSwitcher";
 import { useI18n } from "@/i18n";
@@ -134,6 +136,7 @@ const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/": RootRedirect,
   "/sessions": SessionsPage,
   "/files": FilesPage,
+  "/voice": VoiceDispatchPage,
   "/analytics": AnalyticsPage,
   "/models": ModelsPage,
   "/logs": LogsPage,
@@ -168,6 +171,11 @@ const BUILTIN_NAV_REST: NavItem[] = [
     icon: MessageSquare,
   },
   { path: "/files", label: "Files", icon: FolderOpen },
+  {
+    path: "/voice",
+    label: "Voice",
+    icon: Mic,
+  },
   {
     path: "/analytics",
     labelKey: "analytics",
@@ -209,6 +217,7 @@ const ICON_MAP: Record<string, ComponentType<{ className?: string }>> = {
   FolderOpen,
   KeyRound,
   MessageSquare,
+  Mic,
   Package,
   Settings,
   Puzzle,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -80,6 +80,7 @@ const PROFILE_SCOPED_PREFIXES = [
   "/api/model/auxiliary",
   "/api/model/moa",
   "/api/model/options",
+  "/api/voice",
 ];
 
 function withManagementProfile(url: string): string {
@@ -479,6 +480,67 @@ export const api = {
   getSchema: () => fetchJSON<{ fields: Record<string, unknown>; category_order: string[] }>("/api/config/schema"),
   getModelInfo: (profile = getManagementProfile()) =>
     fetchJSON<ModelInfoResponse>(appendProfileParam("/api/model/info", profile)),
+  getVoiceRealtimeConfig: (profile = getManagementProfile()) =>
+    fetchJSON<VoiceRealtimeConfig>(appendProfileParam("/api/voice/realtime/config", profile)),
+  createVoiceRealtimeClientSecret: (profile = getManagementProfile()) =>
+    fetchJSON<VoiceRealtimeClientSecretResponse>(
+      appendProfileParam("/api/voice/realtime/xai-client-secret", profile),
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      },
+    ),
+  startVoiceDelegate: (
+    body: { input: string; instructions?: string; session_id?: string },
+    profile = getManagementProfile(),
+  ) =>
+    fetchJSON<VoiceRunStartResponse>(appendProfileParam("/api/voice/delegates", profile), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  getVoiceDelegate: (delegateId: string, profile = getManagementProfile()) =>
+    fetchJSON<VoiceRunStatus>(
+      appendProfileParam(`/api/voice/delegates/${encodeURIComponent(delegateId)}`, profile),
+    ),
+  getVoiceDelegateEvents: (delegateId: string, profile = getManagementProfile()) =>
+    fetchJSON<{ object: string; delegate_id: string; run_id: string; events: Array<Record<string, unknown>> }>(
+      appendProfileParam(`/api/voice/delegates/${encodeURIComponent(delegateId)}/events`, profile),
+    ),
+  approveVoiceDelegate: (
+    delegateId: string,
+    body: { choice: VoiceApprovalChoice; resolve_all?: boolean },
+    profile = getManagementProfile(),
+  ) =>
+    fetchJSON<VoiceRunApprovalResponse>(
+      appendProfileParam(`/api/voice/delegates/${encodeURIComponent(delegateId)}/approval`, profile),
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      },
+    ),
+  stopVoiceDelegate: (delegateId: string, profile = getManagementProfile()) =>
+    fetchJSON<VoiceRunStatus>(
+      appendProfileParam(`/api/voice/delegates/${encodeURIComponent(delegateId)}/stop`, profile),
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      },
+    ),
+  startVoiceRun: (
+    body: { input: string; instructions?: string; session_id?: string },
+    profile = getManagementProfile(),
+  ) => api.startVoiceDelegate(body, profile),
+  getVoiceRun: (runId: string, profile = getManagementProfile()) => api.getVoiceDelegate(runId, profile),
+  approveVoiceRun: (
+    runId: string,
+    body: { choice: VoiceApprovalChoice; resolve_all?: boolean },
+    profile = getManagementProfile(),
+  ) => api.approveVoiceDelegate(runId, body, profile),
+  stopVoiceRun: (runId: string, profile = getManagementProfile()) => api.stopVoiceDelegate(runId, profile),
   getModelOptions: (
     profileOrOptions?: string | { profile?: string; refresh?: boolean },
   ) => {
@@ -2264,6 +2326,88 @@ export interface ModelInfoResponse {
     max_output_tokens?: number;
     model_family?: string;
   };
+}
+
+export interface VoiceRealtimeToolSchema {
+  type: "function";
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+}
+
+export interface VoiceRealtimeConfig {
+  enabled: boolean;
+  provider: "xai" | string;
+  model: string;
+  voice: string;
+  turn_detection: {
+    type: "server_vad" | string;
+    threshold: number;
+    silence_duration_ms: number;
+    prefix_padding_ms: number;
+  };
+  audio: {
+    input_rate: number;
+    output_rate: number;
+  };
+  tools: VoiceRealtimeToolSchema[];
+}
+
+export interface VoiceRealtimeClientSecretResponse {
+  client_secret: {
+    value: string;
+    expires_at: number;
+  };
+  model: string;
+  voice: string;
+}
+
+export type VoiceApprovalChoice = "once" | "session" | "deny";
+
+export interface VoiceApprovalRequest {
+  command?: string;
+  description?: string;
+  pattern_key?: string;
+  pattern_keys?: string[];
+  choices?: VoiceApprovalChoice[];
+  timestamp?: number;
+  [key: string]: unknown;
+}
+
+export interface VoiceRunStatus {
+  object: "hermes.voice.delegate" | "hermes.voice.run" | string;
+  delegate_id?: string;
+  run_id: string;
+  status: "queued" | "running" | "waiting_for_approval" | "stopping" | "completed" | "failed" | "cancelled" | "stopped" | string;
+  created_at?: number;
+  updated_at?: number;
+  session_id?: string;
+  input_preview?: string;
+  output?: string;
+  error?: string;
+  last_event?: string;
+  usage?: {
+    input_tokens: number;
+    output_tokens: number;
+    total_tokens: number;
+  };
+  events?: Array<Record<string, unknown>>;
+  approval_request?: VoiceApprovalRequest;
+}
+
+export interface VoiceRunStartResponse {
+  object: "hermes.voice.delegate" | "hermes.voice.run" | string;
+  delegate_id?: string;
+  run_id: string;
+  status: "started" | string;
+}
+
+export interface VoiceRunApprovalResponse {
+  object: "hermes.voice.delegate.approval_response" | "hermes.voice.run.approval_response" | string;
+  delegate_id?: string;
+  run_id: string;
+  choice: string;
+  resolved: number;
 }
 
 // ── Model options / assignment types ──────────────────────────────────

--- a/web/src/lib/voiceAudio.ts
+++ b/web/src/lib/voiceAudio.ts
@@ -1,0 +1,58 @@
+export function resampleFloat32(input: Float32Array, fromRate: number, toRate: number): Float32Array {
+  if (!Number.isFinite(fromRate) || !Number.isFinite(toRate) || fromRate <= 0 || toRate <= 0) {
+    return input;
+  }
+  if (Math.abs(fromRate - toRate) < 1) {
+    return input;
+  }
+
+  const ratio = fromRate / toRate;
+  const outLength = Math.max(1, Math.round(input.length / ratio));
+  const output = new Float32Array(outLength);
+  for (let i = 0; i < outLength; i += 1) {
+    const sourceIndex = i * ratio;
+    const left = Math.floor(sourceIndex);
+    const right = Math.min(left + 1, input.length - 1);
+    const weight = sourceIndex - left;
+    output[i] = input[left] * (1 - weight) + input[right] * weight;
+  }
+  return output;
+}
+
+export function float32ToPcm16Base64(float32: Float32Array): string {
+  const pcm16 = new Int16Array(float32.length);
+  for (let i = 0; i < float32.length; i += 1) {
+    const sample = Math.max(-1, Math.min(1, float32[i]));
+    pcm16[i] = sample < 0 ? sample * 0x8000 : sample * 0x7fff;
+  }
+  return bytesToBase64(new Uint8Array(pcm16.buffer));
+}
+
+export function pcm16Base64ToFloat32(base64: string): Float32Array {
+  const bytes = base64ToBytes(base64);
+  const pcm16 = new Int16Array(bytes.buffer, bytes.byteOffset, Math.floor(bytes.byteLength / 2));
+  const out = new Float32Array(pcm16.length);
+  for (let i = 0; i < pcm16.length; i += 1) {
+    out[i] = pcm16[i] / (pcm16[i] < 0 ? 0x8000 : 0x7fff);
+  }
+  return out;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    const chunk = bytes.subarray(i, i + chunkSize);
+    binary += String.fromCharCode(...chunk);
+  }
+  return btoa(binary);
+}
+
+function base64ToBytes(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}

--- a/web/src/lib/voiceDispatchNotifications.ts
+++ b/web/src/lib/voiceDispatchNotifications.ts
@@ -1,0 +1,67 @@
+export const TERMINAL_VOICE_DELEGATE_STATUSES = new Set(["completed", "failed", "cancelled", "stopped"]);
+
+export type VoiceDelegateStatusLike = {
+  delegate_id?: string;
+  run_id: string;
+  status: string;
+  output?: string;
+  error?: string;
+  last_event?: string;
+  events?: Array<Record<string, unknown>>;
+};
+
+export type VoiceDelegateStatusNotification = {
+  key: string;
+  kind: "run" | "approval";
+  title: string;
+  transcriptBody: string;
+  voicePrompt: string;
+};
+
+const MAX_OUTPUT_CHARS = 900;
+
+function truncateForVoice(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= MAX_OUTPUT_CHARS) return trimmed;
+  return `${trimmed.slice(0, MAX_OUTPUT_CHARS).trimEnd()}…`;
+}
+
+export function summarizeVoiceDelegateStatus(status: VoiceDelegateStatusLike): string {
+  if (status.error) return `${status.status}: ${truncateForVoice(status.error)}`;
+  if (status.output) return `${status.status}: ${truncateForVoice(status.output)}`;
+  if (status.last_event) return `${status.status}: ${status.last_event}`;
+  return status.status;
+}
+
+export function buildVoiceDelegateStatusNotification(
+  status: VoiceDelegateStatusLike,
+): VoiceDelegateStatusNotification | null {
+  const delegateId = status.delegate_id ?? status.run_id;
+  const summary = summarizeVoiceDelegateStatus(status);
+
+  if (status.status === "waiting_for_approval") {
+    return {
+      key: `${delegateId}:waiting_for_approval`,
+      kind: "approval",
+      title: "Approval needed",
+      transcriptBody: summary,
+      voicePrompt:
+        `Hermes delegate status update: approval is required. Summary: ${summary}. `
+        + "Tell the user proactively in one concise spoken update. Explain that approval requires an explicit Hermes UI click. Available choices are approve once, approve for this session, or deny. Do not invent missing details.",
+    };
+  }
+
+  if (!TERMINAL_VOICE_DELEGATE_STATUSES.has(status.status)) {
+    return null;
+  }
+
+  return {
+    key: `${delegateId}:${status.status}`,
+    kind: "run",
+    title: "Delegate finished",
+    transcriptBody: summary,
+    voicePrompt:
+      `Hermes delegate finished with status ${status.status}. Summary: ${summary}. `
+      + "Tell the user proactively now in one concise spoken update. Do not call another tool unless the user asks for follow-up. Do not mention internal delegate IDs unless necessary.",
+  };
+}

--- a/web/src/pages/VoiceDispatchPage.tsx
+++ b/web/src/pages/VoiceDispatchPage.tsx
@@ -1,0 +1,1035 @@
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Mic,
+  Radio,
+  RefreshCw,
+  ShieldCheck,
+  Volume2,
+  WifiOff,
+} from "lucide-react";
+import { Badge } from "@nous-research/ui/ui/components/badge";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import { usePageHeader } from "@/contexts/usePageHeader";
+import { api, type VoiceApprovalChoice, type VoiceRealtimeConfig, type VoiceRunStatus } from "@/lib/api";
+import {
+  TERMINAL_VOICE_DELEGATE_STATUSES,
+  buildVoiceDelegateStatusNotification,
+  summarizeVoiceDelegateStatus,
+} from "@/lib/voiceDispatchNotifications";
+import { float32ToPcm16Base64, pcm16Base64ToFloat32, resampleFloat32 } from "@/lib/voiceAudio";
+import { PluginSlot } from "@/plugins";
+
+const XAI_REALTIME_URL = "wss://api.x.ai/v1/realtime";
+const MAX_EVENT_LOG = 16;
+
+type ConnectionState = "idle" | "connecting" | "connected" | "error";
+
+type VoiceEvent = {
+  id: string;
+  timestamp: string;
+  type: string;
+};
+
+type VoiceTranscriptItem = {
+  id: string;
+  kind: "assistant" | "user" | "run" | "approval" | "system";
+  title?: string;
+  body: string;
+  timestamp: string;
+};
+
+type RealtimeEvent = {
+  type?: string;
+  error?: { message?: string } | string;
+  item?: Record<string, unknown>;
+  call_id?: string;
+  item_id?: string;
+  name?: string;
+  arguments?: string | Record<string, unknown>;
+  delta?: string;
+  [key: string]: unknown;
+};
+
+type FunctionCall = {
+  callId: string;
+  name: string;
+  args: Record<string, unknown>;
+};
+
+type InputAudioPipeline = {
+  stream: MediaStream;
+  context: AudioContext;
+  source: MediaStreamAudioSourceNode;
+  processor: ScriptProcessorNode;
+};
+
+type OutputAudioPipeline = {
+  context: AudioContext;
+};
+
+const VOICE_APPROVAL_CHOICES: VoiceApprovalChoice[] = ["once", "session", "deny"];
+
+function voiceApprovalChoices(status: VoiceRunStatus | null): VoiceApprovalChoice[] {
+  const rawChoices = status?.approval_request?.choices;
+  const allowed = rawChoices?.filter((choice): choice is VoiceApprovalChoice =>
+    VOICE_APPROVAL_CHOICES.includes(choice as VoiceApprovalChoice),
+  ) ?? VOICE_APPROVAL_CHOICES;
+  return Array.from(new Set(allowed.length ? allowed : VOICE_APPROVAL_CHOICES));
+}
+
+function approvalDetailRows(status: VoiceRunStatus | null): Array<{ label: string; value: string }> {
+  const request = status?.approval_request;
+  if (!request) return [];
+  const rows: Array<{ label: string; value: string }> = [];
+  if (typeof request.description === "string" && request.description.trim()) {
+    rows.push({ label: "Description", value: request.description.trim() });
+  }
+  if (typeof request.command === "string" && request.command.trim()) {
+    rows.push({ label: "Command", value: request.command.trim() });
+  }
+  if (typeof request.pattern_key === "string" && request.pattern_key.trim()) {
+    rows.push({ label: "Pattern", value: request.pattern_key.trim() });
+  }
+  if (Array.isArray(request.pattern_keys) && request.pattern_keys.length > 0) {
+    rows.push({ label: "Matched policies", value: request.pattern_keys.join(", ") });
+  }
+  return rows;
+}
+
+function approvalTranscriptBody(status: VoiceRunStatus): string {
+  const summary = summarizeVoiceDelegateStatus(status);
+  const rows = approvalDetailRows(status);
+  if (!rows.length) return summary;
+  return [summary, "", ...rows.map((row) => `${row.label}: ${row.value}`)].join("\n");
+}
+
+function formatEpochSeconds(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) return "Not minted";
+  const millis = value > 10_000_000_000 ? value : value * 1000;
+  return new Date(millis).toLocaleString();
+}
+
+function describeError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+function eventErrorMessage(event: RealtimeEvent): string | null {
+  if (!event.error) return null;
+  if (typeof event.error === "string") return event.error;
+  return event.error.message ?? null;
+}
+
+function parseFunctionArgs(value: unknown): Record<string, unknown> {
+  if (!value) return {};
+  if (typeof value === "object" && !Array.isArray(value)) return value as Record<string, unknown>;
+  if (typeof value !== "string") return {};
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed as Record<string, unknown> : {};
+  } catch {
+    return {};
+  }
+}
+
+function functionCallFromEvent(event: RealtimeEvent): FunctionCall | null {
+  if (event.type === "response.function_call_arguments.done") {
+    const name = typeof event.name === "string" ? event.name : "";
+    const callId = typeof event.call_id === "string" ? event.call_id : typeof event.item_id === "string" ? event.item_id : "";
+    if (!name || !callId) return null;
+    return { callId, name, args: parseFunctionArgs(event.arguments) };
+  }
+
+  if (event.type === "response.output_item.done" && event.item && event.item.type === "function_call") {
+    const item = event.item;
+    const name = typeof item.name === "string" ? item.name : "";
+    const callId = typeof item.call_id === "string" ? item.call_id : typeof item.id === "string" ? item.id : "";
+    if (!name || !callId) return null;
+    return { callId, name, args: parseFunctionArgs(item.arguments) };
+  }
+
+  return null;
+}
+
+function voiceStatus(config: VoiceRealtimeConfig | null, connection: ConnectionState): string {
+  if (connection === "connected") return "connected";
+  if (connection === "connecting") return "connecting";
+  if (connection === "error") return "error";
+  if (!config) return "loading";
+  return config.enabled ? "ready" : "disabled";
+}
+
+function conciseRunStatus(status: VoiceRunStatus | null): string {
+  if (!status) return "No Hermes delegate yet";
+  return summarizeVoiceDelegateStatus(status);
+}
+
+function nowLabel(): string {
+  return new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+}
+
+function transcriptId(prefix: string): string {
+  return `${prefix}:${Date.now()}:${Math.random().toString(36).slice(2)}`;
+}
+
+export default function VoiceDispatchPage() {
+  const [config, setConfig] = useState<VoiceRealtimeConfig | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [connection, setConnection] = useState<ConnectionState>("idle");
+  const [connectError, setConnectError] = useState<string | null>(null);
+  const [expiresAt, setExpiresAt] = useState<number | null>(null);
+  const [events, setEvents] = useState<VoiceEvent[]>([]);
+  const [transcript, setTranscript] = useState<VoiceTranscriptItem[]>([
+    {
+      id: "welcome",
+      kind: "assistant",
+      title: "Voice dispatch is ready.",
+      body: "Start a voice session, speak the work you want done, and I’ll launch an isolated Hermes delegate without exposing local tools directly to the voice model.",
+      timestamp: "Now",
+    },
+  ]);
+  const [activeRunId, setActiveRunId] = useState<string | null>(null);
+  const [runStatus, setRunStatus] = useState<VoiceRunStatus | null>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+  const sessionUpdateSentRef = useRef(false);
+  const configuredRef = useRef(false);
+  const handledCallIdsRef = useRef<Set<string>>(new Set());
+  const inputAudioRef = useRef<InputAudioPipeline | null>(null);
+  const inputAudioStartingRef = useRef(false);
+  const outputAudioRef = useRef<OutputAudioPipeline | null>(null);
+  const outputNextTimeRef = useRef(0);
+  const activeRunIdRef = useRef<string | null>(null);
+  const pollTimerRef = useRef<number | null>(null);
+  const voiceConnectionSeqRef = useRef(0);
+  const responseActiveRef = useRef(false);
+  const pendingVoicePromptsRef = useRef<string[]>([]);
+  const notifiedRunStatusKeysRef = useRef<Set<string>>(new Set());
+  const { setAfterTitle, setEnd } = usePageHeader();
+
+  const status = voiceStatus(config, connection);
+
+  const addEvent = useCallback((type: string) => {
+    if (type === "input_audio_buffer.append" || type === "response.output_audio.delta") {
+      return;
+    }
+    setEvents((prev) => [
+      {
+        id: `${Date.now()}:${Math.random().toString(36).slice(2)}`,
+        timestamp: new Date().toLocaleTimeString(),
+        type,
+      },
+      ...prev,
+    ].slice(0, MAX_EVENT_LOG));
+  }, []);
+
+  const addTranscript = useCallback((item: Omit<VoiceTranscriptItem, "id" | "timestamp"> & { id?: string; timestamp?: string }) => {
+    setTranscript((prev) => [
+      ...prev,
+      {
+        id: item.id ?? transcriptId(item.kind),
+        kind: item.kind,
+        title: item.title,
+        body: item.body,
+        timestamp: item.timestamp ?? nowLabel(),
+      },
+    ]);
+  }, []);
+
+  const setActiveRun = useCallback((runId: string | null) => {
+    activeRunIdRef.current = runId;
+    setActiveRunId(runId);
+  }, []);
+
+  const loadConfig = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    api
+      .getVoiceRealtimeConfig()
+      .then((nextConfig) => {
+        setConfig(nextConfig);
+      })
+      .catch((err) => {
+        setError(describeError(err));
+        setConfig(null);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  const stopInputAudio = useCallback(() => {
+    const pipeline = inputAudioRef.current;
+    inputAudioRef.current = null;
+    if (!pipeline) return;
+    pipeline.processor.disconnect();
+    pipeline.source.disconnect();
+    pipeline.stream.getTracks().forEach((track) => track.stop());
+    void pipeline.context.close().catch(() => undefined);
+  }, []);
+
+  const stopOutputAudio = useCallback(() => {
+    const pipeline = outputAudioRef.current;
+    outputAudioRef.current = null;
+    outputNextTimeRef.current = 0;
+    if (!pipeline) return;
+    void pipeline.context.close().catch(() => undefined);
+  }, []);
+
+  const stopAudio = useCallback(() => {
+    stopInputAudio();
+    stopOutputAudio();
+  }, [stopInputAudio, stopOutputAudio]);
+
+  const sendFunctionOutput = useCallback((ws: WebSocket, callId: string, result: unknown) => {
+    if (ws.readyState !== WebSocket.OPEN) return;
+    ws.send(JSON.stringify({
+      type: "conversation.item.create",
+      item: {
+        type: "function_call_output",
+        call_id: callId,
+        output: JSON.stringify(result),
+      },
+    }));
+    responseActiveRef.current = true;
+    ws.send(JSON.stringify({ type: "response.create" }));
+    addEvent("dashboard.function_output.sent");
+  }, [addEvent]);
+
+  const sendRealtimeVoicePrompt = useCallback((prompt: string): boolean => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN || !configuredRef.current) {
+      addEvent("delegate.notification.skipped");
+      return false;
+    }
+
+    ws.send(JSON.stringify({
+      type: "conversation.item.create",
+      item: {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: prompt }],
+      },
+    }));
+    responseActiveRef.current = true;
+    ws.send(JSON.stringify({ type: "response.create" }));
+    addEvent("delegate.notification.sent");
+    return true;
+  }, [addEvent]);
+
+  const flushPendingVoicePrompts = useCallback(() => {
+    if (responseActiveRef.current) return;
+    const nextPrompt = pendingVoicePromptsRef.current.shift();
+    if (!nextPrompt) return;
+    window.setTimeout(() => {
+      if (!responseActiveRef.current) {
+        sendRealtimeVoicePrompt(nextPrompt);
+      } else {
+        pendingVoicePromptsRef.current.unshift(nextPrompt);
+      }
+    }, 0);
+  }, [sendRealtimeVoicePrompt]);
+
+  const queueRealtimeVoicePrompt = useCallback((prompt: string): boolean => {
+    if (responseActiveRef.current) {
+      pendingVoicePromptsRef.current.push(prompt);
+      addEvent("delegate.notification.queued");
+      return true;
+    }
+    return sendRealtimeVoicePrompt(prompt);
+  }, [addEvent, sendRealtimeVoicePrompt]);
+
+  const maybeNotifyVoiceDelegateStatus = useCallback((nextStatus: VoiceRunStatus) => {
+    const notification = buildVoiceDelegateStatusNotification(nextStatus);
+    if (!notification || notifiedRunStatusKeysRef.current.has(notification.key)) return;
+    if (!queueRealtimeVoicePrompt(notification.voicePrompt)) return;
+    notifiedRunStatusKeysRef.current.add(notification.key);
+    addTranscript({
+      kind: notification.kind,
+      title: notification.title,
+      body: notification.kind === "approval" ? approvalTranscriptBody(nextStatus) : notification.transcriptBody,
+    });
+  }, [addTranscript, queueRealtimeVoicePrompt]);
+
+  const executeVoiceTool = useCallback(async (call: FunctionCall): Promise<unknown> => {
+    addEvent(`tool.${call.name}.called`);
+    if (call.name === "start_delegate" || call.name === "start_hermes_run") {
+      const rawInput = typeof call.args.input === "string" ? call.args.input : typeof call.args.objective === "string" ? call.args.objective : "";
+      const input = rawInput.trim();
+      if (!input) return { ok: false, error: "Missing required input." };
+      addTranscript({ kind: "user", title: "Delegate request", body: input });
+      const started = await api.startVoiceDelegate({ input });
+      const delegateId = started.delegate_id ?? started.run_id;
+      notifiedRunStatusKeysRef.current.clear();
+      setActiveRun(delegateId);
+      const nextStatus = await api.getVoiceDelegate(delegateId);
+      setRunStatus(nextStatus);
+      const initialNotification = buildVoiceDelegateStatusNotification(nextStatus);
+      if (initialNotification) notifiedRunStatusKeysRef.current.add(initialNotification.key);
+      addTranscript({
+        kind: "run",
+        title: "Hermes delegate started",
+        body: `${delegateId} is ${nextStatus.status}. The delegate is handling the work locally while the voice session stays free.`,
+      });
+      return { ok: true, delegate_id: delegateId, run_id: delegateId, status: nextStatus.status, events: nextStatus.events ?? [] };
+    }
+
+    if (call.name === "get_delegate_status" || call.name === "get_hermes_run") {
+      const delegateId = typeof call.args.delegate_id === "string" && call.args.delegate_id.trim() ? call.args.delegate_id.trim() : activeRunIdRef.current;
+      if (!delegateId) return { ok: false, error: "No active Hermes delegate." };
+      const nextStatus = await api.getVoiceDelegate(delegateId);
+      setRunStatus(nextStatus);
+      const notification = buildVoiceDelegateStatusNotification(nextStatus);
+      if (notification) {
+        notifiedRunStatusKeysRef.current.add(notification.key);
+        addTranscript({
+          kind: notification.kind,
+          title: notification.title,
+          body: notification.kind === "approval" ? approvalTranscriptBody(nextStatus) : notification.transcriptBody,
+        });
+      }
+      return { ok: true, delegate: nextStatus, run: nextStatus, summary: conciseRunStatus(nextStatus), events: nextStatus.events ?? [] };
+    }
+
+
+    if (call.name === "stop_delegate" || call.name === "stop_hermes_run") {
+      const delegateId = typeof call.args.delegate_id === "string" && call.args.delegate_id.trim() ? call.args.delegate_id.trim() : activeRunIdRef.current;
+      if (!delegateId) return { ok: false, error: "No active Hermes delegate." };
+      const stopped = await api.stopVoiceDelegate(delegateId);
+      setRunStatus(stopped);
+      const stopNotification = buildVoiceDelegateStatusNotification(stopped);
+      if (stopNotification) notifiedRunStatusKeysRef.current.add(stopNotification.key);
+      addTranscript({ kind: "run", title: "Delegate stop requested", body: conciseRunStatus(stopped) });
+      return { ok: true, delegate: stopped, run: stopped };
+    }
+
+    return { ok: false, error: `Unsupported voice dispatch tool: ${call.name}` };
+  }, [addEvent, addTranscript, setActiveRun]);
+
+  const playOutputAudio = useCallback((base64: string, sampleRate: number) => {
+    if (!base64) return;
+    const AudioContextCtor = window.AudioContext || (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!AudioContextCtor) return;
+    const pipeline = outputAudioRef.current ?? { context: new AudioContextCtor({ sampleRate }) };
+    outputAudioRef.current = pipeline;
+    const samples = new Float32Array(pcm16Base64ToFloat32(base64));
+    const buffer = pipeline.context.createBuffer(1, samples.length, sampleRate);
+    buffer.copyToChannel(samples, 0);
+    const source = pipeline.context.createBufferSource();
+    source.buffer = buffer;
+    source.connect(pipeline.context.destination);
+    const startAt = Math.max(pipeline.context.currentTime, outputNextTimeRef.current);
+    source.start(startAt);
+    outputNextTimeRef.current = startAt + buffer.duration;
+    void pipeline.context.resume().catch(() => undefined);
+  }, []);
+
+  const startInputAudio = useCallback(async (ws: WebSocket, inputRate: number, connectionSeq: number) => {
+    if (inputAudioStartingRef.current || inputAudioRef.current) {
+      addEvent("microphone.start.skipped");
+      return;
+    }
+
+    const isCurrentSession = () => (
+      wsRef.current === ws
+      && voiceConnectionSeqRef.current === connectionSeq
+      && ws.readyState === WebSocket.OPEN
+      && configuredRef.current
+    );
+
+    inputAudioStartingRef.current = true;
+    let stream: MediaStream | null = null;
+    let context: AudioContext | null = null;
+    let source: MediaStreamAudioSourceNode | null = null;
+    let processor: ScriptProcessorNode | null = null;
+
+    const cleanupPendingPipeline = () => {
+      if (stream && inputAudioRef.current?.stream === stream) {
+        inputAudioRef.current = null;
+      }
+      try {
+        processor?.disconnect();
+      } catch {
+        // Ignore cleanup failures from already-disconnected nodes.
+      }
+      try {
+        source?.disconnect();
+      } catch {
+        // Ignore cleanup failures from already-disconnected nodes.
+      }
+      stream?.getTracks().forEach((track) => track.stop());
+      if (context) {
+        void context.close().catch(() => undefined);
+      }
+    };
+
+    try {
+      stopInputAudio();
+      const AudioContextCtor = window.AudioContext || (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+      if (!AudioContextCtor || !navigator.mediaDevices?.getUserMedia) {
+        throw new Error("Browser microphone capture is not available.");
+      }
+      stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          channelCount: 1,
+          echoCancellation: true,
+          noiseSuppression: true,
+          autoGainControl: true,
+        },
+      });
+      if (!isCurrentSession()) {
+        cleanupPendingPipeline();
+        return;
+      }
+      context = new AudioContextCtor();
+      source = context.createMediaStreamSource(stream);
+      processor = context.createScriptProcessor(4096, 1, 1);
+      processor.onaudioprocess = (event) => {
+        if (!isCurrentSession()) return;
+        const input = event.inputBuffer.getChannelData(0);
+        const mono = new Float32Array(input);
+        const resampled = resampleFloat32(mono, context?.sampleRate ?? inputRate, inputRate);
+        const audio = float32ToPcm16Base64(resampled);
+        ws.send(JSON.stringify({ type: "input_audio_buffer.append", audio }));
+        const output = event.outputBuffer.getChannelData(0);
+        output.fill(0);
+      };
+      source.connect(processor);
+      processor.connect(context.destination);
+      inputAudioRef.current = { stream, context, source, processor };
+      await context.resume();
+      if (!isCurrentSession()) {
+        if (inputAudioRef.current?.stream === stream) {
+          inputAudioRef.current = null;
+        }
+        cleanupPendingPipeline();
+        return;
+      }
+      addEvent("microphone.started");
+    } catch (err) {
+      cleanupPendingPipeline();
+      throw err;
+    } finally {
+      if (voiceConnectionSeqRef.current === connectionSeq) {
+        inputAudioStartingRef.current = false;
+      }
+    }
+  }, [addEvent, stopInputAudio]);
+
+  const disconnect = useCallback(() => {
+    voiceConnectionSeqRef.current += 1;
+    sessionUpdateSentRef.current = false;
+    configuredRef.current = false;
+    inputAudioStartingRef.current = false;
+    responseActiveRef.current = false;
+    pendingVoicePromptsRef.current = [];
+    handledCallIdsRef.current.clear();
+    stopAudio();
+    if (wsRef.current) {
+      wsRef.current.close(1000, "dashboard disconnect");
+      wsRef.current = null;
+    }
+    setConnection("idle");
+    addEvent("dashboard.disconnected");
+  }, [addEvent, stopAudio]);
+
+  const connect = useCallback(async () => {
+    if (!config) return;
+    if (!config.enabled) {
+      setConnectError("Realtime voice dispatch is disabled in config.");
+      return;
+    }
+
+    disconnect();
+    const connectionSeq = voiceConnectionSeqRef.current + 1;
+    voiceConnectionSeqRef.current = connectionSeq;
+    setConnectError(null);
+    setConnection("connecting");
+    addTranscript({ kind: "system", title: "Starting voice session", body: "Minting a short-lived xAI realtime secret through Hermes." });
+    addEvent("dashboard.client_secret.requested");
+
+    try {
+      const session = await api.createVoiceRealtimeClientSecret();
+      const ephemeralSecret = session.client_secret.value;
+      setExpiresAt(session.client_secret.expires_at);
+      addEvent("dashboard.client_secret.minted");
+
+      configuredRef.current = false;
+      sessionUpdateSentRef.current = false;
+      responseActiveRef.current = false;
+      pendingVoicePromptsRef.current = [];
+      const ws = new WebSocket(`${XAI_REALTIME_URL}?model=${encodeURIComponent(session.model)}`, [
+        "realtime",
+        `openai-insecure-api-key.${ephemeralSecret}`,
+        "openai-beta.realtime-v1",
+      ]);
+      wsRef.current = ws;
+
+      const send = (message: Record<string, unknown>) => {
+        if (ws.readyState !== WebSocket.OPEN) return;
+        ws.send(JSON.stringify(message));
+        addEvent(String(message.type ?? "dashboard.sent"));
+      };
+
+      const configureSession = () => {
+        if (sessionUpdateSentRef.current) return;
+        sessionUpdateSentRef.current = true;
+        send({
+          type: "session.update",
+          session: {
+            voice: session.voice,
+            instructions:
+              "You are Hermes Voice Dispatch. You are a conversational controller, not the worker. When the user asks for work to be done, start a secure isolated Hermes delegate using the supplied dispatch tools. Do not claim direct shell, file, browser, MCP, credential, or local-machine access. The delegate performs work through Hermes' normal tool and approval system while the main Hermes session stays free. Ask a brief clarification only when required. Give concise progress updates from delegate status/events. Surface approval requests clearly. Approval requires an explicit Hermes UI click in this page; you cannot approve actions by tool call, voice narration, or user speech alone. Tell the user to review the approval card and choose once, session, or deny. Never invent tool results, never say work completed until delegate status confirms it, never bypass approval, never request or repeat secrets, and stop the delegate if the user asks.",
+            tools: config.tools,
+            tool_choice: "auto",
+            audio: {
+              input: { format: { type: "audio/pcm", rate: config.audio.input_rate } },
+              output: { format: { type: "audio/pcm", rate: config.audio.output_rate } },
+            },
+            turn_detection: config.turn_detection,
+          },
+        });
+      };
+
+      ws.onopen = () => {
+        if (wsRef.current !== ws) return;
+        setConnection("connected");
+        addEvent("websocket.open");
+      };
+
+      ws.onmessage = (event) => {
+        if (wsRef.current !== ws) return;
+        let message: RealtimeEvent;
+        try {
+          message = JSON.parse(String(event.data)) as RealtimeEvent;
+        } catch {
+          addEvent("websocket.message.unparseable");
+          return;
+        }
+
+        const type = message.type ?? "websocket.message";
+        addEvent(type);
+
+        if (type === "response.created") {
+          responseActiveRef.current = true;
+        }
+
+        if (type === "response.done" || type === "response.cancelled" || type === "response.failed") {
+          responseActiveRef.current = false;
+          flushPendingVoicePrompts();
+        }
+
+        if ((type === "conversation.created" || type === "session.created") && !configuredRef.current) {
+          configureSession();
+        }
+
+        if (type === "session.updated") {
+          configuredRef.current = true;
+          if (inputAudioStartingRef.current || inputAudioRef.current) {
+            addEvent("session.updated.duplicate_ignored");
+          } else {
+            addTranscript({ kind: "assistant", title: "Voice session live", body: "I’m listening. Tell me what you want Hermes to do." });
+            void startInputAudio(ws, config.audio.input_rate, connectionSeq).catch((err) => {
+              setConnection("error");
+              setConnectError(describeError(err));
+              addEvent("microphone.failed");
+            });
+          }
+        }
+
+        if (type === "response.output_audio.delta" && typeof message.delta === "string") {
+          playOutputAudio(message.delta, config.audio.output_rate);
+        }
+
+        const call = functionCallFromEvent(message);
+        if (call && !handledCallIdsRef.current.has(call.callId)) {
+          handledCallIdsRef.current.add(call.callId);
+          void executeVoiceTool(call)
+            .then((result) => sendFunctionOutput(ws, call.callId, result))
+            .catch((err) => sendFunctionOutput(ws, call.callId, { ok: false, error: describeError(err) }));
+        }
+
+        if (type === "error") {
+          responseActiveRef.current = false;
+          setConnection("error");
+          setConnectError(eventErrorMessage(message) ?? "xAI realtime session returned an error.");
+        }
+      };
+
+      ws.onerror = () => {
+        if (wsRef.current !== ws) return;
+        setConnection("error");
+        setConnectError("WebSocket error while connecting to xAI realtime.");
+        addEvent("websocket.error");
+      };
+
+      ws.onclose = () => {
+        if (wsRef.current !== ws) return;
+        voiceConnectionSeqRef.current += 1;
+        wsRef.current = null;
+        sessionUpdateSentRef.current = false;
+        configuredRef.current = false;
+        inputAudioStartingRef.current = false;
+        responseActiveRef.current = false;
+        pendingVoicePromptsRef.current = [];
+        stopAudio();
+        setConnection((current) => (current === "error" ? current : "idle"));
+        addEvent("websocket.closed");
+      };
+    } catch (err) {
+      setConnection("error");
+      setConnectError(describeError(err));
+      addEvent("dashboard.client_secret.failed");
+    }
+  }, [addEvent, addTranscript, config, disconnect, executeVoiceTool, flushPendingVoicePrompts, playOutputAudio, sendFunctionOutput, startInputAudio, stopAudio]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(loadConfig, 0);
+    return () => window.clearTimeout(timer);
+  }, [loadConfig]);
+
+  useEffect(() => disconnect, [disconnect]);
+
+  useEffect(() => {
+    if (pollTimerRef.current !== null) {
+      window.clearInterval(pollTimerRef.current);
+      pollTimerRef.current = null;
+    }
+    if (!activeRunId) return undefined;
+
+    const refreshDelegateStatus = () => {
+      void api.getVoiceDelegate(activeRunId).then((nextStatus) => {
+        setRunStatus(nextStatus);
+        maybeNotifyVoiceDelegateStatus(nextStatus);
+        if (TERMINAL_VOICE_DELEGATE_STATUSES.has(nextStatus.status) && pollTimerRef.current !== null) {
+          window.clearInterval(pollTimerRef.current);
+          pollTimerRef.current = null;
+        }
+      }).catch((err) => {
+        setConnectError(describeError(err));
+      });
+    };
+
+    refreshDelegateStatus();
+    pollTimerRef.current = window.setInterval(refreshDelegateStatus, 2_000);
+
+    return () => {
+      if (pollTimerRef.current !== null) {
+        window.clearInterval(pollTimerRef.current);
+        pollTimerRef.current = null;
+      }
+    };
+  }, [activeRunId, maybeNotifyVoiceDelegateStatus]);
+
+  useLayoutEffect(() => {
+    setAfterTitle(
+      <Badge
+        tone={status === "connected" || status === "ready" ? "success" : status === "error" ? "destructive" : "outline"}
+        className="rounded-full border-white/10 bg-[#121214] px-3 py-1 font-mono-ui text-xs uppercase tracking-[0.16em] text-white"
+      >
+        {status}
+      </Badge>,
+    );
+    setEnd(
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          size="sm"
+          outlined
+          onClick={loadConfig}
+          disabled={loading}
+          prefix={loading ? <Spinner /> : <RefreshCw />}
+          className="rounded-full border-white/10 bg-white/[0.06] px-4 text-white backdrop-blur-xl hover:bg-white/[0.1] disabled:text-white/35"
+        >
+          Refresh
+        </Button>
+      </div>,
+    );
+    return () => {
+      setAfterTitle(null);
+      setEnd(null);
+    };
+  }, [loadConfig, loading, setAfterTitle, setEnd, status]);
+
+  const toolNames = useMemo(() => config?.tools.map((tool) => tool.name) ?? [], [config]);
+  const canConnect = Boolean(config?.enabled) && connection !== "connecting" && connection !== "connected";
+
+  const approveFromUi = useCallback(async (choice: "once" | "session" | "deny") => {
+    if (!activeRunId) return;
+    const approved = await api.approveVoiceDelegate(activeRunId, { choice });
+    const nextStatus = await api.getVoiceDelegate(activeRunId);
+    setRunStatus(nextStatus);
+    addTranscript({ kind: "approval", title: "Approval response", body: `${approved.choice} sent to the delegate. ${nextStatus.status}.` });
+  }, [activeRunId, addTranscript]);
+
+  const stopActiveRun = useCallback(async () => {
+    if (!activeRunId) return;
+    const stopped = await api.stopVoiceDelegate(activeRunId);
+    setRunStatus(stopped);
+    addTranscript({ kind: "run", title: "Delegate stop requested", body: conciseRunStatus(stopped) });
+  }, [activeRunId, addTranscript]);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-2">
+      <PluginSlot name="voice:top" />
+
+      <div className="flex min-h-0 flex-1 flex-col gap-2 lg:flex-row lg:gap-3">
+        <section className="flex min-h-[32rem] min-w-0 flex-1 flex-col overflow-hidden rounded-lg border border-border bg-background-base/60">
+          <header className="flex shrink-0 flex-col gap-3 border-b border-border px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex min-w-0 items-center gap-3">
+              <div className="grid h-10 w-10 shrink-0 place-items-center rounded border border-current/25 bg-background-base text-midground">
+                <Mic className="h-5 w-5" />
+              </div>
+              <div className="min-w-0">
+                <h2 className="font-mondwest text-display text-[1.375rem] font-bold leading-none tracking-[0.06em] text-midground">
+                  Voice Dispatch
+                </h2>
+                <p className="mt-1 truncate text-xs text-text-secondary">
+                  Voice chat interface for launching isolated Hermes delegates safely.
+                </p>
+              </div>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge tone={status === "connected" || status === "ready" ? "success" : status === "error" ? "destructive" : "outline"} className="shrink-0 text-xs">
+                {status}
+              </Badge>
+              <Badge tone="secondary" className="shrink-0 font-mono-ui text-xs">
+                {config?.model ?? "grok-voice-latest"}
+              </Badge>
+            </div>
+          </header>
+
+          <main className="min-h-0 flex-1 overflow-y-auto px-3 py-4 sm:px-5">
+            <div className="mx-auto flex max-w-3xl flex-col gap-3">
+              {error && (
+                <div className="border border-destructive/30 bg-destructive/[0.06] p-3 text-sm text-destructive">
+                  <div className="mb-1 flex items-center gap-2 font-medium"><AlertTriangle className="h-4 w-4" />Config error</div>
+                  {error}
+                </div>
+              )}
+              {connectError && (
+                <div className="border border-warning/40 bg-warning/10 p-3 text-sm text-warning">
+                  <div className="mb-1 flex items-center gap-2 font-medium"><AlertTriangle className="h-4 w-4" />Voice session issue</div>
+                  {connectError}
+                </div>
+              )}
+
+              {transcript.map((item) => {
+                const isUser = item.kind === "user";
+                const isRun = item.kind === "run" || item.kind === "approval";
+                return (
+                  <div key={item.id} className={isUser ? "flex justify-end" : "flex justify-start"}>
+                    <div
+                      className={
+                        isUser
+                          ? "max-w-[78%] border border-current/25 bg-midground px-4 py-3 text-background-base"
+                          : isRun
+                            ? "w-full border border-border bg-background-base/80 p-4"
+                            : "max-w-[82%] border border-border bg-background-base/50 px-4 py-3"
+                      }
+                    >
+                      <div className="mb-2 flex items-center justify-between gap-3">
+                        <div className="flex min-w-0 items-center gap-2">
+                          {!isUser && (
+                            <span className={isRun ? "grid h-7 w-7 shrink-0 place-items-center rounded border border-current/25 bg-midground text-background-base" : "grid h-7 w-7 shrink-0 place-items-center rounded border border-border bg-background-base text-midground"}>
+                              {item.kind === "approval" ? <ShieldCheck className="h-3.5 w-3.5" /> : item.kind === "run" ? <Radio className="h-3.5 w-3.5" /> : <Mic className="h-3.5 w-3.5" />}
+                            </span>
+                          )}
+                          <span className={isUser ? "truncate text-xs font-mondwest tracking-[0.08em] text-background-base/80" : "truncate text-xs font-mondwest tracking-[0.08em] text-midground"}>
+                            {item.title ?? (isUser ? "You" : "Hermes")}
+                          </span>
+                        </div>
+                        <span className={isUser ? "shrink-0 text-[0.6875rem] text-background-base/55" : "shrink-0 text-[0.6875rem] text-text-tertiary"}>{item.timestamp}</span>
+                      </div>
+                      <p className={isUser ? "whitespace-pre-wrap text-sm leading-relaxed text-background-base" : "whitespace-pre-wrap text-sm leading-relaxed text-text-secondary"}>{item.body}</p>
+                      {item.kind === "approval" && activeRunId && runStatus?.status === "waiting_for_approval" && (
+                        <div className="mt-4 border border-warning/40 bg-warning/10 p-3 text-xs text-text-secondary">
+                          <div className="mb-2 font-mondwest tracking-[0.08em] text-warning">Explicit human approval required</div>
+                          <p className="mb-3 leading-relaxed">Grok can explain this request, but only your click here can approve or deny it.</p>
+                          <div className="space-y-2">
+                            {approvalDetailRows(runStatus).map((row) => (
+                              <div key={row.label} className="grid gap-1 border border-border/60 bg-background-base/60 p-2 sm:grid-cols-[6rem_1fr]">
+                                <span className="font-mondwest tracking-[0.08em] text-text-tertiary">{row.label}</span>
+                                <span className={row.label === "Command" ? "break-all font-mono-ui text-foreground" : "text-foreground"}>{row.value}</span>
+                              </div>
+                            ))}
+                          </div>
+                          <div className="mt-3 flex flex-wrap gap-2">
+                          {voiceApprovalChoices(runStatus).map((choice) => (
+                            <Button
+                              key={choice}
+                              type="button"
+                              size="sm"
+                              outlined={choice === "deny"}
+                              onClick={() => void approveFromUi(choice)}
+                              className="font-mondwest text-xs tracking-[0.08em]"
+                            >
+                              {choice}
+                            </Button>
+                          ))}
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </main>
+
+          <footer className="shrink-0 border-t border-border bg-background-base/80 px-3 py-3 sm:px-4">
+            <div className="mx-auto max-w-3xl border border-border bg-background-base p-3">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="min-w-0">
+                  <div className="font-mondwest text-sm tracking-[0.08em] text-midground">
+                    {connection === "connected" ? "Listening for dispatch" : connection === "connecting" ? "Opening realtime session" : config?.enabled ? "Ready for voice" : "Voice disabled"}
+                  </div>
+                  <div className="mt-1 truncate text-xs text-text-secondary">
+                    {connection === "connected"
+                      ? "Speak naturally. Grok can start delegates; approvals still require a UI click."
+                      : config?.enabled
+                        ? "Start a session to launch Hermes delegates through Grok Voice."
+                        : "Enable voice.realtime.enabled and set XAI_API_KEY to start."}
+                  </div>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  {connection === "connected" ? (
+                    <Button type="button" outlined onClick={disconnect} prefix={<WifiOff />}>
+                      End session
+                    </Button>
+                  ) : (
+                    <Button type="button" onClick={connect} disabled={!canConnect || loading} prefix={connection === "connecting" ? <Spinner /> : <Mic />}>
+                      {connection === "connecting" ? "Connecting" : "Start voice"}
+                    </Button>
+                  )}
+                </div>
+              </div>
+              <div className="mt-3 grid grid-cols-3 gap-2 text-center text-xs text-text-secondary">
+                <div className="border border-border bg-background-base/50 px-3 py-2 font-mono-ui">{config?.provider ?? "xai"}</div>
+                <div className="border border-border bg-background-base/50 px-3 py-2 font-mono-ui">{config?.voice ?? "eve"}</div>
+                <div className="border border-border bg-background-base/50 px-3 py-2 font-mono-ui">{toolNames.length} tools</div>
+              </div>
+            </div>
+          </footer>
+        </section>
+
+        <aside className="flex min-h-0 flex-col gap-2 overflow-y-auto pr-1 lg:w-80 lg:shrink-0">
+          <div className="border border-border bg-background-base/60 p-4">
+            <div className="mb-3 flex items-center justify-between gap-2">
+              <h3 className="font-mondwest text-sm tracking-[0.08em] text-midground">Dispatch context</h3>
+              <Button type="button" size="sm" outlined onClick={loadConfig} disabled={loading} prefix={loading ? <Spinner /> : <RefreshCw />}>
+                Refresh
+              </Button>
+            </div>
+            <div className="space-y-2 text-sm">
+              <div className="flex items-center justify-between border border-border bg-background-base/50 px-3 py-2">
+                <span className="text-text-secondary">Realtime</span>
+                <span className="flex items-center gap-1 font-medium text-foreground">{config?.enabled ? <CheckCircle2 className="h-3.5 w-3.5 text-success" /> : <AlertTriangle className="h-3.5 w-3.5 text-warning" />}{config?.enabled ? "Enabled" : "Disabled"}</span>
+              </div>
+              <div className="flex items-center justify-between border border-border bg-background-base/50 px-3 py-2">
+                <span className="text-text-secondary">Connection</span>
+                <span className="font-medium text-foreground">{connection}</span>
+              </div>
+              <div className="flex items-center justify-between border border-border bg-background-base/50 px-3 py-2">
+                <span className="text-text-secondary">Secret expiry</span>
+                <span className="max-w-[9.5rem] truncate font-medium text-foreground">{formatEpochSeconds(expiresAt)}</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="border border-border bg-background-base/60 p-4">
+            <div className="mb-3 flex items-center gap-2">
+              <Radio className="h-4 w-4 text-midground" />
+              <h3 className="font-mondwest text-sm tracking-[0.08em] text-midground">Active delegate</h3>
+            </div>
+            <div className="space-y-2 text-sm text-text-secondary">
+              <div>Delegate ID: <span className="font-mono-ui text-xs text-foreground">{activeRunId ?? "—"}</span></div>
+              <div>Status: <span className="font-medium text-foreground">{runStatus?.status ?? "—"}</span></div>
+              {runStatus?.last_event && <div>Last event: <span className="font-medium text-foreground">{runStatus.last_event}</span></div>}
+              {runStatus?.status === "waiting_for_approval" && (
+                <div className="border border-warning/40 bg-warning/10 p-3">
+                  <div className="mb-2 font-mondwest text-xs tracking-[0.08em] text-warning">Approval pending</div>
+                  <div className="space-y-2">
+                    {approvalDetailRows(runStatus).map((row) => (
+                      <div key={row.label}>
+                        <div className="font-mondwest text-[0.6875rem] tracking-[0.08em] text-text-tertiary">{row.label}</div>
+                        <div className={row.label === "Command" ? "break-all font-mono-ui text-xs text-foreground" : "text-xs text-foreground"}>{row.value}</div>
+                      </div>
+                    ))}
+                  </div>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {voiceApprovalChoices(runStatus).map((choice) => (
+                      <Button
+                        key={choice}
+                        type="button"
+                        size="sm"
+                        outlined={choice === "deny"}
+                        onClick={() => void approveFromUi(choice)}
+                        className="font-mondwest text-xs tracking-[0.08em]"
+                      >
+                        {choice}
+                      </Button>
+                    ))}
+                  </div>
+                </div>
+              )}
+              {runStatus?.events && runStatus.events.length > 0 && (
+                <div className="border border-border bg-background-base/50 p-3">
+                  <div className="mb-2 font-mondwest text-xs tracking-[0.08em] text-midground">Recent delegate events</div>
+                  <div className="space-y-1">
+                    {runStatus.events.slice(-5).map((event, index) => (
+                      <div key={index} className="flex items-center justify-between gap-2 text-xs">
+                        <span className="font-mono-ui text-text-secondary">{typeof event.event === "string" ? event.event : "event"}</span>
+                        {typeof event.tool === "string" && <span className="truncate text-text-tertiary">{event.tool}</span>}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+              {runStatus?.output && <div className="border border-border bg-background-base/50 p-3 text-foreground">{runStatus.output}</div>}
+              {runStatus?.error && <div className="border border-destructive/30 bg-destructive/[0.06] p-3 text-destructive">{runStatus.error}</div>}
+            </div>
+            {activeRunId && runStatus?.status && !TERMINAL_VOICE_DELEGATE_STATUSES.has(runStatus.status) && (
+              <Button type="button" outlined onClick={() => void stopActiveRun()} className="mt-4 w-full">
+                Stop delegate
+              </Button>
+            )}
+          </div>
+
+          <div className="border border-border bg-background-base/60 p-4">
+            <div className="mb-3 flex items-center gap-2">
+              <ShieldCheck className="h-4 w-4 text-midground" />
+              <h3 className="font-mondwest text-sm tracking-[0.08em] text-midground">Allowed delegate tools</h3>
+            </div>
+            <div className="space-y-2">
+              {config?.tools.map((tool) => (
+                <div key={tool.name} className="border border-border bg-background-base/50 px-3 py-2">
+                  <div className="font-mono-ui text-[0.6875rem] uppercase tracking-[0.08em] text-foreground">{tool.name}</div>
+                  <p className="mt-1 text-xs leading-relaxed text-text-secondary">{tool.description}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="border border-border bg-background-base/60 p-4">
+            <div className="mb-3 flex items-center gap-2">
+              <Volume2 className="h-4 w-4 text-midground" />
+              <h3 className="font-mondwest text-sm tracking-[0.08em] text-midground">Diagnostics</h3>
+            </div>
+            <div className="max-h-48 space-y-2 overflow-auto">
+              {events.length ? events.map((event) => (
+                <div key={event.id} className="flex items-center justify-between gap-3 border border-border bg-background-base/50 px-3 py-2 text-xs">
+                  <span className="font-mono-ui text-text-secondary">{event.type}</span>
+                  <span className="text-text-tertiary">{event.timestamp}</span>
+                </div>
+              )) : <div className="text-sm text-text-secondary">No realtime events yet.</div>}
+            </div>
+          </div>
+        </aside>
+      </div>
+
+      <PluginSlot name="voice:bottom" />
+    </div>
+  );
+}

--- a/web/tests/voiceDispatchApprovalSafety.test.ts
+++ b/web/tests/voiceDispatchApprovalSafety.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const webRoot = resolve(__dirname, "..");
+const page = readFileSync(resolve(webRoot, "src/pages/VoiceDispatchPage.tsx"), "utf8");
+const api = readFileSync(resolve(webRoot, "src/lib/api.ts"), "utf8");
+
+assert.doesNotMatch(page, /call\.name\s*===\s*["']approve_delegate_action["']/, "Grok-callable approve_delegate_action must not be handled by the browser");
+assert.doesNotMatch(page, /call\.name\s*===\s*["']approve_hermes_action["']/, "Grok-callable approve_hermes_action must not be handled by the browser");
+assert.doesNotMatch(page, /"always"\s*,\s*"deny"/, "Voice approval UI must not offer always approval in v1");
+assert.match(page, /explicit\s+Hermes\s+UI\s+click/i, "Voice instructions should tell Grok approval requires an explicit UI click");
+assert.match(page, /approveFromUi\s*=\s*useCallback\(async \(choice: "once" \| "session" \| "deny"\)/, "UI approval handler must only accept once/session/deny");
+assert.match(api, /export type VoiceApprovalChoice = "once" \| "session" \| "deny";/, "API should expose a narrowed voice approval choice type");
+assert.doesNotMatch(api, /choice:\s*"once" \| "session" \| "always" \| "deny"/, "API approval requests must not accept always");
+
+console.log("voiceDispatchApprovalSafety tests passed");

--- a/web/tests/voiceDispatchNotifications.test.ts
+++ b/web/tests/voiceDispatchNotifications.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import {
+  buildVoiceDelegateStatusNotification,
+  summarizeVoiceDelegateStatus,
+} from "../src/lib/voiceDispatchNotifications.ts";
+
+const running = buildVoiceDelegateStatusNotification({
+  run_id: "voice_delegate_running",
+  status: "running",
+});
+assert.equal(running, null, "running delegates should not trigger proactive voice updates");
+
+const completed = buildVoiceDelegateStatusNotification({
+  delegate_id: "voice_delegate_done",
+  run_id: "voice_delegate_done",
+  status: "completed",
+  output: "Built the feature and all checks passed.",
+});
+assert.equal(completed?.key, "voice_delegate_done:completed");
+assert.equal(completed?.kind, "run");
+assert.equal(completed?.title, "Delegate finished");
+assert.match(completed?.voicePrompt ?? "", /proactively now/i);
+assert.match(completed?.voicePrompt ?? "", /Built the feature/);
+
+const failed = buildVoiceDelegateStatusNotification({
+  run_id: "voice_delegate_failed",
+  status: "failed",
+  error: "Command exited 1",
+});
+assert.equal(failed?.key, "voice_delegate_failed:failed");
+assert.match(failed?.transcriptBody ?? "", /failed: Command exited 1/);
+
+const approval = buildVoiceDelegateStatusNotification({
+  delegate_id: "voice_delegate_approval",
+  run_id: "voice_delegate_approval",
+  status: "waiting_for_approval",
+  last_event: "Tool approval required",
+});
+assert.equal(approval?.key, "voice_delegate_approval:waiting_for_approval");
+assert.equal(approval?.kind, "approval");
+assert.match(approval?.voicePrompt ?? "", /approval is required/i);
+assert.match(approval?.voicePrompt ?? "", /explicit Hermes UI click/i);
+assert.doesNotMatch(approval?.voicePrompt ?? "", /always approve/i);
+
+const longSummary = summarizeVoiceDelegateStatus({
+  run_id: "voice_delegate_long",
+  status: "completed",
+  output: "x".repeat(1200),
+});
+assert.ok(longSummary.length < 950, "voice summaries should be capped before sending to realtime");
+assert.ok(longSummary.endsWith("…"), "truncated voice summaries should show truncation");
+
+console.log("voiceDispatchNotifications tests passed");

--- a/website/docs/user-guide/features/voice-dispatch.md
+++ b/website/docs/user-guide/features/voice-dispatch.md
@@ -1,0 +1,174 @@
+---
+sidebar_position: 11
+title: "Grok Voice Dispatch"
+description: "Realtime Grok voice control for dispatching work to isolated Hermes delegates from the web dashboard"
+---
+
+# Grok Voice Dispatch
+
+Grok Voice Dispatch is a dashboard voice interface for controlling Hermes Agent with realtime speech. It is different from [Voice Mode](./voice-mode.md): Voice Mode adds speech input/output to the CLI and messaging platforms, while Grok Voice Dispatch runs in the web dashboard and uses Grok Voice as a fast conversational controller for isolated Hermes delegates.
+
+The safety model is simple:
+
+```text
+Browser microphone
+  → xAI realtime voice session using a short-lived client secret
+  → narrow voice tool calls only
+  → Hermes dashboard bridge
+  → isolated Hermes delegate
+  → normal Hermes tools, sessions, approvals, and logs
+```
+
+Grok Voice does **not** receive direct shell, file, browser, MCP, or credential tools. It can start, check, and stop delegate work. Hermes still performs the work under the normal Hermes execution and approval model.
+
+## Setup
+
+Run the dedicated setup section:
+
+```bash
+hermes setup voice
+```
+
+The setup flow is disabled by default. It only enables realtime voice dispatch when you explicitly opt in.
+
+When enabled, setup writes non-secret settings to `~/.hermes/config.yaml` and stores the xAI API key in `~/.hermes/.env`:
+
+```bash
+XAI_API_KEY=...
+```
+
+The setup wizard never prints the key. If `XAI_API_KEY` already exists, Hermes detects it without echoing the value and asks before replacing it.
+
+## Configuration
+
+Default config values:
+
+```yaml
+voice:
+  realtime:
+    enabled: false
+    provider: xai
+    model: grok-voice-latest
+    voice: eve
+    ephemeral_token_ttl_seconds: 300
+    turn_detection:
+      type: server_vad
+      threshold: 0.85
+      silence_duration_ms: 900
+      prefix_padding_ms: 333
+    audio:
+      input_rate: 24000
+      output_rate: 24000
+    dispatch:
+      max_active_delegates: 1
+      default_toolsets: []
+      summarize_events_for_voice: true
+```
+
+You can edit these with:
+
+```bash
+hermes config edit
+```
+
+or by re-running:
+
+```bash
+hermes setup voice
+```
+
+## Start the dashboard
+
+Install the web dashboard dependencies if needed:
+
+```bash
+pip install 'hermes-agent[web]'
+```
+
+Start the local dashboard:
+
+```bash
+hermes dashboard
+```
+
+Open the **Voice** tab at `/voice`.
+
+The dashboard protects voice endpoints with the dashboard session token. The browser requests a short-lived xAI realtime client secret from Hermes; the long-lived `XAI_API_KEY` stays server-side in `.env`.
+
+## How dispatch works
+
+Voice Dispatch exposes only narrow control functions to the realtime voice session:
+
+- `start_delegate` — start an isolated Hermes delegate for a user task
+- `get_delegate_status` — check active or specified delegate status
+- `stop_delegate` — request cancellation/stop for a delegate
+
+The delegate runs as its own Hermes agent session. That keeps the main dashboard/chat session free while the work runs.
+
+Delegate status and events are written to a local SQLite ledger under the Hermes home directory. Event previews are redacted before persistence so obvious secret-shaped values are not stored as raw audit output.
+
+## Approvals
+
+Voice Dispatch preserves Hermes approvals.
+
+If a delegate hits an action that needs approval, Grok Voice may tell you approval is required, but it cannot approve privileged actions by itself. You approve or deny through the Hermes UI, with the actual command/tool/action details visible before you click.
+
+Voice Dispatch v1 does not offer voice-mediated `always` approvals. Available approval choices are limited to:
+
+- approve once
+- approve for this session
+- deny
+
+This prevents a remote realtime voice model from permanently widening local permissions.
+
+## Phone or remote access
+
+The safest default is local-only dashboard access:
+
+```bash
+hermes dashboard --host 127.0.0.1
+```
+
+For phone access, prefer a private network or authenticated tunnel:
+
+- Tailscale
+- Cloudflare Tunnel with Access
+- ngrok with authentication
+
+Do not expose the dashboard directly on a public interface. Avoid `--insecure` unless you understand the risk and have separate network controls in place.
+
+## Troubleshooting
+
+### Voice tab says disabled
+
+Run:
+
+```bash
+hermes setup voice
+```
+
+and explicitly enable Grok Voice Dispatch.
+
+### Missing xAI credentials
+
+Set the key through setup:
+
+```bash
+hermes setup voice
+```
+
+or edit `~/.hermes/.env`:
+
+```bash
+XAI_API_KEY=...
+```
+
+Restart the dashboard after changing `.env`.
+
+### Browser microphone fails
+
+If the config endpoint and xAI client-secret endpoint work but audio fails, check browser and operating-system microphone permissions. In automated browsers, `getUserMedia` often fails with permission denied even when the backend is configured correctly.
+
+### Delegate finishes but voice does not announce it
+
+Keep the `/voice` page open while the delegate runs. The dashboard watches active delegate status and pushes concise completion summaries into the realtime voice conversation while the WebSocket is live.

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -8,6 +8,8 @@ description: "Real-time voice conversations with Hermes Agent — CLI, Telegram,
 
 Hermes Agent supports full voice interaction across CLI and messaging platforms. Talk to the agent using your microphone, hear spoken replies, and have live voice conversations in Discord voice channels.
 
+For dashboard-based realtime voice control that dispatches work to isolated Hermes delegates through Grok Voice, see [Grok Voice Dispatch](./voice-dispatch.md).
+
 If you want a practical setup walkthrough with recommended configurations and real usage patterns, see [Use Voice Mode with Hermes](/guides/use-voice-mode-with-hermes).
 
 ## Prerequisites

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -181,6 +181,19 @@ curl -s http://VM_IP:9119/api/status | jq '.auth_required, .auth_providers'
 
 If `/api/status` shows the gate is on with the `"basic"` provider and Desktop *still* fails to connect after signing in, the issue is past basic setup — grab a fresh `desktop.log` (Settings → Gateway → Open logs) plus the dashboard's logs from the same retry window and look for the `/api/ws` close code (4403 = chat WS rejected by the request guard, e.g. Host/peer mismatch; 4401 = the WS ticket didn't authenticate).
 
+
+### Voice
+
+The **Voice** tab provides [Grok Voice Dispatch](./voice-dispatch.md): a realtime browser voice session that can start, monitor, and stop isolated Hermes delegates. Grok Voice is the conversational controller only; Hermes delegates perform the actual work using the normal Hermes tool and approval model.
+
+The browser never receives your long-lived `XAI_API_KEY`. The dashboard mints a short-lived xAI realtime client secret server-side and protects all `/api/voice/*` endpoints with the dashboard session token. Voice config, env lookup, ledger storage, and delegate agents honor the selected dashboard management profile.
+
+Enable it with:
+
+```bash
+hermes setup voice
+```
+
 ### Config
 
 A form-based editor for `config.yaml`. All 150+ configuration fields are auto-discovered from `DEFAULT_CONFIG` and organized into tabbed categories:

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -100,6 +100,7 @@ const sidebars: SidebarsConfig = {
           label: 'Media & Web',
           items: [
             'user-guide/features/voice-mode',
+            'user-guide/features/voice-dispatch',
             'user-guide/features/web-search',
             'user-guide/features/x-search',
             'user-guide/features/browser',


### PR DESCRIPTION
## Summary

This PR adds **Grok Voice Dispatch** to the Hermes dashboard.

It is a voice-mode control surface for Hermes: the user talks to Grok Voice in the browser, Grok handles the fast conversational loop, and Hermes does the actual work through isolated delegate runs on the user's machine.

The core design is deliberately conservative:

- **Grok Voice is the controller, not the executor.**
- **Hermes remains the operator.**
- **Local tools, approvals, files, shell, and credentials stay behind Hermes' existing security model.**
- **Browser clients never receive the long-lived `XAI_API_KEY`.**

## What this enables

A user can open the Hermes dashboard, start a voice session, and say things like:

> "Start a Hermes delegate to inspect the failing setup tests and summarize the root cause."

The voice layer can then dispatch the task to Hermes, check the delegate's status, stop it if needed, and announce completion while the realtime voice session is still active.

The main Hermes chat/session stays free. Voice-dispatched work runs separately and is tracked in a local audit ledger.

## Architecture

```mermaid
flowchart TD
  A[Browser / Hermes dashboard Voice tab] -->|short-lived xAI client secret| B[xAI realtime / Grok Voice]
  B -->|narrow function calls only| C[Hermes voice dispatch bridge]
  C -->|isolated delegate run| D[Hermes AIAgent]
  D -->|normal tools + approvals| E[User machine]
  C --> F[(Local SQLite run/event ledger)]
```

Voice-callable tools are intentionally narrow:

- `start_delegate`
- `get_delegate_status`
- `stop_delegate`

Grok Voice does **not** receive direct shell, file, browser, MCP, or credential tools.

## Security model

- `voice.realtime.enabled` defaults to `false`.
- Setup is explicit through `hermes setup voice`.
- The server reads `XAI_API_KEY` through Hermes env helpers.
- The browser receives only short-lived xAI client secrets.
- Ephemeral token TTL is clamped server-side.
- Dashboard session auth protects the voice endpoints.
- Voice approval choices are restricted to:
  - `once`
  - `session`
  - `deny`
- Persistent voice-mediated `always` approvals are intentionally disallowed.
- Delegate output/events are redacted for secret-shaped values before being written to SQLite.
- Stale nonterminal delegates loaded after dashboard restart are safely marked stopped when there is no active agent task.

## User flow

1. User runs:

   ```bash
   hermes setup voice
   ```

2. User opts in and provides/stores `XAI_API_KEY` through Hermes env handling.
3. User starts the Hermes dashboard.
4. User opens the Voice tab.
5. Browser requests a short-lived xAI client secret from Hermes.
6. Browser connects to xAI realtime.
7. Grok Voice talks with the user and calls only the narrow dispatch tools.
8. Hermes launches isolated delegates for real work.
9. The dashboard tracks status/events and can proactively tell the voice session when a delegate completes.

## Why this is Hermes-native

This does not add a separate hosted SaaS, a new auth system, or a public local-tool bridge.

It reuses Hermes' existing shape:

- dashboard server
- dashboard session auth
- model/config/env helpers
- Hermes agent execution
- approval posture
- local-first operation

The goal is to make voice mode a safe frontend to Hermes execution, not a parallel agent runtime.

## Implementation highlights

- Adds voice realtime config defaults.
- Adds `hermes setup voice` and wires the voice section into full setup.
- Adds protected dashboard voice endpoints.
- Adds xAI ephemeral client-secret brokering.
- Adds the dashboard Voice page.
- Adds frontend audio/realtime helpers.
- Adds local SQLite delegate run/event persistence.
- Adds proactive completion notification handling for live voice sessions.
- Adds backend and frontend tests around dispatch, approvals, setup, restart handling, and notification dedupe.
- Adds user/security documentation for Voice Dispatch.

## Reviewer map

Key files:

- `hermes_cli/web_server.py` — voice endpoints, xAI client-secret broker, delegate ledger/status/events.
- `hermes_cli/setup.py` — `hermes setup voice`, opt-in flow, env/config integration.
- `hermes_cli/config.py` — default voice realtime config.
- `hermes_cli/main.py` — setup parser/help integration.
- `web/src/pages/VoiceDispatchPage.tsx` — dashboard Voice tab.
- `web/src/lib/api.ts` — frontend API helpers.
- `web/src/lib/voiceAudio.ts` — browser audio pipeline helpers.
- `web/src/lib/voiceDispatchNotifications.ts` — proactive completion notification logic.
- `tests/hermes_cli/test_voice_realtime.py` — backend dispatch/security/restart tests.
- `tests/hermes_cli/test_setup.py` — setup behavior tests.
- `web/tests/voiceDispatchApprovalSafety.test.ts` — frontend approval safety test.
- `web/tests/voiceDispatchNotifications.test.ts` — frontend notification helper test.
- `website/docs/user-guide/features/voice-dispatch.md` — user-facing setup/security docs.

## Test Plan

- `python -m py_compile hermes_cli/web_server.py tests/hermes_cli/test_voice_realtime.py hermes_cli/setup.py hermes_cli/main.py`
- `python -m pytest tests/hermes_cli/test_voice_realtime.py tests/hermes_cli/test_setup.py -q -o 'addopts='`
- `node --experimental-strip-types tests/voiceDispatchApprovalSafety.test.ts`
- `node --experimental-strip-types tests/voiceDispatchNotifications.test.ts`
- `npx eslint src/pages/VoiceDispatchPage.tsx src/lib/voiceAudio.ts src/lib/voiceDispatchNotifications.ts tests/voiceDispatchApprovalSafety.test.ts tests/voiceDispatchNotifications.test.ts`
- `npm run build`
- `git diff --check`

Latest local backend/setup result:

```text
45 passed
```

## Notes for reviewers

The most important review question is whether the boundary is strict enough:

> Can the voice model talk to the user and dispatch/status/stop work without bypassing Hermes' existing approval and execution model?

This PR is built around that boundary. Grok Voice gets conversation and narrow dispatch. Hermes keeps execution.
