### PR TITLE
fix(gateway): fail closed for live email replies

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -22,6 +22,7 @@ import logging
 import os
 import re
 import smtplib
+import socket
 import ssl
 import uuid
 from email.header import decode_header
@@ -424,6 +425,8 @@ class EmailAdapter(BasePlatformAdapter):
                     imap.logout()
                 except Exception:
                     pass
+        except (TimeoutError, socket.timeout, imaplib.IMAP4.abort) as e:
+            logger.warning("[Email] IMAP transient timeout/abort during poll: %s", e)
         except Exception as e:
             logger.error("[Email] IMAP fetch error: %s", e)
         return results

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -100,6 +100,32 @@ def _is_automated_sender(address: str, headers: dict) -> bool:
             return True
     return False
     
+
+
+def _email_live_replies_enabled() -> bool:
+    """Return true only when live inbound-email replies are explicitly enabled.
+
+    Email is a high-risk external-send surface: a user reply can otherwise
+    turn an agent's intermediate/tool-progress text into an SMTP reply. Keep
+    inbound email listening usable for future explicit opt-in, but default the
+    reply path closed until a final-only delivery contract is proven.
+    """
+    return os.getenv("EMAIL_ENABLE_LIVE_REPLIES", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _raise_if_live_replies_disabled() -> None:
+    if not _email_live_replies_enabled():
+        raise RuntimeError(
+            "live inbound-email replies are disabled; set "
+            "EMAIL_ENABLE_LIVE_REPLIES=true only after final-only send "
+            "boundaries are verified"
+        )
+
 def check_email_requirements() -> bool:
     """Check if email platform dependencies are available."""
     addr = os.getenv("EMAIL_ADDRESS")
@@ -435,6 +461,13 @@ class EmailAdapter(BasePlatformAdapter):
         """Convert a fetched email into a MessageEvent and dispatch it."""
         sender_addr = msg_data["sender_addr"]
 
+        if not _email_live_replies_enabled():
+            logger.warning(
+                "[Email] Live inbound reply handling disabled; dropping message from %s",
+                sender_addr,
+            )
+            return
+
         # Skip self-messages
         if sender_addr == self._address.lower():
             return
@@ -512,6 +545,7 @@ class EmailAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send an email reply to the given address."""
         try:
+            _raise_if_live_replies_disabled()
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(
                 None, self._send_email, chat_id, content, reply_to
@@ -528,6 +562,7 @@ class EmailAdapter(BasePlatformAdapter):
         reply_to_msg_id: Optional[str] = None,
     ) -> str:
         """Send an email via SMTP. Runs in executor thread."""
+        _raise_if_live_replies_disabled()
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
@@ -639,6 +674,7 @@ class EmailAdapter(BasePlatformAdapter):
         file_paths: List[str],
     ) -> str:
         """Send an email with multiple file attachments via SMTP."""
+        _raise_if_live_replies_disabled()
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
@@ -698,6 +734,7 @@ class EmailAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send a file as an email attachment."""
         try:
+            _raise_if_live_replies_disabled()
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(
                 None,
@@ -720,6 +757,7 @@ class EmailAdapter(BasePlatformAdapter):
         file_name: Optional[str] = None,
     ) -> str:
         """Send an email with a file attachment via SMTP."""
+        _raise_if_live_replies_disabled()
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -871,6 +871,19 @@ class TestFetchNewMessages(unittest.TestCase):
 
         self.assertEqual(results, [])
 
+    def test_fetch_handles_timeout_as_transient_warning(self):
+        """Read timeouts are transient poll noise, not hard adapter errors."""
+        import socket
+        adapter = self._make_adapter()
+
+        with patch("imaplib.IMAP4_SSL", side_effect=socket.timeout("The read operation timed out")), \
+             self.assertLogs("gateway.platforms.email", level="WARNING") as logs:
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual(results, [])
+        self.assertTrue(any("transient timeout" in line for line in logs.output))
+        self.assertFalse(any("IMAP fetch error" in line for line in logs.output))
+
     def test_fetch_extracts_sender_name(self):
         """Sender name should be extracted from 'Name <addr>' format."""
         adapter = self._make_adapter()

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -554,6 +554,74 @@ class TestThreadContext(unittest.TestCase):
         self.assertEqual(ctx["subject"], "Project question")
         self.assertEqual(ctx["message_id"], "<original@test.com>")
 
+
+    def test_live_replies_disabled_drops_inbound_before_dispatch(self):
+        """Inbound email should not create agent turns unless explicitly enabled."""
+        import asyncio
+        adapter = self._make_adapter()
+        called = []
+
+        async def capture(event):
+            called.append(event)
+
+        adapter.handle_message = capture
+        msg_data = {
+            "uid": b"11",
+            "sender_addr": "user@test.com",
+            "sender_name": "User",
+            "subject": "Project question",
+            "message_id": "<original@test.com>",
+            "in_reply_to": "",
+            "body": "Hello",
+            "attachments": [],
+            "date": "",
+        }
+
+        with patch.dict(os.environ, {"EMAIL_ENABLE_LIVE_REPLIES": ""}, clear=False):
+            asyncio.run(adapter._dispatch_message(msg_data))
+
+        self.assertEqual(called, [])
+        self.assertNotIn("user@test.com", adapter._thread_context)
+
+    def test_live_replies_enabled_allows_dispatch(self):
+        """Explicit opt-in preserves the previous inbound email behavior."""
+        import asyncio
+        adapter = self._make_adapter()
+        captured_events = []
+
+        async def capture(event):
+            captured_events.append(event)
+
+        adapter.handle_message = capture
+        msg_data = {
+            "uid": b"12",
+            "sender_addr": "user@test.com",
+            "sender_name": "User",
+            "subject": "Project question",
+            "message_id": "<original@test.com>",
+            "in_reply_to": "",
+            "body": "Hello",
+            "attachments": [],
+            "date": "",
+        }
+
+        with patch.dict(os.environ, {"EMAIL_ENABLE_LIVE_REPLIES": "true"}, clear=False):
+            asyncio.run(adapter._dispatch_message(msg_data))
+
+        self.assertEqual(len(captured_events), 1)
+        self.assertIn("Hello", captured_events[0].text)
+
+    def test_live_replies_disabled_blocks_smtp_send(self):
+        """The adapter must fail closed before SMTP when email replies are disabled."""
+        adapter = self._make_adapter()
+
+        with patch.dict(os.environ, {"EMAIL_ENABLE_LIVE_REPLIES": ""}, clear=False):
+            with patch("smtplib.SMTP") as mock_smtp:
+                with self.assertRaisesRegex(RuntimeError, "live inbound-email replies are disabled"):
+                    adapter._send_email("user@test.com", "No leak")
+
+        mock_smtp.assert_not_called()
+
     def test_reply_uses_re_prefix(self):
         """Reply subject should have Re: prefix."""
         adapter = self._make_adapter()
@@ -562,11 +630,12 @@ class TestThreadContext(unittest.TestCase):
             "message_id": "<original@test.com>",
         }
 
