### PR TITLE
feat(hindsight): surface recall provenance metadata

### DIFF
--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -76,6 +76,10 @@ Config file: `~/.hermes/hindsight/config.json`
 | `recall_tags` | — | Tags to filter when searching memories |
 | `recall_tags_match` | `any` | Tag matching mode: `any` / `all` / `any_strict` / `all_strict` |
 | `recall_types` | `observation` | Fact types surfaced by recall (both auto-recall and the `hindsight_recall` tool). Comma-separated string or JSON list. **Default narrowed to `observation` only** (see "Behavior change" below). Set to `observation,world,experience` to also include raw facts. |
+| `recall_include_tags` | `false` | Include Hindsight result tags in explicit recall output and auto-recall context |
+| `recall_include_metadata` | `false` | Include allowlisted Hindsight result metadata in explicit recall output and auto-recall context |
+| `recall_metadata_keys` | `source,scope,platform,source_system,agent_identity,machine,confidence` | Metadata keys to include when `recall_include_metadata` is enabled |
+| `recall_include_document_id` | `false` | Include the source `document_id` in explicit recall output and auto-recall context |
 | `auto_recall` | `true` | Automatically recall memories before each turn |
 
 > **Behavior change — `recall_types` defaults to `observation` only.**
@@ -141,6 +145,10 @@ Available in `hybrid` and `tools` memory modes:
 | `HINDSIGHT_BANK_ID` | Override bank name |
 | `HINDSIGHT_BUDGET` | Override recall budget |
 | `HINDSIGHT_MODE` | Override mode (`cloud`, `local_embedded`, `local_external`) |
+| `HINDSIGHT_RECALL_INCLUDE_TAGS` | Include Hindsight result tags in recall output/context |
+| `HINDSIGHT_RECALL_INCLUDE_METADATA` | Include allowlisted Hindsight result metadata in recall output/context |
+| `HINDSIGHT_RECALL_METADATA_KEYS` | Comma-separated metadata keys to include when metadata surfacing is enabled |
+| `HINDSIGHT_RECALL_INCLUDE_DOCUMENT_ID` | Include source `document_id` in recall output/context |
 
 ## Client Version
 

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -19,6 +19,10 @@ Config via environment variables:
   HINDSIGHT_IDLE_TIMEOUT           — embedded daemon idle timeout seconds; 0 disables shutdown (default: 300)
   HINDSIGHT_RETAIN_TAGS            — comma-separated tags attached to retained memories
   HINDSIGHT_RETAIN_SOURCE          — metadata source value attached to retained memories
+  HINDSIGHT_RECALL_INCLUDE_TAGS    — include result tags in recall output/context
+  HINDSIGHT_RECALL_INCLUDE_METADATA — include allowlisted metadata in recall output/context
+  HINDSIGHT_RECALL_METADATA_KEYS   — comma-separated metadata keys to include
+  HINDSIGHT_RECALL_INCLUDE_DOCUMENT_ID — include source document_id in recall output/context
   HINDSIGHT_RETAIN_USER_PREFIX     — label used before user turns in retained transcripts
   HINDSIGHT_RETAIN_ASSISTANT_PREFIX — label used before assistant turns in retained transcripts
 
@@ -59,6 +63,16 @@ _DEFAULT_IDLE_TIMEOUT = 300  # seconds — Hindsight embedded daemon default
 # unique document_id fallback for older APIs.
 _MIN_VERSION_FOR_UPDATE_MODE_APPEND = "0.5.0"
 _VALID_BUDGETS = {"low", "mid", "high"}
