### PR TITLE
fix(gateway): drop tool progress SSE events on Chat Completions stream

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1417,17 +1417,19 @@ class APIServerAdapter(BasePlatformAdapter):
                 """Write a single queue item to the SSE stream.
 
                 Plain strings are sent as normal ``delta.content`` chunks.
-                Tagged tuples ``("__tool_progress__", payload)`` are sent
-                as a custom ``event: hermes.tool.progress`` SSE event so
-                frontends can display them without storing the markers in
-                conversation history.  See #6972 for the original event,
-                #16588 for the ``toolCallId``/``status`` lifecycle fields.
+                Tagged tuples ``("__tool_progress__", payload)`` are
+                silently dropped.  Previously they were emitted as custom
+                ``event: hermes.tool.progress`` SSE events, but many
+                OpenAI-compatible frontends (Jan, Open WebUI via Vercel
+                AI SDK) parse *all* ``data:`` lines as chat completion
+                chunks regardless of the ``event:`` field, causing
+                ``Type validation failed`` errors.  See #6972, #16588.
                 """
                 if isinstance(item, tuple) and len(item) == 2 and item[0] == "__tool_progress__":
-                    event_data = json.dumps(item[1])
-                    await response.write(
-                        f"event: hermes.tool.progress\ndata: {event_data}\n\n".encode()
-                    )
+                    # Skip — cosmetic tool progress breaks strict
+                    # OpenAI-compatible clients (Jan, Open WebUI, etc.).
+                    # See #4804 for discussion of configurable alternatives.
+                    logger.debug("Dropping tool progress event: %s", item[1].get("tool", "unknown"))
                 else:
                     content_chunk = {
                         "id": completion_id, "object": "chat.completion.chunk",

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -910,8 +910,15 @@ class TestChatCompletionsEndpoint:
                 assert " about it..." in body
 
     @pytest.mark.asyncio
-    async def test_stream_includes_tool_progress(self, adapter):
-        """tool_start_callback fires → progress appears as custom SSE event, not in delta.content."""
+    async def test_stream_drops_tool_progress_for_openai_compat(self, adapter):
+        """tool_start_callback fires → progress is silently dropped from SSE stream.
+
+        OpenAI-compatible frontends (Jan, Open WebUI via Vercel AI SDK)
+        parse all ``data:`` lines as chat.completion.chunk objects regardless
+        of the ``event:`` field, causing Type validation errors.  Tool progress
+        events are purely cosmetic and must not appear on the Chat Completions
+        SSE stream.
+        """
         import asyncio
 
         app = _create_app(adapter)
@@ -942,35 +949,22 @@ class TestChatCompletionsEndpoint:
                 assert resp.status == 200
                 body = await resp.text()
                 assert "[DONE]" in body
-                # Tool progress must appear as a custom SSE event, not in
-                # delta.content — prevents model from learning to imitate
-                # markers instead of calling tools (#6972).
-                assert "event: hermes.tool.progress" in body
-                assert '"tool": "terminal"' in body
-                # ``label`` is now derived by ``build_tool_preview`` from the
-                # tool args rather than passed by the caller, so we assert
-                # only that *some* label exists rather than a literal value.
-                assert '"label":' in body
-                # The progress marker must NOT appear inside any
-                # chat.completion.chunk delta.content field.
+                # Tool progress must NOT appear in the SSE stream — it
+                # breaks strict OpenAI-compatible clients.
+                assert "event: hermes.tool.progress" not in body
+                assert '"tool": "terminal"' not in body
+                # Every data: line must be valid chat.completion.chunk or [DONE]
                 import json as _json
                 for line in body.splitlines():
                     if line.startswith("data: ") and line.strip() != "data: [DONE]":
-                        try:
-                            chunk = _json.loads(line[len("data: "):])
-                        except _json.JSONDecodeError:
-                            continue
-                        if chunk.get("object") == "chat.completion.chunk":
-                            for choice in chunk.get("choices", []):
-                                content = choice.get("delta", {}).get("content", "")
-                                # Tool emoji markers must never leak into content
-                                assert "ls -la" not in content or content == "Here are the files."
-                # Final content must also be present
+                        chunk = _json.loads(line[len("data: "):])
+                        assert "choices" in chunk, f"Non-chunk data line: {chunk}"
+                # Final content must still arrive
                 assert "Here are the files." in body
 
     @pytest.mark.asyncio
-    async def test_stream_tool_progress_skips_internal_events(self, adapter):
-        """Internal tool calls (name starting with ``_``) are not streamed."""
+    async def test_stream_tool_progress_skips_all_events(self, adapter):
+        """All tool progress events (internal and external) are dropped from SSE stream."""
         import asyncio
 
         app = _create_app(adapter)
@@ -1000,33 +994,20 @@ class TestChatCompletionsEndpoint:
                 )
                 assert resp.status == 200
                 body = await resp.text()
-                # Internal _thinking event should NOT appear anywhere
+                # No tool progress of any kind should appear
+                assert "event: hermes.tool.progress" not in body
                 assert "some internal state" not in body
                 assert "call_internal_1" not in body
