### PR TITLE
feat: add target-bound kanban dispatch

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -130,6 +130,14 @@ def _parse_branch_flag(value: Optional[str]) -> Optional[str]:
     return branch
 
 
+def _parse_task_id_flag(value: str) -> str:
+    """Parse an explicit task-id CLI argument, failing closed on blanks."""
+    v = str(value or "").strip()
+    if not v:
+        raise argparse.ArgumentTypeError("task id must not be empty")
+    return v
+
+
 def _check_dispatcher_presence() -> tuple[bool, str]:
     """Return ``(running, message)``.
 
@@ -608,6 +616,8 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                         help="Don't actually spawn processes; just print what would happen")
     p_disp.add_argument("--max", type=int, default=None,
                         help="Cap number of spawns this pass")
+    p_disp.add_argument("--task-id", default=None, type=_parse_task_id_flag,
+                        help="Target-bound dispatch: only plan/spawn this exact ready task id")
     p_disp.add_argument("--failure-limit", type=int,
                         default=kb.DEFAULT_SPAWN_FAILURE_LIMIT,
                         help=f"Auto-block a task after this many consecutive non-success attempts "
@@ -2093,6 +2103,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             dry_run=args.dry_run,
             max_spawn=args.max,
             failure_limit=getattr(args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT),
+            target_task_id=getattr(args, "task_id", None),
         )
     if getattr(args, "json", False):
         print(json.dumps({
@@ -2108,6 +2119,8 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             ],
             "skipped_unassigned": res.skipped_unassigned,
             "skipped_nonspawnable": res.skipped_nonspawnable,
+            "target_task_id": res.target_task_id,
+            "target_miss_reason": res.target_miss_reason,
         }, indent=2))
         return 0
     print(f"Reclaimed:    {res.reclaimed}")
@@ -2135,6 +2148,11 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             f"Skipped (non-spawnable assignee — terminal lane, OK): "
             f"{', '.join(res.skipped_nonspawnable)}"
         )
+    if res.target_task_id:
+        if res.target_miss_reason:
+            print(f"Target:       {res.target_task_id} ({res.target_miss_reason})")
+        else:
+            print(f"Target:       {res.target_task_id} (eligible)")
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1743,6 +1743,16 @@ def create_task(
                         "skills": list(skills_list) if skills_list else None,
                     },
                 )
+                if task_status == "blocked" and initial_status == "blocked":
+                    _append_event(
+                        conn,
+                        task_id,
+                        "blocked",
+                        {
+                            "reason": "initial_status",
+                            "source": "create_task",
+                        },
+                    )
             return task_id
         except sqlite3.IntegrityError:
             if attempt == 1:
@@ -4001,6 +4011,15 @@ class DispatchResult:
     Reasons: ``"blocker_auth"`` (quota/auth error — also auto-blocked),
     ``"recent_success"`` (completed run within guard window),
     ``"active_pr"`` (GitHub PR URL in a recent comment)."""
+    target_task_id: Optional[str] = None
+    """Optional task id requested by a target-bound dispatcher tick."""
+    target_miss_reason: Optional[str] = None
+    """Why a target-bound dispatcher tick did not spawn the requested task.
+
+    ``None`` means no target was requested, or the target was eligible and
+    spawned/planned. Values are intentionally compact and stable for JSON
+    automation callers.
+    """
 
 
 # Bounded registry of recently-reaped worker child exits, populated by the
@@ -5001,6 +5020,7 @@ def dispatch_once(
     failure_limit: int = DEFAULT_SPAWN_FAILURE_LIMIT,
     stale_timeout_seconds: int = 0,
     board: Optional[str] = None,
+    target_task_id: Optional[str] = None,
 ) -> DispatchResult:
     """Run one dispatcher tick.
 
@@ -5029,6 +5049,10 @@ def dispatch_once(
     ``spawn_fn`` defaults to ``_default_spawn``. Tests pass a stub.
     ``board`` pins workspace/log/db resolution for this tick to a specific
     board. When omitted, the current-board resolution chain is used.
+    ``target_task_id`` makes the spawn phase target-bound: after normal
+    housekeeping, only that exact task may be planned/spawned. Broad ready
+    queue ordering is ignored so automation can preflight one card without a
+    TOCTOU window where another ready card sorts earlier and gets spawned.
     """
     # Reap zombie children from previously spawned workers.
     # The gateway-embedded dispatcher is the parent of every worker spawned
