### PR TITLE
Read-only API add-ons (providers/usage/events) + Kanban CRUD (depends-on #31125, #23742)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1481,11 +1481,26 @@ class APIServerAdapter(BasePlatformAdapter):
                 "python_version": _python_runtime_version(),
                 "openai_sdk_version": _openai_sdk_version(),
                 "released": _hermes_agent_released(),
-                # Reserved for follow-up PRs that introduce optional
-                # subsystems (kanban write API, providers list,
-                # recent events, usage summary, …). Empty here,
-                # populated by the matching subsystem PRs as they land.
-                "subsystem_capabilities": [],
+                # Runtime list of optional subsystems this gateway
+                # actually ships. Distinct from
+                # `/v1/capabilities.features.*` (which advertises the
+                # protocol/endpoint shape) — this list is the
+                # "does the runtime have this loaded?" signal for
+                # client-side UI degradation. Order is stable;
+                # presence is the contract, not position.
+                # `kanban` is conditional on the optional dependency
+                # being importable; the other three ship
+                # unconditionally with the add-on endpoints.
+                "subsystem_capabilities": [
+                    name
+                    for name, available in (
+                        ("providers", True),
+                        ("usage", True),
+                        ("events", True),
+                        ("kanban", _KANBAN_AVAILABLE),
+                    )
+                    if available
+                ],
             }
         )
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -588,6 +588,91 @@ def _list_provider_status(profile_dir: Path) -> Tuple[List[Dict[str, Any]], Opti
 
 
 # ---------------------------------------------------------------------------
+# Usage summary helper (used by /api/usage/summary)
+# ---------------------------------------------------------------------------
+#
+# Aggregates token counts + estimated cost from the sessions
+# table. Pure read; no mutation. Optionally windowed by ISO
+# timestamp via the ``since_iso`` argument. Returns the same
+# shape as the handler ships, so the handler is a thin
+# adapter.
+
+
+def _read_usage_summary(db_path: Path, since_iso: Optional[str] = None) -> Dict[str, Any]:
+    """Read aggregate token + cost data from a sessions DB."""
+    import sqlite3
+
+    where = ""
+    params: List[Any] = []
+    if since_iso:
+        where = "WHERE started_at >= ?"
+        params.append(since_iso)
+
+    with sqlite3.connect(str(db_path)) as conn:
+        try:
+            agg = conn.execute(
+                f"""SELECT
+                    COALESCE(SUM(input_tokens), 0)         AS in_tok,
+                    COALESCE(SUM(output_tokens), 0)        AS out_tok,
+                    COALESCE(SUM(cache_read_tokens), 0)    AS cr_tok,
+                    COALESCE(SUM(cache_write_tokens), 0)   AS cw_tok,
+                    COALESCE(SUM(estimated_cost_usd), 0.0) AS cost,
+                    MIN(started_at)                        AS first_at,
+                    MAX(COALESCE(ended_at, started_at))    AS last_at
+                FROM sessions
+                {where}""",
+                params,
+            ).fetchone()
+        except sqlite3.OperationalError:
+            # Schema mismatch (e.g. a legacy DB without one of the
+            # cache_* columns). Surface an empty summary rather
+            # than a 500.
+            return {
+                "window_start": since_iso,
+                "window_end": None,
+                "tokens": {"input": 0, "output": 0, "cache_read": 0, "cache_write": 0},
+                "estimated_cost_usd": None,
+                "by_model": [],
+            }
+
+        try:
+            by_model_rows = conn.execute(
+                f"""SELECT model,
+                       COUNT(*) AS requests,
+                       COALESCE(SUM(input_tokens + output_tokens), 0) AS tokens
+                FROM sessions
+                {where}
+                GROUP BY model
+                ORDER BY tokens DESC""",
+                params,
+            ).fetchall()
+        except sqlite3.OperationalError:
+            by_model_rows = []
+
+    by_model = [
+        {
+            "model_id": (row[0] or "unknown"),
+            "requests": int(row[1] or 0),
+            "tokens": int(row[2] or 0),
+        }
+        for row in by_model_rows
+    ]
+    cost_total = float(agg[4] or 0.0)
+    return {
+        "window_start": agg[5],
+        "window_end": agg[6],
+        "tokens": {
+            "input": int(agg[0] or 0),
+            "output": int(agg[1] or 0),
+            "cache_read": int(agg[2] or 0),
+            "cache_write": int(agg[3] or 0),
+        },
+        "estimated_cost_usd": cost_total if cost_total > 0 else None,
+        "by_model": by_model,
+    }
+
+
+# ---------------------------------------------------------------------------
 # CORS middleware
 # ---------------------------------------------------------------------------
 
@@ -1636,6 +1721,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "remote_toolsets": True,
                 "remote_gateway_status": True,
                 "remote_providers": True,
+                "remote_usage_summary": True,
                 "session_continuity_header": "X-Hermes-Session-Id",
                 "session_key_header": "X-Hermes-Session-Key",
                 "cors": bool(self._cors_origins),
@@ -1669,6 +1755,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "bundled_skills": {"method": "GET", "path": "/api/skills/bundled"},
                 "skill_content": {"method": "GET", "path": "/api/skills/content"},
                 "providers": {"method": "GET", "path": "/api/providers"},
+                "usage_summary": {"method": "GET", "path": "/api/usage/summary"},
             },
         })
 
@@ -3330,6 +3417,50 @@ class APIServerAdapter(BasePlatformAdapter):
             return _api_json_error(str(exc), status=500)
 
     # ------------------------------------------------------------------
+    # Usage summary — token + cost aggregates from SessionDB
+    # ------------------------------------------------------------------
+
+    async def _handle_usage_summary(self, request: "web.Request") -> "web.Response":
+        """GET /api/usage/summary — aggregate token + cost usage
+        from the persisted session DB.
+
+        Query params:
+          * ``since`` — ISO timestamp; only sessions started at or
+            after are counted. Omit for all-time totals.
+
+        Response shape: aggregated counts only; per-message detail
+        is intentionally omitted.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        since_iso = request.query.get("since") or None
+        try:
+            profile_dir = _profile_dir_for_request(request)
+            db_path = profile_dir / "state.db"
+            if not db_path.exists():
+                return web.json_response(
+                    {
+                        "window_start": since_iso,
+                        "window_end": None,
+                        "tokens": {
+                            "input": 0,
+                            "output": 0,
+                            "cache_read": 0,
+                            "cache_write": 0,
+                        },
+                        "estimated_cost_usd": None,
+                        "by_model": [],
+                    }
+                )
+            data = _read_usage_summary(db_path, since_iso=since_iso)
+            return web.json_response(data)
+        except Exception as exc:
+            logger.exception("GET /api/usage/summary failed")
+            return _api_json_error(str(exc), status=500)
+
+    # ------------------------------------------------------------------
     # Providers — read-only inventory; never the API keys
     # ------------------------------------------------------------------
 
@@ -4380,6 +4511,8 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_get("/api/skills/content", self._handle_skill_content)
             # Providers inventory (no keys, just configured flags)
             self._app.router.add_get("/api/providers", self._handle_list_providers)
+            # Usage summary aggregates (token + cost)
+            self._app.router.add_get("/api/usage/summary", self._handle_usage_summary)
             # Cron jobs management API
             self._app.router.add_get("/api/jobs", self._handle_list_jobs)
             self._app.router.add_post("/api/jobs", self._handle_create_job)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -971,6 +971,14 @@ except ImportError:
     _cron_trigger = None
 
 
+_KANBAN_AVAILABLE = False
+try:
+    from hermes_cli import kanban_db as _kanban_db
+    _KANBAN_AVAILABLE = True
+except ImportError:
+    _kanban_db = None  # type: ignore[assignment]
+
+
 MEMORY_ENTRY_DELIMITER = "\n\u00a7\n"
 MEMORY_CHAR_LIMIT = 2200
 USER_PROFILE_CHAR_LIMIT = 1375
@@ -1845,6 +1853,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "remote_providers": True,
                 "remote_usage_summary": True,
                 "remote_recent_events": True,
+                "remote_kanban": _KANBAN_AVAILABLE,
                 "session_continuity_header": "X-Hermes-Session-Id",
                 "session_key_header": "X-Hermes-Session-Key",
                 "cors": bool(self._cors_origins),
@@ -1880,6 +1889,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 "providers": {"method": "GET", "path": "/api/providers"},
                 "usage_summary": {"method": "GET", "path": "/api/usage/summary"},
                 "recent_events": {"method": "GET", "path": "/api/events/recent"},
+                "kanban_boards": {"method": "GET/POST", "path": "/api/kanban/boards"},
+                "kanban_board_delete": {"method": "DELETE", "path": "/api/kanban/boards/{slug}"},
+                "kanban_tasks": {"method": "GET/POST", "path": "/api/kanban/tasks"},
+                "kanban_task_delete": {"method": "DELETE", "path": "/api/kanban/tasks/{task_id}"},
+                "kanban_task_complete": {"method": "POST", "path": "/api/kanban/tasks/{task_id}/complete"},
             },
         })
 
@@ -3655,6 +3669,312 @@ class APIServerAdapter(BasePlatformAdapter):
             return _api_json_error(str(exc), status=500)
 
     # ------------------------------------------------------------------
+    # Kanban — boards + tasks, light CRUD surface
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _check_kanban_available() -> Optional["web.Response"]:
+        if not _KANBAN_AVAILABLE:
+            return web.json_response(
+                {"error": "Kanban subsystem not available"}, status=501,
+            )
+        return None
+
+    @staticmethod
+    def _serialise_kanban_task(task: "Any") -> Dict[str, Any]:
+        """Flatten a kanban_db.Task dataclass to a JSON-safe dict.
+
+        Includes the task body verbatim — kanban tasks are user-authored
+        plain prose by design (titles, body, result). Sanitisation is
+        the responsibility of the response middleware on the
+        identity-bearing endpoints (memory, sessions), NOT here.
+        """
+        return {
+            "id": task.id,
+            "title": task.title,
+            "body": task.body,
+            "assignee": task.assignee,
+            "status": task.status,
+            "priority": int(task.priority or 0),
+            "created_by": task.created_by,
+            "created_at": task.created_at,
+            "started_at": task.started_at,
+            "completed_at": task.completed_at,
+            "workspace_kind": task.workspace_kind,
+            "workspace_path": task.workspace_path,
+            "tenant": task.tenant,
+            "result": task.result,
+            "consecutive_failures": int(task.consecutive_failures or 0),
+            "skills": list(task.skills) if task.skills else None,
+            "max_retries": task.max_retries,
+            "max_runtime_seconds": task.max_runtime_seconds,
+        }
+
+    async def _handle_kanban_list_boards(
+        self, request: "web.Request"
+    ) -> "web.Response":
+        """GET /api/kanban/boards — list every board on disk."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        unavail = self._check_kanban_available()
+        if unavail:
+            return unavail
+        include_archived = (
+            request.query.get("include_archived", "").lower() in ("1", "true")
+        )
+        try:
+            boards = _kanban_db.list_boards(include_archived=include_archived)
+            return web.json_response({"boards": boards})
+        except Exception as exc:
+            logger.exception("GET /api/kanban/boards failed")
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_kanban_create_board(
+        self, request: "web.Request"
+    ) -> "web.Response":
+        """POST /api/kanban/boards — create a new board.
+
+        Body: ``{"slug": "...", "name": "...", "description": "...",
+                  "icon": "...", "color": "..."}``. Idempotent — an
+        existing board with the same slug returns its current metadata.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        unavail = self._check_kanban_available()
+        if unavail:
+            return unavail
+        try:
+            body = await request.json()
+        except Exception:
+            return _api_json_error("Body must be valid JSON")
+        slug = (body.get("slug") or "").strip()
+        if not slug:
+            return _api_json_error("Board slug is required")
+        try:
+            meta = _kanban_db.create_board(
+                slug,
+                name=(body.get("name") or None),
+                description=(body.get("description") or None),
+                icon=(body.get("icon") or None),
+                color=(body.get("color") or None),
+            )
+            return web.json_response({"board": meta})
+        except ValueError as exc:
+            return _api_json_error(str(exc), status=400)
+        except Exception as exc:
+            logger.exception("POST /api/kanban/boards failed")
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_kanban_delete_board(
+        self, request: "web.Request"
+    ) -> "web.Response":
+        """DELETE /api/kanban/boards/{slug} — archive or delete a board.
+
+        Default behaviour archives (moves the directory under
+        ``_archived/``). Pass ``?archive=false`` to delete outright.
+        The ``default`` board cannot be removed.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        unavail = self._check_kanban_available()
+        if unavail:
+            return unavail
+        slug = request.match_info.get("slug", "")
+        archive = (
+            request.query.get("archive", "true").lower() not in ("0", "false")
+        )
+        try:
+            summary = _kanban_db.remove_board(slug, archive=archive)
+            return web.json_response(summary)
+        except ValueError as exc:
+            return _api_json_error(str(exc), status=400)
+        except Exception as exc:
+            logger.exception("DELETE /api/kanban/boards/%s failed", slug)
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_kanban_list_tasks(
+        self, request: "web.Request"
+    ) -> "web.Response":
+        """GET /api/kanban/tasks — list tasks for a board.
+
+        Query params: ``board``, ``status``, ``assignee``,
+        ``include_archived``, ``limit``.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        unavail = self._check_kanban_available()
+        if unavail:
+            return unavail
+        board = request.query.get("board") or None
+        status = request.query.get("status") or None
+        assignee = request.query.get("assignee") or None
+        include_archived = (
+            request.query.get("include_archived", "").lower() in ("1", "true")
+        )
+        try:
+            limit = int(request.query.get("limit", 0)) or None
+        except (TypeError, ValueError):
+            limit = None
+        try:
+            conn = _kanban_db.connect(board=board)
+            try:
+                tasks = _kanban_db.list_tasks(
+                    conn,
+                    assignee=assignee,
+                    status=status,
+                    include_archived=include_archived,
+                    limit=limit,
+                )
+            finally:
+                conn.close()
+            return web.json_response(
+                {"tasks": [self._serialise_kanban_task(t) for t in tasks]}
+            )
+        except ValueError as exc:
+            return _api_json_error(str(exc), status=400)
+        except Exception as exc:
+            logger.exception("GET /api/kanban/tasks failed")
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_kanban_create_task(
+        self, request: "web.Request"
+    ) -> "web.Response":
+        """POST /api/kanban/tasks — create a task.
+
+        Body: ``{"title": "...", "body": "...", "assignee": "...",
+                  "priority": 0, "skills": [...], "triage": false,
+                  "board": "..."}``.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        unavail = self._check_kanban_available()
+        if unavail:
+            return unavail
+        try:
+            body = await request.json()
+        except Exception:
+            return _api_json_error("Body must be valid JSON")
+        title = (body.get("title") or "").strip()
+        if not title:
+            return _api_json_error("Task title is required")
+        board = body.get("board") or None
+        try:
+            conn = _kanban_db.connect(board=board)
+            try:
+                task_id = _kanban_db.create_task(
+                    conn,
+                    title=title,
+                    body=body.get("body") or None,
+                    assignee=body.get("assignee") or None,
+                    created_by=body.get("created_by") or "api",
+                    priority=int(body.get("priority") or 0),
+                    triage=bool(body.get("triage", False)),
+                    skills=body.get("skills") or None,
+                    max_retries=body.get("max_retries"),
+                    max_runtime_seconds=body.get("max_runtime_seconds"),
+                    idempotency_key=(
+                        request.headers.get("Idempotency-Key")
+                        or body.get("idempotency_key")
+                        or None
+                    ),
+                )
+                task = _kanban_db.get_task(conn, task_id)
+            finally:
+                conn.close()
+            if task is None:
+                return _api_json_error("Task creation failed", status=500)
+            return web.json_response(
+                {"task": self._serialise_kanban_task(task)}
+            )
+        except ValueError as exc:
+            return _api_json_error(str(exc), status=400)
+        except Exception as exc:
+            logger.exception("POST /api/kanban/tasks failed")
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_kanban_archive_task(
+        self, request: "web.Request"
+    ) -> "web.Response":
+        """DELETE /api/kanban/tasks/{task_id} — archive a task."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        unavail = self._check_kanban_available()
+        if unavail:
+            return unavail
+        task_id = request.match_info.get("task_id", "")
+        if not task_id:
+            return _api_json_error("Task id is required")
+        board = request.query.get("board") or None
+        try:
+            conn = _kanban_db.connect(board=board)
+            try:
+                ok = _kanban_db.archive_task(conn, task_id)
+            finally:
+                conn.close()
+            if not ok:
+                return _api_json_error("Task not found", status=404)
+            return web.json_response({"task_id": task_id, "archived": True})
+        except Exception as exc:
+            logger.exception("DELETE /api/kanban/tasks/%s failed", task_id)
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_kanban_complete_task(
+        self, request: "web.Request"
+    ) -> "web.Response":
+        """POST /api/kanban/tasks/{task_id}/complete — mark done.
+
+        Optional body: ``{"result": "...", "summary": "...",
+        "board": "..."}``.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        unavail = self._check_kanban_available()
+        if unavail:
+            return unavail
+        task_id = request.match_info.get("task_id", "")
+        if not task_id:
+            return _api_json_error("Task id is required")
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        board = body.get("board") or request.query.get("board") or None
+        try:
+            conn = _kanban_db.connect(board=board)
+            try:
+                ok = _kanban_db.complete_task(
+                    conn,
+                    task_id,
+                    result=body.get("result") or None,
+                    summary=body.get("summary") or None,
+                )
+                task = _kanban_db.get_task(conn, task_id) if ok else None
+            finally:
+                conn.close()
+            if not ok or task is None:
+                return _api_json_error(
+                    "Task not found or not in a completable state",
+                    status=404,
+                )
+            return web.json_response(
+                {"task": self._serialise_kanban_task(task)}
+            )
+        except ValueError as exc:
+            return _api_json_error(str(exc), status=400)
+        except Exception as exc:
+            logger.exception(
+                "POST /api/kanban/tasks/%s/complete failed", task_id
+            )
+            return _api_json_error(str(exc), status=500)
+
+    # ------------------------------------------------------------------
     # Cron jobs API
     # ------------------------------------------------------------------
 
