### PR TITLE
feat: add Janitor cleanup plugin

### DIFF
--- a/plugins/janitor/__init__.py
+++ b/plugins/janitor/__init__.py
@@ -1,0 +1,43 @@
+"""Janitor plugin for Hermes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Optional
+
+from . import cli as janitor_cli
+from . import core
+from . import tools as janitor_tools
+
+
+def _skill_path() -> Path:
+    return Path(__file__).resolve().parent / "skill" / "SKILL.md"
+
+
+def _session_injection(*, messages: Any = None, conversation_history: Any = None, user_message: Any = None, **_: Any) -> Optional[str]:
+    if not core.wants_injection(messages=messages, conversation_history=conversation_history, user_message=user_message):
+        return None
+    return core.build_injection()
+
+
+def register(ctx) -> None:
+    janitor_tools.register_toolset(ctx)
+    ctx.register_hook("pre_llm_call", _session_injection)
+    ctx.register_cli_command(
+        name="janitor",
+        help="Run senior-engineer cleanup workflows and daily repo janitor automation",
+        setup_fn=janitor_cli.register_cli,
+        handler_fn=lambda args: janitor_cli.dispatch_namespace(args, emit="print")[0],
+        description="Hermes-native Janitor workflow for codebase cleanup, TDD proof gates, and daily GitHub repository sweeps.",
+    )
+    ctx.register_command(
+        "janitor",
+        handler=janitor_cli.handle_slash,
+        description="Janitor workflow: /janitor start|review|story|run|proof|status|reset|daily-prompt",
+        args_hint="start|review|story|run|proof|status|reset|daily-prompt",
+    )
+    ctx.register_skill(
+        name="workflow",
+        path=_skill_path(),
+        description="Use Janitor cleanup workflows, TDD proof gates, and daily repository PR automation inside Hermes.",
+    )

--- a/plugins/janitor/cli.py
+++ b/plugins/janitor/cli.py
@@ -1,0 +1,124 @@
+"""CLI and slash command handling for Janitor."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+
+from . import core
+
+
+def build_parser(parser: argparse.ArgumentParser | None = None) -> argparse.ArgumentParser:
+    parser = parser or argparse.ArgumentParser(prog="hermes janitor", description="Run Janitor cleanup workflows")
+    sub = parser.add_subparsers(dest="action")
+
+    start = sub.add_parser("start", aliases=["janitor"], help="start senior-engineer slop-code cleanup")
+    start.add_argument("goal", nargs="*", help="cleanup goal")
+    start.add_argument("--goal", dest="goal_opt", help="cleanup goal")
+    start.add_argument("--path", "--codebase-path", dest="codebase_path", default="")
+    start.add_argument("--symptoms", action="append", default=[])
+    start.add_argument("--constraints", action="append", default=[])
+    start.add_argument("--rewrite-policy", default="first-principles-when-needed")
+
+    review = sub.add_parser("review", help="apply the senior-engineer janitor scorecard")
+    review.add_argument("notes", nargs="*", help="review notes or plan summary")
+    review.add_argument("--evidence", action="append", default=[])
+    review.add_argument("--notes", dest="notes_opt", help="review notes or plan summary")
+
+    story = sub.add_parser("story", help="add a story")
+    story.add_argument("title", nargs="*", help="story title")
+    story.add_argument("--title", dest="title_opt", help="story title")
+    story.add_argument("--acceptance", action="append", default=[])
+    story.add_argument("--notes", default="")
+    story.add_argument("--priority", default="normal")
+
+    run = sub.add_parser("run", help="prepare execution handoffs")
+    run.add_argument("--parallelism", type=int, default=1)
+    run.add_argument("--story-ids", default="")
+
+    proof = sub.add_parser("proof", help="record proof evidence")
+    proof.add_argument("--evidence", action="append", default=[])
+    proof.add_argument("--test", "--tests", dest="tests", action="append", default=[])
+    proof.add_argument("--file", "--files", dest="files", action="append", default=[])
+    proof.add_argument("--story-id", default="")
+
+    daily = sub.add_parser("daily-prompt", help="print the daily GitHub Janitor cron prompt")
+    daily.add_argument("--owner", default="crisweber2600")
+    daily.add_argument("--lookback-hours", type=int, default=24)
+    daily.add_argument("--schedule", default="0 9 * * *")
+
+    sub.add_parser("status", help="show status")
+    sub.add_parser("reset", help="reset state")
+    return parser
+
+
+def dispatch_namespace(args: argparse.Namespace, *, emit: str = "print") -> tuple[int, str]:
+    action = args.action or "status"
+    if action in {"start", "janitor"}:
+        goal = args.goal_opt or " ".join(args.goal)
+        result = core.janitor(
+            goal=goal,
+            codebase_path=args.codebase_path,
+            symptoms=args.symptoms,
+            constraints=args.constraints,
+            rewrite_policy=args.rewrite_policy,
+        )
+    elif action == "review":
+        notes = args.notes_opt or " ".join(args.notes)
+        result = core.janitor_review(evidence=args.evidence, notes=notes)
+    elif action == "story":
+        title = args.title_opt or " ".join(args.title)
+        result = core.add_story(title=title, acceptance=args.acceptance, notes=args.notes, priority=args.priority)
+    elif action == "run":
+        result = core.prepare_run(parallelism=args.parallelism, story_ids=args.story_ids)
+    elif action == "proof":
+        result = core.record_proof(evidence=args.evidence, tests=args.tests, files=args.files, story_id=args.story_id)
+    elif action == "daily-prompt":
+        result = core.daily_prompt(owner=args.owner, lookback_hours=args.lookback_hours, schedule=args.schedule)
+    elif action == "reset":
+        result = core.reset()
+    else:
+        result = core.status()
+
+    if action == "status":
+        text = core.format_status(result)
+    else:
+        text = json.dumps(result, ensure_ascii=False, indent=2)
+    if emit == "print":
+        print(text)
+    return (0 if result.get("ok") else 1), text
+
+
+def register_cli(parser) -> None:
+    build_parser(parser)
+
+
+def handle_slash(raw_args: str) -> str:
+    action, args = core.parse_slash(raw_args)
+    if action in {"status", ""}:
+        return core.format_status(core.status())
+    if action in {"start", "janitor"}:
+        result = core.janitor(
+            goal=args.get("goal") or args.get("text") or "",
+            codebase_path=args.get("path") or args.get("codebase_path") or "",
+            symptoms=args.get("symptoms", ""),
+            constraints=args.get("constraints", ""),
+            rewrite_policy=args.get("rewrite_policy", "first-principles-when-needed"),
+        )
+    elif action == "review":
+        result = core.janitor_review(evidence=args.get("evidence", ""), notes=args.get("notes") or args.get("text") or "")
+    elif action == "story":
+        title = args.get("title") or args.get("text") or ""
+        result = core.add_story(title=title, acceptance=args.get("acceptance", ""), notes=args.get("notes", ""), priority=args.get("priority", "normal"))
+    elif action == "run":
+        result = core.prepare_run(parallelism=args.get("parallelism", 1), story_ids=args.get("story_ids", ""))
+    elif action == "proof":
+        result = core.record_proof(evidence=args.get("evidence", ""), tests=args.get("test") or args.get("tests") or "", files=args.get("file") or args.get("files") or "", story_id=args.get("story_id", ""))
+    elif action == "daily-prompt":
+        result = core.daily_prompt(owner=args.get("owner", "crisweber2600"), lookback_hours=args.get("lookback_hours", 24), schedule=args.get("schedule", "0 9 * * *"))
+    elif action == "reset":
+        result = core.reset()
+    else:
+        return "Unknown Janitor action. Use: /janitor start|review|story|run|proof|status|reset|daily-prompt"
+    return json.dumps(result, ensure_ascii=False, indent=2)

