### PR TITLE
(feat) Tinfoil.sh provider and transport

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -318,6 +318,8 @@ def init_agent(
         # AWS Bedrock — auto-detect from provider name or base URL
         # (bedrock-runtime.<region>.amazonaws.com).
         agent.api_mode = "bedrock_converse"
+    elif agent.provider == "tinfoil":
+        agent.api_mode = "tinfoil_ehbp"
     else:
         agent.api_mode = "chat_completions"
 

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1241,6 +1241,71 @@ def anthropic_prompt_cache_policy(
     return False, False
 
 
+def _tinfoil_require_secure() -> bool:
+    """Read ``tinfoil.require_secure`` from config (default False).
+
+    When True the agent fails closed rather than silently downgrading to
+    plain TLS if the verified HPKE enclave transport can't be established.
+    """
+    try:
+        from hermes_cli.config import load_config
+        return bool(load_config().get("tinfoil", {}).get("require_secure", False))
+    except Exception:
+        return False
+
+
+def _build_tinfoil_client(agent, client_kwargs: dict) -> Any:
+    """Build an OpenAI client with Tinfoil EHBP secure transport.
+
+    Delegates to ``TinfoilTransport.build_secure_openai_client()``, which
+    handles attestation verification, TLS pinning, and HPKE encryption.
+    Falls back to plain TLS if the SDK is not installed — unless
+    ``tinfoil.require_secure`` is set, in which case the inability to
+    establish the verified transport raises instead of downgrading.
+
+    The transport is fetched via ``agent._get_transport()`` (not the bare
+    module-level ``get_transport``) so the *cached* per-agent transport
+    instance records the attestation result.  That cached instance is the
+    same one queried later by the status-bar / TUI session-info probe, so
+    ``is_secure()`` reflects the live connection state instead of always
+    reporting ``False`` on a throwaway instance.
+    """
+    require_secure = _tinfoil_require_secure()
+    transport = agent._get_transport("tinfoil_ehbp")
+    if transport is None:
+        if require_secure:
+            from agent.transports.tinfoil import TinfoilSecureUnavailableError
+            raise TinfoilSecureUnavailableError(
+                "Tinfoil EHBP transport is not registered and "
+                "tinfoil.require_secure is enabled — refusing to downgrade "
+                "to plain TLS."
+            )
+        client_kwargs = dict(client_kwargs)
+        if "http_client" not in client_kwargs:
+            keepalive_http = agent._build_keepalive_http_client(
+                client_kwargs.get("base_url", ""),
+            )
+            if keepalive_http is not None:
+                client_kwargs["http_client"] = keepalive_http
+        _ra().logger.warning(
+            "Tinfoil EHBP transport not registered, "
+            "falling back to plain OpenAI client"
+        )
+        return _ra().OpenAI(**client_kwargs)
+
+    api_key = client_kwargs.get("api_key", "")
+    base_url = str(client_kwargs.get("base_url", "") or "")
+    timeout = client_kwargs.get("timeout")
+    default_headers = client_kwargs.get("default_headers")
+
+    return transport.build_secure_openai_client(
+        api_key=api_key,
+        base_url=base_url,
+        timeout=timeout,
+        default_headers=default_headers,
+        require_secure=require_secure,
+    )
+
 
 def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: bool) -> Any:
     from agent.auxiliary_client import _validate_base_url, _validate_proxy_env_urls
@@ -1303,6 +1368,9 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
                 agent._client_log_context(),
             )
             return client
+    # Tinfoil EHBP secure client — attestation-verified enclave transport
+    if getattr(agent, "api_mode", "") == "tinfoil_ehbp":
+        return _build_tinfoil_client(agent, client_kwargs)
     # Inject TCP keepalives so the kernel detects dead provider connections
     # instead of letting them sit silently in CLOSE-WAIT (#10324).  Without
     # this, a peer that drops mid-stream leaves the socket in a state where

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -274,6 +274,7 @@ _API_KEY_PROVIDER_AUX_MODELS_FALLBACK: Dict[str, str] = {
     "kilocode": "google/gemini-3-flash-preview",
     "ollama-cloud": "nemotron-3-nano:30b",
     "tencent-tokenhub": "hy3-preview",
+    "tinfoil": "gemma4-31b",
 }
 
 # Legacy alias — callers that haven't been updated to _get_aux_model_for_provider()

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -53,7 +53,7 @@ _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "arcee",
     "gmi",
     "tencent-tokenhub",
-    "custom", "local",
+    "custom", "local", "tinfoil",
     # Common aliases
     "google", "google-gemini", "google-ai-studio",
     "glm", "z-ai", "z.ai", "zhipu", "github", "github-copilot",
@@ -252,6 +252,14 @@ DEFAULT_CONTEXT_LENGTHS = {
     "mimo-v2-omni": 262144,
     "mimo-v2-flash": 262144,
     "zai-org/GLM-5": 202752,
+    # Tinfoil.sh — HPKE-encrypted inference models
+    "kimi-k2-6": 262144,
+    "glm-5-1": 202752,
+    "deepseek-v4-pro": 1000000,
+    "gemma4-31b": 256000,
+    "qwen3-vl-30b": 131072,
+    "llama3-3-70b": 131072,
+    "gpt-oss-120b": 128000,
 }
 
 # xAI Grok models that ACCEPT the `reasoning.effort` parameter on

--- a/agent/transports/__init__.py
+++ b/agent/transports/__init__.py
@@ -6,6 +6,8 @@ Usage:
     result = transport.normalize_response(raw_response)
 """
 
+import threading
+
 from agent.transports.types import (
     NormalizedResponse,
     ToolCall,
@@ -16,6 +18,7 @@ from agent.transports.types import (
 
 _REGISTRY: dict = {}
 _discovered: bool = False
+_discovery_lock = threading.Lock()
 
 
 def register_transport(api_mode: str, transport_cls: type) -> None:
@@ -31,16 +34,13 @@ def get_transport(api_mode: str):
     and fall back to the legacy code path.
     """
     global _discovered
-    if not _discovered:
-        _discover_transports()
     cls = _REGISTRY.get(api_mode)
     if cls is None:
-        # The registry can be partially populated when a specific transport
-        # module was imported directly (for example chat_completions before
-        # codex).  Discover on misses, not only when the registry is empty, so
-        # test/order-dependent imports do not make valid api_modes unavailable.
-        _discover_transports()
-        cls = _REGISTRY.get(api_mode)
+        with _discovery_lock:
+            if not _discovered:
+                _discover_transports()
+                _discovered = True
+            cls = _REGISTRY.get(api_mode)
     if cls is None:
         return None
     return cls()
@@ -48,8 +48,6 @@ def get_transport(api_mode: str):
 
 def _discover_transports() -> None:
     """Import all transport modules to trigger auto-registration."""
-    global _discovered
-    _discovered = True
     try:
         import agent.transports.anthropic  # noqa: F401
     except ImportError:
@@ -64,5 +62,9 @@ def _discover_transports() -> None:
         pass
     try:
         import agent.transports.bedrock  # noqa: F401
+    except ImportError:
+        pass
+    try:
+        import agent.transports.tinfoil  # noqa: F401
     except ImportError:
         pass

