### PR TITLE
fix(web_server): propagate --insecure flag to WebSocket security guards

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3375,6 +3375,12 @@ def _ws_client_is_allowed(ws: "WebSocket") -> bool:
     ``?token=<_SESSION_TOKEN>`` path is the only auth we have, so we
     don't want LAN hosts guessing tokens.
 
+    ``--insecure`` mode: non-loopback binding without an OAuth gate.
+    The operator has explicitly opted out of localhost-only mode, so
+    the loopback-only IP restriction is lifted here too. Without this,
+    ``--insecure`` is a no-op for WebSocket upgrades and every
+    non-loopback client gets 403 even though HTTP requests are allowed.
+
     Gated mode: any peer is allowed — uvicorn's ``proxy_headers=True``
     (enabled when the OAuth gate is active so cookies can pick up
     ``X-Forwarded-Proto``) rewrites ``ws.client.host`` to the
@@ -3384,6 +3390,8 @@ def _ws_client_is_allowed(ws: "WebSocket") -> bool:
     blocks DNS-rebinding here, not the peer IP.
     """
     if getattr(app.state, "auth_required", False):
+        return True
+    if getattr(app.state, "insecure", False):
         return True
     client_host = ws.client.host if ws.client else ""
     if not client_host:
@@ -4904,6 +4912,10 @@ def start_server(
     # PTY child uses to publish events to the dashboard sidebar.
     app.state.bound_host = host
     app.state.bound_port = port
+    # Expose allow_public on app.state so WebSocket security guards can read
+    # it at request time.  Without this, every getattr(app.state, "insecure",
+    # False) call evaluates to False regardless of the flag passed by the user.
+    app.state.insecure = allow_public
 
     if open_browser:
         import webbrowser

--- a/tests/hermes_cli/test_web_server_host_header.py
+++ b/tests/hermes_cli/test_web_server_host_header.py
@@ -246,9 +246,14 @@ class TestInsecureMode:
     def test_start_server_writes_insecure_to_app_state(self, monkeypatch):
         """start_server() must persist allow_public to app.state.insecure so
         WebSocket guards can read it at request time."""
+        import uvicorn
+
         import hermes_cli.web_server as ws
 
-        monkeypatch.setattr("hermes_cli.web_server.uvicorn.run", lambda *a, **kw: None)
+        # uvicorn is lazily imported inside start_server(), so patch
+        # uvicorn.run on the uvicorn module itself rather than on the
+        # web_server module (where the name doesn't exist yet).
+        monkeypatch.setattr(uvicorn, "run", lambda *a, **kw: None)
 
         ws.start_server(host="127.0.0.1", port=9119, open_browser=False, allow_public=True)
         assert ws.app.state.insecure is True

--- a/tests/hermes_cli/test_web_server_host_header.py
+++ b/tests/hermes_cli/test_web_server_host_header.py
@@ -215,3 +215,43 @@ class TestWebSocketHostOriginGuard:
             },
         ):
             pass
+
+
+class TestInsecureMode:
+    """When --insecure is active, _ws_client_is_allowed must lift the
+    loopback-only IP restriction so that non-loopback clients can connect.
+    start_server() is responsible for writing allow_public to app.state so
+    every runtime guard can read it."""
+
+    def test_non_loopback_client_rejected_without_insecure(self, monkeypatch):
+        """Baseline: a non-loopback peer is blocked in normal mode."""
+        from unittest.mock import MagicMock
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws.app.state, "insecure", False, raising=False)
+        mock_ws = MagicMock()
+        mock_ws.client.host = "10.0.0.5"
+        assert not ws._ws_client_is_allowed(mock_ws)
+
+    def test_non_loopback_client_allowed_with_insecure(self, monkeypatch):
+        """With --insecure, any client IP must pass _ws_client_is_allowed."""
+        from unittest.mock import MagicMock
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws.app.state, "insecure", True, raising=False)
+        mock_ws = MagicMock()
+        mock_ws.client.host = "10.0.0.5"
+        assert ws._ws_client_is_allowed(mock_ws)
+
+    def test_start_server_writes_insecure_to_app_state(self, monkeypatch):
+        """start_server() must persist allow_public to app.state.insecure so
+        WebSocket guards can read it at request time."""
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr("hermes_cli.web_server.uvicorn.run", lambda *a, **kw: None)
+
+        ws.start_server(host="127.0.0.1", port=9119, open_browser=False, allow_public=True)
+        assert ws.app.state.insecure is True
+
+        ws.start_server(host="127.0.0.1", port=9119, open_browser=False, allow_public=False)
+        assert ws.app.state.insecure is False


### PR DESCRIPTION
## Problem

When the dashboard is bound to a non-loopback address using `--insecure`, all WebSocket connections to `/api/pty`, `/api/ws`, `/api/pub`, and `/api/events` fail with **403 Forbidden**. HTTP endpoints work fine.

## Root cause

`start_server()` accepts `allow_public` (the runtime value of `--insecure`) and uses it to skip the startup `SystemExit` guard — but never writes it to `app.state`:

```python
app.state.bound_host = host
app.state.bound_port = port
# app.state.insecure is never set
```

Every `getattr(app.state, "insecure", False)` call in the runtime security guards therefore always returns `False`, making `--insecure` a no-op at request time.

The direct consequence: `_ws_client_is_allowed()` enforces loopback-only peer IPs unconditionally. When the server is bound to a non-loopback address, the connecting client also has a non-loopback IP, so every WebSocket upgrade is rejected. HTTP works because `_is_accepted_host()` resolves the host match from `app.state.bound_host` directly, which is correctly set.

## Fix

- Set `app.state.insecure = allow_public` in `start_server()`.
- Short-circuit `_ws_client_is_allowed()` when `app.state.insecure` is `True`. The operator has already accepted the security trade-off by passing `--insecure`; enforcing the loopback IP gate on top of that contradicts the intent of the flag.

## Tests

Three new cases in `TestInsecureMode`:

| Test | What it checks |
|---|---|
| `test_non_loopback_client_rejected_without_insecure` | Baseline — non-loopback IP is still blocked in normal mode |
| `test_non_loopback_client_allowed_with_insecure` | Non-loopback IP passes when `--insecure` is active |
| `test_start_server_writes_insecure_to_app_state` | `start_server()` correctly persists `allow_public` to `app.state` |