### PR TITLE
fix(gateway): extract markdown media attachments

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -908,6 +908,8 @@ def validate_media_delivery_path(path: str) -> Optional[str]:
 SUPPORTED_DOCUMENT_TYPES = {
     ".pdf": "application/pdf",
     ".md": "text/markdown",
+    ".html": "text/html",
+    ".htm": "text/html",
     ".txt": "text/plain",
     ".csv": "text/csv",
     ".log": "text/plain",
@@ -2295,10 +2297,11 @@ class BasePlatformAdapter(ABC):
         # keep it out of the user-visible cleaned text.
         cleaned = cleaned.replace("[[as_document]]", "")
         
-        # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
-        # and quoted/backticked paths for LLM-formatted outputs.
+        # Extract MEDIA:<path> tags, allowing optional whitespace after the colon,
+        # quoted/backticked paths, and case-insensitive file extensions.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|md|html?|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?''',
+            re.IGNORECASE,
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16692,7 +16692,7 @@ class GatewayRunner:
                         _TOOL_MEDIA_RE = re.compile(
                             r'MEDIA:((?:/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
                             r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
-                            r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
+                            r'flac|epub|pdf|md|html?|zip|rar|7z|docx?|xlsx?|pptx?|'
                             r'txt|csv|apk|ipa))',
                             re.IGNORECASE
                         )
@@ -16998,7 +16998,7 @@ class GatewayRunner:
                             _TOOL_MEDIA_RE = re.compile(
                                 r'MEDIA:((?:/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
                                 r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
-                                r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
+                                r'flac|epub|pdf|md|html?|zip|rar|7z|docx?|xlsx?|pptx?|'
                                 r'txt|csv|apk|ipa))',
                                 re.IGNORECASE
                             )

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -329,6 +329,22 @@ class TestExtractMedia:
         assert media == [("/tmp/Jane Doe/speech.flac", False)]
         assert cleaned == ""
 
+    @pytest.mark.parametrize(
+        ("filename", "expected"),
+        [
+            ("report.md", "/tmp/report.md"),
+            ("REPORT.MD", "/tmp/REPORT.MD"),
+            ("report.html", "/tmp/report.html"),
+            ("report.htm", "/tmp/report.htm"),
+        ],
+    )
+    def test_media_tag_supports_text_report_attachments(self, filename, expected):
+        content = f"Here is the file:\nMEDIA:/tmp/{filename}"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [(expected, False)]
+        assert "MEDIA:" not in cleaned
+        assert "Here is the file" in cleaned
+
     def test_as_document_directive_stripped_from_cleaned_text(self):
         """[[as_document]] is a routing directive — strip it from
         user-visible text just like [[audio_as_voice]]. Callers detect the


### PR DESCRIPTION
Fixes #31560.

## Summary
- include `.md`, `.html`, and `.htm` in shared `MEDIA:` extraction
- make `MEDIA:` extension matching case-insensitive so paths like `REPORT.MD` are delivered
- keep gateway tool-result MEDIA scanners aligned with the shared extractor
- add HTML MIME entries to the shared document type map

## Pre-implement audit
- Existing-helper check: reused `BasePlatformAdapter.extract_media()` and `SUPPORTED_DOCUMENT_TYPES`; no new extractor/helper added.
- Shared-helper caller check: reviewed gateway/tool callers of `extract_media()` and aligned the two `gateway/run.py` tool-result scanners.
- Broader-fix rival scan: no open PR found for #31560 or the markdown/HTML MEDIA extraction gap.

## Tests
- `python -m pytest -o addopts='' tests/gateway/test_platform_base.py::TestExtractMedia -q`
- `python -m pytest -o addopts='' tests/gateway/test_platform_base.py::TestExtractMedia tests/gateway/test_document_cache.py -q`
- `python -m py_compile gateway/platforms/base.py gateway/run.py`
- `git diff --check`

## Note
`tests/gateway/test_telegram_documents.py::TestSendDocument` could not run in my local environment because pytest reports async tests need a plugin such as `pytest-asyncio`; this patch does not change Telegram send_document behavior.