@@ -4682,6 +5002,14 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_get("/api/usage/summary", self._handle_usage_summary)
             # Recent structural events for a remote activity feed
             self._app.router.add_get("/api/events/recent", self._handle_recent_events)
+            # Kanban boards + tasks (light CRUD)
+            self._app.router.add_get("/api/kanban/boards", self._handle_kanban_list_boards)
+            self._app.router.add_post("/api/kanban/boards", self._handle_kanban_create_board)
+            self._app.router.add_delete("/api/kanban/boards/{slug}", self._handle_kanban_delete_board)
+            self._app.router.add_get("/api/kanban/tasks", self._handle_kanban_list_tasks)
+            self._app.router.add_post("/api/kanban/tasks", self._handle_kanban_create_task)
+            self._app.router.add_delete("/api/kanban/tasks/{task_id}", self._handle_kanban_archive_task)
+            self._app.router.add_post("/api/kanban/tasks/{task_id}/complete", self._handle_kanban_complete_task)
             # Cron jobs management API
             self._app.router.add_get("/api/jobs", self._handle_list_jobs)
             self._app.router.add_post("/api/jobs", self._handle_create_job)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -414,6 +414,71 @@ class ResponseStore:
 
 
 # ---------------------------------------------------------------------------
+# Runtime-detail helpers for /api/gateway/status
+# ---------------------------------------------------------------------------
+#
+# These give a Desktop-in-remote-mode client the same information
+# that `hermes --version` produces locally: which hermes-agent
+# version is running, the Python interpreter, the openai SDK
+# version (when installed), and the most recent release tag.
+#
+# Each helper is best-effort and never raises: on lookup failure
+# it returns None so the response field becomes JSON null rather
+# than the request failing.
+
+
+def _hermes_agent_version() -> Optional[str]:
+    """Installed hermes-agent package version, or None on failure."""
+    try:
+        from importlib.metadata import version
+
+        return version("hermes-agent")
+    except Exception:
+        return None
+
+
+def _python_runtime_version() -> str:
+    """Runtime Python version, e.g. ``"3.11.15"``. Always available."""
+    import sys
+
+    return (
+        f"{sys.version_info.major}."
+        f"{sys.version_info.minor}."
+        f"{sys.version_info.micro}"
+    )
+
+
+def _openai_sdk_version() -> Optional[str]:
+    """Installed `openai` package version (None if not importable)."""
+    try:
+        from importlib.metadata import version
+
+        return version("openai")
+    except Exception:
+        return None
+
+
+def _hermes_agent_released() -> Optional[str]:
+    """Most recent dated release tag in the local git checkout.
+
+    Falls back to None if git isn't reachable or the working tree
+    isn't a checkout. Cheap subprocess call gated to 2s so a
+    misconfigured environment can't slow this endpoint down.
+    """
+    try:
+        import subprocess
+
+        out = subprocess.check_output(
+            ["git", "describe", "--tags", "--abbrev=0"],
+            stderr=subprocess.DEVNULL,
+            timeout=2,
+        )
+        return out.decode("utf-8", "replace").strip().lstrip("v") or None
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
 # CORS middleware
 # ---------------------------------------------------------------------------
 
@@ -1082,6 +1147,21 @@ class APIServerAdapter(BasePlatformAdapter):
                 "active_agents": runtime.get("active_agents", 0),
                 "exit_reason": runtime.get("exit_reason"),
                 "updated_at": runtime.get("updated_at"),
+                # Version + runtime detail block — lets remote clients
+                # render an "About this Hermes" panel without shelling
+                # out `hermes --version` (which doesn't exist on a
+                # desktop-in-remote-mode host). All fields are
+                # best-effort: a lookup failure yields null, never an
+                # exception.
+                "version": _hermes_agent_version(),
+                "python_version": _python_runtime_version(),
+                "openai_sdk_version": _openai_sdk_version(),
+                "released": _hermes_agent_released(),
+                # Reserved for follow-up PRs that introduce optional
+                # subsystems (kanban write API, providers list,
+                # recent events, usage summary, …). Empty here,
+                # populated by the matching subsystem PRs as they land.
+                "subsystem_capabilities": [],
             }
         )
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -50,7 +50,7 @@ import sqlite3
 import time
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 try:
     from aiohttp import web
@@ -476,6 +476,115 @@ def _hermes_agent_released() -> Optional[str]:
         return out.decode("utf-8", "replace").strip().lstrip("v") or None
     except Exception:
         return None
+
+
+# ---------------------------------------------------------------------------
+# Provider inventory helpers (used by /api/providers)
+# ---------------------------------------------------------------------------
+#
+# Detects which LLM providers the user has set up, without ever
+# returning the credentials themselves. Layered detection:
+#
+# - .env file:    `<NAME>_API_KEY=<non-empty value>` → configured
+# - config.yaml:  any key under `providers: {…}` → configured
+# - config.yaml:  `model.provider` value → configured + marked active
+#
+# Both files are read with broad exception handling — a missing or
+# malformed file yields an empty contribution rather than a 500.
+
+_KNOWN_PROVIDERS: Tuple[str, ...] = (
+    "nous",
+    "openrouter",
+    "anthropic",
+    "openai",
+    "openai-codex",
+    "copilot",
+    "huggingface",
+    "google",
+    "deepseek",
+    "minimax",
+    "alibaba",
+    "kimi",
+    "zai",
+    "vercel",
+    "custom",
+)
+
+
+def _env_value_is_empty(env_text: str, pattern: str) -> bool:
+    """True if ``pattern=`` is followed by empty / whitespace /
+    quoted-empty content in a `.env`-style text blob."""
+    idx = env_text.find(pattern)
+    if idx < 0:
+        return True
+    line_end = env_text.find("\n", idx)
+    line = env_text[idx + len(pattern) : line_end if line_end > 0 else None]
+    value = line.strip().strip('"').strip("'")
+    return not value
+
+
+def _list_provider_status(profile_dir: Path) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+    """Return ``(providers, active_provider)`` for the given profile.
+
+    Each providers entry is ``{key, label, configured, active}``.
+    ``active`` is the lowercase ``model.provider`` value from
+    config.yaml, or None if unset.
+    """
+    env_text = ""
+    env_path = profile_dir / ".env"
+    if env_path.exists():
+        try:
+            env_text = env_path.read_text(encoding="utf-8")
+        except Exception:
+            env_text = ""
+
+    configured_via_yaml: set = set()
+    active_provider: Optional[str] = None
+    cfg_path = profile_dir / "config.yaml"
+    if cfg_path.exists():
+        try:
+            import yaml  # PyYAML already a hermes-agent dep
+
+            cfg = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+            if isinstance(cfg, dict):
+                providers_map = cfg.get("providers") or {}
+                if isinstance(providers_map, dict):
+                    for key in providers_map.keys():
+                        configured_via_yaml.add(str(key).lower())
+                model_section = cfg.get("model") or {}
+                if isinstance(model_section, dict):
+                    prov = model_section.get("provider")
+                    if isinstance(prov, str) and prov.strip():
+                        active_provider = prov.strip().lower()
+                        configured_via_yaml.add(active_provider)
+        except Exception:
+            pass
+
+    providers_out: List[Dict[str, Any]] = []
+    # Union of known set + anything custom mentioned in config.yaml
+    # that we don't already know about.
+    all_keys = list(_KNOWN_PROVIDERS) + [
+        k for k in sorted(configured_via_yaml) if k not in _KNOWN_PROVIDERS
+    ]
+    for name in all_keys:
+        env_patterns = (
+            f"{name.upper()}_API_KEY=",
+            f"{name.upper().replace('-', '_')}_API_KEY=",
+        )
+        configured_via_env = any(
+            pat in env_text and not _env_value_is_empty(env_text, pat)
+            for pat in env_patterns
+        )
+        configured = configured_via_env or name in configured_via_yaml
+        providers_out.append(
+            {
+                "key": name,
+                "label": name.replace("-", " ").title(),
+                "configured": configured,
+                "active": active_provider == name,
+            }
+        )
+    return providers_out, active_provider
 
 
 # ---------------------------------------------------------------------------
@@ -1526,6 +1635,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "remote_skills": True,
                 "remote_toolsets": True,
                 "remote_gateway_status": True,
+                "remote_providers": True,
                 "session_continuity_header": "X-Hermes-Session-Id",
                 "session_key_header": "X-Hermes-Session-Key",
                 "cors": bool(self._cors_origins),
@@ -1558,6 +1668,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "installed_skills": {"method": "GET", "path": "/api/skills/installed"},
                 "bundled_skills": {"method": "GET", "path": "/api/skills/bundled"},
                 "skill_content": {"method": "GET", "path": "/api/skills/content"},
+                "providers": {"method": "GET", "path": "/api/providers"},
             },
         })
 
@@ -3219,6 +3330,33 @@ class APIServerAdapter(BasePlatformAdapter):
             return _api_json_error(str(exc), status=500)
 
     # ------------------------------------------------------------------
+    # Providers — read-only inventory; never the API keys
+    # ------------------------------------------------------------------
+
+    async def _handle_list_providers(self, request: "web.Request") -> "web.Response":
+        """GET /api/providers — list known LLM providers + a
+        ``configured`` flag derived from ``~/.hermes/.env`` and
+        ``~/.hermes/config.yaml``. **Never** returns the credentials.
+
+        A provider counts as configured if EITHER its
+        ``<NAME>_API_KEY`` env var is set in ``~/.hermes/.env``
+        with a non-empty value, OR it appears as a key under the
+        ``providers`` map in ``~/.hermes/config.yaml``, OR it is
+        the currently-selected ``model.provider``. The active
+        provider name is returned at the top level.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        try:
+            profile_dir = _profile_dir_for_request(request)
+            providers, active = _list_provider_status(profile_dir)
+            return web.json_response({"providers": providers, "active": active})
+        except Exception as exc:
+            logger.exception("GET /api/providers failed")
+            return _api_json_error(str(exc), status=500)
+
+    # ------------------------------------------------------------------
     # Cron jobs API
     # ------------------------------------------------------------------
 
@@ -4240,6 +4378,8 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_get("/api/skills/installed", self._handle_installed_skills)
             self._app.router.add_get("/api/skills/bundled", self._handle_bundled_skills)
             self._app.router.add_get("/api/skills/content", self._handle_skill_content)
+            # Providers inventory (no keys, just configured flags)
+            self._app.router.add_get("/api/providers", self._handle_list_providers)
             # Cron jobs management API
             self._app.router.add_get("/api/jobs", self._handle_list_jobs)
             self._app.router.add_post("/api/jobs", self._handle_create_job)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -673,6 +673,128 @@ def _read_usage_summary(db_path: Path, since_iso: Optional[str] = None) -> Dict[
 
 
 # ---------------------------------------------------------------------------
+# Recent events helper (used by /api/events/recent)
+# ---------------------------------------------------------------------------
+#
+# Synthesises gateway-level *structural* events from the sessions
+# table. Two event types per session: ``session.start`` and (when
+# the session has terminated) ``session.end``. The output is
+# newest-first and capped at ``limit``.
+#
+# **Security note:** the helper only emits *structural metadata* —
+# session id, source, model, timestamp, end_reason, message and
+# tool-call counts, duration. It NEVER reads or returns message
+# content, system prompts, tool output, or any other text body.
+# A remote activity feed can be rendered from this without
+# leaking conversation content.
+
+
+def _parse_iso_to_epoch(value: Optional[str]) -> Optional[float]:
+    """Convert an ISO-8601 string (with or without ``Z``) to a UNIX
+    epoch float. Returns ``None`` for ``None`` or malformed input."""
+    if not value:
+        return None
+    from datetime import datetime
+
+    try:
+        normalised = value.replace("Z", "+00:00")
+        return datetime.fromisoformat(normalised).timestamp()
+    except (TypeError, ValueError):
+        return None
+
+
+def _epoch_to_iso(epoch: Optional[float]) -> Optional[str]:
+    """Convert a UNIX epoch float to an ISO-8601 string with ``Z``
+    suffix (UTC). Returns ``None`` for ``None`` or non-numeric input."""
+    if epoch is None:
+        return None
+    from datetime import datetime, timezone
+
+    try:
+        dt = datetime.fromtimestamp(float(epoch), tz=timezone.utc)
+        return dt.isoformat().replace("+00:00", "Z")
+    except (TypeError, ValueError, OSError):
+        return None
+
+
+def _read_recent_events(
+    db_path: Path,
+    *,
+    limit: int = 50,
+    since_iso: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Build a newest-first list of structural session events."""
+    import sqlite3
+
+    since_epoch = _parse_iso_to_epoch(since_iso)
+
+    # We fetch up to 2x the limit at the SQL layer because each
+    # session yields up to two events (start + end). The final
+    # cap is applied after the Python-side filter.
+    sql_limit = max(1, int(limit) * 2)
+
+    with sqlite3.connect(str(db_path)) as conn:
+        try:
+            rows = conn.execute(
+                """SELECT id, source, model, started_at, ended_at,
+                          end_reason, message_count, tool_call_count
+                   FROM sessions
+                   ORDER BY started_at DESC
+                   LIMIT ?""",
+                (sql_limit,),
+            ).fetchall()
+        except sqlite3.OperationalError:
+            # Legacy DB missing a column — degrade to empty rather
+            # than 500.
+            return []
+
+    events: List[Dict[str, Any]] = []
+    for row in rows:
+        sid, source, model, started_at, ended_at, end_reason, mc, tc = row
+
+        if started_at is not None and (
+            since_epoch is None or float(started_at) >= since_epoch
+        ):
+            events.append(
+                {
+                    "type": "session.start",
+                    "timestamp": _epoch_to_iso(started_at),
+                    "session_id": sid,
+                    "source": source,
+                    "model": model,
+                }
+            )
+
+        if ended_at is not None and (
+            since_epoch is None or float(ended_at) >= since_epoch
+        ):
+            duration: Optional[float] = None
+            try:
+                if started_at is not None:
+                    duration = float(ended_at) - float(started_at)
+            except (TypeError, ValueError):
+                duration = None
+            events.append(
+                {
+                    "type": "session.end",
+                    "timestamp": _epoch_to_iso(ended_at),
+                    "session_id": sid,
+                    "source": source,
+                    "model": model,
+                    "metadata": {
+                        "end_reason": end_reason,
+                        "message_count": int(mc or 0),
+                        "tool_call_count": int(tc or 0),
+                        "duration_seconds": duration,
+                    },
+                }
+            )
+
+    events.sort(key=lambda ev: ev.get("timestamp") or "", reverse=True)
+    return events[: max(1, int(limit))]
+
+
+# ---------------------------------------------------------------------------
 # CORS middleware
 # ---------------------------------------------------------------------------
 
