### PR TITLE
Fix notification replies for inactive WebUI sessions

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -126,6 +126,50 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
 
 from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run
 
+
+def _register_notification_route_from_send_result(
+    *,
+    platform_name: str,
+    chat_id: str,
+    thread_id: Optional[str],
+    send_result,
+    job: dict,
+    origin: dict,
+) -> None:
+    """Record cron notification message ids so Telegram replies route to origin."""
+    if not send_result or not getattr(send_result, "success", True):
+        return
+    message_ids = []
+    message_id = getattr(send_result, "message_id", None)
+    if message_id is not None:
+        message_ids.append(str(message_id))
+    raw = getattr(send_result, "raw_response", None)
+    if isinstance(raw, dict):
+        for mid in raw.get("message_ids") or []:
+            if mid is not None:
+                message_ids.append(str(mid))
+    if not message_ids:
+        return
+    try:
+        from gateway.notification_routes import register_outbound_notification
+
+        route = {
+            "kind": "cron_delivery",
+            "job_id": job.get("id"),
+            "state": "delivered",
+            "source": origin,
+        }
+        register_outbound_notification(
+            platform=platform_name,
+            chat_id=chat_id,
+            thread_id=thread_id,
+            message_ids=message_ids,
+            route=route,
+        )
+    except Exception as exc:
+        logger.debug("Job '%s': failed to register notification route: %s", job.get("id", "?"), exc)
+
+
 # Sentinel: when a cron agent has nothing new to report, it can start its
 # response with this marker to suppress delivery.  Output is still saved
 # locally for audit.
@@ -695,7 +739,16 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                                 job["id"], platform_name, chat_id, err,
                             )
                             adapter_ok = False  # fall through to standalone path
