### PR TITLE
fix(kanban): change synchronous=NORMAL to FULL + add wal_autocheckpoint=100

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1181,7 +1181,8 @@ def connect(
             # See hermes_state._WAL_INCOMPAT_MARKERS for detection logic.
             from hermes_state import apply_wal_with_fallback
             apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
-            conn.execute("PRAGMA synchronous=NORMAL")
+            conn.execute("PRAGMA synchronous=FULL")
+            conn.execute("PRAGMA wal_autocheckpoint=100")
             conn.execute("PRAGMA foreign_keys=ON")
             needs_init = resolved not in _INITIALIZED_PATHS
             if needs_init:


### PR DESCRIPTION
## Problem

`PRAGMA synchronous=NORMAL` (line 1184 of `hermes_cli/kanban_db.py`) defers fsync in WAL mode, leaving `kanban.db` vulnerable to corruption when a process is SIGKILL'd mid-transaction or when WAL frames are partially written during concurrent access. This causes `database disk image is malformed` errors after ~9-10 rapid task creations.

## Root Cause

`synchronous=NORMAL` means SQLite only syncs at checkpoint boundaries, not after every WAL frame write. If a writer process is killed mid-transaction (SIGKILL from reclaim, gateway shutdown, OOM killer), WAL frames may be written but the main DB is left in an inconsistent state. Next connection: malformed DB.

Also, the default 1000-page WAL checkpoint threshold lets the WAL grow large between checkpoints, widening the window where a SIGKILL can leave a huge WAL in a fragile state.

## Fix — 2 lines, 1 file

1. **`synchronous=NORMAL` → `FULL`**: ensures every WAL frame is fsync'd before the write completes, preventing WAL/main-DB inconsistency even after SIGKILL
2. **`wal_autocheckpoint=100`**: caps WAL at 100 pages between automatic checkpoints — bounds the checkpoint I/O spike and reduces the window where a large WAL is fragile

These match the fix proposed in upstream PRs #30969 / #30973 which are not yet merged.

## Trade-off

`synchronous=FULL` adds one fsync per write — ~1ms overhead on SSD, ~5-10ms on HDD. For kanban (create/show/complete operations, not a high-throughput OLTP path), this is negligible vs. the cost of DB corruption and manual recovery.

```diff
 hermes_cli/kanban_db.py | 3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)
```

Fixes: #31502
Related: #31618, #30896