+_DEFAULT_RECALL_METADATA_KEYS = (
+    "source",
+    "scope",
+    "platform",
+    "source_system",
+    "agent_identity",
+    "machine",
+    "confidence",
+)
+_RECALL_ANNOTATION_VALUE_MAX_CHARS = 200
 _PROVIDER_DEFAULT_MODELS = {
     "openai": "gpt-4o-mini",
     "anthropic": "claude-haiku-4-5",
@@ -81,6 +95,28 @@ def _parse_int_setting(value: Any, default: int) -> int:
     except (TypeError, ValueError):
         logger.warning("Invalid integer Hindsight setting %r; using default %s", value, default)
         return default
+
+
+def _parse_bool_setting(value: Any, default: bool = False) -> bool:
+    """Parse a boolean config/env value, falling back on invalid input."""
+    if value is None or value == "":
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "y", "on"}:
+        return True
+    if text in {"0", "false", "no", "n", "off"}:
+        return False
+    logger.warning("Invalid boolean Hindsight setting %r; using default %s", value, default)
+    return default
+
+
+def _normalize_string_list(value: Any) -> List[str]:
+    """Normalize list or comma/JSON-list config values to unique strings."""
+    return _normalize_retain_tags(value)
 
 
 def _check_local_runtime() -> tuple[bool, str | None]:
@@ -329,6 +365,10 @@ def _load_config() -> dict:
         "retain_source": os.environ.get("HINDSIGHT_RETAIN_SOURCE", ""),
         "retain_user_prefix": os.environ.get("HINDSIGHT_RETAIN_USER_PREFIX", "User"),
         "retain_assistant_prefix": os.environ.get("HINDSIGHT_RETAIN_ASSISTANT_PREFIX", "Assistant"),
+        "recall_include_tags": _parse_bool_setting(os.environ.get("HINDSIGHT_RECALL_INCLUDE_TAGS"), False),
+        "recall_include_metadata": _parse_bool_setting(os.environ.get("HINDSIGHT_RECALL_INCLUDE_METADATA"), False),
+        "recall_include_document_id": _parse_bool_setting(os.environ.get("HINDSIGHT_RECALL_INCLUDE_DOCUMENT_ID"), False),
+        "recall_metadata_keys": os.environ.get("HINDSIGHT_RECALL_METADATA_KEYS", ""),
         "banks": {
             "hermes": {
                 "bankId": os.environ.get("HINDSIGHT_BANK_ID", "hermes"),
@@ -594,6 +634,10 @@ class HindsightMemoryProvider(MemoryProvider):
         self._recall_types: list[str] = ["observation"]
         self._recall_prompt_preamble = ""
         self._recall_max_input_chars = 800
+        self._recall_include_tags = False
+        self._recall_include_metadata = False
+        self._recall_include_document_id = False
+        self._recall_metadata_keys = list(_DEFAULT_RECALL_METADATA_KEYS)
 
         # Bank
         self._bank_mission = ""
@@ -879,6 +923,10 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "recall_max_tokens", "description": "Maximum tokens for recall results", "default": 4096},
             {"key": "recall_max_input_chars", "description": "Maximum input query length for auto-recall", "default": 800},
             {"key": "recall_prompt_preamble", "description": "Custom preamble for recalled memories in context"},
+            {"key": "recall_include_tags", "description": "Include Hindsight result tags in recall output and auto-recall context", "default": False},
+            {"key": "recall_include_metadata", "description": "Include allowlisted Hindsight result metadata in recall output and auto-recall context", "default": False},
+            {"key": "recall_metadata_keys", "description": "Metadata keys to include when recall_include_metadata is enabled (comma-separated)", "default": ",".join(_DEFAULT_RECALL_METADATA_KEYS)},
+            {"key": "recall_include_document_id", "description": "Include Hindsight source document_id in recall output and auto-recall context", "default": False},
             {"key": "timeout", "description": "API request timeout in seconds", "default": _DEFAULT_TIMEOUT},
             {"key": "idle_timeout", "description": "Embedded daemon idle timeout in seconds (0 disables auto-shutdown)", "default": _DEFAULT_IDLE_TIMEOUT, "when": {"mode": "local_embedded"}},
         ]
@@ -1217,6 +1265,25 @@ class HindsightMemoryProvider(MemoryProvider):
             self._recall_types = list(configured_types) or ["observation"]
         self._recall_prompt_preamble = self._config.get("recall_prompt_preamble", "")
         self._recall_max_input_chars = int(self._config.get("recall_max_input_chars", 800))
