### PR TITLE
/api/tools/toolsets honors ?profile= for cross-profile config (depends-on #23742)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3021,7 +3021,18 @@ class APIServerAdapter(BasePlatformAdapter):
             return _api_json_error(str(exc), status=500)
 
     async def _handle_list_toolsets(self, request: "web.Request") -> "web.Response":
-        """GET /api/tools/toolsets — list configurable toolsets."""
+        """GET /api/tools/toolsets — list configurable toolsets.
+
+        Scoping (per plan v11):
+        - ``?platform=<key>`` (default ``api_server``) selects which
+          platform's toolset config to inspect.
+        - ``?profile=<name>`` (optional) selects WHICH profile's
+          ``config.yaml`` is read. Omitted → falls through to
+          ``get_hermes_home()`` exactly as before (back-compat).
+          Named → reads ``<profile_dir>/config.yaml`` via
+          ``load_config(profile_dir)``. Invalid name → 400 via
+          ``_resolve_profile_dir`` raising ValueError.
+        """
         auth_err = self._check_auth(request)
         if auth_err:
             return auth_err
@@ -3036,7 +3047,16 @@ class APIServerAdapter(BasePlatformAdapter):
             )
             from toolsets import resolve_toolset
 
-            config = load_config()
+            # Profile resolution: None means "default process scope"
+            # so we keep load_config() back-compat. Named profile →
+            # pass profile_dir through.
+            profile_query = request.query.get("profile")
+            profile_dir = (
+                _resolve_profile_dir(profile_query)
+                if profile_query
+                else None
+            )
+            config = load_config(profile_dir)
             enabled = _get_platform_tools(config, platform, include_default_mcp_servers=False)
             toolsets = []
             for key, label, description in _get_effective_configurable_toolsets():
@@ -3057,13 +3077,24 @@ class APIServerAdapter(BasePlatformAdapter):
                         "tools": tools,
                     }
                 )
-            return web.json_response({"toolsets": toolsets, "platform": platform})
+            return web.json_response({
+                "toolsets": toolsets,
+                "platform": platform,
+                "profile": profile_query or None,
+            })
+        except (ValueError, FileNotFoundError) as exc:
+            return _api_json_error(str(exc), status=400)
         except Exception as exc:
             logger.exception("GET /api/tools/toolsets failed")
             return _api_json_error(str(exc), status=500)
 
     async def _handle_set_toolset(self, request: "web.Request") -> "web.Response":
-        """PUT /api/tools/toolsets/{key} — enable or disable a toolset."""
+        """PUT /api/tools/toolsets/{key} — enable or disable a toolset.
+
+        Same scoping rules as ``_handle_list_toolsets`` above:
+        ``?profile=<name>`` selects which profile's ``config.yaml``
+        is mutated. Omitted → default process scope (back-compat).
+        """
         auth_err = self._check_auth(request)
         if auth_err:
             return auth_err
@@ -3079,10 +3110,24 @@ class APIServerAdapter(BasePlatformAdapter):
             from hermes_cli.config import load_config, save_config
             from hermes_cli.tools_config import _apply_toolset_change
 
-            config = load_config()
+            profile_query = request.query.get("profile")
+            profile_dir = (
+                _resolve_profile_dir(profile_query)
+                if profile_query
+                else None
+            )
+            config = load_config(profile_dir)
             _apply_toolset_change(config, platform, [key], "enable" if enabled else "disable")
-            save_config(config)
-            return web.json_response({"ok": True, "key": key, "enabled": enabled, "platform": platform})
+            save_config(config, profile_dir)
+            return web.json_response({
+                "ok": True,
+                "key": key,
+                "enabled": enabled,
+                "platform": platform,
+                "profile": profile_query or None,
+            })
+        except (ValueError, FileNotFoundError) as exc:
+            return _api_json_error(str(exc), status=400)
         except Exception as exc:
             logger.exception("PUT /api/tools/toolsets/%s failed", key)
             return _api_json_error(str(exc), status=500)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3107,7 +3107,7 @@ class APIServerAdapter(BasePlatformAdapter):
         platform = request.query.get("platform") or "api_server"
         enabled = bool(body.get("enabled"))
         try:
-            from hermes_cli.config import load_config, save_config
+            from hermes_cli.config import load_config
             from hermes_cli.tools_config import _apply_toolset_change
 
             profile_query = request.query.get("profile")
@@ -3117,8 +3117,17 @@ class APIServerAdapter(BasePlatformAdapter):
                 else None
             )
             config = load_config(profile_dir)
