### PR TITLE
fix(cli): show recap after in-session /resume + tunable recap limits

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6617,6 +6617,7 @@ class HermesCLI:
                 f" ({msg_count} user message{'s' if msg_count != 1 else ''},"
                 f" {len(self.conversation_history)} total)"
             )
+            self._display_resumed_history()
         else:
             _cprint(f"  ↻ Resumed session {target_id}{title_part} — no messages, starting fresh.")
 

--- a/cli.py
+++ b/cli.py
@@ -5088,10 +5088,13 @@ class HermesCLI:
         if self.resume_display == "minimal":
             return
 
-        MAX_DISPLAY_EXCHANGES = 10   # max user+assistant pairs to show
-        MAX_USER_LEN = 300           # truncate user messages
-        MAX_ASST_LEN = 200           # truncate assistant text
-        MAX_ASST_LINES = 3           # max lines of assistant text
+        # Read limits from config (with hardcoded defaults)
+        _disp = CLI_CONFIG.get("display", {})
+        MAX_DISPLAY_EXCHANGES = int(_disp.get("resume_exchanges", 10))
+        MAX_USER_LEN = int(_disp.get("resume_max_user_chars", 300))
+        MAX_ASST_LEN = int(_disp.get("resume_max_assistant_chars", 200))
+        MAX_ASST_LINES = int(_disp.get("resume_max_assistant_lines", 3))
+        SKIP_TOOL_ONLY = _disp.get("resume_skip_tool_only", True)
 
         # Collect displayable entries (skip system, tool-result messages)
         entries = []  # list of (role, display_text)
@@ -5153,6 +5156,10 @@ class HermesCLI:
                     full_parts.append(tc_summary)
                 if not parts:
                     # Skip pure-reasoning messages that have no visible output
+                    continue
+                # Skip tool-call-only entries when SKIP_TOOL_ONLY is enabled
+                has_text = bool(text)
+                if SKIP_TOOL_ONLY and not has_text and tool_calls:
                     continue
                 entries.append(("assistant", " ".join(parts)))
                 _last_asst_idx = len(entries) - 1

