### PR TITLE
fix(compression): 3-line fix for infinite compression loop (#29335)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -484,7 +484,8 @@ def run_conversation(
             tools=agent.tools or None,
         )
 
-        if _preflight_tokens >= agent.context_compressor.threshold_tokens:
+        if _preflight_tokens >= agent.context_compressor.threshold_tokens \
+           and agent.context_compressor.should_compress(_preflight_tokens):
             logger.info(
                 "Preflight compression: ~%s tokens >= %s threshold (model %s, ctx %s)",
                 f"{_preflight_tokens:,}",
@@ -4180,6 +4181,7 @@ def run_conversation(
         "estimated_cost_usd": agent.session_estimated_cost_usd,
         "cost_status": agent.session_cost_status,
         "cost_source": agent.session_cost_source,
+        "session_id": agent.session_id,
     }
     if agent._tool_guardrail_halt_decision is not None:
         result["guardrail"] = agent._tool_guardrail_halt_decision.to_metadata()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8699,6 +8699,7 @@ class GatewayRunner:
             # session_entry so transcript writes below go to the right session.
             if agent_result.get("session_id") and agent_result["session_id"] != session_entry.session_id:
                 session_entry.session_id = agent_result["session_id"]
+                self.session_store._save()
 
             # Prepend reasoning/thinking if display is enabled (per-platform)
             try:


### PR DESCRIPTION
## Problem

When context compression fires, three compounding issues cause an **infinite compression loop**:

### Issue A — session_id not propagated
`_compress_context()` updates `self.session_id` to the new session, but `run_conversation()` never includes `session_id` in its return dict. The gateway at `gateway/run.py:8700` has a guard but it's dead code — the agent never sends `session_id`.

### Issue B — preflight bypasses anti-thrashing
Preflight compression uses a raw threshold comparison, bypassing `should_compress()` which has anti-thrashing logic. When system prompt + tool schemas dominate token count, compressing messages doesn't bring total below threshold — preflight re-triggers every turn despite saving <10%.

### Issue C — gateway doesn't persist session_id update
Gateway updates `session_entry.session_id` in memory but doesn't call `session_store._save()`. Two other compression paths in the same file DO persist — this one was missed.

## Fix — 4 lines, 2 files

```diff
 agent/conversation_loop.py | 3 +++
 gateway/run.py              | 1 +
 2 files changed, 4 insertions(+), 1 deletion(-)
```

Fixes: #29335