### PR TITLE
fix(gateway): bound webhook direct delivery sends

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -651,6 +651,17 @@ class WebhookAdapter(BasePlatformAdapter):
                     route_name,
                     delivery_id,
                 )
+                if route_config.get("direct_delivery_ack_on_failure"):
+                    return web.json_response(
+                        {
+                            "status": "accepted",
+                            "delivery_status": "target_failed",
+                            "route": route_name,
+                            "target": delivery["deliver"],
+                            "delivery_id": delivery_id,
+                        },
+                        status=202,
+                    )
                 return web.json_response(
                     {"status": "error", "error": "Delivery failed", "delivery_id": delivery_id},
                     status=502,

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -510,7 +510,9 @@ class WebhookAdapter(BasePlatformAdapter):
                 {"status": "duplicate", "delivery_id": delivery_id},
                 status=200,
             )
-        self._seen_deliveries[delivery_id] = now
+
+        def _mark_delivery_seen() -> None:
+            self._seen_deliveries[delivery_id] = now
 
         # ── Direct delivery mode (deliver_only) ─────────────────
         # Skip the agent entirely — the rendered prompt IS the message we
@@ -643,6 +645,7 @@ class WebhookAdapter(BasePlatformAdapter):
                                 )
 
                         task.add_done_callback(_log_background_direct_delivery_failure)
