### PR TITLE
fix(gateway+setup): repair Matrix E2EE deps and stop Discord auto-enable (#31116, salvages #31236)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1807,22 +1807,52 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             pass
 
     # Registry-driven enable for plugin platforms.  Built-ins have explicit
-    # blocks above; plugins expose check_fn() which is the single source of
-    # truth for "are my env vars set?".  When it returns True, ensure the
-    # platform is enabled so start() will create its adapter.  Plugins that
-    # need to seed ``PlatformConfig.extra`` from env vars (e.g. Google Chat's
-    # project_id / subscription_name) can supply ``env_enablement_fn`` on
-    # their PlatformEntry — called here BEFORE adapter construction.
+    # blocks above; plugins expose two hooks with subtly different meanings:
+    #
+    #   * ``check_fn()``     — "are my Python deps importable?" (often
+    #                          lazy-installs the SDK as a side effect)
+    #   * ``is_connected()`` — "did the user actually configure me?"
+    #                          (env vars / config.yaml present)
+    #
+    # Older code here gated on ``check_fn`` alone, which silently auto-
+    # enabled any plugin whose SDK happened to be on disk — including the
+    # Discord plugin, whose ``check_fn`` lazy-installs ``discord.py`` and
+    # then returns True even when the user never set ``DISCORD_BOT_TOKEN``.
+    # The result was log-spam loops (``[Discord] No bot token configured``,
+    # repeated reconnect attempts) for users who only picked Matrix in
+    # the setup wizard. Issue #31116.
+    #
+    # Prefer ``is_connected`` when the plugin defines it — that hook
+    # matches the user-intent semantics ``hermes_cli/gateway.py``'s
+    # ``_platform_status`` already uses for the setup picker. Fall back to
+    # ``check_fn`` for plugins that haven't adopted ``is_connected`` yet,
+    # so the historic "deps installed → enable" behavior is preserved for
+    # them. Plugins that need to seed ``PlatformConfig.extra`` from env
+    # vars can still supply ``env_enablement_fn`` — called below BEFORE
+    # adapter construction.
     try:
         from hermes_cli.plugins import discover_plugins
         discover_plugins()  # idempotent
         from gateway.platform_registry import platform_registry
         for entry in platform_registry.plugin_entries():
             try:
-                if not entry.check_fn():
-                    continue
+                if entry.is_connected is not None:
+                    # Synthesize a minimal PlatformConfig matching what the
+                    # adapter would see post-load. ``is_connected`` callers
+                    # only read env vars + ``config.extra`` so a default
+                    # ``PlatformConfig(enabled=True)`` is the right input
+                    # — same shape used by ``_platform_status`` in the
+                    # setup picker (see ``hermes_cli/gateway.py``).
+                    if not entry.is_connected(PlatformConfig(enabled=True)):
+                        continue
+                else:
+                    if not entry.check_fn():
+                        continue
             except Exception as e:
-                logger.debug("check_fn for %s raised: %s", entry.name, e)
+                logger.debug(
+                    "registry-driven enable check for %s raised: %s",
+                    entry.name, e,
+                )
                 continue
             platform = Platform(entry.name)
             if platform not in config.platforms:

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1827,23 +1827,43 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # ``_platform_status`` already uses for the setup picker. Fall back to
     # ``check_fn`` for plugins that haven't adopted ``is_connected`` yet,
     # so the historic "deps installed → enable" behavior is preserved for
-    # them. Plugins that need to seed ``PlatformConfig.extra`` from env
-    # vars can still supply ``env_enablement_fn`` — called below BEFORE
-    # adapter construction.
+    # them.
+    #
+    # Ordering matters: ``env_enablement_fn`` (when present) is what seeds
+    # ``PlatformConfig.extra`` from env vars, and some plugins'
+    # ``is_connected`` hooks read those extras (e.g. Google Chat's
+    # ``_is_connected`` inspects ``config.extra["project_id"]``). So we
+    # build a CANDIDATE config first — extras seeded by
+    # ``env_enablement_fn`` — and pass that to ``is_connected``. Only
+    # commit the candidate to ``config.platforms`` if the gate passes.
     try:
         from hermes_cli.plugins import discover_plugins
         discover_plugins()  # idempotent
         from gateway.platform_registry import platform_registry
         for entry in platform_registry.plugin_entries():
+            # Build a candidate config with extras pre-seeded so plugins
+            # whose ``is_connected`` reads ``config.extra`` see the same
+            # state they will after enablement.
+            candidate = PlatformConfig(enabled=True)
+            candidate_home = None
+            if entry.env_enablement_fn is not None:
+                try:
+                    seed = entry.env_enablement_fn()
+                except Exception as e:
+                    logger.debug(
+                        "env_enablement_fn for %s raised: %s", entry.name, e
+                    )
+                    seed = None
+                if isinstance(seed, dict) and seed:
+                    # ``home_channel`` is not part of ``extra`` — set it
+                    # aside so we can wire it up as a ``HomeChannel`` only
+                    # if the gate passes.
+                    candidate_home = seed.pop("home_channel", None)
+                    candidate.extra.update(seed)
+
             try:
                 if entry.is_connected is not None:
-                    # Synthesize a minimal PlatformConfig matching what the
-                    # adapter would see post-load. ``is_connected`` callers
-                    # only read env vars + ``config.extra`` so a default
-                    # ``PlatformConfig(enabled=True)`` is the right input
-                    # — same shape used by ``_platform_status`` in the
-                    # setup picker (see ``hermes_cli/gateway.py``).
-                    if not entry.is_connected(PlatformConfig(enabled=True)):
+                    if not entry.is_connected(candidate):
                         continue
                 else:
                     if not entry.check_fn():
@@ -1854,35 +1874,26 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                     entry.name, e,
                 )
                 continue