@@ -1722,6 +1844,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "remote_gateway_status": True,
                 "remote_providers": True,
                 "remote_usage_summary": True,
+                "remote_recent_events": True,
                 "session_continuity_header": "X-Hermes-Session-Id",
                 "session_key_header": "X-Hermes-Session-Key",
                 "cors": bool(self._cors_origins),
@@ -1756,6 +1879,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "skill_content": {"method": "GET", "path": "/api/skills/content"},
                 "providers": {"method": "GET", "path": "/api/providers"},
                 "usage_summary": {"method": "GET", "path": "/api/usage/summary"},
+                "recent_events": {"method": "GET", "path": "/api/events/recent"},
             },
         })
 
@@ -3488,6 +3612,49 @@ class APIServerAdapter(BasePlatformAdapter):
             return _api_json_error(str(exc), status=500)
 
     # ------------------------------------------------------------------
+    # Recent events — structural session lifecycle, no content
+    # ------------------------------------------------------------------
+
+    async def _handle_recent_events(self, request: "web.Request") -> "web.Response":
+        """GET /api/events/recent — newest-first list of structural
+        session events synthesised from the persisted sessions
+        table.
+
+        Two event types are emitted: ``session.start`` (one per
+        session) and ``session.end`` (when the session has
+        terminated). Each event carries only structural metadata
+        — id, source, model, timestamp, plus end-time aggregates
+        for ``session.end``. **No** message bodies, **no** system
+        prompts, **no** tool output.
+
+        Query params:
+          * ``limit`` — newest-first cap (default 50, max 200)
+          * ``since`` — ISO-8601 timestamp; events older than
+            this are filtered out
+
+        Intended consumer: a remote activity feed in a desktop or
+        dashboard UI.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        limit, _ = _coerce_limit_offset(request, default_limit=50)
+        since_iso = request.query.get("since") or None
+        try:
+            profile_dir = _profile_dir_for_request(request)
+            db_path = profile_dir / "state.db"
+            if not db_path.exists():
+                return web.json_response({"events": [], "limit": limit})
+            events = _read_recent_events(
+                db_path, limit=limit, since_iso=since_iso
+            )
+            return web.json_response({"events": events, "limit": limit})
+        except Exception as exc:
+            logger.exception("GET /api/events/recent failed")
+            return _api_json_error(str(exc), status=500)
+
+    # ------------------------------------------------------------------
     # Cron jobs API
     # ------------------------------------------------------------------
 
@@ -4513,6 +4680,8 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_get("/api/providers", self._handle_list_providers)
             # Usage summary aggregates (token + cost)
             self._app.router.add_get("/api/usage/summary", self._handle_usage_summary)
+            # Recent structural events for a remote activity feed
+            self._app.router.add_get("/api/events/recent", self._handle_recent_events)
             # Cron jobs management API
             self._app.router.add_get("/api/jobs", self._handle_list_jobs)
             self._app.router.add_post("/api/jobs", self._handle_create_job)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -15,6 +15,20 @@ Exposes an HTTP server with endpoints:
 - POST /v1/runs/{run_id}/stop       — interrupt a running agent
 - GET  /health                     — health check
 - GET  /health/detailed            — rich status for cross-container dashboard probing
+- GET  /api/sessions               — persisted session summaries
+- GET  /api/sessions/search        — full-text session search
+- GET  /api/sessions/{id}/messages — persisted session messages
+- GET  /api/profiles               — profile metadata
+- POST /api/profiles               — create profile
+- DELETE /api/profiles/{name}      — delete profile
+- POST /api/profiles/{name}/activate — set active profile
+- GET/PUT/POST /api/profiles/{name}/soul — read, write, reset persona
+- GET/POST/PUT/DELETE /api/memory  — read and edit memory/user profile files
+- GET/PUT /api/tools/toolsets      — list and update toolsets
+- GET /api/skills/installed        — installed skills
+- GET /api/skills/bundled          — bundled skills
+- GET /api/skills/content          — read a skill's SKILL.md
+- GET /api/gateway/status          — gateway runtime status
 
 Any OpenAI-compatible frontend (Open WebUI, LobeChat, LibreChat,
 AnythingLLM, NextChat, ChatBox, etc.) can connect to hermes-agent
@@ -35,6 +49,7 @@ import re
 import sqlite3
 import time
 import uuid
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 try:
@@ -575,6 +590,167 @@ except ImportError:
     _cron_trigger = None
 
 
+MEMORY_ENTRY_DELIMITER = "\n\u00a7\n"
+MEMORY_CHAR_LIMIT = 2200
+USER_PROFILE_CHAR_LIMIT = 1375
+
+
+def _api_json_error(message: str, status: int = 400) -> "web.Response":
+    return web.json_response({"error": message}, status=status)
+
+
+def _coerce_limit_offset(request: "web.Request", *, default_limit: int = 30) -> tuple[int, int]:
+    try:
+        limit = int(request.query.get("limit", default_limit))
+    except (TypeError, ValueError):
+        limit = default_limit
+    try:
+        offset = int(request.query.get("offset", 0))
+    except (TypeError, ValueError):
+        offset = 0
+    return max(1, min(limit, 200)), max(0, offset)
+
+
+def _csv_query_values(request: "web.Request", *names: str) -> list[str]:
+    values: list[str] = []
+    for name in names:
+        for raw in request.query.getall(name, []):
+            values.extend(part.strip() for part in raw.split(","))
+    return [value for value in values if value]
+
+
+def _session_source_filters(request: "web.Request") -> tuple[Optional[str], Optional[list[str]]]:
+    source = (request.query.get("source") or "").strip() or None
+    exclude_sources = _csv_query_values(request, "exclude_source", "exclude_sources")
+    return source, (exclude_sources or None)
+
+
+def _profile_dir_for_request(request: "web.Request") -> Path:
+    return _resolve_profile_dir(request.query.get("profile"))
+
+
+def _resolve_profile_dir(profile: Optional[str]) -> Path:
+    if not profile or profile == "current":
+        from hermes_constants import get_hermes_home
+
+        return get_hermes_home()
+
+    from hermes_cli import profiles as profiles_mod
+
+    name = profiles_mod.normalize_profile_name(profile)
+    profiles_mod.validate_profile_name(name)
+    if not profiles_mod.profile_exists(name):
+        raise FileNotFoundError(f"Profile '{name}' does not exist.")
+    return profiles_mod.get_profile_dir(name)
+
+
+def _read_text_file(path: Path) -> dict:
+    try:
+        st = path.stat()
+        return {
+            "content": path.read_text(encoding="utf-8"),
+            "exists": True,
+            "lastModified": int(st.st_mtime),
+            "last_modified": int(st.st_mtime),
+        }
+    except FileNotFoundError:
+        return {
+            "content": "",
+            "exists": False,
+            "lastModified": None,
+            "last_modified": None,
+        }
+
+
+def _parse_memory_entries(content: str) -> list[dict]:
+    if not content.strip():
+        return []
+    entries = []
+    for idx, entry in enumerate(content.split(MEMORY_ENTRY_DELIMITER)):
+        entry = entry.strip()
+        if entry:
+            entries.append({"index": idx, "content": entry})
+    return entries
+
+
+def _serialize_memory_entries(entries: list[dict]) -> str:
+    return MEMORY_ENTRY_DELIMITER.join(str(entry.get("content", "")).strip() for entry in entries)
+
+
+def _ensure_parent_and_write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _skill_frontmatter(content: str) -> tuple[str, str]:
+    name = ""
+    description = ""
+    if content.startswith("---"):
+        end = content.find("---", 3)
+        if end != -1:
+            frontmatter = content[3:end]
+            if match := re.search(r"^\s*name:\s*[\"']?([^\"'\n]+)[\"']?\s*$", frontmatter, re.M):
+                name = match.group(1).strip()
+            if match := re.search(r"^\s*description:\s*[\"']?([^\"'\n]+)[\"']?\s*$", frontmatter, re.M):
+                description = match.group(1).strip()
+    if not name:
+        if match := re.search(r"^#\s+(.+)$", content, re.M):
+            name = match.group(1).strip()
+    if not description:
+        for line in content.splitlines():
+            stripped = line.strip()
+            if stripped and not stripped.startswith(("#", "---")):
+                description = stripped[:160]
+                break
+    return name, description
+
+
+def _scan_skills(root: Path, *, source: str) -> list[dict]:
+    if not root.is_dir():
+        return []
+    skills: list[dict] = []
+    for skill_md in sorted(root.rglob("SKILL.md")):
+        if ".git" in skill_md.parts or ".hub" in skill_md.parts:
+            continue
+        try:
+            rel = skill_md.parent.relative_to(root)
+        except ValueError:
+            continue
+        parts = rel.parts
+        category = parts[0] if len(parts) > 1 else "local"
+        slug = parts[-1] if parts else skill_md.parent.name
+        try:
+            content = skill_md.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            content = ""
+        name, description = _skill_frontmatter(content[:4000])
+        skills.append(
+            {
+                "name": name or slug,
+                "slug": slug,
+                "category": category,
+                "description": description,
+                "source": source,
+                "path": str(skill_md.parent),
+            }
+        )
+    return skills
+
+
+def _path_within(path: Path, roots: list[Path]) -> bool:
+    try:
+        resolved = path.resolve()
+    except OSError:
+        return False
+    for root in roots:
+        try:
+            resolved.relative_to(root.resolve())
+            return True
+        except (OSError, ValueError):
+            continue
+    return False
+
+
 class APIServerAdapter(BasePlatformAdapter):
     """
     OpenAI-compatible HTTP API server adapter.
@@ -887,6 +1063,320 @@ class APIServerAdapter(BasePlatformAdapter):
             "pid": os.getpid(),
         })
 