-            _apply_toolset_change(config, platform, [key], "enable" if enabled else "disable")
-            save_config(config, profile_dir)
+            # _apply_toolset_change → _save_platform_tools →
+            # save_config(config, profile_dir) — the helper persists
+            # for us. No extra save_config() call here (would
+            # double-write).
+            _apply_toolset_change(
+                config,
+                platform,
+                [key],
+                "enable" if enabled else "disable",
+                profile_dir,
+            )
             return web.json_response({
                 "ok": True,
                 "key": key,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -15,6 +15,20 @@ Exposes an HTTP server with endpoints:
 - POST /v1/runs/{run_id}/stop       — interrupt a running agent
 - GET  /health                     — health check
 - GET  /health/detailed            — rich status for cross-container dashboard probing
+- GET  /api/sessions               — persisted session summaries
+- GET  /api/sessions/search        — full-text session search
+- GET  /api/sessions/{id}/messages — persisted session messages
+- GET  /api/profiles               — profile metadata
+- POST /api/profiles               — create profile
+- DELETE /api/profiles/{name}      — delete profile
+- POST /api/profiles/{name}/activate — set active profile
+- GET/PUT/POST /api/profiles/{name}/soul — read, write, reset persona
+- GET/POST/PUT/DELETE /api/memory  — read and edit memory/user profile files
+- GET/PUT /api/tools/toolsets      — list and update toolsets
+- GET /api/skills/installed        — installed skills
+- GET /api/skills/bundled          — bundled skills
+- GET /api/skills/content          — read a skill's SKILL.md
+- GET /api/gateway/status          — gateway runtime status
 
 Any OpenAI-compatible frontend (Open WebUI, LobeChat, LibreChat,
 AnythingLLM, NextChat, ChatBox, etc.) can connect to hermes-agent
@@ -35,6 +49,7 @@ import re
 import sqlite3
 import time
 import uuid
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 try:
@@ -575,6 +590,167 @@ except ImportError:
     _cron_trigger = None
 
 
+MEMORY_ENTRY_DELIMITER = "\n\u00a7\n"
+MEMORY_CHAR_LIMIT = 2200
+USER_PROFILE_CHAR_LIMIT = 1375
+
+
+def _api_json_error(message: str, status: int = 400) -> "web.Response":
+    return web.json_response({"error": message}, status=status)
+
+
+def _coerce_limit_offset(request: "web.Request", *, default_limit: int = 30) -> tuple[int, int]:
+    try:
+        limit = int(request.query.get("limit", default_limit))
+    except (TypeError, ValueError):
+        limit = default_limit
+    try:
+        offset = int(request.query.get("offset", 0))
+    except (TypeError, ValueError):
+        offset = 0
+    return max(1, min(limit, 200)), max(0, offset)
+
+
+def _csv_query_values(request: "web.Request", *names: str) -> list[str]:
+    values: list[str] = []
+    for name in names:
+        for raw in request.query.getall(name, []):
+            values.extend(part.strip() for part in raw.split(","))
+    return [value for value in values if value]
+
+
+def _session_source_filters(request: "web.Request") -> tuple[Optional[str], Optional[list[str]]]:
+    source = (request.query.get("source") or "").strip() or None
+    exclude_sources = _csv_query_values(request, "exclude_source", "exclude_sources")
+    return source, (exclude_sources or None)
+
+
+def _profile_dir_for_request(request: "web.Request") -> Path:
+    return _resolve_profile_dir(request.query.get("profile"))
+
+
+def _resolve_profile_dir(profile: Optional[str]) -> Path:
+    if not profile or profile == "current":
+        from hermes_constants import get_hermes_home
+
+        return get_hermes_home()
+
+    from hermes_cli import profiles as profiles_mod
+
+    name = profiles_mod.normalize_profile_name(profile)
+    profiles_mod.validate_profile_name(name)
+    if not profiles_mod.profile_exists(name):
+        raise FileNotFoundError(f"Profile '{name}' does not exist.")
+    return profiles_mod.get_profile_dir(name)
+
+
+def _read_text_file(path: Path) -> dict:
+    try:
+        st = path.stat()
+        return {
+            "content": path.read_text(encoding="utf-8"),
+            "exists": True,
+            "lastModified": int(st.st_mtime),
+            "last_modified": int(st.st_mtime),
+        }
+    except FileNotFoundError:
+        return {
+            "content": "",
+            "exists": False,
+            "lastModified": None,
+            "last_modified": None,
+        }
+
+
+def _parse_memory_entries(content: str) -> list[dict]:
+    if not content.strip():
+        return []
+    entries = []
+    for idx, entry in enumerate(content.split(MEMORY_ENTRY_DELIMITER)):
+        entry = entry.strip()
+        if entry:
+            entries.append({"index": idx, "content": entry})
+    return entries
+
+
+def _serialize_memory_entries(entries: list[dict]) -> str:
+    return MEMORY_ENTRY_DELIMITER.join(str(entry.get("content", "")).strip() for entry in entries)
+
+
+def _ensure_parent_and_write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _skill_frontmatter(content: str) -> tuple[str, str]:
+    name = ""
+    description = ""
+    if content.startswith("---"):
+        end = content.find("---", 3)
+        if end != -1:
+            frontmatter = content[3:end]
+            if match := re.search(r"^\s*name:\s*[\"']?([^\"'\n]+)[\"']?\s*$", frontmatter, re.M):
+                name = match.group(1).strip()
+            if match := re.search(r"^\s*description:\s*[\"']?([^\"'\n]+)[\"']?\s*$", frontmatter, re.M):
+                description = match.group(1).strip()
+    if not name:
+        if match := re.search(r"^#\s+(.+)$", content, re.M):
+            name = match.group(1).strip()
+    if not description:
+        for line in content.splitlines():
+            stripped = line.strip()
+            if stripped and not stripped.startswith(("#", "---")):
+                description = stripped[:160]
+                break
+    return name, description
+
+
+def _scan_skills(root: Path, *, source: str) -> list[dict]:
+    if not root.is_dir():
+        return []
+    skills: list[dict] = []
+    for skill_md in sorted(root.rglob("SKILL.md")):
+        if ".git" in skill_md.parts or ".hub" in skill_md.parts:
+            continue
+        try:
+            rel = skill_md.parent.relative_to(root)
+        except ValueError:
+            continue
+        parts = rel.parts
+        category = parts[0] if len(parts) > 1 else "local"
+        slug = parts[-1] if parts else skill_md.parent.name
+        try:
+            content = skill_md.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            content = ""
+        name, description = _skill_frontmatter(content[:4000])
+        skills.append(
+            {
+                "name": name or slug,
+                "slug": slug,
+                "category": category,
+                "description": description,
+                "source": source,
+                "path": str(skill_md.parent),
+            }
+        )
+    return skills
+
+
+def _path_within(path: Path, roots: list[Path]) -> bool:
+    try:
+        resolved = path.resolve()
+    except OSError:
+        return False
+    for root in roots:
+        try:
+            resolved.relative_to(root.resolve())
+            return True
+        except (OSError, ValueError):
+            continue
+    return False
+
+
 class APIServerAdapter(BasePlatformAdapter):
     """
     OpenAI-compatible HTTP API server adapter.
@@ -887,6 +1063,320 @@ class APIServerAdapter(BasePlatformAdapter):
             "pid": os.getpid(),
         })
 
+    async def _handle_gateway_status(self, request: "web.Request") -> "web.Response":
+        """GET /api/gateway/status — return persisted gateway runtime status."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        from gateway.status import read_runtime_status
+
+        runtime = read_runtime_status() or {}
+        return web.json_response(
+            {
+                "ok": True,
+                "running": True,
+                "pid": os.getpid(),
+                "gateway_state": runtime.get("gateway_state"),
+                "platforms": runtime.get("platforms", {}),
+                "active_agents": runtime.get("active_agents", 0),
+                "exit_reason": runtime.get("exit_reason"),
+                "updated_at": runtime.get("updated_at"),
+            }
+        )
+
+    async def _handle_list_sessions(self, request: "web.Request") -> "web.Response":
+        """GET /api/sessions — list persisted session summaries."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        limit, offset = _coerce_limit_offset(request)
+        source, exclude_sources = _session_source_filters(request)
+        try:
+            from hermes_state import SessionDB
+
+            db_path = _profile_dir_for_request(request) / "state.db"
+            if not db_path.exists():
+                return web.json_response(
+                    {"sessions": [], "total": 0, "limit": limit, "offset": offset}
+                )
+            db = SessionDB(db_path)
+            try:
+                sessions = db.list_sessions_rich(
+                    source=source,
+                    exclude_sources=exclude_sources,
+                    limit=limit,
+                    offset=offset,
+                    order_by_last_active=True,
+                )
+                total = db.session_count(source=source) if not exclude_sources else len(sessions)
+            finally:
+                db.close()
+        except Exception as exc:
+            logger.exception("GET /api/sessions failed")
+            return _api_json_error(str(exc), status=500)
+
+        normalized = []
+        for item in sessions:
+            row = dict(item)
+            row.setdefault("preview", row.get("preview") or "")
+            row.setdefault("title", row.get("title"))
+            row["startedAt"] = row.get("started_at")
+            row["endedAt"] = row.get("ended_at")
+            row["messageCount"] = row.get("message_count", 0)
+            normalized.append(row)
+        return web.json_response(
+            {"sessions": normalized, "total": total, "limit": limit, "offset": offset}
+        )
+
+    async def _handle_search_sessions(self, request: "web.Request") -> "web.Response":
+        """GET /api/sessions/search?q=... — search persisted messages."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        query = (request.query.get("q") or "").strip()
+        if not query:
+            return web.json_response({"results": []})
+        try:
+            limit = max(1, min(int(request.query.get("limit", 20)), 100))
+        except (TypeError, ValueError):
+            limit = 20
+
+        try:
+            from hermes_state import SessionDB
+
+            db_path = _profile_dir_for_request(request) / "state.db"
+            if not db_path.exists():
+                return web.json_response({"results": []})
+            db = SessionDB(db_path)
+            try:
+                source, exclude_sources = _session_source_filters(request)
+                matches = db.search_messages(
+                    query=query,
+                    source_filter=[source] if source else None,
+                    exclude_sources=exclude_sources,
+                    limit=limit,
+                )
+            finally:
+                db.close()
+        except Exception as exc:
+            logger.exception("GET /api/sessions/search failed")
+            return _api_json_error(str(exc), status=500)
+
+        seen: dict[str, dict] = {}
+        for match in matches:
+            sid = match.get("session_id")
+            if not sid or sid in seen:
+                continue
+            seen[sid] = {
+                "session_id": sid,
+                "sessionId": sid,
+                "title": match.get("title"),
+                "snippet": match.get("snippet", ""),
+                "role": match.get("role"),
+                "source": match.get("source"),
+                "model": match.get("model"),
+                "started_at": match.get("session_started"),
+                "startedAt": match.get("session_started"),
+            }
+        return web.json_response({"results": list(seen.values())})
+
+    async def _handle_session_messages(self, request: "web.Request") -> "web.Response":
+        """GET /api/sessions/{session_id}/messages — fetch persisted messages."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        session_id = request.match_info["session_id"]
+        try:
+            from hermes_state import SessionDB
+
+            db_path = _profile_dir_for_request(request) / "state.db"
+            if not db_path.exists():
+                return _api_json_error("Session not found", status=404)
+            db = SessionDB(db_path)
+            try:
+                resolved = db.resolve_session_id(session_id)
+                if not resolved:
+                    return _api_json_error("Session not found", status=404)
+                messages = db.get_messages(resolved)
+            finally:
+                db.close()
+        except Exception as exc:
+            logger.exception("GET /api/sessions/%s/messages failed", session_id)
+            return _api_json_error(str(exc), status=500)
+
+        return web.json_response({"session_id": resolved, "sessionId": resolved, "messages": messages})
+
+    async def _handle_list_profiles(self, request: "web.Request") -> "web.Response":
+        """GET /api/profiles — list Hermes profiles."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            from hermes_cli import profiles as profiles_mod
+
+            active = profiles_mod.get_active_profile_name()
+            items = []
+            for profile in profiles_mod.list_profiles():
+                has_soul = (Path(profile.path) / "SOUL.md").exists()
+                item = {
+                    "name": profile.name,
+                    "path": str(profile.path),
+                    "is_default": profile.is_default,
+                    "isDefault": profile.is_default,
+                    "is_active": profile.name == active,
+                    "isActive": profile.name == active,
+                    "model": profile.model or "",
+                    "provider": profile.provider or "",
+                    "has_env": profile.has_env,
+                    "hasEnv": profile.has_env,
+                    "has_soul": has_soul,
+                    "hasSoul": has_soul,
+                    "skill_count": profile.skill_count,
+                    "skillCount": profile.skill_count,
+                    "gateway_running": profile.gateway_running,
+                    "gatewayRunning": profile.gateway_running,
+                }
+                items.append(item)
+            return web.json_response({"profiles": items, "active": active})
+        except Exception as exc:
+            logger.exception("GET /api/profiles failed")
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_create_profile(self, request: "web.Request") -> "web.Response":
+        """POST /api/profiles — create a Hermes profile."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            body = await request.json()
+        except Exception:
+            return _api_json_error("Invalid JSON in request body", status=400)
+        name = str(body.get("name") or "").strip()
+        clone = bool(body.get("clone") or body.get("clone_from_default"))
+        no_skills = bool(body.get("no_skills"))
+        if not name:
+            return _api_json_error("Profile name is required", status=400)
+
+        try:
+            from hermes_cli import profiles as profiles_mod
+
+            path = profiles_mod.create_profile(
+                name=name,
+                clone_from="default" if clone else None,
+                clone_config=clone,
+                no_skills=no_skills,
+            )
+            if not clone:
+                profiles_mod.seed_profile_skills(path, quiet=True)
+            if not profiles_mod.check_alias_collision(name):
+                profiles_mod.create_wrapper_script(name)
+            return web.json_response({"ok": True, "name": name, "path": str(path)})
+        except (ValueError, FileExistsError, FileNotFoundError) as exc:
+            return _api_json_error(str(exc), status=400)
+        except Exception as exc:
+            logger.exception("POST /api/profiles failed")
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_delete_profile(self, request: "web.Request") -> "web.Response":
+        """DELETE /api/profiles/{name} — delete a Hermes profile."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        name = request.match_info["name"]
+        try:
+            from hermes_cli import profiles as profiles_mod
+
+            path = profiles_mod.delete_profile(name, yes=True)
+            return web.json_response({"ok": True, "path": str(path)})
+        except FileNotFoundError as exc:
+            return _api_json_error(str(exc), status=404)
+        except ValueError as exc:
+            return _api_json_error(str(exc), status=400)
+        except Exception as exc:
+            logger.exception("DELETE /api/profiles/%s failed", name)
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_activate_profile(self, request: "web.Request") -> "web.Response":
+        """POST /api/profiles/{name}/activate — set the active profile."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        name = request.match_info["name"]
+        try:
+            from hermes_cli import profiles as profiles_mod
+
+            profiles_mod.set_active_profile(name)
+            return web.json_response({"ok": True, "active": profiles_mod.get_active_profile_name()})
+        except (ValueError, FileNotFoundError) as exc:
+            return _api_json_error(str(exc), status=400)
+        except Exception as exc:
+            logger.exception("POST /api/profiles/%s/activate failed", name)
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_get_soul(self, request: "web.Request") -> "web.Response":
+        """GET /api/profiles/{name}/soul — read persona/SOUL.md."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            profile_dir = _resolve_profile_dir(request.match_info["name"])
+            return web.json_response(_read_text_file(profile_dir / "SOUL.md"))
+        except FileNotFoundError as exc:
+            return _api_json_error(str(exc), status=404)
+        except ValueError as exc:
+            return _api_json_error(str(exc), status=400)
+
+    async def _handle_write_soul(self, request: "web.Request") -> "web.Response":
+        """PUT /api/profiles/{name}/soul — write persona/SOUL.md."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            body = await request.json()
+        except Exception:
+            return _api_json_error("Invalid JSON in request body", status=400)
+        try:
+            profile_dir = _resolve_profile_dir(request.match_info["name"])
+            _ensure_parent_and_write(profile_dir / "SOUL.md", str(body.get("content") or ""))
+            return web.json_response({"ok": True})
+        except FileNotFoundError as exc:
+            return _api_json_error(str(exc), status=404)
+        except ValueError as exc:
+            return _api_json_error(str(exc), status=400)
+        except Exception as exc:
+            logger.exception("PUT /api/profiles/%s/soul failed", request.match_info["name"])
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_reset_soul(self, request: "web.Request") -> "web.Response":
+        """POST /api/profiles/{name}/soul/reset — reset persona/SOUL.md."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            from hermes_cli.default_soul import DEFAULT_SOUL_MD
+
+            profile_dir = _resolve_profile_dir(request.match_info["name"])
+            _ensure_parent_and_write(profile_dir / "SOUL.md", DEFAULT_SOUL_MD)
+            return web.json_response({"ok": True, "content": DEFAULT_SOUL_MD})
+        except FileNotFoundError as exc:
+            return _api_json_error(str(exc), status=404)
+        except ValueError as exc:
+            return _api_json_error(str(exc), status=400)
+        except Exception as exc:
+            logger.exception("POST /api/profiles/%s/soul/reset failed", request.match_info["name"])
+            return _api_json_error(str(exc), status=500)
+
     async def _handle_models(self, request: "web.Request") -> "web.Response":
         """GET /v1/models — return hermes-agent as an available model."""
         auth_err = self._check_auth(request)
@@ -949,6 +1439,13 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_approval_response": True,
                 "tool_progress_events": True,
                 "approval_events": True,
+                "remote_sessions": True,
+                "remote_profiles": True,
+                "remote_memory": True,
+                "remote_persona": True,
+                "remote_skills": True,
+                "remote_toolsets": True,
+                "remote_gateway_status": True,
                 "session_continuity_header": "X-Hermes-Session-Id",
                 "session_key_header": "X-Hermes-Session-Key",
                 "cors": bool(self._cors_origins),
@@ -964,6 +1461,23 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_events": {"method": "GET", "path": "/v1/runs/{run_id}/events"},
                 "run_approval": {"method": "POST", "path": "/v1/runs/{run_id}/approval"},
                 "run_stop": {"method": "POST", "path": "/v1/runs/{run_id}/stop"},
+                "gateway_status": {"method": "GET", "path": "/api/gateway/status"},
+                "sessions": {"method": "GET", "path": "/api/sessions"},
+                "session_search": {"method": "GET", "path": "/api/sessions/search"},
+                "session_messages": {"method": "GET", "path": "/api/sessions/{session_id}/messages"},
+                "profiles": {"method": "GET", "path": "/api/profiles"},
+                "profile_create": {"method": "POST", "path": "/api/profiles"},
+                "profile_delete": {"method": "DELETE", "path": "/api/profiles/{name}"},
+                "profile_activate": {"method": "POST", "path": "/api/profiles/{name}/activate"},
+                "profile_soul": {"method": "GET/PUT", "path": "/api/profiles/{name}/soul"},
+                "profile_soul_reset": {"method": "POST", "path": "/api/profiles/{name}/soul/reset"},
+                "memory": {"method": "GET", "path": "/api/memory"},
+                "memory_entries": {"method": "POST/PUT/DELETE", "path": "/api/memory/entries"},
+                "memory_user": {"method": "PUT", "path": "/api/memory/user"},
+                "toolsets": {"method": "GET/PUT", "path": "/api/tools/toolsets"},
+                "installed_skills": {"method": "GET", "path": "/api/skills/installed"},
+                "bundled_skills": {"method": "GET", "path": "/api/skills/bundled"},
+                "skill_content": {"method": "GET", "path": "/api/skills/content"},
             },
         })
 
