### PR TITLE
feat: add morning PR report helper

### DIFF
--- a/docs/plans/morning-pr-report.md
+++ b/docs/plans/morning-pr-report.md
@@ -1,0 +1,48 @@
+# Morning PR Report Implementation Plan
+
+> **For Hermes:** Use test-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Add a small local script that turns a Hermes Agent worktree into a concise Traditional Chinese morning PR report for Joe.
+
+**Architecture:** Keep this as a reversible, standalone developer utility under `scripts/` with pure formatting/parsing helpers covered by tests. The script shells out to `git`/optional `gh` only at the CLI boundary and can be used by future nightly cron jobs without changing Hermes runtime behavior.
+
+**Tech Stack:** Python standard library, pytest via `scripts/run_tests.sh`.
+
+---
+
+### Task 1: Specify report behavior with tests
+
+**Objective:** Lock down report formatting, git status parsing, and silent-empty behavior before implementation.
+
+**Files:**
+- Create: `tests/scripts/test_morning_pr_report.py`
+- Create: `scripts/morning_pr_report.py`
+
+**Steps:**
+1. Add tests for parsing `git status --porcelain=v1` lines into stable changed-file entries.
+2. Add tests for Traditional Chinese report output including branch, PR URL, files, verification, blockers, and Joe-focused why/impact.
+3. Add a test that `--silent-if-empty` emits exactly `[SILENT]` when there are no commits, no changed files, and no PR URL.
+4. Run the focused test and verify RED.
+
+### Task 2: Implement minimal script
+
+**Objective:** Make the failing tests pass with a small standalone script.
+
+**Files:**
+- Modify: `scripts/morning_pr_report.py`
+
+**Steps:**
+1. Add `ChangedFile` and `GitSnapshot` dataclasses.
+2. Implement `parse_porcelain_status`, `should_silence`, and `format_report`.
+3. Add CLI collection helpers around `git` and optional `gh pr view`.
+4. Run focused tests and verify GREEN.
+
+### Task 3: Verify and prepare PR
+
+**Objective:** Validate the utility, commit, push, and open a PR.
+
+**Steps:**
+1. Run `scripts/run_tests.sh tests/scripts/test_morning_pr_report.py`.
+2. Smoke-run `python scripts/morning_pr_report.py --title ... --why ... --verify ...`.
+3. Commit with `feat: add morning PR report helper`.
+4. Push branch and create a PR against `main`.

