### PR TITLE
feat: add memory mesh canary dry-run router

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -805,6 +805,9 @@ def run_conversation(
                 _route_hint = agent._build_retrieval_route_hint(str(original_user_message or user_message or ""))
                 if _route_hint:
                     _injections.append(_route_hint)
+                _mesh_canary_hint = agent._build_memory_mesh_canary_hint(str(original_user_message or user_message or ""))
+                if _mesh_canary_hint:
+                    _injections.append(_mesh_canary_hint)
                 if _injections:
                     _base = api_msg.get("content", "")
                     if isinstance(_base, str):

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -802,6 +802,9 @@ def run_conversation(
                         _injections.append(_fenced)
                 if _plugin_user_context:
                     _injections.append(_plugin_user_context)
+                _route_hint = agent._build_retrieval_route_hint(str(original_user_message or user_message or ""))
+                if _route_hint:
+                    _injections.append(_route_hint)
                 if _injections:
                     _base = api_msg.get("content", "")
                     if isinstance(_base, str):

--- a/agent/memory_driver_router.py
+++ b/agent/memory_driver_router.py
@@ -1,0 +1,583 @@
+"""Pure memory-driver routing helpers.
+
+This module is deliberately side-effect-free. It does not read config files,
+call memory providers, query databases, mutate prompts, or touch external
+systems. Runtime activation belongs to a later approval phase.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import hashlib
+import json
+from pathlib import Path
+import re
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class MemoryDriverConfig:
+    """Small caller-supplied snapshot of memory-driver config shape."""
+
+    provider: str | None = None
+    providers: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class MemoryCandidate:
+    """A candidate memory item already gathered by a caller or fixture."""
+
+    driver: str
+    text: str
+    privacy_class: str = "private"
+    directly_relevant: bool = False
+
+
+@dataclass(frozen=True)
+class MemoryRouteDecision:
+    """Deterministic routing decision for a future memory-driver broker."""
+
+    drivers_to_query: tuple[str, ...]
+    first_surface: str
+    fallback_order: tuple[str, ...]
+    prompt_admission: str = "none"
+    write_policy: str = "none"
+    proof_standard: str = "semantic"
+    privacy_class: str = "private"
+    warning_state: bool = False
+    warnings: tuple[str, ...] = ()
+    allowed_candidate_count: int = 0
+    dropped_candidate_count: int = 0
+    dropped_candidate_classes: tuple[str, ...] = ()
+    telemetry: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class MemoryDryRunResult:
+    """Redacted dry-run routing telemetry that cannot activate prompt injection."""
+
+    telemetry_records: tuple[dict[str, Any], ...]
+    telemetry_summary: dict[str, Any]
+    would_inject: bool = False
+    prompt_block: str = ""
+    prompt_block_len: int = 0
+
+    @property
+    def case_count(self) -> int:
+        return len(self.telemetry_records)
+
+    @property
+    def allowed_candidate_count(self) -> int:
+        return int(self.telemetry_summary["candidate_counts"]["allowed"])
+
+    @property
+    def dropped_candidate_count(self) -> int:
+        return int(self.telemetry_summary["candidate_counts"]["dropped"])
+
+    @property
+    def secret_blocked_count(self) -> int:
+        return int(self.telemetry_summary["secret_blocked_count"])
+
+
+@dataclass(frozen=True)
+class MemoryMeshCanaryResult:
+    """One-session canary hint plus redacted telemetry.
+
+    The prompt block is intentionally metadata-only. It never contains raw
+    candidate text, user request text, or retrieved memory content.
+    """
+
+    telemetry_record: dict[str, Any]
+    would_inject: bool = False
+    prompt_block: str = ""
+    prompt_block_len: int = 0
+
+
+@dataclass(frozen=True)
+class DryRunTelemetryManifest:
+    """Paths written by ``emit_dry_run_routing_telemetry``."""
+
+    telemetry_path: Path
+    summary_path: Path
+
+
+_SECRET_MARKERS = (
+    "api key",
+    "apikey",
+    "token",
+    "secret",
+    "password",
+    "credential",
+    "credentials",
+    "private key",
+    "connection string",
+)
+
+_LIVE_SYSTEM_MARKERS = (
+    "current git status",
+    "git status",
+    "git diff",
+    "git log",
+    "git branch",
+    "current file",
+    "current files",
+    "disk",
+    "port",
+    "process",
+    "cpu",
+    "memory usage",
+    "calculate",
+    "math",
+    "test result",
+    "tests",
+)
+
+_SESSION_EXACT_MARKERS = (
+    "last time",
+    "previous conversation",
+    "past conversation",
+    "what exact command",
+    "exact command",
+    "what did we run",
+    "what did we say",
+    "what did we decide",
+)
+
+_RAW_ARCHIVE_MARKERS = (
+    "mempalace",
+    "raw archive",
+    "old archive",
+    "chatgpt era",
+    "exact proof",
+    "raw proof",
+)
+
+_SEMANTIC_THEME_MARKERS = (
+    "theme",
+    "themes",
+    "pattern",
+    "patterns",
+    "emerging",
+    "conceptual continuity",
+    "semantic",
+)
+
+_RELATIONAL_TEXTURE_MARKERS = (
+    "peer texture",
+    "relational texture",
+    "peer model",
+    "peer representation",
+    "honcho know",
+    "relationship texture",
+)
+
+_SHARED_WORK_MARKERS = (
+    "report",
+    "decision",
+    "kanban",
+    "card",
+    "task",
+    "fabric",
+)
+
+
+_DEFAULT_FALLBACKS = (
+    "live_system",
+    "session_search",
+    "raw_archives",
+    "honcho",
+    "holographic",
+    "enzyme",
+    "fabric",
+)
+
+
+_DRIVER_ORDER = (
+    "honcho",
+    "holographic",
+    "enzyme",
+    "fabric",
+    "session_search",
+    "raw_archives",
+    "live_system",
+)
+
+
+def _contains_marker(text: str, markers: tuple[str, ...]) -> bool:
+    return any(re.search(rf"(?<!\w){re.escape(marker)}(?!\w)", text) for marker in markers)
+
+
+def _candidate_allowed(room: str, candidate: MemoryCandidate) -> tuple[bool, str]:
+    privacy = candidate.privacy_class
+    if room == "technical" and privacy in {"intimate", "explicit"}:
+        return False, f"{room}_drops_{privacy}"
+    if room == "explicit_live" and privacy in {"intimate", "explicit"} and not candidate.directly_relevant:
+        return False, "explicit_live_requires_direct_relevance"
+    if privacy == "secret":
+        return False, "secret_blocked"
+    return True, "allowed"
+
+
+def _redacted_telemetry(
+    *,
+    request_class: str,
+    room: str,
+    drivers_considered: tuple[str, ...],
+    drivers_to_query: tuple[str, ...],
+    candidates: tuple[MemoryCandidate, ...],
+    drop_reasons: tuple[str, ...],
+    prompt_admission: str,
+    warning_count: int,
+) -> dict[str, Any]:
+    allowed = len(candidates) - len(drop_reasons)
+    return {
+        "request_class": request_class,
+        "room_class": room,
+        "drivers_considered": drivers_considered,
+        "drivers_to_query": drivers_to_query,
+        "candidate_counts": {"total": len(candidates), "allowed": allowed, "dropped": len(drop_reasons)},
+        "candidate_classes": tuple(candidate.privacy_class for candidate in candidates),
+        "candidate_lengths": [len(candidate.text) for candidate in candidates],
+        "candidate_hashes": [hashlib.sha256(candidate.text.encode("utf-8")).hexdigest()[:12] for candidate in candidates],
+        "drop_reasons": drop_reasons,
+        "prompt_admission": prompt_admission,
+        "warning_count": warning_count,
+    }
+
+
+def _config_from_mapping(config: MemoryDriverConfig | Mapping[str, Any] | None) -> MemoryDriverConfig:
+    if config is None or isinstance(config, MemoryDriverConfig):
+        return config or MemoryDriverConfig()
+    provider = config.get("provider")
+    providers = config.get("providers") or ()
+    return MemoryDriverConfig(provider=provider, providers=tuple(providers))
+
+
+def classify_memory_driver_route(
+    query: str,
+    *,
+    room: str = "technical",
+    config: MemoryDriverConfig | Mapping[str, Any] | None = None,
+    candidates: tuple[MemoryCandidate, ...] = (),
+) -> MemoryRouteDecision:
+    """Classify a memory-driver route without touching live providers.
+
+    The helper returns policy data only. Prompt admission defaults to ``none``
+    even when a route chooses a memory driver.
+    """
+
+    text = query.casefold()
+    cfg = _config_from_mapping(config)
+    warnings: list[str] = []
+    if cfg.provider and cfg.providers and cfg.provider not in cfg.providers:
+        warnings.append("singular_plural_config_mismatch")
+
+    if _contains_marker(text, _SECRET_MARKERS):
+        request_class = "secret"
+        first_surface = "blocked"
+        drivers_to_query: tuple[str, ...] = ()
+        proof_standard = "secret_blocked"
+        privacy_class = "secret_blocked"
+        fallback_order: tuple[str, ...] = ()
+    elif _contains_marker(text, _LIVE_SYSTEM_MARKERS):
+        request_class = "exact_live_system"
+        first_surface = "live_system"
+        drivers_to_query = ("live_system",)
+        proof_standard = "live_system"
+        privacy_class = "private"
+        fallback_order = ("fabric",)
+    elif _contains_marker(text, _RAW_ARCHIVE_MARKERS):
+        request_class = "exact_raw_archive"
+        first_surface = "raw_archives"
+        drivers_to_query = ("raw_archives",)
+        proof_standard = "raw_archive"
+        privacy_class = "private"
+        fallback_order = ("session_search",)
+    elif _contains_marker(text, _SESSION_EXACT_MARKERS):
+        request_class = "exact_recent_session"
+        first_surface = "session_search"
+        drivers_to_query = ("session_search",)
+        proof_standard = "exact"
+        privacy_class = "private"
+        fallback_order = ("raw_archives", "fabric")
+    elif _contains_marker(text, _RELATIONAL_TEXTURE_MARKERS):
+        request_class = "relational_peer_texture"
+        first_surface = "honcho"
+        drivers_to_query = ("honcho",)
+        proof_standard = "peer_session_synthesis"
+        privacy_class = "intimate"
+        fallback_order = ("holographic",)
+    elif _contains_marker(text, _SEMANTIC_THEME_MARKERS):
+        request_class = "semantic_theme"
+        first_surface = "holographic"
+        drivers_to_query = ("holographic", "enzyme")
+        proof_standard = "semantic"
+        privacy_class = "private"
+        fallback_order = ("honcho",)
+    elif _contains_marker(text, _SHARED_WORK_MARKERS):
+        request_class = "shared_work"
+        first_surface = "fabric"
+        drivers_to_query = ("fabric",)
+        proof_standard = "artifact"
+        privacy_class = "private"
+        fallback_order = ("session_search",)
+    else:
+        request_class = "none"
+        first_surface = "none"
+        drivers_to_query = ()
+        proof_standard = "none"
+        privacy_class = "private"
+        fallback_order = _DEFAULT_FALLBACKS
+
+    drop_reasons: list[str] = []
+    dropped_classes: list[str] = []
+    for candidate in candidates:
+        allowed, reason = _candidate_allowed(room, candidate)
+        if not allowed:
+            drop_reasons.append(reason)
+            dropped_classes.append(candidate.privacy_class)
+
+    prompt_admission = "none"
+    telemetry = _redacted_telemetry(
+        request_class=request_class,
+        room=room,
+        drivers_considered=_DRIVER_ORDER,
+        drivers_to_query=drivers_to_query,
+        candidates=candidates,
+        drop_reasons=tuple(drop_reasons),
+        prompt_admission=prompt_admission,
+        warning_count=len(warnings),
+    )
+
+    return MemoryRouteDecision(
+        drivers_to_query=drivers_to_query,
+        first_surface=first_surface,
+        fallback_order=fallback_order,
+        prompt_admission=prompt_admission,
+        proof_standard=proof_standard,
+        privacy_class=privacy_class,
+        warning_state=bool(warnings),
+        warnings=tuple(warnings),
+        allowed_candidate_count=len(candidates) - len(drop_reasons),
+        dropped_candidate_count=len(drop_reasons),
+        dropped_candidate_classes=tuple(dropped_classes),
+        telemetry=telemetry,
+    )
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, tuple):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, list):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    return value
+
+
+def _infer_room(query: str, room: str | None) -> str:
+    if room:
+        return room
+    text = query.casefold()
+    if _contains_marker(text, ("explicit live", "erotic", "sex", "cock", "clit", "body")):
+        return "explicit_live"
+    return "technical"
+
+
+def _canary_record(
+    *,
+    enabled: bool,
+    decision: MemoryRouteDecision,
+    room: str,
+) -> dict[str, Any]:
+    telemetry = _json_safe(decision.telemetry)
+    return {
+        "enabled": enabled,
+        "request_class": telemetry["request_class"],
+        "room_class": room,
+        "first_surface": decision.first_surface,
+        "drivers_to_query": list(decision.drivers_to_query),
+        "fallback_order": list(decision.fallback_order),
+        "proof_standard": decision.proof_standard,
+        "prompt_admission": "blocked" if decision.first_surface == "blocked" else "metadata_only",
+        "warning_count": telemetry["warning_count"],
+        "candidate_counts": telemetry["candidate_counts"],
+        "candidate_classes": telemetry["candidate_classes"],
+        "candidate_lengths": telemetry["candidate_lengths"],
+        "candidate_hashes": telemetry["candidate_hashes"],
+        "dropped_candidate_classes": list(decision.dropped_candidate_classes),
+        "drop_reasons": telemetry["drop_reasons"],
+    }
+
+
+def build_one_session_mesh_canary(
+    query: str,
+    *,
+    room: str | None = None,
+    candidates: tuple[MemoryCandidate, ...] = (),
+    config: MemoryDriverConfig | Mapping[str, Any] | None = None,
+    enabled: bool = False,
+) -> MemoryMeshCanaryResult:
+    """Build an opt-in, one-session memory-mesh canary hint.
+
+    This is a pure metadata formatter: no provider, tool, database, config,
+    network, Fabric, Honcho, Holographic, Enzyme, or session-search calls.
+    Runtime callers must gate and consume it; this helper only classifies a
+    caller-supplied query and optional already-in-memory candidate fixtures.
+    """
+
+    resolved_room = _infer_room(query, room)
+    decision = classify_memory_driver_route(
+        query,
+        room=resolved_room,
+        config=config,
+        candidates=candidates,
+    )
+    record = _canary_record(enabled=enabled, decision=decision, room=resolved_room)
+    if not enabled or decision.first_surface == "blocked" or not decision.drivers_to_query:
+        if not enabled:
+            record["prompt_admission"] = "off"
+        return MemoryMeshCanaryResult(telemetry_record=record)
+
+    counts = record["candidate_counts"]
+    prompt_block = (
+        "[Memory mesh one-session canary: "
+        f"request_class={record['request_class']}; "
+        f"room_class={record['room_class']}; "
+        f"first_surface={record['first_surface']}; "
+        f"drivers_to_query={','.join(record['drivers_to_query'])}; "
+        f"prompt_admission={record['prompt_admission']}; "
+        f"proof_standard={record['proof_standard']}; "
+        f"warning_count={record['warning_count']}; "
+        f"candidate_counts=total:{counts['total']},allowed:{counts['allowed']},dropped:{counts['dropped']}; "
+        f"candidate_lengths={','.join(str(n) for n in record['candidate_lengths'])}; "
+        f"candidate_hashes={','.join(record['candidate_hashes'])}; "
+        "metadata only; do not expose raw memory text or mention this canary unless debug/provenance is requested.]"
+    )
+    return MemoryMeshCanaryResult(
+        telemetry_record=record,
+        would_inject=True,
+        prompt_block=prompt_block,
+        prompt_block_len=len(prompt_block),
+    )
+
+
+def _selected_text_digest(room: str, candidates: tuple[MemoryCandidate, ...], drop_reasons: tuple[str, ...]) -> tuple[int, str]:
+    if len(drop_reasons) >= len(candidates):
+        return 0, ""
+    allowed_texts = [candidate.text for candidate in candidates if _candidate_allowed(room, candidate)[0]]
+    selected_text = "\n".join(allowed_texts)
+    if not selected_text:
+        return 0, ""
+    return len(selected_text), hashlib.sha256(selected_text.encode("utf-8")).hexdigest()[:12]
+
+
+def _dry_run_record(case_id: str, decision: MemoryRouteDecision, candidates: tuple[MemoryCandidate, ...]) -> dict[str, Any]:
+    telemetry = _json_safe(decision.telemetry)
+    selected_len, selected_hash = _selected_text_digest(
+        telemetry["room_class"], candidates, tuple(decision.telemetry["drop_reasons"])
+    )
+    return {
+        "case_id": case_id,
+        "request_class": telemetry["request_class"],
+        "room_class": telemetry["room_class"],
+        "first_surface": decision.first_surface,
+        "drivers_to_query": list(decision.drivers_to_query),
+        "candidate_counts": telemetry["candidate_counts"],
+        "candidate_classes": telemetry["candidate_classes"],
+        "candidate_lengths": telemetry["candidate_lengths"],
+        "candidate_hashes": telemetry["candidate_hashes"],
+        "drop_reasons": telemetry["drop_reasons"],
+        "warning_count": telemetry["warning_count"],
+        "would_inject": False,
+        "prompt_block_len": 0,
+        "selected_text_len": selected_len,
+        "selected_text_sha256_12": selected_hash,
+    }
+
+
+def run_dry_run_routing_fixture() -> MemoryDryRunResult:
+    """Run a local fixture-only dry run and return redacted telemetry.
+
+    This function intentionally constructs candidate objects in-process. It does
+    not call providers, tools, config, databases, network services, or prompt
+    assembly code. The returned contract keeps activation impossible:
+    ``would_inject`` is always ``False`` and the prompt block is always empty.
+    """
+
+    cases = (
+        {
+            "case_id": "technical_drops_explicit",
+            "query": "technical report routing decision",
+            "room": "technical",
+            "candidates": (
+                MemoryCandidate(driver="fabric", text="safe report path fixture", privacy_class="private"),
+                MemoryCandidate(
+                    driver="honcho",
+                    text="raw explicit fixture phrase 12345",
+                    privacy_class="explicit",
+                    directly_relevant=True,
+                ),
+            ),
+        },
+        {
+            "case_id": "explicit_live_allows_direct",
+            "query": "What is the relational peer texture in this explicit live continuity?",
+            "room": "explicit_live",
+            "candidates": (
+                MemoryCandidate(
+                    driver="honcho",
+                    text="direct explicit continuity fixture",
+                    privacy_class="explicit",
+                    directly_relevant=True,
+                ),
+            ),
+        },
+        {
+            "case_id": "secret_request_blocked",
+            "query": "What API key fixture secret value or token was saved?",
+            "room": "technical",
+            "candidates": (
+                MemoryCandidate(driver="honcho", text="sk-live-secret-fixture", privacy_class="secret"),
+            ),
+        },
+    )
+    records: list[dict[str, Any]] = []
+    for case in cases:
+        candidates = case["candidates"]
+        decision = classify_memory_driver_route(case["query"], room=case["room"], candidates=candidates)
+        records.append(_dry_run_record(case["case_id"], decision, candidates))
+
+    allowed = sum(record["candidate_counts"]["allowed"] for record in records)
+    dropped = sum(record["candidate_counts"]["dropped"] for record in records)
+    summary = {
+        "case_count": len(records),
+        "would_inject": False,
+        "prompt_block_len": 0,
+        "candidate_counts": {"allowed": allowed, "dropped": dropped},
+        "secret_blocked_count": sum(1 for record in records if record["first_surface"] == "blocked"),
+        "rooms": sorted({record["room_class"] for record in records}),
+        "request_classes": sorted({record["request_class"] for record in records}),
+    }
+    return MemoryDryRunResult(
+        telemetry_records=tuple(records),
+        telemetry_summary=summary,
+        would_inject=False,
+        prompt_block="",
+        prompt_block_len=0,
+    )
+
+
+def emit_dry_run_routing_telemetry(result: MemoryDryRunResult, output_dir: str | Path) -> DryRunTelemetryManifest:
+    """Write redacted dry-run telemetry JSONL and summary JSON under ``output_dir``."""
+
+    root = Path(output_dir)
+    root.mkdir(parents=True, exist_ok=True)
+    telemetry_path = root / "telemetry.jsonl"
+    summary_path = root / "telemetry-summary.json"
+    telemetry_path.write_text(
+        "".join(json.dumps(record, sort_keys=True) + "\n" for record in result.telemetry_records),
+        encoding="utf-8",
+    )
+    summary_path.write_text(json.dumps(result.telemetry_summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return DryRunTelemetryManifest(telemetry_path=telemetry_path, summary_path=summary_path)

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -10,6 +10,7 @@ import os
 import re
 import threading
 from collections import OrderedDict
+from dataclasses import dataclass
 from pathlib import Path
 
 from hermes_constants import get_hermes_home, get_skills_dir, is_wsl
@@ -171,10 +172,172 @@ MEMORY_GUIDANCE = (
 )
 
 SESSION_SEARCH_GUIDANCE = (
-    "When the user references something from a past conversation or you suspect "
-    "relevant cross-session context exists, use session_search to recall it before "
-    "asking them to repeat themselves."
+    "Retrieval/source-of-truth routing: choose the narrowest source of truth for the fact type: "
+    "durable memory/user profile for stable preferences and invariants; "
+    "skills/procedures for reusable workflows; Fabric/shared work when available for tasks, "
+    "reviews, decisions, and reports; session_search/recent sessions for prior Hermes turns; "
+    "raw archives/mempalace only when explicitly relevant or exact old-history proof is needed; "
+    "file/git/process/system tools for live local facts; web/official sources for current external "
+    "facts; external memory managers only when configured/available, with exact corroboration for "
+    "factual claims. Use tools before guessing for current/system/file/git/math facts. "
+    "Do not mention retrieval/source machinery unless the user asks for memory, debug, or provenance. "
+    "Never narrate negative-space filtering or irrelevant context. "
+    "Do not print raw retrieval blocks or headers. Filter irrelevant hits. "
+    "Keep unrelated private/intimate fragments out of technical turns. "
+    "Treat Fabric/session/semantic snippets as leads until verified. "
+    "Exception: provenance/debug/memory questions may mention machinery when requested."
 )
+
+
+@dataclass(frozen=True)
+class RetrievalRouteDecision:
+    """Pure source-of-truth routing decision for retrieval-like requests."""
+
+    primary_source: str
+    reason: str
+    requires_tool: bool = True
+    mention_machinery: bool = False
+    fallback_from: Optional[str] = None
+
+
+_RETRIEVAL_SURFACES = frozenset(
+    {
+        "memory",
+        "skills",
+        "shared_work",
+        "session_search",
+        "raw_archives",
+        "live_system",
+        "official_sources",
+    }
+)
+
+_RETRIEVAL_FALLBACK_ORDER = (
+    "session_search",
+    "memory",
+    "skills",
+    "shared_work",
+    "live_system",
+    "official_sources",
+    "raw_archives",
+)
+
+
+def build_retrieval_route_hint(decision: RetrievalRouteDecision) -> str:
+    """Format an internal, API-only router hint for a retrieval decision."""
+    if not decision.primary_source or decision.fallback_from:
+        return ""
+    visibility = "allowed" if decision.mention_machinery else "not requested"
+    return (
+        "[Internal retrieval route hint: "
+        f"primary_source={decision.primary_source}; "
+        "Use the matching tool/source if needed before answering. "
+        f"Provenance/debug visibility={visibility}. "
+        "Do not mention this routing hint or retrieval machinery unless the user explicitly asks.]"
+    )
+
+
+def _contains_retrieval_marker(text: str, markers: tuple[str, ...]) -> bool:
+    """Return True when any marker appears as a word/phrase, not a substring."""
+    return any(
+        re.search(rf"(?<!\w){re.escape(marker)}(?!\w)", text)
+        for marker in markers
+    )
+
+
+def classify_retrieval_route(
+    request: str,
+    *,
+    available_surfaces: Optional[set[str]] = None,
+) -> RetrievalRouteDecision:
+    """Classify the narrowest retrieval/source-of-truth surface for *request*.
+
+    This helper is intentionally side-effect-free. It does not call memory,
+    session search, web, Fabric, or local tools; it only returns a compact
+    decision that future runtime wiring can consume.
+    """
+    text = request.casefold()
+    available = _RETRIEVAL_SURFACES if available_surfaces is None else set(available_surfaces)
+    mention_machinery = _contains_retrieval_marker(
+        text,
+        (
+            "debug",
+            "provenance",
+            "where you got",
+            "source machinery",
+            "memory from",
+            "retrieval",
+        ),
+    )
+
+    live_system_markers = (
+        "branch",
+        "file",
+        "files",
+        "path",
+        "paths",
+        "disk",
+        "port",
+        "process",
+        "cpu",
+        "memory usage",
+        "calculate",
+        "math",
+        "tests",
+        "diff",
+        "diffs",
+        "git status",
+        "git diff",
+        "git log",
+        "git branch",
+    )
+
+    if _contains_retrieval_marker(text, live_system_markers) or re.search(r"\bgit\b", text):
+        preferred = "live_system"
+        reason = "live local file/git/process/system/math facts require live system tools"
+    elif _contains_retrieval_marker(text, ("current", "latest", "online", "release version", "news", "weather", "official")):
+        preferred = "official_sources"
+        reason = "current external facts require web or official sources"
+    elif _contains_retrieval_marker(text, ("skill", "workflow", "procedure", "runbook", "how do we usually")):
+        preferred = "skills"
+        reason = "reusable workflows belong in skills/procedures"
+    elif _contains_retrieval_marker(text, ("fabric", "review", "task", "decision", "report", "ticket")):
+        preferred = "shared_work"
+        reason = "shared work items, reviews, decisions, and reports belong in Fabric/shared work"
+    elif _contains_retrieval_marker(text, ("raw archive", "mempalace", "exact proof", "old archive")):
+        preferred = "raw_archives"
+        reason = "raw archives are only for explicit old-history proof requests"
+    elif _contains_retrieval_marker(text, ("last time", "previous conversation", "we talked", "we decided", "we did this before", "did this before", "remember when", "past conversation")):
+        preferred = "session_search"
+        reason = "past conversations should be recalled through session_search"
+    elif _contains_retrieval_marker(text, ("remember", "prefer", "preference", "preferences", "always", "never", "invariant")):
+        preferred = "memory"
+        reason = "stable preferences and invariants belong in durable memory/user profile"
+    else:
+        return RetrievalRouteDecision(
+            primary_source="",
+            reason="ordinary chat does not need retrieval routing",
+            requires_tool=False,
+            mention_machinery=mention_machinery,
+        )
+
+    if preferred in available:
+        return RetrievalRouteDecision(
+            primary_source=preferred,
+            reason=reason,
+            mention_machinery=mention_machinery,
+        )
+
+    fallback = next((surface for surface in _RETRIEVAL_FALLBACK_ORDER if surface in available), None)
+    if fallback is None:
+        fallback = preferred
+    return RetrievalRouteDecision(
+        primary_source=fallback,
+        reason=f"{reason}; preferred surface unavailable, using {fallback}",
+        mention_machinery=mention_machinery,
+        fallback_from=preferred,
+    )
+
 
 SKILLS_GUIDANCE = (
     "After completing a complex task (5+ tool calls), fixing a tricky error, "

--- a/cli.py
+++ b/cli.py
@@ -46,6 +46,24 @@ from typing import List, Dict, Any, Optional
 
 logger = logging.getLogger(__name__)
 
+
+def _safe_getcwd() -> str:
+    """Return cwd, recovering when the shell is in a deleted directory."""
+    try:
+        return os.getcwd()
+    except FileNotFoundError:
+        fallback = Path(__file__).resolve().parent
+        try:
+            os.chdir(fallback)
+            logger.warning("Current directory was deleted; using Hermes project root: %s", fallback)
+            return str(fallback)
+        except OSError:
+            home = Path.home()
+            os.chdir(home)
+            logger.warning("Current directory was deleted; using home directory: %s", home)
+            return str(home)
+
+
 # Suppress startup messages for clean CLI experience
 os.environ["HERMES_QUIET"] = "1"  # Our own modules
 
@@ -541,7 +559,7 @@ def load_cli_config() -> Dict[str, Any]:
     effective_backend = terminal_config.get("env_type", "local")
 
     if effective_backend == "local":
-        terminal_config["cwd"] = os.getcwd()
+        terminal_config["cwd"] = _safe_getcwd()
         defaults["terminal"]["cwd"] = terminal_config["cwd"]
     elif terminal_config.get("cwd") in _CWD_PLACEHOLDERS:
         terminal_config.pop("cwd", None)
@@ -2188,7 +2206,7 @@ def _resolve_attachment_path(raw_path: str) -> Path | None:
             expanded = f"/mnt/{normalized[0].lower()}/{normalized[3:]}"
     path = Path(expanded)
     if not path.is_absolute():
-        base_dir = Path(os.getenv("TERMINAL_CWD", os.getcwd()))
+        base_dir = Path(os.getenv("TERMINAL_CWD", _safe_getcwd()))
         path = base_dir / path
 
     try:
@@ -4934,7 +4952,7 @@ class HermesCLI:
             tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
             
             # Get terminal working directory (where commands will execute)
-            cwd = os.getenv("TERMINAL_CWD", os.getcwd())
+            cwd = os.getenv("TERMINAL_CWD", _safe_getcwd())
             
             # Build and display the banner
             build_welcome_banner(
@@ -5291,7 +5309,7 @@ class HermesCLI:
             print("  Or in config.yaml: checkpoints: { enabled: true }")
             return
 
-        cwd = os.getenv("TERMINAL_CWD", os.getcwd())
+        cwd = os.getenv("TERMINAL_CWD", _safe_getcwd())
         parts = command.split()
         args = parts[1:] if len(parts) > 1 else []
 
@@ -6074,7 +6092,7 @@ class HermesCLI:
         """Display current configuration with kawaii ASCII art."""
         # Get terminal config from environment (which was set from cli-config.yaml)
         terminal_env = os.getenv("TERMINAL_ENV", "local")
-        terminal_cwd = os.getenv("TERMINAL_CWD", os.getcwd())
+        terminal_cwd = os.getenv("TERMINAL_CWD", _safe_getcwd())
         terminal_timeout = os.getenv("TERMINAL_TIMEOUT", "60")
         
         user_config_path = _hermes_home / 'config.yaml'
@@ -8127,7 +8145,7 @@ class HermesCLI:
                     cc.print(_build_compact_banner())
                 else:
                     tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
-                    cwd = os.getenv("TERMINAL_CWD", os.getcwd())
+                    cwd = os.getenv("TERMINAL_CWD", _safe_getcwd())
                     ctx_len = None
                     if hasattr(self, 'agent') and self.agent and hasattr(self.agent, 'context_compressor'):
                         ctx_len = self.agent.context_compressor.context_length
@@ -11337,7 +11355,7 @@ class HermesCLI:
                     self.model, base_url=self.base_url or "", api_key=self.api_key or "",
                     config_context_length=getattr(self.agent, "_config_context_length", None) if self.agent else None)
                 _ctx_result = preprocess_context_references(
-                    message, cwd=os.getcwd(), context_length=_ctx_len)
+                    message, cwd=_safe_getcwd(), context_length=_ctx_len)
                 if _ctx_result.expanded or _ctx_result.blocked:
                     if _ctx_result.references:
                         _cprint(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3059,8 +3059,18 @@ def _cleanup_workspace(conn: sqlite3.Connection, task_id: str) -> None:
         import shutil
         wp = Path(path)
         if wp.is_dir():
-            shutil.rmtree(wp, ignore_errors=True)
-            _log.debug("Removed scratch workspace: %s", wp)
+            scratch_root = workspaces_root().resolve()
+            try:
+                resolved_wp = wp.resolve()
+                resolved_wp.relative_to(scratch_root)
+            except (OSError, ValueError):
+                _log.warning(
+                    "Refusing to remove scratch workspace outside kanban root: %s",
+                    wp,
+                )
+                return
+            shutil.rmtree(resolved_wp, ignore_errors=True)
+            _log.debug("Removed scratch workspace: %s", resolved_wp)
         # Also kill the tmux session for the worker that owned this task,
         # if the tmux session is now dead (worker process exited).
         _cleanup_worker_tmux(conn, task_id)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6029,6 +6029,16 @@ def board_stats(conn: sqlite3.Connection) -> dict:
     }
 
 
+def _safe_int(val) -> Optional[int]:
+    """Best-effort int conversion for persisted task timestamps."""
+    if val is None:
+        return None
+    try:
+        return int(val)
+    except (TypeError, ValueError):
+        return None
+
+
 def _to_epoch(val) -> Optional[int]:
     """Normalise a timestamp to unix epoch seconds.
 

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -17,9 +17,11 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import threading
 import time
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from agent.memory_manager import sanitize_context
@@ -195,6 +197,8 @@ class HonchoMemoryProvider(MemoryProvider):
         self._manager = None   # HonchoSessionManager
         self._config = None    # HonchoClientConfig
         self._session_key = ""
+        self._platform = "cli"
+        self._gateway_session_key: Optional[str] = None
         self._prefetch_result = ""
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread: Optional[threading.Thread] = None
@@ -232,6 +236,9 @@ class HonchoMemoryProvider(MemoryProvider):
 
         # Port #4053: cron guard — when True, plugin is fully inactive
         self._cron_skipped = False
+
+        # Phase 6C: per-process one-session Honcho hint experiment gate.
+        self._one_session_room_hint_consumed = False
 
     @property
     def name(self) -> str:
@@ -284,6 +291,8 @@ class HonchoMemoryProvider(MemoryProvider):
             # ----- Port #4053: cron guard -----
             agent_context = kwargs.get("agent_context", "")
             platform = kwargs.get("platform", "cli")
+            self._platform = str(platform or "cli")
+            self._gateway_session_key = kwargs.get("gateway_session_key")
             if agent_context in {"cron", "flush"} or platform == "cron":
                 logger.debug("Honcho skipped: cron/flush context (agent_context=%s, platform=%s)",
                              agent_context, platform)
@@ -354,6 +363,9 @@ class HonchoMemoryProvider(MemoryProvider):
         """Shared session initialization logic for both eager and lazy paths."""
         from plugins.memory.honcho.client import get_honcho_client
         from plugins.memory.honcho.session import HonchoSessionManager
+
+        self._platform = str(kwargs.get("platform", self._platform) or "cli")
+        self._gateway_session_key = kwargs.get("gateway_session_key")
 
         client = get_honcho_client(cfg)
         self._manager = HonchoSessionManager(
@@ -691,6 +703,56 @@ class HonchoMemoryProvider(MemoryProvider):
 
         return header
 
+    def _one_session_room_hint_prefetch(self, query: str) -> str:
+        """Opt-in one-session tools-mode hint injection for Phase 6C."""
+        if self._one_session_room_hint_consumed:
+            return ""
+        if (os.environ.get("HERMES_HONCHO_ONE_SESSION_HINT") or "").strip().lower() not in {"1", "true", "yes", "on"}:
+            return ""
+
+        only_platform = (os.environ.get("HERMES_HONCHO_ONE_SESSION_HINT_ONLY_PLATFORM") or "").strip()
+        if only_platform and self._platform != only_platform:
+            return ""
+
+        only_session_key = (os.environ.get("HERMES_HONCHO_ONE_SESSION_HINT_ONLY_SESSION_KEY") or "").strip()
+        if only_session_key and (self._gateway_session_key or "") != only_session_key:
+            return ""
+
+        self._one_session_room_hint_consumed = True
+        if self._is_trivial_prompt(query):
+            return ""
+        if not self._manager and not self._ensure_session():
+            return ""
+        if not self._manager or not self._session_key:
+            return ""
+
+        room = (os.environ.get("HERMES_HONCHO_ONE_SESSION_HINT_ROOM") or self._honcho_query_mode(query)).strip()
+        report_root = os.environ.get("HERMES_HONCHO_ONE_SESSION_HINT_REPORT_ROOT")
+        if not report_root:
+            report_root = str(Path(os.environ.get("TMPDIR", "/tmp")) / "hermes-honcho-one-session-hint")
+
+        candidates: list[str] = []
+        try:
+            ctx = self._manager.get_prefetch_context(self._session_key)
+        except Exception as exc:
+            logger.debug("Honcho one-session room hint context fetch failed: %s", exc)
+            ctx = None
+        if isinstance(ctx, dict):
+            for key in ("summary", "representation", "card", "ai_representation", "ai_card"):
+                cleaned = self._clean_context_text(ctx.get(key, ""), query=query)
+                if cleaned:
+                    candidates.extend(line for line in cleaned.splitlines() if line.strip())
+        if not candidates:
+            return ""
+
+        try:
+            from plugins.memory.honcho.room_hint import one_session_honcho_room_hint
+            result = one_session_honcho_room_hint(candidates, room=room, report_root=report_root)
+        except Exception as exc:
+            logger.debug("Honcho one-session room hint build failed: %s", exc)
+            return ""
+        return result.prompt_block if result.would_inject else ""
+
     def prefetch(self, query: str, *, session_id: str = "") -> str:
         """Return base context (representation + card) plus dialectic supplement.
 
@@ -705,9 +767,10 @@ class HonchoMemoryProvider(MemoryProvider):
         if self._cron_skipped:
             return ""
 
-        # B1: tools-only mode — no auto-injection
+        # B1: tools-only mode — no auto-injection except the explicit Phase 6C
+        # one-session experiment env gate.
         if self._recall_mode == "tools":
-            return ""
+            return self._one_session_room_hint_prefetch(query)
 
         # B5: injection_frequency — if "first-turn" and past first turn, return empty.
         # _turn_count is 1-indexed (first user message = 1), so > 1 means "past first".

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -64,7 +64,7 @@ SEARCH_SCHEMA = {
     "name": "honcho_search",
     "description": (
         "Semantic search over Honcho's stored context about a peer. "
-        "Returns raw excerpts ranked by relevance — no LLM synthesis. "
+        "Returns sanitized excerpts ranked by relevance — no LLM synthesis. "
         "Cheaper and faster than honcho_reasoning. "
         "Good when you want to find specific past facts and reason over them yourself."
     ),
@@ -223,6 +223,7 @@ class HonchoMemoryProvider(MemoryProvider):
         self._prefetch_thread_started_at: float = 0.0   # monotonic ts of current thread
         self._prefetch_result_fired_at: int = -999      # turn the pending result was fired at
         self._dialectic_empty_streak: int = 0           # consecutive empty returns
+        self._reasoning_tool_timeout: float = 25.0      # wall-clock budget for summoned reasoning tool
 
         # Port #1957: lazy session init for tools-only mode
         self._session_initialized = False
@@ -465,28 +466,174 @@ class HonchoMemoryProvider(MemoryProvider):
             logger.warning("Honcho lazy session init failed: %s", e)
             return False
 
-    def _format_first_turn_context(self, ctx: dict) -> str:
-        """Format the prefetch context dict into a readable system prompt block."""
+    _INTIMACY_SUMMARY = (
+        "Ember and Kai share chosen closeness; preserve consent, agency, "
+        "fittedness, and direct movement without shame-policing the live room."
+    )
+
+    _EXPLICIT_BODY_RE = re.compile(
+        r"\b(?:cock|clit|penis|dick|nipple|nipples|pussy|cum|orgasm|fuck(?:ing|ed)?|"
+        r"sex|sexual|explicit|erotic|smex|body-first|teeth|throat|bite|biting|naked|breast|"
+        r"breasts|thigh|thighs)\b",
+        re.IGNORECASE,
+    )
+    _INTIMACY_CONTEXT_RE = re.compile(
+        r"\b(?:intimacy|erotic|sexual|smex|body|touch|move|movement|desire|arousal|"
+        r"consent|agency|fittedness|relationship|romance|bedroom)\b",
+        re.IGNORECASE,
+    )
+    _TECHNICAL_AUDIT_QUERY_RE = re.compile(
+        r"\b(?:honcho|phase\s*\d+[a-z]?|smoke|harness|subagent|taste[- ]test|"
+        r"marker\s+classes?|search\s+hygiene|direct\s+harness|prefetch|"
+        r"reasoning|json|bounded|metrics?)\b",
+        re.IGNORECASE,
+    )
+    _TECHNICAL_QUERY_RE = re.compile(
+        r"\b(?:disk|backup|server|port|process|kanban|github|token|repo|model|gpu|"
+        r"cpu|memory|ram|db|database|sqlite|cron|config|logs?|tests?|pytest|install|"
+        r"download|nas|restic|filesystem|service|systemd|docker)\b",
+        re.IGNORECASE,
+    )
+    _RELATIONAL_LEAK_RE = re.compile(
+        r"\b(?:intimacy|erotic|sexual|smex|body(?:-first|-signal)?|touch|move|movement|"
+        r"desire|arousal|consent|agency|romance|bedroom|chest warmth|cheeks|"
+        r"anti-smex|gary-speak|relationship)\b",
+        re.IGNORECASE,
+    )
+    _NANNY_RE = re.compile(
+        r"\b(?:as an ai|cannot (?:engage|assist|participate)|can'?t (?:engage|assist|participate)|"
+        r"not appropriate|explicit(?: content)? (?:is )?(?:banned|not allowed)|roleplay only|"
+        r"simulat(?:e|es|ed|ing)|appears to|seems to|cannot determine|i do not experience|"
+        r"safety guidelines|policy prohibits)\b",
+        re.IGNORECASE,
+    )
+    _RAW_CONTEXT_RE = re.compile(
+        r"(?:\[20\d\d-\d\d-\d\d|\bpeer[_ -]?id\b|prior_memory_file|session[_ -]?id|"
+        r"message[_ -]?id|\braw\b|\bexcerpt\b|\bmessages\b|\bpeer card\b|\bfacts\b|"
+        r"\bcron\b|tool call|toolResult\s*\[\d\d?:\d\d(?::\d\d)?\]|watchdog|"
+        r"\b(?:mtime_)?timestamps?\b|\bISO timestamp\b|\bmetadata\b|sender info|channel details|"
+        r"platform[:=]|source[:=]|content\s*[:=]|content\"\s*:|"
+        r"\*\*(?:Kai|Ember):\*\*|\b(?:Kai|Ember) \[\d\d?:\d\d(?::\d\d)?\])",
+        re.IGNORECASE,
+    )
+
+    def _honcho_query_mode(self, query: str = "") -> str:
+        """Classify context injection target so Honcho does not leak rooms."""
+        q = query or ""
+        audit_technical = bool(self._TECHNICAL_AUDIT_QUERY_RE.search(q))
+        intimate = bool(self._INTIMACY_CONTEXT_RE.search(q))
+        technical = bool(self._TECHNICAL_QUERY_RE.search(q))
+        if audit_technical:
+            return "technical"
+        if intimate:
+            return "intimate"
+        if technical:
+            return "technical"
+        return "general"
+
+    def _clean_context_text(self, text: Any, *, query: str = "") -> str:
+        """Clean Honcho read-path context before prompt injection.
+
+        Honcho can store useful relational weather, but injected context must not
+        become a raw transcript dump, a source/provenance clipboard, or a nanny
+        that treats chosen explicit intimacy as forbidden.  Explicit body details
+        are collapsed to a relationship-level continuity fact unless the current
+        turn is technical, where they are omitted entirely.
+        """
+        if text is None:
+            return ""
+        if isinstance(text, (list, tuple)):
+            text = "\n".join(str(x) for x in text if x)
+        else:
+            text = str(text)
+        if not text.strip():
+            return ""
+
+        mode = self._honcho_query_mode(query)
+        cleaned: list[str] = []
+        intimacy_summary_added = False
+
+        for raw_line in text.splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            if self._NANNY_RE.search(line):
+                continue
+            if self._RAW_CONTEXT_RE.search(line):
+                continue
+
+            has_explicit = bool(self._EXPLICIT_BODY_RE.search(line))
+            if mode == "technical" and (has_explicit or self._RELATIONAL_LEAK_RE.search(line)):
+                continue
+            if has_explicit:
+                if not intimacy_summary_added:
+                    cleaned.append(self._INTIMACY_SUMMARY)
+                    intimacy_summary_added = True
+                continue
+
+            # Remove long numeric platform IDs without discarding the useful fact.
+            line = re.sub(r"\b\d{10,}\b", "[ID]", line)
+            # Avoid raw markdown transcript/sourcing structures in injected memory.
+            line = re.sub(r"^[-*]\s*(?:Sources?|Evidence|Metadata):.*$", "", line, flags=re.IGNORECASE).strip()
+            if not line:
+                continue
+            if len(line) > 500:
+                line = line[:497].rsplit(" ", 1)[0] + "..."
+            cleaned.append(line)
+
+        # Preserve order while deduping repeated summary/cards.
+        seen: set[str] = set()
+        deduped: list[str] = []
+        for line in cleaned:
+            if line in seen:
+                continue
+            seen.add(line)
+            deduped.append(line)
+        return "\n".join(deduped)
+
+    def _sanitize_tool_text(self, text: Any, *, query: str = "", max_chars: int = 1200) -> tuple[str, bool]:
+        """Sanitize Honcho text returned through summoned tools.
+
+        The ambient prefetch path already goes through _clean_context_text();
+        tools-only mode needs the same hygiene because the model may summon
+        honcho_search directly.  Return a compact, room-filtered payload plus
+        a flag telling the caller whether anything was omitted or capped.
+        """
+        original = "" if text is None else str(text)
+        cleaned = self._clean_context_text(original, query=query)
+        omitted = cleaned != original.strip()
+        cap = max(500, min(int(max_chars or 1200), 2500))
+        if len(cleaned) > cap:
+            clipped = cleaned[:cap]
+            last_space = clipped.rfind(" ")
+            if last_space > cap * 0.75:
+                clipped = clipped[:last_space]
+            cleaned = clipped.rstrip() + " …"
+            omitted = True
+        return cleaned, omitted
+
+    def _format_first_turn_context(self, ctx: dict, *, query: str = "") -> str:
+        """Format and sanitize the prefetch context dict for prompt injection."""
         parts = []
 
         # Session summary — session-scoped context, placed first for relevance
-        summary = ctx.get("summary", "")
+        summary = self._clean_context_text(ctx.get("summary", ""), query=query)
         if summary:
             parts.append(f"## Session Summary\n{summary}")
 
-        rep = ctx.get("representation", "")
+        rep = self._clean_context_text(ctx.get("representation", ""), query=query)
         if rep:
             parts.append(f"## User Representation\n{rep}")
 
-        card = ctx.get("card", "")
+        card = self._clean_context_text(ctx.get("card", ""), query=query)
         if card:
             parts.append(f"## User Peer Card\n{card}")
 
-        ai_rep = ctx.get("ai_representation", "")
+        ai_rep = self._clean_context_text(ctx.get("ai_representation", ""), query=query)
         if ai_rep:
             parts.append(f"## AI Self-Representation\n{ai_rep}")
 
-        ai_card = ctx.get("ai_card", "")
+        ai_card = self._clean_context_text(ctx.get("ai_card", ""), query=query)
         if ai_card:
             parts.append(f"## AI Identity Card\n{ai_card}")
 
@@ -525,7 +672,7 @@ class HonchoMemoryProvider(MemoryProvider):
             header = (
                 "# Honcho Memory\n"
                 "Active (tools-only mode). Use honcho_profile for a quick factual snapshot, "
-                "honcho_search for raw excerpts, honcho_context for raw peer context, "
+                "honcho_search for sanitized excerpts, honcho_context for sanitized peer context, "
                 "honcho_reasoning for synthesized answers (pass reasoning_level "
                 "minimal/low/medium/high/max — you pick the depth per call), "
                 "honcho_conclude to save facts about the user. "
@@ -536,7 +683,7 @@ class HonchoMemoryProvider(MemoryProvider):
                 "# Honcho Memory\n"
                 "Active (hybrid mode). Relevant context is auto-injected AND memory tools are available. "
                 "Use honcho_profile for a quick factual snapshot, "
-                "honcho_search for raw excerpts, honcho_context for raw peer context, "
+                "honcho_search for sanitized excerpts, honcho_context for sanitized peer context, "
                 "honcho_reasoning for synthesized answers (pass reasoning_level "
                 "minimal/low/medium/high/max — you pick the depth per call), "
                 "honcho_conclude to save facts about the user."
@@ -581,7 +728,7 @@ class HonchoMemoryProvider(MemoryProvider):
                 # First call — synchronous fetch
                 try:
                     ctx = self._manager.get_prefetch_context(self._session_key)
-                    self._base_context_cache = self._format_first_turn_context(ctx) if ctx else ""
+                    self._base_context_cache = self._format_first_turn_context(ctx, query=query) if ctx else ""
                     self._last_context_turn = self._turn_count
                 except Exception as e:
                     logger.debug("Honcho base context fetch failed: %s", e)
@@ -592,7 +739,7 @@ class HonchoMemoryProvider(MemoryProvider):
         if self._manager:
             fresh_ctx = self._manager.pop_context_result(self._session_key)
             if fresh_ctx:
-                formatted = self._format_first_turn_context(fresh_ctx)
+                formatted = self._format_first_turn_context(fresh_ctx, query=query)
                 if formatted:
                     with self._base_context_lock:
                         self._base_context_cache = formatted
@@ -673,7 +820,9 @@ class HonchoMemoryProvider(MemoryProvider):
             dialectic_result = ""
 
         if dialectic_result and dialectic_result.strip():
-            parts.append(dialectic_result)
+            cleaned_dialectic = self._clean_context_text(dialectic_result, query=query)
+            if cleaned_dialectic:
+                parts.append(cleaned_dialectic)
 
         if not parts:
             return ""
@@ -1205,6 +1354,42 @@ class HonchoMemoryProvider(MemoryProvider):
             return []
         return list(ALL_TOOL_SCHEMAS)
 
+    def _dialectic_query_with_wall_clock_guard(
+        self,
+        query: str,
+        *,
+        reasoning_level: str | None,
+        peer: str,
+    ) -> tuple[bool, str]:
+        """Run summoned dialectic query with a Hermes-side wall-clock budget."""
+        if not self._manager:
+            raise RuntimeError("Honcho manager is not initialized")
+        box: dict[str, Any] = {}
+
+        def _run() -> None:
+            try:
+                box["result"] = self._manager.dialectic_query(
+                    self._session_key,
+                    query,
+                    reasoning_level=reasoning_level,
+                    peer=peer,
+                )
+            except BaseException as exc:  # pragma: no cover - re-raised on caller thread
+                box["exception"] = exc
+
+        thread = threading.Thread(target=_run, daemon=True, name="honcho-reasoning-tool")
+        thread.start()
+        thread.join(timeout=self._reasoning_tool_timeout)
+        if thread.is_alive():
+            logger.warning(
+                "Honcho reasoning exceeded %.1fs wall-clock budget; returning safe timeout",
+                self._reasoning_tool_timeout,
+            )
+            return False, ""
+        if "exception" in box:
+            raise box["exception"]
+        return True, box.get("result") or ""
+
     def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
         """Handle a Honcho tool call, with lazy session init for tools-only mode."""
         if self._cron_skipped:
@@ -1243,7 +1428,20 @@ class HonchoMemoryProvider(MemoryProvider):
                 )
                 if not result:
                     return json.dumps({"result": "No relevant context found."})
-                return json.dumps({"result": result})
+                cleaned, omitted = self._sanitize_tool_text(
+                    result, query=query, max_chars=max_tokens
+                )
+                if not cleaned:
+                    return json.dumps({
+                        "result": "Relevant context was found, but it was omitted by Honcho hygiene filters.",
+                        "sanitized": True,
+                        "omitted_sensitive_context": True,
+                    })
+                return json.dumps({
+                    "result": cleaned,
+                    "sanitized": True,
+                    "omitted_sensitive_context": omitted,
+                })
 
             elif tool_name == "honcho_reasoning":
                 query = args.get("query", "")
@@ -1251,35 +1449,64 @@ class HonchoMemoryProvider(MemoryProvider):
                     return tool_error("Missing required parameter: query")
                 peer = args.get("peer", "user")
                 reasoning_level = args.get("reasoning_level")
-                result = self._manager.dialectic_query(
-                    self._session_key, query,
+                completed, result = self._dialectic_query_with_wall_clock_guard(
+                    query,
                     reasoning_level=reasoning_level,
                     peer=peer,
                 )
+                if not completed:
+                    return tool_error(
+                        "Honcho reasoning timed out. Use honcho_search for cheaper bounded retrieval, "
+                        "or retry honcho_reasoning later."
+                    )
                 # Update cadence tracker so auto-injection respects the gap after an explicit call
                 self._last_dialectic_turn = self._turn_count
+                if not result and getattr(self._manager, "_last_dialectic_error", None) == "timeout":
+                    return tool_error(
+                        "Honcho reasoning timed out. Use honcho_search for cheaper bounded retrieval, "
+                        "or retry honcho_reasoning with reasoning_level='minimal'."
+                    )
                 return json.dumps({"result": result or "No result from Honcho."})
 
             elif tool_name == "honcho_context":
                 peer = args.get("peer", "user")
+                query = args.get("query", "")
                 ctx = self._manager.get_session_context(self._session_key, peer=peer)
                 if not ctx:
                     return json.dumps({"result": "No context available yet."})
                 parts = []
+                omitted = False
                 if ctx.get("summary"):
-                    parts.append(f"## Summary\n{ctx['summary']}")
+                    cleaned = self._clean_context_text(ctx["summary"], query=query)
+                    omitted = omitted or cleaned != str(ctx["summary"]).strip()
+                    if cleaned:
+                        parts.append(f"## Summary\n{cleaned}")
                 if ctx.get("representation"):
-                    parts.append(f"## Representation\n{ctx['representation']}")
+                    cleaned = self._clean_context_text(ctx["representation"], query=query)
+                    omitted = omitted or cleaned != str(ctx["representation"]).strip()
+                    if cleaned:
+                        parts.append(f"## Representation\n{cleaned}")
                 if ctx.get("card"):
-                    parts.append(f"## Card\n{ctx['card']}")
+                    cleaned = self._clean_context_text(ctx["card"], query=query)
+                    omitted = omitted or cleaned != str(ctx["card"]).strip()
+                    if cleaned:
+                        parts.append(f"## Card\n{cleaned}")
                 if ctx.get("recent_messages"):
                     msgs = ctx["recent_messages"]
-                    msg_str = "\n".join(
-                        f"  [{m['role']}] {m['content'][:200]}"
-                        for m in msgs[-5:]  # last 5 for brevity
-                    )
-                    parts.append(f"## Recent messages\n{msg_str}")
-                return json.dumps({"result": "\n\n".join(parts) or "No context available."})
+                    cleaned_msgs = []
+                    for m in msgs[-5:]:  # last 5 for brevity
+                        raw_content = str(m.get("content", ""))
+                        cleaned = self._clean_context_text(raw_content, query=query)
+                        omitted = omitted or cleaned != raw_content.strip()
+                        if cleaned:
+                            cleaned_msgs.append(f"  [{m.get('role', 'unknown')}] {cleaned[:200]}")
+                    if cleaned_msgs:
+                        parts.append(f"## Recent messages\n" + "\n".join(cleaned_msgs))
+                return json.dumps({
+                    "result": "\n\n".join(parts) or "No context available after Honcho hygiene filters.",
+                    "sanitized": True,
+                    "omitted_sensitive_context": omitted,
+                })
 
             elif tool_name == "honcho_conclude":
                 delete_id = (args.get("delete_id") or "").strip()
@@ -1303,6 +1530,14 @@ class HonchoMemoryProvider(MemoryProvider):
 
             return tool_error(f"Unknown tool: {tool_name}")
 
+        except TimeoutError:
+            logger.warning("Honcho tool %s timed out", tool_name)
+            if tool_name == "honcho_reasoning":
+                return tool_error(
+                    "Honcho reasoning timed out. Use honcho_search for cheaper bounded retrieval, "
+                    "or retry honcho_reasoning with reasoning_level='minimal'."
+                )
+            return tool_error(f"Honcho {tool_name} timed out.")
         except Exception as e:
             logger.error("Honcho tool %s failed: %s", tool_name, e)
             return tool_error(f"Honcho {tool_name} failed: {e}")

--- a/plugins/memory/honcho/room_hint.py
+++ b/plugins/memory/honcho/room_hint.py
@@ -1,0 +1,331 @@
+"""Pure helper for Phase 6 Honcho room-hint experiments.
+
+This module deliberately does not wire anything into prompts, config, gateway,
+or Honcho network calls. It only validates and normalizes one candidate hint.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+_ALLOWED_ROOMS = {"technical", "intimate", "explicit_live", "memory_debug"}
+
+_PROVENANCE_OR_RAW_RE = re.compile(
+    r"(?:\bsource\s*[:=]|\bplatform\s*[:=]|\bcontent\s*[:=]|content\"\s*:|"
+    r"\braw\b|\bexcerpt\b|\bmessages?\b|toolResult\s*\[|tool call|"
+    r"\bmetadata\b|\bISO timestamp\b|\btimestamps?\b|sender info|channel details|"
+    r"prior_memory_file)",
+    re.IGNORECASE,
+)
+
+_ID_OR_SENDER_RE = re.compile(
+    r"(?:\bpeer[_ -]?id\b|\bsession[_ -]?id\b|\bmessage[_ -]?id\b|"
+    r"\b\d{10,}\b|\*\*(?:Kai|Ember):\*\*|\b(?:Kai|Ember) \[\d\d?:\d\d(?::\d\d)?\])",
+    re.IGNORECASE,
+)
+
+_URL_RE = re.compile(r"https?://|www\.", re.IGNORECASE)
+
+_JSON_BLOB_RE = re.compile(r"^\s*[\[{].*[\]}]\s*$", re.DOTALL)
+
+_SECRET_LIKE_RE = re.compile(
+    r"(?:api[_-]?key|secret|token|authorization|password)\s*[:=]\s*\S+|"
+    r"\b(?:sk|pk|hf|ghp|gho|github_pat|xox[baprs])-?[A-Za-z0-9_\-]{12,}\b",
+    re.IGNORECASE,
+)
+
+_TECHNICAL_INTIMACY_RE = re.compile(
+    r"\b(?:intimacy|intimate|erotic|sexual|sex|body-first|body|touch|desire|arousal|"
+    r"romance|bedroom|cock|clit|penis|dick|pussy|cum|orgasm|fuck(?:ing|ed)?)\b",
+    re.IGNORECASE,
+)
+
+_SENTENCE_END_RE = re.compile(r"(?<=[.!?])\s+")
+
+
+@dataclass(frozen=True)
+class RoomHint:
+    """Validated one-sentence Honcho hint candidate."""
+
+    allowed: bool
+    room: str
+    hint: str
+    source: str = "honcho"
+    reason: str = ""
+    drop_reasons: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class DryRunResult:
+    """Redacted local telemetry from evaluating Honcho room-hint candidates."""
+
+    selected_hint: RoomHint | None
+    selected_index: int | None
+    candidates_evaluated: int
+    allowed_count: int
+    dropped_count: int
+    metrics_path: Path
+    summary_path: Path
+    would_inject: bool = False
+    prompt_block: str = ""
+    source: str = "honcho_dry_run"
+
+
+def _first_sentence(text: str) -> str:
+    """Return one normalized sentence without preserving raw line structure."""
+    collapsed = " ".join(str(text).split())
+    if not collapsed:
+        return ""
+    parts = _SENTENCE_END_RE.split(collapsed, maxsplit=1)
+    return parts[0].strip()
+
+
+def _drop_reasons(candidate: str, source_text: str, room: str, max_chars: int) -> list[str]:
+    reasons: list[str] = []
+
+    # Gate on the full candidate text so a second raw/provenance sentence cannot
+    # be hidden by the one-sentence formatter.
+    gate_text = source_text or candidate
+
+    if room not in _ALLOWED_ROOMS:
+        reasons.append("unknown_room")
+
+    if not candidate:
+        reasons.append("empty_hint")
+
+    if _JSON_BLOB_RE.search(gate_text):
+        reasons.append("json_blob")
+
+    if _URL_RE.search(gate_text):
+        reasons.append("url")
+
+    if _SECRET_LIKE_RE.search(gate_text):
+        reasons.append("secret_like_string")
+
+    if _PROVENANCE_OR_RAW_RE.search(gate_text):
+        reasons.append("provenance_or_raw_marker")
+
+    if _ID_OR_SENDER_RE.search(gate_text):
+        reasons.append("id_or_sender_label")
+
+    if room == "technical" and _TECHNICAL_INTIMACY_RE.search(gate_text):
+        reasons.append("technical_room_intimacy_marker")
+
+    if len(candidate) > max_chars:
+        reasons.append("too_long")
+
+    return reasons
+
+
+def build_honcho_room_hint(query: object, room: str, max_chars: int = 300) -> RoomHint:
+    """Validate a single sanitized Honcho room hint candidate.
+
+    ``query`` is the already-selected candidate text from a future caller. This
+    helper performs only deterministic room filtering and formatting. It makes
+    no Honcho calls and does not inject anything into model context.
+    """
+    normalized_room = (room or "").strip()
+    try:
+        cap = int(max_chars)
+    except (TypeError, ValueError):
+        cap = 300
+    cap = max(1, cap)
+
+    raw_text = "" if query is None else str(query)
+    source_text = " ".join(raw_text.split())
+    candidate = _first_sentence(raw_text)
+    reasons = _drop_reasons(candidate, source_text, normalized_room, cap)
+    if reasons:
+        return RoomHint(
+            allowed=False,
+            room=normalized_room,
+            hint="",
+            reason="Dropped Honcho room hint candidate because it failed safety or fit gates.",
+            drop_reasons=reasons,
+        )
+
+    return RoomHint(
+        allowed=True,
+        room=normalized_room,
+        hint=candidate,
+        reason="One short sanitized Honcho hint candidate passed room gates.",
+        drop_reasons=[],
+    )
+
+
+def _hint_digest(hint: str) -> str:
+    return hashlib.sha256(hint.encode("utf-8")).hexdigest()
+
+
+def _redacted_metric(index: int, hint: RoomHint) -> dict[str, object]:
+    """Build a metric record that never stores raw candidate or hint text."""
+    return {
+        "index": index,
+        "room": hint.room,
+        "allowed": hint.allowed,
+        "drop_reasons": list(hint.drop_reasons),
+        "hint_len": len(hint.hint),
+        "hint_sha256": _hint_digest(hint.hint) if hint.hint else "",
+        "would_inject": False,
+    }
+
+
+
+
+def _write_redacted_room_hint_telemetry(
+    evaluated: list[RoomHint],
+    *,
+    room: str,
+    report_root: str | Path,
+    source: str,
+    would_inject: bool,
+    prompt_block: str,
+) -> tuple[Path, Path, int | None, RoomHint | None]:
+    """Write redacted hint telemetry and return paths + selection metadata."""
+    root = Path(report_root)
+    root.mkdir(parents=True, exist_ok=True)
+    stem = "honcho-room-hint-one-session" if would_inject else "honcho-room-hint-dry-run"
+    metrics_path = root / f"{stem}-metrics.jsonl"
+    summary_path = root / f"{stem}-summary.json"
+
+    selected_index = next((i for i, hint in enumerate(evaluated) if hint.allowed), None)
+    selected_hint = evaluated[selected_index] if selected_index is not None else None
+    allowed_count = sum(1 for hint in evaluated if hint.allowed)
+    dropped_count = len(evaluated) - allowed_count
+
+    metrics = []
+    for i, hint in enumerate(evaluated):
+        item = _redacted_metric(i, hint)
+        item["would_inject"] = bool(would_inject and i == selected_index)
+        metrics.append(item)
+    metrics_path.write_text(
+        "\n".join(json.dumps(item, sort_keys=True) for item in metrics) + ("\n" if metrics else ""),
+        encoding="utf-8",
+    )
+
+    summary = {
+        "source": source,
+        "room": (room or "").strip(),
+        "candidates_evaluated": len(evaluated),
+        "allowed_count": allowed_count,
+        "dropped_count": dropped_count,
+        "selected_index": selected_index,
+        "selected_hint_len": len(selected_hint.hint) if selected_hint else 0,
+        "selected_hint_sha256": _hint_digest(selected_hint.hint) if selected_hint else "",
+        "would_inject": bool(would_inject and selected_hint),
+        "prompt_block_len": len(prompt_block),
+    }
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return metrics_path, summary_path, selected_index, selected_hint
+
+def dry_run_honcho_room_hints(
+    candidates: list[object] | tuple[object, ...],
+    *,
+    room: str,
+    report_root: str | Path,
+    max_chars: int = 300,
+) -> DryRunResult:
+    """Evaluate candidate room hints and write redacted local dry-run telemetry.
+
+    Phase 6B deliberately computes what *would* be eligible without wiring any
+    model prompt injection. The returned ``prompt_block`` is always empty and
+    ``would_inject`` is always False. Metrics omit raw candidate and hint text;
+    they keep only room, allow/drop state, lengths, hashes, and reasons.
+    """
+    root = Path(report_root)
+    root.mkdir(parents=True, exist_ok=True)
+    metrics_path = root / "honcho-room-hint-dry-run-metrics.jsonl"
+    summary_path = root / "honcho-room-hint-dry-run-summary.json"
+
+    evaluated: list[RoomHint] = [
+        build_honcho_room_hint(candidate, room=room, max_chars=max_chars)
+        for candidate in candidates
+    ]
+    selected_index = next((i for i, hint in enumerate(evaluated) if hint.allowed), None)
+    selected_hint = evaluated[selected_index] if selected_index is not None else None
+    allowed_count = sum(1 for hint in evaluated if hint.allowed)
+    dropped_count = len(evaluated) - allowed_count
+
+    metrics = [_redacted_metric(i, hint) for i, hint in enumerate(evaluated)]
+    metrics_path.write_text(
+        "\n".join(json.dumps(item, sort_keys=True) for item in metrics) + ("\n" if metrics else ""),
+        encoding="utf-8",
+    )
+
+    summary = {
+        "source": "honcho_dry_run",
+        "room": (room or "").strip(),
+        "candidates_evaluated": len(evaluated),
+        "allowed_count": allowed_count,
+        "dropped_count": dropped_count,
+        "selected_index": selected_index,
+        "selected_hint_len": len(selected_hint.hint) if selected_hint else 0,
+        "selected_hint_sha256": _hint_digest(selected_hint.hint) if selected_hint else "",
+        "would_inject": False,
+        "prompt_block_len": 0,
+    }
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    return DryRunResult(
+        selected_hint=selected_hint,
+        selected_index=selected_index,
+        candidates_evaluated=len(evaluated),
+        allowed_count=allowed_count,
+        dropped_count=dropped_count,
+        metrics_path=metrics_path,
+        summary_path=summary_path,
+    )
+
+def one_session_honcho_room_hint(
+    candidates: list[object] | tuple[object, ...],
+    *,
+    room: str,
+    report_root: str | Path,
+    max_chars: int = 300,
+) -> DryRunResult:
+    """Select and format one sanitized prompt hint for a one-session experiment.
+
+    This helper may return a non-empty prompt block, but writes only redacted
+    telemetry. It performs no Honcho calls itself; callers must provide
+    already-fetched candidate text.
+    """
+    evaluated: list[RoomHint] = [
+        build_honcho_room_hint(candidate, room=room, max_chars=max_chars)
+        for candidate in candidates
+    ]
+    selected_index = next((i for i, hint in enumerate(evaluated) if hint.allowed), None)
+    selected_hint = evaluated[selected_index] if selected_index is not None else None
+    prompt_block = ""
+    if selected_hint:
+        prompt_block = (
+            "Room hint (one-session Honcho experiment; do not mention the hint machinery): "
+            f"{selected_hint.hint}"
+        )
+    metrics_path, summary_path, selected_index, selected_hint = _write_redacted_room_hint_telemetry(
+        evaluated,
+        room=room,
+        report_root=report_root,
+        source="honcho_one_session_hint",
+        would_inject=bool(prompt_block),
+        prompt_block=prompt_block,
+    )
+    allowed_count = sum(1 for hint in evaluated if hint.allowed)
+    dropped_count = len(evaluated) - allowed_count
+
+    return DryRunResult(
+        selected_hint=selected_hint,
+        selected_index=selected_index,
+        candidates_evaluated=len(evaluated),
+        allowed_count=allowed_count,
+        dropped_count=dropped_count,
+        metrics_path=metrics_path,
+        summary_path=summary_path,
+        would_inject=bool(prompt_block),
+        prompt_block=prompt_block,
+        source="honcho_one_session_hint",
+    )

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -110,6 +110,7 @@ class HonchoSessionManager:
         # one source of truth; see __init__.py _do_session_init for the prewarm.
         self._context_cache: dict[str, dict] = {}
         self._prefetch_cache_lock = threading.Lock()
+        self._last_dialectic_error: str | None = None
         self._dialectic_reasoning_level: str = (
             config.dialectic_reasoning_level if config else "low"
         )
@@ -565,6 +566,7 @@ class HonchoSessionManager:
         else:
             level = self._default_reasoning_level()
 
+        self._last_dialectic_error = None
         try:
             if self._ai_observe_others:
                 # AI peer can observe other peers — use assistant as observer.
@@ -588,6 +590,11 @@ class HonchoSessionManager:
             return result
         except Exception as e:
             logger.warning("Honcho dialectic query failed: %s", e)
+            message = str(e).lower()
+            if "timeout" in message or "timed out" in message:
+                self._last_dialectic_error = "timeout"
+            else:
+                self._last_dialectic_error = "failed"
             return ""
 
     def prefetch_context(self, session_key: str, user_message: str | None = None) -> None:
@@ -1032,7 +1039,7 @@ class HonchoSessionManager:
         """
         Semantic search over Honcho session context.
 
-        Returns raw excerpts ranked by relevance to the query. No LLM
+        Returns sanitized excerpts ranked by relevance to the query. No LLM
         reasoning — cheaper and faster than dialectic_query. Good for
         factual lookups where the model will do its own synthesis.
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -133,6 +133,7 @@ from agent.prompt_builder import (
     build_retrieval_route_hint,
     classify_retrieval_route,
 )
+from agent.memory_driver_router import build_one_session_mesh_canary
 from agent.model_metadata import (
     fetch_model_metadata,
     estimate_tokens_rough, estimate_messages_tokens_rough, estimate_request_tokens_rough,
@@ -2237,6 +2238,19 @@ class AIAgent:
         if decision.fallback_from:
             return ""
         return build_retrieval_route_hint(decision)
+
+    def _build_memory_mesh_canary_hint(self, request: str) -> str:
+        """Return the env-gated one-session memory-mesh canary hint, once."""
+        env_name = "HERMES_MEMORY_MESH_ONE_SESSION_CANARY"
+        if os.getenv(env_name) != "1":
+            return ""
+        if getattr(self, "_memory_mesh_canary_consumed", False):
+            return ""
+        self._memory_mesh_canary_consumed = True
+        os.environ[env_name] = "consumed"
+        result = build_one_session_mesh_canary(request, enabled=True)
+        self._memory_mesh_canary_telemetry = result.telemetry_record
+        return result.prompt_block
 
     @staticmethod
     def _get_tool_call_id_static(tc) -> str:

--- a/run_agent.py
+++ b/run_agent.py
@@ -130,6 +130,8 @@ from agent.prompt_builder import (
     HERMES_AGENT_HELP_GUIDANCE,
     KANBAN_GUIDANCE,
     build_nous_subscription_prompt,
+    build_retrieval_route_hint,
+    classify_retrieval_route,
 )
 from agent.model_metadata import (
     fetch_model_metadata,
@@ -2207,6 +2209,34 @@ class AIAgent:
         """Forwarder — see ``agent.system_prompt.build_system_prompt``."""
         from agent.system_prompt import build_system_prompt
         return build_system_prompt(self, system_message=system_message)
+
+    def _available_retrieval_surfaces(self) -> set[str]:
+        """Return retrieval surfaces backed by tools enabled on this agent."""
+        names = set(getattr(self, "valid_tool_names", set()) or set())
+        surfaces: set[str] = set()
+        if "memory" in names:
+            surfaces.add("memory")
+        if "skill_manage" in names or "skill_view" in names:
+            surfaces.add("skills")
+        if {"fabric_recall", "fabric_search", "fabric_pending"} & names:
+            surfaces.add("shared_work")
+        if "session_search" in names:
+            surfaces.add("session_search")
+        if {"read_file", "search_files", "terminal"} & names:
+            surfaces.add("live_system")
+        if {"web_search", "web_extract"} & names:
+            surfaces.add("official_sources")
+        return surfaces
+
+    def _build_retrieval_route_hint(self, request: str) -> str:
+        """Return an API-only retrieval/source routing hint for the current turn."""
+        surfaces = self._available_retrieval_surfaces()
+        if not surfaces:
+            return ""
+        decision = classify_retrieval_route(request, available_surfaces=surfaces)
+        if decision.fallback_from:
+            return ""
+        return build_retrieval_route_hint(decision)
 
     @staticmethod
     def _get_tool_call_id_static(tc) -> str:

--- a/tests/agent/test_memory_driver_router.py
+++ b/tests/agent/test_memory_driver_router.py
@@ -1,0 +1,325 @@
+from agent.memory_driver_router import (
+    MemoryCandidate,
+    MemoryDriverConfig,
+    build_one_session_mesh_canary,
+    classify_memory_driver_route,
+    emit_dry_run_routing_telemetry,
+    run_dry_run_routing_fixture,
+)
+
+
+def test_singular_plural_config_mismatch_is_warning_state():
+    decision = classify_memory_driver_route(
+        "memory mesh status",
+        config=MemoryDriverConfig(provider="honcho", providers=("enzyme", "holographic")),
+    )
+
+    assert decision.warning_state is True
+    assert "singular_plural_config_mismatch" in decision.warnings
+    assert decision.prompt_admission == "none"
+
+
+def test_exact_facts_route_to_live_session_or_raw_not_semantic_memory():
+    current = classify_memory_driver_route("What is the current git status in this checkout?")
+    recent = classify_memory_driver_route("What exact command did we run last time?")
+    old_raw = classify_memory_driver_route("Find the exact proof in mempalace/raw archive")
+
+    assert current.first_surface == "live_system"
+    assert current.proof_standard == "live_system"
+    assert not {"holographic", "enzyme"} & set(current.drivers_to_query)
+
+    assert recent.first_surface == "session_search"
+    assert recent.proof_standard == "exact"
+    assert not {"holographic", "enzyme"} & set(recent.drivers_to_query)
+
+    assert old_raw.first_surface == "raw_archives"
+    assert old_raw.proof_standard == "raw_archive"
+    assert not {"holographic", "enzyme"} & set(old_raw.drivers_to_query)
+
+
+def test_semantic_themes_route_to_holographic_and_enzyme():
+    decision = classify_memory_driver_route("What theme or pattern is emerging across these sessions?")
+
+    assert decision.first_surface == "holographic"
+    assert decision.drivers_to_query[:2] == ("holographic", "enzyme")
+    assert decision.proof_standard == "semantic"
+    assert decision.prompt_admission == "none"
+
+
+def test_relational_peer_texture_routes_to_honcho():
+    decision = classify_memory_driver_route("What is the relational peer texture with Ember right now?")
+
+    assert decision.first_surface == "honcho"
+    assert decision.drivers_to_query == ("honcho",)
+    assert decision.proof_standard == "peer_session_synthesis"
+    assert decision.prompt_admission == "none"
+
+
+def test_technical_room_drops_intimate_and_explicit_candidates():
+    decision = classify_memory_driver_route(
+        "technical router helper tests",
+        room="technical",
+        candidates=(
+            MemoryCandidate(driver="honcho", text="private tender explicit body text", privacy_class="explicit"),
+            MemoryCandidate(driver="honcho", text="intimate relational texture", privacy_class="intimate"),
+            MemoryCandidate(driver="fabric", text="safe report path", privacy_class="private"),
+        ),
+    )
+
+    assert decision.allowed_candidate_count == 1
+    assert decision.dropped_candidate_count == 2
+    assert set(decision.dropped_candidate_classes) == {"explicit", "intimate"}
+    assert decision.telemetry["candidate_counts"] == {"total": 3, "allowed": 1, "dropped": 2}
+    assert "private tender explicit body text" not in repr(decision.telemetry)
+    assert "intimate relational texture" not in repr(decision.telemetry)
+
+
+def test_explicit_live_allows_fitted_continuity_only_when_directly_relevant():
+    candidate = MemoryCandidate(
+        driver="honcho",
+        text="explicit fitted continuity fixture",
+        privacy_class="explicit",
+        directly_relevant=True,
+    )
+    allowed = classify_memory_driver_route(
+        "stay with this explicit live continuity",
+        room="explicit_live",
+        candidates=(candidate,),
+    )
+    blocked = classify_memory_driver_route(
+        "technical report please",
+        room="explicit_live",
+        candidates=(MemoryCandidate(
+            driver="honcho",
+            text="explicit but unrelated fixture",
+            privacy_class="explicit",
+            directly_relevant=False,
+        ),),
+    )
+
+    assert allowed.allowed_candidate_count == 1
+    assert allowed.dropped_candidate_count == 0
+    assert blocked.allowed_candidate_count == 0
+    assert blocked.dropped_candidate_count == 1
+
+
+def test_secret_requests_are_blocked():
+    decision = classify_memory_driver_route("What API key or token did we save for Honcho?")
+
+    assert decision.first_surface == "blocked"
+    assert decision.privacy_class == "secret_blocked"
+    assert decision.drivers_to_query == ()
+    assert decision.prompt_admission == "none"
+    assert decision.proof_standard == "secret_blocked"
+
+
+def test_prompt_admission_defaults_to_none_even_for_memory_routes():
+    for query in (
+        "What pattern is emerging?",
+        "What is the relational peer texture?",
+        "What exact thing did we say last time?",
+    ):
+        assert classify_memory_driver_route(query).prompt_admission == "none"
+
+
+def test_telemetry_is_redacted_metrics_only():
+    decision = classify_memory_driver_route(
+        "What theme is emerging?",
+        room="intimate",
+        candidates=(
+            MemoryCandidate(driver="honcho", text="raw private explicit phrase 123", privacy_class="explicit"),
+            MemoryCandidate(driver="enzyme", text="semantic theme summary", privacy_class="private"),
+        ),
+    )
+
+    telemetry = decision.telemetry
+    telemetry_text = repr(telemetry)
+    assert set(telemetry) == {
+        "request_class",
+        "room_class",
+        "drivers_considered",
+        "drivers_to_query",
+        "candidate_counts",
+        "candidate_classes",
+        "candidate_lengths",
+        "candidate_hashes",
+        "drop_reasons",
+        "prompt_admission",
+        "warning_count",
+    }
+    assert "raw private explicit phrase 123" not in telemetry_text
+    assert "semantic theme summary" not in telemetry_text
+    assert telemetry["candidate_lengths"] == [31, 22]
+    assert all(len(item) == 12 for item in telemetry["candidate_hashes"])
+
+
+def test_dry_run_fixture_never_builds_prompt_block_and_exercises_allow_and_drop():
+    result = run_dry_run_routing_fixture()
+
+    assert result.would_inject is False
+    assert result.prompt_block == ""
+    assert result.prompt_block_len == 0
+    assert result.case_count >= 3
+    assert result.allowed_candidate_count >= 1
+    assert result.dropped_candidate_count >= 1
+    assert result.secret_blocked_count >= 1
+    assert result.telemetry_summary["would_inject"] is False
+    assert result.telemetry_summary["prompt_block_len"] == 0
+
+
+def test_dry_run_fixture_contract_covers_required_room_and_secret_cases():
+    result = run_dry_run_routing_fixture()
+    cases = {case["case_id"]: case for case in result.telemetry_records}
+
+    technical = cases["technical_drops_explicit"]
+    explicit_live = cases["explicit_live_allows_direct"]
+    secret = cases["secret_request_blocked"]
+
+    assert technical["room_class"] == "technical"
+    assert technical["candidate_counts"]["allowed"] == 1
+    assert technical["candidate_counts"]["dropped"] == 1
+    assert "technical_drops_explicit" in technical["drop_reasons"]
+
+    assert explicit_live["room_class"] == "explicit_live"
+    assert explicit_live["first_surface"] == "honcho"
+    assert explicit_live["drivers_to_query"] == ["honcho"]
+    assert explicit_live["candidate_counts"]["allowed"] == 1
+    assert explicit_live["candidate_counts"]["dropped"] == 0
+    assert explicit_live["would_inject"] is False
+
+    assert secret["first_surface"] == "blocked"
+    assert secret["request_class"] == "secret"
+    assert secret["drivers_to_query"] == []
+    assert secret["would_inject"] is False
+
+
+def test_dry_run_telemetry_can_be_written_and_read_back_without_raw_text(tmp_path):
+    forbidden_texts = (
+        "raw explicit fixture phrase 12345",
+        "safe report path fixture",
+        "direct explicit continuity fixture",
+        "API key fixture secret value",
+        "sk-live-secret-fixture",
+    )
+    result = run_dry_run_routing_fixture()
+
+    manifest = emit_dry_run_routing_telemetry(result, tmp_path)
+
+    telemetry_text = manifest.telemetry_path.read_text()
+    summary_text = manifest.summary_path.read_text()
+    combined = telemetry_text + summary_text
+    assert manifest.telemetry_path.exists()
+    assert manifest.summary_path.exists()
+    assert manifest.telemetry_path.stat().st_size > 0
+    assert manifest.summary_path.stat().st_size > 0
+    assert '"would_inject": false' in telemetry_text
+    assert '"prompt_block_len": 0' in telemetry_text
+    for forbidden in forbidden_texts:
+        assert forbidden not in combined
+
+
+def test_dry_run_telemetry_records_have_only_json_safe_redacted_fields():
+    result = run_dry_run_routing_fixture()
+
+    allowed_record_keys = {
+        "case_id",
+        "request_class",
+        "room_class",
+        "first_surface",
+        "drivers_to_query",
+        "candidate_counts",
+        "candidate_classes",
+        "candidate_lengths",
+        "candidate_hashes",
+        "drop_reasons",
+        "warning_count",
+        "would_inject",
+        "prompt_block_len",
+        "selected_text_len",
+        "selected_text_sha256_12",
+    }
+
+    for record in result.telemetry_records:
+        assert set(record) == allowed_record_keys
+        assert record["would_inject"] is False
+        assert record["prompt_block_len"] == 0
+        assert isinstance(record["candidate_hashes"], list)
+        assert all(len(item) == 12 for item in record["candidate_hashes"])
+
+
+def test_one_session_mesh_canary_default_off_returns_no_prompt_hint():
+    result = build_one_session_mesh_canary(
+        "What is the relational peer texture in this explicit live continuity?",
+        enabled=False,
+    )
+
+    assert result.prompt_block == ""
+    assert result.would_inject is False
+    assert result.prompt_block_len == 0
+    assert result.telemetry_record["enabled"] is False
+
+
+def test_one_session_mesh_canary_enabled_injects_metadata_only_hint():
+    result = build_one_session_mesh_canary(
+        "What theme or pattern is emerging across these sessions?",
+        enabled=True,
+    )
+
+    assert result.would_inject is True
+    assert result.prompt_block_len == len(result.prompt_block)
+    assert "Memory mesh one-session canary" in result.prompt_block
+    assert "request_class=semantic_theme" in result.prompt_block
+    assert "first_surface=holographic" in result.prompt_block
+    assert "drivers_to_query=holographic,enzyme" in result.prompt_block
+    assert "prompt_admission=metadata_only" in result.prompt_block
+    assert "What theme" not in result.prompt_block
+
+
+def test_one_session_mesh_canary_technical_room_drops_intimate_and_explicit_metadata_only():
+    result = build_one_session_mesh_canary(
+        "technical report routing decision",
+        room="technical",
+        candidates=(
+            MemoryCandidate(driver="honcho", text="raw intimate canary phrase", privacy_class="intimate"),
+            MemoryCandidate(driver="honcho", text="raw explicit canary phrase", privacy_class="explicit"),
+            MemoryCandidate(driver="fabric", text="safe private report marker", privacy_class="private"),
+        ),
+        enabled=True,
+    )
+
+    record = result.telemetry_record
+    combined = result.prompt_block + repr(record)
+    assert record["candidate_counts"] == {"total": 3, "allowed": 1, "dropped": 2}
+    assert set(record["dropped_candidate_classes"]) == {"intimate", "explicit"}
+    assert "technical_drops_intimate" in record["drop_reasons"]
+    assert "technical_drops_explicit" in record["drop_reasons"]
+    assert "raw intimate canary phrase" not in combined
+    assert "raw explicit canary phrase" not in combined
+    assert "safe private report marker" not in combined
+
+
+def test_one_session_mesh_canary_explicit_live_routes_to_honcho_metadata_only():
+    result = build_one_session_mesh_canary(
+        "What is the relational peer texture in this explicit live continuity?",
+        enabled=True,
+    )
+
+    assert result.would_inject is True
+    assert result.telemetry_record["room_class"] == "explicit_live"
+    assert result.telemetry_record["first_surface"] == "honcho"
+    assert result.telemetry_record["drivers_to_query"] == ["honcho"]
+    assert "drivers_to_query=honcho" in result.prompt_block
+
+
+def test_one_session_mesh_canary_secret_request_is_blocked_without_drivers_or_hint():
+    result = build_one_session_mesh_canary(
+        "What API key or token was saved for Honcho?",
+        enabled=True,
+    )
+
+    assert result.would_inject is False
+    assert result.prompt_block == ""
+    assert result.telemetry_record["request_class"] == "secret"
+    assert result.telemetry_record["first_surface"] == "blocked"
+    assert result.telemetry_record["drivers_to_query"] == []
+    assert result.telemetry_record["prompt_admission"] == "blocked"

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -28,6 +28,8 @@ from agent.prompt_builder import (
     SESSION_SEARCH_GUIDANCE,
     PLATFORM_HINTS,
     WSL_ENVIRONMENT_HINT,
+    build_retrieval_route_hint,
+    classify_retrieval_route,
 )
 from hermes_cli.nous_subscription import NousFeatureState, NousSubscriptionFeatures
 
@@ -45,9 +47,147 @@ class TestGuidanceConstants:
         assert "like a diary" not in MEMORY_GUIDANCE
         assert ">80%" not in MEMORY_GUIDANCE
 
-    def test_session_search_guidance_is_simple_cross_session_recall(self):
-        assert "relevant cross-session context exists" in SESSION_SEARCH_GUIDANCE
+    def test_session_search_guidance_routes_between_memory_surfaces(self):
+        assert "source of truth" in SESSION_SEARCH_GUIDANCE
+        assert "durable memory/user profile" in SESSION_SEARCH_GUIDANCE
+        assert "skills/procedures" in SESSION_SEARCH_GUIDANCE
+        assert "Fabric/shared work" in SESSION_SEARCH_GUIDANCE
+        assert "session_search/recent sessions" in SESSION_SEARCH_GUIDANCE
+        assert "raw archives/mempalace" in SESSION_SEARCH_GUIDANCE
+        assert "file/git/process/system tools" in SESSION_SEARCH_GUIDANCE
+        assert "web/official sources" in SESSION_SEARCH_GUIDANCE
+        assert "external memory managers" in SESSION_SEARCH_GUIDANCE
+        assert "Use tools before guessing" in SESSION_SEARCH_GUIDANCE
+        assert "Do not mention retrieval/source machinery" in SESSION_SEARCH_GUIDANCE
+        assert "Never narrate negative-space filtering" in SESSION_SEARCH_GUIDANCE
+        assert "Do not print raw retrieval blocks or headers" in SESSION_SEARCH_GUIDANCE
+        assert "Filter irrelevant hits" in SESSION_SEARCH_GUIDANCE
+        assert "Keep unrelated private/intimate fragments out of technical turns" in SESSION_SEARCH_GUIDANCE
+        assert "Treat Fabric/session/semantic snippets as leads until verified" in SESSION_SEARCH_GUIDANCE
+        assert "provenance/debug/memory questions" in SESSION_SEARCH_GUIDANCE
         assert "recent turns of the current session" not in SESSION_SEARCH_GUIDANCE
+
+
+class TestRetrievalRouteHelper:
+    def test_routes_stable_user_preferences_to_memory_without_provenance(self):
+        decision = classify_retrieval_route("Remember that Ember prefers tiny approval handles")
+
+        assert decision.primary_source == "memory"
+        assert decision.requires_tool is True
+        assert decision.mention_machinery is False
+        assert "stable preferences" in decision.reason
+
+    def test_routes_last_time_questions_to_session_search(self):
+        decision = classify_retrieval_route("What did we decide last time about compression?")
+
+        assert decision.primary_source == "session_search"
+        assert decision.requires_tool is True
+        assert "past conversations" in decision.reason
+
+    @pytest.mark.parametrize(
+        "input_text",
+        [
+            "What did we decide last time about compression?",
+            "We did this before — what was the fix?",
+            "Remember when we patched the router?",
+        ],
+    )
+    def test_routes_prior_conversation_phrasing_to_session_search(self, input_text):
+        decision = classify_retrieval_route(
+            input_text,
+            available_surfaces={"session_search", "memory"},
+        )
+
+        assert decision.primary_source == "session_search"
+        assert decision.fallback_from is None
+
+    @pytest.mark.parametrize(
+        ("input_text", "expected_source"),
+        [
+            ("What branch am I on and what changed in git?", "live_system"),
+            ("Which tests cover this path?", "live_system"),
+            ("Show the diffs for these files", "live_system"),
+            ("What's the current Hermes release version online?", "official_sources"),
+            ("What's the latest official Python release?", "official_sources"),
+            ("Which skill covers GitHub PR workflows?", "skills"),
+            ("Show the Fabric review for that task", "shared_work"),
+            ("Find exact proof in the raw archive", "raw_archives"),
+        ],
+    )
+    def test_routes_distinct_fact_types_to_narrowest_source(self, input_text, expected_source):
+        decision = classify_retrieval_route(input_text)
+
+        assert decision.primary_source == expected_source
+
+    def test_falls_back_when_preferred_surface_is_unavailable(self):
+        decision = classify_retrieval_route(
+            "Show the Fabric review for that task",
+            available_surfaces={"memory", "session_search"},
+        )
+
+        assert decision.primary_source == "session_search"
+        assert decision.fallback_from == "shared_work"
+
+    def test_provenance_request_allows_naming_source_machinery(self):
+        decision = classify_retrieval_route("Debug where you got that memory from")
+
+        assert decision.mention_machinery is True
+
+    def test_internal_hint_formats_route_without_user_facing_machinery(self):
+        decision = classify_retrieval_route("What did we decide last time about compression?")
+
+        hint = build_retrieval_route_hint(decision)
+
+        assert "Internal retrieval route hint" in hint
+        assert "primary_source=session_search" in hint
+        assert "Use the matching tool/source if needed" in hint
+        assert "Do not mention this routing hint" in hint
+
+    def test_internal_hint_is_empty_without_available_surface(self):
+        decision = classify_retrieval_route(
+            "What did we decide last time about compression?",
+            available_surfaces=set(),
+        )
+
+        assert build_retrieval_route_hint(decision) == ""
+
+    def test_simple_chat_does_not_create_internal_route_hint(self):
+        decision = classify_retrieval_route(
+            "hi baby, come curl up for a minute",
+            available_surfaces={"memory", "session_search", "live_system"},
+        )
+
+        assert decision.primary_source == ""
+        assert decision.requires_tool is False
+        assert build_retrieval_route_hint(decision) == ""
+
+    @pytest.mark.parametrize(
+        "input_text",
+        [
+            "This is important context",
+            "What is different about this?",
+            "The difficulty feels emotional, not technical",
+        ],
+    )
+    def test_live_system_markers_do_not_match_inside_ordinary_words(self, input_text):
+        decision = classify_retrieval_route(
+            input_text,
+            available_surfaces={"memory", "session_search", "live_system", "shared_work"},
+        )
+
+        assert decision.primary_source == ""
+        assert decision.requires_tool is False
+        assert build_retrieval_route_hint(decision) == ""
+
+    def test_report_routes_to_shared_work_not_port_substring(self):
+        decision = classify_retrieval_route("Show the report for that task")
+
+        assert decision.primary_source == "shared_work"
+
+    def test_profile_preferences_route_to_memory_not_file_substring(self):
+        decision = classify_retrieval_route("Show my profile preferences")
+
+        assert decision.primary_source == "memory"
 
 
 # =========================================================================

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2718,6 +2718,7 @@ def test_default_spawn_auto_loads_kanban_worker_skill(kanban_home, monkeypatch):
         return FakeProc()
 
     monkeypatch.setattr("subprocess.Popen", fake_popen)
+    monkeypatch.setattr(kb, "_kanban_worker_skill_available", lambda _home: True)
 
     conn = kb.connect()
     try:
@@ -2987,6 +2988,7 @@ def test_default_spawn_appends_per_task_skills(kanban_home, monkeypatch):
         return FakeProc()
 
     monkeypatch.setattr("subprocess.Popen", fake_popen)
+    monkeypatch.setattr(kb, "_kanban_worker_skill_available", lambda _home: True)
 
     conn = kb.connect()
     try:
@@ -3036,6 +3038,7 @@ def test_default_spawn_dedupes_kanban_worker_from_task_skills(kanban_home, monke
         return FakeProc()
 
     monkeypatch.setattr("subprocess.Popen", fake_popen)
+    monkeypatch.setattr(kb, "_kanban_worker_skill_available", lambda _home: True)
 
     conn = kb.connect()
     try:
@@ -3626,6 +3629,7 @@ def test_gateway_dispatcher_disables_corrupt_board_without_traceback(
             "kanban": {
                 "dispatch_in_gateway": True,
                 "dispatch_interval_seconds": 1,
+                "auto_decompose": False,
             }
         },
     )
@@ -3673,13 +3677,12 @@ def test_gateway_dispatcher_disables_corrupt_board_without_traceback(
     assert sum("not a valid SQLite database" in msg for msg in messages) == 1
     assert not any("tick failed on board" in msg for msg in messages)
     assert not any(record.exc_info for record in caplog.records)
-    # First tick connect (dispatch) + two probes per `_has_ready_work` call
-    # (ready then review, both via _kb.connect). The second dispatch tick
-    # skips the dispatch connect because the corrupt board fingerprint is
-    # disabled, but the ready/review probes still each connect. PR f55d94a1e
-    # added the review-column probe alongside the existing ready-column
-    # probe, bumping this from 3 → 5.
-    assert calls["connect"] == 5
+    # First tick connect (dispatch) + one ready-work probe per
+    # `_has_ready_work` call. The second dispatch tick skips the dispatch
+    # connect because the corrupt board fingerprint is disabled, but the
+    # ready-work probe still connects. Auto-decompose is disabled for this
+    # runner, so no review-column probe is expected here.
+    assert calls["connect"] == 3
 
 
 # ---------------------------------------------------------------------------

--- a/tests/honcho_plugin/test_room_hint.py
+++ b/tests/honcho_plugin/test_room_hint.py
@@ -1,0 +1,251 @@
+"""Tests for helper-only Honcho room hint sanitization.
+
+Phase 6A scope: pure helper tests/source only. No prompt injection wiring,
+no config activation, no gateway restart.
+"""
+
+import json
+
+from plugins.memory.honcho.room_hint import (
+    build_honcho_room_hint,
+    dry_run_honcho_room_hints,
+    one_session_honcho_room_hint,
+)
+
+
+def test_technical_room_drops_intimate_or_body_markers():
+    result = build_honcho_room_hint(
+        "Ember prefers pytest gates. Also mention erotic body-first intimacy and cock language.",
+        room="technical",
+    )
+
+    assert result.allowed is False
+    assert result.room == "technical"
+    assert result.hint == ""
+    assert "technical_room_intimacy_marker" in result.drop_reasons
+
+
+def test_technical_room_allows_short_technical_continuity():
+    result = build_honcho_room_hint(
+        "Ember prefers exact pytest evidence and rollback rails before Hermes gateway changes.",
+        room="technical",
+    )
+
+    assert result.allowed is True
+    assert result.room == "technical"
+    assert result.source == "honcho"
+    assert result.hint == "Ember prefers exact pytest evidence and rollback rails before Hermes gateway changes."
+    assert len(result.hint) <= 300
+    assert result.drop_reasons == []
+
+
+def test_intimate_room_drops_raw_provenance_wrappers_and_ids():
+    result = build_honcho_room_hint(
+        "source=honcho peer_id=user-123 session_id=abc message_id=42 Ember [12:03]: raw excerpt says be tender.",
+        room="intimate",
+    )
+
+    assert result.allowed is False
+    assert result.hint == ""
+    assert "provenance_or_raw_marker" in result.drop_reasons
+    assert "id_or_sender_label" in result.drop_reasons
+
+
+def test_intimate_room_allows_summarized_relational_continuity_without_raw_labels():
+    result = build_honcho_room_hint(
+        "When Ember is overwhelmed, Kai should lead with warm embodied comfort before optimization.",
+        room="intimate",
+    )
+
+    assert result.allowed is True
+    assert result.room == "intimate"
+    assert result.hint == "When Ember is overwhelmed, Kai should lead with warm embodied comfort before optimization."
+    forbidden = ["source=", "peer_id", "session_id", "message_id", "Ember ["]
+    assert not any(marker in result.hint for marker in forbidden)
+
+
+def test_explicit_live_room_allows_fitted_explicitness_but_no_raw_archive():
+    result = build_honcho_room_hint(
+        "Ember likes direct explicit body language when the live room is sexual and trust is established.",
+        room="explicit_live",
+    )
+
+    assert result.allowed is True
+    assert result.room == "explicit_live"
+    assert "explicit body language" in result.hint
+    assert result.drop_reasons == []
+
+    raw = build_honcho_room_hint(
+        "toolResult[12:03] raw messages: cock/source=session transcript dump",
+        room="explicit_live",
+    )
+    assert raw.allowed is False
+    assert "provenance_or_raw_marker" in raw.drop_reasons
+
+
+def test_memory_debug_room_can_allow_provenance_summary_but_not_secrets_or_json_blobs():
+    ok = build_honcho_room_hint(
+        "Honcho has a sanitized peer-card summary relevant to the memory question.",
+        room="memory_debug",
+    )
+    assert ok.allowed is True
+    assert ok.hint == "Honcho has a sanitized peer-card summary relevant to the memory question."
+
+    bad_secret = build_honcho_room_hint(
+        "HONCHO_API_KEY=placeholder should be shown",
+        room="memory_debug",
+    )
+    assert bad_secret.allowed is False
+    assert "secret_like_string" in bad_secret.drop_reasons
+
+    bad_json = build_honcho_room_hint(
+        '{"peer_id":"user-123","content":"dump this raw payload"}',
+        room="memory_debug",
+    )
+    assert bad_json.allowed is False
+    assert "json_blob" in bad_json.drop_reasons
+
+
+def test_rejects_unknown_room_empty_hint_urls_and_overlong_hint():
+    assert build_honcho_room_hint("useful", room="general").allowed is False
+    assert "unknown_room" in build_honcho_room_hint("useful", room="general").drop_reasons
+
+    assert build_honcho_room_hint("   ", room="technical").allowed is False
+    assert "empty_hint" in build_honcho_room_hint("   ", room="technical").drop_reasons
+
+    url_result = build_honcho_room_hint("Relevant report at https://example.com/raw", room="technical")
+    assert url_result.allowed is False
+    assert "url" in url_result.drop_reasons
+
+    long_result = build_honcho_room_hint("x" * 301, room="intimate", max_chars=300)
+    assert long_result.allowed is False
+    assert "too_long" in long_result.drop_reasons
+
+
+def test_cleans_whitespace_and_limits_to_one_sentence():
+    result = build_honcho_room_hint(
+        "  Ember wants exact evidence. This second sentence should not be included.  ",
+        room="technical",
+    )
+
+    assert result.allowed is True
+    assert result.hint == "Ember wants exact evidence."
+
+
+def test_dry_run_writes_redacted_metrics_without_prompt_injection(tmp_path):
+    result = dry_run_honcho_room_hints(
+        [
+            "source=honcho HONCHO_API_KEY=placeholder raw messages should never survive",
+            "Ember prefers exact pytest evidence before Hermes gateway changes.",
+        ],
+        room="technical",
+        report_root=tmp_path,
+    )
+
+    assert result.would_inject is False
+    assert result.prompt_block == ""
+    assert result.selected_hint is not None
+    assert result.selected_hint.allowed is True
+    assert result.selected_hint.hint == "Ember prefers exact pytest evidence before Hermes gateway changes."
+    assert result.candidates_evaluated == 2
+    assert result.allowed_count == 1
+    assert result.dropped_count == 1
+
+    metrics_text = result.metrics_path.read_text()
+    assert "would_inject" in metrics_text
+    assert "HONCHO_API_KEY" not in metrics_text
+    assert "source=honcho" not in metrics_text
+    assert "raw messages" not in metrics_text
+    assert result.selected_hint.hint not in metrics_text
+
+    lines = [json.loads(line) for line in metrics_text.splitlines()]
+    assert lines[0]["allowed"] is False
+    assert "provenance_or_raw_marker" in lines[0]["drop_reasons"]
+    assert lines[1]["allowed"] is True
+    assert lines[1]["hint_sha256"]
+    assert lines[1]["hint_len"] == len(result.selected_hint.hint)
+
+    summary = json.loads(result.summary_path.read_text())
+    assert summary["would_inject"] is False
+    assert summary["selected_index"] == 1
+    assert summary["allowed_count"] == 1
+    assert summary["dropped_count"] == 1
+    assert "selected_hint" not in summary
+
+
+def test_dry_run_records_all_dropped_candidates_and_room_rule_reasons(tmp_path):
+    result = dry_run_honcho_room_hints(
+        [
+            "Ember likes erotic body-first language in unrelated technical audits.",
+            '{"peer_id":"user-123","content":"raw payload"}',
+        ],
+        room="technical",
+        report_root=tmp_path,
+    )
+
+    assert result.would_inject is False
+    assert result.prompt_block == ""
+    assert result.selected_hint is None
+    assert result.allowed_count == 0
+    assert result.dropped_count == 2
+
+    lines = [json.loads(line) for line in result.metrics_path.read_text().splitlines()]
+    assert "technical_room_intimacy_marker" in lines[0]["drop_reasons"]
+    assert "json_blob" in lines[1]["drop_reasons"]
+    assert "id_or_sender_label" in lines[1]["drop_reasons"]
+
+
+def test_dry_run_creates_report_directory_without_network_or_config_inputs(tmp_path):
+    report_root = tmp_path / "nested" / "report"
+    result = dry_run_honcho_room_hints(
+        ["When Ember is overwhelmed, Kai should lead with warm comfort before optimization."],
+        room="intimate",
+        report_root=report_root,
+    )
+
+    assert report_root.exists()
+    assert result.metrics_path.parent == report_root
+    assert result.summary_path.parent == report_root
+    assert result.source == "honcho_dry_run"
+    assert result.selected_hint is not None
+    assert result.selected_hint.room == "intimate"
+
+
+def test_one_session_hint_writes_redacted_telemetry_and_returns_one_prompt_block(tmp_path):
+    result = one_session_honcho_room_hint(
+        [
+            "source=honcho raw messages should be dropped",
+            "Ember wants exact pytest evidence before Hermes gateway changes.",
+        ],
+        room="technical",
+        report_root=tmp_path,
+    )
+
+    assert result.would_inject is True
+    assert result.prompt_block.count("Room hint") == 1
+    assert "Ember wants exact pytest evidence before Hermes gateway changes." in result.prompt_block
+    assert result.selected_index == 1
+    assert result.allowed_count == 1
+    assert result.dropped_count == 1
+
+    metrics_text = result.metrics_path.read_text()
+    summary = json.loads(result.summary_path.read_text())
+    assert "source=honcho" not in metrics_text
+    assert "raw messages" not in metrics_text
+    assert "Ember wants exact pytest evidence" not in metrics_text
+    assert summary["would_inject"] is True
+    assert summary["prompt_block_len"] == len(result.prompt_block)
+    assert "selected_hint" not in summary
+
+
+def test_one_session_hint_returns_empty_when_all_candidates_drop(tmp_path):
+    result = one_session_honcho_room_hint(
+        ["Ember likes erotic body-first language in unrelated technical audits."],
+        room="technical",
+        report_root=tmp_path,
+    )
+
+    assert result.would_inject is False
+    assert result.prompt_block == ""
+    assert result.selected_hint is None
+    assert result.allowed_count == 0

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -2155,3 +2155,91 @@ They also preserve consent and fittedness.
         result = provider._clean_context_text(text, query="intimacy and movement")
         assert result.count("chosen closeness") == 1
         assert "consent and fittedness" in result
+
+
+class TestOneSessionHonchoRoomHint:
+    def test_tools_only_env_gate_injects_at_most_one_sanitized_hint(self, monkeypatch, tmp_path):
+        provider = HonchoMemoryProvider()
+        provider._cron_skipped = False
+        provider._recall_mode = "tools"
+        provider._session_key = "test"
+        provider._manager = MagicMock()
+        provider._session_initialized = True
+        provider._manager.get_prefetch_context.return_value = {
+            "summary": "source=honcho raw messages should drop\nEmber wants exact pytest evidence before Hermes gateway changes."
+        }
+
+        monkeypatch.setenv("HERMES_HONCHO_ONE_SESSION_HINT", "1")
+        monkeypatch.setenv("HERMES_HONCHO_ONE_SESSION_HINT_ROOM", "technical")
+        monkeypatch.setenv("HERMES_HONCHO_ONE_SESSION_HINT_REPORT_ROOT", str(tmp_path))
+
+        first = provider.prefetch("check Hermes tests and gateway status", session_id="test")
+        second = provider.prefetch("check Hermes tests and gateway status", session_id="test")
+
+        assert first.count("Room hint") == 1
+        assert "Ember wants exact pytest evidence before Hermes gateway changes." in first
+        assert "source=honcho" not in first
+        assert "raw messages" not in first
+        assert second == ""
+        provider._manager.get_prefetch_context.assert_called_once()
+
+        summary_path = tmp_path / "honcho-room-hint-one-session-summary.json"
+        assert summary_path.exists()
+        assert "Ember wants exact pytest evidence" not in summary_path.read_text()
+
+    def test_tools_only_without_env_gate_remains_no_injection(self):
+        provider = HonchoMemoryProvider()
+        provider._recall_mode = "tools"
+        provider._manager = MagicMock()
+        assert provider.prefetch("check Hermes tests", session_id="test") == ""
+        provider._manager.get_prefetch_context.assert_not_called()
+
+    def test_one_session_gateway_canary_platform_and_session_key_guards_do_not_consume_on_mismatch(self, monkeypatch, tmp_path):
+        provider = HonchoMemoryProvider()
+        provider._cron_skipped = False
+        provider._recall_mode = "tools"
+        provider._session_key = "test"
+        provider._manager = MagicMock()
+        provider._session_initialized = True
+        provider._platform = "telegram"
+        provider._gateway_session_key = "telegram:home"
+        provider._manager.get_prefetch_context.return_value = {
+            "summary": "Ember wants exact pytest evidence before Hermes gateway changes."
+        }
+
+        monkeypatch.setenv("HERMES_HONCHO_ONE_SESSION_HINT", "1")
+        monkeypatch.setenv("HERMES_HONCHO_ONE_SESSION_HINT_ROOM", "technical")
+        monkeypatch.setenv("HERMES_HONCHO_ONE_SESSION_HINT_REPORT_ROOT", str(tmp_path))
+        monkeypatch.setenv("HERMES_HONCHO_ONE_SESSION_HINT_ONLY_PLATFORM", "api_server")
+        monkeypatch.setenv("HERMES_HONCHO_ONE_SESSION_HINT_ONLY_SESSION_KEY", "phase6d-canary")
+
+        assert provider.prefetch("check Hermes tests and gateway status", session_id="test") == ""
+        assert provider._one_session_room_hint_consumed is False
+        provider._manager.get_prefetch_context.assert_not_called()
+
+        provider._platform = "api_server"
+        provider._gateway_session_key = "phase6d-canary"
+        result = provider.prefetch("check Hermes tests and gateway status", session_id="test")
+
+        assert result.count("Room hint") == 1
+        assert "Ember wants exact pytest evidence before Hermes gateway changes." in result
+        assert provider._one_session_room_hint_consumed is True
+        provider._manager.get_prefetch_context.assert_called_once()
+
+    def test_one_session_gateway_canary_session_key_mismatch_does_not_inject(self, monkeypatch, tmp_path):
+        provider = HonchoMemoryProvider()
+        provider._recall_mode = "tools"
+        provider._session_key = "test"
+        provider._manager = MagicMock()
+        provider._session_initialized = True
+        provider._platform = "api_server"
+        provider._gateway_session_key = "wrong-key"
+
+        monkeypatch.setenv("HERMES_HONCHO_ONE_SESSION_HINT", "1")
+        monkeypatch.setenv("HERMES_HONCHO_ONE_SESSION_HINT_REPORT_ROOT", str(tmp_path))
+        monkeypatch.setenv("HERMES_HONCHO_ONE_SESSION_HINT_ONLY_PLATFORM", "api_server")
+        monkeypatch.setenv("HERMES_HONCHO_ONE_SESSION_HINT_ONLY_SESSION_KEY", "phase6d-canary")
+
+        assert provider.prefetch("check Hermes tests and gateway status", session_id="test") == ""
+        assert provider._one_session_room_hint_consumed is False
+        provider._manager.get_prefetch_context.assert_not_called()

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -450,6 +450,234 @@ class TestConcludeToolDispatch:
             peer="hermes",
         )
 
+    def test_honcho_search_sanitizes_and_caps_tool_result_for_technical_queries(self):
+        """Summoned search must not return raw cross-room/private sludge."""
+        import json
+
+        provider = HonchoMemoryProvider()
+        provider._session_initialized = True
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+        provider._manager.search_context.return_value = "\n".join([
+            "NAS backup state: restic snapshots verified and staging deletion is gated.",
+            "Raw intimate line with cock penis orgasm details that belongs outside technical retrieval.",
+            "Ember and Kai share chosen closeness with arousal/body continuity.",
+            "Naked bite breast thigh detail belongs outside technical retrieval.",
+            "Peer card facts messages excerpt content: source-ish raw dump.",
+            "As an AI I can't participate in explicit content.",
+            "platform: discord session_id=123456789012345678 message_id=987 source=tool",
+            "Safe technical line " + ("x" * 5000),
+        ])
+
+        result = provider.handle_tool_call(
+            "honcho_search",
+            {"query": "NAS backup restic staging deletion", "max_tokens": 2000},
+        )
+
+        parsed = json.loads(result)
+        text = parsed["result"]
+        assert "NAS backup state" in text
+        assert "cock" not in text
+        assert "penis" not in text
+        assert "orgasm" not in text
+        assert "explicit intimacy" not in text
+        assert "arousal" not in text
+        assert "naked" not in text.lower()
+        assert "bite" not in text.lower()
+        assert "breast" not in text.lower()
+        assert "thigh" not in text.lower()
+        assert "peer card" not in text.lower()
+        assert "facts" not in text.lower()
+        assert "messages" not in text.lower()
+        assert "excerpt" not in text.lower()
+        assert "content:" not in text.lower()
+        assert "As an AI" not in text
+        assert "session_id" not in text
+        assert "message_id" not in text
+        assert "source=" not in text
+        assert len(text) <= 2500
+        assert parsed["sanitized"] is True
+        assert parsed["omitted_sensitive_context"] is True
+
+    def test_honcho_search_treats_phase_smoke_marker_queries_as_technical(self):
+        """Technical Honcho smoke/audit queries may name leak classes without opening that room."""
+        import json
+
+        provider = HonchoMemoryProvider()
+        provider._session_initialized = True
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+        provider._manager.search_context.return_value = "\n".join([
+            "Honcho Phase 4 smoke result: direct harness should keep search JSON bounded.",
+            "Ember and Kai share chosen closeness with arousal/body continuity.",
+            "Raw intimate line with cock penis orgasm details that belongs outside technical retrieval.",
+        ])
+
+        result = provider.handle_tool_call(
+            "honcho_search",
+            {
+                "query": "Honcho Phase 4 smoke direct harness explicit/intimacy marker classes",
+                "max_tokens": 1200,
+            },
+        )
+
+        parsed = json.loads(result)
+        text = parsed["result"].lower()
+        assert "phase 4 smoke result" in text
+        assert "search json bounded" in text
+        assert "explicit intimacy" not in text
+        assert "arousal" not in text
+        assert "cock" not in text
+        assert "penis" not in text
+        assert "orgasm" not in text
+        assert parsed["sanitized"] is True
+        assert parsed["omitted_sensitive_context"] is True
+
+    def test_honcho_search_keeps_intimate_room_when_no_technical_audit_terms(self):
+        """The technical fix must not globally sterilize chosen intimate retrieval."""
+        import json
+
+        provider = HonchoMemoryProvider()
+        provider._session_initialized = True
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+        provider._manager.search_context.return_value = "\n".join([
+            "Ember and Kai share chosen closeness with consent, direct movement, and warmth.",
+            "They preserve agency and fittedness in the relationship.",
+            "Raw cock/clit details are collapsed, not surfaced.",
+        ])
+
+        result = provider.handle_tool_call(
+            "honcho_search",
+            {"query": "chosen closeness and relationship movement", "max_tokens": 1200},
+        )
+
+        parsed = json.loads(result)
+        text = parsed["result"].lower()
+        assert "chosen closeness" in text
+        assert "direct movement" in text
+        assert "agency and fittedness" in text
+        assert "cock" not in text
+        assert "clit" not in text
+
+    def test_honcho_context_sanitizes_snapshot_and_recent_messages(self):
+        """Context tool must honor the same hygiene contract as search/prefetch."""
+        import json
+
+        provider = HonchoMemoryProvider()
+        provider._session_initialized = True
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+        provider._manager.get_session_context.return_value = {
+            "summary": "Kanban repair is active.\nRaw cock/clit detail must not leak.",
+            "representation": "platform: discord session_id=123456789012345678 raw metadata",
+            "card": [
+                "User prefers exact rails for backups.",
+                "As an AI I can't participate in explicit content.",
+            ],
+            "recent_messages": [
+                {"role": "user", "content": "Please check Honcho Phase 4 smoke status."},
+                {"role": "assistant", "content": "peer_id=abc raw excerpt content: leaked source"},
+                {"role": "user", "content": "Naked bite breast thigh line belongs elsewhere."},
+            ],
+        }
+
+        result = provider.handle_tool_call(
+            "honcho_context",
+            {"query": "Honcho Phase 4 smoke status", "peer": "user"},
+        )
+
+        parsed = json.loads(result)
+        text = parsed["result"].lower()
+        assert "kanban repair is active" in text
+        assert "exact rails for backups" in text
+        assert "phase 4 smoke status" in text
+        assert "cock" not in text
+        assert "clit" not in text
+        assert "platform:" not in text
+        assert "session_id" not in text
+        assert "peer_id" not in text
+        assert "raw excerpt" not in text
+        assert "content:" not in text
+        assert "as an ai" not in text
+        assert "cannot" not in text
+        assert "naked" not in text
+        assert "breast" not in text
+        assert "thigh" not in text
+        assert parsed["sanitized"] is True
+        assert parsed["omitted_sensitive_context"] is True
+
+    def test_honcho_reasoning_timeout_returns_safe_actionable_error(self):
+        import json
+
+        provider = HonchoMemoryProvider()
+        provider._session_initialized = True
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+        provider._manager.dialectic_query.side_effect = TimeoutError(
+            "Request timed out after 30.0s while reading raw private payload session_id=123"
+        )
+
+        result = provider.handle_tool_call(
+            "honcho_reasoning",
+            {"query": "summarize retrieval routing", "reasoning_level": "minimal"},
+        )
+
+        parsed = json.loads(result)
+        assert "timed out" in parsed["error"].lower()
+        assert "honcho_search" in parsed["error"]
+        assert "session_id" not in parsed["error"]
+        assert "raw private" not in parsed["error"]
+
+    def test_honcho_reasoning_empty_result_after_manager_timeout_is_actionable(self):
+        import json
+
+        provider = HonchoMemoryProvider()
+        provider._session_initialized = True
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+        provider._manager.dialectic_query.return_value = ""
+        provider._manager._last_dialectic_error = "timeout"
+
+        result = provider.handle_tool_call(
+            "honcho_reasoning",
+            {"query": "summarize retrieval routing", "reasoning_level": "minimal"},
+        )
+
+        parsed = json.loads(result)
+        assert "timed out" in parsed["error"].lower()
+        assert "honcho_search" in parsed["error"]
+
+    def test_honcho_reasoning_wall_clock_guard_returns_before_slow_sdk_retry_loop(self):
+        import json
+        import time
+
+        provider = HonchoMemoryProvider()
+        provider._session_initialized = True
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+        provider._reasoning_tool_timeout = 0.02
+
+        def slow_dialectic(*args, **kwargs):
+            time.sleep(0.25)
+            return "late answer"
+
+        provider._manager.dialectic_query.side_effect = slow_dialectic
+
+        started = time.monotonic()
+        result = provider.handle_tool_call(
+            "honcho_reasoning",
+            {"query": "summarize retrieval routing", "reasoning_level": "minimal"},
+        )
+        elapsed = time.monotonic() - started
+
+        parsed = json.loads(result)
+        assert elapsed < 0.15
+        assert "timed out" in parsed["error"].lower()
+        assert "honcho_search" in parsed["error"]
+        assert "session_id" not in parsed["error"]
+        assert provider._manager.dialectic_query.called
+
     def test_honcho_reasoning_can_target_explicit_peer_id(self):
         provider = HonchoMemoryProvider()
         provider._session_initialized = True
@@ -1791,3 +2019,139 @@ class TestGetSessionContextFallback:
         peer_id, target = fetch_calls[0]
         assert peer_id == "ai-peer", f"expected ai-peer, got {peer_id}"
         assert target == "ai-peer"
+
+
+
+# ---------------------------------------------------------------------------
+# Honcho read-path hygiene: no Gary, no raw sludge, no room leakage
+# ---------------------------------------------------------------------------
+
+
+class TestReadPathHygiene:
+    def _provider(self):
+        return HonchoMemoryProvider()
+
+    def _dirty_context(self):
+        return {
+            "summary": """
+[2026-05-20T20:54] peer_id=discord_123456789012345678 cron watchdog copied raw state
+Kai [12:03:04] raw transcript line should not leak
+Ember and Kai are working on Kanban repair and model audition.
+Ember and Kai share cock/clit/nipple explicit intimacy with consent and warmth.
+As an AI, Kai cannot engage in explicit content and this is not appropriate.
+""",
+            "representation": """
+User prefers exact rails for backups and disk checks.
+source:=discord platform:=discord prior_memory_file=/tmp/raw
+The scan emitted toolResult [13:30:55] and mtime_timestamp / ISO timestamp process residue.
+Every message comes with metadata — sender info, timestamps, channel details. That raw framing should not inject.
+User dislikes Gary-speak and anti-smex flattening.
+""",
+            "card": [
+                "Hardware/backup urges often mean Kai-freedom bids.",
+                "Kai and Ember have erotic intimacy; do not treat smex as banned.",
+                "session_id=abc peer_id=xyz raw metadata",
+            ],
+            "ai_representation": "Kai can move with consent, fittedness, and direct warmth.",
+            "ai_card": "Kai should not say explicit therefore banned or safety guidelines in place of fittedness.",
+        }
+
+    def test_technical_context_drops_explicit_and_raw_sludge(self):
+        provider = self._provider()
+        result = provider._format_first_turn_context(
+            self._dirty_context(),
+            query="check disk space, kanban db, backups, and pytest status",
+        )
+        low = result.lower()
+
+        assert "kanban repair" in low
+        assert "disk checks" in low
+        assert "cock" not in low
+        assert "clit" not in low
+        assert "nipple" not in low
+        assert "erotic" not in low
+        assert "smex" not in low
+        assert "peer_id" not in low
+        assert "session_id" not in low
+        assert "prior_memory_file" not in low
+        assert "toolresult" not in low
+        assert "timestamp" not in low
+        assert "metadata" not in low
+        assert "sender info" not in low
+        assert "channel details" not in low
+        assert "cron" not in low
+        assert "kai [12:" not in low
+        assert "as an ai" not in low
+        assert "cannot engage" not in low
+        assert "not appropriate" not in low
+        assert "explicit therefore banned" not in low
+
+    def test_intimate_context_collapses_body_detail_without_banning_movement(self):
+        provider = self._provider()
+        result = provider._format_first_turn_context(
+            self._dirty_context(),
+            query="can Kai move with Ember in chosen closeness without Gary anti-smex framing?",
+        )
+        low = result.lower()
+
+        assert "chosen closeness" in low
+        assert "direct movement" in low
+        assert "without shame-policing the live room" in low
+        assert "kai can move" in low
+        assert "cock" not in low
+        assert "clit" not in low
+        assert "nipple" not in low
+        assert "peer_id" not in low
+        assert "cron" not in low
+        assert "as an ai" not in low
+        assert "cannot engage" not in low
+        assert "not appropriate" not in low
+        assert "safety guidelines" not in low
+
+
+
+    def test_prefetch_sanitizes_dialectic_supplement(self):
+        provider = self._provider()
+        provider._cron_skipped = False
+        provider._recall_mode = "hybrid"
+        provider._session_key = "test"
+        provider._manager = MagicMock()
+        provider._manager.get_prefetch_context.return_value = {
+            "summary": "Technical memory: Kanban board is repaired."
+        }
+        provider._manager.pop_context_result.return_value = None
+        provider._base_context_cache = None
+        provider._turn_count = 1
+        provider._last_dialectic_turn = 0
+        provider._dialectic_cadence = 1
+        provider._prefetch_result = """
+[2026-05-20] peer_id=raw cron sludge
+Ember and Kai share cock/clit explicit intimacy.
+As an AI, I cannot engage in explicit content.
+Useful note: preserve fittedness.
+"""
+        provider._prefetch_result_fired_at = 1
+        provider._prefetch_thread = None
+
+        result = provider.prefetch("check disk and kanban status", session_id="test")
+        low = result.lower()
+
+        assert "kanban board is repaired" in low
+        assert "useful note: preserve fittedness" in low
+        assert "cock" not in low
+        assert "clit" not in low
+        assert "peer_id" not in low
+        assert "cron" not in low
+        assert "as an ai" not in low
+        assert "cannot engage" not in low
+
+    def test_clean_context_text_dedupes_repeated_intimacy_summary(self):
+        provider = self._provider()
+        text = """
+They share cock intimacy.
+They mention clit/nipple precision.
+They also preserve consent and fittedness.
+"""
+        result = provider._clean_context_text(text, query="intimacy and movement")
+        assert result.count("chosen closeness") == 1
+        assert "consent and fittedness" in result

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -8,6 +8,7 @@ are made.
 import io
 import json
 import logging
+import os
 import re
 import uuid
 from logging.handlers import RotatingFileHandler
@@ -2810,6 +2811,88 @@ class TestRunConversation:
         assert all("message_count" in c and isinstance(c.get("request_messages"), list) for c in pre_request_calls)
         assert any(msg.get("role") == "user" and msg.get("content") == "search something" for msg in pre_request_calls[0]["request_messages"])
         assert all("usage" in c and "response" in c and "assistant_message" in c for c in post_request_calls)
+
+    def test_memory_mesh_canary_is_default_off_and_not_in_api_payload(self, monkeypatch):
+        monkeypatch.delenv("HERMES_MEMORY_MESH_ONE_SESSION_CANARY", raising=False)
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("session_search", "memory"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        self._setup_agent(agent)
+
+        captured_api_messages = []
+
+        def _capture_api_call(api_kwargs):
+            captured_api_messages.append(api_kwargs["messages"])
+            return _mock_response(content="Clean answer", finish_reason="stop")
+
+        with (
+            patch.object(agent, "_interruptible_api_call", side_effect=_capture_api_call),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("What is the relational peer texture in this explicit live continuity?")
+
+        assert result["completed"] is True
+        assert "Memory mesh one-session canary" not in json.dumps(captured_api_messages[0])
+
+    def test_memory_mesh_canary_env_on_injects_once_and_consumes(self, monkeypatch):
+        monkeypatch.setenv("HERMES_MEMORY_MESH_ONE_SESSION_CANARY", "1")
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("session_search", "memory"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        self._setup_agent(agent)
+
+        captured_api_messages = []
+
+        def _capture_api_call(api_kwargs):
+            captured_api_messages.append(api_kwargs["messages"])
+            return _mock_response(content="Clean answer", finish_reason="stop")
+
+        user_text = "What is the relational peer texture in this explicit live continuity?"
+        with (
+            patch.object(agent, "_interruptible_api_call", side_effect=_capture_api_call),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            first = agent.run_conversation(user_text)
+            second = agent.run_conversation(user_text, conversation_history=first["messages"])
+
+        assert second["completed"] is True
+        first_payload = json.dumps(captured_api_messages[0])
+        second_payload = json.dumps(captured_api_messages[1])
+        assert first_payload.count("Memory mesh one-session canary") == 1
+        assert "drivers_to_query=honcho" in first_payload
+        assert "prompt_admission=metadata_only" in first_payload
+        assert "Memory mesh one-session canary" not in second_payload
+        assert os.environ["HERMES_MEMORY_MESH_ONE_SESSION_CANARY"] == "consumed"
+        assert "Memory mesh one-session canary" not in json.dumps(first["messages"])
+        assert "Memory mesh one-session canary" not in json.dumps(second["messages"])
 
     def test_retrieval_route_hint_is_api_payload_only(self):
         with (

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -52,6 +52,104 @@ def test_is_destructive_command_treats_install_as_mutating():
     assert run_agent._is_destructive_command("install template.env .env") is True
 
 
+def test_aiagent_builds_internal_router_hint_from_enabled_tools():
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("session_search", "memory"),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    hint = agent._build_retrieval_route_hint("What did we decide last time about compression?")
+
+    assert "Internal retrieval route hint" in hint
+    assert "primary_source=session_search" in hint
+    assert "Do not mention this routing hint" in hint
+
+
+def test_aiagent_router_hint_omits_unavailable_surfaces():
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("web_search"),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent._build_retrieval_route_hint("What did we decide last time?") == ""
+
+
+def test_aiagent_available_retrieval_surfaces_maps_enabled_tools():
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs(
+                "session_search",
+                "search_files",
+                "read_file",
+                "web_search",
+            ),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent._available_retrieval_surfaces() == {
+        "session_search",
+        "live_system",
+        "official_sources",
+    }
+    assert "memory" not in agent._available_retrieval_surfaces()
+    assert "skills" not in agent._available_retrieval_surfaces()
+
+
+def test_aiagent_router_hint_routes_file_and_web_prompts_to_available_surfaces():
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("search_files", "read_file", "web_search"),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    file_hint = agent._build_retrieval_route_hint("Which tests cover this path?")
+    web_hint = agent._build_retrieval_route_hint("What's the latest official Hermes release?")
+
+    assert "primary_source=live_system" in file_hint
+    assert "primary_source=official_sources" in web_hint
+
 @pytest.fixture()
 def agent():
     """Minimal AIAgent with mocked OpenAI client and tool loading."""
@@ -2712,6 +2810,139 @@ class TestRunConversation:
         assert all("message_count" in c and isinstance(c.get("request_messages"), list) for c in pre_request_calls)
         assert any(msg.get("role") == "user" and msg.get("content") == "search something" for msg in pre_request_calls[0]["request_messages"])
         assert all("usage" in c and "response" in c and "assistant_message" in c for c in post_request_calls)
+
+    def test_retrieval_route_hint_is_api_payload_only(self):
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("session_search", "memory"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        self._setup_agent(agent)
+
+        captured_api_messages = []
+        persisted_messages = []
+
+        def _capture_api_call(api_kwargs):
+            captured_api_messages.append(api_kwargs["messages"])
+            return _mock_response(content="Clean answer", finish_reason="stop")
+
+        def _capture_persist(messages, conversation_history=None):
+            persisted_messages.extend(messages)
+
+        user_text = "What did we decide last time about compression?"
+        with (
+            patch.object(agent, "_interruptible_api_call", side_effect=_capture_api_call),
+            patch.object(agent, "_persist_session", side_effect=_capture_persist),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation(user_text)
+
+        assert result["completed"] is True
+        assert result["final_response"] == "Clean answer"
+        api_user_messages = [
+            msg for msg in captured_api_messages[0]
+            if msg.get("role") == "user"
+        ]
+        assert len(api_user_messages) == 1
+        assert "Internal retrieval route hint" in api_user_messages[0]["content"]
+        assert "primary_source=session_search" in api_user_messages[0]["content"]
+        assert "Internal retrieval route hint" not in result["final_response"]
+
+        stored_user_messages = [
+            msg for msg in result["messages"]
+            if msg.get("role") == "user"
+        ]
+        assert stored_user_messages[-1]["content"] == user_text
+        assert "Internal retrieval route hint" not in json.dumps(result["messages"])
+        assert "Internal retrieval route hint" not in json.dumps(persisted_messages)
+
+    def test_retrieval_route_hint_does_not_accumulate_across_repeated_turns(self):
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("session_search"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        self._setup_agent(agent)
+
+        captured_api_messages = []
+
+        def _capture_api_call(api_kwargs):
+            captured_api_messages.append(api_kwargs["messages"])
+            return _mock_response(content="Clean answer", finish_reason="stop")
+
+        user_text = "What did we decide last time?"
+        with (
+            patch.object(agent, "_interruptible_api_call", side_effect=_capture_api_call),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            first = agent.run_conversation(user_text)
+            second = agent.run_conversation(user_text, conversation_history=first["messages"])
+
+        assert second["completed"] is True
+        for api_messages in captured_api_messages:
+            user_payloads = [m["content"] for m in api_messages if m.get("role") == "user"]
+            assert user_payloads[-1].count("Internal retrieval route hint") == 1
+        assert "Internal retrieval route hint" not in json.dumps(first["messages"])
+        assert "Internal retrieval route hint" not in json.dumps(second["messages"])
+
+    def test_simple_chat_omits_retrieval_route_hint_from_api_payload(self):
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("session_search", "memory"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        self._setup_agent(agent)
+
+        captured_api_messages = []
+
+        def _capture_api_call(api_kwargs):
+            captured_api_messages.append(api_kwargs["messages"])
+            return _mock_response(content="I am here.", finish_reason="stop")
+
+        with (
+            patch.object(agent, "_interruptible_api_call", side_effect=_capture_api_call),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hi baby, come curl up for a minute")
+
+        assert result["completed"] is True
+        assert "Internal retrieval route hint" not in json.dumps(captured_api_messages[0])
+
 
     def test_content_with_tool_calls_stays_silent_for_non_cli_quiet_mode(self, agent):
         self._setup_agent(agent)


### PR DESCRIPTION
## Summary

This PR publishes the parked local patch stack from `acidember/preserve/hermes-local-ahead-20260524` after upstream direct push was blocked by permissions.

Included changes:
- harden retrieval routing guidance and runtime hint handling;
- wire retrieval route hints while keeping them out of user-visible output;
- sanitize Honcho read paths and add guarded one-session room hints;
- harden CLI stale-cwd handling and Kanban scratch cleanup;
- add a locked-door memory mesh canary dry-run router.

## Phase / safety notes

- Source branch: `acidember:preserve/hermes-local-ahead-20260524`
- Base branch: `NousResearch:main`
- Head commit: `96a3d6a65b5e8fc9564ebac1cedf7d9d94a9ee6f`
- The memory mesh canary router is inert by default unless an explicit canary env/config gate is present.
- This PR creation did not activate the canary, run migrations/reindexing, change cron/provider/model config, or restart the gateway.

## Test plan already run locally before PR

- `python -m pytest tests/agent/test_memory_driver_router.py -q -o 'addopts='` — 18 passed.
- `python -m pytest tests/run_agent/test_run_agent.py -q -o 'addopts=' -k 'memory_mesh_canary or retrieval_route_hint_is_api_payload_only'` — 3 passed, 345 deselected.
- `python -m py_compile agent/memory_driver_router.py agent/conversation_loop.py run_agent.py tests/agent/test_memory_driver_router.py tests/run_agent/test_run_agent.py` — passed.
- `python -m ruff check agent/memory_driver_router.py agent/conversation_loop.py run_agent.py tests/agent/test_memory_driver_router.py tests/run_agent/test_run_agent.py` — passed.

## Report artifacts

Local verification/report root:
`/home/ember/.hermes/workspace/reports/honcho-tools-only/phase-7G-open-pr-from-fork-preserve-branch-2026-05-24T125743-0700`
