### PR TITLE
feat(spotify): multi-account auth with sender-based routing

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import shutil
 import shlex
 import ssl
@@ -2358,16 +2359,277 @@ def _refresh_spotify_oauth_state(
     )
 
 
+# ---------------------------------------------------------------------------
+# Spotify multi-account auth state
+#
+# auth.json supports two shapes for providers.spotify:
+#
+#   1. Legacy (single account) — flat token state at providers.spotify:
+#        providers.spotify = {access_token, refresh_token, client_id, ...}
+#      Pre-multi-account installs land here. Resolver returns
+#      account_source="legacy" and account_id=None.
+#
+#   2. v2 (multi-account):
+#        providers.spotify = {
+#            "schema_version": 2,
+#            "default_account": "mark",
+#            "accounts": {"mark": {...}, "amy": {...}},
+#            "routing": {"telegram": {"<user_id>": "<account_id>"}},
+#        }
+#      `hermes auth spotify login --account amy` (and `migrate`) write
+#      this shape. Resolver routes by explicit account, then by
+#      (platform, user_id) → routing lookup, then by env override, then
+#      by default_account.
+#
+# Both shapes coexist forever — no auto-migration on read.
+# ---------------------------------------------------------------------------
+
+_SPOTIFY_ACCOUNT_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+
+def _normalize_spotify_account_id(raw: Optional[str]) -> Optional[str]:
+    """Lowercase + validate a Spotify account id slug. Returns None for blank input."""
+    if raw is None:
+        return None
+    account_id = str(raw).strip().lower()
+    if not account_id:
+        return None
+    if not _SPOTIFY_ACCOUNT_ID_RE.match(account_id):
+        raise AuthError(
+            "Spotify account id must match [a-z0-9][a-z0-9_-]{0,63}",
+            provider="spotify",
+            code="spotify_account_id_invalid",
+        )
+    return account_id
+
+
+def _is_spotify_multi_account_state(state: Optional[Dict[str, Any]]) -> bool:
+    """True if providers.spotify is in v2 multi-account shape."""
+    return isinstance(state, dict) and isinstance(state.get("accounts"), dict)
+
+
+def _spotify_accounts(state: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """Return the accounts map from v2 provider state, filtered to dict values."""
+    accounts = state.get("accounts")
+    if isinstance(accounts, dict):
+        return {str(k): v for k, v in accounts.items() if isinstance(v, dict)}
+    return {}
+
+
+def _spotify_legacy_state_as_account(state: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Treat flat providers.spotify state as a single legacy account.
+
+    Returns a shallow copy of the legacy state if it looks like a token bundle
+    (has access_token or refresh_token), else None. Does not mutate `state`.
+    """
+    if not isinstance(state, dict):
+        return None
+    if "access_token" not in state and "refresh_token" not in state:
+        return None
+    return dict(state)
+
+
+def _ensure_spotify_multi_account_state(
+    provider_state: Dict[str, Any],
+    *,
+    legacy_account_id: str = "default",
+) -> Dict[str, Any]:
+    """Convert legacy flat state into v2 shape (in memory), or normalize v2 keys.
+
+    Used by `hermes auth spotify login --account <id>` and `migrate`. Idempotent.
+    If `provider_state` is already v2, just ensures schema_version/accounts/routing
+    keys exist and returns it. If legacy, wraps its token bundle under
+    accounts[legacy_account_id].
+    """
+    if _is_spotify_multi_account_state(provider_state):
+        provider_state.setdefault("schema_version", 2)
+        provider_state.setdefault("accounts", {})
+        provider_state.setdefault("routing", {})
+        return provider_state
+
+    legacy = _spotify_legacy_state_as_account(provider_state)
+    new_state: Dict[str, Any] = {
+        "schema_version": 2,
+        "default_account": legacy_account_id if legacy else None,
+        "accounts": {},
+        "routing": {},
+    }
+    if legacy:
+        new_state["accounts"][legacy_account_id] = legacy
+    return new_state
+
+
+def _spotify_account_from_source(
+    spotify_provider_state: Dict[str, Any],
+    platform: Optional[str],
+    user_id: Optional[str],
+) -> Optional[str]:
+    """Look up routing[platform][user_id] → account_id. Returns None if not configured."""
+    if not platform or not user_id:
+        return None
+    routing = spotify_provider_state.get("routing")
+    if not isinstance(routing, dict):
+        return None
+    platform_routes = routing.get(str(platform).lower())
+    if not isinstance(platform_routes, dict):
+        return None
+    account_id = platform_routes.get(str(user_id))
+    return _normalize_spotify_account_id(account_id) if account_id else None
+
+
+def _select_spotify_account_state(
+    provider_state: Dict[str, Any],
+    *,
+    account_id: Optional[str] = None,
+    platform: Optional[str] = None,
+    user_id: Optional[str] = None,
+) -> Tuple[Optional[str], Dict[str, Any], str]:
+    """Pick which account's token state to use.
+
+    Resolution order:
+        1. Explicit `account_id` arg.
+        2. Source-derived: routing[platform][user_id] (Telegram sender id, etc.)
+        3. HERMES_SPOTIFY_ACCOUNT env var.
+        4. provider_state.default_account.
+        5. Single configured account (degenerate v2 with one entry).
+        6. Legacy flat state (only if no v2 accounts map exists).
+
+    Returns (selected_account_id, token_state_copy, source_label).
+    `selected_account_id` is None in legacy mode. `source_label` is one of:
+    "explicit", "source", "default", "single_configured_account", "legacy".
+    """
+    explicit = _normalize_spotify_account_id(account_id)
+
+    if _is_spotify_multi_account_state(provider_state):
+        accounts = _spotify_accounts(provider_state)
+
+        if explicit:
+            if explicit not in accounts:
+                raise AuthError(
+                    f"Spotify account '{explicit}' is not configured.",
+                    provider="spotify",
+                    code="spotify_account_missing",
+                    relogin_required=True,
+                )
+            return explicit, dict(accounts[explicit]), "explicit"
+
+        routed = _spotify_account_from_source(provider_state, platform, user_id)
+        if routed:
+            if routed not in accounts:
+                raise AuthError(
+                    f"Spotify routing points to missing account '{routed}'. "
+                    "Run `hermes auth spotify login --account` or remove the stale route.",
+                    provider="spotify",
+                    code="spotify_route_account_missing",
+                    relogin_required=True,
+                )
+            return routed, dict(accounts[routed]), "source"
+
+        default_account = _normalize_spotify_account_id(
+            os.getenv("HERMES_SPOTIFY_ACCOUNT") or provider_state.get("default_account")
+        )
+        if default_account and default_account in accounts:
+            return default_account, dict(accounts[default_account]), "default"
+
+        if len(accounts) == 1:
+            only_id, only_state = next(iter(accounts.items()))
+            return only_id, dict(only_state), "single_configured_account"
+
+        raise AuthError(
+            "Multiple Spotify accounts are configured but no account could be "
+            "selected. Set providers.spotify.default_account, add a routing rule, "
+            "or pass account=...",
+            provider="spotify",
+            code="spotify_account_ambiguous",
+        )
+
+    legacy = _spotify_legacy_state_as_account(provider_state)
+    if legacy is not None:
+        if explicit:
+            raise AuthError(
+                "Spotify is in legacy single-account mode; explicit account "
+                "selection requires `hermes auth spotify migrate` or "
+                "`login --account` first.",
+                provider="spotify",
+                code="spotify_legacy_no_named_account",
+            )
+        return None, legacy, "legacy"
+
+    raise AuthError(
+        "Spotify is not authenticated. Run `hermes auth spotify login` first.",
+        provider="spotify",
+        code="spotify_auth_missing",
+        relogin_required=True,
+    )
+
+
+def _store_spotify_selected_account_state(
+    auth_store: Dict[str, Any],
+    *,
+    account_id: Optional[str],
+    selected_state: Dict[str, Any],
+) -> None:
+    """Write refreshed token state back to the right slot.
+
+    v2 mode (account_id is set): updates providers.spotify.accounts[account_id].
+    Legacy mode (account_id is None): replaces flat providers.spotify state.
+    Neither path touches active_provider (set_active=False).
+    """
+    provider_state = _load_provider_state(auth_store, "spotify") or {}
+    if account_id and _is_spotify_multi_account_state(provider_state):
+        provider_state.setdefault("accounts", {})[account_id] = selected_state
+        _store_provider_state(auth_store, "spotify", provider_state, set_active=False)
+    else:
+        _store_provider_state(auth_store, "spotify", selected_state, set_active=False)
+
+
 def resolve_spotify_runtime_credentials(
     *,
+    account_id: Optional[str] = None,
+    platform: Optional[str] = None,
+    user_id: Optional[str] = None,
     force_refresh: bool = False,
     refresh_if_expiring: bool = True,
     refresh_skew_seconds: int = SPOTIFY_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
 ) -> Dict[str, Any]:
+    """Resolve Spotify access_token + metadata for the right account.
+
+    Account selection priority (see `_select_spotify_account_state`):
+        explicit account_id > (platform, user_id) routing > env > default >
+        single-configured-account > legacy flat state.
+
+    Refresh writes back only to the selected nested account; legacy mode
+    keeps writing to flat providers.spotify.
+
+    When ``platform`` or ``user_id`` are not passed explicitly, falls back
+    to the gateway's per-task session ContextVars (HERMES_SESSION_PLATFORM
+    / HERMES_SESSION_USER_ID), which are set by gateway.run.set_session_vars
+    around every request/cron tick. This means gateway-origin Spotify tool
+    calls auto-route by sender without any wiring in model_tools or
+    run_agent — the ContextVar is task-local so concurrent messages can't
+    clobber each other. CLI/cron-origin calls leave both unset and fall
+    through to provider default.
+    """
+    # Auto-discover source context from gateway-set ContextVars when the
+    # caller didn't supply it. Empty-string from get_session_env means
+    # "explicitly cleared" — treat as no context so we don't accidentally
+    # route based on a stale clear.
+    if platform is None or user_id is None:
+        try:
+            from gateway.session_context import get_session_env
+            if platform is None:
+                platform = get_session_env("HERMES_SESSION_PLATFORM") or None
+            if user_id is None:
+                user_id = get_session_env("HERMES_SESSION_USER_ID") or None
+        except Exception:
+            # gateway.session_context may not be importable in some test
+            # / packaging configurations; degrade to no source context.
+            pass
+
     with _auth_store_lock():
         auth_store = _load_auth_store()
-        state = _load_provider_state(auth_store, "spotify")
-        if not state:
+        provider_state = _load_provider_state(auth_store, "spotify")
+        if not provider_state:
             raise AuthError(
                 "Spotify is not authenticated. Run `hermes auth spotify` first.",
                 provider="spotify",
@@ -2375,12 +2637,23 @@ def resolve_spotify_runtime_credentials(
                 relogin_required=True,
             )
 
+        selected_account_id, state, account_source = _select_spotify_account_state(
+            provider_state,
+            account_id=account_id,
+            platform=platform,
+            user_id=user_id,
+        )
+
         should_refresh = bool(force_refresh)
         if not should_refresh and refresh_if_expiring:
             should_refresh = _is_expiring(state.get("expires_at"), refresh_skew_seconds)
         if should_refresh:
             state = _refresh_spotify_oauth_state(state)
-            _store_provider_state(auth_store, "spotify", state, set_active=False)
+            _store_spotify_selected_account_state(
+                auth_store,
+                account_id=selected_account_id,
+                selected_state=state,
+            )
             _save_auth_store(auth_store)
 
     access_token = str(state.get("access_token", "") or "").strip()
@@ -2394,6 +2667,8 @@ def resolve_spotify_runtime_credentials(
 
     return {
         "provider": "spotify",
+        "account_id": selected_account_id,
+        "account_source": account_source,
         "access_token": access_token,
         "api_key": access_token,
         "token_type": str(state.get("token_type", "Bearer") or "Bearer"),
@@ -2570,15 +2845,347 @@ def login_spotify_command(args) -> None:
         api_base_url=api_base_url,
     )
 
+    # Multi-account login routing. With --account <id>, store the new token
+    # bundle under providers.spotify.accounts[<id>] (auto-promoting legacy
+    # flat state to v2 along the way). Without --account, preserve legacy
+    # single-account behaviour UNLESS the provider state is already v2,
+    # in which case bail with a clear error rather than silently flatten
+    # the multi-account store back to a single bundle.
+    account_id = _normalize_spotify_account_id(getattr(args, "account", None))
+    owner_name = getattr(args, "owner_name", None) or None
+    # --telegram-user-id is shorthand for --platform telegram --user-id <id>.
+    route_user_id = getattr(args, "user_id", None) or getattr(args, "telegram_user_id", None)
+    route_platform = getattr(args, "platform", None)
+    if route_user_id and not route_platform:
+        route_platform = "telegram"
+    set_default_flag = bool(getattr(args, "set_default", False))
+
     with _auth_store_lock():
         auth_store = _load_auth_store()
-        _store_provider_state(auth_store, "spotify", spotify_state, set_active=False)
+        existing_provider_state = _load_provider_state(auth_store, "spotify") or {}
+
+        if account_id:
+            # v2 storage path.
+            provider_state = _ensure_spotify_multi_account_state(existing_provider_state)
+            if owner_name:
+                spotify_state["owner_name"] = owner_name
+            if route_user_id:
+                spotify_state["owner_platform"] = route_platform
+                spotify_state["owner_user_id"] = str(route_user_id)
+                provider_state.setdefault("routing", {}).setdefault(
+                    str(route_platform).lower(), {}
+                )[str(route_user_id)] = account_id
+            provider_state.setdefault("accounts", {})[account_id] = spotify_state
+            if set_default_flag or not provider_state.get("default_account"):
+                provider_state["default_account"] = account_id
+            _store_provider_state(auth_store, "spotify", provider_state, set_active=False)
+        else:
+            # Legacy single-account login. If the user already has v2 state,
+            # refuse to overwrite — they need to pick which account to update.
+            if _is_spotify_multi_account_state(existing_provider_state):
+                raise SystemExit(
+                    "Spotify is configured in multi-account mode. "
+                    "Pass `--account <id>` to specify which account to log in to "
+                    "(e.g. `hermes auth spotify login --account mark`)."
+                )
+            _store_provider_state(auth_store, "spotify", spotify_state, set_active=False)
+
         saved_to = _save_auth_store(auth_store)
 
     print("Spotify login successful!")
     print(f"  Auth state: {saved_to}")
+    if account_id:
+        print(f"  Account: {account_id}")
+        if route_user_id:
+            print(f"  Routing: {route_platform}:{route_user_id} -> {account_id}")
     print("  Provider state saved under providers.spotify")
     print(f"  Docs: {SPOTIFY_DOCS_URL}")
+
+
+# ---------------------------------------------------------------------------
+# Spotify multi-account CLI subcommands
+# ---------------------------------------------------------------------------
+
+def spotify_status_command(args) -> None:
+    """`hermes auth spotify status [--account <id>]` — provider/account status.
+
+    Without --account: shows whether spotify is logged in (legacy behavior).
+    With --account: shows status of just that account, raising if it's
+    missing from a v2 store.
+    """
+    account_id = _normalize_spotify_account_id(getattr(args, "account", None))
+    provider_state = get_provider_auth_state("spotify")
+    if not provider_state:
+        print("spotify: logged out")
+        return
+
+    if account_id:
+        if not _is_spotify_multi_account_state(provider_state):
+            raise SystemExit(
+                "Spotify is in legacy single-account mode; --account is not "
+                "supported. Run `hermes auth spotify migrate --account <id>` first."
+            )
+        accounts = _spotify_accounts(provider_state)
+        if account_id not in accounts:
+            raise SystemExit(f"Spotify account '{account_id}' is not configured.")
+        state = accounts[account_id]
+        print(f"spotify[{account_id}]: logged in")
+        for key in ("owner_name", "owner_platform", "owner_user_id",
+                    "auth_type", "client_id", "redirect_uri",
+                    "scope", "expires_at", "api_base_url"):
+            value = state.get(key)
+            if value:
+                print(f"  {key}: {value}")
+        return
+
+    # No --account specified: show the whole provider status.
+    if _is_spotify_multi_account_state(provider_state):
+        default_account = provider_state.get("default_account")
+        accounts = _spotify_accounts(provider_state)
+        print(f"spotify: logged in (multi-account, {len(accounts)} account(s))")
+        if default_account:
+            print(f"  default_account: {default_account}")
+        for acct_id, state in accounts.items():
+            label = state.get("owner_name") or acct_id
+            marker = " *" if acct_id == default_account else ""
+            print(f"  - {acct_id} ({label}){marker}")
+        return
+
+    # Legacy flat state — defer to the generic status formatter.
+    status = get_spotify_auth_status()
+    if not status.get("logged_in"):
+        print("spotify: logged out")
+        return
+    print("spotify: logged in")
+    for key in ("auth_type", "client_id", "redirect_uri", "scope",
+                "expires_at", "api_base_url"):
+        value = status.get(key)
+        if value:
+            print(f"  {key}: {value}")
+
+
+def spotify_list_accounts_command(args) -> None:
+    """`hermes auth spotify list` — show all configured accounts and routes."""
+    _ = args  # parser-required arg unused
+    provider_state = get_provider_auth_state("spotify")
+    if not provider_state:
+        print("spotify: not configured")
+        return
+
+    if not _is_spotify_multi_account_state(provider_state):
+        # Legacy single-account display.
+        print("spotify: legacy single-account mode")
+        owner = provider_state.get("owner_name") or "(unnamed)"
+        scope = str(provider_state.get("granted_scope") or provider_state.get("scope") or "")
+        print(f"  owner: {owner}")
+        if scope:
+            print(f"  scope: {scope}")
+        print("  (run `hermes auth spotify migrate --account <id>` to upgrade)")
+        return
+
+    default_account = provider_state.get("default_account")
+    accounts = _spotify_accounts(provider_state)
+    routing = provider_state.get("routing") or {}
+
+    print(f"Spotify accounts ({len(accounts)} configured):")
+    if not accounts:
+        print("  (none)")
+    for acct_id, state in accounts.items():
+        owner = state.get("owner_name") or "(unnamed)"
+        marker = " * default" if acct_id == default_account else ""
+        print(f"  - {acct_id}: {owner}{marker}")
+        if state.get("owner_platform") and state.get("owner_user_id"):
+            print(f"      owner_route: {state['owner_platform']}:{state['owner_user_id']}")
+
+    if isinstance(routing, dict) and routing:
+        print()
+        print("Routing rules:")
+        for platform, platform_routes in routing.items():
+            if not isinstance(platform_routes, dict):
+                continue
+            for user_id, acct_id in platform_routes.items():
+                marker = "" if acct_id in accounts else "  [BROKEN: account missing]"
+                print(f"  {platform}:{user_id} -> {acct_id}{marker}")
+
+
+def spotify_route_account_command(args) -> None:
+    """`hermes auth spotify route --account <id> --platform <p> --user-id <uid>`.
+
+    Adds/updates a routing rule mapping a platform sender to an account.
+    """
+    account_id = _normalize_spotify_account_id(getattr(args, "account", None))
+    if not account_id:
+        raise SystemExit("--account is required (e.g. --account amy).")
+    user_id = getattr(args, "user_id", None) or getattr(args, "telegram_user_id", None)
+    if not user_id:
+        raise SystemExit("--user-id (or --telegram-user-id shortcut) is required.")
+    platform = str(getattr(args, "platform", None) or "telegram").strip().lower()
+    if not platform:
+        raise SystemExit("--platform must be non-empty.")
+
+    with _auth_store_lock():
+        auth_store = _load_auth_store()
+        provider_state = _load_provider_state(auth_store, "spotify") or {}
+        if not _is_spotify_multi_account_state(provider_state):
+            raise SystemExit(
+                "Spotify is in legacy single-account mode. Run `hermes auth "
+                "spotify migrate --account <id>` first."
+            )
+        accounts = _spotify_accounts(provider_state)
+        if account_id not in accounts:
+            raise SystemExit(f"Spotify account '{account_id}' is not configured.")
+
+        provider_state.setdefault("routing", {}).setdefault(platform, {})[str(user_id)] = account_id
+        _store_provider_state(auth_store, "spotify", provider_state, set_active=False)
+        saved_to = _save_auth_store(auth_store)
+
+    print(f"Routed {platform}:{user_id} -> {account_id}")
+    print(f"  Auth state: {saved_to}")
+
+
+def spotify_set_default_account_command(args) -> None:
+    """`hermes auth spotify set-default --account <id>`."""
+    account_id = _normalize_spotify_account_id(getattr(args, "account", None))
+    if not account_id:
+        raise SystemExit("--account is required (e.g. --account mark).")
+
+    with _auth_store_lock():
+        auth_store = _load_auth_store()
+        provider_state = _load_provider_state(auth_store, "spotify") or {}
+        if not _is_spotify_multi_account_state(provider_state):
+            raise SystemExit(
+                "Spotify is in legacy single-account mode; no default to set. "
+                "Run `hermes auth spotify migrate --account <id>` first."
+            )
+        accounts = _spotify_accounts(provider_state)
+        if account_id not in accounts:
+            raise SystemExit(f"Spotify account '{account_id}' is not configured.")
+
+        provider_state["default_account"] = account_id
+        _store_provider_state(auth_store, "spotify", provider_state, set_active=False)
+        saved_to = _save_auth_store(auth_store)
+
+    print(f"Default Spotify account set to '{account_id}'")
+    print(f"  Auth state: {saved_to}")
+
+
+def spotify_migrate_legacy_command(args) -> None:
+    """`hermes auth spotify migrate --account <id> [...]`.
+
+    Wraps an existing legacy flat providers.spotify state into the v2 shape
+    under accounts[<id>], without re-running the OAuth flow. Idempotent —
+    if state is already v2, this is a no-op for the existing slot but can
+    still add owner metadata and routing if flags are provided.
+    """
+    account_id = _normalize_spotify_account_id(getattr(args, "account", None))
+    if not account_id:
+        raise SystemExit("--account is required (e.g. --account mark).")
+    owner_name = getattr(args, "owner_name", None) or None
+    route_user_id = getattr(args, "user_id", None) or getattr(args, "telegram_user_id", None)
+    route_platform = getattr(args, "platform", None) or ("telegram" if route_user_id else None)
+    set_default_flag = bool(getattr(args, "set_default", False))
+
+    with _auth_store_lock():
+        auth_store = _load_auth_store()
+        provider_state = _load_provider_state(auth_store, "spotify") or {}
+        if not provider_state:
+            raise SystemExit(
+                "Spotify is not authenticated. Run `hermes auth spotify login` first."
+            )
+
+        if _is_spotify_multi_account_state(provider_state):
+            print(f"Spotify is already in multi-account mode.")
+        else:
+            provider_state = _ensure_spotify_multi_account_state(
+                provider_state, legacy_account_id=account_id,
+            )
+            print(f"Migrated legacy single-account state to account '{account_id}'.")
+
+        account_state = provider_state.get("accounts", {}).get(account_id)
+        if account_state is None:
+            raise SystemExit(
+                f"After migration, account '{account_id}' is not present. "
+                "Has the legacy state already been migrated under a different id?"
+            )
+
+        if owner_name:
+            account_state["owner_name"] = owner_name
+        if route_user_id:
+            account_state["owner_platform"] = route_platform
+            account_state["owner_user_id"] = str(route_user_id)
+            provider_state.setdefault("routing", {}).setdefault(
+                str(route_platform).lower(), {}
+            )[str(route_user_id)] = account_id
+
+        if set_default_flag or not provider_state.get("default_account"):
+            provider_state["default_account"] = account_id
+
+        _store_provider_state(auth_store, "spotify", provider_state, set_active=False)
+        saved_to = _save_auth_store(auth_store)
+
+    print(f"  Auth state: {saved_to}")
+    if route_user_id:
+        print(f"  Routing: {route_platform}:{route_user_id} -> {account_id}")
+    if provider_state.get("default_account") == account_id:
+        print(f"  Default account: {account_id}")
+
+
+def spotify_logout_command(args) -> None:
+    """`hermes auth spotify logout [--account <id>]`.
+
+    Without --account: clears all Spotify auth (delegates to clear_provider_auth).
+    With --account: removes just that account + any routing rules pointing at it.
+    If the default account is removed, default falls back to another remaining
+    account, or is cleared.
+    """
+    account_id = _normalize_spotify_account_id(getattr(args, "account", None))
+    if not account_id:
+        # Legacy "logout all" behaviour.
+        from hermes_cli.auth_commands import auth_logout_command
+        from types import SimpleNamespace
+        auth_logout_command(SimpleNamespace(provider="spotify"))
+        return
+
+    with _auth_store_lock():
+        auth_store = _load_auth_store()
+        provider_state = _load_provider_state(auth_store, "spotify") or {}
+        if not _is_spotify_multi_account_state(provider_state):
+            raise SystemExit(
+                "Spotify is in legacy single-account mode; --account is not "
+                "supported. Use plain `hermes auth spotify logout` instead."
+            )
+        accounts = _spotify_accounts(provider_state)
+        if account_id not in accounts:
+            raise SystemExit(f"Spotify account '{account_id}' is not configured.")
+
+        del provider_state["accounts"][account_id]
+
+        # Drop any routing rules pointing at the removed account.
+        routing = provider_state.get("routing")
+        if isinstance(routing, dict):
+            for platform, platform_routes in list(routing.items()):
+                if not isinstance(platform_routes, dict):
+                    continue
+                for user_id, mapped_id in list(platform_routes.items()):
+                    if mapped_id == account_id:
+                        del platform_routes[user_id]
+                if not platform_routes:
+                    del routing[platform]
+
+        # Fix up default_account if we just deleted it.
+        if provider_state.get("default_account") == account_id:
+            remaining = list(provider_state.get("accounts", {}).keys())
+            provider_state["default_account"] = remaining[0] if remaining else None
+
+        _store_provider_state(auth_store, "spotify", provider_state, set_active=False)
+        saved_to = _save_auth_store(auth_store)
+
+    print(f"Removed Spotify account '{account_id}'.")
+    print(f"  Auth state: {saved_to}")
+    if provider_state.get("default_account"):
+        print(f"  New default account: {provider_state['default_account']}")
+    elif not provider_state.get("accounts"):
+        print("  No accounts remain.")
 
 # =============================================================================
 # SSH / remote session detection

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -530,10 +530,27 @@ def auth_spotify_command(args) -> None:
         auth_mod.login_spotify_command(args)
         return
     if action == "status":
-        auth_status_command(SimpleNamespace(provider="spotify"))
+        # Account-aware status. Falls back to generic provider status (no
+        # --account) when no multi-account state is configured, preserving
+        # the legacy single-account UX.
+        auth_mod.spotify_status_command(args)
         return
     if action == "logout":
-        auth_logout_command(SimpleNamespace(provider="spotify"))
+        # Supports `--account <id>` for per-account logout. Without it,
+        # clears all spotify auth (legacy behaviour).
+        auth_mod.spotify_logout_command(args)
+        return
+    if action == "list":
+        auth_mod.spotify_list_accounts_command(args)
+        return
+    if action == "route":
+        auth_mod.spotify_route_account_command(args)
+        return
+    if action == "set-default":
+        auth_mod.spotify_set_default_account_command(args)
+        return
+    if action == "migrate":
+        auth_mod.spotify_migrate_legacy_command(args)
         return
     raise SystemExit(f"Unknown Spotify auth action: {action}")
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10239,8 +10239,17 @@ def main():
     auth_spotify.add_argument(
         "spotify_action",
         nargs="?",
-        choices=["login", "status", "logout"],
+        choices=["login", "status", "logout", "list", "route", "set-default", "migrate"],
         default="login",
+        help=(
+            "login: PKCE flow (use --account to store under a named slot). "
+            "status: show current account or --account <id>. "
+            "logout: clear all spotify auth, or just --account <id>. "
+            "list: list configured accounts and routes. "
+            "route: --account <id> --platform <p> --user-id <uid> sets a routing rule. "
+            "set-default: --account <id> sets providers.spotify.default_account. "
+            "migrate: wrap existing legacy state under --account <id>."
+        ),
     )
     auth_spotify.add_argument(
         "--client-id", help="Spotify app client_id (or set HERMES_SPOTIFY_CLIENT_ID)"
@@ -10257,6 +10266,37 @@ def main():
     )
     auth_spotify.add_argument(
         "--timeout", type=float, help="Callback/token exchange timeout in seconds"
+    )
+    # Multi-account routing flags. All optional; legacy single-account login
+    # ignores these.
+    auth_spotify.add_argument(
+        "--account",
+        help="Named Spotify account id, e.g. 'mark' or 'amy'. Lowercase slug.",
+    )
+    auth_spotify.add_argument(
+        "--owner-name",
+        dest="owner_name",
+        help="Human-readable owner label stored on the account state (e.g. 'Mark').",
+    )
+    auth_spotify.add_argument(
+        "--telegram-user-id",
+        dest="telegram_user_id",
+        help="Shortcut for --platform telegram --user-id <id>.",
+    )
+    auth_spotify.add_argument(
+        "--platform",
+        help="Platform for routing rule (e.g. telegram). Default telegram when --user-id is given.",
+    )
+    auth_spotify.add_argument(
+        "--user-id",
+        dest="user_id",
+        help="Platform user id to route to --account.",
+    )
+    auth_spotify.add_argument(
+        "--set-default",
+        dest="set_default",
+        action="store_true",
+        help="On `login`, set this account as the new default (auto-set when no default exists).",
     )
     auth_parser.set_defaults(func=cmd_auth)
 

--- a/tests/hermes_cli/test_spotify_multi_account_auth.py
+++ b/tests/hermes_cli/test_spotify_multi_account_auth.py
@@ -1,0 +1,681 @@
+"""Tests for Spotify multi-account auth resolution.
+
+Covers the v2 ``providers.spotify`` shape with named ``accounts`` and
+``routing.telegram[user_id] -> account_id`` lookups, alongside the legacy
+flat-state compatibility path.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict
+
+import pytest
+
+from hermes_cli import auth as auth_mod
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _spotify_state(access_token: str, *, expires_at: str = "2099-01-01T00:00:00+00:00") -> Dict[str, Any]:
+    """Stub Spotify per-account token bundle used in tests."""
+    return {
+        "auth_type": "oauth_pkce",
+        "client_id": "spotify-client",
+        "redirect_uri": "http://127.0.0.1:43827/spotify/callback",
+        "api_base_url": auth_mod.DEFAULT_SPOTIFY_API_BASE_URL,
+        "accounts_base_url": auth_mod.DEFAULT_SPOTIFY_ACCOUNTS_BASE_URL,
+        "scope": auth_mod.DEFAULT_SPOTIFY_SCOPE,
+        "access_token": access_token,
+        "refresh_token": f"{access_token}-refresh",
+        "token_type": "Bearer",
+        "expires_at": expires_at,
+    }
+
+
+def _write_spotify_provider(tmp_path, provider_state: Dict[str, Any]) -> None:
+    """Persist a providers.spotify state into the HERMES_HOME-rooted auth store.
+
+    Caller must have set ``HERMES_HOME`` via monkeypatch first.
+    """
+    with auth_mod._auth_store_lock():
+        store = auth_mod._load_auth_store()
+        store["active_provider"] = "nous"
+        auth_mod._store_provider_state(store, "spotify", provider_state, set_active=False)
+        auth_mod._save_auth_store(store)
+
+
+# ---------------------------------------------------------------------------
+# Pure helper tests
+# ---------------------------------------------------------------------------
+
+class TestNormalizeAccountId:
+    def test_accepts_simple_slugs(self) -> None:
+        assert auth_mod._normalize_spotify_account_id("mark") == "mark"
+        assert auth_mod._normalize_spotify_account_id("amy") == "amy"
+        assert auth_mod._normalize_spotify_account_id("user_1") == "user_1"
+        assert auth_mod._normalize_spotify_account_id("user-1") == "user-1"
+
+    def test_lowercases(self) -> None:
+        assert auth_mod._normalize_spotify_account_id("MARK") == "mark"
+        assert auth_mod._normalize_spotify_account_id("  Amy  ") == "amy"
+
+    def test_blank_returns_none(self) -> None:
+        assert auth_mod._normalize_spotify_account_id(None) is None
+        assert auth_mod._normalize_spotify_account_id("") is None
+        assert auth_mod._normalize_spotify_account_id("   ") is None
+
+    def test_rejects_invalid_chars(self) -> None:
+        for bad in ("mark!", "mark.amy", "mark amy", "mark/amy", "-mark", "_mark"):
+            with pytest.raises(auth_mod.AuthError) as exc:
+                auth_mod._normalize_spotify_account_id(bad)
+            assert exc.value.code == "spotify_account_id_invalid"
+
+
+class TestShapeDetection:
+    def test_legacy_state_is_not_multi_account(self) -> None:
+        assert not auth_mod._is_spotify_multi_account_state({"access_token": "abc"})
+        assert not auth_mod._is_spotify_multi_account_state({})
+        assert not auth_mod._is_spotify_multi_account_state(None)
+
+    def test_v2_state_with_accounts_is_multi_account(self) -> None:
+        assert auth_mod._is_spotify_multi_account_state(
+            {"schema_version": 2, "accounts": {"mark": {}}}
+        )
+
+    def test_legacy_state_round_trip(self) -> None:
+        state = {"access_token": "abc", "refresh_token": "def"}
+        wrapped = auth_mod._spotify_legacy_state_as_account(state)
+        assert wrapped == state
+        # Make sure it's a copy, not the same object.
+        assert wrapped is not state
+
+    def test_legacy_state_without_tokens_returns_none(self) -> None:
+        assert auth_mod._spotify_legacy_state_as_account({"client_id": "x"}) is None
+        assert auth_mod._spotify_legacy_state_as_account({}) is None
+
+
+class TestEnsureMultiAccountState:
+    def test_idempotent_on_v2_state(self) -> None:
+        original = {"schema_version": 2, "accounts": {"mark": {"access_token": "x"}}}
+        result = auth_mod._ensure_spotify_multi_account_state(original)
+        assert result["schema_version"] == 2
+        assert result["accounts"]["mark"]["access_token"] == "x"
+        assert "routing" in result
+
+    def test_converts_legacy_to_v2(self) -> None:
+        legacy = {"access_token": "legacy-access", "refresh_token": "legacy-refresh"}
+        result = auth_mod._ensure_spotify_multi_account_state(legacy, legacy_account_id="mark")
+        assert result["schema_version"] == 2
+        assert result["default_account"] == "mark"
+        assert result["accounts"]["mark"]["access_token"] == "legacy-access"
+        assert result["routing"] == {}
+
+
+# ---------------------------------------------------------------------------
+# Resolver tests
+# ---------------------------------------------------------------------------
+
+class TestResolveSpotifyRuntimeCredentials:
+    """Behavioural tests for ``resolve_spotify_runtime_credentials``.
+
+    Each test sets HERMES_HOME to a tmp dir, writes a providers.spotify state
+    into the auth store, then asserts the resolver picks the right account.
+    """
+
+    def test_legacy_single_account_resolves(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_spotify_provider(tmp_path, _spotify_state("legacy-access"))
+
+        runtime = auth_mod.resolve_spotify_runtime_credentials(refresh_if_expiring=False)
+
+        assert runtime["access_token"] == "legacy-access"
+        assert runtime["account_id"] is None
+        assert runtime["account_source"] == "legacy"
+
+    def test_explicit_account_selection(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_spotify_provider(tmp_path, {
+            "schema_version": 2,
+            "default_account": "mark",
+            "accounts": {
+                "mark": _spotify_state("mark-access"),
+                "amy": _spotify_state("amy-access"),
+            },
+            "routing": {},
+        })
+
+        runtime = auth_mod.resolve_spotify_runtime_credentials(
+            account_id="amy", refresh_if_expiring=False,
+        )
+
+        assert runtime["access_token"] == "amy-access"
+        assert runtime["account_id"] == "amy"
+        assert runtime["account_source"] == "explicit"
+
+    def test_uses_default_account_when_no_routing(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_spotify_provider(tmp_path, {
+            "schema_version": 2,
+            "default_account": "mark",
+            "accounts": {
+                "mark": _spotify_state("mark-access"),
+                "amy": _spotify_state("amy-access"),
+            },
+            "routing": {},
+        })
+
+        runtime = auth_mod.resolve_spotify_runtime_credentials(refresh_if_expiring=False)
+
+        assert runtime["access_token"] == "mark-access"
+        assert runtime["account_id"] == "mark"
+        assert runtime["account_source"] == "default"
+
+    def test_routes_by_telegram_user_id(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The whole point of multi-account: Amy's Telegram messages -> Amy's Spotify."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_spotify_provider(tmp_path, {
+            "schema_version": 2,
+            "default_account": "mark",
+            "accounts": {
+                "mark": _spotify_state("mark-access"),
+                "amy": _spotify_state("amy-access"),
+            },
+            "routing": {
+                "telegram": {
+                    "8610423590": "mark",
+                    "8634968316": "amy",
+                },
+            },
+        })
+
+        amy = auth_mod.resolve_spotify_runtime_credentials(
+            platform="telegram", user_id="8634968316", refresh_if_expiring=False,
+        )
+        assert amy["access_token"] == "amy-access"
+        assert amy["account_id"] == "amy"
+        assert amy["account_source"] == "source"
+
+        mark = auth_mod.resolve_spotify_runtime_credentials(
+            platform="telegram", user_id="8610423590", refresh_if_expiring=False,
+        )
+        assert mark["access_token"] == "mark-access"
+        assert mark["account_id"] == "mark"
+        assert mark["account_source"] == "source"
+
+    def test_session_contextvars_route_when_kwargs_unset(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When platform/user_id aren't passed explicitly, the resolver falls
+        back to the gateway's per-task ContextVars (HERMES_SESSION_PLATFORM
+        / HERMES_SESSION_USER_ID). This is the path that lets gateway-origin
+        Spotify tool calls auto-route without touching model_tools/run_agent.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # get_session_env falls back to os.environ when the ContextVar was
+        # never set in this task (which is the case for synchronous tests).
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+        monkeypatch.setenv("HERMES_SESSION_USER_ID", "8634968316")
+        _write_spotify_provider(tmp_path, {
+            "schema_version": 2,
+            "default_account": "mark",
+            "accounts": {
+                "mark": _spotify_state("mark-access"),
+                "amy": _spotify_state("amy-access"),
+            },
+            "routing": {
+                "telegram": {
+                    "8610423590": "mark",
+                    "8634968316": "amy",
+                },
+            },
+        })
+
+        runtime = auth_mod.resolve_spotify_runtime_credentials(refresh_if_expiring=False)
+
+        assert runtime["access_token"] == "amy-access"
+        assert runtime["account_id"] == "amy"
+        assert runtime["account_source"] == "source"
+
+    def test_explicit_kwargs_override_contextvars(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Explicit platform/user_id kwargs beat the ContextVar fallback."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+        monkeypatch.setenv("HERMES_SESSION_USER_ID", "8634968316")  # Amy in env
+        _write_spotify_provider(tmp_path, {
+            "schema_version": 2,
+            "default_account": "mark",
+            "accounts": {
+                "mark": _spotify_state("mark-access"),
+                "amy": _spotify_state("amy-access"),
+            },
+            "routing": {
+                "telegram": {
+                    "8610423590": "mark",
+                    "8634968316": "amy",
+                },
+            },
+        })
+
+        # Even though env says Amy, explicit kwargs say Mark.
+        runtime = auth_mod.resolve_spotify_runtime_credentials(
+            platform="telegram",
+            user_id="8610423590",
+            refresh_if_expiring=False,
+        )
+
+        assert runtime["access_token"] == "mark-access"
+        assert runtime["account_id"] == "mark"
+
+    def test_env_override_beats_default(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_SPOTIFY_ACCOUNT", "amy")
+        _write_spotify_provider(tmp_path, {
+            "schema_version": 2,
+            "default_account": "mark",
+            "accounts": {
+                "mark": _spotify_state("mark-access"),
+                "amy": _spotify_state("amy-access"),
+            },
+            "routing": {},
+        })
+
+        runtime = auth_mod.resolve_spotify_runtime_credentials(refresh_if_expiring=False)
+
+        assert runtime["account_id"] == "amy"
+        assert runtime["access_token"] == "amy-access"
+
+    def test_refresh_updates_only_selected_account(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A refresh of Amy's token must not touch Mark's stored state."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_spotify_provider(tmp_path, {
+            "schema_version": 2,
+            "default_account": "mark",
+            "accounts": {
+                "mark": _spotify_state("mark-old", expires_at="2000-01-01T00:00:00+00:00"),
+                "amy": _spotify_state("amy-old", expires_at="2000-01-01T00:00:00+00:00"),
+            },
+            "routing": {},
+        })
+        monkeypatch.setattr(
+            auth_mod,
+            "_refresh_spotify_oauth_state",
+            lambda state, timeout_seconds=20.0: {
+                **state,
+                "access_token": f"{state['access_token']}-refreshed",
+                "expires_at": "2099-01-01T00:00:00+00:00",
+            },
+        )
+
+        runtime = auth_mod.resolve_spotify_runtime_credentials(account_id="amy")
+
+        assert runtime["access_token"] == "amy-old-refreshed"
+        persisted = auth_mod.get_provider_auth_state("spotify")
+        assert persisted["accounts"]["amy"]["access_token"] == "amy-old-refreshed"
+        # Mark's state must be untouched.
+        assert persisted["accounts"]["mark"]["access_token"] == "mark-old"
+
+    def test_unknown_explicit_account_raises(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_spotify_provider(tmp_path, {
+            "schema_version": 2,
+            "default_account": "mark",
+            "accounts": {"mark": _spotify_state("mark-access")},
+            "routing": {},
+        })
+
+        with pytest.raises(auth_mod.AuthError) as exc:
+            auth_mod.resolve_spotify_runtime_credentials(account_id="ghost")
+        assert exc.value.code == "spotify_account_missing"
+
+    def test_route_to_missing_account_raises(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A routing rule pointing at an account that no longer exists is loud, not silent."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_spotify_provider(tmp_path, {
+            "schema_version": 2,
+            "default_account": "mark",
+            "accounts": {"mark": _spotify_state("mark-access")},
+            "routing": {"telegram": {"8634968316": "amy"}},  # amy doesn't exist
+        })
+
+        with pytest.raises(auth_mod.AuthError) as exc:
+            auth_mod.resolve_spotify_runtime_credentials(
+                platform="telegram", user_id="8634968316",
+            )
+        assert exc.value.code == "spotify_route_account_missing"
+
+    def test_ambiguous_state_no_default_raises(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Multi-account state with no default + no routing + no explicit pick = error."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_spotify_provider(tmp_path, {
+            "schema_version": 2,
+            "default_account": None,
+            "accounts": {
+                "mark": _spotify_state("mark-access"),
+                "amy": _spotify_state("amy-access"),
+            },
+            "routing": {},
+        })
+
+        with pytest.raises(auth_mod.AuthError) as exc:
+            auth_mod.resolve_spotify_runtime_credentials(refresh_if_expiring=False)
+        assert exc.value.code == "spotify_account_ambiguous"
+
+    def test_legacy_with_explicit_account_raises(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Asking for `--account` on legacy auth requires migrating first."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_spotify_provider(tmp_path, _spotify_state("legacy-access"))
+
+        with pytest.raises(auth_mod.AuthError) as exc:
+            auth_mod.resolve_spotify_runtime_credentials(account_id="mark")
+        assert exc.value.code == "spotify_legacy_no_named_account"
+
+
+# ---------------------------------------------------------------------------
+# CLI subcommand tests (storage logic only; no network)
+# ---------------------------------------------------------------------------
+
+class TestSpotifyMigrateLegacy:
+    def test_migrate_wraps_legacy_under_named_account(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_spotify_provider(tmp_path, _spotify_state("legacy-access"))
+
+        auth_mod.spotify_migrate_legacy_command(SimpleNamespace(
+            account="mark",
+            owner_name="Mark",
+            telegram_user_id="8610423590",
+            user_id=None,
+            platform=None,
+            set_default=True,
+        ))
+
+        persisted = auth_mod.get_provider_auth_state("spotify")
+        assert persisted is not None
+        assert auth_mod._is_spotify_multi_account_state(persisted)
+        assert persisted["default_account"] == "mark"
+        assert persisted["accounts"]["mark"]["access_token"] == "legacy-access"
+        assert persisted["accounts"]["mark"]["owner_name"] == "Mark"
+        assert persisted["routing"]["telegram"]["8610423590"] == "mark"
+
+        out = capsys.readouterr().out
+        assert "Migrated legacy single-account state to account 'mark'" in out
+
+    def test_migrate_requires_existing_state(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        with pytest.raises(SystemExit) as exc:
+            auth_mod.spotify_migrate_legacy_command(SimpleNamespace(
+                account="mark", owner_name=None, telegram_user_id=None,
+                user_id=None, platform=None, set_default=False,
+            ))
+        assert "not authenticated" in str(exc.value)
+
+    def test_migrate_idempotent_on_v2(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_spotify_provider(tmp_path, {
+            "schema_version": 2,
+            "default_account": "mark",
+            "accounts": {"mark": _spotify_state("mark-access")},
+            "routing": {},
+        })
+
+        auth_mod.spotify_migrate_legacy_command(SimpleNamespace(
+            account="mark", owner_name="Mark Baker",
+            telegram_user_id="8610423590", user_id=None, platform=None,
+            set_default=False,
+        ))
+
+        out = capsys.readouterr().out
+        assert "already in multi-account mode" in out
+        persisted = auth_mod.get_provider_auth_state("spotify")
+        # Owner metadata and routing got layered on top.
+        assert persisted["accounts"]["mark"]["owner_name"] == "Mark Baker"
+        assert persisted["routing"]["telegram"]["8610423590"] == "mark"
+
+
+class TestSpotifyRouteCommand:
+    def test_route_adds_telegram_rule(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_spotify_provider(tmp_path, {
+            "schema_version": 2,
+            "default_account": "mark",
+            "accounts": {
+                "mark": _spotify_state("mark-access"),
+                "amy": _spotify_state("amy-access"),
+            },
+            "routing": {},
+        })
+
+        auth_mod.spotify_route_account_command(SimpleNamespace(
+            account="amy", platform="telegram",
+            user_id="8634968316", telegram_user_id=None,
+        ))
+
+        persisted = auth_mod.get_provider_auth_state("spotify")
+        assert persisted["routing"]["telegram"]["8634968316"] == "amy"
+
+    def test_route_rejects_missing_account(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_spotify_provider(tmp_path, {
+            "schema_version": 2,
+            "default_account": "mark",
+            "accounts": {"mark": _spotify_state("mark-access")},
+            "routing": {},
+        })
+
+        with pytest.raises(SystemExit) as exc:
+            auth_mod.spotify_route_account_command(SimpleNamespace(
+                account="amy", platform="telegram",
+                user_id="8634968316", telegram_user_id=None,
+            ))
+        assert "'amy' is not configured" in str(exc.value)
+
+
+class TestSpotifySetDefault:
+    def test_set_default_changes_active_default(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_spotify_provider(tmp_path, {
+            "schema_version": 2,
+            "default_account": "mark",
+            "accounts": {
+                "mark": _spotify_state("mark-access"),
+                "amy": _spotify_state("amy-access"),
+            },
+            "routing": {},
+        })
+
+        auth_mod.spotify_set_default_account_command(SimpleNamespace(account="amy"))
+
+        persisted = auth_mod.get_provider_auth_state("spotify")
+        assert persisted["default_account"] == "amy"
+
+
+class TestSpotifyListAccounts:
+    def test_list_shows_accounts_and_routes(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_spotify_provider(tmp_path, {
+            "schema_version": 2,
+            "default_account": "mark",
+            "accounts": {
+                "mark": {**_spotify_state("mark-access"), "owner_name": "Mark"},
+                "amy": {**_spotify_state("amy-access"), "owner_name": "Amy"},
+            },
+            "routing": {
+                "telegram": {
+                    "8610423590": "mark",
+                    "8634968316": "amy",
+                },
+            },
+        })
+
+        auth_mod.spotify_list_accounts_command(SimpleNamespace())
+
+        out = capsys.readouterr().out
+        assert "Spotify accounts (2 configured)" in out
+        assert "mark: Mark * default" in out
+        assert "amy: Amy" in out
+        assert "telegram:8634968316 -> amy" in out
+        # No bare token leakage in human output.
+        assert "amy-access" not in out
+        assert "mark-access" not in out
+
+    def test_list_flags_broken_route(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_spotify_provider(tmp_path, {
+            "schema_version": 2,
+            "default_account": "mark",
+            "accounts": {"mark": _spotify_state("mark-access")},
+            "routing": {"telegram": {"8634968316": "amy"}},  # amy doesn't exist
+        })
+
+        auth_mod.spotify_list_accounts_command(SimpleNamespace())
+
+        out = capsys.readouterr().out
+        assert "BROKEN" in out
+
+
+class TestSpotifyLogoutPerAccount:
+    def test_logout_account_removes_account_and_routes(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_spotify_provider(tmp_path, {
+            "schema_version": 2,
+            "default_account": "amy",
+            "accounts": {
+                "mark": _spotify_state("mark-access"),
+                "amy": _spotify_state("amy-access"),
+            },
+            "routing": {
+                "telegram": {
+                    "8610423590": "mark",
+                    "8634968316": "amy",
+                },
+            },
+        })
+
+        auth_mod.spotify_logout_command(SimpleNamespace(account="amy"))
+
+        persisted = auth_mod.get_provider_auth_state("spotify")
+        assert "amy" not in persisted["accounts"]
+        assert "mark" in persisted["accounts"]
+        # Default falls back to the remaining account.
+        assert persisted["default_account"] == "mark"
+        # Routing rule pointing at amy is gone.
+        assert "8634968316" not in persisted["routing"].get("telegram", {})
+        # Mark's routing untouched.
+        assert persisted["routing"]["telegram"]["8610423590"] == "mark"
+
+    def test_logout_last_account_clears_default(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_spotify_provider(tmp_path, {
+            "schema_version": 2,
+            "default_account": "mark",
+            "accounts": {"mark": _spotify_state("mark-access")},
+            "routing": {},
+        })
+
+        auth_mod.spotify_logout_command(SimpleNamespace(account="mark"))
+
+        persisted = auth_mod.get_provider_auth_state("spotify")
+        assert persisted["accounts"] == {}
+        assert persisted.get("default_account") is None
+
+    def test_logout_rejects_account_in_legacy_mode(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_spotify_provider(tmp_path, _spotify_state("legacy-access"))
+
+        with pytest.raises(SystemExit) as exc:
+            auth_mod.spotify_logout_command(SimpleNamespace(account="mark"))
+        assert "legacy single-account mode" in str(exc.value)
+
+
+class TestSpotifyStatusAccountFilter:
+    def test_status_with_account_shows_just_that_account(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_spotify_provider(tmp_path, {
+            "schema_version": 2,
+            "default_account": "mark",
+            "accounts": {
+                "mark": {**_spotify_state("mark-access"), "owner_name": "Mark"},
+                "amy": {**_spotify_state("amy-access"), "owner_name": "Amy"},
+            },
+            "routing": {},
+        })
+
+        auth_mod.spotify_status_command(SimpleNamespace(account="amy"))
+
+        out = capsys.readouterr().out
+        assert "spotify[amy]: logged in" in out
+        assert "owner_name: Amy" in out
+        # No token leakage.
+        assert "amy-access" not in out
+        # Mark's owner_name should NOT appear when filtering by Amy.
+        assert "Mark" not in out
+
+    def test_status_without_account_shows_summary(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_spotify_provider(tmp_path, {
+            "schema_version": 2,
+            "default_account": "mark",
+            "accounts": {
+                "mark": _spotify_state("mark-access"),
+                "amy": _spotify_state("amy-access"),
+            },
+            "routing": {},
+        })
+
+        auth_mod.spotify_status_command(SimpleNamespace(account=None))
+
+        out = capsys.readouterr().out
+        assert "multi-account" in out
+        assert "default_account: mark" in out
+        assert "- mark" in out
+        assert "- amy" in out


### PR DESCRIPTION
## Summary

Adds first-class multi-account support to the Spotify auth provider so a single Hermes instance can serve multiple human senders (Mark, Amy), each backed by their own Spotify OAuth bundle. Gateway-origin tool calls auto-route by sender; CLI/cron-origin calls fall back to a configurable default.

## Auth shape

Legacy `providers.spotify = {access_token, refresh_token, ...}` continues to work unchanged. New v2 shape:

```json
{
  "providers": {
    "spotify": {
      "schema_version": 2,
      "default_account": "mark",
      "accounts": {
        "mark": { "...token state..." },
        "amy":  { "...token state..." }
      },
      "routing": {
        "telegram": {
          "<user_id>": "<account_id>"
        }
      }
    }
  }
}
```

## Account selection priority

In `resolve_spotify_runtime_credentials`:

1. Explicit `account_id` kwarg.
2. Source-derived: `routing[platform][user_id]`. ``(platform, user_id)`` come from explicit kwargs OR fall back to `gateway.session_context.get_session_env("HERMES_SESSION_PLATFORM" / "HERMES_SESSION_USER_ID")`. The ContextVar fallback is what lets gateway-origin tool calls auto-route by sender **without any wiring in `model_tools` / `run_agent`** — the gateway already sets these per task via `gateway.run.set_session_vars`. Big simplification vs the original plan.
3. `HERMES_SPOTIFY_ACCOUNT` env override.
4. `providers.spotify.default_account`.
5. Single configured account (degenerate v2 with one entry).
6. Legacy flat state.

Token refresh writes back to the right slot only — refreshing Amy never touches Mark.

## CLI surface

```bash
hermes auth spotify login    [--account <id> --owner-name <name>
                              --telegram-user-id <uid> --set-default]
hermes auth spotify status   [--account <id>]
hermes auth spotify logout   [--account <id>]
hermes auth spotify list
hermes auth spotify route    --account <id> --platform <p> --user-id <uid>
hermes auth spotify set-default --account <id>
hermes auth spotify migrate  --account <id> [...]
```

Bare ``login`` against v2 state refuses to overwrite instead of silently flattening multi-account state back to a single bundle.

## Test plan

- [x] 35 new tests in ``tests/hermes_cli/test_spotify_multi_account_auth.py`` covering helpers, resolution priority, ContextVar routing, refresh isolation, error cases, and every new CLI subcommand.
- [x] All 6 existing ``tests/hermes_cli/test_spotify_auth.py`` tests still pass (legacy resolver path preserved).
- [x] Static parse: ``hermes_cli/auth.py``, ``hermes_cli/auth_commands.py``, ``hermes_cli/main.py`` all parse clean.

Deferred to deploy:
- [ ] Manual VPS smoke: rebuild image from this tag, deploy, migrate Mark, login Amy, verify Telegram routing.

## Note on upstream contribution

This fork is currently personal-use (gates on the household's Telegram sender IDs being meaningful). The auth-shape extension and ContextVar-based routing are generic enough to upstream eventually, but the plugin-side wiring (in the deploy-mechanics repo) is household-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)