### PR TITLE
feat(telegram): add smart mention router

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -401,7 +401,8 @@ prompt_caching:
 # Auxiliary Models (Advanced — Experimental)
 # =============================================================================
 # Hermes uses lightweight "auxiliary" models for side tasks: image analysis,
-# browser screenshot analysis, web page summarization, and context compression.
+# browser screenshot analysis, web page summarization, context compression,
+# approval scoring, and Telegram smart mention routing.
 #
 # By default these use Gemini Flash via OpenRouter or Nous Portal and are
 # auto-detected from your credentials.  You do NOT need to change anything
@@ -445,6 +446,14 @@ prompt_caching:
 #   web_extract:
 #     provider: "auto"
 #     model: ""
+#
+#   # Telegram smart mention routing classifier
+#   smart_mention:
+#     provider: "auto"
+#     model: ""
+#     base_url: ""           # e.g. "http://localhost:11434/v1" for local Ollama
+#     api_key: ""            # for Ollama-compatible local endpoints, "ollama" is fine
+#     timeout: 30
 #
 #   # Session search — summarizes matching past sessions
 #   session_search:
@@ -689,6 +698,28 @@ platform_toolsets:
 #     # allowed_chats: ["-1001234567890"]
 #     extra:
 #       disable_link_previews: false  # Set true to suppress Telegram URL previews in bot messages
+#
+# Telegram-specific settings (canonical top-level config):
+#
+# telegram:
+#   require_mention: true
+#   mention_patterns: []              # Regex wake words checked next to @mentions
+#   allowed_chats: ""                 # Optional group/supergroup whitelist
+#   allowed_topics: ""                # Optional forum topic whitelist; General topic is 1
+#   ignored_threads: ""               # Optional forum topic IDs to ignore
+#   reactions: false
+#   smart_mention:
+#     enabled: false
+#     include_recent_context: true
+#     recent_context_messages: 5
+#     recent_context_max_chars: 2000
+#     pass_recent_context_to_agent: false
+#     min_confidence: 0.6
+#     max_tokens: 128
+#     log_decisions: true
+#     log_message_text: false
+#     on_error: ignore
+#     system_prompt: ""               # Blank falls back to Hermes's built-in prompt
 #
 # Discord-specific settings (config.yaml top-level, not under platforms:):
 #

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -953,6 +953,20 @@ def load_gateway_config() -> GatewayConfig:
                         "disable_topic_auto_rename",
                         telegram_cfg["disable_topic_auto_rename"],
                     )
+                # Canonical user-facing config for Telegram smart mention lives
+                # at telegram.smart_mention. Bridge it into the platform extra
+                # dict consumed by the adapter; top-level wins over legacy
+                # platforms.telegram.extra.smart_mention.
+                if "smart_mention" in telegram_cfg:
+                    _tg_plat = platforms_data.setdefault(Platform.TELEGRAM.value, {})
+                    if not isinstance(_tg_plat, dict):
+                        _tg_plat = {}
+                        platforms_data[Platform.TELEGRAM.value] = _tg_plat
+                    _tg_extra = _tg_plat.setdefault("extra", {})
+                    if not isinstance(_tg_extra, dict):
+                        _tg_extra = {}
+                        _tg_plat["extra"] = _tg_extra
+                    _tg_extra["smart_mention"] = telegram_cfg["smart_mention"]
                 # Prefer telegram.require_mention; fall back to the top-level shorthand.
                 _effective_rm = telegram_cfg.get("require_mention", yaml_cfg.get("require_mention"))
                 if _effective_rm is not None and not os.getenv("TELEGRAM_REQUIRE_MENTION"):

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -15,6 +15,7 @@ import os
 import tempfile
 import html as _html
 import re
+from collections import deque
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Any
 
@@ -85,6 +86,13 @@ from gateway.platforms.telegram_network import (
     TelegramFallbackTransport,
     discover_fallback_ips,
     parse_fallback_ip_env,
+)
+from gateway.platforms.telegram_smart_mention import (
+    SmartMentionConfig,
+    build_smart_mention_messages,
+    format_recent_context_for_agent,
+    normalize_smart_mention_config,
+    parse_smart_mention_response,
 )
 from utils import atomic_replace
 
@@ -407,6 +415,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self._bot: Optional[Bot] = None
         self._webhook_mode: bool = False
         self._mention_patterns = self._compile_mention_patterns()
+        self._smart_mention_context: Dict[tuple[str, str], deque] = {}
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
         self._disable_link_previews: bool = self._coerce_bool_extra("disable_link_previews", False)
         # Buffer rapid/album photo updates so Telegram image bursts are handled
@@ -4834,6 +4843,274 @@ class TelegramAdapter(BasePlatformAdapter):
             adapter_name = getattr(self, "name", "telegram")
             logger.warning("[%s] Failed to observe Telegram group message: %s", adapter_name, exc)
 
