### PR TITLE
fix(gateway): tighten Telegram proxy-pool keepalive to stop fd leak

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -86,6 +86,7 @@ from gateway.platforms.telegram_network import (
     discover_fallback_ips,
     parse_fallback_ip_env,
 )
+from gateway.platforms._http_client_limits import platform_httpx_limits
 from utils import atomic_replace
 
 _TELEGRAM_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
@@ -106,6 +107,33 @@ _TELEGRAM_IMAGE_EXT_TO_MIME = {
 
 
 MAX_COMMANDS_PER_SCOPE = 30
+
+
+def _proxy_request_httpx_kwargs(connection_pool_size: int) -> Dict[str, Any]:
+    """``httpx_kwargs`` for the proxy-path HTTPXRequest pools.
+
+    Through a proxy, httpcore's tunnel path can leave the underlying socket
+    half-closed on ConnectError. With httpx's default ``keepalive_expiry`` of
+    5s those CLOSED sockets pile up in the pool faster than they drain,
+    exhausting the fd budget after days of flaky-proxy operation (#31599).
+
+    We reuse the shared keepalive tuning (#18451) so idle/dead connections
+    are evicted promptly, while keeping ``max_connections`` at the configured
+    pool size so concurrent sends are unaffected. Returns an empty dict when
+    httpx is unavailable, letting HTTPXRequest fall back to its own limits.
+    """
+    base_limits = platform_httpx_limits()
+    if base_limits is None:
+        return {}
+    import httpx
+
+    return {
+        "limits": httpx.Limits(
+            max_connections=connection_pool_size,
+            max_keepalive_connections=base_limits.max_keepalive_connections,
+            keepalive_expiry=base_limits.keepalive_expiry,
+        )
+    }
 
 
 def check_telegram_requirements() -> bool:
@@ -1421,8 +1449,9 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             elif proxy_url:
                 logger.info("[%s] Proxy detected; passing explicitly to HTTPXRequest: %s", self.name, proxy_url)
-                request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
-                get_updates_request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
+                proxy_httpx_kwargs = _proxy_request_httpx_kwargs(request_kwargs["connection_pool_size"])
+                request = HTTPXRequest(**request_kwargs, proxy=proxy_url, httpx_kwargs=proxy_httpx_kwargs)
+                get_updates_request = HTTPXRequest(**request_kwargs, proxy=proxy_url, httpx_kwargs=proxy_httpx_kwargs)
             else:
                 if disable_fallback:
                     logger.info("[%s] Telegram fallback-IP transport disabled via env", self.name)

--- a/tests/gateway/test_telegram_proxy_pool_limits.py
+++ b/tests/gateway/test_telegram_proxy_pool_limits.py
@@ -1,0 +1,59 @@
+"""Regression tests for the Telegram proxy-path connection-pool leak (#31599).
+
+Behind a flaky local HTTP proxy, httpcore's tunnel path can leave sockets
+half-closed on ConnectError. With httpx's default ``keepalive_expiry`` of 5s
+those CLOSED sockets accumulate in the general pool faster than they drain,
+eventually exhausting the process fd budget after days of operation.
+
+The fix tightens keepalive eviction on the proxy-path HTTPXRequest pools
+(reusing the shared #18451 tuning) while preserving the configured
+``max_connections`` ceiling so concurrent sends are unaffected.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.platforms.telegram import _proxy_request_httpx_kwargs
+
+
+def test_proxy_kwargs_tighten_keepalive_below_httpx_default():
+    """keepalive_expiry must be shorter than httpx's 5s default so CLOSED
+    sockets through the proxy drain promptly instead of piling up."""
+    import httpx
+
+    kwargs = _proxy_request_httpx_kwargs(512)
+    limits = kwargs["limits"]
+    assert isinstance(limits, httpx.Limits)
+    assert limits.keepalive_expiry is not None
+    assert limits.keepalive_expiry < 5.0
+    assert limits.max_keepalive_connections is not None
+    assert 1 <= limits.max_keepalive_connections <= 50
+
+
+def test_proxy_kwargs_preserve_max_connections_ceiling():
+    """The configured connection_pool_size is the max_connections ceiling —
+    tightening keepalive must not silently shrink concurrent-send headroom."""
+    assert _proxy_request_httpx_kwargs(512)["limits"].max_connections == 512
+    assert _proxy_request_httpx_kwargs(64)["limits"].max_connections == 64
+
+
+def test_proxy_kwargs_empty_when_httpx_unavailable(monkeypatch):
+    """If the shared limits helper can't build limits (httpx missing), the
+    proxy kwargs are empty so HTTPXRequest falls back to its own limits."""
+    import gateway.platforms.telegram as mod
+
+    monkeypatch.setattr(mod, "platform_httpx_limits", lambda: None)
+    assert _proxy_request_httpx_kwargs(512) == {}
+
+
+def test_proxy_kwargs_respect_shared_keepalive_env_override(monkeypatch):
+    """The proxy path reuses the shared #18451 tuning, so its env overrides
+    apply here too."""
+    monkeypatch.setenv("HERMES_GATEWAY_HTTPX_MAX_KEEPALIVE", "3")
+    monkeypatch.setenv("HERMES_GATEWAY_HTTPX_KEEPALIVE_EXPIRY", "1.0")
+    limits = _proxy_request_httpx_kwargs(512)["limits"]
+    assert limits.max_keepalive_connections == 3
+    assert limits.keepalive_expiry == 1.0
+    # max_connections still tracks the pool size, not the env override.
+    assert limits.max_connections == 512


### PR DESCRIPTION
Tightens keepalive eviction on the Telegram proxy-path HTTPXRequest pools so half-closed sockets stop accumulating until the process hits its fd limit.

## What does this PR do?
Behind a flaky local HTTP proxy, the Telegram adapter's general request pool accumulates hundreds of half-closed (`CLOSED`) sockets over days of operation until the process exceeds its fd budget and every `bot.send_message()` / `set_my_commands()` fails with `httpx.ConnectError: All connection attempts failed` (#31599).

Root cause: PTB's `HTTPXRequest` derives `httpx.Limits` from `connection_pool_size` but only sets `max_connections`, leaving `max_keepalive_connections` / `keepalive_expiry` at httpx's defaults (20 / 5s). Telegram is the only long-lived httpx client in the gateway *not* using the shared `platform_httpx_limits()` keepalive hardening added for the same fd-exhaustion-through-proxy class of bug in #18451 — every other persistent adapter (QQ Bot, Feishu, WeCom, DingTalk, Signal, BlueBubbles, WeCom-callback) already does.

This PR closes that gap for the proxy path: it builds the proxy-path `HTTPXRequest` pools with the shared #18451 keepalive tuning (shorter `keepalive_expiry` so idle/dead sockets drain promptly) while keeping `max_connections` at the configured pool size, so concurrent sends are unaffected and the deliberate 512-slot pool is preserved. The helper returns empty kwargs when httpx is unavailable, so `HTTPXRequest` falls back to its own limits.

## Related Issue
Refs #31599

This addresses the proxy-path keepalive accumulation (the reporter's suggested fix 1, adapted to preserve `max_connections`). The periodic general-pool drain (fix 2) and send-path heartbeat observability (fix 3) the reporter also proposed are left as follow-ups, so this is `Refs`, not `Closes`.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made
- `gateway/platforms/telegram.py`: add `_proxy_request_httpx_kwargs()` that reuses `platform_httpx_limits()` (#18451) to bound keepalive while keeping `max_connections` at the configured pool size; pass it into the proxy-path `HTTPXRequest` constructions.
- `tests/gateway/test_telegram_proxy_pool_limits.py`: regression tests asserting keepalive is tightened below httpx's 5s default, the `max_connections` ceiling is preserved, kwargs are empty when httpx is unavailable, and the shared keepalive env overrides apply.

## How to Test
1. `pytest tests/gateway/test_telegram_proxy_pool_limits.py tests/gateway/test_platform_http_client_limits.py -q` — all pass.
2. Manual: with a Telegram proxy configured, the proxy-path pools now build with the shared tighter `httpx.Limits` (`keepalive_expiry` < 5s, bounded `max_keepalive_connections`, `max_connections` still equal to `HERMES_TELEGRAM_HTTP_POOL_SIZE`), so idle/half-closed sockets through the proxy drain promptly instead of piling up as `CLOSED` fds.

## What platforms tested on
- macOS on darwin-arm64 (local): `pytest` + `ruff check` pass; the change is pure-Python httpx pool configuration with no platform-specific syscalls.

## Checklist
### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (ran the affected gateway tests)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (darwin-arm64)

### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (covered by docstrings)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (reuses existing `HERMES_GATEWAY_HTTPX_*` env overrides)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — N/A (no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

<!-- autocontrib:worker-id=issue-new-861084ba kind=pr-open -->