### PR TITLE
fix(acp): request approval for denied edit reattempts

### DIFF
--- a/acp_adapter/edit_approval.py
+++ b/acp_adapter/edit_approval.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import logging
 import re
+import shlex
 import tempfile
 from concurrent.futures import TimeoutError as FutureTimeout
 from contextvars import ContextVar, Token
@@ -81,6 +82,8 @@ _DENIED_EDIT_WRITE_PATTERNS = (
     re.compile(r"\b(?:tee|truncate|touch|mv|cp|rm|install)\b"),
     re.compile(r"\b(?:sed|perl)\b[^\n]*\s-i(?:\s|$)", re.DOTALL),
 )
+_SHELL_REDIRECT_OPERATOR = re.compile(r"^(?:\d*|&)?>{1,2}$")
+_SHELL_REDIRECT_ATTACHED = re.compile(r"^(?:\d*|&)?>{1,2}(.+)$")
 
 
 def set_edit_approval_requester(requester: EditApprovalRequester | None) -> Token:
@@ -246,10 +249,52 @@ def _write_capable_tool_text(tool_name: str, arguments: dict[str, Any]) -> str |
     return None
 
 
+def _path_matches_denied_edit(candidate: str, denied: DeniedEdit) -> bool:
+    if not candidate:
+        return False
+    if candidate in {denied.path, denied.resolved_path}:
+        return True
+    try:
+        return _resolved_edit_path(candidate) == denied.resolved_path
+    except (OSError, RuntimeError):
+        return False
+
+
 def _mentions_denied_path(text: str, denied: DeniedEdit) -> bool:
     path_candidates = {denied.path, denied.resolved_path}
     path_candidates.discard("")
     return any(candidate in text for candidate in path_candidates)
+
+
+def _shell_redirection_targets(command: str) -> tuple[str, ...]:
+    """Return obvious shell redirection targets after quote expansion.
+
+    This is not a shell parser; it covers simple redirect forms so shell-quoted
+    denied paths (for example paths containing apostrophes) still require fresh
+    ACP approval instead of bypassing the literal string containment check.
+    """
+
+    try:
+        tokens = shlex.split(command, posix=True)
+    except ValueError:
+        return ()
+
+    targets: list[str] = []
+    for index, token in enumerate(tokens):
+        if _SHELL_REDIRECT_OPERATOR.match(token):
+            if index + 1 < len(tokens):
+                targets.append(tokens[index + 1])
+            continue
+        attached = _SHELL_REDIRECT_ATTACHED.match(token)
+        if attached:
+            targets.append(attached.group(1))
+    return tuple(targets)
+
+
+def _terminal_mentions_denied_path(command: str, denied: DeniedEdit) -> bool:
+    if _mentions_denied_path(command, denied):
+        return True
+    return any(_path_matches_denied_edit(target, denied) for target in _shell_redirection_targets(command))
 
 
 def _has_write_intent(text: str) -> bool:
@@ -265,7 +310,12 @@ def _denied_edit_reattempt(tool_name: str, arguments: dict[str, Any]) -> DeniedE
     if not text or not _has_write_intent(text):
         return None
     for denied in _DENIED_EDITS.get():