-                        elif (
+                        else:
+                            _register_notification_route_from_send_result(
+                                platform_name=platform_name,
+                                chat_id=chat_id,
+                                thread_id=thread_id,
+                                send_result=send_result,
+                                job=job,
+                                origin=origin,
+                            )
+                        if (
                             send_result
                             and thread_id
                             and getattr(send_result, "raw_response", None)

--- a/gateway/notification_routes.py
+++ b/gateway/notification_routes.py
@@ -84,6 +84,11 @@ def build_webui_session_url(session_id: Optional[str] = None) -> Optional[str]:
 
     Returns None instead of inventing a link when session id, host, or port is
     unavailable.
+
+    The path is ``/chat?resume=<session_id>`` — the same deep link the WebUI's
+    Sessions page uses to resume a session in its embedded TUI. The earlier
+    ``/session/<id>`` shape does not exist as a React route, so the WebUI's
+    catch-all redirected the user to ``/sessions`` instead of the actual chat.
     """
     sid = (session_id or os.getenv("HERMES_SESSION_ID") or "").strip()
     if not sid:
@@ -96,14 +101,14 @@ def build_webui_session_url(session_id: Optional[str] = None) -> Optional[str]:
         or ""
     ).strip()
     if base:
-        return f"{base.rstrip('/')}/session/{encoded}"
+        return f"{base.rstrip('/')}/chat?resume={encoded}"
     port = (os.getenv("HERMES_WEBUI_PORT") or "").strip()
     if not port:
         return None
     host = _detect_server_ip()
     if not host:
         return None
-    return f"http://{host}:{port}/session/{encoded}"
+    return f"http://{host}:{port}/chat?resume={encoded}"
 
 
 def _load_state() -> Dict[str, Any]:

--- a/gateway/notification_routes.py
+++ b/gateway/notification_routes.py
@@ -1,0 +1,310 @@
+"""Durable routing index for replies to outbound gateway notifications.
+
+Notifications from cron/background/watchers are delivered into a platform chat,
+but user replies should often continue the originating session/process rather
+than create a new delivery-chat workflow.  This module stores only routing-safe
+metadata under HERMES_HOME; it intentionally does not persist notification body
+text or secrets.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import time
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping, Optional
+from urllib.parse import quote
+
+from hermes_constants import get_hermes_home
+
+from .config import Platform
+from .session import SessionSource
+
+_DEFAULT_TTL_SECONDS = 30 * 60
+_CONTEXTUAL_PREFIXES = (
+    "ok",
+    "okay",
+    "ок",
+    "окей",
+    "да",
+    "yes",
+    "yep",
+    "продолж",
+    "continue",
+    "go on",
+    "проверь",
+    "check",
+    "останов",
+    "stop",
+    "отмени",
+    "cancel",
+    "сделай",
+    "do it",
+    "запусти",
+    "run",
+)
+
+
+def _hermes_home() -> Path:
+    return Path(get_hermes_home())
+
+
+def _routes_path() -> Path:
+    return _hermes_home() / "gateway" / "notification_routes.json"
+
+
+def _detect_server_ip() -> Optional[str]:
+    """Best-effort externally usable server IP for WebUI link fallback."""
+    try:
+        candidates = socket.gethostbyname_ex(socket.gethostname())[2]
+    except OSError:
+        candidates = []
+    for ip in candidates:
+        if not ip.startswith("127.") and not ip.startswith("169.254."):
+            return ip
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            sock.connect(("8.8.8.8", 80))
+            ip = sock.getsockname()[0]
+            if ip and not ip.startswith("127."):
+                return ip
+    except OSError:
+        return None
+    return None
+
+
+def build_webui_session_url(session_id: Optional[str] = None) -> Optional[str]:
+    """Build a direct WebUI chat/session URL when enough runtime data exists.
+
+    Priority:
+    1. Explicit public/base URL: HERMES_WEBUI_PUBLIC_URL or HERMES_WEBUI_BASE_URL.
+    2. Runtime fallback: detected server IP + HERMES_WEBUI_PORT.
+
+    Returns None instead of inventing a link when session id, host, or port is
+    unavailable.
+    """
+    sid = (session_id or os.getenv("HERMES_SESSION_ID") or "").strip()
+    if not sid:
+        return None
+    encoded = quote(sid, safe="")
+    base = (
+        os.getenv("HERMES_WEBUI_PUBLIC_URL")
+        or os.getenv("HERMES_WEBUI_BASE_URL")
+        or os.getenv("WEBUI_PUBLIC_URL")
+        or ""
+    ).strip()
+    if base:
+        return f"{base.rstrip('/')}/session/{encoded}"
+    port = (os.getenv("HERMES_WEBUI_PORT") or "").strip()
+    if not port:
+        return None
+    host = _detect_server_ip()
+    if not host:
+        return None
+    return f"http://{host}:{port}/session/{encoded}"
+
+
+def _load_state() -> Dict[str, Any]:
+    path = _routes_path()
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except FileNotFoundError:
+        return {"messages": {}, "latest_by_scope": {}}
+    except (OSError, json.JSONDecodeError):
+        return {"messages": {}, "latest_by_scope": {}}
+    if not isinstance(data, dict):
+        return {"messages": {}, "latest_by_scope": {}}
+    data.setdefault("messages", {})
+    data.setdefault("latest_by_scope", {})
+    return data
+
+
+def _save_state(state: Mapping[str, Any]) -> None:
+    path = _routes_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as fh:
+        json.dump(state, fh, ensure_ascii=False, sort_keys=True, indent=2)
+    tmp.replace(path)
+
+
+def _norm(value: Any) -> str:
+    return "" if value is None else str(value)
+
+
+def _message_key(platform: str, chat_id: Any, message_id: Any, thread_id: Any = None) -> str:
+    return f"{_norm(platform)}:{_norm(chat_id)}:{_norm(thread_id)}:{_norm(message_id)}"
+
+
+def _scope_key(platform: str, chat_id: Any, thread_id: Any = None) -> str:
+    return f"{_norm(platform)}:{_norm(chat_id)}:{_norm(thread_id)}"
+
+
+def _source_from_route(route: Mapping[str, Any]) -> Optional[SessionSource]:
+    raw = route.get("source")
+    if not isinstance(raw, Mapping):
+        return None
+    data = dict(raw)
+    if "platform" in data and not isinstance(data["platform"], Platform):
+        data["platform"] = str(data["platform"])
+    try:
+        return SessionSource.from_dict(data)
+    except Exception:
+        return None
+
+
+def _sanitize_route(route: Mapping[str, Any]) -> Dict[str, Any]:
+    clean: Dict[str, Any] = {}
+    for key in ("kind", "session_key", "session_id", "job_id", "process_id", "repo", "branch", "issue", "pr", "state"):
+        value = route.get(key)
+        if value is not None:
+            clean[key] = str(value)
+    source = route.get("source")
+    if isinstance(source, SessionSource):
+        clean["source"] = source.to_dict()
+    elif isinstance(source, Mapping):
+        allowed = {
+            "platform",
+            "chat_id",
+            "chat_name",
+            "chat_type",
+            "user_id",
+            "user_name",
+            "thread_id",
+            "chat_topic",
+            "user_id_alt",
+            "chat_id_alt",
+            "guild_id",
+            "parent_chat_id",
+        }
+        clean["source"] = {k: v for k, v in source.items() if k in allowed and v is not None}
+    return clean
+
+
+def register_outbound_notification(
+    *,
+    platform: str,
+    chat_id: Any,
+    message_ids: Iterable[Any],
+    route: Mapping[str, Any],
+    thread_id: Any = None,
+    ttl_seconds: int = _DEFAULT_TTL_SECONDS,
+    now: Optional[float] = None,
+) -> None:
+    """Register routing metadata for an actionable outbound notification."""
+    created_at = time.time() if now is None else float(now)
+    expires_at = created_at + max(1, int(ttl_seconds))
+    clean = _sanitize_route(route)
+    clean.update({"created_at": created_at, "expires_at": expires_at})
+
+    state = _load_state()
+    messages = state.setdefault("messages", {})
+    latest = state.setdefault("latest_by_scope", {})
+
+    first_key: Optional[str] = None
+    for message_id in message_ids:
+        if message_id is None:
+            continue
+        key = _message_key(platform, chat_id, message_id, thread_id)
+        messages[key] = dict(clean)
+        if first_key is None:
+            first_key = key
+    if first_key is not None:
+        latest[_scope_key(platform, chat_id, thread_id)] = first_key
+    _save_state(state)
+
+
+def _route_if_fresh(route: Mapping[str, Any], *, now: Optional[float] = None) -> Optional[Dict[str, Any]]:
+    current = time.time() if now is None else float(now)
+    try:
+        expires_at = float(route.get("expires_at", 0))
+    except (TypeError, ValueError):
+        return None
+    if expires_at < current:
+        return None
+    source = _source_from_route(route)
+    if source is None:
+        return None
+    return {"source": source, "route": dict(route)}
+
+
+def resolve_exact_reply(
+    *,
+    platform: str,
+    chat_id: Any,
+    reply_to_message_id: Any,
+    thread_id: Any = None,
+    now: Optional[float] = None,
+) -> Optional[Dict[str, Any]]:
+    if reply_to_message_id is None:
+        return None
+    state = _load_state()
+    messages = state.get("messages", {})
+    route = messages.get(_message_key(platform, chat_id, reply_to_message_id, thread_id))
+    if route is None and thread_id is not None:
+        route = messages.get(_message_key(platform, chat_id, reply_to_message_id, None))
+    if not isinstance(route, Mapping):
+        return None
+    return _route_if_fresh(route, now=now)
+
+
+def _looks_like_continuation(text: str) -> bool:
+    stripped = (text or "").strip().lower()
+    if not stripped or stripped.startswith("/"):
+        return False
+    return any(stripped.startswith(prefix) for prefix in _CONTEXTUAL_PREFIXES)
+
+
+def resolve_latest_followup(
+    *,
+    platform: str,
+    chat_id: Any,
+    text: str,
+    thread_id: Any = None,
+    now: Optional[float] = None,
+) -> Optional[Dict[str, Any]]:
+    if not _looks_like_continuation(text):
+        return None
+    state = _load_state()
+    latest = state.get("latest_by_scope", {})
+    messages = state.get("messages", {})
+    route_key = latest.get(_scope_key(platform, chat_id, thread_id))
+    if route_key is None and thread_id is not None:
+        route_key = latest.get(_scope_key(platform, chat_id, None))
+    if not route_key:
+        return None
+    route = messages.get(route_key)
+    if not isinstance(route, Mapping):
+        return None
+    return _route_if_fresh(route, now=now)
+
+
+def resolve_notification_route_for_message(
+    *,
+    platform: str,
+    chat_id: Any,
+    text: str,
+    reply_to_message_id: Any = None,
+    thread_id: Any = None,
+    now: Optional[float] = None,
+) -> Optional[Dict[str, Any]]:
+    """Resolve an inbound platform message to a notification origin if safe."""
+    exact = resolve_exact_reply(
+        platform=platform,
+        chat_id=chat_id,
+        reply_to_message_id=reply_to_message_id,
+        thread_id=thread_id,
+        now=now,
+    )
+    if exact is not None:
+        return exact
+    return resolve_latest_followup(
+        platform=platform,
+        chat_id=chat_id,
+        text=text,
+        thread_id=thread_id,
+        now=now,
+    )

--- a/gateway/notification_routes.py
+++ b/gateway/notification_routes.py
@@ -158,7 +158,20 @@ def _source_from_route(route: Mapping[str, Any]) -> Optional[SessionSource]:
 
 def _sanitize_route(route: Mapping[str, Any]) -> Dict[str, Any]:
     clean: Dict[str, Any] = {}
-    for key in ("kind", "session_key", "session_id", "job_id", "process_id", "repo", "branch", "issue", "pr", "state"):
+    for key in (
+        "kind",
+        "session_key",
+        "session_id",
+        "api_session_id",
+        "webui_url",
+        "job_id",
+        "process_id",
+        "repo",
+        "branch",
+        "issue",
+        "pr",
+        "state",
+    ):
         value = route.get(key)
         if value is not None:
             clean[key] = str(value)
@@ -226,9 +239,12 @@ def _route_if_fresh(route: Mapping[str, Any], *, now: Optional[float] = None) ->
     if expires_at < current:
         return None
     source = _source_from_route(route)
-    if source is None:
+    if source is None and not route.get("api_session_id"):
         return None
-    return {"source": source, "route": dict(route)}
+    result: Dict[str, Any] = {"route": dict(route)}
+    if source is not None:
+        result["source"] = source
+    return result
 
 
 def resolve_exact_reply(

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -662,6 +662,11 @@ class APIServerAdapter(BasePlatformAdapter):
         # Active run agent/task references for stop support
         self._active_run_agents: Dict[str, Any] = {}
         self._active_run_tasks: Dict[str, "asyncio.Task"] = {}
+        # Active API/WebUI session -> current run/agent. Telegram notification
+        # replies use this to inject guidance into the origin process instead
+        # of spawning a competing run on the same session.
+        self._active_session_agents: Dict[str, Any] = {}
+        self._active_session_run_ids: Dict[str, str] = {}
         # Pollable run status for dashboards and external control-plane UIs.
         self._run_statuses: Dict[str, Dict[str, Any]] = {}
         # Active approval session key for each run_id.  The approval core
@@ -2859,6 +2864,47 @@ class APIServerAdapter(BasePlatformAdapter):
 
         return _callback
 
+    def _steer_active_session(self, session_id: str, text: str) -> tuple[bool, Optional[str]]:
+        """Inject text into the currently running API/WebUI agent for session_id."""
+        sid = str(session_id or "").strip()
+        if not sid or not text or not str(text).strip():
+            return False, None
+        agent = getattr(self, "_active_session_agents", {}).get(sid)
+        if agent is None:
+            return False, None
+        try:
+            accepted = bool(agent.steer(str(text)))
+        except Exception:
+            logger.exception("[api_server] active-session steer failed for %s", sid)
+            return False, None
+        if not accepted:
+            return False, None
+        return True, getattr(self, "_active_session_run_ids", {}).get(sid)
+
+    async def _handle_steer_session(self, request: "web.Request") -> "web.Response":
+        """POST /v1/sessions/{session_id}/steer — inject into active origin run."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        session_id = request.match_info.get("session_id", "")
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response(_openai_error("Invalid JSON"), status=400)
+        raw_input = body.get("input") or body.get("text") or body.get("message")
+        if not raw_input:
+            return web.json_response(_openai_error("Missing 'input' field"), status=400)
+        accepted, run_id = self._steer_active_session(session_id, str(raw_input))
+        if not accepted:
+            return web.json_response(
+                _openai_error(f"No active run for session: {session_id}", code="session_not_active"),
+                status=404,
+            )
+        return web.json_response(
+            {"object": "hermes.session.steer", "status": "accepted", "session_id": session_id, "run_id": run_id},
+            status=202,
+        )
+
     async def _handle_runs(self, request: "web.Request") -> "web.Response":
         """POST /v1/runs — start an agent run, return run_id immediately."""
         auth_err = self._check_auth(request)
@@ -2983,6 +3029,8 @@ class APIServerAdapter(BasePlatformAdapter):
                     gateway_session_key=gateway_session_key,
                 )
                 self._active_run_agents[run_id] = agent
+                self._active_session_agents[session_id] = agent
+                self._active_session_run_ids[session_id] = run_id
 
                 def _approval_notify(approval_data: Dict[str, Any]) -> None:
                     event = dict(approval_data or {})
@@ -3135,6 +3183,9 @@ class APIServerAdapter(BasePlatformAdapter):
                     pass
                 self._active_run_agents.pop(run_id, None)
                 self._active_run_tasks.pop(run_id, None)
+                if self._active_session_run_ids.get(session_id) == run_id:
+                    self._active_session_run_ids.pop(session_id, None)
+                    self._active_session_agents.pop(session_id, None)
                 self._run_approval_sessions.pop(run_id, None)
 
         task = asyncio.create_task(_run_and_close())
@@ -3417,6 +3468,7 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_post("/api/jobs/{job_id}/run", self._handle_run_job)
             # Structured event streaming
             self._app.router.add_post("/v1/runs", self._handle_runs)
+            self._app.router.add_post("/v1/sessions/{session_id}/steer", self._handle_steer_session)
             self._app.router.add_get("/v1/runs/{run_id}", self._handle_get_run)
             self._app.router.add_get("/v1/runs/{run_id}/events", self._handle_run_events)
             self._app.router.add_post("/v1/runs/{run_id}/approval", self._handle_run_approval)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -18,7 +18,7 @@ import sys
 import time
 import uuid
 from abc import ABC, abstractmethod
-from urllib.parse import urlsplit
+from urllib.parse import quote, urlsplit
 
 from utils import normalize_proxy_url
 
@@ -3203,39 +3203,52 @@ class BasePlatformAdapter(ABC):
         else:
             text = f"[Telegram semantic follow-up to Hermes notification]\n\n{text}"
 
-        def _start_api_run() -> tuple[bool, str]:
+        def _post_origin_turn() -> tuple[bool, str, bool]:
             import json as _json
             import os as _os
             import urllib.error as _urlerr
             import urllib.request as _urlreq
             api_key = (_os.getenv("API_SERVER_KEY") or _os.getenv("HERMES_API_SERVER_KEY") or "").strip()
             port = (_os.getenv("API_SERVER_PORT") or "8642").strip()
-            payload = _json.dumps({
-                "input": text,
-                "session_id": api_session_id,
-                "model": "Hermes Agent",
-            }).encode("utf-8")
             headers = {"Content-Type": "application/json", "X-Hermes-Session-Id": api_session_id}
             if api_key:
                 headers["Authorization"] = f"Bearer {api_key}"
-            req = _urlreq.Request(f"http://127.0.0.1:{port}/v1/runs", data=payload, headers=headers, method="POST")
-            try:
-                # /v1/runs is the enqueue/start endpoint: it returns 202 as
-                # soon as the origin API/WebUI session has accepted the user
-                # turn.  Do not wait for the agent's final answer here; long
-                # tasks should keep running in the origin process and report
-                # via its normal WebUI/status channels.
-                with _urlreq.urlopen(req, timeout=10) as resp:
+
+            def _request(url: str, payload: dict, timeout: float) -> tuple[int, str]:
+                data = _json.dumps(payload).encode("utf-8")
+                req = _urlreq.Request(url, data=data, headers=headers, method="POST")
+                with _urlreq.urlopen(req, timeout=timeout) as resp:
                     body = resp.read(1000).decode("utf-8", "replace")
                     status = int(getattr(resp, "status", 200) or 200)
-                    return 200 <= status < 300, body
+                    return status, body
+
+            steer_url = f"http://127.0.0.1:{port}/v1/sessions/{quote(api_session_id, safe='')}/steer"
+            try:
+                status, body = _request(steer_url, {"input": text}, timeout=5)
+                if 200 <= status < 300:
+                    return True, body, True
+            except _urlerr.HTTPError as exc:
+                if exc.code not in {404, 409}:
+                    body = exc.read(1000).decode("utf-8", "replace") if exc.fp else ""
+                    return False, f"HTTP {exc.code}: {body[:500]}", False
+            except Exception as exc:
+                return False, f"{type(exc).__name__}: {str(exc)[:500]}", False
+
+            runs_url = f"http://127.0.0.1:{port}/v1/runs"
+            try:
+                status, body = _request(
+                    runs_url,
+                    {"input": text, "session_id": api_session_id, "model": "Hermes Agent"},
+                    timeout=10,
+                )
+                return 200 <= status < 300, body, False
             except _urlerr.HTTPError as exc:
                 body = exc.read(1000).decode("utf-8", "replace") if exc.fp else ""
-                return False, f"HTTP {exc.code}: {body[:500]}"
+                return False, f"HTTP {exc.code}: {body[:500]}", False
             except Exception as exc:
-                return False, f"{type(exc).__name__}: {str(exc)[:500]}"
+                return False, f"{type(exc).__name__}: {str(exc)[:500]}", False
 
-        ok, detail = await asyncio.to_thread(_start_api_run)
+        ok, detail, steered_active = await asyncio.to_thread(_post_origin_turn)
         if ok:
             run_id = ""
             try:
@@ -3244,7 +3257,10 @@ class BasePlatformAdapter(ABC):
                     run_id = str(parsed.get("run_id") or "").strip()
             except Exception:
                 run_id = ""
-            msg = "Reply delivered to the origin WebUI chat and processing started."
+            if steered_active:
+                msg = "Reply delivered to the active origin WebUI run."
+            else:
+                msg = "Reply delivered to the origin WebUI chat and processing started."
             if run_id:
                 msg += f"\nRun: `{run_id}`"
             if webui_url:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3203,7 +3203,7 @@ class BasePlatformAdapter(ABC):
         else:
             text = f"[Telegram semantic follow-up to Hermes notification]\n\n{text}"
 
-        def _post_to_api() -> tuple[bool, str]:
+        def _start_api_run() -> tuple[bool, str]:
             import json as _json
             import os as _os
             import urllib.error as _urlerr
@@ -3211,26 +3211,42 @@ class BasePlatformAdapter(ABC):
             api_key = (_os.getenv("API_SERVER_KEY") or _os.getenv("HERMES_API_SERVER_KEY") or "").strip()
             port = (_os.getenv("API_SERVER_PORT") or "8642").strip()
             payload = _json.dumps({
+                "input": text,
+                "session_id": api_session_id,
                 "model": "Hermes Agent",
-                "messages": [{"role": "user", "content": text}],
-                "stream": False,
             }).encode("utf-8")
             headers = {"Content-Type": "application/json", "X-Hermes-Session-Id": api_session_id}
             if api_key:
                 headers["Authorization"] = f"Bearer {api_key}"
-            req = _urlreq.Request(f"http://127.0.0.1:{port}/v1/chat/completions", data=payload, headers=headers, method="POST")
+            req = _urlreq.Request(f"http://127.0.0.1:{port}/v1/runs", data=payload, headers=headers, method="POST")
             try:
-                with _urlreq.urlopen(req, timeout=240) as resp:
-                    return True, resp.read(500).decode("utf-8", "replace")
+                # /v1/runs is the enqueue/start endpoint: it returns 202 as
+                # soon as the origin API/WebUI session has accepted the user
+                # turn.  Do not wait for the agent's final answer here; long
+                # tasks should keep running in the origin process and report
+                # via its normal WebUI/status channels.
+                with _urlreq.urlopen(req, timeout=10) as resp:
+                    body = resp.read(1000).decode("utf-8", "replace")
+                    status = int(getattr(resp, "status", 200) or 200)
+                    return 200 <= status < 300, body
             except _urlerr.HTTPError as exc:
                 body = exc.read(1000).decode("utf-8", "replace") if exc.fp else ""
                 return False, f"HTTP {exc.code}: {body[:500]}"
             except Exception as exc:
                 return False, f"{type(exc).__name__}: {str(exc)[:500]}"
 
-        ok, detail = await asyncio.to_thread(_post_to_api)
+        ok, detail = await asyncio.to_thread(_start_api_run)
         if ok:
-            msg = "Reply forwarded to the origin WebUI chat."
+            run_id = ""
+            try:
+                parsed = __import__("json").loads(detail or "{}")
+                if isinstance(parsed, dict):
+                    run_id = str(parsed.get("run_id") or "").strip()
+            except Exception:
+                run_id = ""
+            msg = "Reply delivered to the origin WebUI chat and processing started."
+            if run_id:
+                msg += f"\nRun: `{run_id}`"
             if webui_url:
                 msg += f"\nChat: {webui_url}"
             try:
@@ -3241,13 +3257,13 @@ class BasePlatformAdapter(ABC):
                     metadata=_thread_metadata_for_source(event.source, _reply_anchor_for_event(event)),
                 )
             except Exception:
-                logger.debug("[%s] WebUI bridge completion ack failed", self.name, exc_info=True)
+                logger.debug("[%s] WebUI bridge accepted ack failed", self.name, exc_info=True)
         else:
-            logger.warning("[%s] WebUI bridge failed: %s", self.name, detail)
+            logger.warning("[%s] WebUI bridge failed to start origin API run: %s", self.name, detail)
             try:
                 await self._send_with_retry(
                     chat_id=event.source.chat_id,
-                    content="Could not forward the reply into the WebUI chat; check gateway/API logs.",
+                    content="Could not deliver the reply into the WebUI chat; check gateway/API logs.",
                     reply_to=_reply_anchor_for_event(event),
                     metadata=_thread_metadata_for_source(event.source, _reply_anchor_for_event(event)),
                 )

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1082,6 +1082,11 @@ class MessageEvent:
     # completion notifications) that must bypass user authorization checks.
     internal: bool = False
 
+    # Metadata-only route for replies/follow-ups to outbound notifications.
+    # Used to bridge Telegram control replies into the originating WebUI/API
+    # session without treating the Telegram DM as the processing workspace.
+    notification_route: Optional[Dict[str, Any]] = None
+
     # Timestamps
     timestamp: datetime = field(default_factory=datetime.now)
     
@@ -3160,6 +3165,95 @@ class BasePlatformAdapter(ABC):
 
         await self._drain_pending_after_session_command(session_key, command_guard)
 
+    def _notification_route_webui_url(self, route: Dict[str, Any]) -> Optional[str]:
+        url = route.get("webui_url") if isinstance(route, dict) else None
+        if isinstance(url, str) and url.strip():
+            return url.strip()
+        sid = (route.get("api_session_id") or route.get("session_id")) if isinstance(route, dict) else None
+        if not sid:
+            return None
+        try:
+            from gateway.notification_routes import build_webui_session_url
+            return build_webui_session_url(str(sid))
+        except Exception:
+            return None
+
+    async def _forward_notification_reply_to_api_session(self, event: MessageEvent, route: Dict[str, Any]) -> None:
+        """Forward a notification reply/follow-up into the origin WebUI/API session."""
+        api_session_id = str(route.get("api_session_id") or route.get("session_id") or "").strip()
+        if not api_session_id:
+            return
+        webui_url = self._notification_route_webui_url(route)
+        ack = "Forwarding reply to the origin WebUI chat."
+        if webui_url:
+            ack += f"\nChat: {webui_url}"
+        try:
+            await self._send_with_retry(
+                chat_id=event.source.chat_id,
+                content=ack,
+                reply_to=_reply_anchor_for_event(event),
+                metadata=_thread_metadata_for_source(event.source, _reply_anchor_for_event(event)),
+            )
+        except Exception:
+            logger.debug("[%s] WebUI bridge ack failed", self.name, exc_info=True)
+
+        text = event.text or ""
+        if getattr(event, "reply_to_text", None):
+            text = f"[Telegram reply/follow-up to Hermes notification]\nReplying to: {event.reply_to_text[:500]}\n\n{text}"
+        else:
+            text = f"[Telegram semantic follow-up to Hermes notification]\n\n{text}"
+
+        def _post_to_api() -> tuple[bool, str]:
+            import json as _json
+            import os as _os
+            import urllib.error as _urlerr
+            import urllib.request as _urlreq
+            api_key = (_os.getenv("API_SERVER_KEY") or _os.getenv("HERMES_API_SERVER_KEY") or "").strip()
+            port = (_os.getenv("API_SERVER_PORT") or "8642").strip()
+            payload = _json.dumps({
+                "model": "Hermes Agent",
+                "messages": [{"role": "user", "content": text}],
+                "stream": False,
+            }).encode("utf-8")
+            headers = {"Content-Type": "application/json", "X-Hermes-Session-Id": api_session_id}
+            if api_key:
+                headers["Authorization"] = f"Bearer {api_key}"
+            req = _urlreq.Request(f"http://127.0.0.1:{port}/v1/chat/completions", data=payload, headers=headers, method="POST")
+            try:
+                with _urlreq.urlopen(req, timeout=240) as resp:
+                    return True, resp.read(500).decode("utf-8", "replace")
+            except _urlerr.HTTPError as exc:
+                body = exc.read(1000).decode("utf-8", "replace") if exc.fp else ""
+                return False, f"HTTP {exc.code}: {body[:500]}"
+            except Exception as exc:
+                return False, f"{type(exc).__name__}: {str(exc)[:500]}"
+
+        ok, detail = await asyncio.to_thread(_post_to_api)
+        if ok:
+            msg = "Reply forwarded to the origin WebUI chat."
+            if webui_url:
+                msg += f"\nChat: {webui_url}"
+            try:
+                await self._send_with_retry(
+                    chat_id=event.source.chat_id,
+                    content=msg,
+                    reply_to=_reply_anchor_for_event(event),
+                    metadata=_thread_metadata_for_source(event.source, _reply_anchor_for_event(event)),
+                )
+            except Exception:
+                logger.debug("[%s] WebUI bridge completion ack failed", self.name, exc_info=True)
+        else:
+            logger.warning("[%s] WebUI bridge failed: %s", self.name, detail)
+            try:
+                await self._send_with_retry(
+                    chat_id=event.source.chat_id,
+                    content="Could not forward the reply into the WebUI chat; check gateway/API logs.",
+                    reply_to=_reply_anchor_for_event(event),
+                    metadata=_thread_metadata_for_source(event.source, _reply_anchor_for_event(event)),
+                )
+            except Exception:
+                pass
+
     async def handle_message(self, event: MessageEvent) -> None:
         """
         Process an incoming message.
@@ -3172,6 +3266,11 @@ class BasePlatformAdapter(ABC):
             return
 
         coerce_plaintext_gateway_command(event)
+
+        route = getattr(event, "notification_route", None)
+        if isinstance(route, dict) and (route.get("api_session_id") or route.get("kind") == "webui_session"):
+            asyncio.create_task(self._forward_notification_reply_to_api_session(event, route))
+            return
         
         session_key = build_session_key(
             event.source,

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3274,6 +3274,19 @@ class BasePlatformAdapter(ABC):
                 )
             except Exception:
                 logger.debug("[%s] WebUI bridge accepted ack failed", self.name, exc_info=True)
+            # Inactive WebUI session fallback: the open /chat?resume tab spawns
+            # its own PTY-backed agent and does NOT subscribe to runs created by
+            # other clients. Poll /v1/runs/{run_id} to terminal status and
+            # mirror the final assistant response back to the originating chat
+            # so the human sees the answer even when nothing is watching the
+            # WebUI session live. Active-steer already streams through the
+            # WebUI, so it does not need mirroring.
+            if not steered_active and run_id:
+                await self._poll_origin_run_and_mirror(
+                    event=event,
+                    run_id=run_id,
+                    webui_url=webui_url,
+                )
         else:
             logger.warning("[%s] WebUI bridge failed to start origin API run: %s", self.name, detail)
             try:
@@ -3285,6 +3298,138 @@ class BasePlatformAdapter(ABC):
                 )
             except Exception:
                 pass
+
+    async def _poll_origin_run_and_mirror(
+        self,
+        *,
+        event: "MessageEvent",
+        run_id: str,
+        webui_url: Optional[str],
+    ) -> None:
+        """Poll a fallback /v1/runs run to completion and mirror its final response.
+
+        The fallback path (POST /v1/runs) creates a new run on an existing
+        WebUI session, but an already-open /chat?resume tab is a separate
+        PTY-backed agent process — it does not stream events from runs it did
+        not spawn. Without this mirror, the human who triggered the reply via
+        Telegram would only see the agent's answer after manually reloading
+        the WebUI session. This polls the API run and, on terminal status,
+        sends a single Telegram follow-up with the result.
+
+        Bounded by HERMES_NOTIFICATION_BRIDGE_WAIT_SECONDS (default 180,
+        clamp [0.5, 1800]) for total wait and
+        HERMES_NOTIFICATION_BRIDGE_POLL_INTERVAL (default 1.0,
+        clamp [0.05, 10.0]) for the initial poll interval (with mild
+        backoff, capped at 5s).
+        """
+        run_id = (run_id or "").strip()
+        if not run_id:
+            return
+        try:
+            timeout_s = float(os.getenv("HERMES_NOTIFICATION_BRIDGE_WAIT_SECONDS", "180") or "180")
+        except (TypeError, ValueError):
+            timeout_s = 180.0
+        timeout_s = max(0.5, min(timeout_s, 1800.0))
+        try:
+            interval_s = float(os.getenv("HERMES_NOTIFICATION_BRIDGE_POLL_INTERVAL", "1") or "1")
+        except (TypeError, ValueError):
+            interval_s = 1.0
+        interval_s = max(0.05, min(interval_s, 10.0))
+
+        def _poll_once() -> Tuple[Optional[int], Optional[Dict[str, Any]]]:
+            import json as _json
+            import os as _os
+            import urllib.error as _urlerr
+            import urllib.request as _urlreq
+            api_key = (_os.getenv("API_SERVER_KEY") or _os.getenv("HERMES_API_SERVER_KEY") or "").strip()
+            port = (_os.getenv("API_SERVER_PORT") or "8642").strip()
+            headers = {"Accept": "application/json"}
+            if api_key:
+                headers["Authorization"] = f"Bearer {api_key}"
+            url = f"http://127.0.0.1:{port}/v1/runs/{quote(run_id, safe='')}"
+            try:
+                req = _urlreq.Request(url, headers=headers, method="GET")
+                with _urlreq.urlopen(req, timeout=5) as resp:
+                    body = resp.read(64000).decode("utf-8", "replace")
+                    try:
+                        parsed = _json.loads(body)
+                    except Exception:
+                        parsed = None
+                    status_code = int(getattr(resp, "status", 200) or 200)
+                    return status_code, parsed if isinstance(parsed, dict) else None
+            except _urlerr.HTTPError as exc:
+                return int(exc.code), None
+            except Exception:
+                return None, None
+
+        async def _send(content: str) -> None:
+            try:
+                await self._send_with_retry(
+                    chat_id=event.source.chat_id,
+                    content=content,
+                    reply_to=_reply_anchor_for_event(event),
+                    metadata=_thread_metadata_for_source(event.source, _reply_anchor_for_event(event)),
+                )
+            except Exception:
+                logger.debug("[%s] WebUI bridge mirror send failed", self.name, exc_info=True)
+
+        deadline = time.monotonic() + timeout_s
+        final_payload: Optional[Dict[str, Any]] = None
+
+        while True:
+            status_code, payload = await asyncio.to_thread(_poll_once)
+            if status_code == 404:
+                await _send(
+                    f"Origin run `{run_id}` was not found; reply was queued — check the WebUI"
+                    + (f": {webui_url}" if webui_url else ".")
+                )
+                return
+            if status_code is not None and 200 <= status_code < 300 and payload is not None:
+                run_status = str(payload.get("status") or "").lower()
+                if run_status in {"completed", "failed", "cancelled"}:
+                    final_payload = payload
+                    break
+                if run_status == "waiting_for_approval":
+                    await _send(
+                        "Origin run is waiting for approval — open the WebUI to resolve"
+                        + (f": {webui_url}" if webui_url else ".")
+                    )
+                    return
+            if time.monotonic() >= deadline:
+                break
+            try:
+                await asyncio.sleep(min(interval_s, max(0.0, deadline - time.monotonic())))
+            except asyncio.CancelledError:
+                raise
+            interval_s = min(interval_s * 1.5, 5.0)
+
+        if final_payload is None:
+            await _send(
+                f"Origin run still running after {int(timeout_s)}s — open the WebUI to follow"
+                + (f": {webui_url}" if webui_url else ".")
+            )
+            return
+
+        status = str(final_payload.get("status") or "").lower()
+        if status == "completed":
+            output = str(final_payload.get("output") or "").strip()
+            if not output:
+                text = "Origin WebUI run completed (no textual response)."
+            else:
+                cap = 3500
+                if len(output) > cap:
+                    output = output[: cap - 1].rstrip() + "…"
+                text = f"Origin WebUI reply:\n\n{output}"
+        elif status == "failed":
+            err = str(final_payload.get("error") or "unknown error")
+            text = f"Origin WebUI run failed: {err[:1000]}"
+        elif status == "cancelled":
+            text = "Origin WebUI run was cancelled before completing."
+        else:
+            text = f"Origin WebUI run ended with status `{status}`."
+        if webui_url:
+            text += f"\nChat: {webui_url}"
+        await _send(text)
 
     async def handle_message(self, event: MessageEvent) -> None:
         """

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5597,6 +5597,23 @@ class TelegramAdapter(BasePlatformAdapter):
                     or None
                 )
 
+        try:
+            from gateway.notification_routes import resolve_notification_route_for_message
+
+            notification_route = resolve_notification_route_for_message(
+                platform="telegram",
+                chat_id=str(chat.id),
+                text=message.text or message.caption or "",
+                reply_to_message_id=reply_to_id,
+                thread_id=thread_id_str,
+            )
+            if notification_route is not None:
+                routed_source = notification_route.get("source")
+                if routed_source is not None:
+                    source = routed_source
+        except Exception as exc:
+            logger.debug("[%s] notification route resolution skipped: %s", self.name, exc)
+
         # Per-channel/topic ephemeral prompt
         from gateway.platforms.base import resolve_channel_prompt
         _chat_id_str = str(chat.id)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5597,6 +5597,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     or None
                 )
 
+        notification_route = None
         try:
             from gateway.notification_routes import resolve_notification_route_for_message
 
@@ -5608,9 +5609,15 @@ class TelegramAdapter(BasePlatformAdapter):
                 thread_id=thread_id_str,
             )
             if notification_route is not None:
-                routed_source = notification_route.get("source")
-                if routed_source is not None:
-                    source = routed_source
+                route_meta = notification_route.get("route") if isinstance(notification_route, dict) else None
+                if isinstance(route_meta, dict) and (route_meta.get("api_session_id") or route_meta.get("kind") == "webui_session"):
+                    # Preserve Telegram as the delivery source; BasePlatformAdapter
+                    # will bridge this turn into the recorded WebUI/API session.
+                    pass
+                else:
+                    routed_source = notification_route.get("source")
+                    if routed_source is not None:
+                        source = routed_source
         except Exception as exc:
             logger.debug("[%s] notification route resolution skipped: %s", self.name, exc)
 
@@ -5634,6 +5641,7 @@ class TelegramAdapter(BasePlatformAdapter):
             reply_to_text=reply_to_text,
             auto_skill=topic_skill,
             channel_prompt=_channel_prompt,
+            notification_route=(notification_route.get("route") if isinstance(notification_route, dict) else None),
             timestamp=message.date,
         )
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -325,6 +325,15 @@ def build_session_context_prompt(
             "current message's Slack block/attachment payload when available, but "
             "you still cannot call Slack APIs yourself."
         )
+    elif context.source.platform == Platform.TELEGRAM:
+        lines.append("")
+        lines.append(
+            "**Telegram routing notes:** You are running inside Telegram. Treat Telegram as a lightweight control inbox, not as the only workspace. "
+            "If the user message is a native reply or a short semantic follow-up to a recent Hermes status/notification/question (for example: ‘да’, ‘ок’, ‘продолжай’, ‘проверь’, ‘он точно?’, ‘проблем не будет?’), continue the originating task/process/chat rather than starting unrelated work in the Telegram DM. "
+            "If the message is a non-trivial standalone task, create or use a fresh WebUI chat/session for that task and send a concise Telegram status with a direct WebUI /session link and git/GitHub artifact links when available. "
+            "For key events, questions, approvals, blockers, and completion statuses, notify Telegram concisely and include direct links to the relevant WebUI chat/session and durable git/GitHub artifacts. "
+            "Do not rely only on Telegram native reply metadata: infer short semantic answers to your latest notification as continuation intent, but do not hijack long or unrelated new tasks into an old process."
+        )
     elif context.source.platform == Platform.DISCORD:
         # Inject the Discord IDs block only when the agent actually has
         # Discord tools loaded this session — i.e. the user opted into

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -788,6 +788,66 @@ class TestDeliverResultWrapping:
         assert "MEDIA:" not in text_sent
         assert "Report" in text_sent
 
+    def test_live_adapter_registers_notification_reply_route(self, tmp_path, monkeypatch):
+        """Cron live-adapter deliveries should register message_id -> origin routes."""
+        from concurrent.futures import Future
+        from gateway.config import Platform
+        import gateway.notification_routes as routes_mod
+        from gateway.notification_routes import resolve_exact_reply
+
+        monkeypatch.setattr(routes_mod, "_hermes_home", lambda: tmp_path)
+
+        adapter = AsyncMock()
+        adapter.send.return_value = MagicMock(success=True, message_id="700", raw_response={})
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        def fake_run_coro(coro, _loop):
+            future = Future()
+            future.set_result(MagicMock(success=True, message_id="700", raw_response={}))
+            coro.close()
+            return future
+
+        job = {
+            "id": "route-job",
+            "name": "route job",
+            "deliver": "origin",
+            "origin": {
+                "platform": "telegram",
+                "chat_id": "123",
+                "chat_type": "dm",
+                "thread_id": "24296",
+                "user_id": "456",
+                "user_name": "Alice",
+            },
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+            assert _deliver_result(
+                job,
+                "done",
+                adapters={Platform.TELEGRAM: adapter},
+                loop=loop,
+            ) is None
+
+        resolved = resolve_exact_reply(
+            platform="telegram",
+            chat_id="123",
+            reply_to_message_id="700",
+            thread_id="24296",
+        )
+        assert resolved is not None
+        assert resolved["source"].chat_id == "123"
+        assert resolved["source"].thread_id == "24296"
+
     def test_no_mirror_to_session_call(self):
         """Cron deliveries should NOT mirror into the gateway session."""
         from gateway.config import Platform

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -529,3 +529,41 @@ class TestStopRun:
                 body = await events_resp.text()
                 # Stream should have received run.failed and closed
                 assert "run.failed" in body or "stream closed" in body
+
+
+def test_api_server_steer_active_session_targets_existing_agent():
+    from gateway.platforms.api_server import APIServerAdapter
+
+    adapter = APIServerAdapter.__new__(APIServerAdapter)
+    adapter._active_session_agents = {}
+    adapter._active_session_run_ids = {}
+
+    class Agent:
+        def __init__(self):
+            self.steered = []
+        def steer(self, text):
+            self.steered.append(text)
+            return True
+
+    agent = Agent()
+    adapter._active_session_agents["sess-1"] = agent
+    adapter._active_session_run_ids["sess-1"] = "run_active"
+
+    accepted, run_id = adapter._steer_active_session("sess-1", "answer from telegram")
+
+    assert accepted is True
+    assert run_id == "run_active"
+    assert agent.steered == ["answer from telegram"]
+
+
+def test_api_server_steer_active_session_rejects_missing_session():
+    from gateway.platforms.api_server import APIServerAdapter
+
+    adapter = APIServerAdapter.__new__(APIServerAdapter)
+    adapter._active_session_agents = {}
+    adapter._active_session_run_ids = {}
+
+    accepted, run_id = adapter._steer_active_session("sess-1", "answer from telegram")
+
+    assert accepted is False
+    assert run_id is None

--- a/tests/gateway/test_notification_routes.py
+++ b/tests/gateway/test_notification_routes.py
@@ -113,7 +113,7 @@ def test_webui_session_url_prefers_explicit_public_url(monkeypatch):
     monkeypatch.setenv("HERMES_WEBUI_PUBLIC_URL", "https://hermes.example.com/base/")
     monkeypatch.setenv("HERMES_WEBUI_PORT", "8788")
 
-    assert build_webui_session_url("abc123") == "https://hermes.example.com/base/session/abc123"
+    assert build_webui_session_url("abc123") == "https://hermes.example.com/base/chat?resume=abc123"
 
 
 def test_webui_session_url_falls_back_to_server_ip_and_port(monkeypatch):
@@ -122,7 +122,7 @@ def test_webui_session_url_falls_back_to_server_ip_and_port(monkeypatch):
     monkeypatch.setenv("HERMES_WEBUI_PORT", "8788")
     monkeypatch.setattr(routes, "_detect_server_ip", lambda: "70.34.246.102")
 
-    assert build_webui_session_url("00cd34bde02b") == "http://70.34.246.102:8788/session/00cd34bde02b"
+    assert build_webui_session_url("00cd34bde02b") == "http://70.34.246.102:8788/chat?resume=00cd34bde02b"
 
 
 def test_webui_session_url_unavailable_without_session_or_host(monkeypatch):
@@ -133,3 +133,17 @@ def test_webui_session_url_unavailable_without_session_or_host(monkeypatch):
 
     assert build_webui_session_url("") is None
     assert build_webui_session_url("abc123") is None
+
+
+def test_webui_session_url_uses_chat_resume_path_not_session_id_path(monkeypatch):
+    """The WebUI router has no ``/session/<id>`` route — only ``/chat?resume=<id>``.
+
+    A stale ``/session/<id>`` link would hit the catch-all and silently bounce
+    the user to ``/sessions``, which presents as the "wrong chat" symptom for
+    Telegram notification replies bridged into a WebUI session.
+    """
+    monkeypatch.setenv("HERMES_WEBUI_PUBLIC_URL", "https://hermes.example.com")
+    url = build_webui_session_url("abc123")
+    assert url is not None
+    assert "/chat?resume=" in url
+    assert "/session/abc123" not in url

--- a/tests/gateway/test_notification_routes.py
+++ b/tests/gateway/test_notification_routes.py
@@ -1,0 +1,106 @@
+"""Tests for outbound notification reply routing metadata."""
+
+import time
+
+import gateway.notification_routes as routes
+from gateway.notification_routes import (
+    build_webui_session_url,
+    register_outbound_notification,
+    resolve_latest_followup,
+)
+
+
+def _route():
+    return {
+        "kind": "background_process",
+        "session_key": "agent:main:telegram:dm:123:24296",
+        "source": {
+            "platform": "telegram",
+            "chat_id": "123",
+            "chat_type": "dm",
+            "thread_id": "24296",
+            "user_id": "456",
+            "user_name": "Alice",
+        },
+    }
+
+
+def test_latest_followup_expires(monkeypatch, tmp_path):
+    monkeypatch.setattr(routes, "_hermes_home", lambda: tmp_path)
+    register_outbound_notification(
+        platform="telegram",
+        chat_id="999",
+        message_ids=["700"],
+        route=_route(),
+        ttl_seconds=10,
+        now=1_000,
+    )
+
+    assert resolve_latest_followup(
+        platform="telegram",
+        chat_id="999",
+        text="ок, продолжай",
+        now=1_020,
+    ) is None
+
+
+def test_latest_followup_does_not_hijack_slash_commands(monkeypatch, tmp_path):
+    monkeypatch.setattr(routes, "_hermes_home", lambda: tmp_path)
+    register_outbound_notification(
+        platform="telegram",
+        chat_id="999",
+        message_ids=["700"],
+        route=_route(),
+        ttl_seconds=1800,
+        now=time.time(),
+    )
+
+    assert resolve_latest_followup(
+        platform="telegram",
+        chat_id="999",
+        text="/new unrelated task",
+    ) is None
+
+
+def test_latest_followup_does_not_hijack_short_new_tasks(monkeypatch, tmp_path):
+    monkeypatch.setattr(routes, "_hermes_home", lambda: tmp_path)
+    register_outbound_notification(
+        platform="telegram",
+        chat_id="999",
+        message_ids=["700"],
+        route=_route(),
+        ttl_seconds=1800,
+        now=time.time(),
+    )
+
+    assert resolve_latest_followup(
+        platform="telegram",
+        chat_id="999",
+        text="создай новый отчет",
+    ) is None
+
+
+def test_webui_session_url_prefers_explicit_public_url(monkeypatch):
+    monkeypatch.setenv("HERMES_WEBUI_PUBLIC_URL", "https://hermes.example.com/base/")
+    monkeypatch.setenv("HERMES_WEBUI_PORT", "8788")
+
+    assert build_webui_session_url("abc123") == "https://hermes.example.com/base/session/abc123"
+
+
+def test_webui_session_url_falls_back_to_server_ip_and_port(monkeypatch):
+    monkeypatch.delenv("HERMES_WEBUI_PUBLIC_URL", raising=False)
+    monkeypatch.delenv("HERMES_WEBUI_BASE_URL", raising=False)
+    monkeypatch.setenv("HERMES_WEBUI_PORT", "8788")
+    monkeypatch.setattr(routes, "_detect_server_ip", lambda: "70.34.246.102")
+
+    assert build_webui_session_url("00cd34bde02b") == "http://70.34.246.102:8788/session/00cd34bde02b"
+
+
+def test_webui_session_url_unavailable_without_session_or_host(monkeypatch):
+    monkeypatch.delenv("HERMES_WEBUI_PUBLIC_URL", raising=False)
+    monkeypatch.delenv("HERMES_WEBUI_BASE_URL", raising=False)
+    monkeypatch.setenv("HERMES_WEBUI_PORT", "8788")
+    monkeypatch.setattr(routes, "_detect_server_ip", lambda: None)
+
+    assert build_webui_session_url("") is None
+    assert build_webui_session_url("abc123") is None

--- a/tests/gateway/test_notification_routes.py
+++ b/tests/gateway/test_notification_routes.py
@@ -80,6 +80,35 @@ def test_latest_followup_does_not_hijack_short_new_tasks(monkeypatch, tmp_path):
     ) is None
 
 
+def test_latest_followup_can_target_webui_api_session_without_platform_source(monkeypatch, tmp_path):
+    monkeypatch.setattr(routes, "_hermes_home", lambda: tmp_path)
+    register_outbound_notification(
+        platform="telegram",
+        chat_id="999",
+        message_ids=["701"],
+        route={
+            "kind": "webui_session",
+            "api_session_id": "20260524_142634_986d3f",
+            "session_id": "20260524_142634_986d3f",
+            "webui_url": "https://hermes.example.com/session/20260524_142634_986d3f",
+        },
+        ttl_seconds=1800,
+        now=time.time(),
+    )
+
+    resolved = resolve_latest_followup(
+        platform="telegram",
+        chat_id="999",
+        text="ок, проверь",
+    )
+
+    assert resolved is not None
+    assert "source" not in resolved
+    assert resolved["route"]["kind"] == "webui_session"
+    assert resolved["route"]["api_session_id"] == "20260524_142634_986d3f"
+    assert resolved["route"]["webui_url"] == "https://hermes.example.com/session/20260524_142634_986d3f"
+
+
 def test_webui_session_url_prefers_explicit_public_url(monkeypatch):
     monkeypatch.setenv("HERMES_WEBUI_PUBLIC_URL", "https://hermes.example.com/base/")
     monkeypatch.setenv("HERMES_WEBUI_PORT", "8788")

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1,6 +1,7 @@
 """Tests for gateway/platforms/base.py — MessageEvent, media extraction, message truncation."""
 
 import json
+import urllib.error
 import os
 from unittest.mock import patch
 
@@ -61,13 +62,18 @@ class _FakeHttpResponse:
 
 @pytest.mark.asyncio
 async def test_webui_notification_reply_starts_api_run_without_waiting_for_completion(monkeypatch):
-    captured = {}
+    captured = []
 
     def fake_urlopen(req, timeout=None):
-        captured["url"] = req.full_url
-        captured["timeout"] = timeout
-        captured["headers"] = dict(req.header_items())
-        captured["body"] = json.loads(req.data.decode("utf-8"))
+        call = {
+            "url": req.full_url,
+            "timeout": timeout,
+            "headers": dict(req.header_items()),
+            "body": json.loads(req.data.decode("utf-8")),
+        }
+        captured.append(call)
+        if req.full_url.endswith("/steer"):
+            raise urllib.error.HTTPError(req.full_url, 404, "not active", {}, None)
         return _FakeHttpResponse()
 
     monkeypatch.setenv("API_SERVER_KEY", "secret-test-key")
@@ -89,15 +95,61 @@ async def test_webui_notification_reply_starts_api_run_without_waiting_for_compl
 
     await adapter._forward_notification_reply_to_api_session(event, route)
 
-    assert captured["url"] == "http://127.0.0.1:18642/v1/runs"
-    assert captured["timeout"] <= 15
-    assert captured["headers"]["X-hermes-session-id"] == "20260524_142634_986d3f"
-    assert captured["headers"]["Authorization"] == "Bearer secret-test-key"
-    assert captured["body"]["session_id"] == "20260524_142634_986d3f"
-    assert captured["body"]["input"].startswith("[Telegram reply/follow-up to Hermes notification]")
+    assert [call["url"] for call in captured] == [
+        "http://127.0.0.1:18642/v1/sessions/20260524_142634_986d3f/steer",
+        "http://127.0.0.1:18642/v1/runs",
+    ]
+    assert captured[0]["timeout"] <= 5
+    assert captured[1]["timeout"] <= 15
+    assert captured[1]["headers"]["X-hermes-session-id"] == "20260524_142634_986d3f"
+    assert captured[1]["headers"]["Authorization"] == "Bearer secret-test-key"
+    assert captured[1]["body"]["session_id"] == "20260524_142634_986d3f"
+    assert captured[1]["body"]["input"].startswith("[Telegram reply/follow-up to Hermes notification]")
     assert len(adapter.sent) == 2
     assert "Forwarding" in adapter.sent[0][1]
     assert "started" in adapter.sent[1][1].lower()
+
+
+@pytest.mark.asyncio
+async def test_webui_notification_reply_steers_active_api_session_before_starting_new_run(monkeypatch):
+    calls = []
+
+    def fake_urlopen(req, timeout=None):
+        calls.append({
+            "url": req.full_url,
+            "timeout": timeout,
+            "headers": dict(req.header_items()),
+            "body": json.loads(req.data.decode("utf-8")),
+        })
+        assert req.full_url == "http://127.0.0.1:18642/v1/sessions/20260524_142634_986d3f/steer"
+        return _FakeHttpResponse(body=b'{"status":"accepted","run_id":"run_active"}')
+
+    monkeypatch.setenv("API_SERVER_KEY", "secret-test-key")
+    monkeypatch.setenv("API_SERVER_PORT", "18642")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    adapter = _StubAdapter()
+    event = MessageEvent(
+        text="ок, правь",
+        source=SessionSource(platform="telegram", chat_id="999", chat_type="dm", user_id="456"),
+        message_id="703",
+        reply_to_text="Need approval?",
+    )
+    route = {
+        "kind": "webui_session",
+        "api_session_id": "20260524_142634_986d3f",
+        "webui_url": "https://hermes.example.com/session/20260524_142634_986d3f",
+    }
+
+    await adapter._forward_notification_reply_to_api_session(event, route)
+
+    assert len(calls) == 1
+    assert calls[0]["headers"]["X-hermes-session-id"] == "20260524_142634_986d3f"
+    assert calls[0]["body"]["input"].startswith("[Telegram reply/follow-up to Hermes notification]")
+    assert len(adapter.sent) == 2
+    assert "Forwarding" in adapter.sent[0][1]
+    assert "active origin WebUI run" in adapter.sent[1][1]
+    assert "run_active" in adapter.sent[1][1]
 
 
 class TestSecretCaptureGuidance:

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1,5 +1,6 @@
 """Tests for gateway/platforms/base.py — MessageEvent, media extraction, message truncation."""
 
+import json
 import os
 from unittest.mock import patch
 
@@ -14,6 +15,89 @@ from gateway.platforms.base import (
     utf16_len,
     _prefix_within_utf16_limit,
 )
+from gateway.session import SessionSource
+
+
+class _StubAdapter(BasePlatformAdapter):
+    """Minimal concrete adapter for BasePlatformAdapter behavior tests."""
+
+    def __init__(self):
+        from gateway.config import Platform, PlatformConfig
+
+        super().__init__(config=PlatformConfig(enabled=True, token="test"), platform=Platform.TELEGRAM)
+        self.sent = []
+
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        pass
+
+    async def send(self, *a, **kw):
+        pass
+
+    async def get_chat_info(self, *a):
+        return {}
+
+    async def _send_with_retry(self, chat_id, content, **kwargs):
+        self.sent.append((chat_id, content, kwargs))
+        return None
+
+
+class _FakeHttpResponse:
+    def __init__(self, body=b'{"run_id":"run_123","status":"started"}', status=202):
+        self._body = body
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self, limit=-1):
+        return self._body[:limit if limit and limit > 0 else None]
+
+
+@pytest.mark.asyncio
+async def test_webui_notification_reply_starts_api_run_without_waiting_for_completion(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["timeout"] = timeout
+        captured["headers"] = dict(req.header_items())
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        return _FakeHttpResponse()
+
+    monkeypatch.setenv("API_SERVER_KEY", "secret-test-key")
+    monkeypatch.setenv("API_SERVER_PORT", "18642")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    adapter = _StubAdapter()
+    event = MessageEvent(
+        text="ок, проверь",
+        source=SessionSource(platform="telegram", chat_id="999", chat_type="dm", user_id="456"),
+        message_id="702",
+        reply_to_text="Need approval?",
+    )
+    route = {
+        "kind": "webui_session",
+        "api_session_id": "20260524_142634_986d3f",
+        "webui_url": "https://hermes.example.com/session/20260524_142634_986d3f",
+    }
+
+    await adapter._forward_notification_reply_to_api_session(event, route)
+
+    assert captured["url"] == "http://127.0.0.1:18642/v1/runs"
+    assert captured["timeout"] <= 15
+    assert captured["headers"]["X-hermes-session-id"] == "20260524_142634_986d3f"
+    assert captured["headers"]["Authorization"] == "Bearer secret-test-key"
+    assert captured["body"]["session_id"] == "20260524_142634_986d3f"
+    assert captured["body"]["input"].startswith("[Telegram reply/follow-up to Hermes notification]")
+    assert len(adapter.sent) == 2
+    assert "Forwarding" in adapter.sent[0][1]
+    assert "started" in adapter.sent[1][1].lower()
 
 
 class TestSecretCaptureGuidance:

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -67,17 +67,30 @@ async def test_webui_notification_reply_starts_api_run_without_waiting_for_compl
     def fake_urlopen(req, timeout=None):
         call = {
             "url": req.full_url,
+            "method": req.get_method(),
             "timeout": timeout,
             "headers": dict(req.header_items()),
-            "body": json.loads(req.data.decode("utf-8")),
+            "body": json.loads(req.data.decode("utf-8")) if req.data else None,
         }
         captured.append(call)
         if req.full_url.endswith("/steer"):
             raise urllib.error.HTTPError(req.full_url, 404, "not active", {}, None)
+        if "/v1/runs/run_123" in req.full_url:
+            return _FakeHttpResponse(
+                body=json.dumps({
+                    "object": "hermes.run",
+                    "run_id": "run_123",
+                    "status": "completed",
+                    "output": "Mirrored answer from the WebUI run.",
+                }).encode("utf-8"),
+                status=200,
+            )
+        # POST /v1/runs
         return _FakeHttpResponse()
 
     monkeypatch.setenv("API_SERVER_KEY", "secret-test-key")
     monkeypatch.setenv("API_SERVER_PORT", "18642")
+    monkeypatch.setenv("HERMES_NOTIFICATION_BRIDGE_POLL_INTERVAL", "0.05")
     monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
 
     adapter = _StubAdapter()
@@ -95,7 +108,7 @@ async def test_webui_notification_reply_starts_api_run_without_waiting_for_compl
 
     await adapter._forward_notification_reply_to_api_session(event, route)
 
-    assert [call["url"] for call in captured] == [
+    assert [call["url"] for call in captured[:2]] == [
         "http://127.0.0.1:18642/v1/sessions/20260524_142634_986d3f/steer",
         "http://127.0.0.1:18642/v1/runs",
     ]
@@ -105,9 +118,262 @@ async def test_webui_notification_reply_starts_api_run_without_waiting_for_compl
     assert captured[1]["headers"]["Authorization"] == "Bearer secret-test-key"
     assert captured[1]["body"]["session_id"] == "20260524_142634_986d3f"
     assert captured[1]["body"]["input"].startswith("[Telegram reply/follow-up to Hermes notification]")
-    assert len(adapter.sent) == 2
+    # Polling fires for the fallback path and finishes on the first GET.
+    assert captured[2]["url"] == "http://127.0.0.1:18642/v1/runs/run_123"
+    assert captured[2]["method"] == "GET"
+    assert captured[2]["headers"]["Authorization"] == "Bearer secret-test-key"
+    assert len(adapter.sent) == 3
     assert "Forwarding" in adapter.sent[0][1]
     assert "started" in adapter.sent[1][1].lower()
+    assert "Mirrored answer from the WebUI run." in adapter.sent[2][1]
+
+
+@pytest.mark.asyncio
+async def test_webui_notification_reply_active_steer_skips_polling(monkeypatch):
+    """Active-steer path already streams through the WebUI; polling must not fire."""
+
+    calls = []
+
+    def fake_urlopen(req, timeout=None):
+        calls.append(req.full_url)
+        assert req.full_url == "http://127.0.0.1:18642/v1/sessions/20260524_142634_986d3f/steer"
+        return _FakeHttpResponse(body=b'{"status":"accepted","run_id":"run_active"}')
+
+    monkeypatch.setenv("API_SERVER_KEY", "secret-test-key")
+    monkeypatch.setenv("API_SERVER_PORT", "18642")
+    monkeypatch.setenv("HERMES_NOTIFICATION_BRIDGE_POLL_INTERVAL", "0.05")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    adapter = _StubAdapter()
+    event = MessageEvent(
+        text="ок, продолжи",
+        source=SessionSource(platform="telegram", chat_id="999", chat_type="dm", user_id="456"),
+        message_id="710",
+    )
+    route = {
+        "kind": "webui_session",
+        "api_session_id": "20260524_142634_986d3f",
+    }
+
+    await adapter._forward_notification_reply_to_api_session(event, route)
+
+    assert calls == ["http://127.0.0.1:18642/v1/sessions/20260524_142634_986d3f/steer"]
+    assert all("/v1/runs/" not in url for url in calls)
+    assert len(adapter.sent) == 2  # ack + accepted-into-active-run notice, no mirror.
+
+
+@pytest.mark.asyncio
+async def test_webui_notification_reply_fallback_mirrors_failed_run(monkeypatch):
+    """Failed origin run is surfaced to the Telegram chat with the error reason."""
+
+    def fake_urlopen(req, timeout=None):
+        if req.full_url.endswith("/steer"):
+            raise urllib.error.HTTPError(req.full_url, 404, "not active", {}, None)
+        if "/v1/runs/run_fail" in req.full_url:
+            return _FakeHttpResponse(
+                body=json.dumps({
+                    "object": "hermes.run",
+                    "run_id": "run_fail",
+                    "status": "failed",
+                    "error": "model timed out",
+                }).encode("utf-8"),
+                status=200,
+            )
+        return _FakeHttpResponse(body=b'{"run_id":"run_fail","status":"started"}')
+
+    monkeypatch.setenv("API_SERVER_PORT", "18642")
+    monkeypatch.setenv("HERMES_NOTIFICATION_BRIDGE_POLL_INTERVAL", "0.05")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    adapter = _StubAdapter()
+    event = MessageEvent(
+        text="ок, продолжи",
+        source=SessionSource(platform="telegram", chat_id="999", chat_type="dm", user_id="456"),
+        message_id="711",
+    )
+    route = {"kind": "webui_session", "api_session_id": "20260524_142634_986d3f"}
+
+    await adapter._forward_notification_reply_to_api_session(event, route)
+
+    mirror = adapter.sent[-1][1]
+    assert "failed" in mirror.lower()
+    assert "model timed out" in mirror
+
+
+@pytest.mark.asyncio
+async def test_webui_notification_reply_fallback_mirrors_cancelled_run(monkeypatch):
+    def fake_urlopen(req, timeout=None):
+        if req.full_url.endswith("/steer"):
+            raise urllib.error.HTTPError(req.full_url, 404, "not active", {}, None)
+        if "/v1/runs/run_cxl" in req.full_url:
+            return _FakeHttpResponse(
+                body=json.dumps({"status": "cancelled"}).encode("utf-8"),
+                status=200,
+            )
+        return _FakeHttpResponse(body=b'{"run_id":"run_cxl","status":"started"}')
+
+    monkeypatch.setenv("API_SERVER_PORT", "18642")
+    monkeypatch.setenv("HERMES_NOTIFICATION_BRIDGE_POLL_INTERVAL", "0.05")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    adapter = _StubAdapter()
+    event = MessageEvent(
+        text="ок",
+        source=SessionSource(platform="telegram", chat_id="999", chat_type="dm", user_id="456"),
+        message_id="712",
+    )
+    route = {"kind": "webui_session", "api_session_id": "sess_cxl"}
+
+    await adapter._forward_notification_reply_to_api_session(event, route)
+
+    assert "cancelled" in adapter.sent[-1][1].lower()
+
+
+@pytest.mark.asyncio
+async def test_webui_notification_reply_fallback_polling_times_out(monkeypatch):
+    """Bounded polling: when the run never reaches a terminal status, we still
+    send a single follow-up pointing the user at the WebUI URL."""
+
+    poll_count = {"n": 0}
+
+    def fake_urlopen(req, timeout=None):
+        if req.full_url.endswith("/steer"):
+            raise urllib.error.HTTPError(req.full_url, 404, "not active", {}, None)
+        if "/v1/runs/run_stuck" in req.full_url:
+            poll_count["n"] += 1
+            return _FakeHttpResponse(
+                body=json.dumps({"status": "running"}).encode("utf-8"),
+                status=200,
+            )
+        return _FakeHttpResponse(body=b'{"run_id":"run_stuck","status":"started"}')
+
+    monkeypatch.setenv("API_SERVER_PORT", "18642")
+    monkeypatch.setenv("HERMES_NOTIFICATION_BRIDGE_WAIT_SECONDS", "0.5")
+    monkeypatch.setenv("HERMES_NOTIFICATION_BRIDGE_POLL_INTERVAL", "0.05")
+    monkeypatch.setenv("HERMES_WEBUI_PUBLIC_URL", "https://hermes.example.com")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    adapter = _StubAdapter()
+    event = MessageEvent(
+        text="ок",
+        source=SessionSource(platform="telegram", chat_id="999", chat_type="dm", user_id="456"),
+        message_id="713",
+    )
+    route = {
+        "kind": "webui_session",
+        "api_session_id": "sess_stuck",
+        "webui_url": "https://hermes.example.com/chat?resume=sess_stuck",
+    }
+
+    await adapter._forward_notification_reply_to_api_session(event, route)
+
+    timeout_msg = adapter.sent[-1][1]
+    assert "still running" in timeout_msg
+    assert "https://hermes.example.com/chat?resume=sess_stuck" in timeout_msg
+    assert poll_count["n"] >= 2  # We actually polled more than once before giving up.
+
+
+@pytest.mark.asyncio
+async def test_webui_notification_reply_fallback_handles_waiting_for_approval(monkeypatch):
+    """waiting_for_approval is indefinite; emit one notice and stop polling."""
+
+    poll_count = {"n": 0}
+
+    def fake_urlopen(req, timeout=None):
+        if req.full_url.endswith("/steer"):
+            raise urllib.error.HTTPError(req.full_url, 404, "not active", {}, None)
+        if "/v1/runs/run_appr" in req.full_url:
+            poll_count["n"] += 1
+            return _FakeHttpResponse(
+                body=json.dumps({"status": "waiting_for_approval"}).encode("utf-8"),
+                status=200,
+            )
+        return _FakeHttpResponse(body=b'{"run_id":"run_appr","status":"started"}')
+
+    monkeypatch.setenv("API_SERVER_PORT", "18642")
+    monkeypatch.setenv("HERMES_NOTIFICATION_BRIDGE_POLL_INTERVAL", "0.05")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    adapter = _StubAdapter()
+    event = MessageEvent(
+        text="ок",
+        source=SessionSource(platform="telegram", chat_id="999", chat_type="dm", user_id="456"),
+        message_id="714",
+    )
+    route = {
+        "kind": "webui_session",
+        "api_session_id": "sess_appr",
+        "webui_url": "https://hermes.example.com/chat?resume=sess_appr",
+    }
+
+    await adapter._forward_notification_reply_to_api_session(event, route)
+
+    final = adapter.sent[-1][1]
+    assert "approval" in final.lower()
+    assert "https://hermes.example.com/chat?resume=sess_appr" in final
+    assert poll_count["n"] == 1  # Exactly one GET; bail without further polling.
+
+
+@pytest.mark.asyncio
+async def test_webui_notification_reply_fallback_truncates_long_output(monkeypatch):
+    long_text = "X" * 5000
+
+    def fake_urlopen(req, timeout=None):
+        if req.full_url.endswith("/steer"):
+            raise urllib.error.HTTPError(req.full_url, 404, "not active", {}, None)
+        if "/v1/runs/run_big" in req.full_url:
+            return _FakeHttpResponse(
+                body=json.dumps({"status": "completed", "output": long_text}).encode("utf-8"),
+                status=200,
+            )
+        return _FakeHttpResponse(body=b'{"run_id":"run_big","status":"started"}')
+
+    monkeypatch.setenv("API_SERVER_PORT", "18642")
+    monkeypatch.setenv("HERMES_NOTIFICATION_BRIDGE_POLL_INTERVAL", "0.05")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    adapter = _StubAdapter()
+    event = MessageEvent(
+        text="ок",
+        source=SessionSource(platform="telegram", chat_id="999", chat_type="dm", user_id="456"),
+        message_id="715",
+    )
+    route = {"kind": "webui_session", "api_session_id": "sess_big"}
+
+    await adapter._forward_notification_reply_to_api_session(event, route)
+
+    mirror = adapter.sent[-1][1]
+    # Cap is 3500 chars of payload + small header; assert truncation happened
+    # and an ellipsis marker is present so the user knows it was cut.
+    assert "…" in mirror
+    assert len(mirror) < len(long_text) + 200
+
+
+@pytest.mark.asyncio
+async def test_webui_notification_reply_fallback_handles_missing_run(monkeypatch):
+    def fake_urlopen(req, timeout=None):
+        if req.full_url.endswith("/steer"):
+            raise urllib.error.HTTPError(req.full_url, 404, "not active", {}, None)
+        if "/v1/runs/run_404" in req.full_url:
+            raise urllib.error.HTTPError(req.full_url, 404, "run swept", {}, None)
+        return _FakeHttpResponse(body=b'{"run_id":"run_404","status":"started"}')
+
+    monkeypatch.setenv("API_SERVER_PORT", "18642")
+    monkeypatch.setenv("HERMES_NOTIFICATION_BRIDGE_POLL_INTERVAL", "0.05")
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    adapter = _StubAdapter()
+    event = MessageEvent(
+        text="ок",
+        source=SessionSource(platform="telegram", chat_id="999", chat_type="dm", user_id="456"),
+        message_id="716",
+    )
+    route = {"kind": "webui_session", "api_session_id": "sess_404"}
+
+    await adapter._forward_notification_reply_to_api_session(event, route)
+
+    mirror = adapter.sent[-1][1]
+    assert "not found" in mirror.lower()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -168,6 +168,107 @@ def test_non_forum_group_reply_thread_id_does_not_fork_session_key():
     assert build_session_key(event.source) == "agent:main:telegram:group:-100123:456"
 
 
+def test_reply_to_registered_notification_reroutes_to_origin_session(monkeypatch, tmp_path):
+    """Replying to a Hermes notification should use the recorded origin route.
+
+    Regression for tradebotint/hermes-agent#4: a reply in the delivery/home chat
+    must not create a fresh workflow keyed by the delivery chat when the outbound
+    notification message id is known to belong to a different origin session.
+    """
+    from gateway.platforms import telegram as telegram_mod
+    import gateway.notification_routes as routes_mod
+    from gateway.notification_routes import register_outbound_notification
+
+    monkeypatch.setattr(routes_mod, "_hermes_home", lambda: tmp_path)
+    register_outbound_notification(
+        platform="telegram",
+        chat_id="999",
+        message_ids=["700"],
+        route={
+            "kind": "background_process",
+            "session_key": "agent:main:telegram:dm:123:24296",
+            "source": {
+                "platform": "telegram",
+                "chat_id": "123",
+                "chat_type": "dm",
+                "thread_id": "24296",
+                "user_id": "456",
+                "user_name": "Alice",
+            },
+        },
+    )
+
+    adapter = _make_adapter()
+    message = SimpleNamespace(
+        text="continue there",
+        caption=None,
+        chat=SimpleNamespace(id=999, type=telegram_mod.ChatType.PRIVATE, title=None, full_name="Alice"),
+        from_user=SimpleNamespace(id=456, full_name="Alice"),
+        message_thread_id=None,
+        is_topic_message=False,
+        reply_to_message=SimpleNamespace(message_id=700, text="Background process completed", caption=None),
+        message_id=701,
+        date=None,
+    )
+
+    event = adapter._build_message_event(message, msg_type=MessageType.TEXT)
+
+    assert event.reply_to_message_id == "700"
+    assert event.source.chat_id == "123"
+    assert event.source.chat_type == "dm"
+    assert event.source.thread_id == "24296"
+    assert event.source.user_id == "456"
+    assert build_session_key(event.source) == "agent:main:telegram:dm:123:24296"
+
+
+def test_recent_registered_notification_followup_reroutes_without_native_reply(monkeypatch, tmp_path):
+    """Fresh semantic follow-ups should continue the latest actionable origin."""
+    from gateway.platforms import telegram as telegram_mod
+    import gateway.notification_routes as routes_mod
+    from gateway.notification_routes import register_outbound_notification
+
+    monkeypatch.setattr(routes_mod, "_hermes_home", lambda: tmp_path)
+    register_outbound_notification(
+        platform="telegram",
+        chat_id="999",
+        message_ids=["700"],
+        route={
+            "kind": "background_process",
+            "session_key": "agent:main:telegram:dm:123:24296",
+            "source": {
+                "platform": "telegram",
+                "chat_id": "123",
+                "chat_type": "dm",
+                "thread_id": "24296",
+                "user_id": "456",
+                "user_name": "Alice",
+            },
+        },
+        ttl_seconds=1800,
+    )
+
+    adapter = _make_adapter()
+    message = SimpleNamespace(
+        text="ок, продолжай",
+        caption=None,
+        chat=SimpleNamespace(id=999, type=telegram_mod.ChatType.PRIVATE, title=None, full_name="Alice"),
+        from_user=SimpleNamespace(id=456, full_name="Alice"),
+        message_thread_id=None,
+        is_topic_message=False,
+        reply_to_message=None,
+        message_id=702,
+        date=None,
+    )
+
+    event = adapter._build_message_event(message, msg_type=MessageType.TEXT)
+
+    assert event.reply_to_message_id is None
+    assert event.source.chat_id == "123"
+    assert event.source.chat_type == "dm"
+    assert event.source.thread_id == "24296"
+    assert build_session_key(event.source) == "agent:main:telegram:dm:123:24296"
+
+
 def test_forum_group_topic_message_preserves_thread_session_key():
     """Real Telegram forum-topic messages should still route by topic id."""
     from gateway.platforms import telegram as telegram_mod


### PR DESCRIPTION
## Summary
- route notification replies to `/chat?resume=<session>` WebUI links when available
- mirror replies into inactive WebUI sessions by POSTing to `/v1/runs` with correlation metadata
- add focused gateway platform tests for reply deep links and inactive session mirroring

## Validation
- `PYTEST_ADDOPTS='' python -m pytest -o addopts='' tests/gateway/test_platform_base.py -q` → 104 passed, 2 skipped

Tradebotint control issue: https://github.com/tradebotint/hermes-agent/issues/4
