### PR TITLE
fix(qqbot): prevent listener busy-loop after closed-WebSocket reconnect failure (#31771)

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -677,6 +677,14 @@ class QQAdapter(BasePlatformAdapter):
         """Read WebSocket frames until connection closes."""
         if not self._ws:
             raise RuntimeError("WebSocket not connected")
+        # Defensive: a stale closed socket left over from a failed reconnect
+        # — e.g. ``_ensure_token`` / ``_get_gateway_url`` raising before
+        # ``_open_ws`` clears the reference — would otherwise let the
+        # ``while not self._ws.closed`` loop exit immediately, return None,
+        # and busy-loop ``_listen_loop`` at 100% CPU.  Surface the closure
+        # so the outer loop's reconnect/backoff path runs.  See #31771.
+        if self._ws.closed:
+            raise RuntimeError("WebSocket closed before read")
 
         while self._running and self._ws and not self._ws.closed:
             msg = await self._ws.receive()
@@ -691,6 +699,15 @@ class QQAdapter(BasePlatformAdapter):
                 raise QQCloseError(msg.data, msg.extra)
             elif msg.type in {aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR}:
                 raise RuntimeError("WebSocket closed")
+
+        # If the loop exited because the socket vanished mid-read while the
+        # listener still wants to run (e.g. ``self._ws`` was nulled out by
+        # another task, or closed silently without surfacing CLOSE / CLOSED
+        # / ERROR frames), surface the closure so ``_listen_loop`` applies
+        # its reconnect/backoff path instead of treating the silent return
+        # as a successful read cycle.
+        if self._running:
+            raise RuntimeError("WebSocket closed during read")
 
     async def _heartbeat_loop(self) -> None:
         """Send periodic heartbeats (QQ Gateway expects op 1 heartbeat with latest seq).

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -671,6 +671,15 @@ class QQAdapter(BasePlatformAdapter):
             return True
         except Exception as exc:
             logger.warning("[%s] Reconnect failed: %s", self._log_tag, exc)
+            # Drop any stale closed WebSocket so the next ``_read_events``
+            # call sees a missing socket and raises ``WebSocket not
+            # connected`` (rather than the closed socket silently
+            # short-circuiting the read loop).  This matters when
+            # ``_ensure_token`` or ``_get_gateway_url`` raises before
+            # ``_open_ws`` could clear ``self._ws`` itself — exactly the
+            # path observed in #31771 (`Failed to get QQ Bot gateway URL`).
+            if self._ws is not None and self._ws.closed:
+                self._ws = None
             return False
 
     async def _read_events(self) -> None:

--- a/tests/gateway/test_qqbot_busy_loop_31771.py
+++ b/tests/gateway/test_qqbot_busy_loop_31771.py
@@ -1,0 +1,306 @@
+"""Regression tests for #31771 — QQBot busy-loop on closed WebSocket.
+
+When the QQ Bot WebSocket closed and the next reconnect attempt failed
+(e.g. ``Failed to get QQ Bot gateway URL: ...`` from a transient DNS
+glitch), ``self._ws`` retained the *old, already-closed* reference
+because the failure happened in ``_ensure_token`` / ``_get_gateway_url``
+before ``_open_ws`` could clear it.  The next ``_listen_loop`` iteration
+re-entered ``_read_events``, where the ``while not self._ws.closed:``
+loop body never ran, the function returned ``None`` immediately, and
+``_listen_loop`` reset the backoff and looped again — pegging the
+process at 99-100 % CPU with no further reconnect logs.
+
+Two layers of defense in this PR:
+
+1. ``_read_events`` raises when entering with a closed socket and again
+   if the read loop exits silently while the listener still wants to
+   run, so a closed-socket return is never mistaken for a successful
+   read cycle.
+2. ``_reconnect`` clears ``self._ws`` on its exception path so the next
+   iteration sees a missing socket rather than a closed one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_adapter(**extra):
+    from gateway.platforms.qqbot import QQAdapter
+    return QQAdapter(PlatformConfig(enabled=True, extra=extra))
+
+
+class _ClosedWS:
+    """Stand-in for an already-closed ``aiohttp.ClientWebSocketResponse``.
+
+    The real closed object is truthy and reports ``closed=True``; calling
+    ``receive()`` on it would either return a CLOSED frame or raise.  The
+    test guards never need ``receive()`` because the read loop body must
+    not run for a closed socket.
+    """
+    closed = True
+
+    async def receive(self):  # pragma: no cover — never reached by the fix
+        raise AssertionError(
+            "receive() must not be called on an already-closed WebSocket"
+        )
+
+
+class _OpenWS:
+    closed = False
+
+    async def receive(self):  # pragma: no cover — not exercised here
+        raise AssertionError("test must not actually receive frames")
+
+
+# ---------------------------------------------------------------------------
+# _read_events: explicit raises on closed / missing / disappearing sockets
+# ---------------------------------------------------------------------------
+
+
+class TestReadEventsRaisesOnClosedSocket:
+    """The read loop must never return silently when the socket is closed."""
+
+    @pytest.mark.asyncio
+    async def test_raises_when_ws_is_already_closed_on_entry(self):
+        """The exact #31771 scenario: stale closed socket from a failed reconnect."""
+        adapter = _make_adapter(app_id="a", client_secret="b")
+        adapter._running = True
+        adapter._ws = _ClosedWS()
+
+        with pytest.raises(RuntimeError, match="closed before read"):
+            await adapter._read_events()
+
+    @pytest.mark.asyncio
+    async def test_raises_when_ws_is_missing(self):
+        """``self._ws is None`` must surface as a connection error, not a silent return."""
+        adapter = _make_adapter(app_id="a", client_secret="b")
+        adapter._running = True
+        adapter._ws = None
+
+        with pytest.raises(RuntimeError, match="not connected"):
+            await adapter._read_events()
+
+    @pytest.mark.asyncio
+    async def test_raises_when_running_but_ws_disappears_mid_read(self):
+        """Open socket → adapter still running → loop exits → must raise.
+
+        Mimics another task setting ``self._ws = None`` while the read
+        loop's predicate is being re-evaluated, or the socket transitioning
+        to closed without a CLOSE / CLOSED / ERROR frame ever surfacing.
+        """
+        adapter = _make_adapter(app_id="a", client_secret="b")
+        adapter._running = True
+
+        # Start with an "open" socket whose closed flag flips to True on
+        # the *next* read loop predicate evaluation.  Returning
+        # ``closed=False`` once and then ``True`` causes the body to skip
+        # and the post-loop guard to fire.
+        flips = [False, True]
+
+        class _FlipWS:
+            @property
+            def closed(self):
+                # First evaluation: False (loop entered);
+                # subsequent: True (loop body skipped).
+                return flips.pop(0) if flips else True
+
+            async def receive(self):  # pragma: no cover — not reached
+                raise AssertionError("receive() must not be called")
+
+        adapter._ws = _FlipWS()
+
+        with pytest.raises(RuntimeError, match="closed during read"):
+            await adapter._read_events()
+
+    @pytest.mark.asyncio
+    async def test_does_not_raise_when_listener_was_stopped(self):
+        """If ``_running`` flipped to False, returning silently is correct.
+
+        The post-loop guard must NOT raise during a clean shutdown — that
+        would surface a spurious "WebSocket closed during read" up to
+        ``_listen_loop`` after the user already requested disconnect.
+        """
+        adapter = _make_adapter(app_id="a", client_secret="b")
+        adapter._running = False
+        adapter._ws = _OpenWS()
+
+        # No exception expected; clean return.
+        result = await adapter._read_events()
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _reconnect: stale closed _ws is cleared so the next read raises cleanly
+# ---------------------------------------------------------------------------
+
+
+class TestReconnectClearsStaleClosedSocket:
+    """A failed reconnect must drop the stale closed ``self._ws`` reference."""
+
+    @pytest.mark.asyncio
+    async def test_clears_ws_when_get_gateway_url_raises(self):
+        """The exact path from the #31771 trace.
+
+        ``Reconnect failed: Failed to get QQ Bot gateway URL`` means
+        ``_get_gateway_url`` raised before ``_open_ws`` ran.  The closed
+        ``self._ws`` from the previous session must be discarded so the
+        next iteration's ``_read_events`` does not silently short-circuit.
+        """
+        adapter = _make_adapter(app_id="a", client_secret="b")
+        stale_ws = _ClosedWS()
+        adapter._ws = stale_ws
+
+        adapter._ensure_token = mock.AsyncMock()
+        adapter._get_gateway_url = mock.AsyncMock(
+            side_effect=RuntimeError("Failed to get QQ Bot gateway URL: dns")
+        )
+
+        # Patch out the backoff sleep so the test runs instantly.
+        with mock.patch("gateway.platforms.qqbot.adapter.asyncio.sleep",
+                        new=mock.AsyncMock()):
+            ok = await adapter._reconnect(backoff_idx=0)
+
+        assert ok is False
+        assert adapter._ws is None, (
+            "stale closed _ws must be dropped on failed reconnect"
+        )
+
+    @pytest.mark.asyncio
+    async def test_does_not_clear_ws_when_open_ws_assigned_a_new_one(self):
+        """A successful reconnect leaves ``self._ws`` set to the new open socket."""
+        adapter = _make_adapter(app_id="a", client_secret="b")
+        adapter._ws = _ClosedWS()  # stale leftover from previous session
+        new_ws = _OpenWS()
+
+        adapter._ensure_token = mock.AsyncMock()
+        adapter._get_gateway_url = mock.AsyncMock(return_value="wss://example")
+
+        async def fake_open_ws(_url):
+            adapter._ws = new_ws
+
+        adapter._open_ws = fake_open_ws
+        adapter._mark_connected = mock.MagicMock()
+
+        with mock.patch("gateway.platforms.qqbot.adapter.asyncio.sleep",
+                        new=mock.AsyncMock()):
+            ok = await adapter._reconnect(backoff_idx=0)
+
+        assert ok is True
+        assert adapter._ws is new_ws
+
+    @pytest.mark.asyncio
+    async def test_does_not_clear_open_ws_on_unrelated_failure(self):
+        """If the surviving ``self._ws`` is somehow open, leave it alone.
+
+        Defensive: only the ``ws.closed`` branch should null out the
+        reference.  This guards against the cleanup accidentally killing
+        a still-live socket.
+        """
+        adapter = _make_adapter(app_id="a", client_secret="b")
+        live_ws = _OpenWS()
+        adapter._ws = live_ws
+
+        adapter._ensure_token = mock.AsyncMock(side_effect=RuntimeError("boom"))
+
+        with mock.patch("gateway.platforms.qqbot.adapter.asyncio.sleep",
+                        new=mock.AsyncMock()):
+            ok = await adapter._reconnect(backoff_idx=0)
+
+        assert ok is False
+        assert adapter._ws is live_ws
+
+
+# ---------------------------------------------------------------------------
+# Integration: the listener no longer busy-loops when reconnect fails
+# ---------------------------------------------------------------------------
+
+
+class TestListenLoopNoBusyLoopAfterReconnectFailure:
+    """End-to-end: the #31771 traceback no longer produces a hot loop."""
+
+    @pytest.mark.asyncio
+    async def test_failed_reconnect_breaks_out_after_max_attempts(self):
+        """``_listen_loop`` increments backoff on each failure and gives up.
+
+        Before the fix: ``_read_events`` returned silently → backoff_idx
+        was reset to 0 each iteration → ``MAX_RECONNECT_ATTEMPTS`` was
+        never reached → infinite hot loop.  After the fix:
+        ``_read_events`` raises, the ``except Exception`` branch ticks
+        ``backoff_idx`` until it hits the cap.
+        """
+        adapter = _make_adapter(app_id="a", client_secret="b")
+        adapter._running = True
+        # Stale closed ws — the #31771 starting state.
+        adapter._ws = _ClosedWS()
+
+        # Every reconnect fails.  Use a shallow attempt cap so the test
+        # finishes quickly.
+        with mock.patch.object(adapter, "_reconnect",
+                               new=mock.AsyncMock(return_value=False)) as recon, \
+             mock.patch("gateway.platforms.qqbot.adapter.MAX_RECONNECT_ATTEMPTS", 3), \
+             mock.patch.object(adapter, "_mark_disconnected") as md, \
+             mock.patch.object(adapter, "_mark_transport_disconnected"):
+
+            await asyncio.wait_for(adapter._listen_loop(), timeout=2.0)
+
+        # Reconnect was called exactly MAX attempts before the loop gave up
+        # — proving _read_events raises (not returns) so backoff progresses.
+        assert recon.await_count == 3
+        md.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_does_not_busy_loop_with_stale_closed_ws(self):
+        """Direct repro of #31771: ``_read_events`` must not return silently.
+
+        Without the fix, this test would loop forever; the
+        ``asyncio.wait_for`` timeout protects the test runner.
+        """
+        adapter = _make_adapter(app_id="a", client_secret="b")
+        adapter._running = True
+        adapter._ws = _ClosedWS()
+
+        # First _read_events() invocation must raise (not return None).
+        with pytest.raises(RuntimeError):
+            await asyncio.wait_for(adapter._read_events(), timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# Source-level guards
+# ---------------------------------------------------------------------------
+
+
+class TestReadEventsSourceGuards:
+    """Pin the defensive checks in source so an accidental revert is loud."""
+
+    def test_read_events_has_closed_pre_check(self):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        src = inspect.getsource(QQAdapter._read_events)
+        # Pre-check: raise on closed socket BEFORE the while loop.
+        assert "closed before read" in src
+        # Post-loop guard: raise if running but loop exited silently.
+        assert "closed during read" in src
+        # Issue reference so the guard isn't refactored away.
+        assert "31771" in src
+
+    def test_reconnect_clears_stale_closed_ws_in_except(self):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        src = inspect.getsource(QQAdapter._reconnect)
+        assert "Reconnect failed" in src
+        # The stale-clear branch is gated on closed=True so it never kills
+        # a still-live socket.
+        assert "self._ws.closed" in src
+        assert "self._ws = None" in src
+        assert "31771" in src


### PR DESCRIPTION
## What does this PR do?

Stops the QQBot adapter from pegging a Hermes Gateway process at 99-100% CPU after the WebSocket closes and the next reconnect attempt fails.

When ``_ensure_token`` or ``_get_gateway_url`` raised inside ``_reconnect`` (e.g. the transient ``Failed to get QQ Bot gateway URL: [Errno 8] nodename nor servname provided`` from the issue trace), the previous session's ``self._ws`` was never cleared because ``_open_ws`` — the only place that nulls the reference — never ran.  The next ``_listen_loop`` iteration re-entered ``_read_events``, where the ``while not self._ws.closed:`` loop body never ran for a closed socket, the function returned ``None`` immediately, and ``_listen_loop`` reset ``backoff_idx = 0`` and looped again.  Result: a hot busy-loop with no further reconnect logs, ``platforms.qqbot.state`` stuck at ``disconnected``, and one Python core fully pinned.

This PR adds two layers of defense:

1. ``_read_events`` raises on entry when the socket is missing / already-closed, and again at the bottom if the read loop exited silently while the listener still wants to run, so a closed-socket return is never mistaken for a successful read cycle.
2. ``_reconnect`` clears ``self._ws`` on its exception path (only when the socket is actually closed — never killing a still-live one) so the next iteration sees a missing socket rather than a closed one.

Either fix on its own breaks the loop; together they make the contract explicit at both ends.

## Related Issue

Closes #31771.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- ``gateway/platforms/qqbot/adapter.py`` — ``_read_events`` raises ``RuntimeError(\"WebSocket closed before read\")`` on entry with a closed socket and ``RuntimeError(\"WebSocket closed during read\")`` after the loop if ``self._running`` is still True; ``_reconnect`` drops a stale closed ``self._ws`` reference on the exception path.
- ``tests/gateway/test_qqbot_busy_loop_31771.py`` — 11 new regression tests:
  - ``TestReadEventsRaisesOnClosedSocket`` (4 cases) — entry with stale closed socket / ``self._ws=None``, the post-loop guard for socket-disappears-mid-read, and clean-shutdown silent return.
  - ``TestReconnectClearsStaleClosedSocket`` (3 cases) — failed reconnect drops a closed reference, a successful reconnect leaves the new socket set, a still-open socket is never killed.
  - ``TestListenLoopNoBusyLoopAfterReconnectFailure`` (2 cases) — end-to-end repro pinned with ``asyncio.wait_for`` so a regression that re-introduces the hot loop will trip the test runner's timeout.
  - ``TestReadEventsSourceGuards`` (2 cases) — ``inspect.getsource``-based guards so an accidental refactor removing the defensive checks is loud during code review.

## How to Test

1. Check out this branch and ensure ``.venv`` is set up: ``python3 -m venv .venv && source .venv/bin/activate && pip install -e \".[all,dev]\"``
2. Run the new regression suite on its own:
   \`\`\`
   scripts/run_tests.sh tests/gateway/test_qqbot_busy_loop_31771.py
   \`\`\`
   Expected: ``11 passed``.
3. Run the full QQBot test suite to confirm no cross-file regressions:
   \`\`\`
   scripts/run_tests.sh tests/gateway/test_qqbot.py tests/gateway/test_qqbot_busy_loop_31771.py
   \`\`\`
   Expected: ``170 passed`` (159 pre-existing + 11 new).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (``fix(qqbot):`` / ``test(qqbot):``)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run ``scripts/run_tests.sh tests/gateway/test_qqbot_busy_loop_31771.py`` and all 11 tests pass
- [x] I've added tests for my changes (11 new cases across 4 classes)
- [x] I've tested on my platform: macOS 15.2 (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, ``docs/``, docstrings) — N/A (defensive guard, no public-API change; rationale captured in code comments + commit bodies)
- [x] I've updated ``cli-config.yaml.example`` if I added/changed config keys — N/A
- [x] I've updated ``CONTRIBUTING.md`` or ``AGENTS.md`` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure asyncio control-flow, no platform-specific calls
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

\`\`\`
\$ scripts/run_tests.sh tests/gateway/test_qqbot_busy_loop_31771.py
24 workers [11 items]
============================== 11 passed in 0.5s ==============================

\$ scripts/run_tests.sh tests/gateway/test_qqbot.py tests/gateway/test_qqbot_busy_loop_31771.py
=== Summary: 2 files, 170 tests passed, 0 failed (100% complete) in 2.6s ===
\`\`\`

After applying this PR, the exact failure trace from #31771:

\`\`\`
2026-05-25 02:30:33,484 WARNING gateway.platforms.qqbot.adapter: [QQBot:1903695542] WebSocket error: WebSocket closed
2026-05-25 02:30:33,488 INFO gateway.platforms.qqbot.adapter: [QQBot:1903695542] Reconnecting in 2s (attempt 1)...
2026-05-25 02:30:35,522 WARNING gateway.platforms.qqbot.adapter: [QQBot:1903695542] Reconnect failed: Failed to get QQ Bot gateway URL: ...
\`\`\`

continues on through the normal backoff/retry path (``WebSocket closed before read`` from ``_read_events`` → ``except Exception`` → next ``_reconnect`` with bumped ``backoff_idx``) instead of looping silently at 100% CPU.