+        self._recall_include_tags = _parse_bool_setting(
+            self._config.get("recall_include_tags", os.environ.get("HINDSIGHT_RECALL_INCLUDE_TAGS")),
+            False,
+        )
+        self._recall_include_metadata = _parse_bool_setting(
+            self._config.get("recall_include_metadata", os.environ.get("HINDSIGHT_RECALL_INCLUDE_METADATA")),
+            False,
+        )
+        self._recall_include_document_id = _parse_bool_setting(
+            self._config.get("recall_include_document_id", os.environ.get("HINDSIGHT_RECALL_INCLUDE_DOCUMENT_ID")),
+            False,
+        )
+        self._recall_metadata_keys = (
+            _normalize_string_list(
+                self._config.get("recall_metadata_keys")
+                or os.environ.get("HINDSIGHT_RECALL_METADATA_KEYS")
+            )
+            or list(_DEFAULT_RECALL_METADATA_KEYS)
+        )
         self._retain_async = self._config.get("retain_async", True)
 
         _client_version = "unknown"
@@ -1358,7 +1425,7 @@ class HindsightMemoryProvider(MemoryProvider):
                     resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
                     num_results = len(resp.results) if resp.results else 0
                     logger.debug("Prefetch: recall returned %d results", num_results)
-                    text = "\n".join(f"- {r.text}" for r in resp.results if r.text) if resp.results else ""
+                    text = self._format_recall_results(resp.results, bullet="-") if resp.results else ""
                 if text:
                     with self._prefetch_lock:
                         self._prefetch_result = text
@@ -1367,6 +1434,104 @@ class HindsightMemoryProvider(MemoryProvider):
 
         self._prefetch_thread = threading.Thread(target=_run, daemon=True, name="hindsight-prefetch")
         self._prefetch_thread.start()
+
+    def _stringify_recall_annotation(self, value: Any) -> str:
+        """Return a compact one-line representation for recall annotations."""
+        if value is None:
+            return ""
+        if isinstance(value, (dict, list, tuple)):
+            try:
+                text = json.dumps(value, ensure_ascii=False, sort_keys=True)
+            except Exception:
+                text = str(value)
+        else:
+            text = str(value)
+        return " ".join(text.split())[:_RECALL_ANNOTATION_VALUE_MAX_CHARS]
+
+    def _filtered_recall_metadata(self, result: Any) -> dict[str, str]:
+        """Return allowlisted metadata for a recall result."""
+        if not self._recall_include_metadata:
+            return {}
+        raw = getattr(result, "metadata", None) or {}
+        if not isinstance(raw, dict):
+            return {}
+        metadata: dict[str, str] = {}
+        for key in self._recall_metadata_keys:
+            if key not in raw:
+                continue
+            value = self._stringify_recall_annotation(raw.get(key))
+            if value:
+                metadata[str(key)] = value
+        return metadata
+
+    def _recall_tags_for_result(self, result: Any) -> list[str]:
+        """Return normalized recall result tags when tag surfacing is enabled."""
+        if not self._recall_include_tags:
+            return []
+        return _normalize_string_list(getattr(result, "tags", None))
+
+    def _recall_document_id_for_result(self, result: Any) -> str:
+        """Return compact document_id when document_id surfacing is enabled."""
+        if not self._recall_include_document_id:
+            return ""
+        return self._stringify_recall_annotation(getattr(result, "document_id", ""))
+
+    def _format_recall_result_text(self, result: Any) -> str:
+        """Format one Hindsight recall result with optional provenance annotations."""
+        text = str(getattr(result, "text", "") or "").strip()
+        if not text:
+            return ""
+        annotations: list[str] = []
+        tags = self._recall_tags_for_result(result)
+        if tags:
+            annotations.append(f"[tags: {', '.join(tags)}]")
+        metadata = self._filtered_recall_metadata(result)
+        if metadata:
+            pairs = ", ".join(f"{key}={value}" for key, value in metadata.items())
+            annotations.append(f"[metadata: {pairs}]")
+        document_id = self._recall_document_id_for_result(result)
+        if document_id:
+            annotations.append(f"[document_id: {document_id}]")
+        if annotations:
+            return f"{' '.join(annotations)} {text}"
+        return text
+
+    def _format_recall_results(self, results: list[Any], *, bullet: str | None = None) -> str:
+        """Format recall results for either tool output or automatic prefetch."""
+        lines: list[str] = []
+        for index, result in enumerate(results, 1):
+            text = self._format_recall_result_text(result)
+            if not text:
+                continue
+            prefix = bullet if bullet is not None else f"{index}."
+            lines.append(f"{prefix} {text}")
+        return "\n".join(lines)
+
+    def _serialize_recall_results(self, results: list[Any]) -> list[dict[str, Any]]:
+        """Return structured recall results when provenance surfacing is enabled."""
+        if not (
+            self._recall_include_tags
+            or self._recall_include_metadata
+            or self._recall_include_document_id
+        ):
+            return []
+        serialized: list[dict[str, Any]] = []
+        for result in results:
+            text = str(getattr(result, "text", "") or "").strip()
+            if not text:
+                continue
+            item: dict[str, Any] = {"text": text}
+            tags = self._recall_tags_for_result(result)
+            if tags:
+                item["tags"] = tags
+            metadata = self._filtered_recall_metadata(result)
+            if metadata:
+                item["metadata"] = metadata
+            document_id = self._recall_document_id_for_result(result)
+            if document_id:
+                item["document_id"] = document_id
+            serialized.append(item)
+        return serialized
 
     def _build_turn_messages(self, user_content: str, assistant_content: str) -> List[Dict[str, str]]:
         now = datetime.now(timezone.utc).isoformat()
