### PR TITLE
feat(memory): trigger background review at session boundaries (#31597)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1600,6 +1600,12 @@ def init_agent(
     agent._memory_enabled = False
     agent._user_profile_enabled = False
     agent._memory_nudge_interval = 10
+    # Session-boundary review triggers (#31597) — all opt-in. Review forks
+    # are built with skip_memory=True, so these stay False on them and a
+    # boundary review can never cascade into another boundary review.
+    agent._memory_review_on_reset = False
+    agent._memory_review_on_session_end = False
+    agent._memory_review_on_compression = False
     agent._turns_since_memory = 0
     agent._iters_since_skill = 0
     # A flush/background agent may pass skip_memory=True to avoid spinning up an
@@ -1615,6 +1621,9 @@ def init_agent(
             agent._memory_enabled = mem_config.get("memory_enabled", False)
             agent._user_profile_enabled = mem_config.get("user_profile_enabled", False)
             agent._memory_nudge_interval = int(mem_config.get("nudge_interval", 10))
+            agent._memory_review_on_reset = bool(mem_config.get("review_on_reset", False))
+            agent._memory_review_on_session_end = bool(mem_config.get("review_on_session_end", False))
+            agent._memory_review_on_compression = bool(mem_config.get("review_on_compression", False))
             if agent._memory_enabled or agent._user_profile_enabled:
                 from tools.memory_tool import MemoryStore
                 agent._memory_store = MemoryStore(

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import threading
 from typing import Any, Dict, List, Optional
 
 from agent.thread_scoped_output import thread_scoped_silence
@@ -981,10 +982,79 @@ def spawn_background_review_thread(
     return _target, prompt
 
 
+# Bounded join used by process-exit callers of maybe_spawn_boundary_review:
+# long enough for a typical review round-trip, short enough that exiting the
+# CLI never feels wedged. The thread is daemonic, so the process is free to
+# exit the moment the join times out.
+SESSION_END_REVIEW_JOIN_TIMEOUT_S = 10.0
+
+_BOUNDARY_REVIEW_FLAG_ATTRS = {
+    "reset": "_memory_review_on_reset",
+    "session_end": "_memory_review_on_session_end",
+    "compression": "_memory_review_on_compression",
+}
+
+
+def maybe_spawn_boundary_review(
+    agent: Any,
+    messages_snapshot: Optional[List[Dict]],
+    *,
+    trigger: str,
+) -> Optional[threading.Thread]:
+    """Spawn an opt-in background memory review at a session boundary (#31597).
+
+    ``trigger`` is one of ``"reset"``, ``"session_end"`` or ``"compression"``,
+    each gated by the matching ``memory.review_on_*`` config flag (all off by
+    default). The gate mirrors the turn-based nudge (turn_context.py): the
+    parent agent must actually have the memory store and memory tool
+    available, so an enabled flag can never spawn a review with nowhere to
+    write. Review forks are built with ``skip_memory=True``, which leaves
+    their own ``review_on_*`` flags False — a boundary review can never
+    cascade into another boundary review.
+
+    Returns the daemon review thread when one was spawned — exit-path callers
+    join it with ``SESSION_END_REVIEW_JOIN_TIMEOUT_S`` — else ``None``.
+    Never raises: boundary reviews are strictly best-effort and must not
+    interfere with the reset / shutdown / compression that triggered them.
+    """
+    try:
+        flag_attr = _BOUNDARY_REVIEW_FLAG_ATTRS.get(trigger)
+        if flag_attr is None or not getattr(agent, flag_attr, False):
+            return None
+        if not messages_snapshot:
+            return None
+        if not getattr(agent, "_memory_store", None):
+            return None
+        if "memory" not in (getattr(agent, "valid_tool_names", None) or ()):
+            return None
+        from tools.thread_context import propagate_context_to_thread
+
+        target, _prompt = spawn_background_review_thread(
+            agent, list(messages_snapshot), review_memory=True
+        )
+        # Same construction as AIAgent._spawn_background_review: carry the
+        # active profile into the review thread so MEMORY.md / USER.md writes
+        # land in the right profile (#54937).
+        thread = threading.Thread(
+            target=propagate_context_to_thread(target),
+            daemon=True,
+            name=f"bg-review-{trigger}",
+        )
+        thread.start()
+        return thread
+    except Exception:
+        logger.warning(
+            "Boundary memory review (%s) failed to spawn", trigger, exc_info=True
+        )
+        return None
+
+
 __all__ = [
     "_MEMORY_REVIEW_PROMPT",
     "_SKILL_REVIEW_PROMPT",
     "_COMBINED_REVIEW_PROMPT",
+    "SESSION_END_REVIEW_JOIN_TIMEOUT_S",
+    "maybe_spawn_boundary_review",
     "spawn_background_review_thread",
     "summarize_background_review_actions",
     "build_memory_write_metadata",

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1872,6 +1872,21 @@ def compress_context(
                 _release_lock()
                 return messages, _existing_sp
 
+        # Past every guard that returns without mutating the session (abort,
+        # semantic no-op, empty transcript, commit-fence cancel), so compression
+        # is now committed to rewriting the transcript — the context-loss
+        # boundary the opt-in review exists for (#31597). Fires in BOTH in-place
+        # and rotation modes, independently of session_db. Hands the review the
+        # pre-dispatch deepcopy rather than a fresh copy: the rollback path
+        # below only ever deepcopies FROM it, so it is read-only from here on
+        # and safe to share with the review thread.
+        if getattr(agent, "_memory_review_on_compression", False):
+            from agent.background_review import maybe_spawn_boundary_review
+
+            maybe_spawn_boundary_review(
+                agent, messages_before_compression, trigger="compression"
+            )
+
         summary_error = getattr(agent.context_compressor, "_last_summary_error", None)
         if summary_error:
             if getattr(agent, "_last_compression_summary_warning", None) != summary_error:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -663,6 +663,19 @@ memory:
   # For exit/reset, only fires if the session had at least this many user turns.
   flush_min_turns: 6        # Min user turns to trigger flush on exit/reset (0 = disabled)
 
+  # Background memory review at session boundaries (#31597). Complements
+  # nudge_interval (which fires mid-conversation) by firing an out-of-band
+  # background review thread at natural boundaries; unlike flush_min_turns
+  # (an inline turn), the review never blocks the conversation or shutdown.
+  # All default to false -- opt in per boundary. Only active when memory is
+  # enabled.
+  review_on_reset: false        # /new, /reset (CLI, TUI, and gateway)
+  review_on_session_end: false  # CLI exit (bounded ~10s join), TUI session
+                                # close, gateway session expiry
+  review_on_compression: false  # After a SUCCESSFUL compression, with a
+                                # snapshot of the pre-compression transcript;
+                                # aborted / no-op compressions never fire
+
 # =============================================================================
 # Session Reset Policy (Messaging Platforms)
 # =============================================================================

--- a/cli.py
+++ b/cli.py
@@ -1215,6 +1215,21 @@ def _run_cleanup(*, notify_session_finalize: bool = True):
             )
     try:
         if _active_agent_ref and hasattr(_active_agent_ref, 'shutdown_memory_provider'):
+            # Opt-in boundary review at CLI exit (memory.review_on_session_end,
+            # #31597). Spawned FIRST so its LLM round-trip overlaps the
+            # provider drain below; joined (bounded) after provider shutdown.
+            # Daemon thread — never blocks process exit beyond the join.
+            _exit_review_thread = None
+            try:
+                from agent.background_review import maybe_spawn_boundary_review
+                _exit_review_msgs = getattr(_active_agent_ref, '_session_messages', None)
+                _exit_review_thread = maybe_spawn_boundary_review(
+                    _active_agent_ref,
+                    _exit_review_msgs if isinstance(_exit_review_msgs, list) else [],
+                    trigger="session_end",
+                )
+            except Exception:
+                pass
             # A /new shortly before exit leaves its end→switch boundary task
             # (old-session extraction, LLM-bound) queued on the memory
             # manager's serialized worker. shutdown_all()'s drain only waits
@@ -1248,6 +1263,9 @@ def _run_cleanup(*, notify_session_finalize: bool = True):
                     getattr(_active_agent_ref, "session_id", None) or "<unknown>",
                 )
                 _active_agent_ref.shutdown_memory_provider()
+            if _exit_review_thread is not None:
+                from agent.background_review import SESSION_END_REVIEW_JOIN_TIMEOUT_S
+                _exit_review_thread.join(timeout=SESSION_END_REVIEW_JOIN_TIMEOUT_S)
     except Exception as e:
         logger.warning("CLI cleanup memory shutdown failed: %s", e, exc_info=True)
 
@@ -7419,6 +7437,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             _boundary_snapshot = self._launch_session_boundary_memory_flush(
                 list(self.conversation_history),
                 session_id=old_session_id,
+            )
+            # Opt-in boundary review on /new (memory.review_on_reset, #31597):
+            # review the conversation being rotated away. It runs on its own
+            # fork with its own snapshot copy and never touches provider
+            # session state, so the provider end→switch task queued below on
+            # the memory manager's serialized worker (#16454) is unaffected.
+            from agent.background_review import maybe_spawn_boundary_review
+
+            maybe_spawn_boundary_review(
+                self.agent, list(self.conversation_history), trigger="reset"
             )
             self._notify_session_boundary("on_session_finalize")
         elif self.agent:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9023,6 +9023,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         if _cached_agent is None:
                             _cached_agent = self._running_agents.get(key)
                         if _cached_agent and _cached_agent is not _AGENT_PENDING_SENTINEL:
+                            # Opt-in boundary review on session expiry
+                            # (memory.review_on_session_end, #31597): the session
+                            # is being permanently finalized — review its
+                            # transcript before the agent's resources are torn
+                            # down. The review fork uses its own clients, so the
+                            # off-loop cleanup below cannot race it.
+                            try:
+                                from agent.background_review import (
+                                    maybe_spawn_boundary_review,
+                                )
+
+                                _exp_msgs = getattr(
+                                    _cached_agent, "_session_messages", None
+                                )
+                                maybe_spawn_boundary_review(
+                                    _cached_agent,
+                                    _exp_msgs if isinstance(_exp_msgs, list) else [],
+                                    trigger="session_end",
+                                )
+                            except Exception:
+                                pass
                             await self._cleanup_agent_resources_off_loop(
                                 _cached_agent, context="session expiry"
                             )

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -139,6 +139,23 @@ class GatewaySlashCommandsMixin:
                 _cached = self._agent_cache.get(session_key)
                 _old_agent = _cached[0] if isinstance(_cached, tuple) else _cached if _cached else None
             if _old_agent is not None:
+                # Opt-in boundary review on gateway /new (memory.review_on_reset,
+                # #31597): snapshot the conversation being reset before the old
+                # agent is torn down. The review runs on its own fork with fresh
+                # clients (skip_memory=True), so the concurrent resource cleanup
+                # below — which only closes the OLD agent's clients/providers —
+                # cannot pull resources out from under it.
+                try:
+                    from agent.background_review import maybe_spawn_boundary_review
+
+                    _old_msgs = getattr(_old_agent, "_session_messages", None)
+                    maybe_spawn_boundary_review(
+                        _old_agent,
+                        _old_msgs if isinstance(_old_msgs, list) else [],
+                        trigger="reset",
+                    )
+                except Exception:
+                    pass
                 try:
                     await asyncio.wait_for(
                         self._run_in_executor_with_context(

--- a/tests/run_agent/test_memory_review_session_boundaries.py
+++ b/tests/run_agent/test_memory_review_session_boundaries.py
@@ -1,0 +1,624 @@
+"""Tests for memory.review_on_reset / review_on_session_end / review_on_compression (#31597).
+
+Each flag gates a call to ``agent.background_review.maybe_spawn_boundary_review``
+at the matching session boundary:
+
+- ``reset``        → CLI ``HermesCLI.new_session``, TUI ``_reset_session_agent``,
+                     gateway ``_handle_reset_command``
+- ``session_end``  → CLI ``_run_cleanup`` (exit, bounded join),
+                     TUI ``_finalize_session``, gateway session expiry
+- ``compression``  → ``compress_context``, only AFTER the abort / no-op guards,
+                     with a snapshot captured BEFORE ``compress()``
+
+Gating (flags, empty snapshots, missing memory store/tool) is centralised in
+the helper and unit-tested here; the per-surface tests exercise the *real*
+wiring code paths and assert the helper is invoked with the right trigger and
+snapshot.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+HISTORY = [
+    {"role": "user", "content": "remember my dog is named Biscuit"},
+    {"role": "assistant", "content": "Got it — Biscuit."},
+]
+
+
+# ---------------------------------------------------------------------------
+# maybe_spawn_boundary_review — central gate
+# ---------------------------------------------------------------------------
+
+class TestMaybeSpawnBoundaryReviewGate:
+    """The helper owns all gating: flags, snapshot, store/tool availability."""
+
+    def _agent(self, **overrides):
+        agent = SimpleNamespace(
+            _memory_review_on_reset=False,
+            _memory_review_on_session_end=False,
+            _memory_review_on_compression=False,
+            _memory_store=object(),
+            valid_tool_names=["memory", "task"],
+        )
+        for key, value in overrides.items():
+            setattr(agent, key, value)
+        return agent
+
+    def _patch_spawn(self, monkeypatch, captured):
+        import agent.background_review as br_mod
+
+        def fake_spawn(agent, messages_snapshot, review_memory=False, review_skills=False):
+            captured["agent"] = agent
+            captured["messages"] = messages_snapshot
+            captured["review_memory"] = review_memory
+            captured["ran"] = threading.Event()
+            return captured["ran"].set, "prompt"
+
+        monkeypatch.setattr(br_mod, "spawn_background_review_thread", fake_spawn)
+
+    def test_spawns_named_daemon_thread_per_trigger(self, monkeypatch):
+        from agent.background_review import maybe_spawn_boundary_review
+
+        flag_by_trigger = {
+            "reset": "_memory_review_on_reset",
+            "session_end": "_memory_review_on_session_end",
+            "compression": "_memory_review_on_compression",
+        }
+        for trigger, flag in flag_by_trigger.items():
+            captured = {}
+            self._patch_spawn(monkeypatch, captured)
+            agent = self._agent(**{flag: True})
+
+            thread = maybe_spawn_boundary_review(agent, HISTORY, trigger=trigger)
+
+            assert thread is not None, f"trigger {trigger!r} should spawn"
+            assert thread.daemon is True
+            assert thread.name == f"bg-review-{trigger}"
+            thread.join(timeout=5)
+            assert captured["ran"].is_set()
+            assert captured["review_memory"] is True
+            assert captured["agent"] is agent
+
+    def test_flag_off_spawns_nothing(self, monkeypatch):
+        from agent.background_review import maybe_spawn_boundary_review
+
+        captured = {}
+        self._patch_spawn(monkeypatch, captured)
+        agent = self._agent()  # all flags False
+
+        for trigger in ("reset", "session_end", "compression"):
+            assert maybe_spawn_boundary_review(agent, HISTORY, trigger=trigger) is None
+        assert captured == {}
+
+    def test_unknown_trigger_spawns_nothing(self, monkeypatch):
+        from agent.background_review import maybe_spawn_boundary_review
+
+        captured = {}
+        self._patch_spawn(monkeypatch, captured)
+        agent = self._agent(_memory_review_on_reset=True)
+
+        assert maybe_spawn_boundary_review(agent, HISTORY, trigger="bogus") is None
+        assert captured == {}
+
+    def test_empty_snapshot_spawns_nothing(self, monkeypatch):
+        from agent.background_review import maybe_spawn_boundary_review
+
+        captured = {}
+        self._patch_spawn(monkeypatch, captured)
+        agent = self._agent(_memory_review_on_reset=True)
+
+        assert maybe_spawn_boundary_review(agent, [], trigger="reset") is None
+        assert maybe_spawn_boundary_review(agent, None, trigger="reset") is None
+        assert captured == {}
+
+    def test_missing_memory_store_spawns_nothing(self, monkeypatch):
+        from agent.background_review import maybe_spawn_boundary_review
+
+        captured = {}
+        self._patch_spawn(monkeypatch, captured)
+        agent = self._agent(_memory_review_on_reset=True, _memory_store=None)
+
+        assert maybe_spawn_boundary_review(agent, HISTORY, trigger="reset") is None
+        assert captured == {}
+
+    def test_missing_memory_tool_spawns_nothing(self, monkeypatch):
+        from agent.background_review import maybe_spawn_boundary_review
+
+        captured = {}
+        self._patch_spawn(monkeypatch, captured)
+        agent = self._agent(
+            _memory_review_on_reset=True, valid_tool_names=["task", "terminal"]
+        )
+
+        assert maybe_spawn_boundary_review(agent, HISTORY, trigger="reset") is None
+        assert captured == {}
+
+    def test_snapshot_is_copied(self, monkeypatch):
+        from agent.background_review import maybe_spawn_boundary_review
+
+        captured = {}
+        self._patch_spawn(monkeypatch, captured)
+        agent = self._agent(_memory_review_on_reset=True)
+        original = list(HISTORY)
+
+        thread = maybe_spawn_boundary_review(agent, original, trigger="reset")
+
+        assert thread is not None
+        thread.join(timeout=5)
+        assert captured["messages"] == original
+        assert captured["messages"] is not original
+
+    def test_spawn_failure_returns_none_without_raising(self, monkeypatch):
+        import agent.background_review as br_mod
+        from agent.background_review import maybe_spawn_boundary_review
+
+        monkeypatch.setattr(
+            br_mod,
+            "spawn_background_review_thread",
+            MagicMock(side_effect=RuntimeError("boom")),
+        )
+        agent = self._agent(_memory_review_on_reset=True)
+
+        assert maybe_spawn_boundary_review(agent, HISTORY, trigger="reset") is None
+
+
+# ---------------------------------------------------------------------------
+# review_on_compression — compress_context wiring
+# ---------------------------------------------------------------------------
+
+class TestReviewOnCompression:
+    """Fires only after the abort / no-op guards, with a pre-compression snapshot."""
+
+    def _make_agent(self):
+        import os
+
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+            from run_agent import AIAgent
+
+            agent = AIAgent(
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+                model="test/model",
+                quiet_mode=True,
+                session_db=None,
+                session_id="original-session",
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        return agent
+
+    def _stub_compressor(self, agent, *, compress_side_effect, aborted=False):
+        compressor = MagicMock()
+        compressor.compress.side_effect = compress_side_effect
+        compressor.compression_count = 1
+        compressor.last_prompt_tokens = 0
+        compressor.last_completion_tokens = 0
+        compressor._last_summary_error = None
+        compressor._last_compress_aborted = aborted
+        compressor._last_aux_model_failure_model = None
+        compressor._last_aux_model_failure_error = None
+        agent.context_compressor = compressor
+        return compressor
+
+    def test_successful_compression_fires_with_pre_compression_snapshot(self):
+        agent = self._make_agent()
+        agent._memory_review_on_compression = True
+        self._stub_compressor(
+            agent,
+            compress_side_effect=lambda msgs, **kw: [
+                {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+                {"role": "user", "content": "tail question"},
+            ],
+        )
+        messages = [{"role": "user", "content": f"m{i}"} for i in range(10)]
+        original = list(messages)
+
+        with patch("agent.background_review.maybe_spawn_boundary_review") as spawn:
+            agent._compress_context(messages, "sys", approx_tokens=10_000)
+
+        spawn.assert_called_once()
+        args, kwargs = spawn.call_args
+        assert args[0] is agent
+        assert kwargs.get("trigger") == "compression"
+        # The snapshot is the PRE-compression transcript, captured as a copy
+        # so the compressor rewriting `messages` cannot mutate it.
+        assert args[1] == original
+        assert args[1] is not messages
+
+    def test_aborted_compression_does_not_fire(self):
+        """An aborted compression retains the transcript — no context-loss
+        boundary, so the opt-in review cost must not be paid (sweeper review
+        of the original patch)."""
+        agent = self._make_agent()
+        agent._memory_review_on_compression = True
+        self._stub_compressor(
+            agent,
+            compress_side_effect=lambda msgs, **kw: msgs,
+            aborted=True,
+        )
+        messages = [{"role": "user", "content": "lots of context"}]
+
+        with patch("agent.background_review.maybe_spawn_boundary_review") as spawn:
+            result, _sp = agent._compress_context(messages, "sys", approx_tokens=10_000)
+
+        spawn.assert_not_called()
+        assert result is messages
+
+    def test_empty_transcript_does_not_fire(self):
+        """A compressor returning an empty transcript is refused upstream (no
+        session split); nothing was discarded, so no review fires."""
+        agent = self._make_agent()
+        agent._memory_review_on_compression = True
+        self._stub_compressor(agent, compress_side_effect=lambda msgs, **kw: [])
+        messages = [{"role": "user", "content": f"m{i}"} for i in range(10)]
+
+        with patch("agent.background_review.maybe_spawn_boundary_review") as spawn:
+            result, _sp = agent._compress_context(messages, "sys", approx_tokens=10_000)
+
+        spawn.assert_not_called()
+        assert result is messages
+
+    def test_cancelled_commit_fence_does_not_fire(self):
+        """A commit fence cancelled before the boundary aborts compression
+        without mutating the session — same no-context-loss invariant as the
+        abort / no-op paths, so the review must not fire."""
+        from agent.conversation_compression import CompressionCommitFence
+
+        agent = self._make_agent()
+        agent._memory_review_on_compression = True
+        self._stub_compressor(
+            agent,
+            compress_side_effect=lambda msgs, **kw: [
+                {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+                {"role": "user", "content": "tail question"},
+            ],
+        )
+        messages = [{"role": "user", "content": f"m{i}"} for i in range(10)]
+
+        fence = CompressionCommitFence()
+        assert fence.cancel_before_commit() is True
+
+        with patch("agent.background_review.maybe_spawn_boundary_review") as spawn:
+            result, _sp = agent._compress_context(
+                messages, "sys", approx_tokens=10_000, commit_fence=fence
+            )
+
+        spawn.assert_not_called()
+        assert result is messages
+
+    def test_noop_compression_does_not_fire(self):
+        """A compressor returning the input object made no structural progress
+        — nothing was discarded, so no review fires."""
+        agent = self._make_agent()
+        agent._memory_review_on_compression = True
+        self._stub_compressor(agent, compress_side_effect=lambda msgs, **kw: msgs)
+        messages = [{"role": "user", "content": "x"}]
+
+        with patch("agent.background_review.maybe_spawn_boundary_review") as spawn:
+            result, _sp = agent._compress_context(messages, "sys", approx_tokens=10_000)
+
+        spawn.assert_not_called()
+        assert result is messages
+
+    def test_flag_off_does_not_fire_or_snapshot(self):
+        agent = self._make_agent()
+        agent._memory_review_on_compression = False
+        self._stub_compressor(
+            agent,
+            compress_side_effect=lambda msgs, **kw: [
+                {"role": "user", "content": "[CONTEXT COMPACTION] summary"}
+            ],
+        )
+        messages = [{"role": "user", "content": f"m{i}"} for i in range(10)]
+
+        with patch("agent.background_review.maybe_spawn_boundary_review") as spawn:
+            agent._compress_context(messages, "sys", approx_tokens=10_000)
+
+        spawn.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# review_on_reset — CLI HermesCLI.new_session
+# ---------------------------------------------------------------------------
+
+class TestReviewOnResetCLI:
+    """/new hands the helper a copy of the history being rotated away,
+    alongside (not inside) the serialized provider end→switch task (#16454)."""
+
+    @patch("hermes_cli.plugins.invoke_hook")
+    def test_new_session_fires_reset_review(self, _mock_hook):
+        from cli import HermesCLI
+
+        cli = HermesCLI()
+        cli.agent = MagicMock()
+        cli.agent.session_id = "old-session-id"
+        cli.conversation_history = list(HISTORY)
+
+        with patch("agent.background_review.maybe_spawn_boundary_review") as spawn:
+            cli.new_session(silent=True)
+
+        spawn.assert_called_once()
+        args, kwargs = spawn.call_args
+        assert args[0] is cli.agent
+        assert kwargs.get("trigger") == "reset"
+        # Copy of the pre-reset history — new_session clears the live list.
+        assert args[1] == HISTORY
+        assert cli.conversation_history == []
+        # The provider end→switch ordering contract (#16454) is untouched:
+        # extraction + rebinding still go through the memory manager's
+        # serialized boundary task, not through the review thread.
+        cli.agent._memory_manager.commit_session_boundary_async.assert_called_once()
+
+    @patch("hermes_cli.plugins.invoke_hook")
+    def test_new_session_without_history_does_not_fire(self, _mock_hook):
+        from cli import HermesCLI
+
+        cli = HermesCLI()
+        cli.agent = MagicMock()
+        cli.agent.session_id = "old-session-id"
+        cli.conversation_history = []
+
+        with patch("agent.background_review.maybe_spawn_boundary_review") as spawn:
+            cli.new_session(silent=True)
+
+        spawn.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# review_on_session_end — CLI exit (_run_cleanup)
+# ---------------------------------------------------------------------------
+
+class TestReviewOnSessionEndCLIExit:
+    """CLI exit spawns the review before the provider drain and joins it
+    (bounded) after provider shutdown, so exit is never wedged."""
+
+    def _run_cleanup_with(self, agent, spawn_return):
+        import cli as cli_mod
+
+        with patch(
+            "agent.background_review.maybe_spawn_boundary_review",
+            return_value=spawn_return,
+        ) as spawn:
+            cli_mod._active_agent_ref = agent
+            cli_mod._cleanup_done = False
+            try:
+                cli_mod._run_cleanup()
+            finally:
+                cli_mod._active_agent_ref = None
+                cli_mod._cleanup_done = False
+        return spawn
+
+    @patch("hermes_cli.plugins.invoke_hook")
+    def test_cleanup_fires_session_end_review_and_joins(self, _mock_hook):
+        from agent.background_review import SESSION_END_REVIEW_JOIN_TIMEOUT_S
+
+        agent = MagicMock()
+        agent.session_id = "cli-session-id"
+        agent._session_messages = list(HISTORY)
+        fake_thread = MagicMock()
+
+        spawn = self._run_cleanup_with(agent, fake_thread)
+
+        spawn.assert_called_once()
+        args, kwargs = spawn.call_args
+        assert args[0] is agent
+        assert args[1] == HISTORY
+        assert kwargs.get("trigger") == "session_end"
+        # Review overlaps the provider drain, then gets a bounded join.
+        fake_thread.join.assert_called_once_with(
+            timeout=SESSION_END_REVIEW_JOIN_TIMEOUT_S
+        )
+        # Provider shutdown still ran.
+        agent.shutdown_memory_provider.assert_called_once()
+
+    @patch("hermes_cli.plugins.invoke_hook")
+    def test_cleanup_non_list_messages_pass_empty_snapshot(self, _mock_hook):
+        agent = MagicMock()
+        agent.session_id = "cli-session-id"
+        # MagicMock auto-synthesises _session_messages as a non-list mock.
+
+        spawn = self._run_cleanup_with(agent, None)
+
+        spawn.assert_called_once()
+        assert spawn.call_args.args[1] == []
+
+    @patch("hermes_cli.plugins.invoke_hook")
+    def test_cleanup_survives_no_spawned_thread(self, _mock_hook):
+        """helper returning None (flag off / gated) must not break cleanup."""
+        agent = MagicMock()
+        agent.session_id = "cli-session-id"
+        agent._session_messages = list(HISTORY)
+
+        self._run_cleanup_with(agent, None)  # must not raise
+
+        agent.shutdown_memory_provider.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# review_on_reset / review_on_session_end — TUI server
+# ---------------------------------------------------------------------------
+
+class TestReviewOnTUIBoundaries:
+    def _make_session(self, agent, history):
+        return {
+            "session_key": "tui-key-001",
+            "agent": agent,
+            "history": list(history),
+            "history_lock": threading.Lock(),
+            "model_override": None,
+        }
+
+    @patch("hermes_cli.plugins.invoke_hook")
+    def test_finalize_session_fires_session_end_review(self, _mock_hook):
+        from tui_gateway.server import _finalize_session
+
+        agent = MagicMock()
+        agent.session_id = "tui-session-id"
+        agent._session_messages = None
+        session = self._make_session(agent, HISTORY)
+
+        with patch("agent.background_review.maybe_spawn_boundary_review") as spawn:
+            _finalize_session(session, end_reason="tui_close")
+
+        spawn.assert_called_once()
+        args, kwargs = spawn.call_args
+        assert args[0] is agent
+        assert args[1] == HISTORY
+        assert kwargs.get("trigger") == "session_end"
+        agent.commit_memory_session.assert_called_once()
+
+    @patch("hermes_cli.plugins.invoke_hook")
+    def test_finalize_session_empty_history_does_not_fire(self, _mock_hook):
+        from tui_gateway.server import _finalize_session
+
+        agent = MagicMock()
+        agent.session_id = "tui-session-id"
+        agent._session_messages = None
+        session = self._make_session(agent, [])
+
+        with patch("agent.background_review.maybe_spawn_boundary_review") as spawn:
+            _finalize_session(session, end_reason="tui_close")
+
+        spawn.assert_not_called()
+
+    def test_reset_session_agent_fires_reset_review_with_old_history(self):
+        import tui_gateway.server as tui_server
+
+        old_agent = MagicMock()
+        session = self._make_session(old_agent, HISTORY)
+
+        with patch.object(tui_server, "_set_session_context", return_value=[]), \
+                patch.object(tui_server, "_clear_session_context"), \
+                patch.object(tui_server, "_make_agent", return_value=MagicMock()), \
+                patch.object(tui_server, "_config_model_target", return_value="m"), \
+                patch.object(tui_server, "_load_show_reasoning", return_value=False), \
+                patch.object(tui_server, "_load_tool_progress_mode", return_value="all"), \
+                patch.object(tui_server, "_session_info", return_value={}), \
+                patch.object(tui_server, "_emit"), \
+                patch.object(tui_server, "_restart_slash_worker"), \
+                patch("agent.background_review.maybe_spawn_boundary_review") as spawn:
+            tui_server._reset_session_agent("sid-1", session)
+
+        spawn.assert_called_once()
+        args, kwargs = spawn.call_args
+        assert args[0] is old_agent
+        assert kwargs.get("trigger") == "reset"
+        # Snapshot of the history that the reset then cleared.
+        assert args[1] == HISTORY
+        assert session["history"] == []
+
+
+# ---------------------------------------------------------------------------
+# review_on_reset — gateway /new (_handle_reset_command)
+# ---------------------------------------------------------------------------
+
+class TestReviewOnGatewayReset:
+    def test_reset_command_fires_reset_review_before_teardown(self):
+        from gateway.slash_commands import GatewaySlashCommandsMixin
+
+        stub_agent = SimpleNamespace(_session_messages=list(HISTORY))
+        gateway = MagicMock()
+        gateway._agent_cache.get.return_value = (stub_agent, object())
+        gateway._run_in_executor_with_context = AsyncMock()
+        event = MagicMock()
+
+        async def _invoke():
+            # The tail of the reset handler touches live-gateway internals the
+            # MagicMock self doesn't model; the review hook fires before them.
+            try:
+                await GatewaySlashCommandsMixin._handle_reset_command(gateway, event)
+            except Exception:
+                pass
+
+        with patch("agent.background_review.maybe_spawn_boundary_review") as spawn:
+            asyncio.run(_invoke())
+
+        spawn.assert_called_once()
+        args, kwargs = spawn.call_args
+        assert args[0] is stub_agent
+        assert args[1] == HISTORY
+        assert kwargs.get("trigger") == "reset"
+
+
+# ---------------------------------------------------------------------------
+# review_on_session_end — gateway session expiry (_session_expiry_watcher)
+# ---------------------------------------------------------------------------
+
+class TestReviewOnGatewayExpiry:
+    """Mirrors the #14981 expiry-watcher fixture from
+    tests/gateway/test_session_boundary_hooks.py."""
+
+    @pytest.mark.asyncio
+    @patch("hermes_cli.plugins.invoke_hook")
+    async def test_session_expiry_fires_session_end_review(self, mock_invoke_hook):
+        from datetime import datetime, timedelta
+
+        from gateway.config import Platform
+        from gateway.run import GatewayRunner
+        from gateway.session import SessionEntry
+
+        runner = object.__new__(GatewayRunner)
+        runner._running = True
+        runner._running_agents = {}
+        runner._last_session_store_prune_ts = 0.0
+
+        stub_agent = SimpleNamespace(_session_messages=list(HISTORY))
+        session_key = "agent:main:telegram:dm:42"
+        runner._agent_cache = {session_key: (stub_agent, object())}
+        runner._agent_cache_lock = threading.Lock()
+
+        expired_entry = SessionEntry(
+            session_key=session_key,
+            session_id="sess-expired",
+            created_at=datetime.now() - timedelta(hours=2),
+            updated_at=datetime.now() - timedelta(hours=2),
+            platform=Platform.TELEGRAM,
+            chat_type="dm",
+        )
+        expired_entry.expiry_finalized = False
+
+        runner.session_store = MagicMock()
+        runner.session_store._ensure_loaded = MagicMock()
+        runner.session_store._entries = {session_key: expired_entry}
+        runner.session_store._is_session_expired = MagicMock(return_value=True)
+        runner.session_store._lock = MagicMock()
+        runner.session_store._lock.__enter__ = MagicMock(return_value=None)
+        runner.session_store._lock.__exit__ = MagicMock(return_value=None)
+        runner.session_store._save = MagicMock()
+
+        runner._evict_cached_agent = MagicMock()
+        runner._cleanup_agent_resources = MagicMock()
+        runner._cleanup_agent_resources_off_loop = AsyncMock()
+        runner._sweep_idle_cached_agents = MagicMock(return_value=0)
+
+        # Make the watcher's initial 60s sleep instant, and stop the loop
+        # after the first expiry pass fires its plugin hook.
+        _orig_sleep = asyncio.sleep
+
+        async def _fast_sleep(_):
+            await _orig_sleep(0)
+
+        def _hook_and_stop(*_a, **_kw):
+            runner._running = False
+            return None
+
+        mock_invoke_hook.side_effect = _hook_and_stop
+
+        with patch("gateway.run.asyncio.sleep", side_effect=_fast_sleep), \
+                patch("agent.background_review.maybe_spawn_boundary_review") as spawn:
+            await runner._session_expiry_watcher(interval=0)
+
+        spawn.assert_called_once()
+        args, kwargs = spawn.call_args
+        assert args[0] is stub_agent
+        assert args[1] == HISTORY
+        assert kwargs.get("trigger") == "session_end"
+        # The review is scheduled before resource teardown, which still runs.
+        runner._cleanup_agent_resources_off_loop.assert_awaited()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -668,6 +668,15 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
             pass
 
     if agent is not None and history and hasattr(agent, "commit_memory_session"):
+        # Opt-in boundary review at TUI session close
+        # (memory.review_on_session_end, #31597) — same boundary moment as
+        # the memory commit below, sharing its history snapshot.
+        try:
+            from agent.background_review import maybe_spawn_boundary_review
+
+            maybe_spawn_boundary_review(agent, history, trigger="session_end")
+        except Exception:
+            pass
         try:
             agent.commit_memory_session(history)
         except Exception:
@@ -5333,6 +5342,24 @@ def _preview_restart_callbacks(parent: str, task_id: str) -> dict:
 
 
 def _reset_session_agent(sid: str, session: dict) -> dict:
+    # Opt-in boundary review (memory.review_on_reset, #31597): the reset below
+    # replaces the agent and clears history — review the conversation being
+    # discarded first, snapshotting history under its lock. Uses the OLD
+    # agent so the review inherits the runtime the conversation actually ran on.
+    _old_agent = session.get("agent")
+    if _old_agent is not None:
+        try:
+            from agent.background_review import maybe_spawn_boundary_review
+
+            _lock = session.get("history_lock")
+            if _lock is not None:
+                with _lock:
+                    _old_history = list(session.get("history") or [])
+            else:
+                _old_history = list(session.get("history") or [])
+            maybe_spawn_boundary_review(_old_agent, _old_history, trigger="reset")
+        except Exception:
+            pass
     tokens = _set_session_context(session["session_key"])
     try:
         # /new is a full conversation boundary: session-scoped runtime


### PR DESCRIPTION
## What does this PR do?

Adds three opt-in config flags under `memory:` that fire a **background memory review** at natural session boundaries, complementing the existing `nudge_interval` (which fires mid-conversation).

```yaml
memory:
  review_on_reset: false        # /new, /reset (CLI, TUI, gateway)
  review_on_session_end: false  # CLI exit, TUI session close, gateway session expiry
  review_on_compression: false  # after a SUCCESSFUL compression (pre-compression snapshot)
```

All flags default to `false` — **no behaviour change for existing users**.

> **Note:** this is a redesign of the original patch against the current boundary lifecycle, addressing the hermes-sweeper review (the original branch predated ~4.5k commits of boundary work on main). See the review thread for the point-by-point mapping.

**Why this approach.** `nudge_interval` triggers reviews at arbitrary mid-conversation turns, but the resulting `MEMORY.md` / `USER.md` writes are only picked up by the system prompt at the **next** session. The natural moments for review are session boundaries. All gating lives in one central helper, `agent.background_review.maybe_spawn_boundary_review(agent, snapshot, trigger=...)`, wired at each surface's existing boundary coordinator.

### Design notes

- **Compression timing.** The pre-compression snapshot is captured *before* `compress()` (the review needs the turns that are about to be summarized away), but the review is spawned only *after* the abort (`_last_compress_aborted`) and no-op (`compressed is messages`) guards — an aborted compression retains the transcript and never pays the review cost. Fires in both in-place and rotation modes, independently of `session_db`.
- **Cross-surface coverage.**
  - `reset` → `HermesCLI.new_session` (CLI), `_reset_session_agent` (TUI), `_handle_reset_command` (gateway)
  - `session_end` → `_run_cleanup` (CLI exit, bounded join), `_finalize_session` (TUI close/reap), `_session_expiry_watcher` (gateway expiry)
  - Teardown paths where the session logically continues (gateway session-hygiene rebuilds, LRU soft-eviction) deliberately get **no** hook, so the opt-in cost only ever buys a real boundary.
- **`/new` ordering contract (#16454).** The review fires in `new_session` beside the boundary snapshot, on its own forked agent with its own snapshot copy. The provider end→switch pair still flows through `MemoryManager.commit_session_boundary_async` as one serialized task — untouched.
- **Recursion safety.** Review forks are built with `skip_memory=True`, so their `review_on_*` flags stay `False` — a boundary review can never cascade into another. The helper also mirrors the turn-nudge gate (memory store + memory tool present), so an enabled flag can't spawn a review with nowhere to write.
- **Session-end thread lifetime.** The review thread is daemonic; the CLI exit path spawns it *before* the provider drain (so the LLM round-trips overlap) and joins it afterwards with `SESSION_END_REVIEW_JOIN_TIMEOUT_S` (10s) — most reviews complete, shutdown never wedges.
- **Relationship to `flush_min_turns`.** Unchanged: `flush_min_turns` is an *inline* turn that lets the agent save memory itself; these flags spawn an *out-of-band* review thread. Complementary, not duplicative — this PR does not touch `flush_min_turns`.

## Related Issue

Fixes #31597

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/agent_init.py` — read the three new flags from `memory:` config (default `False`; stay `False` under `skip_memory=True`)
- `agent/background_review.py` — new central gate `maybe_spawn_boundary_review()` + `SESSION_END_REVIEW_JOIN_TIMEOUT_S`
- `agent/conversation_compression.py` — pre-compression snapshot captured before `compress()`, review spawned only after the abort / no-op guards
- `cli.py` — `reset` wired into `new_session` (beside the serialized boundary task), `session_end` into `_run_cleanup` (spawn before provider drain, bounded join after shutdown)
- `gateway/slash_commands.py` — `reset` wired into `_handle_reset_command` before old-agent teardown
- `gateway/run.py` — `session_end` wired into the session-expiry sweep
- `tui_gateway/server.py` — `reset` wired into `_reset_session_agent`, `session_end` into `_finalize_session`
- `cli-config.yaml.example` — document the three new flags alongside `nudge_interval` / `flush_min_turns`
- `tests/run_agent/test_memory_review_session_boundaries.py` — 22 tests: central-gate unit tests, per-surface wiring tests, and explicit non-firing tests for compression abort / no-op

## How to Test

1. Run the new tests:
   ```bash
   scripts/run_tests.sh tests/run_agent/test_memory_review_session_boundaries.py
   # 22 passed
   ```

2. Regression check on adjacent suites (all green locally, 137 tests):
   ```bash
   scripts/run_tests.sh \
     tests/run_agent/test_background_review.py \
     tests/run_agent/test_background_review_summary.py \
     tests/run_agent/test_background_review_cost_controls.py \
     tests/run_agent/test_compression_boundary.py \
     tests/run_agent/test_compression_boundary_hook.py \
     tests/run_agent/test_413_compression.py \
     tests/run_agent/test_compression_feasibility.py \
     tests/cli/test_session_boundary_hooks.py \
     tests/cli/test_cli_shutdown_memory_messages.py \
     tests/cli/test_cli_new_session.py \
     tests/gateway/test_session_boundary_hooks.py \
     tests/gateway/test_35994_reset_button_deadlock.py \
     tests/gateway/test_10710_auto_reset_evicts_cached_agent.py \
     tests/gateway/test_35809_auto_reset_clean_context.py \
     tests/tui_gateway/test_finalize_session_persist.py
   ```

3. Manual end-to-end (opt-in flow):
   - In `~/.hermes/config.yaml`, set `memory.review_on_reset: true`
   - Start `hermes`, have a multi-turn conversation that produces something memory-worthy
   - Run `/new` → confirm a `bg-review-reset` thread fires and `MEMORY.md` / `USER.md` update before the next session loads its system prompt
   - Repeat with `review_on_compression: true` against a long session that hits the auto-compression threshold (and confirm no review fires when compression aborts)
   - Repeat with `review_on_session_end: true` and exit the CLI cleanly — confirm the review completes within ~10s

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(memory): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run the new tests + adjacent suites (22 + 137 passed via `scripts/run_tests.sh`). I did **not** run the full `pytest tests/ -q` locally; happy to do so or rely on CI.
- [x] I've added tests for my changes (22 tests exercising the real `HermesCLI.new_session`, `_run_cleanup`, `compress_context`, `_finalize_session`, `_reset_session_agent`, `_handle_reset_command`, and `_session_expiry_watcher` code paths)
- [x] I've tested on my platform: Ubuntu (WSL2) / Python 3.12

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — **N/A** (new config keys are documented in `cli-config.yaml.example`)
- [x] I've updated `cli-config.yaml.example` for the new config keys
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — **N/A** (wires existing boundary coordinators; no architectural change)
- [x] I've considered cross-platform impact — pure-Python threading + config flags, no OS-specific behaviour
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — **N/A**

## Screenshots / Logs

N/A — change is observable via existing logs (`bg-review-<trigger>` thread spawn) and `MEMORY.md` / `USER.md` writes at the new trigger points.
