### PR TITLE
fix(agent): normalize empty tool-call content for strict chat APIs

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -120,6 +120,9 @@ class ChatCompletionsTransport(ProviderTransport):
         - Codex Responses API fields: ``codex_reasoning_items`` /
           ``codex_message_items`` on the message, ``call_id`` /
           ``response_item_id`` on ``tool_calls`` entries.
+        - Empty assistant ``content`` on pure tool-call turns. Strict OpenAI-
+          compatible providers reject empty text blocks there; ``null`` is the
+          compatible Chat Completions representation.
         - ``tool_name`` on tool-result messages — written by
           ``make_tool_result_message()`` for the SQLite FTS index, but not
           part of the Chat Completions schema. Strict providers (Fireworks,
@@ -141,6 +144,14 @@ class ChatCompletionsTransport(ProviderTransport):
                 break
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):
+                content = msg.get("content")
+                if (
+                    msg.get("role") == "assistant"
+                    and tool_calls
+                    and (content is None or (isinstance(content, str) and not content.strip()))
+                ):
+                    needs_sanitize = True
+                    break
                 for tc in tool_calls:
                     if isinstance(tc, dict) and (
                         "call_id" in tc or "response_item_id" in tc
@@ -162,6 +173,13 @@ class ChatCompletionsTransport(ProviderTransport):
             msg.pop("tool_name", None)
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):
+                content = msg.get("content")
+                if (
+                    msg.get("role") == "assistant"
+                    and tool_calls
+                    and (content is None or (isinstance(content, str) and not content.strip()))
+                ):
+                    msg["content"] = None
                 for tc in tool_calls:
                     if isinstance(tc, dict):
                         tc.pop("call_id", None)

--- a/run_agent.py
+++ b/run_agent.py
@@ -3862,9 +3862,10 @@ class AIAgent:
 
         Providers like Mistral, Fireworks, and other strict OpenAI-compatible APIs
         validate the Chat Completions schema and reject unknown fields (call_id,
-        response_item_id) with 400 or 422 errors. These fields are preserved in
-        the internal message history — this method only modifies the outgoing
-        API copy.
+        response_item_id) with 400 or 422 errors. Some strict validators also
+        reject empty assistant text content on pure tool-call turns. These fields
+        are preserved in the internal message history — this method only modifies
+        the outgoing API copy.
 
         Creates new tool_call dicts rather than mutating in-place, so the
         original messages list retains call_id/response_item_id for Codex
@@ -3872,6 +3873,7 @@ class AIAgent:
         Codex provider later).
 
         Fields stripped: call_id, response_item_id
+        Fields normalized: empty assistant content -> null when tool_calls exist
         """
         tool_calls = api_msg.get("tool_calls")
         if not isinstance(tool_calls, list):
@@ -3882,6 +3884,10 @@ class AIAgent:
             if isinstance(tc, dict) else tc
             for tc in tool_calls
         ]
+        if tool_calls and api_msg.get("role") == "assistant":
+            content = api_msg.get("content")
+            if content is None or (isinstance(content, str) and not content.strip()):
+                api_msg["content"] = None
         return api_msg
 
     @staticmethod

--- a/tests/run_agent/test_strict_api_validation.py
+++ b/tests/run_agent/test_strict_api_validation.py
@@ -92,6 +92,75 @@ class TestStrictApiValidation:
         # Standard fields should remain
         assert tool_call["id"] == "call_123"
         assert tool_call["function"]["name"] == "terminal"
+        # Substantive assistant narration should be preserved.
+        assert assistant_msg["content"] == "Checking now."
+
+    @pytest.mark.parametrize("content", ["", "   \n\t"])
+    def test_empty_assistant_content_with_tool_calls_becomes_null(self, monkeypatch, content):
+        """Strict chat APIs should not receive empty text with assistant tool_calls."""
+        agent = _make_agent(monkeypatch, "openrouter")
+        agent.api_mode = "chat_completions"
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": content,
+                "tool_calls": [
+                    {
+                        "id": "call_123",
+                        "call_id": "call_123",
+                        "response_item_id": "fc_123",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": '{"command":"pwd"}'},
+                    }
+                ],
+            },
+        ]
+
+        kwargs = agent._build_api_kwargs(messages)
+
+        assert kwargs["messages"][1]["content"] is None
+        # The session history copy remains unchanged for Codex replay/fallback.
+        assert messages[1]["content"] == content
+
+    def test_missing_assistant_content_with_tool_calls_becomes_null(self, monkeypatch):
+        """Strict chat APIs should receive explicit null content for pure tool-call turns."""
+        agent = _make_agent(monkeypatch, "openrouter")
+        agent.api_mode = "chat_completions"
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": '{"command":"pwd"}'},
+                    }
+                ],
+            },
+        ]
+
+        kwargs = agent._build_api_kwargs(messages)
+
+        assert kwargs["messages"][1]["content"] is None
+        assert "content" not in messages[1]
+
+    def test_empty_assistant_content_without_tool_calls_stays_empty(self, monkeypatch):
+        """Only pure tool-call assistant turns need content normalization."""
+        agent = _make_agent(monkeypatch, "openrouter")
+        agent.api_mode = "chat_completions"
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": ""},
+        ]
+
+        kwargs = agent._build_api_kwargs(messages)
+
+        assert kwargs["messages"][1]["content"] == ""
 
     def test_codex_preserves_fields_for_replay(self, monkeypatch):
         """Codex mode should preserve fields for Responses API replay."""


### PR DESCRIPTION
## Summary
- Normalize empty/whitespace assistant content to `null` for pure tool-call turns sent through strict Chat Completions paths
- Apply the same normalization in the strict tool-call sanitizer used before provider replay
- Add regression coverage for empty, whitespace-only, missing, and substantive assistant content with tool calls

Fixes #31583.

## Test Plan
- `../hermes-upstream-full-20260513-201914/.venv/bin/pytest -o addopts='' tests/run_agent/test_strict_api_validation.py -q`
- `../hermes-upstream-full-20260513-201914/.venv/bin/pytest -o addopts='' tests/run_agent/test_provider_parity.py -q`
- `../hermes-upstream-full-20260513-201914/.venv/bin/pytest -o addopts='' tests/agent/transports/test_transport.py -q`
- `../hermes-upstream-full-20260513-201914/.venv/bin/python -m py_compile run_agent.py agent/transports/chat_completions.py tests/run_agent/test_strict_api_validation.py`
- `git diff --check`