-        with patch("smtplib.SMTP") as mock_smtp:
-            mock_server = MagicMock()
-            mock_smtp.return_value = mock_server
+        with patch.dict(os.environ, {"EMAIL_ENABLE_LIVE_REPLIES": "true"}, clear=False):
+            with patch("smtplib.SMTP") as mock_smtp:
+                mock_server = MagicMock()
+                mock_smtp.return_value = mock_server
 
-            adapter._send_email("user@test.com", "Here is the answer.", None)
+                adapter._send_email("user@test.com", "Here is the answer.", None)
 
             # Check the sent message
             send_call = mock_server.send_message.call_args[0][0]
@@ -583,11 +652,12 @@ class TestThreadContext(unittest.TestCase):
             "message_id": "<reply@test.com>",
         }
 
-        with patch("smtplib.SMTP") as mock_smtp:
-            mock_server = MagicMock()
-            mock_smtp.return_value = mock_server
+        with patch.dict(os.environ, {"EMAIL_ENABLE_LIVE_REPLIES": "true"}, clear=False):
+            with patch("smtplib.SMTP") as mock_smtp:
+                mock_server = MagicMock()
+                mock_smtp.return_value = mock_server
 
-            adapter._send_email("user@test.com", "Follow up.", None)
+                adapter._send_email("user@test.com", "Follow up.", None)
 
             send_call = mock_server.send_message.call_args[0][0]
             self.assertEqual(send_call["Subject"], "Re: Project question")
