### PR TITLE
fix(gateway): respect explicit plugin platform disables

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -876,7 +876,6 @@ def load_gateway_config() -> GatewayConfig:
                 plat_data, extra = _ensure_platform_extra_dict(platforms_data, plat.value)
                 if enabled_was_explicit:
                     plat_data["enabled"] = platform_cfg["enabled"]
-                if plat == Platform.SLACK and enabled_was_explicit:
                     extra["_enabled_explicit"] = True
                 extra.update(bridged)
 
@@ -1827,7 +1826,10 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             platform = Platform(entry.name)
             if platform not in config.platforms:
                 config.platforms[platform] = PlatformConfig()
-            config.platforms[platform].enabled = True
+            platform_config = config.platforms[platform]
+            if not platform_config.enabled and platform_config.extra.pop("_enabled_explicit", False):
+                continue
+            platform_config.enabled = True
             # Seed extras from env if the plugin opted in.
             if entry.env_enablement_fn is not None:
                 try:

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -413,6 +413,27 @@ class TestLoadGatewayConfig:
             "456": "Therapist mode",
         }
 
+    def test_explicit_discord_disable_survives_plugin_auto_enable(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  enabled: false\n"
+            "  require_mention: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+        monkeypatch.delenv("DISCORD_REQUIRE_MENTION", raising=False)
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.DISCORD].enabled is False
+        assert config.platforms[Platform.DISCORD].token is None
+        assert os.getenv("DISCORD_REQUIRE_MENTION") == "true"
+
     def test_bridges_discord_history_backfill_settings_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()


### PR DESCRIPTION
## Summary
- Preserve explicit platform enabled state for all YAML platform configs, not only Slack
- Skip plugin auto-enable when a platform was explicitly disabled
- Add a Discord regression test covering discord.enabled: false with YAML env bridging

## Test Plan
- /Users/ben/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_config.py -q -o 'addopts='
- git diff --check