@@ -2344,6 +2858,286 @@ class APIServerAdapter(BasePlatformAdapter):
             "deleted": True,
         })
 
+    async def _handle_read_memory(self, request: "web.Request") -> "web.Response":
+        """GET /api/memory — read MEMORY.md and USER.md for a profile."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            profile_dir = _profile_dir_for_request(request)
+            memory_file = _read_text_file(profile_dir / "memories" / "MEMORY.md")
+            user_file = _read_text_file(profile_dir / "memories" / "USER.md")
+            entries = _parse_memory_entries(memory_file["content"])
+            stats = {"totalSessions": 0, "totalMessages": 0, "total_sessions": 0, "total_messages": 0}
+            try:
+                db_path = profile_dir / "state.db"
+                if db_path.exists():
+                    with sqlite3.connect(str(db_path)) as conn:
+                        row = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()
+                        total_sessions = int(row[0]) if row else 0
+                        row = conn.execute("SELECT COUNT(*) FROM messages").fetchone()
+                        total_messages = int(row[0]) if row else 0
+                else:
+                    total_sessions = 0
+                    total_messages = 0
+                stats = {
+                    "totalSessions": total_sessions,
+                    "totalMessages": total_messages,
+                    "total_sessions": total_sessions,
+                    "total_messages": total_messages,
+                }
+            except Exception:
+                pass
+            return web.json_response(
+                {
+                    "memory": {
+                        **memory_file,
+                        "entries": entries,
+                        "charCount": len(memory_file["content"]),
+                        "char_count": len(memory_file["content"]),
+                        "charLimit": MEMORY_CHAR_LIMIT,
+                        "char_limit": MEMORY_CHAR_LIMIT,
+                    },
+                    "user": {
+                        **user_file,
+                        "charCount": len(user_file["content"]),
+                        "char_count": len(user_file["content"]),
+                        "charLimit": USER_PROFILE_CHAR_LIMIT,
+                        "char_limit": USER_PROFILE_CHAR_LIMIT,
+                    },
+                    "stats": stats,
+                }
+            )
+        except (FileNotFoundError, ValueError) as exc:
+            return _api_json_error(str(exc), status=400)
+        except Exception as exc:
+            logger.exception("GET /api/memory failed")
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_add_memory_entry(self, request: "web.Request") -> "web.Response":
+        """POST /api/memory/entries — append a memory entry."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            body = await request.json()
+        except Exception:
+            return _api_json_error("Invalid JSON in request body", status=400)
+        try:
+            profile_dir = _profile_dir_for_request(request)
+            path = profile_dir / "memories" / "MEMORY.md"
+            existing = _read_text_file(path)
+            entries = _parse_memory_entries(existing["content"])
+            entries.append({"index": len(entries), "content": str(body.get("content") or "").strip()})
+            content = _serialize_memory_entries(entries)
+            if len(content) > MEMORY_CHAR_LIMIT:
+                return _api_json_error(
+                    f"Would exceed memory limit ({len(content)}/{MEMORY_CHAR_LIMIT} chars)",
+                    status=400,
+                )
+            _ensure_parent_and_write(path, content)
+            return web.json_response({"ok": True})
+        except Exception as exc:
+            logger.exception("POST /api/memory/entries failed")
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_update_memory_entry(self, request: "web.Request") -> "web.Response":
+        """PUT /api/memory/entries/{index} — update a memory entry."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            body = await request.json()
+            index = int(request.match_info["index"])
+        except Exception:
+            return _api_json_error("Invalid request", status=400)
+        try:
+            profile_dir = _profile_dir_for_request(request)
+            path = profile_dir / "memories" / "MEMORY.md"
+            entries = _parse_memory_entries(_read_text_file(path)["content"])
+            if index < 0 or index >= len(entries):
+                return _api_json_error("Entry not found", status=404)
+            entries[index]["content"] = str(body.get("content") or "").strip()
+            content = _serialize_memory_entries(entries)
+            if len(content) > MEMORY_CHAR_LIMIT:
+                return _api_json_error(
+                    f"Would exceed memory limit ({len(content)}/{MEMORY_CHAR_LIMIT} chars)",
+                    status=400,
+                )
+            _ensure_parent_and_write(path, content)
+            return web.json_response({"ok": True})
+        except Exception as exc:
+            logger.exception("PUT /api/memory/entries/%s failed", request.match_info.get("index"))
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_delete_memory_entry(self, request: "web.Request") -> "web.Response":
+        """DELETE /api/memory/entries/{index} — remove a memory entry."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            index = int(request.match_info["index"])
+        except Exception:
+            return _api_json_error("Invalid entry index", status=400)
+        try:
+            profile_dir = _profile_dir_for_request(request)
+            path = profile_dir / "memories" / "MEMORY.md"
+            entries = _parse_memory_entries(_read_text_file(path)["content"])
+            if index < 0 or index >= len(entries):
+                return _api_json_error("Entry not found", status=404)
+            entries.pop(index)
+            _ensure_parent_and_write(path, _serialize_memory_entries(entries))
+            return web.json_response({"ok": True})
+        except Exception as exc:
+            logger.exception("DELETE /api/memory/entries/%s failed", request.match_info.get("index"))
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_write_user_profile(self, request: "web.Request") -> "web.Response":
+        """PUT /api/memory/user — write USER.md."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            body = await request.json()
+        except Exception:
+            return _api_json_error("Invalid JSON in request body", status=400)
+        content = str(body.get("content") or "")
+        if len(content) > USER_PROFILE_CHAR_LIMIT:
+            return _api_json_error(
+                f"Exceeds limit ({len(content)}/{USER_PROFILE_CHAR_LIMIT} chars)",
+                status=400,
+            )
+        try:
+            profile_dir = _profile_dir_for_request(request)
+            _ensure_parent_and_write(profile_dir / "memories" / "USER.md", content)
+            return web.json_response({"ok": True})
+        except Exception as exc:
+            logger.exception("PUT /api/memory/user failed")
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_list_toolsets(self, request: "web.Request") -> "web.Response":
+        """GET /api/tools/toolsets — list configurable toolsets."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        platform = request.query.get("platform") or "api_server"
+        try:
+            from hermes_cli.config import load_config
+            from hermes_cli.tools_config import (
+                _get_effective_configurable_toolsets,
+                _get_platform_tools,
+                _toolset_has_keys,
+            )
+            from toolsets import resolve_toolset
+
+            config = load_config()
+            enabled = _get_platform_tools(config, platform, include_default_mcp_servers=False)
+            toolsets = []
+            for key, label, description in _get_effective_configurable_toolsets():
+                try:
+                    tools = sorted(set(resolve_toolset(key)))
+                except Exception:
+                    tools = []
+                is_enabled = key in enabled
+                toolsets.append(
+                    {
+                        "key": key,
+                        "name": key,
+                        "label": label,
+                        "description": description,
+                        "enabled": is_enabled,
+                        "available": is_enabled,
+                        "configured": _toolset_has_keys(key, config),
+                        "tools": tools,
+                    }
+                )
+            return web.json_response({"toolsets": toolsets, "platform": platform})
+        except Exception as exc:
+            logger.exception("GET /api/tools/toolsets failed")
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_set_toolset(self, request: "web.Request") -> "web.Response":
+        """PUT /api/tools/toolsets/{key} — enable or disable a toolset."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            body = await request.json()
+        except Exception:
+            return _api_json_error("Invalid JSON in request body", status=400)
+        key = request.match_info["key"]
+        platform = request.query.get("platform") or "api_server"
+        enabled = bool(body.get("enabled"))
+        try:
+            from hermes_cli.config import load_config, save_config
+            from hermes_cli.tools_config import _apply_toolset_change
+
+            config = load_config()
+            _apply_toolset_change(config, platform, [key], "enable" if enabled else "disable")
+            save_config(config)
+            return web.json_response({"ok": True, "key": key, "enabled": enabled, "platform": platform})
+        except Exception as exc:
+            logger.exception("PUT /api/tools/toolsets/%s failed", key)
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_installed_skills(self, request: "web.Request") -> "web.Response":
+        """GET /api/skills/installed — list installed skills."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            profile_dir = _profile_dir_for_request(request)
+            return web.json_response({"skills": _scan_skills(profile_dir / "skills", source="installed")})
+        except Exception as exc:
+            logger.exception("GET /api/skills/installed failed")
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_bundled_skills(self, request: "web.Request") -> "web.Response":
+        """GET /api/skills/bundled — list bundled skills from the repo."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        root = Path(__file__).resolve().parents[2] / "skills"
+        return web.json_response({"skills": _scan_skills(root, source="bundled")})
+
+    async def _handle_skill_content(self, request: "web.Request") -> "web.Response":
+        """GET /api/skills/content?path=... — read a SKILL.md under allowed roots."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        raw_path = request.query.get("path") or ""
+        if not raw_path:
+            return _api_json_error("path is required", status=400)
+        try:
+            profile_dir = _profile_dir_for_request(request)
+            repo_skills = Path(__file__).resolve().parents[2] / "skills"
+            skill_dir = Path(raw_path)
+            skill_file = skill_dir / "SKILL.md"
+            allowed_roots = [profile_dir / "skills", repo_skills]
+            if not _path_within(skill_file, allowed_roots):
+                return _api_json_error("Skill path is outside the allowed skills directories", status=403)
+            return web.json_response(
+                {
+                    "content": skill_file.read_text(encoding="utf-8", errors="replace"),
+                    "path": str(skill_dir),
+                }
+            )
+        except FileNotFoundError:
+            return _api_json_error("Skill not found", status=404)
+        except Exception as exc:
+            logger.exception("GET /api/skills/content failed")
+            return _api_json_error(str(exc), status=500)
+
     # ------------------------------------------------------------------
     # Cron jobs API
     # ------------------------------------------------------------------