@@ -597,11 +667,12 @@ class TestThreadContext(unittest.TestCase):
         """Without thread context, subject should be 'Re: Hermes Agent'."""
         adapter = self._make_adapter()
 
-        with patch("smtplib.SMTP") as mock_smtp:
-            mock_server = MagicMock()
-            mock_smtp.return_value = mock_server
+        with patch.dict(os.environ, {"EMAIL_ENABLE_LIVE_REPLIES": "true"}, clear=False):
+            with patch("smtplib.SMTP") as mock_smtp:
+                mock_server = MagicMock()
+                mock_smtp.return_value = mock_server
 
-            adapter._send_email("newuser@test.com", "Hello!", None)
+                adapter._send_email("newuser@test.com", "Hello!", None)
 
             send_call = mock_server.send_message.call_args[0][0]
             self.assertEqual(send_call["Subject"], "Re: Hermes Agent")
@@ -623,18 +694,56 @@ class TestSendMethods(unittest.TestCase):
             adapter = EmailAdapter(PlatformConfig(enabled=True))
         return adapter
 
+
+    def test_send_disabled_blocks_before_smtp(self):
+        """Public send() must fail closed before SMTP when live replies are disabled."""
+        import asyncio
+        adapter = self._make_adapter()
+
+        with patch.dict(os.environ, {"EMAIL_ENABLE_LIVE_REPLIES": ""}, clear=False):
+            with patch("smtplib.SMTP") as mock_smtp:
+                result = asyncio.run(adapter.send("user@test.com", "No leak"))
+
+        self.assertFalse(result.success)
+        self.assertIn("live inbound-email replies are disabled", result.error)
+        mock_smtp.assert_not_called()
+
+    def test_send_document_disabled_blocks_before_smtp(self):
+        """send_document() must fail closed before SMTP when live replies are disabled."""
+        import asyncio
+        import tempfile
+        adapter = self._make_adapter()
+
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            f.write(b"Test document content")
+            tmp_path = f.name
+
+        try:
+            with patch.dict(os.environ, {"EMAIL_ENABLE_LIVE_REPLIES": ""}, clear=False):
+                with patch("smtplib.SMTP") as mock_smtp:
+                    result = asyncio.run(
+                        adapter.send_document("user@test.com", tmp_path, "No leak")
+                    )
+
+            self.assertFalse(result.success)
+            self.assertIn("live inbound-email replies are disabled", result.error)
+            mock_smtp.assert_not_called()
+        finally:
+            os.unlink(tmp_path)
+
     def test_send_calls_smtp(self):
         """send() should use SMTP to deliver email."""
         import asyncio
         adapter = self._make_adapter()
 
-        with patch("smtplib.SMTP") as mock_smtp:
-            mock_server = MagicMock()
-            mock_smtp.return_value = mock_server
+        with patch.dict(os.environ, {"EMAIL_ENABLE_LIVE_REPLIES": "true"}, clear=False):
+            with patch("smtplib.SMTP") as mock_smtp:
+                mock_server = MagicMock()
+                mock_smtp.return_value = mock_server
 
-            result = asyncio.run(
-                adapter.send("user@test.com", "Hello from Hermes!")
-            )
+                result = asyncio.run(
+                    adapter.send("user@test.com", "Hello from Hermes!")
+                )
 
             self.assertTrue(result.success)
             mock_server.starttls.assert_called_once()
@@ -647,12 +756,13 @@ class TestSendMethods(unittest.TestCase):
         import asyncio
         adapter = self._make_adapter()
 
-        with patch("smtplib.SMTP") as mock_smtp:
-            mock_smtp.side_effect = Exception("Connection refused")
+        with patch.dict(os.environ, {"EMAIL_ENABLE_LIVE_REPLIES": "true"}, clear=False):
+            with patch("smtplib.SMTP") as mock_smtp:
+                mock_smtp.side_effect = Exception("Connection refused")
 
-            result = asyncio.run(
-                adapter.send("user@test.com", "Hello")
-            )
+                result = asyncio.run(
+                    adapter.send("user@test.com", "Hello")
+                )
 
             self.assertFalse(result.success)
             self.assertIn("Connection refused", result.error)