+    async def _handle_gateway_status(self, request: "web.Request") -> "web.Response":
+        """GET /api/gateway/status — return persisted gateway runtime status."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        from gateway.status import read_runtime_status
+
+        runtime = read_runtime_status() or {}
+        return web.json_response(
+            {
+                "ok": True,
+                "running": True,
+                "pid": os.getpid(),
+                "gateway_state": runtime.get("gateway_state"),
+                "platforms": runtime.get("platforms", {}),
+                "active_agents": runtime.get("active_agents", 0),
+                "exit_reason": runtime.get("exit_reason"),
+                "updated_at": runtime.get("updated_at"),
+            }
+        )
+
+    async def _handle_list_sessions(self, request: "web.Request") -> "web.Response":
+        """GET /api/sessions — list persisted session summaries."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        limit, offset = _coerce_limit_offset(request)
+        source, exclude_sources = _session_source_filters(request)
+        try:
+            from hermes_state import SessionDB
+
+            db_path = _profile_dir_for_request(request) / "state.db"
+            if not db_path.exists():
+                return web.json_response(
+                    {"sessions": [], "total": 0, "limit": limit, "offset": offset}
+                )
+            db = SessionDB(db_path)
+            try:
+                sessions = db.list_sessions_rich(
+                    source=source,
+                    exclude_sources=exclude_sources,
+                    limit=limit,
+                    offset=offset,
+                    order_by_last_active=True,
+                )
+                total = db.session_count(source=source) if not exclude_sources else len(sessions)
+            finally:
+                db.close()
+        except Exception as exc:
+            logger.exception("GET /api/sessions failed")
+            return _api_json_error(str(exc), status=500)
+
+        normalized = []
+        for item in sessions:
+            row = dict(item)
+            row.setdefault("preview", row.get("preview") or "")
+            row.setdefault("title", row.get("title"))
+            row["startedAt"] = row.get("started_at")
+            row["endedAt"] = row.get("ended_at")
+            row["messageCount"] = row.get("message_count", 0)
+            normalized.append(row)
+        return web.json_response(
+            {"sessions": normalized, "total": total, "limit": limit, "offset": offset}
+        )
+
+    async def _handle_search_sessions(self, request: "web.Request") -> "web.Response":
+        """GET /api/sessions/search?q=... — search persisted messages."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        query = (request.query.get("q") or "").strip()
+        if not query:
+            return web.json_response({"results": []})
+        try:
+            limit = max(1, min(int(request.query.get("limit", 20)), 100))
+        except (TypeError, ValueError):
+            limit = 20
+
+        try:
+            from hermes_state import SessionDB
+
+            db_path = _profile_dir_for_request(request) / "state.db"
+            if not db_path.exists():
+                return web.json_response({"results": []})
+            db = SessionDB(db_path)
+            try:
+                source, exclude_sources = _session_source_filters(request)
+                matches = db.search_messages(
+                    query=query,
+                    source_filter=[source] if source else None,
+                    exclude_sources=exclude_sources,
+                    limit=limit,
+                )
+            finally:
+                db.close()
+        except Exception as exc:
+            logger.exception("GET /api/sessions/search failed")
+            return _api_json_error(str(exc), status=500)
+
+        seen: dict[str, dict] = {}
+        for match in matches:
+            sid = match.get("session_id")
+            if not sid or sid in seen:
+                continue
+            seen[sid] = {
+                "session_id": sid,
+                "sessionId": sid,
+                "title": match.get("title"),
+                "snippet": match.get("snippet", ""),
+                "role": match.get("role"),
+                "source": match.get("source"),
+                "model": match.get("model"),
+                "started_at": match.get("session_started"),
+                "startedAt": match.get("session_started"),
+            }
+        return web.json_response({"results": list(seen.values())})
+
+    async def _handle_session_messages(self, request: "web.Request") -> "web.Response":
+        """GET /api/sessions/{session_id}/messages — fetch persisted messages."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        session_id = request.match_info["session_id"]
+        try:
+            from hermes_state import SessionDB
+
+            db_path = _profile_dir_for_request(request) / "state.db"
+            if not db_path.exists():
+                return _api_json_error("Session not found", status=404)
+            db = SessionDB(db_path)
+            try:
+                resolved = db.resolve_session_id(session_id)
+                if not resolved:
+                    return _api_json_error("Session not found", status=404)
+                messages = db.get_messages(resolved)
+            finally:
+                db.close()
+        except Exception as exc:
+            logger.exception("GET /api/sessions/%s/messages failed", session_id)
+            return _api_json_error(str(exc), status=500)
+
+        return web.json_response({"session_id": resolved, "sessionId": resolved, "messages": messages})
+
+    async def _handle_list_profiles(self, request: "web.Request") -> "web.Response":
+        """GET /api/profiles — list Hermes profiles."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            from hermes_cli import profiles as profiles_mod
+
+            active = profiles_mod.get_active_profile_name()
+            items = []
+            for profile in profiles_mod.list_profiles():
+                has_soul = (Path(profile.path) / "SOUL.md").exists()
+                item = {
+                    "name": profile.name,
+                    "path": str(profile.path),
+                    "is_default": profile.is_default,
+                    "isDefault": profile.is_default,
+                    "is_active": profile.name == active,
+                    "isActive": profile.name == active,
+                    "model": profile.model or "",
+                    "provider": profile.provider or "",
+                    "has_env": profile.has_env,
+                    "hasEnv": profile.has_env,
+                    "has_soul": has_soul,
+                    "hasSoul": has_soul,
+                    "skill_count": profile.skill_count,
+                    "skillCount": profile.skill_count,
+                    "gateway_running": profile.gateway_running,
+                    "gatewayRunning": profile.gateway_running,
+                }
+                items.append(item)
+            return web.json_response({"profiles": items, "active": active})
+        except Exception as exc:
+            logger.exception("GET /api/profiles failed")
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_create_profile(self, request: "web.Request") -> "web.Response":
+        """POST /api/profiles — create a Hermes profile."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            body = await request.json()
+        except Exception:
+            return _api_json_error("Invalid JSON in request body", status=400)
+        name = str(body.get("name") or "").strip()
+        clone = bool(body.get("clone") or body.get("clone_from_default"))
+        no_skills = bool(body.get("no_skills"))
+        if not name:
+            return _api_json_error("Profile name is required", status=400)
+
+        try:
+            from hermes_cli import profiles as profiles_mod
+
+            path = profiles_mod.create_profile(
+                name=name,
+                clone_from="default" if clone else None,
+                clone_config=clone,
+                no_skills=no_skills,
+            )
+            if not clone:
+                profiles_mod.seed_profile_skills(path, quiet=True)
+            if not profiles_mod.check_alias_collision(name):
+                profiles_mod.create_wrapper_script(name)
+            return web.json_response({"ok": True, "name": name, "path": str(path)})
+        except (ValueError, FileExistsError, FileNotFoundError) as exc:
+            return _api_json_error(str(exc), status=400)
+        except Exception as exc:
+            logger.exception("POST /api/profiles failed")
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_delete_profile(self, request: "web.Request") -> "web.Response":
+        """DELETE /api/profiles/{name} — delete a Hermes profile."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        name = request.match_info["name"]
+        try:
+            from hermes_cli import profiles as profiles_mod
+
+            path = profiles_mod.delete_profile(name, yes=True)
+            return web.json_response({"ok": True, "path": str(path)})
+        except FileNotFoundError as exc:
+            return _api_json_error(str(exc), status=404)
+        except ValueError as exc:
+            return _api_json_error(str(exc), status=400)
+        except Exception as exc:
+            logger.exception("DELETE /api/profiles/%s failed", name)
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_activate_profile(self, request: "web.Request") -> "web.Response":
+        """POST /api/profiles/{name}/activate — set the active profile."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        name = request.match_info["name"]
+        try:
+            from hermes_cli import profiles as profiles_mod
+
+            profiles_mod.set_active_profile(name)
+            return web.json_response({"ok": True, "active": profiles_mod.get_active_profile_name()})
+        except (ValueError, FileNotFoundError) as exc:
+            return _api_json_error(str(exc), status=400)
+        except Exception as exc:
+            logger.exception("POST /api/profiles/%s/activate failed", name)
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_get_soul(self, request: "web.Request") -> "web.Response":
+        """GET /api/profiles/{name}/soul — read persona/SOUL.md."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            profile_dir = _resolve_profile_dir(request.match_info["name"])
+            return web.json_response(_read_text_file(profile_dir / "SOUL.md"))
+        except FileNotFoundError as exc:
+            return _api_json_error(str(exc), status=404)
+        except ValueError as exc:
+            return _api_json_error(str(exc), status=400)
+
+    async def _handle_write_soul(self, request: "web.Request") -> "web.Response":
+        """PUT /api/profiles/{name}/soul — write persona/SOUL.md."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            body = await request.json()
+        except Exception:
+            return _api_json_error("Invalid JSON in request body", status=400)
+        try:
+            profile_dir = _resolve_profile_dir(request.match_info["name"])
+            _ensure_parent_and_write(profile_dir / "SOUL.md", str(body.get("content") or ""))
+            return web.json_response({"ok": True})
+        except FileNotFoundError as exc:
+            return _api_json_error(str(exc), status=404)
+        except ValueError as exc:
+            return _api_json_error(str(exc), status=400)
+        except Exception as exc:
+            logger.exception("PUT /api/profiles/%s/soul failed", request.match_info["name"])
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_reset_soul(self, request: "web.Request") -> "web.Response":
+        """POST /api/profiles/{name}/soul/reset — reset persona/SOUL.md."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            from hermes_cli.default_soul import DEFAULT_SOUL_MD
+
+            profile_dir = _resolve_profile_dir(request.match_info["name"])
+            _ensure_parent_and_write(profile_dir / "SOUL.md", DEFAULT_SOUL_MD)
+            return web.json_response({"ok": True, "content": DEFAULT_SOUL_MD})
+        except FileNotFoundError as exc:
+            return _api_json_error(str(exc), status=404)
+        except ValueError as exc:
+            return _api_json_error(str(exc), status=400)
+        except Exception as exc:
+            logger.exception("POST /api/profiles/%s/soul/reset failed", request.match_info["name"])
+            return _api_json_error(str(exc), status=500)
+
     async def _handle_models(self, request: "web.Request") -> "web.Response":
         """GET /v1/models — return hermes-agent as an available model."""
         auth_err = self._check_auth(request)
@@ -949,6 +1439,13 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_approval_response": True,
                 "tool_progress_events": True,
                 "approval_events": True,
+                "remote_sessions": True,
+                "remote_profiles": True,
+                "remote_memory": True,
+                "remote_persona": True,
+                "remote_skills": True,
+                "remote_toolsets": True,
+                "remote_gateway_status": True,
                 "session_continuity_header": "X-Hermes-Session-Id",
                 "session_key_header": "X-Hermes-Session-Key",
                 "cors": bool(self._cors_origins),
@@ -964,6 +1461,23 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_events": {"method": "GET", "path": "/v1/runs/{run_id}/events"},
                 "run_approval": {"method": "POST", "path": "/v1/runs/{run_id}/approval"},
                 "run_stop": {"method": "POST", "path": "/v1/runs/{run_id}/stop"},
+                "gateway_status": {"method": "GET", "path": "/api/gateway/status"},
+                "sessions": {"method": "GET", "path": "/api/sessions"},
+                "session_search": {"method": "GET", "path": "/api/sessions/search"},
+                "session_messages": {"method": "GET", "path": "/api/sessions/{session_id}/messages"},
+                "profiles": {"method": "GET", "path": "/api/profiles"},
+                "profile_create": {"method": "POST", "path": "/api/profiles"},
+                "profile_delete": {"method": "DELETE", "path": "/api/profiles/{name}"},
+                "profile_activate": {"method": "POST", "path": "/api/profiles/{name}/activate"},
+                "profile_soul": {"method": "GET/PUT", "path": "/api/profiles/{name}/soul"},
+                "profile_soul_reset": {"method": "POST", "path": "/api/profiles/{name}/soul/reset"},
+                "memory": {"method": "GET", "path": "/api/memory"},
+                "memory_entries": {"method": "POST/PUT/DELETE", "path": "/api/memory/entries"},
+                "memory_user": {"method": "PUT", "path": "/api/memory/user"},
+                "toolsets": {"method": "GET/PUT", "path": "/api/tools/toolsets"},
+                "installed_skills": {"method": "GET", "path": "/api/skills/installed"},
+                "bundled_skills": {"method": "GET", "path": "/api/skills/bundled"},
+                "skill_content": {"method": "GET", "path": "/api/skills/content"},
             },
         })
 
@@ -2344,6 +2858,286 @@ class APIServerAdapter(BasePlatformAdapter):
             "deleted": True,
         })
 
+    async def _handle_read_memory(self, request: "web.Request") -> "web.Response":
+        """GET /api/memory — read MEMORY.md and USER.md for a profile."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            profile_dir = _profile_dir_for_request(request)
+            memory_file = _read_text_file(profile_dir / "memories" / "MEMORY.md")
+            user_file = _read_text_file(profile_dir / "memories" / "USER.md")
+            entries = _parse_memory_entries(memory_file["content"])
+            stats = {"totalSessions": 0, "totalMessages": 0, "total_sessions": 0, "total_messages": 0}
+            try:
+                db_path = profile_dir / "state.db"
+                if db_path.exists():
+                    with sqlite3.connect(str(db_path)) as conn:
+                        row = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()
+                        total_sessions = int(row[0]) if row else 0
+                        row = conn.execute("SELECT COUNT(*) FROM messages").fetchone()
+                        total_messages = int(row[0]) if row else 0
+                else:
+                    total_sessions = 0
+                    total_messages = 0
+                stats = {
+                    "totalSessions": total_sessions,
+                    "totalMessages": total_messages,
+                    "total_sessions": total_sessions,
+                    "total_messages": total_messages,
+                }
+            except Exception:
+                pass
+            return web.json_response(
+                {
+                    "memory": {
+                        **memory_file,
+                        "entries": entries,
+                        "charCount": len(memory_file["content"]),
+                        "char_count": len(memory_file["content"]),
+                        "charLimit": MEMORY_CHAR_LIMIT,
+                        "char_limit": MEMORY_CHAR_LIMIT,
+                    },
+                    "user": {
+                        **user_file,
+                        "charCount": len(user_file["content"]),
+                        "char_count": len(user_file["content"]),
+                        "charLimit": USER_PROFILE_CHAR_LIMIT,
+                        "char_limit": USER_PROFILE_CHAR_LIMIT,
+                    },
+                    "stats": stats,
+                }
+            )
+        except (FileNotFoundError, ValueError) as exc:
+            return _api_json_error(str(exc), status=400)
+        except Exception as exc:
+            logger.exception("GET /api/memory failed")
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_add_memory_entry(self, request: "web.Request") -> "web.Response":
+        """POST /api/memory/entries — append a memory entry."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            body = await request.json()
+        except Exception:
+            return _api_json_error("Invalid JSON in request body", status=400)
+        try:
+            profile_dir = _profile_dir_for_request(request)
+            path = profile_dir / "memories" / "MEMORY.md"
+            existing = _read_text_file(path)
+            entries = _parse_memory_entries(existing["content"])
+            entries.append({"index": len(entries), "content": str(body.get("content") or "").strip()})
+            content = _serialize_memory_entries(entries)
+            if len(content) > MEMORY_CHAR_LIMIT:
+                return _api_json_error(
+                    f"Would exceed memory limit ({len(content)}/{MEMORY_CHAR_LIMIT} chars)",
+                    status=400,
+                )
+            _ensure_parent_and_write(path, content)
+            return web.json_response({"ok": True})
+        except Exception as exc:
+            logger.exception("POST /api/memory/entries failed")
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_update_memory_entry(self, request: "web.Request") -> "web.Response":
+        """PUT /api/memory/entries/{index} — update a memory entry."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            body = await request.json()
+            index = int(request.match_info["index"])
+        except Exception:
+            return _api_json_error("Invalid request", status=400)
+        try:
+            profile_dir = _profile_dir_for_request(request)
+            path = profile_dir / "memories" / "MEMORY.md"
+            entries = _parse_memory_entries(_read_text_file(path)["content"])
+            if index < 0 or index >= len(entries):
+                return _api_json_error("Entry not found", status=404)
+            entries[index]["content"] = str(body.get("content") or "").strip()
+            content = _serialize_memory_entries(entries)
+            if len(content) > MEMORY_CHAR_LIMIT:
+                return _api_json_error(
+                    f"Would exceed memory limit ({len(content)}/{MEMORY_CHAR_LIMIT} chars)",
+                    status=400,
+                )
+            _ensure_parent_and_write(path, content)
+            return web.json_response({"ok": True})
+        except Exception as exc:
+            logger.exception("PUT /api/memory/entries/%s failed", request.match_info.get("index"))
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_delete_memory_entry(self, request: "web.Request") -> "web.Response":
+        """DELETE /api/memory/entries/{index} — remove a memory entry."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            index = int(request.match_info["index"])
+        except Exception:
+            return _api_json_error("Invalid entry index", status=400)
+        try:
+            profile_dir = _profile_dir_for_request(request)
+            path = profile_dir / "memories" / "MEMORY.md"
+            entries = _parse_memory_entries(_read_text_file(path)["content"])
+            if index < 0 or index >= len(entries):
+                return _api_json_error("Entry not found", status=404)
+            entries.pop(index)
+            _ensure_parent_and_write(path, _serialize_memory_entries(entries))
+            return web.json_response({"ok": True})
+        except Exception as exc:
+            logger.exception("DELETE /api/memory/entries/%s failed", request.match_info.get("index"))
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_write_user_profile(self, request: "web.Request") -> "web.Response":
+        """PUT /api/memory/user — write USER.md."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            body = await request.json()
+        except Exception:
+            return _api_json_error("Invalid JSON in request body", status=400)
+        content = str(body.get("content") or "")
+        if len(content) > USER_PROFILE_CHAR_LIMIT:
+            return _api_json_error(
+                f"Exceeds limit ({len(content)}/{USER_PROFILE_CHAR_LIMIT} chars)",
+                status=400,
+            )
+        try:
+            profile_dir = _profile_dir_for_request(request)
+            _ensure_parent_and_write(profile_dir / "memories" / "USER.md", content)
+            return web.json_response({"ok": True})
+        except Exception as exc:
+            logger.exception("PUT /api/memory/user failed")
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_list_toolsets(self, request: "web.Request") -> "web.Response":
+        """GET /api/tools/toolsets — list configurable toolsets."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        platform = request.query.get("platform") or "api_server"
+        try:
+            from hermes_cli.config import load_config
+            from hermes_cli.tools_config import (
+                _get_effective_configurable_toolsets,
+                _get_platform_tools,
+                _toolset_has_keys,
+            )
+            from toolsets import resolve_toolset
+
+            config = load_config()
+            enabled = _get_platform_tools(config, platform, include_default_mcp_servers=False)
+            toolsets = []
+            for key, label, description in _get_effective_configurable_toolsets():
+                try:
+                    tools = sorted(set(resolve_toolset(key)))
+                except Exception:
+                    tools = []
+                is_enabled = key in enabled
+                toolsets.append(
+                    {
+                        "key": key,
+                        "name": key,
+                        "label": label,
+                        "description": description,
+                        "enabled": is_enabled,
+                        "available": is_enabled,
+                        "configured": _toolset_has_keys(key, config),
+                        "tools": tools,
+                    }
+                )
+            return web.json_response({"toolsets": toolsets, "platform": platform})
+        except Exception as exc:
+            logger.exception("GET /api/tools/toolsets failed")
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_set_toolset(self, request: "web.Request") -> "web.Response":
+        """PUT /api/tools/toolsets/{key} — enable or disable a toolset."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            body = await request.json()
+        except Exception:
+            return _api_json_error("Invalid JSON in request body", status=400)
+        key = request.match_info["key"]
+        platform = request.query.get("platform") or "api_server"
+        enabled = bool(body.get("enabled"))
+        try:
+            from hermes_cli.config import load_config, save_config
+            from hermes_cli.tools_config import _apply_toolset_change
+
+            config = load_config()
+            _apply_toolset_change(config, platform, [key], "enable" if enabled else "disable")
+            save_config(config)
+            return web.json_response({"ok": True, "key": key, "enabled": enabled, "platform": platform})
+        except Exception as exc:
+            logger.exception("PUT /api/tools/toolsets/%s failed", key)
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_installed_skills(self, request: "web.Request") -> "web.Response":
+        """GET /api/skills/installed — list installed skills."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            profile_dir = _profile_dir_for_request(request)
+            return web.json_response({"skills": _scan_skills(profile_dir / "skills", source="installed")})
+        except Exception as exc:
+            logger.exception("GET /api/skills/installed failed")
+            return _api_json_error(str(exc), status=500)
+
+    async def _handle_bundled_skills(self, request: "web.Request") -> "web.Response":
+        """GET /api/skills/bundled — list bundled skills from the repo."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        root = Path(__file__).resolve().parents[2] / "skills"
+        return web.json_response({"skills": _scan_skills(root, source="bundled")})
+
+    async def _handle_skill_content(self, request: "web.Request") -> "web.Response":
+        """GET /api/skills/content?path=... — read a SKILL.md under allowed roots."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        raw_path = request.query.get("path") or ""
+        if not raw_path:
+            return _api_json_error("path is required", status=400)
+        try:
+            profile_dir = _profile_dir_for_request(request)
+            repo_skills = Path(__file__).resolve().parents[2] / "skills"
+            skill_dir = Path(raw_path)
+            skill_file = skill_dir / "SKILL.md"
+            allowed_roots = [profile_dir / "skills", repo_skills]
+            if not _path_within(skill_file, allowed_roots):
+                return _api_json_error("Skill path is outside the allowed skills directories", status=403)
+            return web.json_response(
+                {
+                    "content": skill_file.read_text(encoding="utf-8", errors="replace"),
+                    "path": str(skill_dir),
+                }
+            )
+        except FileNotFoundError:
+            return _api_json_error("Skill not found", status=404)
+        except Exception as exc:
+            logger.exception("GET /api/skills/content failed")
+            return _api_json_error(str(exc), status=500)
+
     # ------------------------------------------------------------------
     # Cron jobs API
     # ------------------------------------------------------------------
@@ -3344,6 +4138,28 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_post("/v1/responses", self._handle_responses)
             self._app.router.add_get("/v1/responses/{response_id}", self._handle_get_response)
             self._app.router.add_delete("/v1/responses/{response_id}", self._handle_delete_response)
+            # Remote management/read APIs for desktop and dashboard clients
+            self._app.router.add_get("/api/gateway/status", self._handle_gateway_status)
+            self._app.router.add_get("/api/sessions", self._handle_list_sessions)
+            self._app.router.add_get("/api/sessions/search", self._handle_search_sessions)
+            self._app.router.add_get("/api/sessions/{session_id}/messages", self._handle_session_messages)
+            self._app.router.add_get("/api/profiles", self._handle_list_profiles)
+            self._app.router.add_post("/api/profiles", self._handle_create_profile)
+            self._app.router.add_delete("/api/profiles/{name}", self._handle_delete_profile)
+            self._app.router.add_post("/api/profiles/{name}/activate", self._handle_activate_profile)
+            self._app.router.add_get("/api/profiles/{name}/soul", self._handle_get_soul)
+            self._app.router.add_put("/api/profiles/{name}/soul", self._handle_write_soul)
+            self._app.router.add_post("/api/profiles/{name}/soul/reset", self._handle_reset_soul)
+            self._app.router.add_get("/api/memory", self._handle_read_memory)
+            self._app.router.add_post("/api/memory/entries", self._handle_add_memory_entry)
+            self._app.router.add_put("/api/memory/entries/{index}", self._handle_update_memory_entry)
+            self._app.router.add_delete("/api/memory/entries/{index}", self._handle_delete_memory_entry)
+            self._app.router.add_put("/api/memory/user", self._handle_write_user_profile)
+            self._app.router.add_get("/api/tools/toolsets", self._handle_list_toolsets)
+            self._app.router.add_put("/api/tools/toolsets/{key}", self._handle_set_toolset)
+            self._app.router.add_get("/api/skills/installed", self._handle_installed_skills)
+            self._app.router.add_get("/api/skills/bundled", self._handle_bundled_skills)
+            self._app.router.add_get("/api/skills/content", self._handle_skill_content)
             # Cron jobs management API
             self._app.router.add_get("/api/jobs", self._handle_list_jobs)
             self._app.router.add_post("/api/jobs", self._handle_create_job)

--- a/tests/gateway/test_api_server_gateway_status.py
+++ b/tests/gateway/test_api_server_gateway_status.py
@@ -165,9 +165,14 @@ class TestGatewayStatusEnrichedResponse:
         assert isinstance(body["python_version"], str)
         assert body["python_version"].count(".") == 2
 
-        # subsystem_capabilities defaults to an empty list — it is
-        # populated by follow-up subsystem PRs as they land.
-        assert body["subsystem_capabilities"] == []
+        # subsystem_capabilities is a list of subsystem keys that
+        # the runtime actually ships. Detailed entries are asserted
+        # in TestSubsystemCapabilities below; here we just guard
+        # the shape (list of strings).
+        assert isinstance(body["subsystem_capabilities"], list)
+        assert all(
+            isinstance(name, str) for name in body["subsystem_capabilities"]
+        )
 
         # version / openai_sdk_version / released are best-effort:
         # may be null when not installed / no git, but if present
@@ -226,3 +231,70 @@ class TestGatewayStatusEnrichedResponse:
         # python_version comes straight from sys.version_info,
         # not from a fallible lookup — must still be there.
         assert isinstance(body["python_version"], str)
+
+
+class TestSubsystemCapabilities:
+    """`/api/gateway/status.subsystem_capabilities` is the runtime
+    list of optional subsystems the gateway actually ships. The
+    matching ``features.remote_*`` flags in `/v1/capabilities`
+    advertise the *protocol/endpoint* shape; this list answers the
+    distinct question "did the runtime load this subsystem?" for
+    UI-degradation in remote clients."""
+
+    @pytest.mark.asyncio
+    async def test_response_includes_unconditional_subsystems(self):
+        """providers / usage / events ship unconditionally with
+        the add-on endpoints — their keys must always be present
+        in `subsystem_capabilities` once those PRs land."""
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/gateway/status")
+            assert resp.status == 200
+            body = await resp.json()
+
+        caps = body["subsystem_capabilities"]
+        for required in ("providers", "usage", "events"):
+            assert required in caps, (
+                f"runtime ships /api/{required} endpoints but "
+                f"{required!r} is missing from subsystem_capabilities"
+            )
+
+    @pytest.mark.asyncio
+    async def test_kanban_presence_tracks_optional_dependency(self):
+        """kanban is conditional on the optional dependency being
+        importable. When `_KANBAN_AVAILABLE` is True it must be in
+        the list; when False it must NOT be."""
+        from gateway.platforms import api_server as api_mod
+
+        # Case 1: kanban available — must be advertised.
+        with patch.object(api_mod, "_KANBAN_AVAILABLE", True):
+            app = _create_app(_make_adapter())
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/api/gateway/status")
+                body = await resp.json()
+            assert "kanban" in body["subsystem_capabilities"]
+
+        # Case 2: kanban unavailable — must NOT be advertised.
+        with patch.object(api_mod, "_KANBAN_AVAILABLE", False):
+            app = _create_app(_make_adapter())
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/api/gateway/status")
+                body = await resp.json()
+            assert "kanban" not in body["subsystem_capabilities"]
+
+    @pytest.mark.asyncio
+    async def test_list_only_contains_keys_we_actually_ship(self):
+        """Defence against drift: every key in the list must come
+        from the known runtime set. A future addition that lands
+        without updating the contract is caught by this test."""
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/gateway/status")
+            body = await resp.json()
+
+        known = {"providers", "usage", "events", "kanban"}
+        unknown = set(body["subsystem_capabilities"]) - known
+        assert not unknown, (
+            f"subsystem_capabilities contains keys not in the "
+            f"known runtime set: {sorted(unknown)}"
+        )

--- a/tests/gateway/test_api_server_gateway_status.py
+++ b/tests/gateway/test_api_server_gateway_status.py
@@ -1,0 +1,228 @@
+"""
+Tests for the enriched /api/gateway/status response.
+
+The base handler (introduced in the same commit as the remote-
+management endpoints) already returns runtime liveness +
+per-platform state. This file covers the version + interpreter
+metadata that the enrichment commit adds — version,
+python_version, openai_sdk_version, released,
+subsystem_capabilities.
+
+Two layers:
+
+* Module-level unit tests for the four helper lookups
+  (``_hermes_agent_version`` / ``_python_runtime_version`` /
+  ``_openai_sdk_version`` / ``_hermes_agent_released``).
+* One HTTP integration test asserting the GET response carries
+  the new fields and that the historic fields are still present
+  (no regression on Codex's shape).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import (
+    APIServerAdapter,
+    _hermes_agent_released,
+    _hermes_agent_version,
+    _openai_sdk_version,
+    _python_runtime_version,
+    cors_middleware,
+)
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+class TestPythonRuntimeVersion:
+    def test_returns_dot_separated_three_part_version(self):
+        v = _python_runtime_version()
+        # Format like "3.11.15" — three integer segments.
+        parts = v.split(".")
+        assert len(parts) == 3
+        assert all(p.isdigit() for p in parts)
+
+    def test_matches_sys_version_info(self):
+        import sys
+
+        expected = (
+            f"{sys.version_info.major}."
+            f"{sys.version_info.minor}."
+            f"{sys.version_info.micro}"
+        )
+        assert _python_runtime_version() == expected
+
+
+class TestHermesAgentVersion:
+    def test_returns_version_string_when_package_installed(self):
+        # Editable install via `uv pip install -e ...` in the test
+        # runner registers the package as `hermes-agent`. Result
+        # is a non-empty string of digits + dots.
+        v = _hermes_agent_version()
+        assert v is None or (isinstance(v, str) and len(v) > 0)
+
+    def test_returns_none_when_package_metadata_unavailable(self):
+        with patch(
+            "gateway.platforms.api_server.version", create=True
+        ) as mock_version:
+            # importlib.metadata.version is imported inside the
+            # helper, so patching the imported name at use-site is
+            # the cleanest way. Easier: patch the module path the
+            # helper actually imports.
+            mock_version.side_effect = Exception("not found")
+            # The helper's `from importlib.metadata import version`
+            # is a local import inside the try block, so the patch
+            # above doesn't reach it. Use a direct call instead:
+        # Re-import importlib.metadata.version and force failure
+        # by mocking at the right level:
+        with patch("importlib.metadata.version") as mock:
+            mock.side_effect = Exception("not found")
+            assert _hermes_agent_version() is None
+
+
+class TestOpenAiSdkVersion:
+    def test_returns_string_or_none(self):
+        v = _openai_sdk_version()
+        assert v is None or isinstance(v, str)
+
+    def test_returns_none_when_openai_not_installed(self):
+        with patch("importlib.metadata.version") as mock:
+            mock.side_effect = Exception("no package")
+            assert _openai_sdk_version() is None
+
+
+class TestHermesAgentReleased:
+    def test_returns_string_or_none(self):
+        v = _hermes_agent_released()
+        assert v is None or isinstance(v, str)
+
+    def test_returns_none_when_git_fails(self):
+        import subprocess
+
+        with patch.object(subprocess, "check_output") as mock:
+            mock.side_effect = subprocess.CalledProcessError(1, "git")
+            assert _hermes_agent_released() is None
+
+    def test_strips_leading_v_prefix(self):
+        import subprocess
+
+        with patch.object(subprocess, "check_output") as mock:
+            mock.return_value = b"v0.14.0\n"
+            assert _hermes_agent_released() == "0.14.0"
+
+    def test_empty_output_becomes_none(self):
+        import subprocess
+
+        with patch.object(subprocess, "check_output") as mock:
+            mock.return_value = b"\n"
+            assert _hermes_agent_released() is None
+
+
+# ---------------------------------------------------------------------------
+# HTTP integration
+# ---------------------------------------------------------------------------
+
+
+def _make_adapter() -> APIServerAdapter:
+    return APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application(middlewares=[cors_middleware])
+    app["api_server_adapter"] = adapter
+    app.router.add_get("/api/gateway/status", adapter._handle_gateway_status)
+    return app
+
+
+class TestGatewayStatusEnrichedResponse:
+    @pytest.mark.asyncio
+    async def test_response_includes_new_runtime_fields(self):
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/gateway/status")
+            assert resp.status == 200
+            body = await resp.json()
+
+        # New fields added by this enrichment.
+        for key in (
+            "version",
+            "python_version",
+            "openai_sdk_version",
+            "released",
+            "subsystem_capabilities",
+        ):
+            assert key in body, f"missing enrichment field {key!r}"
+
+        # python_version is always available, never null.
+        assert isinstance(body["python_version"], str)
+        assert body["python_version"].count(".") == 2
+
+        # subsystem_capabilities defaults to an empty list — it is
+        # populated by follow-up subsystem PRs as they land.
+        assert body["subsystem_capabilities"] == []
+
+        # version / openai_sdk_version / released are best-effort:
+        # may be null when not installed / no git, but if present
+        # they must be strings.
+        for key in ("version", "openai_sdk_version", "released"):
+            assert body[key] is None or isinstance(body[key], str)
+
+    @pytest.mark.asyncio
+    async def test_historic_runtime_fields_still_present(self):
+        # Codex's original response shape. None of these may
+        # disappear or change semantics.
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/gateway/status")
+            assert resp.status == 200
+            body = await resp.json()
+
+        for key in (
+            "ok",
+            "running",
+            "pid",
+            "gateway_state",
+            "platforms",
+            "active_agents",
+            "exit_reason",
+            "updated_at",
+        ):
+            assert key in body, f"historic field {key!r} disappeared"
+
+        assert body["ok"] is True
+        assert body["running"] is True
+        assert isinstance(body["pid"], int)
+
+    @pytest.mark.asyncio
+    async def test_helper_failures_do_not_propagate(self):
+        """If every optional helper fails simultaneously, the
+        handler still returns 200 with the null fields plus the
+        always-available ones."""
+        import subprocess
+
+        with patch("importlib.metadata.version") as mock_v, patch.object(
+            subprocess, "check_output"
+        ) as mock_git:
+            mock_v.side_effect = Exception("metadata unavailable")
+            mock_git.side_effect = Exception("git unavailable")
+
+            app = _create_app(_make_adapter())
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/api/gateway/status")
+                assert resp.status == 200
+                body = await resp.json()
+
+        assert body["version"] is None
+        assert body["openai_sdk_version"] is None
+        assert body["released"] is None
+        # python_version comes straight from sys.version_info,
+        # not from a fallible lookup — must still be there.
+        assert isinstance(body["python_version"], str)