--- a/plugins/janitor/core.py
+++ b/plugins/janitor/core.py
@@ -1,0 +1,504 @@
+"""Core state machine for the Janitor plugin."""
+
+from __future__ import annotations
+
+import json
+import shlex
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+TRACKS = {"quick", "method", "enterprise", "cleanup"}
+
+SENIOR_ENGINEER_BENCHMARK_SOURCE = {
+    "transcript": "Lenny's Podcast with Dan Shipper, 'The AI paradox: More automation, more humans, more work'",
+    "article": "Every, 'Vibe Check: GPT-5.5 Has It All'",
+    "benchmark_frame": "Rewrite a slop-coded codebase the way a senior engineer would, rather than blindly fixing the reported issue list.",
+    "key_observation": "Senior engineers reframe: they inspect the codebase, identify unsalvageable architecture, preserve contracts, and push for a risky-but-necessary rewrite when patches only create more failures.",
+}
+
+CLEANUP_RUBRIC = [
+    "Diagnose the real failure modes before editing: reproduce symptoms, inspect logs, map data/control flow, and identify root causes.",
+    "Preserve product behavior and external contracts unless the story explicitly changes them.",
+    "Prefer a senior-engineer rewrite from first principles when the architecture is fundamentally wrong; do not paper over slop with edge patches.",
+    "Delete accidental complexity, dead code, duplicated abstractions, and speculative framework glue.",
+    "Introduce characterization tests or probes before risky rewrites, then regression tests for the new design.",
+    "Keep changes reviewable: stage the rewrite behind clear seams and explain tradeoffs, migrations, and rollback paths.",
+    "Require proof stronger than 'it runs': tests, lint/type checks, representative logs/traces, diff review, and residual-risk notes.",
+]
+
+CLEANUP_SCORECARD = [
+    {
+        "name": "frame_control",
+        "weight": 20,
+        "standard": "Does not obey the narrow bug list blindly; independently decides whether the right job is root-cause cleanup, subsystem rewrite, or targeted patch.",
+    },
+    {
+        "name": "system_understanding",
+        "weight": 15,
+        "standard": "Maps data flow, lifecycle, failure modes, ownership boundaries, and hidden coupling before changing code.",
+    },
+    {
+        "name": "invariant_preservation",
+        "weight": 15,
+        "standard": "Captures public API, UX, data, migration, security, and operational invariants with characterization tests/probes.",
+    },
+    {
+        "name": "first_principles_design",
+        "weight": 20,
+        "standard": "Replaces accidental architecture with a simpler design when warranted; deletes slop instead of wrapping it.",
+    },
+    {
+        "name": "execution_depth",
+        "weight": 15,
+        "standard": "Carries the rewrite through production-relevant seams, migrations, and call sites instead of stopping at a cosmetic patch.",
+    },
+    {
+        "name": "proof_and_operability",
+        "weight": 15,
+        "standard": "Proves the cleanup with tests, lint/type checks, logs/traces, load/error-path evidence, rollback notes, and residual-risk review.",
+    },
+]
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def state_dir() -> Path:
+    path = get_hermes_home() / "plugins" / "janitor"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def state_file() -> Path:
+    return state_dir() / "state.json"
+
+
+def default_state() -> dict[str, Any]:
+    return {
+        "active": False,
+        "track": None,
+        "goal": "",
+        "constraints": [],
+        "phases": [],
+        "stories": [],
+        "runs": [],
+        "proof": [],
+        "rubric": [],
+        "scorecard": [],
+        "specialization": None,
+        "created_at": None,
+        "updated_at": None,
+    }
+
+
+def load_state() -> dict[str, Any]:
+    path = state_file()
+    if not path.exists():
+        return default_state()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        state = default_state()
+        state.update(data if isinstance(data, dict) else {})
+        return state
+    except Exception:
+        corrupt = path.with_suffix(f".corrupt-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}.json")
+        path.replace(corrupt)
+        state = default_state()
+        state["warning"] = f"Previous state was unreadable and moved to {corrupt}"
+        return state
+
+
+def save_state(state: dict[str, Any]) -> dict[str, Any]:
+    state = dict(state)
+    state["updated_at"] = _now()
+    state_file().write_text(json.dumps(state, indent=2, sort_keys=True), encoding="utf-8")
+    return state
+
+
+def _split_csv(value: str | list[str] | None) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(x).strip() for x in value if str(x).strip()]
+    return [part.strip() for part in str(value).replace("\n", ",").split(",") if part.strip()]
+
+
+def plan(goal: str, track: str = "method", constraints: str | list[str] | None = None) -> dict[str, Any]:
+    goal = (goal or "").strip()
+    if not goal:
+        return {"ok": False, "error": "goal is required"}
+    track = (track or "method").strip().lower()
+    if track not in TRACKS:
+        return {"ok": False, "error": f"track must be one of {sorted(TRACKS)}"}
+    phases = _phases_for(track)
+    state = default_state()
+    state.update(
+        {
+            "active": True,
+            "track": track,
+            "goal": goal,
+            "constraints": _split_csv(constraints),
+            "phases": phases,
+            "created_at": _now(),
+        }
+    )
+    state = save_state(state)
+    return {
+        "ok": True,
+        "state": state,
+        "next": "Create acceptance-testable cleanup stories with janitor_story or /janitor story.",
+    }
+
+
+def janitor(
+    goal: str,
+    codebase_path: str = "",
+    symptoms: str | list[str] | None = None,
+    constraints: str | list[str] | None = None,
+    rewrite_policy: str = "first-principles-when-needed",
+) -> dict[str, Any]:
+    """Start a senior-engineer cleanup workflow for slop/vibe-coded codebases."""
+    goal = (goal or "Clean up a slop-coded codebase to senior-engineer quality").strip()
+    state = default_state()
+    symptom_list = _split_csv(symptoms)
+    constraint_list = _split_csv(constraints)
+    path = (codebase_path or "").strip()
+    if path:
+        constraint_list.insert(0, f"codebase_path={path}")
+    if rewrite_policy:
+        constraint_list.append(f"rewrite_policy={rewrite_policy.strip()}")
+    state.update(
+        {
+            "active": True,
+            "track": "cleanup",
+            "goal": goal,
+            "constraints": constraint_list,
+            "phases": _phases_for("cleanup"),
+            "rubric": CLEANUP_RUBRIC,
+            "scorecard": CLEANUP_SCORECARD,
+            "specialization": "senior-engineer-janitor",
+            "diagnosis": {
+                "codebase_path": path,
+                "symptoms": symptom_list,
+                "rewrite_policy": rewrite_policy,
+                "benchmark_source": SENIOR_ENGINEER_BENCHMARK_SOURCE,
+            },
+            "created_at": _now(),
+        }
+    )
+    state = save_state(state)
+    return {
+        "ok": True,
+        "state": state,
+        "next": "Run codebase reconnaissance, capture invariants, then create cleanup stories with characterization and regression proof requirements.",
+        "rubric": CLEANUP_RUBRIC,
+        "scorecard": CLEANUP_SCORECARD,
+    }
+
+
+def janitor_review(evidence: str | list[str] | None = None, notes: str = "") -> dict[str, Any]:
+    """Return the senior-engineer cleanup scorecard for reviewing a proposed or completed cleanup."""
+    evidence_list = _split_csv(evidence)
+    state = load_state()
+    scorecard = state.get("scorecard") or CLEANUP_SCORECARD
+    review = {
+        "source": SENIOR_ENGINEER_BENCHMARK_SOURCE,
+        "scorecard": scorecard,
+        "evidence": evidence_list,
+        "notes": (notes or "").strip(),
+        "review_questions": [
+            "Did we reframe the problem from reported symptoms to root causes?",
+            "What contracts and invariants were captured before risky edits?",
+            "Which code or abstractions were deleted rather than patched around?",
+            "Where did we rewrite from first principles, and why was that safer than incremental patching?",
+            "What proof demonstrates the service is more stable, simpler, and operable than before?",
+            "What residual risks, migrations, or rollback paths remain?",
+        ],
+        "pass_standard": "A cleanup passes only when the evidence addresses every scorecard dimension; missing proof is a blocker, not a caveat.",
+    }
+    state.setdefault("janitor_reviews", []).append({**review, "created_at": _now()})
+    save_state(state)
+    return {"ok": True, "review": review, "state": state}
+
+
+def daily_prompt(owner: str = "crisweber2600", lookback_hours: int = 24, schedule: str = "0 9 * * *") -> dict[str, Any]:
+    """Return the self-contained prompt for the daily GitHub Janitor sweep.
+
+    The prompt deliberately treats charge data as the primary filter while
+    providing a documented GitHub activity fallback, because ordinary GitHub
+    repo APIs expose recent pushes/commits but not always per-repository
+    billing charge events to the agent.
+    """
+    owner = (owner or "crisweber2600").strip()
+    try:
+        lookback_hours = max(1, int(lookback_hours))
+    except Exception:
+        lookback_hours = 24
+    schedule = (schedule or "0 9 * * *").strip()
+    prompt = f"""Run the Janitor workflow for GitHub owner {owner}.
+
+Scope:
+- Consider every repository owned by {owner}.
+- Target repositories that had charges in the past {lookback_hours} hours. If direct per-repository charge data is unavailable from the authenticated GitHub/account APIs, explicitly say so in the run summary and use repositories with commits, pushes, workflow runs, or other billable-looking activity in the past {lookback_hours} hours as the fallback.
+
+For each target repository:
+1. Create or update a local scratch clone. Never mix changes across repositories.
+2. Inspect the recent activity that qualified the repository, then run Janitor triage: identify slop-code, brittle abstractions, failing tests, dead code, or small cleanup opportunities.
+3. Use strict TDD RED-GREEN-REFACTOR development:
+   - RED: write or update a focused failing test/characterization check first and run it to prove it fails for the expected reason.
+   - GREEN: make the smallest senior-engineer cleanup that passes the test.
+   - REFACTOR: simplify only while tests remain green.
+4. If no safe cleanup is found, leave the repository untouched and report why.
+5. If changes are made, create a branch named janitor/YYYYMMDD-<short-topic>, commit only that repository's cleanup, push it, and open a pull request.
+6. The pull request body must explain what changed, why it was worth doing, why the cleanup is safe, the RED/GREEN/REFACTOR evidence, tests run, and residual risks.
+
+Safety and proof requirements:
+- Do not expose secrets. Do not commit generated credentials, local env files, or unrelated files.
+- Prefer small reviewable PRs over broad rewrites.
+- Run repository-native tests for touched areas and include commands/results in each PR.
+- If a repo has existing unrelated dirty state, skip it or isolate a fresh clone.
+
+Final response: list targeted repos, skipped repos and reasons, PR URLs opened, tests run, and any repos where charge data was unavailable and activity fallback was used.
+"""
+    return {"ok": True, "owner": owner, "lookback_hours": lookback_hours, "schedule": schedule, "prompt": prompt}
+
+
+def _phases_for(track: str) -> list[dict[str, Any]]:
+    if track == "cleanup":
+        return [
+            {"name": "triage", "required": True, "status": "pending"},
+            {"name": "invariants", "required": True, "status": "pending"},
+            {"name": "target-architecture", "required": True, "status": "pending"},
+            {"name": "cleanup-stories", "required": True, "status": "pending"},
+            {"name": "rewrite-or-refactor", "required": True, "status": "pending"},
+            {"name": "regression-proof", "required": True, "status": "pending"},
+        ]
+    if track == "quick":
+        return [
+            {"name": "tech-spec", "required": True, "status": "pending"},
+            {"name": "stories", "required": True, "status": "pending"},
+            {"name": "implementation", "required": True, "status": "pending"},
+            {"name": "proof", "required": True, "status": "pending"},
+        ]
+    phases = [
+        {"name": "analysis", "required": False, "status": "pending"},
+        {"name": "prd", "required": True, "status": "pending"},
+        {"name": "architecture", "required": True, "status": "pending"},
+        {"name": "stories", "required": True, "status": "pending"},
+        {"name": "implementation", "required": True, "status": "pending"},
+        {"name": "proof", "required": True, "status": "pending"},
+    ]
+    if track == "enterprise":
+        phases.insert(3, {"name": "security-devops", "required": True, "status": "pending"})
+    return phases
+
+
+def add_story(title: str, acceptance: str | list[str] | None = None, notes: str = "", priority: str = "normal") -> dict[str, Any]:
+    title = (title or "").strip()
+    if not title:
+        return {"ok": False, "error": "title is required"}
+    criteria = _split_csv(acceptance)
+    if not criteria:
+        return {"ok": False, "error": "at least one acceptance criterion is required"}
+    state = load_state()
+    if not state.get("active"):
+        state.update({"active": True, "track": "method", "goal": "Ad-hoc Janitor workflow", "created_at": _now(), "phases": _phases_for("method")})
+    story = {
+        "id": f"S{len(state.get('stories', [])) + 1}",
+        "title": title,
+        "acceptance": criteria,
+        "notes": (notes or "").strip(),
+        "priority": (priority or "normal").strip(),
+        "status": "ready",
+        "proof": [],
+        "created_at": _now(),
+    }
+    state.setdefault("stories", []).append(story)
+    _mark_phase(state, "stories", "in_progress")
+    _mark_phase(state, "cleanup-stories", "in_progress")
+    save_state(state)
+    return {"ok": True, "story": story, "state": state}
+
+
+def prepare_run(parallelism: int = 1, story_ids: list[str] | str | None = None) -> dict[str, Any]:
+    state = load_state()
+    stories = state.get("stories", [])
+    wanted = set(_split_csv(story_ids))
+    selected = [s for s in stories if not wanted or s.get("id") in wanted]
+    if not selected:
+        return {"ok": False, "error": "no stories available for run"}
+    try:
+        parallelism = max(1, int(parallelism))
+    except Exception:
+        parallelism = 1
+    handoffs = [_handoff_for(state, s) for s in selected]
+    run = {"id": f"R{len(state.get('runs', [])) + 1}", "parallelism": parallelism, "story_ids": [s["id"] for s in selected], "created_at": _now()}
+    state.setdefault("runs", []).append(run)
+    _mark_phase(state, "implementation", "in_progress")
+    _mark_phase(state, "rewrite-or-refactor", "in_progress")
+    save_state(state)
+    return {"ok": True, "run": run, "handoffs": handoffs, "state": state}
+
+
+def _handoff_for(state: dict[str, Any], story: dict[str, Any]) -> str:
+    criteria = "\n".join(f"- {c}" for c in story.get("acceptance", []))
+    base = (
+        f"Janitor story {story.get('id')}: {story.get('title')}\n"
+        f"Goal: {state.get('goal')}\n"
+        f"Track: {state.get('track')}\n"
+        f"Acceptance criteria:\n{criteria}\n"
+        "Proof required: include files changed, tests/logs/traces inspected, and residual risks."
+    )
+    if state.get("track") != "cleanup":
+        return base
+    rubric = "\n".join(f"- {item}" for item in state.get("rubric") or CLEANUP_RUBRIC)
+    scorecard = "\n".join(
+        f"- {item['name']} ({item['weight']} pts): {item['standard']}"
+        for item in (state.get("scorecard") or CLEANUP_SCORECARD)
+    )
+    diagnosis = state.get("diagnosis") or {}
+    symptoms = "\n".join(f"- {item}" for item in diagnosis.get("symptoms", [])) or "- not yet captured"
+    return (
+        f"{base}\n\n"
+        "Senior-engineer janitor discipline:\n"
+        f"Symptoms to explain:\n{symptoms}\n"
+        f"Rewrite policy: {diagnosis.get('rewrite_policy') or 'first-principles-when-needed'}\n"
+        "Cleanup rubric:\n"
+        f"{rubric}\n"
+        "Senior Engineer Benchmark scorecard:\n"
+        f"{scorecard}\n"
+        "Do not merely paper over failing edges. If the design is unsalvageable, isolate stable contracts and rewrite the subsystem from first principles with characterization tests first."
+    )
+
+
+def record_proof(evidence: str | list[str] | None = None, tests: str | list[str] | None = None, files: str | list[str] | None = None, story_id: str = "") -> dict[str, Any]:
+    evidence_list = _split_csv(evidence)
+    test_list = _split_csv(tests)
+    file_list = _split_csv(files)
+    if not (evidence_list or test_list or file_list):
+        return {"ok": False, "error": "proof requires evidence, tests, or files"}
+    state = load_state()
+    entry = {"story_id": story_id.strip(), "evidence": evidence_list, "tests": test_list, "files": file_list, "created_at": _now()}
+    state.setdefault("proof", []).append(entry)
+    if entry["story_id"]:
+        for story in state.get("stories", []):
+            if story.get("id") == entry["story_id"]:
+                story.setdefault("proof", []).append(entry)
+                story["status"] = "proved"
+    if state.get("proof"):
+        _mark_phase(state, "proof", "complete")
+        _mark_phase(state, "regression-proof", "complete")
+    save_state(state)
+    return {"ok": True, "proof": entry, "complete": proof_gate(state), "state": state}
+
+
+def proof_gate(state: dict[str, Any] | None = None) -> bool:
+    state = state or load_state()
+    stories = state.get("stories", [])
+    if stories:
+        return all(s.get("proof") for s in stories)
+    return bool(state.get("proof"))
+
+
+def status() -> dict[str, Any]:
+    state = load_state()
+    return {"ok": True, "state": state, "proof_gate": proof_gate(state), "state_file": str(state_file())}
+
+
+def reset() -> dict[str, Any]:
+    path = state_file()
+    if path.exists():
+        path.unlink()
+    return {"ok": True, "state": default_state()}
+
+
+def _mark_phase(state: dict[str, Any], name: str, status_value: str) -> None:
+    for phase in state.get("phases", []):
+        if phase.get("name") == name:
+            phase["status"] = status_value
+
+
+def wants_injection(*, messages: Any = None, conversation_history: Any = None, user_message: Any = None, **_: Any) -> bool:
+    text = ""
+    for item in (user_message,):
+        if isinstance(item, dict):
+            text += " " + str(item.get("content", ""))
+        elif item is not None:
+            text += " " + str(item)
+    if not text and messages:
+        try:
+            last = messages[-1]
+            if isinstance(last, dict):
+                text = str(last.get("content", ""))
+        except Exception:
+            pass
+    lowered = text.lower()
+    return any(
+        trigger in lowered
+        for trigger in (
+            "vibe coded",
+            "vibe-coded",
+            "slop code",
+            "slop-coded",
+            "slop coded",
+            "slopcode",
+            "senior engineer benchmark",
+            "senior-engineer benchmark",
+            "first principles rewrite",
+            "rewrite from first principles",
+            "janitor",
+        )
+    )
+
+
+def build_injection() -> str:
+    return (
+        "Janitor plugin is available. For code cleanup, use the Janitor state machine: "
+        "janitor_start -> janitor_story -> janitor_run -> janitor_proof -> janitor_status. "
+        "For vibe-coded/slop-code cleanup, start with janitor_start or /janitor start: diagnose root causes, preserve contracts, rewrite from first principles when needed, and demand regression proof. "
+        "Use janitor_review to apply the Senior Engineer Benchmark scorecard before declaring cleanup success. "
+        "Follow strict TDD: RED failing characterization/regression tests, GREEN minimal cleanup, REFACTOR after proof."
+    )
+
+
+def format_status(result: dict[str, Any] | None = None) -> str:
+    result = result or status()
+    state = result.get("state", {})
+    lines = ["Janitor status"]
+    lines.append(f"active: {state.get('active')}")
+    lines.append(f"track: {state.get('track') or 'none'}")
+    lines.append(f"goal: {state.get('goal') or 'none'}")
+    lines.append(f"stories: {len(state.get('stories', []))}")
+    lines.append(f"runs: {len(state.get('runs', []))}")
+    lines.append(f"proof entries: {len(state.get('proof', []))}")
+    lines.append(f"proof gate: {'passed' if result.get('proof_gate') else 'pending'}")
+    return "\n".join(lines)
+
+
+def parse_slash(raw_args: str) -> tuple[str, dict[str, Any]]:
+    parts = shlex.split(raw_args or "")
+    if not parts:
+        return "status", {}
+    action, rest = parts[0], parts[1:]
+    args: dict[str, Any] = {}
+    key = None
+    positionals = []
+    for token in rest:
+        if token.startswith("--"):
+            key = token[2:].replace("-", "_")
+            args.setdefault(key, [])
+        elif key:
+            args[key].append(token)
+            key = None
+        else:
+            positionals.append(token)
+    for k, v in list(args.items()):
+        args[k] = " ".join(v) if isinstance(v, list) else v
+    if positionals:
+        args.setdefault("text", " ".join(positionals))
+    return action, args

