### PR TITLE
fix(gateway): respect explicit platform disables

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -779,7 +779,7 @@ def load_gateway_config() -> GatewayConfig:
                         existing = {}
                     # Deep-merge extra dicts so gateway.json defaults survive
                     merged_extra = {**existing.get("extra", {}), **plat_block.get("extra", {})}
-                    if plat_name == Platform.SLACK.value and "enabled" in plat_block:
+                    if "enabled" in plat_block:
                         merged_extra["_enabled_explicit"] = True
                     merged = {**existing, **plat_block}
                     if merged_extra:
@@ -1825,7 +1825,11 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 logger.debug("check_fn for %s raised: %s", entry.name, e)
                 continue
             platform = Platform(entry.name)
-            if platform not in config.platforms:
+            if platform in config.platforms:
+                existing = config.platforms[platform]
+                if existing.enabled is False and existing.extra.get("_enabled_explicit"):
+                    continue
+            else:
                 config.platforms[platform] = PlatformConfig()
             config.platforms[platform].enabled = True
             # Seed extras from env if the plugin opted in.

--- a/tests/gateway/test_gateway_plugin_platform_disable.py
+++ b/tests/gateway/test_gateway_plugin_platform_disable.py
@@ -1,0 +1,35 @@
+from types import SimpleNamespace
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig, _apply_env_overrides
+
+
+def test_plugin_enable_pass_respects_explicit_disabled_platform(monkeypatch):
+    """A plugin dependency check must not override platforms.<name>.enabled=false."""
+
+    from gateway import platform_registry
+    from hermes_cli import plugins
+
+    fake_entry = SimpleNamespace(
+        name="discord",
+        check_fn=lambda: True,
+        env_enablement_fn=None,
+    )
+
+    monkeypatch.setattr(plugins, "discover_plugins", lambda: None)
+    monkeypatch.setattr(platform_registry.platform_registry, "plugin_entries", lambda: [fake_entry])
+    monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("DISCORD_HOME_CHANNEL", raising=False)
+    monkeypatch.delenv("DISCORD_REPLY_TO_MODE", raising=False)
+
+    config = GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(
+                enabled=False,
+                extra={"_enabled_explicit": True},
+            )
+        }
+    )
+
+    _apply_env_overrides(config)
+
+    assert config.platforms[Platform.DISCORD].enabled is False


### PR DESCRIPTION
## Summary
- Respect explicit `platforms.<name>.enabled=false` settings during plugin platform auto-enable.
- Preserve the explicit enabled marker for all platforms, not just Slack.
- Add a regression test covering Discord remaining disabled when its dependency check passes.

## Test plan
- `./venv/bin/python -m pytest tests/gateway/test_gateway_plugin_platform_disable.py -q -o 'addopts='`
- `./venv/bin/python -m pytest tests/test_gateway_streaming_nested_config.py tests/gateway/test_gateway_plugin_platform_disable.py -q -o 'addopts='`