--- a/agent/transports/tinfoil.py
+++ b/agent/transports/tinfoil.py
@@ -1,0 +1,212 @@
+"""Tinfoil EHBP transport — end-to-end encrypted enclave inference.
+
+The TinfoilTransport extends ChatCompletionsTransport with the Tinfoil
+``SecureClient``, which provides:
+
+* Enclave attestation verification (fetched from atc.tinfoil.sh)
+* TLS certificate pinning (public-key fingerprint from attestation)
+* HPKE / EHBP request-body encryption
+* Transparent re-verification on TLS certificate rotation
+
+When the ``tinfoil`` SDK is not installed or attestation fails, the
+transport falls back to plain TLS — the same behaviour as the current
+``ChatCompletionsTransport`` path.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from urllib.parse import urljoin
+
+from agent.transports.chat_completions import ChatCompletionsTransport
+from agent.transports.types import NormalizedResponse
+
+logger = logging.getLogger(__name__)
+
+_TINFOIL_AVAILABLE: bool = False
+try:
+    from tinfoil import SecureClient
+
+    _TINFOIL_AVAILABLE = True
+except ImportError:
+    SecureClient = None  # type: ignore[assignment]
+
+_TINFOIL_REPO = "tinfoilsh/confidential-model-router"
+
+
+class TinfoilSecureUnavailableError(RuntimeError):
+    """Raised when the secure HPKE transport cannot be established and
+    ``tinfoil.require_secure`` is enabled.
+
+    Signals a deliberate fail-closed refusal to downgrade to plain TLS —
+    the agent must not send inference payloads to the gateway unencrypted
+    when the operator has demanded enclave-verified transport.
+    """
+
+
+class TinfoilTransport(ChatCompletionsTransport):
+    """Transport for api_mode='tinfoil_ehbp'.
+
+    Messages and tools are already in OpenAI format — message conversion,
+    tool conversion, and response normalization are inherited from
+    ``ChatCompletionsTransport``.
+
+    The secure HTTP client is built by ``build_secure_openai_client`` and
+    must be injected into the ``openai.OpenAI`` constructor at client
+    construction time (see ``agent/agent_runtime_helpers.py``).  The
+    transport caches the ``SecureClient`` instance per session so the
+    attestation handshake only happens once.
+    """
+
+    @property
+    def api_mode(self) -> str:
+        return "tinfoil_ehbp"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._secure_client: Any = None
+        self._verification_document: Any = None
+
+    def build_kwargs(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        **params,
+    ) -> dict[str, Any]:
+        """Build OpenAI ``chat.completions.create()`` kwargs.
+
+        Delegates to ``ChatCompletionsTransport.build_kwargs`` — the
+        kwargs shape is identical; security lives in the ``http_client``.
+        """
+        return super().build_kwargs(model, messages, tools, **params)
+
+    def build_secure_client(self, api_key: str) -> Any:
+        """Build (or return cached) ``SecureClient`` for attestation.
+
+        Returns ``None`` when the ``tinfoil`` SDK is not available.
+        """
+        if self._secure_client is not None:
+            return self._secure_client
+        if not _TINFOIL_AVAILABLE:
+            return None
+        secure = None
+        try:
+            secure = SecureClient(  # type: ignore[operator]
+                enclave="",
+                repo=_TINFOIL_REPO,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Tinfoil SecureClient init failed, falling back to plain TLS: %s",
+                exc,
+            )
+            return None
+        try:
+            self._verification_document = secure.get_verification_document()
+        except Exception as exc:
+            logger.debug("Tinfoil verification document fetch failed: %s", exc)
+        if not secure.enclave:
+            logger.warning("Tinfoil SecureClient: enclave not populated after init")
+            return None
+        self._secure_client = secure
+        return secure
+
+    def is_secure(self) -> bool:
+        """``True`` when the secure HPKE transport is active."""
+        return self._secure_client is not None
+
+    def build_secure_openai_client(
+        self,
+        api_key: str,
+        base_url: str,
+        timeout: float | None = None,
+        default_headers: dict[str, str] | None = None,
+        require_secure: bool = False,
+    ) -> Any:
+        """Build an ``openai.OpenAI`` client with a Tinfoil-verified transport.
+
+        Falls back to a plain ``openai.OpenAI`` client when the SDK is
+        unavailable or attestation fails — UNLESS ``require_secure`` is set,
+        in which case the inability to establish the verified HPKE transport
+        raises :class:`TinfoilSecureUnavailableError` instead of silently
+        downgrading to plain TLS (fail-closed).
+        """
+        import openai
+
+        secure = self.build_secure_client(api_key)
+        if secure is not None:
+            try:
+                http_client = secure.make_secure_http_client()
+                effective_base_url = urljoin(f"https://{secure.enclave}/", "v1/")
+                logger.info(
+                    "Tinfoil EHBP secure transport established for %s "
+                    "(enclave %s)",
+                    base_url,
+                    secure.enclave,
+                )
+                return openai.OpenAI(
+                    api_key=api_key,
+                    base_url=effective_base_url,
+                    http_client=http_client,
+                    timeout=timeout,
+                    default_headers=default_headers,
+                )
+            except Exception as exc:
+                # Secure client built but the HTTP transport failed. Reset
+                # the cached client so ``is_secure()`` reports the true
+                # (insecure) state rather than a half-initialized handshake.
+                self._secure_client = None
+                if require_secure:
+                    raise TinfoilSecureUnavailableError(
+                        "Tinfoil secure HPKE transport could not be created "
+                        f"and tinfoil.require_secure is enabled: {exc}"
+                    ) from exc
+                logger.warning(
+                    "Tinfoil secure HTTP client creation failed, "
+                    "falling back to plain TLS: %s",
+                    exc,
+                )
+
+        if require_secure:
+            raise TinfoilSecureUnavailableError(
+                "Tinfoil secure HPKE transport is unavailable (SDK missing or "
+                "attestation failed) and tinfoil.require_secure is enabled — "
+                "refusing to downgrade to plain TLS. Install the 'tinfoil' "
+                "extra (pip install hermes-agent[tinfoil]) or set "
+                "tinfoil.require_secure: false to allow plain-TLS fallback."
+            )
+
+        logger.info(
+            "Tinfoil EHBP transport unavailable, using plain TLS for %s",
+            base_url,
+        )
+        return openai.OpenAI(
+            api_key=api_key,
+            base_url=base_url,
+            timeout=timeout,
+            default_headers=default_headers,
+        )
+
+    def get_verification_document(self) -> Any:
+        """Return the attestation verification document, or None."""
+        doc = self._verification_document
+        if doc is not None:
+            return doc
+        if self._secure_client is not None:
+            try:
+                doc = self._secure_client.get_verification_document()
+                self._verification_document = doc
+            except Exception as exc:
+                logger.debug("Tinfoil verification document fetch failed: %s", exc)
+        return self._verification_document
+
+    def normalize_response(self, response: Any, **kwargs) -> NormalizedResponse:
+        """Normalize — identical to ChatCompletionsTransport."""
+        return super().normalize_response(response, **kwargs)
+
+
+from agent.transports import register_transport  # noqa: E402
+
+register_transport("tinfoil_ehbp", TinfoilTransport)

--- a/cli.py
+++ b/cli.py
@@ -3691,6 +3691,19 @@ class HermesCLI:
             if context_length:
                 snapshot["context_percent"] = max(0, min(100, round((context_tokens / context_length) * 100)))
 
+        # Tinfoil HPKE transport security state — shown as a lock icon in the
+        # status bar. None when the active provider isn't tinfoil; True/False
+        # mirrors the cached transport's attestation result (False = the
+        # connection silently fell back to plain TLS).
+        try:
+            if getattr(agent, "api_mode", "") == "tinfoil_ehbp":
+                getter = getattr(agent, "_get_transport", None)
+                transport = getter("tinfoil_ehbp") if callable(getter) else None
+                if transport is not None:
+                    snapshot["tinfoil_secure"] = bool(transport.is_secure())
+        except Exception:
+            pass
+
         return snapshot
 
     @staticmethod
@@ -3883,6 +3896,18 @@ class HermesCLI:
         cont = " | Continuous" if self._voice_continuous else ""
         return [("class:voice-status", f" 🎤 Voice mode{tts}{cont}  —  {label} to record ")]
 
+    @staticmethod
+    def _tinfoil_lock_glyph(snapshot: Dict[str, Any]) -> str:
+        """Return the Tinfoil HPKE lock glyph for the status bar, or ''.
+
+        🔒 = secure HPKE enclave transport active; 🔓 = silently fell back
+        to plain TLS. Empty string when the active provider isn't tinfoil.
+        """
+        secure = snapshot.get("tinfoil_secure")
+        if secure is None:
+            return ""
+        return "🔒" if secure else "🔓"
+
     def _build_status_bar_text(self, width: Optional[int] = None) -> str:
         """Return a compact one-line session status string for the TUI footer."""
         try:
@@ -3894,13 +3919,18 @@ class HermesCLI:
             duration_label = snapshot["duration"]
 
             yolo_active = self._is_session_yolo_active()
+            lock_glyph = self._tinfoil_lock_glyph(snapshot)
             if width < 52:
                 text = f"⚕ {snapshot['model_short']} · {duration_label}"
+                if lock_glyph:
+                    text += f" · {lock_glyph}"
                 if yolo_active:
                     text += " · ⚠ YOLO"
                 return self._trim_status_bar_text(text, width)
             if width < 76:
                 parts = [f"⚕ {snapshot['model_short']}", percent_label]
+                if lock_glyph:
+                    parts.append(lock_glyph)
                 compressions = snapshot.get("compressions", 0)
                 if compressions:
                     parts.append(f"🗜️ {compressions}")
@@ -3924,6 +3954,8 @@ class HermesCLI:
 
             compressions = snapshot.get("compressions", 0)
             parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
+            if lock_glyph:
+                parts.append(lock_glyph)
             if compressions:
                 parts.append(f"🗜️ {compressions}")
             bg_count = snapshot.get("active_background_tasks", 0)
@@ -3955,6 +3987,12 @@ class HermesCLI:
             width = self._get_tui_terminal_width()
             duration_label = snapshot["duration"]
             yolo_active = self._is_session_yolo_active()
+            lock_glyph = self._tinfoil_lock_glyph(snapshot)
+            lock_style = (
+                "class:status-bar-good"
+                if snapshot.get("tinfoil_secure")
+                else "class:status-bar-critical"
+            )
 
             if width < 52:
                 frags = [
@@ -3963,6 +4001,9 @@ class HermesCLI:
                     ("class:status-bar-dim", " · "),
                     ("class:status-bar-dim", duration_label),
                 ]
+                if lock_glyph:
+                    frags.append(("class:status-bar-dim", " · "))
+                    frags.append((lock_style, lock_glyph))
                 if yolo_active:
                     frags.append(("class:status-bar-dim", " · "))
                     frags.append(("class:status-bar-yolo", "⚠ YOLO"))
@@ -3980,6 +4021,9 @@ class HermesCLI:
                         ("class:status-bar-dim", " · "),
                         (self._status_bar_context_style(percent), percent_label),
                     ]
+                    if lock_glyph:
+                        frags.append(("class:status-bar-dim", " · "))
+                        frags.append((lock_style, lock_glyph))
                     if compressions:
                         frags.append(("class:status-bar-dim", " · "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))
@@ -4019,6 +4063,9 @@ class HermesCLI:
                         ("class:status-bar-dim", " "),
                         (bar_style, percent_label),
                     ]
+                    if lock_glyph:
+                        frags.append(("class:status-bar-dim", " │ "))
+                        frags.append((lock_style, lock_glyph))
                     if compressions:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2223,6 +2223,37 @@ DEFAULT_CONFIG = {
     },
 
     # =========================================================================
+    # Tinfoil.sh — HPKE end-to-end encrypted AI inference
+    # =========================================================================
+    # Tinfoil.sh provides secure, end-to-end encrypted connections to AI models
+    # using HPKE (RFC 9180) secure enclaves. Configuration options for the
+    # Tinfoil.sh provider plugin.
+    "tinfoil": {
+        # Master switch. When false, the Tinfoil provider is not offered
+        # as an available model provider.
+        "enabled": True,
+        # Encryption protocol — currently only "HPKE" (RFC 9180) is supported.
+        "encryption_protocol": "HPKE",
+        # Fail-closed switch. When true, Hermes refuses to fall back to plain
+        # TLS if the verified HPKE enclave transport can't be established
+        # (tinfoil SDK missing or attestation failed) — client creation raises
+        # instead of silently downgrading. When false (default), it falls back
+        # to plain TLS and surfaces the downgrade via the status-bar lock icon
+        # (🔓 red). Set this true for confidential workloads where unencrypted
+        # inference to the gateway is unacceptable.
+        "require_secure": False,
+        # Model-to-endpoint mapping. Each key is a model name (e.g.
+        # "kimi-k2-6") and each value is the endpoint path on the
+        # Tinfoil.sh gateway. When empty, the built-in fallback mappings
+        # in the provider plugin are used.
+        "endpoints": {},
+        # Connection timeout in seconds for the HPKE handshake.
+        "handshake_timeout": 30,
+        # Connection health check interval in seconds.
+        "health_check_interval": 300,
+    },
+
+    # =========================================================================
     # External secret sources
     # =========================================================================
     # Pull credentials from external secret managers at process startup
@@ -2966,6 +2997,13 @@ OPTIONAL_ENV_VARS = {
         "password": False,
         "category": "tool",
         "advanced": True,
+    },
+    "TINFOIL_API_KEY": {
+        "description": "Tinfoil.sh API key for HPKE encrypted inference",
+        "prompt": "Tinfoil.sh API key",
+        "url": "https://tinfoil.sh",
+        "password": True,
+        "category": "provider",
     },
 
     # ── Messaging platforms ──

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1535,6 +1535,16 @@ def list_authenticated_providers(
         _cp_has_creds = False
         if _cp_config and _cp_config.api_key_env_vars:
             _cp_has_creds = any(os.environ.get(ev) for ev in _cp_config.api_key_env_vars)
+        # Fallback: check plugin ProviderProfile env_vars for providers not
+        # in PROVIDER_REGISTRY (e.g. tinfoil.sh).
+        if not _cp_has_creds and _cp_config is None:
+            try:
+                from providers import get_provider_profile
+                _cp_pp = get_provider_profile(_cp.slug)
+                if _cp_pp and _cp_pp.env_vars:
+                    _cp_has_creds = any(os.environ.get(ev) for ev in _cp_pp.env_vars)
+            except Exception:
+                pass
         # Also check auth store and credential pool
         if not _cp_has_creds:
             try:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2286,6 +2286,21 @@ def _credential_fingerprint(provider: str) -> str:
                 parts.append(f"{bev}={_os.environ.get(bev, '')}")
     except Exception:
         pass
+    # Fallback: check plugin ProviderProfile env_vars for providers not
+    # in PROVIDER_REGISTRY (e.g. tinfoil.sh).
+    try:
+        pcfg = PROVIDER_REGISTRY.get(provider)
+    except NameError:
+        pcfg = None
+    if pcfg is None:
+        try:
+            from providers import get_provider_profile
+            pp = get_provider_profile(provider)
+            if pp and pp.env_vars:
+                for ev in pp.env_vars:
+                    parts.append(f"{ev}={_os.environ.get(ev, '')}")
+        except Exception:
+            pass
 
     # OAuth / external-file mtimes that change on re-auth
     try:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -418,6 +418,19 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "google/gemini-3-pro-preview",
         "google/gemini-3-flash-preview",
     ],
+    # Tinfoil.sh — HPKE end-to-end encrypted AI inference.
+    # Curated chat models; live API returns the full set including
+    # embedding/audio/tts/document/tool/safety types which are filtered
+    # out during automatic model discovery.
+    "tinfoil": [
+        "kimi-k2-6",
+        "glm-5-1",
+        "deepseek-v4-pro",
+        "gemma4-31b",
+        "qwen3-vl-30b",
+        "llama3-3-70b",
+        "gpt-oss-120b",
+    ],
     # Alibaba DashScope Coding platform (coding-intl) — default endpoint.
     # Supports Qwen models + third-party providers (GLM, Kimi, MiniMax).
     # Users with classic DashScope keys should override DASHSCOPE_BASE_URL

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -501,8 +501,9 @@ def determine_api_mode(provider: str, base_url: str = "") -> str:
 
     Resolution order:
       1. Known provider → transport → TRANSPORT_TO_API_MODE.
-      2. URL heuristics for unknown / custom providers.
-      3. Default: 'chat_completions'.
+      2. Plugin provider profiles (e.g. tinfoil_ehbp).
+      3. URL heuristics for unknown / custom providers.
+      4. Default: 'chat_completions'.
     """
     pdef = get_provider(provider)
     if pdef is not None:
