### PR TITLE
fix(kanban): fail closed and serialize sqlite writes

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1033,6 +1033,18 @@ from gateway.whatsapp_identity import (
 logger = logging.getLogger(__name__)
 
 
+def _is_fatal_kanban_board_db_error(exc: Exception) -> bool:
+    """Return True for SQLite failures that should disable a Kanban board."""
+    if not isinstance(exc, sqlite3.DatabaseError):
+        return False
+    msg = str(exc).lower()
+    return (
+        "disk i/o error" in msg
+        or "file is not a database" in msg
+        or "database disk image is malformed" in msg
+    )
+
+
 # Sentinel placed into _running_agents immediately when a session starts
 # processing, *before* any await.  Prevents a second message for the same
 # session from bypassing the "already running" guard during the async gap
@@ -5332,13 +5344,7 @@ class GatewayRunner:
             return (resolved, stat.st_mtime_ns, stat.st_size)
 
         def _is_corrupt_board_db_error(exc: Exception) -> bool:
-            if not isinstance(exc, sqlite3.DatabaseError):
-                return False
-            msg = str(exc).lower()
-            return (
-                "file is not a database" in msg
-                or "database disk image is malformed" in msg
-            )
+            return _is_fatal_kanban_board_db_error(exc)
 
         def _tick_once_for_board(slug: str) -> "Optional[object]":
             """Run one dispatch_once for a specific board.
@@ -5380,13 +5386,14 @@ class GatewayRunner:
                 if _is_corrupt_board_db_error(exc):
                     disabled_corrupt_boards[slug] = fingerprint
                     logger.error(
-                        "kanban dispatcher: board %s database %s is not a valid "
-                        "SQLite database; disabling dispatch for this board "
+                        "kanban dispatcher: board %s database %s hit fatal "
+                        "SQLite error (%s); disabling dispatch for this board "
                         "until the file changes or the gateway restarts. Move "
                         "or restore the file, then run `hermes kanban init` if "
                         "you need a fresh board.",
                         slug,
                         fingerprint[0],
+                        exc,
                     )
                     return None
                 logger.exception("kanban dispatcher: tick failed on board %s", slug)
@@ -5436,6 +5443,9 @@ class GatewayRunner:
                 boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
             for b in boards:
                 slug = b.get("slug") or _kb.DEFAULT_BOARD
+                fingerprint = _board_db_fingerprint(slug)
+                if disabled_corrupt_boards.get(slug) == fingerprint:
+                    continue
                 conn = None
                 try:
                     conn = _kb.connect(board=slug)
@@ -5489,6 +5499,9 @@ class GatewayRunner:
             successes = 0
             for b in boards:
                 slug = b.get("slug") or _kb.DEFAULT_BOARD
+                fingerprint = _board_db_fingerprint(slug)
+                if disabled_corrupt_boards.get(slug) == fingerprint:
+                    continue
                 if attempted >= auto_decompose_per_tick:
                     break
                 # Pin this board for the duration of the call — same

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1034,10 +1034,12 @@ logger = logging.getLogger(__name__)
 
 
 def _is_fatal_kanban_board_db_error(exc: Exception) -> bool:
-    """Return True for SQLite failures that should disable a Kanban board."""
+    """Return True for storage failures that should disable a Kanban board."""
+    msg = str(exc).lower()
+    if exc.__class__.__name__ == "KanbanDbCorruptError":
+        return True
     if not isinstance(exc, sqlite3.DatabaseError):
         return False
-    msg = str(exc).lower()
     return (
         "disk i/o error" in msg
         or "file is not a database" in msg
@@ -5382,12 +5384,12 @@ class GatewayRunner:
                     failure_limit=failure_limit,
                     stale_timeout_seconds=stale_timeout_seconds,
                 )
-            except sqlite3.DatabaseError as exc:
+            except Exception as exc:
                 if _is_corrupt_board_db_error(exc):
                     disabled_corrupt_boards[slug] = fingerprint
                     logger.error(
                         "kanban dispatcher: board %s database %s hit fatal "
-                        "SQLite error (%s); disabling dispatch for this board "
+                        "storage error (%s); disabling dispatch for this board "
                         "until the file changes or the gateway restarts. Move "
                         "or restore the file, then run `hermes kanban init` if "
                         "you need a fresh board.",
@@ -5396,9 +5398,6 @@ class GatewayRunner:
                         exc,
                     )
                     return None
-                logger.exception("kanban dispatcher: tick failed on board %s", slug)
-                return None
-            except Exception:
                 logger.exception("kanban dispatcher: tick failed on board %s", slug)
                 return None
             finally:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -58,11 +58,12 @@ worktrees so that research / ops / digital-twin workloads work alongside
 coding workloads.  See ``docs/hermes-kanban-v1-spec.pdf`` for the full
 design specification.
 
-Concurrency strategy: WAL mode + ``BEGIN IMMEDIATE`` for write
-transactions + compare-and-swap (CAS) updates on ``tasks.status`` and
-``tasks.claim_lock``.  SQLite serializes writers via its WAL lock, so at
-most one claimer can win any given task.  Losers observe zero affected
-rows and move on -- no retry loops, no distributed-lock machinery.
+Concurrency strategy: WAL mode + an app-level per-DB interprocess write
+lock + ``BEGIN IMMEDIATE`` for write transactions + compare-and-swap
+(CAS) updates on ``tasks.status`` and ``tasks.claim_lock``.  SQLite still
+enforces transactional correctness; the file lock throttles Hermes worker
+fan-out before the journal layer so storage/lock IOERRs fail closed
+instead of compounding under retry pressure.
 The CAS coordination is **per-board** — each board is a separate DB,
 so multi-board installs get the same atomicity guarantees without any
 new locking.
@@ -1467,6 +1468,63 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
 
 
 @contextlib.contextmanager
+def _interprocess_file_lock(lock_path: Path, *, timeout_seconds: float = 30.0):
+    """Acquire an exclusive process-wide file lock with a bounded wait."""
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    deadline = time.monotonic() + max(0.1, timeout_seconds)
+    with lock_path.open("a+b") as fh:
+        if _IS_WINDOWS:  # pragma: no cover - exercised on Windows CI only
+            import msvcrt
+
+            lock_fn = getattr(msvcrt, "locking")
+            lk_nblck = getattr(msvcrt, "LK_NBLCK")
+            lk_unlck = getattr(msvcrt, "LK_UNLCK")
+            while True:
+                try:
+                    fh.seek(0)
+                    lock_fn(fh.fileno(), lk_nblck, 1)
+                    break
+                except OSError:
+                    if time.monotonic() >= deadline:
+                        raise TimeoutError(f"timed out acquiring kanban write lock {lock_path}")
+                    time.sleep(0.05)
+            try:
+                yield
+            finally:
+                fh.seek(0)
+                lock_fn(fh.fileno(), lk_unlck, 1)
+        else:
+            import fcntl
+
+            while True:
+                try:
+                    fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    break
+                except BlockingIOError:
+                    if time.monotonic() >= deadline:
+                        raise TimeoutError(f"timed out acquiring kanban write lock {lock_path}")
+                    time.sleep(0.05)
+            try:
+                yield
+            finally:
+                fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
+
+def _connection_db_path(conn: sqlite3.Connection) -> Path:
+    """Return the main database path for a sqlite connection."""
+    row = conn.execute("PRAGMA database_list").fetchone()
+    if row is None:
+        raise RuntimeError("unable to resolve kanban database path")
+    try:
+        value = row["file"]
+    except (IndexError, KeyError, TypeError):
+        value = row[2]
+    if not value:
+        raise RuntimeError("kanban database path is empty")
+    return Path(value)
+
+
+@contextlib.contextmanager
 def write_txn(conn: sqlite3.Connection):
     """Context manager for an IMMEDIATE write transaction.
 
@@ -1474,14 +1532,17 @@ def write_txn(conn: sqlite3.Connection):
     task + recording an event, etc.).  A claim CAS inside this context is
     atomic -- at most one concurrent writer can succeed.
     """
-    conn.execute("BEGIN IMMEDIATE")
-    try:
-        yield conn
-    except Exception:
-        conn.execute("ROLLBACK")
-        raise
-    else:
-        conn.execute("COMMIT")
+    db_path = _connection_db_path(conn)
+    lock_path = db_path.with_suffix(db_path.suffix + ".write.lock")
+    with _interprocess_file_lock(lock_path):
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            yield conn
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
+        else:
+            conn.execute("COMMIT")
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -48,13 +48,13 @@ SCHEMA_VERSION = 13
 # propagate that, every feature backed by state.db / kanban.db breaks
 # silently — /resume, /title, /history, /branch, kanban dispatcher, etc.
 #
-# Instead, fall back to ``journal_mode=DELETE`` (the pre-WAL default) which
-# works on NFS.  Concurrency drops — concurrent readers are blocked during
-# a write — but the feature works.
+# Instead, fall back to ``journal_mode=DELETE`` (the pre-WAL default) only
+# for known WAL-incompatibility signals. Generic ``disk I/O error`` is a
+# storage/journal failure signal and must propagate so callers fail closed
+# instead of continuing to write against an unsafe DB state.
 _WAL_INCOMPAT_MARKERS = (
     "locking protocol",       # SQLITE_PROTOCOL on NFS/SMB
     "not authorized",         # Some FUSE mounts block WAL pragma outright
-    "disk i/o error",         # Flaky network FS during WAL setup
 )
 
 # Last SessionDB() init error, per-process.  Surfaced in /resume and

--- a/tests/gateway/test_kanban_sqlite_fatal_errors.py
+++ b/tests/gateway/test_kanban_sqlite_fatal_errors.py
@@ -1,6 +1,7 @@
 import sqlite3
 
 from gateway.run import _is_fatal_kanban_board_db_error
+from hermes_cli.kanban_db import KanbanDbCorruptError
 
 
 def test_disk_io_error_is_fatal_for_kanban_board_dispatch():
@@ -12,6 +13,16 @@ def test_disk_io_error_is_fatal_for_kanban_board_dispatch():
 def test_malformed_database_is_fatal_for_kanban_board_dispatch():
     assert _is_fatal_kanban_board_db_error(
         sqlite3.DatabaseError("database disk image is malformed")
+    )
+
+
+def test_integrity_guard_corrupt_error_is_fatal_for_kanban_board_dispatch(tmp_path):
+    assert _is_fatal_kanban_board_db_error(
+        KanbanDbCorruptError(
+            tmp_path / "kanban.db",
+            tmp_path / "kanban.db.corrupt.bak",
+            "integrity_check returned malformed page tree",
+        )
     )
 
 

--- a/tests/gateway/test_kanban_sqlite_fatal_errors.py
+++ b/tests/gateway/test_kanban_sqlite_fatal_errors.py
@@ -1,0 +1,21 @@
+import sqlite3
+
+from gateway.run import _is_fatal_kanban_board_db_error
+
+
+def test_disk_io_error_is_fatal_for_kanban_board_dispatch():
+    assert _is_fatal_kanban_board_db_error(
+        sqlite3.OperationalError("disk I/O error")
+    )
+
+
+def test_malformed_database_is_fatal_for_kanban_board_dispatch():
+    assert _is_fatal_kanban_board_db_error(
+        sqlite3.DatabaseError("database disk image is malformed")
+    )
+
+
+def test_busy_locked_database_is_not_classified_as_corruption():
+    assert not _is_fatal_kanban_board_db_error(
+        sqlite3.OperationalError("database is locked")
+    )

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import contextlib
 import os
 import sqlite3
 import time
@@ -316,6 +317,35 @@ def test_claim_once_wins_second_loses(kanban_home):
         assert first is not None and first.status == "running"
         second = kb.claim_task(conn, t, claimer="host:2")
         assert second is None
+
+
+def test_write_txn_takes_interprocess_lock_before_begin(monkeypatch, tmp_path):
+    events: list[str] = []
+    db_path = tmp_path / "kanban.db"
+
+    class FakeConn:
+        def execute(self, sql):
+            events.append(f"sql:{sql}")
+
+    @contextlib.contextmanager
+    def fake_lock(path):
+        events.append(f"lock:{path.name}:enter")
+        yield
+        events.append(f"lock:{path.name}:exit")
+
+    monkeypatch.setattr(kb, "_connection_db_path", lambda conn: db_path)
+    monkeypatch.setattr(kb, "_interprocess_file_lock", fake_lock)
+
+    with kb.write_txn(FakeConn()):
+        events.append("inside")
+
+    assert events == [
+        "lock:kanban.db.write.lock:enter",
+        "sql:BEGIN IMMEDIATE",
+        "inside",
+        "sql:COMMIT",
+        "lock:kanban.db.write.lock:exit",
+    ]
 
 
 def test_claim_uses_env_default_ttl(kanban_home, monkeypatch):

--- a/tests/hermes_cli/test_kanban_multiprocess_integrity.py
+++ b/tests/hermes_cli/test_kanban_multiprocess_integrity.py
@@ -1,0 +1,88 @@
+"""Multiprocess integrity stress tests for the Kanban SQLite backend."""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import os
+import random
+import sqlite3
+import sys
+import time
+import traceback
+from pathlib import Path
+
+
+def _stress_worker(repo_root: str, db_path: str, idx: int, iterations: int, q) -> None:
+    sys.path.insert(0, repo_root)
+    from hermes_cli import kanban_db as kb
+
+    try:
+        random.seed(os.getpid() + idx)
+        conn = kb.connect(Path(db_path))
+        made: list[str] = []
+        for i in range(iterations):
+            op = i % 5
+            if op == 0 or not made:
+                tid = kb.create_task(
+                    conn,
+                    title=f"stress task {idx}-{i}",
+                    body="temp stress regression",
+                    assignee="default",
+                    created_by=f"worker-{idx}",
+                    initial_status="running",
+                )
+                made.append(tid)
+            else:
+                tid = random.choice(made)
+                if op == 1:
+                    kb.add_comment(conn, tid, f"worker-{idx}", f"comment {i}")
+                elif op == 2:
+                    kb.complete_task(conn, tid, result=f"done {idx}-{i}")
+                elif op == 3:
+                    kb.block_task(conn, tid, reason=f"blocked {idx}-{i}")
+                else:
+                    kb.add_comment(conn, tid, f"worker-{idx}", f"post {i}")
+            if i % 11 == 0:
+                time.sleep(random.random() / 1000)
+        conn.close()
+        q.put(("ok", idx, len(made)))
+    except Exception:
+        q.put(("err", idx, traceback.format_exc()))
+
+
+def test_multiprocess_writers_preserve_sqlite_integrity(tmp_path):
+    from hermes_cli import kanban_db as kb
+
+    db_path = tmp_path / "kanban.db"
+    conn = kb.connect(db_path)
+    conn.close()
+
+    procs = 4
+    iterations = 80
+    q = mp.Queue()
+    repo_root = str(Path(__file__).resolve().parents[2])
+    workers = [
+        mp.Process(target=_stress_worker, args=(repo_root, str(db_path), i, iterations, q))
+        for i in range(procs)
+    ]
+    for proc in workers:
+        proc.start()
+    for proc in workers:
+        proc.join(60)
+    for proc in workers:
+        if proc.is_alive():
+            proc.terminate()
+            proc.join(5)
+            raise AssertionError(f"stress worker timed out: pid={proc.pid}")
+
+    results = [q.get(timeout=5) for _ in workers]
+    failures = [r for r in results if r[0] != "ok"]
+    assert not failures, failures
+
+    raw = sqlite3.connect(db_path)
+    try:
+        assert raw.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+        assert raw.execute("SELECT count(*) FROM tasks").fetchone()[0] == procs * (iterations // 5)
+        assert raw.execute("SELECT count(*) FROM tasks WHERE id IS NULL OR created_at IS NULL").fetchone()[0] == 0
+    finally:
+        raw.close()

--- a/tests/test_hermes_state_wal_fallback.py
+++ b/tests/test_hermes_state_wal_fallback.py
@@ -110,13 +110,13 @@ class TestApplyWalWithFallback:
         assert mode == "delete"
         conn.close()
 
-    def test_falls_back_on_disk_io_error(self, tmp_path):
-        """Flaky network FS → disk I/O error → still fall back."""
+    def test_reraises_disk_io_error(self, tmp_path):
+        """Generic IOERR is storage failure, not a WAL-compat signal."""
         conn, _ = _open_blocking(
             tmp_path / "flaky.db", reason="disk I/O error", isolation_level=None
         )
-        mode = apply_wal_with_fallback(conn)
-        assert mode == "delete"
+        with pytest.raises(sqlite3.OperationalError, match="disk I/O error"):
+            apply_wal_with_fallback(conn)
         conn.close()
 
     def test_reraises_unrelated_operational_error(self, tmp_path):


### PR DESCRIPTION
## Summary
- fail closed on generic SQLite `disk I/O error` instead of treating it as WAL-incompatible fallback
- serialize Kanban writes with a per-database interprocess file lock before `BEGIN IMMEDIATE`
- disable Kanban boards by DB fingerprint after fatal storage errors so the gateway stops retrying known-bad DBs
- add regression coverage for fatal error classification, write lock ordering, and multiprocess Kanban integrity

## Why
On WSL under concurrent Kanban dispatcher/worker load, a board hit SQLite B-tree corruption after generic `disk I/O error` was handled like a safe WAL fallback. That let workers continue against degraded storage state. This makes IOERR/malformed/not-a-db fail closed and adds app-level write serialization around board mutations.

## Test plan
- `PYTHONPATH=. /home/usmc1/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_hermes_state_wal_fallback.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_multiprocess_integrity.py tests/gateway/test_kanban_sqlite_fatal_errors.py -o addopts= -q`
  - Result after rebase onto upstream `main`: `192 passed, 1 warning in 12.78s`
- Earlier heavy temp-DB stress on Beast WSL: 8 processes x 300 iterations, `PRAGMA integrity_check` => `ok`, counts tasks=480 comments=960 events=1846 runs=406

## Operational notes
- Does not attempt to repair existing corrupted boards.
- Operators should initialize a fresh board after deploying this patch.
- For Beast WSL recovery, resume dispatch conservatively (`--max 1`) and run integrity checks before/after batches until confidence is rebuilt.
