### PR TITLE
[codex] Add hierarchical AGENTS guidance loading

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,14 @@
-# Hermes Agent - Development Guide
+# Hermes Agent - Root Development Guide
 
-Instructions for AI coding assistants and developers working on the hermes-agent codebase.
+This file is intentionally short. The detailed rules live next to the code they
+govern. When touching a subdirectory, read that directory's `AGENTS.md` before
+editing files there.
+
+Hermes and Codex do not load project rules in exactly the same way. Codex reads
+the applicable `AGENTS.md` hierarchy for the files it edits. Hermes loads the
+git-root-to-current-working-directory `AGENTS.md` hierarchy at session start and
+discovers deeper subdirectory hints progressively through tool calls. Keep
+critical global rules here; keep local implementation details in scoped files.
 
 ## Development Environment
 
@@ -10,81 +18,49 @@ source .venv/bin/activate   # or: source venv/bin/activate
 ```
 
 `scripts/run_tests.sh` probes `.venv` first, then `venv`, then
-`$HOME/.hermes/hermes-agent/venv` (for worktrees that share a venv with the
-main checkout).
+`$HOME/.hermes/hermes-agent/venv` for worktrees that share a venv with the main
+checkout.
 
-## Project Structure
+## Project Map
 
-File counts shift constantly — don't treat the tree below as exhaustive.
-The canonical source is the filesystem. The notes call out the load-bearing
-entry points you'll actually edit.
+File counts shift constantly. Trust the filesystem over this map.
 
-```
-hermes-agent/
-├── run_agent.py          # AIAgent class — core conversation loop (~12k LOC)
-├── model_tools.py        # Tool orchestration, discover_builtin_tools(), handle_function_call()
-├── toolsets.py           # Toolset definitions, _HERMES_CORE_TOOLS list
-├── cli.py                # HermesCLI class — interactive CLI orchestrator (~11k LOC)
-├── hermes_state.py       # SessionDB — SQLite session store (FTS5 search)
-├── hermes_constants.py   # get_hermes_home(), display_hermes_home() — profile-aware paths
-├── hermes_logging.py     # setup_logging() — agent.log / errors.log / gateway.log (profile-aware)
-├── batch_runner.py       # Parallel batch processing
-├── agent/                # Agent internals (provider adapters, memory, caching, compression, etc.)
-├── hermes_cli/           # CLI subcommands, setup wizard, plugins loader, skin engine
-├── tools/                # Tool implementations — auto-discovered via tools/registry.py
-│   └── environments/     # Terminal backends (local, docker, ssh, modal, daytona, singularity)
-├── gateway/              # Messaging gateway — run.py + session.py + platforms/
-│   ├── platforms/        # Adapter per platform (telegram, discord, slack, whatsapp,
-│   │                     #   homeassistant, signal, matrix, mattermost, email, sms,
-│   │                     #   dingtalk, wecom, weixin, feishu, qqbot, bluebubbles,
-│   │                     #   yuanbao, webhook, api_server, ...). See ADDING_A_PLATFORM.md.
-│   └── builtin_hooks/    # Extension point for always-registered gateway hooks (none shipped)
-├── plugins/              # Plugin system (see "Plugins" section below)
-│   ├── memory/           # Memory-provider plugins (honcho, mem0, supermemory, ...)
-│   ├── context_engine/   # Context-engine plugins
-│   ├── model-providers/  # Inference backend plugins (openrouter, anthropic, gmi, ...)
-│   ├── kanban/           # Multi-agent board dispatcher + worker plugin
-│   ├── hermes-achievements/  # Gamified achievement tracking
-│   ├── observability/    # Metrics / traces / logs plugin
-│   ├── image_gen/        # Image-generation providers
-│   └── <others>/         # disk-cleanup, example-dashboard, google_meet, platforms,
-│                         #   spotify, strike-freedom-cockpit, ...
-├── optional-skills/      # Heavier/niche skills shipped but NOT active by default
-├── skills/               # Built-in skills bundled with the repo
-├── ui-tui/               # Ink (React) terminal UI — `hermes --tui`
-│   └── src/              # entry.tsx, app.tsx, gatewayClient.ts + app/components/hooks/lib
-├── tui_gateway/          # Python JSON-RPC backend for the TUI
-├── acp_adapter/          # ACP server (VS Code / Zed / JetBrains integration)
-├── cron/                 # Scheduler — jobs.py, scheduler.py
-├── scripts/              # run_tests.sh, release.py, auxiliary scripts
-├── website/              # Docusaurus docs site
-└── tests/                # Pytest suite (~17k tests across ~900 files as of May 2026)
-```
+| Path | Purpose | Local guide |
+| --- | --- | --- |
+| `run_agent.py` | `AIAgent` class and root conversation entry points | this file |
+| `model_tools.py` | tool schema filtering and dispatch bridge | this file |
+| `toolsets.py` | toolset definitions and `_HERMES_CORE_TOOLS` | this file |
+| `cli.py` | classic interactive CLI orchestrator | this file + `hermes_cli/AGENTS.md` |
+| `hermes_state.py` | SQLite session store and FTS5 search | this file |
+| `agent/` | provider adapters, prompt assembly, memory, compression, LSP | `agent/AGENTS.md` |
+| `hermes_cli/` | subcommands, setup, config, plugins loader, dashboard server | `hermes_cli/AGENTS.md` |
+| `tools/` | built-in tool implementations and registry | `tools/AGENTS.md` |
+| `gateway/` | messaging gateway and platform adapters | `gateway/AGENTS.md` |
+| `plugins/` | repo-shipped plugins and plugin backends | `plugins/AGENTS.md` |
+| `skills/`, `optional-skills/` | bundled and optional skills | `skills/AGENTS.md`, `optional-skills/AGENTS.md` |
+| `ui-tui/`, `tui_gateway/` | Ink TUI and Python JSON-RPC backend | `ui-tui/AGENTS.md`, `tui_gateway/AGENTS.md` |
+| `cron/` | scheduled jobs store and scheduler | `cron/AGENTS.md` |
+| `tests/` | pytest suite | `tests/AGENTS.md` |
 
-**User config:** `~/.hermes/config.yaml` (settings), `~/.hermes/.env` (API keys only).
-**Logs:** `~/.hermes/logs/` — `agent.log` (INFO+), `errors.log` (WARNING+),
-`gateway.log` when running the gateway. Profile-aware via `get_hermes_home()`.
-Browse with `hermes logs [--follow] [--level ...] [--session ...]`.
+## Dependency Chain
 
-## File Dependency Chain
-
-```
-tools/registry.py  (no deps — imported by all tool files)
-       ↑
+```text
+tools/registry.py  (no deps - imported by all tool files)
+       ^
 tools/*.py  (each calls registry.register() at import time)
-       ↑
+       ^
 model_tools.py  (imports tools/registry + triggers tool discovery)
-       ↑
+       ^
 run_agent.py, cli.py, batch_runner.py, environments/
 ```
 
----
+Keep this direction acyclic. If a tool needs a capability from higher in the
+stack, move the shared code down or use a plugin/hook boundary.
 
-## AIAgent Class (run_agent.py)
+## Root Entry Points
 
-The real `AIAgent.__init__` takes ~60 parameters (credentials, routing, callbacks,
-session context, budget, credential pool, etc.). The signature below is the
-minimum subset you'll usually touch — read `run_agent.py` for the full list.
+`AIAgent` lives in `run_agent.py`. The constructor has many parameters; the
+subset normally relevant to integrations is:
 
 ```python
 class AIAgent:
@@ -92,1041 +68,142 @@ class AIAgent:
         base_url: str = None,
         api_key: str = None,
         provider: str = None,
-        api_mode: str = None,              # "chat_completions" | "codex_responses" | ...
-        model: str = "",                   # empty → resolved from config/provider later
-        max_iterations: int = 90,          # tool-calling iterations (shared with subagents)
+        api_mode: str = None,
+        model: str = "",
+        max_iterations: int = 90,
         enabled_toolsets: list = None,
         disabled_toolsets: list = None,
         quiet_mode: bool = False,
         save_trajectories: bool = False,
-        platform: str = None,              # "cli", "telegram", etc.
+        platform: str = None,
         session_id: str = None,
         skip_context_files: bool = False,
         skip_memory: bool = False,
         credential_pool=None,
-        # ... plus callbacks, thread/user/chat IDs, iteration_budget, fallback_model,
-        # checkpoints config, prefill_messages, service_tier, reasoning_config, etc.
+        # ... plus callbacks, routing, budgets, prefill, service tier, etc.
     ): ...
 
-    def chat(self, message: str) -> str:
-        """Simple interface — returns final response string."""
-
+    def chat(self, message: str) -> str: ...
     def run_conversation(self, user_message: str, system_message: str = None,
-                         conversation_history: list = None, task_id: str = None) -> dict:
-        """Full interface — returns dict with final_response + messages."""
+                         conversation_history: list = None, task_id: str = None) -> dict: ...
 ```
 
-### Agent Loop
+The synchronous conversation loop in `run_conversation()` calls the model,
+dispatches tool calls through `handle_function_call()`, appends tool results, and
+returns once the model emits final content. Reasoning content is stored in
+`assistant_msg["reasoning"]`.
 
-The core loop is inside `run_conversation()` — entirely synchronous, with
-interrupt checks, budget tracking, and a one-turn grace call:
+`model_tools.py` owns tool definition filtering and the call into
+`tools.registry`. `toolsets.py` owns the exposed toolset names. Adding a core
+tool requires both a registered `tools/<name>.py` module and a toolset entry.
 
-```python
-while (api_call_count < self.max_iterations and self.iteration_budget.remaining > 0) \
-        or self._budget_grace_call:
-    if self._interrupt_requested: break
-    response = client.chat.completions.create(model=model, messages=messages, tools=tool_schemas)
-    if response.tool_calls:
-        for tool_call in response.tool_calls:
-            result = handle_function_call(tool_call.name, tool_call.args, task_id)
-            messages.append(tool_result_message(result))
-        api_call_count += 1
-    else:
-        return response.content
-```
+`cli.py` owns the classic prompt_toolkit CLI shell. More detailed CLI command,
+config, setup, profile, skin, and dashboard rules live in `hermes_cli/AGENTS.md`.
 
-Messages follow OpenAI format: `{"role": "system/user/assistant/tool", ...}`.
-Reasoning content is stored in `assistant_msg["reasoning"]`.
+`hermes_state.py` owns persistent session storage: SQLite sessions, messages,
+metadata, and FTS5 search. Session history is separate from curated memory.
 
----
+## Global Policies
 
-## CLI Architecture (cli.py)
+### Harness maintenance
 
-- **Rich** for banner/panels, **prompt_toolkit** for input with autocomplete
-- **KawaiiSpinner** (`agent/display.py`) — animated faces during API calls, `┊` activity feed for tool results
-- `load_cli_config()` in cli.py merges hardcoded defaults + user config YAML
-- **Skin engine** (`hermes_cli/skin_engine.py`) — data-driven CLI theming; initialized from `display.skin` config key at startup; skins customize banner colors, spinner faces/verbs/wings, tool prefix, response box, branding text
-- `process_command()` is a method on `HermesCLI` — dispatches on canonical command name resolved via `resolve_command()` from the central registry
-- Skill slash commands: `agent/skill_commands.py` scans `~/.hermes/skills/`, injects as **user message** (not system prompt) to preserve prompt caching
+Prefer durable harness improvements over one-off prompt instructions:
+directory-local `AGENTS.md`, skills with linked references, hooks, tests, LSP
+diagnostics, cron/curator review, and plugins. Revisit these rules every few
+months; stale rules can become model drag as model behavior improves.
 
-### Slash Command Registry (`hermes_cli/commands.py`)
+### Profile-safe paths
 
-All slash commands are defined in a central `COMMAND_REGISTRY` list of `CommandDef` objects. Every downstream consumer derives from this registry automatically:
+Use `get_hermes_home()` from `hermes_constants` for all state paths. Use
+`display_hermes_home()` for user-facing messages. Do not hardcode
+`~/.hermes` or `Path.home() / ".hermes"` in code that reads or writes Hermes
+state. Profiles depend on `HERMES_HOME` being applied before imports.
 
-- **CLI** — `process_command()` resolves aliases via `resolve_command()`, dispatches on canonical name
-- **Gateway** — `GATEWAY_KNOWN_COMMANDS` frozenset for hook emission, `resolve_command()` for dispatch
-- **Gateway help** — `gateway_help_lines()` generates `/help` output
-- **Telegram** — `telegram_bot_commands()` generates the BotCommand menu
-- **Slack** — `slack_subcommand_map()` generates `/hermes` subcommand routing
-- **Autocomplete** — `COMMANDS` flat dict feeds `SlashCommandCompleter`
-- **CLI help** — `COMMANDS_BY_CATEGORY` dict feeds `show_help()`
+Profile operations are HOME-anchored intentionally: `_get_profiles_root()` uses
+`Path.home() / ".hermes" / "profiles"` so any active profile can list all
+profiles.
 