+
             platform = Platform(entry.name)
             if platform not in config.platforms:
                 config.platforms[platform] = PlatformConfig()
             config.platforms[platform].enabled = True
-            # Seed extras from env if the plugin opted in.
-            if entry.env_enablement_fn is not None:
-                try:
-                    seed = entry.env_enablement_fn()
-                except Exception as e:
-                    logger.debug(
-                        "env_enablement_fn for %s raised: %s", entry.name, e
-                    )
-                    seed = None
-                if isinstance(seed, dict) and seed:
-                    # Extract the home_channel dict (if provided) so we wire it
-                    # up as a proper HomeChannel dataclass.  Everything else is
-                    # merged into ``extra``.
-                    home = seed.pop("home_channel", None)
-                    config.platforms[platform].extra.update(seed)
-                    if isinstance(home, dict) and home.get("chat_id"):
-                        config.platforms[platform].home_channel = HomeChannel(
-                            platform=platform,
-                            chat_id=str(home["chat_id"]),
-                            name=str(home.get("name") or "Home"),
-                            thread_id=(
-                                str(home["thread_id"])
-                                if home.get("thread_id")
-                                else None
-                            ),
-                        )
+            # Commit candidate extras + home_channel now that the gate has
+            # passed. Merge into any extras already on the platform (e.g.
+            # from earlier YAML loading) without clobbering them.
+            if candidate.extra:
+                config.platforms[platform].extra.update(candidate.extra)
+            if isinstance(candidate_home, dict) and candidate_home.get("chat_id"):
+                config.platforms[platform].home_channel = HomeChannel(
+                    platform=platform,
+                    chat_id=str(candidate_home["chat_id"]),
+                    name=str(candidate_home.get("name") or "Home"),
+                    thread_id=(
+                        str(candidate_home["thread_id"])
+                        if candidate_home.get("thread_id")
+                        else None
+                    ),
+                )
     except Exception as e:
         logger.debug("Plugin platform enable pass failed: %s", e)

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2187,29 +2187,63 @@ def _setup_matrix():
             save_env_value("MATRIX_ENCRYPTION", "true")
             print_success("E2EE enabled")
 
-        matrix_pkg = "mautrix[encryption]" if want_e2ee else "mautrix"
-        try:
-            __import__("mautrix")
-        except ImportError:
-            print_info(f"Installing {matrix_pkg}...")
-            import subprocess
-            uv_bin = shutil.which("uv")
-            if uv_bin:
-                result = subprocess.run(
-                    [uv_bin, "pip", "install", "--python", sys.executable, matrix_pkg],
-                    capture_output=True, text=True,
-                )
+        # Install the full Matrix stack via the lazy-deps allowlist so we get
+        # everything ``gateway/platforms/matrix.py`` actually imports at
+        # runtime — not just ``mautrix[encryption]``. The crypto-store path
+        # ``from mautrix.crypto.store.asyncpg import PgCryptoStore`` runs
+        # ``import asyncpg`` at module load, and ``Database.create("sqlite://")``
+        # needs ``aiosqlite`` to register the sqlite scheme. Neither is a
+        # transitive dep of the upstream ``mautrix[encryption]`` extra, so
+        # the gateway crashed at first connect with
+        # ``No module named 'asyncpg'`` even though the wizard said the
+        # install succeeded. The ``platform.matrix`` group in
+        # ``tools/lazy_deps.py`` mirrors the ``[matrix]`` extra in
+        # ``pyproject.toml`` and pulls the complete set. Issue #31116.
+        if want_e2ee:
+            try:
+                from tools.lazy_deps import ensure as _lazy_ensure, FeatureUnavailable
+            except ImportError:
+                _lazy_ensure = None
+                FeatureUnavailable = Exception  # type: ignore[assignment,misc]
+            print_info("Installing Matrix E2EE stack (mautrix[encryption], asyncpg, aiosqlite)...")
+            if _lazy_ensure is not None:
+                try:
+                    _lazy_ensure("platform.matrix", prompt=False)
+                    print_success("Matrix E2EE stack installed")
+                except FeatureUnavailable as exc:
+                    print_warning(
+                        "Install failed — run manually: "
+                        "pip install 'hermes-agent[matrix]'"
+                    )
+                    print_info(f"  Error: {str(exc).splitlines()[0]}")
             else:
