### PR TITLE
fix(opencode-go): avoid mixed Kimi reasoning controls

### DIFF
--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -41,17 +41,18 @@ class OpenCodeGoProfile(ProviderProfile):
         top_level: dict[str, Any] = {}
 
         if _is_kimi_k2_model(model):
-            # Kimi K2 on OpenCode Go uses Moonshot's native wire shape:
-            # extra_body.thinking (binary toggle) + top-level reasoning_effort
-            # (low|medium|high). Mirrors the KimiProfile (api.moonshot.ai/v1).
+            # OpenCode Go/Kimi accepts either Moonshot's native ``thinking``
+            # switch or top-level ``reasoning_effort``.  Sending both is
+            # rejected by the provider with
+            # ``cannot specify both 'thinking' and 'reasoning_effort'``.
             if not isinstance(reasoning_config, dict):
-                # No config → leave server defaults alone.
+                # No config → leave server defaults alone.  Kimi K2.6 thinks by
+                # default, so an explicit ``thinking: enabled`` is unnecessary.
                 return extra_body, top_level
 
             enabled = reasoning_config.get("enabled") is not False
-            extra_body["thinking"] = {"type": "enabled" if enabled else "disabled"}
-
             if not enabled:
+                extra_body["thinking"] = {"type": "disabled"}
                 return extra_body, top_level
 
             effort = (reasoning_config.get("effort") or "").strip().lower()
@@ -59,6 +60,9 @@ class OpenCodeGoProfile(ProviderProfile):
                 top_level["reasoning_effort"] = "high"
             elif effort in {"low", "medium", "high"}:
                 top_level["reasoning_effort"] = effort
+            # For minimal / unknown efforts, omit both controls and rely on
+            # Kimi's default thinking behavior rather than risking a mixed wire
+            # shape.
             return extra_body, top_level
 
         if not _is_deepseek_thinking_model(model):

--- a/tests/plugins/model_providers/test_opencode_go_profile.py
+++ b/tests/plugins/model_providers/test_opencode_go_profile.py
@@ -17,14 +17,14 @@ def opencode_go_profile():
 
 
 class TestOpenCodeGoKimiReasoning:
-    """Kimi K2 models use Moonshot's thinking + reasoning_effort shape on OpenCode Go."""
+    """Kimi K2 models use one OpenCode Go reasoning control at a time."""
 
-    def test_high_effort_emits_thinking_and_effort(self, opencode_go_profile):
+    def test_high_effort_emits_effort_without_thinking_enabled(self, opencode_go_profile):
         extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": "high"},
             model="kimi-k2.6",
         )
-        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert extra_body == {}
         assert top_level == {"reasoning_effort": "high"}
 
     def test_disabled_emits_thinking_disabled_without_effort(self, opencode_go_profile):
@@ -35,13 +35,15 @@ class TestOpenCodeGoKimiReasoning:
         assert extra_body == {"thinking": {"type": "disabled"}}
         assert top_level == {}
 
-    def test_minimal_effort_enables_thinking_without_effort(self, opencode_go_profile):
-        # "minimal" is not a Moonshot-supported value — drop it, keep thinking on.
+    def test_minimal_effort_preserves_kimi_default(self, opencode_go_profile):
+        # "minimal" is not a Moonshot-supported value. Omit both request
+        # controls: Kimi K2.6 thinks by default, and OpenCode Go rejects mixed
+        # thinking + reasoning_effort payloads.
         extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": "minimal"},
             model="kimi-k2.6",
         )
-        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert extra_body == {}
         assert top_level == {}
 
     @pytest.mark.parametrize(
@@ -56,7 +58,7 @@ class TestOpenCodeGoKimiReasoning:
             reasoning_config={"enabled": True, "effort": effort},
             model="moonshotai/kimi-k2.6",
         )
-        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert extra_body == {}
         assert top_level == {"reasoning_effort": "high"}
 
     def test_low_and_medium_pass_through(self, opencode_go_profile):
@@ -65,7 +67,7 @@ class TestOpenCodeGoKimiReasoning:
                 reasoning_config={"enabled": True, "effort": effort},
                 model="kimi-k2.5",
             )
-            assert extra_body == {"thinking": {"type": "enabled"}}
+            assert extra_body == {}
             assert top_level == {"reasoning_effort": effort}
 
     def test_no_config_preserves_server_default(self, opencode_go_profile):
@@ -149,7 +151,7 @@ class TestOpenCodeGoModelGating:
 class TestOpenCodeGoFullKwargsIntegration:
     """End-to-end transport kwargs include the profile-provided controls."""
 
-    def test_kimi_reasoning_reaches_extra_body_and_top_level(self, opencode_go_profile):
+    def test_kimi_reasoning_reaches_top_level_only(self, opencode_go_profile):
         from agent.transports.chat_completions import ChatCompletionsTransport
 
         kwargs = ChatCompletionsTransport().build_kwargs(
@@ -160,7 +162,7 @@ class TestOpenCodeGoFullKwargsIntegration:
             reasoning_config={"enabled": True, "effort": "high"},
             base_url="https://opencode.ai/zen/go/v1",
         )
-        assert kwargs["extra_body"] == {"thinking": {"type": "enabled"}}
+        assert "extra_body" not in kwargs
         assert kwargs["reasoning_effort"] == "high"
 
     def test_deepseek_thinking_reaches_extra_body_and_top_level(


### PR DESCRIPTION
## Summary
- avoid sending both `thinking` and `reasoning_effort` for OpenCode Go Kimi models
- send top-level `reasoning_effort` only for enabled Kimi efforts (`low`/`medium`/`high`, with `xhigh`/`max` clamped to `high`)
- keep `thinking: {type: disabled}` for disabled Kimi reasoning and preserve existing DeepSeek behavior
- update OpenCode Go provider tests for the exclusive Kimi control shape

## Why
OpenCode Go/Kimi rejects requests that include both top-level `reasoning_effort` and `extra_body.thinking` with:

```text
cannot specify both 'thinking' and 'reasoning_effort'
```

Direct probes showed Kimi accepts each control independently, but rejects the mixed wire shape.

## Test plan
- `./venv/bin/python -m pytest tests/plugins/model_providers/test_opencode_go_profile.py` — 21 passed
- `./venv/bin/ruff check plugins/model-providers/opencode-zen/__init__.py tests/plugins/model_providers/test_opencode_go_profile.py` — passed
- `hermes --profile copilotbot chat -Q --provider opencode-go -m kimi-k2.6 -q 'Reply exactly: KIMI_PR_SMOKE_OK'` — returned `KIMI_PR_SMOKE_OK`