--- a/cli.py
+++ b/cli.py
@@ -415,6 +415,12 @@ def load_cli_config() -> Dict[str, Any]:
         "display": {
             "compact": False,
             "resume_display": "full",
+            # Recap tuning for /resume — see hermes_cli/config.py DEFAULT_CONFIG.
+            "resume_exchanges": 10,
+            "resume_max_user_chars": 300,
+            "resume_max_assistant_chars": 200,
+            "resume_max_assistant_lines": 3,
+            "resume_skip_tool_only": True,
             "show_reasoning": False,
             "streaming": True,
             "busy_input_mode": "interrupt",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1008,6 +1008,19 @@ DEFAULT_CONFIG = {
         "compact": False,
         "personality": "kawaii",
         "resume_display": "full",
+        # Recap tuning for /resume and startup resume. The defaults match the
+        # historical hardcoded values; expose them as config so power users can
+        # widen or tighten the snapshot to taste.
+        "resume_exchanges": 10,            # max user+assistant pairs to show
+        "resume_max_user_chars": 300,      # truncate user message text
+        "resume_max_assistant_chars": 200, # truncate non-last assistant text
+        "resume_max_assistant_lines": 3,   # truncate non-last assistant lines
+        # When True (default), assistant entries that are *only* tool calls
+        # (no visible text) are skipped in the recap. This prevents the recap
+        # from being dominated by `[2 tool calls: terminal, read_file]` lines
+        # when an exchange was tool-heavy. Set False to restore the legacy
+        # behavior of showing tool-call summaries inline.
+        "resume_skip_tool_only": True,
         "busy_input_mode": "interrupt",  # interrupt | queue | steer
         # When true, `hermes --tui` auto-resumes the most recent human-
         # facing session on launch instead of forging a fresh one.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1278,6 +1278,7 @@ AUTHOR_MAP = {
     "erik.engervall@gmail.com": "erikengervall",  # PR #28774 (firecrawl integration tag)
     "egilewski@egilewski.com": "egilewski",  # PR #30432 (MEDIA path traversal fix, GHSA-jmf9-9729-7pp8)
     "edison@mcclean.codes": "McClean-Edison",  # PR #29817 (register_auxiliary_task plugin API)
+    "zhangsamuel12@gmail.com": "SamuelZ12",  # PR #7480 (show recap after in-session resume)
 }
 
 

--- a/tests/cli/test_resume_display.py
+++ b/tests/cli/test_resume_display.py
@@ -155,13 +155,33 @@ class TestDisplayResumedHistory:
         assert "Page content" not in output
 
     def test_tool_calls_shown_as_summary(self):
-        cli = _make_cli()
+        # Disable tool-only skip so the summary line is rendered for this fixture.
+        cli = _make_cli(config_overrides={"display": {"resume_skip_tool_only": False}})
         cli.conversation_history = _tool_call_history()
-        output = self._capture_display(cli)
+        import cli as _cli_mod
+        # CLI_CONFIG is read at call-time inside _display_resumed_history, so
+        # apply the override for the duration of the capture, not just at init.
+        with patch.dict(_cli_mod.__dict__, {"CLI_CONFIG": {
+            "display": {"resume_skip_tool_only": False, "resume_display": "full"}
+        }}):
+            output = self._capture_display(cli)
 
         assert "2 tool calls" in output
         assert "web_search" in output
         assert "web_extract" in output
+
+    def test_tool_only_message_skipped_by_default(self):
+        """Assistant messages with only tool_calls (no text) are skipped when
+        resume_skip_tool_only=True (the default). The summary line is hidden.
+        """
+        cli = _make_cli()
+        cli.conversation_history = _tool_call_history()
+        output = self._capture_display(cli)
+
+        # The tool-only assistant entry should be skipped
+        assert "2 tool calls" not in output
+        # The final text reply should still appear
+        assert "Here are some great Python tutorials" in output
 
     def test_long_user_message_truncated(self):
         cli = _make_cli()
@@ -625,6 +645,8 @@ class TestHandleResumeCommandRecap:
         mock_db = MagicMock()
         mock_db.get_session.return_value = {"id": "target_session", "title": "Test Session"}
         mock_db.get_messages_as_conversation.return_value = messages
+        # resolve_resume_session_id passes the id through when no compression chain.
+        mock_db.resolve_resume_session_id.return_value = "target_session"
         cli._session_db = mock_db
 
         with (
@@ -646,6 +668,7 @@ class TestHandleResumeCommandRecap:
         mock_db = MagicMock()
         mock_db.get_session.return_value = {"id": "target_session", "title": None}
         mock_db.get_messages_as_conversation.return_value = []
+        mock_db.resolve_resume_session_id.return_value = "target_session"
         cli._session_db = mock_db
 
         with (

--- a/tests/cli/test_resume_display.py
+++ b/tests/cli/test_resume_display.py
@@ -611,6 +611,52 @@ class TestPreloadResumedSession:
         assert "1 user messages" not in output
 
 
+# ── Tests for _handle_resume_command recap display ───────────────────
+
+
+class TestHandleResumeCommandRecap:
+    """In-session /resume should show the same recap panel as startup resume."""
+
+    def test_resume_command_displays_recap_when_messages_restored(self):
+        cli = _make_cli()
+        cli.session_id = "current_session"
+        messages = _simple_history()
+
+        mock_db = MagicMock()
+        mock_db.get_session.return_value = {"id": "target_session", "title": "Test Session"}
+        mock_db.get_messages_as_conversation.return_value = messages
+        cli._session_db = mock_db
+
+        with (
+            patch("hermes_cli.main._resolve_session_by_name_or_id", return_value="target_session"),
+            patch.object(cli, "_display_resumed_history") as display_mock,
+        ):
+            cli._handle_resume_command("/resume test session")
+
+        assert cli.session_id == "target_session"
+        assert cli.conversation_history == messages
+        mock_db.end_session.assert_called_once_with("current_session", "resumed_other")
+        mock_db.reopen_session.assert_called_once_with("target_session")
+        display_mock.assert_called_once_with()
+
+    def test_resume_command_skips_recap_when_session_has_no_messages(self):
+        cli = _make_cli()
+        cli.session_id = "current_session"
+
+        mock_db = MagicMock()
+        mock_db.get_session.return_value = {"id": "target_session", "title": None}
+        mock_db.get_messages_as_conversation.return_value = []
+        cli._session_db = mock_db
+
+        with (
+            patch("hermes_cli.main._resolve_session_by_name_or_id", return_value="target_session"),
+            patch.object(cli, "_display_resumed_history") as display_mock,
+        ):
+            cli._handle_resume_command("/resume target_session")
+
+        display_mock.assert_not_called()
+
+
 # ── Integration: _init_agent skips when preloaded ────────────────────
 
 


### PR DESCRIPTION
## Summary
In-session `/resume` now shows the conversation recap that startup `--resume` already prints — closing a UX gap that 7 independent contributors filed PRs for.

## Changes
- **cli.py** — `_handle_resume_command` now calls `_display_resumed_history()` after restoring the conversation (the missing 1-line wire-up). The recap renderer skips tool-call-only assistant entries by default and reads its truncation limits from config keys instead of hardcoded constants.
- **hermes_cli/config.py + cli.py** — declare the new tuning keys in `DEFAULT_CONFIG`: `display.resume_exchanges`, `display.resume_max_user_chars`, `display.resume_max_assistant_chars`, `display.resume_max_assistant_lines`, `display.resume_skip_tool_only`.
- **tests/cli/test_resume_display.py** — 40 tests covering the recap renderer + the new wire-up. Stale fixtures updated to account for two post-PR-#7480 code paths (`SessionDB.resolve_resume_session_id` compression-chain redirect, and the new `resume_skip_tool_only` default).
- **scripts/release.py** — `AUTHOR_MAP` entry for @SamuelZ12 so CI doesn't block the salvage.

## Validation
| | Before | After |
|---|---|---|
| In-session `/resume` recap | only banner, no history shown | banner + full Rich panel with recent exchanges |
| `_display_resumed_history` tunables | 4 hardcoded constants | 5 config keys, defaults match prior behavior |
| Tool-call-only noise in recap | rendered as `[2 tool calls: ...]` lines | skipped by default (can re-enable with `display.resume_skip_tool_only: false`) |

Live E2E: constructed `HermesCLI`, called `_handle_resume_command("/resume <id>")` against a mocked SessionDB with a 5-message history, captured the Rich console output. Recap panel renders with both user and assistant entries. Targeted suite `tests/cli/test_resume_display.py` → 40/40 passing.

## Salvage notes
- Cherry-picks **#7480** (@SamuelZ12, the 1-line bug fix) and **#4434** (@ygd58, the polish: skip-tool-only + config limits) onto current main.
- Co-authorship preserved per-commit so `git log` credits both contributors.
- Once merged, this supersedes the following open PRs in the `/resume` recap cluster: **#7480, #4434, #9494, #16496, #10708, #12270, #7834, #31331**. They'll be closed pointing at this PR.

Closes #4337

## Infographic

![resume-cluster-may2026](https://v3b.fal.media/files/b/0a9b8dba/ucpCob-R0FRGUY2LPu-vU_fuesjt14.png)

This infographic covers the full /resume command cluster salvage from May 2026 — PRs #31695, #31709, and #31710. Each PR's body links to the same image because they shipped together as a coherent UX upgrade.
