### PR TITLE
fix: expose memory provider tools in cron

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -127,6 +127,7 @@ def init_agent(
     skip_context_files: bool = False,
     load_soul_identity: bool = False,
     skip_memory: bool = False,
+    memory_provider_tools_only: bool = False,
     session_db=None,
     parent_session_id: str = None,
     iteration_budget: "IterationBudget" = None,
@@ -935,6 +936,8 @@ def init_agent(
     agent._memory_nudge_interval = 10
     agent._turns_since_memory = 0
     agent._iters_since_skill = 0
+    agent._memory_provider_tools_only = bool(memory_provider_tools_only)
+    mem_config = {}
     if not skip_memory:
         try:
             mem_config = _agent_cfg.get("memory", {})
@@ -956,8 +959,10 @@ def init_agent(
     # Memory provider plugin (external — one at a time, alongside built-in)
     # Reads memory.provider from config to select which plugin to activate.
     agent._memory_manager = None
-    if not skip_memory:
+    if not skip_memory or agent._memory_provider_tools_only:
         try:
+            if not mem_config:
+                mem_config = _agent_cfg.get("memory", {})
             _mem_provider_name = mem_config.get("provider", "") if mem_config else ""
 
             if _mem_provider_name and _mem_provider_name.strip():
@@ -972,7 +977,7 @@ def init_agent(
                         "session_id": agent.session_id,
                         "platform": platform or "cli",
                         "hermes_home": str(get_hermes_home()),
-                        "agent_context": "primary",
+                        "agent_context": "memory-tools-only" if agent._memory_provider_tools_only else "primary",
                     }
                     # Thread session title for memory provider scoping
                     # (e.g. honcho uses this to derive chat-scoped session keys)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -561,7 +561,7 @@ def run_conversation(
     # Notify memory providers of the new turn so cadence tracking works.
     # Must happen BEFORE prefetch_all() so providers know which turn it is
     # and can gate context/dialectic refresh via contextCadence/dialecticCadence.
-    if agent._memory_manager:
+    if agent._memory_manager and not getattr(agent, "_memory_provider_tools_only", False):
         try:
             _turn_msg = original_user_message if isinstance(original_user_message, str) else ""
             agent._memory_manager.on_turn_start(agent._user_turn_count, _turn_msg)
@@ -574,7 +574,7 @@ def run_conversation(
     # Use original_user_message (clean input) — user_message may contain
     # injected skill content that bloats / breaks provider queries.
     _ext_prefetch_cache = ""
-    if agent._memory_manager:
+    if agent._memory_manager and not getattr(agent, "_memory_provider_tools_only", False):
         try:
             _query = original_user_message if isinstance(original_user_message, str) else ""
             _ext_prefetch_cache = agent._memory_manager.prefetch_all(_query) or ""

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1462,6 +1462,10 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             skip_context_files=not bool(_job_workdir),
             load_soul_identity=True,
             skip_memory=True,  # Cron system prompts would corrupt user representations
+            # Keep explicit memory-provider tools (e.g. Mycel) available for jobs
+            # that ask for them, without injecting recalled memory context or
+            # auto-syncing cron turns back into the user's memory backend.
+            memory_provider_tools_only=True,
             platform="cron",
             session_id=_cron_session_id,
             session_db=_session_db,

--- a/run_agent.py
+++ b/run_agent.py
@@ -402,6 +402,7 @@ class AIAgent:
         skip_context_files: bool = False,
         load_soul_identity: bool = False,
         skip_memory: bool = False,
+        memory_provider_tools_only: bool = False,
         session_db=None,
         parent_session_id: str = None,
         iteration_budget: "IterationBudget" = None,
@@ -471,6 +472,7 @@ class AIAgent:
             skip_context_files=skip_context_files,
             load_soul_identity=load_soul_identity,
             skip_memory=skip_memory,
+            memory_provider_tools_only=memory_provider_tools_only,
             session_db=session_db,
             parent_session_id=parent_session_id,
             iteration_budget=iteration_budget,
@@ -1980,6 +1982,8 @@ class AIAgent:
         backend must not block the user from seeing their response.
         """
         if interrupted:
+            return
+        if getattr(self, "_memory_provider_tools_only", False):
             return
         if not (self._memory_manager and final_response and original_user_message):
             return

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1,6 +1,7 @@
 """Tests for the memory provider interface, manager, and builtin provider."""
 
 import json
+
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -1060,3 +1061,59 @@ class TestHonchoCadenceTracking:
         p.on_turn_start(2, "second message")
         should_skip = p._injection_frequency == "first-turn" and p._turn_count > 1
         assert should_skip, "Second turn (turn 2) SHOULD be skipped"
+
+
+def test_memory_provider_tools_only_skips_external_memory_turn_sync():
+    """Tools-only memory provider mode exposes explicit tools but must not
+    mirror cron/batch turns into the memory backend automatically.
+    """
+    from run_agent import AIAgent
+
+    memory_manager = MagicMock()
+    agent = AIAgent.__new__(AIAgent)
+    setattr(agent, "_memory_provider_tools_only", True)
+    setattr(agent, "_memory_manager", memory_manager)
+    setattr(agent, "session_id", "cron-session")
+
+    AIAgent._sync_external_memory_for_turn(
+        agent,
+        original_user_message="remember?",
+        final_response="done",
+        interrupted=False,
+    )
+
+    memory_manager.sync_all.assert_not_called()
+    memory_manager.queue_prefetch_all.assert_not_called()
+
+
+def test_skip_memory_can_still_load_memory_provider_tools_only():
+    """skip_memory suppresses built-in memory, but cron tools-only mode still
+    exposes explicit external memory provider tools such as Mycel.
+    """
+    from run_agent import AIAgent
+
+    tool_schema = {
+        "name": "mycel_health",
+        "description": "health",
+        "parameters": {"type": "object", "properties": {}},
+    }
+    provider = FakeMemoryProvider("mycel", tools=[tool_schema])
+
+    with patch("run_agent.get_tool_definitions", return_value=[]), \
+         patch("hermes_cli.config.load_config", return_value={"memory": {"provider": "mycel"}}), \
+         patch("plugins.memory.load_memory_provider", return_value=provider):
+        agent = AIAgent(
+            model="test/model",
+            api_key="test-key",
+            base_url="https://example.invalid/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            memory_provider_tools_only=True,
+        )
+
+    assert getattr(agent, "_memory_store") is None
+    assert getattr(agent, "_memory_provider_tools_only") is True
+    assert "mycel_health" in getattr(agent, "valid_tool_names")
+    assert provider.initialized is True
+    assert provider._init_kwargs["agent_context"] == "memory-tools-only"

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -959,6 +959,31 @@ class TestRunJobSessionPersistence:
         kwargs = mock_agent_cls.call_args.kwargs
         assert kwargs["enabled_toolsets"] == ["web", "terminal", "file"]
 
+    def test_run_job_keeps_memory_provider_tools_without_memory_context(self, tmp_path):
+        """Cron should expose memory-provider tools (Mycel-style) without
+        opting into ordinary memory context injection / turn sync.
+
+        ``skip_memory=True`` prevents built-in MEMORY.md/USER.md prompt
+        injection, while ``memory_provider_tools_only=True`` lets AIAgent load
+        the configured external memory provider's explicit tools.
+        """
+        job = {
+            "id": "memory-tools-job",
+            "name": "test",
+            "prompt": "use mycel_health if needed",
+        }
+        fake_db, patches = self._make_run_job_patches(tmp_path)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            run_job(job)
+
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["skip_memory"] is True
+        assert kwargs["memory_provider_tools_only"] is True
+
     def test_run_job_enabled_toolsets_resolves_from_platform_config_when_not_set(self, tmp_path):
         """When a job has no explicit enabled_toolsets, the scheduler now
         resolves them from ``hermes tools`` platform config for ``cron``


### PR DESCRIPTION
## Summary\n- add a memory-provider tools-only mode so cron can expose explicit external memory tools like Mycel while still skipping built-in memory prompt injection\n- prevent tools-only cron runs from prefetching memory context or syncing cron turns back into memory providers\n- pass the new mode from cron scheduler and cover it with focused cron/memory-provider tests\n\n## Tests\n- python -m pytest tests/cron/test_scheduler.py tests/cron/test_scheduler_mcp_init.py tests/agent/test_memory_provider.py -q -o 'addopts='