### PR TITLE
Docs: add Kanban SQLite malformed + stale-running recovery playbook

### DIFF
--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -856,12 +856,18 @@ API routes begin 500'ing), use this sequence:
 # Default board path (single-board installs)
 DB="${HERMES_HOME:-$HOME/.hermes}/kanban.db"
 
-# Multi-board path example (replace <slug>)
+# Multi-board installs: discover board slugs, then replace <slug> below.
+ls "${HERMES_HOME:-$HOME/.hermes}/kanban/boards/"
 # DB="${HERMES_HOME:-$HOME/.hermes}/kanban/boards/<slug>/kanban.db"
 
-cp -a "$DB" "$DB.pre-recover.$(date +%Y%m%d_%H%M%S).bak"
-[ -f "$DB-wal" ] && cp -a "$DB-wal" "$DB-wal.pre-recover.bak"
-[ -f "$DB-shm" ] && cp -a "$DB-shm" "$DB-shm.pre-recover.bak"
+# If SQLite can still open the DB, checkpoint committed WAL content into the
+# main file before .recover reads raw pages. This may fail on severe corruption.
+sqlite3 "$DB" "PRAGMA wal_checkpoint(TRUNCATE);" 2>/dev/null || true
+
+TS=$(date +%Y%m%d_%H%M%S)
+cp -p "$DB" "$DB.pre-recover.$TS.bak"
+[ -f "$DB-wal" ] && cp -p "$DB-wal" "$DB-wal.pre-recover.$TS.bak"
+[ -f "$DB-shm" ] && cp -p "$DB-shm" "$DB-shm.pre-recover.$TS.bak"
 
 sqlite3 "$DB" ".recover" > "$DB.recover.sql"
 # Some SQLite versions emit a sqlite_sequence CREATE statement during .recover;
@@ -872,6 +878,9 @@ sqlite3 "$DB.recovered" < "$DB.recover.sql" || \
 sqlite3 "$DB.recovered" "PRAGMA quick_check; PRAGMA integrity_check;"
 mv "$DB.recovered" "$DB"
 ```
+
+`cp -p` preserves file metadata for these single-file backups and works across
+Linux and macOS without relying on GNU-specific archive semantics.
 
 After replacing the DB, run a bounded dispatcher pass to clean up stale in-flight
 rows and promote newly-unblocked work:
@@ -885,7 +894,9 @@ If specific tasks still show `running` with no live worker, reclaim them
 explicitly:
 
 ```bash
-hermes kanban reclaim <task_id> --reason "post-recover stale running cleanup"
+hermes kanban show <task_id>
+hermes kanban reclaim <task_id> \
+  --reason "post-recover stale running cleanup"
 ```
 
 Then restart gateway/dispatcher and confirm board health from either surface:

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -841,6 +841,60 @@ Every transition appends a row to `task_events`. Each row carries an optional `r
 
 `hermes kanban tail <id>` shows these for a single task. `hermes kanban watch` streams them board-wide.
 
+## Recovery playbook (SQLite + stale running)
+
+If the board starts returning `database disk image is malformed` (or dashboard
+API routes begin 500'ing), use this sequence:
+
+1. Stop active workers and the gateway/dispatcher so no process is writing to
+   the DB while you recover it.
+2. Back up the damaged DB and sidecars (`-wal`, `-shm`).
+3. Rebuild with SQLite's recover flow.
+4. Re-run dispatcher recovery to reclaim stale `running` rows.
+
+```bash
+# Default board path (single-board installs)
+DB="${HERMES_HOME:-$HOME/.hermes}/kanban.db"
+
+# Multi-board path example (replace <slug>)
+# DB="${HERMES_HOME:-$HOME/.hermes}/kanban/boards/<slug>/kanban.db"
+
+cp -a "$DB" "$DB.pre-recover.$(date +%Y%m%d_%H%M%S).bak"
+[ -f "$DB-wal" ] && cp -a "$DB-wal" "$DB-wal.pre-recover.bak"
+[ -f "$DB-shm" ] && cp -a "$DB-shm" "$DB-shm.pre-recover.bak"
+
+sqlite3 "$DB" ".recover" > "$DB.recover.sql"
+# Some SQLite versions emit a sqlite_sequence CREATE statement during .recover;
+# filter it if the import fails with "object name reserved for internal use".
+sqlite3 "$DB.recovered" < "$DB.recover.sql" || \
+  grep -v '^CREATE TABLE sqlite_sequence' "$DB.recover.sql" | sqlite3 "$DB.recovered"
+
+sqlite3 "$DB.recovered" "PRAGMA quick_check; PRAGMA integrity_check;"
+mv "$DB.recovered" "$DB"
+```
+
+After replacing the DB, run a bounded dispatcher pass to clean up stale in-flight
+rows and promote newly-unblocked work:
+
+```bash
+hermes kanban dispatch --max 1
+hermes kanban diagnostics
+```
+
+If specific tasks still show `running` with no live worker, reclaim them
+explicitly:
+
+```bash
+hermes kanban reclaim <task_id> --reason "post-recover stale running cleanup"
+```
+
+Then restart gateway/dispatcher and confirm board health from either surface:
+
+```bash
+hermes kanban list
+# or dashboard: /api/plugins/kanban/diagnostics
+```
+
 ## Out of scope
 
 Kanban is deliberately single-host. `~/.hermes/kanban.db` is a local SQLite file and the dispatcher spawns workers on the same machine. Running a shared board across two hosts is not supported — there's no coordination primitive for "worker X on host A, worker Y on host B," and the crash-detection path assumes PIDs are host-local. If you need multi-host, run an independent board per host and use `delegate_task` / a message queue to bridge them.


### PR DESCRIPTION
## Summary
This PR adds a focused operator recovery runbook to the Kanban user guide for the incident class where:
- SQLite board DB becomes malformed (`database disk image is malformed`), and/or
- tasks remain `running` without a live worker after crash/restart scenarios.

The new section provides explicit, minimal commands to:
1. stop writers,
2. back up DB/WAL/SHM,
3. recover with `sqlite3 .recover`,
4. run a bounded dispatcher pass (`hermes kanban dispatch --max 1`),
5. reclaim specific stale tasks (`hermes kanban reclaim <id>`), and
6. validate board health (`kanban list` / diagnostics endpoint).

## Why docs (not code) in this patch
The upstream tree already has guardrails preventing dashboard/manual status updates from directly setting tasks to `running` without a worker claim path:
- API rejection in dashboard PATCH and bulk endpoints (`plugins/kanban/dashboard/plugin_api.py`).
- Regression tests covering both paths in `tests/plugins/test_kanban_dashboard_plugin.py`:
  - `test_patch_status_running_rejected`
  - `test_bulk_status_running_rejected`

Given those guardrails are already present and tested, this contribution focuses on the remaining operator gap: concise recovery instructions for malformed DB + stale running cleanup.

## Files changed
- `website/docs/user-guide/features/kanban.md`

## Verification
Executed targeted tests for existing status-guardrails:

```bash
pytest -q -o addopts='' tests/plugins/test_kanban_dashboard_plugin.py -k "patch_status_running_rejected or bulk_status_running_rejected"
# 2 passed
```

(Used `-o addopts=''` because this local environment lacks the timeout plugin expected by repo-level pytest defaults.)

## Risk
Low. Documentation-only change; no runtime behavior changes.
