### PR TITLE
fix(process_registry): keep poll() read-only — do not mark completions consumed

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -102,6 +102,49 @@ class TestGetAndPoll:
         assert result["status"] == "exited"
         assert result["exit_code"] == 0
 
+    def test_poll_does_not_mark_completion_consumed(self, registry):
+        """poll() must NOT mark completions consumed (regression guard for #10156).
+
+        notify_on_complete watcher notifications were silently suppressed
+        because poll() added sessions to _completion_consumed. This caused
+        drain_notifications() to skip completion events after a poll() call.
+
+        poll() is a read-only status query — it should not have the side
+        effect of consuming the notification event.
+        """
+        sid = "proc_poll_not_consumed"
+        s = _make_session(sid=sid, exited=True, exit_code=0, output="done")
+        registry._finished[s.id] = s
+
+        # Queue a completion event for this session
+        registry.completion_queue.put({
+            "type": "completion",
+            "session_id": sid,
+            "command": "echo done",
+            "exit_code": 0,
+            "output": "done",
+        })
+
+        try:
+            # Poll should return the exited status
+            result = registry.poll(sid)
+            assert result["status"] == "exited"
+            assert result["exit_code"] == 0
+
+            # After poll(), the session should NOT be marked as consumed
+            assert not registry.is_completion_consumed(sid), (
+                "poll() should not mark completions consumed"
+            )
+
+            # drain_notifications() should still return the event
+            notifications = registry.drain_notifications()
+            assert len(notifications) == 1
+            assert notifications[0][0]["session_id"] == sid
+        finally:
+            registry._completion_consumed.discard(sid)
+            while not registry.completion_queue.empty():
+                registry.completion_queue.get_nowait()
+
 
 # =========================================================================
 # Orphaned-pipe reconciliation (issue #17327)

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -997,7 +997,6 @@ class ProcessRegistry:
         }
         if session.exited:
             result["exit_code"] = session.exit_code
-            self._completion_consumed.add(session_id)
         if session.detached:
             result["detached"] = True
             result["note"] = "Process recovered after restart -- output history unavailable"


### PR DESCRIPTION
## Summary

Keeps `process_registry.poll()` read-only for exited background processes.

`poll()` should report status, not mark a `notify_on_complete` result as consumed. Otherwise a normal status check can race with the gateway watcher and permanently suppress the synthetic completion event before it is delivered back to the chat.

## Root cause

PR #8228 (`f53a5a7f`) added `_completion_consumed` tracking to avoid duplicate completion notifications. That behavior is correct for explicit consumption paths like `wait()` and `read_log()`, but not for `poll()`:

- `wait()` = blocking consume ("give me the result, I'm done")
- `read_log()` = explicit consumption ("I read the output, I'm done")
- `poll()` = read-only status query ("what's the current state?")

Treating `poll()` as consumption can cause a race:
1. Agent starts a background process with `notify_on_complete=true`
2. Gateway creates a watcher asyncio task (polls every 5s)
3. Process exits
4. Agent calls `process(action='poll')` on the next turn
5. `poll()` marks `_completion_consumed.add(session_id)` (the bug)
6. Watcher wakes up → checks `is_completion_consumed()` → returns `True` → **skips notification** → breaks (never retries)

## Changes

- `tools/process_registry.py`: removed `self._completion_consumed.add(session_id)` from `poll()`
- `tests/tools/test_process_registry.py`: added `test_poll_does_not_mark_completion_consumed` regression guard

## Test plan

```
python -m pytest tests/tools/test_process_registry.py -x -q
65 passed in 3.86s
```

Closes #10156