### PR TITLE
fix(tools): use str on Windows pywinpty PTY write

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -293,6 +293,58 @@ class TestStdinHelpers:
         pty.sendeof.assert_called_once()
         assert result["status"] == "ok"
 
+    def test_write_stdin_pty_mode_posix_encodes_to_bytes(self, registry):
+        """POSIX ptyprocess.PtyProcess.write() expects bytes."""
+        pty = MagicMock()
+        s = _make_session()
+        s._pty = pty
+        registry._running[s.id] = s
+
+        with patch("tools.process_registry._IS_WINDOWS", False):
+            result = registry.write_stdin(s.id, "hello\n")
+
+        assert result["status"] == "ok"
+        pty.write.assert_called_once()
+        written = pty.write.call_args.args[0]
+        assert isinstance(written, bytes)
+        assert written == b"hello\n"
+
+    def test_write_stdin_pty_mode_windows_keeps_str(self, registry):
+        """Windows pywinpty.PtyProcess.write() is a PyO3 binding whose
+        signature is ``write(to_write: str) -> int`` — handing it bytes
+        raises ``"argument 'to_write': 'bytes' object cannot be converted
+        to 'PyString'"`` (#31675)."""
+        pty = MagicMock()
+        s = _make_session()
+        s._pty = pty
+        registry._running[s.id] = s
+
+        with patch("tools.process_registry._IS_WINDOWS", True):
+            result = registry.write_stdin(s.id, "hello\n")
+
+        assert result["status"] == "ok"
+        pty.write.assert_called_once()
+        written = pty.write.call_args.args[0]
+        assert isinstance(written, str)
+        assert written == "hello\n"
+
+    def test_submit_stdin_pty_mode_windows_keeps_str(self, registry):
+        """submit_stdin delegates to write_stdin — verify the same str
+        contract holds on Windows for the trailing-newline path."""
+        pty = MagicMock()
+        s = _make_session()
+        s._pty = pty
+        registry._running[s.id] = s
+
+        with patch("tools.process_registry._IS_WINDOWS", True):
+            result = registry.submit_stdin(s.id, "hello")
+
+        assert result["status"] == "ok"
+        pty.write.assert_called_once()
+        written = pty.write.call_args.args[0]
+        assert isinstance(written, str)
+        assert written == "hello\n"
+
     def test_close_stdin_allows_eof_driven_process_to_finish(self, registry, tmp_path):
         """PTY mode: writing data + sending EOF lets an EOF-driven child finish.
 

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -345,6 +345,22 @@ class TestStdinHelpers:
         assert isinstance(written, str)
         assert written == "hello\n"
 
+    def test_write_stdin_pty_returns_actual_bytes_written(self, registry):
+        """Both ptyprocess and pywinpty's ``write()`` return the count
+        actually written; prefer that over ``len(data)`` which under-
+        reports multi-byte UTF-8 on POSIX."""
+        pty = MagicMock()
+        pty.write.return_value = 7  # actual byte count from POSIX backend
+        s = _make_session()
+        s._pty = pty
+        registry._running[s.id] = s
+
+        with patch("tools.process_registry._IS_WINDOWS", False):
+            result = registry.write_stdin(s.id, "héllo")  # 6 UTF-8 bytes
+
+        assert result["status"] == "ok"
+        assert result["bytes_written"] == 7
+
     def test_close_stdin_allows_eof_driven_process_to_finish(self, registry, tmp_path):
         """PTY mode: writing data + sending EOF lets an EOF-driven child finish.
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1189,10 +1189,17 @@ class ProcessRegistry:
         if session.exited:
             return {"status": "already_exited", "error": "Process has already finished"}
 
-        # PTY mode -- write through pty handle (expects bytes)
+        # PTY mode -- write through pty handle.  POSIX ``ptyprocess`` writes
+        # bytes; Windows ``pywinpty`` is a PyO3 binding whose ``write()``
+        # signature is ``write(to_write: str) -> int`` and raises
+        # ``"argument 'to_write': 'bytes' object cannot be converted to
+        # 'PyString'"`` if handed bytes (#31675).
         if hasattr(session, '_pty') and session._pty:
             try:
