### PR TITLE
feat(telegram): add TELEGRAM_ALLOW_BOTS for bot-to-bot communication

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -4494,6 +4494,28 @@ class TelegramAdapter(BasePlatformAdapter):
                     return True
         return False
 
+    def _telegram_bot_sender(self, message) -> bool:
+        """Return True when the message sender is another bot.
+
+        Used for bot-to-bot communication: allows agents to see and respond to
+        each other's messages in shared groups without requiring human mention.
+        """
+        user = getattr(message, "from_user", None) or getattr(message, "from", None)
+        return bool(getattr(user, "is_bot", False))
+
+    def _telegram_allow_bots(self) -> str:
+        """Return the bot-to-bot admission policy.
+
+        Values: 'none' (default), 'mentions' (only when this bot is @-mentioned
+        by another bot), 'all' (process all bot messages as triggers).
+        Uses TELEGRAM_ALLOW_BOTS env var or config extra 'allow_bots'.
+        """
+        configured = self.config.extra.get("allow_bots")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower().strip()
+        return os.getenv("TELEGRAM_ALLOW_BOTS", "none").lower().strip() or "none"
+
     def _is_guest_mention(self, message: Message) -> bool:
         """Return True for the narrow guest-mode bypass: explicit bot mention.
 
@@ -4697,6 +4719,18 @@ class TelegramAdapter(BasePlatformAdapter):
             return True
         if chat_id_str in self._telegram_free_response_chats():
             return True
+
+        # Bot-to-bot: bypass require_mention for other bot senders when
+        # TELEGRAM_ALLOW_BOTS is 'all'. When 'mentions', only process if
+        # the other bot @-mentions this bot (handled below).
+        allow_bots = self._telegram_allow_bots()
+        if allow_bots in {"all", "mentions"} and self._telegram_bot_sender(message):
+            if allow_bots == "all":
+                return True
+            # 'mentions' — only allow if bot mentioned this bot
+            if self._message_mentions_bot(message):
+                return True
+
         if not self._telegram_require_mention():
             return True
         if self._is_reply_to_bot(message):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6189,6 +6189,7 @@ class GatewayRunner:
         platform_allow_bots_map = {
             Platform.DISCORD: "DISCORD_ALLOW_BOTS",
             Platform.FEISHU: "FEISHU_ALLOW_BOTS",
+            Platform.TELEGRAM: "TELEGRAM_ALLOW_BOTS",
         }
 
         # Plugin platforms: check the registry for auth env var names


### PR DESCRIPTION
## Summary

Add bot-to-bot communication support for Telegram, mirroring existing patterns for Discord (`DISCORD_ALLOW_BOTS`) and Feishu (`FEISHU_ALLOW_BOTS`).

## Changes

### `gateway/run.py`
- Added `Platform.TELEGRAM: "TELEGRAM_ALLOW_BOTS"` to `platform_allow_bots_map`
- Allows bot messages to pass through the gateway authorizer when TELEGRAM_ALLOW_BOTS is set

### `gateway/platforms/telegram.py`
- Added `_telegram_bot_sender(message)`: detects if message sender is another bot via `from_user.is_bot`
- Added `_telegram_allow_bots()`: reads the allow_bots policy from config.extra or `TELEGRAM_ALLOW_BOTS` env var
- Updated `_should_process_message()`: bypasses `require_mention` for bot senders when `TELEGRAM_ALLOW_BOTS=all`

## Usage

Set `TELEGRAM_ALLOW_BOTS=all` in `.env` or `allow_bots: all` in telegram config to allow all bot messages.
Set `TELEGRAM_ALLOW_BOTS=mentions` to only process messages where another bot @-mentions yours.

## Configuration
```yaml
telegram:
  require_mention: true
  observe_unmentioned_group_messages: true
  group_allowed_chats: "-5046253288"
  allow_bots: all
```

Or via environment variable:
```bash
# ~/.hermes/.env
TELEGRAM_ALLOW_BOTS=all
```

## Motivation

Multi-agent setups (e.g., Hermes + OpenClaw) need to see each others messages in shared Telegram groups. Previously, the gateway authorizer blocked all bot messages regardless of `observe_unmentioned_group_messages` settings. This change brings Telegram in parity with Discord and Feishu bot-to-bot support.