@@ -1582,8 +1747,13 @@ class HindsightMemoryProvider(MemoryProvider):
                 logger.debug("Tool hindsight_recall: %d results", num_results)
                 if not resp.results:
                     return json.dumps({"result": "No relevant memories found."})
-                lines = [f"{i}. {r.text}" for i, r in enumerate(resp.results, 1)]
-                return json.dumps({"result": "\n".join(lines)})
+                payload: dict[str, Any] = {
+                    "result": self._format_recall_results(resp.results),
+                }
+                memories = self._serialize_recall_results(resp.results)
+                if memories:
+                    payload["memories"] = memories
+                return json.dumps(payload)
             except Exception as e:
                 logger.warning("hindsight_recall failed: %s", e, exc_info=True)
                 return tool_error(f"Failed to search memory: {e}")

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -42,6 +42,8 @@ def _clean_env(monkeypatch):
         "HINDSIGHT_IDLE_TIMEOUT", "HINDSIGHT_LLM_API_KEY",
         "HINDSIGHT_RETAIN_TAGS", "HINDSIGHT_RETAIN_SOURCE",
         "HINDSIGHT_RETAIN_USER_PREFIX", "HINDSIGHT_RETAIN_ASSISTANT_PREFIX",
+        "HINDSIGHT_RECALL_INCLUDE_TAGS", "HINDSIGHT_RECALL_INCLUDE_METADATA",
+        "HINDSIGHT_RECALL_INCLUDE_DOCUMENT_ID", "HINDSIGHT_RECALL_METADATA_KEYS",
     ):
         monkeypatch.delenv(key, raising=False)
 
@@ -242,6 +244,10 @@ class TestConfig:
             recall_types=["world", "experience"],
             recall_prompt_preamble="Custom preamble:",
             recall_max_input_chars=500,
+            recall_include_tags=True,
+            recall_include_metadata=True,
+            recall_include_document_id=True,
+            recall_metadata_keys=["source", "platform"],
             bank_mission="Test agent mission",
         )
         assert p._tags == ["tag1", "tag2"]
@@ -260,6 +266,10 @@ class TestConfig:
         assert p._recall_types == ["world", "experience"]
         assert p._recall_prompt_preamble == "Custom preamble:"
         assert p._recall_max_input_chars == 500
