### PR TITLE
fix(gateway): inject video file path into message text

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7789,6 +7789,26 @@ class GatewayRunner:
                 )
                 message_text = f"{_note}\n\n{message_text}"
 
+        # Video file attachments — inject path so the agent knows a video was
+        # sent and where to find it (parallels the audio-file and document
+        # handlers above).
+        if event.media_urls and event.message_type == MessageType.VIDEO:
+            from tools.credential_files import to_agent_visible_cache_path as _vid_agent_path
+
+            for _vpath in event.media_urls:
+                _vbasename = os.path.basename(_vpath)
+                _vparts = _vbasename.split("_", 2)
+                _vdisplay = _vparts[2] if len(_vparts) >= 3 else _vbasename
+                _vdisplay = re.sub(r'[^\w.\- ]', '_', _vdisplay)
+                _vagent_path = _vid_agent_path(_vpath)
+                _vnote = (
+                    f"[The user sent a video: '{_vdisplay}'. "
+                    f"It is saved at: {_vagent_path}. "
+                    f"Use vision_analyze to extract key frames, or ask the user "
+                    f"what they'd like you to do with it.]"
+                )
+                message_text = f"{_vnote}\n\n{message_text}"
+
         if event.media_urls and event.message_type == MessageType.DOCUMENT:
             import mimetypes as _mimetypes
             from tools.credential_files import to_agent_visible_cache_path


### PR DESCRIPTION
## Problem

Video messages received via messaging platforms (WeChat, Telegram, etc.) are downloaded successfully by the gateway, but the file path is never injected into the message text. The agent receives an empty message and has no idea a video was sent.

## Root Cause

The media routing block in `gateway/run.py` `_process_inbound_message()` handles:
- **Images** → vision routing (native or text enrichment)
- **Audio/Voice** → STT transcription
- **Audio file attachments** → path injection into message text
- **Documents** → path injection into message text
- **Video** → ❌ **no handling at all**

The downloaded video path sits in `event.media_urls` with `event.media_type == MessageType.VIDEO` but is never surfaced to the agent.

## Fix

Added a `MessageType.VIDEO` handler block, parallel to the existing audio-file and document handlers, that injects the video file path into the message text with a note suggesting `vision_analyze` for frame extraction.

## Testing

Verified locally: a video sent via WeChat now arrives as:
```
[The user sent a video: 'video.mp4'. It is saved at: /root/.hermes/cache/documents/doc_xxx_video.mp4. Use vision_analyze to extract key frames, or ask the user what they'd like you to do with it.]
```

Previously the same message arrived as an empty string.