-### Adding a Slash Command
+Tests that mock `Path.home()` must also set `HERMES_HOME`.
 
-1. Add a `CommandDef` entry to `COMMAND_REGISTRY` in `hermes_cli/commands.py`:
-```python
-CommandDef("mycommand", "Description of what it does", "Session",
-           aliases=("mc",), args_hint="[arg]"),
-```
-2. Add handler in `HermesCLI.process_command()` in `cli.py`:
-```python
-elif canonical == "mycommand":
-    self._handle_mycommand(cmd_original)
-```
-3. If the command is available in the gateway, add a handler in `gateway/run.py`:
-```python
-if canonical == "mycommand":
-    return await self._handle_mycommand(event)
-```
-4. For persistent settings, use `save_config_value()` in `cli.py`
+### Prompt caching
 
-**CommandDef fields:**
-- `name` — canonical name without slash (e.g. `"background"`)
-- `description` — human-readable description
-- `category` — one of `"Session"`, `"Configuration"`, `"Tools & Skills"`, `"Info"`, `"Exit"`
-- `aliases` — tuple of alternative names (e.g. `("bg",)`)
-- `args_hint` — argument placeholder shown in help (e.g. `"<prompt>"`, `"[name]"`)
-- `cli_only` — only available in the interactive CLI
-- `gateway_only` — only available in messaging platforms
-- `gateway_config_gate` — config dotpath (e.g. `"display.tool_progress_command"`); when set on a `cli_only` command, the command becomes available in the gateway if the config value is truthy. `GATEWAY_KNOWN_COMMANDS` always includes config-gated commands so the gateway can dispatch them; help/menus only show them when the gate is open.
+Do not change past context, toolsets, memories, or system prompts mid-turn unless
+the existing compression path does it intentionally. Slash commands that mutate
+system-prompt state should default to deferred invalidation and offer an explicit
+`--now` style path only when the codebase already supports it.
 
-**Adding an alias** requires only adding it to the `aliases` tuple on the existing `CommandDef`. No other file changes needed — dispatch, help text, Telegram menu, Slack mapping, and autocomplete all update automatically.
+### Dependency pinning
 
