### PR TITLE
fix(cli): honor skills in oneshot mode

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10884,6 +10884,7 @@ def _try_termux_fast_cli_launch() -> bool:
                 model=getattr(args, "model", None),
                 provider=getattr(args, "provider", None),
                 toolsets=getattr(args, "toolsets", None),
+                skills=getattr(args, "skills", None),
             )
         )
 
@@ -13800,6 +13801,7 @@ Examples:
                 model=getattr(args, "model", None),
                 provider=getattr(args, "provider", None),
                 toolsets=getattr(args, "toolsets", None),
+                skills=getattr(args, "skills", None),
             )
         )
 

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -48,6 +48,37 @@ def _normalize_toolsets(toolsets: object = None) -> list[str] | None:
     return [item for item in normalized if item] or None
 
 
+def _normalize_skills(skills: object = None) -> list[str]:
+    """Normalize argparse/Fire-style --skills input into a de-duplicated list."""
+    if not skills:
+        return []
+
+    raw_items = [skills] if isinstance(skills, str) else skills
+    if not isinstance(raw_items, (list, tuple)):
+        raw_items = [raw_items]
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for item in raw_items:
+        for part in str(item).split(","):
+            skill = part.strip()
+            if not skill or skill in seen:
+                continue
+            seen.add(skill)
+            normalized.append(skill)
+    return normalized
+
+
+def _build_preloaded_skills_prompt(skills: object = None) -> tuple[str, list[str], list[str]]:
+    skill_names = _normalize_skills(skills)
+    if not skill_names:
+        return "", [], []
+
+    from agent.skill_commands import build_preloaded_skills_prompt
+
+    return build_preloaded_skills_prompt(skill_names)
+
+
 def _validate_explicit_toolsets(toolsets: object = None) -> tuple[list[str] | None, str | None]:
     normalized = _normalize_toolsets(toolsets)
     if normalized is None:
@@ -127,6 +158,7 @@ def run_oneshot(
     model: Optional[str] = None,
     provider: Optional[str] = None,
     toolsets: object = None,
+    skills: object = None,
 ) -> int:
     """Execute a single prompt and print only the final content block.
 
@@ -137,6 +169,7 @@ def run_oneshot(
         provider: Optional provider override. Falls back to config.yaml's
             model.provider, then "auto".
         toolsets: Optional comma-separated string or iterable of toolsets.
+        skills: Optional comma-separated string or iterable of skills to preload.
 
     Returns the exit code.  Caller should sys.exit() with the return.
     """
@@ -166,6 +199,11 @@ def run_oneshot(
         return 2
     use_config_toolsets = _normalize_toolsets(toolsets) is None
 
+    skills_prompt, _loaded_skills, missing_skills = _build_preloaded_skills_prompt(skills)
+    if missing_skills:
+        sys.stderr.write(f"hermes -z: unknown skill(s): {', '.join(missing_skills)}\n")
+        return 2
+
     # Auto-approve any shell / tool approvals.  Non-interactive by
     # definition — a prompt would hang forever.
     os.environ["HERMES_YOLO_MODE"] = "1"
@@ -184,6 +222,7 @@ def run_oneshot(
                 provider=provider,
                 toolsets=explicit_toolsets,
                 use_config_toolsets=use_config_toolsets,
+                skills_prompt=skills_prompt or None,
             )
     finally:
         try:
@@ -221,6 +260,7 @@ def _run_agent(
     provider: Optional[str] = None,
     toolsets: object = None,
     use_config_toolsets: bool = True,
+    skills_prompt: Optional[str] = None,
 ) -> str:
     """Build an AIAgent exactly like a normal CLI chat turn would, then
     run a single conversation.  Returns the final response string."""
@@ -313,6 +353,7 @@ def _run_agent(
         model=effective_model,
         enabled_toolsets=toolsets_list,
         quiet_mode=True,
+        ephemeral_system_prompt=skills_prompt,
         platform="cli",
         session_db=session_db,
         credential_pool=runtime.get("credential_pool"),

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -379,6 +379,7 @@ def test_termux_fast_cli_launch_oneshot_uses_light_parser(monkeypatch, main_mod)
         "model": "gpt-test",
         "provider": "openai",
         "toolsets": None,
+        "skills": None,
     }
 
 
@@ -617,7 +618,77 @@ def test_main_top_level_oneshot_accepts_toolsets(monkeypatch, main_mod):
         "model": None,
         "provider": None,
         "toolsets": "web,terminal",
+        "skills": None,
     }
+
+
+def test_main_top_level_oneshot_accepts_skills(monkeypatch, main_mod):
+    captured = {}
+
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setattr(sys, "argv", ["hermes", "-z", "hello", "--skills", "demo-skill"])
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(discover_plugins=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        types.SimpleNamespace(discover_mcp_tools=lambda: None),
+    )
+    monkeypatch.setattr(config_mod, "load_config", lambda: {})
+    monkeypatch.setattr(config_mod, "get_container_exec_info", lambda: None)
+    monkeypatch.setitem(
+        sys.modules,
+        "agent.shell_hooks",
+        types.SimpleNamespace(register_from_config=lambda _cfg, accept_hooks=False: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.oneshot",
+        types.SimpleNamespace(
+            run_oneshot=lambda prompt, **kwargs: captured.update({"prompt": prompt, **kwargs})
+            or 0
+        ),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod.main()
+
+    assert exc.value.code == 0
+    assert captured == {
+        "prompt": "hello",
+        "model": None,
+        "provider": None,
+        "toolsets": None,
+        "skills": ["demo-skill"],
+    }
+
+
+def test_oneshot_preloads_skills_into_ephemeral_system_prompt(monkeypatch):
+    from hermes_cli.oneshot import run_oneshot
+
+    captured = {}
+
+    monkeypatch.setattr(
+        "hermes_cli.oneshot._validate_explicit_toolsets",
+        lambda toolsets=None: (None, None),
+    )
+    monkeypatch.setattr("hermes_cli.oneshot._normalize_toolsets", lambda toolsets=None: None)
+    monkeypatch.setattr(
+        "hermes_cli.oneshot._build_preloaded_skills_prompt",
+        lambda skills: ("SKILL PROMPT", ["demo-skill"], []),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.oneshot._run_agent",
+        lambda prompt, **kwargs: captured.update({"prompt": prompt, **kwargs}) or "ok",
+    )
+
+    assert run_oneshot("hello", skills="demo-skill") == 0
+    assert captured["prompt"] == "hello"
+    assert captured["skills_prompt"] == "SKILL PROMPT"
 
 
 def _stub_plugin_discovery(monkeypatch):


### PR DESCRIPTION
## Summary
- Thread top-level and Termux fast-path `--skills` through to oneshot mode
- Preload requested skills with the same skill prompt builder used by chat mode
- Fail loudly when oneshot receives an unknown skill instead of silently ignoring it

## Test Plan
- `pytest tests/hermes_cli/test_tui_resume_flow.py::test_termux_fast_cli_launch_oneshot_uses_light_parser tests/hermes_cli/test_tui_resume_flow.py::test_main_top_level_oneshot_accepts_toolsets tests/hermes_cli/test_tui_resume_flow.py::test_main_top_level_oneshot_accepts_skills tests/hermes_cli/test_tui_resume_flow.py::test_oneshot_preloads_skills_into_ephemeral_system_prompt -o addopts='' -q`
- `pytest tests/hermes_cli/test_tui_resume_flow.py -o addopts='' -q`
- `python -m py_compile hermes_cli/oneshot.py hermes_cli/main.py tests/hermes_cli/test_tui_resume_flow.py`
- `git diff --check`

Fixes #31548