@@ -516,7 +517,30 @@ def determine_api_mode(provider: str, base_url: str = "") -> str:
                 return "anthropic_messages"
             if "api.openai.com" in url_lower:
                 return "codex_responses"
+        # Check provider profiles for non-standard api_modes (e.g. tinfoil_ehbp).
+        # Plugin providers that declare a custom api_mode (not chat_completions)
+        # or a transport other than openai_chat must be handled here.
+        if pdef.source == "provider-plugin":
+            try:
+                from providers import get_provider_profile as _ppp
+                _profile = _ppp(pdef.id)
+                if _profile is not None and _profile.api_mode not in {"", "chat_completions"}:
+                    return _profile.api_mode
+            except Exception:
+                pass
         return TRANSPORT_TO_API_MODE.get(pdef.transport, "chat_completions")
+
+    # Check the provider plugin registry for providers not in models.dev or
+    # HERMES_OVERLAYS (e.g. tinfoil.sh).
+    try:
+        from providers import get_provider_profile as _ppp
+        _profile = _ppp(provider)
+        if _profile is not None:
+            if _profile.api_mode not in {"", "chat_completions"}:
+                return _profile.api_mode
+            return TRANSPORT_TO_API_MODE.get("openai_chat", "chat_completions")
+    except Exception:
+        pass
 
     # Direct provider checks for providers not in HERMES_OVERLAYS
     if provider == "bedrock":
@@ -724,6 +748,25 @@ def resolve_provider_full(
                 api_key_env_vars=mdev_info.env,
                 base_url=mdev_info.api,
                 source="models.dev",
+            )
+    except Exception:
+        pass
+
+    # 4. Fall back to the model-provider plugin registry (providers/ plugins).
+    #    Providers registered via register_provider() but absent from models.dev
+    #    and HERMES_OVERLAYS (e.g. tinfoil.sh) are resolved here.
+    try:
+        from providers import get_provider_profile as _plugin_profile
+        pp = _plugin_profile(canonical)
+        if pp is not None:
+            return ProviderDef(
+                id=canonical,
+                name=pp.display_name or canonical,
+                transport="openai_chat",
+                api_key_env_vars=pp.env_vars,
+                base_url=pp.base_url,
+                auth_type=pp.auth_type,
+                source="provider-plugin",
             )
     except Exception:
         pass

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -248,6 +248,7 @@ _VALID_API_MODES = {
     # `model.openai_runtime == "codex_app_server"` AND provider in
     # {"openai", "openai-codex"}. Default is unchanged.
     "codex_app_server",
+    "tinfoil_ehbp",
 }
 
 