-        if _mentions_denied_path(text, denied):
+        mentions_denied_path = (
+            _terminal_mentions_denied_path(text, denied)
+            if tool_name == "terminal"
+            else _mentions_denied_path(text, denied)
+        )
+        if mentions_denied_path:
             return DeniedEditReattempt(
                 tool_name=tool_name,
                 path=denied.path,

--- a/acp_adapter/edit_approval.py
+++ b/acp_adapter/edit_approval.py
@@ -42,7 +42,20 @@ class DeniedEdit:
     tool_name: str
 
 
-EditApprovalRequester = Callable[[EditProposal], bool]
+@dataclass(frozen=True)
+class DeniedEditReattempt:
+    """A write-capable tool call that appears to retry a denied edit path."""
+
+    tool_name: str
+    path: str
+    resolved_path: str
+    denied_tool_name: str
+    arguments: dict[str, Any]
+
+
+EditApprovalRequest = EditProposal | DeniedEditReattempt
+EditApprovalRequester = Callable[[EditApprovalRequest], bool]
+
 
 _EDIT_APPROVAL_REQUESTER: ContextVar[EditApprovalRequester | None] = ContextVar(
     "ACP_EDIT_APPROVAL_REQUESTER",
@@ -243,8 +256,8 @@ def _has_write_intent(text: str) -> bool:
     return any(pattern.search(text) for pattern in _DENIED_EDIT_WRITE_PATTERNS)
 
 
-def _blocked_denied_edit_path(tool_name: str, arguments: dict[str, Any]) -> str | None:
-    """Return the denied path if a write-capable tool tries to mutate it."""
+def _denied_edit_reattempt(tool_name: str, arguments: dict[str, Any]) -> DeniedEditReattempt | None:
+    """Return a fresh approval request if a tool appears to retry a denied edit."""
 
     if tool_name not in DENIED_EDIT_BYPASS_TOOLS:
         return None
@@ -253,7 +266,13 @@ def _blocked_denied_edit_path(tool_name: str, arguments: dict[str, Any]) -> str 
         return None
     for denied in _DENIED_EDITS.get():
         if _mentions_denied_path(text, denied):
-            return denied.path
+            return DeniedEditReattempt(
+                tool_name=tool_name,
+                path=denied.path,
+                resolved_path=denied.resolved_path,
+                denied_tool_name=denied.tool_name,
+                arguments=dict(arguments),
+            )
     return None
 
 
@@ -275,13 +294,20 @@ def maybe_require_edit_approval(tool_name: str, arguments: dict[str, Any]) -> st
         return json.dumps({"error": f"Edit approval denied: could not prepare diff ({exc})"}, ensure_ascii=False)
 
     if proposal is None:
-        denied_path = _blocked_denied_edit_path(tool_name, arguments)
-        if denied_path is not None:
+        reattempt = _denied_edit_reattempt(tool_name, arguments)
+        if reattempt is not None:
+            try:
+                approved = bool(requester(reattempt))
+            except Exception as exc:
+                logger.warning("ACP alternate write approval requester failed: %s", exc)
+                approved = False
+            if approved:
+                return None
             return json.dumps(
                 {
                     "error": (
-                        "Tool call blocked because it attempts to modify a path "
-                        f"from a denied ACP edit approval: {denied_path}"
+                        "Alternate write approval denied by ACP client; "
+                        f"tool was not run for previously denied path: {reattempt.path}"
                     )
                 },
                 ensure_ascii=False,
@@ -323,6 +349,32 @@ def build_acp_edit_tool_call(proposal: EditProposal):
     )
 
 
+def build_acp_write_reattempt_tool_call(proposal: DeniedEditReattempt):
+    """Build the ToolCallUpdate payload for same-path write reattempt approval."""
+
+    import acp
+
+    tool_call_id = f"edit-reattempt-{next(_PERMISSION_REQUEST_IDS)}"
+    text = (
+        f"A previous ACP edit request for `{proposal.path}` was denied. "
+        f"The `{proposal.tool_name}` tool call appears able to modify the same path. "
+        "Run it only with fresh approval."
+    )
+    return acp.update_tool_call(
+        tool_call_id,
+        title=f"Approve previously denied write: {proposal.path}",
+        kind="execute",
+        status="pending",
+        content=[acp.tool_content(acp.text_block(text))],
+        raw_input={
+            "tool": proposal.tool_name,
+            "arguments": proposal.arguments,
+            "denied_path": proposal.path,
+            "denied_tool": proposal.denied_tool_name,
+        },
+    )
+
+
 def make_acp_edit_approval_requester(
     request_permission_fn: Callable,
     loop: asyncio.AbstractEventLoop,
@@ -332,11 +384,11 @@ def make_acp_edit_approval_requester(
 ) -> EditApprovalRequester:
     """Return a sync requester that bridges edit proposals to ACP permissions."""
 
-    def _requester(proposal: EditProposal) -> bool:
+    def _requester(proposal: EditApprovalRequest) -> bool:
         from acp.schema import PermissionOption
         from agent.async_utils import safe_schedule_threadsafe
 
-        if auto_approve_getter is not None:
+        if isinstance(proposal, EditProposal) and auto_approve_getter is not None:
             try:
                 policy, cwd = auto_approve_getter()
                 if should_auto_approve_edit(proposal, policy, cwd):
@@ -349,7 +401,10 @@ def make_acp_edit_approval_requester(
             PermissionOption(option_id="allow_once", kind="allow_once", name="Allow edit"),
             PermissionOption(option_id="deny", kind="reject_once", name="Deny"),
         ]
-        tool_call = build_acp_edit_tool_call(proposal)
+        if isinstance(proposal, EditProposal):
+            tool_call = build_acp_edit_tool_call(proposal)
+        else:
+            tool_call = build_acp_write_reattempt_tool_call(proposal)
         coro = request_permission_fn(
             session_id=session_id,
             tool_call=tool_call,

--- a/acp_adapter/edit_approval.py
+++ b/acp_adapter/edit_approval.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 import tempfile
 from concurrent.futures import TimeoutError as FutureTimeout
 from contextvars import ContextVar, Token
@@ -32,11 +33,24 @@ class EditProposal:
     arguments: dict[str, Any]
 
 
+@dataclass(frozen=True)
+class DeniedEdit:
+    """A denied ACP edit path that later write-capable tools must not mutate."""
+
+    path: str
+    resolved_path: str
+    tool_name: str
+
+
 EditApprovalRequester = Callable[[EditProposal], bool]
 
 _EDIT_APPROVAL_REQUESTER: ContextVar[EditApprovalRequester | None] = ContextVar(
     "ACP_EDIT_APPROVAL_REQUESTER",
     default=None,
+)
+_DENIED_EDITS: ContextVar[tuple[DeniedEdit, ...]] = ContextVar(
+    "ACP_DENIED_EDITS",
+    default=(),
 )
 _PERMISSION_REQUEST_IDS = count(1)
 
@@ -45,23 +59,35 @@ SENSITIVE_AUTO_APPROVE_NAMES = {".env", ".env.local", ".env.production", "id_rsa
 AUTO_APPROVE_ASK = "ask"
 AUTO_APPROVE_WORKSPACE = "workspace_session"
 AUTO_APPROVE_SESSION = "session"
+DENIED_EDIT_BYPASS_TOOLS = {"terminal", "execute_code"}
+_DENIED_EDIT_WRITE_PATTERNS = (
+    re.compile(r"\bwrite_(?:text|bytes)\s*\("),
+    re.compile(r"\bopen\s*\([^)]*,\s*['\"][^'\"]*[wax+][^'\"]*['\"]", re.DOTALL),
+    re.compile(r"(?:^|[\s;&|])(?:cat|echo|printf)\b[^\n]*(?:>|>>)", re.DOTALL),
+    re.compile(r"(?:^|[^<])>{1,2}\s*\S+"),
+    re.compile(r"\b(?:tee|truncate|touch|mv|cp|rm|install)\b"),
+    re.compile(r"\b(?:sed|perl)\b[^\n]*\s-i(?:\s|$)", re.DOTALL),
+)
 
 
 def set_edit_approval_requester(requester: EditApprovalRequester | None) -> Token:
     """Bind an ACP edit approval requester for the current context."""
 
+    _DENIED_EDITS.set(())
     return _EDIT_APPROVAL_REQUESTER.set(requester)
 
 
 def reset_edit_approval_requester(token: Token) -> None:
     """Restore a previous edit approval requester binding."""
 
+    _DENIED_EDITS.set(())
     _EDIT_APPROVAL_REQUESTER.reset(token)
 
 
 def clear_edit_approval_requester() -> None:
     """Clear the current requester; primarily used by tests."""
 
+    _DENIED_EDITS.set(())
     _EDIT_APPROVAL_REQUESTER.set(None)
 
 
@@ -178,6 +204,59 @@ def should_auto_approve_edit(proposal: EditProposal, policy: str, cwd: str | Non
     return False
 
 
+def _resolved_edit_path(path: str) -> str:
+    return str(Path(path).expanduser().resolve(strict=False))
+
+
+def _record_denied_edit(proposal: EditProposal) -> None:
+    denied = DeniedEdit(
+        path=proposal.path,
+        resolved_path=_resolved_edit_path(proposal.path),
+        tool_name=proposal.tool_name,
+    )
+    existing = tuple(item for item in _DENIED_EDITS.get() if item.resolved_path != denied.resolved_path)
+    _DENIED_EDITS.set((*existing, denied))
+
+
+def _forget_denied_edit(proposal: EditProposal) -> None:
+    resolved_path = _resolved_edit_path(proposal.path)
+    _DENIED_EDITS.set(tuple(item for item in _DENIED_EDITS.get() if item.resolved_path != resolved_path))
+
+
+def _write_capable_tool_text(tool_name: str, arguments: dict[str, Any]) -> str | None:
+    if tool_name == "terminal":
+        command = arguments.get("command")
+        return str(command) if command is not None else None
+    if tool_name == "execute_code":
+        code = arguments.get("code")
+        return str(code) if code is not None else None
+    return None
+
+
+def _mentions_denied_path(text: str, denied: DeniedEdit) -> bool:
+    path_candidates = {denied.path, denied.resolved_path}
+    path_candidates.discard("")
+    return any(candidate in text for candidate in path_candidates)
+
+
+def _has_write_intent(text: str) -> bool:
+    return any(pattern.search(text) for pattern in _DENIED_EDIT_WRITE_PATTERNS)
+
+
+def _blocked_denied_edit_path(tool_name: str, arguments: dict[str, Any]) -> str | None:
+    """Return the denied path if a write-capable tool tries to mutate it."""
+
+    if tool_name not in DENIED_EDIT_BYPASS_TOOLS:
+        return None
+    text = _write_capable_tool_text(tool_name, arguments)
+    if not text or not _has_write_intent(text):
+        return None
+    for denied in _DENIED_EDITS.get():
+        if _mentions_denied_path(text, denied):
+            return denied.path
+    return None
+
+
 def maybe_require_edit_approval(tool_name: str, arguments: dict[str, Any]) -> str | None:
     """Run ACP edit approval if bound.
 
@@ -196,6 +275,17 @@ def maybe_require_edit_approval(tool_name: str, arguments: dict[str, Any]) -> st
         return json.dumps({"error": f"Edit approval denied: could not prepare diff ({exc})"}, ensure_ascii=False)
 
     if proposal is None:
+        denied_path = _blocked_denied_edit_path(tool_name, arguments)
+        if denied_path is not None:
+            return json.dumps(
+                {
+                    "error": (
+                        "Tool call blocked because it attempts to modify a path "
+                        f"from a denied ACP edit approval: {denied_path}"
+                    )
+                },
+                ensure_ascii=False,
+            )
         return None
 
     try:
@@ -205,7 +295,9 @@ def maybe_require_edit_approval(tool_name: str, arguments: dict[str, Any]) -> st
         approved = False
 
     if approved:
+        _forget_denied_edit(proposal)
         return None
+    _record_denied_edit(proposal)
     return json.dumps({"error": "Edit approval denied by ACP client; file was not modified."}, ensure_ascii=False)
 
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -801,15 +801,19 @@ def handle_function_call(
         # ACP/Zed edit approval runs before any file mutation.  The requester
         # is bound via ContextVar only for ACP sessions, so CLI/gateway paths
         # are unaffected when it is unset.
+        edit_approval_requester_active = False
         try:
-            from acp_adapter.edit_approval import maybe_require_edit_approval
+            from acp_adapter import edit_approval as _edit_approval
 
-            edit_block_message = maybe_require_edit_approval(function_name, function_args)
+            edit_approval_requester_active = _edit_approval.get_edit_approval_requester() is not None
+            edit_block_message = _edit_approval.maybe_require_edit_approval(function_name, function_args)
             if edit_block_message is not None:
                 return edit_block_message
         except Exception as _edit_approval_err:
             logger.debug("ACP edit approval guard error: %s", _edit_approval_err)
-            if function_name in {"write_file", "patch"}:
+            if function_name in {"write_file", "patch"} or (
+                edit_approval_requester_active and function_name in {"terminal", "execute_code"}
+            ):
                 return json.dumps({"error": "Edit approval denied: approval guard failed"}, ensure_ascii=False)
 
         # Notify the read-loop tracker when a non-read/search tool runs,

--- a/tests/acp/test_edit_approval.py
+++ b/tests/acp/test_edit_approval.py
@@ -243,6 +243,86 @@ def test_denied_write_file_fails_closed_when_reattempt_requester_raises(tmp_path
     assert isinstance(requests[1], DeniedEditReattempt)
 
 
+def test_active_acp_guard_exception_blocks_terminal_instead_of_fail_open(monkeypatch, tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("before\n", encoding="utf-8")
+    set_edit_approval_requester(lambda _proposal: True)
+
+    import acp_adapter.edit_approval as edit_approval
+
+    def broken_guard(_tool_name, _arguments):
+        raise RuntimeError("guard bug")
+
+    monkeypatch.setattr(edit_approval, "maybe_require_edit_approval", broken_guard)
+
+    code = f"from pathlib import Path; Path({str(target)!r}).write_text('after\\n', encoding='utf-8')"
+    command = f"{shlex.quote(sys.executable)} -c {shlex.quote(code)}"
+    result = json.loads(
+        handle_function_call(
+            "terminal",
+            {"command": command},
+            task_id="acp-edit-terminal-guard-exception",
+        )
+    )
+
+    assert "approval guard failed" in result["error"]
+    assert target.read_text(encoding="utf-8") == "before\n"
+
+
+def test_active_acp_guard_exception_blocks_execute_code_instead_of_fail_open(monkeypatch, tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("before\n", encoding="utf-8")
+    set_edit_approval_requester(lambda _proposal: True)
+
+    import acp_adapter.edit_approval as edit_approval
+
+    def broken_guard(_tool_name, _arguments):
+        raise RuntimeError("guard bug")
+
+    monkeypatch.setattr(edit_approval, "maybe_require_edit_approval", broken_guard)
+
+    result = json.loads(
+        handle_function_call(
+            "execute_code",
+            {
+                "code": (
+                    "from pathlib import Path\n"
+                    f"Path({str(target)!r}).write_text('after\\n', encoding='utf-8')\n"
+                )
+            },
+            task_id="acp-edit-code-guard-exception",
+        )
+    )
+
+    assert "approval guard failed" in result["error"]
+    assert target.read_text(encoding="utf-8") == "before\n"
+
+
+def test_inactive_acp_guard_exception_does_not_block_terminal_tool(monkeypatch, tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("before\n", encoding="utf-8")
+
+    import acp_adapter.edit_approval as edit_approval
+
+    def broken_guard(_tool_name, _arguments):
+        raise RuntimeError("guard bug")
+
+    monkeypatch.setattr(edit_approval, "maybe_require_edit_approval", broken_guard)
+
+    code = f"from pathlib import Path; Path({str(target)!r}).write_text('after\\n', encoding='utf-8')"
+    command = f"{shlex.quote(sys.executable)} -c {shlex.quote(code)}"
+    result = json.loads(
+        handle_function_call(
+            "terminal",
+            {"command": command},
+            task_id="non-acp-terminal-guard-exception",
+        )
+    )
+
+    assert result.get("exit_code") == 0
+    assert target.read_text(encoding="utf-8") == "after\n"
+
+
 def test_denied_write_file_prompts_for_shell_quoted_terminal_redirect_to_same_path(tmp_path):
     target = tmp_path / "quo'te.txt"
     target.write_text("before\n", encoding="utf-8")

--- a/tests/acp/test_edit_approval.py
+++ b/tests/acp/test_edit_approval.py
@@ -169,6 +169,118 @@ def test_denied_write_file_prompts_before_execute_code_write_to_same_path(tmp_pa
     assert requests[1].path == str(target)
 
 
+def test_denied_write_file_blocks_terminal_reattempt_when_fresh_request_denied(tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("before\n", encoding="utf-8")
+    requests = []
+
+    def deny(proposal):
+        requests.append(proposal)
+        return False
+
+    set_edit_approval_requester(deny)
+
+    denied = json.loads(
+        handle_function_call(
+            "write_file",
+            {"path": str(target), "content": "after\n"},
+            task_id="acp-edit-terminal-reattempt-deny",
+        )
+    )
+    assert "Edit approval denied" in denied["error"]
+
+    code = f"from pathlib import Path; Path({str(target)!r}).write_text('after\\n', encoding='utf-8')"
+    command = f"{shlex.quote(sys.executable)} -c {shlex.quote(code)}"
+    result = json.loads(
+        handle_function_call(
+            "terminal",
+            {"command": command},
+            task_id="acp-edit-terminal-reattempt-deny",
+        )
+    )
+
+    assert "Alternate write approval denied" in result["error"]
+    assert target.read_text(encoding="utf-8") == "before\n"
+    assert len(requests) == 2
+    assert isinstance(requests[1], DeniedEditReattempt)
+
+
+def test_denied_write_file_fails_closed_when_reattempt_requester_raises(tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("before\n", encoding="utf-8")
+    requests = []
+
+    def disconnect_on_reattempt(proposal):
+        requests.append(proposal)
+        if len(requests) == 2:
+            raise RuntimeError("zed disconnected")
+        return False
+
+    set_edit_approval_requester(disconnect_on_reattempt)
+
+    denied = json.loads(
+        handle_function_call(
+            "write_file",
+            {"path": str(target), "content": "after\n"},
+            task_id="acp-edit-terminal-reattempt-exception",
+        )
+    )
+    assert "Edit approval denied" in denied["error"]
+
+    code = f"from pathlib import Path; Path({str(target)!r}).write_text('after\\n', encoding='utf-8')"
+    command = f"{shlex.quote(sys.executable)} -c {shlex.quote(code)}"
+    result = json.loads(
+        handle_function_call(
+            "terminal",
+            {"command": command},
+            task_id="acp-edit-terminal-reattempt-exception",
+        )
+    )
+
+    assert "Alternate write approval denied" in result["error"]
+    assert target.read_text(encoding="utf-8") == "before\n"
+    assert len(requests) == 2
+    assert isinstance(requests[1], DeniedEditReattempt)
+
+
+def test_denied_write_file_prompts_for_shell_quoted_terminal_redirect_to_same_path(tmp_path):
+    target = tmp_path / "quo'te.txt"
+    target.write_text("before\n", encoding="utf-8")
+    requests = []
+
+    def decide(proposal):
+        requests.append(proposal)
+        return len(requests) == 2
+
+    set_edit_approval_requester(decide)
+
+    denied = json.loads(
+        handle_function_call(
+            "write_file",
+            {"path": str(target), "content": "after direct\n"},
+            task_id="acp-edit-terminal-shell-quoted-path",
+        )
+    )
+    assert "Edit approval denied" in denied["error"]
+
+    payload = "after via shell\n"
+    command = f"printf %s {shlex.quote(payload)} > {shlex.quote(str(target))}"
+    result = json.loads(
+        handle_function_call(
+            "terminal",
+            {"command": command},
+            task_id="acp-edit-terminal-shell-quoted-path",
+        )
+    )
+
+    assert result.get("exit_code") == 0
+    assert target.read_text(encoding="utf-8") == "after via shell\n"
+    assert len(requests) == 2
+    assert isinstance(requests[1], DeniedEditReattempt)
+    assert requests[1].tool_name == "terminal"
+    assert requests[1].path == str(target)
+
+
 def test_denied_write_file_still_allows_terminal_read_of_same_path(tmp_path):
     target = tmp_path / "sample.txt"
     target.write_text("before\n", encoding="utf-8")

--- a/tests/acp/test_edit_approval.py
+++ b/tests/acp/test_edit_approval.py
@@ -9,8 +9,10 @@ import tempfile
 from pathlib import Path
 
 from acp_adapter.edit_approval import (
+    DeniedEditReattempt,
     EditProposal,
     build_acp_edit_tool_call,
+    build_acp_write_reattempt_tool_call,
     clear_edit_approval_requester,
     set_edit_approval_requester,
     should_auto_approve_edit,
@@ -43,6 +45,31 @@ def test_acp_permission_tool_call_uses_edit_kind_and_diff_content():
     assert diff.newText == "new\n"
 
 
+def test_acp_write_reattempt_tool_call_uses_execute_kind_and_denied_path_context():
+    proposal = DeniedEditReattempt(
+        tool_name="terminal",
+        path="demo.txt",
+        resolved_path="/tmp/demo.txt",
+        denied_tool_name="write_file",
+        arguments={"command": "python -c 'write demo.txt'"},
+    )
+
+    tool_call = build_acp_write_reattempt_tool_call(proposal)
+
+    assert tool_call.kind == "execute"
+    assert tool_call.status == "pending"
+    assert tool_call.rawInput == {
+        "tool": "terminal",
+        "arguments": proposal.arguments,
+        "denied_path": "demo.txt",
+        "denied_tool": "write_file",
+    }
+    assert "previously denied" in tool_call.title
+    assert "demo.txt" in tool_call.title
+    assert len(tool_call.content) == 1
+    assert "fresh approval" in tool_call.content[0].content.text
+
+
 def test_write_file_rejection_does_not_mutate_existing_file(tmp_path):
     target = tmp_path / "sample.txt"
     target.write_text("before\n", encoding="utf-8")
@@ -62,10 +89,16 @@ def test_write_file_rejection_does_not_mutate_existing_file(tmp_path):
     assert target.read_text(encoding="utf-8") == "before\n"
 
 
-def test_denied_write_file_blocks_terminal_write_to_same_path(tmp_path):
+def test_denied_write_file_prompts_before_terminal_write_to_same_path(tmp_path):
     target = tmp_path / "sample.txt"
     target.write_text("before\n", encoding="utf-8")
-    set_edit_approval_requester(lambda _proposal: False)
+    requests = []
+
+    def decide(proposal):
+        requests.append(proposal)
+        return len(requests) == 2
+
+    set_edit_approval_requester(decide)
 
     denied = json.loads(
         handle_function_call(
@@ -86,15 +119,24 @@ def test_denied_write_file_blocks_terminal_write_to_same_path(tmp_path):
         )
     )
 
-    assert "error" in result
-    assert "denied ACP edit" in result["error"]
-    assert target.read_text(encoding="utf-8") == "before\n"
+    assert result.get("exit_code") == 0
+    assert target.read_text(encoding="utf-8") == "after\n"
+    assert len(requests) == 2
+    assert isinstance(requests[1], DeniedEditReattempt)
+    assert requests[1].tool_name == "terminal"
+    assert requests[1].path == str(target)
 
 
-def test_denied_write_file_blocks_execute_code_write_to_same_path(tmp_path):
+def test_denied_write_file_prompts_before_execute_code_write_to_same_path(tmp_path):
     target = tmp_path / "sample.txt"
     target.write_text("before\n", encoding="utf-8")
-    set_edit_approval_requester(lambda _proposal: False)
+    requests = []
+
+    def decide(proposal):
+        requests.append(proposal)
+        return len(requests) == 2
+
+    set_edit_approval_requester(decide)
 
     denied = json.loads(
         handle_function_call(
@@ -119,9 +161,12 @@ def test_denied_write_file_blocks_execute_code_write_to_same_path(tmp_path):
         )
     )
 
-    assert "error" in result
-    assert "denied ACP edit" in result["error"]
-    assert target.read_text(encoding="utf-8") == "before\n"
+    assert result.get("status") == "success"
+    assert target.read_text(encoding="utf-8") == "after\n"
+    assert len(requests) == 2
+    assert isinstance(requests[1], DeniedEditReattempt)
+    assert requests[1].tool_name == "execute_code"
+    assert requests[1].path == str(target)
 
 
 def test_denied_write_file_still_allows_terminal_read_of_same_path(tmp_path):

--- a/tests/acp/test_edit_approval.py
+++ b/tests/acp/test_edit_approval.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import shlex
+import sys
 import tempfile
 from pathlib import Path
 
@@ -57,6 +59,97 @@ def test_write_file_rejection_does_not_mutate_existing_file(tmp_path):
 
     assert "error" in result
     assert "Edit approval denied" in result["error"]
+    assert target.read_text(encoding="utf-8") == "before\n"
+
+
+def test_denied_write_file_blocks_terminal_write_to_same_path(tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("before\n", encoding="utf-8")
+    set_edit_approval_requester(lambda _proposal: False)
+
+    denied = json.loads(
+        handle_function_call(
+            "write_file",
+            {"path": str(target), "content": "after\n"},
+            task_id="acp-edit-terminal-bypass",
+        )
+    )
+    assert "Edit approval denied" in denied["error"]
+
+    code = f"from pathlib import Path; Path({str(target)!r}).write_text('after\\n', encoding='utf-8')"
+    command = f"{shlex.quote(sys.executable)} -c {shlex.quote(code)}"
+    result = json.loads(
+        handle_function_call(
+            "terminal",
+            {"command": command},
+            task_id="acp-edit-terminal-bypass",
+        )
+    )
+
+    assert "error" in result
+    assert "denied ACP edit" in result["error"]
+    assert target.read_text(encoding="utf-8") == "before\n"
+
+
+def test_denied_write_file_blocks_execute_code_write_to_same_path(tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("before\n", encoding="utf-8")
+    set_edit_approval_requester(lambda _proposal: False)
+
+    denied = json.loads(
+        handle_function_call(
+            "write_file",
+            {"path": str(target), "content": "after\n"},
+            task_id="acp-edit-code-bypass",
+        )
+    )
+    assert "Edit approval denied" in denied["error"]
+
+    result = json.loads(
+        handle_function_call(
+            "execute_code",
+            {
+                "code": (
+                    "from pathlib import Path\n"
+                    f"Path({str(target)!r}).write_text('after\\n', encoding='utf-8')\n"
+                    "print('wrote file')\n"
+                )
+            },
+            task_id="acp-edit-code-bypass",
+        )
+    )
+
+    assert "error" in result
+    assert "denied ACP edit" in result["error"]
+    assert target.read_text(encoding="utf-8") == "before\n"
+
+
+def test_denied_write_file_still_allows_terminal_read_of_same_path(tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("before\n", encoding="utf-8")
+    set_edit_approval_requester(lambda _proposal: False)
+
+    denied = json.loads(
+        handle_function_call(
+            "write_file",
+            {"path": str(target), "content": "after\n"},
+            task_id="acp-edit-terminal-read",
+        )
+    )
+    assert "Edit approval denied" in denied["error"]
+
+    code = f"from pathlib import Path; print(Path({str(target)!r}).read_text(encoding='utf-8'), end='')"
+    command = f"{shlex.quote(sys.executable)} -c {shlex.quote(code)}"
+    result = json.loads(
+        handle_function_call(
+            "terminal",
+            {"command": command},
+            task_id="acp-edit-terminal-read",
+        )
+    )
+
+    assert result.get("exit_code") == 0
+    assert result.get("output") == "before"
     assert target.read_text(encoding="utf-8") == "before\n"
 
 

--- a/tests/acp/test_edit_approval.py
+++ b/tests/acp/test_edit_approval.py
@@ -14,6 +14,7 @@ from acp_adapter.edit_approval import (
     build_acp_edit_tool_call,
     build_acp_write_reattempt_tool_call,
     clear_edit_approval_requester,
+    reset_edit_approval_requester,
     set_edit_approval_requester,
     should_auto_approve_edit,
 )
@@ -321,6 +322,117 @@ def test_inactive_acp_guard_exception_does_not_block_terminal_tool(monkeypatch, 
 
     assert result.get("exit_code") == 0
     assert target.read_text(encoding="utf-8") == "after\n"
+
+
+def test_inactive_acp_guard_exception_does_not_block_execute_code_tool(monkeypatch, tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("before\n", encoding="utf-8")
+
+    import acp_adapter.edit_approval as edit_approval
+
+    def broken_guard(_tool_name, _arguments):
+        raise RuntimeError("guard bug")
+
+    monkeypatch.setattr(edit_approval, "maybe_require_edit_approval", broken_guard)
+
+    result = json.loads(
+        handle_function_call(
+            "execute_code",
+            {
+                "code": (
+                    "from pathlib import Path\n"
+                    f"Path({str(target)!r}).write_text('after\\n', encoding='utf-8')\n"
+                )
+            },
+            task_id="non-acp-code-guard-exception",
+        )
+    )
+
+    assert result.get("status") == "success"
+    assert target.read_text(encoding="utf-8") == "after\n"
+
+
+def test_reset_edit_approval_requester_clears_denied_reattempt_state(tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("before\n", encoding="utf-8")
+    outer_requests = []
+
+    outer_token = set_edit_approval_requester(lambda proposal: outer_requests.append(proposal) or False)
+    inner_token = set_edit_approval_requester(lambda _proposal: False)
+
+    try:
+        denied = json.loads(
+            handle_function_call(
+                "write_file",
+                {"path": str(target), "content": "after direct\n"},
+                task_id="acp-edit-reset-clears-denied-state",
+            )
+        )
+        assert "Edit approval denied" in denied["error"]
+
+        reset_edit_approval_requester(inner_token)
+
+        code = f"from pathlib import Path; Path({str(target)!r}).write_text('after\\n', encoding='utf-8')"
+        command = f"{shlex.quote(sys.executable)} -c {shlex.quote(code)}"
+        result = json.loads(
+            handle_function_call(
+                "terminal",
+                {"command": command},
+                task_id="acp-edit-reset-clears-denied-state",
+            )
+        )
+
+        assert result.get("exit_code") == 0
+        assert target.read_text(encoding="utf-8") == "after\n"
+        assert outer_requests == []
+    finally:
+        reset_edit_approval_requester(outer_token)
+
+
+def test_approved_direct_edit_forgets_prior_denial_for_same_path(tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("before\n", encoding="utf-8")
+    requests = []
+
+    def decide(proposal):
+        requests.append(proposal)
+        return len(requests) == 2
+
+    set_edit_approval_requester(decide)
+
+    denied = json.loads(
+        handle_function_call(
+            "write_file",
+            {"path": str(target), "content": "denied direct\n"},
+            task_id="acp-edit-forget-approved-direct-edit",
+        )
+    )
+    assert "Edit approval denied" in denied["error"]
+
+    approved = json.loads(
+        handle_function_call(
+            "write_file",
+            {"path": str(target), "content": "approved direct\n"},
+            task_id="acp-edit-forget-approved-direct-edit",
+        )
+    )
+    assert approved.get("bytes_written") == len("approved direct\n")
+    assert target.read_text(encoding="utf-8") == "approved direct\n"
+    assert len(requests) == 2
+
+    code = f"from pathlib import Path; Path({str(target)!r}).write_text('after terminal\\n', encoding='utf-8')"
+    command = f"{shlex.quote(sys.executable)} -c {shlex.quote(code)}"
+    result = json.loads(
+        handle_function_call(
+            "terminal",
+            {"command": command},
+            task_id="acp-edit-forget-approved-direct-edit",
+        )
+    )
+
+    assert result.get("exit_code") == 0
+    assert target.read_text(encoding="utf-8") == "after terminal\n"
+    assert len(requests) == 2
 
 
 def test_denied_write_file_prompts_for_shell_quoted_terminal_redirect_to_same_path(tmp_path):


### PR DESCRIPTION
## What does this PR do?

Requires fresh ACP permission when a previously denied direct edit is reattempted through an obvious same-path execution surface in the same ACP context.

Hermes already asks ACP clients for permission before supported direct file-edit tools such as `write_file` and replace-mode `patch`. Before this change, if the client denied that edit, the denial was returned as an ordinary tool error and the model could still pivot to `terminal` or `execute_code` to write the same file without another prompt.

This PR records denied ACP edit paths in context-scoped state. Later top-level `terminal` / `execute_code` calls that appear to target a denied path with clear write intent are converted into a fresh ACP `execute` permission request. If the fresh request is approved, the alternate tool may run; if it is denied, times out, or fails to deliver, the alternate tool does not run.

Covered in this narrow pass:

- literal raw/resolved denied path mentions in top-level `terminal` / `execute_code` text;
- obvious write-intent patterns such as Python `write_text`, write-mode `open(...)`, shell redirects, `tee`, `touch`, `mv`, `cp`, `rm`, `truncate`, or in-place `sed`/`perl`; and
- simple shell redirection targets after quote expansion, so paths containing quotes cannot bypass the literal string check.

Read-only terminal access remains allowed after a denial. Non-ACP sessions remain unaffected because the guard only runs when the ACP edit approval requester is bound.

This is intentionally a conservative hardening pass for the known bypass, not arbitrary shell/code sandboxing. Follow-up scope remains for nested `execute_code` Hermes-tool RPC, terminal `workdir` + relative path writes, V4A `patch mode="patch"`, and broader shell parsing.

## Related Issue

Fixes #31682

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `acp_adapter/edit_approval.py`
  - Adds context-scoped denied-edit tracking for ACP edit approvals.
  - Records denied direct edit proposals by normalized path.
  - Adds a structured `DeniedEditReattempt` request for alternate same-path writes.
  - Requests fresh ACP permission for detected `terminal` / `execute_code` reattempts.
  - Fails closed when the fresh reattempt permission is denied or the requester errors.
  - Handles simple shell redirection targets with `shlex` quote expansion.
  - Clears denied-edit state when the ACP edit approval requester is reset/cleared and forgets a path when a later direct proposal for that path is approved.
- `model_tools.py`
  - Fails closed for `terminal` / `execute_code` approval-guard exceptions while an ACP approval requester is active.
  - Preserves non-ACP `terminal` / `execute_code` execution when the guard is inactive.
- `tests/acp/test_edit_approval.py`
  - Adds regression coverage for denied `write_file` followed by approved terminal and `execute_code` writes to the same path.
  - Adds coverage that denied/failing fresh reattempt approval prevents execution and leaves the file unchanged.
  - Adds dispatcher fail-closed coverage for active ACP guard exceptions on `terminal` / `execute_code`, plus inactive-context coverage that normal terminal / `execute_code` execution is preserved.
  - Adds coverage for shell-quoted terminal redirect targets resolving to the denied path.
  - Adds coverage that reset requester state and later approved direct edits clear prior denied-path state.
  - Adds coverage that read-only terminal access to the same path remains allowed after denial.

## How to Test

1. Reproduce the original bug on `origin/main`: deny a `write_file` ACP edit proposal, then write the same target path through `terminal` or `execute_code`; the later write succeeds silently.
2. Check out this branch and run:

```bash
scripts/run_tests.sh tests/acp/test_edit_approval.py
scripts/run_tests.sh tests/acp
git diff --check
python scripts/check-windows-footguns.py --diff origin/main
```

Observed local results:

```text
scripts/run_tests.sh tests/acp/test_edit_approval.py
# 21 passed

scripts/run_tests.sh tests/acp
# 288 passed

git diff --check
# clean

python scripts/check-windows-footguns.py --diff origin/main
# ✓ No Windows footguns found
```

No interactive editor/ACP client smoke test was run; this was verified at the dispatcher/helper level with ACP edit approval bound in tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - Focused ACP suites were run via the repo wrapper instead: `scripts/run_tests.sh tests/acp/test_edit_approval.py` and `scripts/run_tests.sh tests/acp`.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux / Arch

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Diff size:

```text
3 files changed, 650 insertions(+), 7 deletions(-)

acp_adapter/edit_approval.py     +201 / -4
model_tools.py                   +7 / -3
tests/acp/test_edit_approval.py  +442 / -0
```
