### PR TITLE
ci(supply-chain): anchor install-hook regex at repo root

### DIFF
--- a/.github/workflows/supply-chain-audit.yml
+++ b/.github/workflows/supply-chain-audit.yml
@@ -100,7 +100,12 @@ jobs:
 
           # --- Install-hook files (setup.py/sitecustomize/usercustomize/__init__.pth) ---
           # These execute during pip install or interpreter startup.
-          SETUP_HITS=$(git diff --name-only "$BASE"..."$HEAD" | grep -E '(^|/)(setup\.py|setup\.cfg|sitecustomize\.py|usercustomize\.py|__init__\.pth)$' || true)
+          # Anchored at repo root: only the top-level setup.py/setup.cfg run during
+          # `pip install`, and only top-level sitecustomize.py/usercustomize.py are
+          # auto-loaded by the interpreter via site.py. Any nested file with the
+          # same name (e.g. hermes_cli/setup.py — the CLI setup wizard) is unrelated
+          # and produced false positives that trained reviewers to ignore the scanner.
+          SETUP_HITS=$(git diff --name-only "$BASE"..."$HEAD" | grep -E '^(setup\.py|setup\.cfg|sitecustomize\.py|usercustomize\.py|__init__\.pth)$' || true)
           if [ -n "$SETUP_HITS" ]; then
             FINDINGS="${FINDINGS}
           ### 🚨 CRITICAL: Install-hook file added or modified


### PR DESCRIPTION
Stops false positives on every PR touching `hermes_cli/setup.py` (the CLI setup wizard).

## Changes
- `.github/workflows/supply-chain-audit.yml`: change `(^|/)(setup\.py|setup\.cfg|sitecustomize\.py|usercustomize\.py|__init__\.pth)$` → `^(setup\.py|setup\.cfg|sitecustomize\.py|usercustomize\.py|__init__\.pth)$`

## Why
Only the top-level `setup.py`/`setup.cfg` run during `pip install`, and only top-level `sitecustomize.py`/`usercustomize.py` are auto-loaded by site.py at interpreter startup. Any nested file with the same name (e.g. `hermes_cli/setup.py` — the CLI setup wizard) is unrelated to install hooks and produced false positives that trained reviewers to ignore the scanner.

PR #30916 (Mattermost plugin migration) is currently red purely because it deletes `_setup_mattermost()` from `hermes_cli/setup.py`. Discord migration (#30591) hit the same false positive yesterday.

## Validation

```
$ printf 'setup.py\nsetup.cfg\nhermes_cli/setup.py\nplugins/something/setup.py\nfoo/sitecustomize.py\n__init__.pth\n' | grep -E '^(setup\.py|setup\.cfg|sitecustomize\.py|usercustomize\.py|__init__\.pth)$'
setup.py
setup.cfg
__init__.pth
```

True positives (root `setup.py`/`setup.cfg`/`__init__.pth`) still match; nested same-named files no longer fire.