### PR TITLE
fix(file-safety): write-deny pairing/ directory (salvage #30412)

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -127,6 +127,12 @@ def is_write_denied(path: str) -> bool:
                 return True
         except Exception:
             pass
+        try:
+            pairing_real = os.path.realpath(os.path.join(base_real, "pairing"))
+            if resolved == pairing_real or resolved.startswith(pairing_real + os.sep):
+                return True
+        except Exception:
+            pass
 
     safe_root = get_safe_write_root()
     if safe_root and not (resolved == safe_root or resolved.startswith(safe_root + os.sep)):

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -68,10 +68,14 @@ class TestIsWriteDenied:
             "webhook_subscriptions.json",
             "mcp-tokens/token1.json",
             "mcp-tokens/subdir/token2.json",
+            "pairing/telegram-approved.json",
+            "pairing/discord-approved.json",
+            "pairing/telegram-pending.json",
+            "pairing",
         ],
     )
     def test_hermes_control_files_and_mcp_tokens_denied(self, path):
-        """Hermes control files and mcp-tokens entries must be write-denied."""
+        """Hermes control files and mcp-tokens/pairing entries must be write-denied."""
         from hermes_constants import get_hermes_home
         hermes_home = get_hermes_home()
         full_path = str(hermes_home / path)
@@ -139,6 +143,29 @@ class TestIsWriteDenied:
         assert _is_write_denied(str(root / "mcp-tokens" / "tok.json")) is True
         # The directory itself must also be denied (not just files inside)
         assert _is_write_denied(str(root / "mcp-tokens")) is True
+
+    def test_pairing_dir_denied(self, tmp_path, monkeypatch):
+        """Regression: pairing/ must be write-denied under both profile and root.
+
+        PR #30383 introduced ~/.hermes/pairing/{platform}-approved.json as the
+        gateway access-control list. Without this block, a prompt-injected agent
+        can write arbitrary user IDs into an approved file, granting persistent
+        gateway access without going through the pairing code flow — the same
+        threat class that motivated protecting webhook_subscriptions.json.
+        """
+        root = tmp_path / "hermes"
+        profile = root / "profiles" / "coder"
+        profile.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(profile))
+
+        # Active profile pairing entries
+        assert _is_write_denied(str(profile / "pairing" / "telegram-approved.json")) is True
+        assert _is_write_denied(str(profile / "pairing" / "discord-pending.json")) is True
+        # The directory itself
+        assert _is_write_denied(str(profile / "pairing")) is True
+        # Root pairing entries (profile mode — same shape as mcp-tokens gap)
+        assert _is_write_denied(str(root / "pairing" / "telegram-approved.json")) is True
+        assert _is_write_denied(str(root / "pairing")) is True
 
 
 


### PR DESCRIPTION
Salvage of #30412 by @AhmetArif0 onto current main. Ships as-is — implementation already mirrors the surrounding mcp-tokens directory-deny shape exactly.

## Summary
`~/.hermes/pairing/{platform}-approved.json` is the gateway's authorized-users ACL (introduced in #30383). The file IS the security policy: an entry there grants persistent gateway access without going through the `/pair` code flow. A prompt-injected agent that can write to it can elevate any Telegram/Discord/Slack user ID to authorized.

Same trust shape as why we already deny writes to `webhook_subscriptions.json` — the agent should never need to write to this surface; pairing happens through the operator-confirmed code flow.

## Changes
- `agent/file_safety.py`: extend `is_write_denied()` to cover `pairing/` directory under both active profile (`HERMES_HOME`) and global root (the same dual-protection shape mcp-tokens uses for the #15981 profile-leak gap).
- `tests/tools/test_file_operations.py`: regression tests for per-platform pairing files + directory + the profile/root dual coverage.

## Test plan
```
pytest tests/tools/test_file_operations.py    # 74 passed
```

Co-authored-by: AhmetArif0 <147827411+AhmetArif0@users.noreply.github.com>

Closes #30412