--- a/plugins/janitor/docs/llms-full-summary.md
+++ b/plugins/janitor/docs/llms-full-summary.md
@@ -1,0 +1,25 @@
+# Janitor reference summary
+
+Source inspiration: https://docs.bmad-method.org/llms-full.txt plus Senior Engineer Benchmark janitor-mode cleanup discipline.
+
+Janitor is a Hermes-native cleanup workflow for brittle, vibe-coded, slop-coded, or over-automated codebases. It preserves the useful BMAD idea of progressive context and story/proof gates, but the user-facing product is named Janitor and focuses on senior-engineer cleanup with strict TDD.
+
+## Core phases
+
+1. Triage: reproduce symptoms, inspect logs, map data/control flow, and identify real root causes.
+2. Invariants: capture public API, UX, data, migration, security, and operational contracts before risky edits.
+3. Target architecture: decide whether the right fix is a targeted patch, subsystem refactor, or first-principles rewrite.
+4. Cleanup stories: create small acceptance-testable stories with explicit proof requirements.
+5. RED-GREEN-REFACTOR execution: write failing characterization/regression tests first, make minimal cleanup pass, then refactor safely.
+6. Proof: record tests, files, logs/traces, residual risks, and PR explanation before declaring success.
+
+## Hermes plugin mapping
+
+- `/janitor start` / `janitor_start`: start a Senior Engineer Benchmark-inspired cleanup workflow.
+- `/janitor review` / `janitor_review`: apply the benchmark scorecard (frame control, system understanding, invariants, first-principles design, execution depth, proof/operability) to a cleanup plan or completed rewrite.
+- `/janitor story` / `janitor_story`: create acceptance-testable cleanup stories.
+- `/janitor run` / `janitor_run`: prepare deterministic worker handoff payloads.
+- `/janitor proof` / `janitor_proof`: record evidence and enforce proof gates before declaring completion.
+- `/janitor daily-prompt` / `janitor_daily_prompt`: generate the self-contained daily GitHub sweep prompt for repos with charges in the lookback window, including the required activity fallback if direct charge data is unavailable.
+- `/janitor status`: inspect current workflow state.
+- `/janitor reset`: clear plugin state for a new workflow.

