### PR TITLE
feat(optional-skills): add Pixeltable multimodal data skill

### DIFF
--- a/optional-skills/mlops/pixeltable/SKILL.md
+++ b/optional-skills/mlops/pixeltable/SKILL.md
@@ -88,11 +88,13 @@ For multi-step workflows, write a Python script with `write_file` and execute wi
 | Create directory | `pxt.create_dir('mydir', if_exists='ignore')` |
 | Create table | `pxt.create_table('mydir.t', {'text': pxt.String, 'img': pxt.Image})` |
 | Insert rows | `t.insert([{'text': 'hello', 'img': 'path/to/img.jpg'}])` |
-| Add computed column | `t.add_computed_column(emb=embed_fn(t.text))` |
-| Add embedding index | `t.add_embedding_index('text', embedding=embed_fn)` |
+| Add computed column | `t.add_computed_column(emb=embed_fn(t.text), if_exists='ignore')` |
+| Add embedding index | `t.add_embedding_index('text', embedding=embed_fn, if_exists='ignore')` |
 | Similarity search | `t.order_by(t.text.similarity(string='query'), asc=False).limit(5).collect()` |
-| Create view | `pxt.create_view('mydir.chunks', t, iterator=document_splitter(t.doc, separators='paragraph'))` |
+| Create view | `pxt.create_view('mydir.chunks', t, iterator=document_splitter(t.doc, separators='token_limit', limit=300))` |
 | Query with filter | `t.where(t.category == 'science').select(t.text, t.score).collect()` |
+| Define a UDF | `@pxt.udf` decorator on a typed Python function |
+| Define a query function | `@pxt.query` decorator — returns a query expression, no `.collect()` inside |
 | Drop table | `pxt.drop_table('mydir.t')` |
 | List tables | `pxt.list_tables()` |
 
