### PR TITLE
fix(caching): enable prompt caching for Qwen on Anthropic-compatible wire

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1155,12 +1155,22 @@ def anthropic_prompt_cache_policy(
         if is_minimax_provider or is_minimax_host:
             return True, True
 
+    # Qwen on Anthropic-compatible wire (third-party proxies like one-api,
+    # LiteLLM, etc.).  These gateways translate cache_control markers to
+    # the upstream Qwen/DashScope KV-cache protocol.  Users who route
+    # Qwen through an Anthropic-speaking proxy get 0% cache hits without
+    # this branch, paying full input cost every turn.
+    # Uses native content-block layout because the wire is Anthropic.
+    model_is_qwen = "qwen" in model_lower
+    if is_anthropic_wire and model_is_qwen:
+        return True, True
+
     # Qwen/Alibaba on OpenCode (Zen/Go) and native DashScope: OpenAI-wire
     # transport that accepts Anthropic-style cache_control markers and
     # rewards them with real cache hits.  Without this branch
     # qwen3.6-plus on opencode-go reports 0% cached tokens and burns
     # through the subscription on every turn.
-    model_is_qwen = "qwen" in model_lower
+    # Note: model_is_qwen is defined above (Anthropic-wire Qwen branch).
     provider_is_alibaba_family = provider_lower in {
         "opencode", "opencode-zen", "opencode-go", "alibaba",
     }

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -90,16 +90,67 @@ class TestThirdPartyAnthropicGateway:
         assert native is True, "Third-party Anthropic gateway uses native cache_control layout"
 
     def test_third_party_anthropic_non_claude_unknown_provider_does_not_cache(self):
-        # A provider exposing e.g. GLM via anthropic_messages transport from
-        # a host we don't recognize — we don't know whether it supports
-        # cache_control, so stay conservative.
+        # A provider exposing an unrecognised model via anthropic_messages
+        # transport from a host we don't recognise — we don't know whether
+        # it supports cache_control, so stay conservative.
         agent = _make_agent(
             provider="custom",
             base_url="https://some-unknown-gateway.example.com/anthropic",
             api_mode="anthropic_messages",
-            model="glm-4.5",
+            model="llama-4-scout",
         )
         assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+
+class TestQwenAnthropicWire:
+    """Qwen via Anthropic-compatible transport (one-api, LiteLLM, etc.).
+
+    Users who proxy Qwen through a gateway that speaks the Anthropic
+    protocol (api_mode=anthropic_messages) expect cache_control markers
+    to be injected so the gateway can translate them to upstream
+    DashScope KV-cache.  Without this, every turn pays full input cost.
+    Native layout because the wire format is Anthropic.
+    """
+
+    def test_qwen_on_custom_provider_anthropic_wire_caches_native_layout(self):
+        agent = _make_agent(
+            provider="custom",
+            base_url="https://one-api.example.com",
+            api_mode="anthropic_messages",
+            model="qwen3.6-plus",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+    def test_qwen37_max_on_custom_anthropic_wire_caches(self):
+        agent = _make_agent(
+            provider="custom",
+            base_url="https://one-api.example.com",
+            api_mode="anthropic_messages",
+            model="qwen3.7-max",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+    def test_qwen_on_openai_wire_does_not_hit_anthropic_branch(self):
+        # Qwen on chat_completions should still fall through to the
+        # alibaba-family check (only matches opencode/alibaba providers).
+        agent = _make_agent(
+            provider="custom",
+            base_url="https://one-api.example.com",
+            api_mode="chat_completions",
+            model="qwen3.6-plus",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+    def test_qwen_opengo_openai_wire_still_uses_envelope_layout(self):
+        # Existing opencode-go path must not be affected — it uses
+        # OpenAI wire with envelope layout, not native Anthropic layout.
+        agent = _make_agent(
+            provider="opencode-go",
+            base_url="https://opencode.ai/v1",
+            api_mode="chat_completions",
+            model="qwen3.6-plus",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, False)
 
 
 class TestMiniMaxAnthropicWire:


### PR DESCRIPTION
## Summary

Users who proxy Qwen models (`qwen3.6-plus`, `qwen3.7-max`, etc.) through third-party gateways (one-api, LiteLLM, etc.) using `api_mode=anthropic_messages` get **0% cache hits** because `_anthropic_prompt_cache_policy()` only enables caching for Qwen on `opencode`/`alibaba` providers (OpenAI-wire envelope layout).

When the transport is `anthropic_messages`, these proxies translate `cache_control` markers to the upstream DashScope KV-cache protocol — but Hermes never injects the markers in the first place, so every turn pays full input cost.

## Changes

**`agent/agent_runtime_helpers.py`** — Add a branch matching Qwen model names on `anthropic_messages` wire, returning `(True, True)` for the native content-block layout (consistent with the existing third-party-gateway Claude and MiniMax branches).

```
is_anthropic_wire and "qwen" in model_lower → (True, True)
```

** unaffected paths:**
- Qwen on OpenAI-wire (`opencode-go`, `alibaba`) → still uses envelope layout `(True, False)` via existing alibaba-family branch
- Qwen on OpenAI-wire with `custom` provider → still `(False, False)` (conservative)

**`tests/run_agent/test_anthropic_prompt_cache_policy.py`** — Add `TestQwenAnthropicWire` class (4 tests). Update unknown-provider test to use a non-Qwen model so it continues testing the conservative fall-through.

All 28 tests pass.