@@ -3344,6 +4138,28 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_post("/v1/responses", self._handle_responses)
             self._app.router.add_get("/v1/responses/{response_id}", self._handle_get_response)
             self._app.router.add_delete("/v1/responses/{response_id}", self._handle_delete_response)
+            # Remote management/read APIs for desktop and dashboard clients
+            self._app.router.add_get("/api/gateway/status", self._handle_gateway_status)
+            self._app.router.add_get("/api/sessions", self._handle_list_sessions)
+            self._app.router.add_get("/api/sessions/search", self._handle_search_sessions)
+            self._app.router.add_get("/api/sessions/{session_id}/messages", self._handle_session_messages)
+            self._app.router.add_get("/api/profiles", self._handle_list_profiles)
+            self._app.router.add_post("/api/profiles", self._handle_create_profile)
+            self._app.router.add_delete("/api/profiles/{name}", self._handle_delete_profile)
+            self._app.router.add_post("/api/profiles/{name}/activate", self._handle_activate_profile)
+            self._app.router.add_get("/api/profiles/{name}/soul", self._handle_get_soul)
+            self._app.router.add_put("/api/profiles/{name}/soul", self._handle_write_soul)
+            self._app.router.add_post("/api/profiles/{name}/soul/reset", self._handle_reset_soul)
+            self._app.router.add_get("/api/memory", self._handle_read_memory)
+            self._app.router.add_post("/api/memory/entries", self._handle_add_memory_entry)
+            self._app.router.add_put("/api/memory/entries/{index}", self._handle_update_memory_entry)
+            self._app.router.add_delete("/api/memory/entries/{index}", self._handle_delete_memory_entry)
+            self._app.router.add_put("/api/memory/user", self._handle_write_user_profile)
+            self._app.router.add_get("/api/tools/toolsets", self._handle_list_toolsets)
+            self._app.router.add_put("/api/tools/toolsets/{key}", self._handle_set_toolset)
+            self._app.router.add_get("/api/skills/installed", self._handle_installed_skills)
+            self._app.router.add_get("/api/skills/bundled", self._handle_bundled_skills)
+            self._app.router.add_get("/api/skills/content", self._handle_skill_content)
             # Cron jobs management API
             self._app.router.add_get("/api/jobs", self._handle_list_jobs)
             self._app.router.add_post("/api/jobs", self._handle_create_job)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -294,8 +294,17 @@ def get_container_exec_info() -> Optional[dict]:
 from hermes_constants import get_hermes_home  # noqa: F811,E402
 from utils import atomic_replace
 
