### PR TITLE
fix(memory): avoid byte-zero Windows lock deadlocks

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -1,9 +1,11 @@
 """Tests for tools/memory_tool.py — MemoryStore, security scanning, and tool dispatcher."""
 
 import json
+from types import SimpleNamespace
 import pytest
 from pathlib import Path
 
+import tools.memory_tool as memory_tool_module
 from tools.memory_tool import (
     MemoryStore,
     memory_tool,
@@ -224,6 +226,43 @@ class TestMemoryStoreSnapshot:
 
     def test_empty_snapshot_returns_none(self, store):
         assert store.format_for_system_prompt("memory") is None
+
+
+class TestMemoryStoreLocking:
+    def test_windows_file_lock_uses_high_offset(self, tmp_path, monkeypatch):
+        lock_target = tmp_path / "MEMORY.md"
+        handle = None
+        lock_fd = None
+        calls = []
+
+        def fake_open(*args, **kwargs):
+            nonlocal handle, lock_fd
+            handle = open(*args, **kwargs)
+            lock_fd = handle.fileno()
+            return handle
+
+        def fake_locking(fd, mode, size):
+            calls.append((fd, mode, size, handle.tell()))
+
+        monkeypatch.setattr(memory_tool_module, "fcntl", None)
+        monkeypatch.setattr(
+            memory_tool_module,
+            "msvcrt",
+            SimpleNamespace(LK_LOCK=1, LK_UNLCK=2, locking=fake_locking),
+            raising=False,
+        )
+        monkeypatch.setattr(memory_tool_module, "open", fake_open, raising=False)
+
+        with MemoryStore._file_lock(lock_target):
+            pass
+
+        assert handle is not None
+        assert lock_fd is not None
+        assert calls == [
+            (lock_fd, 1, 1, memory_tool_module._WINDOWS_LOCK_OFFSET),
+            (lock_fd, 2, 1, memory_tool_module._WINDOWS_LOCK_OFFSET),
+        ]
+        assert lock_target.with_suffix(".md.lock").read_text(encoding="utf-8") == "\n"
 
 
 # =========================================================================

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -49,6 +49,11 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+# Windows byte-range locks are mandatory for other readers. Lock a byte well
+# past the text payload so recreating or reading the .lock file never contends
+# with the mutual-exclusion byte itself.
+_WINDOWS_LOCK_OFFSET = 1024 * 1024
+
 # Where memory files live — resolved dynamically so profile overrides
 # (HERMES_HOME env var changes) are always respected.  The old module-level
 # constant was cached at import time and could go stale if a profile switch
@@ -192,7 +197,11 @@ class MemoryStore:
             if fcntl:
                 fcntl.flock(fd, fcntl.LOCK_EX)
             else:
-                fd.seek(0)
+                fd.seek(0, os.SEEK_END)
+                if fd.tell() == 0:
+                    fd.write("\n")
+                    fd.flush()
+                fd.seek(_WINDOWS_LOCK_OFFSET)
                 msvcrt.locking(fd.fileno(), msvcrt.LK_LOCK, 1)
             yield
         finally:
@@ -203,7 +212,7 @@ class MemoryStore:
                     pass
             elif msvcrt:
                 try:
-                    fd.seek(0)
+                    fd.seek(_WINDOWS_LOCK_OFFSET)
                     msvcrt.locking(fd.fileno(), msvcrt.LK_UNLCK, 1)
                 except (OSError, IOError):
                     pass
@@ -684,7 +693,6 @@ registry.register(
     check_fn=check_memory_requirements,
     emoji="🧠",
 )
-
 
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes a Windows-specific memory tool failure where Hermes tried to lock byte 0 of a freshly created `.lock` file. On Windows, `msvcrt.locking()` uses mandatory byte-range locks, and locking the first byte of an empty lock file can fail with `Errno 36 Resource deadlock avoided` before any memory write happens.

This patch aligns `tools/memory_tool.py` with the repository's existing Windows lock strategy from `gateway/status.py`: seed the lock file with a newline when empty, then lock a byte at a high offset instead of byte 0. That keeps the mutual-exclusion byte away from normal text I/O and avoids the deadlock-prone empty-file path.

## Related Issue

Fixes #31738

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Seed memory `.lock` files with a newline on Windows when first created.
- Acquire and release the Windows byte-range lock at a high offset instead of byte 0.
- Add a regression test that exercises the Windows `msvcrt` lock path and asserts the offset behavior.

## How to Test

1. `uv run --active --frozen --with pytest python -m pytest -o addopts='' tests/tools/test_memory_tool.py tests/tools/test_memory_tool_import_fallback.py -q`
2. `uv run --active --frozen --with ruff ruff check tools/memory_tool.py tests/tools/test_memory_tool.py tests/tools/test_memory_tool_import_fallback.py`
3. `git diff --check origin/main...HEAD`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted proof on `HEAD` `ec21eec94fcca8f37ce7d90fc612b7da02e5eb07`:

```text
uv run --active --frozen --with pytest python -m pytest -o addopts='' tests/tools/test_memory_tool.py tests/tools/test_memory_tool_import_fallback.py -q
..........................................                               [100%]
42 passed in 0.40s

uv run --active --frozen --with ruff ruff check tools/memory_tool.py tests/tools/test_memory_tool.py tests/tools/test_memory_tool_import_fallback.py
All checks passed!

git diff --check origin/main...HEAD
```
