### PR TITLE
docs: document Z.AI MCP web research pilot

### DIFF
--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -366,6 +366,20 @@ On macOS, a Keychain-backed launcher is a good pattern: keep the key in Apple Ke
 MCP registration exposes separate tools named like `mcp_zai_web_search_webSearchPrime`; it does not transparently replace Hermes' built-in `web_search` or `web_extract` tools. For seamless replacement, add a web-provider plugin named `zai` that normalizes Z.AI Web Search / Reader responses to Hermes' web provider contracts, then configure `web.search_backend: "zai"` and `web.extract_backend: "zai"`.
 :::
 
+#### Z.AI integration options
+
+Use this decision table when choosing how to adopt Z.AI web capabilities:
+
+| Option | Best for | Seamless `web_search` / `web_extract` replacement | Hermes source changes | Operational cost | Recommendation |
+|--------|----------|---------------------------------------------------|-----------------------|------------------|----------------|
+| MCP pilot | Fast validation of Z.AI Search, Reader, and Zread quality | No — exposes additive `mcp_*` tools | None | Low | Start here to validate credentials, quota, latency, and result quality. |
+| Tavily-shaped local proxy | Older Hermes installs that do not yet have `plugins/web` support | Yes, by configuring `web.backend: "tavily"` and `TAVILY_BASE_URL` | None | Medium — local service or launchd job | Good temporary bridge; keep it local because Hermes will report the backend as Tavily. |
+| Native `plugins/web/zai` provider | Current Hermes with web-provider plugin support | Yes, via `web.search_backend: "zai"` / `web.extract_backend: "zai"` | Add a plugin, not core dispatcher edits | Low | Best durable design once the runtime has plugin support. |
+| Provider-native model search | Provider-specific search inside Codex/GLM model calls | Partial — search is hidden inside the model call, not Hermes tools | Transport/provider changes | Low to medium | Useful later for provider-native modes; not the default web-tool abstraction. |
+| Firecrawl-shaped proxy | Avoiding Hermes edits while impersonating an existing extract backend | Possibly | None | High | Avoid unless necessary; Firecrawl SDK/API shape is broader and more fragile than Tavily's simple REST shape. |
+
+A practical rollout is: MCP pilot first, Tavily-shaped proxy only if the live runtime cannot be upgraded yet, then a native `plugins/web/zai` provider for the long-lived solution. Keep Zread separate from generic `web_extract`: it is repository/documentation intelligence rather than a general page reader.
+
 ---
 
 ## Configuration

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -321,6 +321,53 @@ Unlike index-backed providers (Brave, Tavily, Exa) which return verbatim search-
 
 ---
 