-def get_config_path() -> Path:
-    """Get the main config file path."""
+def get_config_path(profile_dir: Optional[Path] = None) -> Path:
+    """Get the main config file path.
+
+    With ``profile_dir`` (Path), returns ``<profile_dir>/config.yaml``
+    so callers operating on a specific profile (e.g. the per-profile
+    `/api/tools/toolsets?profile=<name>` handler) don't have to fight
+    the process-wide ``HERMES_HOME`` env-var. Without it, behaviour
+    is unchanged: ``get_hermes_home() / "config.yaml"``.
+    """
+    if profile_dir is not None:
+        return profile_dir / "config.yaml"
     return get_hermes_home() / "config.yaml"
 
 def get_env_path() -> Path:
@@ -4020,7 +4029,7 @@ def cfg_get(cfg: Optional[Dict[str, Any]], *keys: str, default: Any = None) -> A
 
 
 
-def read_raw_config() -> Dict[str, Any]:
+def read_raw_config(profile_dir: Optional[Path] = None) -> Dict[str, Any]:
     """Read ~/.hermes/config.yaml as-is, without merging defaults or migrating.
 
     Returns the raw YAML dict, or ``{}`` if the file doesn't exist or can't
@@ -4031,10 +4040,15 @@ def read_raw_config() -> Dict[str, Any]:
     Cached on the config file's (mtime_ns, size) — same strategy as
     ``load_config()``. Returns a deepcopy on every call since some callers
     mutate the result before passing to ``save_config()``.
+
+    ``profile_dir`` (optional): when provided, reads
+    ``<profile_dir>/config.yaml`` instead of the process-default
+    ``get_config_path()``. The cache is keyed on the resolved path so
+    a per-profile read and a default read coexist cleanly.
     """
     with _CONFIG_LOCK:
         try:
-            config_path = get_config_path()
+            config_path = get_config_path(profile_dir)
             st = config_path.stat()
             cache_key = (st.st_mtime_ns, st.st_size)
         except (FileNotFoundError, OSError):
@@ -4058,7 +4072,7 @@ def read_raw_config() -> Dict[str, Any]:
         return data
 
 
-def load_config() -> Dict[str, Any]:
+def load_config(profile_dir: Optional[Path] = None) -> Dict[str, Any]:
     """Load configuration from ~/.hermes/config.yaml.
 
     Cached on the config file's (mtime_ns, size). Returns a deepcopy of
@@ -4067,10 +4081,20 @@ def load_config() -> Dict[str, Any]:
     The cache is keyed on ``str(config_path)`` so profile switches
     (which change ``HERMES_HOME`` and therefore ``get_config_path()``)
     don't collide.
+
+    ``profile_dir`` (optional): when provided, loads
+    ``<profile_dir>/config.yaml`` instead of the process-default
+    ``get_config_path()``. Used by `/api/tools/toolsets?profile=…` to
+    operate on the targeted profile's config without restarting the
+    gateway process.
     """
     with _CONFIG_LOCK:
-        ensure_hermes_home()
-        config_path = get_config_path()
+        if profile_dir is None:
+            # Only ensure the default Hermes home when we're operating
+            # on it; for a specific profile_dir the caller (typically
+            # `_resolve_profile_dir`) has already validated it exists.
+            ensure_hermes_home()
+        config_path = get_config_path(profile_dir)
         path_key = str(config_path)
 
         try:
@@ -4186,19 +4210,28 @@ _COMMENTED_SECTIONS = """
 """
 
 
-def save_config(config: Dict[str, Any]):
-    """Save configuration to ~/.hermes/config.yaml."""
+def save_config(config: Dict[str, Any], profile_dir: Optional[Path] = None):
+    """Save configuration to ~/.hermes/config.yaml.
+
+    ``profile_dir`` (optional): when provided, writes
+    ``<profile_dir>/config.yaml`` instead of the process-default
+    ``get_config_path()``. Used by `/api/tools/toolsets?profile=…`
+    so a toolset toggle on the `mira-uitest` profile lands in
+    `~/.hermes/profiles/mira-uitest/config.yaml`, not in the
+    gateway's HERMES_HOME-pinned default.
+    """
     with _CONFIG_LOCK:
         if is_managed():
             managed_error("save configuration")
             return
         from utils import atomic_yaml_write
 
