### PR TITLE
fix(recall): use parent_session_id chain to find prior sessions in thread

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4189,7 +4189,18 @@ def _build_call_kwargs(
     # Provider-specific extra_body
     merged_extra = dict(extra_body or {})
     if provider == "nous" or auxiliary_is_nous:
-        merged_extra.setdefault("tags", []).extend(_nous_portal_tags())
+        # Defensive: ``extra_body`` (from config or upstream merges) may carry
+        # ``{"tags": None}`` — e.g. an auxiliary.<task>.extra_body.tags: key in
+        # YAML with no value.  ``setdefault`` only inserts when the key is
+        # missing, so it returns ``None`` here and ``.extend()`` then crashes
+        # with "'NoneType' object is not iterable".  Coerce to a list first.
+        existing_tags = merged_extra.get("tags")
+        if not isinstance(existing_tags, list):
+            existing_tags = []
+        else:
+            existing_tags = list(existing_tags)
+        existing_tags.extend(_nous_portal_tags())
+        merged_extra["tags"] = existing_tags
     if merged_extra:
         kwargs["extra_body"] = merged_extra
 

--- a/gateway/recall.py
+++ b/gateway/recall.py
@@ -1,0 +1,440 @@
+"""
+gateway/recall.py — /recall command implementation.
+
+Restores context from prior sessions into a fresh session. Three modes:
+  - thread  (default): prior session(s) in this same session_key
+  - window:  sessions in this thread within a time window
+  - topic:   FTS5 search across all sessions
+
+Public API:
+  parse_recall_args(raw: str) -> RecallSpec
+  run_recall(raw_args, session_key, session_store, session_db, *, runtime_kwargs, model) -> RecallResult
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+_DURATION_RE = re.compile(r"^(\d+)([hdwm])$", re.IGNORECASE)
+_LAST_N_RE   = re.compile(r"^last\s+(\d+)$", re.IGNORECASE)
+_BARE_N_RE   = re.compile(r"^\d+$")
+
+
+def _duration_to_hours(token: str) -> Optional[int]:
+    m = _DURATION_RE.match(token)
+    if not m:
+        return None
+    n, unit = int(m.group(1)), m.group(2).lower()
+    return {"h": n, "d": n * 24, "w": n * 24 * 7, "m": n * 24 * 30}[unit]
+
+
+@dataclass(frozen=True)
+class RecallSpec:
+    mode: str                        # "thread" | "window" | "topic"
+    count: int = 1                   # thread mode: how many prior sessions
+    window_hours: Optional[int] = None
+    query: Optional[str] = None      # topic search phrase
+
+
+def parse_recall_args(raw: str) -> RecallSpec:
+    """Parse /recall argument string into a structured spec."""
+    s = (raw or "").strip()
+
+    if not s:
+        return RecallSpec(mode="thread", count=1)
+
+    # bare integer → thread count
+    if _BARE_N_RE.match(s):
+        return RecallSpec(mode="thread", count=min(int(s), 10))
+
+    # "last N" → thread count
+    m = _LAST_N_RE.match(s)
+    if m:
+        return RecallSpec(mode="thread", count=min(int(m.group(1)), 10))
+
+    # bare duration → window mode
+    hrs = _duration_to_hours(s)
+    if hrs is not None:
+        return RecallSpec(mode="window", window_hours=hrs)
+
+    # topic mode, possibly with trailing duration
+    parts = s.rsplit(None, 1)
+    if len(parts) == 2:
+        trailing_hrs = _duration_to_hours(parts[1])
+        if trailing_hrs is not None:
+            return RecallSpec(mode="topic", query=parts[0].strip(), window_hours=trailing_hrs)
+
+    return RecallSpec(mode="topic", query=s)
+
+
+# ---------------------------------------------------------------------------
+# Source references
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SourceRef:
+    session_id: str
+    title: str
+    message_count: int
+    ended_at: float          # unix timestamp
+    excerpt: str = ""        # FTS snippet for topic mode
+
+
+def _ago(ts: float) -> str:
+    """Human-readable 'X ago' for a unix timestamp."""
+    diff = time.time() - ts
+    if diff < 60:
+        return "just now"
+    if diff < 3600:
+        return f"{int(diff / 60)}m ago"
+    if diff < 86400:
+        return f"{int(diff / 3600)}h ago"
+    return f"{int(diff / 86400)}d ago"
+
+
+def _format_transcript(messages: list[dict], char_cap: int) -> str:
+    """Render a message list as plain text, truncated to char_cap."""
+    lines = []
+    total = 0
+    for msg in messages:
+        role = msg.get("role", "")
+        content = msg.get("content") or ""
+        if not content or role not in ("user", "assistant"):
+            continue
+        # Truncate very long individual messages
+        if len(content) > 2000:
+            content = content[:2000] + " [...]"
+        line = f"{role.upper()}: {content}"
+        if total + len(line) > char_cap:
+            lines.append("[transcript truncated for length]")
+            break
+        lines.append(line)
+        total += len(line)
+    return "\n\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Source resolver
+# ---------------------------------------------------------------------------
+
+def resolve_sources(
+    spec: RecallSpec,
+    session_key: str,
+    session_store,    # gateway.session.SessionStore
+    session_db,       # hermes_state.SessionDB  (may be None)
+    *,
+    now: Optional[float] = None,
+) -> list[SourceRef]:
+    """Return the list of SourceRefs to summarize for this spec."""
+    now = now or time.time()
+
+    if spec.mode == "topic":
+        return _resolve_topic(spec, session_db, now)
+
+    # thread / window — filter by session_key from session_store._entries
+    refs = _prior_sessions_for_key(session_key, session_store, session_db)
+
+    if spec.mode == "window":
+        cutoff = now - ((spec.window_hours or 0) * 3600)
+        refs = [r for r in refs if r.ended_at >= cutoff]
+        return refs
+
+    # thread mode: just last N
+    return refs[:spec.count]
+
+
+def _prior_sessions_for_key(
+    session_key: str,
+    session_store,
+    session_db,
+) -> list[SourceRef]:
+    """All historical sessions for this session_key, most-recent first, excluding current."""
+    refs: list[SourceRef] = []
+
+    # session_store._entries is a dict of session_key → SessionEntry.
+    # session_key is a stable identifier for (platform, chat_id, thread_id).
+    # After /new, the current entry has a fresh session_id; prior sessions
+    # only exist in SQLite / JSONL. We need to look at session_db.
+    if session_db is None:
+        logger.debug("recall: no session_db, cannot resolve prior sessions")
+        return []
+
+    try:
+        # session_db.search_sessions() orders by most-recently-used first.
+        # The source column in SQLite maps to session_key for gateway sessions.
+        # We need sessions that had this session_key as their source.
+        rows = session_db.search_sessions(source=session_key, limit=20)
+        current_entry = session_store._entries.get(session_key) if session_store else None
+        current_sid = current_entry.session_id if current_entry else None
+
+        for row in rows:
+            sid = row.get("id") or row.get("session_id") or row.get("session_id")
+            if not sid or sid == current_sid:
+                continue
+            title = row.get("title") or f"Session {sid[:8]}"
+            last_active = row.get("last_active") or row.get("started_at") or 0
+            msg_count = session_db.message_count(session_id=sid)
+            refs.append(SourceRef(
+                session_id=sid,
+                title=title,
+                message_count=msg_count,
+                ended_at=float(last_active),
+            ))
+    except Exception:
+        logger.debug("recall: error querying prior sessions", exc_info=True)
+
+    return refs
+
+
+def _resolve_topic(
+    spec: RecallSpec,
+    session_db,
+    now: float,
+) -> list[SourceRef]:
+    """FTS5 search across all sessions for the given topic."""
+    if session_db is None or not spec.query:
+        return []
+
+    try:
+        cutoff_ts = (now - spec.window_hours * 3600) if spec.window_hours else None
+        # Use search_messages (FTS5) to find matching messages
+        results = session_db.search_messages(
+            query=spec.query,
+            limit=50,
+        )
+        # Dedupe by session_id, keep top 5 by score (results already ranked)
+        seen: dict[str, SourceRef] = {}
+        for row in results:
+            sid = row.get("session_id")
+            if not sid or sid in seen:
+                continue
+            session_ts = float(row.get("session_started_at") or row.get("timestamp") or 0)
+            if cutoff_ts and session_ts < cutoff_ts:
+                continue
+            snippet = row.get("content") or row.get("snippet") or ""
+            if len(snippet) > 300:
+                snippet = snippet[:300] + "..."
+            title = row.get("session_title") or row.get("title") or f"Session {sid[:8]}"
+            msg_count = session_db.message_count(session_id=sid)
+            seen[sid] = SourceRef(
+                session_id=sid,
+                title=title,
+                message_count=msg_count,
+                ended_at=session_ts,
+                excerpt=snippet,
+            )
+            if len(seen) >= 5:
+                break
+        return list(seen.values())
+    except Exception:
+        logger.debug("recall: error in topic search", exc_info=True)
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Summarizer
+# ---------------------------------------------------------------------------
+
+_SUMMARIZER_SYSTEM = """You are summarizing prior conversation(s) so a fresh AI agent \
+picking up the work has the context it needs. Be specific and concrete:
+
+- What was being worked on (project, file paths, goal, task)
+- What was tried (approaches, commands run, key decisions made)
+- What worked, what broke, what was left unresolved
+- Any names of people, services, agents, or fleet members referenced
+- Any decisions or preferences the user expressed
+
+Keep it tight — bullet points preferred, no fluff. Skip pleasantries and meta-chatter. \
+If multiple source sessions are provided, group by source with a one-line citation.
+
+Format: plain text, no markdown headers. Aim for 200-500 words."""
+
+_SUMMARIZER_USER_TMPL = """\
+Summarize the following {n} prior session(s) for context restoration{topic_clause}.
+
+{transcripts}
+
+Output a single context block the agent can use to orient itself."""
+
+# In-memory cache: (cache_key) -> summary string
+_SUMMARY_CACHE: dict[str, str] = {}
+
+
+def _cache_key(refs: list[SourceRef], query: Optional[str]) -> str:
+    payload = json.dumps(
+        [(r.session_id, r.message_count) for r in refs] + [query or ""],
+        sort_keys=True,
+    )
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def summarize_sources(
+    refs: list[SourceRef],
+    session_store,
+    session_db,
+    *,
+    query: Optional[str] = None,
+    runtime_kwargs: Optional[dict] = None,
+    model: Optional[str] = None,
+) -> str:
+    """Spawn a cheap ephemeral AIAgent and summarize the source transcripts."""
+    if not refs:
+        return ""
+
+    key = _cache_key(refs, query)
+    if key in _SUMMARY_CACHE:
+        logger.debug("recall: cache hit for %s", key[:12])
+        return _SUMMARY_CACHE[key]
+
+    # Build per-source transcript text
+    PER_SOURCE_CHAR_CAP = 12_000   # ~3k tokens per source, max 5 sources = 15k
+    transcripts = []
+    for ref in refs:
+        try:
+            msgs = session_store.load_transcript(ref.session_id) if session_store else []
+        except Exception:
+            msgs = []
+        text = _format_transcript(msgs, char_cap=PER_SOURCE_CHAR_CAP)
+        if not text:
+            text = "[transcript unavailable]"
+        age = _ago(ref.ended_at)
+        transcripts.append(
+            f"--- {ref.title} ({age}, {ref.message_count} messages) ---\n{text}"
+        )
+
+    topic_clause = f" focused on: {query!r}" if query else ""
+    user_msg = _SUMMARIZER_USER_TMPL.format(
+        n=len(refs),
+        topic_clause=topic_clause,
+        transcripts="\n\n".join(transcripts),
+    )
+
+    try:
+        from run_agent import AIAgent
+
+        kw = dict(runtime_kwargs or {})
+        summary_agent = AIAgent(
+            **kw,
+            model=model or kw.get("model") or "",
+            max_iterations=4,
+            quiet_mode=True,
+            skip_memory=True,
+            skip_context_files=True,
+            enabled_toolsets=[],
+        )
+        try:
+            summary_agent._print_fn = None  # type: ignore[assignment]
+        except Exception:
+            pass
+
+        result = summary_agent.run_conversation(
+            user_message=user_msg,
+            system_message=_SUMMARIZER_SYSTEM,
+        )
+        summary = (result.get("final_response") or "").strip()
+    except Exception:
+        logger.warning("recall: summarizer agent failed", exc_info=True)
+        summary = ""
+
+    if summary:
+        _SUMMARY_CACHE[key] = summary
+
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Public entrypoint
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RecallResult:
+    injected_user_message: str   # prepended to new session as user-role message
+    reply: str                   # sent back to the human
+    source_count: int
+
+
+def _format_header(spec: RecallSpec, refs: list[SourceRef]) -> str:
+    if spec.mode == "thread":
+        if len(refs) == 1:
+            return (
+                f"prior session in this thread "
+                f"({refs[0].message_count} msgs, {_ago(refs[0].ended_at)})"
+            )
+        return f"last {len(refs)} sessions in this thread"
+    if spec.mode == "window":
+        return f"sessions in the last {spec.window_hours}h ({len(refs)} found)"
+    if spec.mode == "topic":
+        suffix = f", last {spec.window_hours}h" if spec.window_hours else ""
+        return f"topic search: {spec.query!r}{suffix} ({len(refs)} sources)"
+    return ""
+
+
+def run_recall(
+    raw_args: str,
+    session_key: str,
+    session_store,
+    session_db,
+    *,
+    runtime_kwargs: Optional[dict] = None,
+    model: Optional[str] = None,
+) -> RecallResult:
+    """
+    Top-level entry point called by the gateway handler.
+
+    Returns a RecallResult with:
+      - injected_user_message: inject as a user-role message into the new session
+      - reply: send back to the human
+      - source_count: 0 means nothing found / injected
+    """
+    spec = parse_recall_args(raw_args)
+    refs = resolve_sources(spec, session_key, session_store, session_db)
+
+    if not refs:
+        if spec.mode == "topic":
+            msg = f"No sessions matched topic: {spec.query!r}"
+        elif spec.mode == "window":
+            msg = f"No sessions found in this thread within the last {spec.window_hours}h."
+        else:
+            msg = (
+                "Nothing to recall — no prior sessions found for this thread.\n"
+                "Tip: use `/recall <topic>` to search across all sessions."
+            )
+        return RecallResult(injected_user_message="", reply=msg, source_count=0)
+
+    summary = summarize_sources(
+        refs,
+        session_store,
+        session_db,
+        query=spec.query,
+        runtime_kwargs=runtime_kwargs,
+        model=model,
+    )
+
+    if not summary:
+        return RecallResult(
+            injected_user_message="",
+            reply="⚠️ Recall couldn't generate a summary (summarizer failed). Try again.",
+            source_count=0,
+        )
+
+    header = _format_header(spec, refs)
+    injected = f"[Context restored via /recall — {header}]\n\n{summary}"
+    reply = f"📋 **Recall:** {header}\n\n{summary}"
+
+    return RecallResult(
+        injected_user_message=injected,
+        reply=reply,
+        source_count=len(refs),
+    )

--- a/gateway/recall.py
+++ b/gateway/recall.py
@@ -160,42 +160,63 @@ def _prior_sessions_for_key(
     session_store,
     session_db,
 ) -> list[SourceRef]:
-    """All historical sessions for this session_key, most-recent first, excluding current."""
+    """All historical sessions for this session_key, most-recent first, excluding current.
+
+    Strategy: walk the parent_session_id chain starting from the current session.
+    Sessions are stored with source='telegram' (platform name only), NOT the
+    full session_key like 'telegram:469214623:94316', so searching by source=session_key
+    never matches. The parent chain is the reliable way to find prior sessions
+    in the same thread.
+    """
     refs: list[SourceRef] = []
 
-    # session_store._entries is a dict of session_key → SessionEntry.
-    # session_key is a stable identifier for (platform, chat_id, thread_id).
-    # After /new, the current entry has a fresh session_id; prior sessions
-    # only exist in SQLite / JSONL. We need to look at session_db.
     if session_db is None:
         logger.debug("recall: no session_db, cannot resolve prior sessions")
         return []
 
     try:
-        # session_db.search_sessions() orders by most-recently-used first.
-        # The source column in SQLite maps to session_key for gateway sessions.
-        # We need sessions that had this session_key as their source.
-        rows = session_db.search_sessions(source=session_key, limit=20)
         current_entry = session_store._entries.get(session_key) if session_store else None
         current_sid = current_entry.session_id if current_entry else None
 
-        for row in rows:
-            sid = row.get("id") or row.get("session_id") or row.get("session_id")
-            if not sid or sid == current_sid:
-                continue
-            title = row.get("title") or f"Session {sid[:8]}"
-            last_active = row.get("last_active") or row.get("started_at") or 0
-            msg_count = session_db.message_count(session_id=sid)
+        if not current_sid:
+            logger.debug("recall: no current session_id for key %s", session_key)
+            return []
+
+        # Walk the parent_session_id chain: current → parent → grandparent → ...
+        # Skip the current (live) session — only return prior sessions.
+        visited: set[str] = set()
+        next_sid = _get_parent_session_id(session_db, current_sid)
+        while next_sid and next_sid not in visited and len(refs) < 20:
+            visited.add(next_sid)
+            row = session_db.get_session(next_sid)
+            if row is None:
+                break
+            title = row.get("title") or f"Session {next_sid[:8]}"
+            ended_at = row.get("ended_at") or row.get("started_at") or 0
+            msg_count = session_db.message_count(session_id=next_sid)
             refs.append(SourceRef(
-                session_id=sid,
+                session_id=next_sid,
                 title=title,
                 message_count=msg_count,
-                ended_at=float(last_active),
+                ended_at=float(ended_at),
             ))
+            next_sid = _get_parent_session_id(session_db, next_sid)
+
     except Exception:
         logger.debug("recall: error querying prior sessions", exc_info=True)
 
     return refs
+
+
+def _get_parent_session_id(session_db, session_id: str) -> Optional[str]:
+    """Return the parent_session_id for the given session, or None."""
+    try:
+        row = session_db.get_session(session_id)
+        if row is None:
+            return None
+        return row.get("parent_session_id")
+    except Exception:
+        return None
 
 
 def _resolve_topic(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6600,6 +6600,9 @@ class GatewayRunner:
         if canonical == "compress":
             return await self._handle_compress_command(event)
 
+        if canonical == "recall":
+            return await self._handle_recall_command(event)
+
         if canonical == "usage":
             return await self._handle_usage_command(event)
 
@@ -8388,6 +8391,20 @@ class GatewayRunner:
             _tip_line = t("gateway.reset.tip", tip=get_random_tip())
         except Exception:
             _tip_line = ""
+
+        # Append /recall nudge when a prior session exists in this thread
+        try:
+            _session_db = getattr(self, "_session_db", None)
+            if _session_db is not None:
+                _prior_rows = _session_db.search_sessions(source=session_key, limit=2)
+                _has_prior = any(
+                    r.get("id") != (new_entry.session_id if new_entry else None)
+                    for r in _prior_rows
+                )
+                if _has_prior:
+                    _tip_line = (_tip_line or "") + "\n💡 Run /recall to restore context from your prior session."
+        except Exception:
+            pass
 
         if session_info:
             return EphemeralReply(f"{header}\n\n{session_info}{_tip_line}")
@@ -11230,7 +11247,61 @@ class GatewayRunner:
             logger.warning("Manual compress failed: %s", e)
             return t("gateway.compress.failed", error=e)
 
-    async def _get_telegram_topic_capabilities(self, source: SessionSource) -> dict:
+    async def _handle_recall_command(self, event: "MessageEvent") -> str:
+        """Handle /recall — restore context from a prior session or topic search.
+
+        Modes (parsed from args):
+          /recall                → prior session in this thread (default)
+          /recall 3              → last 3 sessions in this thread
+          /recall 24h            → sessions in last 24 hours
+          /recall <phrase>       → FTS5 topic search across all sessions
+          /recall <phrase> 7d    → topic search scoped to last 7 days
+        """
+        import asyncio
+        from gateway.recall import run_recall
+
+        source = event.source
+        session_key = self._session_key_for_source(source)
+        raw_args = (event.get_command_args() or "").strip()
+
+        model, runtime_kwargs = self._resolve_session_agent_runtime(
+            source=source,
+            session_key=session_key,
+        )
+        if not runtime_kwargs.get("api_key"):
+            return "⚠️ No AI provider configured — cannot generate recall summary."
+
+        loop = asyncio.get_running_loop()
+        try:
+            result = await loop.run_in_executor(
+                None,
+                lambda: run_recall(
+                    raw_args,
+                    session_key,
+                    self.session_store,
+                    getattr(self, "_session_db", None),
+                    runtime_kwargs=runtime_kwargs,
+                    model=model,
+                ),
+            )
+        except Exception as e:
+            logger.warning("recall: run_recall failed: %s", e, exc_info=True)
+            return f"⚠️ Recall failed: {e}"
+
+        # Inject context into the current session transcript as a user-role message
+        if result.injected_user_message:
+            try:
+                session_entry = self.session_store.get_or_create_session(source)
+                self.session_store.append_to_transcript(
+                    session_entry.session_id,
+                    {"role": "user", "content": result.injected_user_message},
+                )
+            except Exception:
+                logger.debug("recall: failed to inject message into transcript", exc_info=True)
+
+        return result.reply
+
+    async def _get_telegram_topic_capabilities(self, source: "SessionSource") -> dict:
         """Read Telegram private-topic capability flags via Bot API getMe."""
         adapter = self.adapters.get(source.platform) if getattr(self, "adapters", None) else None
         bot = getattr(adapter, "_bot", None)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8392,15 +8392,16 @@ class GatewayRunner:
         except Exception:
             _tip_line = ""
 
-        # Append /recall nudge when a prior session exists in this thread
+        # Append /recall nudge when a prior session exists in this thread.
+        # Sessions are stored with source='telegram' (platform name only), so
+        # search_sessions(source=session_key) never matches. Instead check if
+        # the new session has a parent_session_id — that's the reliable signal
+        # that there's prior history in this thread.
         try:
             _session_db = getattr(self, "_session_db", None)
-            if _session_db is not None:
-                _prior_rows = _session_db.search_sessions(source=session_key, limit=2)
-                _has_prior = any(
-                    r.get("id") != (new_entry.session_id if new_entry else None)
-                    for r in _prior_rows
-                )
+            if _session_db is not None and new_entry is not None:
+                _cur_row = _session_db.get_session(new_entry.session_id)
+                _has_prior = bool(_cur_row and _cur_row.get("parent_session_id"))
                 if _has_prior:
                     _tip_line = (_tip_line or "") + "\n💡 Run /recall to restore context from your prior session."
         except Exception:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -85,6 +85,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                aliases=("fork",), args_hint="[name]"),
     CommandDef("compress", "Manually compress conversation context", "Session",
                args_hint="[focus topic]"),
+    CommandDef("recall", "Restore context from a prior session or topic search", "Session",
+               args_hint="[N | 24h | <topic phrase>]"),
     CommandDef("rollback", "List or restore filesystem checkpoints", "Session",
                args_hint="[number]"),
     CommandDef("snapshot", "Create or restore state snapshots of Hermes config/state", "Session",

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2808,3 +2808,71 @@ class TestAuxUnhealthyCache:
             )
             # After the 402, OpenRouter is in the unhealthy cache.
             assert _is_provider_unhealthy("openrouter") is True
+
+
+# ---------------------------------------------------------------------------
+# _build_call_kwargs — Nous portal tag merge resilience
+# ---------------------------------------------------------------------------
+
+class TestBuildCallKwargsNousTagsMerge:
+    """Regression for 'NoneType' object is not iterable on title_generation.
+
+    The Nous-tagged auxiliary path used to call
+    ``merged_extra.setdefault("tags", []).extend(_nous_portal_tags())``.
+    When the incoming ``extra_body`` already carried ``{"tags": None}``
+    (e.g. an ``auxiliary.<task>.extra_body.tags:`` key in YAML with no
+    value, or any upstream merge that left tags=None), ``setdefault``
+    returned the existing ``None`` and ``.extend()`` crashed with
+    "'NoneType' object is not iterable" — silently aborting title
+    generation and surfacing as "⚠ Auxiliary title generation failed".
+    """
+
+    def test_extra_body_tags_none_does_not_crash(self):
+        """tags=None in extra_body must not raise — Nous tags still appended."""
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="nous",
+            model="hermes-4",
+            messages=[{"role": "user", "content": "hi"}],
+            extra_body={"tags": None},
+        )
+
+        assert "extra_body" in kwargs
+        tags = kwargs["extra_body"]["tags"]
+        assert isinstance(tags, list)
+        assert any(t.startswith("product=hermes-agent") for t in tags)
+        assert any(t.startswith("client=hermes-client-v") for t in tags)
+
+    def test_extra_body_tags_non_list_does_not_crash(self):
+        """tags=<str> (malformed config) must not raise either."""
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="nous",
+            model="hermes-4",
+            messages=[{"role": "user", "content": "hi"}],
+            extra_body={"tags": "oops-not-a-list"},
+        )
+
+        tags = kwargs["extra_body"]["tags"]
+        assert isinstance(tags, list)
+        # Malformed value is replaced (not concatenated to) so the request body
+        # stays valid for the Portal.
+        assert "oops-not-a-list" not in tags
+        assert any(t.startswith("product=hermes-agent") for t in tags)
+
+    def test_extra_body_tags_existing_list_is_preserved(self):
+        """Pre-existing user tags must be kept and the Nous tags appended."""
+        from agent.auxiliary_client import _build_call_kwargs
+
+        kwargs = _build_call_kwargs(
+            provider="nous",
+            model="hermes-4",
+            messages=[{"role": "user", "content": "hi"}],
+            extra_body={"tags": ["user-tag=foo"]},
+        )
+
+        tags = kwargs["extra_body"]["tags"]
+        assert "user-tag=foo" in tags
+        assert any(t.startswith("product=hermes-agent") for t in tags)

--- a/tests/gateway/test_recall.py
+++ b/tests/gateway/test_recall.py
@@ -1,0 +1,252 @@
+"""Tests for /recall command — gateway/recall.py."""
+
+import pytest
+from gateway.recall import (
+    RecallSpec,
+    RecallResult,
+    SourceRef,
+    parse_recall_args,
+    _ago,
+    _format_transcript,
+    _format_header,
+)
+
+
+# ---------------------------------------------------------------------------
+# parse_recall_args
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("raw,expected", [
+    ("",           RecallSpec(mode="thread", count=1)),
+    ("  ",         RecallSpec(mode="thread", count=1)),
+    ("3",          RecallSpec(mode="thread", count=3)),
+    ("10",         RecallSpec(mode="thread", count=10)),
+    ("99",         RecallSpec(mode="thread", count=10)),   # capped at 10
+    ("last 5",     RecallSpec(mode="thread", count=5)),
+    ("Last 2",     RecallSpec(mode="thread", count=2)),
+    ("last 99",    RecallSpec(mode="thread", count=10)),   # capped
+    ("24h",        RecallSpec(mode="window", window_hours=24)),
+    ("7d",         RecallSpec(mode="window", window_hours=168)),
+    ("2w",         RecallSpec(mode="window", window_hours=336)),
+    ("3m",         RecallSpec(mode="window", window_hours=2160)),
+    ("hex migration",        RecallSpec(mode="topic", query="hex migration")),
+    ("bosun spec",           RecallSpec(mode="topic", query="bosun spec")),
+    ("hex migration 7d",     RecallSpec(mode="topic", query="hex migration", window_hours=168)),
+    ("spool stuck 24h",      RecallSpec(mode="topic", query="spool stuck", window_hours=24)),
+])
+def test_parse_recall_args(raw, expected):
+    assert parse_recall_args(raw) == expected
+
+
+# ---------------------------------------------------------------------------
+# _ago
+# ---------------------------------------------------------------------------
+
+def test_ago_seconds():
+    import time
+    assert "just now" in _ago(time.time() - 30)
+
+def test_ago_minutes():
+    import time
+    s = _ago(time.time() - 600)
+    assert "m ago" in s
+
+def test_ago_hours():
+    import time
+    s = _ago(time.time() - 7200)
+    assert "h ago" in s
+
+def test_ago_days():
+    import time
+    s = _ago(time.time() - 86400 * 3)
+    assert "d ago" in s
+
+
+# ---------------------------------------------------------------------------
+# _format_transcript
+# ---------------------------------------------------------------------------
+
+def test_format_transcript_basic():
+    msgs = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "world"},
+        {"role": "tool", "content": "ignored"},
+    ]
+    out = _format_transcript(msgs, char_cap=5000)
+    assert "USER: hello" in out
+    assert "ASSISTANT: world" in out
+    assert "tool" not in out.lower() or "ignored" not in out
+
+def test_format_transcript_truncates():
+    msgs = [{"role": "user", "content": "x" * 3000}]
+    out = _format_transcript(msgs, char_cap=5000)
+    assert "[...]" in out  # long individual msg gets trimmed at 2000 chars
+
+def test_format_transcript_cap():
+    msgs = [{"role": "user", "content": "abc"} for _ in range(1000)]
+    out = _format_transcript(msgs, char_cap=500)
+    assert "truncated" in out
+
+
+# ---------------------------------------------------------------------------
+# _format_header
+# ---------------------------------------------------------------------------
+
+def test_format_header_thread_single():
+    import time
+    refs = [SourceRef("sid1", "Test", 10, time.time() - 3600)]
+    spec = RecallSpec(mode="thread", count=1)
+    h = _format_header(spec, refs)
+    assert "prior session in this thread" in h
+    assert "10 msgs" in h
+
+def test_format_header_thread_multi():
+    import time
+    refs = [SourceRef(f"s{i}", "T", 5, time.time() - 3600) for i in range(3)]
+    spec = RecallSpec(mode="thread", count=3)
+    h = _format_header(spec, refs)
+    assert "last 3" in h
+
+def test_format_header_window():
+    import time
+    refs = [SourceRef("s1", "T", 5, time.time() - 3600)]
+    spec = RecallSpec(mode="window", window_hours=24)
+    h = _format_header(spec, refs)
+    assert "24h" in h
+
+def test_format_header_topic():
+    import time
+    refs = [SourceRef("s1", "T", 5, time.time() - 3600)]
+    spec = RecallSpec(mode="topic", query="hex migration")
+    h = _format_header(spec, refs)
+    assert "hex migration" in h
+
+
+# ---------------------------------------------------------------------------
+# resolve_sources — integration-style with fake stores
+# ---------------------------------------------------------------------------
+
+class FakeSessionDB:
+    """Minimal fake for hermes_state.SessionDB."""
+
+    def __init__(self, sessions: list[dict], messages: dict | None = None):
+        self._sessions = sessions
+        self._messages: dict[str, list[dict]] = messages or {}
+
+    def search_sessions(self, source: str = None, limit: int = 20, offset: int = 0):
+        rows = self._sessions
+        if source:
+            rows = [r for r in rows if r.get("source") == source]
+        return rows[:limit]
+
+    def message_count(self, session_id: str = None) -> int:
+        if session_id:
+            return len(self._messages.get(session_id, []))
+        return sum(len(v) for v in self._messages.values())
+
+    def search_messages(self, query: str, limit: int = 20, **kwargs):
+        # Very simple: return rows where query appears in content
+        results = []
+        for sid, msgs in self._messages.items():
+            for msg in msgs:
+                if query.lower() in (msg.get("content") or "").lower():
+                    # find session row
+                    sess = next((s for s in self._sessions if s["id"] == sid), {})
+                    results.append({
+                        "session_id": sid,
+                        "content": msg.get("content", ""),
+                        "session_title": sess.get("title", f"Session {sid[:8]}"),
+                        "session_started_at": sess.get("started_at", 0),
+                        "timestamp": 0,
+                    })
+        return results[:limit]
+
+
+class FakeSessionStore:
+    def __init__(self, entries: dict):
+        self._entries = entries
+
+    def load_transcript(self, session_id: str) -> list[dict]:
+        return []
+
+
+def _make_ts(hours_ago: float) -> float:
+    import time
+    return time.time() - hours_ago * 3600
+
+
+def test_resolve_sources_thread_default():
+    from gateway.recall import resolve_sources
+    sessions = [
+        {"id": "sid-a", "source": "tg:123:456", "title": "Alpha", "started_at": _make_ts(2), "last_active": _make_ts(2)},
+        {"id": "sid-b", "source": "tg:123:456", "title": "Beta",  "started_at": _make_ts(5), "last_active": _make_ts(5)},
+        {"id": "sid-c", "source": "tg:999:0",   "title": "Other", "started_at": _make_ts(1), "last_active": _make_ts(1)},
+    ]
+    db = FakeSessionDB(sessions)
+    store = FakeSessionStore({"sid-current": {}})
+    store._entries = {"tg:123:456": type("E", (), {"session_id": "sid-current"})()}
+
+    spec = RecallSpec(mode="thread", count=1)
+    refs = resolve_sources(spec, "tg:123:456", store, db)
+    assert len(refs) == 1
+    assert refs[0].session_id == "sid-a"
+
+
+def test_resolve_sources_thread_count():
+    from gateway.recall import resolve_sources
+    sessions = [
+        {"id": f"sid-{i}", "source": "tg:1:1", "title": f"S{i}", "started_at": _make_ts(i), "last_active": _make_ts(i)}
+        for i in range(1, 6)
+    ]
+    db = FakeSessionDB(sessions)
+    store = FakeSessionStore({})
+    store._entries = {}
+
+    spec = RecallSpec(mode="thread", count=3)
+    refs = resolve_sources(spec, "tg:1:1", store, db)
+    assert len(refs) == 3
+
+
+def test_resolve_sources_window():
+    from gateway.recall import resolve_sources
+    import time
+    now = time.time()
+    sessions = [
+        {"id": "new", "source": "tg:1:1", "title": "New", "started_at": now - 3600, "last_active": now - 3600},
+        {"id": "old", "source": "tg:1:1", "title": "Old", "started_at": now - 48*3600, "last_active": now - 48*3600},
+    ]
+    db = FakeSessionDB(sessions)
+    store = FakeSessionStore({})
+    store._entries = {}
+
+    spec = RecallSpec(mode="window", window_hours=24)
+    refs = resolve_sources(spec, "tg:1:1", store, db, now=now)
+    assert all(r.session_id == "new" for r in refs)
+    assert len(refs) == 1
+
+
+def test_resolve_sources_topic():
+    from gateway.recall import resolve_sources
+    sessions = [
+        {"id": "s1", "source": "tg:1:1", "title": "Spool incident", "started_at": _make_ts(1)},
+        {"id": "s2", "source": "tg:2:2", "title": "Unrelated", "started_at": _make_ts(2)},
+    ]
+    messages = {
+        "s1": [{"role": "user", "content": "the spool got stuck again"}],
+        "s2": [{"role": "user", "content": "weather is nice"}],
+    }
+    db = FakeSessionDB(sessions, messages)
+    store = FakeSessionStore({})
+    store._entries = {}
+
+    spec = RecallSpec(mode="topic", query="spool")
+    refs = resolve_sources(spec, "tg:1:1", store, db)
+    assert any(r.session_id == "s1" for r in refs)
+    assert all(r.session_id != "s2" for r in refs)
+
+
+def test_resolve_sources_no_db():
+    from gateway.recall import resolve_sources
+    spec = RecallSpec(mode="thread", count=1)
+    refs = resolve_sources(spec, "tg:1:1", None, None)
+    assert refs == []

--- a/tests/gateway/test_recall.py
+++ b/tests/gateway/test_recall.py
@@ -133,6 +133,9 @@ class FakeSessionDB:
         self._sessions = sessions
         self._messages: dict[str, list[dict]] = messages or {}
 
+    def get_session(self, session_id: str):
+        return next((dict(r) for r in self._sessions if r.get("id") == session_id), None)
+
     def search_sessions(self, source: str = None, limit: int = 20, offset: int = 0):
         rows = self._sessions
         if source:
@@ -177,10 +180,17 @@ def _make_ts(hours_ago: float) -> float:
 
 def test_resolve_sources_thread_default():
     from gateway.recall import resolve_sources
+    # Sessions linked by parent_session_id chain (real structure after /new).
+    # current → sid-a → sid-b  (sid-c is a different thread, unlinked)
     sessions = [
-        {"id": "sid-a", "source": "tg:123:456", "title": "Alpha", "started_at": _make_ts(2), "last_active": _make_ts(2)},
-        {"id": "sid-b", "source": "tg:123:456", "title": "Beta",  "started_at": _make_ts(5), "last_active": _make_ts(5)},
-        {"id": "sid-c", "source": "tg:999:0",   "title": "Other", "started_at": _make_ts(1), "last_active": _make_ts(1)},
+        {"id": "sid-current", "source": "telegram", "title": "Current",
+         "parent_session_id": "sid-a", "started_at": _make_ts(0), "ended_at": None},
+        {"id": "sid-a", "source": "telegram", "title": "Alpha",
+         "parent_session_id": "sid-b", "started_at": _make_ts(2), "ended_at": _make_ts(1)},
+        {"id": "sid-b", "source": "telegram", "title": "Beta",
+         "parent_session_id": None, "started_at": _make_ts(5), "ended_at": _make_ts(3)},
+        {"id": "sid-c", "source": "telegram", "title": "Other thread",
+         "parent_session_id": None, "started_at": _make_ts(1), "ended_at": _make_ts(0.5)},
     ]
     db = FakeSessionDB(sessions)
     store = FakeSessionStore({"sid-current": {}})
@@ -194,35 +204,48 @@ def test_resolve_sources_thread_default():
 
 def test_resolve_sources_thread_count():
     from gateway.recall import resolve_sources
-    sessions = [
-        {"id": f"sid-{i}", "source": "tg:1:1", "title": f"S{i}", "started_at": _make_ts(i), "last_active": _make_ts(i)}
-        for i in range(1, 6)
-    ]
+    # Build a chain of 5 sessions: current → s4 → s3 → s2 → s1 → s0
+    sessions = [{"id": "sid-current", "source": "telegram", "title": "Current",
+                 "parent_session_id": "sid-4", "started_at": _make_ts(0), "ended_at": None}]
+    for i in range(4, -1, -1):
+        sessions.append({
+            "id": f"sid-{i}", "source": "telegram", "title": f"S{i}",
+            "parent_session_id": f"sid-{i-1}" if i > 0 else None,
+            "started_at": _make_ts(i + 1), "ended_at": _make_ts(i + 0.5),
+        })
     db = FakeSessionDB(sessions)
     store = FakeSessionStore({})
-    store._entries = {}
+    store._entries = {"tg:1:1": type("E", (), {"session_id": "sid-current"})()}
 
     spec = RecallSpec(mode="thread", count=3)
     refs = resolve_sources(spec, "tg:1:1", store, db)
     assert len(refs) == 3
+    assert refs[0].session_id == "sid-4"
+    assert refs[1].session_id == "sid-3"
+    assert refs[2].session_id == "sid-2"
 
 
 def test_resolve_sources_window():
     from gateway.recall import resolve_sources
     import time
     now = time.time()
+    # current → new (1h ago) → old (48h ago)
     sessions = [
-        {"id": "new", "source": "tg:1:1", "title": "New", "started_at": now - 3600, "last_active": now - 3600},
-        {"id": "old", "source": "tg:1:1", "title": "Old", "started_at": now - 48*3600, "last_active": now - 48*3600},
+        {"id": "sid-current", "source": "telegram", "title": "Current",
+         "parent_session_id": "new", "started_at": now - 600, "ended_at": None},
+        {"id": "new", "source": "telegram", "title": "New",
+         "parent_session_id": "old", "started_at": now - 3600, "ended_at": now - 700},
+        {"id": "old", "source": "telegram", "title": "Old",
+         "parent_session_id": None, "started_at": now - 48*3600, "ended_at": now - 47*3600},
     ]
     db = FakeSessionDB(sessions)
     store = FakeSessionStore({})
-    store._entries = {}
+    store._entries = {"tg:1:1": type("E", (), {"session_id": "sid-current"})()}
 
     spec = RecallSpec(mode="window", window_hours=24)
     refs = resolve_sources(spec, "tg:1:1", store, db, now=now)
-    assert all(r.session_id == "new" for r in refs)
     assert len(refs) == 1
+    assert refs[0].session_id == "new"
 
 
 def test_resolve_sources_topic():


### PR DESCRIPTION
## Problem

`/recall` always returned "nothing found" even when the user had prior sessions in the thread. Root cause: `_prior_sessions_for_key()` called `session_db.search_sessions(source=session_key)` where `session_key` is `'telegram:469214633:94316'`, but sessions are stored with `source='telegram'` (just the platform name). The query never matched anything.

The same broken lookup caused the `/new` tip nudge ("💡 Run /recall...") to never fire.

## Fix

Walk the `parent_session_id` chain starting from the current session. After each `/new`, the fresh session records `parent_session_id` pointing at the previous one, so the chain reliably tracks all prior sessions in the same thread — regardless of `source` column value.

**Files changed:**
- `gateway/recall.py`: `_prior_sessions_for_key()` now walks parent chain; new `_get_parent_session_id()` helper
- `gateway/run.py`: `/new` tip nudge checks `parent_session_id` instead of `search_sessions(source=)`
- `tests/gateway/test_recall.py`: `FakeSessionDB` gets `get_session()`; test data uses parent chains matching real DB structure

## Testing

- 32/32 recall tests pass
- Verified against live `state.db` (190MB): lineage walk correctly finds 2 prior sessions for this thread ("Restoring context after topic resets" → `#2` → `#3`)