-                result = subprocess.run(
-                    [sys.executable, "-m", "pip", "install", matrix_pkg],
-                    capture_output=True, text=True,
+                print_warning(
+                    "Install helper unavailable — run manually: "
+                    "pip install 'hermes-agent[matrix]'"
                 )
-            if result.returncode == 0:
-                print_success(f"{matrix_pkg} installed")
-            else:
-                print_warning(f"Install failed — run manually: pip install '{matrix_pkg}'")
-                if result.stderr:
-                    print_info(f"  Error: {result.stderr.strip().splitlines()[-1]}")
+        else:
+            try:
+                __import__("mautrix")
+            except ImportError:
+                print_info("Installing mautrix...")
+                import subprocess
+                uv_bin = shutil.which("uv")
+                if uv_bin:
+                    result = subprocess.run(
+                        [uv_bin, "pip", "install", "--python", sys.executable, "mautrix"],
+                        capture_output=True, text=True,
+                    )
+                else:
+                    result = subprocess.run(
+                        [sys.executable, "-m", "pip", "install", "mautrix"],
+                        capture_output=True, text=True,
+                    )
+                if result.returncode == 0:
+                    print_success("mautrix installed")
+                else:
+                    print_warning("Install failed — run manually: pip install mautrix")
+                    if result.stderr:
+                        print_info(f"  Error: {result.stderr.strip().splitlines()[-1]}")
 
         print()
         print_info("🔒 Security: Restrict who can use your bot")

--- a/tests/gateway/test_plugin_platform_enable_31116.py
+++ b/tests/gateway/test_plugin_platform_enable_31116.py
@@ -1,0 +1,263 @@
+"""Registry-driven plugin platform enablement gating (issue #31116).
+
+The bug: ``gateway/config.py`` auto-enabled every plugin platform whose
+``check_fn`` returned True. For Discord, ``check_fn`` lazy-installs the
+``discord.py`` SDK and *always* returns True afterwards. So a fresh
+gateway start would enable the Discord adapter even though the user
+never configured ``DISCORD_BOT_TOKEN`` or picked Discord in the setup
+wizard, producing repeating ``[Discord] No bot token configured``
+errors and 60s reconnect spam.
+
+The fix: prefer ``entry.is_connected(synthetic_cfg)`` (which checks
+actual user-intent — env vars / config.yaml) over ``entry.check_fn``
+(which only checks whether deps are installed). Plugins that haven't
+defined ``is_connected`` keep the old behavior.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Discord-specific: the original repro from the issue.
+# ---------------------------------------------------------------------------
+
+
+class TestDiscordNotEnabledWithoutToken:
+    """User picked Matrix only — Discord must stay out of config.platforms."""
+
+    def _clean_env(self, monkeypatch):
+        for v in (
+            "DISCORD_BOT_TOKEN",
+            "DISCORD_HOME_CHANNEL",
+            "DISCORD_REPLY_TO_MODE",
+        ):
+            monkeypatch.delenv(v, raising=False)
+
+    def test_no_discord_token_means_no_discord_platform(
+        self, monkeypatch, tmp_path
+    ):
+        """Pre-fix: this asserted Discord WAS in cfg.platforms (the bug).
+
+        Post-fix: the registry-driven loop consults ``is_connected``, which
+        for Discord requires ``DISCORD_BOT_TOKEN``. With no token set,
+        Discord must not show up in the loaded config.
+        """
+        self._clean_env(monkeypatch)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        from gateway.config import Platform, load_gateway_config
+
+        cfg = load_gateway_config()
+        assert Platform("discord") not in cfg.platforms, (
+            "Discord platform was auto-enabled despite no DISCORD_BOT_TOKEN. "
+            "The registry-driven enable loop is gating on check_fn (deps "
+            "available) instead of is_connected (user actually configured). "
+            "Issue #31116."
+        )
+
+    def test_discord_token_does_enable_discord_platform(
+        self, monkeypatch, tmp_path
+    ):
+        """The fallback path: when the user *has* set the token, Discord
+        must still be enabled. _apply_env_overrides handles this for
+        built-in platforms; this test pins that the Discord plugin's own
+        env-var handling continues to work alongside the new is_connected
+        gate (the env-var code at gateway/config.py:_apply_env_overrides
+        runs irrespective of the registry loop).
+        """
+        self._clean_env(monkeypatch)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "fake-token-for-test")
+
+        from gateway.config import Platform, load_gateway_config
+
+        cfg = load_gateway_config()
+        platform = Platform("discord")
+        assert platform in cfg.platforms
+        assert cfg.platforms[platform].enabled is True
+
+
+# ---------------------------------------------------------------------------
+# Behavior matrix: is_connected vs check_fn precedence.
+# ---------------------------------------------------------------------------
+
+
+class _FakeRegistry:
+    """Stub platform_registry whose plugin_entries() returns a fixture set."""
+
+    def __init__(self, entries):
+        self._entries = entries
+
+    def plugin_entries(self):
+        return list(self._entries)
+
+    def all_entries(self):  # pragma: no cover - exercised by other tests
+        return list(self._entries)
+
+
+class _FakeEntry:
+    """Subset of PlatformEntry the gating loop reads from."""
+
+    def __init__(
+        self,
+        name,
+        *,
+        check_fn,
+        is_connected=None,
+        env_enablement_fn=None,
+        apply_yaml_config_fn=None,
+    ):
+        self.name = name
+        self.check_fn = check_fn
+        self.is_connected = is_connected
+        self.env_enablement_fn = env_enablement_fn
+        self.apply_yaml_config_fn = apply_yaml_config_fn
+
+
+@pytest.fixture
+def make_fake_platform_class(monkeypatch):
+    """Patch ``gateway.config.Platform`` so unknown plugin names resolve."""
+
+    from gateway.config import Platform as _RealPlatform
+
+    def _make(extra_names):
+        class _PatchedPlatform(_RealPlatform):
+            @classmethod
+            def _missing_(cls, value):
+                if value in extra_names:
+                    # Reuse the existing _missing_ on the real enum which
+                    # creates dynamic members.
+                    return _RealPlatform._missing_(value)
+                return _RealPlatform._missing_(value)
+
+        return _PatchedPlatform
+
+    return _make
+
+
+class TestRegistryDrivenEnableGating:
+    """Black-box regression: plug a synthetic registry and watch which
+    platforms end up enabled after _apply_env_overrides."""
+
+    def _clean_discord_env(self, monkeypatch):
+        for v in ("DISCORD_BOT_TOKEN", "DISCORD_HOME_CHANNEL"):
+            monkeypatch.delenv(v, raising=False)
+
+    def test_is_connected_false_skips_enable_even_if_check_fn_true(
+        self, monkeypatch, tmp_path
+    ):
+        """The exact discord scenario: deps installed, no user config."""
+        self._clean_discord_env(monkeypatch)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        captured = {"check_fn_calls": 0, "is_connected_calls": 0}
+
+        def _check_fn():
+            captured["check_fn_calls"] += 1
+            return True  # deps available
+
+        def _is_connected(cfg):
+            captured["is_connected_calls"] += 1
+            return False  # no user config
+
+        fake = _FakeRegistry([
+            _FakeEntry(
+                "discord",
+                check_fn=_check_fn,
+                is_connected=_is_connected,
+            )
+        ])
+        import gateway.platform_registry as _pr_mod
+
+        monkeypatch.setattr(_pr_mod, "platform_registry", fake)
+
+        from gateway.config import Platform, load_gateway_config
+
+        cfg = load_gateway_config()
+
+        assert Platform("discord") not in cfg.platforms
+        assert captured["is_connected_calls"] >= 1, (
+            "is_connected must be consulted when defined"
+        )
+
+    def test_is_connected_true_enables_platform(
+        self, monkeypatch, tmp_path
+    ):
+        self._clean_discord_env(monkeypatch)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        fake = _FakeRegistry([
+            _FakeEntry(
+                "discord",
+                check_fn=lambda: True,
+                is_connected=lambda cfg: True,
+            )
+        ])
+        import gateway.platform_registry as _pr_mod
+
+        monkeypatch.setattr(_pr_mod, "platform_registry", fake)
+
+        from gateway.config import Platform, load_gateway_config
+
+        cfg = load_gateway_config()
+        assert Platform("discord") in cfg.platforms
+        assert cfg.platforms[Platform("discord")].enabled is True
+
+    def test_no_is_connected_falls_back_to_check_fn(
+        self, monkeypatch, tmp_path
+    ):
+        """Plugins predating the is_connected hook keep the old behavior:
+        ``check_fn`` decides. This pins the back-compat path."""
+        self._clean_discord_env(monkeypatch)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        # The "telegram" name happens to be a built-in Platform value; using
+        # it lets ``Platform(name)`` succeed without any extra plumbing.
+        fake = _FakeRegistry([
+            _FakeEntry(
+                "telegram",
+                check_fn=lambda: True,
+                is_connected=None,
+            )
+        ])
+        import gateway.platform_registry as _pr_mod
+
+        monkeypatch.setattr(_pr_mod, "platform_registry", fake)
+
+        from gateway.config import Platform, load_gateway_config
+
+        cfg = load_gateway_config()
+        assert Platform("telegram") in cfg.platforms
+        assert cfg.platforms[Platform("telegram")].enabled is True
+
+    def test_is_connected_raising_does_not_enable(
+        self, monkeypatch, tmp_path
+    ):
+        """Defensive: a raising is_connected must be treated as "not
+        connected" rather than crashing the gateway boot."""
+        self._clean_discord_env(monkeypatch)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        def _boom(cfg):
+            raise RuntimeError("synthetic plugin failure")
+
+        fake = _FakeRegistry([
+            _FakeEntry(
+                "discord",
+                check_fn=lambda: True,
+                is_connected=_boom,
+            )
+        ])
+        import gateway.platform_registry as _pr_mod
+
+        monkeypatch.setattr(_pr_mod, "platform_registry", fake)
+
+        from gateway.config import Platform, load_gateway_config
+
+        cfg = load_gateway_config()  # must not raise
+        assert Platform("discord") not in cfg.platforms

--- a/tests/gateway/test_plugin_platform_enable_31116.py
+++ b/tests/gateway/test_plugin_platform_enable_31116.py
@@ -261,3 +261,84 @@ class TestRegistryDrivenEnableGating:
 
         cfg = load_gateway_config()  # must not raise
         assert Platform("discord") not in cfg.platforms
+
+
+class TestEnvEnablementFnOrdering:
+    """Pin the ``env_enablement_fn`` → ``is_connected`` ordering.
+
+    Some plugins' ``is_connected`` hooks read ``config.extra`` (e.g. Google
+    Chat's ``_is_connected`` checks ``config.extra["project_id"]``). The
+    extras only get populated when ``env_enablement_fn`` runs. So the gate
+    must see a candidate config that already has the env-seeded extras —
+    otherwise plugins on env-var-only setups would be silently dropped
+    even though the user is genuinely configured.
+    """
+
+    def test_extras_seeded_before_is_connected_called(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        seen = {}
+
+        def _env_enablement():
+            return {"project_id": "p", "subscription_name": "s"}
+
+        def _is_connected(cfg):
+            # Mimic Google Chat: pass only if extras are populated.
+            seen["extra_keys"] = sorted(getattr(cfg, "extra", {}).keys())
+            extra = getattr(cfg, "extra", {}) or {}
+            return bool(extra.get("project_id") and extra.get("subscription_name"))
+
+        fake = _FakeRegistry([
+            _FakeEntry(
+                "google_chat",
+                check_fn=lambda: True,
+                is_connected=_is_connected,
+                env_enablement_fn=_env_enablement,
+            )
+        ])
+        import gateway.platform_registry as _pr_mod
+
+        monkeypatch.setattr(_pr_mod, "platform_registry", fake)
+
+        from gateway.config import Platform, load_gateway_config
+
+        cfg = load_gateway_config()
+        assert Platform("google_chat") in cfg.platforms, (
+            "is_connected was called with empty extras — extras must be "
+            "seeded by env_enablement_fn BEFORE the gate"
+        )
+        assert seen["extra_keys"] == ["project_id", "subscription_name"]
+        # And the extras must actually land on the platform config after
+        # the gate passes.
+        assert (
+            cfg.platforms[Platform("google_chat")].extra.get("project_id")
+            == "p"
+        )
+
+    def test_env_enablement_fn_not_committed_when_gate_fails(
+        self, monkeypatch, tmp_path
+    ):
+        """If ``is_connected`` returns False, extras seeded for the gate
+        must NOT leak onto ``config.platforms`` (the platform isn't
+        enabled, so its extras shouldn't be partially populated either).
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        fake = _FakeRegistry([
+            _FakeEntry(
+                "google_chat",
+                check_fn=lambda: True,
+                is_connected=lambda cfg: False,
+                env_enablement_fn=lambda: {"project_id": "p"},
+            )
+        ])
+        import gateway.platform_registry as _pr_mod
+
+        monkeypatch.setattr(_pr_mod, "platform_registry", fake)
+
+        from gateway.config import Platform, load_gateway_config
+
+        cfg = load_gateway_config()
+        assert Platform("google_chat") not in cfg.platforms

--- a/tests/hermes_cli/test_setup_matrix_e2ee_install_31116.py
+++ b/tests/hermes_cli/test_setup_matrix_e2ee_install_31116.py
@@ -1,0 +1,245 @@
+"""Setup-wizard E2EE install path (issue #31116).
+
+Pre-fix: when the user enabled E2EE, the wizard ran
+``pip install 'mautrix[encryption]'``. That extra only pulls
+``python-olm`` / ``pycryptodome`` / ``unpaddedbase64`` — *not* the two
+packages the gateway actually imports at runtime when an encrypted
+client is created:
+
+* ``asyncpg``  — ``mautrix.crypto.store.asyncpg.store`` does
+  ``from asyncpg import UniqueViolationError`` at module import time,
+  so even SQLite-backed crypto stores need it on the import path.
+* ``aiosqlite`` — ``mautrix.util.async_db.Database.create("sqlite:///…")``
+  refuses to start without it ("Unknown database scheme sqlite").
+
+The result was the gateway crashing at first connect with
+``No module named 'asyncpg'`` despite the wizard reporting
+``mautrix[encryption] installed``.
+
+Fix: route the install through ``tools.lazy_deps.ensure("platform.matrix")``,
+which mirrors the ``[matrix]`` extra in ``pyproject.toml`` and pulls
+the complete dep set.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+
+# ---------------------------------------------------------------------------
+# Lazy-deps allowlist must include the two packages that were missing.
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformMatrixLazyDepsAreComplete:
+    """Without this, the wizard fix is meaningless — ``ensure`` would
+    install whatever is in the allowlist and we'd still be missing the
+    two packages."""
+
+    def test_asyncpg_in_platform_matrix(self):
+        from tools.lazy_deps import LAZY_DEPS
+
+        specs = LAZY_DEPS["platform.matrix"]
+        names = [s.split("[")[0].split("=")[0].split(">")[0].split("<")[0]
+                 for s in specs]
+        assert "asyncpg" in names, (
+            f"platform.matrix lazy-deps must include asyncpg "
+            f"(mautrix.crypto.store.asyncpg imports it at module load). "
+            f"Got: {specs}"
+        )
+
+    def test_aiosqlite_in_platform_matrix(self):
+        from tools.lazy_deps import LAZY_DEPS
+
+        specs = LAZY_DEPS["platform.matrix"]
+        names = [s.split("[")[0].split("=")[0].split(">")[0].split("<")[0]
+                 for s in specs]
+        assert "aiosqlite" in names, (
+            f"platform.matrix lazy-deps must include aiosqlite "
+            f"(Database.create('sqlite://...') refuses to start without it). "
+            f"Got: {specs}"
+        )
+
+    def test_mautrix_encryption_in_platform_matrix(self):
+        """The original install kept mautrix[encryption] — sanity check."""
+        from tools.lazy_deps import LAZY_DEPS
+
+        specs = LAZY_DEPS["platform.matrix"]
+        assert any("mautrix" in s and "encryption" in s for s in specs), (
+            f"platform.matrix must still include mautrix[encryption]. "
+            f"Got: {specs}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Wizard install path: when E2EE is enabled, lazy_deps.ensure must be the
+# install vector (not a one-off pip subprocess that misses asyncpg/aiosqlite).
+# ---------------------------------------------------------------------------
+
+
+class TestMatrixSetupWithE2eeUsesLazyEnsure:
+    """The setup wizard's Matrix branch is the fix surface for the user."""
+
+    def _make_prompt_stack(self, answers):
+        """Returns a callable that pops answers in order."""
+        queue = list(answers)
+
+        def _prompt(label, *args, **kwargs):
+            if not queue:
+                return ""
+            return queue.pop(0)
+
+        return _prompt
+
+    def test_e2ee_enabled_calls_lazy_ensure_for_platform_matrix(
+        self, monkeypatch, tmp_path
+    ):
+        """The full path: user picks Matrix, enters a token, says yes to
+        E2EE → wizard must call ``tools.lazy_deps.ensure('platform.matrix')``
+        rather than its old custom subprocess that only installed
+        ``mautrix[encryption]``."""
+
+        # Hermes home isolation so save_env_value writes don't pollute.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        # Force a non-existing existing-token path so the wizard runs to the
+        # E2EE branch.
+        monkeypatch.setattr(
+            "hermes_cli.setup.get_env_value",
+            lambda key, default=None: None,
+        )
+
+        # Capture writes without touching the real .env.
+        saved = {}
+        monkeypatch.setattr(
+            "hermes_cli.setup.save_env_value",
+            lambda key, value: saved.setdefault(key, value) or saved.update({key: value}),
+        )
+
+        # Stub the prompts: homeserver, access-token, user-id (auto-detect),
+        # then E2EE yes, allowlist empty, home-room empty.
+        prompts = self._make_prompt_stack([
+            "https://matrix.example.org",
+            "fake-access-token",
+            "@bot:example.org",
+            "",  # allowlist
+            "",  # home room
+        ])
+        monkeypatch.setattr("hermes_cli.setup.prompt", prompts)
+
+        # E2EE = yes; reconfigure-Matrix never asked because no existing
+        # config (get_env_value returns None above).
+        yn_queue = [True]
+
+        def _yn(*args, **kwargs):
+            return yn_queue.pop(0) if yn_queue else False
+
+        monkeypatch.setattr("hermes_cli.setup.prompt_yes_no", _yn)
+
+        # No-op all the cosmetic CLI helpers so the test stays quiet.
+        for fn in (
+            "print_header",
+            "print_info",
+            "print_success",
+            "print_warning",
+        ):
+            monkeypatch.setattr(f"hermes_cli.setup.{fn}", lambda *a, **k: None)
+
+        # Stub the lazy-deps ensure call so the test doesn't actually run pip.
+        # Capture its invocations.
+        ensure_calls = []
+
+        def _fake_ensure(feature, *, prompt=True):
+            ensure_calls.append((feature, prompt))
+
+        # The wizard imports lazy_deps lazily inside the matrix branch.
+        # Inject our stub via a real module entry so the local import
+        # (`from tools.lazy_deps import ensure as ...`) picks it up.
+        import tools.lazy_deps as _ld
+
+        monkeypatch.setattr(_ld, "ensure", _fake_ensure)
+
+        from hermes_cli.setup import _setup_matrix
+
+        _setup_matrix()
+
+        assert ensure_calls, (
+            "Wizard did not call tools.lazy_deps.ensure(...) when E2EE was "
+            "enabled. With this regression the install only pulls "
+            "mautrix[encryption] and the runtime still crashes with "
+            "'No module named asyncpg'. Issue #31116."
+        )
+        feature, prompt_flag = ensure_calls[0]
+        assert feature == "platform.matrix", (
+            f"Wizard called lazy_deps.ensure({feature!r}), expected "
+            f"'platform.matrix' so asyncpg + aiosqlite come along."
+        )
+        assert prompt_flag is False, (
+            "Wizard ran lazy install with prompt=True; this would block on "
+            "an extra confirmation in the middle of the setup flow."
+        )
+
+        # MATRIX_ENCRYPTION must be persisted regardless of install outcome.
+        assert saved.get("MATRIX_ENCRYPTION") == "true"
+
+    def test_e2ee_install_failure_is_surfaced_not_silent(
+        self, monkeypatch, tmp_path
+    ):
+        """A FeatureUnavailable from lazy_deps must reach the user with a
+        manual-install hint — not be silently swallowed (which is what
+        led to the original ticket: install reported success but Matrix
+        was still broken)."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(
+            "hermes_cli.setup.get_env_value",
+            lambda key, default=None: None,
+        )
+        saved = {}
+        monkeypatch.setattr(
+            "hermes_cli.setup.save_env_value",
+            lambda key, value: saved.update({key: value}),
+        )
+        prompts = self._make_prompt_stack([
+            "https://matrix.example.org",
+            "fake-access-token",
+            "@bot:example.org",
+            "",
+            "",
+        ])
+        monkeypatch.setattr("hermes_cli.setup.prompt", prompts)
+
+        yn_queue = [True]
+        monkeypatch.setattr(
+            "hermes_cli.setup.prompt_yes_no",
+            lambda *a, **k: yn_queue.pop(0) if yn_queue else False,
+        )
+
+        # Capture warnings emitted by the wizard.
+        warnings = []
+        monkeypatch.setattr(
+            "hermes_cli.setup.print_warning",
+            lambda msg: warnings.append(msg),
+        )
+        for fn in ("print_header", "print_info", "print_success"):
+            monkeypatch.setattr(f"hermes_cli.setup.{fn}", lambda *a, **k: None)
+
+        import tools.lazy_deps as _ld
+
+        def _fake_ensure_fail(feature, *, prompt=True):
+            raise _ld.FeatureUnavailable(
+                feature,
+                ("asyncpg==0.31.0",),
+                "pip install failed: simulated PyPI 503",
+            )
+
+        monkeypatch.setattr(_ld, "ensure", _fake_ensure_fail)
+
+        from hermes_cli.setup import _setup_matrix
+
+        _setup_matrix()
+
+        assert any("hermes-agent[matrix]" in w for w in warnings), (
+            f"Install-failure path must print a manual-install hint. "
+            f"Got warnings: {warnings}"
+        )


### PR DESCRIPTION
Salvage of #31236 with one follow-up to fix a Google Chat regression in the original PR's design.

## Summary

Fresh installs that picked only one platform in the setup wizard (Slack-only, Matrix-only, etc.) saw two bugs from #31116:

1. **Discord auto-enables itself** with no `DISCORD_BOT_TOKEN` because the registry-driven enable loop in `gateway/config.py` gates on `check_fn()`, and Discord's `check_fn` lazy-installs `discord.py` then returns True unconditionally. Result: `[Discord] No bot token configured` reconnect spam every 60s.
2. **Matrix E2EE crashes at first connect.** The wizard ran `pip install 'mautrix[encryption]'` but the gateway's E2EE path needs `asyncpg` and `aiosqlite` (neither is in the upstream extra). `No module named 'asyncpg'` on every reconnect.

## Changes

- `gateway/config.py` — registry enable loop now consults `entry.is_connected(candidate_cfg)` instead of `entry.check_fn()`, falling back to `check_fn` for plugins predating the hook. (#31236 by @xxxigm)
- `hermes_cli/setup.py` — Matrix E2EE branch installs via `tools.lazy_deps.ensure("platform.matrix")` which mirrors the `[matrix]` extra in `pyproject.toml`. (#31236 by @xxxigm)
- `gateway/config.py` — **follow-up:** build a candidate `PlatformConfig` and run `env_enablement_fn` to seed its extras BEFORE calling `is_connected`, then commit extras to the platform only if the gate passes. Without this, Google Chat's `_is_connected` (which reads `config.extra["project_id"]`) silently fails to enable on env-var-only setups even though the user is configured.
- 2 new regression tests pin the ordering and the don't-leak-extras-on-fail invariant.

## Validation

```
20 files, 876 tests passed, 0 failed
  tests/gateway/test_plugin_platform_enable_31116.py  (8 — includes 2 new)
  tests/hermes_cli/test_setup_matrix_e2ee_install_31116.py
  tests/gateway/{test_matrix,test_google_chat,test_ntfy_plugin,test_simplex_plugin,test_discord_connect,test_telegram_group_gating,test_signal,test_mattermost,test_bluebubbles,test_msgraph_webhook,test_sms}.py
  tests/hermes_cli/{test_gateway_platform_gating,test_setup_matrix_e2ee,test_setup,test_setup_openclaw_migration,test_setup_irc,test_setup_reconfigure}.py
  tests/tools/test_lazy_deps.py

+ adjacent sweep: tests/gateway/{test_config,test_platform_registry,test_irc_adapter,test_line_plugin,test_teams}.py
  → 300 tests, 0 failed
```

E2E confirmed live (isolated HERMES_HOME):

| scenario | result |
|---|---|
| Slack-only install, Discord SDK installed, no `DISCORD_BOT_TOKEN` | Discord stays OUT of `config.platforms` |
| Google Chat env vars set (`GOOGLE_CHAT_PROJECT_ID` + `GOOGLE_CHAT_SUBSCRIPTION_NAME`) | enables with extras seeded |
| Discord token set | enables |

## Credit

xxxigm authored the four substantive commits (cherry-picked with original authorship). I added one follow-up to fix the Google Chat ordering regression.

Closes #31116