### PR TITLE
fix: strip base64 image blobs from session DB to prevent context overflow

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1409,6 +1409,52 @@ class SessionDB:
     _CONTENT_JSON_PREFIX = "\x00json:"
 
     @classmethod
+    def _strip_image_blobs(cls, content: Any) -> Any:
+        """Replace base64 data-URL blobs in multimodal content with a short placeholder.
+
+        When a user sends an image (especially an uncompressed photo-as-file),
+        the native-vision path encodes it as a ``data:image/...;base64,...`` URL
+        and stores the whole blob in the ``image_url`` part of the content list.
+        Re-loading that blob on every subsequent turn can push the outgoing
+        API request far past provider body-size or context-window limits
+        ("session overflow").
+
+        The local file path is already annotated in the companion ``text`` part
+        (``[Image attached at: /path/to/cached.jpg]``), so the model and any
+        tools that need the image can re-read it from disk via ``vision_analyze``
+        or similar.  The blob itself adds no value once the turn is persisted.
+
+        Only ``data:`` URLs are stripped; plain ``https://`` URLs (Telegram CDN
+        etc.) are left intact because they are tiny strings.
+        """
+        if not isinstance(content, list):
+            return content
+        if not any(
+            isinstance(p, dict)
+            and p.get("type") == "image_url"
+            and isinstance(p.get("image_url"), dict)
+            and str(p["image_url"].get("url", "")).startswith("data:")
+            for p in content
+        ):
+            return content  # fast path — nothing to strip
+
+        new_parts: list = []
+        for p in content:
+            if (
+                isinstance(p, dict)
+                and p.get("type") == "image_url"
+                and isinstance(p.get("image_url"), dict)
+                and str(p["image_url"].get("url", "")).startswith("data:")
+            ):
+                new_parts.append({
+                    "type": "text",
+                    "text": "[Attached image — base64 stripped for storage; re-read from the path above if needed]",
+                })
+            else:
+                new_parts.append(p)
+        return new_parts
+
+    @classmethod
     def _encode_content(cls, content: Any) -> Any:
         """Serialize structured (list/dict) message content for sqlite.
 
@@ -1418,12 +1464,20 @@ class SessionDB:
         raises ``ProgrammingError: Error binding parameter N: type 'list' is
         not supported`` when bound directly.
 
+        Base64 image blobs are stripped before serialisation via
+        :meth:`_strip_image_blobs` so that large uncompressed images (e.g.
+        photos sent as files) cannot accumulate in the session DB and overflow
+        subsequent API requests.  The local cache path is already present in the
+        companion ``text`` part, so the model can re-access the image on demand.
+
         Returns the value unchanged when it's already a safe scalar, or a
         sentinel-prefixed JSON string for lists/dicts. Paired with
         :meth:`_decode_content` on read.
         """
         if content is None or isinstance(content, (str, bytes, int, float)):
             return content
+        if isinstance(content, list):
+            content = cls._strip_image_blobs(content)
         try:
             return cls._CONTENT_JSON_PREFIX + json.dumps(content)
         except (TypeError, ValueError):

