### PR TITLE
fix: shut down Honcho memory provider after oneshot

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -337,7 +337,17 @@ def _run_agent(
     agent.stream_delta_callback = None
     agent.tool_gen_callback = None
 
-    return agent.chat(prompt) or ""
+    try:
+        return agent.chat(prompt) or ""
+    finally:
+        # Oneshot exits the process immediately after printing the response.
+        # Persistent memory providers such as Honcho run background daemon
+        # threads; leaving them alive races Python interpreter shutdown and can
+        # abort the process after the correct answer has already been printed.
+        try:
+            agent.shutdown_memory_provider()
+        except Exception:
+            logging.debug("Oneshot memory-provider shutdown failed", exc_info=True)
 
 
 def _oneshot_clarify_callback(question: str, choices=None) -> str:

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1311,10 +1311,10 @@ class HonchoMemoryProvider(MemoryProvider):
         for t in (self._prefetch_thread, self._sync_thread):
             if t and t.is_alive():
                 t.join(timeout=5.0)
-        # Flush any remaining messages
+        # Flush any remaining messages and stop manager-owned background work.
         if self._manager:
             try:
-                self._manager.flush_all()
+                self._manager.shutdown()
             except Exception:
                 pass
 

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -137,6 +137,7 @@ class HonchoSessionManager:
         # Async write queue — started lazily on first enqueue
         self._async_queue: queue.Queue | None = None
         self._async_thread: threading.Thread | None = None
+        self._prefetch_threads: list[threading.Thread] = []
         if write_frequency == "async":
             self._async_queue = queue.Queue()
             self._async_thread = threading.Thread(
@@ -473,9 +474,19 @@ class HonchoSessionManager:
                     break
 
     def shutdown(self) -> None:
-        """Gracefully shut down the async writer thread."""
+        """Gracefully shut down background Honcho work before process exit."""
+        with self._cache_lock:
+            prefetch_threads = list(self._prefetch_threads)
+            self._prefetch_threads.clear()
+        for thread in prefetch_threads:
+            if thread.is_alive():
+                thread.join(timeout=5)
+
+        # Preserve the old shutdown contract: all write-frequency modes flush
+        # unsynced messages at session end, not only async mode.
+        self.flush_all()
+
         if self._async_queue is not None and self._async_thread is not None:
-            self.flush_all()
             self._async_queue.put(_ASYNC_SHUTDOWN)
             self._async_thread.join(timeout=10)
 
@@ -603,6 +614,9 @@ class HonchoSessionManager:
                 self.set_context_result(session_key, result)
 
         t = threading.Thread(target=_run, name="honcho-context-prefetch", daemon=True)
+        with self._cache_lock:
+            self._prefetch_threads = [thr for thr in self._prefetch_threads if thr.is_alive()]
+            self._prefetch_threads.append(t)
         t.start()
 
     def set_context_result(self, session_key: str, result: dict[str, str]) -> None:

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -804,6 +804,68 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
     assert captured["prompt"] == "recall this"
 
 
+
+def test_oneshot_shuts_down_memory_provider(monkeypatch):
+    """Oneshot must tear down memory-provider threads before process exit."""
+    from hermes_cli.oneshot import _run_agent
+
+    captured = {"shutdowns": 0}
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            self.suppress_status_output = False
+            self.stream_delta_callback = object()
+            self.tool_gen_callback = object()
+
+        def chat(self, prompt):
+            captured["prompt"] = prompt
+            return "ok"
+
+        def shutdown_memory_provider(self):
+            captured["shutdowns"] += 1
+
+    def mod(name, **attrs):
+        module = types.ModuleType(name)
+        for key, value in attrs.items():
+            setattr(module, key, value)
+        return module
+
+    monkeypatch.setitem(sys.modules, "run_agent", mod("run_agent", AIAgent=FakeAgent))
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        mod("hermes_cli.config", load_config=lambda: {"model": {"default": "m"}}),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.models",
+        mod("hermes_cli.models", detect_provider_for_model=lambda *_args, **_kwargs: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.runtime_provider",
+        mod(
+            "hermes_cli.runtime_provider",
+            resolve_runtime_provider=lambda **_kwargs: {
+                "api_key": "k",
+                "base_url": "u",
+                "provider": "p",
+                "api_mode": "chat_completions",
+                "credential_pool": None,
+            },
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.tools_config",
+        mod("hermes_cli.tools_config", _get_platform_tools=lambda *_args, **_kwargs: set()),
+    )
+
+    assert _run_agent("shutdown please") == "ok"
+    assert captured["prompt"] == "shutdown please"
+    assert captured["shutdowns"] == 1
+
+
 def test_launch_tui_exports_model_provider_and_toolsets(monkeypatch, main_mod):
     captured = {}
     active_path_during_call = None

--- a/tests/honcho_plugin/test_async_memory.py
+++ b/tests/honcho_plugin/test_async_memory.py
@@ -292,6 +292,38 @@ class TestAsyncWriterThread:
         mgr.shutdown()
         assert not mgr._async_thread.is_alive()
 
+    def test_shutdown_flushes_session_mode(self):
+        mgr = _make_manager(write_frequency="session")
+        sess = _make_session()
+        sess.add_message("user", "pending")
+        mgr._cache = {sess.key: sess}
+
+        with patch.object(mgr, "_flush_session") as mock_flush:
+            mgr.shutdown()
+
+        mock_flush.assert_called_once_with(sess)
+
+    def test_shutdown_joins_prefetch_threads(self):
+        mgr = _make_manager(write_frequency="turn")
+        started = threading.Event()
+        release = threading.Event()
+
+        def wait_for_release():
+            started.set()
+            release.wait(timeout=2)
+
+        thread = threading.Thread(target=wait_for_release, name="honcho-context-prefetch", daemon=True)
+        thread.start()
+        assert started.wait(timeout=1)
+        with mgr._cache_lock:
+            mgr._prefetch_threads.append(thread)
+
+        release.set()
+        mgr.shutdown()
+
+        assert not thread.is_alive()
+        assert mgr._prefetch_threads == []
+
     def test_async_writer_calls_flush(self):
         mgr = _make_manager(write_frequency="async")
         sess = _make_session()


### PR DESCRIPTION
## Summary
- shut down the configured memory provider when `hermes chat -q` / oneshot exits
- route Honcho provider shutdown through `HonchoSessionManager.shutdown()` instead of only flushing
- track and join Honcho context-prefetch threads during shutdown
- preserve the old shutdown contract by flushing pending session writes for all write-frequency modes

## Test plan
- `python -m pytest tests/hermes_cli/test_tui_resume_flow.py::test_oneshot_shuts_down_memory_provider tests/honcho_plugin/test_async_memory.py::TestAsyncWriterThread::test_shutdown_flushes_session_mode tests/honcho_plugin/test_async_memory.py::TestAsyncWriterThread::test_shutdown_joins_prefetch_threads -q -o 'addopts='`
- `python -m pytest tests/hermes_cli/test_tui_resume_flow.py tests/honcho_plugin/test_async_memory.py tests/honcho_plugin/test_session.py -q -o 'addopts='`
- `git diff --check`