+    def _telegram_smart_mention_config(self) -> SmartMentionConfig:
+        raw = self.config.extra.get("smart_mention")
+        config = normalize_smart_mention_config(raw)
+        if (
+            config.enabled
+            and isinstance(raw, dict)
+            and "system_prompt" in raw
+            and not str(raw.get("system_prompt") or "").strip()
+            and not getattr(self, "_smart_mention_blank_prompt_warned", False)
+        ):
+            logger.warning(
+                "[%s] telegram.smart_mention.system_prompt is blank; using default prompt",
+                getattr(self, "name", "telegram"),
+            )
+            self._smart_mention_blank_prompt_warned = True
+        return config
+
+    def _telegram_smart_mention_context_key(self, message: Message) -> tuple[str, str]:
+        chat = getattr(message, "chat", None)
+        chat_id = str(getattr(chat, "id", ""))
+        thread_id = getattr(message, "message_thread_id", None)
+        if thread_id is None and getattr(chat, "is_forum", False) is True:
+            return chat_id, self._GENERAL_TOPIC_THREAD_ID
+        return chat_id, str(thread_id or self._GENERAL_TOPIC_THREAD_ID)
+
+    def _telegram_smart_mention_text(self, message: Message) -> str:
+        return str(getattr(message, "text", None) or getattr(message, "caption", None) or "").strip()
+
+    def _telegram_smart_mention_media_metadata(self, message: Message) -> dict[str, Any]:
+        metadata: dict[str, Any] = {}
+        if getattr(message, "sticker", None):
+            sticker = message.sticker
+            metadata["type"] = "sticker"
+            metadata["emoji"] = getattr(sticker, "emoji", None)
+            metadata["file_size"] = getattr(sticker, "file_size", None)
+        elif getattr(message, "photo", None):
+            metadata["type"] = "photo"
+        elif getattr(message, "video", None):
+            video = message.video
+            metadata["type"] = "video"
+            metadata["mime_type"] = getattr(video, "mime_type", None)
+            metadata["file_size"] = getattr(video, "file_size", None)
+        elif getattr(message, "audio", None):
+            audio = message.audio
+            metadata["type"] = "audio"
+            metadata["mime_type"] = getattr(audio, "mime_type", None)
+            metadata["file_name"] = getattr(audio, "file_name", None)
+            metadata["file_size"] = getattr(audio, "file_size", None)
+        elif getattr(message, "voice", None):
+            voice = message.voice
+            metadata["type"] = "voice"
+            metadata["mime_type"] = getattr(voice, "mime_type", None)
+            metadata["duration"] = getattr(voice, "duration", None)
+            metadata["file_size"] = getattr(voice, "file_size", None)
+        elif getattr(message, "document", None):
+            doc = message.document
+            metadata["type"] = "document"
+            metadata["mime_type"] = getattr(doc, "mime_type", None)
+            metadata["file_name"] = getattr(doc, "file_name", None)
+            metadata["file_size"] = getattr(doc, "file_size", None)
+        return metadata
+
+    def _telegram_smart_mention_candidate_allowed(self, message: Message, *, is_command: bool = False) -> bool:
+        config = self._telegram_smart_mention_config()
+        if not config.enabled or is_command:
+            return False
+        if not self._is_group_chat(message):
+            return False
+        # Do not run local download/transcription/vision before routing. Media
+        # without a caption has no text signal for smart mention classification.
+        return bool(self._telegram_smart_mention_text(message))
+
+    def _telegram_group_trigger_decision(self, message: Message, *, is_command: bool = False) -> str:
+        """Return process, ignore, or smart_mention_candidate for group routing."""
+        if not self._is_group_chat(message):
+            return "process"
+
+        thread_id = getattr(message, "message_thread_id", None)
+        allowed_topics = self._telegram_allowed_topics()
+        if allowed_topics:
+            topic_id = str(thread_id) if thread_id is not None else self._GENERAL_TOPIC_THREAD_ID
+            if topic_id not in allowed_topics:
+                return "ignore"
+
+        if thread_id is not None:
+            try:
+                if int(thread_id) in self._telegram_ignored_threads():
+                    return "ignore"
+            except (TypeError, ValueError):
+                logger.warning(
+                    "[%s] Ignoring non-numeric Telegram message_thread_id: %r",
+                    getattr(self, "name", "telegram"),
+                    thread_id,
+                )
+
+        chat_id_str = str(getattr(getattr(message, "chat", None), "id", ""))
+
+        if self._telegram_exclusive_bot_mentions() and self._explicit_bot_mentions_exclude_self(message):
+            return "ignore"
+
+        guest_mention = self._is_guest_mention(message)
+
+        allowed = self._telegram_allowed_chats()
+        if allowed and chat_id_str not in allowed:
+            return "process" if guest_mention else "ignore"
+
+        if guest_mention:
+            return "process"
+        if chat_id_str in self._telegram_free_response_chats():
+            return "process"
+        if not self._telegram_require_mention():
+            return "process"
+        if self._is_reply_to_bot(message):
+            return "process"
+        if not self._telegram_guest_mode() and self._message_mentions_bot(message):
+            return "process"
+        if self._message_matches_mention_patterns(message):
+            return "process"
+        if self._telegram_smart_mention_candidate_allowed(message, is_command=is_command):
+            return "smart_mention_candidate"
+        return "ignore"
+
+    def _telegram_smart_mention_recent_context(self, message: Message) -> list[dict[str, Any]]:
+        key = self._telegram_smart_mention_context_key(message)
+        return list(getattr(self, "_smart_mention_context", {}).get(key, ()))
+
+    def _telegram_smart_mention_sender_authorized(self, message: Message) -> bool:
+        """Check gateway auth before sending smart candidates to an auxiliary LLM."""
+        runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+        auth_fn = getattr(runner, "_is_user_authorized", None)
+        if not callable(auth_fn):
+            return True
+        try:
+            # Message type does not affect SessionSource construction. Avoid
+            # dispatching into handle_message(), which would trigger pairing
+            # and plugin side effects before the routing decision is known.
+            source = self._build_message_event(message, MessageType.TEXT).source
+            return bool(auth_fn(source))
+        except Exception as exc:
+            logger.warning(
+                "[%s] Telegram smart mention auth check failed: %s",
+                getattr(self, "name", "telegram"),
+                exc,
+            )
+            return False
+
+    def _telegram_smart_mention_sender(self, message: Message) -> str:
+        user = getattr(message, "from_user", None)
+        if not user:
+            return "user"
+        return (
+            getattr(user, "full_name", None)
+            or getattr(user, "first_name", None)
+            or getattr(user, "username", None)
+            or "user"
+        )
+
+    def _append_telegram_smart_mention_context(self, message: Message) -> None:
+        config = self._telegram_smart_mention_config()
+        max_items = max(config.recent_context_messages, 0)
+        if not config.enabled or max_items <= 0:
+            return
+        if not self._is_group_chat(message):
+            return
+        text = self._telegram_smart_mention_text(message)
+        if not text:
+            return
+        key = self._telegram_smart_mention_context_key(message)
+        store = getattr(self, "_smart_mention_context", None)
+        if store is None:
+            self._smart_mention_context = {}
+            store = self._smart_mention_context
+        ring = store.get(key)
+        if ring is None or getattr(ring, "maxlen", None) != max_items:
+            existing = list(ring or [])[-max_items:]
+            ring = deque(existing, maxlen=max_items)
+            store[key] = ring
+        ring.append(
+            {
+                "sender": self._telegram_smart_mention_sender(message),
+                "text": text,
+                "media": self._telegram_smart_mention_media_metadata(message).get("type", ""),
+            }
+        )
+
+    async def _evaluate_telegram_smart_mention(
+        self,
+        message: Message,
+        *,
+        recent_context: Optional[list[dict[str, Any]]] = None,
+    ) -> bool:
+        config = self._telegram_smart_mention_config()
+        text = self._telegram_smart_mention_text(message)
+        if not config.enabled or not text:
+            return False
+
+        from agent.auxiliary_client import async_call_llm, extract_content_or_reasoning
+
+        chat = getattr(message, "chat", None)
+        bot_username = (getattr(getattr(self, "_bot", None), "username", None) or "").lstrip("@")
+        chat_id, thread_id = self._telegram_smart_mention_context_key(message)
+        messages = build_smart_mention_messages(
+            config=config,
+            current_text=text,
+            recent_context=recent_context if recent_context is not None else self._telegram_smart_mention_recent_context(message),
+            media_metadata=self._telegram_smart_mention_media_metadata(message),
+            bot_username=bot_username,
+            chat_id=chat_id or str(getattr(chat, "id", "")),
+            thread_id=thread_id,
+        )
+        try:
+            response = await async_call_llm(
+                task="smart_mention",
+                messages=messages,
+                temperature=0,
+                max_tokens=config.max_tokens,
+            )
+            raw = extract_content_or_reasoning(response)
+            classification = parse_smart_mention_response(raw)
+            accepted = classification.should_respond and classification.confidence >= config.min_confidence
+            if config.log_decisions:
+                if config.log_message_text:
+                    logger.info(
+                        "[%s] Telegram smart mention decision=%s confidence=%.2f reason=%s text=%r",
+                        getattr(self, "name", "telegram"),
+                        "process" if accepted else "ignore",
+                        classification.confidence,
+                        classification.reason,
+                        text,
+                    )
+                else:
+                    logger.info(
+                        "[%s] Telegram smart mention decision=%s confidence=%.2f text_len=%d",
+                        getattr(self, "name", "telegram"),
+                        "process" if accepted else "ignore",
+                        classification.confidence,
+                        len(text),
+                    )
+            return accepted
+        except Exception as exc:
+            logger.warning(
+                "[%s] Telegram smart mention classifier failed: %s",
+                getattr(self, "name", "telegram"),
+                exc,
+            )
+            return config.on_error == "process"
+
+    def _apply_telegram_smart_mention_context_prompt(
+        self,
+        event: MessageEvent,
+        recent_context: list[dict[str, Any]],
+    ) -> MessageEvent:
+        config = self._telegram_smart_mention_config()
+        if not config.pass_recent_context_to_agent:
+            return event
+        context_prompt = format_recent_context_for_agent(
+            recent_context,
+            config.recent_context_max_chars,
+        )
+        if not context_prompt:
+            return event
+        event.channel_prompt = (
+            f"{event.channel_prompt}\n\n{context_prompt}"
+            if event.channel_prompt
+            else context_prompt
+        )
+        return event
+
     def _should_process_message(self, message: Message, *, is_command: bool = False) -> bool:
         """Apply Telegram group trigger rules.
 
@@ -4856,61 +5133,7 @@ class TelegramAdapter(BasePlatformAdapter):
         mentioning the bot (``@botname /command``), both of which are
         recognised as mentions by :meth:`_message_mentions_bot`.
         """