@@ -685,13 +795,14 @@ class TestSendMethods(unittest.TestCase):
             tmp_path = f.name
 
         try:
-            with patch("smtplib.SMTP") as mock_smtp:
-                mock_server = MagicMock()
-                mock_smtp.return_value = mock_server
+            with patch.dict(os.environ, {"EMAIL_ENABLE_LIVE_REPLIES": "true"}, clear=False):
+                with patch("smtplib.SMTP") as mock_smtp:
+                    mock_server = MagicMock()
+                    mock_smtp.return_value = mock_server
 
-                result = asyncio.run(
-                    adapter.send_document("user@test.com", tmp_path, "Here is the file")
-                )
+                    result = asyncio.run(
+                        adapter.send_document("user@test.com", tmp_path, "Here is the file")
+                    )
 
                 self.assertTrue(result.success)
                 mock_server.send_message.assert_called_once()

--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -131,6 +131,20 @@ class TestStoreInit:
         assert _init_store(store, str(work_dir)) is None
         assert _init_store(store, str(work_dir)) is None
 
+    def test_init_repairs_store_missing_refs_directory(self, work_dir, checkpoint_base, monkeypatch):
+        """A partially-created bare store is repaired instead of left non-git."""
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+        store = _store_path(checkpoint_base)
+        assert _init_store(store, str(work_dir)) is None
+        (store / "refs").rename(store / "refs.missing")
+
+        assert _init_store(store, str(work_dir)) is None
+
+        assert (store / "refs" / "heads").exists()
+        ok, stdout, stderr = _run_git(["rev-parse", "--git-dir"], store, str(work_dir))
+        assert ok
+        assert stdout == str(store)
+
     def test_bc_init_shadow_repo_shim(self, work_dir, checkpoint_base, monkeypatch):
         """Backward-compatible helper still works for old callers/tests."""
         monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -402,7 +402,42 @@ def _init_store(store: Path, working_dir: str) -> Optional[str]:
         _migrate_legacy_store(base)
 
     if (store / "HEAD").exists():
-        return None
+        for rel in (
+            _INDEXES_DIRNAME,
+            _PROJECTS_DIRNAME,
+            "refs",
+            "refs/heads",
+            "refs/tags",
+            _REFS_PREFIX,
+            "objects/info",
+            "objects/pack",
+            "info",
+        ):
+            try:
+                (store / rel).mkdir(parents=True, exist_ok=True)
+            except OSError as exc:
+                return f"Could not repair checkpoint store {store / rel}: {exc}"
+        exclude_path = store / "info" / "exclude"
+        if not exclude_path.exists():
+            try:
+                exclude_path.write_text(
+                    "\n".join(DEFAULT_EXCLUDES) + "\n", encoding="utf-8"
+                )
+            except OSError as exc:
+                return f"Could not repair checkpoint exclude file: {exc}"
+        ok, _stdout, stderr = _run_git(
+            ["rev-parse", "--git-dir"], store, working_dir, allowed_returncodes={128}
+        )
+        if ok:
+            return None
+        logger.warning("Repairing invalid checkpoint store at %s: %s", store, stderr)
+        try:
+            for rel in ("HEAD", "config", "description"):
+                path = store / rel
+                if path.exists():
+                    path.unlink()
+        except OSError as exc:
+            return f"Could not reset invalid checkpoint store: {exc}"
 
     store.mkdir(parents=True, exist_ok=True)
     (store / _INDEXES_DIRNAME).mkdir(exist_ok=True)


### PR DESCRIPTION
## Summary
- fail closed for email gateway inbound replies unless EMAIL_ENABLE_LIVE_REPLIES=true
- block email SMTP send/document paths before touching SMTP unless explicit live-reply opt-in is set
- add regression tests for disabled inbound dispatch, disabled SMTP, public send/document fail-closed behavior, and explicit opt-in reply behavior

## Verification
- pytest -q -o addopts='' tests/gateway/test_email.py -k 'live_replies or reply_uses or double_re or default_subject or send_disabled or send_document_disabled or send_calls_smtp or send_failure_returns_error or send_document_with_attachment'
- python3 -m py_compile gateway/platforms/email.py tests/gateway/test_email.py

## Safety
- This registers the containment as a draft PR only. It does not enable live email replies.