### PR TITLE
fix(auth): make MiniMax OAuth status refresh-aware

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -7228,13 +7228,24 @@ def get_minimax_oauth_auth_status() -> Dict[str, Any]:
     state = get_provider_auth_state("minimax-oauth")
     if not state or not state.get("access_token"):
         return {"logged_in": False, "provider": "minimax-oauth"}
+
     try:
-        expires_at = datetime.fromisoformat(state.get("expires_at", "")).timestamp()
-        token_valid = (expires_at - time.time()) > 0
-    except Exception:
-        token_valid = bool(state.get("access_token"))
+        # Mirror the runtime path: MiniMax access tokens are intentionally
+        # short-lived and are refreshed on demand when still recoverable.
+        resolve_minimax_oauth_runtime_credentials()
+    except AuthError as exc:
+        state = get_provider_auth_state("minimax-oauth") or state
+        return {
+            "logged_in": False,
+            "provider": "minimax-oauth",
+            "region": state.get("region", "global"),
+            "expires_at": state.get("expires_at"),
+            "error": str(exc),
+        }
+
+    state = get_provider_auth_state("minimax-oauth") or state
     return {
-        "logged_in": token_valid,
+        "logged_in": True,
         "provider": "minimax-oauth",
         "region": state.get("region", "global"),
         "expires_at": state.get("expires_at"),

--- a/tests/test_minimax_oauth.py
+++ b/tests/test_minimax_oauth.py
@@ -622,11 +622,82 @@ def test_get_minimax_oauth_auth_status_logged_in():
         "region": "global",
     }
 
-    with patch("hermes_cli.auth.get_provider_auth_state", return_value=state):
+    with patch("hermes_cli.auth.get_provider_auth_state", side_effect=[state, state]), \
+         patch(
+             "hermes_cli.auth.resolve_minimax_oauth_runtime_credentials",
+             return_value={
+                 "provider": "minimax-oauth",
+                 "api_key": "tok",
+                 "base_url": MINIMAX_OAUTH_GLOBAL_INFERENCE,
+                 "source": "oauth",
+             },
+         ):
         status = get_minimax_oauth_auth_status()
 
     assert status["logged_in"] is True
     assert status["region"] == "global"
+
+
+def test_get_minimax_oauth_auth_status_refreshes_expired_but_recoverable_state():
+    expired_state = {
+        "access_token": "old-token",
+        "refresh_token": "rt",
+        "expires_at": _past_iso(60),
+        "region": "global",
+    }
+    refreshed_state = {
+        "access_token": "new-token",
+        "refresh_token": "rt",
+        "expires_at": _future_iso(3600),
+        "region": "global",
+    }
+
+    with patch(
+        "hermes_cli.auth.get_provider_auth_state",
+        side_effect=[expired_state, refreshed_state],
+    ), patch(
+        "hermes_cli.auth.resolve_minimax_oauth_runtime_credentials",
+        return_value={
+            "provider": "minimax-oauth",
+            "api_key": "new-token",
+            "base_url": MINIMAX_OAUTH_GLOBAL_INFERENCE,
+            "source": "oauth",
+        },
+    ) as mock_resolve:
+        status = get_minimax_oauth_auth_status()
+
+    mock_resolve.assert_called_once_with()
+    assert status["logged_in"] is True
+    assert status["expires_at"] == refreshed_state["expires_at"]
+    assert status["region"] == "global"
+
+
+def test_get_minimax_oauth_auth_status_reports_refresh_failures():
+    state = {
+        "access_token": "old-token",
+        "refresh_token": "rt",
+        "expires_at": _past_iso(60),
+        "region": "cn",
+    }
+
+    with patch(
+        "hermes_cli.auth.get_provider_auth_state",
+        side_effect=[state, state],
+    ), patch(
+        "hermes_cli.auth.resolve_minimax_oauth_runtime_credentials",
+        side_effect=AuthError(
+            "MiniMax OAuth refresh failed: invalid_grant",
+            provider="minimax-oauth",
+            code="refresh_failed",
+            relogin_required=True,
+        ),
+    ) as mock_resolve:
+        status = get_minimax_oauth_auth_status()
+
+    mock_resolve.assert_called_once_with()
+    assert status["logged_in"] is False
+    assert status["region"] == "cn"
+    assert "refresh failed" in status["error"].lower()
 
 
 def test_generic_auth_status_dispatches_minimax_oauth():
@@ -636,7 +707,16 @@ def test_generic_auth_status_dispatches_minimax_oauth():
         "region": "global",
     }
 
-    with patch("hermes_cli.auth.get_provider_auth_state", return_value=state):
+    with patch("hermes_cli.auth.get_provider_auth_state", side_effect=[state, state]), \
+         patch(
+             "hermes_cli.auth.resolve_minimax_oauth_runtime_credentials",
+             return_value={
+                 "provider": "minimax-oauth",
+                 "api_key": "tok",
+                 "base_url": MINIMAX_OAUTH_GLOBAL_INFERENCE,
+                 "source": "oauth",
+             },
+         ):
         status = get_auth_status("minimax-oauth")
 
     assert status["logged_in"] is True


### PR DESCRIPTION
## What does this PR do?

Fixes a wrong-auth-state bug in the MiniMax OAuth status path.

Before this change, `get_minimax_oauth_auth_status()` treated an expired MiniMax access token as logged out even when the stored refresh token could still recover the session. That made `hermes status`, `hermes doctor`, and the dashboard report MiniMax OAuth as logged out during the normal short-lived token cycle, despite the runtime path being able to refresh and continue working.

This PR makes the status helper validate MiniMax auth through the same runtime refresh path used by actual requests. If the token is refreshable, status remains logged in. If refresh really fails, status returns logged out with the refresh error.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `hermes_cli/auth.py` so `get_minimax_oauth_auth_status()` calls `resolve_minimax_oauth_runtime_credentials()` instead of making a local expiry-only decision.
- Preserved MiniMax region / expiry metadata in the status response after runtime validation.
- Added focused tests in `tests/test_minimax_oauth.py` for:
  - expired-but-refreshable MiniMax OAuth state reporting as logged in
  - refresh failure reporting as logged out with an error
  - existing logged-in dispatch path continuing to work

## How to Test

1. Reproduce the old bug by creating a MiniMax OAuth state with an expired `access_token` but a valid `refresh_token`.
2. Call `get_minimax_oauth_auth_status()` or check a status surface that uses it (`hermes status`, `hermes doctor`, dashboard OAuth provider status).
3. Confirm the provider is reported as logged in when runtime refresh succeeds, and reported as logged out with an error when runtime refresh fails.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: w10

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs



- `tests/test_minimax_oauth.py`: `30 passed`
- `tests/hermes_cli/test_status.py tests/hermes_cli/test_doctor.py`: `78 passed`

