### PR TITLE
fix(gateway): add canonical cache paths to MEDIA_DELIVERY_SAFE_ROOTS

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -833,11 +833,21 @@ MEDIA_DELIVERY_SAFE_ROOTS = (
     VIDEO_CACHE_DIR,
     DOCUMENT_CACHE_DIR,
     SCREENSHOT_CACHE_DIR,
+    # Legacy paths (backward compat for users with existing cache dirs)
     _HERMES_HOME / "image_cache",
     _HERMES_HOME / "audio_cache",
     _HERMES_HOME / "video_cache",
     _HERMES_HOME / "document_cache",
     _HERMES_HOME / "browser_screenshots",
+    # Canonical new paths — image_generate and other tools save here
+    # regardless of whether a legacy dir exists on disk. Without these,
+    # generated images under cache/images/ fail MEDIA delivery on Telegram
+    # even though the identical file at image_cache/ works (issue #31733).
+    _HERMES_HOME / "cache" / "images",
+    _HERMES_HOME / "cache" / "audio",
+    _HERMES_HOME / "cache" / "videos",
+    _HERMES_HOME / "cache" / "documents",
+    _HERMES_HOME / "cache" / "screenshots",
 )
 
 

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -426,6 +426,50 @@ class TestMediaDeliveryPathValidation:
 
         assert BasePlatformAdapter.validate_media_delivery_path(str(media_file)) == str(media_file.resolve())
 
+    def test_allows_canonical_cache_images_path(self, tmp_path, monkeypatch):
+        """Verify that the canonical cache/images path is deliverable (regression for #31733)."""
+        root = tmp_path / ".hermes" / "cache" / "images"
+        media_file = root / "generated.png"
+        media_file.parent.mkdir(parents=True)
+        media_file.write_bytes(b"\x89PNG\r\n\x1a\n")
+        self._patch_roots(monkeypatch, root)
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(media_file)) == str(media_file.resolve())
+
+    def test_allows_both_legacy_and_canonical_cache_images(self, tmp_path, monkeypatch):
+        """Both legacy image_cache/ and canonical cache/images/ should be deliverable."""
+        legacy_root = tmp_path / ".hermes" / "image_cache"
+        canonical_root = tmp_path / ".hermes" / "cache" / "images"
+        legacy_file = legacy_root / "legacy.png"
+        canonical_file = canonical_root / "canonical.png"
+        legacy_file.parent.mkdir(parents=True)
+        canonical_file.parent.mkdir(parents=True)
+        legacy_file.write_bytes(b"\x89PNG\r\n\x1a\n")
+        canonical_file.write_bytes(b"\x89PNG\r\n\x1a\n")
+        self._patch_roots(monkeypatch, legacy_root, canonical_root)
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(legacy_file)) == str(legacy_file.resolve())
+        assert BasePlatformAdapter.validate_media_delivery_path(str(canonical_file)) == str(canonical_file.resolve())
+
+    def test_allows_all_canonical_cache_dirs(self, tmp_path, monkeypatch):
+        """All canonical cache subdirs should be deliverable (cache/images, cache/audio, etc.)."""
+        subdirs = ["images", "audio", "videos", "documents", "screenshots"]
+        roots = []
+        for sub in subdirs:
+            d = tmp_path / ".hermes" / "cache" / sub
+            d.mkdir(parents=True)
+            roots.append(d)
+        # Write a file in each
+        files = []
+        for i, sub in enumerate(subdirs):
+            f = roots[i] / f"test.{'png' if sub == 'images' else 'ogg' if sub == 'audio' else 'mp4' if sub == 'videos' else 'pdf' if sub == 'documents' else 'png'}"
+            f.write_bytes(b"fake content")
+            files.append(f)
+        self._patch_roots(monkeypatch, *roots)
+
+        for f in files:
+            assert BasePlatformAdapter.validate_media_delivery_path(str(f)) == str(f.resolve()), f"Failed for {f}"
+
 
 # ---------------------------------------------------------------------------
 # should_send_media_as_audio


### PR DESCRIPTION
## Summary

`image_generate` saves generated images under `~/.hermes/cache/images/`, but the gateway's `MEDIA_DELIVERY_SAFE_ROOTS` only validated paths under the legacy `~/.hermes/image_cache/` and the `IMAGE_CACHE_DIR` variable — which resolves to the legacy path when it exists on disk, creating a mismatch.

This adds the canonical new paths (`cache/images`, `cache/audio`, `cache/videos`, `cache/documents`, `cache/screenshots`) alongside the existing legacy paths so generated media is deliverable regardless of cache layout.

## Changes

- `gateway/platforms/base.py`: Added 5 canonical paths to `MEDIA_DELIVERY_SAFE_ROOTS`
- `tests/gateway/test_platform_base.py`: Added 3 regression tests

## Testing

```
8 passed in 0.38s
```

Fixes #31733