### PR TITLE
fix(install): probe SSH connectivity before cloning instead of hiding…

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -966,13 +966,14 @@ clone_repo() {
         # GitHub commonly returns 1 when authentication succeeds but no shell is
         # provided, and 255 when authentication or connection fails.
         # Use StrictHostKeyChecking=accept-new to avoid host key verification hangs in CI.
+        local git_ssh_command="ssh -o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new"
         local ssh_probe_status=0
         ssh -o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new \
             -T "git@${ssh_host}" >/dev/null 2>&1 || ssh_probe_status=$?
         
         if [ "$ssh_probe_status" -eq 0 ] || [ "$ssh_probe_status" -eq 1 ]; then
             log_info "Cloning via SSH..."
-            if git clone --branch "$BRANCH" "$REPO_URL_SSH" "$INSTALL_DIR"; then
+            if GIT_SSH_COMMAND="$git_ssh_command" git clone --branch "$BRANCH" "$REPO_URL_SSH" "$INSTALL_DIR"; then
                 log_success "Cloned via SSH"
             else
                 rm -rf "$INSTALL_DIR" 2>/dev/null

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -957,16 +957,35 @@ clone_repo() {
             exit 1
         fi
     else
-        # Try SSH first (for private repo access), fall back to HTTPS
-        # GIT_SSH_COMMAND disables interactive prompts and sets a short timeout
-        # so SSH fails fast instead of hanging when no key is configured.
-        log_info "Trying SSH clone..."
-        if GIT_SSH_COMMAND="ssh -o BatchMode=yes -o ConnectTimeout=5" \
-           git clone --branch "$BRANCH" "$REPO_URL_SSH" "$INSTALL_DIR" 2>/dev/null; then
-            log_success "Cloned via SSH"
+        # Extract SSH host from REPO_URL_SSH (e.g., git@github.com:NousResearch/hermes-agent.git → github.com)
+        # This allows the probe to work with GitHub Enterprise, GitLab, or other Git hosts.
+        local ssh_host="${REPO_URL_SSH#*@}"  # Remove "git@"
+        ssh_host="${ssh_host%%:*}"            # Remove everything after ":"
+        
+        # Probe SSH connectivity first (fast, silent) using the SSH exit status.
+        # GitHub commonly returns 1 when authentication succeeds but no shell is
+        # provided, and 255 when authentication or connection fails.
+        # Use StrictHostKeyChecking=accept-new to avoid host key verification hangs in CI.
+        local ssh_probe_status=0
+        ssh -o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new \
+            -T "git@${ssh_host}" >/dev/null 2>&1 || ssh_probe_status=$?
+        
+        if [ "$ssh_probe_status" -eq 0 ] || [ "$ssh_probe_status" -eq 1 ]; then
+            log_info "Cloning via SSH..."
+            if git clone --branch "$BRANCH" "$REPO_URL_SSH" "$INSTALL_DIR"; then
+                log_success "Cloned via SSH"
+            else
+                rm -rf "$INSTALL_DIR" 2>/dev/null
+                log_info "SSH clone failed, trying HTTPS..."
+                if git clone --branch "$BRANCH" "$REPO_URL_HTTPS" "$INSTALL_DIR"; then
+                    log_success "Cloned via HTTPS"
+                else
+                    log_error "Failed to clone repository"
+                    exit 1
+                fi
+            fi
         else
-            rm -rf "$INSTALL_DIR" 2>/dev/null  # Clean up partial SSH clone
-            log_info "SSH failed, trying HTTPS..."
+            log_info "No SSH key for $ssh_host, cloning via HTTPS..."
             if git clone --branch "$BRANCH" "$REPO_URL_HTTPS" "$INSTALL_DIR"; then
                 log_success "Cloned via HTTPS"
             else


### PR DESCRIPTION
## What does this PR do?

The install script tries SSH first, hides all output with `2>/dev/null`, and falls back to HTTPS if SSH fails. The idea is to hide SSH error messages from users who don't have keys configured.

Problem is, `2>/dev/null` doesn't just hide errors — it hides git progress bars too. When SSH takes a while (slow connection, large repo), the installer sits on "Trying SSH clone..." with zero feedback. Users have no way to tell if it's working or frozen.

This PR replaces that pattern with a quick SSH probe before cloning. The probe checks if you have a GitHub SSH key in about 5 seconds, silently. If it passes, clone via SSH with full output. If it fails, skip straight to HTTPS — also with full output.

No more stderr suppression on the actual clone. Users always see progress bars.

## Related Issue

No existing issue. Found during install when the script sat on "Trying SSH clone..." for 3+ minutes with no visible progress, despite having a valid SSH key and the clone actually working.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/install.sh`: Replaced the SSH-then-HTTP-fallback with a connectivity-probe-then-clone approach in `clone_repo()`.

## How to Test

1. Run the installer with a valid SSH key — should clone via SSH with visible git progress
2. Run the installer without an SSH key (or `ssh -o BatchMode=yes -T git@github.com` fails) — should skip straight to HTTPS
3. Both paths should show git's progress output, not hang silently

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(install): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `scripts/run_tests.sh` and all tests pass (install.sh change only, no test coverage for installer)
- [ ] I've added tests for my changes (installer logic is tested manually)
- [x] I've tested on my platform: Arch Linux

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, docs/, docstrings) — N/A
- [ ] I've updated cli-config.yaml.example if I added/changed config keys — N/A
- [ ] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — SSH probe is Linux/macOS-only; `install.ps1` doesn't have this blocking of the output, so no parallel change needed
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

<img width="628" height="520" alt="image" src="https://github.com/user-attachments/assets/36f32648-1c3e-4d0c-b323-0cce8972e63a" />

For me it took about 3 minutes and i could not see what is wrong?

Before the fix:
```
→ Trying SSH clone...
```
(3+ minutes of silence, no progress bars, user assumes it's hung)

After the fix (SSH key present):
```
→ Cloning via SSH...
Receiving objects: 15% (375/2500), 42.1 MiB | 1.2 MiB/s
```

After the fix (no SSH key):
```
→ No SSH key for GitHub, cloning via HTTPS...
Receiving objects: 15% (375/2500), 42.1 MiB | 1.2 MiB/s
```
