### PR TITLE
fix(hindsight-plugin): propagate local LLM concurrency setting

### DIFF
--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -108,8 +108,23 @@ Config file: `~/.hermes/hindsight/config.json`
 | `llm_provider` | `openai` | `openai`, `anthropic`, `gemini`, `groq`, `openrouter`, `minimax`, `ollama`, `lmstudio`, `openai_compatible` |
 | `llm_model` | per-provider | Model name (e.g. `gpt-4o-mini`, `qwen/qwen3.5-9b`) |
 | `llm_base_url` | — | Endpoint URL for `openai_compatible` (e.g. `http://192.168.1.10:8080/v1`) |
+| `llm_max_concurrent` | `32` | Maximum concurrent Hindsight LLM requests; lower for shared local endpoints to prevent slot starvation |
 
 The LLM API key is stored in `~/.hermes/.env` as `HINDSIGHT_LLM_API_KEY`.
+#### Local LLM Concurrency
+
+Hindsight's default `HINDSIGHT_API_LLM_MAX_CONCURRENT=32` is tuned for cloud APIs. When pointing Hindsight at a **local** LLM server (`llama-server`, vLLM, LM Studio) that also serves Hermes's main agent or subagents, the default will saturate the endpoint's slot pool and block Hermes from getting an inference slot — the symptom looks like Hermes "freezing" mid-conversation.
+
+For a shared local LLM endpoint, lower the limit to match the Ollama blog recommendation:
+
+```bash
+echo "HINDSIGHT_API_LLM_MAX_CONCURRENT=1" >> ~/.hermes/.env
+# Restart Hermes so the daemon respawns with the new env.
+```
+
+Set Hindsight's limit below the endpoint's total slot count when possible. On a one-slot server, `1` serializes Hindsight requests and prevents a 32-request burst, but Hermes may still wait behind the active Hindsight request. If Hindsight has its own **dedicated** LLM endpoint, you can raise the limit to match the endpoint's slot count.
+
+See the upstream [Hindsight docs](https://hindsight.vectorize.io/sdks/integrations/hermes) for the full caveat and diagnostic commands.
 
 ## Tools
 
@@ -128,6 +143,7 @@ Available in `hybrid` and `tools` memory modes:
 | `HINDSIGHT_API_KEY` | API key for Hindsight Cloud |
 | `HINDSIGHT_LLM_API_KEY` | LLM API key for local mode |
 | `HINDSIGHT_API_LLM_BASE_URL` | LLM Base URL for local mode (e.g. OpenRouter) |
+| `HINDSIGHT_API_LLM_MAX_CONCURRENT` | Maximum concurrent Hindsight LLM requests; use a low value for shared local endpoints to prevent slot starvation (see Local LLM Concurrency above) |
 | `HINDSIGHT_API_URL` | Override API endpoint |
 | `HINDSIGHT_BANK_ID` | Override bank name |
 | `HINDSIGHT_BUDGET` | Override recall budget |

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -52,6 +52,7 @@ _DEFAULT_LOCAL_URL = "http://localhost:8888"
 _MIN_CLIENT_VERSION = "0.4.22"
 _DEFAULT_TIMEOUT = 120  # seconds — cloud API can take 30-40s per request
 _DEFAULT_IDLE_TIMEOUT = 300  # seconds — Hindsight embedded daemon default
+_DEFAULT_LLM_MAX_CONCURRENT = 32  # mirrors SDK default (hindsight-api-slim config.py)
 # Mirrors hindsight-integrations/openclaw — Hindsight 0.5.0 added
 # `update_mode='append'` semantics on retain (vectorize-io/hindsight#932).
 # Without it, reusing a stable session-scoped document_id silently
@@ -436,6 +437,26 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
         env_values["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] = str(
             _parse_int_setting(idle_timeout, _DEFAULT_IDLE_TIMEOUT)
         )
+
+    # Wire HINDSIGHT_API_LLM_MAX_CONCURRENT through the profile environment so that:
+    #  (a) setting it in ~/.hermes/.env actually propagates to the embedded daemon on restart,
+    #  (b) config-change detection sees the delta and respawns the daemon with the new value.
+    max_concurrent = (
+        config.get("llm_max_concurrent")
+        if config.get("llm_max_concurrent") is not None
+        else os.environ.get("HINDSIGHT_API_LLM_MAX_CONCURRENT")
+    )
+    if max_concurrent is not None and max_concurrent != "":
+        parsed = _parse_int_setting(max_concurrent, _DEFAULT_LLM_MAX_CONCURRENT)
+        # Reject 0 / negative: asyncio.Semaphore(0) blocks forever, negatives raise ValueError.
+        clamped = max(1, parsed)
+        if clamped != parsed:
+            logger.warning(
+                "Hindsight LLM max_concurrent %r clamped to 1 (zero/negative values block all requests)",
+                max_concurrent,
+            )
+        env_values["HINDSIGHT_API_LLM_MAX_CONCURRENT"] = str(clamped)
+
     return env_values
 
 
@@ -843,6 +864,7 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "llm_base_url", "description": "Endpoint URL (e.g. http://192.168.1.10:8080/v1)", "default": "", "when": {"mode": "local_embedded", "llm_provider": "openai_compatible"}},
             {"key": "llm_api_key", "description": "LLM API key (optional for openai_compatible)", "secret": True, "env_var": "HINDSIGHT_LLM_API_KEY", "when": {"mode": "local_embedded"}},
             {"key": "llm_model", "description": "LLM model", "default": "gpt-4o-mini", "default_from": {"field": "llm_provider", "map": _PROVIDER_DEFAULT_MODELS}, "when": {"mode": "local_embedded"}},