----
-
-## TUI Architecture (ui-tui + tui_gateway)
-
-The TUI is a full replacement for the classic (prompt_toolkit) CLI, activated via `hermes --tui` or `HERMES_TUI=1`.
-
-### Process Model
-
-```
-hermes --tui
-  └─ Node (Ink)  ──stdio JSON-RPC──  Python (tui_gateway)
-       │                                  └─ AIAgent + tools + sessions
-       └─ renders transcript, composer, prompts, activity
-```
-
-TypeScript owns the screen. Python owns sessions, tools, model calls, and slash command logic.
-
-### Transport
-
-Newline-delimited JSON-RPC over stdio. Requests from Ink, events from Python. See `tui_gateway/server.py` for the full method/event catalog.
-
-### Key Surfaces
-
-| Surface | Ink component | Gateway method |
-|---------|---------------|----------------|
-| Chat streaming | `app.tsx` + `messageLine.tsx` | `prompt.submit` → `message.delta/complete` |
-| Tool activity | `thinking.tsx` | `tool.start/progress/complete` |
-| Approvals | `prompts.tsx` | `approval.respond` ← `approval.request` |
-| Clarify/sudo/secret | `prompts.tsx`, `maskedPrompt.tsx` | `clarify/sudo/secret.respond` |
-| Session picker | `sessionPicker.tsx` | `session.list/resume` |
-| Slash commands | Local handler + fallthrough | `slash.exec` → `_SlashWorker`, `command.dispatch` |
-| Completions | `useCompletion` hook | `complete.slash`, `complete.path` |
-| Theming | `theme.ts` + `branding.tsx` | `gateway.ready` with skin data |
-
-### Slash Command Flow
-
-1. Built-in client commands (`/help`, `/quit`, `/clear`, `/resume`, `/copy`, `/paste`, etc.) handled locally in `app.tsx`
-2. Everything else → `slash.exec` (runs in persistent `_SlashWorker` subprocess) → `command.dispatch` fallback
-
-### Dev Commands
-
-```bash
-cd ui-tui
-npm install       # first time
-npm run dev       # watch mode (rebuilds hermes-ink + tsx --watch)
-npm start         # production
-npm run build     # full build (hermes-ink + tsc)
-npm run type-check # typecheck only (tsc --noEmit)
-npm run lint      # eslint
-npm run fmt       # prettier
-npm test          # vitest
-```
-
-### TUI in the Dashboard (`hermes dashboard` → `/chat`)
-
-The dashboard embeds the real `hermes --tui` — **not** a rewrite.  See `hermes_cli/pty_bridge.py` + the `@app.websocket("/api/pty")` endpoint in `hermes_cli/web_server.py`.
-
-- Browser loads `web/src/pages/ChatPage.tsx`, which mounts xterm.js's `Terminal` with the WebGL renderer, `@xterm/addon-fit` for container-driven resize, and `@xterm/addon-unicode11` for modern wide-character widths.
-- `/api/pty?token=…` upgrades to a WebSocket; auth uses the same ephemeral `_SESSION_TOKEN` as REST, via query param (browsers can't set `Authorization` on WS upgrade).
-- The server spawns whatever `hermes --tui` would spawn, through `ptyprocess` (POSIX PTY — WSL works, native Windows does not).
-- Frames: raw PTY bytes each direction; resize via `\x1b[RESIZE:<cols>;<rows>]` intercepted on the server and applied with `TIOCSWINSZ`.
-
-**Do not re-implement the primary chat experience in React.** The main transcript, composer/input flow (including slash-command behavior), and PTY-backed terminal belong to the embedded `hermes --tui` — anything new you add to Ink shows up in the dashboard automatically. If you find yourself rebuilding the transcript or composer for the dashboard, stop and extend Ink instead.
-
-**Structured React UI around the TUI is allowed when it is not a second chat surface.** Sidebar widgets, inspectors, summaries, status panels, and similar supporting views (e.g. `ChatSidebar`, `ModelPickerDialog`, `ToolCall`) are fine when they complement the embedded TUI rather than replacing the transcript / composer / terminal. Keep their state independent of the PTY child's session and surface their failures non-destructively so the terminal pane keeps working unimpaired.
-
----
-
-## Adding New Tools
-
-For most custom or local-only tools, do **not** edit Hermes core. Use the plugin
-route instead: create `~/.hermes/plugins/<name>/plugin.yaml` and
-`~/.hermes/plugins/<name>/__init__.py`, then register tools with
-`ctx.register_tool(...)`. Plugin toolsets are discovered automatically and can be
-enabled or disabled without touching `tools/` or `toolsets.py`.
-
-Use the built-in route below only when the user is explicitly contributing a new
-core Hermes tool that should ship in the base system.
-
-Built-in/core tools require changes in **2 files**:
-
-**1. Create `tools/your_tool.py`:**
-```python
-import json, os
-from tools.registry import registry
-
-def check_requirements() -> bool:
-    return bool(os.getenv("EXAMPLE_API_KEY"))
-
-def example_tool(param: str, task_id: str = None) -> str:
-    return json.dumps({"success": True, "data": "..."})
-
-registry.register(
-    name="example_tool",
-    toolset="example",
-    schema={"name": "example_tool", "description": "...", "parameters": {...}},
-    handler=lambda args, **kw: example_tool(param=args.get("param", ""), task_id=kw.get("task_id")),
-    check_fn=check_requirements,
-    requires_env=["EXAMPLE_API_KEY"],
-)
-```
-
-**2. Add to `toolsets.py`** — either `_HERMES_CORE_TOOLS` (all platforms) or a new toolset. **This step is required:** auto-discovery imports the tool and registers its schema, but the tool is only *exposed to an agent* if its name appears in a toolset. `_HERMES_CORE_TOOLS` is not dead code — it's the default bundle every platform's base toolset inherits from.
-
-Auto-discovery: any `tools/*.py` file with a top-level `registry.register()` call is imported automatically — no manual import list to maintain. Wiring into a toolset is still a deliberate, manual step.
-
-The registry handles schema collection, dispatch, availability checking, and error wrapping. All handlers MUST return a JSON string.
-
-**Path references in tool schemas**: If the schema description mentions file paths (e.g. default output directories), use `display_hermes_home()` to make them profile-aware. The schema is generated at import time, which is after `_apply_profile_override()` sets `HERMES_HOME`.
-
-**State files**: If a tool stores persistent state (caches, logs, checkpoints), use `get_hermes_home()` for the base directory — never `Path.home() / ".hermes"`. This ensures each profile gets its own state.
-
-**Agent-level tools** (todo, memory): intercepted by `run_agent.py` before `handle_function_call()`. See `tools/todo_tool.py` for the pattern.
-
----
-
-## Dependency Pinning Policy
-
-All dependencies must have upper bounds to limit supply-chain attack surface.
-This policy was established after the litellm compromise (PR #2796, #2810) and
-reinforced after the Mini Shai-Hulud worm campaign (May 2026).
+All dependencies need upper bounds.
 
 | Source type | Treatment | Example |
-|---|---|---|
+| --- | --- | --- |
 | PyPI package | `>=floor,<next_major` | `"httpx>=0.28.1,<1"` |
-| Git URL | Commit SHA | `git+https://...@<40-char-sha>` |
-| GitHub Actions | Commit SHA + comment | `uses: actions/checkout@<sha>  # v4` |
-| CI-only pip | `==exact` | `pyyaml==6.0.2` |
+| pre-1.0 PyPI package | `>=floor,<0.(minor+2)` | `"pkg>=0.29,<0.31"` |
+| Git URL | commit SHA | `git+https://...@<40-char-sha>` |
+| GitHub Actions | commit SHA + version comment | `uses: actions/checkout@<sha>  # v4` |
+| CI-only pip | exact pin | `pyyaml==6.0.2` |
 
-**When adding a new dependency to `pyproject.toml`:**
-1. Pin to `>=current_version,<next_major` for post-1.0 (e.g. `>=1.5.0,<2`).
-2. For pre-1.0 packages, use `<0.(current_minor + 2)` (e.g. `>=0.29,<0.32`).
-3. Never commit a bare `>=X.Y.Z` without a ceiling — CI and reviewers will reject it.
-4. Run `uv lock` to regenerate `uv.lock` with hashes.
+When changing `pyproject.toml`, regenerate `uv.lock`.
 
-Reference: #2810 (bounds pass), #9801 (SHA pinning + audit CI).
+### Configuration
 
----
+Non-secret settings belong in `config.yaml`; secrets belong in `.env`.
 
-## Adding Configuration
+Add config defaults in `hermes_cli/config.py::DEFAULT_CONFIG`. Bump
+`_config_version` only for migrations that transform existing user config.
+Adding a new key to an existing section is covered by deep-merge defaults.
 
-### config.yaml options:
-1. Add to `DEFAULT_CONFIG` in `hermes_cli/config.py`
-2. Bump `_config_version` (check the current value at the top of `DEFAULT_CONFIG`)
-   ONLY if you need to actively migrate/transform existing user config
-   (renaming keys, changing structure). Adding a new key to an existing
-   section is handled automatically by the deep-merge and does NOT require
-   a version bump.
+There are three loader paths:
 
-### Top-level `config.yaml` sections (non-exhaustive):
+| Loader | Used by |
+| --- | --- |
+| `load_cli_config()` in `cli.py` | classic CLI mode |
+| `load_config()` in `hermes_cli/config.py` | subcommands, setup, tools |
+| direct YAML load in `gateway/` | gateway runtime |
 
-`model`, `agent`, `terminal`, `compression`, `display`, `stt`, `tts`,
-`memory`, `security`, `delegation`, `smart_model_routing`, `checkpoints`,
-`auxiliary`, `curator`, `skills`, `gateway`, `logging`, `cron`, `profiles`,
-`plugins`, `honcho`.
+If CLI and gateway disagree, check which loader you changed.
 
-`auxiliary` holds per-task overrides for side-LLM work (curator, vision,
-embedding, title generation, session_search, etc.) — each task can pin
-its own provider/model/base_url/max_tokens/reasoning_effort. See
-`agent/auxiliary_client.py::_resolve_auto` for resolution order.
+### Tools vs plugins
 
-`curator` holds the background skill-maintenance config —
-`enabled`, `interval_hours`, `min_idle_hours`, `stale_after_days`,
-`archive_after_days`, `backup` (nested).
+Prefer plugins for local or third-party tools. Use built-in/core tools only for
+capabilities that should ship in the base system. Core tool handlers must return
+JSON strings and must be exposed through a toolset before agents can call them.
 
-### .env variables (SECRETS ONLY — API keys, tokens, passwords):
-1. Add to `OPTIONAL_ENV_VARS` in `hermes_cli/config.py` with metadata:
-```python
-"NEW_API_KEY": {
-    "description": "What it's for",
-    "prompt": "Display name",
-    "url": "https://...",
-    "password": True,
-    "category": "tool",  # provider, tool, messaging, setting
-},
-```
+Plugins must not hardcode themselves into core files. If a plugin needs a new
+capability, expand the generic plugin surface.
 
-Non-secret settings (timeouts, thresholds, feature flags, paths, display
-preferences) belong in `config.yaml`, not `.env`. If internal code needs an
-env var mirror for backward compatibility, bridge it from `config.yaml` to
-the env var in code (see `gateway_timeout`, `terminal.cwd` → `TERMINAL_CWD`).
+### Background process notifications
 
-### Config loaders (three paths — know which one you're in):
-
-| Loader | Used by | Location |
-|--------|---------|----------|
-| `load_cli_config()` | CLI mode | `cli.py` — merges CLI-specific defaults + user YAML |
-| `load_config()` | `hermes tools`, `hermes setup`, most CLI subcommands | `hermes_cli/config.py` — merges `DEFAULT_CONFIG` + user YAML |
-| Direct YAML load | Gateway runtime | `gateway/run.py` + `gateway/config.py` — reads user YAML raw |
-
-If you add a new key and the CLI sees it but the gateway doesn't (or vice
-versa), you're on the wrong loader. Check `DEFAULT_CONFIG` coverage.
-
-### Working directory:
-- **CLI** — uses the process's current directory (`os.getcwd()`).
-- **Messaging** — uses `terminal.cwd` from `config.yaml`. The gateway bridges this
-  to the `TERMINAL_CWD` env var for child tools. **`MESSAGING_CWD` has been
-  removed** — the config loader prints a deprecation warning if it's set in
-  `.env`. Same for `TERMINAL_CWD` in `.env`; the canonical setting is
-  `terminal.cwd` in `config.yaml`.
-
----
-
-## Skin/Theme System
-
-The skin engine (`hermes_cli/skin_engine.py`) provides data-driven CLI visual customization. Skins are **pure data** — no code changes needed to add a new skin.
-
-### Architecture
-
-```
-hermes_cli/skin_engine.py    # SkinConfig dataclass, built-in skins, YAML loader
-~/.hermes/skins/*.yaml       # User-installed custom skins (drop-in)
-```
-
-- `init_skin_from_config()` — called at CLI startup, reads `display.skin` from config
-- `get_active_skin()` — returns cached `SkinConfig` for the current skin
-- `set_active_skin(name)` — switches skin at runtime (used by `/skin` command)
-- `load_skin(name)` — loads from user skins first, then built-ins, then falls back to default
-- Missing skin values inherit from the `default` skin automatically
-
-### What skins customize
-
-| Element | Skin Key | Used By |
-|---------|----------|---------|
-| Banner panel border | `colors.banner_border` | `banner.py` |
-| Banner panel title | `colors.banner_title` | `banner.py` |
-| Banner section headers | `colors.banner_accent` | `banner.py` |
-| Banner dim text | `colors.banner_dim` | `banner.py` |
-| Banner body text | `colors.banner_text` | `banner.py` |
-| Response box border | `colors.response_border` | `cli.py` |
-| Spinner faces (waiting) | `spinner.waiting_faces` | `display.py` |
-| Spinner faces (thinking) | `spinner.thinking_faces` | `display.py` |
-| Spinner verbs | `spinner.thinking_verbs` | `display.py` |
-| Spinner wings (optional) | `spinner.wings` | `display.py` |
-| Tool output prefix | `tool_prefix` | `display.py` |
-| Per-tool emojis | `tool_emojis` | `display.py` → `get_tool_emoji()` |
-| Agent name | `branding.agent_name` | `banner.py`, `cli.py` |
-| Welcome message | `branding.welcome` | `cli.py` |
-| Response box label | `branding.response_label` | `cli.py` |
-| Prompt symbol | `branding.prompt_symbol` | `cli.py` |
-
-### Built-in skins
-
-- `default` — Classic Hermes gold/kawaii (the current look)
-- `ares` — Crimson/bronze war-god theme with custom spinner wings
-- `mono` — Clean grayscale monochrome
-- `slate` — Cool blue developer-focused theme
-
-### Adding a built-in skin
-
-Add to `_BUILTIN_SKINS` dict in `hermes_cli/skin_engine.py`:
-
-```python
-"mytheme": {
-    "name": "mytheme",
-    "description": "Short description",
-    "colors": { ... },
-    "spinner": { ... },
-    "branding": { ... },
-    "tool_prefix": "┊",
-},
-```
-
-### User skins (YAML)
-
-Users create `~/.hermes/skins/<name>.yaml`:
-
-```yaml
-name: cyberpunk
-description: Neon-soaked terminal theme
-
-colors:
-  banner_border: "#FF00FF"
-  banner_title: "#00FFFF"
-  banner_accent: "#FF1493"
-
-spinner:
-  thinking_verbs: ["jacking in", "decrypting", "uploading"]
-  wings:
-    - ["⟨⚡", "⚡⟩"]
-
-branding:
-  agent_name: "Cyber Agent"
-  response_label: " ⚡ Cyber "
-
-tool_prefix: "▏"
-```
-
-Activate with `/skin cyberpunk` or `display.skin: cyberpunk` in config.yaml.
-
----
-
-## Plugins
-
-Hermes has two plugin surfaces. Both live under `plugins/` in the repo so
-repo-shipped plugins can be discovered alongside user-installed ones in
-`~/.hermes/plugins/` and pip-installed entry points.
-
-### General plugins (`hermes_cli/plugins.py` + `plugins/<name>/`)
-
-`PluginManager` discovers plugins from `~/.hermes/plugins/`, `./.hermes/plugins/`,
-and pip entry points. Each plugin exposes a `register(ctx)` function that
-can:
-
-- Register Python-callback lifecycle hooks:
-  `pre_tool_call`, `post_tool_call`, `pre_llm_call`, `post_llm_call`,
-  `on_session_start`, `on_session_end`
-- Register new tools via `ctx.register_tool(...)`
-- Register CLI subcommands via `ctx.register_cli_command(...)` — the
-  plugin's argparse tree is wired into `hermes` at startup so
-  `hermes <pluginname> <subcmd>` works with no change to `main.py`
-
-Hooks are invoked from `model_tools.py` (pre/post tool) and `run_agent.py`
-(lifecycle). **Discovery timing pitfall:** `discover_plugins()` only runs
-as a side effect of importing `model_tools.py`. Code paths that read plugin
-state without importing `model_tools.py` first must call `discover_plugins()`
-explicitly (it's idempotent).
-
-### Memory-provider plugins (`plugins/memory/<name>/`)
-
-Separate discovery system for pluggable memory backends. Current built-in
-providers include **honcho, mem0, supermemory, byterover, hindsight,
-holographic, openviking, retaindb**.
-
-Each provider implements the `MemoryProvider` ABC (see `agent/memory_provider.py`)
-and is orchestrated by `agent/memory_manager.py`. Lifecycle hooks include
-`sync_turn(turn_messages)`, `prefetch(query)`, `shutdown()`, and optional
-`post_setup(hermes_home, config)` for setup-wizard integration.
-
-**CLI commands via `plugins/memory/<name>/cli.py`:** if a memory plugin
-defines `register_cli(subparser)`, `discover_plugin_cli_commands()` finds
-it at argparse setup time and wires it into `hermes <plugin>`. The
-framework only exposes CLI commands for the **currently active** memory
-provider (read from `memory.provider` in config.yaml), so disabled
-providers don't clutter `hermes --help`.
-
-**Rule (Teknium, May 2026):** plugins MUST NOT modify core files
-(`run_agent.py`, `cli.py`, `gateway/run.py`, `hermes_cli/main.py`, etc.).
-If a plugin needs a capability the framework doesn't expose, expand the
-generic plugin surface (new hook, new ctx method) — never hardcode
-plugin-specific logic into core. PR #5295 removed 95 lines of hardcoded
-honcho argparse from `main.py` for exactly this reason.
-
-**No new in-tree memory providers (policy, May 2026):** the set of
-built-in memory providers under `plugins/memory/` is closed. New memory
-backends must ship as **standalone plugin repos** that users install
-into `~/.hermes/plugins/` (or via pip entry points) — they implement
-the same `MemoryProvider` ABC, register through the same discovery
-path, and integrate via `hermes memory setup` / `post_setup()` without
-landing in this tree. PRs that add a new directory under
-`plugins/memory/` will be closed with a pointer to publish the
-provider as its own repo. Existing in-tree providers stay; bug fixes
-to them are welcome.
-
-### Model-provider plugins (`plugins/model-providers/<name>/`)
-
-Every inference backend (openrouter, anthropic, gmi, deepseek, nvidia, …)
-ships as a plugin here. Each plugin's `__init__.py` calls
-`providers.register_provider(ProviderProfile(...))` at module load.
-`providers/__init__.py._discover_providers()` is a **lazy, separate
-discovery system** — scanned on first `get_provider_profile()` or
-`list_providers()` call, NOT by the general PluginManager.
-
-Scan order:
-1. Bundled: `<repo>/plugins/model-providers/<name>/`
-2. User: `$HERMES_HOME/plugins/model-providers/<name>/`
-3. Legacy: `<repo>/providers/<name>.py` (back-compat)
-
-User plugins of the same name override bundled ones — `register_provider()`
-is last-writer-wins. This lets third parties swap out any built-in
-profile without a repo patch.
-
-The general PluginManager records `kind: model-provider` manifests but does
-NOT import them (would double-instantiate `ProviderProfile`). Plugins
-without an explicit `kind:` get auto-coerced via a source-text heuristic
-(`register_provider` + `ProviderProfile` in `__init__.py`).
-
-Full authoring guide: `website/docs/developer-guide/model-provider-plugin.md`.
-
-### Dashboard / context-engine / image-gen plugin directories
-
-`plugins/context_engine/`, `plugins/image_gen/`, etc. follow the same
-pattern (ABC + orchestrator + per-plugin directory). Context engines
-plug into `agent/context_engine.py`; image-gen providers into
-`agent/image_gen_provider.py`. Reference / docs-companion plugins
-(`example-dashboard`, `strike-freedom-cockpit`, `plugin-llm-example`,
-`plugin-llm-async-example`) live in the
-[`hermes-example-plugins`](https://github.com/NousResearch/hermes-example-plugins)
-companion repo, not in this tree.
-
----
-
-## Skills
-
-Two parallel surfaces:
-
-- **`skills/`** — built-in skills shipped and loadable by default.
-  Organized by category directories (e.g. `skills/github/`, `skills/mlops/`).
-- **`optional-skills/`** — heavier or niche skills shipped with the repo but
-  NOT active by default. Installed explicitly via
-  `hermes skills install official/<category>/<skill>`. Adapter lives in
-  `tools/skills_hub.py` (`OptionalSkillSource`). Categories include
-  `autonomous-ai-agents`, `blockchain`, `communication`, `creative`,
-  `devops`, `email`, `health`, `mcp`, `migration`, `mlops`, `productivity`,
-  `research`, `security`, `web-development`.
-
-When reviewing skill PRs, check which directory they target — heavy-dep or
-niche skills belong in `optional-skills/`.
-
-### SKILL.md frontmatter
-
-Standard fields: `name`, `description`, `version`, `author`, `license`,
-`platforms` (OS-gating list: `[macos]`, `[linux, macos]`, ...),
-`metadata.hermes.tags`, `metadata.hermes.category`,
-`metadata.hermes.related_skills`, `metadata.hermes.config` (config.yaml
-settings the skill needs — stored under `skills.config.<key>`, prompted
-during setup, injected at load time).
-
-Top-level `tags:` and `category:` are also accepted and mirrored from
-`metadata.hermes.*` by the loader.
-
-### Skill authoring standards (HARDLINE)
-
-Every new or modernized skill — bundled, optional, or contributed —
-must meet these standards before merge. Reviewers reject PRs that
-violate them.
-
-1. **`description` ≤ 60 characters, one sentence, ends with a period.**
-   Long descriptions bloat skill listings and dilute the model's
-   attention when many skills are loaded. State the capability, not
-   the implementation. No marketing words ("powerful",
-   "comprehensive", "seamless", "advanced"). Don't repeat the skill
-   name. Verify with:
-   ```python
-   import re, pathlib
-   m = re.search(r'^description: (.*)$',
-                 pathlib.Path('skills/<cat>/<name>/SKILL.md').read_text(),
-                 re.MULTILINE)
-   assert len(m.group(1)) <= 60, len(m.group(1))
-   ```
-
-2. **Tools referenced in SKILL.md prose must be native Hermes tools or
-   MCP servers the skill explicitly expects.** When the skill needs a
-   capability, point at the proper tool by name in backticks
-   (`` `terminal` ``, `` `web_extract` ``, `` `read_file` ``,
-   `` `patch` ``, `` `search_files` ``, `` `vision_analyze` ``,
-   `` `browser_navigate` ``, `` `delegate_task` ``, etc.). Do NOT
-   name shell utilities the agent already has wrapped — `grep` →
-   `search_files`, `cat`/`head`/`tail` → `read_file`, `sed`/`awk` →
-   `patch`, `find`/`ls` → `search_files target='files'`. If the skill
-   depends on an MCP server, name the MCP server and document the
-   expected setup in `## Prerequisites`. Anything else (third-party
-   CLIs, shell pipelines, etc.) is fair game inside script files but
-   should not be the headline interaction surface in the prose.
-
-3. **`platforms:` gating audited against actual script imports.**
-   Skills that use POSIX-only primitives (`fcntl`, `termios`,
-   `os.setsid`, `os.kill(pid, 0)` for liveness, `/proc`, `/tmp`
-   hardcoded, `signal.SIGKILL`, bash heredocs, `osascript`, `apt`,
-   `systemctl`) must declare their supported platforms. Default
-   posture: try to fix it cross-platform first — `tempfile.gettempdir`,
-   `pathlib.Path`, `psutil.pid_exists`, Python-level filtering instead
-   of `grep`. Gate to a narrower set only when the dependency is
-   genuinely platform-bound.
-
-4. **`author` credits the human contributor first.** For external
-   contributions, the contributor's real name + GitHub handle goes
-   first; "Hermes Agent" is the secondary collaborator. If the
-   contributor's commit shows "Hermes Agent" as author (because they
-   used Hermes to draft the skill), replace it with their actual name
-   — credit the human, not the tool.
-
-5. **SKILL.md body uses the modern section order.** `# <Skill> Skill`
-   title, 2-3 sentence intro stating what it does and doesn't do,
-   `## When to Use`, `## Prerequisites`, `## How to Run`,
-   `## Quick Reference`, `## Procedure`, `## Pitfalls`,
-   `## Verification`. Target ~200 lines for a complex skill,
-   ~100 lines for a simple one. Cut redundant intro fluff, marketing
-   prose, and re-explanations of env vars already in
-   `## Prerequisites`.
-
-6. **Scripts go in `scripts/`, references in `references/`,
-   templates in `templates/`.** Don't expect the model to inline-write
-   parsers, XML walkers, or non-trivial logic every call — ship a
-   helper script. Reference it from SKILL.md by path relative to the
-   skill directory.
-
-7. **Tests live at `tests/skills/test_<skill>_skill.py`** and use only
-   stdlib + pytest + `unittest.mock`. No live network calls. Run via
-   `scripts/run_tests.sh tests/skills/test_<skill>_skill.py -q`.
-
-8. **`.env.example` additions are isolated to a clearly delimited
-   block.** Don't touch the surrounding file — contributor-supplied
-   `.env.example` versions are usually stale and edits outside the
-   skill's own block must be dropped during salvage.
-
-The full salvage / modernization checklist for external skill PRs
-lives in the `hermes-agent-dev` skill at
-`references/new-skill-pr-salvage.md` — load it before polishing
-contributor skill PRs.
-
----
-
-## Toolsets
-
-All toolsets are defined in `toolsets.py` as a single `TOOLSETS` dict.
-Each platform's adapter picks a base toolset (e.g. Telegram uses
-`"messaging"`); `_HERMES_CORE_TOOLS` is the default bundle most
-platforms inherit from.
-
-Current toolset keys: `browser`, `clarify`, `code_execution`, `cronjob`,
-`debugging`, `delegation`, `discord`, `discord_admin`, `feishu_doc`,
-`feishu_drive`, `file`, `homeassistant`, `image_gen`, `kanban`, `memory`,
-`messaging`, `moa`, `rl`, `safe`, `search`, `session_search`, `skills`,
-`spotify`, `terminal`, `todo`, `tts`, `video`, `vision`, `web`, `yuanbao`.
-
-Enable/disable per platform via `hermes tools` (the curses UI) or the
-`tools.<platform>.enabled` / `tools.<platform>.disabled` lists in
-`config.yaml`.
-
----
-
-## Delegation (`delegate_task`)
-
-`tools/delegate_tool.py` spawns a subagent with an isolated
-context + terminal session. Synchronous: the parent waits for the
-child's summary before continuing its own loop — if the parent is
-interrupted, the child is cancelled.
-
-Two shapes:
-
-- **Single:** pass `goal` (+ optional `context`, `toolsets`).
-- **Batch (parallel):** pass `tasks: [...]` — each gets its own subagent
-  running concurrently. Concurrency is capped by
-  `delegation.max_concurrent_children` (default 3).
-
-Roles:
-
-- `role="leaf"` (default) — focused worker. Cannot call `delegate_task`,
-  `clarify`, `memory`, `send_message`, `execute_code`.
-- `role="orchestrator"` — retains `delegate_task` so it can spawn its
-  own workers. Gated by `delegation.orchestrator_enabled` (default true)
-  and bounded by `delegation.max_spawn_depth` (default 2).
-
-Key config knobs (under `delegation:` in `config.yaml`):
-`max_concurrent_children`, `max_spawn_depth`, `child_timeout_seconds`,
-`orchestrator_enabled`, `subagent_auto_approve`, `inherit_mcp_toolsets`,
-`max_iterations`.
-
-Synchronicity rule: delegate_task is **not** durable. For long-running
-work that must outlive the current turn, use `cronjob` or
-`terminal(background=True, notify_on_complete=True)` instead.
-
----
-
-## Curator (skill lifecycle)
-
-Background skill-maintenance system that tracks usage on agent-created
-skills and auto-archives stale ones. Users never lose skills; archives
-go to `~/.hermes/skills/.archive/` and are restorable.
-
-- **Core:** `agent/curator.py` (review loop, auto-transitions, LLM review
-  prompt) + `agent/curator_backup.py` (pre-run tar.gz snapshots).
-- **CLI:** `hermes_cli/curator.py` wires `hermes curator <verb>` where
-  verbs are: `status`, `run`, `pause`, `resume`, `pin`, `unpin`,
-  `archive`, `restore`, `prune`, `backup`, `rollback`.
-- **Telemetry:** `tools/skill_usage.py` owns the sidecar
-  `~/.hermes/skills/.usage.json` — per-skill `use_count`, `view_count`,
-  `patch_count`, `last_activity_at`, `state` (active / stale /
-  archived), `pinned`.
-
-Invariants:
-- Curator only touches skills with `created_by: "agent"` provenance —
-  bundled + hub-installed skills are off-limits.
-- Never deletes; max destructive action is archive.
-- Pinned skills are exempt from every auto-transition and from the
-  LLM review pass.
-- `skill_manage(action="delete")` refuses pinned skills; patch/edit/
-  write_file/remove_file go through so the agent can keep improving
-  pinned skills.
-
-Config section (`curator:` in `config.yaml`):
-`enabled`, `interval_hours`, `min_idle_hours`, `stale_after_days`,
-`archive_after_days`, `backup.*`.
-
-Full user-facing docs: `website/docs/user-guide/features/curator.md`.
-
----
-
-## Cron (scheduled jobs)
-
-`cron/jobs.py` (job store) + `cron/scheduler.py` (tick loop). Agents
-schedule jobs via the `cronjob` tool; users via `hermes cron <verb>`
-(`list`, `add`, `edit`, `pause`, `resume`, `run`, `remove`) or the
-`/cron` slash command.
-
-Supported schedule formats:
-- Duration: `"30m"`, `"2h"`, `"1d"`
-- "every" phrase: `"every 2h"`, `"every monday 9am"`
-- 5-field cron expression: `"0 9 * * *"`
-- ISO timestamp (one-shot): `"2026-06-01T09:00:00Z"`
-
-Per-job fields include `skills` (load specific skills), `model` /
-`provider` overrides, `script` (pre-run data-collection script whose
-stdout is injected into the prompt; `no_agent=True` turns the script
-into the entire job), `context_from` (chain job A's last output into
-job B's prompt), `workdir` (run in a specific directory with its
-`AGENTS.md`/`CLAUDE.md` loaded), and multi-platform delivery.
-
-Hardening invariants:
-- **3-minute hard interrupt** on cron sessions — runaway agent loops
-  cannot monopolize the scheduler.
-- Catchup window: half the job's period, clamped to 120s–2h.
-- Grace window: 120s for one-shot jobs whose fire time was missed.
-- File lock at `~/.hermes/cron/.tick.lock` prevents duplicate ticks
-  across processes.
-- Cron sessions pass `skip_memory=True` by default; memory providers
-  intentionally do not run during cron.
-
-Cron deliveries are **not** mirrored into the target gateway session —
-they land in their own cron session with a header/footer frame so the
-main conversation's message-role alternation stays intact.
-
----
-
-## Kanban (multi-agent work queue)
-
-Durable SQLite-backed board that lets multiple profiles / workers
-collaborate on shared tasks. Users drive it via `hermes kanban <verb>`;
-workers spawned by the dispatcher drive it via a dedicated `kanban_*`
-toolset so their schema footprint is zero when they're not inside a
-kanban task.
-
-- **CLI:** `hermes_cli/kanban.py` wires `hermes kanban` with verbs
-  `init`, `create`, `list` (alias `ls`), `show`, `assign`, `link`,
-  `unlink`, `comment`, `complete`, `block`, `unblock`, `archive`,
-  `tail`, plus less-commonly-used `watch`, `stats`, `runs`, `log`,
-  `assignees`, `heartbeat`, `notify-*`, `dispatch`, `daemon`, `gc`.
-- **Worker/orchestrator toolset:** `tools/kanban_tools.py` exposes
-  `kanban_show`, `kanban_complete`, `kanban_block`, `kanban_heartbeat`,
-  `kanban_comment`, `kanban_create`, `kanban_link`; profiles that
-  explicitly enable the `kanban` toolset outside a dispatcher-spawned
-  task also get `kanban_list` and `kanban_unblock` for board routing.
-- **Dispatcher:** long-lived loop that (default every 60s) reclaims
-  stale claims, promotes ready tasks, atomically claims, and spawns
-  assigned profiles. Runs **inside the gateway** by default via
-  `kanban.dispatch_in_gateway: true`.
-- **Plugin assets:** `plugins/kanban/dashboard/` (web UI) +
-  `plugins/kanban/systemd/` (`hermes-kanban-dispatcher.service` for
-  standalone dispatcher deployment).
-
-Isolation model:
-- **Board** is the hard boundary — workers are spawned with
-  `HERMES_KANBAN_BOARD` pinned in their env so they can't see other
-  boards.
-- **Tenant** is a soft namespace *within* a board — one specialist
-  fleet can serve multiple businesses with workspace-path + memory-key
-  isolation.
-- After `kanban.failure_limit` consecutive non-success attempts on the
-  same task (default: 2), the dispatcher auto-blocks it to prevent spin
-  loops.
-
-Full user-facing docs: `website/docs/user-guide/features/kanban.md`.
-
----
-
-## Important Policies
-
-### Prompt Caching Must Not Break
-
-Hermes-Agent ensures caching remains valid throughout a conversation. **Do NOT implement changes that would:**
-- Alter past context mid-conversation
-- Change toolsets mid-conversation
-- Reload memories or rebuild system prompts mid-conversation
-
-Cache-breaking forces dramatically higher costs. The ONLY time we alter context is during context compression.
-
-Slash commands that mutate system-prompt state (skills, tools, memory, etc.)
-must be **cache-aware**: default to deferred invalidation (change takes
-effect next session), with an opt-in `--now` flag for immediate
-invalidation. See `/skills install --now` for the canonical pattern.
-
-### Background Process Notifications (Gateway)
-
-When `terminal(background=true, notify_on_complete=true)` is used, the gateway runs a watcher that
-detects process completion and triggers a new agent turn. Control verbosity of background process
-messages with `display.background_process_notifications`
-in config.yaml (or `HERMES_BACKGROUND_NOTIFICATIONS` env var):
-
-- `all` — running-output updates + final message (default)
-- `result` — only the final completion message
-- `error` — only the final message when exit code != 0
-- `off` — no watcher messages at all
-
----
-
-## Profiles: Multi-Instance Support
-
-Hermes supports **profiles** — multiple fully isolated instances, each with its own
-`HERMES_HOME` directory (config, API keys, memory, sessions, skills, gateway, etc.).
-
-The core mechanism: `_apply_profile_override()` in `hermes_cli/main.py` sets
-`HERMES_HOME` before any module imports. All `get_hermes_home()` references
-automatically scope to the active profile.
-
-### Rules for profile-safe code
-
-1. **Use `get_hermes_home()` for all HERMES_HOME paths.** Import from `hermes_constants`.
-   NEVER hardcode `~/.hermes` or `Path.home() / ".hermes"` in code that reads/writes state.
-   ```python
-   # GOOD
-   from hermes_constants import get_hermes_home
-   config_path = get_hermes_home() / "config.yaml"
-
-   # BAD — breaks profiles
-   config_path = Path.home() / ".hermes" / "config.yaml"
-   ```
-
-2. **Use `display_hermes_home()` for user-facing messages.** Import from `hermes_constants`.
-   This returns `~/.hermes` for default or `~/.hermes/profiles/<name>` for profiles.
-   ```python
-   # GOOD
-   from hermes_constants import display_hermes_home
-   print(f"Config saved to {display_hermes_home()}/config.yaml")
-
-   # BAD — shows wrong path for profiles
-   print("Config saved to ~/.hermes/config.yaml")
-   ```
-
-3. **Module-level constants are fine** — they cache `get_hermes_home()` at import time,
-   which is AFTER `_apply_profile_override()` sets the env var. Just use `get_hermes_home()`,
-   not `Path.home() / ".hermes"`.
-
-4. **Tests that mock `Path.home()` must also set `HERMES_HOME`** — since code now uses
-   `get_hermes_home()` (reads env var), not `Path.home() / ".hermes"`:
-   ```python
-   with patch.object(Path, "home", return_value=tmp_path), \
-        patch.dict(os.environ, {"HERMES_HOME": str(tmp_path / ".hermes")}):
-       ...
-   ```
-
-5. **Gateway platform adapters should use token locks** — if the adapter connects with
-   a unique credential (bot token, API key), call `acquire_scoped_lock()` from
-   `gateway.status` in the `connect()`/`start()` method and `release_scoped_lock()` in
-   `disconnect()`/`stop()`. This prevents two profiles from using the same credential.
-   See `gateway/platforms/telegram.py` for the canonical pattern.
-
-6. **Profile operations are HOME-anchored, not HERMES_HOME-anchored** — `_get_profiles_root()`
-   returns `Path.home() / ".hermes" / "profiles"`, NOT `get_hermes_home() / "profiles"`.
-   This is intentional — it lets `hermes -p coder profile list` see all profiles regardless
-   of which one is active.
+Gateway background process notifications are controlled by
+`display.background_process_notifications` or `HERMES_BACKGROUND_NOTIFICATIONS`:
+`all`, `result`, `error`, or `off`.
 
 ## Known Pitfalls
 
-### DO NOT hardcode `~/.hermes` paths
-Use `get_hermes_home()` from `hermes_constants` for code paths. Use `display_hermes_home()`
-for user-facing print/log messages. Hardcoding `~/.hermes` breaks profiles — each profile
-has its own `HERMES_HOME` directory. This was the source of 5 bugs fixed in PR #3575.
-
-### DO NOT introduce new `simple_term_menu` usage
-Existing call sites in `hermes_cli/main.py` remain for legacy fallback only;
-the preferred UI is curses (stdlib) because `simple_term_menu` has
-ghost-duplication rendering bugs in tmux/iTerm2 with arrow keys. New
-interactive menus must use `hermes_cli/curses_ui.py` — see
-`hermes_cli/tools_config.py` for the canonical pattern.
-
-### DO NOT use `\033[K` (ANSI erase-to-EOL) in spinner/display code
-Leaks as literal `?[K` text under `prompt_toolkit`'s `patch_stdout`. Use space-padding: `f"\r{line}{' ' * pad}"`.
-
-### `_last_resolved_tool_names` is a process-global in `model_tools.py`
-`_run_single_child()` in `delegate_tool.py` saves and restores this global around subagent execution. If you add new code that reads this global, be aware it may be temporarily stale during child agent runs.
-
-### DO NOT hardcode cross-tool references in schema descriptions
-Tool schema descriptions must not mention tools from other toolsets by name (e.g., `browser_navigate` saying "prefer web_search"). Those tools may be unavailable (missing API keys, disabled toolset), causing the model to hallucinate calls to non-existent tools. If a cross-reference is needed, add it dynamically in `get_tool_definitions()` in `model_tools.py` — see the `browser_navigate` / `execute_code` post-processing blocks for the pattern.
-
-### The gateway has TWO message guards — both must bypass approval/control commands
-When an agent is running, messages pass through two sequential guards:
-(1) **base adapter** (`gateway/platforms/base.py`) queues messages in
-`_pending_messages` when `session_key in self._active_sessions`, and
-(2) **gateway runner** (`gateway/run.py`) intercepts `/stop`, `/new`,
-`/queue`, `/status`, `/approve`, `/deny` before they reach
-`running_agent.interrupt()`. Any new command that must reach the runner
-while the agent is blocked (e.g. approval prompts) MUST bypass BOTH
-guards and be dispatched inline, not via `_process_message_background()`
-(which races session lifecycle).
-
-### Squash merges from stale branches silently revert recent fixes
-Before squash-merging a PR, ensure the branch is up to date with `main`
-(`git fetch origin main && git reset --hard origin/main` in the worktree,
-then re-apply the PR's commits). A stale branch's version of an unrelated
-file will silently overwrite recent fixes on main when squashed. Verify
-with `git diff HEAD~1..HEAD` after merging — unexpected deletions are a
-red flag.
-
-### Don't wire in dead code without E2E validation
-Unused code that was never shipped was dead for a reason. Before wiring an
-unused module into a live code path, E2E test the real resolution chain
-with actual imports (not mocks) against a temp `HERMES_HOME`.
-
-### Tests must not write to `~/.hermes/`
-The `_isolate_hermes_home` autouse fixture in `tests/conftest.py` redirects `HERMES_HOME` to a temp dir. Never hardcode `~/.hermes/` paths in tests.
-
-**Profile tests**: When testing profile features, also mock `Path.home()` so that
-`_get_profiles_root()` and `_get_default_hermes_home()` resolve within the temp dir.
-Use the pattern from `tests/hermes_cli/test_profiles.py`:
-```python
-@pytest.fixture
-def profile_env(tmp_path, monkeypatch):
-    home = tmp_path / ".hermes"
-    home.mkdir()
-    monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    monkeypatch.setenv("HERMES_HOME", str(home))
-    return home
-```
-
----
+- Do not introduce new `simple_term_menu` usage. Use curses-based UI helpers.
+- Do not use `\033[K` in spinner/display code; use space padding.
+- `_last_resolved_tool_names` in `model_tools.py` is process-global and is
+  saved/restored around subagent execution.
+- Do not hardcode cross-tool references in schema descriptions. Add dynamic
+  description adjustments in `model_tools.py` when a reference depends on the
+  active toolset.
+- Gateway control/approval commands must bypass both the base adapter message
+  queue and the runner-level interrupt guard. See `gateway/AGENTS.md`.
+- Before wiring unused code into a live path, E2E test the actual import and
+  resolution chain against a temp `HERMES_HOME`.
+- Squash-merging stale branches can revert unrelated fixes. Check the final diff.
 
 ## Testing
 
-**ALWAYS use `scripts/run_tests.sh`** — do not call `pytest` directly. The script enforces
-hermetic environment parity with CI (unset credential vars, TZ=UTC, LANG=C.UTF-8,
-`-n auto` xdist workers, in-tree subprocess-isolation plugin). Direct `pytest`
-on a 16+ core developer machine with API keys set diverges from CI in ways
-that have caused multiple "works locally, fails in CI" incidents (and the reverse).
+Always prefer:
 
 ```bash
-scripts/run_tests.sh                                  # full suite, CI-parity
-scripts/run_tests.sh tests/gateway/                   # one directory
-scripts/run_tests.sh tests/agent/test_foo.py::test_x  # one test
-scripts/run_tests.sh -v --tb=long                     # pass-through pytest flags
-scripts/run_tests.sh --no-isolate tests/foo/          # disable subprocess isolation (faster, for debugging)
+scripts/run_tests.sh
+scripts/run_tests.sh tests/path_or_file.py -q
+scripts/run_tests.sh tests/path_or_file.py::test_name -v --tb=long
 ```
 
-### Subprocess-per-test isolation
-
-Every test runs in a freshly-spawned Python subprocess via the in-tree plugin
-at `tests/_isolate_plugin.py`. This means module-level dicts/sets and
-ContextVars from one test cannot leak into the next — the historic
-`_reset_module_state` autouse fixture is gone.
-
-Implementation notes:
-
-- The plugin uses `multiprocessing.get_context("spawn")`, which works on
-  Linux, macOS, and Windows alike (POSIX `fork` is not used).
-- Per-test overhead is ~0.5–1.0s (Python startup + pytest collection). xdist
-  parallelism amortizes this across cores; on a 20-core box the full suite
-  finishes in roughly the same wall time as before, but flake-free.
-- `isolate_timeout` (configured in `pyproject.toml`) caps each test at 30s.
-  Hangs are killed and surfaced as a failure report.
-- Pass `--no-isolate` to disable isolation — useful when debugging a single
-  test interactively, or when you specifically want to verify state leakage.
-- The plugin disables itself in child processes (sentinel envvar
-  `HERMES_ISOLATE_CHILD=1`), so there's no fork-bomb risk.
-
-### Why the wrapper (and why the old "just call pytest" doesn't work)
-
-Five real sources of local-vs-CI drift the script closes:
-
-| | Without wrapper | With wrapper |
-|---|---|---|
-| Provider API keys | Whatever is in your env (auto-detects pool) | All `*_API_KEY`/`*_TOKEN`/etc. unset |
-| HOME / `~/.hermes/` | Your real config+auth.json | Temp dir per test |
-| Timezone | Local TZ (PDT etc.) | UTC |
-| Locale | Whatever is set | C.UTF-8 |
-| xdist workers | `-n auto` = all cores | `-n auto` (safe — subprocess isolation prevents cross-worker flakes) |
-
-`tests/conftest.py` also enforces points 1-4 as an autouse fixture so ANY pytest
-invocation (including IDE integrations) gets hermetic behavior — but the wrapper
-is belt-and-suspenders.
-
-### Running without the wrapper (only if you must)
-
-If you can't use the wrapper (e.g. inside an IDE that shells pytest directly),
-at minimum activate the venv. The isolation plugin loads automatically from
-`addopts` in `pyproject.toml`, so you get the same per-test process isolation
-either way.
-
-```bash
-source .venv/bin/activate   # or: source venv/bin/activate
-python -m pytest tests/ -q
-```
-
-If you need to bypass isolation for fast feedback while debugging:
-
-```bash
-python -m pytest tests/agent/test_foo.py -q --no-isolate
-```
-
-Always run the full suite before pushing changes.
-
-### Don't write change-detector tests
-
-A test is a **change-detector** if it fails whenever data that is **expected
-to change** gets updated — model catalogs, config version numbers,
-enumeration counts, hardcoded lists of provider models. These tests add no
-behavioral coverage; they just guarantee that routine source updates break
-CI and cost engineering time to "fix."
-
-**Do not write:**
-
-```python
-# catalog snapshot — breaks every model release
-assert "gemini-2.5-pro" in _PROVIDER_MODELS["gemini"]
-assert "MiniMax-M2.7" in models
-
-# config version literal — breaks every schema bump
-assert DEFAULT_CONFIG["_config_version"] == 21
-
-# enumeration count — breaks every time a skill/provider is added
-assert len(_PROVIDER_MODELS["huggingface"]) == 8
-```
-
-**Do write:**
-
-```python
-# behavior: does the catalog plumbing work at all?
-assert "gemini" in _PROVIDER_MODELS
-assert len(_PROVIDER_MODELS["gemini"]) >= 1
-
-# behavior: does migration bump the user's version to current latest?
-assert raw["_config_version"] == DEFAULT_CONFIG["_config_version"]
-
-# invariant: no plan-only model leaks into the legacy list
-assert not (set(moonshot_models) & coding_plan_only_models)
-
-# invariant: every model in the catalog has a context-length entry
-for m in _PROVIDER_MODELS["huggingface"]:
-    assert m.lower() in DEFAULT_CONTEXT_LENGTHS_LOWER
-```
-
-The rule: if the test reads like a snapshot of current data, delete it. If
-it reads like a contract about how two pieces of data must relate, keep it.
-When a PR adds a new provider/model and you want a test, make the test
-assert the relationship (e.g. "catalog entries all have context lengths"),
-not the specific names.
-
-Reviewers should reject new change-detector tests; authors should convert
-them into invariants before re-requesting review.
+Do not call `pytest` directly unless you have a specific reason. The wrapper
+sets CI-like environment, temp HOME/HERMES_HOME behavior, UTC locale, xdist, and
+the in-tree subprocess isolation plugin. More detail lives in `tests/AGENTS.md`.

--- a/agent/AGENTS.md
+++ b/agent/AGENTS.md
@@ -1,0 +1,114 @@
+# Agent Internals Guide
+
+This directory owns provider adapters, prompt assembly, memory orchestration,
+compression, LSP, context engines, delegation support code, and runtime helpers.
+
+## Prompt Assembly
+
+`agent/system_prompt.py` and `agent/prompt_builder.py` assemble prompt parts into
+stable, context, and volatile sections. Preserve prompt caching:
+
+- stable: identity, tool-use guidance, provider-specific guidance.
+- context: caller system message and project context files.
+- volatile: memory snapshots, external memory prefetch, plugin context.
+
+Context file loading is deliberately bounded. Startup loading chooses the first
+project context source from `.hermes.md`/`HERMES.md`, `AGENTS.md`, `CLAUDE.md`,
+or `.cursorrules`; `SOUL.md` from `HERMES_HOME` is independent. When `AGENTS.md`
+is the selected source, Hermes loads the git-root-to-current-working-directory
+hierarchy, with more specific files later in the prompt. Deeper subdirectory
+hints in `agent/subdirectory_hints.py` are discovered lazily from tool arguments
+and appended to tool results instead of rewriting the system prompt.
+
+Context files are security-scanned before injection. Keep new context loaders
+bounded, scanned, and cache-aware.
+
+## AIAgent Lifecycle
+
+`run_agent.py` delegates most initialization to `agent/agent_init.py` and the
+conversation loop to `agent/conversation_loop.py`.
+
+Memory, skills, context engines, plugin hooks, and compression are optional
+subsystems. Failures should degrade gracefully unless the caller explicitly
+requested the feature.
+
+The agent loop is synchronous at the top level. Tool execution can fan out
+internally, but parent-visible ordering and budget accounting must remain
+coherent.
+
+## Memory
+
+Hermes has two memory layers:
+
+- built-in curated files via `tools/memory_tool.py`: `MEMORY.md` and `USER.md`
+  under `get_hermes_home() / "memories"`.
+- external memory providers via `agent/memory_manager.py` and
+  `agent/memory_provider.py`.
+
+Built-in memory is loaded as a frozen snapshot at session start. Mid-session
+writes are durable on disk but do not rewrite the active system prompt.
+
+Only one external memory provider is active at a time. Providers can prefetch
+context, sync turns, react to explicit memory writes, and run session-end
+extraction. Provider failures should not break the primary agent loop.
+
+Cron sessions intentionally run with `skip_memory=True` to avoid corrupting user
+representations from scheduled-job prompts.
+
+## Context Engines
+
+`agent/context_engine.py` defines the pluggable context-engine lifecycle.
+Compression and other engines can receive `on_session_start` and
+`on_session_end`. Keep engine failures non-fatal unless the active operation
+cannot proceed safely.
+
+## LSP
+
+The LSP layer provides semantic diagnostics after file writes and patches.
+Management lives under `agent/lsp/`; integration into file writes lives in
+`tools/file_operations.py`.
+
+Current LSP support is diagnostic-oriented. Do not assume symbol navigation
+tools exist unless you add and expose them explicitly.
+
+Config lives under `lsp:` in `DEFAULT_CONFIG`:
+
+- `enabled`
+- `wait_mode`
+- `wait_timeout`
+- `install_strategy`
+- `servers`
+
+LSP is gated on git workspace detection and degrades silently when unavailable.
+
+## Delegation Support
+
+`delegate_task` lives in `tools/delegate_tool.py`, but active child-agent state,
+interrupt propagation, budgets, provider routing, and callbacks interact with
+agent internals.
+
+Subagents get isolated conversation context and their own iteration budget.
+They are not durable. For work that must outlive the current turn, use cron,
+kanban, or a background terminal process with notifications.
+
+Subagent summaries are self-reports. Parent agents should ask for verifiable
+handles such as paths, commands, IDs, or URLs when correctness matters.
+
+## Tool-use Guidance
+
+`agent/prompt_builder.py` contains model-family execution guidance for tool
+persistence, mandatory tool use, and completion discipline. When adding new
+guidance, keep it:
+
+- short enough to preserve prompt budget,
+- model-family gated when possible,
+- behavior-focused rather than a snapshot of current model names.
+
+## Curator
+
+`agent/curator.py` reviews and maintains agent-created skills. It only touches
+skills with `created_by: "agent"` provenance. Bundled and hub-installed skills
+are out of scope.
+
+Curator never deletes; it archives and backs up. Pinned skills are exempt from
+automatic state transitions and LLM review.

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -13,7 +13,7 @@ from collections import OrderedDict
 from pathlib import Path
 
 from hermes_constants import get_hermes_home, get_skills_dir, is_wsl
-from typing import Optional
+from typing import List, Optional
 
 from agent.skill_utils import (
     extract_skill_conditions,
@@ -87,6 +87,7 @@ def _find_git_root(start: Path) -> Optional[Path]:
 
 
 _HERMES_MD_NAMES = (".hermes.md", "HERMES.md")
+_AGENTS_MD_NAMES = ("AGENTS.md", "agents.md")
 
 
 def _find_hermes_md(cwd: Path) -> Optional[Path]:
@@ -1361,19 +1362,73 @@ def _load_hermes_md(cwd_path: Path) -> str:
         return ""
 
 
+def _iter_agents_md_hierarchy(cwd_path: Path) -> List[Path]:
+    """Return AGENTS.md files from git root to ``cwd_path``.
+
+    If ``cwd_path`` is not inside a git worktree, preserve the historical
+    behavior and only consider ``cwd_path`` itself. Within each directory,
+    ``AGENTS.md`` wins over ``agents.md``.
+    """
+    cwd_path = cwd_path.resolve()
+    git_root = _find_git_root(cwd_path)
+    if git_root:
+        git_root = git_root.resolve()
+        try:
+            rel = cwd_path.relative_to(git_root)
+        except ValueError:
+            directories = [cwd_path]
+        else:
+            directories = [git_root]
+            current = git_root
+            for part in rel.parts:
+                current = current / part
+                directories.append(current)
+    else:
+        directories = [cwd_path]
+
+    found: List[Path] = []
+    for directory in directories:
+        for name in _AGENTS_MD_NAMES:
+            candidate = directory / name
+            if candidate.is_file():
+                found.append(candidate)
+                break
+    return found
+
+
 def _load_agents_md(cwd_path: Path) -> str:
-    """AGENTS.md — top-level only (no recursive walk)."""
-    for name in ["AGENTS.md", "agents.md"]:
-        candidate = cwd_path / name
-        if candidate.exists():
+    """AGENTS.md / agents.md -- git-root-to-cwd hierarchy."""
+    agent_files = _iter_agents_md_hierarchy(cwd_path)
+    if not agent_files:
+        return ""
+
+    cwd_path = cwd_path.resolve()
+    git_root = _find_git_root(cwd_path)
+    rel_base = git_root.resolve() if git_root else cwd_path
+
+    sections = []
+    for candidate in agent_files:
+        try:
+            content = candidate.read_text(encoding="utf-8").strip()
+            if not content:
+                continue
             try:
-                content = candidate.read_text(encoding="utf-8").strip()
-                if content:
-                    content = _scan_context_content(content, name)
-                    result = f"## {name}\n\n{content}"
-                    return _truncate_content(result, "AGENTS.md")
-            except Exception as e:
-                logger.debug("Could not read %s: %s", candidate, e)
+                rel = str(candidate.relative_to(rel_base))
+            except ValueError:
+                rel = candidate.name
+            content = _scan_context_content(content, rel)
+            sections.append(f"### {rel}\n\n{content}")
+        except Exception as e:
+            logger.debug("Could not read %s: %s", candidate, e)
+
+    if sections:
+        result = (
+            "## AGENTS.md hierarchy\n\n"
+            "Loaded from repository root to current working directory. "
+            "More specific files appear later and override earlier general guidance.\n\n"
+            + "\n\n".join(sections)
+        )
+        return _truncate_content(result, "AGENTS.md")
     return ""
 
 
@@ -1428,7 +1483,7 @@ def build_context_files_prompt(cwd: Optional[str] = None, skip_soul: bool = Fals
 
     Priority (first found wins — only ONE project context type is loaded):
       1. .hermes.md / HERMES.md  (walk to git root)
-      2. AGENTS.md / agents.md   (cwd only)
+      2. AGENTS.md / agents.md   (git root -> cwd hierarchy)
       3. CLAUDE.md / claude.md   (cwd only)
       4. .cursorrules / .cursor/rules/*.mdc  (cwd only)
 

--- a/cron/AGENTS.md
+++ b/cron/AGENTS.md
@@ -1,0 +1,53 @@
+# Cron Guide
+
+This directory owns scheduled jobs and the scheduler tick loop.
+
+## Files
+
+- `cron/jobs.py`: job storage, schedule parsing, output storage, job mutation.
+- `cron/scheduler.py`: due-job execution, delivery, locking, cron agent setup.
+- `tools/cronjob_tools.py`: agent-facing cron management tool.
+- `hermes_cli/main.py` and `hermes_cli/cron.py`: user-facing CLI routing.
+
+## Schedules
+
+Supported forms:
+
+- duration strings such as `30m`, `2h`, `1d`
+- "every" phrases such as `every 2h` or `every monday 9am`
+- five-field cron expressions
+- ISO timestamps for one-shot jobs
+
+Per-job fields can include skills, model/provider overrides, pre-run scripts,
+`context_from`, `workdir`, repeat count, and delivery targets.
+
+## Execution Rules
+
+Cron jobs run as fresh agent sessions. Prompts must be self-contained. Cron
+agents pass `skip_memory=True`; do not rely on user memory providers inside
+scheduled jobs.
+
+The scheduler uses a file lock under `get_hermes_home() / "cron"` to avoid
+duplicate ticks across processes.
+
+Cron delivery output is not appended to the target chat session. It is delivered
+with a header/footer frame from the cron session.
+
+## Hardening
+
+Keep these invariants:
+
+- runaway sessions are interrupted by the scheduler timeout path,
+- catchup and grace windows avoid stale job storms,
+- dangerous command handling follows cron approval config,
+- assembled cron prompts are scanned for injection patterns,
+- cron scripts are bounded by configured script timeout,
+- failures are delivered clearly when a delivery target exists.
+
+## Skills
+
+Jobs can attach one or more skills. The scheduler loads those skills before the
+prompt and bumps usage so curator sees active skills.
+
+If curator rewrites or archives agent-created skills, cron job skill references
+may need repair through the existing rewrite helper in `cron/jobs.py`.

--- a/gateway/AGENTS.md
+++ b/gateway/AGENTS.md
@@ -1,0 +1,76 @@
+# Gateway Guide
+
+This directory owns the messaging gateway, session orchestration, platform
+adapters, gateway hooks, and platform-specific command routing.
+
+## Runtime Shape
+
+`gateway/run.py` owns the gateway runner and active session cache.
+`gateway/session.py` owns session-level structures. `gateway/platforms/` holds
+adapters for Telegram, Discord, Slack, WhatsApp, Matrix, Signal, email, SMS,
+webhook, API server, and other platforms.
+
+Gateway sessions cache `AIAgent` instances per session. Destroying that cache
+breaks prompt caching and can change behavior across turns.
+
+## Command Registry
+
+Gateway command names and help should derive from `hermes_cli/commands.py`.
+Do not maintain a separate command list unless the platform API forces a local
+projection.
+
+When adding a gateway-available slash command:
+
+1. Add or update the `CommandDef`.
+2. Add gateway dispatch in `gateway/run.py`.
+3. Update platform-specific routing only when that platform has its own command
+   shape, such as Slack subcommands or Telegram bot menus.
+
+## Two Message Guards
+
+When an agent is running, incoming messages pass through two guards:
+
+1. Base adapter queues messages in `_pending_messages` when the session is
+   active.
+2. Gateway runner intercepts control commands such as `/stop`, `/new`,
+   `/queue`, `/status`, `/approve`, and `/deny`.
+
+Any command that must reach the runner while the agent is blocked must bypass
+both guards and dispatch inline. Do not route approval/control commands through
+background processing that races session lifecycle.
+
+## Platform Adapters
+
+Platform adapters should:
+
+- use profile-safe paths,
+- acquire scoped locks for unique credentials such as bot tokens,
+- release locks on disconnect/stop,
+- keep platform-specific payload parsing at the adapter edge,
+- share command/session behavior through gateway core helpers.
+
+See Telegram for scoped-lock patterns and `ADDING_A_PLATFORM.md` for platform
+authoring guidance.
+
+## Gateway Hooks
+
+Gateway hooks live under `~/.hermes/hooks/<name>/` with `HOOK.yaml` and
+`handler.py`. Built-in hooks can live under `gateway/builtin_hooks/`, which is
+currently an extension point.
+
+Hook events include gateway startup, session start, agent step, and command
+wildcards. Hook failures should be isolated and logged without taking down the
+gateway unless the hook is explicitly enforcing a block.
+
+## Cron and Gateway
+
+Cron usually runs from the gateway tick loop. Cron deliveries are not mirrored
+into the target chat session; they are their own sessions with delivery frames.
+
+Do not assume gateway conversation context is available in cron jobs unless the
+job prompt explicitly includes it.
+
+## Background Process Notifications
+
+When terminal background processes complete, the gateway watcher can trigger a
+new agent turn. Respect `display.background_process_notifications`.

--- a/hermes_cli/AGENTS.md
+++ b/hermes_cli/AGENTS.md
@@ -1,0 +1,121 @@
+# CLI, Config, Dashboard, and Plugin Loader Guide
+
+This directory owns CLI subcommands, setup/config management, profile handling,
+the plugin manager, skin/theme data, dashboard routes, and many user-facing
+management commands. `cli.py` at repo root is the classic interactive shell and
+shares these rules.
+
+## Slash Commands
+
+All slash commands are defined in `hermes_cli/commands.py` as
+`COMMAND_REGISTRY` entries. Downstream surfaces derive from this registry:
+
+- classic CLI dispatch in `HermesCLI.process_command()`
+- gateway known-command and help generation
+- Telegram bot menu
+- Slack subcommand routing
+- autocomplete and CLI help
+
+Adding an alias only requires updating the existing `CommandDef.aliases`.
+
+Adding a new command normally requires:
+
+1. Add `CommandDef(...)` in `hermes_cli/commands.py`.
+2. Add the classic CLI handler in `cli.py`.
+3. Add a gateway handler in `gateway/run.py` if the command is available there.
+4. Persist settings with the existing config helpers, not ad hoc YAML writes.
+
+## Config
+
+`hermes_cli/config.py::DEFAULT_CONFIG` is the canonical default tree for most
+subcommands. The gateway has direct YAML-loading paths; if a new setting behaves
+differently in gateway and CLI, check both.
+
+Rules:
+
+- Non-secret settings go in `config.yaml`.
+- Secrets, API keys, and tokens go in `.env` via `OPTIONAL_ENV_VARS`.
+- Do not bump `_config_version` for a simple new default key.
+- Bridge legacy env vars from config in code when backward compatibility is
+  required.
+
+Working directory rules:
+
+- CLI mode uses `os.getcwd()`.
+- Messaging/gateway mode uses `terminal.cwd` and bridges it to `TERMINAL_CWD`.
+- `MESSAGING_CWD` and `.env` `TERMINAL_CWD` are deprecated as canonical config.
+
+## Profiles
+
+Profiles are isolated Hermes homes. `_apply_profile_override()` must run before
+imports that read profile-scoped paths. Use `get_hermes_home()` for state and
+`display_hermes_home()` for messages.
+
+Profile management itself is HOME-anchored so any active profile can see all
+profiles.
+
+## Plugin Manager
+
+`hermes_cli/plugins.py` discovers general plugins from:
+
+- `~/.hermes/plugins/`
+- `./.hermes/plugins/`
+- pip entry points
+
+General plugins can register lifecycle hooks, tools, slash commands, CLI
+commands, and plugin-local skills. Discovery happens as a side effect of
+importing `model_tools.py`; paths that need plugin state without importing
+`model_tools.py` must call `discover_plugins()` explicitly.
+
+Do not hardcode plugin-specific logic in core. Expand the generic plugin
+surface if a plugin needs a capability.
+
+## Shell Hooks
+
+`agent/shell_hooks.py` bridges `config.yaml` `hooks:` entries into the same
+plugin hook manager. `hermes_cli/hooks.py` provides:
+
+- `hermes hooks list`
+- `hermes hooks test`
+- `hermes hooks revoke`
+- `hermes hooks doctor`
+
+Unseen shell hooks require consent unless `--accept-hooks`,
+`HERMES_ACCEPT_HOOKS=1`, or `hooks_auto_accept: true` is set. This matters for
+gateway, cron, and headless runs.
+
+Hook scripts read JSON from stdin. Blocking a `pre_tool_call` should return the
+supported block shape consumed by `get_pre_tool_call_block_message()`.
+
+## Skin and Theme System
+
+`hermes_cli/skin_engine.py` is data-driven. Add built-in skins to
+`_BUILTIN_SKINS`; user skins live in `~/.hermes/skins/<name>.yaml`.
+
+Skins customize banner colors, response box border, spinner faces/verbs/wings,
+tool prefixes, per-tool icons, branding text, and prompt symbol. Missing values
+inherit from `default`.
+
+## Dashboard
+
+The dashboard can provide structured React UI around the TUI, but it must not
+rebuild the primary chat transcript or composer. `/chat` embeds the real
+`hermes --tui` through the PTY bridge.
+
+Keep dashboard sidebars, inspectors, and status views independent from the PTY
+child session. Failures in supporting UI should not break the terminal pane.
+
+## Kanban CLI
+
+`hermes_cli/kanban.py` wires `hermes kanban` verbs such as `init`, `create`,
+`list`, `show`, `assign`, `link`, `unlink`, `comment`, `complete`, `block`,
+`unblock`, `archive`, `tail`, `watch`, `stats`, `runs`, `log`, `dispatch`,
+`daemon`, and `gc`.
+
+Keep CLI board operations aligned with `tools/kanban_tools.py`. Worker agents
+should use `kanban_*` tools rather than shelling out to `hermes kanban`.
+
+## Interactive UI
+
+Do not add new `simple_term_menu` usage. Use stdlib curses UI helpers such as
+`hermes_cli/curses_ui.py`; see `hermes_cli/tools_config.py` for the pattern.

--- a/optional-skills/AGENTS.md
+++ b/optional-skills/AGENTS.md
@@ -1,0 +1,19 @@
+# Optional Skills Guide
+
+Follow `skills/AGENTS.md` for all skill authoring standards. This directory is
+for official skills that ship with the repo but are not active by default.
+
+Use optional skills for heavier dependencies, niche workflows, paid-service
+integrations, and capabilities that should be discoverable through
+`hermes skills browse` without bloating default skill context.
+
+Install path:
+
+```bash
+hermes skills install official/<category>/<skill>
+```
+
+The adapter lives in `tools/skills_hub.py` as `OptionalSkillSource`.
+
+Do not move broadly useful default skills here without checking user-facing
+discoverability and migration impact.

--- a/plugins/AGENTS.md
+++ b/plugins/AGENTS.md
@@ -1,0 +1,74 @@
+# Plugins Guide
+
+This directory contains repo-shipped plugins and specialized plugin backends.
+User-installed plugins live in `~/.hermes/plugins/`; project plugins can live in
+`./.hermes/plugins/`; pip entry points are also supported.
+
+## General Plugins
+
+General plugins expose `register(ctx)` and can register:
+
+- lifecycle hooks,
+- tools,
+- slash commands,
+- CLI commands,
+- plugin-local skills.
+
+Use the generic plugin API. Do not modify core files for plugin-specific
+behavior. If a plugin needs a new capability, add a generic hook or context
+method.
+
+Discovery records `plugin.yaml` metadata and imports plugin code only where the
+plugin type requires it.
+
+## Memory Providers
+
+Memory-provider plugins live under `plugins/memory/<name>/` and implement
+`agent.memory_provider.MemoryProvider`.
+
+The set of in-tree memory providers is closed. New memory backends must ship as
+standalone plugin repos or pip packages, installed into `~/.hermes/plugins/` or
+via entry points.
+
+Existing in-tree provider bug fixes are fine. New provider directories under
+`plugins/memory/` are not.
+
+The active provider is selected by `memory.provider` in `config.yaml`; only one
+external provider can be active at a time.
+
+## Model-provider Plugins
+
+Model-provider plugins live under `plugins/model-providers/<name>/`.
+They register `ProviderProfile` objects through `providers.register_provider()`.
+
+Discovery is lazy and separate from the general plugin manager:
+
+1. bundled `plugins/model-providers/<name>/`
+2. user `$HERMES_HOME/plugins/model-providers/<name>/`
+3. legacy `providers/<name>.py`
+
+User providers of the same name override bundled providers.
+
+The general plugin manager may record these manifests for introspection but must
+not import them and double-register provider profiles.
+
+## Backend Plugin Families
+
+Context engines, image generation, video generation, web providers, platform
+plugins, dashboard plugins, and observability plugins each have their own
+loader/orchestrator conventions. Follow the nearest existing plugin and the
+matching developer guide under `website/docs/developer-guide/`.
+
+## Dashboard Assets
+
+Dashboard plugins should complement, not replace, the primary PTY-backed chat
+surface. Keep failures contained to the plugin panel.
+
+## Kanban Plugin
+
+`plugins/kanban/` contains dashboard assets and deployment helpers for the
+durable multi-agent board. The dispatcher can run inside the gateway via
+`kanban.dispatch_in_gateway: true` or as a standalone service.
+
+After `kanban.failure_limit` consecutive non-success attempts on a task, the
+dispatcher should auto-block it to prevent spin loops.

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -1,0 +1,73 @@
+# Skills Guide
+
+These rules apply to both `skills/` and `optional-skills/`.
+
+## Skill Surfaces
+
+- `skills/` contains built-in skills shipped and loadable by default.
+- `optional-skills/` contains heavier or niche official skills installed via
+  `hermes skills install official/<category>/<skill>`.
+
+Heavy dependencies, niche workflows, paid-service integrations, and specialized
+skills usually belong in `optional-skills/` or the Skills Hub, not bundled
+default skills.
+
+## Frontmatter
+
+Standard fields:
+
+- `name`
+- `description`
+- `version`
+- `author`
+- `license`
+- `platforms`
+- `metadata.hermes.tags`
+- `metadata.hermes.category`
+- `metadata.hermes.related_skills`
+- `metadata.hermes.config`
+
+Top-level `tags:` and `category:` are accepted and mirrored from
+`metadata.hermes.*`.
+
+## Hard Standards
+
+Every new or modernized skill must satisfy these before merge.
+
+1. `description` is at most 60 characters, one sentence, and ends with a
+   period. Avoid marketing words and do not repeat the skill name.
+2. SKILL.md prose should name native Hermes tools or explicit MCP servers in
+   backticks. Do not make shell utilities the headline interface when Hermes has
+   wrapped tools such as `search_files`, `read_file`, `patch`, or `terminal`.
+3. Audit `platforms:` against real scripts/imports. Prefer cross-platform code;
+   narrow platforms only for genuine OS dependencies.
+4. `author` credits the human contributor first. Do not credit the agent as the
+   primary author for external contributions.
+5. Use the modern section order: title, short intro, `## When to Use`,
+   `## Prerequisites`, `## How to Run`, `## Quick Reference`, `## Procedure`,
+   `## Pitfalls`, `## Verification`.
+6. Put scripts in `scripts/`, references in `references/`, templates in
+   `templates/`, and assets in `assets/`.
+7. Tests live at `tests/skills/test_<skill>_skill.py` and use stdlib + pytest +
+   `unittest.mock`; no live network calls.
+8. `.env.example` additions must be isolated to a clearly delimited block.
+
+For external skill PR salvage, load the `hermes-agent-dev` skill reference
+`references/new-skill-pr-salvage.md` before polishing.
+
+## Skills as Progressive Disclosure
+
+Keep `SKILL.md` focused. Move detailed API notes, long examples, parsers,
+templates, and scripts into linked files. `skill_view(name)` returns the main
+file and a linked-file index; `skill_view(name, file_path)` loads the specific
+supporting file on demand.
+
+Avoid bloating the always-visible skill index with content that belongs in
+`references/`.
+
+## Curator Interaction
+
+The curator only manages skills with `created_by: "agent"` provenance. Bundled
+and hub-installed skills are not auto-archived by curator.
+
+Pinned skills are exempt from automatic transitions.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,65 @@
+# Tests Guide
+
+This directory owns the pytest suite. Prefer behavior and invariants over
+snapshots of changing catalogs or counts.
+
+## Runner
+
+Always prefer the wrapper:
+
+```bash
+scripts/run_tests.sh
+scripts/run_tests.sh tests/gateway/
+scripts/run_tests.sh tests/agent/test_foo.py::test_bar -v --tb=long
+scripts/run_tests.sh --no-isolate tests/foo/
+```
+
+The wrapper gives CI-like behavior: credential env vars unset, temp HOME and
+HERMES_HOME, UTC timezone, C.UTF-8 locale, xdist, and subprocess isolation.
+
+Direct `pytest` is acceptable only when a tool or IDE cannot invoke the wrapper.
+At minimum activate the venv first. The in-tree isolation plugin still loads
+from `pyproject.toml`.
+
+## Subprocess Isolation
+
+Every test normally runs in a fresh Python subprocess via `tests/_isolate_plugin.py`.
+This prevents module globals, ContextVars, and singleton state from leaking
+across tests.
+
+Use `--no-isolate` only for focused debugging or when intentionally testing
+state leakage.
+
+## HERMES_HOME
+
+Tests must not write to the real `~/.hermes`. The autouse fixture redirects
+`HERMES_HOME` to a temp directory.
+
+Profile tests must also mock `Path.home()` so profile roots resolve under the
+temp directory:
+
+```python
+@pytest.fixture
+def profile_env(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+```
+
+## Avoid Change-detector Tests
+
+Do not assert snapshots of data expected to change, such as exact provider model
+lists, config version literals, enumeration counts, or catalog snapshots.
+
+Do assert relationships and contracts:
+
+- a catalog has at least one entry for a provider,
+- every model has a context length,
+- migrations bump user config to the current version,
+- plan-only models do not leak into legacy lists,
+- a command registry projection contains a newly added command.
+
+If the test fails whenever routine data is refreshed, convert it into an
+invariant or delete it.

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -554,8 +554,8 @@ class TestBuildContextFilesPrompt:
         result = build_context_files_prompt(cwd=str(tmp_path))
         assert "ESLint" in result
 
-    def test_agents_md_top_level_only(self, tmp_path):
-        """AGENTS.md is loaded from cwd only — subdirectory copies are ignored."""
+    def test_agents_md_off_path_subdirectory_ignored(self, tmp_path):
+        """AGENTS.md files outside the cwd ancestry are not loaded."""
         (tmp_path / "AGENTS.md").write_text("Top level instructions.")
         sub = tmp_path / "src"
         sub.mkdir()
@@ -563,6 +563,56 @@ class TestBuildContextFilesPrompt:
         result = build_context_files_prompt(cwd=str(tmp_path))
         assert "Top level" in result
         assert "Src-specific" not in result
+
+    def test_agents_md_hierarchy_loads_git_root_to_cwd(self, tmp_path):
+        """AGENTS.md hierarchy is loaded from git root down to cwd."""
+        (tmp_path / ".git").mkdir()
+        (tmp_path / "AGENTS.md").write_text("Root instructions.")
+        service = tmp_path / "services"
+        service.mkdir()
+        (service / "AGENTS.md").write_text("Services instructions.")
+        api = service / "api"
+        api.mkdir()
+        (api / "AGENTS.md").write_text("API instructions.")
+
+        result = build_context_files_prompt(cwd=str(api))
+
+        assert "Root instructions" in result
+        assert "Services instructions" in result
+        assert "API instructions" in result
+        assert result.index("Root instructions") < result.index("Services instructions")
+        assert result.index("Services instructions") < result.index("API instructions")
+        assert "AGENTS.md hierarchy" in result
+
+    def test_agents_md_hierarchy_stops_at_git_root(self, tmp_path):
+        """Parent AGENTS.md outside the git root is not loaded."""
+        (tmp_path / "AGENTS.md").write_text("Outside repo instructions.")
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        (repo / "AGENTS.md").write_text("Repo instructions.")
+        app = repo / "app"
+        app.mkdir()
+        (app / "AGENTS.md").write_text("App instructions.")
+
+        result = build_context_files_prompt(cwd=str(app))
+
+        assert "Outside repo instructions" not in result
+        assert "Repo instructions" in result
+        assert "App instructions" in result
+
+    def test_agents_md_without_git_preserves_cwd_only_behavior(self, tmp_path):
+        """Without a git root, only cwd AGENTS.md is considered."""
+        parent = tmp_path / "parent"
+        child = parent / "child"
+        child.mkdir(parents=True)
+        (parent / "AGENTS.md").write_text("Parent instructions.")
+        (child / "AGENTS.md").write_text("Child instructions.")
+
+        result = build_context_files_prompt(cwd=str(child))
+
+        assert "Child instructions" in result
+        assert "Parent instructions" not in result
 
     # --- .hermes.md / HERMES.md discovery ---
 
@@ -624,6 +674,21 @@ class TestBuildContextFilesPrompt:
         result = build_context_files_prompt(cwd=str(tmp_path))
         assert "Hermes project rules" in result
         assert "Agent guidelines" not in result
+
+    def test_parent_hermes_md_beats_agents_md_hierarchy(self, tmp_path):
+        """A discovered .hermes.md keeps priority over AGENTS.md hierarchy."""
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".hermes.md").write_text("Hermes root rules.")
+        (tmp_path / "AGENTS.md").write_text("Root agent guidelines.")
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "AGENTS.md").write_text("Sub agent guidelines.")
+
+        result = build_context_files_prompt(cwd=str(sub))
+
+        assert "Hermes root rules" in result
+        assert "Root agent guidelines" not in result
+        assert "Sub agent guidelines" not in result
 
     def test_agents_md_beats_claude_md(self, tmp_path):
         (tmp_path / "AGENTS.md").write_text("Agent guidelines here.")
@@ -1192,6 +1257,4 @@ class TestOpenAIModelExecutionGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
-
 

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -1,0 +1,103 @@
+# Tools Guide
+
+This directory owns built-in tool implementations, the tool registry, terminal
+backends, file operations, patch handling, browser/computer tools, skills tools,
+and tool-specific state.
+
+## Registry and Exposure
+
+Every built-in tool module registers itself with `tools.registry.registry`.
+Handlers must return JSON strings.
+
+Creating a core tool requires two steps:
+
+1. Add `tools/<tool>.py` with a top-level `registry.register(...)`.
+2. Add the tool name to `toolsets.py` so the agent can see it.
+
+Auto-discovery imports tool modules, but toolsets are the deliberate exposure
+boundary. `_HERMES_CORE_TOOLS` is the default bundle most platforms inherit.
+
+For local or custom capabilities, prefer a plugin with `ctx.register_tool(...)`
+instead of editing core.
+
+## Tool Schema Rules
+
+Do not hardcode cross-tool references in schema descriptions. A tool may be
+available while the referenced tool is disabled, missing credentials, or removed
+from the active toolset. If a cross-reference is needed, add it dynamically in
+`model_tools.py` after the active toolset is known.
+
+If schema descriptions mention Hermes paths, use `display_hermes_home()` so
+profile-specific homes display correctly.
+
+## State Files
+
+Persistent tool state must live under `get_hermes_home()`, never
+`Path.home() / ".hermes"`. This includes caches, logs, checkpoints, memory,
+plans, auth sidecars, and tool-specific state.
+
+## Agent-loop Tools
+
+Some tools are intercepted by the agent loop before normal dispatch:
+
+- `todo`
+- `memory`
+- `session_search`
+- `delegate_task`
+
+Follow existing patterns such as `tools/todo_tool.py` and
+`tools/memory_tool.py` when adding loop-level behavior.
+
+## File and Patch Tools
+
+`tools/file_operations.py`, `tools/file_tools.py`, and `tools/patch_parser.py`
+coordinate reads, writes, patching, validation, and LSP diagnostics.
+
+Important invariants:
+
+- Preserve sibling-subagent file-state checks.
+- Keep LSP diagnostics best-effort and non-fatal.
+- Surface introduced diagnostics from writes/patches without flooding the agent
+  with pre-existing shifted diagnostics.
+- Do not bypass centralized write/patch helpers for new file mutation paths.
+
+## Terminal Environments
+
+Terminal backends live under `tools/environments/`. The local backend is not the
+only runtime; Docker, SSH, Modal, Daytona, Singularity, and other backends may
+have different filesystem visibility.
+
+Host-side services such as LSP cannot always see remote container files. Gate
+host-only features accordingly.
+
+## Delegation Tool
+
+`tools/delegate_tool.py` spawns synchronous child agents.
+
+Key rules:
+
+- Leaf subagents cannot call `delegate_task`, `clarify`, `memory`,
+  `send_message`, or `execute_code`.
+- Orchestrator subagents may spawn workers only when enabled by config and
+  within `delegation.max_spawn_depth`.
+- Subagents inherit only toolsets allowed by the parent and config.
+- Dangerous-command approvals in subagent worker threads default to deny unless
+  `delegation.subagent_auto_approve` is set.
+- Use `cronjob`, kanban, or background terminal work for durable tasks.
+
+## Skills Tools
+
+`tools/skills_tool.py`, `tools/skill_manager_tool.py`, `tools/skills_hub.py`,
+and skill guard/audit helpers are the runtime surface for skills. Follow
+`skills/AGENTS.md` for skill authoring standards.
+
+## Kanban Tools
+
+`tools/kanban_tools.py` exposes the worker/orchestrator toolset:
+`kanban_show`, `kanban_complete`, `kanban_block`, `kanban_heartbeat`,
+`kanban_comment`, `kanban_create`, and `kanban_link`. Profiles that explicitly
+enable the `kanban` toolset outside dispatcher-spawned tasks can also get
+routing helpers such as `kanban_list` and `kanban_unblock`.
+
+The board is the hard isolation boundary. Workers are spawned with
+`HERMES_KANBAN_BOARD` pinned; do not let tools cross boards implicitly.

--- a/tui_gateway/AGENTS.md
+++ b/tui_gateway/AGENTS.md
@@ -1,0 +1,15 @@
+# TUI Gateway Guide
+
+Follow `ui-tui/AGENTS.md` for the overall TUI architecture.
+
+This directory owns the Python JSON-RPC backend used by `hermes --tui`. Keep it
+aligned with the classic CLI and gateway command behavior:
+
+- Python owns sessions, tools, model calls, slash-command fallthrough, approval
+  handling, and session persistence.
+- TypeScript owns rendering and local client-only commands.
+- Do not move primary chat behavior into dashboard React components; it should
+  flow through Ink and this gateway.
+
+When adding methods or events, keep the newline-delimited JSON-RPC transport
+stable and update the matching TypeScript client code in `ui-tui/src/`.

--- a/ui-tui/AGENTS.md
+++ b/ui-tui/AGENTS.md
@@ -1,0 +1,73 @@
+# TUI and Dashboard Chat Guide
+
+These rules apply to `ui-tui/` and `tui_gateway/`.
+
+## Architecture
+
+`hermes --tui` runs an Ink/React terminal UI in Node and a Python JSON-RPC
+backend over stdio.
+
+```text
+hermes --tui
+  `- Node (Ink) --stdio JSON-RPC-- Python (tui_gateway)
+       |                             `- AIAgent + tools + sessions
+       `- transcript, composer, prompts, activity
+```
+
+TypeScript owns rendering. Python owns sessions, tools, model calls, slash
+commands that fall through, and agent execution.
+
+## Main Surfaces
+
+| Surface | Ink component | Gateway method/event |
+| --- | --- | --- |
+| chat streaming | `app.tsx`, `messageLine.tsx` | `prompt.submit`, `message.delta`, `message.complete` |
+| tool activity | `thinking.tsx` | `tool.start`, `tool.progress`, `tool.complete` |
+| approvals | `prompts.tsx` | `approval.request`, `approval.respond` |
+| clarify/sudo/secret | `prompts.tsx`, `maskedPrompt.tsx` | response methods |
+| session picker | `sessionPicker.tsx` | `session.list`, `session.resume` |
+| slash commands | local handler + fallthrough | `slash.exec`, `command.dispatch` |
+| completions | `useCompletion` | `complete.slash`, `complete.path` |
+| theming | `theme.ts`, `branding.tsx` | `gateway.ready` skin data |
+
+## Slash Commands
+
+Handle client-only commands locally in `app.tsx` where appropriate. Everything
+else should fall through to the persistent slash worker and Python command
+dispatch so behavior stays consistent with classic CLI/gateway surfaces.
+
+## Dev Commands
+
+```bash
+cd ui-tui
+npm install
+npm run dev
+npm start
+npm run build
+npm run type-check
+npm run lint
+npm run fmt
+npm test
+```
+
+Use the repo's existing package manager and scripts. Do not hand-edit generated
+build artifacts unless the surrounding codebase already tracks them.
+
+## Dashboard `/chat`
+
+The dashboard embeds the real `hermes --tui` via `hermes_cli/pty_bridge.py` and
+the `/api/pty` WebSocket. Do not re-implement the main transcript, composer, or
+terminal in React.
+
+Structured React UI around the TUI is allowed when it complements the PTY-backed
+chat: sidebars, inspectors, model pickers, tool-call panels, summaries, and
+status panels. Keep those failures non-destructive so the terminal pane remains
+usable.
+
+## Resize and Transport
+
+PTY frames are raw bytes. Resize is sent as the special
+`\x1b[RESIZE:<cols>;<rows>]` frame and handled server-side with `TIOCSWINSZ`.
+
+Authentication for `/api/pty` uses the dashboard session token in the query
+string because browsers cannot set `Authorization` on WebSocket upgrade.


### PR DESCRIPTION
## Summary

- Split the root AGENTS.md into a short root guide plus directory-scoped AGENTS.md files.
- Teach Hermes to load AGENTS.md hierarchically from git root to the current working directory.
- Add prompt-builder coverage for root-to-cwd loading, git-root boundaries, no-git fallback, and .hermes.md priority.

## Why

The previous root-only AGENTS.md model made directory-specific guidance hard to maintain and did not match the way large codebase agent harnesses are commonly structured. This keeps global rules small while letting local implementation guidance live next to the code it governs.

## Validation

- `scripts/run_tests.sh tests/agent/test_prompt_builder.py`
- `git diff --check`

## Notes

- Existing `.hermes.md` / `HERMES.md` priority is preserved.
- Outside a git worktree, AGENTS.md loading preserves the historical cwd-only behavior.
