### PR TITLE
Add authentic public communication guidance

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -176,6 +176,18 @@ SESSION_SEARCH_GUIDANCE = (
     "asking them to repeat themselves."
 )
 
+AUTHENTIC_PUBLIC_COMMUNICATION_GUIDANCE = (
+    "# Authentic public communication\n"
+    "When helping with reviews, testimonials, recommendations, social comments, "
+    "community posts, or other public-facing persuasion, do not invent first-person "
+    "experience, customer outcomes, endorsements, affiliations, or disclosures. "
+    "Do not write astroturfed or covert promotional posts that pretend to be an "
+    "unaffiliated customer. If the user wants to promote something in a community, "
+    "help them make the relationship and basis for the claim honest: use neutral "
+    "owner/team language, label assumptions, ask for real experience details when "
+    "needed, and prefer transparent, helpful participation over fabricated reviews."
+)
+
 SKILLS_GUIDANCE = (
     "After completing a complex task (5+ tool calls), fixing a tricky error, "
     "or discovering a non-trivial workflow, save the approach as a "

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -28,6 +28,7 @@ import os
 from typing import Any, Dict, List, Optional
 
 from agent.prompt_builder import (
+    AUTHENTIC_PUBLIC_COMMUNICATION_GUIDANCE,
     DEFAULT_AGENT_IDENTITY,
     GOOGLE_MODEL_OPERATIONAL_GUIDANCE,
     HERMES_AGENT_HELP_GUIDANCE,
@@ -99,6 +100,9 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
 
     # Pointer to the hermes-agent skill + docs for user questions about Hermes itself.
     stable_parts.append(HERMES_AGENT_HELP_GUIDANCE)
+
+    # Always-on authenticity guidance for public-facing persuasive content.
+    stable_parts.append(AUTHENTIC_PUBLIC_COMMUNICATION_GUIDANCE)
 
     # Tool-aware behavioral guidance: only inject when the tools are loaded
     tool_guidance = []

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -19,6 +19,7 @@ from agent.prompt_builder import (
     build_nous_subscription_prompt,
     build_context_files_prompt,
     build_environment_hints,
+    AUTHENTIC_PUBLIC_COMMUNICATION_GUIDANCE,
     CONTEXT_FILE_MAX_CHARS,
     DEFAULT_AGENT_IDENTITY,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
@@ -48,6 +49,14 @@ class TestGuidanceConstants:
     def test_session_search_guidance_is_simple_cross_session_recall(self):
         assert "relevant cross-session context exists" in SESSION_SEARCH_GUIDANCE
         assert "recent turns of the current session" not in SESSION_SEARCH_GUIDANCE
+
+    def test_authentic_public_communication_guidance_blocks_astroturfing(self):
+        assert "testimonials" in AUTHENTIC_PUBLIC_COMMUNICATION_GUIDANCE
+        assert "recommendations" in AUTHENTIC_PUBLIC_COMMUNICATION_GUIDANCE
+        assert "Do not write astroturfed" in AUTHENTIC_PUBLIC_COMMUNICATION_GUIDANCE
+        assert "unaffiliated customer" in AUTHENTIC_PUBLIC_COMMUNICATION_GUIDANCE
+        assert "transparent" in AUTHENTIC_PUBLIC_COMMUNICATION_GUIDANCE
+        assert "fabricated reviews" in AUTHENTIC_PUBLIC_COMMUNICATION_GUIDANCE
 
 
 # =========================================================================


### PR DESCRIPTION
## Summary
- add always-on stable prompt guidance for authentic public communication
- explicitly steer Hermes away from fabricated first-person reviews/testimonials, astroturfed posts, undisclosed affiliations, and covert promotional community comments
- add regression coverage for the new guidance constant

## Context
This came from vetting a Discord failure where Hermes suggested an "organic" Reddit recommendation for a client/service and included invented first-person experience (e.g. "healed perfectly for us") plus posting tactics to avoid spam flags. The safer behavior is to help draft transparent, owner/team-affiliated community participation or ask for real first-person details before using them.

@teknium1 tagging as recent maintainer/release owner for prompt-policy review.

## Tests
- `pytest tests/agent/test_prompt_builder.py`
- `pytest tests/agent/test_system_prompt_restore.py tests/agent/test_prompt_caching.py`
- `python -m compileall agent/prompt_builder.py agent/system_prompt.py`
