### PR TITLE
fix: support service tier for compression auxiliary calls

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -668,6 +668,9 @@ class _CodexCompletionsAdapter:
         timeout = kwargs.get("timeout")
         if timeout is not None:
             resp_kwargs["timeout"] = timeout
+        service_tier = kwargs.get("service_tier")
+        if isinstance(service_tier, str) and service_tier.strip():
+            resp_kwargs["service_tier"] = service_tier.strip()
 
         # Note: the Codex endpoint (chatgpt.com/backend-api/codex) does NOT
         # support max_output_tokens or temperature — omit to avoid 400 errors.
@@ -4410,6 +4413,18 @@ def _get_task_extra_body(task: str) -> Dict[str, Any]:
     return {}
 
 
+def _get_task_service_tier(task: str) -> Optional[str]:
+    """Read auxiliary.<task>.service_tier and normalize fast-mode aliases."""
+    task_config = _get_auxiliary_task_config(task)
+    value = str(task_config.get("service_tier") or "").strip().lower()
+    if not value or value in {"normal", "default", "standard", "off", "none"}:
+        return None
+    if value in {"fast", "priority", "on"}:
+        return "priority"
+    logger.warning("Unknown auxiliary.%s.service_tier %r, ignoring", task, value)
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Anthropic-compatible endpoint detection + image block conversion
 # ---------------------------------------------------------------------------
@@ -4718,6 +4733,9 @@ def call_llm(
         temperature=temperature, max_tokens=max_tokens,
         tools=tools, timeout=effective_timeout, extra_body=effective_extra_body,
         base_url=_base_info or resolved_base_url)
+    service_tier = _get_task_service_tier(task)
+    if service_tier:
+        kwargs["service_tier"] = service_tier
 
     # Convert image blocks for Anthropic-compatible endpoints (e.g. MiniMax)
     _client_base = str(getattr(client, "base_url", "") or "")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -913,6 +913,7 @@ DEFAULT_CONFIG = {
             "base_url": "",
             "api_key": "",
             "timeout": 120,        # seconds — compression summarises large contexts; increase for local models
+            "service_tier": "",    # fast/priority enables priority service where supported
             "extra_body": {},
         },
         # Note: session_search no longer uses an auxiliary LLM (PR #27590 —

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -28,6 +28,7 @@ from agent.auxiliary_client import (
     _resolve_auto,
     _resolve_xai_oauth_for_aux,
     _CodexCompletionsAdapter,
+    CodexAuxiliaryClient,
 )
 
 
@@ -814,6 +815,68 @@ class TestAuxiliaryPoolAwareness:
 
         assert client is not None
         assert model == "google/gemini-3-flash-preview"
+
+    def test_call_llm_applies_auxiliary_task_service_tier(self):
+        fake_client = MagicMock()
+        fake_client.base_url = "https://chatgpt.com/backend-api/codex"
+        fake_client.chat.completions.create.return_value = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+        )
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model", return_value=("openai-codex", "gpt-5.5", None, None, None)),
+            patch("agent.auxiliary_client._get_cached_client", return_value=(fake_client, "gpt-5.5")),
+            patch("agent.auxiliary_client._get_auxiliary_task_config", return_value={"service_tier": "fast"}),
+        ):
+            call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert fake_client.chat.completions.create.call_args.kwargs["service_tier"] == "priority"
+
+    def test_codex_auxiliary_client_forwards_service_tier(self):
+        seen = {}
+
+        class _Stream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def __iter__(self):
+                return iter([])
+
+            def get_final_response(self):
+                return SimpleNamespace(
+                    output=[SimpleNamespace(
+                        type="message",
+                        content=[SimpleNamespace(type="output_text", text="ok")],
+                    )]
+                )
+
+        class _Responses:
+            def stream(self, **kwargs):
+                seen.update(kwargs)
+                return _Stream()
+
+        real_client = SimpleNamespace(
+            responses=_Responses(),
+            api_key="test",
+            base_url="https://chatgpt.com/backend-api/codex",
+            close=lambda: None,
+        )
+        client = CodexAuxiliaryClient(real_client, "gpt-5.5")
+
+        response = client.chat.completions.create(
+            model="gpt-5.5",
+            messages=[{"role": "user", "content": "hi"}],
+            service_tier="priority",
+        )
+
+        assert seen["service_tier"] == "priority"
+        assert response.choices[0].message.content == "ok"
 
     def test_call_llm_retries_nous_after_401(self):
         class _Auth401(Exception):


### PR DESCRIPTION
## Summary
- Adds auxiliary.<task>.service_tier support, normalizing fast/priority/on to Responses API priority service
- Forwards service_tier through the Codex auxiliary Responses adapter
- Adds regression coverage for compression task service_tier and Codex adapter forwarding

## Test Plan
- uv run --with pytest --with pytest-asyncio pytest tests/agent/test_auxiliary_client.py tests/hermes_cli/test_aux_config.py -q -o 'addopts='

## Review
- Static added-line scan for secrets/injection/eval/pickle/SQL: no findings
- Independent reviewer: passed