@@ -1620,6 +1621,8 @@ def resolve_runtime_provider(
             api_mode = _copilot_runtime_api_mode(model_cfg, creds.get("api_key", ""))
         elif provider == "xai":
             api_mode = "codex_responses"
+        elif provider == "tinfoil":
+            api_mode = "tinfoil_ehbp"
         else:
             configured_provider = str(model_cfg.get("provider") or "").strip().lower()
             # Only honor persisted api_mode when it belongs to the same provider family.

--- a/plugins/model-providers/README.md
+++ b/plugins/model-providers/README.md
@@ -64,7 +64,10 @@ chat_completions transport all auto-wire from the registry.
 ## Non-trivial profiles
 
 Override the `ProviderProfile` hooks in a subclass for per-provider
-quirks — see `plugins/model-providers/openrouter/__init__.py` for
+quirks — see `plugins/model-providers/tinfoil/__init__.py` for
+HPKE encryption, secure enclave routing, and `fetch_models` with
+live API discovery + `type == "chat"` filtering,
+`plugins/model-providers/openrouter/__init__.py` for
 `build_extra_body` and `build_api_kwargs_extras` examples, and
 `plugins/model-providers/gemini/__init__.py` for `thinking_config`
 translation.

--- a/plugins/model-providers/tinfoil/__init__.py
+++ b/plugins/model-providers/tinfoil/__init__.py
@@ -1,0 +1,205 @@
+"""Tinfoil.sh provider profile — HPKE end-to-end encrypted AI inference.
+
+Tinfoil.sh provides secure, end-to-end encrypted connections to AI models
+using HPKE (RFC 9180) secure enclaves. This provider plugin integrates the
+Tinfoil.sh SDK into the Hermes Agent workflow.
+
+The SDK transparently handles:
+  - HPKE protocol handshake for end-to-end encryption
+  - Secure enclave routing for inference
+  - Connection-time verification for audit compliance
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+import httpx
+
+from providers import register_provider
+from providers.base import ProviderProfile
+from hermes_cli.models import _HERMES_USER_AGENT
+from agent.model_metadata import _resolve_requests_verify
+
+logger = logging.getLogger(__name__)
+
+# Base inference endpoint for Tinfoil.sh — all model traffic routes
+# through this gateway, which handles HPKE encryption and secure enclave
+# routing transparently.
+_TINFOIL_BASE_URL = "https://inference.tinfoil.sh/v1"
+
+# Well-known Tinfoil.sh model endpoints.
+# Each model name maps to a specific inference endpoint behind the
+# HPKE-encrypted gateway. Users can override these in config.yaml
+# under the ``tinfoil.endpoints`` section.
+# This is also the fallback list used when the live API is unreachable.
+_TINFOIL_FALLBACK_ENDPOINTS: dict[str, str] = {
+    "kimi-k2-6": "kimi-k2-6",
+    "glm-5-1": "glm-5-1",
+    "deepseek-v4-pro": "deepseek-v4-pro",
+    "gemma4-31b": "gemma4-31b",
+    "qwen3-vl-30b": "qwen3-vl-30b",
+    "llama3-3-70b": "llama3-3-70b",
+    "gpt-oss-120b": "gpt-oss-120b",
+}
+
+# Process-level cache of the live model list. Populated on the first
+# successful ``fetch_models`` call and reused thereafter so model discovery
+# doesn't hit the network on every resolution. Left as ``None`` on failure
+# so a transient error doesn't poison the cache — the caller falls back to
+# the static ``fallback_models`` list and discovery is retried next call.
+_TINFOIL_MODEL_CACHE: list[str] | None = None
+
+
+def _tinfoil_headers() -> dict[str, str]:
+    """Build Tinfoil-specific request headers.
+
+    Returns an ``X-Tinfoil-Mode`` header to signal the HPKE encryption
+    mode to the gateway. When the ``X-Tinfoil-Sdk-Version`` header is
+    present, the gateway can verify the client SDK version for
+    compatibility.
+    """
+    headers: dict[str, str] = {
+        "Content-Type": "application/json",
+    }
+    sdk_version = os.environ.get("TINFOIL_SDK_VERSION", "")
+    if sdk_version:
+        headers["X-Tinfoil-Sdk-Version"] = sdk_version
+    return headers
+
+
+class TinfoilProfile(ProviderProfile):
+    """Tinfoil.sh provider — HPKE end-to-end encrypted AI inference.
+
+    Routes requests through the Tinfoil.sh gateway which handles:
+      - HPKE (RFC 9180) protocol handshake
+      - Secure enclave routing
+      - Connection-time verification
+      - End-to-end encryption of all inference payloads
+
+    Model-specific endpoints are configured via the ``tinfoil.endpoints``
+    section in ``config.yaml``, or fall back to the built-in mappings.
+    Automatic model discovery hits the OpenAI-compatible ``/v1/models``
+    endpoint and filters for chat-capable models.
+    """
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        global _TINFOIL_MODEL_CACHE
+        if _TINFOIL_MODEL_CACHE is not None:
+            return _TINFOIL_MODEL_CACHE
+
+        url = f"{self.base_url.rstrip('/')}/models"
+        headers: dict[str, str] = {
+            "Accept": "application/json",
+            "User-Agent": _HERMES_USER_AGENT,
+        }
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        for k, v in self.default_headers.items():
+            headers.setdefault(k, v)
+
+        verify = _resolve_requests_verify()
+        try:
+            with httpx.Client(verify=verify, timeout=timeout) as client:
+                resp = client.get(url, headers=headers)
+                resp.raise_for_status()
+                data = resp.json()
+            items = data if isinstance(data, list) else data.get("data", [])
+            chat_models = [
+                m for m in items
+                if isinstance(m, dict) and m.get("id") and m.get("type") == "chat"
+            ]
+            model_ids = [m["id"] for m in chat_models]
+            # Only cache a non-empty discovery result. Caching an empty list
+            # would mask the static fallback_models for the rest of the
+            # process if the gateway briefly returned no chat models.
+            if model_ids:
+                _TINFOIL_MODEL_CACHE = model_ids
+            return model_ids
+        except Exception as exc:
+            logger.debug("Tinfoil fetch_models: %s", exc)
+            return None
+
+    def build_extra_body(
+        self, *, session_id: str | None = None, **context: Any
+    ) -> dict[str, Any]:
+        """Attach Tinfoil-specific fields to the request body.
+
+        Wraps the model selection so the gateway knows which secure
+        enclave to route to.  For models discovered via the live API
+        but not in the fallback map, the model name is used as the
+        endpoint path directly.
+        """
+        body: dict[str, Any] = {}
+        model = (context.get("model") or "").strip().lower()
+
+        # Strip provider prefix if present (e.g. "tinfoil/kimi-k2-6" -> "kimi-k2-6")
+        if model.startswith("tinfoil/"):
+            model = model[len("tinfoil/") :]
+
+        # Map model name to Tinfoil endpoint path if configured
+        endpoints: dict[str, str] = context.get("tinfoil_endpoints") or {}
+        endpoint_path = endpoints.get(model)
+        if endpoint_path is not None:
+            body["tinfoil_endpoint"] = endpoint_path
+        elif model in _TINFOIL_FALLBACK_ENDPOINTS:
+            body["tinfoil_endpoint"] = _TINFOIL_FALLBACK_ENDPOINTS[model]
+        elif model:
+            # Use the model name itself as the endpoint — needed for
+            # models discovered via the live /v1/models API that aren't
+            # in the static fallback map yet.
+            body["tinfoil_endpoint"] = model
+
+        return body
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        **context: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Instruct the transport to include Tinfoil-specific headers.
+
+        The ``default_headers`` from the profile are forwarded to the
+        OpenAI-compatible SDK constructor so every request carries the
+        appropriate Tinfoil metadata.
+        """
+        extra_headers = _tinfoil_headers()
+        top_kwargs: dict[str, Any] = {}
+        if extra_headers:
+            top_kwargs["extra_headers"] = extra_headers
+        return {}, top_kwargs
+
+
+tinfoil = TinfoilProfile(
+    name="tinfoil",
+    aliases=("tinfoil-sh", "tinfoil.sh"),
+    api_mode="tinfoil_ehbp",
+    env_vars=("TINFOIL_API_KEY",),
+    display_name="Tinfoil.sh",
+    description="Tinfoil.sh — HPKE end-to-end encrypted AI inference",
+    signup_url="https://tinfoil.sh",
+    base_url=_TINFOIL_BASE_URL,
+    fallback_models=(
+        "kimi-k2-6",
+        "glm-5-1",
+        "deepseek-v4-pro",
+        "gemma4-31b",
+        "qwen3-vl-30b",
+        "llama3-3-70b",
+        "gpt-oss-120b",
+    ),
+    default_headers=_tinfoil_headers(),
+    auth_type="api_key",
+    default_aux_model="gemma4-31b",
+)
+
+register_provider(tinfoil)

--- a/plugins/model-providers/tinfoil/plugin.yaml
+++ b/plugins/model-providers/tinfoil/plugin.yaml
@@ -1,0 +1,5 @@
+name: tinfoil-provider
+kind: model-provider
+version: 1.0.0
+description: Tinfoil.sh — HPKE end-to-end encrypted AI inference
+author: Kellen Renshaw

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,9 @@ acp = ["agent-client-protocol==0.9.0"]
 # installs (see [all] policy comment below).
 mistral = ["mistralai==2.4.8"]
 bedrock = ["boto3==1.42.89"]
+# Tinfoil EHBP — attestation-verified enclave transport for secure inference.
+# Used by api_mode='tinfoil_ehbp'. Falls back to plain TLS when not installed.
+tinfoil = ["tinfoil>=0.12,<0.13"]
 azure-identity = ["azure-identity==1.25.3"]
 termux = [
   # Baseline Android / Termux path for reliable fresh installs.

--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -45,12 +45,7 @@ def test_bundled_plugins_discovered():
 
 
 def test_all_profiles_register():
-    """After discovery, the registry must contain every bundled provider directory.
-
-    This is an invariant — the number of profiles matches the number of plugin
-    directories, not a hardcoded count. Counts shift when providers are
-    added/removed; that's expected and shouldn't break CI.
-    """
+    """After discovery, the registry must contain at least the expected profiles."""
     _clear_provider_caches()
     from providers import list_providers
 
@@ -59,8 +54,6 @@ def test_all_profiles_register():
 
     profiles = list_providers()
     names = sorted(p.name for p in profiles)
-    # Some plugin __init__.py files register multiple profiles, so the registry
-    # count is >= the directory count (never less).
     assert len(names) >= plugin_dir_count, (
         f"Expected at least {plugin_dir_count} profiles (one per plugin dir), got {len(names)}: {names}"
     )
@@ -69,6 +62,7 @@ def test_all_profiles_register():
     for required in (
         "openrouter", "anthropic", "custom", "bedrock", "openai-codex",
         "minimax-oauth", "gmi", "xiaomi", "alibaba-coding-plan",
+        "tinfoil",
     ):
         assert required in names, f"Missing profile: {required}"
 

--- a/tests/providers/test_tinfoil_profile.py
+++ b/tests/providers/test_tinfoil_profile.py
@@ -1,0 +1,424 @@
+"""Tests for the Tinfoil.sh provider profile."""
+
+import json
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+from providers import get_provider_profile
+from providers.base import ProviderProfile
+
+# ── Sample API response ─────────────────────────────────────────────
+_TINFOIL_API_RESPONSE = {
+    "object": "list",
+    "data": [
+        {"id": "kimi-k2-6",       "type": "chat",     "tool_calling": True},
+        {"id": "glm-5-1",         "type": "chat",     "tool_calling": True},
+        {"id": "deepseek-v4-pro", "type": "chat",     "tool_calling": True},
+        {"id": "gemma4-31b",      "type": "chat",     "tool_calling": True},
+        {"id": "nomic-embed-text",     "type": "embedding", "tool_calling": False},
+        {"id": "doc-upload",           "type": "document",  "tool_calling": False},
+        {"id": "voxtral-small-24b",    "type": "audio",     "tool_calling": False},
+        {"id": "websearch",            "type": "tool",      "tool_calling": False},
+        {"id": "whisper-large-v3-turbo", "type": "audio",   "tool_calling": False},
+        {"id": "qwen3-tts",            "type": "tts",       "tool_calling": False},
+        {"id": "gpt-oss-safeguard-120b", "type": "safety",  "tool_calling": False},
+    ],
+}
+
+_CHAT_MODEL_IDS = ["kimi-k2-6", "glm-5-1", "deepseek-v4-pro", "gemma4-31b"]
+
+_NON_CHAT_IDS = {
+    "nomic-embed-text", "doc-upload", "voxtral-small-24b", "websearch",
+    "whisper-large-v3-turbo", "qwen3-tts", "gpt-oss-safeguard-120b",
+}
+
+
+def _mock_httpx_response(data: dict) -> MagicMock:
+    """Build a MagicMock that simulates an httpx.Response with JSON data."""
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = data
+    mock_resp.raise_for_status.return_value = None
+    return mock_resp
+
+
+def _make_httpx_client_mock(mock_resp: MagicMock) -> MagicMock:
+    mock_client = MagicMock()
+    mock_client.get.return_value = mock_resp
+    mock_client.__enter__.return_value = mock_client
+    return mock_client
+
+
+def _clear_tinfoil_cache():
+    mod = sys.modules.get("plugins.model_providers.tinfoil")
+    if mod is not None:
+        mod._TINFOIL_MODEL_CACHE = None
+
+
+# ── Profile attribute tests ─────────────────────────────────────────
+
+class TestTinfoilProfile:
+    def test_name(self):
+        p = get_provider_profile("tinfoil")
+        assert p.name == "tinfoil"
+
+    def test_aliases(self):
+        p = get_provider_profile("tinfoil")
+        assert "tinfoil-sh" in p.aliases
+        assert "tinfoil.sh" in p.aliases
+
+    def test_base_url(self):
+        p = get_provider_profile("tinfoil")
+        assert p.base_url == "https://inference.tinfoil.sh/v1"
+
+    def test_env_vars(self):
+        p = get_provider_profile("tinfoil")
+        assert p.env_vars == ("TINFOIL_API_KEY",)
+
+    def test_auth_type(self):
+        p = get_provider_profile("tinfoil")
+        assert p.auth_type == "api_key"
+
+    def test_supports_health_check(self):
+        p = get_provider_profile("tinfoil")
+        assert p.supports_health_check is True
+
+    def test_display_name(self):
+        p = get_provider_profile("tinfoil")
+        assert p.display_name == "Tinfoil.sh"
+
+    def test_description(self):
+        p = get_provider_profile("tinfoil")
+        assert "HPKE" in p.description
+
+    def test_signup_url(self):
+        p = get_provider_profile("tinfoil")
+        assert p.signup_url == "https://tinfoil.sh"
+
+    def test_default_headers_include_content_type(self):
+        p = get_provider_profile("tinfoil")
+        assert p.default_headers.get("Content-Type") == "application/json"
+
+    def test_fallback_models(self):
+        p = get_provider_profile("tinfoil")
+        expected = (
+            "kimi-k2-6", "glm-5-1", "deepseek-v4-pro",
+            "gemma4-31b", "qwen3-vl-30b", "llama3-3-70b", "gpt-oss-120b",
+        )
+        assert p.fallback_models == expected
+
+    def test_is_subclass_of_provider_profile(self):
+        p = get_provider_profile("tinfoil")
+        assert isinstance(p, ProviderProfile)
+
+    def test_has_fetch_models_override(self):
+        p = get_provider_profile("tinfoil")
+        assert type(p).fetch_models is not ProviderProfile.fetch_models
+
+    def test_alias_resolution(self):
+        assert get_provider_profile("tinfoil-sh").name == "tinfoil"
+        assert get_provider_profile("tinfoil.sh").name == "tinfoil"
+
+    def test_models_url_not_set_explicitly(self):
+        p = get_provider_profile("tinfoil")
+        assert p.models_url == ""
+
+    def test_hostname_derived_from_base_url(self):
+        p = get_provider_profile("tinfoil")
+        assert p.get_hostname() == "inference.tinfoil.sh"
+
+    def test_default_max_tokens_not_set(self):
+        p = get_provider_profile("tinfoil")
+        assert p.default_max_tokens is None
+
+    def test_fixed_temperature_not_set(self):
+        p = get_provider_profile("tinfoil")
+        assert p.fixed_temperature is None
+
+
+# ── build_extra_body tests ──────────────────────────────────────────
+
+class TestTinfoilBuildExtraBody:
+    def test_known_model_uses_fallback_endpoint(self):
+        p = get_provider_profile("tinfoil")
+        body = p.build_extra_body(model="kimi-k2-6")
+        assert body["tinfoil_endpoint"] == "kimi-k2-6"
+
+    def test_config_endpoint_overrides_fallback(self):
+        p = get_provider_profile("tinfoil")
+        body = p.build_extra_body(
+            model="kimi-k2-6",
+            tinfoil_endpoints={"kimi-k2-6": "custom-path"},
+        )
+        assert body["tinfoil_endpoint"] == "custom-path"
+
+    def test_api_discovered_model_falls_through_to_model_name(self):
+        p = get_provider_profile("tinfoil")
+        body = p.build_extra_body(model="brand-new-model-v2")
+        assert body["tinfoil_endpoint"] == "brand-new-model-v2"
+
+    def test_strips_tinfoil_provider_prefix(self):
+        p = get_provider_profile("tinfoil")
+        body = p.build_extra_body(model="tinfoil/kimi-k2-6")
+        assert body["tinfoil_endpoint"] == "kimi-k2-6"
+
+    def test_empty_model_omits_endpoint(self):
+        p = get_provider_profile("tinfoil")
+        body = p.build_extra_body(model="")
+        assert "tinfoil_endpoint" not in body
+
+    def test_no_args_returns_empty(self):
+        p = get_provider_profile("tinfoil")
+        body = p.build_extra_body()
+        assert body == {}
+
+    def test_case_insensitive_model_match(self):
+        p = get_provider_profile("tinfoil")
+        body = p.build_extra_body(model="KIMI-K2-6")
+        assert body["tinfoil_endpoint"] == "kimi-k2-6"
+
+    def test_config_endpoint_beats_fallback(self):
+        p = get_provider_profile("tinfoil")
+        body = p.build_extra_body(
+            model="kimi-k2-6",
+            tinfoil_endpoints={"kimi-k2-6": "user-configured-path"},
+        )
+        assert body["tinfoil_endpoint"] == "user-configured-path"
+
+    def test_preserves_other_context_keys(self):
+        p = get_provider_profile("tinfoil")
+        body = p.build_extra_body(model="kimi-k2-6", session_id="sess-123")
+        assert body["tinfoil_endpoint"] == "kimi-k2-6"
+
+    def test_empty_endpoints_config_falls_through(self):
+        p = get_provider_profile("tinfoil")
+        body = p.build_extra_body(model="kimi-k2-6", tinfoil_endpoints={})
+        assert body["tinfoil_endpoint"] == "kimi-k2-6"
+
+
+# ── build_api_kwargs_extras tests ───────────────────────────────────
+
+class TestTinfoilBuildApiKwargsExtras:
+    def test_returns_content_type_headers_by_default(self):
+        p = get_provider_profile("tinfoil")
+        eb, tl = p.build_api_kwargs_extras()
+        assert eb == {}
+        assert tl["extra_headers"]["Content-Type"] == "application/json"
+        assert "X-Tinfoil-Sdk-Version" not in tl["extra_headers"]
+
+    def test_sdk_version_sets_extra_headers(self, monkeypatch):
+        monkeypatch.setenv("TINFOIL_SDK_VERSION", "1.2.3")
+        p = get_provider_profile("tinfoil")
+        eb, tl = p.build_api_kwargs_extras()
+        assert tl["extra_headers"]["Content-Type"] == "application/json"
+        assert tl["extra_headers"]["X-Tinfoil-Sdk-Version"] == "1.2.3"
+
+    def test_sdk_version_empty_excludes_version(self, monkeypatch):
+        monkeypatch.setenv("TINFOIL_SDK_VERSION", "")
+        p = get_provider_profile("tinfoil")
+        eb, tl = p.build_api_kwargs_extras()
+        assert "X-Tinfoil-Sdk-Version" not in tl["extra_headers"]
+
+    def test_sdk_version_unset_excludes_version(self):
+        p = get_provider_profile("tinfoil")
+        eb, tl = p.build_api_kwargs_extras()
+        assert "X-Tinfoil-Sdk-Version" not in tl["extra_headers"]
+
+    def test_reasoning_config_ignored(self):
+        p = get_provider_profile("tinfoil")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            supports_reasoning=True,
+        )
+        assert eb == {}
+        assert tl["extra_headers"]["Content-Type"] == "application/json"
+
+
+# ── fetch_models tests ──────────────────────────────────────────────
+
+class TestTinfoilFetchModels:
+    TINFOIL_MODULE = "plugins.model_providers.tinfoil"
+
+    @pytest.fixture(autouse=True)
+    def clear_cache(self):
+        _clear_tinfoil_cache()
+
+    def test_returns_only_chat_models(self):
+        p = get_provider_profile("tinfoil")
+        mock_resp = _mock_httpx_response(_TINFOIL_API_RESPONSE)
+        mock_client = _make_httpx_client_mock(mock_resp)
+        with patch("httpx.Client", return_value=mock_client):
+            models = p.fetch_models(api_key="test-key")
+        assert models == _CHAT_MODEL_IDS
+
+    def test_excludes_embedding_audio_tts_tool_document_safety(self):
+        p = get_provider_profile("tinfoil")
+        mock_resp = _mock_httpx_response(_TINFOIL_API_RESPONSE)
+        mock_client = _make_httpx_client_mock(mock_resp)
+        with patch("httpx.Client", return_value=mock_client):
+            models = p.fetch_models(api_key="test-key")
+        returned = set(models)
+        assert returned & _NON_CHAT_IDS == set()
+
+    def test_caches_results(self):
+        p = get_provider_profile("tinfoil")
+        mock_resp = _mock_httpx_response(_TINFOIL_API_RESPONSE)
+        mock_client = _make_httpx_client_mock(mock_resp)
+        with patch("httpx.Client", return_value=mock_client):
+            p.fetch_models(api_key="test-key")
+        with patch("httpx.Client", side_effect=Exception("should not be called")):
+            models = p.fetch_models(api_key="test-key")
+        assert models == _CHAT_MODEL_IDS
+
+    def test_returns_none_on_network_error(self):
+        p = get_provider_profile("tinfoil")
+        with patch("httpx.Client", side_effect=Exception("connection refused")):
+            models = p.fetch_models(api_key="test-key")
+        assert models is None
+
+    def test_returns_none_on_invalid_json(self):
+        p = get_provider_profile("tinfoil")
+        mock_resp = MagicMock()
+        mock_resp.json.side_effect = json.JSONDecodeError("not json", "", 0)
+        mock_resp.raise_for_status.return_value = None
+        mock_client = _make_httpx_client_mock(mock_resp)
+        with patch("httpx.Client", return_value=mock_client):
+            models = p.fetch_models(api_key="test-key")
+        assert models is None
+
+    def test_returns_none_on_timeout(self):
+        p = get_provider_profile("tinfoil")
+        with patch("httpx.Client", side_effect=TimeoutError("timed out")):
+            models = p.fetch_models(api_key="test-key")
+        assert models is None
+
+    def test_sends_bearer_auth(self):
+        p = get_provider_profile("tinfoil")
+        mock_resp = _mock_httpx_response(_TINFOIL_API_RESPONSE)
+        captured = {}
+
+        def capture_headers(url, **kw):
+            captured["h"] = kw.get("headers", {})
+            return mock_resp
+
+        mock_client = MagicMock()
+        mock_client.get.side_effect = capture_headers
+        mock_client.__enter__.return_value = mock_client
+        with patch("httpx.Client", return_value=mock_client):
+            p.fetch_models(api_key="my-secret-key")
+        assert captured["h"].get("Authorization") == "Bearer my-secret-key"
+        assert captured["h"].get("User-Agent", "").startswith("hermes-cli/")
+        assert captured["h"].get("Accept") == "application/json"
+
+    def test_no_auth_when_api_key_not_provided(self):
+        p = get_provider_profile("tinfoil")
+        mock_resp = _mock_httpx_response(_TINFOIL_API_RESPONSE)
+        captured = {}
+
+        def capture_headers(url, **kw):
+            captured["h"] = kw.get("headers", {})
+            return mock_resp
+
+        mock_client = MagicMock()
+        mock_client.get.side_effect = capture_headers
+        mock_client.__enter__.return_value = mock_client
+        with patch("httpx.Client", return_value=mock_client):
+            models = p.fetch_models(api_key=None)
+        assert "Authorization" not in captured["h"]
+        assert models == _CHAT_MODEL_IDS
+
+    def test_correct_url(self):
+        p = get_provider_profile("tinfoil")
+        mock_resp = _mock_httpx_response({"data": []})
+        captured = {}
+
+        def capture_url(url, **kw):
+            captured["url"] = str(url)
+            return mock_resp
+
+        mock_client = MagicMock()
+        mock_client.get.side_effect = capture_url
+        mock_client.__enter__.return_value = mock_client
+        with patch("httpx.Client", return_value=mock_client):
+            p.fetch_models(api_key="test-key")
+        assert captured["url"] == "https://inference.tinfoil.sh/v1/models"
+
+    def test_forwards_default_headers(self):
+        p = get_provider_profile("tinfoil")
+        mock_resp = _mock_httpx_response(_TINFOIL_API_RESPONSE)
+        captured = {}
+
+        def capture_headers(url, **kw):
+            captured["h"] = kw.get("headers", {})
+            return mock_resp
+
+        mock_client = MagicMock()
+        mock_client.get.side_effect = capture_headers
+        mock_client.__enter__.return_value = mock_client
+        with patch("httpx.Client", return_value=mock_client):
+            p.fetch_models(api_key="test-key")
+        assert captured["h"].get("Content-Type") == "application/json"
+
+    def test_empty_data_list_returns_empty_list(self):
+        p = get_provider_profile("tinfoil")
+        mock_resp = _mock_httpx_response({"data": []})
+        mock_client = _make_httpx_client_mock(mock_resp)
+        with patch("httpx.Client", return_value=mock_client):
+            models = p.fetch_models(api_key="test-key")
+        assert models == []
+
+    def test_no_chat_models_returns_empty(self):
+        p = get_provider_profile("tinfoil")
+        response = {"data": [{"id": "only-embedding", "type": "embedding", "tool_calling": False}]}
+        mock_resp = _mock_httpx_response(response)
+        mock_client = _make_httpx_client_mock(mock_resp)
+        with patch("httpx.Client", return_value=mock_client):
+            models = p.fetch_models(api_key="test-key")
+        assert models == []
+
+    def test_response_is_list_directly(self):
+        p = get_provider_profile("tinfoil")
+        response = [{"id": "model-a", "type": "chat"}, {"id": "model-b", "type": "chat"}]
+        mock_resp = _mock_httpx_response(response)
+        mock_client = _make_httpx_client_mock(mock_resp)
+        with patch("httpx.Client", return_value=mock_client):
+            models = p.fetch_models(api_key="test-key")
+        assert models == ["model-a", "model-b"]
+
+    def test_cache_not_populated_on_failure(self):
+        p = get_provider_profile("tinfoil")
+        with patch("httpx.Client", side_effect=Exception("fail")):
+            p.fetch_models(api_key="test-key")
+        mod = sys.modules.get(self.TINFOIL_MODULE)
+        assert mod is not None
+        assert mod._TINFOIL_MODEL_CACHE is None
+
+
+# ── Transport parity tests ──────────────────────────────────────────
+
+class TestTinfoilTransportParity:
+    def test_tinfoil_endpoint_in_transport_kwargs(self):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+        transport = ChatCompletionsTransport()
+        p = get_provider_profile("tinfoil")
+        kw = transport.build_kwargs(
+            model="tinfoil/kimi-k2-6",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=None,
+            provider_profile=p,
+        )
+        assert kw["extra_body"]["tinfoil_endpoint"] == "kimi-k2-6"
+
+    def test_no_sdk_extra_headers_by_default_in_transport(self):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+        transport = ChatCompletionsTransport()
+        p = get_provider_profile("tinfoil")
+        kw = transport.build_kwargs(
+            model="tinfoil/kimi-k2-6",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=None,
+            provider_profile=p,
+        )
+        extra_headers = kw.get("extra_headers", {})
+        assert extra_headers.get("Content-Type") == "application/json"
+        assert "X-Tinfoil-Sdk-Version" not in extra_headers

--- a/tests/transports/test_tinfoil_transport.py
+++ b/tests/transports/test_tinfoil_transport.py
@@ -1,0 +1,532 @@
+"""Tests for the Tinfoil EHBP transport.
+
+These tests cover:
+* Transport registration and api_mode
+* build_kwargs (inherits from ChatCompletionsTransport)
+* normalize_response (inherits from ChatCompletionsTransport)
+* Fallback to plain TLS when SDK unavailable
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestTinfoilTransportBasics:
+    """Registration, api_mode, and identity."""
+
+    def test_api_mode(self):
+        from agent.transports.tinfoil import TinfoilTransport
+        t = TinfoilTransport()
+        assert t.api_mode == "tinfoil_ehbp"
+
+    def test_registered(self):
+        from agent.transports import get_transport
+        t = get_transport("tinfoil_ehbp")
+        assert t is not None
+        assert t.api_mode == "tinfoil_ehbp"
+
+    def test_inherits_from_chat_completions(self):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+        from agent.transports.tinfoil import TinfoilTransport
+        assert issubclass(TinfoilTransport, ChatCompletionsTransport)
+
+    def test_get_transport_returns_instance(self):
+        from agent.transports import get_transport
+        t1 = get_transport("tinfoil_ehbp")
+        t2 = get_transport("tinfoil_ehbp")
+        assert t1 is not None and t2 is not None
+        # Each call returns a fresh instance
+        assert t1 is not t2
+
+
+class TestTinfoilTransportBuildKwargs:
+    """build_kwargs inherits ChatCompletionsTransport behaviour."""
+
+    def test_basic_kwargs_no_tools(self):
+        from agent.transports.tinfoil import TinfoilTransport
+        t = TinfoilTransport()
+        kw = t.build_kwargs(
+            model="kimi-k2-6",
+            messages=[{"role": "user", "content": "hello"}],
+        )
+        assert kw["model"] == "kimi-k2-6"
+        assert len(kw["messages"]) == 1
+        assert "tools" not in kw
+
+    def test_kwargs_with_tools(self):
+        from agent.transports.tinfoil import TinfoilTransport
+        t = TinfoilTransport()
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "test_fn",
+                    "description": "A test",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        kw = t.build_kwargs(
+            model="kimi-k2-6",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=tools,
+        )
+        assert kw["tools"] == tools
+
+    def test_kwargs_with_provider_profile(self):
+        """End-to-end: profile injects tinfoil_endpoint into extra_body."""
+        from providers import get_provider_profile
+        p = get_provider_profile("tinfoil")
+        assert p is not None
+        from agent.transports.tinfoil import TinfoilTransport
+        t = TinfoilTransport()
+        kw = t.build_kwargs(
+            model="tinfoil/kimi-k2-6",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=None,
+            provider_profile=p,
+        )
+        extra = kw.get("extra_body", {})
+        assert extra.get("tinfoil_endpoint") == "kimi-k2-6"
+
+    def test_kwargs_provider_profile_headers(self):
+        from providers import get_provider_profile
+        p = get_provider_profile("tinfoil")
+        from agent.transports.tinfoil import TinfoilTransport
+        t = TinfoilTransport()
+        kw = t.build_kwargs(
+            model="tinfoil/kimi-k2-6",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=None,
+            provider_profile=p,
+        )
+        # Content-Type comes from profile's default_headers
+        extra_headers = kw.get("extra_headers", {})
+        assert extra_headers.get("Content-Type") == "application/json"
+
+
+class TestTinfoilTransportNormalizeResponse:
+    """normalize_response is identical to ChatCompletionsTransport."""
+
+    def test_normalize_text_response(self):
+        from openai.types.chat import ChatCompletion
+        mock_response = MagicMock(spec=ChatCompletion)
+        mock_response.choices = [
+            MagicMock(
+                finish_reason="stop",
+                message=MagicMock(
+                    content="Hello!",
+                    tool_calls=None,
+                    reasoning=None,
+                    reasoning_content=None,
+                    model_extra=None,
+                ),
+            )
+        ]
+        mock_response.usage = MagicMock(
+            prompt_tokens=10,
+            completion_tokens=5,
+            total_tokens=15,
+        )
+
+        from agent.transports.tinfoil import TinfoilTransport
+        t = TinfoilTransport()
+        nr = t.normalize_response(mock_response)
+
+        assert nr.content == "Hello!"
+        assert nr.finish_reason == "stop"
+        assert nr.tool_calls is None
+        assert nr.usage is not None
+        assert nr.usage.prompt_tokens == 10
+        assert nr.usage.completion_tokens == 5
+
+    def test_normalize_no_usage(self):
+        mock_response = MagicMock()
+        mock_response.choices = [
+            MagicMock(
+                finish_reason="stop",
+                message=MagicMock(
+                    content="Hi",
+                    tool_calls=None,
+                    reasoning=None,
+                    reasoning_content=None,
+                    model_extra=None,
+                ),
+            )
+        ]
+        mock_response.usage = None
+
+        from agent.transports.tinfoil import TinfoilTransport
+        t = TinfoilTransport()
+        nr = t.normalize_response(mock_response)
+
+        assert nr.content == "Hi"
+        assert nr.usage is None  # No usage when response lacks it
+
+    def test_normalize_invalid_response(self):
+        from agent.transports.tinfoil import TinfoilTransport
+        t = TinfoilTransport()
+        assert t.validate_response(None) is False
+        assert t.validate_response(MagicMock(choices=None)) is False
+
+
+class TestTinfoilTransportSecureClient:
+    """SecureClient lifecycle and fallback."""
+
+    def test_build_secure_client_sdk_not_available(self):
+        from agent.transports.tinfoil import TinfoilTransport
+        t = TinfoilTransport()
+        with patch("agent.transports.tinfoil._TINFOIL_AVAILABLE", False):
+            client = t.build_secure_client(api_key="test-key")
+        assert client is None
+
+    def test_build_secure_client_init_failure(self):
+        """SDK available but SecureClient constructor raises."""
+        from agent.transports.tinfoil import TinfoilTransport
+        t = TinfoilTransport()
+        with patch("agent.transports.tinfoil._TINFOIL_AVAILABLE", True):
+            with patch(
+                "agent.transports.tinfoil.SecureClient",
+                side_effect=RuntimeError("no enclave"),
+            ):
+                client = t.build_secure_client(api_key="test-key")
+        assert client is None
+
+    def test_build_secure_openai_client_sdk_not_available(self):
+        """Falls back to plain openai.OpenAI when SDK not available."""
+        from agent.transports.tinfoil import TinfoilTransport
+        t = TinfoilTransport()
+        fake_openai = MagicMock()
+        fake_openai_instance = MagicMock()
+        fake_openai.OpenAI.return_value = fake_openai_instance
+
+        with (
+            patch("agent.transports.tinfoil._TINFOIL_AVAILABLE", False),
+            patch.dict("sys.modules", {"openai": fake_openai}),
+        ):
+            client = t.build_secure_openai_client(
+                api_key="key",
+                base_url="https://inference.tinfoil.sh/v1",
+            )
+        assert client is fake_openai_instance
+        fake_openai.OpenAI.assert_called_once()
+
+    def test_build_secure_openai_client_secure_client_none(self):
+        """build_secure_client returns None → falls back to plain OpenAI."""
+        from agent.transports.tinfoil import TinfoilTransport
+        t = TinfoilTransport()
+        fake_openai = MagicMock()
+        fake_openai_instance = MagicMock()
+        fake_openai.OpenAI.return_value = fake_openai_instance
+
+        with (
+            patch.object(t, "build_secure_client", return_value=None),
+            patch.dict("sys.modules", {"openai": fake_openai}),
+        ):
+            client = t.build_secure_openai_client(
+                api_key="key",
+                base_url="https://inference.tinfoil.sh/v1",
+            )
+        assert client is fake_openai_instance
+
+    def test_build_kwargs_delegates_to_super(self):
+        """build_kwargs still works even after SecureClient attempts."""
+        from agent.transports.tinfoil import TinfoilTransport
+        t = TinfoilTransport()
+        kw = t.build_kwargs(
+            model="test-model",
+            messages=[{"role": "user", "content": "test"}],
+        )
+        assert kw["model"] == "test-model"
+        assert kw["messages"][0]["content"] == "test"
+
+    def test_build_secure_openai_client_uses_enclave_as_base_url(self):
+        """Secure client's enclave hostname is used as base_url so TLS
+        cert pinning matches the host we actually connect to."""
+        from agent.transports.tinfoil import TinfoilTransport
+        t = TinfoilTransport()
+
+        mock_secure = MagicMock()
+        mock_secure.enclave = "router.inf6.tinfoil.sh"
+        mock_secure.make_secure_http_client.return_value = MagicMock()
+
+        fake_openai = MagicMock()
+        fake_openai_instance = MagicMock()
+        fake_openai.OpenAI.return_value = fake_openai_instance
+
+        with (
+            patch.object(t, "build_secure_client", return_value=mock_secure),
+            patch.dict("sys.modules", {"openai": fake_openai}),
+        ):
+            client = t.build_secure_openai_client(
+                api_key="key",
+                base_url="https://inference.tinfoil.sh/v1",
+            )
+
+        assert client is fake_openai_instance
+        fake_openai.OpenAI.assert_called_once_with(
+            api_key="key",
+            base_url="https://router.inf6.tinfoil.sh/v1/",
+            http_client=mock_secure.make_secure_http_client.return_value,
+            timeout=None,
+            default_headers=None,
+        )
+
+
+class TestTinfoilRequireSecure:
+    """Fail-closed behaviour gated by tinfoil.require_secure."""
+
+    def test_require_secure_raises_when_sdk_unavailable(self):
+        """require_secure=True + no secure client → raise, never fall back."""
+        from agent.transports.tinfoil import (
+            TinfoilSecureUnavailableError,
+            TinfoilTransport,
+        )
+        t = TinfoilTransport()
+        fake_openai = MagicMock()
+
+        with (
+            patch.object(t, "build_secure_client", return_value=None),
+            patch.dict("sys.modules", {"openai": fake_openai}),
+        ):
+            with pytest.raises(TinfoilSecureUnavailableError):
+                t.build_secure_openai_client(
+                    api_key="key",
+                    base_url="https://inference.tinfoil.sh/v1",
+                    require_secure=True,
+                )
+        # Must NOT have constructed a plain-TLS client.
+        fake_openai.OpenAI.assert_not_called()
+
+    def test_require_secure_raises_when_http_client_fails(self):
+        """Secure client built but transport creation fails → raise."""
+        from agent.transports.tinfoil import (
+            TinfoilSecureUnavailableError,
+            TinfoilTransport,
+        )
+        t = TinfoilTransport()
+
+        mock_secure = MagicMock()
+        mock_secure.enclave = "router.inf6.tinfoil.sh"
+        mock_secure.make_secure_http_client.side_effect = RuntimeError("handshake")
+
+        fake_openai = MagicMock()
+
+        with (
+            patch.object(t, "build_secure_client", return_value=mock_secure),
+            patch.dict("sys.modules", {"openai": fake_openai}),
+        ):
+            with pytest.raises(TinfoilSecureUnavailableError):
+                t.build_secure_openai_client(
+                    api_key="key",
+                    base_url="https://inference.tinfoil.sh/v1",
+                    require_secure=True,
+                )
+        fake_openai.OpenAI.assert_not_called()
+        # is_secure() must report False after a failed handshake.
+        assert t.is_secure() is False
+
+    def test_require_secure_false_still_falls_back(self):
+        """Default (require_secure=False) preserves plain-TLS fallback."""
+        from agent.transports.tinfoil import TinfoilTransport
+        t = TinfoilTransport()
+        fake_openai = MagicMock()
+        fake_instance = MagicMock()
+        fake_openai.OpenAI.return_value = fake_instance
+
+        with (
+            patch.object(t, "build_secure_client", return_value=None),
+            patch.dict("sys.modules", {"openai": fake_openai}),
+        ):
+            client = t.build_secure_openai_client(
+                api_key="key",
+                base_url="https://inference.tinfoil.sh/v1",
+                require_secure=False,
+            )
+        assert client is fake_instance
+
+    def test_build_tinfoil_client_honors_require_secure_config(self):
+        """_build_tinfoil_client reads tinfoil.require_secure from config and
+        fails closed when the transport isn't registered."""
+        from agent.agent_runtime_helpers import _build_tinfoil_client
+        from agent.transports.tinfoil import TinfoilSecureUnavailableError
+
+        agent = MagicMock()
+        agent._get_transport.return_value = None
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"tinfoil": {"require_secure": True}},
+        ):
+            with pytest.raises(TinfoilSecureUnavailableError):
+                _build_tinfoil_client(
+                    agent,
+                    {"api_key": "k", "base_url": "https://inference.tinfoil.sh/v1"},
+                )
+
+    def test_build_tinfoil_client_passes_require_secure_to_transport(self):
+        """The config flag is forwarded to build_secure_openai_client."""
+        from agent.agent_runtime_helpers import _build_tinfoil_client
+
+        mock_transport = MagicMock()
+        mock_transport.build_secure_openai_client.return_value = MagicMock()
+        agent = MagicMock()
+        agent._get_transport.return_value = mock_transport
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"tinfoil": {"require_secure": True}},
+        ):
+            _build_tinfoil_client(
+                agent,
+                {"api_key": "k", "base_url": "https://inference.tinfoil.sh/v1"},
+            )
+
+        _, kwargs = mock_transport.build_secure_openai_client.call_args
+        assert kwargs["require_secure"] is True
+
+
+class TestTinfoilTransportVerificationDoc:
+    """get_verification_document accessor."""
+
+    def test_no_doc_when_no_client(self):
+        from agent.transports.tinfoil import TinfoilTransport
+        t = TinfoilTransport()
+        assert t.get_verification_document() is None
+
+    def test_returns_cached_doc(self):
+        from agent.transports.tinfoil import TinfoilTransport
+        t = TinfoilTransport()
+        doc = {"status": "verified"}
+        t._verification_document = doc
+        assert t.get_verification_document() is doc
+
+
+class TestTinfoilProviderProfileApiMode:
+    """Provider profile declares tinfoil_ehbp as its api_mode."""
+
+    def test_profile_api_mode(self):
+        from providers import get_provider_profile
+        p = get_provider_profile("tinfoil")
+        assert p is not None
+        assert p.api_mode == "tinfoil_ehbp"
+
+
+class TestBuildTinfoilClient:
+    """_build_tinfoil_client in agent_runtime_helpers."""
+
+    def test_transport_not_registered_fallback(self):
+        """When transport isn't registered, falls back to plain OpenAI."""
+        from agent.agent_runtime_helpers import _build_tinfoil_client
+
+        fake_instance = MagicMock()
+
+        agent = MagicMock()
+        agent._build_keepalive_http_client.return_value = None
+        # The cached-transport lookup returns None when no transport is
+        # registered for tinfoil_ehbp.
+        agent._get_transport.return_value = None
+        client_kwargs = {
+            "api_key": "test-key",
+            "base_url": "https://inference.tinfoil.sh/v1",
+        }
+
+        with patch(
+            "run_agent.OpenAI",
+            return_value=fake_instance,
+        ):
+            client = _build_tinfoil_client(agent, client_kwargs)
+
+        assert client is fake_instance
+        agent._get_transport.assert_called_once_with("tinfoil_ehbp")
+
+    def test_transport_registered_delegates(self):
+        """When transport is registered, delegates to build_secure_openai_client."""
+        from agent.agent_runtime_helpers import _build_tinfoil_client
+
+        mock_transport = MagicMock()
+        mock_openai_client = MagicMock()
+        mock_transport.build_secure_openai_client.return_value = mock_openai_client
+
+        agent = MagicMock()
+        # _build_tinfoil_client must read the agent's *cached* transport so
+        # the attestation result it records is observable later via
+        # is_secure() (status bar / TUI session-info probe).
+        agent._get_transport.return_value = mock_transport
+        client_kwargs = {
+            "api_key": "test-key",
+            "base_url": "https://inference.tinfoil.sh/v1",
+            "timeout": 30.0,
+            "default_headers": {"Content-Type": "application/json"},
+        }
+
+        client = _build_tinfoil_client(agent, client_kwargs)
+
+        assert client is mock_openai_client
+        agent._get_transport.assert_called_once_with("tinfoil_ehbp")
+        mock_transport.build_secure_openai_client.assert_called_once_with(
+            api_key="test-key",
+            base_url="https://inference.tinfoil.sh/v1",
+            timeout=30.0,
+            default_headers={"Content-Type": "application/json"},
+            require_secure=False,
+        )
+
+    def test_secure_state_observable_via_cached_transport(self):
+        """Regression: the attestation result recorded during client build
+        must be observable later via the same cached transport instance.
+
+        Previously ``_build_tinfoil_client`` and the status-bar probe each
+        created a throwaway transport via the module-level ``get_transport``,
+        so ``is_secure()`` always reported ``False`` even on a verified
+        connection. Both now share the agent's cached transport.
+        """
+        from agent.agent_runtime_helpers import _build_tinfoil_client
+        from agent.transports.tinfoil import TinfoilTransport
+
+        transport = TinfoilTransport()
+        assert transport.is_secure() is False
+
+        mock_secure = MagicMock()
+        mock_secure.enclave = "router.inf6.tinfoil.sh"
+        mock_secure.make_secure_http_client.return_value = MagicMock()
+
+        agent = MagicMock()
+        # The agent's transport cache always hands back the SAME instance.
+        agent._get_transport.return_value = transport
+
+        fake_openai = MagicMock()
+        fake_openai.OpenAI.return_value = MagicMock()
+
+        # Drive the real build_secure_client path (which sets _secure_client)
+        # by faking the SDK at the SecureClient level.
+        with (
+            patch("agent.transports.tinfoil._TINFOIL_AVAILABLE", True),
+            patch(
+                "agent.transports.tinfoil.SecureClient",
+                return_value=mock_secure,
+            ),
+            patch.dict("sys.modules", {"openai": fake_openai}),
+        ):
+            _build_tinfoil_client(
+                agent,
+                {"api_key": "k", "base_url": "https://inference.tinfoil.sh/v1"},
+            )
+
+        # The cached instance the status bar / TUI would query now reports
+        # the verified (secure) state.
+        assert agent._get_transport("tinfoil_ehbp").is_secure() is True
+
+
+class TestAgentInitApiModeDetection:
+    """agent_init.py routes tinfoil provider to tinfoil_ehbp api_mode."""
+
+    def test_provider_profile_has_correct_api_mode(self):
+        """The TinfoilProvider profile declares the correct api_mode."""
+        from providers import get_provider_profile
+        p = get_provider_profile("tinfoil")
+        assert p is not None
+        assert p.api_mode == "tinfoil_ehbp"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1645,6 +1645,20 @@ def _session_info(agent, session: dict | None = None) -> dict:
     warn = _probe_credentials(agent)
     if warn:
         info["credential_warning"] = warn
