### PR TITLE
fix(telegram): resolve gmail-triage script paths via active get_hermes_home

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3333,7 +3333,11 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         script_name, extra_args, success_label, is_state_verb = entry
 
-        script_path = _Path.home() / ".hermes" / "scripts" / "gmail-triage" / script_name
+        # Profile-aware script root: gmail-triage assets live under the
+        # active HERMES_HOME, not always the default ~/.hermes.
+        from hermes_constants import get_hermes_home
+
+        script_path = get_hermes_home() / "scripts" / "gmail-triage" / script_name
         if not script_path.exists():
             await query.answer(text=f"❌ {script_name} missing")
             logger.error("[%s] gmail-triage script missing: %s", self.name, script_path)

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -240,6 +240,56 @@ class TestTelegramApprovalCallback:
     """Test the approval callback handling in _handle_callback_query."""
 
     @pytest.mark.asyncio
+    async def test_gmail_triage_callback_uses_active_hermes_home_for_scripts(self, tmp_path):
+        adapter = _make_adapter()
+        adapter._is_callback_user_authorized = lambda *args, **kwargs: True
+
+        profile_home = tmp_path / "profiles" / "reviewer"
+        script_dir = profile_home / "scripts" / "gmail-triage"
+        script_dir.mkdir(parents=True)
+        script_path = script_dir / "archive.sh"
+        script_path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+
+        call_log = {}
+
+        class _FakeProc:
+            returncode = 0
+
+            async def communicate(self):
+                return b"", b""
+
+        async def _fake_create_subprocess_exec(*cmd, **kwargs):
+            call_log["cmd"] = cmd
+            call_log["kwargs"] = kwargs
+            return _FakeProc()
+
+        query = SimpleNamespace(
+            from_user=SimpleNamespace(id=123, first_name="Alice"),
+            message=SimpleNamespace(text="Triage this", chat_id=12345),
+            answer=AsyncMock(),
+            edit_message_text=AsyncMock(),
+        )
+
+        with patch("hermes_constants.get_hermes_home", return_value=profile_home):
+            with patch(
+                "gateway.platforms.telegram.asyncio.create_subprocess_exec",
+                side_effect=_fake_create_subprocess_exec,
+            ):
+                await adapter._handle_gmail_triage_callback(
+                    query,
+                    "gt:archive:msg-42",
+                    query_chat_id="12345",
+                    query_chat_type="private",
+                    query_thread_id=None,
+                    query_user_name="Alice",
+                )
+
+        assert call_log["cmd"][0] == str(script_path)
+        assert call_log["cmd"][1:] == ("msg-42",)
+        query.answer.assert_called_once()
+        query.edit_message_text.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_resolves_approval_on_click(self):
         adapter = _make_adapter()
         # Set up approval state


### PR DESCRIPTION
## What does this PR do?

Fixes a profile-awareness bug in Telegram gmail-triage callbacks.

Previously, the callback path for gmail-triage action scripts was hardcoded to `~/.hermes/scripts/gmail-triage/`, which ignored the active `HERMES_HOME`. In profile mode, this could cause the callback to fail with a missing-script error or execute the wrong profile’s script.

This change switches script resolution to the active profile’s Hermes home via `get_hermes_home()`, which matches the repo’s documented profile model and existing path-handling conventions.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `gateway/platforms/telegram.py` to resolve gmail-triage callback scripts from `get_hermes_home() / "scripts" / "gmail-triage"` instead of a hardcoded default `~/.hermes` path
- Added a regression test in `tests/gateway/test_telegram_approval_buttons.py` covering active-profile script resolution for gmail-triage callbacks

## How to Test

1. Install/update dev dependencies:
   ```bash
   uv sync --extra all --extra dev
   ```
2. Run the targeted Telegram regression test:
   ```bash
   uv run --no-sync python -m pytest tests/gateway/test_telegram_approval_buttons.py --timeout-method=thread -q
   ```
3. Confirm the result:
   ```text
   21 passed in 0.61s
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: w10

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Targeted verification passed:
  - `uv run --no-sync python -m pytest tests/gateway/test_telegram_approval_buttons.py --timeout-method=thread -q`
  - Result: `21 passed in 0.61s`