-        if not self._is_group_chat(message):
-            return True
-
-        thread_id = getattr(message, "message_thread_id", None)
-        allowed_topics = self._telegram_allowed_topics()
-        if allowed_topics:
-            topic_id = str(thread_id) if thread_id is not None else self._GENERAL_TOPIC_THREAD_ID
-            if topic_id not in allowed_topics:
-                return False
-
-        # Check ignored_threads first — applies to both groups and DM topics
-        if thread_id is not None:
-            try:
-                if int(thread_id) in self._telegram_ignored_threads():
-                    return False
-            except (TypeError, ValueError):
-                logger.warning("[%s] Ignoring non-numeric Telegram message_thread_id: %r", self.name, thread_id)
-
-        if not self._is_group_chat(message):
-            # Root DM (non-topic): ignore if ignore_root_dm is configured
-            if thread_id is None and self.config.extra.get("ignore_root_dm", False):
-                chat_id = str(getattr(getattr(message, "chat", None), "id", ""))
-                if not is_command and chat_id in self._dm_topic_chat_ids:
-                    return False
-            return True
-
-        chat_id_str = str(getattr(getattr(message, "chat", None), "id", ""))
-
-        if self._telegram_exclusive_bot_mentions() and self._explicit_bot_mentions_exclude_self(message):
-            return False
-
-        # Resolve guest-mode mention bypass once so _message_mentions_bot
-        # is not called redundantly in the normal flow below.
-        guest_mention = self._is_guest_mention(message)
-
-        # allowed_chats check (whitelist). When set, group messages from chats
-        # outside the whitelist are ignored unless guest_mode permits this
-        # exact message as an explicit direct mention. DMs are excluded above.
-        allowed = self._telegram_allowed_chats()
-        if allowed and chat_id_str not in allowed:
-            return guest_mention
-
-        if guest_mention:
-            return True
-        if chat_id_str in self._telegram_free_response_chats():
-            return True
-        if not self._telegram_require_mention():
-            return True
-        if self._is_reply_to_bot(message):
-            return True
-        # When guest_mode is True, _is_guest_mention already called
-        # _message_mentions_bot above — skip the redundant second call.
-        if not self._telegram_guest_mode() and self._message_mentions_bot(message):
-            return True
-        return self._message_matches_mention_patterns(message)
+        return self._telegram_group_trigger_decision(message, is_command=is_command) == "process"
 
     async def _ensure_forum_commands(self, message) -> None:
         """Lazy-register bot commands for forum supergroups.
@@ -4957,15 +5180,33 @@ class TelegramAdapter(BasePlatformAdapter):
         msg = self._effective_update_message(update)
         if not msg or not msg.text:
             return
-        if not self._should_process_message(msg):
+        decision = self._telegram_group_trigger_decision(msg)
+        smart_recent_context: list[dict[str, Any]] = []
+        smart_accepted = False
+        if decision == "smart_mention_candidate":
+            if not self._telegram_smart_mention_sender_authorized(msg):
+                return
+            smart_recent_context = self._telegram_smart_mention_recent_context(msg)
+            smart_accepted = await self._evaluate_telegram_smart_mention(
+                msg,
+                recent_context=smart_recent_context,
+            )
+            self._append_telegram_smart_mention_context(msg)
+            if not smart_accepted:
+                return
+        elif decision != "process":
             if self._should_observe_unmentioned_group_message(msg):
                 self._observe_unmentioned_group_message(msg, MessageType.TEXT, update_id=update.update_id)
             return
-        await self._ensure_forum_commands(update.message)
+        else:
+            self._append_telegram_smart_mention_context(msg)
+        await self._ensure_forum_commands(msg)
 
         event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)
         event = self._apply_telegram_group_observe_attribution(event)
+        if smart_accepted:
+            event = self._apply_telegram_smart_mention_context_prompt(event, smart_recent_context)
         self._enqueue_text_event(event)
 
     async def _handle_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -4973,7 +5214,7 @@ class TelegramAdapter(BasePlatformAdapter):
         msg = self._effective_update_message(update)
         if not msg or not msg.text:
             return
-        if not self._should_process_message(msg, is_command=True):
+        if self._telegram_group_trigger_decision(msg, is_command=True) != "process":
             return
         await self._ensure_forum_commands(msg)
 
@@ -4987,7 +5228,7 @@ class TelegramAdapter(BasePlatformAdapter):
         msg = self._effective_update_message(update)
         if not msg:
             return
-        if not self._should_process_message(msg):
+        if self._telegram_group_trigger_decision(msg) != "process":
             if self._should_observe_unmentioned_group_message(msg):
                 self._observe_unmentioned_group_message(msg, MessageType.LOCATION, update_id=update.update_id)
             return
@@ -5152,6 +5393,12 @@ class TelegramAdapter(BasePlatformAdapter):
             existing.media_types.extend(event.media_types)
             if event.text:
                 existing.text = self._merge_caption(existing.text, event.text)
+            if event.channel_prompt and event.channel_prompt not in (existing.channel_prompt or ""):
+                existing.channel_prompt = (
+                    f"{existing.channel_prompt}\n\n{event.channel_prompt}"
+                    if existing.channel_prompt
+                    else event.channel_prompt
+                )
 
         prior_task = self._pending_photo_batch_tasks.get(batch_key)
         if prior_task and not prior_task.done():
@@ -5163,9 +5410,24 @@ class TelegramAdapter(BasePlatformAdapter):
         """Handle incoming media messages, downloading images to local cache."""
         if not update.message:
             return
-        if not self._should_process_message(update.message):
-            if self._should_observe_unmentioned_group_message(update.message):
-                _m = update.message
+        msg = update.message
+        decision = self._telegram_group_trigger_decision(msg)
+        smart_recent_context: list[dict[str, Any]] = []
+        smart_accepted = False
+        if decision == "smart_mention_candidate":
+            if not self._telegram_smart_mention_sender_authorized(msg):
+                return
+            smart_recent_context = self._telegram_smart_mention_recent_context(msg)
+            smart_accepted = await self._evaluate_telegram_smart_mention(
+                msg,
+                recent_context=smart_recent_context,
+            )
+            self._append_telegram_smart_mention_context(msg)
+            if not smart_accepted:
+                return
+        elif decision != "process":
+            if self._should_observe_unmentioned_group_message(msg):
+                _m = msg
                 if _m.sticker:
                     _observe_type = MessageType.STICKER
                 elif _m.photo:
@@ -5180,8 +5442,8 @@ class TelegramAdapter(BasePlatformAdapter):
                     _observe_type = MessageType.DOCUMENT
                 self._observe_unmentioned_group_message(_m, _observe_type, update_id=update.update_id)
             return
-
-        msg = update.message
+        else:
+            self._append_telegram_smart_mention_context(msg)
         
         # Determine media type
         if msg.sticker:
@@ -5209,12 +5471,16 @@ class TelegramAdapter(BasePlatformAdapter):
         if msg.sticker:
             await self._handle_sticker(msg, event)
             event = self._apply_telegram_group_observe_attribution(event)
+            if smart_accepted:
+                event = self._apply_telegram_smart_mention_context_prompt(event, smart_recent_context)
             await self.handle_message(event)
             return
 
         # Apply observe attribution after caption is set; sticker is handled above
         # because _handle_sticker overwrites event.text with its vision description.
         event = self._apply_telegram_group_observe_attribution(event)
+        if smart_accepted:
+            event = self._apply_telegram_smart_mention_context_prompt(event, smart_recent_context)
 
         # Download photo to local image cache so the vision tool can access it
         # even after Telegram's ephemeral file URLs expire (~1 hour).
@@ -5446,6 +5712,12 @@ class TelegramAdapter(BasePlatformAdapter):
             existing.media_types.extend(event.media_types)
             if event.text:
                 existing.text = self._merge_caption(existing.text, event.text)
+            if event.channel_prompt and event.channel_prompt not in (existing.channel_prompt or ""):
+                existing.channel_prompt = (
+                    f"{existing.channel_prompt}\n\n{event.channel_prompt}"
+                    if existing.channel_prompt
+                    else event.channel_prompt
+                )
 
         prior_task = self._media_group_tasks.get(media_group_id)
         if prior_task:

--- a/gateway/platforms/telegram_smart_mention.py
+++ b/gateway/platforms/telegram_smart_mention.py
@@ -1,0 +1,203 @@
+"""Helpers for Telegram smart mention routing."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+
+DEFAULT_SMART_MENTION_SYSTEM_PROMPT = """You are Hermes's Telegram smart mention router.
+
+Decide whether the current Telegram group message is addressed to Hermes or asks Hermes to do something.
+
+Return only JSON with this shape:
+{"should_respond": true|false, "confidence": 0.0-1.0, "reason": "short reason"}
+
+Return true when the message asks Hermes, the bot, or an assistant to help, answer, summarize, decide, run a task, or otherwise take action. Recent context is only supporting evidence; the current message is the one being classified.
+
+Return false for ordinary human-to-human conversation, status chatter, jokes, messages addressed to someone else, or messages that only mention a topic without asking Hermes to act.
+
+Do not answer the user. Only classify routing."""
+
+
+@dataclass(frozen=True)
+class SmartMentionConfig:
+    enabled: bool = False
+    system_prompt: str = DEFAULT_SMART_MENTION_SYSTEM_PROMPT
+    include_recent_context: bool = True
+    recent_context_messages: int = 5
+    recent_context_max_chars: int = 2000
+    pass_recent_context_to_agent: bool = False
+    min_confidence: float = 0.6
+    max_tokens: int = 128
+    log_decisions: bool = True
+    log_message_text: bool = False
+    on_error: str = "ignore"
+
+
+@dataclass(frozen=True)
+class SmartMentionClassification:
+    should_respond: bool
+    confidence: float = 0.0
+    reason: str = ""
+    raw: str = ""
+
+
+def _coerce_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "1", "yes", "on"}
+    return bool(value)
+
+
+def _coerce_int(value: Any, default: int, *, min_value: int, max_value: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = default
+    return max(min_value, min(max_value, parsed))
+
+
+def _coerce_float(value: Any, default: float, *, min_value: float, max_value: float) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        parsed = default
+    return max(min_value, min(max_value, parsed))
+
+
+def normalize_smart_mention_config(raw: Any) -> SmartMentionConfig:
+    if isinstance(raw, bool):
+        return SmartMentionConfig(enabled=raw)
+    if not isinstance(raw, dict):
+        return SmartMentionConfig()
+
+    prompt = raw.get("system_prompt")
+    if not isinstance(prompt, str) or not prompt.strip():
+        prompt = DEFAULT_SMART_MENTION_SYSTEM_PROMPT
+    else:
+        prompt = prompt.strip()
+
+    return SmartMentionConfig(
+        enabled=_coerce_bool(raw.get("enabled"), False),
+        system_prompt=prompt,
+        include_recent_context=_coerce_bool(raw.get("include_recent_context"), True),
+        recent_context_messages=_coerce_int(raw.get("recent_context_messages"), 5, min_value=0, max_value=50),
+        recent_context_max_chars=_coerce_int(raw.get("recent_context_max_chars"), 2000, min_value=0, max_value=20000),
+        pass_recent_context_to_agent=_coerce_bool(raw.get("pass_recent_context_to_agent"), False),
+        min_confidence=_coerce_float(raw.get("min_confidence"), 0.6, min_value=0.0, max_value=1.0),
+        max_tokens=_coerce_int(raw.get("max_tokens"), 128, min_value=16, max_value=1024),
+        log_decisions=_coerce_bool(raw.get("log_decisions"), True),
+        log_message_text=_coerce_bool(raw.get("log_message_text"), False),
+        on_error=str(raw.get("on_error") or "ignore").strip().lower() or "ignore",
+    )
+
+
+def truncate_text(text: str, max_chars: int) -> str:
+    if max_chars <= 0 or len(text) <= max_chars:
+        return text
+    return text[: max_chars - 3].rstrip() + "..."
+
+
+def build_smart_mention_messages(
+    *,
+    config: SmartMentionConfig,
+    current_text: str,
+    recent_context: Iterable[dict[str, Any]] = (),
+    media_metadata: dict[str, Any] | None = None,
+    bot_username: str = "",
+    chat_id: str = "",
+    thread_id: str = "",
+) -> list[dict[str, str]]:
+    context_lines: list[str] = []
+    if config.include_recent_context and config.recent_context_messages > 0:
+        for item in list(recent_context)[-config.recent_context_messages:]:
+            sender = str(item.get("sender") or "user").strip() or "user"
+            text = str(item.get("text") or "").strip()
+            if not text:
+                continue
+            media = str(item.get("media") or "").strip()
+            suffix = f" [{media}]" if media else ""
+            context_lines.append(f"- {sender}{suffix}: {text}")
+
+    context_block = "\n".join(context_lines)
+    if config.recent_context_max_chars > 0:
+        context_block = truncate_text(context_block, config.recent_context_max_chars)
+
+    metadata_lines = [
+        f"bot_username: @{bot_username}" if bot_username else "bot_username: unknown",
+        f"chat_id: {chat_id}" if chat_id else "chat_id: unknown",
+        f"thread_id: {thread_id}" if thread_id else "thread_id: general",
+    ]
+    if media_metadata:
+        metadata_lines.append("media:")
+        for key, value in sorted(media_metadata.items()):
+            if value is None or value == "":
+                continue
+            metadata_lines.append(f"  {key}: {value}")
+
+    user_parts = [
+        "Telegram group routing decision.",
+        "",
+        "Metadata:",
+        "\n".join(metadata_lines),
+        "",
+        "Recent context:",
+        context_block or "(none)",
+        "",
+        "Current message:",
+        current_text.strip() or "(no text)",
+    ]
+    return [
+        {"role": "system", "content": config.system_prompt},
+        {"role": "user", "content": "\n".join(user_parts)},
+    ]
+
+
+def parse_smart_mention_response(raw: Any) -> SmartMentionClassification:
+    text = str(raw or "").strip()
+    if not text:
+        return SmartMentionClassification(False, raw=text)
+
+    match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL | re.IGNORECASE)
+    candidate = match.group(1).strip() if match else text
+    if not candidate.startswith("{"):
+        brace = re.search(r"\{.*\}", candidate, re.DOTALL)
+        if brace:
+            candidate = brace.group(0)
+
+    try:
+        payload = json.loads(candidate)
+    except Exception:
+        return SmartMentionClassification(False, raw=text)
+
+    value = payload.get("should_respond", payload.get("respond", payload.get("process", False)))
+    should_respond = _coerce_bool(value, False)
+    confidence = _coerce_float(payload.get("confidence"), 1.0 if should_respond else 0.0, min_value=0.0, max_value=1.0)
+    reason = str(payload.get("reason") or "").strip()
+    return SmartMentionClassification(should_respond, confidence=confidence, reason=reason, raw=text)
+
+
+def format_recent_context_for_agent(recent_context: Iterable[dict[str, Any]], max_chars: int) -> str:
+    lines: list[str] = []
+    for item in recent_context:
+        sender = str(item.get("sender") or "user").strip() or "user"
+        text = str(item.get("text") or "").strip()
+        if not text:
+            continue
+        media = str(item.get("media") or "").strip()
+        suffix = f" [{media}]" if media else ""
+        lines.append(f"- {sender}{suffix}: {text}")
+    body = truncate_text("\n".join(lines), max_chars)
+    if not body:
+        return ""
+    return (
+        "Telegram recent group context before the current smart-routed message:\n"
+        f"{body}\n\n"
+        "Use this only as ephemeral context. The current message is the user request."
+    )