+            {"key": "llm_max_concurrent", "description": "Maximum concurrent embedded Hindsight LLM requests; lower for shared local endpoints to prevent slot starvation", "default": _DEFAULT_LLM_MAX_CONCURRENT, "when": {"mode": "local_embedded"}},
             {"key": "bank_id", "description": "Memory bank name (static fallback when bank_id_template is unset)", "default": "hermes"},
             {"key": "bank_id_template", "description": "Optional template to derive bank_id dynamically. Placeholders: {profile}, {workspace}, {platform}, {user}, {session}. Example: hermes-{profile}", "default": ""},
             {"key": "bank_mission", "description": "Mission/purpose description for the memory bank"},

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -40,6 +40,7 @@ def _clean_env(monkeypatch):
         "HINDSIGHT_IDLE_TIMEOUT", "HINDSIGHT_LLM_API_KEY",
         "HINDSIGHT_RETAIN_TAGS", "HINDSIGHT_RETAIN_SOURCE",
         "HINDSIGHT_RETAIN_USER_PREFIX", "HINDSIGHT_RETAIN_ASSISTANT_PREFIX",
+        "HINDSIGHT_API_LLM_MAX_CONCURRENT",
     ):
         monkeypatch.delenv(key, raising=False)
 
@@ -272,6 +273,62 @@ class TestConfig:
         })
 
         assert env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "42"
+
+    def test_embedded_profile_env_includes_max_concurrent_from_config(self):
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+            "llm_max_concurrent": 1,
+        })
+        assert env["HINDSIGHT_API_LLM_MAX_CONCURRENT"] == "1"
+
+    def test_embedded_profile_env_includes_max_concurrent_from_env(self, monkeypatch):
+        monkeypatch.setenv("HINDSIGHT_API_LLM_MAX_CONCURRENT", "4")
+
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+        })
+
+        assert env["HINDSIGHT_API_LLM_MAX_CONCURRENT"] == "4"
+
+    def test_embedded_profile_env_omits_max_concurrent_when_unset(self):
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+        })
+        # SDK uses its own default (32) when the key is absent.
+        assert "HINDSIGHT_API_LLM_MAX_CONCURRENT" not in env
+
+    def test_embedded_profile_env_max_concurrent_config_overrides_env(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("HINDSIGHT_API_LLM_MAX_CONCURRENT", "4")
+
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+            "llm_max_concurrent": 1,
+        })
+
+        # Config takes precedence over environment.
+        assert env["HINDSIGHT_API_LLM_MAX_CONCURRENT"] == "1"
+
+    def test_embedded_profile_env_max_concurrent_clamped_at_one(self):
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+            "llm_max_concurrent": 0,
+        })
+        assert env["HINDSIGHT_API_LLM_MAX_CONCURRENT"] == "1"
+
+    def test_embedded_profile_env_max_concurrent_clamped_negative(self):
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+            "llm_max_concurrent": -1,
+        })
+        assert env["HINDSIGHT_API_LLM_MAX_CONCURRENT"] == "1"
 
     def test_get_client_passes_idle_timeout_to_hindsight_embedded(self, monkeypatch):
         captured = {}


### PR DESCRIPTION
## What

- Documents the risk of Hindsight's default `HINDSIGHT_API_LLM_MAX_CONCURRENT=32` when sharing a local LLM endpoint.
- Propagates `HINDSIGHT_API_LLM_MAX_CONCURRENT` through the embedded daemon's per-profile environment.
- Includes the setting in configuration-change detection so an existing daemon is restarted when the value changes.
- Clamps zero and negative values to `1`.
- Exposes `llm_max_concurrent` for direct plugin configuration.
- Adds focused provider tests.

## Why

When Hermes and Hindsight share a local LLM server, Hindsight's default concurrency can saturate the endpoint's slot pool and starve Hermes of inference slots. The symptom looks like Hermes freezing mid-conversation.

Previously, setting the variable in `~/.hermes/.env` did not participate in embedded-daemon restart detection, so restarting Hermes could leave an already-running daemon on the old value.

## Testing

- `tests/plugins/memory/test_hindsight_provider.py` — 102 tests passed
- Ruff check clean

## Context

Closes #31680.

Related upstream work:

- vectorize-io/hindsight#1720
- vectorize-io/hindsight#1721