+        assert p._recall_include_tags is True
+        assert p._recall_include_metadata is True
+        assert p._recall_include_document_id is True
+        assert p._recall_metadata_keys == ["source", "platform"]
         assert p._bank_mission == "Test agent mission"
 
     def test_config_from_env_fallback(self, tmp_path, monkeypatch):
@@ -272,11 +282,19 @@ class TestConfig:
         monkeypatch.setenv("HINDSIGHT_API_KEY", "env-key")
         monkeypatch.setenv("HINDSIGHT_BANK_ID", "env-bank")
         monkeypatch.setenv("HINDSIGHT_BUDGET", "high")
+        monkeypatch.setenv("HINDSIGHT_RECALL_INCLUDE_TAGS", "true")
+        monkeypatch.setenv("HINDSIGHT_RECALL_INCLUDE_METADATA", "1")
+        monkeypatch.setenv("HINDSIGHT_RECALL_INCLUDE_DOCUMENT_ID", "yes")
+        monkeypatch.setenv("HINDSIGHT_RECALL_METADATA_KEYS", "source, scope")
 
         cfg = _load_config()
         assert cfg["apiKey"] == "env-key"
         assert cfg["banks"]["hermes"]["bankId"] == "env-bank"
         assert cfg["banks"]["hermes"]["budget"] == "high"
+        assert cfg["recall_include_tags"] is True
+        assert cfg["recall_include_metadata"] is True
+        assert cfg["recall_include_document_id"] is True
+        assert cfg["recall_metadata_keys"] == "source, scope"
 
     def test_embedded_profile_env_includes_idle_timeout_from_config(self):
         env = _build_embedded_profile_env({
@@ -505,6 +523,93 @@ class TestToolHandlers:
         ))
         assert "Memory 1" in result["result"]
         assert "Memory 2" in result["result"]
+        assert "tags:" not in result["result"]
+        assert "metadata:" not in result["result"]
+
+    def test_recall_can_surface_tags_metadata_and_document_id(self, provider_with_config):
+        p = provider_with_config(
+            recall_include_tags=True,
+            recall_include_metadata=True,
+            recall_include_document_id=True,
+            recall_metadata_keys=["source", "platform"],
+        )
+        p._client.arecall.return_value = SimpleNamespace(
+            results=[
+                SimpleNamespace(
+                    text="David prefers concise answers.",
+                    tags=["scope=core", "source=macbook"],
+                    metadata={
+                        "source": "macbook",
+                        "platform": "discord",
+                        "chat_id": "private-chat-id",
+                    },
+                    document_id="doc-123",
+                )
+            ]
+        )
+
+        result = json.loads(p.handle_tool_call(
+            "hindsight_recall", {"query": "style"}
+        ))
+
+        assert result["result"] == (
+            "1. [tags: scope=core, source=macbook] "
+            "[metadata: source=macbook, platform=discord] "
+            "[document_id: doc-123] David prefers concise answers."
+        )
+        assert result["memories"] == [
+            {
+                "text": "David prefers concise answers.",
+                "tags": ["scope=core", "source=macbook"],
+                "metadata": {"source": "macbook", "platform": "discord"},
+                "document_id": "doc-123",
+            }
+        ]
+        assert "private-chat-id" not in result["result"]
+
+    def test_recall_metadata_uses_default_safe_allowlist(self, provider_with_config):
+        p = provider_with_config(recall_include_metadata=True)
+        p._client.arecall.return_value = SimpleNamespace(
+            results=[
+                SimpleNamespace(
+                    text="Memory text",
+                    metadata={"source": "volt", "chat_id": "private-chat-id"},
+                )
+            ]
+        )
+
+        result = json.loads(p.handle_tool_call(
+            "hindsight_recall", {"query": "memory"}
+        ))
+
+        assert "metadata: source=volt" in result["result"]
+        assert "chat_id" not in result["result"]
+        assert result["memories"][0]["metadata"] == {"source": "volt"}
+
+    def test_recall_annotations_are_bounded(self, provider_with_config):
+        p = provider_with_config(
+            recall_include_metadata=True,
+            recall_include_document_id=True,
+            recall_metadata_keys=["source"],
+        )
+        p._client.arecall.return_value = SimpleNamespace(
+            results=[
+                SimpleNamespace(
+                    text="Memory text",
+                    metadata={"source": "x" * 250},
+                    document_id="d" * 250,
+                )
+            ]
+        )
+
+        result = json.loads(p.handle_tool_call(
+            "hindsight_recall", {"query": "memory"}
+        ))
+
+        assert f"source={'x' * 200}" in result["result"]
+        assert "x" * 201 not in result["result"]
+        assert f"document_id: {'d' * 200}" in result["result"]
+        assert "d" * 201 not in result["result"]
 
     def test_recall_passes_max_tokens(self, provider_with_config):
         p = provider_with_config(recall_max_tokens=2048)
