### PR TITLE
fix: include plugin.yaml in setuptools package-data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,9 +218,10 @@ py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajector
 hermes_cli = ["web_dist/**/*", "tui_dist/**/*", "scripts/install.sh", "scripts/install.ps1"]
 gateway = ["assets/**/*"]
 plugins = [
-  "*/dashboard/manifest.json",
-  "*/dashboard/dist/*",
-  "*/dashboard/dist/**/*",
+    "*/dashboard/manifest.json",
+    "*/dashboard/dist/*",
+    "*/dashboard/dist/**/*",
+    "**/plugin.yaml",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
plugins/platforms/*/plugin.yaml files define env var metadata (requires_env, optional_env) used by the gateway setup wizard and hermes config UI. Without them:

- `hermes gateway setup` lists platform entries but the interactive_setup() function has no env var metadata to guide prompts
- `hermes config` UI shows no env var hints for plugin-based platform adapters
- Editable installs work (read from source checkout) but baked wheels and pip-installed releases silently drop plugin.yaml

Add `**/plugin.yaml` to the plugins package-data glob list so every platform plugin's plugin.yaml is included in installed wheels.