### PR TITLE
Add live present-state memory

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1056,6 +1056,7 @@ def init_agent(
 
     # Persistent memory (MEMORY.md + USER.md) -- loaded from disk
     agent._memory_store = None
+    agent._present_state_memory = None
     agent._memory_enabled = False
     agent._user_profile_enabled = False
     agent._memory_nudge_interval = 10
@@ -1076,6 +1077,23 @@ def init_agent(
                 agent._memory_store.load_from_disk()
         except Exception:
             pass  # Memory is optional -- don't break agent init
+
+    if not skip_memory:
+        try:
+            mem_config = _agent_cfg.get("memory", {}) if _agent_cfg else {}
+            if mem_config.get("present_state_enabled", True):
+                from agent.present_state_memory import PresentStateMemory
+                agent._present_state_memory = PresentStateMemory(
+                    max_profile_facts=mem_config.get("present_state_max_profile_facts", 80),
+                    max_session_facts=mem_config.get("present_state_max_session_facts", 80),
+                    max_fact_chars=mem_config.get("present_state_max_fact_chars", 360),
+                    render_char_budget=mem_config.get("present_state_render_char_budget", 5000),
+                    auto_capture=mem_config.get("present_state_auto_capture", True),
+                )
+                agent._present_state_memory.initialize(agent.session_id or "")
+        except Exception as _psm_err:
+            _ra().logger.debug("Present-state memory init failed: %s", _psm_err)
+            agent._present_state_memory = None
     
 
 

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1577,17 +1577,36 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
         # Bridge: notify external memory provider of built-in memory writes
         if agent._memory_manager and function_args.get("action") in {"add", "replace"}:
             try:
+                _memory_metadata = agent._build_memory_write_metadata(
+                    task_id=effective_task_id,
+                    tool_call_id=tool_call_id,
+                )
                 agent._memory_manager.on_memory_write(
                     function_args.get("action", ""),
                     target,
                     function_args.get("content", ""),
-                    metadata=agent._build_memory_write_metadata(
-                        task_id=effective_task_id,
-                        tool_call_id=tool_call_id,
-                    ),
+                    metadata=_memory_metadata,
                 )
             except Exception:
                 pass
+        if function_args.get("action") in {"add", "replace"}:
+            try:
+                _memory_result = json.loads(result)
+            except Exception:
+                _memory_result = {}
+            if isinstance(_memory_result, dict) and _memory_result.get("success"):
+                try:
+                    agent._capture_present_state_memory_write(
+                        action=function_args.get("action", ""),
+                        target=target,
+                        content=function_args.get("content", ""),
+                        metadata=agent._build_memory_write_metadata(
+                            task_id=effective_task_id,
+                            tool_call_id=tool_call_id,
+                        ),
+                    )
+                except Exception:
+                    pass
         return result
     elif agent._memory_manager and agent._memory_manager.has_tool(function_name):
         return agent._memory_manager.handle_tool_call(function_name, function_args)

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -441,6 +441,18 @@ def compress_context(
             )
     except Exception as _me_err:
         logger.debug("memory manager on_session_switch (compression): %s", _me_err)
+    try:
+        _old_sid = locals().get("old_session_id")
+        _psm = getattr(agent, "_present_state_memory", None)
+        if _old_sid and _psm:
+            _psm.on_session_switch(
+                agent.session_id or "",
+                parent_session_id=_old_sid,
+                reset=False,
+                reason="compression",
+            )
+    except Exception as _psm_err:
+        logger.debug("present-state memory on_session_switch (compression): %s", _psm_err)
 
     # Warn on repeated compressions (quality degrades with each pass)
     _cc = agent.context_compressor.compression_count

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -796,6 +796,21 @@ def run_conversation(
             # never mutated, so nothing leaks into session persistence.
             if idx == current_turn_user_idx and msg.get("role") == "user":
                 _injections = []
+                _present_state_context = ""
+                if getattr(agent, "_present_state_memory", None):
+                    try:
+                        _present_state_context = (
+                            agent._present_state_memory.render_context(
+                                session_id=agent.session_id or ""
+                            )
+                            or ""
+                        )
+                    except Exception:
+                        _present_state_context = ""
+                if _present_state_context:
+                    _fenced = build_memory_context_block(_present_state_context)
+                    if _fenced:
+                        _injections.append(_fenced)
                 if _ext_prefetch_cache:
                     _fenced = build_memory_context_block(_ext_prefetch_cache)
                     if _fenced:
@@ -4210,6 +4225,11 @@ def run_conversation(
         agent._iters_since_skill = 0
 
     # External memory provider: sync the completed turn + queue next prefetch.
+    agent._sync_present_state_for_turn(
+        original_user_message=original_user_message,
+        final_response=final_response,
+        interrupted=interrupted,
+    )
     agent._sync_external_memory_for_turn(
         original_user_message=original_user_message,
         final_response=final_response,

--- a/agent/present_state_memory.py
+++ b/agent/present_state_memory.py
@@ -1,0 +1,490 @@
+"""Live present-state memory for active Hermes conversations.
+
+This module stores compact, current facts separately from the curated
+``MEMORY.md`` / ``USER.md`` snapshot.  The state is profile-scoped under
+``HERMES_HOME/memories`` and is rendered into the per-turn user-message
+context so newly learned facts can affect the current conversation without
+rebuilding the cached system prompt.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import tempfile
+import time
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from hermes_constants import get_hermes_home
+from utils import atomic_replace
+
+msvcrt = None
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
+    try:
+        import msvcrt
+    except ImportError:
+        pass
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+STATE_FILE_NAME = "PRESENT_STATE.json"
+
+
+@dataclass
+class PresentStateFact:
+    """A compact fact that is true or relevant right now."""
+
+    id: str
+    scope: str
+    target: str
+    content: str
+    source: str
+    session_id: str = ""
+    created_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
+    confidence: float = 1.0
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+def get_present_state_path() -> Path:
+    """Return the profile-scoped present-state JSON path."""
+    return get_hermes_home() / "memories" / STATE_FILE_NAME
+
+
+def _now() -> float:
+    return time.time()
+
+
+def _normalize_content(content: str) -> str:
+    return re.sub(r"\s+", " ", content.strip()).lower()
+
+
+def _fact_id(scope: str, target: str, content: str, session_id: str = "") -> str:
+    raw = "|".join([scope, target, session_id or "", _normalize_content(content)])
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
+def _clean_fact_text(text: str, max_chars: int) -> str:
+    cleaned = re.sub(r"\s+", " ", text.strip())
+    cleaned = cleaned.strip(" -:\t\r\n")
+    if max_chars > 0 and len(cleaned) > max_chars:
+        cleaned = cleaned[: max_chars - 1].rstrip() + "."
+    return cleaned
+
+
+class PresentStateMemory:
+    """Profile-scoped live state store for current facts."""
+
+    def __init__(
+        self,
+        *,
+        max_profile_facts: int = 80,
+        max_session_facts: int = 80,
+        max_fact_chars: int = 360,
+        render_char_budget: int = 5000,
+        auto_capture: bool = True,
+    ) -> None:
+        self.max_profile_facts = int(max_profile_facts)
+        self.max_session_facts = int(max_session_facts)
+        self.max_fact_chars = int(max_fact_chars)
+        self.render_char_budget = int(render_char_budget)
+        self.auto_capture = bool(auto_capture)
+        self._session_id = ""
+
+    def initialize(self, session_id: str = "") -> None:
+        """Create the state file if needed and mark the active session."""
+        self._session_id = session_id or ""
+        with self._file_lock():
+            state = self._load_unlocked()
+            state["active_session_id"] = self._session_id
+            state["updated_at"] = _now()
+            self._write_unlocked(state)
+
+    def render_context(self, *, session_id: str = "") -> str:
+        """Render present facts for injection into the next model call."""
+        sid = session_id or self._session_id
+        state = self._load()
+        profile_facts = self._coerce_facts(state.get("profile_facts", []))
+        session_facts = self._session_facts_from_state(state, sid)
+
+        if not profile_facts and not session_facts:
+            return ""
+
+        lines = ["ACTIVE PRESENT STATE (live facts for this conversation)"]
+        if profile_facts:
+            lines.append("Profile facts:")
+            for fact in profile_facts:
+                lines.append(f"- {fact.content}")
+        if session_facts:
+            lines.append("Current session facts:")
+            for fact in session_facts:
+                lines.append(f"- {fact.content}")
+
+        rendered = "\n".join(lines)
+        if self.render_char_budget > 0 and len(rendered) > self.render_char_budget:
+            rendered = rendered[: self.render_char_budget].rstrip()
+        return rendered
+
+    def capture_memory_write(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        *,
+        session_id: str = "",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Mirror explicit long-term memory writes into live state."""
+        if action not in {"add", "replace"}:
+            return
+        clean = _clean_fact_text(content or "", self.max_fact_chars)
+        if not clean:
+            return
+        scope = "profile"
+        fact_target = "user" if target == "user" else "memory"
+        self._upsert_fact(
+            PresentStateFact(
+                id=_fact_id(scope, fact_target, clean),
+                scope=scope,
+                target=fact_target,
+                content=clean,
+                source="memory_tool",
+                session_id=session_id or self._session_id,
+                metadata=dict(metadata or {}),
+            )
+        )
+
+    def capture_turn(
+        self,
+        user_content: Any,
+        assistant_content: Any,
+        *,
+        session_id: str = "",
+    ) -> None:
+        """Extract and store obvious key facts from a completed turn."""
+        if not self.auto_capture:
+            return
+        user_text = user_content if isinstance(user_content, str) else ""
+        assistant_text = assistant_content if isinstance(assistant_content, str) else ""
+        sid = session_id or self._session_id
+        facts = list(self._extract_user_facts(user_text, sid))
+        facts.extend(self._extract_session_facts(user_text, assistant_text, sid))
+        for fact in facts:
+            self._upsert_fact(fact)
+
+    def on_session_switch(
+        self,
+        new_session_id: str,
+        *,
+        parent_session_id: str = "",
+        reset: bool = False,
+        reason: str = "",
+    ) -> None:
+        """Update active session and optionally carry state across lineage."""
+        if not new_session_id:
+            return
+        with self._file_lock():
+            state = self._load_unlocked()
+            sessions = state.setdefault("sessions", {})
+            sessions.setdefault(new_session_id, {"facts": []})
+            if parent_session_id and not reset:
+                parent_facts = list(
+                    sessions.get(parent_session_id, {}).get("facts", [])
+                )
+                existing = list(sessions[new_session_id].get("facts", []))
+                merged = self._merge_fact_dicts(existing, parent_facts)
+                sessions[new_session_id]["facts"] = self._trim_facts(
+                    merged, self.max_session_facts
+                )
+            state["active_session_id"] = new_session_id
+            state["updated_at"] = _now()
+            state["last_switch_reason"] = reason
+            self._session_id = new_session_id
+            self._write_unlocked(state)
+
+    def _extract_user_facts(self, text: str, session_id: str) -> Iterable[PresentStateFact]:
+        for content in self._remember_statements(text):
+            yield self._make_fact("profile", "memory", content, "user_remembered", session_id)
+
+        patterns = [
+            (r"\bcall me\s+([^.\n!?]+)", "user", "User wants to be called {0}."),
+            (r"\bmy\s+([a-z][a-z0-9 _-]{1,32})\s+is\s+([^.\n!?]+)", "user", "User's {0} is {1}."),
+            (r"\bi\s+prefer\s+([^.\n!?]+)", "user", "User prefers {0}."),
+            (r"\bi\s+like\s+([^.\n!?]+)", "user", "User likes {0}."),
+            (r"\bi\s+use\s+([^.\n!?]+)", "user", "User uses {0}."),
+            (r"\bi(?:'m| am)\s+using\s+([^.\n!?]+)", "user", "User is using {0}."),
+        ]
+        for pattern, target, template in patterns:
+            for match in re.finditer(pattern, text, flags=re.IGNORECASE):
+                if len(match.groups()) == 2:
+                    content = template.format(match.group(1).strip(), match.group(2).strip())
+                else:
+                    content = template.format(match.group(1).strip())
+                clean = _clean_fact_text(content, self.max_fact_chars)
+                if clean:
+                    yield self._make_fact("profile", target, clean, "user_statement", session_id)
+
+        shared_patterns = [
+            r"\bwe\s+(?:use|are using|prefer|need|run)\s+([^.\n!?]+)",
+            r"\bthis project\s+(?:uses|needs|runs|is)\s+([^.\n!?]+)",
+        ]
+        for pattern in shared_patterns:
+            for match in re.finditer(pattern, text, flags=re.IGNORECASE):
+                content = f"Project/conversation fact: {match.group(0).strip()}."
+                yield self._make_fact("profile", "memory", content, "user_statement", session_id)
+
+    def _extract_session_facts(
+        self,
+        user_text: str,
+        assistant_text: str,
+        session_id: str,
+    ) -> Iterable[PresentStateFact]:
+        current_goal_patterns = [
+            r"\bwe\s+are\s+going\s+to\s+([^.\n!?]+)",
+            r"\bwe(?:'re| are)\s+working\s+on\s+([^.\n!?]+)",
+            r"\bcurrent\s+(?:goal|task)\s+is\s+([^.\n!?]+)",
+            r"\bthe\s+(?:goal|task)\s+is\s+([^.\n!?]+)",
+        ]
+        for pattern in current_goal_patterns:
+            for match in re.finditer(pattern, user_text, flags=re.IGNORECASE):
+                content = f"Current goal: {match.group(1).strip()}."
+                yield self._make_fact("session", "conversation", content, "user_goal", session_id)
+
+        if re.search(r"\b(done|implemented|added|fixed|changed|updated)\b", assistant_text, re.IGNORECASE):
+            summary = self._first_sentence(assistant_text)
+            if summary:
+                content = f"Latest assistant outcome: {summary}"
+                yield self._make_fact("session", "conversation", content, "assistant_outcome", session_id)
+
+    def _remember_statements(self, text: str) -> Iterable[str]:
+        for match in re.finditer(
+            r"\bremember(?:\s+(?:that|this))?:?\s+([^.\n!?]+)",
+            text,
+            flags=re.IGNORECASE,
+        ):
+            yield match.group(1).strip()
+
+    def _first_sentence(self, text: str) -> str:
+        stripped = re.sub(r"\s+", " ", text.strip())
+        if not stripped:
+            return ""
+        match = re.search(r"^(.{20,260}?[.!?])(?:\s|$)", stripped)
+        if match:
+            return _clean_fact_text(match.group(1), self.max_fact_chars)
+        return _clean_fact_text(stripped[:260], self.max_fact_chars)
+
+    def _make_fact(
+        self,
+        scope: str,
+        target: str,
+        content: str,
+        source: str,
+        session_id: str,
+    ) -> PresentStateFact:
+        clean = _clean_fact_text(content, self.max_fact_chars)
+        return PresentStateFact(
+            id=_fact_id(scope, target, clean, session_id if scope == "session" else ""),
+            scope=scope,
+            target=target,
+            content=clean,
+            source=source,
+            session_id=session_id,
+            confidence=0.75 if source == "assistant_outcome" else 0.9,
+        )
+
+    def _upsert_fact(self, fact: PresentStateFact) -> None:
+        with self._file_lock():
+            state = self._load_unlocked()
+            if fact.scope == "session":
+                sessions = state.setdefault("sessions", {})
+                session = sessions.setdefault(fact.session_id or self._session_id, {"facts": []})
+                facts = self._upsert_in_list(session.get("facts", []), fact)
+                session["facts"] = self._trim_facts(facts, self.max_session_facts)
+            else:
+                facts = self._upsert_in_list(state.get("profile_facts", []), fact)
+                state["profile_facts"] = self._trim_facts(facts, self.max_profile_facts)
+            state["active_session_id"] = fact.session_id or self._session_id
+            state["updated_at"] = _now()
+            self._write_unlocked(state)
+
+    def _upsert_in_list(
+        self,
+        raw_facts: List[Dict[str, Any]],
+        fact: PresentStateFact,
+    ) -> List[Dict[str, Any]]:
+        facts = self._coerce_facts(raw_facts)
+        normalized = _normalize_content(fact.content)
+        now = _now()
+        for existing in facts:
+            if existing.id == fact.id or _normalize_content(existing.content) == normalized:
+                existing.content = fact.content
+                existing.source = fact.source
+                existing.updated_at = now
+                existing.session_id = fact.session_id or existing.session_id
+                existing.metadata.update(fact.metadata)
+                return [asdict(item) for item in facts]
+        facts.append(fact)
+        return [asdict(item) for item in facts]
+
+    def _merge_fact_dicts(
+        self,
+        base: List[Dict[str, Any]],
+        extra: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        facts = list(base)
+        seen = {
+            _normalize_content(str(item.get("content") or ""))
+            for item in facts
+            if isinstance(item, dict)
+        }
+        for item in extra:
+            if not isinstance(item, dict):
+                continue
+            key = _normalize_content(str(item.get("content") or ""))
+            if key and key not in seen:
+                facts.append(dict(item))
+                seen.add(key)
+        return facts
+
+    def _trim_facts(self, raw_facts: List[Dict[str, Any]], max_facts: int) -> List[Dict[str, Any]]:
+        facts = self._coerce_facts(raw_facts)
+        facts.sort(key=lambda item: item.updated_at, reverse=True)
+        if max_facts > 0:
+            facts = facts[:max_facts]
+        return [asdict(item) for item in facts]
+
+    def _session_facts_from_state(self, state: Dict[str, Any], session_id: str) -> List[PresentStateFact]:
+        sessions = state.get("sessions", {})
+        if not isinstance(sessions, dict) or not session_id:
+            return []
+        session = sessions.get(session_id, {})
+        if not isinstance(session, dict):
+            return []
+        return self._coerce_facts(session.get("facts", []))
+
+    def _coerce_facts(self, raw_facts: Any) -> List[PresentStateFact]:
+        facts = []
+        if not isinstance(raw_facts, list):
+            return facts
+        for item in raw_facts:
+            if not isinstance(item, dict):
+                continue
+            content = _clean_fact_text(str(item.get("content") or ""), self.max_fact_chars)
+            if not content:
+                continue
+            facts.append(
+                PresentStateFact(
+                    id=str(item.get("id") or _fact_id(
+                        str(item.get("scope") or "profile"),
+                        str(item.get("target") or "memory"),
+                        content,
+                        str(item.get("session_id") or ""),
+                    )),
+                    scope=str(item.get("scope") or "profile"),
+                    target=str(item.get("target") or "memory"),
+                    content=content,
+                    source=str(item.get("source") or "unknown"),
+                    session_id=str(item.get("session_id") or ""),
+                    created_at=float(item.get("created_at") or _now()),
+                    updated_at=float(item.get("updated_at") or item.get("created_at") or _now()),
+                    confidence=float(item.get("confidence") or 1.0),
+                    metadata=dict(item.get("metadata") or {}),
+                )
+            )
+        facts.sort(key=lambda item: item.updated_at, reverse=True)
+        return facts
+
+    def _default_state(self) -> Dict[str, Any]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "active_session_id": self._session_id,
+            "profile_facts": [],
+            "sessions": {},
+            "updated_at": _now(),
+        }
+
+    def _load(self) -> Dict[str, Any]:
+        with self._file_lock():
+            return self._load_unlocked()
+
+    def _load_unlocked(self) -> Dict[str, Any]:
+        path = get_present_state_path()
+        if not path.exists():
+            return self._default_state()
+        try:
+            with open(path, encoding="utf-8") as handle:
+                data = json.load(handle)
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.debug("Failed to read present-state memory: %s", exc)
+            return self._default_state()
+        if not isinstance(data, dict):
+            return self._default_state()
+        data.setdefault("schema_version", SCHEMA_VERSION)
+        data.setdefault("profile_facts", [])
+        data.setdefault("sessions", {})
+        return data
+
+    def _write_unlocked(self, state: Dict[str, Any]) -> None:
+        path = get_present_state_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(path.parent), suffix=".tmp", prefix=".present_state_"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(state, handle, indent=2, sort_keys=True, ensure_ascii=False)
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            atomic_replace(tmp_path, path)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+
+    @contextmanager
+    def _file_lock(self):
+        path = get_present_state_path()
+        lock_path = path.with_suffix(path.suffix + ".lock")
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+
+        if fcntl is None and msvcrt is None:
+            yield
+            return
+
+        handle = open(lock_path, "a+", encoding="utf-8")
+        try:
+            if fcntl:
+                fcntl.flock(handle, fcntl.LOCK_EX)
+            else:
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+            yield
+        finally:
+            if fcntl:
+                try:
+                    fcntl.flock(handle, fcntl.LOCK_UN)
+                except (OSError, IOError):
+                    pass
+            elif msvcrt:
+                try:
+                    handle.seek(0)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                except (OSError, IOError):
+                    pass
+            handle.close()
+
+
+__all__ = ["PresentStateFact", "PresentStateMemory", "get_present_state_path"]

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -640,17 +640,36 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             # Bridge: notify external memory provider of built-in memory writes
             if agent._memory_manager and function_args.get("action") in {"add", "replace"}:
                 try:
+                    _memory_metadata = agent._build_memory_write_metadata(
+                        task_id=effective_task_id,
+                        tool_call_id=getattr(tool_call, "id", None),
+                    )
                     agent._memory_manager.on_memory_write(
                         function_args.get("action", ""),
                         target,
                         function_args.get("content", ""),
-                        metadata=agent._build_memory_write_metadata(
-                            task_id=effective_task_id,
-                            tool_call_id=getattr(tool_call, "id", None),
-                        ),
+                        metadata=_memory_metadata,
                     )
                 except Exception:
                     pass
+            if function_args.get("action") in {"add", "replace"}:
+                try:
+                    _memory_result = json.loads(function_result)
+                except Exception:
+                    _memory_result = {}
+                if isinstance(_memory_result, dict) and _memory_result.get("success"):
+                    try:
+                        agent._capture_present_state_memory_write(
+                            action=function_args.get("action", ""),
+                            target=target,
+                            content=function_args.get("content", ""),
+                            metadata=agent._build_memory_write_metadata(
+                                task_id=effective_task_id,
+                                tool_call_id=getattr(tool_call, "id", None),
+                            ),
+                        )
+                    except Exception:
+                        pass
             tool_duration = time.time() - tool_start_time
             if agent._should_emit_quiet_tool_messages():
                 agent._vprint(f"  {_get_cute_tool_message_impl('memory', function_args, tool_duration, result=function_result)}")

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -483,6 +483,17 @@ memory:
   # every N user turns. Set to 0 to disable. Only active when memory is enabled.
   nudge_interval: 10        # Nudge every 10 user turns (0 = disabled)
 
+  # Live present-state memory: compact facts available during the current
+  # conversation without rebuilding the cached system prompt. Stored under
+  # HERMES_HOME/memories/PRESENT_STATE.json and shared by all platforms using
+  # this profile.
+  present_state_enabled: true
+  present_state_auto_capture: true
+  present_state_max_profile_facts: 80
+  present_state_max_session_facts: 80
+  present_state_max_fact_chars: 360
+  present_state_render_char_budget: 5000
+
   # Memory flush: give the agent one turn to save memories before context is
   # lost (compression, /new, /reset, exit). Set to 0 to disable.
   # For exit/reset, only fires if the session had at least this many user turns.

--- a/cli.py
+++ b/cli.py
@@ -6360,6 +6360,14 @@ class HermesCLI:
                         reset=True,
                         reason="new_session",
                     )
+                _psm = getattr(self.agent, "_present_state_memory", None)
+                if _psm is not None:
+                    _psm.on_session_switch(
+                        self.session_id,
+                        parent_session_id=old_session_id or "",
+                        reset=True,
+                        reason="new_session",
+                    )
             except Exception:
                 pass
             self._notify_session_boundary("on_session_reset")
@@ -6630,6 +6638,14 @@ class HermesCLI:
                         reset=False,
                         reason="resume",
                     )
+                _psm = getattr(self.agent, "_present_state_memory", None)
+                if _psm is not None:
+                    _psm.on_session_switch(
+                        target_id,
+                        parent_session_id=old_session_id or "",
+                        reset=False,
+                        reason="resume",
+                    )
             except Exception:
                 pass
 
@@ -6790,6 +6806,14 @@ class HermesCLI:
                 _mm = getattr(self.agent, "_memory_manager", None)
                 if _mm is not None:
                     _mm.on_session_switch(
+                        new_session_id,
+                        parent_session_id=parent_session_id or "",
+                        reset=False,
+                        reason="branch",
+                    )
+                _psm = getattr(self.agent, "_present_state_memory", None)
+                if _psm is not None:
+                    _psm.on_session_switch(
                         new_session_id,
                         parent_session_id=parent_session_id or "",
                         reset=False,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1206,6 +1206,12 @@ DEFAULT_CONFIG = {
         "user_profile_enabled": True,
         "memory_char_limit": 2200,   # ~800 tokens at 2.75 chars/token
         "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
+        "present_state_enabled": True,
+        "present_state_auto_capture": True,
+        "present_state_max_profile_facts": 80,
+        "present_state_max_session_facts": 80,
+        "present_state_max_fact_chars": 360,
+        "present_state_render_char_budget": 5000,
         # External memory provider plugin (empty = built-in only).
         # Set to a provider name to activate: "openviking", "mem0",
         # "hindsight", "holographic", "retaindb", "byterover".

--- a/run_agent.py
+++ b/run_agent.py
@@ -1151,6 +1151,29 @@ class AIAgent:
             tool_call_id=tool_call_id,
         )
 
+    def _capture_present_state_memory_write(
+        self,
+        *,
+        action: str,
+        target: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Mirror explicit memory writes into live present-state memory."""
+        present_state = getattr(self, "_present_state_memory", None)
+        if not present_state:
+            return
+        try:
+            present_state.capture_memory_write(
+                action,
+                target,
+                content,
+                session_id=self.session_id or "",
+                metadata=metadata or {},
+            )
+        except Exception:
+            pass
+
     def _apply_persist_user_message_override(self, messages: List[Dict]) -> None:
         """Rewrite the current-turn user message before persistence/return.
 
@@ -2038,6 +2061,28 @@ class AIAgent:
                 )
             except Exception:
                 pass
+
+    def _sync_present_state_for_turn(
+        self,
+        *,
+        original_user_message: Any,
+        final_response: Any,
+        interrupted: bool,
+    ) -> None:
+        """Capture obvious key facts into live present-state memory."""
+        if interrupted:
+            return
+        present_state = getattr(self, "_present_state_memory", None)
+        if not (present_state and final_response and original_user_message):
+            return
+        try:
+            present_state.capture_turn(
+                original_user_message,
+                final_response,
+                session_id=self.session_id or "",
+            )
+        except Exception:
+            pass
 
     def _sync_external_memory_for_turn(
         self,

--- a/tests/agent/test_present_state_memory.py
+++ b/tests/agent/test_present_state_memory.py
@@ -1,0 +1,146 @@
+"""Tests for live present-state memory."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent.present_state_memory import PresentStateMemory, get_present_state_path
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from run_agent import AIAgent
+
+
+@pytest.fixture()
+def hermes_home(tmp_path):
+    token = set_hermes_home_override(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_initialize_uses_profile_scoped_state_file(hermes_home: Path):
+    memory = PresentStateMemory()
+    memory.initialize("session-1")
+
+    path = get_present_state_path()
+    assert path == hermes_home / "memories" / "PRESENT_STATE.json"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["active_session_id"] == "session-1"
+    assert data["schema_version"] == 1
+
+
+def test_memory_write_is_available_in_same_session_context(hermes_home: Path):
+    memory = PresentStateMemory()
+    memory.initialize("session-1")
+
+    memory.capture_memory_write(
+        "add",
+        "user",
+        "Volmarr prefers direct, implementation-first answers.",
+        session_id="session-1",
+    )
+
+    rendered = memory.render_context(session_id="session-1")
+    assert "ACTIVE PRESENT STATE" in rendered
+    assert "Volmarr prefers direct" in rendered
+
+
+def test_completed_turn_extracts_profile_and_current_session_facts(hermes_home: Path):
+    memory = PresentStateMemory()
+    memory.initialize("session-1")
+
+    memory.capture_turn(
+        "Call me Volmarr. I prefer concise updates. We are going to improve Hermes memory.",
+        "Implemented the first slice.",
+        session_id="session-1",
+    )
+
+    rendered = memory.render_context(session_id="session-1")
+    assert "User wants to be called Volmarr" in rendered
+    assert "User prefers concise updates" in rendered
+    assert "Current goal: improve Hermes memory" in rendered
+    assert "Latest assistant outcome: Implemented the first slice." in rendered
+
+
+def test_session_switch_carries_lineage_but_reset_starts_fresh_session(hermes_home: Path):
+    memory = PresentStateMemory()
+    memory.initialize("session-1")
+    memory.capture_turn(
+        "We are going to improve Hermes memory.",
+        "Implemented the first slice.",
+        session_id="session-1",
+    )
+
+    memory.on_session_switch("session-2", parent_session_id="session-1", reset=False)
+    assert "Current goal: improve Hermes memory" in memory.render_context(session_id="session-2")
+
+    memory.on_session_switch("session-3", parent_session_id="session-2", reset=True)
+    assert "Current goal: improve Hermes memory" not in memory.render_context(session_id="session-3")
+
+
+def test_corrupt_state_file_falls_back_without_crashing(hermes_home: Path):
+    path = get_present_state_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not valid json", encoding="utf-8")
+
+    memory = PresentStateMemory()
+    memory.initialize("session-1")
+
+    rendered = memory.render_context(session_id="session-1")
+    assert rendered == ""
+
+
+def test_agent_bridge_captures_memory_write(hermes_home: Path):
+    memory = PresentStateMemory()
+    memory.initialize("session-1")
+    agent = type("AgentStub", (), {})()
+    agent._present_state_memory = memory
+    agent.session_id = "session-1"
+
+    AIAgent._capture_present_state_memory_write(
+        agent,
+        action="add",
+        target="memory",
+        content="Hermes runs in a profile-scoped HERMES_HOME.",
+    )
+
+    rendered = memory.render_context(session_id="session-1")
+    assert "Hermes runs in a profile-scoped HERMES_HOME" in rendered
+
+
+def test_agent_bridge_captures_completed_turn(hermes_home: Path):
+    memory = PresentStateMemory()
+    memory.initialize("session-1")
+    agent = type("AgentStub", (), {})()
+    agent._present_state_memory = memory
+    agent.session_id = "session-1"
+
+    AIAgent._sync_present_state_for_turn(
+        agent,
+        original_user_message="Remember that Hermes should keep live present state.",
+        final_response="Done.",
+        interrupted=False,
+    )
+
+    rendered = memory.render_context(session_id="session-1")
+    assert "Hermes should keep live present state" in rendered
+
+
+def test_agent_bridge_skips_interrupted_turns(hermes_home: Path):
+    memory = PresentStateMemory()
+    memory.initialize("session-1")
+    agent = type("AgentStub", (), {})()
+    agent._present_state_memory = memory
+    agent.session_id = "session-1"
+
+    AIAgent._sync_present_state_for_turn(
+        agent,
+        original_user_message="Remember that this should not persist.",
+        final_response="Partial.",
+        interrupted=True,
+    )
+
+    assert "this should not persist" not in memory.render_context(session_id="session-1")


### PR DESCRIPTION
## Summary
- add a profile-scoped live present-state memory store at HERMES_HOME/memories/PRESENT_STATE.json
- inject present state into the current turn through the existing API-call-time user context path, preserving cached system-prompt stability
- mirror successful built-in memory writes immediately and capture obvious post-turn facts such as user preferences, remembered facts, current goals, and latest outcomes
- carry present-state session facts across resume, branch, and compression while resetting session facts for new sessions

## Tests
- uv run ruff check agent/present_state_memory.py tests/agent/test_present_state_memory.py agent/agent_init.py agent/conversation_loop.py run_agent.py agent/tool_executor.py agent/agent_runtime_helpers.py agent/conversation_compression.py cli.py
- uv run python -m py_compile agent/present_state_memory.py agent/agent_init.py agent/conversation_loop.py run_agent.py agent/tool_executor.py agent/agent_runtime_helpers.py agent/conversation_compression.py cli.py
- scripts/run_tests.sh tests/agent/test_present_state_memory.py tests/agent/test_memory_provider.py tests/agent/test_memory_session_switch.py tests/run_agent/test_memory_sync_interrupted.py tests/run_agent/test_memory_nudge_counter_hydration.py
- scripts/run_tests.sh tests/run_agent/test_memory_provider_init.py tests/run_agent/test_run_agent.py -- -q