### PR TITLE
test(acp): isolate model switch provider selection

### DIFF
--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -971,17 +971,14 @@ class TestSessionConfiguration:
             "hermes_cli.runtime_provider.resolve_runtime_provider",
             fake_resolve_runtime_provider,
         )
-        # Pin the parser so this test doesn't depend on live
-        # ``_KNOWN_PROVIDER_NAMES`` / ``_PROVIDER_ALIASES`` module state
-        # (sibling of the same hardening on
-        # ``test_model_switch_uses_requested_provider``).
+        # Pin ACP's resolver directly so the test doesn't depend on live
+        # ``hermes_cli.models`` module state or import aliases in this xdist
+        # worker. Mutating provider registries in sibling tests has flaked
+        # this class as ``custom`` instead of ``anthropic``.
         monkeypatch.setattr(
-            "hermes_cli.models.parse_model_input",
-            lambda raw, current: ("anthropic", "claude-sonnet-4-6"),
-        )
-        monkeypatch.setattr(
-            "hermes_cli.models.detect_provider_for_model",
-            lambda model, current: None,
+            HermesACPAgent,
+            "_resolve_model_selection",
+            staticmethod(lambda raw, current: ("anthropic", "claude-sonnet-4-6")),
         )
         manager = SessionManager(db=SessionDB(tmp_path / "state.db"))
 
@@ -1597,19 +1594,15 @@ class TestSlashCommands:
             "hermes_cli.runtime_provider.resolve_runtime_provider",
             fake_resolve_runtime_provider,
         )
-        # Pin the model-string parser independently of the live
-        # ``_KNOWN_PROVIDER_NAMES`` / ``_PROVIDER_ALIASES`` module state.
-        # Otherwise any test in the same xdist worker that mutates those
-        # globals (e.g. registers a custom provider that shadows
-        # ``anthropic``) flakes this one — observed once in CI as
-        # ``'custom' == 'anthropic'``.
+        # Pin ACP's resolver directly so this slash-command test is isolated
+        # from mutable ``hermes_cli.models`` provider-registry state and module
+        # aliasing in the xdist worker. Patching parse_model_input indirectly
+        # still allowed this to flake in CI as ``custom`` instead of
+        # ``anthropic``.
         monkeypatch.setattr(
-            "hermes_cli.models.parse_model_input",
-            lambda raw, current: ("anthropic", "claude-sonnet-4-6"),
-        )
-        monkeypatch.setattr(
-            "hermes_cli.models.detect_provider_for_model",
-            lambda model, current: None,
+            HermesACPAgent,
+            "_resolve_model_selection",
+            staticmethod(lambda raw, current: ("anthropic", "claude-sonnet-4-6")),
         )
         manager = SessionManager(db=SessionDB(tmp_path / "state.db"))
 


### PR DESCRIPTION
## Summary
Hardens two ACP model-switch tests by patching ACP's own `_resolve_model_selection()` helper directly instead of indirectly patching `hermes_cli.models.parse_model_input()` and `detect_provider_for_model()`.

## Root cause
`test_model_switch_uses_requested_provider` was already trying to guard against mutable provider-registry state in `hermes_cli.models`, with an inline note about the exact CI flake shape: `custom` instead of `anthropic`. The patch still depended on import/module identity for `hermes_cli.models`, so a sibling test in the same xdist worker could still leave ACP model resolution observing polluted provider state.

## Changes
- `tests/acp/test_server.py`
  - Patch `HermesACPAgent._resolve_model_selection()` directly in the two ACP provider-prefixed model switch tests.
  - Keep the test intent the same: verify `/model provider:model` and `session/set_model` rebuild the ACP agent with the requested provider.

## Validation
```bash
.venv/bin/python -m py_compile tests/acp/test_server.py
```

The targeted ACP test could not run in this local checkout because the local venv is missing the `acp` package:

```text
ModuleNotFoundError: No module named 'acp'
```

## Notes
This is intentionally separate from #31625. It only changes ACP tests and does not touch runtime ACP or API-server code.