--- a/tests/gateway/test_api_server_kanban.py
+++ b/tests/gateway/test_api_server_kanban.py
@@ -1,0 +1,274 @@
+"""
+Tests for the light kanban CRUD surface on the API server.
+
+Endpoints under test:
+
+  * ``GET   /api/kanban/boards``
+  * ``POST  /api/kanban/boards``
+  * ``DELETE /api/kanban/boards/{slug}``
+  * ``GET   /api/kanban/tasks``
+  * ``POST  /api/kanban/tasks``
+  * ``DELETE /api/kanban/tasks/{task_id}``
+  * ``POST  /api/kanban/tasks/{task_id}/complete``
+
+Each test isolates the kanban home via ``HERMES_KANBAN_HOME`` so
+the suite never touches the user's real ``~/.hermes/kanban``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter, cors_middleware
+
+
+def _make_adapter(api_key: str = "") -> APIServerAdapter:
+    extra: Dict[str, Any] = {"key": api_key} if api_key else {}
+    return APIServerAdapter(PlatformConfig(enabled=True, extra=extra))
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application(middlewares=[cors_middleware])
+    app["api_server_adapter"] = adapter
+    app.router.add_get("/api/kanban/boards", adapter._handle_kanban_list_boards)
+    app.router.add_post("/api/kanban/boards", adapter._handle_kanban_create_board)
+    app.router.add_delete(
+        "/api/kanban/boards/{slug}", adapter._handle_kanban_delete_board
+    )
+    app.router.add_get("/api/kanban/tasks", adapter._handle_kanban_list_tasks)
+    app.router.add_post("/api/kanban/tasks", adapter._handle_kanban_create_task)
+    app.router.add_delete(
+        "/api/kanban/tasks/{task_id}", adapter._handle_kanban_archive_task
+    )
+    app.router.add_post(
+        "/api/kanban/tasks/{task_id}/complete",
+        adapter._handle_kanban_complete_task,
+    )
+    app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
+    return app
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Pin the kanban root to a per-test tmpdir.
+
+    The kanban subsystem walks ``HERMES_KANBAN_HOME`` first, so this
+    fixture is the single source of truth. We also wipe the
+    connection cache on the way out so test order can't leak state."""
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    # Force a fresh connection on the first call by clearing the
+    # module-level path cache that kanban_db keeps.
+    try:
+        from hermes_cli import kanban_db
+        kanban_db._INITIALIZED_PATHS.clear()
+    except (ImportError, AttributeError):
+        pass
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Boards
+# ---------------------------------------------------------------------------
+
+
+class TestKanbanBoards:
+    @pytest.mark.asyncio
+    async def test_list_boards_includes_default(self, kanban_home):
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/kanban/boards")
+            assert resp.status == 200
+            body = await resp.json()
+        slugs = [b.get("slug") for b in body["boards"]]
+        assert "default" in slugs
+
+    @pytest.mark.asyncio
+    async def test_create_board_then_appears_in_list(self, kanban_home):
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/api/kanban/boards",
+                json={"slug": "marketing", "name": "Marketing"},
+            )
+            assert resp.status == 200
+            created = await resp.json()
+            assert created["board"]["slug"] == "marketing"
+
+            resp = await cli.get("/api/kanban/boards")
+            body = await resp.json()
+        slugs = [b.get("slug") for b in body["boards"]]
+        assert "marketing" in slugs
+
+    @pytest.mark.asyncio
+    async def test_create_board_requires_slug(self, kanban_home):
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/api/kanban/boards", json={})
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_delete_board_archives_by_default(self, kanban_home):
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            await cli.post(
+                "/api/kanban/boards", json={"slug": "throwaway"}
+            )
+            resp = await cli.delete("/api/kanban/boards/throwaway")
+            assert resp.status == 200
+            body = await resp.json()
+        assert body["action"] == "archived"
+        assert body["slug"] == "throwaway"
+
+    @pytest.mark.asyncio
+    async def test_delete_default_board_is_rejected(self, kanban_home):
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.delete("/api/kanban/boards/default")
+            assert resp.status == 400
+
+
+# ---------------------------------------------------------------------------
+# Tasks
+# ---------------------------------------------------------------------------
+
+
+class TestKanbanTasks:
+    @pytest.mark.asyncio
+    async def test_create_task_returns_serialised_task(self, kanban_home):
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/api/kanban/tasks",
+                json={"title": "Plan PR-3 follow-up", "priority": 2},
+            )
+            assert resp.status == 200
+            body = await resp.json()
+        task = body["task"]
+        assert task["title"] == "Plan PR-3 follow-up"
+        assert task["priority"] == 2
+        assert task["status"] in ("ready", "todo")
+        assert task["id"].startswith("t_")
+
+    @pytest.mark.asyncio
+    async def test_create_task_requires_title(self, kanban_home):
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/api/kanban/tasks", json={"title": ""})
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_list_tasks_returns_created_task(self, kanban_home):
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            await cli.post("/api/kanban/tasks", json={"title": "alpha"})
+            await cli.post("/api/kanban/tasks", json={"title": "beta"})
+            resp = await cli.get("/api/kanban/tasks")
+            assert resp.status == 200
+            body = await resp.json()
+        titles = sorted(t["title"] for t in body["tasks"])
+        assert titles == ["alpha", "beta"]
+
+    @pytest.mark.asyncio
+    async def test_archive_task_then_excluded_from_list(self, kanban_home):
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/api/kanban/tasks", json={"title": "to be archived"}
+            )
+            task_id = (await resp.json())["task"]["id"]
+
+            resp = await cli.delete(f"/api/kanban/tasks/{task_id}")
+            assert resp.status == 200
+
+            resp = await cli.get("/api/kanban/tasks")
+            body = await resp.json()
+        assert all(t["id"] != task_id for t in body["tasks"])
+
+    @pytest.mark.asyncio
+    async def test_complete_task_transitions_to_done(self, kanban_home):
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/api/kanban/tasks", json={"title": "to be completed"}
+            )
+            task_id = (await resp.json())["task"]["id"]
+
+            resp = await cli.post(
+                f"/api/kanban/tasks/{task_id}/complete",
+                json={"result": "all good"},
+            )
+            assert resp.status == 200
+            body = await resp.json()
+        assert body["task"]["status"] == "done"
+        assert body["task"]["result"] == "all good"
+
+    @pytest.mark.asyncio
+    async def test_complete_nonexistent_task_is_404(self, kanban_home):
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/api/kanban/tasks/t_doesnotexist00/complete", json={}
+            )
+            assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_idempotency_key_header_dedupes_create(self, kanban_home):
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            r1 = await cli.post(
+                "/api/kanban/tasks",
+                json={"title": "idempo"},
+                headers={"Idempotency-Key": "abc123"},
+            )
+            r2 = await cli.post(
+                "/api/kanban/tasks",
+                json={"title": "idempo"},
+                headers={"Idempotency-Key": "abc123"},
+            )
+            t1 = (await r1.json())["task"]["id"]
+            t2 = (await r2.json())["task"]["id"]
+        assert t1 == t2
+
+
+# ---------------------------------------------------------------------------
+# Auth + capabilities
+# ---------------------------------------------------------------------------
+
+
+class TestKanbanAuth:
+    @pytest.mark.asyncio
+    async def test_endpoints_require_auth_when_key_configured(
+        self, kanban_home
+    ):
+        app = _create_app(_make_adapter(api_key="sk-secret"))
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/kanban/boards")
+            assert resp.status == 401
+            resp = await cli.get(
+                "/api/kanban/boards",
+                headers={"Authorization": "Bearer sk-secret"},
+            )
+            assert resp.status == 200
+
+
+class TestCapabilitiesAdvertisesKanban:
+    @pytest.mark.asyncio
+    async def test_capabilities_lists_kanban_endpoints(self, kanban_home):
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/capabilities")
+            body = await resp.json()
+        assert body["features"]["remote_kanban"] is True
+        endpoints = body["endpoints"]
+        assert endpoints["kanban_boards"]["path"] == "/api/kanban/boards"
+        assert endpoints["kanban_tasks"]["path"] == "/api/kanban/tasks"
+        assert (
+            endpoints["kanban_task_complete"]["path"]
+            == "/api/kanban/tasks/{task_id}/complete"
+        )

