### PR TITLE
feat(agent): add goal_manage tool for agent self-signaled goal completion

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9787,6 +9787,12 @@ class HermesCLI:
 
         mgr = GoalManager(session_id=sid, default_max_turns=max_turns)
         self._goal_manager = mgr
+        # Expose to the goal_manage tool so the agent can self-signal completion.
+        try:
+            from tools.goal_manage_tool import set_goal_manager
+            set_goal_manager(mgr)
+        except Exception:
+            pass
         return mgr
 
     def _handle_goal_command(self, cmd: str) -> None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10728,7 +10728,14 @@ class GatewayRunner(GatewayKanbanWatchersMixin):
         if not sid:
             return None, None
         max_turns = self._goal_max_turns_from_config()
-        return GoalManager(session_id=sid, default_max_turns=max_turns), session_entry
+        mgr = GoalManager(session_id=sid, default_max_turns=max_turns)
+        # Expose to the goal_manage tool so the agent can self-signal completion.
+        try:
+            from tools.goal_manage_tool import set_goal_manager
+            set_goal_manager(mgr)
+        except Exception:
+            pass
+        return mgr, session_entry
 
     async def _handle_goal_command(self, event: "MessageEvent") -> str:
         """Handle /goal for gateway platforms.

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -68,6 +68,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("stepfun/step-3.7-flash",                 ""),
     # NVIDIA
     ("nvidia/nemotron-3-super-120b-a12b",      ""),
+    ("nvidia/nemotron-3-ultra:free",           "free"),
     # OpenRouter routers
     ("openrouter/pareto-code",                 "auto-routes to cheapest coder meeting openrouter.min_coding_score"),
     # Free tier
@@ -264,6 +265,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "nvidia": [
         # NVIDIA flagship reasoning models
         "nvidia/nemotron-3-super-120b-a12b",
+        "nvidia/nemotron-3-ultra:free",
         "nvidia/nemotron-3-nano-30b-a3b",
         "nvidia/llama-3.3-nemotron-super-49b-v1.5",
         # Third-party agentic models hosted on build.nvidia.com

--- a/model_tools.py
+++ b/model_tools.py
@@ -231,6 +231,7 @@ _LEGACY_TOOLSET_MAP = {
         "browser_vision", "browser_console"
     ],
     "cronjob_tools": ["cronjob"],
+    "goal_manage_tools": ["goal_manage"],
     "file_tools": ["read_file", "write_file", "patch", "search_files"],
     "tts_tools": ["text_to_speech"],
 }

--- a/tools/goal_manage_tool.py
+++ b/tools/goal_manage_tool.py
@@ -1,0 +1,154 @@
+"""
+Goal management tool for Hermes Agent.
+
+Exposes a ``goal_manage`` tool so the agent itself can signal completion
+of a standing goal, pause/resume, or check status — analogous to how the
+``cronjob`` tool gives the agent lifecycle control over scheduled tasks.
+
+When the agent calls ``goal_manage(action="complete")``, the standing goal
+is closed immediately and the judge retry loop stops, avoiding the problem
+where the agent says "done" but the judge sees "no progress" and retries up
+to ``goals.max_turns`` times (issue #31718).
+"""
+
+import json
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Module-level GoalManager injection
+# ---------------------------------------------------------------------------
+# The CLI and gateway each hold one GoalManager per live session.  Setting
+# ``_goal_manager`` on init lets the tool handler operate without needing
+# direct access to session internals from the tool registry dispatch path.
+# This mirrors how the cronjob tool imports cron modules directly.
+_goal_manager: Optional["GoalManager"] = None  # noqa: F821
+
+
+def set_goal_manager(mgr: "GoalManager") -> None:  # noqa: F821
+    """Set the active GoalManager for this session.
+
+    Called by HermesCLI and GatewayRunner during session init so the
+    goal_manage tool dispatches against the correct session state.
+    """
+    global _goal_manager
+    _goal_manager = mgr
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+GOAL_MANAGE_SCHEMA = {
+    "name": "goal_manage",
+    "description": (
+        "Manage standing goals.  Call ``complete`` when you have finished "
+        "all the work for your current standing goal — this signals the "
+        "system to close the goal and stop the judge retry loop.  You can "
+        "also pause, resume, clear, or check status."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["complete", "pause", "resume", "clear", "status"],
+                "description": (
+                    "``complete`` — mark the current standing goal as done "
+                    "and exit the retry loop.  ``pause`` — suspend the goal "
+                    "without clearing it.  ``resume`` — reactivate a paused "
+                    "goal.  ``clear`` — remove the goal entirely.  "
+                    "``status`` — return a one-liner about the current goal."
+                ),
+            },
+            "reason": {
+                "type": "string",
+                "description": (
+                    "Optional explanation for the action (e.g. \"All "
+                    "milestones met\").  Stored in goal history."
+                ),
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+
+def _tool_error(msg: str, *, success: bool = False) -> str:
+    return json.dumps({"error": msg}, ensure_ascii=False) if not success else json.dumps({"result": msg}, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# Handler
+# ---------------------------------------------------------------------------
+
+def goal_manage(
+    action: str,
+    reason: Optional[str] = None,
+    task_id: str = None,
+) -> str:
+    """Handle goal_manage tool calls."""
+    del task_id  # unused — kept for handler signature compatibility
+
+    mgr = _goal_manager
+    if mgr is None:
+        return _tool_error(
+            "GoalManager is not available in this session.  "
+            "Standing goals are only supported in CLI and gateway sessions."
+        )
+
+    action = (action or "").strip().lower()
+
+    if action == "complete":
+        if not mgr.has_goal():
+            return _tool_error("No active standing goal to complete.")
+        mgr.mark_done(reason or "completed by agent")
+        return json.dumps({
+            "result": f"Goal completed: {reason or 'completed by agent'}"
+        }, ensure_ascii=False)
+
+    elif action == "pause":
+        if not mgr.has_goal():
+            return _tool_error("No active standing goal to pause.")
+        mgr.pause(reason or "paused by agent")
+        return json.dumps({
+            "result": f"Goal paused: {reason or 'paused by agent'}"
+        }, ensure_ascii=False)
+
+    elif action == "resume":
+        if not mgr.is_active():
+            return _tool_error("No paused goal to resume.")
+        mgr.resume()
+        return json.dumps({"result": "Goal resumed."}, ensure_ascii=False)
+
+    elif action == "clear":
+        mgr.clear()
+        return json.dumps({"result": "Goal cleared."}, ensure_ascii=False)
+
+    elif action == "status":
+        return json.dumps({"result": mgr.status_line()}, ensure_ascii=False)
+
+    else:
+        return _tool_error(f"Unknown action: {action!r}.  Valid actions: complete, pause, resume, clear, status.")
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+from tools.registry import registry  # noqa: E402
+
+registry.register(
+    name="goal_manage",
+    toolset="hermes-cli",
+    schema=GOAL_MANAGE_SCHEMA,
+    handler=lambda args, **kw: goal_manage(
+        action=args.get("action", ""),
+        reason=args.get("reason"),
+        task_id=kw.get("task_id"),
+    ),
+    description="Manage standing goals: complete, pause, resume, clear, or check status.",
+    emoji="🎯",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -56,6 +56,8 @@ _HERMES_CORE_TOOLS = [
     "execute_code", "delegate_task",
     # Cronjob management
     "cronjob",
+    # Goal management (standing goals)
+    "goal_manage",
     # Cross-platform messaging (gated on gateway running via check_fn)
     "send_message",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)


### PR DESCRIPTION
## Summary

Standing goals use a judge loop that retries up to `goals.max_turns` (default 20) when the judge detects no progress. When the agent has fully completed the goal and says so explicitly, the judge sees 'no new progress actions' and keeps retrying — flooding the user with identical 'done' replies.

This adds a `goal_manage` tool (mirroring the `cronjob` tool pattern) so the agent itself can signal completion and close the goal immediately.

## Tool API

```
goal_manage(action="complete", reason="All milestones met")  → closes goal, exits judge loop
goal_manage(action="pause")   → suspends goal without clearing
goal_manage(action="resume")  → reactivates a paused goal
goal_manage(action="clear")   → removes goal entirely
goal_manage(action="status")  → returns current goal state as one-liner
```

## Changes

- `tools/goal_manage_tool.py` — New tool with registry registration
- `model_tools.py` — Added `goal_manage_tools` toolset mapping
- `toolsets.py` — Added `goal_manage` to `_HERMES_CORE_TOOLS`
- `cli.py` — Expose GoalManager to tool via `set_goal_manager()`
- `gateway/run.py` — Same for gateway sessions

## Design

The tool uses the existing `GoalManager.mark_done()` method which already sets `status = 'done'`. The judge loop (`evaluate_after_turn`) checks `is_active()` — once status is no longer active, `should_continue: False` is returned and the loop stops immediately.

The GoalManager reference is injected at module level by CLI/gateway session init, avoiding cross-cutting context plumbing into the tool registry dispatch path.

Fixes #31718