### PR TITLE
fix(telegram): use choice labels as inline keyboard button captions

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4721,8 +4721,9 @@ class TelegramAdapter(BasePlatformAdapter):
             if choices:
                 # Render full option text in the message body so mobile
                 # users can read long choices that would be truncated in
-                # inline button labels.  Buttons keep short numeric labels
-                # (1, 2, …, Other) to avoid Telegram truncation.
+                # inline button labels.  Buttons show a truncated copy of
+                # the same label (see below) so the captions are
+                # meaningful instead of bare numbers.
                 option_lines = "\n".join(
                     f"{i + 1}. {_html.escape(str(c))}"
                     for i, c in enumerate(choices)
@@ -4738,12 +4739,24 @@ class TelegramAdapter(BasePlatformAdapter):
 
             if choices:
                 # Telegram caps callback_data at 64 bytes; keep "cl:<id>:<idx>"
-                # short.
+                # short.  Button captions use a truncated copy of the
+                # choice label so users see the actual option, not "1/2/3".
                 rows = []
-                for idx in range(len(choices)):
+                for idx, choice in enumerate(choices):
+                    label = str(choice).strip() or str(idx + 1)
+                    # Telegram inline-button text is capped at 64 chars
+                    # (and long labels wrap awkwardly on mobile).  Keep
+                    # ~30 visible chars to stay readable across clients.
+                    # NOTE: slicing is by code point, so a label longer
+                    # than 30 whose 30th boundary falls inside a grapheme
+                    # cluster (ZWJ emoji, skin-tone/VS16 sequences, flags)
+                    # can split mid-cluster.  Acceptable for choice labels,
+                    # which are short and rarely emoji-dense.
+                    if len(label) > 30:
+                        label = label[:29].rstrip() + "…"
                     rows.append([
                         InlineKeyboardButton(
-                            str(idx + 1),
+                            label,
                             callback_data=f"cl:{clarify_id}:{idx}",
                         )
                     ])

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6291,8 +6291,9 @@ class TelegramAdapter(BasePlatformAdapter):
             if choices:
                 # Render full option text in the message body so mobile
                 # users can read long choices that would be truncated in
-                # inline button labels.  Buttons keep short numeric labels
-                # (1, 2, …, Other) to avoid Telegram truncation.
+                # inline button labels.  Buttons show a truncated copy of
+                # the same label (see below) so the captions are
+                # meaningful instead of bare numbers.
                 option_lines = "\n".join(
                     f"{i + 1}. {_html.escape(str(c))}"
                     for i, c in enumerate(choices)
@@ -6308,12 +6309,24 @@ class TelegramAdapter(BasePlatformAdapter):
 
             if choices:
                 # Telegram caps callback_data at 64 bytes; keep "cl:<id>:<idx>"
-                # short.
+                # short.  Button captions use a truncated copy of the
+                # choice label so users see the actual option, not "1/2/3".
                 rows = []
-                for idx in range(len(choices)):
+                for idx, choice in enumerate(choices):
+                    label = str(choice).strip() or str(idx + 1)
+                    # Telegram inline-button text is capped at 64 chars
+                    # (and long labels wrap awkwardly on mobile).  Keep
+                    # ~30 visible chars to stay readable across clients.
+                    # NOTE: slicing is by code point, so a label longer
+                    # than 30 whose 30th boundary falls inside a grapheme
+                    # cluster (ZWJ emoji, skin-tone/VS16 sequences, flags)
+                    # can split mid-cluster.  Acceptable for choice labels,
+                    # which are short and rarely emoji-dense.
+                    if len(label) > 30:
+                        label = label[:29].rstrip() + "…"
                     rows.append([
                         InlineKeyboardButton(
-                            str(idx + 1),
+                            label,
                             callback_data=f"cl:{clarify_id}:{idx}",
                         )
                     ])

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -146,29 +146,74 @@ class TestTelegramSendClarify:
         assert result.success is False
 
     @pytest.mark.asyncio
-    async def test_long_choice_rendered_in_body_not_truncated(self):
+    async def test_long_choice_rendered_in_body_and_truncated_label(self):
         """Long choice text appears in full in the message body;
-        button labels stay short numeric (1, 2, …)."""
+        button labels are truncated copies of the choice text (not bare
+        numeric labels — see fix/telegram-clarify-button-labels)."""
         adapter = _make_adapter()
         mock_msg = MagicMock()
         mock_msg.message_id = 102
         adapter._bot.send_message = AsyncMock(return_value=mock_msg)
 
         long_choice = "x" * 200
-        result = await adapter.send_clarify(
-            chat_id="12345",
-            question="?",
-            choices=[long_choice],
-            clarify_id="cid4",
-            session_key="sk4",
-        )
+        from plugins.platforms.telegram import adapter as tg_mod
+
+        with patch.object(tg_mod, "InlineKeyboardButton") as mock_btn:
+            result = await adapter.send_clarify(
+                chat_id="12345",
+                question="?",
+                choices=[long_choice],
+                clarify_id="cid4",
+                session_key="sk4",
+            )
         assert result.success is True
         kwargs = adapter._bot.send_message.call_args[1]
         # The full long choice text appears in the message body
         assert long_choice in kwargs["text"]
-        # The button label should be short ("1"), not the long choice
-        # (we can't inspect mock button labels directly, but the send
-        # succeeded — old truncation code could raise on edge cases)
+        # First button call: label is a truncated copy of the choice,
+        # NOT a bare numeric label.
+        first_call = mock_btn.call_args_list[0]
+        label = first_call.args[0] if first_call.args else first_call.kwargs.get("text")
+        assert label != "1", "button label should not be bare numeric"
+        assert label.startswith("x")
+        assert len(label) <= 30
+        assert label.endswith("…")
+
+    @pytest.mark.asyncio
+    async def test_button_labels_use_choice_text(self):
+        """Buttons should display the choice text (truncated), not bare 1/2/3."""
+        adapter = _make_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 104
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        choices = ["✅ Update all", "❌ Skip all", "Pick per stack"]
+        from plugins.platforms.telegram import adapter as tg_mod
+
+        with patch.object(tg_mod, "InlineKeyboardButton") as mock_btn:
+            result = await adapter.send_clarify(
+                chat_id="12345",
+                question="What now?",
+                choices=choices,
+                clarify_id="cid_lbl",
+                session_key="sk_lbl",
+            )
+        assert result.success is True
+
+        # Pull the first N button labels (one per choice, in order).
+        labels = []
+        callback_data = []
+        for call in mock_btn.call_args_list[: len(choices)]:
+            labels.append(call.args[0] if call.args else call.kwargs.get("text"))
+            callback_data.append(call.kwargs.get("callback_data"))
+
+        assert labels == choices  # short enough to be untruncated
+        # callback_data still encodes the index so the existing handler works
+        assert callback_data == [
+            "cl:cid_lbl:0",
+            "cl:cid_lbl:1",
+            "cl:cid_lbl:2",
+        ]
 
     @pytest.mark.asyncio
     async def test_html_escapes_question(self):

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -111,9 +111,73 @@ class TestTelegramSendClarify:
         assert adapter._clarify_state["cid1"] == "sk1"
 
 
-        # The button label should be short ("1"), not the long choice
-        # (we can't inspect mock button labels directly, but the send
-        # succeeded — old truncation code could raise on edge cases)
+        # Button labels use choice text (not bare numbers). Verified by the
+        # dedicated tests below; here we confirm the send round-trip succeeds.
+
+    @pytest.mark.asyncio
+    async def test_long_choice_rendered_in_body_and_truncated_label(self):
+        """Long choice text appears in full in the message body; button labels
+        are truncated copies of the choice text (not bare numeric labels)."""
+        adapter = _make_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 102
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        long_choice = "x" * 200
+        import plugins.platforms.telegram.adapter as tg_mod
+
+        with patch.object(tg_mod, "InlineKeyboardButton") as mock_btn:
+            result = await adapter.send_clarify(
+                chat_id="12345",
+                question="?",
+                choices=[long_choice],
+                clarify_id="cid4",
+                session_key="sk4",
+            )
+        assert result.success is True
+        kwargs = adapter._bot.send_message.call_args[1]
+        assert long_choice in kwargs["text"]
+        # First InlineKeyboardButton call: label is truncated choice text, not "1"
+        first_call = mock_btn.call_args_list[0]
+        label = first_call.args[0] if first_call.args else first_call.kwargs.get("text")
+        assert label != "1", "button label must not be a bare ordinal number"
+        assert label.startswith("x")
+        assert len(label) <= 30
+        assert label.endswith("…")
+
+    @pytest.mark.asyncio
+    async def test_button_labels_use_choice_text(self):
+        """Buttons display the choice text (truncated if needed), not bare 1/2/3."""
+        adapter = _make_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 104
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        choices = ["✅ Update all", "❌ Skip all", "Pick per stack"]
+        import plugins.platforms.telegram.adapter as tg_mod
+
+        with patch.object(tg_mod, "InlineKeyboardButton") as mock_btn:
+            result = await adapter.send_clarify(
+                chat_id="12345",
+                question="What now?",
+                choices=choices,
+                clarify_id="cid_lbl",
+                session_key="sk_lbl",
+            )
+        assert result.success is True
+
+        labels = []
+        callback_data = []
+        for call in mock_btn.call_args_list[: len(choices)]:
+            labels.append(call.args[0] if call.args else call.kwargs.get("text"))
+            callback_data.append(call.kwargs.get("callback_data"))
+
+        assert labels == choices  # short enough to be untruncated
+        assert callback_data == [
+            "cl:cid_lbl:0",
+            "cl:cid_lbl:1",
+            "cl:cid_lbl:2",
+        ]
 
     @pytest.mark.asyncio
     async def test_html_escapes_question(self):


### PR DESCRIPTION
## Problem

When the `clarify` tool sends a multi-choice prompt via the Telegram gateway, the inline keyboard buttons render with bare numeric captions (`1`, `2`, `3`, …) instead of the actual choice labels supplied by the agent.

The choice text **does** appear in the message body above the buttons (because we render `option_lines` there), but on mobile clients the buttons themselves look meaningless — users see something like:

> ❓ What now?
>
> 1. ✅ Update all
> 2. ❌ Skip all
> 3. Pick per stack
>
> `[ 1 ]`
> `[ 2 ]`
> `[ 3 ]`
> `[ ✏️ Other (type answer) ]`

Reported by Mario over the gateway after multiple `clarify` calls with different labels all rendered as `1/2/3`.

## Fix

`gateway/platforms/telegram.py::TelegramAdapter.send_clarify` now uses the choice text itself as the inline-button caption, truncated to ~30 visible characters (with an ellipsis) to stay well under Telegram's 64-char button-text limit and avoid awkward wrapping on mobile.

`callback_data` still encodes the choice index (`cl:<clarify_id>:<idx>`), so the existing `_handle_callback_query` dispatch path is unchanged — only the visible caption changed.

## Tests

- Updated `test_long_choice_rendered_in_body_not_truncated` → `test_long_choice_rendered_in_body_and_truncated_label` to assert the new truncated-label behavior (label starts with the choice text, ends with `…`, ≤30 chars).
- Added `test_button_labels_use_choice_text` covering the reported bug verbatim (emoji-prefixed `✅ Update all` / `❌ Skip all` / `Pick per stack` choices).
- All 13 tests in `tests/gateway/test_telegram_clarify_buttons.py` pass.

```
$ scripts/run_tests.sh tests/gateway/test_telegram_clarify_buttons.py
✓ tests/gateway/test_telegram_clarify_buttons.py (13✓, 2.6s)
=== Summary: 1 files, 13 tests passed, 0 failed ===
```