-        ensure_hermes_home()
-        config_path = get_config_path()
+        if profile_dir is None:
+            ensure_hermes_home()
+        config_path = get_config_path(profile_dir)
         current_normalized = _normalize_root_model_keys(_normalize_max_turns_config(config))
         normalized = current_normalized
-        raw_existing = _normalize_root_model_keys(_normalize_max_turns_config(read_raw_config()))
+        raw_existing = _normalize_root_model_keys(_normalize_max_turns_config(read_raw_config(profile_dir)))
         if raw_existing:
             normalized = _preserve_env_ref_templates(
                 normalized,

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1185,11 +1185,24 @@ def _get_platform_tools(
     return enabled_toolsets
 
 
-def _save_platform_tools(config: dict, platform: str, enabled_toolset_keys: Set[str]):
+def _save_platform_tools(
+    config: dict,
+    platform: str,
+    enabled_toolset_keys: Set[str],
+    profile_dir: "Optional[Path]" = None,
+):
     """Save the selected toolset keys for a platform to config.
 
     Preserves any non-configurable toolset entries (like MCP server names)
     that were already in the config for this platform.
+
+    ``profile_dir`` (optional): when provided, the final ``save_config``
+    writes to that profile's ``config.yaml`` instead of the
+    HERMES_HOME-pinned default. Used by
+    ``/api/tools/toolsets?profile=<name>`` so a toggle on the
+    `mira-uitest` profile lands in
+    `~/.hermes/profiles/mira-uitest/config.yaml` instead of the
+    gateway process default.
     """
     config.setdefault("platform_toolsets", {})
 
@@ -1238,7 +1251,7 @@ def _save_platform_tools(config: dict, platform: str, enabled_toolset_keys: Set[
         config.setdefault("known_plugin_toolsets", {})
         config["known_plugin_toolsets"][platform] = sorted(plugin_keys)
 
-    save_config(config)
+    save_config(config, profile_dir)
 
 
 def _toolset_has_keys(ts_key: str, config: dict = None) -> bool:
@@ -2649,14 +2662,26 @@ def _configure_mcp_tools_interactive(config: dict):
 # ─── Non-interactive disable/enable ──────────────────────────────────────────
 
 
-def _apply_toolset_change(config: dict, platform: str, toolset_names: List[str], action: str):
-    """Add or remove built-in toolsets for a platform."""
+def _apply_toolset_change(
+    config: dict,
+    platform: str,
+    toolset_names: List[str],
+    action: str,
+    profile_dir: "Optional[Path]" = None,
+):
+    """Add or remove built-in toolsets for a platform.
+
+    ``profile_dir`` (optional): forwarded to ``_save_platform_tools``
+    so the persisted ``config.yaml`` lands in the targeted profile
+    directory rather than the process-default. See the
+    ``_save_platform_tools`` docstring for the motivation.
+    """
     enabled = _get_platform_tools(config, platform, include_default_mcp_servers=False)
     if action == "disable":
         updated = enabled - set(toolset_names)
     else:
         updated = enabled | set(toolset_names)
-    _save_platform_tools(config, platform, updated)
+    _save_platform_tools(config, platform, updated, profile_dir)
 
 
 def _apply_mcp_change(config: dict, targets: List[str], action: str) -> Set[str]:

--- a/tests/gateway/test_api_server_management.py
+++ b/tests/gateway/test_api_server_management.py
@@ -1,0 +1,173 @@
+"""Tests for remote management endpoints on the API server adapter."""
+
+from pathlib import Path
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter, cors_middleware
+from hermes_state import SessionDB
+
+
+def _make_adapter(api_key: str = "") -> APIServerAdapter:
+    extra = {"key": api_key} if api_key else {}
+    return APIServerAdapter(PlatformConfig(enabled=True, extra=extra))
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application(middlewares=[cors_middleware])
+    app["api_server_adapter"] = adapter
+    app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
+    app.router.add_get("/api/memory", adapter._handle_read_memory)
+    app.router.add_post("/api/memory/entries", adapter._handle_add_memory_entry)
+    app.router.add_put("/api/memory/entries/{index}", adapter._handle_update_memory_entry)
+    app.router.add_delete("/api/memory/entries/{index}", adapter._handle_delete_memory_entry)
+    app.router.add_put("/api/memory/user", adapter._handle_write_user_profile)
+    app.router.add_get("/api/sessions", adapter._handle_list_sessions)
+    app.router.add_get("/api/sessions/search", adapter._handle_search_sessions)
+    app.router.add_get("/api/skills/content", adapter._handle_skill_content)
+    return app
+
+
+class TestCapabilities:
+    @pytest.mark.asyncio
+    async def test_capabilities_advertise_remote_management(self):
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/capabilities")
+            assert resp.status == 200
+            data = await resp.json()
+
+        assert data["features"]["remote_sessions"] is True
+        assert data["features"]["remote_profiles"] is True
+        assert data["features"]["remote_memory"] is True
+        assert data["features"]["remote_persona"] is True
+        assert data["features"]["remote_skills"] is True
+        assert data["features"]["remote_toolsets"] is True
+        assert data["endpoints"]["sessions"]["path"] == "/api/sessions"
+        assert data["endpoints"]["profile_soul"]["path"] == "/api/profiles/{name}/soul"
+
+
+class TestSessionsApi:
+    @pytest.mark.asyncio
+    async def test_list_sessions_can_filter_by_source(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        db = SessionDB(tmp_path / "state.db")
+        try:
+            db.create_session("api-session", "api_server", model="gpt-test")
+            db.append_message("api-session", "user", "desktop chat")
+            db.create_session("cron-session", "cron", model="gpt-test")
+            db.append_message("cron-session", "user", "background job")
+        finally:
+            db.close()
+
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/sessions", params={"source": "api_server"})
+            assert resp.status == 200
+            data = await resp.json()
+
+        assert [session["id"] for session in data["sessions"]] == ["api-session"]
+        assert data["sessions"][0]["source"] == "api_server"
+
+    @pytest.mark.asyncio
+    async def test_search_sessions_can_filter_by_source(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        db = SessionDB(tmp_path / "state.db")
+        try:
+            db.create_session("api-session", "api_server", model="gpt-test")
+            db.append_message("api-session", "user", "find unique desktop phrase")
+            db.create_session("cron-session", "cron", model="gpt-test")
+            db.append_message("cron-session", "user", "find unique cron phrase")
+        finally:
+            db.close()
+
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get(
+                "/api/sessions/search",
+                params={"q": "unique", "source": "api_server"},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+
+        assert [result["session_id"] for result in data["results"]] == ["api-session"]
+
+
+class TestMemoryApi:
+    @pytest.mark.asyncio
+    async def test_memory_read_and_edit_roundtrip(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        app = _create_app(_make_adapter())
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/api/memory/entries", json={"content": "first fact"})
+            assert resp.status == 200
+            resp = await cli.post("/api/memory/entries", json={"content": "second fact"})
+            assert resp.status == 200
+
+            resp = await cli.get("/api/memory")
+            assert resp.status == 200
+            data = await resp.json()
+            assert [entry["content"] for entry in data["memory"]["entries"]] == [
+                "first fact",
+                "second fact",
+            ]
+
+            resp = await cli.put("/api/memory/entries/0", json={"content": "updated fact"})
+            assert resp.status == 200
+            resp = await cli.delete("/api/memory/entries/1")
+            assert resp.status == 200
+            resp = await cli.put("/api/memory/user", json={"content": "user profile"})
+            assert resp.status == 200
+
+            resp = await cli.get("/api/memory")
+            assert resp.status == 200
+            data = await resp.json()
+
+        assert [entry["content"] for entry in data["memory"]["entries"]] == ["updated fact"]
+        assert data["user"]["content"] == "user profile"
+
+    @pytest.mark.asyncio
+    async def test_memory_requires_auth_when_api_key_configured(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        app = _create_app(_make_adapter(api_key="sk-secret"))
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/memory")
+            assert resp.status == 401
+            resp = await cli.get("/api/memory", headers={"Authorization": "Bearer sk-secret"})
+            assert resp.status == 200
+
+
+class TestSkillContentApi:
+    @pytest.mark.asyncio
+    async def test_skill_content_rejects_paths_outside_skill_roots(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        outside = tmp_path / "not-a-skill"
+        outside.mkdir()
+        (outside / "SKILL.md").write_text("secret", encoding="utf-8")
+        app = _create_app(_make_adapter())
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/skills/content", params={"path": str(outside)})
+            assert resp.status == 403
+
+    @pytest.mark.asyncio
+    async def test_skill_content_reads_installed_skill(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        skill_dir = hermes_home / "skills" / "productivity" / "focus"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\nname: focus\n---\nBody", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        app = _create_app(_make_adapter())
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/skills/content", params={"path": str(skill_dir)})
+            assert resp.status == 200
+            data = await resp.json()
+
+        assert data["content"].startswith("---")
+        assert Path(data["path"]) == skill_dir

--- a/tests/gateway/test_api_server_toolset_profile.py
+++ b/tests/gateway/test_api_server_toolset_profile.py
@@ -1,0 +1,235 @@
+"""
+Tests for `?profile=<name>` scoping on /api/tools/toolsets.
+
+PR `feat/tools-profile-scoped` (plan v11): the GET (list) and
+PUT (toggle) handlers learn to read the targeted profile's
+``config.yaml`` instead of the HERMES_HOME-pinned default.
+This avoids the previous race where a CLI ``hermes profile
+use mira-uitest`` had no effect on the running gateway process.
+
+Test surface:
+
+* GET reads the named profile's config (returns its enabled set).
+* PUT writes back into the named profile's config.yaml.
+* Back-compat: no `?profile=` → reads/writes the process default,
+  byte-identical to the pre-PR behaviour.
+* Invalid profile → 400 (matches `_resolve_profile_dir`).
+* Cross-profile isolation: PUT on profile A leaves profile B's
+  config.yaml untouched (hash check).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+import yaml
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter, cors_middleware
+
+
+def _make_adapter(api_key: str = "") -> APIServerAdapter:
+    extra: Dict[str, Any] = {"key": api_key} if api_key else {}
+    return APIServerAdapter(PlatformConfig(enabled=True, extra=extra))
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application(middlewares=[cors_middleware])
+    app["api_server_adapter"] = adapter
+    app.router.add_get("/api/tools/toolsets", adapter._handle_list_toolsets)
+    app.router.add_put("/api/tools/toolsets/{key}", adapter._handle_set_toolset)
+    return app
+
+
+def _seed_profile(hermes_home: Path, name: str, enabled_toolsets: list[str]) -> Path:
+    """Create a profile directory + minimal config.yaml with the given
+    enabled toolsets pinned for the api_server platform.
+
+    The 'default' profile uses ~/.hermes/ directly; named profiles
+    use ~/.hermes/profiles/<name>/.
+    """
+    if name == "default":
+        profile_dir = hermes_home
+    else:
+        profile_dir = hermes_home / "profiles" / name
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    config = {
+        "platform_toolsets": {"api_server": enabled_toolsets},
+    }
+    (profile_dir / "config.yaml").write_text(yaml.safe_dump(config), encoding="utf-8")
+    return profile_dir
+
+
+def _sha256_file(p: Path) -> str:
+    return hashlib.sha256(p.read_bytes()).hexdigest()
+
+
+class TestListToolsetsByProfile:
+    @pytest.mark.asyncio
+    async def test_no_profile_reads_default(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_profile(tmp_path, "default", ["web", "terminal"])
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/tools/toolsets")
+            assert resp.status == 200
+            body = await resp.json()
+        # The default profile's enabled set should win.
+        enabled_keys = {t["key"] for t in body["toolsets"] if t["enabled"]}
+        assert "web" in enabled_keys
+        assert "terminal" in enabled_keys
+        assert body.get("profile") is None
+
+    @pytest.mark.asyncio
+    async def test_named_profile_reads_its_own_config(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # Default profile has different toolsets so we can tell them apart.
+        _seed_profile(tmp_path, "default", ["web"])
+        _seed_profile(tmp_path, "mira-uitest", ["browser", "file"])
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/tools/toolsets?profile=mira-uitest")
+            assert resp.status == 200
+            body = await resp.json()
+        enabled_keys = {t["key"] for t in body["toolsets"] if t["enabled"]}
+        # mira-uitest's set, NOT default's.
+        assert "browser" in enabled_keys
+        assert "file" in enabled_keys
+        assert "web" not in enabled_keys
+        assert body["profile"] == "mira-uitest"
+
+    @pytest.mark.asyncio
+    async def test_invalid_profile_returns_400(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_profile(tmp_path, "default", [])
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/tools/toolsets?profile=does-not-exist")
+            assert resp.status == 400
+            body = await resp.json()
+        assert "error" in body
+
+
+class TestSetToolsetByProfile:
+    @pytest.mark.asyncio
+    async def test_named_profile_write_lands_in_correct_yaml(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_profile(tmp_path, "default", ["web"])
+        mira_dir = _seed_profile(tmp_path, "mira-uitest", [])
+
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.put(
+                "/api/tools/toolsets/browser?profile=mira-uitest",
+                json={"enabled": True},
+            )
+            assert resp.status == 200
+            body = await resp.json()
+        assert body["ok"] is True
+        assert body["enabled"] is True
+        assert body["profile"] == "mira-uitest"
+
+        # Verify the WRITE landed in mira-uitest, not in default.
+        mira_cfg = yaml.safe_load(
+            (mira_dir / "config.yaml").read_text(encoding="utf-8")
+        )
+        assert "browser" in mira_cfg.get("platform_toolsets", {}).get(
+            "api_server", []
+        )
+
+    @pytest.mark.asyncio
+    async def test_named_profile_write_does_NOT_touch_default(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_profile(tmp_path, "default", ["web"])
+        _seed_profile(tmp_path, "mira-uitest", [])
+        default_cfg_path = tmp_path / "config.yaml"
+        default_sha_before = _sha256_file(default_cfg_path)
+
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.put(
+                "/api/tools/toolsets/browser?profile=mira-uitest",
+                json={"enabled": True},
+            )
+            assert resp.status == 200
+
+        default_sha_after = _sha256_file(default_cfg_path)
+        assert default_sha_before == default_sha_after, (
+            "PUT on mira-uitest profile must not modify the default "
+            "profile's config.yaml — byte-identical sha256 required"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_profile_writes_to_default(self, tmp_path, monkeypatch):
+        """Back-compat: omitting ?profile= mutates the default
+        (HERMES_HOME) config exactly as before."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_profile(tmp_path, "default", [])
+
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.put(
+                "/api/tools/toolsets/web",
+                json={"enabled": True},
+            )
+            assert resp.status == 200
+            body = await resp.json()
+        assert body["profile"] is None
+
+        default_cfg = yaml.safe_load(
+            (tmp_path / "config.yaml").read_text(encoding="utf-8")
+        )
+        assert "web" in default_cfg.get("platform_toolsets", {}).get(
+            "api_server", []
+        )
+
+    @pytest.mark.asyncio
+    async def test_invalid_profile_on_PUT_returns_400(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_profile(tmp_path, "default", [])
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.put(
+                "/api/tools/toolsets/browser?profile=does-not-exist",
+                json={"enabled": True},
+            )
+            assert resp.status == 400
+
+
+class TestAuthStillRequired:
+    @pytest.mark.asyncio
+    async def test_GET_requires_auth_when_key_configured(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_profile(tmp_path, "default", [])
+        app = _create_app(_make_adapter(api_key="sk-secret"))
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/tools/toolsets?profile=default")
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_PUT_requires_auth_when_key_configured(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_profile(tmp_path, "default", [])
+        app = _create_app(_make_adapter(api_key="sk-secret"))
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.put(
+                "/api/tools/toolsets/web?profile=default",
+                json={"enabled": True},
+            )
+            assert resp.status == 401


### PR DESCRIPTION
## `/api/tools/toolsets` honors `?profile=` for cross-profile config

### Why

`/api/tools/toolsets` (read + write) introduced in #23742 currently
operates on the gateway process's active profile only — toolset
state is read from / written to whichever `config.yaml` matches
`HERMES_HOME` at startup time. Once the gateway is up, there is no
way to inspect or mutate another profile's toolset config without
restarting.

For desktop / dashboard clients that manage multiple profiles from
one backend, that pinning is the whole reason the
"manage toolsets from the UI" feature can't ship end-to-end today:
the active backend profile is a moving target tied to the
long-lived process, not to the request.

This PR threads an optional `?profile=<name>` through both handlers
without changing the omit-case behaviour.

### Wire change (additive, back-compat)

```http
# Read — back-compat (default)
GET /api/tools/toolsets?platform=api_server
→ reads from get_hermes_home()/config.yaml (= today)

# Read — new optional scope
GET /api/tools/toolsets?platform=api_server&profile=mira-uitest
→ reads from <profiles_dir>/mira-uitest/config.yaml

# Write — back-compat (default)
PUT /api/tools/toolsets/web?platform=api_server  {enabled: true}
→ writes to get_hermes_home()/config.yaml (= today)

# Write — new optional scope
PUT /api/tools/toolsets/web?platform=api_server&profile=mira-uitest
→ writes to <profiles_dir>/mira-uitest/config.yaml
```

The response on the GET path picks up one new key, `profile`, that
echoes back the resolved value (`null` for the omit-case). Clients
can use it to confirm the server interpreted their scope as
expected.

Invalid profile names raise 400 via the existing
`_resolve_profile_dir` validation — same code path as the other
profile-scoped endpoints introduced in #23742
(`/api/memory?profile=`, `/api/skills/installed?profile=`, …).

### Backend allowlist policy: NONE

The backend accepts `?profile=<name>` for any name that passes
`_resolve_profile_dir` validation (existing helper from #23742 —
checks the name resolves to a real profile directory, rejects path-
traversal). There is intentionally no allowlist of "approved"
profiles in this PR. The Hermes backend stays a clean
general-purpose API; profile-restriction policies (e.g. "tonight
only the `mira-uitest` sandbox is writable") belong in the client
layer, not here.

### Files

- **`hermes_cli/config.py`** — four config helpers gain an optional
  `profile_dir: Optional[Path] = None` kwarg:
  - `get_config_path(profile_dir=None)` — returns
    `profile_dir / "config.yaml"` when provided, else
    `get_hermes_home() / "config.yaml"`.
  - `read_raw_config(profile_dir=None)` — uses the resolved path,
    keeps the existing `(mtime_ns, size)` cache keyed on the
    resolved path so per-profile and default reads coexist
    cleanly.
  - `load_config(profile_dir=None)` — same plumbing; only calls
    `ensure_hermes_home()` when operating on the default
    (a named `profile_dir` is already validated upstream by
    `_resolve_profile_dir`).
  - `save_config(config, profile_dir=None)` — atomic-replace write
    into the resolved path. **Internally calls
    `read_raw_config(profile_dir)`** to drive its `_preserve_env_ref_templates`
    step — so the template-preservation logic operates on the
    *same* file it's about to write back to. Without this both-paths
    pass-through, a named-profile write could pick up template
    references from the default's `config.yaml` and mix them into
    the per-profile file. The cross-profile-isolation sha256 test
    (`test_named_profile_write_does_NOT_touch_default`) fails any
    regression that would re-introduce that mixing.
  All four are pure additions; omitting the kwarg keeps existing
  call sites identical.

- **`hermes_cli/tools_config.py`** — two helpers thread the
  `profile_dir` through:
  - `_apply_toolset_change(config, platform, toolset_names, action, profile_dir=None)`
  - `_save_platform_tools(config, platform, enabled_toolset_keys, profile_dir=None)`
  No changes to `_get_platform_tools` (read-only on the dict
  argument) or to the user-facing CLI subcommands — they continue
  to operate on the process default.

- **`gateway/platforms/api_server.py`** — both handlers
  (`_handle_list_toolsets`, `_handle_set_toolset`) resolve the
  optional `?profile=` via the existing `_resolve_profile_dir`
  helper and pass `profile_dir` down. Read handler echoes the
  resolved profile in the response.

- **`tests/gateway/test_api_server_toolset_profile.py`** (new) —
  9 async tests covering both handlers under back-compat and
  Option-B scoping.

Net change: 3 commits, +373 / -26.

### Tests

9 tests, all new in this PR:

**Back-compat (omit `?profile=`)**:
- `test_no_profile_reads_default` — `GET …/toolsets` without
  profile reads `get_hermes_home()/config.yaml` exactly as today
- `test_no_profile_writes_to_default` — `PUT …/toolsets/<key>`
  without profile writes there too

**Scoped behaviour (named `?profile=`)**:
- `test_named_profile_reads_its_own_config` — reads from
  `<profile_dir>/config.yaml`
- `test_named_profile_write_lands_in_correct_yaml` — writes the
  toggle into the named profile's `config.yaml`
- `test_named_profile_write_does_NOT_touch_default` — explicit
  cross-profile isolation regression-guard: compare default's
  `config.yaml` sha256 before / after the named-profile write,
  must be byte-identical

**Error handling**:
- `test_invalid_profile_returns_400` — GET with a name that fails
  `_resolve_profile_dir` validation → 400
- `test_invalid_profile_on_PUT_returns_400` — same on PUT

**Auth**:
- `test_GET_requires_auth_when_key_configured` — Bearer-gating
  still enforced (auth check runs before profile resolution)
- `test_PUT_requires_auth_when_key_configured` — same on PUT

Total: 9 tests passing.

### Acceptance criteria

Verifiable against any backend running this branch:

```bash
TOKEN=…

# 1. Back-compat unchanged: omit ?profile=
curl -sH "Authorization: Bearer $TOKEN" \
  "$URL/api/tools/toolsets?platform=api_server" | jq .profile
# → null
# (reads from get_hermes_home()/config.yaml — same as today)

# 2. Named scope: read from a specific profile's config
curl -sH "Authorization: Bearer $TOKEN" \
  "$URL/api/tools/toolsets?platform=api_server&profile=mira-uitest" \
  | jq '{profile, platform, toolsets: (.toolsets | length)}'
# → profile: "mira-uitest", platform: "api_server", toolsets: 8

# 3. Named scope: write lands in the right yaml; default untouched
curl -sH "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
  -X PUT "$URL/api/tools/toolsets/web?platform=api_server&profile=mira-uitest" \
  -d '{"enabled": true}'
# → reads back from <profiles_dir>/mira-uitest/config.yaml;
#   <hermes_home>/config.yaml sha256 unchanged

# 4. Invalid profile → 400 (matches /api/memory behaviour)
curl -sw '\n%{http_code}\n' -H "Authorization: Bearer $TOKEN" \
  "$URL/api/tools/toolsets?platform=api_server&profile=../etc"
# → 400
```

### Non-goals

- Not changing the toolset config schema. `config.yaml` shape
  stays exactly as today.
- Not introducing a new endpoint. Same paths, same Bearer, an
  optional query param.
- Not validating *which* profiles are allowed. The backend
  honours any name accepted by `_resolve_profile_dir` (existing
  validation: real profile dir, no path-traversal); allowlisting
  is a client concern.
- Not touching the CLI (`hermes tools toolsets …`). The CLI still
  operates on the process default — `hermes -p <name>` already
  lets users target a specific profile by setting `HERMES_HOME`
  for the CLI run.

### Depends on

`#23742` — Remote Management API. The `/api/tools/toolsets` GET
and PUT handlers ship in #23742; this PR is the cross-profile
scoping layer for them.

### Commit chain

1. `feat(config): accept optional profile_dir in load/save_config`
   — four config helpers gain `profile_dir=None`; back-compat preserved.
2. `feat(api): /api/tools/toolsets honors ?profile= for cross-profile config`
   — both handlers resolve and pass `profile_dir` down.
3. `test(api): cover ?profile= scoping on toolsets read + write`
   — 9 async tests incl. cross-profile-isolation sha256 guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
