### PR TITLE
fix(mcp): warn when an MCP server name collides with a built-in toolset

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1287,6 +1287,7 @@ AUTHOR_MAP = {
     "edison@mcclean.codes": "McClean-Edison",  # PR #29817 (register_auxiliary_task plugin API)
     "zhangsamuel12@gmail.com": "SamuelZ12",  # PR #7480 (show recap after in-session resume)
     "490408354@qq.com": "daizhonggeng",  # PR #9020 (numbered /resume selection)
+    "officialasishkumar@gmail.com": "officialasishkumar",  # MCP toolset-name collision warning (#30563)
 }
 
 

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -3615,6 +3615,87 @@ class TestMCPBuiltinCollisionGuard:
         _servers.pop("srv", None)
 
 
+class TestMCPToolsetNameCollisionWarning:
+    """An MCP server whose name matches a built-in toolset is warned about.
+
+    The built-in toolset shadows the ``<name>`` -> ``mcp-<name>`` alias during
+    toolset resolution, leaving the MCP tools unreachable via the bare
+    ``<name>`` toolset. The tools still register (under the namespaced
+    toolset), but the collision must be surfaced loudly instead of failing
+    silently — issue #30563.
+    """
+
+    def test_warns_when_server_name_shadows_builtin_toolset(self, caplog):
+        import logging
+        from toolsets import TOOLSETS
+        from tools.registry import ToolRegistry
+        from tools.mcp_tool import _discover_and_register_server, _servers, MCPServerTask
+
+        # 'kanban' is a built-in toolset, so it shadows the mcp-kanban alias.
+        assert "kanban" in TOOLSETS
+
+        mock_registry = ToolRegistry()
+        mock_tools = [_make_mcp_tool("list_tasks", "List kanban tasks")]
+        mock_session = MagicMock()
+
+        async def fake_connect(name, config):
+            server = MCPServerTask(name)
+            server.session = mock_session
+            server._tools = mock_tools
+            return server
+
+        with caplog.at_level(logging.WARNING, logger="tools.mcp_tool"), \
+             patch("tools.mcp_tool._connect_server", side_effect=fake_connect), \
+             patch("tools.registry.registry", mock_registry):
+            registered = asyncio.run(
+                _discover_and_register_server("kanban", {"command": "test", "args": []})
+            )
+
+        # Tools still register, under the namespaced 'mcp-kanban' toolset ...
+        assert "mcp_kanban_list_tasks" in registered
+        assert mock_registry.get_toolset_for_tool("mcp_kanban_list_tasks") == "mcp-kanban"
+        # ... but the shadowing is surfaced loudly instead of failing silently.
+        assert any(
+            "built-in toolset" in r.message and "kanban" in r.message
+            for r in caplog.records
+        ), [r.message for r in caplog.records]
+
+        _servers.pop("kanban", None)
+
+    def test_no_warning_when_server_name_is_unique(self, caplog):
+        import logging
+        from toolsets import TOOLSETS
+        from tools.registry import ToolRegistry
+        from tools.mcp_tool import _discover_and_register_server, _servers, MCPServerTask
+
+        unique_name = "totallyuniquemcp"
+        assert unique_name not in TOOLSETS
+
+        mock_registry = ToolRegistry()
+        mock_tools = [_make_mcp_tool("do_thing", "Do a thing")]
+        mock_session = MagicMock()
+
+        async def fake_connect(name, config):
+            server = MCPServerTask(name)
+            server.session = mock_session
+            server._tools = mock_tools
+            return server
+
+        with caplog.at_level(logging.WARNING, logger="tools.mcp_tool"), \
+             patch("tools.mcp_tool._connect_server", side_effect=fake_connect), \
+             patch("tools.registry.registry", mock_registry):
+            registered = asyncio.run(
+                _discover_and_register_server(unique_name, {"command": "test", "args": []})
+            )
+
+        assert f"mcp_{unique_name}_do_thing" in registered
+        assert not any(
+            "built-in toolset" in r.message for r in caplog.records
+        ), [r.message for r in caplog.records]
+
+        _servers.pop(unique_name, None)
+
+
 # ---------------------------------------------------------------------------
 # sanitize_mcp_name_component
 # ---------------------------------------------------------------------------

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3161,6 +3161,28 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
         registered_names.append(util_name)
 
     if registered_names:
