### PR TITLE
fix: use IPv4 loopback for BlueBubbles webhooks

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -227,7 +227,11 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         """Compute the external webhook URL for BlueBubbles registration."""
         host = self.webhook_host
         if host in {"0.0.0.0", "127.0.0.1", "localhost", "::"}:
-            host = "localhost"
+            # BlueBubbles dispatches webhooks with Node/Axios. On macOS,
+            # localhost commonly resolves to ::1 before 127.0.0.1, while the
+            # Hermes webhook listener is typically bound to IPv4 loopback.
+            # Advertise explicit IPv4 loopback to avoid ECONNREFUSED ::1.
+            host = "127.0.0.1"
         return f"http://{host}:{self.webhook_port}{self.webhook_path}"
 
     @property

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -423,19 +423,21 @@ class TestBlueBubblesAttachmentDownload:
 
 
 class TestBlueBubblesWebhookUrl:
-    """_webhook_url property normalises local hosts to 'localhost'."""
+    """_webhook_url property normalizes local hosts to explicit IPv4 loopback."""
 
     def test_default_host(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
-        # Default webhook_host is 0.0.0.0 → normalized to localhost
-        assert "localhost" in adapter._webhook_url
+        # Default webhook_host is 0.0.0.0 → advertised as explicit IPv4 loopback.
+        # Avoid localhost because Node/Axios may resolve it to ::1 while aiohttp is
+        # only bound on IPv4, causing BlueBubbles webhook delivery to fail.
+        assert "127.0.0.1" in adapter._webhook_url
         assert str(adapter.webhook_port) in adapter._webhook_url
         assert adapter.webhook_path in adapter._webhook_url
 
     @pytest.mark.parametrize("host", ["0.0.0.0", "127.0.0.1", "localhost", "::"])
     def test_local_hosts_normalized(self, monkeypatch, host):
         adapter = _make_adapter(monkeypatch, webhook_host=host)
-        assert adapter._webhook_url.startswith("http://localhost:")
+        assert adapter._webhook_url.startswith("http://127.0.0.1:")
 
     def test_custom_host_preserved(self, monkeypatch):
         adapter = _make_adapter(monkeypatch, webhook_host="192.168.1.50")


### PR DESCRIPTION
## Summary
BlueBubbles webhook registration currently normalizes local webhook hosts to `localhost`. On macOS, `localhost` may resolve to IPv6 `::1` before IPv4 `127.0.0.1`.

BlueBubbles dispatches webhooks through Node/Axios. In a local multi-profile setup, Axios attempted to POST webhook events to `::1:<port>`, while Hermes was listening on IPv4 loopback. This caused webhook delivery failures such as `ECONNREFUSED ::1:8645` / `ECONNREFUSED ::1:8646`.

This changes local BlueBubbles webhook registration URLs to advertise `127.0.0.1` explicitly, avoiding IPv4/IPv6 localhost ambiguity.

## Test Plan
- `./venv/bin/python -m pytest tests/gateway/test_bluebubbles.py -q`
- Verified registered BlueBubbles webhooks use `127.0.0.1`
- Verified inbound iMessage replies work for separate Hermes profiles on ports 8645 and 8646