-                # Real tool progress should appear as custom SSE event
-                assert "event: hermes.tool.progress" in body
-                assert '"tool": "web_search"' in body
-                # Label is derived from the args dict by build_tool_preview;
-                # asserting on the structural fact (label exists, call id
-                # is correlated) rather than a literal preview string keeps
-                # the test robust against preview-formatter tweaks.
-                assert '"label":' in body
-                assert '"toolCallId": "call_search_1"' in body
+                assert '"tool": "web_search"' not in body
+                assert "call_search_1" not in body
 
     @pytest.mark.asyncio
-    async def test_stream_emits_tool_lifecycle_with_call_id(self, adapter):
-        """Regression for #16588.
+    async def test_stream_tool_lifecycle_dropped_on_chat_completions(self, adapter):
+        """Regression: tool lifecycle events are dropped on Chat Completions SSE.
 
-        ``/v1/chat/completions`` streaming previously emitted only a
-        ``tool.started``-style ``hermes.tool.progress`` event; clients
-        rendering tool lifecycle UI had no way to mark a tool as finished
-        because no matching ``status: completed`` event was emitted, and
-        no ``toolCallId`` was carried for correlation.
-
-        The fix adds ``tool_start_callback`` / ``tool_complete_callback``
-        to the chat completions agent invocation and writes both halves
-        of the lifecycle pair on the same ``event: hermes.tool.progress``
-        SSE line, with stable ``toolCallId`` and ``status``.
+        Previously (#16588) these were emitted as ``hermes.tool.progress``
+        events with ``status: running/completed``.  Now they are silently
+        dropped to maintain strict OpenAI compatibility.
         """
         import asyncio
         import json as _json
@@ -1064,31 +1045,12 @@ class TestChatCompletionsEndpoint:
                 assert resp.status == 200
                 body = await resp.text()
 
-            # Walk the SSE body and collect *(status, toolCallId)* pairs
-            # per event so the assertions verify per-event correlation —
-            # an event missing ``toolCallId`` would not pass even if a
-            # different event happens to carry the right id.
-            pairs: list[tuple[str | None, str | None]] = []
-            lines = body.splitlines()
-            for i, line in enumerate(lines):
-                if line.strip() != "event: hermes.tool.progress":
-                    continue
-                for follow in lines[i + 1: i + 4]:
-                    if follow.startswith("data: "):
-                        try:
-                            payload = _json.loads(follow[len("data: "):])
-                        except _json.JSONDecodeError:
-                            break
-                        pairs.append((payload.get("status"), payload.get("toolCallId")))
-                        break
-
-            # Each tool start must emit exactly one event (no duplicate
-            # legacy + new emit), and each lifecycle pair must carry the
-            # same toolCallId on every event — not just somewhere in the
-            # aggregate.
-            assert len(pairs) == 2, f"expected 2 events (running+completed), got {pairs}"
-            assert pairs[0] == ("running", "call_terminal_1"), pairs
-            assert pairs[1] == ("completed", "call_terminal_1"), pairs
+            # No tool progress events should appear at all
+            assert "event: hermes.tool.progress" not in body
+            assert '"status": "running"' not in body
+            assert '"status": "completed"' not in body
+            # Content still arrives
+            assert "done." in body
 
     @pytest.mark.asyncio
     async def test_stream_tool_lifecycle_skips_internal_and_orphan_completes(self, adapter):


### PR DESCRIPTION
## What does this PR do?

Fixes Chat Completions SSE streaming for OpenAI-compatible frontends (Jan, Open WebUI, etc.) that crash on custom SSE event types.

Custom `event: hermes.tool.progress` SSE events break clients using Vercel AI SDK — the SDK parses all `data:` lines as `chat.completion.chunk` objects regardless of the `event:` field, causing "Type validation failed" errors. Fix: drop these cosmetic events on the Chat Completions endpoint (debug-logged for troubleshooting).

Simpler alternative to #4805, #8373, #20109 (which add configurability). Since the Chat Completions endpoint exists for OpenAI-compatible clients, non-standard SSE events shouldn't be emitted on it. Tool progress is cosmetic and available via the Responses API for clients that need it.

## Related Issue

Fixes #4804

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/api_server.py`: `_emit()` in `_write_sse_chat_completion()` drops `__tool_progress__` tuples with a debug log instead of emitting them as custom SSE events
- `tests/gateway/test_api_server.py`: Updated 3 tests to assert tool progress is NOT emitted on Chat Completions SSE stream

Only Chat Completions is affected — Responses API and Runs API have separate stream writers.

## How to Test

1. Start gateway with API server enabled (`API_SERVER_ENABLED=true`)
2. Connect Jan (or any Vercel AI SDK frontend) to `http://localhost:8642/v1`
3. Send a message that triggers tool use (e.g., anything that calls `session_search`)
4. Verify: response streams cleanly, no "Type validation failed" errors

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

**Before (Jan error):**
```
Type validation failed: Value: {"tool":"session_search","label":"recall: \"Jan app OR chat frontend ...\"","toolCallId":"toolu_bdrk_01KTGZRVHsSsSqRSrocZJSbRG"}
- Expected "array" at path ["choices"]
- Expected "object" at path ["error"]
- Invalid input
```

**After:** Clean streaming response, no errors.

## Attribution

This PR was prepared by a Hermes Agent.