--- a/tests/gateway/test_session_db_strip_image_blobs.py
+++ b/tests/gateway/test_session_db_strip_image_blobs.py
@@ -1,0 +1,141 @@
+"""Tests for SessionDB._strip_image_blobs and the _encode_content integration.
+
+Sending a photo as a file (uncompressed document) used to persist the full
+base64 data URL blob in the session DB, which caused every subsequent turn to
+re-inject several MB of image data into the conversation history and overflow
+the context window.  _strip_image_blobs() is called by _encode_content() to
+strip data: blobs before persistence, replacing them with a short placeholder.
+The local path hint in the companion text part remains intact so the model can
+re-access the image via vision_analyze or similar tools.
+"""
+
+import json
+import pytest
+from hermes_state import SessionDB
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+PLACEHOLDER = "[Attached image — base64 stripped for storage; re-read from the path above if needed]"
+PREFIX = SessionDB._CONTENT_JSON_PREFIX
+
+DATA_URL = "data:image/png;base64," + "A" * 100  # fake base64 blob
+HTTPS_URL = "https://cdn.example.com/photo.jpg"
+
+
+def _img_part(url: str) -> dict:
+    return {"type": "image_url", "image_url": {"url": url}}
+
+
+def _text_part(text: str) -> dict:
+    return {"type": "text", "text": text}
+
+
+# ── _strip_image_blobs ────────────────────────────────────────────────────────
+
+
+class TestStripImageBlobs:
+    def test_scalar_passthrough(self):
+        assert SessionDB._strip_image_blobs("hello") == "hello"
+        assert SessionDB._strip_image_blobs(None) is None
+        assert SessionDB._strip_image_blobs(42) == 42
+
+    def test_no_images_unchanged(self):
+        parts = [_text_part("just text")]
+        assert SessionDB._strip_image_blobs(parts) is parts  # identity
+
+    def test_https_url_unchanged(self):
+        parts = [_text_part("caption"), _img_part(HTTPS_URL)]
+        result = SessionDB._strip_image_blobs(parts)
+        assert result is parts  # no copy needed
+
+    def test_data_url_replaced(self):
+        parts = [
+            _text_part("[Image attached at: /tmp/img.png]"),
+            _img_part(DATA_URL),
+        ]
+        result = SessionDB._strip_image_blobs(parts)
+        assert result is not parts
+        assert len(result) == 2
+        assert result[0] == _text_part("[Image attached at: /tmp/img.png]")
+        assert result[1] == {"type": "text", "text": PLACEHOLDER}
+
+    def test_multiple_data_urls_all_replaced(self):
+        parts = [
+            _text_part("two images"),
+            _img_part(DATA_URL),
+            _img_part("data:image/jpeg;base64," + "B" * 50),
+        ]
+        result = SessionDB._strip_image_blobs(parts)
+        assert len(result) == 3
+        for part in result[1:]:
+            assert part == {"type": "text", "text": PLACEHOLDER}
+
+    def test_mixed_data_and_https_urls(self):
+        """data: blobs stripped; https: URLs left intact."""
+        parts = [
+            _text_part("mixed"),
+            _img_part(DATA_URL),
+            _img_part(HTTPS_URL),
+        ]
+        result = SessionDB._strip_image_blobs(parts)
+        assert result[1] == {"type": "text", "text": PLACEHOLDER}
+        assert result[2] == _img_part(HTTPS_URL)
+
+    def test_input_not_mutated(self):
+        original_url = DATA_URL
+        parts = [_text_part("x"), _img_part(original_url)]
+        _ = SessionDB._strip_image_blobs(parts)
+        # original list unchanged
+        assert parts[1]["image_url"]["url"] == original_url
+
+    def test_idempotent(self):
+        """Calling twice on already-stripped content is a no-op (fast path)."""
+        parts = [_text_part("x"), _img_part(DATA_URL)]
+        first = SessionDB._strip_image_blobs(parts)
+        second = SessionDB._strip_image_blobs(first)
+        assert second is first  # identity — fast path triggered
+
+
+# ── _encode_content integration ───────────────────────────────────────────────
+
+
+class TestEncodeContentStripsBlobs:
+    def test_scalar_passthrough(self):
+        assert SessionDB._encode_content("hello") == "hello"
+        assert SessionDB._encode_content(None) is None
+
+    def test_data_url_stripped_in_encoded_json(self):
+        parts = [
+            _text_part("[Image attached at: /tmp/a.jpg]"),
+            _img_part(DATA_URL),
+        ]
+        encoded = SessionDB._encode_content(parts)
+        assert isinstance(encoded, str)
+        assert encoded.startswith(PREFIX)
+        decoded = json.loads(encoded[len(PREFIX):])
+        # blob must not appear in the stored JSON
+        assert DATA_URL not in encoded
+        assert decoded[1] == {"type": "text", "text": PLACEHOLDER}
+
+    def test_https_url_preserved_in_encoded_json(self):
+        parts = [_text_part("caption"), _img_part(HTTPS_URL)]
+        encoded = SessionDB._encode_content(parts)
+        decoded = json.loads(encoded[len(PREFIX):])
+        assert decoded[1] == _img_part(HTTPS_URL)
+
+    def test_roundtrip_decode_has_no_blob(self):
+        """encode → decode must never restore a base64 blob."""
+        parts = [
+            _text_part("[Image attached at: /tmp/b.png]"),
+            _img_part(DATA_URL),
+        ]
+        encoded = SessionDB._encode_content(parts)
+        decoded = SessionDB._decode_content(encoded)
+        assert isinstance(decoded, list)
+        # The image_url part is gone; only placeholder text remains
+        urls = [
+            p.get("image_url", {}).get("url", "")
+            for p in decoded
+            if isinstance(p, dict) and p.get("type") == "image_url"
+        ]
+        assert not any(u.startswith("data:") for u in urls)


### PR DESCRIPTION
## Problem

Sending a photo as an **uncompressed file** (document) in Telegram caused session context overflow. The native-vision path encodes the image as a `data:image/...;base64,...` URL and persists it in the SQLite messages table. `get_messages_as_conversation()` decodes and re-injects the full blob on every subsequent turn, growing the outgoing API request by ~7 MB per image until the provider rejects it.

Normal compressed photos are worse than URLs but still manageable; uncompressed documents (5–20 MB originals) hit the limit quickly.

## Fix

Add `SessionDB._strip_image_blobs()`, called from `_encode_content()`, that replaces `data:` base64 blobs in multimodal content lists with a short text placeholder before the JSON is written to SQLite.

- Plain `https://` URLs (Telegram CDN etc.) are **not** affected
- The local cache path is already present in the companion `text` part (`[Image attached at: /tmp/...]`), so the model can re-read the image via `vision_analyze` if needed
- Existing sessions with blobs already stored are still handled by `_strip_historical_media` in the context compressor (existing safety net, now a last resort rather than first line of defence)

## Tests

12 new unit tests in `tests/gateway/test_session_db_strip_image_blobs.py` covering:
- scalar passthrough
- no-image fast path (identity / no copy)
- `https://` URL untouched
- single / multiple `data:` blobs replaced
- mixed `data:`/`https:` content
- input not mutated
- idempotency (double-strip is a no-op)
- `_encode_content` integration
- encode→decode roundtrip never restores a blob