### PR TITLE
fix: make gateway diagnostics secret-safe

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -626,7 +626,9 @@ class DiscordAdapter(BasePlatformAdapter):
                 logger.warning("Opus codec not found — voice channel playback disabled")
 
         if not self.config.token:
-            logger.error("[%s] No bot token configured", self.name)
+            message = "Discord bot token is missing; set DISCORD_BOT_TOKEN and restart the gateway."
+            logger.error("[%s] %s", self.name, message)
+            self._set_fatal_error("discord_missing_token", message, retryable=False)
             return False
 
         try:
@@ -850,11 +852,42 @@ class DiscordAdapter(BasePlatformAdapter):
             if self._slash_commands:
                 self._register_slash_commands()
 
-            # Start the bot in background
+            # Start the bot in background and race readiness against immediate
+            # startup failure. Invalid/revoked tokens fail inside the background
+            # task before on_ready fires; waiting only on _ready_event hid that
+            # root cause behind a generic timeout and retry loop.
             self._bot_task = asyncio.create_task(self._client.start(self.config.token))
+            ready_task = asyncio.create_task(self._ready_event.wait())
+            done, pending = await asyncio.wait(
+                {ready_task, self._bot_task},
+                timeout=30,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for task in pending:
+                if task is ready_task:
+                    task.cancel()
+                    try:
+                        await task
+                    except asyncio.CancelledError:
+                        pass
 
-            # Wait for ready
-            await asyncio.wait_for(self._ready_event.wait(), timeout=30)
+            if self._bot_task in done:
+                exc = self._bot_task.exception()
+                if exc is not None:
+                    raise exc
+                if not self._ready_event.is_set():
+                    logger.error("[%s] Discord client stopped before becoming ready", self.name)
+                    self._release_platform_lock()
+                    return False
+
+            if ready_task not in done and not self._ready_event.is_set():
+                if self._bot_task and not self._bot_task.done():
+                    self._bot_task.cancel()
+                    try:
+                        await self._bot_task
+                    except asyncio.CancelledError:
+                        pass
+                raise asyncio.TimeoutError()
 
             self._running = True
             return True
@@ -864,7 +897,17 @@ class DiscordAdapter(BasePlatformAdapter):
             self._release_platform_lock()
             return False
         except Exception as e:  # pragma: no cover - defensive logging
-            logger.error("[%s] Failed to connect to Discord: %s", self.name, e, exc_info=True)
+            login_failure_type = getattr(discord, "LoginFailure", None) if discord else None
+            privileged_intents_type = getattr(discord, "PrivilegedIntentsRequired", None) if discord else None
+            nonretryable_types = tuple(
+                t for t in (login_failure_type, privileged_intents_type) if isinstance(t, type)
+            )
+            if nonretryable_types and isinstance(e, nonretryable_types):
+                message = "Discord bot token was rejected; check DISCORD_BOT_TOKEN and restart the gateway."
+                logger.error("[%s] %s", self.name, message)
+                self._set_fatal_error("discord_auth_failed", message, retryable=False)
+            else:
+                logger.error("[%s] Failed to connect to Discord: %s", self.name, e, exc_info=True)
             self._release_platform_lock()
             return False
 

--- a/plugins/web/tavily/provider.py
+++ b/plugins/web/tavily/provider.py
@@ -41,6 +41,15 @@ from agent.web_search_provider import WebSearchProvider
 logger = logging.getLogger(__name__)
 
 
+def _sanitize_tavily_error(exc: Exception) -> str:
+    """Return bounded, credential-safe Tavily diagnostics for tool users/logs."""
+    status = getattr(getattr(exc, "response", None), "status_code", None)
+    detail = f"HTTP {status}" if status else type(exc).__name__[:80]
+    if status in {401, 403}:
+        return f"Tavily request failed ({detail}); check TAVILY_API_KEY."
+    return f"Tavily request failed ({detail})."
+
+
 def _tavily_request(endpoint: str, payload: Dict[str, Any]) -> Dict[str, Any]:
     """POST to the Tavily API and return the parsed JSON response.
 
@@ -184,8 +193,9 @@ class TavilyWebSearchProvider(WebSearchProvider):
         except ValueError as exc:
             return {"success": False, "error": str(exc)}
         except Exception as exc:  # noqa: BLE001 — including httpx errors
-            logger.warning("Tavily search error: %s", exc)
-            return {"success": False, "error": f"Tavily search failed: {exc}"}
+            error = _sanitize_tavily_error(exc)
+            logger.warning("Tavily search error: %s", error)
+            return {"success": False, "error": error}
 
     def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
         """Extract content from one or more URLs via Tavily.
@@ -215,9 +225,10 @@ class TavilyWebSearchProvider(WebSearchProvider):
         except ValueError as exc:
             return [{"url": u, "title": "", "content": "", "error": str(exc)} for u in urls]
         except Exception as exc:  # noqa: BLE001
-            logger.warning("Tavily extract error: %s", exc)
+            error = _sanitize_tavily_error(exc)
+            logger.warning("Tavily extract error: %s", error)
             return [
-                {"url": u, "title": "", "content": "", "error": f"Tavily extract failed: {exc}"}
+                {"url": u, "title": "", "content": "", "error": error}
                 for u in urls
             ]
 
@@ -258,14 +269,15 @@ class TavilyWebSearchProvider(WebSearchProvider):
         except ValueError as exc:
             return {"results": [{"url": url, "title": "", "content": "", "error": str(exc)}]}
         except Exception as exc:  # noqa: BLE001
-            logger.warning("Tavily crawl error: %s", exc)
+            error = _sanitize_tavily_error(exc)
+            logger.warning("Tavily crawl error: %s", error)
             return {
                 "results": [
                     {
                         "url": url,
                         "title": "",
                         "content": "",
-                        "error": f"Tavily crawl failed: {exc}",
+                        "error": error,
                     }
                 ]
             }

--- a/tests/gateway/test_discord_startup_diagnostics.py
+++ b/tests/gateway/test_discord_startup_diagnostics.py
@@ -1,0 +1,109 @@
+"""Secret-safe Discord startup diagnostics."""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from gateway.config import PlatformConfig
+from tests.gateway._plugin_adapter_loader import load_plugin_adapter
+
+
+class _FakeOpus:
+    @staticmethod
+    def is_loaded():
+        return True
+
+
+class _FakeIntents:
+    message_content = False
+    dm_messages = False
+    guild_messages = False
+    members = False
+    voice_states = False
+
+    @classmethod
+    def default(cls):
+        return cls()
+
+
+@pytest.mark.asyncio
+async def test_discord_missing_token_sets_nonretryable_fatal_error(monkeypatch):
+    discord_mod = load_plugin_adapter("discord")
+
+    monkeypatch.setattr(discord_mod, "DISCORD_AVAILABLE", True)
+    monkeypatch.setattr(
+        discord_mod,
+        "discord",
+        types.SimpleNamespace(opus=_FakeOpus()),
+    )
+
+    adapter = discord_mod.DiscordAdapter(PlatformConfig(enabled=True, token=None))
+
+    result = await adapter.connect()
+
+    assert result is False
+    assert adapter.has_fatal_error is True
+    assert adapter.fatal_error_retryable is False
+    assert adapter.fatal_error_code == "discord_missing_token"
+    assert adapter.fatal_error_message is not None
+    assert "DISCORD_BOT_TOKEN" in adapter.fatal_error_message
+
+
+@pytest.mark.asyncio
+async def test_discord_login_failure_sets_redacted_nonretryable_fatal_error(monkeypatch):
+    discord_mod = load_plugin_adapter("discord")
+
+    class FakeLoginFailure(Exception):
+        pass
+
+    class FakeBot:
+        user = object()
+
+        def __init__(self, *args, **kwargs):
+            self.tree = types.SimpleNamespace()
+
+        def event(self, func):
+            return func
+
+        async def start(self, token):
+            assert token == "super-secret-token"
+            raise FakeLoginFailure("Improper token has been passed: super-secret-token")
+
+        def is_closed(self):
+            return True
+
+    monkeypatch.setattr(discord_mod, "DISCORD_AVAILABLE", True)
+    monkeypatch.setattr(
+        discord_mod,
+        "discord",
+        types.SimpleNamespace(
+            opus=_FakeOpus(),
+            Intents=_FakeIntents,
+            LoginFailure=FakeLoginFailure,
+            PrivilegedIntentsRequired=type("PrivilegedIntentsRequired", (Exception,), {}),
+            MessageType=types.SimpleNamespace(default=0, reply=1),
+            DMChannel=type("DMChannel", (), {}),
+        ),
+    )
+    monkeypatch.setattr(discord_mod, "commands", types.SimpleNamespace(Bot=FakeBot))
+    monkeypatch.setattr(discord_mod, "_build_allowed_mentions", lambda: None)
+
+    adapter = discord_mod.DiscordAdapter(
+        PlatformConfig(enabled=True, token="super-secret-token", extra={"slash_commands": False})
+    )
+    monkeypatch.setattr(adapter, "_acquire_platform_lock", lambda *args, **kwargs: True)
+    released = {"called": False}
+    monkeypatch.setattr(adapter, "_release_platform_lock", lambda: released.__setitem__("called", True))
+
+    result = await adapter.connect()
+
+    assert result is False
+    assert adapter.has_fatal_error is True
+    assert adapter.fatal_error_retryable is False
+    assert adapter.fatal_error_code == "discord_auth_failed"
+    assert adapter.fatal_error_message is not None
+    assert "DISCORD_BOT_TOKEN" in adapter.fatal_error_message
+    assert "super-secret-token" not in adapter.fatal_error_message
+    assert released["called"] is True

--- a/tests/tools/test_web_tools_tavily.py
+++ b/tests/tools/test_web_tools_tavily.py
@@ -61,6 +61,52 @@ class TestTavilyRequest:
                 with pytest.raises(_httpx.HTTPStatusError):
                     _tavily_request("search", {"query": "test"})
 
+    def test_search_http_error_is_redacted_and_actionable(self, monkeypatch):
+        """Invalid Tavily credentials return bounded diagnostics without echoing the API key."""
+        import httpx as _httpx
+        from plugins.web.tavily.provider import TavilyWebSearchProvider
+
+        secret = "tvly-super-secret-key"
+        request = _httpx.Request("POST", "https://api.tavily.com/search")
+        response = _httpx.Response(401, request=request, text=f"bad key {secret}")
+        err = _httpx.HTTPStatusError(
+            f"401 Unauthorized for key {secret}", request=request, response=response
+        )
+
+        def fake_request(endpoint, payload):
+            raise err
+
+        monkeypatch.setattr("plugins.web.tavily.provider._tavily_request", fake_request)
+        monkeypatch.setenv("TAVILY_API_KEY", secret)
+
+        result = TavilyWebSearchProvider().search("test")
+
+        assert result["success"] is False
+        assert "TAVILY_API_KEY" in result["error"]
+        assert "401" in result["error"]
+        assert secret not in result["error"]
+        assert len(result["error"]) < 240
+
+    def test_non_http_error_uses_allowlisted_diagnostic(self, monkeypatch):
+        """Arbitrary exception strings may contain headers/bodies, so never echo them."""
+        from plugins.web.tavily.provider import TavilyWebSearchProvider
+
+        leaked = "Authorization: Bearer super-secret-token body={'api_key': 'tvly-super-secret-key'}"
+
+        def fake_request(endpoint, payload):
+            raise RuntimeError(leaked)
+
+        monkeypatch.setattr("plugins.web.tavily.provider._tavily_request", fake_request)
+        monkeypatch.setenv("TAVILY_API_KEY", "tvly-super-secret-key")
+
+        result = TavilyWebSearchProvider().search("test")
+
+        assert result["success"] is False
+        assert result["error"] == "Tavily request failed (RuntimeError)."
+        assert "super-secret-token" not in result["error"]
+        assert "tvly-super-secret-key" not in result["error"]
+        assert "Authorization" not in result["error"]
+
 
 # ─── _normalize_tavily_search_results ─────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- set non-retryable fatal diagnostics for missing/rejected Discord bot tokens without logging token values
- race Discord readiness against early bot startup failures and clean up startup tasks on timeout
- make Tavily provider errors return/log allowlisted bounded diagnostics instead of raw exception strings

## Verification
- python -m compileall -q plugins/platforms/discord/adapter.py plugins/web/tavily/provider.py tests/gateway/test_discord_startup_diagnostics.py tests/tools/test_web_tools_tavily.py
- python -m pytest tests/gateway/test_discord_startup_diagnostics.py tests/tools/test_web_tools_tavily.py tests/gateway/test_telegram_group_gating.py tests/tools/test_send_message_tool.py::TestCheckSendMessage::test_messaging_platform_session_grants_access -q -o 'addopts='
- git diff --check
- independent read-only adviser review: no blockers