+        # Toolset-name collision guard (the toolset-level analogue of the
+        # tool-name guard above). The MCP server's tools live under the
+        # ``mcp-<name>`` toolset, reached via a ``<name>`` -> ``mcp-<name>``
+        # alias. But ``toolsets.get_toolset`` / ``resolve_toolset`` consult the
+        # static ``TOOLSETS`` table before the registry alias map, so when the
+        # server name matches a built-in toolset the built-in shadows the alias
+        # and the freshly-registered tools are silently unreachable via the
+        # bare ``<name>`` toolset. Warn — otherwise this is a multi-hour,
+        # zero-feedback debugging hunt (see issue #30563).
+        try:
+            from toolsets import TOOLSETS
+        except Exception:
+            TOOLSETS = {}
+        if name in TOOLSETS:
+            logger.warning(
+                "MCP server '%s' shares its name with a built-in toolset — the "
+                "built-in takes precedence during toolset resolution, so these "
+                "MCP tools (registered under '%s') are NOT reachable via the "
+                "'%s' toolset. Rename the MCP server in your config to a name "
+                "that does not collide with a built-in toolset.",
+                name, toolset_name, name,
+            )
         registry.register_toolset_alias(name, toolset_name)
 
     return registered_names


### PR DESCRIPTION
## What does this PR do?

When an MCP server is configured under `mcp_servers` with a name that matches a **built-in Hermes toolset** (e.g. `kanban`, `web`, `memory`), the server connects and its tools register successfully, but the agent never receives them — and nothing warns.

Root cause: MCP tools are registered under the `mcp-<name>` toolset and reached via a `<name>` → `mcp-<name>` alias. However `toolsets.get_toolset` / `resolve_toolset` consult the static `TOOLSETS` table **before** the registry alias map, so a built-in toolset named `<name>` shadows the alias. The freshly-registered MCP tools become silently unreachable via the bare `<name>` toolset (the signature is `prompt_tokens` staying flat even though registration logged success).

This mirrors the **existing** tool-name collision guard a few lines above in `_register_server_tools` (which warns "skipping to preserve built-in" for colliding tool *names*). That same "built-in wins, warn the user" philosophy was simply never applied to the toolset-*name* collision. This PR adds the missing toolset-name guard: when the server name matches a built-in toolset, it emits a warning explaining that the built-in takes precedence, that the MCP tools (registered under `mcp-<name>`) are unreachable via `<name>`, and advising a rename.

A warning was the reporter's explicitly-requested minimum ("A warning at minimum would turn a multi-hour silent debugging session into a one-line fix"), and keeps behavior consistent with the existing collision handling rather than changing resolution precedence.

## Related Issue

Fixes #30563

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py` — in `_register_server_tools`, before `register_toolset_alias`, warn when the MCP server `name` is also a built-in toolset (`name in toolsets.TOOLSETS`). Uses a guarded lazy import to avoid a circular import (`toolsets` imports `tools.registry`).
- `tests/tools/test_mcp_tool.py` — new `TestMCPToolsetNameCollisionWarning` with two cases: colliding name (`kanban`) warns while tools still register under `mcp-kanban`; a unique server name does not warn.
- `scripts/release.py` — add contributor to `AUTHOR_MAP` (required by the `contributor-check` workflow).

## How to Test

1. Configure an MCP server whose name collides with a built-in toolset:
   ```yaml
   mcp_servers:
     kanban:
       url: "https://example.com/mcp"
   ```
2. Start Hermes. `agent.log` now contains a warning that the MCP server name collides with a built-in toolset and the tools are unreachable via `kanban` (previously: silent).
3. Run the tests:
   ```bash
   python -m pytest tests/tools/test_mcp_tool.py::TestMCPToolsetNameCollisionWarning \
                    tests/tools/test_mcp_tool.py::TestMCPBuiltinCollisionGuard -q
   ```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(mcp): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests and they pass (`7 passed`, new + existing collision tests)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 (Python 3.12)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (behavior is a log warning; no user-facing docs/config keys changed)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure logging, no OS-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
