### PR TITLE
fix: preserve named custom vision providers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -165,10 +165,7 @@ _PROVIDER_ALIASES = {
 def _normalize_aux_provider(provider: Optional[str]) -> str:
     normalized = (provider or "auto").strip().lower()
     if normalized.startswith("custom:"):
-        suffix = normalized.split(":", 1)[1].strip()
-        if not suffix:
-            return "custom"
-        normalized = suffix
+        return normalized if normalized.split(":", 1)[1].strip() else "custom"
     if normalized == "codex":
         return "openai-codex"
     if normalized == "main":

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -60,7 +60,11 @@ class TestNormalizeVisionProvider:
 
     def test_custom_colon_named_provider_preserved(self):
         from agent.auxiliary_client import _normalize_vision_provider
-        assert _normalize_vision_provider("custom:beans") == "beans"
+        assert _normalize_vision_provider("custom:beans") == "custom:beans"
+
+    def test_custom_colon_named_provider_does_not_hit_builtin_alias(self):
+        from agent.auxiliary_client import _normalize_vision_provider
+        assert _normalize_vision_provider("custom:moonshot") == "custom:moonshot"
 
     def test_codex_alias_still_works(self):
         from agent.auxiliary_client import _normalize_vision_provider


### PR DESCRIPTION
## Summary
- Preserve custom:<name> providers during auxiliary vision provider normalization.
- Prevent custom:moonshot from being rewritten to built-in kimi-coding.
- Add regression coverage for named custom vision providers.

## Test Plan
- python -m pytest tests/agent/test_auxiliary_named_custom_providers.py tests/agent/test_vision_resolved_args.py tests/tools/test_vision_tools.py -q