+### Z.AI MCP pilot (Search / Reader / Zread)
+
+Z.AI provides hosted MCP servers for GLM Coding Plan users:
+
+| Server | Endpoint | MCP tool | Closest Hermes capability |
+|--------|----------|----------|---------------------------|
+| Web Search | `https://api.z.ai/api/mcp/web_search_prime/mcp` | `webSearchPrime` | Search/discovery, similar to `web_search` |
+| Web Reader | `https://api.z.ai/api/mcp/web_reader/mcp` | `webReader` | Page reading/extraction, similar to `web_extract` |
+| Zread | `https://api.z.ai/api/mcp/zread/mcp` | `search_doc`, `get_repo_structure`, `read_file` | Open-source repository/documentation intelligence |
+
+Add them under `mcp_servers` to try them as additive MCP tools:
+
+```yaml
+# ~/.hermes/config.yaml
+mcp_servers:
+  zai_web_search:
+    url: "https://api.z.ai/api/mcp/web_search_prime/mcp"
+    headers:
+      Authorization: "Bearer ${ZAI_API_KEY}"
+    timeout: 120
+    connect_timeout: 60
+  zai_web_reader:
+    url: "https://api.z.ai/api/mcp/web_reader/mcp"
+    headers:
+      Authorization: "Bearer ${ZAI_API_KEY}"
+    timeout: 180
+    connect_timeout: 60
+  zai_zread:
+    url: "https://api.z.ai/api/mcp/zread/mcp"
+    headers:
+      Authorization: "Bearer ${ZAI_API_KEY}"
+    timeout: 180
+    connect_timeout: 60
+```
+
+:::caution Secret handling
+Do not paste raw API keys into prompts, docs, logs, or screenshots. The `${ZAI_API_KEY}` form assumes the process environment supplies the key and that your active Hermes build expands environment variables in MCP headers. If it does not, use a local launcher that retrieves the key from your OS credential store and exports `ZAI_API_KEY` before starting Hermes.
+
+On macOS, a Keychain-backed launcher is a good pattern: keep the key in Apple Keychain, resolve it at process startup, export only `ZAI_API_KEY` into the Hermes process environment, and avoid storing the raw value in `config.yaml`.
+:::
+
+:::info MCP tools are not backend replacement
+MCP registration exposes separate tools named like `mcp_zai_web_search_webSearchPrime`; it does not transparently replace Hermes' built-in `web_search` or `web_extract` tools. For seamless replacement, add a web-provider plugin named `zai` that normalizes Z.AI Web Search / Reader responses to Hermes' web provider contracts, then configure `web.search_backend: "zai"` and `web.extract_backend: "zai"`.
+:::
+
+---
+
 ## Configuration
 
 ### Single backend


### PR DESCRIPTION
## Summary
- Document Z.AI Web Search / Web Reader / Zread as an MCP pilot path for GLM Coding Plan users.
- Clarify that MCP tools are additive and do not transparently replace Hermes `web_search` / `web_extract`.
- Add a weighted options table comparing MCP pilot, Tavily-shaped proxy, native `plugins/web/zai`, provider-native search, and Firecrawl-shaped proxy.
- Document a secret-safe `ZAI_API_KEY` environment-variable pattern, including macOS Keychain-backed launchers.

## Tracking notes
- Verified upstream `main` has `plugins/web` support:
  - `plugins/web/` present
  - `agent/web_search_provider.py` present
  - `agent/web_search_registry.py` present
  - bundled provider plugin count: 8
- Verified plugin discovery on this branch with Python 3.11:
  - `brave-free`, `ddgs`, `exa`, `firecrawl`, `parallel`, `searxng`, `tavily`, `xai`
- Local live install currently lacks `plugins/web` / `agent.web_search_registry`, so using a Z.AI web-provider plugin locally requires updating the live install first. The docs now call out Tavily-shaped proxy as a temporary bridge for that older runtime.

## Deferred / next scope
- Add a first-class `plugins/web/zai` provider that maps:
  - Z.AI Web Search API → Hermes `web_search` result contract
  - Z.AI Web Reader API → Hermes `web_extract` result contract
- Optionally build a local Tavily-shaped proxy for older Hermes installs that cannot use `plugins/web` yet.
- Decide whether Zread should remain MCP-only or become a separate Hermes toolset; it should not be treated as generic `web_extract`.
- Smoke-test MCP header environment interpolation before recommending `${ZAI_API_KEY}` as a live config pattern.

## Secret handling
- Do not store raw Z.AI keys in `config.yaml`, prompts, docs, logs, or screenshots.
- For macOS, use a Keychain resolver/launcher that exports `ZAI_API_KEY` only into the Hermes process environment. Existing reference pattern: `anthonylei/agents:pi/pi-keychain-resolver`.

## Verification
- `git diff --check`
- `python3` file-presence check for `plugins/web`, `agent/web_search_provider.py`, `agent/web_search_registry.py`, and bundled plugin YAMLs
- `/Users/tony/.hermes/hermes-agent/venv/bin/python` plugin-discovery smoke via `hermes_cli.plugins.discover_plugins(force=True)` and `agent.web_search_registry.list_providers()`
