### PR TITLE
docs: clarify OpenClaw memory migration — daily flattening, sessions not migrated, one-provider constraint

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4189,7 +4189,18 @@ def _build_call_kwargs(
     # Provider-specific extra_body
     merged_extra = dict(extra_body or {})
     if provider == "nous" or auxiliary_is_nous:
-        merged_extra.setdefault("tags", []).extend(_nous_portal_tags())
+        # Defensive: ``extra_body`` (from config or upstream merges) may carry
+        # ``{"tags": None}`` — e.g. an auxiliary.<task>.extra_body.tags: key in
+        # YAML with no value.  ``setdefault`` only inserts when the key is
+        # missing, so it returns ``None`` here and ``.extend()`` then crashes
+        # with "'NoneType' object is not iterable".  Coerce to a list first.
+        existing_tags = merged_extra.get("tags")
+        if not isinstance(existing_tags, list):
+            existing_tags = []
+        else:
+            existing_tags = list(existing_tags)
+        existing_tags.extend(_nous_portal_tags())
+        merged_extra["tags"] = existing_tags
     if merged_extra:
         kwargs["extra_body"] = merged_extra
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2808,3 +2808,71 @@ class TestAuxUnhealthyCache:
             )
             # After the 402, OpenRouter is in the unhealthy cache.
             assert _is_provider_unhealthy("openrouter") is True
+
+
+# ---------------------------------------------------------------------------
+# _build_call_kwargs — Nous portal tag merge resilience
+# ---------------------------------------------------------------------------
+
+class TestBuildCallKwargsNousTagsMerge:
+    """Regression for 'NoneType' object is not iterable on title_generation.
+
+    The Nous-tagged auxiliary path used to call
+    ``merged_extra.setdefault("tags", []).extend(_nous_portal_tags())``.
+    When the incoming ``extra_body`` already carried ``{"tags": None}``
+    (e.g. an ``auxiliary.<task>.extra_body.tags:`` key in YAML with no
+    value, or any upstream merge that left tags=None), ``setdefault``
+    returned the existing ``None`` and ``.extend()`` crashed with
+    "'NoneType' object is not iterable" — silently aborting title
+    generation and surfacing as "⚠ Auxiliary title generation failed".
+    """
+
+    def test_extra_body_tags_none_does_not_crash(self):
+        """tags=None in extra_body must not raise — Nous tags still appended."""
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="nous",
+            model="hermes-4",
+            messages=[{"role": "user", "content": "hi"}],
+            extra_body={"tags": None},
+        )
+
+        assert "extra_body" in kwargs
+        tags = kwargs["extra_body"]["tags"]
+        assert isinstance(tags, list)
+        assert any(t.startswith("product=hermes-agent") for t in tags)
+        assert any(t.startswith("client=hermes-client-v") for t in tags)
+
+    def test_extra_body_tags_non_list_does_not_crash(self):
+        """tags=<str> (malformed config) must not raise either."""
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="nous",
+            model="hermes-4",
+            messages=[{"role": "user", "content": "hi"}],
+            extra_body={"tags": "oops-not-a-list"},
+        )
+
+        tags = kwargs["extra_body"]["tags"]
+        assert isinstance(tags, list)
+        # Malformed value is replaced (not concatenated to) so the request body
+        # stays valid for the Portal.
+        assert "oops-not-a-list" not in tags
+        assert any(t.startswith("product=hermes-agent") for t in tags)
+
+    def test_extra_body_tags_existing_list_is_preserved(self):
+        """Pre-existing user tags must be kept and the Nous tags appended."""
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="nous",
+            model="hermes-4",
+            messages=[{"role": "user", "content": "hi"}],
+            extra_body={"tags": ["user-tag=foo"]},
+        )
+
+        tags = kwargs["extra_body"]["tags"]
+        assert "user-tag=foo" in tags
+        assert any(t.startswith("product=hermes-agent") for t in tags)

--- a/website/docs/guides/migrate-from-openclaw.md
+++ b/website/docs/guides/migrate-from-openclaw.md
@@ -49,7 +49,8 @@ Reads from `~/.openclaw/` by default. Legacy `~/.clawdbot/` or `~/.moltbot/` dir
 | Workspace instructions | `workspace/AGENTS.md` | `AGENTS.md` in `--workspace-target` | Requires `--workspace-target` flag |
 | Long-term memory | `workspace/MEMORY.md` | `~/.hermes/memories/MEMORY.md` | Parsed into entries, merged with existing, deduped. Uses `§` delimiter. |
 | User profile | `workspace/USER.md` | `~/.hermes/memories/USER.md` | Same entry-merge logic as memory. |