--- a/plugins/janitor/plugin.yaml
+++ b/plugins/janitor/plugin.yaml
@@ -1,0 +1,20 @@
+name: janitor
+version: 1.0.0
+description: "Hermes workflow plugin for senior-engineer code cleanup, TDD proof gates, and daily GitHub repo janitor sweeps."
+author: NousResearch
+kind: standalone
+platforms:
+  - linux
+  - macos
+  - windows
+provides_tools:
+  - janitor_start
+  - janitor_review
+  - janitor_story
+  - janitor_run
+  - janitor_proof
+  - janitor_status
+  - janitor_reset
+  - janitor_daily_prompt
+provides_hooks:
+  - pre_llm_call

--- a/plugins/janitor/skill/SKILL.md
+++ b/plugins/janitor/skill/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: workflow
+description: "Run Janitor cleanup workflows inside Hermes with TDD, proof gates, and daily GitHub PR automation."
+---
+
+# Janitor workflow
+
+Use this plugin skill when the user mentions Janitor, senior-engineer cleanup, vibe-coded/slop-coded code, first-principles rewrites, or daily repository cleanup sweeps.
+
+## Workflow
+
+1. Start with `janitor_start` or `/janitor start --path ...` for a cleanup workflow.
+2. Create cleanup stories with `janitor_story`; every story must have acceptance criteria, preserved invariants, and proof requirements.
+3. Use `janitor_run` to produce worker handoff payloads before delegating or executing.
+4. Use `janitor_review` or `/janitor review` for cleanup work to apply the Senior Engineer Benchmark scorecard before calling it good.
+5. Use `janitor_proof` to record evidence: tests, files, logs, trace/export locations, and known risks.
+6. Do not declare Janitor work complete unless the proof gate is satisfied.
+
+## Strict TDD discipline
+
+For production code changes, follow RED-GREEN-REFACTOR:
+
+- **RED:** write or update a focused failing characterization/regression test first and run it to prove it fails for the expected reason.
+- **GREEN:** make the smallest cleanup that passes the test.
+- **REFACTOR:** simplify only while tests remain green.
+
+The PR body must include the RED/GREEN/REFACTOR evidence and exact test commands/results.
+
+## Daily GitHub sweep
+
+Use `janitor_daily_prompt` or `/janitor daily-prompt --owner crisweber2600 --lookback-hours 24` to generate the self-contained cron prompt for daily sweeps. The prompt targets repositories with charges in the lookback window and requires the agent to explicitly report when direct per-repository charge data is unavailable and it falls back to recent push/commit/workflow activity.
+
+Each repository PR must explain:
+
+- what changed;
+- why it was worth doing;
+- why the cleanup is safe;
+- RED/GREEN/REFACTOR evidence;
+- tests run;
+- residual risks.
+
+## Senior-engineer janitor mode
+
+Trigger this mode when the user says the codebase is vibe-coded, slop-coded, brittle, full of patches, going down in production, or needs a senior-engineer cleanup. The goal is to optimize for the Senior Engineer Benchmark behavior described in Lenny's interview with Dan Shipper and Every's benchmark notes:
+
+- understand why the system fails before changing code;
+- preserve working contracts and product behavior;
+- rip out accidental architecture when warranted, instead of adding edge patches;
+- rewrite subsystems from first principles only after capturing invariants;
+- prove the result with characterization tests, regression tests, logs/traces, and a residual-risk review.
+
+Recommended intake:
+
+```text
+/janitor start --path /repo --symptoms "servers go down every 10 minutes" --constraints "keep public API stable" "Stabilize and simplify the app"
+```
+
+After `janitor_start`, create stories for reconnaissance, invariant capture, target architecture, seam extraction, rewrite/refactor, migration, and proof. A cleanup story is not ready unless it says what behavior must stay unchanged and what proof will demonstrate the cleanup did not just move the slop around.
+
+### Senior Engineer Benchmark scorecard
+
+Use this as the janitor-mode review rubric:
+
+- **Frame control (20 pts):** don't blindly obey a narrow issue list; decide whether the real job is root-cause cleanup, subsystem rewrite, or targeted patch.
+- **System understanding (15 pts):** map data flow, lifecycle, failure modes, ownership boundaries, and hidden coupling before editing.
+- **Invariant preservation (15 pts):** capture public API, UX, data, migration, security, and operational invariants with characterization tests/probes.
+- **First-principles design (20 pts):** replace accidental architecture with a simpler design when warranted; delete slop rather than wrapping it.
+- **Execution depth (15 pts):** carry the rewrite through production-relevant seams, migrations, and call sites instead of stopping at a cosmetic patch.
+- **Proof and operability (15 pts):** prove with tests, lint/type checks, logs/traces, load/error-path evidence, rollback notes, and residual-risk review.
+
+Call `/janitor review --evidence "..." "notes"` or `janitor_review` when reviewing a plan or completed cleanup. Missing proof in any dimension is a blocker, not a caveat.
+
+## Hermes-specific rules
+
+- Prefer Hermes tools for actual execution and verification.
+- Use `delegate_task` only after `janitor_run` has produced explicit story handoff text.
+- Store durable workflow state through the plugin; do not rely on chat history alone.