@@ -5064,6 +5088,15 @@ def dispatch_once(
             pass
 
     result = DispatchResult()
+    if target_task_id is None:
+        normalized_target_task_id = None
+    else:
+        normalized_target_task_id = str(target_task_id).strip()
+    result.target_task_id = normalized_target_task_id
+    if target_task_id is not None and not normalized_target_task_id:
+        result.target_miss_reason = "invalid_target"
+        return result
+    target_task_id = normalized_target_task_id
     result.reclaimed = release_stale_claims(conn)
     result.stale = detect_stale_running(
         conn, stale_timeout_seconds=stale_timeout_seconds,
@@ -5095,11 +5128,24 @@ def dispatch_once(
             ).fetchone()[0]
         )
 
-    ready_rows = conn.execute(
-        "SELECT id, assignee FROM tasks "
-        "WHERE status = 'ready' AND claim_lock IS NULL "
-        "ORDER BY priority DESC, created_at ASC"
-    ).fetchall()
+    if target_task_id:
+        target_row = conn.execute(
+            "SELECT id, assignee, status, claim_lock FROM tasks WHERE id = ?",
+            (target_task_id,),
+        ).fetchone()
+        if target_row is None:
+            result.target_miss_reason = "not_found"
+            return result
+        if target_row["status"] != "ready" or target_row["claim_lock"]:
+            result.target_miss_reason = "not_ready"
+            return result
+        ready_rows = [target_row]
+    else:
+        ready_rows = conn.execute(
+            "SELECT id, assignee FROM tasks "
+            "WHERE status = 'ready' AND claim_lock IS NULL "
+            "ORDER BY priority DESC, created_at ASC"
+        ).fetchall()
     # Honour kanban.max_in_progress: if the board already has enough running
     # tasks, skip spawning this tick so slow workers (local LLMs,
     # resource-constrained hosts) can finish what they have before more tasks
@@ -5109,6 +5155,8 @@ def dispatch_once(
             "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
         ).fetchone()[0]
         if in_progress >= max_in_progress:
+            if target_task_id:
+                result.target_miss_reason = "capacity"
             return result
         # Only spawn enough to reach the cap, respecting max_spawn too.
         remaining = max_in_progress - in_progress
@@ -5117,9 +5165,13 @@ def dispatch_once(
     spawned = 0
     for row in ready_rows:
         if max_spawn is not None and running_count + spawned >= max_spawn:
+            if target_task_id:
+                result.target_miss_reason = "capacity"
             break
         if not row["assignee"]:
             result.skipped_unassigned.append(row["id"])
+            if target_task_id:
+                result.target_miss_reason = "unassigned"
             continue
         # Skip ready tasks whose assignee is not a real Hermes profile.
         # `_default_spawn` invokes ``hermes -p <assignee>`` which fails
@@ -5143,6 +5195,8 @@ def dispatch_once(
             # multi-lane setups where the ready queue is steadily full
             # of human-pulled work.
             result.skipped_nonspawnable.append(row["id"])
+            if target_task_id:
+                result.target_miss_reason = "nonspawnable"
             continue
         # Respawn guard: refuse to re-spawn when useful work is already
         # in-flight/recent, or when the last failure is a deterministic
@@ -5170,6 +5224,8 @@ def dispatch_once(
             continue
         claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
+            if target_task_id:
+                result.target_miss_reason = "claim_lost"
             continue
         try:
             workspace = resolve_workspace(claimed, board=board)
@@ -5180,6 +5236,8 @@ def dispatch_once(
             )
             if auto:
                 result.auto_blocked.append(claimed.id)
+            if target_task_id:
+                result.target_miss_reason = "workspace_error"
             continue
         # Persist the resolved workspace path so the worker can cd there.
         set_workspace_path(conn, claimed.id, str(workspace))
@@ -5216,6 +5274,11 @@ def dispatch_once(
             )
             if auto:
                 result.auto_blocked.append(claimed.id)
+            if target_task_id:
+                result.target_miss_reason = "spawn_failed"
+
+    if target_task_id:
+        return result
 
     # ---- review column dispatch ----
     # Review tasks are tasks that a worker moved to 'review' after

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -173,6 +173,53 @@ def test_run_slash_dispatch_dry_run_counts(kanban_home):
     assert "Spawned:" in out
 
 
+def test_dispatch_parser_accepts_target_task_id():
+    parser = argparse.ArgumentParser()
+    subcommands = parser.add_subparsers(dest="command")
+    kc.build_parser(subcommands)
+    args = parser.parse_args(["kanban", "dispatch", "--task-id", "t_target", "--json"])
+    assert args.command == "kanban"
+    assert args.kanban_action == "dispatch"
+    assert args.task_id == "t_target"
+    assert args.json is True
+
+
+def test_dispatch_parser_rejects_empty_target_task_id():
+    parser = argparse.ArgumentParser()
+    subcommands = parser.add_subparsers(dest="command")
+    kc.build_parser(subcommands)
+    with pytest.raises(SystemExit):
+        parser.parse_args(["kanban", "dispatch", "--task-id", "   ", "--json"])
+
+
+def test_run_slash_dispatch_task_id_json_includes_target_fields(kanban_home):
+    out = kc.run_slash("dispatch --task-id t_missing --dry-run --json")
+    payload = json.loads(out)
+    assert payload["target_task_id"] == "t_missing"
+    assert payload["target_miss_reason"] == "not_found"
+    assert payload["spawned"] == []
+
+
+def test_run_slash_dispatch_task_id_dry_run_targets_exact_card(
+    kanban_home, monkeypatch
+):
+    from hermes_cli import profiles
+    monkeypatch.setattr(profiles, "profile_exists", lambda name: True)
+    first = kc.run_slash("create 'first' --assignee alice --json")
+    target = kc.run_slash("create 'target' --assignee bob --json")
+    first_id = json.loads(first)["id"]
+    target_id = json.loads(target)["id"]
+
+    out = kc.run_slash(f"dispatch --task-id {target_id} --dry-run --json")
+    payload = json.loads(out)
+
+    assert payload["target_task_id"] == target_id
+    assert payload["target_miss_reason"] is None
+    assert [item["task_id"] for item in payload["spawned"]] == [target_id]
+    show_first = kc.run_slash(f"show {first_id}")
+    assert "ready" in show_first.lower()
+
+
 def test_run_slash_context_output_format(kanban_home):
     out = kc.run_slash("create 'tech spec' --assignee alice --body 'write an RFC'")
     import re

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -294,6 +294,31 @@ def test_recompute_ready_promotes_blocked_with_done_parents(kanban_home):
         assert task.last_failure_error is None
 
 
+def test_recompute_ready_preserves_initial_blocked_human_hold(kanban_home):
+    """Tasks created directly into blocked are explicit holds, not dependency blocks."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="operator hold",
+            assignee="a",
+            initial_status="blocked",
+        )
+
+        promoted = kb.recompute_ready(conn)
+
+        assert promoted == 0
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "blocked"
+        rows = conn.execute(
+            "SELECT kind, payload FROM task_events WHERE task_id = ? ORDER BY id",
+            (task_id,),
+        ).fetchall()
+        kinds = [row["kind"] for row in rows]
+        assert kinds == ["created", "blocked"]
+        assert "initial_status" in (rows[-1]["payload"] or "")
+
+
 def test_recompute_ready_fan_in_waits_for_all_parents(kanban_home):
     with kb.connect() as conn:
         a = kb.create_task(conn, title="a")
@@ -1149,6 +1174,106 @@ def test_dispatch_max_spawn_fills_remaining_capacity(
         assert spawns == [ready_a]
         assert kb.get_task(conn, ready_a).status == "running"
         assert kb.get_task(conn, ready_b).status == "ready"
+
+
+def test_dispatch_target_task_id_spawns_only_exact_task(
+    kanban_home, all_assignees_spawnable
+):
+    """Target-bound dispatch must not spawn earlier ready cards.
+
+    This guards against the board-wide ``dispatch --max 1`` TOCTOU shape:
+    the caller can verify one card, but a broad dispatcher tick may spawn a
+    different ready card that sorts earlier in the queue.
+    """
+    spawns = []
+
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+
+    with kb.connect() as conn:
+        earlier = kb.create_task(conn, title="earlier", assignee="alice")
+        target = kb.create_task(conn, title="target", assignee="bob")
+
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn, target_task_id=target)
+
+        assert res.target_task_id == target
+        assert res.target_miss_reason is None
+        assert spawns == [target]
+        assert [item[0] for item in res.spawned] == [target]
+        target_task = kb.get_task(conn, target)
+        earlier_task = kb.get_task(conn, earlier)
+        assert target_task is not None
+        assert earlier_task is not None
+        assert target_task.status == "running"
+        assert earlier_task.status == "ready"
+
+
+def test_dispatch_target_task_id_runs_housekeeping_before_target_selection(
+    kanban_home, all_assignees_spawnable
+):
+    with kb.connect() as conn:
+        stale = kb.create_task(conn, title="stale", assignee="alice")
+        target = kb.create_task(conn, title="target", assignee="bob")
+        kb.claim_task(conn, stale)
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ? WHERE id = ?",
+            (int(time.time()) - 1, stale),
+        )
+
+        res = kb.dispatch_once(conn, dry_run=True, target_task_id=target)
+
+        assert res.reclaimed == 1
+        assert res.target_task_id == target
+        assert res.target_miss_reason is None
+        assert [item[0] for item in res.spawned] == [target]
+        stale_task = kb.get_task(conn, stale)
+        target_task = kb.get_task(conn, target)
+        assert stale_task is not None
+        assert target_task is not None
+        assert stale_task.status == "ready"
+        assert target_task.status == "ready"
+
+
+def test_dispatch_target_task_id_reports_not_ready_without_spawning(
+    kanban_home, all_assignees_spawnable
+):
+    spawns = []
+
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+
+    with kb.connect() as conn:
+        target = kb.create_task(conn, title="target", assignee="bob")
+        kb.claim_task(conn, target)
+
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn, target_task_id=target)
+
+        assert res.target_task_id == target
+        assert res.target_miss_reason == "not_ready"
+        assert spawns == []
+        assert res.spawned == []
+
+
+def test_dispatch_empty_target_task_id_fails_closed(
+    kanban_home, all_assignees_spawnable
+):
+    spawns = []
+
+    def fake_spawn(task, workspace):
+        spawns.append(task.id)
+
+    with kb.connect() as conn:
+        ready = kb.create_task(conn, title="ready", assignee="alice")
+
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn, target_task_id="  ")
+
+        assert res.target_task_id == ""
+        assert res.target_miss_reason == "invalid_target"
+        assert spawns == []
+        assert res.spawned == []
+        task = kb.get_task(conn, ready)
+        assert task is not None
+        assert task.status == "ready"
 
 
 def test_dispatch_reclaims_stale_before_spawning(kanban_home):


### PR DESCRIPTION
## What does this PR do?

Adds explicit target-bound dispatch support to Hermes Kanban so automation can dispatch or dry-run exactly one verified task/card without falling back to board-wide ready-task selection.

This is needed by downstream governance/protocol adapters that first prove a Journal-owned task has a clean Kanban binding, then invoke Hermes as an execution surface for that exact card only.

Key behavior:
- `hermes kanban dispatch --task-id <id>` targets one card.
- Target-bound mode returns machine-readable `target_task_id` and `target_miss_reason` fields.
- Missing, not-ready, claimed, capacity-limited, unassigned, nonspawnable, claim-lost, workspace-error, spawn-failed, or invalid target cases do not fall back to another ready card.
- Existing board-wide dispatch behavior is preserved when `--task-id` is omitted.

## Related Issue

No linked GitHub issue. This supports downstream Agent-Protocol Journal → Hermes Kanban worker-dispatch gating.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/kanban.py`
  - Adds `--task-id` to `kanban dispatch`.
  - Rejects empty target ids at the CLI parser.
  - Includes target proof fields in JSON/plain dispatch output.
- `hermes_cli/kanban_db.py`
  - Adds `target_task_id` / `target_miss_reason` to `DispatchResult`.
  - Makes `dispatch_once(..., target_task_id=...)` select zero-or-one exact target after normal housekeeping.
  - Preserves broad ready/review dispatch when no target is specified.
- `tests/hermes_cli/test_kanban_cli.py`
  - Covers CLI parser, slash command, JSON proof fields, and dry-run exact-card targeting.
- `tests/hermes_cli/test_kanban_db.py`
  - Covers exact target dispatch, housekeeping before target selection, not-ready miss behavior, and invalid empty targets.

## How to Test

1. Targeted behavior tests:
   - `venv/bin/python -m pytest -o addopts='' tests/hermes_cli/test_kanban_cli.py::test_dispatch_parser_accepts_target_task_id tests/hermes_cli/test_kanban_cli.py::test_dispatch_parser_rejects_empty_target_task_id tests/hermes_cli/test_kanban_cli.py::test_run_slash_dispatch_task_id_json_includes_target_fields tests/hermes_cli/test_kanban_cli.py::test_run_slash_dispatch_task_id_dry_run_targets_exact_card tests/hermes_cli/test_kanban_db.py::test_dispatch_target_task_id_spawns_only_exact_task tests/hermes_cli/test_kanban_db.py::test_dispatch_target_task_id_runs_housekeeping_before_target_selection tests/hermes_cli/test_kanban_db.py::test_dispatch_target_task_id_reports_not_ready_without_spawning tests/hermes_cli/test_kanban_db.py::test_dispatch_empty_target_task_id_fails_closed -q`
   - Result: `8 passed in 0.52s`
2. Broader Kanban CLI/DB tests:
   - `venv/bin/python -m pytest -o addopts='' tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_db.py -q`
   - Result: `219 passed in 6.05s`
3. Runtime probe after install/deploy:
   - `hermes kanban --board <board> dispatch --json --dry-run --max 1 --task-id <card_id>`
   - Expected: plans/spawns only the target, or returns a target miss such as `target_miss_reason=not_ready` without selecting another card.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this feature.
- [ ] I've run `pytest tests/ -q` and all tests pass.
- [x] I've added tests for my changes.
- [x] I've tested on my platform: Linux.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, CLI help and tests document the behavior.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A.
- [x] I've considered cross-platform impact — no shell/platform-specific runtime dependency added.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A for Kanban CLI command.

## For New Skills

N/A.

## Screenshots / Logs

Targeted tests:

```text
8 passed in 0.52s
219 passed in 6.05s
```
