### PR TITLE
feat(stt): add prompt files and Speaches hotwords

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1231,6 +1231,8 @@ stt:
   openai:
     model: "whisper-1"         # whisper-1 | gpt-4o-mini-transcribe | gpt-4o-transcribe | gpt-transcribe
     language: ""               # auto-detect; set to "en", "es", "fr", etc. to force
+    # prompt_file: ""          # optional UTF-8 file with a reusable prompt
+    # hotwords: ""             # optional endpoint-specific vocabulary hints (e.g. Speaches)
   # mistral:
   #   model: "voxtral-mini-latest"  # voxtral-mini-latest | voxtral-mini-2602
   # deepinfra:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1441,6 +1441,8 @@ stt:
   openai:
     model: "whisper-1"         # whisper-1 | gpt-4o-mini-transcribe | gpt-4o-transcribe | gpt-transcribe
     language: ""               # auto-detect; set to "en", "es", "fr", etc. to force
+    # prompt_file: ""          # optional UTF-8 file with a reusable prompt
+    # hotwords: ""             # optional endpoint-specific vocabulary hints (e.g. Speaches)
   # mistral:
   #   model: "voxtral-mini-latest"  # voxtral-mini-latest | voxtral-mini-2602
   # deepinfra:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1585,6 +1585,8 @@ DEFAULT_CONFIG = {
         "openai": {
             "model": "whisper-1",  # whisper-1, gpt-4o-mini-transcribe, gpt-4o-transcribe, gpt-transcribe
             "language": "",  # auto-detect by default; set to "en", "es", "fr", etc. to force
+            "prompt_file": "",  # optional UTF-8 file with a reusable transcription prompt
+            "hotwords": "",  # optional endpoint-specific vocabulary hints (e.g. Speaches)
         },
         "mistral": {
             "model": "voxtral-mini-latest",  # voxtral-mini-latest, voxtral-mini-2602

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1886,6 +1886,8 @@ DEFAULT_CONFIG = {
         "openai": {
             "model": "whisper-1",  # whisper-1, gpt-4o-mini-transcribe, gpt-4o-transcribe, gpt-transcribe
             "language": "",  # auto-detect by default; set to "en", "es", "fr", etc. to force
+            "prompt_file": "",  # optional UTF-8 file with a reusable transcription prompt
+            "hotwords": "",  # optional endpoint-specific vocabulary hints (e.g. Speaches)
         },
         "mistral": {
             "model": "voxtral-mini-latest",  # voxtral-mini-latest, voxtral-mini-2602

--- a/tests/tools/test_transcription_prompt_config.py
+++ b/tests/tools/test_transcription_prompt_config.py
@@ -1,0 +1,159 @@
+"""Tests for OpenAI-compatible STT prompt-file and hotword support."""
+
+from unittest.mock import MagicMock, patch
+
+
+def test_default_config_declares_prompt_file_and_hotwords():
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+    openai_cfg = DEFAULT_CONFIG["stt"]["openai"]
+    assert openai_cfg["prompt_file"] == ""
+    assert openai_cfg["hotwords"] == ""
+
+
+def test_openai_transcription_forwards_prompt_file_and_hotwords(monkeypatch, tmp_path):
+    from tools import transcription_tools as tt
+
+    audio = tmp_path / "sample.wav"
+    audio.write_bytes(b"RIFF....WAVEfmt ")
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("Prompt depuis fichier.\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        tt,
+        "_load_stt_config",
+        lambda: {
+            "openai": {
+                "prompt_file": str(prompt_file),
+                "hotwords": "Hermes, Hephaistos, Speaches, high",
+            }
+        },
+    )
+
+    mock_client = MagicMock()
+    mock_client.audio.transcriptions.create.return_value = {"text": "ok"}
+
+    with (
+        patch.object(tt, "_HAS_OPENAI", True),
+        patch("openai.OpenAI", return_value=mock_client),
+    ):
+        result = tt._transcribe_openai(
+            str(audio),
+            "Systran/faster-whisper-large-v3",
+            api_key="test-key",
+            base_url="http://speaches.test/v1",
+        )
+
+    assert result["success"] is True
+    kwargs = mock_client.audio.transcriptions.create.call_args.kwargs
+    assert kwargs["prompt"] == "Prompt depuis fichier."
+    assert kwargs["extra_body"] == {
+        "hotwords": "Hermes, Hephaistos, Speaches, high",
+    }
+
+
+def test_threaded_prompt_takes_precedence_over_prompt_file(monkeypatch, tmp_path):
+    from tools import transcription_tools as tt
+
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("file prompt", encoding="utf-8")
+    openai_cfg = {"prompt_file": str(prompt_file)}
+
+    assert tt._get_openai_stt_prompt(openai_cfg, "hook prompt") == "hook prompt"
+
+
+def test_missing_prompt_file_fails_open(monkeypatch, tmp_path, caplog):
+    from tools import transcription_tools as tt
+
+    missing = tmp_path / "missing.txt"
+
+    assert tt._get_openai_stt_prompt({"prompt_file": str(missing)}) is None
+    assert "could not be read" in caplog.text
+
+
+def test_non_utf8_prompt_file_fails_open(tmp_path, caplog):
+    from tools import transcription_tools as tt
+
+    invalid = tmp_path / "invalid-prompt.txt"
+    invalid.write_bytes(b"\xff\xfe\x00")
+
+    assert tt._get_openai_stt_prompt({"prompt_file": str(invalid)}) is None
+    assert "could not be read" in caplog.text
+
+
+def test_shared_openai_helper_does_not_leak_provider_specific_hints(
+    monkeypatch, tmp_path
+):
+    from tools import transcription_tools as tt
+
+    audio = tmp_path / "sample.wav"
+    audio.write_bytes(b"RIFF....WAVEfmt ")
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("Speaches-only prompt", encoding="utf-8")
+    monkeypatch.setattr(
+        tt,
+        "_load_stt_config",
+        lambda: {
+            "openai": {
+                "prompt_file": str(prompt_file),
+                "hotwords": "Speaches-only hotwords",
+            }
+        },
+    )
+
+    mock_client = MagicMock()
+    mock_client.audio.transcriptions.create.return_value = {"text": "ok"}
+
+    with (
+        patch.object(tt, "_HAS_OPENAI", True),
+        patch("openai.OpenAI", return_value=mock_client),
+    ):
+        result = tt._transcribe_openai(
+            str(audio),
+            "whisper-large-v3",
+            api_key="test-key",
+            base_url="http://deepinfra.test/v1",
+            provider_label="deepinfra",
+        )
+
+    assert result["success"] is True
+    kwargs = mock_client.audio.transcriptions.create.call_args.kwargs
+    assert "prompt" not in kwargs
+    assert "extra_body" not in kwargs
+
+
+def test_gpt_transcribe_merges_language_and_hotwords(monkeypatch, tmp_path):
+    """The current gpt-transcribe language extension must not erase hotwords."""
+    from tools import transcription_tools as tt
+
+    audio = tmp_path / "sample.wav"
+    audio.write_bytes(b"RIFF....WAVEfmt ")
+    monkeypatch.setattr(
+        tt,
+        "_load_stt_config",
+        lambda: {
+            "language": "fr",
+            "openai": {"hotwords": "Hermes, Speaches"},
+        },
+    )
+
+    mock_client = MagicMock()
+    mock_client.audio.transcriptions.create.return_value = {"text": "ok"}
+
+    with (
+        patch.object(tt, "_HAS_OPENAI", True),
+        patch("openai.OpenAI", return_value=mock_client),
+    ):
+        result = tt._transcribe_openai(
+            str(audio),
+            "gpt-transcribe",
+            api_key="test-key",
+        )
+
+    assert result["success"] is True
+    kwargs = mock_client.audio.transcriptions.create.call_args.kwargs
+    assert "language" not in kwargs
+    assert kwargs["extra_body"] == {
+        "hotwords": "Hermes, Speaches",
+        "languages": ["fr"],
+    }

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2254,6 +2254,38 @@ def _transcribe_groq(
 # ---------------------------------------------------------------------------
 
 
+def _get_openai_stt_prompt(
+    openai_cfg: Optional[dict] = None,
+    prompt: Optional[str] = None,
+) -> Optional[str]:
+    """Resolve an OpenAI-compatible STT prompt with inline input first.
+
+    The optional ``prompt`` argument is the dynamic/static value threaded by
+    the generic STT prompt work in #65632.  ``stt.openai.prompt_file`` is a
+    provider-specific fallback for reusable, version-controlled vocabulary
+    hints.  Reading the file at transcription time lets edits take effect
+    without restarting Hermes.
+    """
+    inline_prompt = str(prompt or "").strip()
+    if inline_prompt:
+        return inline_prompt
+
+    if openai_cfg is None:
+        openai_cfg = _load_stt_config().get("openai", {})
+    if not isinstance(openai_cfg, dict):
+        openai_cfg = {}
+
+    prompt_file = str(openai_cfg.get("prompt_file") or "").strip()
+    if not prompt_file:
+        return None
+
+    try:
+        return Path(prompt_file).expanduser().read_text(encoding="utf-8").strip() or None
+    except (OSError, UnicodeError) as exc:
+        logger.warning("Configured STT prompt file '%s' could not be read: %s", prompt_file, exc)
+        return None
+
+
 def _transcribe_openai(
     file_path: str,
     model_name: str,
@@ -2294,6 +2326,27 @@ def _transcribe_openai(
         logger.info("Model %s not available on OpenAI, using %s", model_name, DEFAULT_STT_MODEL)
         model_name = DEFAULT_STT_MODEL
 
+    # Provider-specific file/hotword settings belong only to the configured
+    # ``openai`` backend.  Shared users of this helper (DeepInfra, plugins)
+    # receive only arguments their caller explicitly passes.
+    openai_cfg = _load_stt_config().get("openai", {}) if provider_label == "openai" else {}
+    if not isinstance(openai_cfg, dict):
+        openai_cfg = {}
+
+    base_create_kwargs: Dict[str, Any] = {
+        "model": model_name,
+        "response_format": "text" if model_name == "whisper-1" else "json",
+    }
+    resolved_prompt = _get_openai_stt_prompt(openai_cfg, prompt)
+    if resolved_prompt:
+        base_create_kwargs["prompt"] = resolved_prompt
+    hotwords = str(openai_cfg.get("hotwords") or "").strip()
+    if hotwords:
+        # ``hotwords`` is a Speaches extension, not a generated OpenAI SDK
+        # parameter.  extra_body merges it into the multipart request while
+        # keeping the call valid for the stock SDK.
+        base_create_kwargs["extra_body"] = {"hotwords": hotwords}
+
     try:
         from openai import (
             OpenAI,
@@ -2306,17 +2359,16 @@ def _transcribe_openai(
 
         def _create_transcription(path: str):
             with open(path, "rb") as audio_file:
-                create_kwargs = {
-                    "model": model_name,
-                    "file": audio_file,
-                    "response_format": "text" if model_name == "whisper-1" else "json",
-                }
+                create_kwargs = dict(base_create_kwargs)
+                create_kwargs["file"] = audio_file
+                if "extra_body" in create_kwargs:
+                    create_kwargs["extra_body"] = dict(create_kwargs["extra_body"])
                 if language:
                     if model_name == "gpt-transcribe":
                         # gpt-transcribe replaces the singular ``language``
                         # field with a ``languages`` list; the API rejects
                         # requests that send the legacy field.
-                        create_kwargs["extra_body"] = {"languages": [language]}
+                        create_kwargs.setdefault("extra_body", {})["languages"] = [language]
                     else:
                         create_kwargs["language"] = language
                     logger.debug("Using language hint '%s' for OpenAI STT", language)

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2027,6 +2027,38 @@ def _transcribe_groq(file_path: str, model_name: str) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
+def _get_openai_stt_prompt(
+    openai_cfg: Optional[dict] = None,
+    prompt: Optional[str] = None,
+) -> Optional[str]:
+    """Resolve an OpenAI-compatible STT prompt with inline input first.
+
+    The optional ``prompt`` argument is the dynamic/static value threaded by
+    the generic STT prompt work in #65632.  ``stt.openai.prompt_file`` is a
+    provider-specific fallback for reusable, version-controlled vocabulary
+    hints.  Reading the file at transcription time lets edits take effect
+    without restarting Hermes.
+    """
+    inline_prompt = str(prompt or "").strip()
+    if inline_prompt:
+        return inline_prompt
+
+    if openai_cfg is None:
+        openai_cfg = _load_stt_config().get("openai", {})
+    if not isinstance(openai_cfg, dict):
+        openai_cfg = {}
+
+    prompt_file = str(openai_cfg.get("prompt_file") or "").strip()
+    if not prompt_file:
+        return None
+
+    try:
+        return Path(prompt_file).expanduser().read_text(encoding="utf-8").strip() or None
+    except (OSError, UnicodeError) as exc:
+        logger.warning("Configured STT prompt file '%s' could not be read: %s", prompt_file, exc)
+        return None
+
+
 def _transcribe_openai(
     file_path: str,
     model_name: str,
@@ -2034,6 +2066,7 @@ def _transcribe_openai(
     api_key: Optional[str] = None,
     base_url: Optional[str] = None,
     provider_label: str = "openai",
+    prompt: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Transcribe via the OpenAI ``audio.transcriptions.create`` SDK shape.
 
@@ -2064,6 +2097,27 @@ def _transcribe_openai(
         logger.info("Model %s not available on OpenAI, using %s", model_name, DEFAULT_STT_MODEL)
         model_name = DEFAULT_STT_MODEL
 
+    # Provider-specific file/hotword settings belong only to the configured
+    # ``openai`` backend.  Shared users of this helper (DeepInfra, plugins)
+    # receive only arguments their caller explicitly passes.
+    openai_cfg = _load_stt_config().get("openai", {}) if provider_label == "openai" else {}
+    if not isinstance(openai_cfg, dict):
+        openai_cfg = {}
+
+    base_create_kwargs: Dict[str, Any] = {
+        "model": model_name,
+        "response_format": "text" if model_name == "whisper-1" else "json",
+    }
+    resolved_prompt = _get_openai_stt_prompt(openai_cfg, prompt)
+    if resolved_prompt:
+        base_create_kwargs["prompt"] = resolved_prompt
+    hotwords = str(openai_cfg.get("hotwords") or "").strip()
+    if hotwords:
+        # ``hotwords`` is a Speaches extension, not a generated OpenAI SDK
+        # parameter.  extra_body merges it into the multipart request while
+        # keeping the call valid for the stock SDK.
+        base_create_kwargs["extra_body"] = {"hotwords": hotwords}
+
     try:
         from openai import (
             OpenAI,
@@ -2076,17 +2130,16 @@ def _transcribe_openai(
 
         def _create_transcription(path: str):
             with open(path, "rb") as audio_file:
-                create_kwargs = {
-                    "model": model_name,
-                    "file": audio_file,
-                    "response_format": "text" if model_name == "whisper-1" else "json",
-                }
+                create_kwargs = dict(base_create_kwargs)
+                create_kwargs["file"] = audio_file
+                if "extra_body" in create_kwargs:
+                    create_kwargs["extra_body"] = dict(create_kwargs["extra_body"])
                 if language:
                     if model_name == "gpt-transcribe":
                         # gpt-transcribe replaces the singular ``language``
                         # field with a ``languages`` list; the API rejects
                         # requests that send the legacy field.
-                        create_kwargs["extra_body"] = {"languages": [language]}
+                        create_kwargs.setdefault("extra_body", {})["languages"] = [language]
                     else:
                         create_kwargs["language"] = language
                     logger.debug("Using language hint '%s' for OpenAI STT", language)

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -448,6 +448,11 @@ stt:
     language: ""                     # optional ISO-639-1 hint; blank = use HERMES_LOCAL_STT_LANGUAGE if set, else auto-detect
   groq:
     language: ""                     # optional ISO-639-1 hint; blank = use HERMES_LOCAL_STT_LANGUAGE if set, else auto-detect
+  openai:
+    model: "whisper-1"               # whisper-1, gpt-4o-mini-transcribe, gpt-4o-transcribe, gpt-transcribe
+    language: ""                     # optional ISO-639-1 hint; blank = global language or auto-detect
+    prompt_file: ""                  # optional UTF-8 file with a reusable prompt
+    hotwords: ""                     # optional endpoint-specific vocabulary hints (e.g. Speaches)
   # model: "whisper-1"              # Legacy: used when provider is not set
 
 # Text-to-Speech
@@ -496,6 +501,8 @@ ELEVENLABS_API_KEY=***             # ElevenLabs (premium quality)
 DISCORD_BOT_TOKEN=...
 DISCORD_ALLOWED_USERS=...
 ```
+
+For OpenAI-compatible STT providers, use `stt.openai.prompt_file` when vocabulary hints are shared across machines or version-controlled; Hermes reads the UTF-8 file at transcription time. A prompt supplied by the generic STT prompt pipeline takes precedence over the file. Some compatible endpoints, including Speaches, also accept `stt.openai.hotwords`; Hermes sends these as an endpoint extension rather than assuming the official OpenAI API supports them.
 
 ### STT Provider Comparison
 

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -430,6 +430,11 @@ stt:
     language: ""                     # optional ISO-639-1 hint; blank = use HERMES_LOCAL_STT_LANGUAGE if set, else auto-detect
   groq:
     language: ""                     # optional ISO-639-1 hint; blank = use HERMES_LOCAL_STT_LANGUAGE if set, else auto-detect
+  openai:
+    model: "whisper-1"               # whisper-1, gpt-4o-mini-transcribe, gpt-4o-transcribe, gpt-transcribe
+    language: ""                     # optional ISO-639-1 hint; blank = global language or auto-detect
+    prompt_file: ""                  # optional UTF-8 file with a reusable prompt
+    hotwords: ""                     # optional endpoint-specific vocabulary hints (e.g. Speaches)
   # model: "whisper-1"              # Legacy: used when provider is not set
 
 # Text-to-Speech
@@ -478,6 +483,8 @@ ELEVENLABS_API_KEY=***             # ElevenLabs (premium quality)
 DISCORD_BOT_TOKEN=...
 DISCORD_ALLOWED_USERS=...
 ```
+
+For OpenAI-compatible STT providers, use `stt.openai.prompt_file` when vocabulary hints are shared across machines or version-controlled; Hermes reads the UTF-8 file at transcription time. A prompt supplied by the generic STT prompt pipeline takes precedence over the file. Some compatible endpoints, including Speaches, also accept `stt.openai.hotwords`; Hermes sends these as an endpoint extension rather than assuming the official OpenAI API supports them.
 
 ### STT Provider Comparison
 


### PR DESCRIPTION
## Summary

This PR is rebased onto current `upstream/main` (`1f8fdc7bd`) and narrowed to complement #65632 rather than duplicate it.

It adds only the OpenAI-compatible provider extensions that #65632 does not cover:

- `stt.openai.prompt_file`: a UTF-8 prompt file read at transcription time, so vocabulary edits take effect without restarting Hermes;
- `stt.openai.hotwords`: endpoint-specific vocabulary hints sent through the OpenAI SDK's `extra_body`, which merges them into the multipart request for compatible servers such as Speaches.

The provider-specific inline `prompt` and `language` settings remain out of this PR. #65632 remains the owner of the generic `stt.prompt`, per-provider language, request-scoped overrides, and `pre_transcription` hook threading.

## Interaction with #65632

The generic prompt argument from #65632 takes precedence. `stt.openai.prompt_file` is only a fallback when the generic/dynamic prompt is empty.

Applying this commit after #65632 produces one expected textual conflict in `_transcribe_openai()` because both PRs modify the SDK call. The intended combined resolution is:

1. retain #65632's `language` and `prompt` parameters;
2. resolve `prompt` through `_get_openai_stt_prompt(openai_cfg, prompt)`;
3. add `language` to the shared `create_kwargs` when set;
4. add Speaches `hotwords` via `extra_body`;
5. make one `client.audio.transcriptions.create(file=audio_file, **create_kwargs)` call.

This keeps #65632's generic hook architecture and adds only file-backed prompts plus native compatible-endpoint hotwords.

## Safety and compatibility

- both settings default to empty and preserve existing behavior;
- unreadable prompt files fail open with a warning;
- `hotwords` is sent through `extra_body`, without treating it as an official OpenAI parameter;
- third-party callers that reuse `_transcribe_openai` do not inherit the configured OpenAI provider hints.

## Validation

On current `upstream/main`:

```text
python -m pytest tests/tools/test_transcription_prompt_config.py tests/tools/test_transcription_tools.py tests/tools/test_transcription.py tests/tools/test_transcription_deepinfra.py tests/tools/test_transcription_plugin_dispatch.py -o addopts= -q

92 passed
```

`git diff --check upstream/main...HEAD` also passes.