### PR TITLE
feat(memory): trigger background memory review at session boundaries

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1067,6 +1067,13 @@ def init_agent(
             agent._memory_enabled = mem_config.get("memory_enabled", False)
             agent._user_profile_enabled = mem_config.get("user_profile_enabled", False)
             agent._memory_nudge_interval = int(mem_config.get("nudge_interval", 10))
+            # Session-boundary background review flags (issue #31597).
+            # Opt-in: when enabled, a background memory review is triggered
+            # at the corresponding session boundary in addition to the
+            # nudge_interval mid-conversation trigger.
+            agent._review_on_reset = bool(mem_config.get("review_on_reset", False))
+            agent._review_on_session_end = bool(mem_config.get("review_on_session_end", False))
+            agent._review_on_compression = bool(mem_config.get("review_on_compression", False))
             if agent._memory_enabled or agent._user_profile_enabled:
                 from tools.memory_tool import MemoryStore
                 agent._memory_store = MemoryStore(

--- a/cli.py
+++ b/cli.py
@@ -6307,6 +6307,24 @@ class HermesCLI:
             # First session or empty history — still finalize the old session
             self._notify_session_boundary("on_session_finalize")
 
+        # Session-boundary background review (issue #31597).
+        # Fires after the old session is finalized but before the new session
+        # starts, so the review sees the full transcript of the session that
+        # just ended.
+        if (
+            self.agent
+            and getattr(self.agent, "_review_on_reset", False)
+            and hasattr(self.agent, "_spawn_background_review")
+        ):
+            try:
+                messages_snapshot = list(self.conversation_history)
+                self.agent._spawn_background_review(
+                    messages_snapshot=messages_snapshot,
+                    review_memory=True,
+                )
+            except Exception:
+                pass  # Background review is best-effort
+
         old_session_id = self.session_id
         if self._session_db and old_session_id:
             try:

--- a/run_agent.py
+++ b/run_agent.py
@@ -2006,6 +2006,21 @@ class AIAgent:
         NOT called per-turn — only at CLI exit, /reset, gateway
         session expiry, etc.
         """
+        # Session-boundary background review (issue #31597).
+        # Fires before the memory provider is torn down so the review
+        # thread can still use the provider.
+        if (
+            getattr(self, "_review_on_session_end", False)
+            and hasattr(self, "_spawn_background_review")
+        ):
+            try:
+                self._spawn_background_review(
+                    messages_snapshot=list(messages or []),
+                    review_memory=True,
+                )
+            except Exception:
+                pass  # Background review is best-effort
+
         if self._memory_manager:
             try:
                 self._memory_manager.on_session_end(messages or [])
@@ -2030,6 +2045,21 @@ class AIAgent:
         Called when session_id rotates (e.g. /new, context compression);
         providers keep their state and continue running under the old
         session_id — they just flush pending extraction now."""
+        # Session-boundary background review (issue #31597).
+        # Fires before the memory extraction so the review sees the
+        # full pre-compression transcript.
+        if (
+            getattr(self, "_review_on_compression", False)
+            and hasattr(self, "_spawn_background_review")
+        ):
+            try:
+                self._spawn_background_review(
+                    messages_snapshot=list(messages or []),
+                    review_memory=True,
+                )
+            except Exception:
+                pass  # Background review is best-effort
+
         if self._memory_manager:
             try:
                 self._memory_manager.on_session_end(messages or [])


### PR DESCRIPTION
## Summary

Adds 3 new opt-in config flags under `memory.*` that trigger background memory review at session boundaries, complementing (not replacing) the existing `nudge_interval` mid-conversation trigger.

Previously, memory review only fired at `nudge_interval` mid-conversation, but the written memory was not reflected in the system prompt until the next session. These flags let users trigger review at the natural boundaries when memory is most useful.

Fixes #31597

## Config

```yaml
memory:
  nudge_interval: 10              # existing, unchanged
  review_on_reset: true           # fire on /reset, /new
  review_on_session_end: true     # fire on CLI exit, gateway session expiry
  review_on_compression: false    # fire after context compression (off by default)
```

## Changes

- `agent/agent_init.py`: Read 3 new config flags (`review_on_reset`, `review_on_session_end`, `review_on_compression`) from `memory.*` config, defaulting to `False`.
- `cli.py` `new_session()`: After finalizing the old session, spawn a background review if `review_on_reset` is enabled.
- `run_agent.py` `shutdown_memory_provider()`: Before tearing down the memory provider, spawn a background review if `review_on_session_end` is enabled.
- `run_agent.py` `commit_memory_session()`: Before flushing memory extraction, spawn a background review if `review_on_compression` is enabled.

All 3 hooks wire into the existing `_spawn_background_review()` path. Failures are silently caught (best-effort). Defaults are `False` to preserve existing behavior.

## Test plan
- [ ] CI passes
- [ ] Manual test: set `review_on_reset: true`, trigger /reset, verify background review thread spawns