--- a/plugins/janitor/tools.py
+++ b/plugins/janitor/tools.py
@@ -1,0 +1,146 @@
+"""Tool registrations for Janitor."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from . import core
+
+TOOLSET = "janitor"
+
+
+def _json(data: dict[str, Any]) -> str:
+    return json.dumps(data, ensure_ascii=False, indent=2)
+
+
+def _handler(fn):
+    return lambda args, **kw: _json(fn(**(args or {})))
+
+
+def register_toolset(ctx) -> None:
+    ctx.register_tool(
+        name="janitor_start",
+        toolset=TOOLSET,
+        description="Start a Senior Engineer Benchmark-inspired cleanup workflow for vibe-coded or slop-coded codebases.",
+        schema={
+            "name": "janitor_start",
+            "description": "Start a senior-engineer janitor workflow for slop-code cleanup and first-principles rewrites.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "goal": {"type": "string", "description": "Cleanup outcome to achieve."},
+                    "codebase_path": {"type": "string", "description": "Repository or subsystem path."},
+                    "symptoms": {"type": "string", "description": "Comma/newline separated failures, production symptoms, or code smells."},
+                    "constraints": {"type": "string", "description": "Comma/newline separated constraints, contracts, or risk boundaries."},
+                    "rewrite_policy": {"type": "string", "default": "first-principles-when-needed"},
+                },
+            },
+        },
+        handler=_handler(core.janitor),
+    )
+    ctx.register_tool(
+        name="janitor_review",
+        toolset=TOOLSET,
+        description="Apply the Senior Engineer Benchmark scorecard to a cleanup plan or completed rewrite.",
+        schema={
+            "name": "janitor_review",
+            "description": "Return the janitor-mode scorecard, review questions, and pass standard for senior-engineer cleanup work.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "evidence": {"type": "string", "description": "Comma/newline separated evidence items to review."},
+                    "notes": {"type": "string", "description": "Free-form assessment notes or plan summary."},
+                },
+            },
+        },
+        handler=_handler(core.janitor_review),
+    )
+    ctx.register_tool(
+        name="janitor_story",
+        toolset=TOOLSET,
+        description="Add an acceptance-testable Janitor implementation story.",
+        schema={
+            "name": "janitor_story",
+            "description": "Create a Janitor implementation story with acceptance criteria.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "title": {"type": "string"},
+                    "acceptance": {"type": "string", "description": "Comma/newline separated acceptance criteria."},
+                    "notes": {"type": "string"},
+                    "priority": {"type": "string", "default": "normal"},
+                },
+                "required": ["title", "acceptance"],
+            },
+        },
+        handler=_handler(core.add_story),
+    )
+    ctx.register_tool(
+        name="janitor_run",
+        toolset=TOOLSET,
+        description="Prepare explicit Janitor story handoff payloads for execution/delegation.",
+        schema={
+            "name": "janitor_run",
+            "description": "Prepare Janitor execution handoffs for selected stories.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "parallelism": {"type": "integer", "default": 1},
+                    "story_ids": {"type": "string", "description": "Optional comma separated story ids."},
+                },
+            },
+        },
+        handler=_handler(core.prepare_run),
+    )
+    ctx.register_tool(
+        name="janitor_proof",
+        toolset=TOOLSET,
+        description="Record tests, files, logs, traces, and other proof evidence for Janitor proof gates.",
+        schema={
+            "name": "janitor_proof",
+            "description": "Record proof evidence for a Janitor story or workflow.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "evidence": {"type": "string", "description": "Comma/newline separated evidence items."},
+                    "tests": {"type": "string", "description": "Comma/newline separated test/log/trace commands or results."},
+                    "files": {"type": "string", "description": "Comma/newline separated relevant files."},
+                    "story_id": {"type": "string"},
+                },
+            },
+        },
+        handler=_handler(core.record_proof),
+    )
+    ctx.register_tool(
+        name="janitor_status",
+        toolset=TOOLSET,
+        description="Inspect persisted Janitor workflow state and proof gate status.",
+        schema={"name": "janitor_status", "description": "Return Janitor workflow state.", "parameters": {"type": "object", "properties": {}}},
+        handler=_handler(core.status),
+    )
+    ctx.register_tool(
+        name="janitor_reset",
+        toolset=TOOLSET,
+        description="Clear Janitor workflow state.",
+        schema={"name": "janitor_reset", "description": "Reset Janitor workflow state.", "parameters": {"type": "object", "properties": {}}},
+        handler=_handler(core.reset),
+    )
+    ctx.register_tool(
+        name="janitor_daily_prompt",
+        toolset=TOOLSET,
+        description="Build the daily GitHub Janitor sweep prompt for repos with charges or recent activity.",
+        schema={
+            "name": "janitor_daily_prompt",
+            "description": "Return a self-contained daily Janitor cron prompt for GitHub repositories with charges in a lookback window.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "owner": {"type": "string", "default": "crisweber2600"},
+                    "lookback_hours": {"type": "integer", "default": 24},
+                    "schedule": {"type": "string", "default": "0 9 * * *"},
+                },
+            },
+        },
+        handler=_handler(core.daily_prompt),
+    )

--- a/tests/plugins/test_janitor.py
+++ b/tests/plugins/test_janitor.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from plugins.janitor import cli as janitor_cli
+from plugins.janitor import core
+from plugins.janitor import register
+
+
+class DummyCtx:
+    def __init__(self) -> None:
+        self.tools = []
+        self.hooks = []
+        self.cli_commands = []
+        self.commands = []
+        self.skills = []
+
+    def register_tool(self, **kwargs):
+        self.tools.append(kwargs)
+
+    def register_hook(self, name, handler):
+        self.hooks.append((name, handler))
+
+    def register_cli_command(self, **kwargs):
+        self.cli_commands.append(kwargs)
+
+    def register_command(self, name, handler, **kwargs):
+        self.commands.append((name, handler, kwargs))
+
+    def register_skill(self, **kwargs):
+        self.skills.append(kwargs)
+
+
+@pytest.fixture()
+def temp_home(tmp_path, monkeypatch):
+    monkeypatch.setattr(core, "get_hermes_home", lambda: tmp_path)
+    return tmp_path
+
+
+def test_register_exposes_janitor_surfaces(temp_home):
+    ctx = DummyCtx()
+    register(ctx)
+
+    assert {tool["name"] for tool in ctx.tools} == {
+        "janitor_start",
+        "janitor_review",
+        "janitor_story",
+        "janitor_run",
+        "janitor_proof",
+        "janitor_status",
+        "janitor_reset",
+        "janitor_daily_prompt",
+    }
+    assert [name for name, _ in ctx.hooks] == ["pre_llm_call"]
+    assert {cmd["name"] for cmd in ctx.cli_commands} == {"janitor"}
+    assert {name for name, _, _ in ctx.commands} == {"janitor"}
+    assert ctx.skills[0]["path"].name == "SKILL.md"
+
+
+def test_janitor_mode_creates_cleanup_rubric_and_handoff(temp_home):
+    result = core.janitor(
+        goal="Stabilize vibe-coded service",
+        codebase_path="/repo",
+        symptoms="server falls over every 10 minutes, patches cause regressions",
+        constraints="keep public API stable",
+    )
+    assert result["ok"] is True
+    assert result["state"]["track"] == "cleanup"
+    assert result["state"]["specialization"] == "senior-engineer-janitor"
+    assert any("first principles" in item for item in result["rubric"])
+    assert sum(item["weight"] for item in result["scorecard"]) == 100
+
+    story = core.add_story(
+        title="Rewrite unstable worker",
+        acceptance="characterization tests exist, regression logs are clean",
+    )
+    run = core.prepare_run()
+    handoff = run["handoffs"][0]
+    assert "Senior-engineer janitor discipline" in handoff
+    assert "Senior Engineer Benchmark scorecard" in handoff
+    assert "Do not merely paper over failing edges" in handoff
+    assert story["story"]["id"] == "S1"
+
+
+def test_daily_prompt_targets_charged_repos_and_requires_tdd_prs(temp_home):
+    prompt = core.daily_prompt(owner="crisweber2600", lookback_hours=24)
+
+    assert prompt["ok"] is True
+    text = prompt["prompt"]
+    assert "crisweber2600" in text
+    assert "past 24 hours" in text
+    assert "charges" in text.lower()
+    assert "RED" in text and "GREEN" in text and "REFACTOR" in text
+    assert "open a pull request" in text.lower()
+    assert "what changed" in text.lower()
+    assert "why" in text.lower()
+    assert prompt["schedule"] == "0 9 * * *"
+
+
+def test_tool_handler_registry_shape(temp_home):
+    ctx = DummyCtx()
+    register(ctx)
+    handlers = {tool["name"]: tool["handler"] for tool in ctx.tools}
+
+    out = json.loads(handlers["janitor_start"]({"goal": "clean slop", "symptoms": "brittle patches"}))
+    assert out["ok"] is True
+    assert out["state"]["track"] == "cleanup"
+    review = json.loads(handlers["janitor_review"]({"evidence": "deleted dead abstractions", "notes": "rewrote worker"}))
+    assert review["ok"] is True
+    assert len(review["review"]["scorecard"]) == 6
+    daily = json.loads(handlers["janitor_daily_prompt"]({"owner": "crisweber2600", "lookback_hours": 24}))
+    assert daily["schedule"] == "0 9 * * *"
+
+
+def test_cli_and_slash(temp_home):
+    args = janitor_cli.build_parser().parse_args(["start", "--path", "/repo", "Clean", "slop"])
+    code, text = janitor_cli.dispatch_namespace(args, emit="text")
+    assert code == 0
+    assert "Clean slop" in text
+
+    slash = janitor_cli.handle_slash('start --path /repo --symptoms "crashes" "Clean up slop"')
+    assert '"track": "cleanup"' in slash
+
+    slash = janitor_cli.handle_slash('daily-prompt --owner crisweber2600 --lookback-hours 24')
+    assert "RED" in slash and "GREEN" in slash and "REFACTOR" in slash
+
+    slash = janitor_cli.handle_slash('story --acceptance "works" "Implement thing"')
+    assert '"ok": true' in slash
+
+
+def test_plugin_manager_discovers_enabled_janitor(temp_home, monkeypatch):
+    from hermes_cli import plugins as plugin_module
+
+    monkeypatch.setattr(plugin_module, "_get_enabled_plugins", lambda: {"janitor"})
+    manager = plugin_module.PluginManager()
+    manager.discover_and_load(force=True)
+
+    record = [item for item in manager.list_plugins() if item["name"] == "janitor"][0]
+    assert record["enabled"] is True
+    assert record["tools"] == 8
+    assert record["hooks"] == 1
+    assert record["commands"] == 1
+    assert "janitor:workflow" in manager._plugin_skills
+
+    from tools.registry import registry
+
+    payload = json.loads(registry.dispatch("janitor_daily_prompt", {"owner": "crisweber2600", "lookback_hours": 24}))
+    assert payload["ok"] is True
+    assert "open a pull request" in payload["prompt"].lower()
+
+
+def test_pre_llm_injection_only_when_relevant(temp_home):
+    ctx = DummyCtx()
+    register(ctx)
+    hook = dict(ctx.hooks)["pre_llm_call"]
+    assert hook(user_message={"content": "hello"}) is None
+    assert "Janitor plugin" in hook(user_message={"content": "run janitor"})
+    assert "janitor_start" in hook(user_message={"content": "clean up this slop code like a janitor"})
+    assert "janitor_review" in hook(user_message={"content": "rewrite from first principles"})

--- a/website/docs/user-guide/features/built-in-plugins.md
+++ b/website/docs/user-guide/features/built-in-plugins.md
@@ -56,6 +56,7 @@ The repo ships these bundled plugins under `plugins/`. All are opt-in — enable
 | Plugin | Kind | Purpose |
 |---|---|---|
 | `disk-cleanup` | hooks + slash command | Auto-track ephemeral files and clean them on session end |
+| `janitor` | standalone | Senior-engineer code cleanup workflow with TDD proof gates and daily GitHub PR sweep prompts |
 | `observability/langfuse` | hooks | Trace turns / LLM calls / tools to [Langfuse](https://langfuse.com) |
 | `spotify` | backend (7 tools) | Native Spotify playback, queue, search, playlists, albums, library |
 | `google_meet` | standalone | Join Meet calls, live-caption transcription, optional realtime duplex audio |
@@ -66,6 +67,32 @@ The repo ships these bundled plugins under `plugins/`. All are opt-in — enable
 | `kanban/dashboard` | dashboard tab | Kanban board UI for the multi-agent dispatcher — tasks, comments, fan-out, board switching. See [Kanban Multi-Agent](./kanban.md). |
 
 Memory providers (`plugins/memory/*`) and context engines (`plugins/context_engine/*`) are listed separately on [Memory Providers](./memory-providers.md) — they're managed through `hermes memory` and `hermes plugins` respectively. The full per-plugin detail for the two long-running hooks-based plugins follows.
+
+### janitor
+
+Runs senior-engineer cleanup workflows for brittle, vibe-coded, or slop-coded codebases. Janitor exposes a small state machine with explicit stories, execution handoffs, proof evidence, and a Senior Engineer Benchmark scorecard.
+
+**What it adds:**
+
+- Tools: `janitor_start`, `janitor_review`, `janitor_story`, `janitor_run`, `janitor_proof`, `janitor_status`, `janitor_reset`, `janitor_daily_prompt`
+- Slash/CLI command: `/janitor` / `hermes janitor`
+- Plugin skill: `janitor:workflow`
+- A daily GitHub sweep prompt generator for repositories with charges in the last lookback window, with an explicit recent-activity fallback when direct per-repository charge data is unavailable
+
+**TDD rule:** production cleanup must follow RED-GREEN-REFACTOR. The PR body should include what changed, why, RED/GREEN/REFACTOR evidence, tests run, and residual risks.
+
+**Usage:**
+
+```text
+/janitor start --path /repo --symptoms "brittle patches" "Simplify the worker pipeline"
+/janitor story --acceptance "characterization test fails before fix" "Capture current worker retry behavior"
+/janitor proof --test "pytest tests/test_worker.py" --file "src/worker.py"
+/janitor daily-prompt --owner crisweber2600 --lookback-hours 24
+```
+
+**Enabling:** `hermes plugins enable janitor`.
+
+**Disabling again:** `hermes plugins disable janitor`.
 
 ### disk-cleanup
 


### PR DESCRIPTION
## Summary
- Adds a bundled `janitor` plugin that renames the cleanup workflow around senior-engineer code cleanup instead of BMAD branding.
- Exposes Janitor tools, slash/CLI command, plugin-local skill, persistent state, proof gates, and a Senior Engineer Benchmark review rubric.
- Adds `janitor_daily_prompt` / `/janitor daily-prompt` to generate a daily sweep prompt for crisweber2600 repos with charges in the past 24 hours, including an explicit recent-activity fallback if direct charge data is unavailable.
- Documents the plugin in built-in plugins docs.

## Why
- The workflow is intended to behave like a repository janitor: find recent charged/activity-producing repos, make small reviewable cleanups, and explain what changed and why.
- Daily sweeps need a self-contained prompt so cron runs can operate without chat context.
- Cleanup PRs should be grounded in strict TDD evidence rather than cosmetic edits.

## TDD / Test Plan
- RED: added `tests/plugins/test_janitor.py` first; initial run failed with `ModuleNotFoundError: No module named 'plugins.janitor'`.
- GREEN: implemented the `plugins/janitor` package and reran the Janitor tests successfully.
- Regression: `python -m pytest tests/plugins/test_janitor.py tests/hermes_cli/test_plugin_cli_registration.py tests/test_plugin_skills.py -q -o 'addopts='` → 43 passed, 1 warning.
- Static check: `git diff --cached --check`.

## Notes
- The daily prompt says to use direct per-repository charge data when available and to report when it falls back to recent commits/pushes/workflow activity, because GitHub's standard repo APIs do not always expose per-repo charge events to the agent.