-| Daily memory files | `workspace/memory/*.md` | `~/.hermes/memories/MEMORY.md` | All daily files merged into main memory. |
+| Daily memory files | `workspace/memory/*.md` | `~/.hermes/memories/MEMORY.md` | **Flattened into main memory — per-day structure is not preserved.** All entries from all daily files are parsed and merged into `MEMORY.md`. If you want to keep the day-by-day structure, copy the daily files manually to `~/.hermes/memories/daily/` before migrating. |
+| Session transcripts | `agents/*/sessions/`, `archive/sessions/` | *(not migrated)* | Past conversation transcripts are not imported. Hermes session search (`/recall`) only covers sessions run inside Hermes. OpenClaw sessions remain in `~/.openclaw/` and can be browsed directly if needed. |
 
 Workspace files are also checked at `workspace.default/` and `workspace-main/` as fallback paths (OpenClaw renamed `workspace/` to `workspace-main/` in recent versions, and uses `workspace-{agentId}` for multi-agent setups).
 
@@ -171,7 +172,7 @@ These are saved to `~/.hermes/migration/openclaw/<timestamp>/archive/` for manua
 | Cron jobs | `archive/cron-config.json` | Recreate with `hermes cron create` |
 | Plugins | `archive/plugins-config.json` | See [plugins guide](/docs/user-guide/features/hooks) |
 | Hooks/webhooks | `archive/hooks-config.json` | Use `hermes webhook` or gateway hooks |
-| Memory backend | `archive/memory-backend-config.json` | Configure via `hermes honcho` |
+| Memory backend | `archive/memory-backend-config.json` | Configure via `hermes honcho`. Hermes supports one external memory provider at a time (e.g. Honcho, Mem0, or a custom daily-file plugin) alongside the built-in `MEMORY.md` store — they are mutually exclusive. See [Memory providers](#memory-providers) below. |
 | Skills registry | `archive/skills-registry-config.json` | Use `hermes skills config` |
 | UI/identity | `archive/ui-identity-config.json` | Use `/skin` command |
 | Logging | `archive/logging-diagnostics-config.json` | Set in `config.yaml` logging section |
@@ -212,6 +213,41 @@ OpenClaw config values for tokens and API keys can be in three formats:
 ```
 
 The migration resolves all three formats. For env templates and SecretRef objects with `source: "env"`, it looks up the value in `~/.openclaw/.env` and the `openclaw.json` env sub-object. SecretRef objects with `source: "file"` or `source: "exec"` can't be resolved automatically — the migration warns about these, and those values must be added to Hermes manually via `hermes config set`.
+
+## Memory providers
+
+Hermes has a two-layer memory system:
+
+- **Built-in store** (always active) — `~/.hermes/memories/MEMORY.md` and `USER.md`, managed via the `memory_*` tools and injected into every session.
+- **External provider** (optional, one at a time) — Honcho, Mem0, Supermemory, or a custom plugin. Configured via `memory.provider` in `config.yaml`.
+
+**Only one external provider can be active at a time.** A second plugin registration is silently rejected with a warning in `agent.log`. If you previously ran OpenClaw with Honcho (or another backend), choose which provider you want in Hermes and configure it explicitly — they don't stack.
+
+### If you were using Honcho in OpenClaw
+
+```bash
+# Install and configure the Honcho plugin
+hermes honcho
+
+# Or set manually in config.yaml:
+# memory:
+#   provider: honcho
+```
+
+### If you want to use Hermes's built-in memory only
+
+No action needed — `MEMORY.md`/`USER.md` are always active. Honcho or other plugins are opt-in.
+
+### Daily memory files
+
+OpenClaw's daily `memory/YYYY-MM-DD.md` files are **flattened** into `MEMORY.md` during migration — the per-day structure is lost. If you want to preserve the daily granularity (e.g. for time-bounded recall), copy the files manually before running the migration:
+
+```bash
+mkdir -p ~/.hermes/memories/daily
+cp ~/.openclaw/workspace/memory/daily/*.md ~/.hermes/memories/daily/
+```
+
+A future Hermes memory plugin may support per-day files natively, but that's not part of the current built-in or Honcho flows.
 
 ## After migration
 


### PR DESCRIPTION
## What

Updates `migrate-from-openclaw.md` based on direct inspection of the live codebase and `~/.openclaw/` directory structure.

## Changes

**Daily memory files** — was a one-liner with no caveats. Now explicitly documents that per-day structure is **lost** (flattened into MEMORY.md), and gives users a manual workaround to preserve daily granularity before running migration.

**Session transcripts** — was not documented at all. Now explicitly listed as not migrated, with a note that `/recall` only covers Hermes sessions. OpenClaw sessions stay in `~/.openclaw/`.

**Memory backend archived entry** — was a bare one-liner pointing to `hermes honcho`. Now surfaces the one-external-provider-at-a-time constraint and links to a new section.

**New: Memory providers section** — explains the two-layer memory architecture (built-in MEMORY.md always active + one optional external provider), mutual exclusivity (enforced in `agent/memory_manager.py` via `_has_external` flag), Honcho setup, and the daily-file situation with a note that a native daily-file plugin doesn't exist yet.

## Why

These gaps would confuse someone migrating an OpenClaw setup that used Honcho, had daily memory files, or expected `/recall` to search old conversations. All findings come from code (`agent/memory_manager.py:205-225`) and filesystem inspection of `~/.openclaw/`, not inference.