### PR TITLE
config: add shutdown_notification as backward-compatible alias for gateway_restart_notification

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -325,10 +325,16 @@ class PlatformConfig:
         # gateway_restart_notification may be bridged into extra via the
         # shared-key loop in load_gateway_config(); check both top-level
         # and extra so YAML ``discord: gateway_restart_notification: false``
-        # works without needing a separate platforms: block.
+        # works without needing a separate platforms: block.  Older local
+        # configs used ``shutdown_notification`` for the same lifecycle-notice
+        # suppression intent, so treat it as a backward-compatible alias.
         _grn = data.get("gateway_restart_notification")
         if _grn is None:
             _grn = data.get("extra", {}).get("gateway_restart_notification")
+        if _grn is None:
+            _grn = data.get("shutdown_notification")
+        if _grn is None:
+            _grn = data.get("extra", {}).get("shutdown_notification")
 
         return cls(
             enabled=_coerce_bool(data.get("enabled"), False),
@@ -870,6 +876,8 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = channel_prompts
                 if "gateway_restart_notification" in platform_cfg:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
+                elif "shutdown_notification" in platform_cfg:
+                    bridged["gateway_restart_notification"] = platform_cfg["shutdown_notification"]
                 enabled_was_explicit = "enabled" in platform_cfg
                 if not bridged and not enabled_was_explicit:
                     continue

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -70,6 +70,14 @@ class TestPlatformConfigRoundtrip:
         restored = PlatformConfig.from_dict({"gateway_restart_notification": "false"})
         assert restored.gateway_restart_notification is False
 
+    def test_shutdown_notification_alias_suppresses_lifecycle_notices(self):
+        restored = PlatformConfig.from_dict({"shutdown_notification": False})
+        assert restored.gateway_restart_notification is False
+
+    def test_shutdown_notification_alias_in_extra_suppresses_lifecycle_notices(self):
+        restored = PlatformConfig.from_dict({"extra": {"shutdown_notification": "false"}})
+        assert restored.gateway_restart_notification is False
+
 
 class TestGetConnectedPlatforms:
     def test_returns_enabled_with_token(self):
@@ -323,6 +331,23 @@ class TestLoadGatewayConfig:
         load_gateway_config()
 
         assert os.environ.get("DISCORD_THREAD_REQUIRE_MENTION") == "true"
+
+    def test_bridges_discord_shutdown_notification_alias_from_config_yaml(self, tmp_path, monkeypatch):
+        """discord.shutdown_notification=false should suppress lifecycle pings."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  shutdown_notification: false\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.DISCORD].gateway_restart_notification is False
 
     def test_thread_require_mention_yaml_does_not_overwrite_env(self, tmp_path, monkeypatch):
         """Explicit env var should win over config.yaml (env > yaml precedence)."""


### PR DESCRIPTION
## Problem

Some older local configurations use `shutdown_notification` for the same lifecycle-notice suppression that `gateway_restart_notification` provides. These configs silently fail.

## Solution

Add `shutdown_notification` as a fallback alias in `PlatformConfig.from_dict()` and bridge it in `load_gateway_config()`. The canonical key remains `gateway_restart_notification`; this alias exists only for backward compatibility.

## Tests

3 new tests covering the alias in direct config, in `extra`, and via YAML bridge.

## Stats

`2 files changed, 34 insertions(+), 1 deletion(-)`