### PR TITLE
fix(acp): suppress cancel interrupt sentinel

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -88,6 +88,20 @@ _executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="acp-agent")
 # does not expose a client-side limit, so this is a fixed cap that clients
 # paginate against using `cursor` / `next_cursor`.
 _LIST_SESSIONS_PAGE_SIZE = 50
+_INTERRUPT_WAITING_FOR_MODEL_PREFIX = (
+    "Operation interrupted: waiting for model response ("
+)
+_INTERRUPT_WAITING_FOR_MODEL_SUFFIX = " elapsed)."
+
+
+def _is_interrupt_waiting_for_model_response(text: Any) -> bool:
+    """Return True for Hermes' local API-wait interruption status string."""
+    response = str(text or "").strip()
+    return (
+        response.startswith(_INTERRUPT_WAITING_FOR_MODEL_PREFIX)
+        and response.endswith(_INTERRUPT_WAITING_FOR_MODEL_SUFFIX)
+    )
+
 _MAX_ACP_RESOURCE_BYTES = 512 * 1024
 _TEXT_RESOURCE_MIME_PREFIXES = ("text/",)
 _TEXT_RESOURCE_MIME_TYPES = {
@@ -1513,7 +1527,12 @@ class HermesACPAgent(acp.Agent):
             self.session_manager.save_session(session_id)
 
         final_response = result.get("final_response", "")
-        if final_response:
+        cancelled = bool(state.cancel_event and state.cancel_event.is_set())
+        interrupted = bool(result.get("interrupted")) or cancelled
+        suppress_interrupt_response = (
+            interrupted and _is_interrupt_waiting_for_model_response(final_response)
+        )
+        if final_response and not suppress_interrupt_response:
             try:
                 from agent.title_generator import maybe_auto_title
 
@@ -1534,7 +1553,12 @@ class HermesACPAgent(acp.Agent):
                 )
             except Exception:
                 logger.debug("Failed to auto-title ACP session %s", session_id, exc_info=True)
-        if final_response and conn and (not streamed_message or result.get("response_transformed")):
+        if (
+            final_response
+            and conn
+            and not suppress_interrupt_response
+            and (not streamed_message or result.get("response_transformed"))
+        ):
             # Deliver the final response when streaming did not already send it,
             # or when a plugin hook transformed the response after streaming
             # finished (e.g. transform_llm_output) — otherwise the appended /
@@ -1576,7 +1600,7 @@ class HermesACPAgent(acp.Agent):
 
         await self._send_usage_update(state)
 
-        stop_reason = "cancelled" if state.cancel_event and state.cancel_event.is_set() else "end_turn"
+        stop_reason = "cancelled" if cancelled else "end_turn"
         return PromptResponse(stop_reason=stop_reason, usage=usage)
 
     # ---- Slash commands (headless) -------------------------------------------

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1103,6 +1103,82 @@ class TestPrompt:
         assert any(update.session_update == "agent_message_chunk" for update in updates)
 
     @pytest.mark.asyncio
