### PR TITLE
feat(gateway): add per-thread free_response and mention override for Telegram

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -870,6 +870,12 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = channel_prompts
                 if "gateway_restart_notification" in platform_cfg:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
+                if "free_response_threads" in platform_cfg:
+                    bridged["free_response_threads"] = platform_cfg["free_response_threads"]
+                if "hub_require_mention_threads" in platform_cfg:
+                    bridged["hub_require_mention_threads"] = [
+                        int(t) for t in platform_cfg["hub_require_mention_threads"]
+                    ]
                 enabled_was_explicit = "enabled" in platform_cfg
                 if not bridged and not enabled_was_explicit:
                     continue

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -4735,6 +4735,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return True
 
         chat_id_str = str(getattr(getattr(message, "chat", None), "id", ""))
+        thread_id_int = int(thread_id) if thread_id is not None else None
 
         if self._telegram_exclusive_bot_mentions() and self._explicit_bot_mentions_exclude_self(message):
             return False
@@ -4752,7 +4753,23 @@ class TelegramAdapter(BasePlatformAdapter):
 
         if guest_mention:
             return True
-        if chat_id_str in self._telegram_free_response_chats():
+
+        # Check for per-thread free_response override (chat_id:thread_id format).
+        # This lets hub chats force @mention on most threads while allowing
+        # one or two threads (e.g. a "bot-chat" topic) to auto-accept messages.
+        _free_threads = self.config.extra.get("free_response_threads", [])
+        if thread_id_int is not None:
+            for entry in _free_threads:
+                parts = str(entry).split(":")
+                if len(parts) == 2 and parts[0] == chat_id_str and str(thread_id_int) == parts[1]:
+                    return True
+
+        # Per-thread mention override: threads listed here require @mention
+        # even when free_response_chats would normally auto-accept.
+        _hub_mention_threads = self.config.extra.get("hub_require_mention_threads", [])
+        if thread_id_int is not None and thread_id_int in _hub_mention_threads:
+            pass  # Skip free_response_chats, go straight to mention checks
+        elif chat_id_str in self._telegram_free_response_chats():
             return True
         if not self._telegram_require_mention():
             return True


### PR DESCRIPTION
## Summary

Adds per-thread (forum topic) configuration for Telegram groups, allowing fine-grained control over which topics require @mention and which auto-accept messages.

## Problem

In a Telegram forum/supergroup with multiple bots and topics, the current `free_response_chats` setting applies to the entire chat — all topics or none. There was no way to:

1. Make specific topics free-response (no @mention needed) while the rest of the group requires mention
2. Force @mention in specific topics (e.g., a "hub" topic) even when the parent chat is in free_response_chats

## Changes

### `gateway/config.py`
- Bridge `free_response_threads` (list of `"chat_id:thread_id"` strings) from platform config
- Bridge `hub_require_mention_threads` (list of thread IDs) from platform config

### `gateway/platforms/telegram.py`
- Check per-thread free_response override before falling back to chat-level check
- Skip chat-level free_response when a thread is listed in `hub_require_mention_threads`

## Example Config

```yaml
telegram:
  free_response_chats:
    - "-10036959766"  # entire group auto-accepts
  free_response_threads:        # NEW
    - "-10036959766:12"       # Topic 12 always auto-accepts
  hub_require_mention_threads:  # NEW
    - 1                         # Topic 1 always requires @mention
```

## Testing

Running in production on a multi-bot Telegram forum group with 7 agents and 10+ topics. Per-thread overrides correctly route messages without @mention conflicts.

---

🤖 This PR was prepared with assistance from [Hermes Agent](https://github.com/NousResearch/hermes-agent).