@@ -116,7 +118,7 @@ imgs = pxt.create_table('images.gallery', {'image': pxt.Image, 'label': pxt.Stri
 
 # CLIP embeds images AND text into the same vector space
 embed_fn = clip.using(model_id='openai/clip-vit-base-patch32')
-imgs.add_embedding_index('image', embedding=embed_fn)
+imgs.add_embedding_index('image', embedding=embed_fn, if_exists='ignore')
 
 # Insert real sample images (COCO dataset hosted on GitHub)
 base = 'https://raw.githubusercontent.com/pixeltable/pixeltable/release/docs/resources/images'
@@ -179,12 +181,12 @@ docs = pxt.create_table('rag.docs', {'doc': pxt.Document}, if_exists='ignore')
 
 chunks = pxt.create_view(
     'rag.chunks', docs,
-    iterator=document_splitter(docs.doc, separators='paragraph'),
+    iterator=document_splitter(docs.doc, separators='token_limit', limit=300),
     if_exists='ignore'
 )
 
 embed_fn = sentence_transformer.using(model_id='intfloat/e5-large-v2')
-chunks.add_embedding_index('text', embedding=embed_fn)
+chunks.add_embedding_index('text', embedding=embed_fn, if_exists='ignore')
 
 docs.insert([{'doc': '/path/to/document.pdf'}])
 
@@ -198,8 +200,19 @@ print(results)
 - **Embedded PostgreSQL**: Pixeltable starts an embedded PostgreSQL process on first import. If port 5432 is already in use, set `PXT_HOME` to an alternate directory or configure a different port in `~/.pixeltable/config.toml`.
 - **Media storage**: Images, video, and audio files are copied to `~/.pixeltable/media/`. For large datasets, ensure sufficient disk space or configure `PXT_HOME` to point to a volume with more room.
 - **Computed column re-execution**: Changing a computed column expression re-processes all existing rows. For large tables, add computed columns before bulk inserts.
+- **`if_exists='ignore'` won't fix bugs**: If a computed column has wrong logic, `if_exists='ignore'` silently skips it. You must `t.drop_column('col')` then recreate.
 - **API keys**: Functions from `pixeltable.functions.openai`, `.anthropic`, etc. require the corresponding API keys set as environment variables.
 - **First import is slow**: The initial `import pixeltable` downloads and starts PostgreSQL (~10 seconds on first run, ~2 seconds thereafter).
+
+**Common mistakes — do NOT use these patterns:**
+
+| Wrong | Correct |
+|---|---|
+| `openai.vision(...)` | Does not exist. Use `openai.chat_completions(messages=[...])` with `image_url` blocks |
+| `from pixeltable.iterators import FrameIterator` | Deprecated. Use `from pixeltable.functions.video import frame_iterator` |
+| `t.col.similarity('query')` | Positional arg deprecated. Use `t.col.similarity(string='query')` |
+| `pxt.Table(...)` or `pxt.connect(...)` | Do not exist. Use `pxt.create_table(...)` and `pxt.get_table(...)` |
+| `for row in data: model.predict(row)` | Use computed columns instead — they auto-execute on insert |
 
 ## Verification
 

--- a/optional-skills/mlops/pixeltable/SKILL.md
+++ b/optional-skills/mlops/pixeltable/SKILL.md
@@ -256,6 +256,7 @@ print(results)
 | `openai.vision(...)` | Does not exist. Use `openai.chat_completions(messages=[...])` with `image_url` blocks |
 | `from pixeltable.iterators import FrameIterator` | Deprecated. Use `from pixeltable.functions.video import frame_iterator` |
 | `t.col.similarity('query')` | Positional arg deprecated. Use `t.col.similarity(string='query')` |
+| `t.col.select()` / `t.col.count()` / `.show()` / `.head()` | Removed in Pixeltable 0.6.8+. Use `t.select(t.col)...` and `t.count()`. (`t.col.count(pattern)` is the string UDF, not a row count.) |
 | `pxt.Table(...)` or `pxt.connect(...)` | Do not exist. Use `pxt.create_table(...)` and `pxt.get_table(...)` |
 | `for row in data: model.predict(row)` | Use computed columns instead — they auto-execute on insert |
 

--- a/optional-skills/mlops/pixeltable/SKILL.md
+++ b/optional-skills/mlops/pixeltable/SKILL.md
@@ -2,8 +2,9 @@
 name: pixeltable
 description: Multimodal data tables with auto-computed AI columns.
 version: 1.0.0
-author: Pixeltable (pixeltable.com)
+author: Pierre Brunelle (@pierrebrunelle), Pixeltable (pixeltable.com)
 license: Apache-2.0
+platforms: [linux, macos]
 prerequisites:
   commands: [python3, pip]
 metadata:
@@ -13,7 +14,7 @@ metadata:
     requires_toolsets: [terminal]
 ---
 
-# Pixeltable
+# Pixeltable Skill
 
 Pixeltable is a Python library for multimodal data infrastructure. Tables store images, video, audio, and documents as native column types. Computed columns declare AI transformations (embedding, transcription, classification) that execute automatically when data is inserted. It is not a vector database — it is a declarative data layer that includes vector search.
 
@@ -33,7 +34,7 @@ Do NOT use for plain text vector search — `chroma`, `qdrant-vector-search`, or
 Install Pixeltable via `terminal`:
 
 ```bash
-pip install pixeltable
+python3 -m pip install pixeltable
 ```
 
 Verify the install:
@@ -165,13 +166,13 @@ print(results)
 
 - **Binary incompatibility warning**: If you see an error like `numpy.dtype size changed, may indicate binary incompatibility`, you need to downgrade numpy:
   ```bash
-  pip install 'numpy>=1.22.4,<2.3.0'
+  python3 -m pip install 'numpy>=1.22.4,<2.3.0'
   ```
 - **HEIF support error**: If `ModuleNotFoundError: No module named 'pillow_heif'`, install it:
   ```bash
-  pip install pillow-heif
+  python3 -m pip install pillow-heif
   ```
-- Always use the python/pip inside your venv: e.g., `.venv/bin/python3` and `.venv/bin/pip` for consistent environments.
+- Always use the same interpreter for install and import: e.g., `.venv/bin/python3 -m pip` then `.venv/bin/python3`.
 
 You can also use public web images for testing by inserting URLs instead of file paths.
 

--- a/optional-skills/mlops/pixeltable/SKILL.md
+++ b/optional-skills/mlops/pixeltable/SKILL.md
@@ -67,7 +67,22 @@ mcpServers:
 
 ## How to Run
 
-Run all Pixeltable operations via `terminal` using Python:
+Before running, verify the correct Python has Pixeltable installed:
+
+```bash
+python3 -c "import pixeltable as pxt; print(f'Pixeltable {pxt.__version__} ready')"
+```
+
+If this fails (ImportError, numpy incompatibility, or wrong version), find the right interpreter:
+
+```bash
+which python3
+pip show pixeltable
+```
+
+If Pixeltable is in a conda or virtualenv (e.g., `/opt/miniconda3/envs/pxt/bin/python3`), use the full path for all commands.
+
+Run Pixeltable operations via `terminal`:
 
 ```bash
 python3 -c "
@@ -106,35 +121,48 @@ Column types: `pxt.String`, `pxt.Int`, `pxt.Float`, `pxt.Bool`, `pxt.Timestamp`,
 
 ### 1. Image cross-modal search with CLIP (no API keys needed)
 
-Search images using natural language. This is runnable as-is -- uses public sample images.
+Search your own local images using natural language and CLIP. Tested patterns and pitfall notes included.
+
+#### To search your local images for a phrase (e.g., "a sunset over mountains"):
 
 ```python
 import pixeltable as pxt
 from pixeltable.functions.huggingface import clip
 
-pxt.create_dir('images', if_exists='ignore')
+# Adjust these as needed
+IMAGES_DIR = 'images'  # Directory to organize images
+TABLE_NAME = 'images.local_gallery'
 
-imgs = pxt.create_table('images.gallery', {'image': pxt.Image, 'label': pxt.String}, if_exists='replace')
+pxt.create_dir(IMAGES_DIR, if_exists='ignore')
+t = pxt.create_table(TABLE_NAME, {'image': pxt.Image}, if_exists='ignore')
 
-# CLIP embeds images AND text into the same vector space
+# (Optional) Insert images if table is empty:
+# t.insert([{'image': '/absolute/path/to/your/image1.jpg'}, ...])
+
 embed_fn = clip.using(model_id='openai/clip-vit-base-patch32')
-imgs.add_embedding_index('image', embedding=embed_fn, if_exists='ignore')
+t.add_embedding_index('image', embedding=embed_fn, if_exists='ignore')
 
-# Insert real sample images (COCO dataset hosted on GitHub)
-base = 'https://raw.githubusercontent.com/pixeltable/pixeltable/release/docs/resources/images'
-imgs.insert([
-    {'image': f'{base}/000000000030.jpg', 'label': 'outdoor scene'},
-    {'image': f'{base}/000000000034.jpg', 'label': 'people'},
-    {'image': f'{base}/000000000042.jpg', 'label': 'animals'},
-    {'image': f'{base}/000000000049.jpg', 'label': 'food'},
-    {'image': f'{base}/000000000057.jpg', 'label': 'sports'},
-])
-
-# Cross-modal search: text query finds matching images
-sim = imgs.image.similarity(string='a dog playing outside')
-results = imgs.order_by(sim, asc=False).limit(3).select(imgs.label, sim).collect()
+# Cross-modal search: 
+t_query = 'a sunset over mountains'
+sim = t.image.similarity(string=t_query)
+results = t.order_by(sim, asc=False).limit(5).select(t.image, sim).collect()
+print(f"Top matches for: '{t_query}'")
 print(results)
 ```
+
+- **Binary incompatibility warning**: If you see an error like `numpy.dtype size changed, may indicate binary incompatibility`, you need to downgrade numpy:
+  ```bash
+  pip install 'numpy>=1.22.4,<2.3.0'
+  ```
+- **HEIF support error**: If `ModuleNotFoundError: No module named 'pillow_heif'`, install it:
+  ```bash
+  pip install pillow-heif
+  ```
+- Always use the python/pip inside your venv: e.g., `.venv/bin/python3` and `.venv/bin/pip` for consistent environments.
+
+You can also use public web images for testing by inserting URLs instead of file paths.
+
+---
 
 ### 2. Video analysis pipeline (requires OPENAI_API_KEY)
 
@@ -203,6 +231,7 @@ print(results)
 - **`if_exists='ignore'` won't fix bugs**: If a computed column has wrong logic, `if_exists='ignore'` silently skips it. You must `t.drop_column('col')` then recreate.
 - **API keys**: Functions from `pixeltable.functions.openai`, `.anthropic`, etc. require the corresponding API keys set as environment variables.
 - **First import is slow**: The initial `import pixeltable` downloads and starts PostgreSQL (~10 seconds on first run, ~2 seconds thereafter).
+- **Wrong Python interpreter**: If `python3` resolves to a system or virtualenv Python without Pixeltable, commands will fail. Run `python3 -c "import pixeltable"` first. If it fails, use the full path to the correct interpreter (e.g., `/opt/miniconda3/envs/pxt/bin/python3`) for all subsequent commands.
 
 **Common mistakes — do NOT use these patterns:**
 

--- a/optional-skills/mlops/pixeltable/SKILL.md
+++ b/optional-skills/mlops/pixeltable/SKILL.md
@@ -47,7 +47,7 @@ Pixeltable auto-starts an embedded PostgreSQL instance on first import. No exter
 **Optional — MCP server for native tool access:**
 
 ```bash
-pip install mcp-server-pixeltable-developer
+uvx mcp-server-pixeltable-developer
 ```
 
 Then add to `~/.hermes/config.yaml`:
@@ -90,7 +90,7 @@ For multi-step workflows, write a Python script with `write_file` and execute wi
 | Insert rows | `t.insert([{'text': 'hello', 'img': 'path/to/img.jpg'}])` |
 | Add computed column | `t.add_computed_column(emb=embed_fn(t.text))` |
 | Add embedding index | `t.add_embedding_index('text', embedding=embed_fn)` |
-| Similarity search | `t.order_by(t.text.similarity('query'), asc=False).limit(5).collect()` |
+| Similarity search | `t.order_by(t.text.similarity(string='query'), asc=False).limit(5).collect()` |
 | Create view | `pxt.create_view('mydir.chunks', t, iterator=document_splitter(t.doc, separators='paragraph'))` |
 | Query with filter | `t.where(t.category == 'science').select(t.text, t.score).collect()` |
 | Drop table | `pxt.drop_table('mydir.t')` |
@@ -98,36 +98,43 @@ For multi-step workflows, write a Python script with `write_file` and execute wi
 
 Column types: `pxt.String`, `pxt.Int`, `pxt.Float`, `pxt.Bool`, `pxt.Timestamp`, `pxt.Json`, `pxt.Array`, `pxt.Image`, `pxt.Video`, `pxt.Audio`, `pxt.Document`.
 
+**ResultSet**: `.collect()` returns a `ResultSet`. Print it directly with `print(results)` for a table view. Iterate with `for row in results: print(row)` (each row is a dict). Do NOT use `.iterrows()`, `.to_string()`, or index with `results[i][1]`.
+
 ## Procedure
 
-### 1. Document RAG pipeline
+### 1. Image cross-modal search with CLIP (no API keys needed)
+
+Search images using natural language. This is runnable as-is -- uses public sample images.
 
 ```python
 import pixeltable as pxt
-from pixeltable.functions.document import document_splitter
-from pixeltable.functions.huggingface import sentence_transformer
+from pixeltable.functions.huggingface import clip
 
-pxt.create_dir('rag', if_exists='ignore')
+pxt.create_dir('images', if_exists='ignore')
 
-docs = pxt.create_table('rag.docs', {'doc': pxt.Document}, if_exists='ignore')
+imgs = pxt.create_table('images.gallery', {'image': pxt.Image, 'label': pxt.String}, if_exists='replace')
 
-chunks = pxt.create_view(
-    'rag.chunks', docs,
-    iterator=document_splitter(docs.doc, separators='paragraph'),
-    if_exists='ignore'
-)
+# CLIP embeds images AND text into the same vector space
+embed_fn = clip.using(model_id='openai/clip-vit-base-patch32')
+imgs.add_embedding_index('image', embedding=embed_fn)
 
-embed_fn = sentence_transformer.using(model_id='intfloat/e5-large-v2')
-chunks.add_embedding_index('text', embedding=embed_fn, if_not_exists=True)
+# Insert real sample images (COCO dataset hosted on GitHub)
+base = 'https://raw.githubusercontent.com/pixeltable/pixeltable/release/docs/resources/images'
+imgs.insert([
+    {'image': f'{base}/000000000030.jpg', 'label': 'outdoor scene'},
+    {'image': f'{base}/000000000034.jpg', 'label': 'people'},
+    {'image': f'{base}/000000000042.jpg', 'label': 'animals'},
+    {'image': f'{base}/000000000049.jpg', 'label': 'food'},
+    {'image': f'{base}/000000000057.jpg', 'label': 'sports'},
+])
 
-docs.insert([{'doc': '/path/to/document.pdf'}])
-
-sim = chunks.text.similarity('What is the main conclusion?')
-results = chunks.order_by(sim, asc=False).limit(5).select(chunks.text, sim).collect()
+# Cross-modal search: text query finds matching images
+sim = imgs.image.similarity(string='a dog playing outside')
+results = imgs.order_by(sim, asc=False).limit(3).select(imgs.label, sim).collect()
 print(results)
 ```
 
-### 2. Video analysis pipeline
+### 2. Video analysis pipeline (requires OPENAI_API_KEY)
 
 ```python
 import pixeltable as pxt
@@ -159,23 +166,30 @@ videos.insert([{'video': '/path/to/video.mp4'}])
 print(frames.select(frames.frame, frames.caption).limit(5).collect())
 ```
 
-### 3. Image similarity search
+### 3. Document RAG pipeline
 
 ```python
 import pixeltable as pxt
-from pixeltable.functions.huggingface import clip
+from pixeltable.functions.document import document_splitter
+from pixeltable.functions.huggingface import sentence_transformer
 
-pxt.create_dir('images', if_exists='ignore')
+pxt.create_dir('rag', if_exists='ignore')
 
-imgs = pxt.create_table('images.gallery', {'image': pxt.Image}, if_exists='ignore')
+docs = pxt.create_table('rag.docs', {'doc': pxt.Document}, if_exists='ignore')
 
-embed_fn = clip.using(model_id='openai/clip-vit-base-patch32')
-imgs.add_embedding_index('image', embedding=embed_fn, if_not_exists=True)
+chunks = pxt.create_view(
+    'rag.chunks', docs,
+    iterator=document_splitter(docs.doc, separators='paragraph'),
+    if_exists='ignore'
+)
 
-imgs.insert([{'image': '/path/to/photo.jpg'}])
+embed_fn = sentence_transformer.using(model_id='intfloat/e5-large-v2')
+chunks.add_embedding_index('text', embedding=embed_fn)
 
-sim = imgs.image.similarity('a sunset over the ocean')
-results = imgs.order_by(sim, asc=False).limit(5).select(imgs.image, sim).collect()
+docs.insert([{'doc': '/path/to/document.pdf'}])
+
+sim = chunks.text.similarity(string='What is the main conclusion?')
+results = chunks.order_by(sim, asc=False).limit(5).select(chunks.text, sim).collect()
 print(results)
 ```
 

--- a/optional-skills/mlops/pixeltable/SKILL.md
+++ b/optional-skills/mlops/pixeltable/SKILL.md
@@ -44,21 +44,6 @@ python3 -c "import pixeltable as pxt; print(f'Pixeltable {pxt.__version__} ready
 
 Pixeltable auto-starts an embedded PostgreSQL instance on first import. No external database setup is needed.
 
-**Optional — MCP server for native tool access:**
-
-```bash
-uvx mcp-server-pixeltable-developer
-```
-
-Then add to `~/.hermes/config.yaml`:
-
-```yaml
-mcpServers:
-  pixeltable:
-    command: uvx
-    args: [mcp-server-pixeltable-developer]
-```
-
 **Optional — AI provider keys** (set in `~/.hermes/.env`):
 
 - `OPENAI_API_KEY` — for OpenAI embeddings, chat completions
@@ -81,6 +66,12 @@ pip show pixeltable
 ```
 
 If Pixeltable is in a conda or virtualenv (e.g., `/opt/miniconda3/envs/pxt/bin/python3`), use the full path for all commands.
+
+**Always check existing state first** before creating tables:
+
+```bash
+python3 -c "import pixeltable as pxt; print(pxt.list_tables())"
+```
 
 Run Pixeltable operations via `terminal`:
 
@@ -112,12 +103,34 @@ For multi-step workflows, write a Python script with `write_file` and execute wi
 | Define a query function | `@pxt.query` decorator — returns a query expression, no `.collect()` inside |
 | Drop table | `pxt.drop_table('mydir.t')` |
 | List tables | `pxt.list_tables()` |
+| Get existing table | `t = pxt.get_table('mydir.t')` |
+| Row count | `t.count()` |
 
 Column types: `pxt.String`, `pxt.Int`, `pxt.Float`, `pxt.Bool`, `pxt.Timestamp`, `pxt.Json`, `pxt.Array`, `pxt.Image`, `pxt.Video`, `pxt.Audio`, `pxt.Document`.
 
 **ResultSet**: `.collect()` returns a `ResultSet`. Print it directly with `print(results)` for a table view. Iterate with `for row in results: print(row)` (each row is a dict). Do NOT use `.iterrows()`, `.to_string()`, or index with `results[i][1]`.
 
 ## Procedure
+
+### 0. Discover existing tables (always run first)
+
+Before creating anything, check what already exists:
+
+```python
+import pixeltable as pxt
+tables = pxt.list_tables()
+print(tables)
+```
+
+If the table you need already exists, reuse it:
+
+```python
+t = pxt.get_table('images.local_gallery')
+print(t.count())
+print(t.select(t.image).limit(3).collect())
+```
+
+Only create new tables if `list_tables()` shows nothing relevant. Use `if_exists='ignore'` so re-runs are safe.
 
 ### 1. Image cross-modal search with CLIP (no API keys needed)
 
@@ -232,6 +245,8 @@ print(results)
 - **API keys**: Functions from `pixeltable.functions.openai`, `.anthropic`, etc. require the corresponding API keys set as environment variables.
 - **First import is slow**: The initial `import pixeltable` downloads and starts PostgreSQL (~10 seconds on first run, ~2 seconds thereafter).
 - **Wrong Python interpreter**: If `python3` resolves to a system or virtualenv Python without Pixeltable, commands will fail. Run `python3 -c "import pixeltable"` first. If it fails, use the full path to the correct interpreter (e.g., `/opt/miniconda3/envs/pxt/bin/python3`) for all subsequent commands.
+
+- **Rebuilding existing tables**: Always call `pxt.list_tables()` before creating. Use `pxt.get_table('name')` to reuse existing tables. Never use `if_exists='replace'` unless the user explicitly asks to start fresh — it destroys all data and computed columns.
 
 **Common mistakes — do NOT use these patterns:**
 

--- a/optional-skills/mlops/pixeltable/SKILL.md
+++ b/optional-skills/mlops/pixeltable/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: pixeltable
+description: Multimodal data tables with auto-computed AI columns.
+version: 1.0.0
+author: Pixeltable (pixeltable.com)
+license: Apache-2.0
+prerequisites:
+  commands: [python3, pip]
+metadata:
+  hermes:
+    tags: [mlops, multimodal, rag, vector-search, data-pipeline]
+    related_skills: [chroma, qdrant-vector-search, qmd]
+    requires_toolsets: [terminal]
+---
+
+# Pixeltable
+
+Pixeltable is a Python library for multimodal data infrastructure. Tables store images, video, audio, and documents as native column types. Computed columns declare AI transformations (embedding, transcription, classification) that execute automatically when data is inserted. It is not a vector database — it is a declarative data layer that includes vector search.
+
+## When to Use
+
+- User wants to process video frames, audio segments, images, or documents through AI models
+- User needs a RAG pipeline over multimodal content (not just text)
+- User wants computed columns that auto-run embeddings, transcriptions, or LLM calls on insert
+- User needs similarity search across images, text, or audio
+- User wants to chain multiple AI transformations declaratively (e.g., video → frames → captions → embeddings)
+- User asks about incremental data pipelines that skip already-processed rows
+
+Do NOT use for plain text vector search — `chroma`, `qdrant-vector-search`, or `qmd` are simpler for that.
+
+## Prerequisites
+
+Install Pixeltable via `terminal`:
+
+```bash
+pip install pixeltable
+```
+
+Verify the install:
+
+```bash
+python3 -c "import pixeltable as pxt; print(f'Pixeltable {pxt.__version__} ready')"
+```
+
+Pixeltable auto-starts an embedded PostgreSQL instance on first import. No external database setup is needed.
+
+**Optional — MCP server for native tool access:**
+
+```bash
+pip install mcp-server-pixeltable-developer
+```
+
+Then add to `~/.hermes/config.yaml`:
+
+```yaml
+mcpServers:
+  pixeltable:
+    command: uvx
+    args: [mcp-server-pixeltable-developer]
+```
+
+**Optional — AI provider keys** (set in `~/.hermes/.env`):
+
+- `OPENAI_API_KEY` — for OpenAI embeddings, chat completions
+- `ANTHROPIC_API_KEY` — for Claude models
+- `TOGETHER_API_KEY` — for open-source models via Together
+
+## How to Run
+
+Run all Pixeltable operations via `terminal` using Python:
+
+```bash
+python3 -c "
+import pixeltable as pxt
+pxt.create_dir('demo', if_exists='ignore')
+t = pxt.create_table('demo.docs', {'text': pxt.String}, if_exists='ignore')
+t.insert([{'text': 'hello world'}])
+print(t.collect())
+"
+```
+
+For multi-step workflows, write a Python script with `write_file` and execute with `terminal`.
+
+## Quick Reference
+
+| Operation | Code |
+|---|---|
+| Create directory | `pxt.create_dir('mydir', if_exists='ignore')` |
+| Create table | `pxt.create_table('mydir.t', {'text': pxt.String, 'img': pxt.Image})` |
+| Insert rows | `t.insert([{'text': 'hello', 'img': 'path/to/img.jpg'}])` |
+| Add computed column | `t.add_computed_column(emb=embed_fn(t.text))` |
+| Add embedding index | `t.add_embedding_index('text', embedding=embed_fn)` |
+| Similarity search | `t.order_by(t.text.similarity('query'), asc=False).limit(5).collect()` |
+| Create view | `pxt.create_view('mydir.chunks', t, iterator=document_splitter(t.doc, separators='paragraph'))` |
+| Query with filter | `t.where(t.category == 'science').select(t.text, t.score).collect()` |
+| Drop table | `pxt.drop_table('mydir.t')` |
+| List tables | `pxt.list_tables()` |
+
+Column types: `pxt.String`, `pxt.Int`, `pxt.Float`, `pxt.Bool`, `pxt.Timestamp`, `pxt.Json`, `pxt.Array`, `pxt.Image`, `pxt.Video`, `pxt.Audio`, `pxt.Document`.
+
+## Procedure
+
+### 1. Document RAG pipeline
+
+```python
+import pixeltable as pxt
+from pixeltable.functions.document import document_splitter
+from pixeltable.functions.huggingface import sentence_transformer
+
+pxt.create_dir('rag', if_exists='ignore')
+
+docs = pxt.create_table('rag.docs', {'doc': pxt.Document}, if_exists='ignore')
+
+chunks = pxt.create_view(
+    'rag.chunks', docs,
+    iterator=document_splitter(docs.doc, separators='paragraph'),
+    if_exists='ignore'
+)
+
+embed_fn = sentence_transformer.using(model_id='intfloat/e5-large-v2')
+chunks.add_embedding_index('text', embedding=embed_fn, if_not_exists=True)
+
+docs.insert([{'doc': '/path/to/document.pdf'}])
+
+sim = chunks.text.similarity('What is the main conclusion?')
+results = chunks.order_by(sim, asc=False).limit(5).select(chunks.text, sim).collect()
+print(results)
+```
+
+### 2. Video analysis pipeline
+
+```python
+import pixeltable as pxt
+from pixeltable.functions.video import frame_iterator
+from pixeltable.functions.openai import chat_completions
+
+pxt.create_dir('video', if_exists='ignore')
+
+videos = pxt.create_table('video.raw', {'video': pxt.Video}, if_exists='ignore')
+
+frames = pxt.create_view(
+    'video.frames', videos,
+    iterator=frame_iterator(videos.video, fps=1),
+    if_exists='ignore'
+)
+
+frames.add_computed_column(
+    caption=chat_completions(
+        messages=[{'role': 'user', 'content': [
+            {'type': 'image_url', 'image_url': {'url': frames.frame}},
+            {'type': 'text', 'text': 'Describe this frame in one sentence.'}
+        ]}],
+        model='gpt-4.1-mini'
+    ).choices[0].message.content,
+    if_exists='ignore'
+)
+
+videos.insert([{'video': '/path/to/video.mp4'}])
+print(frames.select(frames.frame, frames.caption).limit(5).collect())
+```
+
+### 3. Image similarity search
+
+```python
+import pixeltable as pxt
+from pixeltable.functions.huggingface import clip
+
+pxt.create_dir('images', if_exists='ignore')
+
+imgs = pxt.create_table('images.gallery', {'image': pxt.Image}, if_exists='ignore')
+
+embed_fn = clip.using(model_id='openai/clip-vit-base-patch32')
+imgs.add_embedding_index('image', embedding=embed_fn, if_not_exists=True)
+
+imgs.insert([{'image': '/path/to/photo.jpg'}])
+
+sim = imgs.image.similarity('a sunset over the ocean')
+results = imgs.order_by(sim, asc=False).limit(5).select(imgs.image, sim).collect()
+print(results)
+```
+
+## Pitfalls
+
+- **Embedded PostgreSQL**: Pixeltable starts an embedded PostgreSQL process on first import. If port 5432 is already in use, set `PXT_HOME` to an alternate directory or configure a different port in `~/.pixeltable/config.toml`.
+- **Media storage**: Images, video, and audio files are copied to `~/.pixeltable/media/`. For large datasets, ensure sufficient disk space or configure `PXT_HOME` to point to a volume with more room.
+- **Computed column re-execution**: Changing a computed column expression re-processes all existing rows. For large tables, add computed columns before bulk inserts.
+- **API keys**: Functions from `pixeltable.functions.openai`, `.anthropic`, etc. require the corresponding API keys set as environment variables.
+- **First import is slow**: The initial `import pixeltable` downloads and starts PostgreSQL (~10 seconds on first run, ~2 seconds thereafter).
+
+## Verification
+
+Run this single command to confirm Pixeltable is working:
+
+```bash
+python3 -c "
+import pixeltable as pxt
+pxt.create_dir('pxtverify', if_exists='ignore')
+t = pxt.create_table('pxtverify.test', {'text': pxt.String}, if_exists='replace')
+t.insert([{'text': 'hello'}, {'text': 'world'}])
+assert len(t.collect()) == 2
+pxt.drop_table('pxtverify.test')
+pxt.drop_dir('pxtverify')
+print('Pixeltable verification passed')
+"
+```

--- a/optional-skills/mlops/pixeltable/references/mcp-integration.md
+++ b/optional-skills/mlops/pixeltable/references/mcp-integration.md
@@ -11,18 +11,10 @@ mcpServers:
     args: [mcp-server-pixeltable-developer]
 ```
 
-If `uvx` is not available, install with:
+If `uvx` is not available, install `uv` first:
 
 ```bash
-pip install mcp-server-pixeltable-developer
-```
-
-Then use:
-
-```yaml
-mcpServers:
-  pixeltable:
-    command: mcp-server-pixeltable-developer
+curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
 Optional environment variables:
@@ -84,15 +76,15 @@ After adding, restart Hermes. Tools appear under `native-mcp` with the `pixeltab
 |---|---|
 | `pixeltable_check_dependencies` | Check if packages needed for a function are installed |
 | `pixeltable_install_dependency` | Install a missing Python dependency |
-| `pixeltable_install_package` | Install an arbitrary pip package |
+| `install_package` | Install an arbitrary pip package |
 
 ### REPL and Introspection
 
 | Tool | What it does |
 |---|---|
-| `pixeltable_execute_python` | Run arbitrary Python in a persistent Pixeltable REPL |
-| `pixeltable_introspect_function` | Get signature and docs for a Pixeltable function |
-| `pixeltable_list_available_functions` | List all registered functions by module |
+| `execute_python` | Run arbitrary Python in a persistent Pixeltable REPL |
+| `introspect_function` | Get signature and docs for a Pixeltable function |
+| `list_available_functions` | List all registered functions by module |
 
 ### Configuration
 
@@ -106,12 +98,12 @@ After adding, restart Hermes. Tools appear under `native-mcp` with the `pixeltab
 
 | Tool | What it does |
 |---|---|
-| `pixeltable_display_in_browser` | Render table data in a browser canvas |
-| `pixeltable_log_bug` | Log a bug for the current session |
-| `pixeltable_log_missing_feature` | Log a feature request |
-| `pixeltable_log_success` | Log a successful operation |
-| `pixeltable_generate_bug_report` | Generate a structured bug report |
-| `pixeltable_get_session_summary` | Get a summary of the current session |
+| `display_in_browser` | Render table data in a browser canvas |
+| `log_bug` | Log a bug for the current session |
+| `log_missing_feature` | Log a feature request |
+| `log_success` | Log a successful operation |
+| `generate_bug_report` | Generate a structured bug report |
+| `get_session_summary` | Get a summary of the current session |
 
 ## Example: Using MCP Tools in Hermes
 

--- a/optional-skills/mlops/pixeltable/references/mcp-integration.md
+++ b/optional-skills/mlops/pixeltable/references/mcp-integration.md
@@ -2,13 +2,16 @@
 
 ## Hermes config.yaml Entry
 
-Add to `~/.hermes/config.yaml`:
+The MCP server is published from GitHub (not PyPI). Add to `~/.hermes/config.yaml`:
 
 ```yaml
 mcp_servers:
   pixeltable:
     command: uvx
-    args: [mcp-server-pixeltable-developer]
+    args:
+      - --from
+      - git+https://github.com/pixeltable/mcp-server-pixeltable-developer
+      - mcp-server-pixeltable-developer
 ```
 
 If `uvx` is not available, install `uv` first:
@@ -23,60 +26,69 @@ Optional environment variables:
 mcp_servers:
   pixeltable:
     command: uvx
-    args: [mcp-server-pixeltable-developer]
+    args:
+      - --from
+      - git+https://github.com/pixeltable/mcp-server-pixeltable-developer
+      - mcp-server-pixeltable-developer
     env:
       PIXELTABLE_HOME: /path/to/custom/home
       OPENAI_API_KEY: ${OPENAI_API_KEY}
 ```
 
-After adding, restart Hermes. Tools appear under `native-mcp` with the `mcp_pixeltable_` prefix
-(Hermes names MCP tools `mcp_<server>_<tool>`).
+After adding, restart Hermes. Hermes names MCP tools `mcp_<server>_<tool>`. With server key
+`pixeltable`, that means:
 
-## Tool Catalog (32 tools)
+- Catalog tools exposed by the server as `pixeltable_*` → `mcp_pixeltable_pixeltable_*`
+  (e.g. `mcp_pixeltable_pixeltable_create_table`)
+- Bare tools such as `execute_python` → `mcp_pixeltable_execute_python`
+
+Requires Pixeltable ≥ 0.6.3 (uvx resolves current latest, including 0.6.8+).
+
+## Tool Catalog (35 tools)
 
 ### Table Operations
 
 | Tool | What it does |
 |---|---|
-| `mcp_pixeltable_create_table` | Create a table with typed columns |
-| `mcp_pixeltable_drop_table` | Delete a table and its data |
-| `mcp_pixeltable_create_view` | Create a view with an iterator (e.g., DocumentSplitter, FrameIterator) |
-| `mcp_pixeltable_create_snapshot` | Create an immutable snapshot of a table |
+| `mcp_pixeltable_pixeltable_create_table` | Create a table with typed columns |
+| `mcp_pixeltable_pixeltable_drop_table` | Delete a table and its data |
+| `mcp_pixeltable_pixeltable_create_view` | Create a view with an iterator (e.g., DocumentSplitter, FrameIterator) |
+| `mcp_pixeltable_pixeltable_create_snapshot` | Create an immutable snapshot of a table |
 
 ### Data Operations
 
 | Tool | What it does |
 |---|---|
-| `mcp_pixeltable_insert_data` | Insert rows into a table |
-| `mcp_pixeltable_query_table` | Query a table with optional filters |
-| `mcp_pixeltable_query` | Run a general query expression |
-| `mcp_pixeltable_create_replica` | Replicate a table from a shared source |
+| `mcp_pixeltable_pixeltable_insert_data` | Insert rows into a table |
+| `mcp_pixeltable_pixeltable_query_table` | Query a table with optional filters |
+| `mcp_pixeltable_pixeltable_query` | Run a general query expression |
+| `mcp_pixeltable_pixeltable_create_replica` | Replicate a table from a shared source |
+| `mcp_pixeltable_pixeltable_add_computed_column` | Add a column that auto-computes on insert |
 
-### Column Operations
+### Column / Type Helpers
 
 | Tool | What it does |
 |---|---|
-| `mcp_pixeltable_add_computed_column` | Add a column that auto-computes on insert |
-| `mcp_pixeltable_create_udf` | Create a user-defined function |
-| `mcp_pixeltable_create_array` | Create an array value for array-typed columns |
-| `mcp_pixeltable_create_type` | Create a column type (Image, Video, Audio, etc.) |
-| `mcp_pixeltable_create_tools` | Register LLM tool-calling functions |
-| `mcp_pixeltable_connect_mcp` | Import tools from another MCP server |
+| `mcp_pixeltable_pixeltable_create_udf` | Create a user-defined function |
+| `mcp_pixeltable_pixeltable_create_array` | Create an array value for array-typed columns |
+| `mcp_pixeltable_pixeltable_create_type` | Create a column type (Image, Video, Audio, etc.) |
+| `mcp_pixeltable_pixeltable_create_tools` | Register LLM tool-calling functions |
+| `mcp_pixeltable_pixeltable_connect_mcp` | Import tools from another MCP server |
 
 ### Directory Operations
 
 | Tool | What it does |
 |---|---|
-| `mcp_pixeltable_create_dir` | Create a namespace directory |
-| `mcp_pixeltable_drop_dir` | Delete a directory and its contents |
-| `mcp_pixeltable_move` | Move/rename a table or directory |
+| `mcp_pixeltable_pixeltable_create_dir` | Create a namespace directory |
+| `mcp_pixeltable_pixeltable_drop_dir` | Delete a directory and its contents |
+| `mcp_pixeltable_pixeltable_move` | Move/rename a table or directory |
 
 ### Dependency Management
 
 | Tool | What it does |
 |---|---|
-| `mcp_pixeltable_check_dependencies` | Check if packages needed for a function are installed |
-| `mcp_pixeltable_install_dependency` | Install a missing Python dependency |
+| `mcp_pixeltable_pixeltable_check_dependencies` | Check if packages needed for a function are installed |
+| `mcp_pixeltable_pixeltable_install_dependency` | Install a missing Python dependency |
 | `mcp_pixeltable_install_package` | Install an arbitrary pip package |
 
 ### REPL and Introspection
@@ -91,9 +103,12 @@ After adding, restart Hermes. Tools appear under `native-mcp` with the `mcp_pixe
 
 | Tool | What it does |
 |---|---|
-| `mcp_pixeltable_configure_logging` | Set logging verbosity |
-| `mcp_pixeltable_set_datastore` | Configure the backing datastore |
-| `mcp_pixeltable_search_docs` | Search Pixeltable documentation |
+| `mcp_pixeltable_pixeltable_configure_logging` | Set logging verbosity |
+| `mcp_pixeltable_pixeltable_set_datastore` | Configure the backing datastore |
+| `mcp_pixeltable_pixeltable_search_docs` | Search Pixeltable documentation |
+| `mcp_pixeltable_pixeltable_init` | Recovery helper for circular env init |
+| `mcp_pixeltable_pixeltable_scaffold_project` | Scaffold a Pixeltable project |
+| `mcp_pixeltable_pixeltable_list_project_templates` | List project templates |
 
 ### Display and Logging
 
@@ -113,22 +128,22 @@ Once configured, the agent can call tools directly via `native-mcp`:
 ```
 User: Create a table for my research papers with title, abstract, and PDF columns
 
-Agent uses: mcp_pixeltable_create_dir(path="research")
-Agent uses: mcp_pixeltable_create_table(
+Agent uses: mcp_pixeltable_pixeltable_create_dir(path="research")
+Agent uses: mcp_pixeltable_pixeltable_create_table(
     path="research.papers",
     schema={"title": "String", "abstract": "String", "pdf": "Document"}
 )
 
 User: Add my paper about transformers
 
-Agent uses: mcp_pixeltable_insert_data(
+Agent uses: mcp_pixeltable_pixeltable_insert_data(
     table_path="research.papers",
     data=[{"title": "Attention Is All You Need", "abstract": "...", "pdf": "/path/to/paper.pdf"}]
 )
 
 User: Search for papers about attention mechanisms
 
-Agent uses: mcp_pixeltable_query_table(
+Agent uses: mcp_pixeltable_pixeltable_query_table(
     table_path="research.papers",
     filter="title.contains('attention')"
 )

--- a/optional-skills/mlops/pixeltable/references/mcp-integration.md
+++ b/optional-skills/mlops/pixeltable/references/mcp-integration.md
@@ -5,7 +5,7 @@
 Add to `~/.hermes/config.yaml`:
 
 ```yaml
-mcpServers:
+mcp_servers:
   pixeltable:
     command: uvx
     args: [mcp-server-pixeltable-developer]
@@ -20,7 +20,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 Optional environment variables:
 
 ```yaml
-mcpServers:
+mcp_servers:
   pixeltable:
     command: uvx
     args: [mcp-server-pixeltable-developer]
@@ -29,7 +29,8 @@ mcpServers:
       OPENAI_API_KEY: ${OPENAI_API_KEY}
 ```
 
-After adding, restart Hermes. Tools appear under `native-mcp` with the `pixeltable_` prefix.
+After adding, restart Hermes. Tools appear under `native-mcp` with the `mcp_pixeltable_` prefix
+(Hermes names MCP tools `mcp_<server>_<tool>`).
 
 ## Tool Catalog (32 tools)
 
@@ -37,73 +38,73 @@ After adding, restart Hermes. Tools appear under `native-mcp` with the `pixeltab
 
 | Tool | What it does |
 |---|---|
-| `pixeltable_create_table` | Create a table with typed columns |
-| `pixeltable_drop_table` | Delete a table and its data |
-| `pixeltable_create_view` | Create a view with an iterator (e.g., DocumentSplitter, FrameIterator) |
-| `pixeltable_create_snapshot` | Create an immutable snapshot of a table |
+| `mcp_pixeltable_create_table` | Create a table with typed columns |
+| `mcp_pixeltable_drop_table` | Delete a table and its data |
+| `mcp_pixeltable_create_view` | Create a view with an iterator (e.g., DocumentSplitter, FrameIterator) |
+| `mcp_pixeltable_create_snapshot` | Create an immutable snapshot of a table |
 
 ### Data Operations
 
 | Tool | What it does |
 |---|---|
-| `pixeltable_insert_data` | Insert rows into a table |
-| `pixeltable_query_table` | Query a table with optional filters |
-| `pixeltable_query` | Run a general query expression |
-| `pixeltable_create_replica` | Replicate a table from a shared source |
+| `mcp_pixeltable_insert_data` | Insert rows into a table |
+| `mcp_pixeltable_query_table` | Query a table with optional filters |
+| `mcp_pixeltable_query` | Run a general query expression |
+| `mcp_pixeltable_create_replica` | Replicate a table from a shared source |
 
 ### Column Operations
 
 | Tool | What it does |
 |---|---|
-| `pixeltable_add_computed_column` | Add a column that auto-computes on insert |
-| `pixeltable_create_udf` | Create a user-defined function |
-| `pixeltable_create_array` | Create an array value for array-typed columns |
-| `pixeltable_create_type` | Create a column type (Image, Video, Audio, etc.) |
-| `pixeltable_create_tools` | Register LLM tool-calling functions |
-| `pixeltable_connect_mcp` | Import tools from another MCP server |
+| `mcp_pixeltable_add_computed_column` | Add a column that auto-computes on insert |
+| `mcp_pixeltable_create_udf` | Create a user-defined function |
+| `mcp_pixeltable_create_array` | Create an array value for array-typed columns |
+| `mcp_pixeltable_create_type` | Create a column type (Image, Video, Audio, etc.) |
+| `mcp_pixeltable_create_tools` | Register LLM tool-calling functions |
+| `mcp_pixeltable_connect_mcp` | Import tools from another MCP server |
 
 ### Directory Operations
 
 | Tool | What it does |
 |---|---|
-| `pixeltable_create_dir` | Create a namespace directory |
-| `pixeltable_drop_dir` | Delete a directory and its contents |
-| `pixeltable_move` | Move/rename a table or directory |
+| `mcp_pixeltable_create_dir` | Create a namespace directory |
+| `mcp_pixeltable_drop_dir` | Delete a directory and its contents |
+| `mcp_pixeltable_move` | Move/rename a table or directory |
 
 ### Dependency Management
 
 | Tool | What it does |
 |---|---|
-| `pixeltable_check_dependencies` | Check if packages needed for a function are installed |
-| `pixeltable_install_dependency` | Install a missing Python dependency |
-| `install_package` | Install an arbitrary pip package |
+| `mcp_pixeltable_check_dependencies` | Check if packages needed for a function are installed |
+| `mcp_pixeltable_install_dependency` | Install a missing Python dependency |
+| `mcp_pixeltable_install_package` | Install an arbitrary pip package |
 
 ### REPL and Introspection
 
 | Tool | What it does |
 |---|---|
-| `execute_python` | Run arbitrary Python in a persistent Pixeltable REPL |
-| `introspect_function` | Get signature and docs for a Pixeltable function |
-| `list_available_functions` | List all registered functions by module |
+| `mcp_pixeltable_execute_python` | Run arbitrary Python in a persistent Pixeltable REPL |
+| `mcp_pixeltable_introspect_function` | Get signature and docs for a Pixeltable function |
+| `mcp_pixeltable_list_available_functions` | List all registered functions by module |
 
 ### Configuration
 
 | Tool | What it does |
 |---|---|
-| `pixeltable_configure_logging` | Set logging verbosity |
-| `pixeltable_set_datastore` | Configure the backing datastore |
-| `pixeltable_search_docs` | Search Pixeltable documentation |
+| `mcp_pixeltable_configure_logging` | Set logging verbosity |
+| `mcp_pixeltable_set_datastore` | Configure the backing datastore |
+| `mcp_pixeltable_search_docs` | Search Pixeltable documentation |
 
 ### Display and Logging
 
 | Tool | What it does |
 |---|---|
-| `display_in_browser` | Render table data in a browser canvas |
-| `log_bug` | Log a bug for the current session |
-| `log_missing_feature` | Log a feature request |
-| `log_success` | Log a successful operation |
-| `generate_bug_report` | Generate a structured bug report |
-| `get_session_summary` | Get a summary of the current session |
+| `mcp_pixeltable_display_in_browser` | Render table data in a browser canvas |
+| `mcp_pixeltable_log_bug` | Log a bug for the current session |
+| `mcp_pixeltable_log_missing_feature` | Log a feature request |
+| `mcp_pixeltable_log_success` | Log a successful operation |
+| `mcp_pixeltable_generate_bug_report` | Generate a structured bug report |
+| `mcp_pixeltable_get_session_summary` | Get a summary of the current session |
 
 ## Example: Using MCP Tools in Hermes
 
@@ -112,26 +113,26 @@ Once configured, the agent can call tools directly via `native-mcp`:
 ```
 User: Create a table for my research papers with title, abstract, and PDF columns
 
-Agent uses: pixeltable_create_dir(path="research")
-Agent uses: pixeltable_create_table(
+Agent uses: mcp_pixeltable_create_dir(path="research")
+Agent uses: mcp_pixeltable_create_table(
     path="research.papers",
     schema={"title": "String", "abstract": "String", "pdf": "Document"}
 )
 
 User: Add my paper about transformers
 
-Agent uses: pixeltable_insert_data(
+Agent uses: mcp_pixeltable_insert_data(
     table_path="research.papers",
     data=[{"title": "Attention Is All You Need", "abstract": "...", "pdf": "/path/to/paper.pdf"}]
 )
 
 User: Search for papers about attention mechanisms
 
-Agent uses: pixeltable_query_table(
+Agent uses: mcp_pixeltable_query_table(
     table_path="research.papers",
     filter="title.contains('attention')"
 )
 ```
 
-For operations not covered by MCP tools, use `pixeltable_execute_python` to run
+For operations not covered by MCP tools, use `mcp_pixeltable_execute_python` to run
 arbitrary Pixeltable Python code in the persistent REPL.

--- a/optional-skills/mlops/pixeltable/references/mcp-integration.md
+++ b/optional-skills/mlops/pixeltable/references/mcp-integration.md
@@ -1,0 +1,145 @@
+# Pixeltable MCP Integration for Hermes
+
+## Hermes config.yaml Entry
+
+Add to `~/.hermes/config.yaml`:
+
+```yaml
+mcpServers:
+  pixeltable:
+    command: uvx
+    args: [mcp-server-pixeltable-developer]
+```
+
+If `uvx` is not available, install with:
+
+```bash
+pip install mcp-server-pixeltable-developer
+```
+
+Then use:
+
+```yaml
+mcpServers:
+  pixeltable:
+    command: mcp-server-pixeltable-developer
+```
+
+Optional environment variables:
+
+```yaml
+mcpServers:
+  pixeltable:
+    command: uvx
+    args: [mcp-server-pixeltable-developer]
+    env:
+      PIXELTABLE_HOME: /path/to/custom/home
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+```
+
+After adding, restart Hermes. Tools appear under `native-mcp` with the `pixeltable_` prefix.
+
+## Tool Catalog (32 tools)
+
+### Table Operations
+
+| Tool | What it does |
+|---|---|
+| `pixeltable_create_table` | Create a table with typed columns |
+| `pixeltable_drop_table` | Delete a table and its data |
+| `pixeltable_create_view` | Create a view with an iterator (e.g., DocumentSplitter, FrameIterator) |
+| `pixeltable_create_snapshot` | Create an immutable snapshot of a table |
+
+### Data Operations
+
+| Tool | What it does |
+|---|---|
+| `pixeltable_insert_data` | Insert rows into a table |
+| `pixeltable_query_table` | Query a table with optional filters |
+| `pixeltable_query` | Run a general query expression |
+| `pixeltable_create_replica` | Replicate a table from a shared source |
+
+### Column Operations
+
+| Tool | What it does |
+|---|---|
+| `pixeltable_add_computed_column` | Add a column that auto-computes on insert |
+| `pixeltable_create_udf` | Create a user-defined function |
+| `pixeltable_create_array` | Create an array value for array-typed columns |
+| `pixeltable_create_type` | Create a column type (Image, Video, Audio, etc.) |
+| `pixeltable_create_tools` | Register LLM tool-calling functions |
+| `pixeltable_connect_mcp` | Import tools from another MCP server |
+
+### Directory Operations
+
+| Tool | What it does |
+|---|---|
+| `pixeltable_create_dir` | Create a namespace directory |
+| `pixeltable_drop_dir` | Delete a directory and its contents |
+| `pixeltable_move` | Move/rename a table or directory |
+
+### Dependency Management
+
+| Tool | What it does |
+|---|---|
+| `pixeltable_check_dependencies` | Check if packages needed for a function are installed |
+| `pixeltable_install_dependency` | Install a missing Python dependency |
+| `pixeltable_install_package` | Install an arbitrary pip package |
+
+### REPL and Introspection
+
+| Tool | What it does |
+|---|---|
+| `pixeltable_execute_python` | Run arbitrary Python in a persistent Pixeltable REPL |
+| `pixeltable_introspect_function` | Get signature and docs for a Pixeltable function |
+| `pixeltable_list_available_functions` | List all registered functions by module |
+
+### Configuration
+
+| Tool | What it does |
+|---|---|
+| `pixeltable_configure_logging` | Set logging verbosity |
+| `pixeltable_set_datastore` | Configure the backing datastore |
+| `pixeltable_search_docs` | Search Pixeltable documentation |
+
+### Display and Logging
+
+| Tool | What it does |
+|---|---|
+| `pixeltable_display_in_browser` | Render table data in a browser canvas |
+| `pixeltable_log_bug` | Log a bug for the current session |
+| `pixeltable_log_missing_feature` | Log a feature request |
+| `pixeltable_log_success` | Log a successful operation |
+| `pixeltable_generate_bug_report` | Generate a structured bug report |
+| `pixeltable_get_session_summary` | Get a summary of the current session |
+
+## Example: Using MCP Tools in Hermes
+
+Once configured, the agent can call tools directly via `native-mcp`:
+
+```
+User: Create a table for my research papers with title, abstract, and PDF columns
+
+Agent uses: pixeltable_create_dir(path="research")
+Agent uses: pixeltable_create_table(
+    path="research.papers",
+    schema={"title": "String", "abstract": "String", "pdf": "Document"}
+)
+
+User: Add my paper about transformers
+
+Agent uses: pixeltable_insert_data(
+    table_path="research.papers",
+    data=[{"title": "Attention Is All You Need", "abstract": "...", "pdf": "/path/to/paper.pdf"}]
+)
+
+User: Search for papers about attention mechanisms
+
+Agent uses: pixeltable_query_table(
+    table_path="research.papers",
+    filter="title.contains('attention')"
+)
+```
+
+For operations not covered by MCP tools, use `pixeltable_execute_python` to run
+arbitrary Pixeltable Python code in the persistent REPL.

--- a/optional-skills/mlops/pixeltable/references/multimodal-pipeline-examples.md
+++ b/optional-skills/mlops/pixeltable/references/multimodal-pipeline-examples.md
@@ -22,13 +22,13 @@ docs = pxt.create_table('rag.docs', {
 # Split into chunks
 chunks = pxt.create_view(
     'rag.chunks', docs,
-    iterator=document_splitter(docs.doc, separators='paragraph'),
+    iterator=document_splitter(docs.doc, separators='token_limit', limit=300),
     if_exists='ignore'
 )
 
 # Add embedding index for similarity search
 embed_fn = sentence_transformer.using(model_id='intfloat/e5-large-v2')
-chunks.add_embedding_index('text', embedding=embed_fn)
+chunks.add_embedding_index('text', embedding=embed_fn, if_exists='ignore')
 
 # Insert documents
 docs.insert([
@@ -105,7 +105,7 @@ imgs = pxt.create_table('images.gallery', {
 
 # Add CLIP embedding index for cross-modal search
 embed_fn = clip.using(model_id='openai/clip-vit-base-patch32')
-imgs.add_embedding_index('image', embedding=embed_fn)
+imgs.add_embedding_index('image', embedding=embed_fn, if_exists='ignore')
 
 # Insert images
 imgs.insert([
@@ -182,7 +182,7 @@ articles.add_computed_column(
 
 # Step 2: Embed the summary for search
 embed_fn = sentence_transformer.using(model_id='all-MiniLM-L6-v2')
-articles.add_embedding_index('summary', embedding=embed_fn)
+articles.add_embedding_index('summary', embedding=embed_fn, if_exists='ignore')
 
 # Insert triggers both summarization and embedding
 articles.insert([{

--- a/optional-skills/mlops/pixeltable/references/multimodal-pipeline-examples.md
+++ b/optional-skills/mlops/pixeltable/references/multimodal-pipeline-examples.md
@@ -1,0 +1,199 @@
+# Multimodal Pipeline Examples
+
+Copy-paste recipes for common Pixeltable workflows. Run each via `terminal`.
+
+## 1. Document RAG with Semantic Search
+
+Index PDFs and search by meaning.
+
+```python
+import pixeltable as pxt
+from pixeltable.functions.document import document_splitter
+from pixeltable.functions.huggingface import sentence_transformer
+
+pxt.create_dir('rag', if_exists='ignore')
+
+# Store documents
+docs = pxt.create_table('rag.docs', {
+    'doc': pxt.Document,
+    'source': pxt.String
+}, if_exists='ignore')
+
+# Split into chunks
+chunks = pxt.create_view(
+    'rag.chunks', docs,
+    iterator=document_splitter(docs.doc, separators='paragraph'),
+    if_exists='ignore'
+)
+
+# Add embedding index for similarity search
+embed_fn = sentence_transformer.using(model_id='intfloat/e5-large-v2')
+chunks.add_embedding_index('text', embedding=embed_fn, if_not_exists=True)
+
+# Insert documents
+docs.insert([
+    {'doc': '/path/to/paper.pdf', 'source': 'arxiv'},
+    {'doc': '/path/to/report.pdf', 'source': 'internal'}
+])
+
+# Search
+sim = chunks.text.similarity('What are the key findings?')
+results = chunks.order_by(sim, asc=False).limit(5).select(
+    chunks.text, sim, docs.source
+).collect()
+print(results)
+```
+
+## 2. Video Frame Analysis with LLM Captions
+
+Extract frames from video and caption each with GPT-4.
+
+```python
+import pixeltable as pxt
+from pixeltable.functions.video import frame_iterator
+from pixeltable.functions.openai import chat_completions
+
+pxt.create_dir('video', if_exists='ignore')
+
+# Store videos
+videos = pxt.create_table('video.raw', {
+    'video': pxt.Video,
+    'title': pxt.String
+}, if_exists='ignore')
+
+# Extract frames at 1 fps
+frames = pxt.create_view(
+    'video.frames', videos,
+    iterator=frame_iterator(videos.video, fps=1),
+    if_exists='ignore'
+)
+
+# Auto-caption every frame with GPT-4 Vision
+frames.add_computed_column(
+    caption=chat_completions(
+        messages=[{'role': 'user', 'content': [
+            {'type': 'image_url', 'image_url': {'url': frames.frame}},
+            {'type': 'text', 'text': 'Describe this frame in one sentence.'}
+        ]}],
+        model='gpt-4.1-mini'
+    ).choices[0].message.content,
+    if_exists='ignore'
+)
+
+# Insert a video -- frames are extracted and captioned automatically
+videos.insert([{'video': '/path/to/video.mp4', 'title': 'Demo'}])
+
+# Query captioned frames
+print(frames.select(frames.frame, frames.caption).limit(10).collect())
+```
+
+## 3. Image Similarity Search with CLIP
+
+Cross-modal search: find images using text queries.
+
+```python
+import pixeltable as pxt
+from pixeltable.functions.huggingface import clip
+
+pxt.create_dir('images', if_exists='ignore')
+
+# Store images with metadata
+imgs = pxt.create_table('images.gallery', {
+    'image': pxt.Image,
+    'tags': pxt.String
+}, if_exists='ignore')
+
+# Add CLIP embedding index for cross-modal search
+embed_fn = clip.using(model_id='openai/clip-vit-base-patch32')
+imgs.add_embedding_index('image', embedding=embed_fn, if_not_exists=True)
+
+# Insert images
+imgs.insert([
+    {'image': '/path/to/sunset.jpg', 'tags': 'nature'},
+    {'image': '/path/to/city.jpg', 'tags': 'urban'}
+])
+
+# Search images with a text query
+sim = imgs.image.similarity('a sunset over the ocean')
+results = imgs.order_by(sim, asc=False).limit(5).select(
+    imgs.image, imgs.tags, sim
+).collect()
+print(results)
+```
+
+## 4. Audio Transcription Pipeline
+
+Transcribe audio files and search transcripts.
+
+```python
+import pixeltable as pxt
+from pixeltable.functions.openai import transcriptions
+
+pxt.create_dir('audio', if_exists='ignore')
+
+recordings = pxt.create_table('audio.recordings', {
+    'audio': pxt.Audio,
+    'speaker': pxt.String
+}, if_exists='ignore')
+
+# Auto-transcribe every audio file with Whisper
+recordings.add_computed_column(
+    transcript=transcriptions(audio=recordings.audio, model='whisper-1').text,
+    if_exists='ignore'
+)
+
+recordings.insert([{'audio': '/path/to/meeting.mp3', 'speaker': 'Alice'}])
+
+# Query transcripts
+print(recordings.select(
+    recordings.speaker, recordings.transcript
+).collect())
+```
+
+## 5. Chained AI Pipeline (Multi-Step)
+
+Combine multiple AI operations in a single table.
+
+```python
+import pixeltable as pxt
+from pixeltable.functions.openai import chat_completions
+from pixeltable.functions.huggingface import sentence_transformer
+
+pxt.create_dir('pipeline', if_exists='ignore')
+
+articles = pxt.create_table('pipeline.articles', {
+    'title': pxt.String,
+    'body': pxt.String
+}, if_exists='ignore')
+
+# Step 1: Auto-summarize on insert
+articles.add_computed_column(
+    summary=chat_completions(
+        messages=[{
+            'role': 'user',
+            'content': pxt.functions.string.format(
+                'Summarize in 2 sentences:\n\n{body}', body=articles.body
+            )
+        }],
+        model='gpt-4.1-mini'
+    ).choices[0].message.content,
+    if_exists='ignore'
+)
+
+# Step 2: Embed the summary for search
+embed_fn = sentence_transformer.using(model_id='all-MiniLM-L6-v2')
+articles.add_embedding_index('summary', embedding=embed_fn, if_not_exists=True)
+
+# Insert triggers both summarization and embedding
+articles.insert([{
+    'title': 'Attention Is All You Need',
+    'body': 'We propose a new simple network architecture...'
+}])
+
+# Semantic search over summaries
+sim = articles.summary.similarity('transformer architecture for NLP')
+results = articles.order_by(sim, asc=False).limit(5).select(
+    articles.title, articles.summary, sim
+).collect()
+print(results)
+```

--- a/optional-skills/mlops/pixeltable/references/multimodal-pipeline-examples.md
+++ b/optional-skills/mlops/pixeltable/references/multimodal-pipeline-examples.md
@@ -28,7 +28,7 @@ chunks = pxt.create_view(
 
 # Add embedding index for similarity search
 embed_fn = sentence_transformer.using(model_id='intfloat/e5-large-v2')
-chunks.add_embedding_index('text', embedding=embed_fn, if_not_exists=True)
+chunks.add_embedding_index('text', embedding=embed_fn)
 
 # Insert documents
 docs.insert([
@@ -37,7 +37,7 @@ docs.insert([
 ])
 
 # Search
-sim = chunks.text.similarity('What are the key findings?')
+sim = chunks.text.similarity(string='What are the key findings?')
 results = chunks.order_by(sim, asc=False).limit(5).select(
     chunks.text, sim, docs.source
 ).collect()
@@ -105,7 +105,7 @@ imgs = pxt.create_table('images.gallery', {
 
 # Add CLIP embedding index for cross-modal search
 embed_fn = clip.using(model_id='openai/clip-vit-base-patch32')
-imgs.add_embedding_index('image', embedding=embed_fn, if_not_exists=True)
+imgs.add_embedding_index('image', embedding=embed_fn)
 
 # Insert images
 imgs.insert([
@@ -114,7 +114,7 @@ imgs.insert([
 ])
 
 # Search images with a text query
-sim = imgs.image.similarity('a sunset over the ocean')
+sim = imgs.image.similarity(string='a sunset over the ocean')
 results = imgs.order_by(sim, asc=False).limit(5).select(
     imgs.image, imgs.tags, sim
 ).collect()
@@ -182,7 +182,7 @@ articles.add_computed_column(
 
 # Step 2: Embed the summary for search
 embed_fn = sentence_transformer.using(model_id='all-MiniLM-L6-v2')
-articles.add_embedding_index('summary', embedding=embed_fn, if_not_exists=True)
+articles.add_embedding_index('summary', embedding=embed_fn)
 
 # Insert triggers both summarization and embedding
 articles.insert([{
@@ -191,7 +191,7 @@ articles.insert([{
 }])
 
 # Semantic search over summaries
-sim = articles.summary.similarity('transformer architecture for NLP')
+sim = articles.summary.similarity(string='transformer architecture for NLP')
 results = articles.order_by(sim, asc=False).limit(5).select(
     articles.title, articles.summary, sim
 ).collect()

--- a/optional-skills/mlops/pixeltable/scripts/setup.sh
+++ b/optional-skills/mlops/pixeltable/scripts/setup.sh
@@ -21,18 +21,16 @@ echo "--- Verifying import ---"
 python3 -c "import pixeltable as pxt; print(f'Pixeltable {pxt.__version__} ready')"
 
 echo ""
-echo "--- Installing MCP server (optional) ---"
-if pip install --quiet mcp-server-pixeltable-developer 2>/dev/null; then
-    echo "MCP server installed"
-    echo ""
-    echo "Add to ~/.hermes/config.yaml:"
+echo "--- Checking MCP server (optional) ---"
+if command -v uvx &>/dev/null; then
+    echo "uvx found. To enable MCP tools, add to ~/.hermes/config.yaml:"
     echo ""
     echo "  mcpServers:"
     echo "    pixeltable:"
     echo "      command: uvx"
     echo "      args: [mcp-server-pixeltable-developer]"
 else
-    echo "MCP server skipped (install manually: pip install mcp-server-pixeltable-developer)"
+    echo "uvx not found. Install uv (https://docs.astral.sh/uv/) for MCP server support."
 fi
 
 echo ""

--- a/optional-skills/mlops/pixeltable/scripts/setup.sh
+++ b/optional-skills/mlops/pixeltable/scripts/setup.sh
@@ -13,7 +13,7 @@ echo "Python: $PY_VERSION"
 
 echo ""
 echo "--- Installing Pixeltable ---"
-pip install --quiet pixeltable
+python3 -m pip install --quiet pixeltable
 echo "Installed pixeltable"
 
 echo ""
@@ -25,7 +25,7 @@ echo "--- Checking MCP server (optional) ---"
 if command -v uvx &>/dev/null; then
     echo "uvx found. To enable MCP tools, add to ~/.hermes/config.yaml:"
     echo ""
-    echo "  mcpServers:"
+    echo "  mcp_servers:"
     echo "    pixeltable:"
     echo "      command: uvx"
     echo "      args: [mcp-server-pixeltable-developer]"

--- a/optional-skills/mlops/pixeltable/scripts/setup.sh
+++ b/optional-skills/mlops/pixeltable/scripts/setup.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== Pixeltable Setup ==="
+
+if ! command -v python3 &>/dev/null; then
+    echo "ERROR: python3 not found. Install Python 3.10+ first."
+    exit 1
+fi
+
+PY_VERSION=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+echo "Python: $PY_VERSION"
+
+echo ""
+echo "--- Installing Pixeltable ---"
+pip install --quiet pixeltable
+echo "Installed pixeltable"
+
+echo ""
+echo "--- Verifying import ---"
+python3 -c "import pixeltable as pxt; print(f'Pixeltable {pxt.__version__} ready')"
+
+echo ""
+echo "--- Installing MCP server (optional) ---"
+if pip install --quiet mcp-server-pixeltable-developer 2>/dev/null; then
+    echo "MCP server installed"
+    echo ""
+    echo "Add to ~/.hermes/config.yaml:"
+    echo ""
+    echo "  mcpServers:"
+    echo "    pixeltable:"
+    echo "      command: uvx"
+    echo "      args: [mcp-server-pixeltable-developer]"
+else
+    echo "MCP server skipped (install manually: pip install mcp-server-pixeltable-developer)"
+fi
+
+echo ""
+echo "--- Running verification ---"
+python3 -c "
+import pixeltable as pxt
+pxt.create_dir('pxtverify', if_exists='ignore')
+t = pxt.create_table('pxtverify.test', {'text': pxt.String}, if_exists='replace')
+t.insert([{'text': 'hello'}, {'text': 'world'}])
+assert len(t.collect()) == 2
+pxt.drop_table('pxtverify.test')
+pxt.drop_dir('pxtverify')
+print('Verification passed')
+"
+
+echo ""
+echo "=== Setup complete ==="

--- a/optional-skills/mlops/pixeltable/scripts/setup.sh
+++ b/optional-skills/mlops/pixeltable/scripts/setup.sh
@@ -28,7 +28,10 @@ if command -v uvx &>/dev/null; then
     echo "  mcp_servers:"
     echo "    pixeltable:"
     echo "      command: uvx"
-    echo "      args: [mcp-server-pixeltable-developer]"
+    echo "      args:"
+    echo "        - --from"
+    echo "        - git+https://github.com/pixeltable/mcp-server-pixeltable-developer"
+    echo "        - mcp-server-pixeltable-developer"
 else
     echo "uvx not found. Install uv (https://docs.astral.sh/uv/) for MCP server support."
 fi

--- a/tests/skills/test_pixeltable_skill.py
+++ b/tests/skills/test_pixeltable_skill.py
@@ -147,3 +147,44 @@ class TestSupportFiles:
     def test_pipeline_reference_has_examples(self) -> None:
         text = PIPELINE_REF.read_text()
         assert 'import pixeltable' in text, 'Pipeline reference must contain runnable Python examples'
+
+
+class TestApiCorrectness:
+    """Verify the skill teaches correct, non-hallucinated Pixeltable API patterns."""
+
+    HALLUCINATED_PATTERNS = [
+        (r'openai\.vision\b', 'openai.vision does not exist'),
+        (r'from pixeltable\.iterators\s+import\s+FrameIterator', 'FrameIterator deprecated import'),
+        (r'pxt\.Table\s*\(', 'pxt.Table() does not exist'),
+        (r'pxt\.load_table\b', 'pxt.load_table does not exist'),
+        (r'pxt\.connect\b', 'pxt.connect does not exist'),
+        (r"if_not_exists\s*=", 'if_not_exists is not a valid kwarg; use if_exists'),
+    ]
+
+    def test_no_hallucinated_apis_in_skill(self, skill_text: str) -> None:
+        code_blocks = re.findall(r'```python\n(.*?)```', skill_text, re.DOTALL)
+        code_text = '\n'.join(code_blocks)
+        for pattern, msg in self.HALLUCINATED_PATTERNS:
+            assert not re.search(pattern, code_text), f'SKILL.md code contains hallucinated API: {msg}'
+
+    def test_no_hallucinated_apis_in_references(self) -> None:
+        text = PIPELINE_REF.read_text()
+        for pattern, msg in self.HALLUCINATED_PATTERNS:
+            assert not re.search(pattern, text), f'Pipeline examples contain hallucinated API: {msg}'
+
+    def test_similarity_uses_keyword_arg(self, skill_text: str) -> None:
+        code_blocks = re.findall(r'```python\n(.*?)```', skill_text, re.DOTALL)
+        code_text = '\n'.join(code_blocks)
+        positional = re.findall(r"\.similarity\(\s*'[^']+'\s*\)", code_text)
+        assert not positional, f'SKILL.md code uses positional similarity(): {positional}'
+
+    def test_similarity_uses_keyword_in_references(self) -> None:
+        text = PIPELINE_REF.read_text()
+        positional = re.findall(r"\.similarity\(\s*'[^']+'\s*\)", text)
+        assert not positional, f'Pipeline examples use positional similarity(): {positional}'
+
+    def test_idempotency_pattern_present(self, skill_text: str) -> None:
+        assert "if_exists='ignore'" in skill_text, 'SKILL.md must demonstrate if_exists=ignore pattern'
+
+    def test_collect_pattern_present(self, skill_text: str) -> None:
+        assert '.collect()' in skill_text, 'SKILL.md must show .collect() to terminate queries'

--- a/tests/skills/test_pixeltable_skill.py
+++ b/tests/skills/test_pixeltable_skill.py
@@ -1,0 +1,149 @@
+"""Tests for the Pixeltable optional skill (HARDLINE compliance)."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+SKILL_DIR = Path(__file__).resolve().parents[2] / 'optional-skills' / 'mlops' / 'pixeltable'
+SKILL_MD = SKILL_DIR / 'SKILL.md'
+SETUP_SH = SKILL_DIR / 'scripts' / 'setup.sh'
+MCP_REF = SKILL_DIR / 'references' / 'mcp-integration.md'
+PIPELINE_REF = SKILL_DIR / 'references' / 'multimodal-pipeline-examples.md'
+
+
+@pytest.fixture(scope='module')
+def skill_text() -> str:
+    return SKILL_MD.read_text()
+
+
+@pytest.fixture(scope='module')
+def frontmatter(skill_text: str) -> str:
+    parts = skill_text.split('---', 2)
+    assert len(parts) >= 3, 'SKILL.md must have YAML frontmatter delimited by ---'
+    return parts[1]
+
+
+@pytest.fixture(scope='module')
+def body(skill_text: str) -> str:
+    parts = skill_text.split('---', 2)
+    return parts[2]
+
+
+class TestFrontmatter:
+    def test_starts_with_delimiter(self, skill_text: str) -> None:
+        assert skill_text.startswith('---'), 'SKILL.md must start with --- at byte 0'
+
+    def test_name_field(self, frontmatter: str) -> None:
+        m = re.search(r'^name:\s*(.+)$', frontmatter, re.MULTILINE)
+        assert m, 'frontmatter must have a name field'
+        name = m.group(1).strip()
+        assert re.match(r'^[a-z][a-z0-9-]*$', name), f'name must be lowercase+hyphens: {name}'
+        assert len(name) <= 64, f'name must be <= 64 chars: {len(name)}'
+
+    def test_description_length(self, frontmatter: str) -> None:
+        m = re.search(r'^description:\s*(.+)$', frontmatter, re.MULTILINE)
+        assert m, 'frontmatter must have a description field'
+        desc = m.group(1).strip()
+        assert len(desc) <= 60, f'description must be <= 60 chars, got {len(desc)}: "{desc}"'
+
+    def test_description_ends_with_period(self, frontmatter: str) -> None:
+        m = re.search(r'^description:\s*(.+)$', frontmatter, re.MULTILINE)
+        desc = m.group(1).strip()
+        assert desc.endswith('.'), f'description must end with a period: "{desc}"'
+
+    def test_version_field(self, frontmatter: str) -> None:
+        assert re.search(r'^version:\s*\d+\.\d+\.\d+', frontmatter, re.MULTILINE), \
+            'frontmatter must have a semver version field'
+
+    def test_author_field(self, frontmatter: str) -> None:
+        assert re.search(r'^author:', frontmatter, re.MULTILINE), \
+            'frontmatter must have an author field'
+
+    def test_license_field(self, frontmatter: str) -> None:
+        assert re.search(r'^license:', frontmatter, re.MULTILINE), \
+            'frontmatter must have a license field'
+
+    def test_no_marketing_words(self, frontmatter: str) -> None:
+        marketing = ['powerful', 'comprehensive', 'seamless', 'advanced', 'revolutionary', 'cutting-edge']
+        desc_match = re.search(r'^description:\s*(.+)$', frontmatter, re.MULTILINE)
+        desc = desc_match.group(1).lower()
+        for word in marketing:
+            assert word not in desc, f'description contains marketing word: "{word}"'
+
+    def test_description_does_not_repeat_name(self, frontmatter: str) -> None:
+        name_match = re.search(r'^name:\s*(.+)$', frontmatter, re.MULTILINE)
+        desc_match = re.search(r'^description:\s*(.+)$', frontmatter, re.MULTILINE)
+        name = name_match.group(1).strip()
+        desc = desc_match.group(1).strip().lower()
+        assert name not in desc, f'description should not repeat the skill name "{name}"'
+
+
+class TestSectionStructure:
+    REQUIRED_SECTIONS = [
+        '## When to Use',
+        '## Prerequisites',
+        '## How to Run',
+        '## Quick Reference',
+        '## Procedure',
+        '## Pitfalls',
+        '## Verification',
+    ]
+
+    @pytest.mark.parametrize('section', REQUIRED_SECTIONS)
+    def test_has_required_section(self, body: str, section: str) -> None:
+        assert section in body, f'SKILL.md body missing required section: {section}'
+
+    def test_has_h1_title(self, body: str) -> None:
+        assert re.search(r'^# \w', body, re.MULTILINE), 'SKILL.md must have an H1 title'
+
+    def test_line_count_reasonable(self, skill_text: str) -> None:
+        lines = skill_text.strip().split('\n')
+        assert 80 <= len(lines) <= 400, f'SKILL.md should be 80-400 lines, got {len(lines)}'
+
+
+class TestToolReferences:
+    NATIVE_TOOLS = {
+        'terminal', 'web_extract', 'web_search', 'read_file', 'write_file',
+        'patch', 'search_files', 'vision_analyze', 'browser_navigate',
+        'delegate_task', 'image_generate', 'text_to_speech', 'cronjob',
+        'memory', 'skill_view', 'todo', 'execute_code', 'native-mcp',
+    }
+
+    FORBIDDEN_TOOL_NAMES = {
+        'grep', 'rg', 'cat', 'head', 'tail', 'sed', 'awk', 'find', 'ls',
+        'curl', 'echo',
+    }
+
+    def test_no_forbidden_tool_references(self, body: str) -> None:
+        for tool in self.FORBIDDEN_TOOL_NAMES:
+            pattern = rf'`{tool}`'
+            assert not re.search(pattern, body), \
+                f'SKILL.md references forbidden tool `{tool}` — use the Hermes-native equivalent'
+
+
+class TestSupportFiles:
+    def test_setup_script_exists(self) -> None:
+        assert SETUP_SH.exists(), 'scripts/setup.sh must exist'
+
+    def test_setup_script_is_shell(self) -> None:
+        text = SETUP_SH.read_text()
+        assert text.startswith('#!/'), 'setup.sh must have a shebang line'
+        assert 'set -' in text, 'setup.sh should use strict mode (set -e or similar)'
+
+    def test_mcp_reference_exists(self) -> None:
+        assert MCP_REF.exists(), 'references/mcp-integration.md must exist'
+
+    def test_pipeline_reference_exists(self) -> None:
+        assert PIPELINE_REF.exists(), 'references/multimodal-pipeline-examples.md must exist'
+
+    def test_mcp_reference_has_config(self) -> None:
+        text = MCP_REF.read_text()
+        assert 'mcpServers:' in text, 'MCP reference must contain config.yaml entry'
+        assert 'pixeltable' in text.lower(), 'MCP reference must mention pixeltable'
+
+    def test_pipeline_reference_has_examples(self) -> None:
+        text = PIPELINE_REF.read_text()
+        assert 'import pixeltable' in text, 'Pipeline reference must contain runnable Python examples'

--- a/tests/skills/test_pixeltable_skill.py
+++ b/tests/skills/test_pixeltable_skill.py
@@ -175,14 +175,25 @@ class TestSupportFiles:
         assert 'mcp_servers:' in text, 'MCP reference must contain mcp_servers: config.yaml entry'
         assert 'mcpServers' not in text, 'MCP reference must not use mcpServers'
         assert 'pixeltable' in text.lower(), 'MCP reference must mention pixeltable'
+        assert 'git+https://github.com/pixeltable/mcp-server-pixeltable-developer' in text, \
+            'MCP reference must install the server from git (not bare PyPI uvx)'
 
     def test_mcp_reference_uses_hermes_tool_prefix(self) -> None:
         text = MCP_REF.read_text()
-        assert 'mcp_pixeltable_' in text, \
-            'MCP reference must document Hermes mcp_pixeltable_ tool prefix'
-        # Reject bare pixeltable_* Hermes names (mcp_pixeltable_* substring is OK).
-        bare = re.findall(r'(?<!mcp_)pixeltable_(?:create_table|insert_data|query_table)\b', text)
-        assert not bare, f'MCP reference must not teach bare pixeltable_* tool names: {bare}'
+        # Live MCP tools are mostly pixeltable_*; Hermes server key pixeltable → double prefix.
+        assert 'mcp_pixeltable_pixeltable_create_table' in text, \
+            'MCP reference must document Hermes name mcp_pixeltable_pixeltable_create_table'
+        assert 'mcp_pixeltable_execute_python' in text, \
+            'MCP reference must document Hermes name mcp_pixeltable_execute_python'
+        assert 'Agent uses: pixeltable_' not in text, \
+            'Examples must not call MCP tools without the Hermes mcp_ prefix'
+        assert '`pixeltable_create_table`' not in text, \
+            'Do not document bare MCP tool names as Hermes-callable tools'
+
+    def test_setup_emits_git_mcp_install(self) -> None:
+        text = SETUP_SH.read_text()
+        assert 'git+https://github.com/pixeltable/mcp-server-pixeltable-developer' in text, \
+            'setup.sh must emit git+ uvx args for the MCP server'
 
     def test_pipeline_reference_has_examples(self) -> None:
         text = PIPELINE_REF.read_text()
@@ -232,3 +243,9 @@ class TestApiCorrectness:
 
     def test_collect_pattern_present(self, skill_text: str) -> None:
         assert '.collect()' in skill_text, 'SKILL.md must show .collect() to terminate queries'
+
+    def test_columnref_query_helpers_pitfall(self, skill_text: str) -> None:
+        assert 't.select(t.col)' in skill_text, \
+            'SKILL.md must warn that ColumnRef query helpers were removed (use t.select)'
+        assert 't.count()' in skill_text, \
+            'SKILL.md must document t.count() for row counts'

--- a/tests/skills/test_pixeltable_skill.py
+++ b/tests/skills/test_pixeltable_skill.py
@@ -62,6 +62,22 @@ class TestFrontmatter:
         assert re.search(r'^author:', frontmatter, re.MULTILINE), \
             'frontmatter must have an author field'
 
+    def test_author_credits_contributor_first(self, frontmatter: str) -> None:
+        m = re.search(r'^author:\s*(.+)$', frontmatter, re.MULTILINE)
+        assert m, 'frontmatter must have an author field'
+        author = m.group(1).strip()
+        assert 'Pierre Brunelle' in author, f'author must credit Pierre Brunelle first: {author}'
+        assert '@pierrebrunelle' in author, f'author must include @pierrebrunelle: {author}'
+        assert author.startswith('Pierre Brunelle'), \
+            f'contributor name must come first in author field: {author}'
+
+    def test_platforms_linux_macos(self, frontmatter: str) -> None:
+        m = re.search(r'^platforms:\s*\[(.+)\]\s*$', frontmatter, re.MULTILINE)
+        assert m, 'frontmatter must declare platforms for Bash-dependent skill'
+        platforms = {p.strip() for p in m.group(1).split(',')}
+        assert platforms == {'linux', 'macos'}, \
+            f'platforms must be [linux, macos], got {sorted(platforms)}'
+
     def test_license_field(self, frontmatter: str) -> None:
         assert re.search(r'^license:', frontmatter, re.MULTILINE), \
             'frontmatter must have a license field'
@@ -99,6 +115,10 @@ class TestSectionStructure:
     def test_has_h1_title(self, body: str) -> None:
         assert re.search(r'^# \w', body, re.MULTILINE), 'SKILL.md must have an H1 title'
 
+    def test_h1_is_pixeltable_skill(self, body: str) -> None:
+        assert re.search(r'^# Pixeltable Skill\s*$', body, re.MULTILINE), \
+            "SKILL.md H1 must be '# Pixeltable Skill' per HARDLINE"
+
     def test_line_count_reasonable(self, skill_text: str) -> None:
         lines = skill_text.strip().split('\n')
         assert 80 <= len(lines) <= 400, f'SKILL.md should be 80-400 lines, got {len(lines)}'
@@ -133,6 +153,17 @@ class TestSupportFiles:
         assert text.startswith('#!/'), 'setup.sh must have a shebang line'
         assert 'set -' in text, 'setup.sh should use strict mode (set -e or similar)'
 
+    def test_setup_uses_python3_m_pip(self) -> None:
+        text = SETUP_SH.read_text()
+        assert 'python3 -m pip' in text, 'setup.sh must install via python3 -m pip'
+        assert not re.search(r'^\s*pip install\b', text, re.MULTILINE), \
+            'setup.sh must not invoke bare pip (wrong interpreter risk)'
+
+    def test_setup_emits_mcp_servers_key(self) -> None:
+        text = SETUP_SH.read_text()
+        assert 'mcp_servers:' in text, 'setup.sh snippet must use mcp_servers:'
+        assert 'mcpServers' not in text, 'setup.sh must not emit mcpServers'
+
     def test_mcp_reference_exists(self) -> None:
         assert MCP_REF.exists(), 'references/mcp-integration.md must exist'
 
@@ -141,12 +172,25 @@ class TestSupportFiles:
 
     def test_mcp_reference_has_config(self) -> None:
         text = MCP_REF.read_text()
-        assert 'mcpServers:' in text, 'MCP reference must contain config.yaml entry'
+        assert 'mcp_servers:' in text, 'MCP reference must contain mcp_servers: config.yaml entry'
+        assert 'mcpServers' not in text, 'MCP reference must not use mcpServers'
         assert 'pixeltable' in text.lower(), 'MCP reference must mention pixeltable'
+
+    def test_mcp_reference_uses_hermes_tool_prefix(self) -> None:
+        text = MCP_REF.read_text()
+        assert 'mcp_pixeltable_' in text, \
+            'MCP reference must document Hermes mcp_pixeltable_ tool prefix'
+        # Reject bare pixeltable_* Hermes names (mcp_pixeltable_* substring is OK).
+        bare = re.findall(r'(?<!mcp_)pixeltable_(?:create_table|insert_data|query_table)\b', text)
+        assert not bare, f'MCP reference must not teach bare pixeltable_* tool names: {bare}'
 
     def test_pipeline_reference_has_examples(self) -> None:
         text = PIPELINE_REF.read_text()
         assert 'import pixeltable' in text, 'Pipeline reference must contain runnable Python examples'
+
+    def test_skill_prerequisites_use_python3_m_pip(self, skill_text: str) -> None:
+        assert 'python3 -m pip install pixeltable' in skill_text, \
+            'SKILL.md Prerequisites must use python3 -m pip install pixeltable'
 
 
 class TestApiCorrectness:


### PR DESCRIPTION
## What does this PR do?

Adds a Pixeltable optional skill to `optional-skills/mlops/pixeltable/`. Pixeltable is a Python library that stores images, video, audio, and documents as native column types, with computed columns that auto-run AI transformations on insert. The skill teaches the agent how to build multimodal pipelines (CLIP image search, video frame captioning, document RAG) using only `terminal` and Python.

This fills a gap in the mlops category: existing skills handle text-only vector search (chroma, qdrant, qmd), but none cover multimodal data where you need to process video frames, audio segments, or cross-modal search (text query against images).

The skill was tested end-to-end with `hermes -m gpt-4.1` on macOS. It correctly discovers existing tables, reuses indexed data across sessions, and runs CLIP similarity search without API keys.

## Type of Change

- [x] 🎯 New skill (bundled or hub)

## Changes Made

- `optional-skills/mlops/pixeltable/SKILL.md` -- HARDLINE-compliant skill with 7 required sections, 3 runnable procedures (CLIP image search, video analysis, document RAG), quick reference table, and tested pitfall guidance
- `optional-skills/mlops/pixeltable/scripts/setup.sh` -- cross-platform install script
- `optional-skills/mlops/pixeltable/references/mcp-integration.md` -- optional MCP server config and tool catalog for advanced users
- `optional-skills/mlops/pixeltable/references/multimodal-pipeline-examples.md` -- 5 copy-paste Python recipes
- `tests/skills/test_pixeltable_skill.py` -- 31 tests covering HARDLINE frontmatter, section structure, support files, and API correctness (catches hallucinated patterns like `openai.vision`, positional `similarity()`, `pxt.Table()`)

## How to Test

1. Install the skill: copy `optional-skills/mlops/pixeltable/` to `~/.hermes/skills/mlops/pixeltable/`
2. Install Pixeltable: `pip install pixeltable`
3. Run the verification command from the skill:
   ```bash
   hermes -m gpt-4.1 -z "Run the Pixeltable verification command from the pixeltable skill"
   ```
4. Try a multimodal query:
   ```bash
   hermes -m gpt-4.1 -z "Use Pixeltable to create a table with 3 sample images from the web and search them for 'a cat sitting on a couch'"
   ```
5. Run the test suite:
   ```bash
   pytest tests/skills/test_pixeltable_skill.py -v --override-ini="addopts="
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6.1 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) -- or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys -- or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows -- or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) -- or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior -- or N/A

## For New Skills

- [x] This skill is **broadly useful** to most users (if bundled) -- placed in `optional-skills/` since it requires `pip install pixeltable`
- [x] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [x] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [x] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

Interactive session showing table discovery and CLIP search reusing existing indexed data:

```
> What Pixeltable tables do I have?

  exec  import pixeltable as pxt  5.0s

  You currently have the following Pixeltable tables:
  - local_images/gallery
  - rag/docs
  - rag/chunks
  - images/local_gallery

> Search my local images for 'a dog playing in the park'

  exec  import pixeltable as pxt  11.6s
  exec  import pixeltable as pxt  8.5s
  exec  import pixeltable as pxt  9.2s

  Top matches for 'a dog playing in the park' in your local images:
  1. cmyk.jpg (similarity: 0.22)
  2. image2.jpg (similarity: 0.22)
  3. image2.jpg (similarity: 0.22)
  4. 000000000872.jpg (similarity: 0.20)
  5. 000000000285.jpg (similarity: 0.19)

> How many rows in my RAG chunks?

  exec  import pixeltable as pxt  9.8s

  Your rag/chunks table currently contains 6 rows.
```

Test output (31/31 passing):

```
tests/skills/test_pixeltable_skill.py::TestFrontmatter::test_starts_with_delimiter PASSED
tests/skills/test_pixeltable_skill.py::TestFrontmatter::test_name_field PASSED
tests/skills/test_pixeltable_skill.py::TestFrontmatter::test_description_length PASSED
tests/skills/test_pixeltable_skill.py::TestFrontmatter::test_description_ends_with_period PASSED
tests/skills/test_pixeltable_skill.py::TestFrontmatter::test_version_field PASSED
tests/skills/test_pixeltable_skill.py::TestFrontmatter::test_author_field PASSED
tests/skills/test_pixeltable_skill.py::TestFrontmatter::test_license_field PASSED
tests/skills/test_pixeltable_skill.py::TestFrontmatter::test_no_marketing_words PASSED
tests/skills/test_pixeltable_skill.py::TestFrontmatter::test_description_does_not_repeat_name PASSED
tests/skills/test_pixeltable_skill.py::TestSectionStructure (7 tests) PASSED
tests/skills/test_pixeltable_skill.py::TestToolReferences PASSED
tests/skills/test_pixeltable_skill.py::TestSupportFiles (6 tests) PASSED
tests/skills/test_pixeltable_skill.py::TestApiCorrectness (6 tests) PASSED
============================== 31 passed in 0.37s ==============================
```