+    async def test_prompt_suppresses_cancel_interrupt_sentinel(self, agent):
+        """ACP cancel status text should not be emitted as assistant output."""
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        sentinel = "Operation interrupted: waiting for model response (3.3s elapsed)."
+
+        def mock_run(*args, **kwargs):
+            state.cancel_event.set()
+            return {
+                "final_response": sentinel,
+                "messages": list(state.history),
+                "interrupted": True,
+                "completed": False,
+            }
+
+        state.agent.run_conversation = mock_run
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        with patch("agent.title_generator.maybe_auto_title") as mock_title:
+            prompt = [TextContentBlock(type="text", text="please do a long task")]
+            resp = await agent.prompt(prompt=prompt, session_id=new_resp.session_id)
+
+        updates = [
+            call.kwargs.get("update") or call.args[1]
+            for call in mock_conn.session_update.call_args_list
+        ]
+        agent_texts = [
+            update.content.text
+            for update in updates
+            if update.session_update == "agent_message_chunk"
+        ]
+        assert resp.stop_reason == "cancelled"
+        assert sentinel not in agent_texts
+        assert not any(text.startswith("Operation interrupted:") for text in agent_texts)
+        mock_title.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_prompt_keeps_real_final_response_on_cancelled_turn(self, agent):
+        """A cancel flag must not suppress actual assistant/model text."""
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        final_text = "The actual model answer arrived before cancellation settled."
+
+        def mock_run(*args, **kwargs):
+            state.cancel_event.set()
+            return {
+                "final_response": final_text,
+                "messages": [],
+                "interrupted": True,
+            }
+
+        state.agent.run_conversation = mock_run
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        prompt = [TextContentBlock(type="text", text="finish if you can")]
+        resp = await agent.prompt(prompt=prompt, session_id=new_resp.session_id)
+
+        updates = [
+            call.kwargs.get("update") or call.args[1]
+            for call in mock_conn.session_update.call_args_list
+        ]
+        agent_texts = [
+            update.content.text
+            for update in updates
+            if update.session_update == "agent_message_chunk"
+        ]
+        assert resp.stop_reason == "cancelled"
+        assert final_text in agent_texts
+
+    @pytest.mark.asyncio
     async def test_prompt_propagates_hermes_session_id_env(self, agent, monkeypatch):
         """ACP must propagate the originating session id to the agent loop
         via ``HERMES_SESSION_ID`` so tools that want to stamp side-effects


### PR DESCRIPTION
## What does this PR do?

Suppresses Hermes' internal API-wait interruption sentinel from ACP assistant-message output when a turn is interrupted/cancelled.

Before this change, cancelling an ACP turn while Hermes was still waiting for the model/provider could produce a `final_response` like:

```text
Operation interrupted: waiting for model response (3.3s elapsed).
```

The ACP adapter forwarded that string through `update_agent_message_text(...)`, so clients rendered it as assistant/model prose even though the turn correctly settled with `stop_reason="cancelled"`.

This PR adds a narrow ACP-side guard for Hermes' local interruption sentinel. It suppresses that sentinel from `agent_message_chunk` emission and session auto-title generation while preserving normal final-response delivery for real assistant/model text, including responses transformed after streaming.

## Related Issue

Fixes #31658

Related context:

- #7921 reports the same interruption sentinel leaking through Telegram/gateway rather than ACP.
- #11947 was a closed/unmerged gateway-side suppression attempt for that symptom.
- #15395 fixed interrupted-turn memory sync poisoning, not ACP transcript emission.
- #28641 may touch nearby ACP post-turn continuation code; if it lands first, rebase should apply the same guard to continuation hooks.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `acp_adapter/server.py`
  - Adds a helper that recognizes Hermes' local `Operation interrupted: waiting for model response (... elapsed).` sentinel.
  - Computes cancelled/interrupted turn state once after `run_conversation()` returns.
  - Skips ACP final-response `agent_message_chunk` emission for interrupted/cancelled sentinel responses.
  - Skips auto-title generation for the same sentinel so cancelled turns are not titled from implementation status text.
  - Keeps real final text propagation unchanged when the response is not the sentinel.
- `tests/acp/test_server.py`
  - Adds a regression proving cancelled/interrupted sentinel text is not emitted as assistant output and `stop_reason` remains `cancelled`.
  - Adds coverage proving a cancelled turn with real final text still sends that text to the ACP client.

## How to Test

1. Reproduce the old behavior with the new regression test before the fix:

   ```bash
   scripts/run_tests.sh tests/acp/test_server.py -- -k test_prompt_suppresses_cancel_interrupt_sentinel -q
   ```

   Before the implementation this failed because the sentinel appeared in an `agent_message_chunk`.

2. Run the focused final-response/cancel regressions:

   ```bash
   scripts/run_tests.sh tests/acp/test_server.py -- -k 'cancel_interrupt_sentinel or keeps_real_final_response_on_cancelled_turn' -q
   ```

   Result: `2 passed`.

3. Run the ACP server test module:

   ```bash
   scripts/run_tests.sh tests/acp/test_server.py
   ```

   Result: `80 passed`.

4. Run housekeeping checks:

   ```bash
   git diff --check origin/main...HEAD
   python scripts/check-windows-footguns.py --diff origin/main
   ```

   Result: no whitespace issues; `No Windows footguns found (2 file(s) scanned).`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux / Linux worktree, focused ACP server tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no user-facing docs/config added
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A — this PR does not add a skill.

## Screenshots / Logs

Focused test evidence:

```text
scripts/run_tests.sh tests/acp/test_server.py
80 passed
```

```text
python scripts/check-windows-footguns.py --diff origin/main
✓ No Windows footguns found (2 file(s) scanned).
```

No interactive editor/ACP-client smoke test was run; verification is via focused ACP adapter tests.