@@ -664,6 +769,33 @@ class TestPrefetch:
         assert call_kwargs["tags"] == ["t1"]
         assert call_kwargs["tags_match"] == "all"
         assert call_kwargs["types"] == ["world"]
+
+    def test_queue_prefetch_can_surface_tags_and_metadata(self, provider_with_config):
+        p = provider_with_config(
+            recall_include_tags=True,
+            recall_include_metadata=True,
+            recall_metadata_keys=["source", "scope"],
+        )
+        p._client.arecall.return_value = SimpleNamespace(
+            results=[
+                SimpleNamespace(
+                    text="Volt runs the home Hermes gateway.",
+                    tags=["source=volt-box"],
+                    metadata={"source": "volt-box", "scope": "machine", "chat_id": "private"},
+                )
+            ]
+        )
+
+        p.queue_prefetch("where does Hermes run?")
+        if p._prefetch_thread:
+            p._prefetch_thread.join(timeout=5.0)
+
+        assert p._prefetch_result == (
+            "- [tags: source=volt-box] "
+            "[metadata: source=volt-box, scope=machine] "
+            "Volt runs the home Hermes gateway."
+        )
+        assert "private" not in p._prefetch_result
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -365,6 +365,10 @@ The setup wizard installs dependencies automatically and only installs what's ne
 | `retain_user_prefix` | `User` | Label used before user turns in auto-retained transcripts |
 | `retain_assistant_prefix` | `Assistant` | Label used before assistant turns in auto-retained transcripts |
 | `recall_tags` | — | Tags to filter on recall |
+| `recall_include_tags` | `false` | Include Hindsight result tags in explicit recall output and auto-recall context |
+| `recall_include_metadata` | `false` | Include allowlisted Hindsight result metadata in explicit recall output and auto-recall context |
+| `recall_metadata_keys` | `source,scope,platform,source_system,agent_identity,machine,confidence` | Metadata keys to include when `recall_include_metadata` is enabled |
+| `recall_include_document_id` | `false` | Include the source `document_id` in explicit recall output and auto-recall context |
 
 See [plugin README](https://github.com/NousResearch/hermes-agent/blob/main/plugins/memory/hindsight/README.md) for the full configuration reference.
 


### PR DESCRIPTION
## Summary
- add opt-in Hindsight recall provenance formatting for tags, allowlisted metadata, and source document IDs
- apply the same formatting to explicit `hindsight_recall` results and automatic recall prefetch context
- keep default recall output unchanged unless the new config flags are enabled
- document the new config/env options and add regression coverage

## Safety / compatibility
- defaults remain off, preserving existing text-only recall behavior
- metadata output is allowlisted and excludes private fields like `chat_id` unless explicitly configured
- annotation values are bounded to avoid bloating injected memory context

## Test plan
- `python -m py_compile plugins/memory/hindsight/__init__.py`
- `python -m pytest -q tests/plugins/memory/test_hindsight_provider.py tests/agent/test_memory_provider.py -o 'addopts='`
- `git diff --check`
- added-line secret scan: none