--- a/gateway/platforms/telegram_smart_mention.py
+++ b/gateway/platforms/telegram_smart_mention.py
@@ -116,12 +116,15 @@ def build_smart_mention_messages(
 ) -> list[dict[str, str]]:
     context_lines: list[str] = []
     if config.include_recent_context and config.recent_context_messages > 0:
-        for item in list(recent_context)[-config.recent_context_messages:]:
+        recent_items = []
+        for item in recent_context:
             sender = str(item.get("sender") or "user").strip() or "user"
             text = str(item.get("text") or "").strip()
             if not text:
                 continue
             media = str(item.get("media") or "").strip()
+            recent_items.append((sender, text, media))
+        for sender, text, media in recent_items[-config.recent_context_messages:]:
             suffix = f" [{media}]" if media else ""
             context_lines.append(f"- {sender}{suffix}: {text}")
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -30,6 +30,19 @@ from hermes_cli.secret_prompt import masked_secret_prompt
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_TELEGRAM_SMART_MENTION_SYSTEM_PROMPT = """You are Hermes's Telegram smart mention router.
+
+Decide whether the current Telegram group message is addressed to Hermes or asks Hermes to do something.
+
+Return only JSON with this shape:
+{"should_respond": true|false, "confidence": 0.0-1.0, "reason": "short reason"}
+
+Return true when the message asks Hermes, the bot, or an assistant to help, answer, summarize, decide, run a task, or otherwise take action. Recent context is only supporting evidence; the current message is the one being classified.
+
+Return false for ordinary human-to-human conversation, status chatter, jokes, messages addressed to someone else, or messages that only mention a topic without asking Hermes to act.
+
+Do not answer the user. Only classify routing."""
+
 # Track which (config_path, mtime_ns, size) tuples we've already warned about
 # so concurrent CLI/gateway loads of a broken config.yaml don't spam stderr
 # every time. Cleared automatically when the file changes (different mtime).
@@ -1029,6 +1042,14 @@ DEFAULT_CONFIG = {
             "timeout": 30,
             "extra_body": {},
         },
+        "smart_mention": {
+            "provider": "auto",
+            "model": "",
+            "base_url": "",
+            "api_key": "",
+            "timeout": 30,
+            "extra_body": {},
+        },
         # Triage specifier — flesh out a rough one-liner in the Kanban
         # Triage column into a concrete spec, then promote it to ``todo``.
         # Invoked by ``hermes kanban specify`` (single id or --all). Set a
@@ -1523,9 +1544,28 @@ DEFAULT_CONFIG = {
 
     # Telegram platform settings (gateway mode)
     "telegram": {
+        "require_mention": False,      # Require @mention/reply/wake pattern to respond in group chats
+        "mention_patterns": [],        # Regex wake-word patterns checked next to @mentions
+        "exclusive_bot_mentions": True,  # Ignore messages explicitly addressed to another @...bot
+        "free_response_chats": "",     # Comma-separated chat IDs where bot responds without mention
+        "allowed_chats": "",           # If set, bot ONLY responds in these group/supergroup chat IDs (whitelist)
+        "allowed_topics": "",          # Optional forum topic allowlist; General topic is 1
+        "ignored_threads": "",         # Optional forum topic IDs to ignore
         "reactions": False,            # Add 👀/✅/❌ reactions to messages during processing
         "channel_prompts": {},         # Per-chat/topic ephemeral system prompts (topics inherit from parent group)
-        "allowed_chats": "",           # If set, bot ONLY responds in these group/supergroup chat IDs (whitelist)
+        "smart_mention": {
+            "enabled": False,
+            "system_prompt": DEFAULT_TELEGRAM_SMART_MENTION_SYSTEM_PROMPT,
+            "include_recent_context": True,
+            "recent_context_messages": 5,
+            "recent_context_max_chars": 2000,
+            "pass_recent_context_to_agent": False,
+            "min_confidence": 0.6,
+            "max_tokens": 128,
+            "log_decisions": True,
+            "log_message_text": False,
+            "on_error": "ignore",
+        },
     },
 
     # Mattermost platform settings (gateway mode)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2503,6 +2503,7 @@ _AUX_TASKS: list[tuple[str, str, str]] = [
     ("approval", "Approval", "smart command approval"),
     ("mcp", "MCP", "MCP tool reasoning"),
     ("title_generation", "Title generation", "session titles"),
+    ("smart_mention", "Smart mention", "Telegram group routing"),
     ("skills_hub", "Skills hub", "skills search/install"),
     ("triage_specifier", "Triage specifier", "kanban spec fleshing"),
     ("kanban_decomposer", "Kanban decomposer", "task decomposition"),

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -376,6 +376,15 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "description": "Reasoning effort for delegated subagents",
         "options": ["", "low", "medium", "high"],
     },