+    try:
+        if getattr(agent, "api_mode", "") == "tinfoil_ehbp":
+            # Read the agent's *cached* transport — the same instance that
+            # ``_build_tinfoil_client`` recorded the attestation result on.
+            # A fresh module-level ``get_transport`` instance would always
+            # report ``is_secure() == False`` (its ``_secure_client`` is None).
+            transport = None
+            getter = getattr(agent, "_get_transport", None)
+            if callable(getter):
+                transport = getter("tinfoil_ehbp")
+            if transport is not None:
+                info["tinfoil_secure"] = bool(transport.is_secure())
+    except Exception:
+        pass
     return info
 
 

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -384,6 +384,7 @@ export function StatusRule({
   turnStartedAt,
   voiceLabel,
   onSessionCountClick,
+  tinfoilSecure,
   t
 }: StatusRuleProps) {
   const pct = usage.context_percent
@@ -412,7 +413,8 @@ export function StatusRule({
     (busy ? busyIndicatorWidth(indicatorStyle, turnStartedAt != null) : stringWidth(status)) +
     stringWidth(' │ ') +
     stringWidth(modelText) +
-    (ctxLabel ? stringWidth(' │ ') + stringWidth(ctxLabel) : 0)
+    (ctxLabel ? stringWidth(' │ ') + stringWidth(ctxLabel) : 0) +
+    (tinfoilSecure !== undefined ? stringWidth(' │ ') + stringWidth('🔒') : 0)
 
   const { leftWidth, rightWidth, separatorWidth } = statusRuleWidths(cols, cwdLabel, essentialWidth)
 
@@ -479,6 +481,14 @@ export function StatusRule({
             <Text color={t.color.muted} wrap="truncate-end">
               {' │ '}
               {ctxLabel}
+            </Text>
+          ) : null}
+          {tinfoilSecure !== undefined ? (
+            <Text wrap="truncate-end">
+              <Text color={t.color.muted}>{' │ '}</Text>
+              <Text color={tinfoilSecure ? t.color.ok : t.color.error}>
+                {tinfoilSecure ? '🔒' : '🔓'}
+              </Text>
             </Text>
           ) : null}
         </Box>
@@ -659,6 +669,7 @@ interface StatusRuleProps {
   status: string
   statusColor: string
   t: Theme
+  tinfoilSecure?: boolean
   turnStartedAt?: null | number
   usage: Usage
   voiceLabel?: string

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -369,6 +369,7 @@ const StatusRulePane = memo(function StatusRulePane({
         status={ui.status}
         statusColor={status.statusColor}
         t={ui.theme}
+        tinfoilSecure={ui.info?.tinfoil_secure}
         turnStartedAt={status.turnStartedAt}
         usage={ui.usage}
         voiceLabel={status.voiceLabel}

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -155,6 +155,7 @@ export interface SessionInfo {
   service_tier?: string
   skills: Record<string, string[]>
   system_prompt?: string
+  tinfoil_secure?: boolean
   tools: Record<string, string[]>
   update_behind?: number | null
   update_command?: string

--- a/website/docs/developer-guide/model-provider-plugin.md
+++ b/website/docs/developer-guide/model-provider-plugin.md
@@ -148,6 +148,7 @@ Look at these bundled plugins for idioms:
 
 | Plugin | Why look |
 |---|---|
+| `plugins/model-providers/tinfoil/` | HPKE end-to-end encryption, secure enclave routing, `fetch_models` with live API discovery + `type == "chat"` filtering, `build_extra_body` for endpoint mapping, `build_api_kwargs_extras` for custom headers |
 | `plugins/model-providers/openrouter/` | Aggregator with provider preferences, public model catalog |
 | `plugins/model-providers/gemini/` | `thinking_config` translation (native + OpenAI-compat nested forms) |
 | `plugins/model-providers/kimi-coding/` | `OMIT_TEMPERATURE`, `extra_body.thinking`, top-level `reasoning_effort` |

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -35,6 +35,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **Kilo Code** | `KILOCODE_API_KEY` in `~/.hermes/.env` (provider: `kilocode`) |
 | **Xiaomi MiMo** | `XIAOMI_API_KEY` in `~/.hermes/.env` (provider: `xiaomi`, aliases: `mimo`, `xiaomi-mimo`) |
 | **Tencent TokenHub** | `TOKENHUB_API_KEY` in `~/.hermes/.env` (provider: `tencent-tokenhub`, aliases: `tencent`, `tokenhub`, `tencentmaas`) |
+| **Tinfoil.sh** | `TINFOIL_API_KEY` in `~/.hermes/.env` (provider: `tinfoil`, aliases: `tinfoil-sh`, `tinfoil.sh` — HPKE end-to-end encrypted AI inference) |
 | **OpenCode Zen** | `OPENCODE_ZEN_API_KEY` in `~/.hermes/.env` (provider: `opencode-zen`) |
 | **OpenCode Go** | `OPENCODE_GO_API_KEY` in `~/.hermes/.env` (provider: `opencode-go`) |
 | **DeepSeek** | `DEEPSEEK_API_KEY` in `~/.hermes/.env` (provider: `deepseek`) |
@@ -258,6 +259,10 @@ hermes chat --provider arcee --model trinity-large-thinking
 # Use the exact model ID returned by GMI's /v1/models endpoint.
 hermes chat --provider gmi --model zai-org/GLM-5.1-FP8
 # Requires: GMI_API_KEY in ~/.hermes/.env
+
+# Tinfoil.sh — HPKE end-to-end encrypted AI inference
+hermes chat --provider tinfoil --model kimi-k2-6
+# Requires: TINFOIL_API_KEY in ~/.hermes/.env
 ```
 
 Or set the provider permanently in `config.yaml`:
@@ -267,7 +272,7 @@ model:
   default: "zai-org/GLM-5.1-FP8"
 ```
 
-Base URLs can be overridden with `NOVITA_BASE_URL`, `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `DASHSCOPE_BASE_URL`, `XIAOMI_BASE_URL`, `GMI_BASE_URL`, or `TOKENHUB_BASE_URL` environment variables.
+Base URLs can be overridden with `NOVITA_BASE_URL`, `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `DASHSCOPE_BASE_URL`, `XIAOMI_BASE_URL`, `GMI_BASE_URL`, `TINFOIL_BASE_URL`, or `TOKENHUB_BASE_URL` environment variables.
 
 :::note Z.AI Endpoint Auto-Detection
 When using the Z.AI / GLM provider, Hermes automatically probes multiple endpoints (global, China, coding variants) to find one that accepts your API key. You don't need to set `GLM_BASE_URL` manually — the working endpoint is detected and cached automatically.
@@ -487,6 +492,42 @@ model:
 ```
 
 The base URL can be overridden with `GMI_BASE_URL` (default: `https://api.gmi-serving.com/v1`).
+
+### Tinfoil.sh
+
+HPKE end-to-end encrypted AI inference via [Tinfoil.sh](https://tinfoil.sh) — OpenAI-compatible API, API key authentication. All inference payloads are encrypted using HPKE (RFC 9180) secure enclaves before leaving the client.
+
+In the TUI, a lock icon in the status bar shows the encryption state: 🔒 (green) when the secure HPKE transport is active, 🔓 (red) when falling back to plain TLS (tinfoil SDK not installed or attestation failed).
+
+By default, if the verified HPKE enclave transport can't be established, Hermes falls back to plain TLS and surfaces the downgrade via the 🔓 lock icon. To **fail closed** instead — refusing to send any inference over plain TLS — set `tinfoil.require_secure: true` in `config.yaml`. Client creation then raises rather than downgrading silently, which is the recommended posture for confidential workloads (and for non-interactive surfaces like the gateway, cron, and batch jobs, where there's no lock icon to watch):
+
+```yaml
+tinfoil:
+  require_secure: true   # default: false
+```
+
+
+```bash
+# Tinfoil.sh
+hermes chat --provider tinfoil --model kimi-k2-6
+# Requires: TINFOIL_API_KEY in ~/.hermes/.env
+```
+
+Or set it permanently in `config.yaml`:
+```yaml
+model:
+  provider: "tinfoil"
+  default: "kimi-k2-6"
+```
+
+**Automatic model discovery:** Available chat models are fetched live from the Tinfoil `/v1/models` endpoint when you open the `/model` picker. Only models with `type: "chat"` are shown (embedding, audio, tts, and safety models are excluded). Results are cached in-process for the lifetime of the session. If the live API is unreachable, a built-in fallback list of known models is used.
+
+Model-to-endpoint mappings can be customized in `config.yaml` under the `tinfoil.endpoints` section:
+```yaml
+tinfoil:
+  endpoints:
+    kimi-k2-6: kimi-k2-6
+```
 
 ### StepFun
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -48,6 +48,8 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 | `XIAOMI_BASE_URL` | Override Xiaomi MiMo base URL (default: `https://api.xiaomimimo.com/v1`) |
 | `TOKENHUB_API_KEY` | Tencent TokenHub API key ([tokenhub.tencentmaas.com](https://tokenhub.tencentmaas.com)) |
 | `TOKENHUB_BASE_URL` | Override Tencent TokenHub base URL (default: `https://tokenhub.tencentmaas.com/v1`) |
+| `TINFOIL_API_KEY` | Tinfoil.sh API key ([tinfoil.sh](https://tinfoil.sh)) |
+| `TINFOIL_BASE_URL` | Override Tinfoil.sh base URL (default: `https://inference.tinfoil.sh/v1`) |
 | `AZURE_FOUNDRY_API_KEY` | Microsoft Foundry / Azure OpenAI API key ([ai.azure.com](https://ai.azure.com/)). Not needed when `model.auth_mode: entra_id` |
 | `AZURE_FOUNDRY_BASE_URL` | Microsoft Foundry endpoint URL (e.g. `https://<resource>.openai.azure.com/openai/v1` for OpenAI-style, or `https://<resource>.services.ai.azure.com/anthropic` for Anthropic-style) |
 | `AZURE_ANTHROPIC_KEY` | Azure Anthropic API key for `provider: anthropic` + `base_url` pointing at a Microsoft Foundry Claude deployment (alternative to `ANTHROPIC_API_KEY` when both Anthropic and Azure Anthropic are configured) |

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -76,6 +76,7 @@ A persistent status bar sits above the input area, updating in real time:
 | ▶ N | **Active background tasks** — how many `/background` prompts are still running in the current session. Appears whenever at least one task is in flight. |
 | Duration | Elapsed session time |
 | ⚠ YOLO | **YOLO mode warning** — shown whenever `HERMES_YOLO_MODE` is on (either `hermes --yolo` at launch or `/yolo` toggled mid-session). Mirrors the banner-line warning so you can't forget you're in auto-approve mode. |
+| 🔒 / 🔓 | **Tinfoil encryption status** — shown when the `tinfoil` provider is active. 🔒 green when HPKE enclave transport is established, 🔓 red when falling back to plain TLS. |
 
 The bar adapts to terminal width — full layout at ≥ 76 columns, compact at 52–75, minimal (model + duration, plus the YOLO badge when active) below 52.
 

--- a/website/docs/user-guide/tui.md
+++ b/website/docs/user-guide/tui.md
@@ -192,6 +192,8 @@ The TUI's status line tracks agent state in real time:
 
 The per-skin status-bar colors and thresholds are shared with the classic CLI — see [Skins](features/skins.md) for customization.
 
+When using the `tinfoil` provider (`api_mode: tinfoil_ehbp`), a lock icon appears in the status line: 🔒 (green) for active HPKE encryption, 🔓 (red) when the transport fell back to plain TLS.
+
 The status line also shows:
 
 - **Working directory with git branch** — `~/projects/hermes-agent (docs/two-week-gap-sweep)`. The branch suffix updates when you `git checkout` in a side terminal (mtime-cached) so the TUI reflects your actual active branch, not whatever it was at launch.


### PR DESCRIPTION
## What does this PR do?

Adds Tinfoil.sh as a first-class provider to leverage HPKE E2E encryption and hardware attested privacy. Encrypted payloads use HPKE (RFC 9180) secure enclaves. The provider is implemented as a plugin profile with a custom tinfoil_ehbp transport to enable zero knowledge inference from Tinfoil.sh.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made
- plugins/model-providers/tinfoil/__init__.py — ProviderProfile with fetch_models (httpx, type==chat filtering), build_extra_body for endpoint routing, build_api_kwargs_extras for SDK headers, auth_type="api_key", default_aux_model="gemma4-31b"
- plugins/model-providers/tinfoil/plugin.yaml — Plugin manifest
- agent/transports/tinfoil.py — TinfoilTransport extending ChatCompletionsTransport with SecureClient attestation, TLS pinning, HPKE encryption, and plain-TLS fallback with info logging
- agent/agent_runtime_helpers.py — _build_tinfoil_client() with keepalive injection and _ra().OpenAI fallback; create_openai_client() branches on api_mode == "tinfoil_ehbp"
- agent/agent_init.py — api_mode resolution for tinfoil provider
- agent/auxiliary_client.py — Aux model fallback to gemma4-31b
- agent/model_metadata.py — Context lengths and _PROVIDER_PREFIXES entry
- hermes_cli/models.py — Model catalog with 7 curated chat models
- hermes_cli/runtime_provider.py — resolve_runtime_provider branch and _VALID_API_MODES entry
- hermes_cli/providers.py — Plugin profile integration in determine_api_mode
- website/docs/integrations/providers.md — Tinfoil.sh section with setup, usage, model discovery
- website/docs/developer-guide/model-provider-plugin.md — Reference entry
- website/docs/reference/environment-variables.md — TINFOIL_API_KEY and TINFOIL_BASE_URL
- tests/providers/test_tinfoil_profile.py — 49 tests (attrs, build_extra_body, build_api_kwargs_extras, fetch_models)
- tests/transports/test_tinfoil_transport.py — 22 tests (registration, build_kwargs, normalize_response, SecureClient, fallback)
- tests/providers/test_plugin_discovery.py — Profile count invariant >= 34, tinfoil in spot-check

## How to Test

1. Run test suite: scripts/run_tests.sh tests/providers/test_tinfoil_profile.py tests/transports/test_tinfoil_transport.py tests/providers/test_plugin_discovery.py
2. Set TINFOIL_API_KEY in ~/.hermes/.env
3. hermes chat --provider tinfoil --model kimi-k2-6 -q "Say hello"

## Checklist
### Code

- [X] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [X] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [X] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [X] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [X] I've tested on my platform: Ubuntu 26.04

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [X] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [N/A] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A