-                pty_data = data.encode("utf-8") if isinstance(data, str) else data
+                if _IS_WINDOWS:
+                    pty_data = data if isinstance(data, str) else data.decode("utf-8", errors="replace")
+                else:
+                    pty_data = data.encode("utf-8") if isinstance(data, str) else data
                 session._pty.write(pty_data)
                 return {"status": "ok", "bytes_written": len(data)}
             except Exception as e:

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1193,15 +1193,23 @@ class ProcessRegistry:
         # bytes; Windows ``pywinpty`` is a PyO3 binding whose ``write()``
         # signature is ``write(to_write: str) -> int`` and raises
         # ``"argument 'to_write': 'bytes' object cannot be converted to
-        # 'PyString'"`` if handed bytes (#31675).
+        # 'PyString'"`` if handed bytes (#31675).  Both backends return the
+        # count actually written (bytes on POSIX, chars on Windows); prefer
+        # that over ``len(data)`` which under-reports multi-byte UTF-8 on
+        # POSIX.
         if hasattr(session, '_pty') and session._pty:
             try:
                 if _IS_WINDOWS:
-                    pty_data = data if isinstance(data, str) else data.decode("utf-8", errors="replace")
+                    # Strict decode: callers are typed ``data: str``; surface
+                    # contract violations rather than silently corrupting
+                    # input via ``errors="replace"``.
+                    pty_data = data if isinstance(data, str) else data.decode("utf-8")
                 else:
                     pty_data = data.encode("utf-8") if isinstance(data, str) else data
-                session._pty.write(pty_data)
-                return {"status": "ok", "bytes_written": len(data)}
+                written = session._pty.write(pty_data)
+                if not isinstance(written, int):
+                    written = len(pty_data)
+                return {"status": "ok", "bytes_written": written}
             except Exception as e:
                 return {"status": "error", "error": str(e)}
 


### PR DESCRIPTION
## What does this PR do?

`ProcessRegistry.write_stdin` unconditionally encoded user input to bytes before handing it to `session._pty.write()`. POSIX `ptyprocess.PtyProcess.write()` accepts bytes, but Windows `pywinpty` is a PyO3 binding whose signature is `write(to_write: str) -> int` and raises `"argument 'to_write': 'bytes' object cannot be converted to 'PyString'"` when given bytes. The consequence: every `process(action='write')` / `process(action='submit')` call against a PTY session on Windows/MSYS failed, blocking interactive TUIs (vim, htop, Python REPL, etc.) entirely on that platform.

Branch on `_IS_WINDOWS` at the write boundary, mirroring `_pty_reader_loop` which already accepts either str or bytes from the PTY handle (`tools/process_registry.py:823`).

> Audited siblings: `submit_stdin` delegates to `write_stdin` (covered automatically); `_pty.write()` has only one call site in the codebase (verified with `rg "_pty\.write|pty\.write" tools/ hermes_cli/`). No widening needed.

## Related Issue

Fixes #31675

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/process_registry.py` — branch `write_stdin`'s PTY-mode encode on `_IS_WINDOWS`: bytes for POSIX `ptyprocess`, str for Windows `pywinpty`.
- `tests/tools/test_process_registry.py` — three new unit tests covering the POSIX-encodes-to-bytes path, the Windows-keeps-str path, and the Windows `submit_stdin` trailing-newline path (delegates to `write_stdin`).

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/tools/test_process_registry.py -v`
2. Regression-guard: with the production fix reverted, the two Windows tests fail with `assert isinstance(b'hello\n', str)` — mirroring the pywinpty PyO3 error exactly. With the fix applied, all 67 tests in the file pass (2.0s).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x (POSIX path); Windows path covered by mocked `_IS_WINDOWS=True` unit tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; added an in-line comment at the write site explaining the PyO3 contract for future readers
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the change itself is the cross-platform fix
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; behavior unchanged on POSIX, fixed on Windows