### PR TITLE
fix(agent): fold system prefill messages into the main system prompt

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -48,6 +48,7 @@ from agent.message_sanitization import (
     _repair_tool_call_arguments,
     _escape_invalid_chars_in_json_strings,
 )
+from agent.prefill_messages import fold_system_prefill_messages
 from agent.tool_dispatch_helpers import (
     _is_multimodal_tool_result,
     _multimodal_text_summary,
@@ -988,10 +989,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             effective_system = (effective_system + "\n\n" + agent.ephemeral_system_prompt).strip()
         if effective_system:
             api_messages = [{"role": "system", "content": effective_system}] + api_messages
-        if agent.prefill_messages:
-            sys_offset = 1 if effective_system else 0
-            for idx, pfm in enumerate(agent.prefill_messages):
-                api_messages.insert(sys_offset + idx, pfm.copy())
+        api_messages = fold_system_prefill_messages(api_messages, agent.prefill_messages)
 
         # Same safety net as the main loop: repair tool-call/result
         # pairing before asking for a final summary.  Compression and

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -60,6 +60,7 @@ from agent.nous_rate_guard import (
     nous_rate_limit_remaining,
     record_nous_rate_limit,
 )
+from agent.prefill_messages import fold_system_prefill_messages
 from agent.process_bootstrap import _install_safe_stdio
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.retry_utils import jittered_backoff
@@ -851,12 +852,7 @@ def run_conversation(
         if effective_system:
             api_messages = [{"role": "system", "content": effective_system}] + api_messages
 
-        # Inject ephemeral prefill messages right after the system prompt
-        # but before conversation history. Same API-call-time-only pattern.
-        if agent.prefill_messages:
-            sys_offset = 1 if (api_messages and api_messages[0].get("role") == "system") else 0
-            for idx, pfm in enumerate(agent.prefill_messages):
-                api_messages.insert(sys_offset + idx, pfm.copy())
+        api_messages = fold_system_prefill_messages(api_messages, agent.prefill_messages)
 
         # Apply Anthropic prompt caching for Claude models on native
         # Anthropic, OpenRouter, and third-party Anthropic-compatible

--- a/agent/prefill_messages.py
+++ b/agent/prefill_messages.py
@@ -1,0 +1,41 @@
+"""Helpers for API-call-time prefill messages."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+def fold_system_prefill_messages(
+    api_messages: List[Dict[str, Any]],
+    prefill_messages: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Fold system prefill messages into the single leading system prompt."""
+    if not prefill_messages:
+        return api_messages
+    messages = [msg.copy() for msg in api_messages]
+
+    system_parts: List[str] = []
+    non_system_prefill: List[Dict[str, Any]] = []
+    for prefill in prefill_messages:
+        copied = prefill.copy()
+        if copied.get("role") == "system":
+            content = copied.get("content", "")
+            if content:
+                system_parts.append(content if isinstance(content, str) else str(content))
+        else:
+            non_system_prefill.append(copied)
+
+    if system_parts:
+        folded_system = "\n\n".join(part.strip() for part in system_parts if part.strip())
+        if messages and messages[0].get("role") == "system":
+            existing = messages[0].get("content", "")
+            existing_text = existing if isinstance(existing, str) else str(existing)
+            combined = "\n\n".join(part for part in (existing_text.strip(), folded_system) if part)
+            messages[0] = {**messages[0], "content": combined}
+        else:
+            messages.insert(0, {"role": "system", "content": folded_system})
+
+    sys_offset = 1 if messages and messages[0].get("role") == "system" else 0
+    for idx, prefill in enumerate(non_system_prefill):
+        messages.insert(sys_offset + idx, prefill)
+    return messages

--- a/tests/agent/test_prefill_messages.py
+++ b/tests/agent/test_prefill_messages.py
@@ -1,0 +1,83 @@
+import importlib
+import importlib.util
+import inspect
+
+
+def test_without_prefill_messages_leaves_request_untouched():
+    prefill_messages = importlib.import_module("agent.prefill_messages")
+    api_messages = [
+        {"role": "system", "content": "base system"},
+        {"role": "user", "content": "hello"},
+    ]
+
+    merged = prefill_messages.fold_system_prefill_messages(api_messages, [])
+
+    assert merged is api_messages
+
+
+def test_system_prefill_messages_fold_into_single_leading_system():
+    spec = importlib.util.find_spec("agent.prefill_messages")
+    assert spec is not None
+    prefill_messages = importlib.import_module("agent.prefill_messages")
+
+    api_messages = [
+        {"role": "system", "content": "base system"},
+        {"role": "user", "content": "hello"},
+    ]
+    prefill = [
+        {"role": "system", "content": "persona rules"},
+        {"role": "assistant", "content": "example answer"},
+    ]
+
+    merged = prefill_messages.fold_system_prefill_messages(api_messages, prefill)
+
+    assert [msg["role"] for msg in merged] == ["system", "assistant", "user"]
+    assert merged[0]["content"] == "base system\n\npersona rules"
+    assert prefill[0]["content"] == "persona rules"
+
+
+def test_system_prefill_creates_leading_system_when_request_has_none():
+    spec = importlib.util.find_spec("agent.prefill_messages")
+    assert spec is not None
+    prefill_messages = importlib.import_module("agent.prefill_messages")
+
+    merged = prefill_messages.fold_system_prefill_messages(
+        [{"role": "user", "content": "hello"}],
+        [
+            {"role": "system", "content": "persona rules"},
+            {"role": "user", "content": "few-shot question"},
+        ],
+    )
+
+    assert [msg["role"] for msg in merged] == ["system", "user", "user"]
+    assert merged[0]["content"] == "persona rules"
+
+
+def test_non_system_prefill_messages_keep_their_existing_order():
+    prefill_messages = importlib.import_module("agent.prefill_messages")
+
+    merged = prefill_messages.fold_system_prefill_messages(
+        [
+            {"role": "system", "content": "base system"},
+            {"role": "user", "content": "real question"},
+        ],
+        [
+            {"role": "user", "content": "few-shot question"},
+            {"role": "assistant", "content": "few-shot answer"},
+        ],
+    )
+
+    assert merged == [
+        {"role": "system", "content": "base system"},
+        {"role": "user", "content": "few-shot question"},
+        {"role": "assistant", "content": "few-shot answer"},
+        {"role": "user", "content": "real question"},
+    ]
+
+
+def test_api_call_paths_use_system_prefill_folding():
+    from agent import chat_completion_helpers, conversation_loop
+
+    for func in (conversation_loop.run_conversation, chat_completion_helpers.handle_max_iterations):
+        source = inspect.getsource(func)
+        assert "fold_system_prefill_messages(" in source


### PR DESCRIPTION
## What does this PR do?

`prefill_messages_file` messages are currently injected immediately after Hermes' leading system message. If that prefill includes a `role: system` message, OpenAI-compatible gateways receive multiple system messages; some strict providers reject that request even though ordinary gateway conversations work.

This PR folds system-role prefill content into the single leading system prompt before dispatch while leaving user/assistant few-shot prefill ordering unchanged. It also keeps requests with no configured prefill as a true no-op.

This applies at the shared `AIAgent` request assembly layer used by messaging gateways. Telegram, WhatsApp, and the other gateway platforms therefore retain the same behavior unless a system-role prefill is configured; in that case they now emit one semantically equivalent system instruction instead of multiple system messages.

## Related Issue

No linked issue. This was reproduced through a messaging gateway using a custom OpenAI-compatible provider that rejected the multiple-system-message request shape.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `agent/prefill_messages.py` to fold system-role prefill messages into the leading system prompt while preserving non-system prefill order.
- Updated `agent/conversation_loop.py` and `agent/chat_completion_helpers.py` to share the same prefill normalization behavior for regular calls and max-iteration summary calls.
- Added `tests/agent/test_prefill_messages.py` coverage for system folding, no-prefill no-op behavior, non-system ordering, and both API assembly call sites.

## How to Test

1. Run `scripts/run_tests.sh tests/agent/test_prefill_messages.py tests/agent/test_system_prompt_restore.py` (15 tests pass locally).
2. Run `python -m ruff check agent/prefill_messages.py tests/agent/test_prefill_messages.py agent/conversation_loop.py agent/chat_completion_helpers.py` and `python scripts/check-windows-footguns.py --diff origin/main`.
3. Configure a gateway `prefill_messages_file` containing a system-role persona message and submit a turn through an OpenAI-compatible endpoint. The outgoing messages now contain one leading `system` message with the prefill content folded into it, instead of a second system message.

Full-suite note: I ran `scripts/run_tests.sh`, which encountered 3 failures in `tests/agent/test_anthropic_adapter.py::TestRunOauthSetupToken` on macOS. I reproduced the identical 3 failures from an unmodified `origin/main` worktree; they are unrelated to this PR's changed files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (blocked by the unrelated baseline failures documented above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (no public configuration surface changed)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `check-windows-footguns.py --diff origin/main` passes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable; this is a request-assembly compatibility fix covered by regression tests and the reproduction described above.