+                        _mark_delivery_seen()
                         return web.json_response(
                             {
                                 "status": "accepted",
@@ -663,6 +666,7 @@ class WebhookAdapter(BasePlatformAdapter):
                     delivery_id,
                 )
                 if route_config.get("direct_delivery_ack_on_failure"):
+                    _mark_delivery_seen()
                     return web.json_response(
                         {
                             "status": "accepted",
@@ -679,6 +683,7 @@ class WebhookAdapter(BasePlatformAdapter):
                 )
 
             if result.success:
+                _mark_delivery_seen()
                 return web.json_response(
                     {
                         "status": "delivered",
@@ -697,6 +702,7 @@ class WebhookAdapter(BasePlatformAdapter):
                 result.error,
             )
             if route_config.get("direct_delivery_ack_on_failure"):
+                _mark_delivery_seen()
                 return web.json_response(
                     {
                         "status": "accepted",
@@ -760,6 +766,7 @@ class WebhookAdapter(BasePlatformAdapter):
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
 
+        _mark_delivery_seen()
         return web.json_response(
             {
                 "status": "accepted",

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -696,10 +696,10 @@ class WebhookAdapter(BasePlatformAdapter):
             # Delivery attempted but target rejected it — surface as 502
             # with a generic error (don't leak adapter-level detail).
             logger.warning(
-                "[webhook] direct-deliver target rejected route=%s target=%s error=%s",
+                "[webhook] direct-deliver target rejected route=%s target=%s delivery=%s",
                 route_name,
                 delivery["deliver"],
-                result.error,
+                delivery_id,
             )
             if route_config.get("direct_delivery_ack_on_failure"):
                 _mark_delivery_seen()

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -622,14 +622,25 @@ class WebhookAdapter(BasePlatformAdapter):
                             if done_task.cancelled():
                                 return
                             exc = done_task.exception()
-                            if exc is None:
+                            if exc is not None:
+                                logger.error(
+                                    "[webhook] background direct-deliver failed route=%s delivery=%s",
+                                    route_name,
+                                    delivery_id,
+                                    exc_info=(type(exc), exc, exc.__traceback__),
+                                )
                                 return
-                            logger.error(
-                                "[webhook] background direct-deliver failed route=%s delivery=%s",
-                                route_name,
-                                delivery_id,
-                                exc_info=(type(exc), exc, exc.__traceback__),
-                            )
+                            try:
+                                bg_result = done_task.result()
+                            except Exception:
+                                return
+                            if isinstance(bg_result, SendResult) and not bg_result.success:
+                                logger.warning(
+                                    "[webhook] direct-deliver target rejected route=%s target=%s delivery=%s",
+                                    route_name,
+                                    delivery["deliver"],
+                                    delivery_id,
+                                )
 
                         task.add_done_callback(_log_background_direct_delivery_failure)
                         return web.json_response(

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -1026,10 +1026,12 @@ class WebhookAdapter(BasePlatformAdapter):
                     error=f"No chat_id or home channel for {platform_name}",
                 )
 
-        # Pass thread_id from deliver_extra so Telegram forum topics work
-        metadata = None
+        # Pass per-route metadata through so delivery targets can tune a single
+        # webhook route without changing the platform's global send behavior.
+        raw_metadata = extra.get("metadata")
+        metadata = dict(raw_metadata) if isinstance(raw_metadata, dict) else {}
         thread_id = extra.get("message_thread_id") or extra.get("thread_id")
         if thread_id:
-            metadata = {"thread_id": thread_id}
+            metadata["thread_id"] = thread_id
 
-        return await adapter.send(chat_id, content, metadata=metadata)
+        return await adapter.send(chat_id, content, metadata=metadata or None)

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -134,6 +134,7 @@ class WebhookAdapter(BasePlatformAdapter):
         # Rate limiting: per-route timestamps in a fixed window.
         self._rate_counts: Dict[str, List[float]] = {}
         self._rate_limit: int = int(config.extra.get("rate_limit", 30))  # per minute
+        self._direct_delivery_inflight: Dict[str, int] = {}
 
         # Body size limit (auth-before-body pattern)
         self._max_body_bytes: int = int(
@@ -533,8 +534,117 @@ class WebhookAdapter(BasePlatformAdapter):
                 len(prompt),
                 delivery_id,
             )
+            timeout_raw = route_config.get("direct_delivery_timeout_seconds")
+            timeout: Optional[float] = None
+            if timeout_raw is not None:
+                try:
+                    timeout = max(0.0, float(timeout_raw))
+                except (TypeError, ValueError):
+                    logger.warning(
+                        "[webhook] Invalid direct_delivery_timeout_seconds=%r for route=%s",
+                        timeout_raw,
+                        route_name,
+                    )
+            max_inflight_raw = route_config.get("direct_delivery_max_inflight")
+            max_inflight: Optional[int] = None
+            if max_inflight_raw is not None:
+                try:
+                    parsed_max_inflight = int(max_inflight_raw)
+                    if parsed_max_inflight > 0:
+                        max_inflight = parsed_max_inflight
+                except (TypeError, ValueError):
+                    logger.warning(
+                        "[webhook] Invalid direct_delivery_max_inflight=%r for route=%s",
+                        max_inflight_raw,
+                        route_name,
+                    )
+
+            inflight = self._direct_delivery_inflight.get(route_name, 0)
+            if max_inflight is not None and inflight >= max_inflight:
+                logger.warning(
+                    "[webhook] direct-deliver busy route=%s target=%s inflight=%d max=%d delivery=%s",
+                    route_name,
+                    delivery["deliver"],
+                    inflight,
+                    max_inflight,
+                    delivery_id,
+                )
+                return web.json_response(
+                    {
+                        "status": "busy",
+                        "error": "Direct delivery busy",
+                        "route": route_name,
+                        "target": delivery["deliver"],
+                        "delivery_id": delivery_id,
+                    },
+                    status=429,
+                )
+
+            counted_inflight = False
+
+            def _increment_direct_delivery_inflight() -> None:
+                nonlocal counted_inflight
+                if max_inflight is None:
+                    return
+                self._direct_delivery_inflight[route_name] = (
+                    self._direct_delivery_inflight.get(route_name, 0) + 1
+                )
+                counted_inflight = True
+
+            def _release_direct_delivery_inflight() -> None:
+                nonlocal counted_inflight
+                if not counted_inflight:
+                    return
+                counted_inflight = False
+                current = self._direct_delivery_inflight.get(route_name, 0)
+                if current <= 1:
+                    self._direct_delivery_inflight.pop(route_name, None)
+                else:
+                    self._direct_delivery_inflight[route_name] = current - 1
+
             try:
-                result = await self._direct_deliver(prompt, delivery)
+                if timeout is None or timeout <= 0:
+                    _increment_direct_delivery_inflight()
+                    try:
+                        result = await self._direct_deliver(prompt, delivery)
+                    finally:
+                        _release_direct_delivery_inflight()
+                else:
+                    _increment_direct_delivery_inflight()
+                    task = asyncio.create_task(self._direct_deliver(prompt, delivery))
+                    task.add_done_callback(lambda _task: _release_direct_delivery_inflight())
+                    done, _pending = await asyncio.wait({task}, timeout=timeout)
+                    if not done:
+                        self._background_tasks.add(task)
+                        task.add_done_callback(self._background_tasks.discard)
+
+                        def _log_background_direct_delivery_failure(done_task: asyncio.Task) -> None:
+                            if done_task.cancelled():
+                                return
+                            exc = done_task.exception()
+                            if exc is None:
+                                return
+                            logger.error(
+                                "[webhook] background direct-deliver failed route=%s delivery=%s",
+                                route_name,
+                                delivery_id,
+                                exc_info=(type(exc), exc, exc.__traceback__),
+                            )
+
+                        task.add_done_callback(_log_background_direct_delivery_failure)
+                        return web.json_response(
+                            {
+                                "status": "accepted",
+                                "route": route_name,
+                                "target": delivery["deliver"],
+                                "delivery_id": delivery_id,
+                            },
+                            status=202,
+                        )
+                    try:
+                        result = task.result()
+                    finally:
+                        _release_direct_delivery_inflight()
             except Exception:
                 logger.exception(
                     "[webhook] direct-deliver failed route=%s delivery=%s",

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -674,6 +674,17 @@ class WebhookAdapter(BasePlatformAdapter):
                 delivery["deliver"],
                 result.error,
             )
+            if route_config.get("direct_delivery_ack_on_failure"):
+                return web.json_response(
+                    {
+                        "status": "accepted",
+                        "delivery_status": "target_failed",
+                        "route": route_name,
+                        "target": delivery["deliver"],
+                        "delivery_id": delivery_id,
+                    },
+                    status=202,
+                )
             return web.json_response(
                 {"status": "error", "error": "Delivery failed", "delivery_id": delivery_id},
                 status=502,

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -976,6 +976,24 @@ def _coerce_bool(value: Any, default: bool = True) -> bool:
     return default
 
 
+def _metadata_non_negative_int(metadata: Optional[Dict[str, Any]], key: str, default: int) -> int:
+    if not isinstance(metadata, dict) or key not in metadata:
+        return default
+    try:
+        return max(0, int(metadata[key]))
+    except (TypeError, ValueError):
+        return default
+
+
+def _metadata_non_negative_float(metadata: Optional[Dict[str, Any]], key: str, default: float) -> float:
+    if not isinstance(metadata, dict) or key not in metadata:
+        return default
+    try:
+        return max(0.0, float(metadata[key]))
+    except (TypeError, ValueError):
+        return default
+
+
 def _extract_text(item_list: List[Dict[str, Any]]) -> str:
     for item in item_list:
         if item.get("type") == ITEM_TEXT:
@@ -1592,6 +1610,9 @@ class WeixinAdapter(BasePlatformAdapter):
         chunk: str,
         context_token: Optional[str],
         client_id: str,
+        max_retries: Optional[int] = None,
+        retry_delay_seconds: Optional[float] = None,
+        rate_limit_backoff_seconds: Optional[float] = None,
     ) -> None:
         """Send a single text chunk with per-chunk retry and backoff.
 
@@ -1602,7 +1623,18 @@ class WeixinAdapter(BasePlatformAdapter):
         """
         last_error: Optional[Exception] = None
         retried_without_token = False
-        for attempt in range(self._send_chunk_retries + 1):
+        max_attempt_retries = self._send_chunk_retries if max_retries is None else max(0, int(max_retries))
+        retry_delay = (
+            self._send_chunk_retry_delay_seconds
+            if retry_delay_seconds is None
+            else max(0.0, float(retry_delay_seconds))
+        )
+        rate_limit_backoff = (
+            self._send_chunk_rate_limit_backoff_seconds
+            if rate_limit_backoff_seconds is None
+            else max(0.0, float(rate_limit_backoff_seconds))
+        )
+        for attempt in range(max_attempt_retries + 1):
             if not self._send_available():
                 raise RuntimeError("Not connected")
             try:
@@ -1653,9 +1685,9 @@ class WeixinAdapter(BasePlatformAdapter):
                             last_error = RuntimeError(
                                 f"iLink sendmessage rate limited: ret={ret} errcode={errcode} errmsg={errmsg}"
                             )
-                            if attempt >= self._send_chunk_retries:
+                            if attempt >= max_attempt_retries:
                                 break
-                            wait = self._send_chunk_rate_limit_backoff_seconds
+                            wait = rate_limit_backoff
                             if not self._send_available():
                                 raise RuntimeError("Not connected")
                             logger.warning(
@@ -1672,15 +1704,15 @@ class WeixinAdapter(BasePlatformAdapter):
                 return
             except Exception as exc:
                 last_error = exc
-                if attempt >= self._send_chunk_retries:
+                if attempt >= max_attempt_retries:
                     break
-                wait = self._send_chunk_retry_delay_seconds * (attempt + 1)
+                wait = retry_delay * (attempt + 1)
                 logger.warning(
                     "[%s] send chunk failed to=%s attempt=%d/%d, retrying in %.2fs: %s",
                     self.name,
                     _safe_id(chat_id),
                     attempt + 1,
-                    self._send_chunk_retries + 1,
+                    max_attempt_retries + 1,
                     wait,
                     exc,
                 )
@@ -1698,6 +1730,19 @@ class WeixinAdapter(BasePlatformAdapter):
     ) -> SendResult:
         context_token = self._token_store.get(self._account_id, chat_id)
         last_message_id: Optional[str] = None
+        send_chunk_retries = _metadata_non_negative_int(
+            metadata, "weixin_send_chunk_retries", self._send_chunk_retries
+        )
+        send_chunk_retry_delay_seconds = _metadata_non_negative_float(
+            metadata,
+            "weixin_send_chunk_retry_delay_seconds",
+            self._send_chunk_retry_delay_seconds,
+        )
+        send_chunk_rate_limit_backoff_seconds = _metadata_non_negative_float(
+            metadata,
+            "weixin_send_chunk_rate_limit_backoff_seconds",
+            self._send_chunk_rate_limit_backoff_seconds,
+        )
 
         # Extract MEDIA: tags and bare local file paths before text delivery.
         media_files, cleaned_content = self.extract_media(content)
@@ -1751,6 +1796,9 @@ class WeixinAdapter(BasePlatformAdapter):
                     chunk=chunk,
                     context_token=context_token,
                     client_id=client_id,
+                    max_retries=send_chunk_retries,
+                    retry_delay_seconds=send_chunk_retry_delay_seconds,
+                    rate_limit_backoff_seconds=send_chunk_rate_limit_backoff_seconds,
                 )
                 last_message_id = client_id
                 if idx < len(chunks) - 1 and self._send_chunk_delay_seconds > 0:

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1210,6 +1210,13 @@ class WeixinAdapter(BasePlatformAdapter):
             extra.get("send_chunk_retry_delay_seconds")
             or os.getenv("WEIXIN_SEND_CHUNK_RETRY_DELAY_SECONDS", "1.0")
         )
+        self._send_chunk_rate_limit_backoff_seconds = float(
+            extra.get("send_chunk_rate_limit_backoff_seconds")
+            or os.getenv(
+                "WEIXIN_SEND_CHUNK_RATE_LIMIT_BACKOFF_SECONDS",
+                str(self._send_chunk_retry_delay_seconds * 3),
+            )
+        )
         self._dm_policy = str(extra.get("dm_policy") or os.getenv("WEIXIN_DM_POLICY", "open")).strip().lower()
         self._group_policy = str(extra.get("group_policy") or os.getenv("WEIXIN_GROUP_POLICY", "disabled")).strip().lower()
         allow_from = extra.get("allow_from")
@@ -1309,6 +1316,15 @@ class WeixinAdapter(BasePlatformAdapter):
         self._release_platform_lock()
         self._mark_disconnected()
         logger.info("[%s] Disconnected", self.name)
+
+    def _send_available(self) -> bool:
+        session = self._send_session
+        return bool(
+            self._running
+            and session
+            and not getattr(session, "closed", False)
+            and self._token
+        )
 
     async def _poll_loop(self) -> None:
         assert self._poll_session is not None
@@ -1587,9 +1603,14 @@ class WeixinAdapter(BasePlatformAdapter):
         last_error: Optional[Exception] = None
         retried_without_token = False
         for attempt in range(self._send_chunk_retries + 1):
+            if not self._send_available():
+                raise RuntimeError("Not connected")
             try:
+                session = self._send_session
+                if session is None:
+                    raise RuntimeError("Not connected")
                 resp = await _send_message(
-                    self._send_session,
+                    session,
                     base_url=self._base_url,
                     token=self._token,
                     to=chat_id,
@@ -1634,12 +1655,15 @@ class WeixinAdapter(BasePlatformAdapter):
                             )
                             if attempt >= self._send_chunk_retries:
                                 break
-                            wait = self._send_chunk_retry_delay_seconds * 3  # 3x backoff for rate limit
+                            wait = self._send_chunk_rate_limit_backoff_seconds
+                            if not self._send_available():
+                                raise RuntimeError("Not connected")
                             logger.warning(
                                 "[%s] rate limited for %s; backing off %.1fs before retry",
                                 self.name, _safe_id(chat_id), wait,
                             )
-                            await asyncio.sleep(wait)
+                            if wait > 0:
+                                await asyncio.sleep(wait)
                             continue
                         errmsg = resp.get("errmsg") or resp.get("msg") or "unknown error"
                         raise RuntimeError(
@@ -1672,8 +1696,6 @@ class WeixinAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        if not self._send_session or not self._token:
-            return SendResult(success=False, error="Not connected")
         context_token = self._token_store.get(self._account_id, chat_id)
         last_message_id: Optional[str] = None
 
@@ -1702,6 +1724,8 @@ class WeixinAdapter(BasePlatformAdapter):
         try:
             # Deliver extracted MEDIA: attachments first.
             for media_path, is_voice in media_files:
+                if not self._send_available():
+                    return SendResult(success=False, error="Not connected")
                 try:
                     await _deliver_media(media_path, is_voice)
                 except Exception as exc:
@@ -1709,6 +1733,8 @@ class WeixinAdapter(BasePlatformAdapter):
 
             # Deliver bare local file paths.
             for file_path in local_files:
+                if not self._send_available():
+                    return SendResult(success=False, error="Not connected")
                 try:
                     await _deliver_media(file_path, is_voice=False)
                 except Exception as exc:
@@ -1716,6 +1742,8 @@ class WeixinAdapter(BasePlatformAdapter):
 
             # Deliver text content.
             chunks = [c for c in self._split_text(self.format_message(final_content)) if c and c.strip()]
+            if chunks and not self._send_available():
+                return SendResult(success=False, error="Not connected")
             for idx, chunk in enumerate(chunks):
                 client_id = f"hermes-weixin-{uuid.uuid4().hex}"
                 await self._send_text_chunk(
@@ -2145,6 +2173,7 @@ async def send_weixin_direct(
         adapter._base_url = base_url
         adapter._cdn_base_url = cdn_base_url
         adapter._token_store = token_store
+        adapter._running = True
 
         last_result: Optional[SendResult] = None
         cleaned = adapter.format_message(message)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -65,6 +65,7 @@ _AGENT_CACHE_MAX_SIZE = 128
 _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
+_LIFECYCLE_NOTIFY_TIMEOUT_SECS_DEFAULT = 3.0
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
@@ -2071,7 +2072,7 @@ class GatewayRunner:
                 if mode in {"voice_only", "all"} and key.startswith(prefix)
             )
 
-    async def _safe_adapter_disconnect(self, adapter, platform) -> None:
+    async def _safe_adapter_disconnect(self, adapter, platform) -> bool:
         """Call adapter.disconnect() defensively, swallowing any error.
 
         Used when adapter.connect() failed or raised — the adapter may
@@ -2088,18 +2089,21 @@ class GatewayRunner:
                 await adapter.disconnect()
             else:
                 await asyncio.wait_for(adapter.disconnect(), timeout=timeout)
+            return True
         except asyncio.TimeoutError:
             logger.warning(
                 "Timed out after %.1fs while disconnecting %s adapter; continuing shutdown",
                 timeout,
                 platform.value if platform is not None else "adapter",
             )
+            return False
         except Exception as e:
             logger.debug(
                 "Defensive %s disconnect after failed connect raised: %s",
                 platform.value if platform is not None else "adapter",
                 e,
             )
+            return False
 
     def _adapter_disconnect_timeout_secs(self) -> float:
         """Return the per-adapter disconnect timeout used during shutdown."""
@@ -2131,6 +2135,25 @@ class GatewayRunner:
                 return max(0.0, timeout)
         return _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT
 
+    def _lifecycle_notify_timeout_secs(self) -> float:
+        """Return the per-message timeout for lifecycle notifications."""
+        env_names = (
+            "HERMES_GATEWAY_LIFECYCLE_NOTIFY_TIMEOUT",
+            # Backward-compatible alias from the original shutdown-only guard.
+            "HERMES_GATEWAY_SHUTDOWN_NOTIFY_TIMEOUT",
+        )
+        for env_name in env_names:
+            raw = os.getenv(env_name, "").strip()
+            if not raw:
+                continue
+            try:
+                timeout = float(raw)
+            except ValueError:
+                logger.warning("Ignoring invalid %s=%r", env_name, raw)
+            else:
+                return max(0.0, timeout)
+        return _LIFECYCLE_NOTIFY_TIMEOUT_SECS_DEFAULT
+
     async def _connect_adapter_with_timeout(self, adapter, platform) -> bool:
         """Connect an adapter without allowing one platform to block others."""
         timeout = self._platform_connect_timeout_secs()
@@ -2141,6 +2164,37 @@ class GatewayRunner:
         except asyncio.TimeoutError as exc:
             raise TimeoutError(
                 f"{platform.value} connect timed out after {timeout:g}s"
+            ) from exc
+
+    async def _send_lifecycle_notification(
+        self,
+        adapter,
+        chat_id: str,
+        content: str,
+        **send_kwargs,
+    ):
+        """Send a lifecycle notice without letting platform backoff stall."""
+        if getattr(adapter, "platform", None) == Platform.WEIXIN:
+            metadata = dict(send_kwargs.get("metadata") or {})
+            metadata.update(
+                {
+                    "weixin_send_chunk_retries": 0,
+                    "weixin_send_chunk_retry_delay_seconds": 0,
+                    "weixin_send_chunk_rate_limit_backoff_seconds": 0,
+                }
+            )
+            send_kwargs["metadata"] = metadata
+        timeout = self._lifecycle_notify_timeout_secs()
+        if timeout <= 0:
+            return await adapter.send(chat_id, content, **send_kwargs)
+        try:
+            return await asyncio.wait_for(
+                adapter.send(chat_id, content, **send_kwargs),
+                timeout=timeout,
+            )
+        except asyncio.TimeoutError as exc:
+            raise TimeoutError(
+                f"lifecycle notification send timed out after {timeout:g}s"
             ) from exc
 
     @property
@@ -3430,7 +3484,12 @@ class GatewayRunner:
                 # correct forum topic / thread.
                 metadata = {"thread_id": thread_id} if thread_id else None
 
-                result = await adapter.send(chat_id, msg, metadata=metadata)
+                result = await self._send_lifecycle_notification(
+                    adapter,
+                    chat_id,
+                    msg,
+                    metadata=metadata,
+                )
                 if result is not None and getattr(result, "success", True) is False:
                     logger.debug(
                         "Failed to send shutdown notification to %s:%s: %s",
@@ -3476,9 +3535,18 @@ class GatewayRunner:
             try:
                 metadata = {"thread_id": home.thread_id} if home.thread_id else None
                 if metadata:
-                    result = await adapter.send(str(home.chat_id), msg, metadata=metadata)
+                    result = await self._send_lifecycle_notification(
+                        adapter,
+                        str(home.chat_id),
+                        msg,
+                        metadata=metadata,
+                    )
                 else:
-                    result = await adapter.send(str(home.chat_id), msg)
+                    result = await self._send_lifecycle_notification(
+                        adapter,
+                        str(home.chat_id),
+                        msg,
+                    )
                 if result is not None and getattr(result, "success", True) is False:
                     logger.debug(
                         "Failed to send shutdown notification to home channel %s:%s: %s",
@@ -6033,19 +6101,17 @@ class GatewayRunner:
                     await adapter.cancel_background_tasks()
                 except Exception as e:
                     logger.debug("✗ %s background-task cancel error: %s", platform.value, e)
-                try:
-                    await adapter.disconnect()
+                if await self._safe_adapter_disconnect(adapter, platform):
                     logger.info(
                         "✓ %s disconnected (%.2fs)",
                         platform.value,
                         time.monotonic() - _adapter_started_at,
                     )
-                except Exception as e:
-                    logger.error(
-                        "✗ %s disconnect error after %.2fs: %s",
+                else:
+                    logger.warning(
+                        "✗ %s disconnect incomplete after %.2fs; continuing shutdown",
                         platform.value,
                         time.monotonic() - _adapter_started_at,
-                        e,
                     )
             logger.info(
                 "Shutdown phase: all adapters disconnected at +%.2fs",
@@ -14368,7 +14434,8 @@ class GatewayRunner:
                 return None
 
             metadata = {"thread_id": thread_id} if thread_id else None
-            result = await adapter.send(
+            result = await self._send_lifecycle_notification(
+                adapter,
                 str(chat_id),
                 "♻ Gateway restarted successfully. Your session continues.",
                 metadata=metadata,
@@ -14413,7 +14480,7 @@ class GatewayRunner:
         skipped = skip_targets or set()
         message = "♻️ Gateway online — Hermes is back and ready."
 
-        for platform, adapter in self.adapters.items():
+        for platform, adapter in list(self.adapters.items()):
             home = self.config.get_home_channel(platform)
             if not home or not home.chat_id:
                 continue
@@ -14433,9 +14500,18 @@ class GatewayRunner:
             try:
                 metadata = {"thread_id": home.thread_id} if home.thread_id else None
                 if metadata:
-                    result = await adapter.send(str(home.chat_id), message, metadata=metadata)
+                    result = await self._send_lifecycle_notification(
+                        adapter,
+                        str(home.chat_id),
+                        message,
+                        metadata=metadata,
+                    )
                 else:
-                    result = await adapter.send(str(home.chat_id), message)
+                    result = await self._send_lifecycle_notification(
+                        adapter,
+                        str(home.chat_id),
+                        message,
+                    )
                 if result is not None and getattr(result, "success", True) is False:
                     logger.warning(
                         "Home-channel startup notification failed for %s:%s: %s",

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -245,3 +245,20 @@ async def test_gateway_stop_kills_tool_subprocesses_on_graceful_path(monkeypatch
 
     # Only the final catch-all fires on the graceful path.
     assert kill_count == 1
+
+
+@pytest.mark.asyncio
+async def test_gateway_stop_times_out_slow_adapter_disconnect(monkeypatch):
+    runner, adapter = make_restart_runner()
+    monkeypatch.setenv("HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT", "0.01")
+
+    async def slow_disconnect():
+        await asyncio.sleep(60)
+
+    adapter.disconnect = AsyncMock(side_effect=slow_disconnect)
+
+    with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"):
+        await asyncio.wait_for(runner.stop(), timeout=0.2)
+
+    adapter.disconnect.assert_awaited_once()
+    assert runner._shutdown_event.is_set() is True

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -337,6 +337,107 @@ async def test_send_home_channel_startup_notification_ignores_false_send_result(
     adapter.send.assert_called_once()
 
 
+@pytest.mark.asyncio
+async def test_home_channel_startup_notification_send_timeout_does_not_block(monkeypatch):
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    monkeypatch.setenv("HERMES_GATEWAY_LIFECYCLE_NOTIFY_TIMEOUT", "0.01")
+
+    async def slow_send(*_args, **_kwargs):
+        await asyncio.sleep(10)
+        return SendResult(success=True, message_id="late")
+
+    adapter.send = AsyncMock(side_effect=slow_send)
+
+    delivered = await asyncio.wait_for(
+        runner._send_home_channel_startup_notifications(),
+        timeout=0.2,
+    )
+
+    assert delivered == set()
+    adapter.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_home_channel_startup_notification_uses_adapter_snapshot(monkeypatch):
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+
+    async def send_and_mutate(*_args, **_kwargs):
+        runner.adapters.pop(Platform.TELEGRAM, None)
+        return SendResult(success=False, error="adapter removed")
+
+    adapter.send = AsyncMock(side_effect=send_and_mutate)
+
+    delivered = await runner._send_home_channel_startup_notifications()
+
+    assert delivered == set()
+    adapter.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_notification_send_timeout_does_not_block_active_chat(monkeypatch):
+    runner, adapter = make_restart_runner()
+    runner._running_agents["agent:main:telegram:dm:999"] = MagicMock()
+    monkeypatch.setenv("HERMES_GATEWAY_SHUTDOWN_NOTIFY_TIMEOUT", "0.01")
+
+    async def slow_send(*_args, **_kwargs):
+        await asyncio.sleep(10)
+        return SendResult(success=True, message_id="late")
+
+    adapter.send = AsyncMock(side_effect=slow_send)
+
+    await asyncio.wait_for(runner._notify_active_sessions_of_shutdown(), timeout=0.2)
+
+    adapter.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_notification_send_timeout_does_not_block_home_channel(monkeypatch):
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    monkeypatch.setenv("HERMES_GATEWAY_SHUTDOWN_NOTIFY_TIMEOUT", "0.01")
+
+    async def slow_send(*_args, **_kwargs):
+        await asyncio.sleep(10)
+        return SendResult(success=True, message_id="late")
+
+    adapter.send = AsyncMock(side_effect=slow_send)
+
+    await asyncio.wait_for(runner._notify_active_sessions_of_shutdown(), timeout=0.2)
+
+    adapter.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_notification_for_weixin_disables_chunk_backoff():
+    runner, adapter = make_restart_runner()
+    adapter.platform = Platform.WEIXIN
+    adapter.send = AsyncMock(return_value=SendResult(success=False, error="rate limited"))
+
+    await runner._send_lifecycle_notification(adapter, "wxid-home", "Gateway restarting")
+
+    adapter.send.assert_awaited_once()
+    metadata = adapter.send.await_args.kwargs.get("metadata")
+    assert metadata == {
+        "weixin_send_chunk_retries": 0,
+        "weixin_send_chunk_retry_delay_seconds": 0,
+        "weixin_send_chunk_rate_limit_backoff_seconds": 0,
+    }
+
+
 # ── _send_restart_notification ───────────────────────────────────────────
 
 

--- a/tests/gateway/test_safe_adapter_disconnect.py
+++ b/tests/gateway/test_safe_adapter_disconnect.py
@@ -32,9 +32,10 @@ async def test_safe_disconnect_calls_adapter_disconnect(bare_runner):
     adapter = MagicMock()
     adapter.disconnect = AsyncMock(return_value=None)
 
-    await bare_runner._safe_adapter_disconnect(adapter, Platform.TELEGRAM)
+    disconnected = await bare_runner._safe_adapter_disconnect(adapter, Platform.TELEGRAM)
 
     adapter.disconnect.assert_awaited_once()
+    assert disconnected is True
 
 
 @pytest.mark.asyncio
@@ -73,7 +74,8 @@ async def test_safe_disconnect_times_out_and_continues(bare_runner, monkeypatch,
     adapter.disconnect = AsyncMock(side_effect=hang)
 
     with caplog.at_level(logging.WARNING, logger="gateway.run"):
-        await bare_runner._safe_adapter_disconnect(adapter, Platform.FEISHU)
+        disconnected = await bare_runner._safe_adapter_disconnect(adapter, Platform.FEISHU)
 
     adapter.disconnect.assert_awaited_once()
+    assert disconnected is False
     assert "Timed out after 0.0s while disconnecting feishu adapter" in caplog.text

--- a/tests/gateway/test_webhook_deliver_only.py
+++ b/tests/gateway/test_webhook_deliver_only.py
@@ -251,6 +251,41 @@ class TestDeliverOnlyStatusCodes:
             assert "rate limited" not in json.dumps(data)
 
     @pytest.mark.asyncio
+    async def test_delivery_failure_logs_generic_rejection(self, caplog):
+        """Adapter error strings should not leak into rejection logs."""
+        routes = {
+            "r": {
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": "telegram",
+                "deliver_only": True,
+                "deliver_extra": {"chat_id": "c-1"},
+                "prompt": "hi",
+            }
+        }
+        adapter = _make_adapter(routes)
+        mock_target = _wire_mock_target(adapter)
+        mock_target.send = AsyncMock(
+            return_value=SendResult(success=False, error="rate limited by tg")
+        )
+
+        app = _create_app(adapter)
+        with caplog.at_level("WARNING", logger="gateway.platforms.webhook"):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/webhooks/r",
+                    json={},
+                    headers={"X-GitHub-Delivery": "d-fail-log-1"},
+                )
+                assert resp.status == 502
+
+        messages = [record.getMessage() for record in caplog.records]
+        assert any(
+            "direct-deliver target rejected route=r target=telegram" in message
+            for message in messages
+        )
+        assert not any("rate limited by tg" in message for message in messages)
+
+    @pytest.mark.asyncio
     async def test_delivery_failure_does_not_poison_idempotency(self):
         """A failed delivery may be retried with the same delivery id."""
         routes = {

--- a/tests/gateway/test_webhook_deliver_only.py
+++ b/tests/gateway/test_webhook_deliver_only.py
@@ -314,6 +314,38 @@ class TestDeliverOnlyStatusCodes:
             assert "exploded" not in json.dumps(data)
 
     @pytest.mark.asyncio
+    async def test_delivery_exception_can_ack_to_webhook_sender(self):
+        """ack_on_failure also accepts webhook calls when adapter.send() raises."""
+        routes = {
+            "r": {
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": "telegram",
+                "deliver_only": True,
+                "direct_delivery_ack_on_failure": True,
+                "deliver_extra": {"chat_id": "c-1"},
+                "prompt": "hi",
+            }
+        }
+        adapter = _make_adapter(routes)
+        mock_target = _wire_mock_target(adapter)
+        mock_target.send = AsyncMock(side_effect=RuntimeError("tg exploded"))
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/r",
+                json={},
+                headers={"X-GitHub-Delivery": "d-exc-ack-1"},
+            )
+            assert resp.status == 202
+            data = await resp.json()
+            assert data["status"] == "accepted"
+            assert data["delivery_status"] == "target_failed"
+            assert data["route"] == "r"
+            assert data["target"] == "telegram"
+            assert "exploded" not in json.dumps(data)
+
+    @pytest.mark.asyncio
     async def test_slow_delivery_returns_202_and_continues_in_background(self):
         """Slow target sends should not block the webhook sender."""
         routes = {

--- a/tests/gateway/test_webhook_deliver_only.py
+++ b/tests/gateway/test_webhook_deliver_only.py
@@ -251,6 +251,47 @@ class TestDeliverOnlyStatusCodes:
             assert "rate limited" not in json.dumps(data)
 
     @pytest.mark.asyncio
+    async def test_delivery_failure_does_not_poison_idempotency(self):
+        """A failed delivery may be retried with the same delivery id."""
+        routes = {
+            "r": {
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": "telegram",
+                "deliver_only": True,
+                "deliver_extra": {"chat_id": "c-1"},
+                "prompt": "hi",
+            }
+        }
+        adapter = _make_adapter(routes)
+        mock_target = _wire_mock_target(adapter)
+        mock_target.send = AsyncMock(
+            side_effect=[
+                SendResult(success=False, error="rate limited by tg"),
+                SendResult(success=True),
+            ]
+        )
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            first = await cli.post(
+                "/webhooks/r",
+                json={},
+                headers={"X-GitHub-Delivery": "retry-fail-1"},
+            )
+            assert first.status == 502
+
+            second = await cli.post(
+                "/webhooks/r",
+                json={},
+                headers={"X-GitHub-Delivery": "retry-fail-1"},
+            )
+            assert second.status == 200
+            data = await second.json()
+            assert data["status"] == "delivered"
+
+        assert mock_target.send.await_count == 2
+
+    @pytest.mark.asyncio
     async def test_delivery_failure_can_ack_to_webhook_sender(self):
         """Routes can accept the webhook even if downstream delivery fails."""
         routes = {
@@ -470,6 +511,60 @@ class TestDeliverOnlyStatusCodes:
         release_send.set()
         await asyncio.sleep(0.05)
         mock_target.send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_busy_delivery_does_not_poison_idempotency(self):
+        """A 429 busy response should allow the provider to retry the same id."""
+        routes = {
+            "r": {
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": "telegram",
+                "deliver_only": True,
+                "direct_delivery_timeout_seconds": 0.01,
+                "direct_delivery_max_inflight": 1,
+                "deliver_extra": {"chat_id": "c-1"},
+                "prompt": "hi",
+            }
+        }
+        adapter = _make_adapter(routes)
+        mock_target = _wire_mock_target(adapter)
+        release_send = asyncio.Event()
+
+        async def slow_send(*_args, **_kwargs):
+            await release_send.wait()
+            return SendResult(success=True)
+
+        mock_target.send = AsyncMock(side_effect=slow_send)
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            first = await cli.post(
+                "/webhooks/r",
+                json={},
+                headers={"X-GitHub-Delivery": "d-slow-limit-holder"},
+            )
+            assert first.status == 202
+
+            busy = await cli.post(
+                "/webhooks/r",
+                json={},
+                headers={"X-GitHub-Delivery": "retry-busy-1"},
+            )
+            assert busy.status == 429
+
+            release_send.set()
+            await asyncio.sleep(0.05)
+
+            retry = await cli.post(
+                "/webhooks/r",
+                json={},
+                headers={"X-GitHub-Delivery": "retry-busy-1"},
+            )
+            assert retry.status == 200
+            data = await retry.json()
+            assert data["status"] == "delivered"
+
+        assert mock_target.send.await_count == 2
 
     @pytest.mark.asyncio
     async def test_target_platform_not_connected_returns_502(self):

--- a/tests/gateway/test_webhook_deliver_only.py
+++ b/tests/gateway/test_webhook_deliver_only.py
@@ -245,6 +245,91 @@ class TestDeliverOnlyStatusCodes:
             assert "exploded" not in json.dumps(data)
 
     @pytest.mark.asyncio
+    async def test_slow_delivery_returns_202_and_continues_in_background(self):
+        """Slow target sends should not block the webhook sender."""
+        routes = {
+            "r": {
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": "telegram",
+                "deliver_only": True,
+                "direct_delivery_timeout_seconds": 0.01,
+                "deliver_extra": {"chat_id": "c-1"},
+                "prompt": "hi",
+            }
+        }
+        adapter = _make_adapter(routes)
+        mock_target = _wire_mock_target(adapter)
+
+        async def slow_send(*_args, **_kwargs):
+            await asyncio.sleep(0.05)
+            return SendResult(success=True)
+
+        mock_target.send = AsyncMock(side_effect=slow_send)
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/r",
+                json={},
+                headers={"X-GitHub-Delivery": "d-slow-1"},
+            )
+            assert resp.status == 202
+            data = await resp.json()
+            assert data["status"] == "accepted"
+            assert data["route"] == "r"
+            assert data["target"] == "telegram"
+
+        await asyncio.sleep(0.08)
+        mock_target.send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_slow_delivery_inflight_limit_rejects_overflow(self):
+        """Bounded background sends prevent slow targets from piling up."""
+        routes = {
+            "r": {
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": "telegram",
+                "deliver_only": True,
+                "direct_delivery_timeout_seconds": 0.01,
+                "direct_delivery_max_inflight": 1,
+                "deliver_extra": {"chat_id": "c-1"},
+                "prompt": "hi",
+            }
+        }
+        adapter = _make_adapter(routes)
+        mock_target = _wire_mock_target(adapter)
+        release_send = asyncio.Event()
+
+        async def slow_send(*_args, **_kwargs):
+            await release_send.wait()
+            return SendResult(success=True)
+
+        mock_target.send = AsyncMock(side_effect=slow_send)
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            first = await cli.post(
+                "/webhooks/r",
+                json={},
+                headers={"X-GitHub-Delivery": "d-slow-limit-1"},
+            )
+            assert first.status == 202
+
+            second = await cli.post(
+                "/webhooks/r",
+                json={},
+                headers={"X-GitHub-Delivery": "d-slow-limit-2"},
+            )
+            assert second.status == 429
+            data = await second.json()
+            assert data["status"] == "busy"
+            assert data["route"] == "r"
+
+        release_send.set()
+        await asyncio.sleep(0.05)
+        mock_target.send.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_target_platform_not_connected_returns_502(self):
         """deliver_only to a platform the gateway doesn't have → 502."""
         routes = {

--- a/tests/gateway/test_webhook_deliver_only.py
+++ b/tests/gateway/test_webhook_deliver_only.py
@@ -384,6 +384,47 @@ class TestDeliverOnlyStatusCodes:
         mock_target.send.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_background_delivery_failure_is_logged(self, caplog):
+        """If a timed-out background send later fails, log the target rejection."""
+        routes = {
+            "r": {
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": "telegram",
+                "deliver_only": True,
+                "direct_delivery_timeout_seconds": 0.01,
+                "deliver_extra": {"chat_id": "c-1"},
+                "prompt": "hi",
+            }
+        }
+        adapter = _make_adapter(routes)
+        mock_target = _wire_mock_target(adapter)
+
+        async def slow_send(*_args, **_kwargs):
+            await asyncio.sleep(0.05)
+            return SendResult(success=False, error="rate limited by tg")
+
+        mock_target.send = AsyncMock(side_effect=slow_send)
+
+        app = _create_app(adapter)
+        with caplog.at_level("WARNING", logger="gateway.platforms.webhook"):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/webhooks/r",
+                    json={},
+                    headers={"X-GitHub-Delivery": "d-slow-fail-1"},
+                )
+                assert resp.status == 202
+
+            await asyncio.sleep(0.08)
+
+        messages = [record.getMessage() for record in caplog.records]
+        assert any(
+            "direct-deliver target rejected route=r target=telegram" in message
+            for message in messages
+        )
+        assert not any("rate limited by tg" in message for message in messages)
+
+    @pytest.mark.asyncio
     async def test_slow_delivery_inflight_limit_rejects_overflow(self):
         """Bounded background sends prevent slow targets from piling up."""
         routes = {

--- a/tests/gateway/test_webhook_deliver_only.py
+++ b/tests/gateway/test_webhook_deliver_only.py
@@ -177,6 +177,41 @@ class TestDeliverOnlyBypassesAgent:
             "thread_id": "topic-42"
         }
 
+    @pytest.mark.asyncio
+    async def test_deliver_extra_metadata_passed_through(self):
+        """deliver_extra.metadata lets routes tune target-adapter delivery."""
+        routes = {
+            "r": {
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": "telegram",
+                "deliver_only": True,
+                "deliver_extra": {
+                    "chat_id": "c-1",
+                    "metadata": {
+                        "weixin_send_chunk_retries": 0,
+                        "weixin_send_chunk_rate_limit_backoff_seconds": 0,
+                    },
+                },
+                "prompt": "hi",
+            }
+        }
+        adapter = _make_adapter(routes)
+        mock_target = _wire_mock_target(adapter)
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/r",
+                json={},
+                headers={"X-GitHub-Delivery": "d-metadata-1"},
+            )
+            assert resp.status == 200
+
+        assert mock_target.send.await_args.kwargs["metadata"] == {
+            "weixin_send_chunk_retries": 0,
+            "weixin_send_chunk_rate_limit_backoff_seconds": 0,
+        }
+
 
 # ===================================================================
 # HTTP status codes

--- a/tests/gateway/test_webhook_deliver_only.py
+++ b/tests/gateway/test_webhook_deliver_only.py
@@ -251,6 +251,40 @@ class TestDeliverOnlyStatusCodes:
             assert "rate limited" not in json.dumps(data)
 
     @pytest.mark.asyncio
+    async def test_delivery_failure_can_ack_to_webhook_sender(self):
+        """Routes can accept the webhook even if downstream delivery fails."""
+        routes = {
+            "r": {
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": "telegram",
+                "deliver_only": True,
+                "direct_delivery_ack_on_failure": True,
+                "deliver_extra": {"chat_id": "c-1"},
+                "prompt": "hi",
+            }
+        }
+        adapter = _make_adapter(routes)
+        mock_target = _wire_mock_target(adapter)
+        mock_target.send = AsyncMock(
+            return_value=SendResult(success=False, error="rate limited by tg")
+        )
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/r",
+                json={},
+                headers={"X-GitHub-Delivery": "d-fail-ack-1"},
+            )
+            assert resp.status == 202
+            data = await resp.json()
+            assert data["status"] == "accepted"
+            assert data["delivery_status"] == "target_failed"
+            assert data["route"] == "r"
+            assert data["target"] == "telegram"
+            assert "rate limited" not in json.dumps(data)
+
+    @pytest.mark.asyncio
     async def test_delivery_exception_returns_502(self):
         """If adapter.send() raises, we return 502 (not 500)."""
         routes = {

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -368,6 +368,7 @@ class TestWeixinChunkDelivery:
         adapter._session = object()
         adapter._send_session = adapter._session
         adapter._token = "test-token"
+        adapter._running = True
         adapter._base_url = "https://weixin.example.com"
         adapter._token_store.get = lambda account_id, chat_id: "ctx-token"
         return adapter
@@ -410,6 +411,20 @@ class TestWeixinChunkDelivery:
         retry = send_message_mock.await_args_list[2].kwargs
         assert first_try["text"] == retry["text"]
         assert first_try["client_id"] == retry["client_id"]
+
+    @patch("gateway.platforms.weixin.asyncio.sleep", new_callable=AsyncMock)
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_rate_limit_does_not_sleep_after_disconnect(self, send_message_mock, sleep_mock):
+        adapter = self._connected_adapter()
+        adapter._running = False
+        send_message_mock.return_value = {"ret": weixin.RATE_LIMIT_ERRCODE, "errmsg": "rate limited"}
+
+        result = asyncio.run(adapter.send("wxid_test123", "hello"))
+
+        assert result.success is False
+        assert "not connected" in (result.error or "").lower()
+        send_message_mock.assert_not_awaited()
+        sleep_mock.assert_not_awaited()
 
 
 class TestWeixinOutboundMedia:

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -426,6 +426,28 @@ class TestWeixinChunkDelivery:
         send_message_mock.assert_not_awaited()
         sleep_mock.assert_not_awaited()
 
+    @patch("gateway.platforms.weixin.asyncio.sleep", new_callable=AsyncMock)
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_rate_limit_respects_metadata_retry_override(self, send_message_mock, sleep_mock):
+        adapter = self._connected_adapter()
+        send_message_mock.return_value = {"ret": weixin.RATE_LIMIT_ERRCODE, "errmsg": "rate limited"}
+
+        result = asyncio.run(
+            adapter.send(
+                "wxid_test123",
+                "hello",
+                metadata={
+                    "weixin_send_chunk_retries": 0,
+                    "weixin_send_chunk_rate_limit_backoff_seconds": 0,
+                },
+            )
+        )
+
+        assert result.success is False
+        assert "rate limited" in (result.error or "").lower()
+        send_message_mock.assert_awaited_once()
+        sleep_mock.assert_not_awaited()
+
 
 class TestWeixinOutboundMedia:
     def test_send_image_file_accepts_keyword_image_path(self):


### PR DESCRIPTION
## Summary
- add optional timeout and max-inflight guards for `deliver_only` webhook direct delivery, so slow downstream sends can return `202 accepted` without allowing unbounded background sends
- pass `deliver_extra.metadata` through to target adapters, allowing a single webhook route to tune delivery behavior without changing global platform settings
- allow Weixin sends to override chunk retry/backoff per route, including fail-fast lifecycle notifications during iLink rate limits
- log direct-delivery target rejections generically and keep webhook caller responses free of adapter error detail
- make lifecycle/restart/startup notifications bounded, and disconnect adapters through the existing defensive timeout path during shutdown

## Tests
- `uv run --with aiohttp --with pytest-asyncio --with pytest-timeout pytest -o addopts="" tests/gateway/test_restart_notification.py tests/gateway/test_restart_drain.py tests/gateway/test_gateway_shutdown.py tests/gateway/test_safe_adapter_disconnect.py tests/gateway/test_webhook_deliver_only.py tests/gateway/test_weixin.py -k "not test_launch_detached_restart_command_uses_setsid"`
  - `139 passed, 1 deselected` on Windows after rebasing onto current upstream `main`