--- a/tests/gateway/test_api_server_management.py
+++ b/tests/gateway/test_api_server_management.py
@@ -1,0 +1,173 @@
+"""Tests for remote management endpoints on the API server adapter."""
+
+from pathlib import Path
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter, cors_middleware
+from hermes_state import SessionDB
+
+
+def _make_adapter(api_key: str = "") -> APIServerAdapter:
+    extra = {"key": api_key} if api_key else {}
+    return APIServerAdapter(PlatformConfig(enabled=True, extra=extra))
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application(middlewares=[cors_middleware])
+    app["api_server_adapter"] = adapter
+    app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
+    app.router.add_get("/api/memory", adapter._handle_read_memory)
+    app.router.add_post("/api/memory/entries", adapter._handle_add_memory_entry)
+    app.router.add_put("/api/memory/entries/{index}", adapter._handle_update_memory_entry)
+    app.router.add_delete("/api/memory/entries/{index}", adapter._handle_delete_memory_entry)
+    app.router.add_put("/api/memory/user", adapter._handle_write_user_profile)
+    app.router.add_get("/api/sessions", adapter._handle_list_sessions)
+    app.router.add_get("/api/sessions/search", adapter._handle_search_sessions)
+    app.router.add_get("/api/skills/content", adapter._handle_skill_content)
+    return app
+
+
+class TestCapabilities:
+    @pytest.mark.asyncio
+    async def test_capabilities_advertise_remote_management(self):
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/capabilities")
+            assert resp.status == 200
+            data = await resp.json()
+
+        assert data["features"]["remote_sessions"] is True
+        assert data["features"]["remote_profiles"] is True
+        assert data["features"]["remote_memory"] is True
+        assert data["features"]["remote_persona"] is True
+        assert data["features"]["remote_skills"] is True
+        assert data["features"]["remote_toolsets"] is True
+        assert data["endpoints"]["sessions"]["path"] == "/api/sessions"
+        assert data["endpoints"]["profile_soul"]["path"] == "/api/profiles/{name}/soul"
+
+
+class TestSessionsApi:
+    @pytest.mark.asyncio
+    async def test_list_sessions_can_filter_by_source(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        db = SessionDB(tmp_path / "state.db")
+        try:
+            db.create_session("api-session", "api_server", model="gpt-test")
+            db.append_message("api-session", "user", "desktop chat")
+            db.create_session("cron-session", "cron", model="gpt-test")
+            db.append_message("cron-session", "user", "background job")
+        finally:
+            db.close()
+
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/sessions", params={"source": "api_server"})
+            assert resp.status == 200
+            data = await resp.json()
+
+        assert [session["id"] for session in data["sessions"]] == ["api-session"]
+        assert data["sessions"][0]["source"] == "api_server"
+
+    @pytest.mark.asyncio
+    async def test_search_sessions_can_filter_by_source(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        db = SessionDB(tmp_path / "state.db")
+        try:
+            db.create_session("api-session", "api_server", model="gpt-test")
+            db.append_message("api-session", "user", "find unique desktop phrase")
+            db.create_session("cron-session", "cron", model="gpt-test")
+            db.append_message("cron-session", "user", "find unique cron phrase")
+        finally:
+            db.close()
+
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get(
+                "/api/sessions/search",
+                params={"q": "unique", "source": "api_server"},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+
+        assert [result["session_id"] for result in data["results"]] == ["api-session"]
+
+
+class TestMemoryApi:
+    @pytest.mark.asyncio
+    async def test_memory_read_and_edit_roundtrip(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        app = _create_app(_make_adapter())
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/api/memory/entries", json={"content": "first fact"})
+            assert resp.status == 200
+            resp = await cli.post("/api/memory/entries", json={"content": "second fact"})
+            assert resp.status == 200
+
+            resp = await cli.get("/api/memory")
+            assert resp.status == 200
+            data = await resp.json()
+            assert [entry["content"] for entry in data["memory"]["entries"]] == [
+                "first fact",
+                "second fact",
+            ]
+
+            resp = await cli.put("/api/memory/entries/0", json={"content": "updated fact"})
+            assert resp.status == 200
+            resp = await cli.delete("/api/memory/entries/1")
+            assert resp.status == 200
+            resp = await cli.put("/api/memory/user", json={"content": "user profile"})
+            assert resp.status == 200
+
+            resp = await cli.get("/api/memory")
+            assert resp.status == 200
+            data = await resp.json()
+
+        assert [entry["content"] for entry in data["memory"]["entries"]] == ["updated fact"]
+        assert data["user"]["content"] == "user profile"
+
+    @pytest.mark.asyncio
+    async def test_memory_requires_auth_when_api_key_configured(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        app = _create_app(_make_adapter(api_key="sk-secret"))
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/memory")
+            assert resp.status == 401
+            resp = await cli.get("/api/memory", headers={"Authorization": "Bearer sk-secret"})
+            assert resp.status == 200
+
+
+class TestSkillContentApi:
+    @pytest.mark.asyncio
+    async def test_skill_content_rejects_paths_outside_skill_roots(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        outside = tmp_path / "not-a-skill"
+        outside.mkdir()
+        (outside / "SKILL.md").write_text("secret", encoding="utf-8")
+        app = _create_app(_make_adapter())
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/skills/content", params={"path": str(outside)})
+            assert resp.status == 403
+
+    @pytest.mark.asyncio
+    async def test_skill_content_reads_installed_skill(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        skill_dir = hermes_home / "skills" / "productivity" / "focus"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\nname: focus\n---\nBody", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        app = _create_app(_make_adapter())
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/skills/content", params={"path": str(skill_dir)})
+            assert resp.status == 200
+            data = await resp.json()
+
+        assert data["content"].startswith("---")
+        assert Path(data["path"]) == skill_dir

--- a/tests/gateway/test_api_server_providers.py
+++ b/tests/gateway/test_api_server_providers.py
@@ -1,0 +1,208 @@
+"""
+Tests for the /api/providers read-only inventory endpoint.
+
+The endpoint reports which LLM providers are configured for the
+current profile (env-var or config.yaml) and which one is the
+currently-selected model.provider. **It never returns the API
+keys themselves.**
+
+Coverage:
+
+* Unit: ``_list_provider_status`` helper across the three
+  detection layers (env var, yaml providers map, active
+  model.provider).
+* Integration: HTTP responses, auth gate, and a regression
+  guard asserting no fixture API key appears in the response.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import (
+    APIServerAdapter,
+    _list_provider_status,
+    cors_middleware,
+)
+
+
+# ---------------------------------------------------------------------------
+# Module-level — _list_provider_status
+# ---------------------------------------------------------------------------
+
+
+class TestListProviderStatusViaEnv:
+    def test_env_with_filled_api_key_marks_provider_configured(self, tmp_path):
+        (tmp_path / ".env").write_text(
+            "ANTHROPIC_API_KEY=sk-test-anthropic\n", encoding="utf-8"
+        )
+        providers, active = _list_provider_status(tmp_path)
+        by_key = {p["key"]: p for p in providers}
+        assert by_key["anthropic"]["configured"] is True
+        assert active is None
+
+    def test_env_with_empty_value_does_not_mark_configured(self, tmp_path):
+        (tmp_path / ".env").write_text("OPENAI_API_KEY=\n", encoding="utf-8")
+        providers, _ = _list_provider_status(tmp_path)
+        by_key = {p["key"]: p for p in providers}
+        assert by_key["openai"]["configured"] is False
+
+    def test_dashed_provider_name_matches_underscored_env_var(self, tmp_path):
+        # openai-codex should be detected by OPENAI_CODEX_API_KEY
+        (tmp_path / ".env").write_text(
+            "OPENAI_CODEX_API_KEY=sk-codex\n", encoding="utf-8"
+        )
+        providers, _ = _list_provider_status(tmp_path)
+        by_key = {p["key"]: p for p in providers}
+        assert by_key["openai-codex"]["configured"] is True
+
+    def test_missing_env_file_yields_no_configured_providers(self, tmp_path):
+        providers, active = _list_provider_status(tmp_path)
+        # All known providers come back with configured=False
+        assert all(p["configured"] is False for p in providers)
+        assert active is None
+
+
+class TestListProviderStatusViaConfigYaml:
+    def test_yaml_providers_map_marks_configured(self, tmp_path):
+        (tmp_path / "config.yaml").write_text(
+            "providers:\n  anthropic:\n    base_url: https://api.anthropic.com\n",
+            encoding="utf-8",
+        )
+        providers, active = _list_provider_status(tmp_path)
+        by_key = {p["key"]: p for p in providers}
+        assert by_key["anthropic"]["configured"] is True
+        assert active is None  # providers map alone doesn't mark active
+
+    def test_yaml_model_provider_marks_active_and_configured(self, tmp_path):
+        (tmp_path / "config.yaml").write_text(
+            "model:\n  provider: openai-codex\n  default: gpt-5.5\n",
+            encoding="utf-8",
+        )
+        providers, active = _list_provider_status(tmp_path)
+        by_key = {p["key"]: p for p in providers}
+        assert active == "openai-codex"
+        assert by_key["openai-codex"]["configured"] is True
+        assert by_key["openai-codex"]["active"] is True
+        # Other known providers stay inactive / unconfigured
+        assert by_key["anthropic"]["active"] is False
+        assert by_key["anthropic"]["configured"] is False
+
+    def test_unknown_provider_in_yaml_is_appended(self, tmp_path):
+        (tmp_path / "config.yaml").write_text(
+            "providers:\n  my-custom-thing:\n    base_url: x\n",
+            encoding="utf-8",
+        )
+        providers, _ = _list_provider_status(tmp_path)
+        keys = [p["key"] for p in providers]
+        assert "my-custom-thing" in keys
+
+    def test_malformed_yaml_does_not_crash_resolver(self, tmp_path):
+        (tmp_path / "config.yaml").write_text(
+            "this is not :: valid yaml [", encoding="utf-8"
+        )
+        # Should silently return the known-providers list with no
+        # configured entries, rather than raising.
+        providers, active = _list_provider_status(tmp_path)
+        assert isinstance(providers, list)
+        assert active is None
+
+
+class TestListProviderStatusNoKeyLeakage:
+    def test_response_payload_never_echoes_api_key_value(self, tmp_path):
+        secret = "sk-FIXTURE-DO-NOT-LEAK-7m4p"
+        (tmp_path / ".env").write_text(
+            f"ANTHROPIC_API_KEY={secret}\nOPENAI_API_KEY={secret}-v2\n",
+            encoding="utf-8",
+        )
+        providers, _ = _list_provider_status(tmp_path)
+        flat = repr(providers)
+        assert secret not in flat, (
+            "API key fixture leaked into the providers listing"
+        )
+
+
+# ---------------------------------------------------------------------------
+# HTTP integration
+# ---------------------------------------------------------------------------
+
+
+def _make_adapter(api_key: str = "") -> APIServerAdapter:
+    extra: Dict[str, Any] = {"key": api_key} if api_key else {}
+    return APIServerAdapter(PlatformConfig(enabled=True, extra=extra))
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application(middlewares=[cors_middleware])
+    app["api_server_adapter"] = adapter
+    app.router.add_get("/api/providers", adapter._handle_list_providers)
+    app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
+    return app
+
+
+class TestProvidersEndpoint:
+    @pytest.mark.asyncio
+    async def test_response_shape(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "model:\n  provider: openai-codex\n", encoding="utf-8"
+        )
+
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/providers")
+            assert resp.status == 200
+            body = await resp.json()
+
+        assert "providers" in body
+        assert "active" in body
+        assert body["active"] == "openai-codex"
+
+        # Each entry has the documented fields, nothing more.
+        for entry in body["providers"]:
+            assert set(entry.keys()) == {"key", "label", "configured", "active"}
+
+    @pytest.mark.asyncio
+    async def test_requires_auth_when_key_configured(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        app = _create_app(_make_adapter(api_key="sk-secret"))
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/providers")
+            assert resp.status == 401
+            resp = await cli.get(
+                "/api/providers", headers={"Authorization": "Bearer sk-secret"}
+            )
+            assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_response_never_contains_real_api_key(self, tmp_path, monkeypatch):
+        secret = "sk-CANARY-providers-test-99zz"
+        (tmp_path / ".env").write_text(
+            f"ANTHROPIC_API_KEY={secret}\n", encoding="utf-8"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/providers")
+            raw = await resp.text()
+
+        assert secret not in raw, "API key leaked into HTTP response body"
+
+
+class TestCapabilitiesAdvertisesProviders:
+    @pytest.mark.asyncio
+    async def test_capabilities_lists_providers_endpoint(self):
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/capabilities")
+            body = await resp.json()
+
+        assert body["features"]["remote_providers"] is True
+        assert body["endpoints"]["providers"]["path"] == "/api/providers"
+        assert body["endpoints"]["providers"]["method"] == "GET"

--- a/tests/gateway/test_api_server_recent_events.py
+++ b/tests/gateway/test_api_server_recent_events.py
@@ -1,0 +1,287 @@
+"""
+Tests for the /api/events/recent read-only endpoint.
+
+The endpoint synthesises structural session lifecycle events
+from the persisted sessions table — ``session.start`` and
+``session.end`` — and returns them newest-first. It carries
+only structural metadata (id, source, model, timestamp, plus
+end-time aggregates). Message bodies, system prompts and tool
+output are deliberately absent.
+
+Coverage:
+
+* Unit: ``_read_recent_events`` plus the two ISO/epoch helpers
+  across happy and degenerate paths.
+* Integration: HTTP responses, auth gate, query-param plumbing,
+  and a regression guard asserting no system-prompt content
+  appears in the response.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any, Dict
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import (
+    APIServerAdapter,
+    _epoch_to_iso,
+    _parse_iso_to_epoch,
+    _read_recent_events,
+    cors_middleware,
+)
+from hermes_state import SessionDB
+
+
+def _make_adapter(api_key: str = "") -> APIServerAdapter:
+    extra: Dict[str, Any] = {"key": api_key} if api_key else {}
+    return APIServerAdapter(PlatformConfig(enabled=True, extra=extra))
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application(middlewares=[cors_middleware])
+    app["api_server_adapter"] = adapter
+    app.router.add_get("/api/events/recent", adapter._handle_recent_events)
+    app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
+    return app
+
+
+def _seed_sessions(db_path, *, with_system_prompt: bool = False) -> None:
+    """Create three sessions with a mix of ended and live state."""
+    db = SessionDB(db_path)
+    try:
+        db.create_session("s-old", "cli", model="claude-opus-4.6")
+        if with_system_prompt:
+            db.update_system_prompt(
+                "s-old",
+                "SECRET_PROMPT_CANARY_dragon_42 — full identity block here.",
+            )
+        db.end_session("s-old", "user_exit")
+
+        db.create_session("s-mid", "api_server", model="gpt-5.5")
+        db.end_session("s-mid", "completed")
+
+        # Live session — only session.start should be emitted.
+        db.create_session("s-live", "cron", model="claude-opus-4.6")
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Module-level — ISO/epoch helpers
+# ---------------------------------------------------------------------------
+
+
+class TestIsoEpochHelpers:
+    def test_parse_iso_accepts_z_suffix(self):
+        epoch = _parse_iso_to_epoch("2026-01-01T00:00:00Z")
+        assert epoch is not None
+        assert isinstance(epoch, float)
+
+    def test_parse_iso_accepts_explicit_offset(self):
+        epoch = _parse_iso_to_epoch("2026-01-01T00:00:00+00:00")
+        assert epoch is not None
+
+    def test_parse_iso_returns_none_for_none(self):
+        assert _parse_iso_to_epoch(None) is None
+
+    def test_parse_iso_returns_none_for_malformed(self):
+        assert _parse_iso_to_epoch("not-a-timestamp") is None
+
+    def test_epoch_to_iso_round_trips_via_parse(self):
+        epoch = _parse_iso_to_epoch("2026-05-23T12:34:56Z")
+        iso = _epoch_to_iso(epoch)
+        assert iso is not None
+        # Should be ISO with Z suffix.
+        assert iso.endswith("Z")
+        # Should re-parse to (approximately) the same epoch.
+        assert _parse_iso_to_epoch(iso) == pytest.approx(epoch, abs=0.001)
+
+    def test_epoch_to_iso_returns_none_for_none(self):
+        assert _epoch_to_iso(None) is None
+
+
+# ---------------------------------------------------------------------------
+# Module-level — _read_recent_events
+# ---------------------------------------------------------------------------
+
+
+class TestReadRecentEvents:
+    def test_empty_db_returns_empty_list(self, tmp_path):
+        db_path = tmp_path / "state.db"
+        SessionDB(db_path).close()  # create empty schema
+        out = _read_recent_events(db_path)
+        assert out == []
+
+    def test_each_session_yields_start_event(self, tmp_path):
+        db_path = tmp_path / "state.db"
+        _seed_sessions(db_path)
+        out = _read_recent_events(db_path, limit=100)
+        starts = [e for e in out if e["type"] == "session.start"]
+        ids = {e["session_id"] for e in starts}
+        assert {"s-old", "s-mid", "s-live"} <= ids
+
+    def test_ended_sessions_yield_end_event_with_metadata(self, tmp_path):
+        db_path = tmp_path / "state.db"
+        _seed_sessions(db_path)
+        out = _read_recent_events(db_path, limit=100)
+        ends = {e["session_id"]: e for e in out if e["type"] == "session.end"}
+        assert "s-old" in ends
+        assert "s-mid" in ends
+        # Live session must NOT have an end event.
+        assert "s-live" not in ends
+        meta = ends["s-old"]["metadata"]
+        assert meta["end_reason"] == "user_exit"
+        assert "message_count" in meta
+        assert "tool_call_count" in meta
+        assert "duration_seconds" in meta
+
+    def test_events_are_newest_first(self, tmp_path):
+        db_path = tmp_path / "state.db"
+        _seed_sessions(db_path)
+        out = _read_recent_events(db_path, limit=100)
+        timestamps = [e["timestamp"] for e in out if e["timestamp"]]
+        assert timestamps == sorted(timestamps, reverse=True)
+
+    def test_limit_caps_result(self, tmp_path):
+        db_path = tmp_path / "state.db"
+        _seed_sessions(db_path)
+        out = _read_recent_events(db_path, limit=2)
+        assert len(out) == 2
+
+    def test_since_filters_older_events(self, tmp_path):
+        db_path = tmp_path / "state.db"
+        _seed_sessions(db_path)
+        # Future timestamp filters everything out.
+        out = _read_recent_events(
+            db_path, limit=100, since_iso="9999-01-01T00:00:00Z"
+        )
+        assert out == []
+
+    def test_missing_columns_yield_empty_not_error(self, tmp_path):
+        """Legacy DB without one of the expected columns must
+        degrade gracefully — empty list rather than 500."""
+        db_path = tmp_path / "legacy.db"
+        with sqlite3.connect(str(db_path)) as conn:
+            conn.execute(
+                "CREATE TABLE sessions (id TEXT, started_at REAL)"
+            )
+        out = _read_recent_events(db_path)
+        assert out == []
+
+    def test_payload_never_includes_system_prompt(self, tmp_path):
+        """Regression guard: even when sessions carry a populated
+        ``system_prompt``, the synthesised event stream must not
+        expose any of it."""
+        db_path = tmp_path / "state.db"
+        _seed_sessions(db_path, with_system_prompt=True)
+        out = _read_recent_events(db_path, limit=100)
+        flat = repr(out)
+        assert "SECRET_PROMPT_CANARY_dragon_42" not in flat
+        # No key called ``system_prompt`` at any depth either.
+        for event in out:
+            assert "system_prompt" not in event
+            assert "system_prompt" not in event.get("metadata", {})
+
+
+# ---------------------------------------------------------------------------
+# HTTP integration
+# ---------------------------------------------------------------------------
+
+
+class TestRecentEventsEndpoint:
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_db_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/events/recent")
+            assert resp.status == 200
+            body = await resp.json()
+        assert body == {"events": [], "limit": 50}
+
+    @pytest.mark.asyncio
+    async def test_returns_events_when_db_present(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_sessions(tmp_path / "state.db")
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/events/recent")
+            assert resp.status == 200
+            body = await resp.json()
+        assert body["limit"] == 50
+        assert len(body["events"]) >= 3  # 3 starts + 2 ends = 5
+        # Each event has the documented top-level shape.
+        for ev in body["events"]:
+            assert ev["type"] in ("session.start", "session.end")
+            assert "timestamp" in ev
+            assert "session_id" in ev
+            assert "source" in ev
+            assert "model" in ev
+
+    @pytest.mark.asyncio
+    async def test_requires_auth_when_key_configured(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        app = _create_app(_make_adapter(api_key="sk-secret"))
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/events/recent")
+            assert resp.status == 401
+            resp = await cli.get(
+                "/api/events/recent",
+                headers={"Authorization": "Bearer sk-secret"},
+            )
+            assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_limit_param_propagates(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_sessions(tmp_path / "state.db")
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/events/recent", params={"limit": "2"})
+            body = await resp.json()
+        assert body["limit"] == 2
+        assert len(body["events"]) <= 2
+
+    @pytest.mark.asyncio
+    async def test_since_param_filters(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_sessions(tmp_path / "state.db")
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get(
+                "/api/events/recent",
+                params={"since": "9999-01-01T00:00:00Z"},
+            )
+            body = await resp.json()
+        assert body["events"] == []
+
+    @pytest.mark.asyncio
+    async def test_response_never_contains_system_prompt(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_sessions(tmp_path / "state.db", with_system_prompt=True)
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/events/recent")
+            raw = await resp.text()
+        assert "SECRET_PROMPT_CANARY_dragon_42" not in raw, (
+            "system_prompt content leaked into events response"
+        )
+
+
+class TestCapabilitiesAdvertisesRecentEvents:
+    @pytest.mark.asyncio
+    async def test_capabilities_lists_recent_events_endpoint(self):
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/capabilities")
+            body = await resp.json()
+        assert body["features"]["remote_recent_events"] is True
+        assert body["endpoints"]["recent_events"]["path"] == "/api/events/recent"
+        assert body["endpoints"]["recent_events"]["method"] == "GET"

--- a/tests/gateway/test_api_server_usage_summary.py
+++ b/tests/gateway/test_api_server_usage_summary.py
@@ -1,0 +1,196 @@
+"""
+Tests for the /api/usage/summary read-only aggregate endpoint.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any, Dict
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import (
+    APIServerAdapter,
+    _read_usage_summary,
+    cors_middleware,
+)
+from hermes_state import SessionDB
+
+
+def _make_adapter(api_key: str = "") -> APIServerAdapter:
+    extra: Dict[str, Any] = {"key": api_key} if api_key else {}
+    return APIServerAdapter(PlatformConfig(enabled=True, extra=extra))
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application(middlewares=[cors_middleware])
+    app["api_server_adapter"] = adapter
+    app.router.add_get("/api/usage/summary", adapter._handle_usage_summary)
+    return app
+
+
+def _seed_sessions(db_path):
+    """Create a few sessions with realistic token counts."""
+    db = SessionDB(db_path)
+    try:
+        db.create_session("s1", "cli", model="claude-opus-4.6")
+        db.update_token_counts(
+            "s1",
+            input_tokens=1000,
+            output_tokens=500,
+            cache_read_tokens=200,
+            cache_write_tokens=50,
+            estimated_cost_usd=0.05,
+        )
+        db.create_session("s2", "cli", model="claude-opus-4.6")
+        db.update_token_counts(
+            "s2",
+            input_tokens=2000,
+            output_tokens=800,
+        )
+        db.create_session("s3", "api_server", model="gpt-5.5")
+        db.update_token_counts(
+            "s3",
+            input_tokens=500,
+            output_tokens=200,
+            estimated_cost_usd=0.02,
+        )
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Module-level — _read_usage_summary
+# ---------------------------------------------------------------------------
+
+
+class TestReadUsageSummary:
+    def test_empty_db_returns_zero_totals(self, tmp_path):
+        db_path = tmp_path / "state.db"
+        SessionDB(db_path).close()  # create empty DB
+        out = _read_usage_summary(db_path)
+        assert out["tokens"] == {
+            "input": 0,
+            "output": 0,
+            "cache_read": 0,
+            "cache_write": 0,
+        }
+        assert out["estimated_cost_usd"] is None
+        assert out["by_model"] == []
+
+    def test_aggregates_token_totals(self, tmp_path):
+        db_path = tmp_path / "state.db"
+        _seed_sessions(db_path)
+        out = _read_usage_summary(db_path)
+        # s1 + s2 + s3
+        assert out["tokens"]["input"] == 1000 + 2000 + 500
+        assert out["tokens"]["output"] == 500 + 800 + 200
+        assert out["tokens"]["cache_read"] == 200
+        assert out["tokens"]["cache_write"] == 50
+
+    def test_aggregates_cost_when_present(self, tmp_path):
+        db_path = tmp_path / "state.db"
+        _seed_sessions(db_path)
+        out = _read_usage_summary(db_path)
+        # s1 (0.05) + s3 (0.02) = 0.07; s2 had no cost.
+        assert out["estimated_cost_usd"] == pytest.approx(0.07)
+
+    def test_by_model_breakdown_ordered_by_tokens(self, tmp_path):
+        db_path = tmp_path / "state.db"
+        _seed_sessions(db_path)
+        out = _read_usage_summary(db_path)
+        models = {row["model_id"]: row for row in out["by_model"]}
+        assert "claude-opus-4.6" in models
+        assert "gpt-5.5" in models
+        # claude has more total tokens (s1+s2 = 4300) vs gpt-5.5 (700)
+        ordered = [row["model_id"] for row in out["by_model"]]
+        assert ordered.index("claude-opus-4.6") < ordered.index("gpt-5.5")
+
+    def test_since_window_filters_older_sessions(self, tmp_path):
+        db_path = tmp_path / "state.db"
+        _seed_sessions(db_path)
+        # Use a far-future timestamp; should match nothing.
+        out = _read_usage_summary(db_path, since_iso="9999-01-01T00:00:00Z")
+        assert out["tokens"] == {
+            "input": 0,
+            "output": 0,
+            "cache_read": 0,
+            "cache_write": 0,
+        }
+
+    def test_missing_columns_yield_empty_summary_not_error(self, tmp_path):
+        """If a legacy DB is missing one of the cache_* columns, the
+        endpoint must degrade gracefully to zeros rather than 500."""
+        db_path = tmp_path / "legacy.db"
+        with sqlite3.connect(str(db_path)) as conn:
+            conn.execute(
+                "CREATE TABLE sessions (id TEXT, model TEXT, started_at TEXT)"
+            )
+        out = _read_usage_summary(db_path)
+        assert out["tokens"] == {
+            "input": 0,
+            "output": 0,
+            "cache_read": 0,
+            "cache_write": 0,
+        }
+        assert out["estimated_cost_usd"] is None
+
+
+# ---------------------------------------------------------------------------
+# HTTP integration
+# ---------------------------------------------------------------------------
+
+
+class TestUsageSummaryEndpoint:
+    @pytest.mark.asyncio
+    async def test_returns_zero_when_db_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/usage/summary")
+            assert resp.status == 200
+            body = await resp.json()
+        assert body["tokens"] == {
+            "input": 0,
+            "output": 0,
+            "cache_read": 0,
+            "cache_write": 0,
+        }
+        assert body["by_model"] == []
+
+    @pytest.mark.asyncio
+    async def test_returns_aggregated_data_when_db_present(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_sessions(tmp_path / "state.db")
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/usage/summary")
+            body = await resp.json()
+        assert body["tokens"]["input"] == 3500
+        assert body["tokens"]["output"] == 1500
+        assert len(body["by_model"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_requires_auth_when_key_configured(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        app = _create_app(_make_adapter(api_key="sk-secret"))
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/usage/summary")
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_since_param_propagates_to_helper(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _seed_sessions(tmp_path / "state.db")
+        app = _create_app(_make_adapter())
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get(
+                "/api/usage/summary",
+                params={"since": "9999-01-01T00:00:00Z"},
+            )
+            body = await resp.json()
+        # Future timestamp filters out everything.
+        assert body["tokens"]["input"] == 0


### PR DESCRIPTION
## Read-only API add-ons (providers / usage / events) + Kanban CRUD

### Why

The Remote Management API in #23742 covers sessions, profiles,
persona, memory, tools, skills, and gateway status. Three
read-only dashboard concerns plus Kanban CRUD are still missing:

| Concern | Today | This PR |
|---|---|---|
| Which providers does this backend have configured? | not exposed | `GET /api/providers` |
| Token + cost aggregates over a window | not exposed | `GET /api/usage/summary` |
| Recent activity (sessions started, tools called, errors) | not exposed | `GET /api/events/recent` |
| Kanban CRUD for project-board UIs | CLI-only (`hermes kanban …`) | `GET/POST /api/kanban/*` |

All four ship under the same Bearer-token auth the rest of the
Remote API uses. The three read endpoints have no write side; the
Kanban surface is the full create / delete / complete flow with
`Idempotency-Key` support.

### Endpoints

#### `GET /api/providers`

Inventory of LLM providers the active profile has configured.
Two detection layers:

1. `.env` file — `<NAME>_API_KEY=<non-empty>` ⇒ `configured: true`
2. `config.yaml` — any key under `providers:` ⇒ `configured: true`;
   plus `model.provider` flagged with `active: true`

```jsonc
{
  "active": "anthropic",
  "providers": [
    {"key": "nous",       "label": "Nous",       "configured": true,  "active": false},
    {"key": "anthropic",  "label": "Anthropic",  "configured": true,  "active": true},
    {"key": "openrouter", "label": "Openrouter", "configured": false, "active": false},
    // … 12 more keys covering the known provider set
  ]
}
```

**API keys themselves never appear in the response** — only the
boolean configured/active flags. The handler reads `.env` for
presence-detection only and never forwards the value.

Optional `?profile=<name>` scopes to a specific profile's
`.env` + `config.yaml` (same `_resolve_profile_dir` validation
as everywhere else).

#### `GET /api/usage/summary`

Aggregate token + cost summary read from the gateway's session
database. Windowed via optional `?since=<ISO8601>`; omitted ⇒
all-time.

```jsonc
{
  "since": "2026-05-17T00:00:00Z",
  "total_input_tokens":  4_823_115,
  "total_output_tokens":   612_408,
  "total_cost_usd":          12.847,
  "by_model": [
    {"model": "anthropic/claude-opus-4.6", "input_tokens": …, "output_tokens": …, "cost_usd": …},
    // …
  ]
}
```

No per-session detail (those live in `/api/sessions`); this is a
header-card endpoint for a usage panel.

#### `GET /api/events/recent`

Newest-first list of structural session events synthesised from
the gateway's persisted session DB (`state.db` `sessions` table).
Two event types emitted:

- `session.start` — one per session row, carrying `timestamp`,
  `session_id`, `source`, `model`.
- `session.end` — emitted only when the session has terminated,
  with `timestamp`, `session_id`, `source`, `model`, plus
  `end_reason`, `message_count`, `tool_call_count`, and
  `duration` (seconds).

Each entry is a structural summary — **no** message body, **no**
system prompt, **no** tool output.

```jsonc
{
  "events": [
    {
      "type": "session.start",
      "timestamp": "2026-05-23T18:42:11Z",
      "session_id": "abc-…",
      "source": "telegram",
      "model": "anthropic/claude-opus-4.6"
    },
    {
      "type": "session.end",
      "timestamp": "2026-05-23T18:45:33Z",
      "session_id": "abc-…",
      "source": "telegram",
      "model": "anthropic/claude-opus-4.6",
      "end_reason": "user_quit",
      "message_count": 12,
      "tool_call_count": 4,
      "duration": 202.4
    }
    // …
  ],
  "limit": 50
}
```

Query params:
- `?limit=N` (default 50, max 200) — newest-first cap
- `?since=<ISO-8601>` — events older than this timestamp are
  filtered out

Because the events are projected from the persistent session DB,
the feed survives gateway restarts. Legacy DBs missing columns
yield an empty list rather than 500 (degraded-OK fallback).

#### Kanban CRUD — `/api/kanban/*`

Drop-in HTTP layer over the existing `hermes kanban` CLI:

| Verb | Path | Action |
|---|---|---|
| `GET` | `/api/kanban/boards` | list boards |
| `POST` | `/api/kanban/boards` | create board (`Idempotency-Key` honoured) |
| `DELETE` | `/api/kanban/boards/{slug}` | delete board |
| `GET` | `/api/kanban/tasks` | list tasks (optional `?board=`) |
| `POST` | `/api/kanban/tasks` | create task (`Idempotency-Key` honoured) |
| `DELETE` | `/api/kanban/tasks/{task_id}` | archive task |
| `POST` | `/api/kanban/tasks/{task_id}/complete` | mark task complete |

`Idempotency-Key` header on the create endpoints lets a flaky
network retry without producing duplicate boards / tasks. The
dedupe is **persistent**: the key is stored on the created
board/task row in the Kanban DB; subsequent POSTs with the
same key return the existing row's `id`.

**Same key, different body**: first write wins. The handler
returns the existing row even if the second POST carries a
different `title` / `body` / other fields — there is no body-
fingerprint validation and no 409. This is the documented
behaviour of `hermes_cli.kanban_db.create_task` /
`create_board` and is shared with the kanban CLI. Clients that
need stricter semantics should generate a fresh key on
content-change.

The Kanban subsystem is an optional dependency. When it's not
importable (older deployment, slimmed install), the endpoints
return 503 with a clear `error` body instead of 500, and the
matching capabilities flag (`features.remote_kanban`) is
`false`.

### `/v1/capabilities` and `/api/gateway/status` integration

Two complementary discovery surfaces, no competing-truth:

| Surface | Question it answers |
|---|---|
| `/v1/capabilities.features.remote_*` + `.endpoints.{…}` | "What protocol / endpoint shape does this backend advertise?" |
| `/api/gateway/status.subsystem_capabilities` | "Which subsystems did the runtime actually load?" |

This PR updates both:

- **`/v1/capabilities`** picks up three coarse-grained feature
  flags (`remote_providers`, `remote_usage_summary`,
  `remote_kanban`) plus endpoint-map entries for **all four**
  new paths (`providers_list`, `usage_summary`, `recent_events`,
  `kanban_boards`/`kanban_tasks`/`kanban_task_complete`). Events
  intentionally only gets the endpoint-map entry, not a
  category-level feature flag — it's a thin structural-summary
  projection over the existing session DB, not a stateful
  subsystem like Kanban.
- **`/api/gateway/status.subsystem_capabilities`** — the
  forward-compat hook reserved by the depends-on PR #31125 is now
  populated with this PR's runtime subsystems: `providers`,
  `usage`, `events`, and `kanban` (conditional on
  `_KANBAN_AVAILABLE`).

Clients use `subsystem_capabilities` to decide whether the
matching tab is backed by a loaded runtime; they use
`/v1/capabilities` to discover the exact endpoint shape.

### Files

- **`gateway/platforms/api_server.py`** — four new handlers + the
  helper functions they depend on (provider inventory, session-DB
  event projection, usage-DB aggregation, Kanban-CLI bridge),
  plus the capabilities + status integration described above.
- **`tests/gateway/test_api_server_providers.py`** (new) — 13 tests
- **`tests/gateway/test_api_server_usage_summary.py`** (new) — 10 tests
- **`tests/gateway/test_api_server_recent_events.py`** (new) — 21 tests
- **`tests/gateway/test_api_server_kanban.py`** (new) — 14 tests
- **`tests/gateway/test_api_server_gateway_status.py`** (touched) —
  added `TestSubsystemCapabilities` class (3 tests) and relaxed the
  pre-existing shape assertion on `subsystem_capabilities`

PR-own delta (excluding rebased-in #31125 commits):
5 commits, 6 files, +1831 / -9.

### Tests

61 tests, all new in this PR (across the four endpoint files + the
three-test `TestSubsystemCapabilities` class on the gateway-status
file). Coverage highlights:

**Providers (13)** — env-only / yaml-only / both / neither, active-
provider extraction from `model.provider`, profile scoping, no
API-key value ever leaked, auth.

**Usage summary (10)** — empty DB, single-session DB, multi-model
aggregation, `?since=` cutoff, cost-rounding stability, auth.

**Recent events (21)** — `_parse_iso_to_epoch` helper variants
(Z suffix, explicit offset, None, malformed), newest-first
ordering, `?limit=` cap, `?since=` ISO cutoff, empty DB,
missing DB, missing columns degraded-OK, payload never contains
`system_prompt`, `/v1/capabilities` advertises the
`recent_events` endpoint, auth.

**Kanban (14)** — happy-path CRUD, `Idempotency-Key` dedupes
duplicate POSTs (regression-guard against retry-storms), missing-
dependency 503 (vs 500), complete is idempotent on already-complete
tasks, `/v1/capabilities` advertises the kanban endpoint map +
`features.remote_kanban`, auth.

**Subsystem capabilities (3)** — the three unconditional
subsystems (`providers`, `usage`, `events`) always present, kanban
presence tracks `_KANBAN_AVAILABLE` exactly, drift-guard that the
list contains no keys outside the known runtime set.

Total: 74 tests passing in the affected files. PR-own
contribution: 61 tests (13 providers + 10 usage + 21 events + 14
kanban + 3 subsystem-capabilities). PR #31125 contributes 13
tests; of those, one (`test_response_includes_new_runtime_fields`)
has its `subsystem_capabilities == []` assertion relaxed by this
PR's 5th commit to a shape check, with the detailed coverage
moving into the new `TestSubsystemCapabilities` class.

### Acceptance criteria

Verifiable against any backend running this branch:

```bash
TOKEN=…

# 1. /api/providers carries no API key values
curl -sH "Authorization: Bearer $TOKEN" $URL/api/providers \
  | jq '.providers[] | {key, configured, active}'
# → list of objects with bool flags only; no string field carries
#   anything resembling a key

# 2. /api/usage/summary aggregates the session DB
curl -sH "Authorization: Bearer $TOKEN" "$URL/api/usage/summary?since=2026-05-17T00:00:00Z" \
  | jq '{total_input_tokens, total_output_tokens, total_cost_usd}'

# 3. /api/events/recent returns a structural feed (no message body)
curl -sH "Authorization: Bearer $TOKEN" "$URL/api/events/recent?limit=10" \
  | jq '[.events[] | select(.type=="session.start")] | .[0] | keys'
# → ["model", "session_id", "source", "timestamp", "type"]
#   (session.end rows additionally include end_reason,
#    message_count, tool_call_count, duration; explicit select
#    above filters to start so the key set is deterministic)

# 4. Kanban CRUD round-trip
curl -sH "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
     -H 'Idempotency-Key: abc-123' \
     -X POST "$URL/api/kanban/boards" -d '{"name":"Demo"}'
# → 200 first call; 200 with same body second call (deduped)

# 5. Subsystem discovery: runtime list AND protocol-shape
curl -sH "Authorization: Bearer $TOKEN" $URL/api/gateway/status \
  | jq .subsystem_capabilities
# → ["providers", "usage", "events", "kanban"]   (last only if available)

curl -sH "Authorization: Bearer $TOKEN" $URL/v1/capabilities \
  | jq '.features | {remote_providers, remote_usage_summary, remote_kanban}'
# → remote_providers=true, remote_usage_summary=true,
#   remote_kanban tracks _KANBAN_AVAILABLE
```

### Non-goals

- No mutations on `/api/providers`. The endpoint is read-only;
  changing provider credentials is a separate (more sensitive)
  PR.
- No per-session cost detail in `/api/usage/summary`. Granular
  detail belongs on the existing `/api/sessions/{id}` shape, not
  on the aggregate.
- No live event stream. `GET /api/events/recent` polls a
  newest-first projection over the persisted session DB; a
  WebSocket / SSE channel for live events is a separate
  transport-layer PR.
- No Kanban-specific auth scopes. Same Bearer as the rest of the
  Remote API.
- No coupling to the sanitiser PR (#31568). None of the new
  endpoints ship identity content. `/api/providers` deliberately
  carries only boolean flags; `/api/events/recent` ships
  structural summaries with no message body; `/api/usage/summary`
  aggregates counters only. The sanitiser sits on a different set
  of endpoints (`/api/memory`, `/api/sessions`,
  `/api/sessions/{id}/messages`) and is orthogonal here.

### Depends on

- **`#23742`** — Remote Management API foundation
- **PR #31125** (gateway-status-enrich) — reserved the
  `subsystem_capabilities` hook on `/api/gateway/status` that this
  PR populates

This branch is rebased onto #31125 so the commit chain stacks
cleanly. **#31125 must merge first**; then this branch should
be rebased onto the new base, at which point the PR-own diff
shrinks to its 5 commits.

### Commit chain (PR-own, on top of #31125)

1. `feat(api): add GET /api/providers read-only inventory endpoint`
2. `feat(api): add GET /api/usage/summary aggregate endpoint`
3. `feat(api): add GET /api/events/recent activity-feed endpoint`
4. `feat(api): add /api/kanban/* CRUD endpoints (boards + tasks)`
5. `feat(api): populate subsystem_capabilities with this PR's subsystems`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