+    "telegram.smart_mention.system_prompt": {
+        "type": "text",
+        "description": "System prompt for Telegram smart mention classification",
+    },
+    "telegram.smart_mention.on_error": {
+        "type": "select",
+        "description": "Fallback behavior when smart mention classification fails",
+        "options": ["ignore", "process"],
+    },
 }
 
 # Categories with fewer fields get merged into "general" to avoid tab sprawl.
@@ -392,17 +401,13 @@ _CATEGORY_MERGE: Dict[str, str] = {
     "code_execution": "agent",
     "prompt_caching": "agent",
     "goals": "agent",
-    # Only `telegram.reactions` currently lives under telegram — fold it in
-    # with the other messaging-platform config (discord) so it isn't an
-    # orphan tab of one field.
-    "telegram": "discord",
 }
 
 # Display order for tabs — unlisted categories sort alphabetically after these.
 _CATEGORY_ORDER = [
     "general", "agent", "terminal", "display", "delegation",
     "memory", "compression", "security", "browser", "voice",
-    "tts", "stt", "logging", "discord", "auxiliary",
+    "tts", "stt", "logging", "telegram", "discord", "auxiliary",
 ]
 
 
@@ -1029,6 +1034,7 @@ _AUX_TASK_SLOTS: Tuple[str, ...] = (
     "triage_specifier",
     "kanban_decomposer",
     "profile_describer",
+    "smart_mention",
     "curator",
 )
 

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock
 
 from gateway.config import Platform, PlatformConfig, load_gateway_config
 from gateway.platforms.base import MessageType
+from gateway.platforms.telegram_smart_mention import parse_smart_mention_response
 from gateway.session import SessionSource
 
 
@@ -21,6 +22,7 @@ def _make_adapter(
     group_allowed_chats=None,
     guest_mode=None,
     observe_unmentioned_group_messages=None,
+    smart_mention=None,
     bot_username="hermes_bot",
 ):
     from gateway.platforms.telegram import TelegramAdapter
