### PR TITLE
fix(kanban): normalize legacy completed task status

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1465,6 +1465,16 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             (new, old),
         )
 
+    # Legacy external boards have been observed with task.status='completed'
+    # even though the kernel has always used 'done'. Normalize those rows so
+    # dependency gates, dashboard promotion, and child auto-unblock logic all
+    # converge on the canonical status vocabulary.
+    repaired_completed = conn.execute(
+        "UPDATE tasks SET status = 'done' WHERE status = 'completed'"
+    ).rowcount
+    if repaired_completed:
+        recompute_ready(conn)
+
 
 @contextlib.contextmanager
 def write_txn(conn: sqlite3.Connection):

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1256,6 +1256,44 @@ def test_migration_renames_legacy_event_kinds(tmp_path, monkeypatch):
         conn.close()
 
 
+def test_migration_normalizes_legacy_completed_status_and_unblocks_children(
+    tmp_path, monkeypatch
+):
+    """Legacy boards that stored task.status='completed' should be healed
+    to 'done' on init_db(), and blocked children should promote to
+    ready immediately after the repair."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="legacy parent")
+        child = kb.create_task(conn, title="legacy child", parents=[parent])
+        assert kb.get_task(conn, child).status == "todo"
+
+        now = int(time.time())
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status='completed', completed_at=? WHERE id=?",
+                (now, parent),
+            )
+
+        assert kb.get_task(conn, parent).status == "completed"
+        assert kb.get_task(conn, child).status == "todo"
+
+        kb.init_db()
+
+        healed_parent = kb.get_task(conn, parent)
+        healed_child = kb.get_task(conn, child)
+        assert healed_parent is not None and healed_parent.status == "done"
+        assert healed_child is not None and healed_child.status == "ready"
+    finally:
+        conn.close()
+
+
 # ---------------------------------------------------------------------------
 # Assignees (item 4 from Multica)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes a legacy kanban compatibility hole where some external boards persisted `tasks.status='completed'` even though Hermes expects the canonical terminal status `done`.

That stale status prevents dependency resolution from recognizing a finished parent, so approval/continuation children can stay stuck in `todo` even after the parent appears completed in the dashboard. This patch normalizes legacy `completed` rows to `done` during `init_db()` migration and immediately reruns `recompute_ready()` so blocked children promote to `ready` as soon as the board is opened.

## Related Issue

Fixes #31717

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Normalize legacy `tasks.status='completed'` rows to `done` inside `hermes_cli/kanban_db.py::_migrate_add_optional_columns()`.
- Trigger `recompute_ready(conn)` when any legacy rows are repaired so dependent child tasks unblock immediately.
- Add a regression test in `tests/hermes_cli/test_kanban_core_functionality.py` that reproduces a parent stored as `completed` and verifies `init_db()` heals it to `done` and promotes the child to `ready`.

## How to Test

1. Run `uv run --frozen --with pytest python -m pytest -o addopts='' tests/hermes_cli/test_kanban_core_functionality.py -k 'legacy_completed_status or migration_renames_legacy_event_kinds' -q`.
2. Run `uv run --frozen --with pytest python -m pytest -o addopts='' tests/hermes_cli/test_kanban_db.py -k 'create_task_with_parent_is_todo_until_parent_done or link_keeps_ready_child_when_parent_already_done' -q`.
3. Run `uv run --frozen --with ruff ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py` and `git diff --check origin/main...HEAD`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted proof on rebased `HEAD` `6fbaabef59e9b471e4d9f1a7c1c3dbb11b1c7723`:

```text
uv run --frozen --with pytest python -m pytest -o addopts='' tests/hermes_cli/test_kanban_core_functionality.py -k 'legacy_completed_status or migration_renames_legacy_event_kinds' -q
..                                                                       [100%]
2 passed, 164 deselected in 0.21s

uv run --frozen --with pytest python -m pytest -o addopts='' tests/hermes_cli/test_kanban_db.py -k 'create_task_with_parent_is_todo_until_parent_done or link_keeps_ready_child_when_parent_already_done' -q
..                                                                       [100%]
2 passed, 170 deselected in 0.16s

uv run --frozen --with ruff ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py
All checks passed!

git diff --check origin/main...HEAD
```
