### PR TITLE
fix(doctor): repair custom_providers auto-fix

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3185,6 +3185,49 @@ def providers_dict_to_custom_providers(providers_dict: Any) -> List[Dict[str, An
     return custom_providers
 
 
+def custom_providers_dict_to_list(custom_providers: Any) -> Optional[List[Dict[str, Any]]]:
+    """Convert on-disk dict-shaped ``custom_providers`` into list form.
+
+    Supports both legacy keyed mappings:
+
+    ```yaml
+    custom_providers:
+      my-provider:
+        api: https://example.com/v1
+    ```
+
+    and the single-entry misindentation shape:
+
+    ```yaml
+    custom_providers:
+      name: my-provider
+      base_url: https://example.com/v1
+    ```
+
+    Returns ``None`` when the dict cannot be converted without dropping data.
+    """
+    if not isinstance(custom_providers, dict):
+        return None
+
+    single_entry = _normalize_custom_provider_entry(dict(custom_providers))
+    if single_entry is not None:
+        single_entry.pop("provider_key", None)
+        return [single_entry]
+
+    converted: List[Dict[str, Any]] = []
+    for provider_key, entry in custom_providers.items():
+        normalized = _normalize_custom_provider_entry(
+            dict(entry) if isinstance(entry, dict) else entry,
+            provider_key=str(provider_key),
+        )
+        if normalized is None:
+            return None
+        normalized.pop("provider_key", None)
+        converted.append(normalized)
+
+    return converted or None
+
+
 def get_compatible_custom_providers(
     config: Optional[Dict[str, Any]] = None,
 ) -> List[Dict[str, Any]]:

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -761,10 +761,28 @@ def run_doctor(args):
 
         # Validate config structure (catches malformed custom_providers, etc.)
         try:
-            from hermes_cli.config import validate_config_structure
+            from hermes_cli.config import (
+                custom_providers_dict_to_list,
+                validate_config_structure,
+            )
             config_issues = validate_config_structure()
             if config_issues:
                 _section("Config Structure")
+                if should_fix and config_path.exists():
+                    import yaml
+                    with open(config_path, encoding="utf-8") as f:
+                        raw_config = yaml.safe_load(f) or {}
+                    converted_custom_providers = custom_providers_dict_to_list(
+                        raw_config.get("custom_providers")
+                    )
+                    if converted_custom_providers is not None:
+                        from utils import atomic_yaml_write
+
+                        raw_config["custom_providers"] = converted_custom_providers
+                        atomic_yaml_write(config_path, raw_config)
+                        check_ok("Converted custom_providers from dict to list format")
+                        fixed_count += 1
+                        config_issues = validate_config_structure(raw_config)
                 for ci in config_issues:
                     if ci.severity == "error":
                         check_fail(ci.message)

--- a/tests/hermes_cli/test_doctor_config_structure_fix.py
+++ b/tests/hermes_cli/test_doctor_config_structure_fix.py
@@ -1,0 +1,139 @@
+"""Regression tests for ``hermes doctor --fix`` config-structure repairs."""
+
+import contextlib
+import io
+import sys
+import types
+from argparse import Namespace
+from pathlib import Path
+
+import yaml
+
+import hermes_cli.config as config_mod
+import hermes_cli.doctor as doctor_mod
+
+
+def _setup_doctor_env(monkeypatch, tmp_path, config_text: str):
+    """Point doctor at an isolated config.yaml and stub unrelated probes."""
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(config_text, encoding="utf-8")
+
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+    venv_bin_dir = project / "venv" / "bin"
+    venv_bin_dir.mkdir(parents=True, exist_ok=True)
+    hermes_bin = venv_bin_dir / "hermes"
+    hermes_bin.write_text("#!/usr/bin/env python\n# entry point\n", encoding="utf-8")
+    hermes_bin.chmod(0o755)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setattr(config_mod, "get_hermes_home", lambda: home)
+    config_mod._LOAD_CONFIG_CACHE.clear()
+    config_mod._RAW_CONFIG_CACHE.clear()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as auth_mod
+
+        for name in (
+            "get_nous_auth_status",
+            "get_codex_auth_status",
+            "get_gemini_oauth_auth_status",
+            "get_minimax_oauth_auth_status",
+        ):
+            monkeypatch.setattr(auth_mod, name, lambda: {})
+    except Exception:
+        pass
+
+    try:
+        import httpx
+
+        monkeypatch.setattr(
+            httpx,
+            "get",
+            lambda *a, **kw: types.SimpleNamespace(status_code=200),
+        )
+    except Exception:
+        pass
+
+    return home
+
+
+def _run_doctor(fix: bool) -> str:
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=fix))
+    return buf.getvalue()
+
+
+def test_doctor_fix_converts_legacy_custom_providers_mapping(monkeypatch, tmp_path):
+    home = _setup_doctor_env(
+        monkeypatch,
+        tmp_path,
+        """
+model:
+  provider: custom
+  default: qwen/qwen3
+custom_providers:
+  modelrelay:
+    api: http://op3:7352/v1
+    model: qwen/qwen3
+    api_mode: openai-completions
+""".lstrip(),
+    )
+
+    out = _run_doctor(fix=True)
+
+    assert "Converted custom_providers from dict to list format" in out
+
+    saved = yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8"))
+    assert saved["custom_providers"] == [
+        {
+            "name": "modelrelay",
+            "base_url": "http://op3:7352/v1",
+            "api_mode": "openai-completions",
+            "model": "qwen/qwen3",
+        }
+    ]
+
+
+def test_doctor_fix_converts_single_custom_provider_dict(monkeypatch, tmp_path):
+    home = _setup_doctor_env(
+        monkeypatch,
+        tmp_path,
+        """
+model:
+  provider: custom
+  default: models/gemini-2.5-flash
+custom_providers:
+  name: GenerativeLanguage
+  base_url: https://generativelanguage.googleapis.com/v1beta
+  api_key: xxx
+  model: models/gemini-2.5-flash
+  rate_limit_delay: 2.0
+""".lstrip(),
+    )
+
+    out = _run_doctor(fix=True)
+
+    assert "Converted custom_providers from dict to list format" in out
+
+    saved = yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8"))
+    assert saved["custom_providers"] == [
+        {
+            "name": "GenerativeLanguage",
+            "base_url": "https://generativelanguage.googleapis.com/v1beta",
+            "api_key": "xxx",
+            "model": "models/gemini-2.5-flash",
+            "rate_limit_delay": 2.0,
+        }
+    ]


### PR DESCRIPTION
## Summary
- add a safe helper to convert dict-form `custom_providers` configs into on-disk list form
- teach `hermes doctor --fix` to rewrite that config shape instead of only reporting it
- add regression tests for both legacy keyed mappings and single-entry misindented dicts

Closes #31780

## Proof
- `uv run --frozen --with pytest python -m pytest -o addopts= tests/hermes_cli/test_doctor_config_structure_fix.py -q`\n- `uv run --frozen --with ruff ruff check hermes_cli/config.py hermes_cli/doctor.py tests/hermes_cli/test_doctor_config_structure_fix.py`\n- `uv run --frozen python -m py_compile hermes_cli/config.py hermes_cli/doctor.py tests/hermes_cli/test_doctor_config_structure_fix.py`\n- `git diff --check origin/main...HEAD`