@@ -62,6 +64,8 @@ def _make_adapter(
         extra["guest_mode"] = guest_mode
     if observe_unmentioned_group_messages is not None:
         extra["observe_unmentioned_group_messages"] = observe_unmentioned_group_messages
+    if smart_mention is not None:
+        extra["smart_mention"] = smart_mention
 
     adapter = object.__new__(TelegramAdapter)
     adapter.platform = Platform.TELEGRAM
@@ -70,6 +74,7 @@ def _make_adapter(
     adapter._message_handler = AsyncMock()
     adapter._pending_text_batches = {}
     adapter._pending_text_batch_tasks = {}
+    adapter._smart_mention_context = {}
     adapter._text_batch_delay_seconds = 0.01
     adapter._text_batch_split_delay_seconds = 0.01
     adapter._mention_patterns = adapter._compile_mention_patterns()
@@ -154,6 +159,144 @@ def test_group_messages_can_be_opened_via_config():
     adapter = _make_adapter(require_mention=False)
 
     assert adapter._should_process_message(_group_message("hello everyone")) is True
+
+
+def test_smart_mention_is_async_candidate_not_sync_process():
+    adapter = _make_adapter(
+        require_mention=True,
+        smart_mention={"enabled": True},
+    )
+    msg = _group_message("could Hermes help with this deploy?")
+
+    assert adapter._telegram_group_trigger_decision(msg) == "smart_mention_candidate"
+    assert adapter._should_process_message(msg) is False
+
+
+def test_bare_group_command_is_not_smart_mention_candidate():
+    adapter = _make_adapter(
+        require_mention=True,
+        smart_mention={"enabled": True},
+    )
+    msg = _group_message("/status", entities=[_bot_command_entity("/status", "/status")])
+
+    assert adapter._telegram_group_trigger_decision(msg, is_command=True) == "ignore"
+
+
+def test_smart_mention_classifier_uses_recent_context(monkeypatch):
+    async def _run():
+        adapter = _make_adapter(
+            require_mention=True,
+            smart_mention={
+                "enabled": True,
+                "recent_context_messages": 3,
+                "pass_recent_context_to_agent": True,
+                "min_confidence": 0.5,
+            },
+        )
+        adapter._append_telegram_smart_mention_context(_group_message("deploy failed with exit 2"))
+        current = _group_message("can you fix it?")
+        captured = {}
+
+        async def fake_call_llm(**kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(
+                            content='{"should_respond": true, "confidence": 0.91, "reason": "asks for help"}'
+                        )
+                    )
+                ]
+            )
+
+        monkeypatch.setattr("agent.auxiliary_client.async_call_llm", fake_call_llm)
+
+        recent = adapter._telegram_smart_mention_recent_context(current)
+        accepted = await adapter._evaluate_telegram_smart_mention(current, recent_context=recent)
+
+        assert accepted is True
+        assert captured["task"] == "smart_mention"
+        assert captured["max_tokens"] == 128
+        user_payload = captured["messages"][1]["content"]
+        assert "deploy failed with exit 2" in user_payload
+        assert "can you fix it?" in user_payload
+
+        event = adapter._build_message_event(current, MessageType.TEXT, update_id=1005)
+        event = adapter._apply_telegram_smart_mention_context_prompt(event, recent)
+        assert "Telegram recent group context" in event.channel_prompt
+        assert "deploy failed with exit 2" in event.channel_prompt
+
+    asyncio.run(_run())
+
+
+def test_smart_mention_malformed_classifier_response_is_ignored():
+    result = parse_smart_mention_response("yes, respond to this message")
+
+    assert result.should_respond is False
+    assert result.confidence == 0.0
+
+
+def test_smart_mention_does_not_call_classifier_for_unauthorized_group_user(monkeypatch):
+    async def _run():
+        adapter = _make_adapter(
+            require_mention=True,
+            smart_mention={"enabled": True},
+        )
+
+        class _Runner:
+            def _is_user_authorized(self, source):
+                assert source.platform == Platform.TELEGRAM
+                assert source.chat_id == "-100"
+                assert source.user_id == "111"
+                return False
+
+        async def _message_handler(_event):
+            raise AssertionError("unauthorized smart mention should not dispatch")
+
+        _message_handler.__self__ = _Runner()
+        adapter._message_handler = _message_handler
+
+        call_llm = AsyncMock()
+        monkeypatch.setattr("agent.auxiliary_client.async_call_llm", call_llm)
+
+        update = SimpleNamespace(
+            update_id=1006,
+            message=_group_message("Hermes should help with this"),
+            effective_message=None,
+        )
+
+        await adapter._handle_text_message(update, SimpleNamespace())
+
+        call_llm.assert_not_awaited()
+
+    asyncio.run(_run())
+
+
+def test_top_level_telegram_smart_mention_bridges_to_platform_extra(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "gateway:\n"
+        "  platforms:\n"
+        "    telegram:\n"
+        "      enabled: true\n"
+        "      token: test-token\n"
+        "      extra:\n"
+        "        smart_mention:\n"
+        "          enabled: false\n"
+        "telegram:\n"
+        "  smart_mention:\n"
+        "    enabled: true\n"
+        "    min_confidence: 0.7\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    config = load_gateway_config()
+
+    telegram = config.platforms[Platform.TELEGRAM]
+    assert telegram.extra["smart_mention"]["enabled"] is True
+    assert telegram.extra["smart_mention"]["min_confidence"] == 0.7
 
 
 def test_unmentioned_group_messages_can_be_observed_without_dispatching():

--- a/tests/gateway/test_telegram_smart_mention.py
+++ b/tests/gateway/test_telegram_smart_mention.py
@@ -1,0 +1,195 @@
+from gateway.platforms.telegram_smart_mention import (
+    DEFAULT_SMART_MENTION_SYSTEM_PROMPT,
+    SmartMentionConfig,
+    build_smart_mention_messages,
+    format_recent_context_for_agent,
+    normalize_smart_mention_config,
+    parse_smart_mention_response,
+)
+
+
+def test_normalize_smart_mention_config_accepts_boolean_shortcut():
+    config = normalize_smart_mention_config(True)
+
+    assert config.enabled is True
+    assert config.system_prompt == DEFAULT_SMART_MENTION_SYSTEM_PROMPT
+
+
+def test_normalize_smart_mention_config_clamps_numeric_fields_and_trims_prompt():
+    config = normalize_smart_mention_config(
+        {
+            "enabled": "yes",
+            "system_prompt": "  classify only  ",
+            "include_recent_context": "off",
+            "recent_context_messages": 999,
+            "recent_context_max_chars": -1,
+            "pass_recent_context_to_agent": "true",
+            "min_confidence": 1.5,
+            "max_tokens": 1,
+            "log_decisions": "false",
+            "log_message_text": "on",
+            "on_error": " escalate ",
+        }
+    )
+
+    assert config.enabled is True
+    assert config.system_prompt == "classify only"
+    assert config.include_recent_context is False
+    assert config.recent_context_messages == 50
+    assert config.recent_context_max_chars == 0
+    assert config.pass_recent_context_to_agent is True
+    assert config.min_confidence == 1.0
+    assert config.max_tokens == 16
+    assert config.log_decisions is False
+    assert config.log_message_text is True
+    assert config.on_error == "escalate"
+
+
+def test_build_smart_mention_messages_includes_metadata_media_and_recent_context():
+    config = SmartMentionConfig(
+        system_prompt="classify",
+        recent_context_messages=2,
+        recent_context_max_chars=1000,
+    )
+
+    messages = build_smart_mention_messages(
+        config=config,
+        current_text="Hermes, summarize the incident",
+        recent_context=[
+            {"sender": "Alice", "text": "old context"},
+            {"sender": "Bob", "text": "deploy failed", "media": "log"},
+            {"sender": "Cara", "text": "rollback started"},
+        ],
+        media_metadata={"type": "photo", "width": 1280, "height": 720, "empty": ""},
+        bot_username="hermes_bot",
+        chat_id="-100",
+        thread_id="42",
+    )
+
+    assert messages[0] == {"role": "system", "content": "classify"}
+    user_payload = messages[1]["content"]
+    assert "bot_username: @hermes_bot" in user_payload
+    assert "chat_id: -100" in user_payload
+    assert "thread_id: 42" in user_payload
+    assert "height: 720" in user_payload
+    assert "type: photo" in user_payload
+    assert "width: 1280" in user_payload
+    assert "old context" not in user_payload
+    assert "- Bob [log]: deploy failed" in user_payload
+    assert "- Cara: rollback started" in user_payload
+    assert "Hermes, summarize the incident" in user_payload
+
+
+def test_build_smart_mention_messages_limits_recent_nonblank_context_items():
+    config = SmartMentionConfig(recent_context_messages=2)
+
+    messages = build_smart_mention_messages(
+        config=config,
+        current_text="Hermes, what changed?",
+        recent_context=[
+            {"sender": "Alice", "text": "first useful context"},
+            {"sender": "Bob", "text": "second useful context"},
+            {"sender": "Noisy", "text": "   "},
+        ],
+    )
+
+    user_payload = messages[1]["content"]
+    assert "first useful context" in user_payload
+    assert "second useful context" in user_payload
+    assert "Noisy" not in user_payload
+
+
+def test_build_smart_mention_messages_omits_context_when_disabled():
+    config = SmartMentionConfig(include_recent_context=False)
+
+    messages = build_smart_mention_messages(
+        config=config,
+        current_text="can you check this?",
+        recent_context=[{"sender": "Alice", "text": "previous request"}],
+    )
+
+    assert "Recent context:\n(none)" in messages[1]["content"]
+    assert "previous request" not in messages[1]["content"]
+
+
+def test_build_smart_mention_messages_truncates_context_without_truncating_current_message():
+    current_text = "Hermes, decide whether this production alert needs escalation"
+    config = SmartMentionConfig(
+        recent_context_messages=3,
+        recent_context_max_chars=40,
+    )
+
+    messages = build_smart_mention_messages(
+        config=config,
+        current_text=current_text,
+        recent_context=[
+            {"sender": "Alice", "text": "A" * 80},
+            {"sender": "Bob", "text": "B" * 80},
+        ],
+    )
+
+    user_payload = messages[1]["content"]
+    recent_context_block = user_payload.split("Recent context:\n", 1)[1].split("\n\nCurrent message:", 1)[0]
+    current_message_block = user_payload.split("Current message:\n", 1)[1]
+    assert recent_context_block.endswith("...")
+    assert len(recent_context_block) <= config.recent_context_max_chars
+    assert current_message_block == current_text
+
+
+def test_parse_smart_mention_response_accepts_fenced_json_and_aliases():
+    classification = parse_smart_mention_response(
+        """```json
+        {"respond": true, "confidence": 0.91, "reason": "direct ask"}
+        ```"""
+    )
+
+    assert classification.should_respond is True
+    assert classification.confidence == 0.91
+    assert classification.reason == "direct ask"
+
+
+def test_parse_smart_mention_response_extracts_json_from_noisy_model_output():
+    classification = parse_smart_mention_response(
+        'I would classify it as: {"should_respond": true, "confidence": "0.74", "reason": "asks Hermes"}'
+    )
+
+    assert classification.should_respond is True
+    assert classification.confidence == 0.74
+    assert classification.reason == "asks Hermes"
+
+
+def test_parse_smart_mention_response_rejects_malformed_text_and_clamps_confidence():
+    malformed = parse_smart_mention_response("yes, answer this")
+    clamped = parse_smart_mention_response('{"process": true, "confidence": 3.5}')
+
+    assert malformed.should_respond is False
+    assert malformed.confidence == 0.0
+    assert clamped.should_respond is True
+    assert clamped.confidence == 1.0
+
+
+def test_format_recent_context_for_agent_formats_and_truncates_context():
+    text = format_recent_context_for_agent(
+        [
+            {"sender": "Alice", "text": "deploy failed", "media": "log"},
+            {"sender": "Bob", "text": "please inspect the traceback"},
+        ],
+        max_chars=36,
+    )
+
+    assert text.startswith("Telegram recent group context")
+    assert "- Alice [log]: deploy failed" in text
+    assert text.endswith("The current message is the user request.")
+    assert "..." in text
+
+
+def test_format_recent_context_for_agent_returns_empty_for_blank_context():
+    text = format_recent_context_for_agent(
+        [
+            {"sender": "Alice", "text": " "},
+            {"sender": "Bob"},
+        ],
+        max_chars=100,
+    )
+
+    assert text == ""

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -404,6 +404,16 @@ class TestBuildSchemaFromConfig:
         assert "privacy" not in categories  # merged into security
         assert "context" not in categories  # merged into agent
 
+    def test_telegram_smart_mention_schema_has_own_category_and_text_prompt(self):
+        from hermes_cli.web_server import CONFIG_SCHEMA
+
+        enabled = CONFIG_SCHEMA["telegram.smart_mention.enabled"]
+        prompt = CONFIG_SCHEMA["telegram.smart_mention.system_prompt"]
+
+        assert enabled["category"] == "telegram"
+        assert prompt["category"] == "telegram"
+        assert prompt["type"] == "text"
+
     def test_no_single_field_categories(self):
         """After merging, no category should have just 1 field."""
         from hermes_cli.web_server import CONFIG_SCHEMA

--- a/web/src/i18n/af.ts
+++ b/web/src/i18n/af.ts
@@ -355,6 +355,7 @@ export const af: Translations = {
       tts: "Teks-na-Spraak",
       stt: "Spraak-na-Teks",
       logging: "Aantekening",
+      telegram: "Telegram",
       discord: "Discord",
       auxiliary: "Hulpmiddels",
     },

--- a/web/src/i18n/de.ts
+++ b/web/src/i18n/de.ts
@@ -355,6 +355,7 @@ export const de: Translations = {
       tts: "Text-zu-Sprache",
       stt: "Sprache-zu-Text",
       logging: "Protokollierung",
+      telegram: "Telegram",
       discord: "Discord",
       auxiliary: "Hilfs",
     },

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -355,6 +355,7 @@ export const en: Translations = {
       tts: "Text-to-Speech",
       stt: "Speech-to-Text",
       logging: "Logging",
+      telegram: "Telegram",
       discord: "Discord",
       auxiliary: "Auxiliary",
     },

--- a/web/src/i18n/es.ts
+++ b/web/src/i18n/es.ts
@@ -355,6 +355,7 @@ export const es: Translations = {
       tts: "Texto a voz",
       stt: "Voz a texto",
       logging: "Registro",
+      telegram: "Telegram",
       discord: "Discord",
       auxiliary: "Auxiliar",
     },

--- a/web/src/i18n/fr.ts
+++ b/web/src/i18n/fr.ts
@@ -355,6 +355,7 @@ export const fr: Translations = {
       tts: "Synthèse vocale",
       stt: "Reconnaissance vocale",
       logging: "Journalisation",
+      telegram: "Telegram",
       discord: "Discord",
       auxiliary: "Auxiliaire",
     },

--- a/web/src/i18n/ga.ts
+++ b/web/src/i18n/ga.ts
@@ -355,6 +355,7 @@ export const ga: Translations = {
       tts: "Téacs go Caint",
       stt: "Caint go Téacs",
       logging: "Logáil",
+      telegram: "Telegram",
       discord: "Discord",
       auxiliary: "Cúntach",
     },

--- a/web/src/i18n/hu.ts
+++ b/web/src/i18n/hu.ts
@@ -355,6 +355,7 @@ export const hu: Translations = {
       tts: "Szövegfelolvasás",
       stt: "Beszédfelismerés",
       logging: "Naplózás",
+      telegram: "Telegram",
       discord: "Discord",
       auxiliary: "Kiegészítő",
     },

--- a/web/src/i18n/it.ts
+++ b/web/src/i18n/it.ts
@@ -355,6 +355,7 @@ export const it: Translations = {
       tts: "Sintesi vocale",
       stt: "Riconoscimento vocale",
       logging: "Log",
+      telegram: "Telegram",
       discord: "Discord",
       auxiliary: "Ausiliario",
     },

--- a/web/src/i18n/ja.ts
+++ b/web/src/i18n/ja.ts
@@ -355,6 +355,7 @@ export const ja: Translations = {
       tts: "音声合成",
       stt: "音声認識",
       logging: "ロギング",
+      telegram: "Telegram",
       discord: "Discord",
       auxiliary: "補助",
     },

--- a/web/src/i18n/ko.ts
+++ b/web/src/i18n/ko.ts
@@ -355,6 +355,7 @@ export const ko: Translations = {
       tts: "텍스트 음성 변환",
       stt: "음성 텍스트 변환",
       logging: "로깅",
+      telegram: "Telegram",
       discord: "Discord",
       auxiliary: "보조",
     },

--- a/web/src/i18n/pt.ts
+++ b/web/src/i18n/pt.ts
@@ -355,6 +355,7 @@ export const pt: Translations = {
       tts: "Texto para fala",
       stt: "Fala para texto",
       logging: "Registo",
+      telegram: "Telegram",
       discord: "Discord",
       auxiliary: "Auxiliar",
     },

--- a/web/src/i18n/ru.ts
+++ b/web/src/i18n/ru.ts
@@ -355,6 +355,7 @@ export const ru: Translations = {
       tts: "Синтез речи",
       stt: "Распознавание речи",
       logging: "Журналирование",
+      telegram: "Telegram",
       discord: "Discord",
       auxiliary: "Вспомогательные",
     },

--- a/web/src/i18n/tr.ts
+++ b/web/src/i18n/tr.ts
@@ -355,6 +355,7 @@ export const tr: Translations = {
       tts: "Metinden Konuşmaya",
       stt: "Konuşmadan Metne",
       logging: "Günlükleme",
+      telegram: "Telegram",
       discord: "Discord",
       auxiliary: "Yardımcı",
     },

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -375,6 +375,7 @@ export interface Translations {
       tts: string;
       stt: string;
       logging: string;
+      telegram: string;
       discord: string;
       auxiliary: string;
     };

--- a/web/src/i18n/uk.ts
+++ b/web/src/i18n/uk.ts
@@ -355,6 +355,7 @@ export const uk: Translations = {
       tts: "Синтез мовлення",
       stt: "Розпізнавання мовлення",
       logging: "Журналювання",
+      telegram: "Telegram",
       discord: "Discord",
       auxiliary: "Додатково",
     },

--- a/web/src/i18n/zh-hant.ts
+++ b/web/src/i18n/zh-hant.ts
@@ -355,6 +355,7 @@ export const zhHant: Translations = {
       tts: "文字轉語音",
       stt: "語音轉文字",
       logging: "日誌",
+      telegram: "Telegram",
       discord: "Discord",
       auxiliary: "輔助",
     },

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -351,6 +351,7 @@ export const zh: Translations = {
       tts: "文字转语音",
       stt: "语音转文字",
       logging: "日志",
+      telegram: "Telegram",
       discord: "Discord",
       auxiliary: "辅助",
     },

--- a/web/src/pages/ConfigPage.tsx
+++ b/web/src/pages/ConfigPage.tsx
@@ -73,6 +73,7 @@ const CATEGORY_ICONS: Record<
   tts: Volume2,
   stt: Ear,
   logging: ClipboardList,
+  telegram: MessageCircle,
   discord: MessageCircle,
   auxiliary: Wrench,
   bedrock: Cloud,
@@ -365,8 +366,13 @@ export default function ConfigPage() {
     let lastCat = "";
     return fields.map(([key, s]) => {
       const parts = key.split(".");
-      const section = parts.length > 1 ? parts[0] : "";
       const cat = String(s.category ?? "general");
+      const section =
+        !showCategory && parts[0] === activeCategory && parts.length > 2
+          ? parts[1]
+          : parts.length > 1
+            ? parts[0]
+            : "";
       const showCatBadge = showCategory && cat !== lastCat;
       const showSection =
         !showCategory &&

--- a/website/docs/guides/local-ollama-setup.md
+++ b/website/docs/guides/local-ollama-setup.md
@@ -227,6 +227,27 @@ hermes gateway
 
 Now message your bot on Telegram — it responds using your local model.
 
+### Use a local model for Telegram smart mention routing
+
+If Telegram smart mention routing is enabled, point only that auxiliary classifier at a small local model:
+
+```yaml
+telegram:
+  require_mention: true
+  smart_mention:
+    enabled: true
+
+auxiliary:
+  smart_mention:
+    provider: custom
+    base_url: "http://localhost:11434/v1"
+    model: "qwen2.5:7b-instruct"
+    api_key: "ollama"
+    timeout: 30
+```
+
+Hermes does not start Ollama for you. Start `ollama serve` yourself, pull the model, and keep it reachable from the Hermes process. If Hermes runs in Docker, use the Ollama container/service hostname instead of `localhost`.
+
 ### Discord
 
 1. Create a Discord application at [discord.com/developers](https://discord.com/developers/applications)

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -828,6 +828,14 @@ auxiliary:
     api_key: ""
     timeout: 30                # seconds
 
+  # Telegram smart mention classifier
+  smart_mention:
+    provider: "auto"
+    model: ""
+    base_url: ""
+    api_key: ""
+    timeout: 30                # seconds
+
   # Context compression timeout (separate from compression.* config)
   compression:
     timeout: 120               # seconds — compression summarizes long conversations, needs more time
@@ -862,7 +870,7 @@ auxiliary:
 ```
 
 :::tip
-Each auxiliary task has a configurable `timeout` (in seconds). Defaults: vision 120s, web_extract 360s, approval 30s, compression 120s. Increase these if you use slow local models for auxiliary tasks. Vision also has a separate `download_timeout` (default 30s) for the HTTP image download — increase this for slow connections or self-hosted image servers.
+Each auxiliary task has a configurable `timeout` (in seconds). Defaults: vision 120s, web_extract 360s, approval 30s, smart_mention 30s, compression 120s. Increase these if you use slow local models for auxiliary tasks. Vision also has a separate `download_timeout` (default 30s) for the HTTP image download — increase this for slow connections or self-hosted image servers.
 :::
 
 :::info

--- a/website/docs/user-guide/configuring-models.md
+++ b/website/docs/user-guide/configuring-models.md
@@ -7,7 +7,7 @@ sidebar_position: 3
 Hermes uses two kinds of model slots:
 
 - **Main model** — what the agent thinks with. Every user message, every tool-call loop, every streamed response goes through this model.
-- **Auxiliary models** — smaller side-jobs the agent offloads. Context compression, vision (image analysis), web-page summarization, approval scoring, MCP tool routing, session-title generation, and skill search. Each has its own slot and can be overridden independently.
+- **Auxiliary models** — smaller side-jobs the agent offloads. Context compression, vision (image analysis), web-page summarization, approval scoring, Telegram smart mention routing, MCP tool routing, session-title generation, and skill search. Each has its own slot and can be overridden independently.
 
 This page covers configuring both from the dashboard. If you prefer config files or the CLI, jump to [Alternative methods](#alternative-methods) at the bottom.
 
@@ -43,7 +43,7 @@ Pick a model, hit **Switch**, and Hermes writes it to `~/.hermes/config.yaml` un
 
 ## Setting auxiliary models
 
-Click **Show auxiliary** to reveal the eight task slots:
+Click **Show auxiliary** to reveal the task slots:
 
 ![Auxiliary panel expanded](/img/docs/dashboard-models/auxiliary-expanded.png)
 
@@ -57,6 +57,7 @@ Every auxiliary task defaults to `auto` — meaning Hermes uses your main model 
 | **Vision** | When your main model is a coding model without vision (e.g. Kimi, DeepSeek). Point it at `google/gemini-2.5-flash` or `gpt-4o-mini`. |
 | **Compression** | When you're burning reasoning tokens on Opus/M2.7 just to summarize context. A fast chat model does the job at 1/50th the cost. |
 | **Approval** | For `approval_mode: smart` — a fast/cheap model (haiku, flash, gpt-5-mini) decides whether to auto-approve low-risk commands. Expensive models here are waste. |
+| **Smart Mention** | For Telegram group smart mention routing — a small local or flash model decides whether an unmentioned group message is actually addressed to Hermes. |
 | **Web Extract** | When you use `web_extract` heavily. Same logic as compression — summarization doesn't need reasoning. |
 | **Skills Hub** | `hermes skills search` uses this. Usually fine at `auto`. |
 | **MCP** | MCP tool routing. Usually fine at `auto`. |
@@ -78,7 +79,7 @@ Every model card on the page has a **Use as** dropdown. This is the fast path �
 The dropdown has:
 
 - **Main model** — same as clicking Change on the main row.
-- **All auxiliary tasks** — assigns this model to all 8 aux slots at once. Useful when you just want every side-job on a cheap flash model.
+- **All auxiliary tasks** — assigns this model to all auxiliary slots at once. Useful when you just want every side-job on a cheap flash model.
 - **Individual task options** — Vision, Web Extract, Compression, etc. The currently-assigned model for each task is marked `current`.
 
 Cards are badged with `main` or `aux · <task>` when they're currently assigned to something — so you can see at a glance which of your historical models are wired in where.

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -319,6 +319,45 @@ To verify what PortAudio sees inside the container:
 docker exec hermes /opt/hermes/.venv/bin/python -c "import sounddevice as sd; print(sd.query_devices())"
 ```
 
+### Running Ollama beside Hermes
+
+Hermes does not launch Ollama or LM Studio automatically. When Hermes runs in Docker, run Ollama as a separate service on the same Compose network and point auxiliary or main model config at the service name:
+
+```yaml
+services:
+  hermes:
+    image: nousresearch/hermes-agent:latest
+    command: gateway run
+    volumes:
+      - ~/.hermes:/opt/data
+    environment:
+      - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
+    depends_on:
+      - ollama
+
+  ollama:
+    image: ollama/ollama:latest
+    volumes:
+      - ollama:/root/.ollama
+    ports:
+      - "11434:11434"
+
+volumes:
+  ollama:
+```
+
+Then configure `/opt/data/config.yaml` (the mounted `~/.hermes/config.yaml`) with the container hostname:
+
+```yaml
+auxiliary:
+  smart_mention:
+    provider: custom
+    base_url: "http://ollama:11434/v1"
+    model: "qwen2.5:7b-instruct"
+    api_key: "ollama"
+    timeout: 30
+```
+
 ## Resource limits
 
 The Hermes container needs moderate resources. Recommended minimums:

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -101,6 +101,48 @@ TELEGRAM_OBSERVE_UNMENTIONED_GROUP_MESSAGES=true
 
 This requires Telegram to deliver ordinary group messages to the gateway, so disable BotFather privacy mode or promote the bot to group admin as described above.
 
+### Smart mention routing for groups
+
+Smart mention routing lets Hermes watch ordinary group/supergroup messages and use a small auxiliary model to decide whether a message is implicitly addressed to the bot. It is an extra trigger alongside `mention_patterns`; explicit `@botname` mentions, replies to the bot, free-response chats, allowed topics, ignored topics, and `allowed_chats` keep their existing behavior.
+
+```yaml
+telegram:
+  require_mention: true
+  allowed_chats:
+    - "-1001234567890"
+  mention_patterns:
+    - "(?i)\\bhermes\\b"
+  smart_mention:
+    enabled: true
+    include_recent_context: true
+    recent_context_messages: 5
+    recent_context_max_chars: 2000
+    pass_recent_context_to_agent: false
+    min_confidence: 0.6
+    max_tokens: 128
+    log_decisions: true
+    log_message_text: false
+    on_error: ignore
+    system_prompt: |
+      You are Hermes's Telegram smart mention router.
+      Decide whether the current Telegram group message is addressed to Hermes.
+      Return only JSON: {"should_respond": true|false, "confidence": 0.0-1.0, "reason": "short reason"}
+
+auxiliary:
+  smart_mention:
+    provider: custom
+    base_url: http://ollama:11434/v1
+    model: qwen2.5:7b-instruct
+    api_key: ollama
+    timeout: 30
+```
+
+The classifier receives the current text/caption plus a volatile in-memory buffer of the last `recent_context_messages` messages from the same chat/topic. That buffer is not persisted and is not sent to the main agent unless `pass_recent_context_to_agent: true`.
+
+Attachment routing is intentionally lightweight: Hermes does not download, transcribe, or vision-analyze media before the smart mention decision. Captioned attachments can be classified from their caption and basic metadata; attachments without text/caption still need an explicit hard trigger such as an `@botname` mention or reply to the bot. Voice-message pre-routing transcription is a separate future feature.
+
+`auxiliary.smart_mention.timeout` is the only timeout for the classifier. If `telegram.smart_mention.system_prompt` is blank, Hermes logs a warning and uses the built-in default prompt.
+
 ## Step 4: Find Your User ID
 
 Hermes Agent uses numeric Telegram user IDs to control access. Your user ID is **not** your username — it's a number like `123456789`.


### PR DESCRIPTION
## Summary

Adds opt-in Telegram smart mention routing for group/supergroup messages that do not explicitly mention Hermes.

When `require_mention` is enabled, Hermes can now use a configured auxiliary model to classify whether an unmentioned group message is actually addressed to Hermes before deciding to route it to the main agent.

## Problem

Telegram groups often keep `require_mention: true` to avoid noisy bot replies. That blocks natural messages like "can someone ask Hermes to summarize this?" unless users remember the exact mention pattern.

The existing mention gates are deterministic and cheap, but they cannot recognize intent in unmentioned group chatter.

## Solution

Add a bounded LLM classifier behind `telegram.smart_mention`, routed through `auxiliary.smart_mention`.

The router only runs after existing Telegram hard gates and only for group/supergroup messages. It uses volatile in-memory recent context by chat/topic, a configurable system prompt, confidence threshold, timeout, and explicit fallback behavior.

## Changes

- Add `gateway/platforms/telegram_smart_mention.py` for classifier prompting, JSON parsing, confidence handling, and recent-context buffering.
- Wire Telegram group routing to call smart mention only after existing allow/ignore/topic/mention gates.
- Add `telegram.smart_mention` config with prompt, context, confidence, timeout, logging, and fallback settings.
- Add `auxiliary.smart_mention` model routing support.
- Expose Telegram smart mention settings in the dashboard config UI.
- Add tests for group-only behavior, hard-gate ordering, malformed classifier output, context buffering, config schema, and auxiliary config coverage.
- Update Telegram, configuration, Docker, local Ollama, and model-routing docs.

## Config example

```yaml
telegram:
  require_mention: true
  smart_mention:
    enabled: true
    include_recent_context: true
    recent_context_messages: 5
    recent_context_max_chars: 2000
    pass_recent_context_to_agent: true
    min_confidence: 0.6
    timeout: 8
    on_error: ignore

auxiliary:
  smart_mention:
    provider: custom
    model: local-smart-mention-model
    base_url: http://ollama:11434/v1
    api_key: ollama
```

## Compatibility notes

- Disabled by default.
- Only applies to Telegram groups and supergroups, not private chats.
- Existing explicit mentions, replies, mention patterns, allowed chats, allowed topics, ignored topics, and slash-command behavior are preserved.
- Attachment handling is limited to captions and lightweight metadata; audio transcription is intentionally left for future work.

## Validation

- Focused Telegram smart mention/config tests: `48 passed`.
- Focused gateway/config test run through `scripts/run_tests.sh`: `213 passed`.
- Broader gateway/CLI/tools regression subset: `524 passed`, `1` failure in `tests/skills/test_openclaw_migration.py`.
- `py_compile` for changed Python modules: passed.
- `npm run build` in `web`: passed, with the existing Vite chunk-size warning.
- `scripts/check-windows-footguns.py --diff upstream/main`: passed.
- `git diff --check upstream/main..HEAD`: passed.

Manual smoke-tested with a Telegram development bot and a local OpenAI-compatible model endpoint.