--- a/scripts/morning_pr_report.py
+++ b/scripts/morning_pr_report.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Generate a concise Traditional Chinese morning PR report for nightly work.
+
+This helper is intentionally standalone: future cron jobs can call it from a
+feature branch after committing/pushing work, and the output can be delivered
+as the final scheduled-task response without touching Hermes runtime code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+_STATUS_LABELS = {
+    "A": "added",
+    "M": "modified",
+    "D": "deleted",
+    "R": "renamed",
+    "C": "copied",
+    "U": "unmerged",
+    "?": "untracked",
+    "!": "ignored",
+}
+
+
+@dataclass(frozen=True)
+class ChangedFile:
+    status: str
+    path: str
+    old_path: str | None = None
+
+
+@dataclass(frozen=True)
+class GitSnapshot:
+    branch: str
+    base_branch: str = "main"
+    commit_subjects: list[str] = field(default_factory=list)
+    changed_files: list[ChangedFile] = field(default_factory=list)
+    pr_url: str | None = None
+
+
+def _status_label(code: str) -> str:
+    for char in code:
+        if char in _STATUS_LABELS and char != " ":
+            return _STATUS_LABELS[char]
+    return "changed"
+
+
+def parse_porcelain_status(output: str) -> list[ChangedFile]:
+    """Parse `git status --porcelain=v1` output into stable file entries."""
+
+    changed: list[ChangedFile] = []
+    for raw_line in output.splitlines():
+        line = raw_line.rstrip("\n")
+        if not line:
+            continue
+        code = line[:2]
+        path_part = line[3:] if len(line) > 3 else ""
+        label = _status_label(code)
+        if " -> " in path_part and ("R" in code or "C" in code):
+            old_path, new_path = path_part.split(" -> ", 1)
+            changed.append(ChangedFile(status=label, path=new_path, old_path=old_path))
+        else:
+            changed.append(ChangedFile(status=label, path=path_part))
+    return changed
+
+
+def should_silence(snapshot: GitSnapshot) -> bool:
+    """Return True when there is genuinely no branch/PR work to report."""
+
+    return not snapshot.pr_url and not snapshot.commit_subjects and not snapshot.changed_files
+
+
+def _bullet_lines(items: Sequence[str], empty: str = "無。") -> list[str]:
+    if not items:
+        return [f"- {empty}"]
+    return [f"- {item}" for item in items]
+
+
+def _changed_file_lines(files: Sequence[ChangedFile]) -> list[str]:
+    if not files:
+        return ["- 無未提交檔案。"]
+    lines = []
+    for item in files:
+        if item.old_path:
+            lines.append(f"- {item.status}: `{item.old_path}` → `{item.path}`")
+        else:
+            lines.append(f"- {item.status}: `{item.path}`")
+    return lines
+
+
+def format_report(
+    snapshot: GitSnapshot,
+    *,
+    title: str,
+    why: str,
+    verification: Sequence[str] = (),
+    blockers: Sequence[str] = (),
+) -> str:
+    """Format a Joe-style morning report in Traditional Chinese."""
+
+    pr_line = snapshot.pr_url or "尚未建立 PR（請看 blockers / commands）。"
+    commits = _bullet_lines(snapshot.commit_subjects, empty="尚無本分支 commit。")
+    changed_files = _changed_file_lines(snapshot.changed_files)
+    verification_lines = _bullet_lines(list(verification))
+    blocker_lines = _bullet_lines(list(blockers))
+
+    return "\n".join(
+        [
+            "## TL;DR",
+            f"- 已完成：{title}",
+            f"- PR：{pr_line}",
+            f"- 分支：`{snapshot.branch} → {snapshot.base_branch}`",
+            f"- 為什麼幫到你：{why}",
+            "",
+            "## 事實 / 已驗證",
+            "- 本次 commit：",
+            *commits,
+            "- 變更檔案：",
+            *changed_files,
+            "- 驗證：",
+            *verification_lines,
+            "",
+            "## Blockers / 需要你看",
+            *blocker_lines,
+        ]
+    )
+
+
+def _run_git(args: Sequence[str], cwd: Path) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return result.stdout.strip()
+
+
+def _run_optional(args: Sequence[str], cwd: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            list(args),
+            cwd=cwd,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+    value = result.stdout.strip()
+    return value or None
+
+
+def collect_snapshot(cwd: Path, base_branch: str) -> GitSnapshot:
+    branch = _run_git(["branch", "--show-current"], cwd) or "HEAD"
+    status = _run_git(["status", "--porcelain=v1"], cwd)
+    commits_output = _run_optional(["git", "log", f"origin/{base_branch}..HEAD", "--pretty=%s"], cwd)
+    pr_url = _run_optional(["gh", "pr", "view", "--json", "url", "--jq", ".url"], cwd)
+    return GitSnapshot(
+        branch=branch,
+        base_branch=base_branch,
+        commit_subjects=commits_output.splitlines() if commits_output else [],
+        changed_files=parse_porcelain_status(status),
+        pr_url=pr_url,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cwd", type=Path, default=Path.cwd(), help="Git repository path")
+    parser.add_argument("--base", default="main", help="Base branch name")
+    parser.add_argument("--title", required=True, help="One-line description of what was built")
+    parser.add_argument("--why", required=True, help="Why this helps Joe")
+    parser.add_argument("--verify", action="append", default=[], help="Verification command/result; repeatable")
+    parser.add_argument("--blocker", action="append", default=[], help="Blocker or question; repeatable")
+    parser.add_argument("--silent-if-empty", action="store_true", help="Emit [SILENT] if no work/PR is detected")
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = build_parser().parse_args(list(argv) if argv is not None else None)
+    snapshot = collect_snapshot(args.cwd.resolve(), args.base)
+    if args.silent_if_empty and should_silence(snapshot):
+        print("[SILENT]")
+        return 0
+    print(
+        format_report(
+            snapshot,
+            title=args.title,
+            why=args.why,
+            verification=args.verify,
+            blockers=args.blocker,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_morning_pr_report.py
+++ b/tests/scripts/test_morning_pr_report.py
@@ -1,0 +1,66 @@
+from scripts.morning_pr_report import (
+    ChangedFile,
+    GitSnapshot,
+    format_report,
+    parse_porcelain_status,
+    should_silence,
+)
+
+
+def test_parse_porcelain_status_summarizes_index_and_worktree_states():
+    status = """
+ M scripts/morning_pr_report.py
+A  tests/scripts/test_morning_pr_report.py
+R  old/name.py -> new/name.py
+?? docs/plans/morning-pr-report.md
+"""
+
+    assert parse_porcelain_status(status) == [
+        ChangedFile(status="modified", path="scripts/morning_pr_report.py"),
+        ChangedFile(status="added", path="tests/scripts/test_morning_pr_report.py"),
+        ChangedFile(status="renamed", path="new/name.py", old_path="old/name.py"),
+        ChangedFile(status="untracked", path="docs/plans/morning-pr-report.md"),
+    ]
+
+
+def test_format_report_returns_traditional_chinese_morning_summary():
+    snapshot = GitSnapshot(
+        branch="joe/nightly-personal-ops-brief",
+        base_branch="main",
+        commit_subjects=["feat: add morning PR report helper"],
+        changed_files=[
+            ChangedFile(status="added", path="scripts/morning_pr_report.py"),
+            ChangedFile(status="added", path="tests/scripts/test_morning_pr_report.py"),
+        ],
+        pr_url="https://github.com/NousResearch/hermes-agent/pull/123",
+    )
+
+    report = format_report(
+        snapshot,
+        title="早晨 PR 報告產生器",
+        why="讓 nightly build 的交付內容更穩定、可複製，減少早上讀報告的認知負擔。",
+        verification=["scripts/run_tests.sh tests/scripts/test_morning_pr_report.py"],
+        blockers=["無。"],
+    )
+
+    assert report.startswith("## TL;DR")
+    assert "早晨 PR 報告產生器" in report
+    assert "https://github.com/NousResearch/hermes-agent/pull/123" in report
+    assert "joe/nightly-personal-ops-brief → main" in report
+    assert "scripts/morning_pr_report.py" in report
+    assert "tests/scripts/test_morning_pr_report.py" in report
+    assert "scripts/run_tests.sh tests/scripts/test_morning_pr_report.py" in report
+    assert "事實 / 已驗證" in report
+    assert "無。" in report
+
+
+def test_should_silence_when_no_work_or_pr_exists():
+    empty = GitSnapshot(branch="main", base_branch="main")
+    not_empty = GitSnapshot(
+        branch="main",
+        base_branch="main",
+        changed_files=[ChangedFile(status="modified", path="README.md")],
+    )
+
+    assert should_silence(empty) is True
+    assert should_silence(not_empty) is False


### PR DESCRIPTION
## Summary
- Add `scripts/morning_pr_report.py`, a standalone helper that formats a Joe-style Traditional Chinese morning PR report from the current git branch/PR state.
- Add tests for porcelain status parsing, report formatting, and `[SILENT]` suppression when there is no work to report.
- Add a small spec/plan in `docs/plans/morning-pr-report.md` documenting the TDD workflow.

## Why
- Nightly Hermes cron work should produce small, repeatable morning reports with consistent TL;DR, evidence, verification, and blocker sections.
- This keeps Joe's morning review lower-friction without changing runtime Hermes behavior.

## Test Plan
- [x] RED observed: `python -m pytest tests/scripts/test_morning_pr_report.py -q -o 'addopts='` failed before implementation with `ModuleNotFoundError: No module named 'scripts.morning_pr_report'`.
- [x] `python -m py_compile scripts/morning_pr_report.py && python -m pytest tests/scripts/test_morning_pr_report.py -q -o 'addopts='` → `3 passed`.
- [x] Smoke: `python scripts/morning_pr_report.py --title 'Morning PR report helper' --why 'Standardizes nightly delivery notes for Joe.' --verify 'python -m pytest tests/scripts/test_morning_pr_report.py -q -o addopts=' --blocker 'scripts/run_tests.sh currently cannot load pytest-timeout in this environment.'`

## Notes
- `scripts/run_tests.sh tests/scripts/test_morning_pr_report.py` currently fails in this local environment before collection because the active pytest environment does not have the `pytest-timeout` plugin (`--timeout=30 --timeout-method=signal` unrecognized). I used the documented direct-pytest fallback for the focused smoke check and verified the missing plugin separately.
