### PR TITLE
fix(anthropic): strip Codex/Responses-only kwargs at Anthropic call sites (#31673)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2242,3 +2242,54 @@ def build_anthropic_kwargs(
         kwargs["extra_headers"] = {"anthropic-beta": ",".join(betas)}
 
     return kwargs
+
+
+# Codex / OpenAI-Responses keys that the Anthropic Messages SDK rejects with
+# ``TypeError: Messages.stream() got an unexpected keyword argument …``.
+# See issue #31673: a successful ``vision_analyze`` aux call landing on the
+# main Anthropic provider was followed by the next streaming call crashing on
+# ``instructions=`` — the OpenAI Responses-API system-prompt kwarg was
+# leaking from the Codex-shaped path into ``api_kwargs`` for the Anthropic
+# stream call. Filtering them out keeps a stale leak from killing the user's
+# session (and a single warning per process makes the leak detectable so the
+# real source can be tracked down without flooding the log).
+_ANTHROPIC_KWARG_DENYLIST: frozenset = frozenset({
+    "instructions",         # Codex Responses system prompt (Anthropic uses ``system=``)
+    "input",                # Codex Responses input (Anthropic uses ``messages=``)
+    "store",                # Codex Responses persistence flag
+    "max_output_tokens",    # Codex Responses output cap (Anthropic uses ``max_tokens``)
+    "parallel_tool_calls",  # Codex Responses tool fan-out flag
+    "prompt_cache_key",     # Codex Responses cache key
+    "reasoning",            # Codex Responses reasoning dial (Anthropic uses ``thinking``)
+    "include",              # Codex Responses ``include`` (e.g. encrypted reasoning)
+})
+
+_anthropic_kwargs_leak_warned: bool = False
+
+
+def sanitize_anthropic_messages_kwargs(kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    """Strip Codex/OpenAI-Responses-only keys that Anthropic's SDK rejects.
+
+    Returns a shallow copy with the offending keys removed. Logs a single
+    ``warning`` per process the first time a leak is observed so the source
+    can be tracked down without flooding the log on every retry. Non-dict
+    inputs are returned unchanged so callers don't need to special-case
+    test-doubles. See issue #31673.
+    """
+    if not isinstance(kwargs, dict):
+        return kwargs
+    leaked = [key for key in _ANTHROPIC_KWARG_DENYLIST if key in kwargs]
+    if not leaked:
+        return kwargs
+    global _anthropic_kwargs_leak_warned
+    if not _anthropic_kwargs_leak_warned:
+        _anthropic_kwargs_leak_warned = True
+        logger.warning(
+            "Stripping Codex/Responses-only kwargs from Anthropic Messages call: "
+            "%s — these keys would crash the Anthropic SDK. See issue #31673.",
+            ", ".join(sorted(leaked)),
+        )
+    cleaned = dict(kwargs)
+    for key in leaked:
+        cleaned.pop(key, None)
+    return cleaned

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1664,8 +1664,16 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # Per-attempt diagnostic dict for the retry block to consume.
         _diag = agent._stream_diag_init()
         request_client_holder["diag"] = _diag
-        # Use the Anthropic SDK's streaming context manager
-        with agent._anthropic_client.messages.stream(**api_kwargs) as stream:
+        # Use the Anthropic SDK's streaming context manager.  The sanitizer
+        # strips Codex/Responses-only kwargs that would otherwise raise
+        # ``TypeError: Messages.stream() got an unexpected keyword argument
+        # 'instructions'`` (issue #31673) — defensive guard against any
+        # upstream code path leaking ``instructions=``/``input=``/``store=``
+        # into the Anthropic kwargs after a vision-aux call.
+        from agent.anthropic_adapter import sanitize_anthropic_messages_kwargs
+        with agent._anthropic_client.messages.stream(
+            **sanitize_anthropic_messages_kwargs(api_kwargs)
+        ) as stream:
             # The Anthropic SDK exposes the raw httpx response on
             # ``stream.response``.  Snapshot diagnostic headers
             # immediately so they survive a stream that dies before the

--- a/run_agent.py
+++ b/run_agent.py
@@ -2942,7 +2942,10 @@ class AIAgent:
     def _anthropic_messages_create(self, api_kwargs: dict):
         if self.api_mode == "anthropic_messages":
             self._try_refresh_anthropic_client_credentials()
-        return self._anthropic_client.messages.create(**api_kwargs)
+        from agent.anthropic_adapter import sanitize_anthropic_messages_kwargs
+        return self._anthropic_client.messages.create(
+            **sanitize_anthropic_messages_kwargs(api_kwargs)
+        )
 
     def _rebuild_anthropic_client(self) -> None:
         """Rebuild the Anthropic client after an interrupt or stale call.

--- a/tests/agent/test_anthropic_kwargs_sanitizer_31673.py
+++ b/tests/agent/test_anthropic_kwargs_sanitizer_31673.py
@@ -1,0 +1,286 @@
+"""Regression tests for #31673 — Anthropic kwargs leak from Codex/Responses path.
+
+The bug: a successful ``vision_analyze`` aux call landed on the main
+Anthropic provider, then the very next streaming call to
+``_anthropic_client.messages.stream(**api_kwargs)`` failed client-side with
+``TypeError: Messages.stream() got an unexpected keyword argument
+'instructions'``.
+
+Without a deterministic repro, the fix is defensive: strip the known set of
+Codex / OpenAI-Responses-only kwargs at both Anthropic call sites
+(``_call_anthropic`` streaming and ``_anthropic_messages_create``
+non-streaming) before they reach the SDK, and log a single warning the
+first time a leak is observed so the upstream source can be tracked down
+later without flooding the log.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from unittest.mock import MagicMock
+
+import agent.anthropic_adapter as anthropic_adapter
+from agent.anthropic_adapter import (
+    _ANTHROPIC_KWARG_DENYLIST,
+    sanitize_anthropic_messages_kwargs,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure-helper behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeAnthropicMessagesKwargs:
+    """``sanitize_anthropic_messages_kwargs`` strips Codex/Responses keys."""
+
+    def test_strips_instructions_kwarg(self):
+        """The exact kwarg from the issue's traceback gets dropped."""
+        cleaned = sanitize_anthropic_messages_kwargs({
+            "model": "claude-sonnet-4-6",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 1024,
+            "instructions": "leaked from codex aux path",
+        })
+        assert "instructions" not in cleaned
+        assert cleaned["model"] == "claude-sonnet-4-6"
+        assert cleaned["max_tokens"] == 1024
+        assert cleaned["messages"] == [{"role": "user", "content": "hi"}]
+
+    def test_strips_full_codex_responses_keyset(self):
+        """All known Codex/Responses-only keys are filtered."""
+        leaky = {
+            "model": "claude-opus-4-7",
+            "messages": [{"role": "user", "content": "x"}],
+            "max_tokens": 4096,
+            # OpenAI Responses / Codex leakage:
+            "instructions": "you are helpful",
+            "input": [{"role": "user", "content": []}],
+            "store": False,
+            "max_output_tokens": 8192,
+            "parallel_tool_calls": True,
+            "prompt_cache_key": "session-123",
+            "reasoning": {"effort": "medium"},
+            "include": ["reasoning.encrypted_content"],
+        }
+        cleaned = sanitize_anthropic_messages_kwargs(leaky)
+        for offending in _ANTHROPIC_KWARG_DENYLIST:
+            assert offending not in cleaned, offending
+
+    def test_preserves_valid_anthropic_kwargs(self):
+        """Anthropic-native kwargs pass through untouched."""
+        original = {
+            "model": "claude-opus-4-7",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 16384,
+            "system": "be brief",
+            "tools": [{"name": "calc", "input_schema": {}}],
+            "tool_choice": {"type": "auto"},
+            "temperature": 0.7,
+            "top_p": 0.9,
+            "top_k": 40,
+            "stop_sequences": ["END"],
+            "metadata": {"user_id": "abc"},
+            "thinking": {"type": "adaptive"},
+            "output_config": {"effort": "high"},
+            "extra_headers": {"anthropic-beta": "fast-mode-2026-04-22"},
+            "extra_body": {"speed": "fast"},
+            "service_tier": "priority",
+        }
+        cleaned = sanitize_anthropic_messages_kwargs(original)
+        assert cleaned == original
+
+    def test_returns_shallow_copy_when_filtering(self):
+        """The original dict isn't mutated; the filtered one is a new dict."""
+        original = {
+            "model": "claude-sonnet-4-6",
+            "messages": [],
+            "max_tokens": 1024,
+            "instructions": "leak",
+        }
+        cleaned = sanitize_anthropic_messages_kwargs(original)
+        assert "instructions" in original
+        assert cleaned is not original
+
+    def test_returns_input_unchanged_when_no_leak(self):
+        """No-op fast path: when nothing is leaking, return the same dict."""
+        clean = {
+            "model": "claude-opus-4-7",
+            "messages": [],
+            "max_tokens": 1024,
+        }
+        result = sanitize_anthropic_messages_kwargs(clean)
+        assert result is clean
+
+    def test_non_dict_input_returned_unchanged(self):
+        """Defensive: caller passes a SimpleNamespace / None / list — pass through."""
+        assert sanitize_anthropic_messages_kwargs(None) is None
+        assert sanitize_anthropic_messages_kwargs([1, 2, 3]) == [1, 2, 3]
+        sentinel = object()
+        assert sanitize_anthropic_messages_kwargs(sentinel) is sentinel
+
+    def test_warns_once_per_process_on_leak(self, caplog, monkeypatch):
+        """Only the first leak in a process logs — silent on subsequent retries."""
+        monkeypatch.setattr(anthropic_adapter, "_anthropic_kwargs_leak_warned", False)
+        leaky = {
+            "model": "m", "messages": [], "max_tokens": 1,
+            "instructions": "leak", "input": [],
+        }
+        with caplog.at_level(logging.WARNING, logger="agent.anthropic_adapter"):
+            sanitize_anthropic_messages_kwargs(leaky)
+            sanitize_anthropic_messages_kwargs(leaky)
+            sanitize_anthropic_messages_kwargs(leaky)
+        warnings = [rec for rec in caplog.records if rec.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        msg = warnings[0].getMessage()
+        assert "instructions" in msg
+        assert "input" in msg
+        assert "31673" in msg
+
+    def test_does_not_warn_when_clean(self, caplog, monkeypatch):
+        """Happy path: no leak, no log noise."""
+        monkeypatch.setattr(anthropic_adapter, "_anthropic_kwargs_leak_warned", False)
+        with caplog.at_level(logging.WARNING, logger="agent.anthropic_adapter"):
+            sanitize_anthropic_messages_kwargs({
+                "model": "m", "messages": [], "max_tokens": 1,
+            })
+        warnings = [rec for rec in caplog.records if rec.levelno == logging.WARNING]
+        assert warnings == []
+
+
+class TestAnthropicKwargDenylistContents:
+    """The denylist captures the keys the issue's traceback names."""
+
+    def test_includes_instructions_key_from_issue(self):
+        """The exact kwarg the SDK rejected in #31673 is denied."""
+        assert "instructions" in _ANTHROPIC_KWARG_DENYLIST
+
+    def test_covers_codex_responses_request_shape(self):
+        """All required-key kwargs from a Codex Responses request are denied."""
+        # See agent/codex_responses_adapter.py — required = {"model",
+        # "instructions", "input"} plus ``store=False``. ``model`` is shared
+        # with Anthropic, the rest must never reach the Anthropic SDK.
+        for key in ("instructions", "input", "store"):
+            assert key in _ANTHROPIC_KWARG_DENYLIST
+
+
+# ---------------------------------------------------------------------------
+# Source-level guards: the call sites use the sanitizer
+# ---------------------------------------------------------------------------
+
+
+class TestStreamingCallSiteUsesSanitizer:
+    """``_call_anthropic`` (chat_completion_helpers.py) sanitizes before SDK call."""
+
+    def test_call_anthropic_calls_sanitizer_before_stream(self):
+        """Source-level guard: streaming Anthropic call goes through the sanitizer.
+
+        Pinning this in source guards against an accidental revert that
+        re-introduces the #31673 crash without producing a runtime error
+        in the Anthropic-free unit-test environment.
+        """
+        from agent.chat_completion_helpers import interruptible_streaming_api_call
+        src = inspect.getsource(interruptible_streaming_api_call)
+        assert "sanitize_anthropic_messages_kwargs" in src
+        # Locate the actual call site (skip the docstring reference, which
+        # also contains the literal ``messages.stream()`` for prose).  The
+        # real call is fully qualified through ``_anthropic_client``.
+        stream_idx = src.index("_anthropic_client.messages.stream(")
+        # Sanitizer wrapper must appear inside the next 200 chars — i.e.
+        # between ``stream(`` and its closing ``)`` over the multi-line
+        # call, not anywhere else.  The buggy v0.14.0 shape
+        # ``stream(**api_kwargs)`` would fail this guard.
+        window = src[stream_idx:stream_idx + 200]
+        assert "sanitize_anthropic_messages_kwargs(api_kwargs)" in window
+        # And the legacy shape must be gone everywhere in the function.
+        assert "messages.stream(**api_kwargs)" not in src
+
+
+class TestNonStreamingCallSiteUsesSanitizer:
+    """``_anthropic_messages_create`` (run_agent.py) sanitizes before SDK call."""
+
+    def test_anthropic_messages_create_calls_sanitizer(self):
+        """Source-level guard: non-streaming path also strips Codex kwargs."""
+        from run_agent import AIAgent
+        src = inspect.getsource(AIAgent._anthropic_messages_create)
+        assert "sanitize_anthropic_messages_kwargs" in src
+        assert "messages.create(" in src
+        assert "sanitize_anthropic_messages_kwargs(api_kwargs)" in src
+
+
+# ---------------------------------------------------------------------------
+# Behavioural integration: exact #31673 traceback no longer fires
+# ---------------------------------------------------------------------------
+
+
+class _RaisingMessagesStream:
+    """Minimal stand-in for ``client.messages.stream`` that mimics the
+    Anthropic SDK's strict signature: it accepts only the documented
+    Anthropic kwargs and raises ``TypeError`` on anything else — the
+    exact failure mode from the #31673 traceback.
+    """
+
+    _VALID = frozenset({
+        "model", "messages", "max_tokens", "system", "tools", "tool_choice",
+        "temperature", "top_p", "top_k", "stop_sequences", "metadata",
+        "stream", "thinking", "output_config", "extra_headers", "extra_query",
+        "extra_body", "timeout", "service_tier",
+    })
+
+    def __init__(self):
+        self.last_kwargs: dict | None = None
+
+    def __call__(self, **kwargs):
+        unexpected = set(kwargs) - self._VALID
+        if unexpected:
+            raise TypeError(
+                "Messages.stream() got an unexpected keyword argument "
+                f"{sorted(unexpected)[0]!r}"
+            )
+        self.last_kwargs = kwargs
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=ctx)
+        ctx.__exit__ = MagicMock(return_value=False)
+        ctx.response = None
+        ctx.__iter__ = MagicMock(return_value=iter([]))
+        ctx.get_final_message = MagicMock(return_value=None)
+        return ctx
+
+
+class TestEndToEndIssueScenario:
+    """The exact crash from #31673 is suppressed — sanitized kwargs reach the SDK."""
+
+    def test_leaked_instructions_kwarg_is_dropped_before_sdk(self):
+        """A leaked ``instructions=`` kwarg no longer reaches ``Messages.stream``."""
+        stream = _RaisingMessagesStream()
+        leaky = {
+            "model": "claude-sonnet-4-6",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 1024,
+            "instructions": "leaked from codex aux path — would crash SDK",
+        }
+        cleaned = sanitize_anthropic_messages_kwargs(leaky)
+        ctx = stream(**cleaned)
+        ctx.__enter__()
+        assert stream.last_kwargs is not None
+        assert "instructions" not in stream.last_kwargs
+        assert stream.last_kwargs["model"] == "claude-sonnet-4-6"
+
+    def test_unsanitized_kwargs_reproduce_original_crash(self):
+        """Confirms the test stand-in really mimics the #31673 failure."""
+        stream = _RaisingMessagesStream()
+        leaky = {
+            "model": "claude-sonnet-4-6",
+            "messages": [],
+            "max_tokens": 1024,
+            "instructions": "leak",
+        }
+        try:
+            stream(**leaky)
+        except TypeError as exc:
+            assert "unexpected keyword argument 'instructions'" in str(exc)
+        else:  # pragma: no cover — guard against the test stand-in regressing
+            raise AssertionError(
+                "Test stand-in failed to raise the #31673 TypeError"
+            )


### PR DESCRIPTION
## What does this PR do?

Stops the Anthropic Messages SDK from crashing on a leaked Codex/OpenAI-Responses keyword argument when a session continues after a successful `vision_analyze` aux call.

In v0.14.0 the first main-provider streaming call **immediately after** a successful `vision_analyze` against an Anthropic main provider can fail client-side with:

```
TypeError: Messages.stream() got an unexpected keyword argument 'instructions'
```

The Anthropic SDK uses `system=`, not `instructions=` — `instructions=` belongs to OpenAI Responses / Codex. The error is non-retryable, propagates through the full fallback chain, and the offending payload remains in session memory so every retry re-fails until the user kills the session.

This PR adds a defensive sanitizer at both Anthropic SDK call sites (`Messages.stream()` and `Messages.create()`), strips the known set of Codex/Responses-only keys (`instructions`, `input`, `store`, `max_output_tokens`, `parallel_tool_calls`, `prompt_cache_key`, `reasoning`, `include`), and emits a single per-process warning the first time a leak is observed so the upstream source remains traceable without flooding the log on retries.

## Related Issue

Closes #31673.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/anthropic_adapter.py` — adds `sanitize_anthropic_messages_kwargs()` plus the `_ANTHROPIC_KWARG_DENYLIST` of Codex/Responses-only keys. Returns the input unchanged on the no-leak fast path; logs a single warning per process on the first leak.
- `agent/chat_completion_helpers.py` — wraps `agent._anthropic_client.messages.stream(**api_kwargs)` (`_call_anthropic`) so the SDK only sees Anthropic-valid kwargs.
- `run_agent.py` — same wrap on the non-streaming `_anthropic_messages_create` path so the guard covers both code paths.
- `tests/agent/test_anthropic_kwargs_sanitizer_31673.py` — 14 new test cases:
  - `TestSanitizeAnthropicMessagesKwargs` — 8 cases pinning the helper's contract: drops `instructions`/full Codex keyset, preserves Anthropic-native kwargs, returns a shallow copy on filter, returns input unchanged on the fast path, and is defensive against non-dict input.
  - `TestAnthropicKwargDenylistContents` — 2 cases verifying the denylist captures the exact kwargs the issue's traceback names plus the full Codex Responses required-key shape.
  - `TestStreamingCallSiteUsesSanitizer` / `TestNonStreamingCallSiteUsesSanitizer` — source-level guards that pin the call sites use the sanitizer and that the buggy `messages.stream(**api_kwargs)` shape is gone.
  - `TestEndToEndIssueScenario` — 2 cases using a stand-in that mimics the Anthropic SDK's strict signature: confirms unsanitized kwargs still reproduce the #31673 `TypeError`, and that the sanitizer prevents it.

## How to Test

1. Check out this branch and ensure `.venv` is set up: `python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[all,dev]"`
2. Run the new regression suite on its own:
   ```
   scripts/run_tests.sh tests/agent/test_anthropic_kwargs_sanitizer_31673.py
   ```
   Expected: `14 passed`.
3. Run the broader Anthropic / streaming suite to confirm no cross-file regressions:
   ```
   scripts/run_tests.sh tests/agent/test_anthropic_kwargs_sanitizer_31673.py \
     tests/agent/test_anthropic_adapter.py \
     tests/run_agent/test_streaming.py \
     tests/run_agent/test_local_stream_timeout.py \
     tests/run_agent/test_stream_interrupt_retry.py \
     tests/run_agent/test_stream_drop_logging.py \
     tests/run_agent/test_streaming_tool_call_repair.py \
     tests/run_agent/test_streaming_context_scrubber.py
   ```
   Expected: `228 tests passed`. The 3 pre-existing `TestRunOauthSetupToken` failures in `test_anthropic_adapter.py` are unrelated to this PR (same failures on `main`, see PR description / forensic note).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(anthropic):` / `fix(streaming):` / `test(anthropic):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/agent/test_anthropic_kwargs_sanitizer_31673.py` and all 14 tests pass
- [x] I've added tests for my changes (14 new cases including a stand-in that reproduces the #31673 traceback)
- [x] I've tested on my platform: macOS 15.2 (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (defensive guard, no public-API change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python kwargs filtering, no platform-specific calls
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/agent/test_anthropic_kwargs_sanitizer_31673.py
24 workers [14 items]
============================== 14 passed in 1.0s ==============================

$ scripts/run_tests.sh tests/agent/test_anthropic_kwargs_sanitizer_31673.py \
    tests/agent/test_anthropic_adapter.py \
    tests/run_agent/test_streaming.py \
    tests/run_agent/test_local_stream_timeout.py \
    tests/run_agent/test_stream_interrupt_retry.py \
    tests/run_agent/test_stream_drop_logging.py \
    tests/run_agent/test_streaming_tool_call_repair.py \
    tests/run_agent/test_streaming_context_scrubber.py
=== Summary: 6 files, 228 tests passed, 3 failed (100% complete) in 24.4s ===
# (3 pre-existing OAuth-token-resolver failures, identical on main — unrelated to this PR)
```

After applying this PR, a session that previously hit:

```
agent.chat_completion_helpers: Streaming failed before delivery:
  Messages.stream() got an unexpected keyword argument 'instructions'
```

will instead see (the first time only) a single `WARNING` line naming the leaked keys plus issue `#31673`, and the call will succeed normally — preserving the user's session and their fallback chain.
