### PR TITLE
Add corrective truth refiner

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1053,6 +1053,14 @@ def init_agent(
     # needed later by the startup feasibility check.  Avoid exposing a
     # broad pseudo-public config object on the agent instance.
     agent._aux_compression_context_length_config = None
+    agent._truth_refiner_config = None
+    try:
+        from agent.truth_refiner import load_truth_refiner_config
+        agent._truth_refiner_config = load_truth_refiner_config(
+            _agent_cfg.get("truth_refiner", {}) if _agent_cfg else {}
+        )
+    except Exception:
+        agent._truth_refiner_config = None
 
     # Persistent memory (MEMORY.md + USER.md) -- loaded from disk
     agent._memory_store = None

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4093,6 +4093,8 @@ def run_conversation(
             logger.debug("file-mutation verifier footer failed: %s", _ver_err)
 
     _response_transformed = False
+    _truth_refined = False
+    _truth_refiner_corrections = 0
 
     # Plugin hook: transform_llm_output
     # Fired once per turn after the tool-calling loop completes.
@@ -4115,6 +4117,47 @@ def run_conversation(
                     break  # First non-empty string wins
         except Exception as exc:
             logger.warning("transform_llm_output hook failed: %s", exc)
+
+    # Truth refiner: corrective final-output verification. This is not a
+    # yes/no gate; it asks for concrete corrections and a corrected answer,
+    # then feeds those corrections back to the main model for one repair pass.
+    if final_response and not interrupted:
+        try:
+            _truth_cfg = getattr(agent, "_truth_refiner_config", None)
+            if _truth_cfg and getattr(_truth_cfg, "enabled", False):
+                _truth_result = agent._refine_final_response_truth(
+                    messages=messages,
+                    original_user_message=original_user_message,
+                    final_response=final_response,
+                )
+                if getattr(_truth_result, "changed", False):
+                    final_response = _truth_result.final_response
+                    _truth_refined = True
+                    _response_transformed = True
+                    _truth_refiner_corrections = len(
+                        getattr(_truth_result, "corrections", []) or []
+                    )
+                    for _msg in reversed(messages):
+                        if (
+                            isinstance(_msg, dict)
+                            and _msg.get("role") == "assistant"
+                            and not _msg.get("tool_calls")
+                        ):
+                            _msg["content"] = final_response
+                            _msg["truth_refined"] = True
+                            _msg["truth_refiner_corrections"] = _truth_refiner_corrections
+                            break
+                    # If streaming already previewed the draft, force callers
+                    # to display the corrected final answer too.
+                    if getattr(agent, "_response_was_previewed", False):
+                        agent._response_was_previewed = False
+                    logger.info(
+                        "Truth refiner corrected final response (%d correction%s)",
+                        _truth_refiner_corrections,
+                        "" if _truth_refiner_corrections == 1 else "s",
+                    )
+        except Exception as exc:
+            logger.warning("truth_refiner failed: %s", exc)
 
     # Plugin hook: post_llm_call
     # Fired once per turn after the tool-calling loop completes.
@@ -4164,6 +4207,8 @@ def run_conversation(
         "partial": False,  # True only when stopped due to invalid tool calls
         "interrupted": interrupted,
         "response_transformed": _response_transformed,
+        "truth_refined": _truth_refined,
+        "truth_refiner_corrections": _truth_refiner_corrections,
         "response_previewed": getattr(agent, "_response_was_previewed", False),
         "model": agent.model,
         "provider": agent.provider,

--- a/agent/truth_refiner.py
+++ b/agent/truth_refiner.py
@@ -1,0 +1,383 @@
+"""Corrective truth refinement for final assistant responses."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TruthRefinerConfig:
+    """Runtime settings for final-output truth refinement."""
+
+    enabled: bool = False
+    max_context_chars: int = 16000
+    max_response_chars: int = 12000
+    repair_with_main_model: bool = True
+    max_repair_tokens: int = 2400
+    temperature: float = 0.0
+
+
+@dataclass
+class TruthCorrection:
+    """A specific untrue or unsupported part and its replacement."""
+
+    claim: str
+    problem: str
+    replacement: str
+    evidence: str = ""
+
+
+@dataclass
+class TruthRefinementResult:
+    """Result of a corrective refinement pass."""
+
+    original_response: str
+    final_response: str
+    corrected_response: str = ""
+    corrections: List[TruthCorrection] = field(default_factory=list)
+    used_main_repair: bool = False
+    error: str = ""
+
+    @property
+    def changed(self) -> bool:
+        return bool(
+            self.final_response
+            and self.final_response.strip() != self.original_response.strip()
+        )
+
+
+def load_truth_refiner_config(raw: Optional[Dict[str, Any]]) -> TruthRefinerConfig:
+    """Build config from a mapping, tolerating malformed user config."""
+    cfg = raw if isinstance(raw, dict) else {}
+    return TruthRefinerConfig(
+        enabled=bool(cfg.get("enabled", False)),
+        max_context_chars=_positive_int(cfg.get("max_context_chars"), 16000),
+        max_response_chars=_positive_int(cfg.get("max_response_chars"), 12000),
+        repair_with_main_model=bool(cfg.get("repair_with_main_model", True)),
+        max_repair_tokens=_positive_int(cfg.get("max_repair_tokens"), 2400),
+        temperature=float(cfg.get("temperature", 0.0) or 0.0),
+    )
+
+
+def refine_final_response(
+    *,
+    agent: Any,
+    messages: List[Dict[str, Any]],
+    original_user_message: Any,
+    final_response: str,
+    config: TruthRefinerConfig,
+) -> TruthRefinementResult:
+    """Correct false or unsupported final-response claims.
+
+    The first pass asks an auxiliary model for concrete corrections and a
+    corrected response.  When configured, the corrections are then fed back
+    to the main model in a single toolless repair pass.
+    """
+    original = final_response or ""
+    if not config.enabled or not original.strip():
+        return TruthRefinementResult(original_response=original, final_response=original)
+
+    try:
+        transcript = _compact_evidence(
+            messages=messages,
+            original_user_message=original_user_message,
+            final_response=original,
+            max_context_chars=config.max_context_chars,
+            max_response_chars=config.max_response_chars,
+        )
+        verifier_output = _call_verifier(
+            agent=agent,
+            transcript=transcript,
+            final_response=original,
+            config=config,
+        )
+        corrected_response, corrections = parse_truth_refiner_output(verifier_output)
+        if not corrections or not corrected_response.strip():
+            return TruthRefinementResult(
+                original_response=original,
+                final_response=original,
+                corrected_response=corrected_response,
+                corrections=corrections,
+            )
+
+        repaired = ""
+        if config.repair_with_main_model:
+            try:
+                repaired = _repair_with_main_model(
+                    agent=agent,
+                    original_response=original,
+                    corrected_response=corrected_response,
+                    corrections=corrections,
+                    config=config,
+                )
+            except Exception as repair_exc:
+                logger.debug("truth refiner main-model repair failed: %s", repair_exc)
+        final = repaired.strip() or corrected_response.strip()
+        return TruthRefinementResult(
+            original_response=original,
+            final_response=final,
+            corrected_response=corrected_response.strip(),
+            corrections=corrections,
+            used_main_repair=bool(repaired.strip()),
+        )
+    except Exception as exc:
+        logger.debug("truth refinement failed: %s", exc, exc_info=True)
+        return TruthRefinementResult(
+            original_response=original,
+            final_response=original,
+            error=str(exc),
+        )
+
+
+def parse_truth_refiner_output(raw: Any) -> tuple[str, List[TruthCorrection]]:
+    """Parse verifier JSON into a corrected response and correction list."""
+    text = _extract_text(raw)
+    if not text.strip():
+        return "", []
+    data = _loads_jsonish(text)
+    if not isinstance(data, dict):
+        return "", []
+
+    corrected = str(data.get("corrected_response") or "").strip()
+    raw_corrections = data.get("corrections") or []
+    corrections: List[TruthCorrection] = []
+    if isinstance(raw_corrections, list):
+        for item in raw_corrections:
+            if not isinstance(item, dict):
+                continue
+            claim = str(item.get("claim") or "").strip()
+            problem = str(item.get("problem") or "").strip()
+            replacement = str(item.get("replacement") or "").strip()
+            evidence = str(item.get("evidence") or "").strip()
+            if claim or problem or replacement:
+                corrections.append(
+                    TruthCorrection(
+                        claim=claim,
+                        problem=problem,
+                        replacement=replacement,
+                        evidence=evidence,
+                    )
+                )
+    return corrected, corrections
+
+
+def format_corrections_for_model(corrections: List[TruthCorrection]) -> str:
+    """Render corrections as concrete repair instructions."""
+    lines = []
+    for idx, correction in enumerate(corrections, start=1):
+        parts = [f"{idx}. Claim: {correction.claim or '(unspecified)'}"]
+        if correction.problem:
+            parts.append(f"Problem: {correction.problem}")
+        if correction.replacement:
+            parts.append(f"Replacement: {correction.replacement}")
+        if correction.evidence:
+            parts.append(f"Evidence: {correction.evidence}")
+        lines.append("\n".join(parts))
+    return "\n\n".join(lines)
+
+
+def _call_verifier(
+    *,
+    agent: Any,
+    transcript: str,
+    final_response: str,
+    config: TruthRefinerConfig,
+) -> Any:
+    from agent.auxiliary_client import call_llm
+
+    messages = [
+        {
+            "role": "system",
+            "content": (
+                "You are a corrective truth refiner for an AI agent. "
+                "Do not answer yes/no. Compare the draft answer against "
+                "the conversation and tool evidence. Return JSON only with "
+                "keys corrected_response and corrections. corrections is an "
+                "array of objects with claim, problem, replacement, evidence. "
+                "If no part needs correction, return the original response "
+                "as corrected_response and an empty corrections array."
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                "Conversation and tool evidence:\n"
+                f"{transcript}\n\n"
+                "Draft final answer:\n"
+                f"{_limit_text(final_response, config.max_response_chars)}"
+            ),
+        },
+    ]
+    return call_llm(
+        task="truth_refiner",
+        main_runtime=agent._current_main_runtime(),
+        messages=messages,
+        temperature=config.temperature,
+        max_tokens=config.max_repair_tokens,
+    )
+
+
+def _repair_with_main_model(
+    *,
+    agent: Any,
+    original_response: str,
+    corrected_response: str,
+    corrections: List[TruthCorrection],
+    config: TruthRefinerConfig,
+) -> str:
+    from agent.auxiliary_client import call_llm
+
+    runtime = agent._current_main_runtime()
+    messages = [
+        {
+            "role": "system",
+            "content": (
+                "You are revising your own final answer after a truth "
+                "refiner identified concrete false or unsupported parts. "
+                "Use the corrections as authoritative. Return only the "
+                "revised final answer for the user."
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                "Original answer:\n"
+                f"{_limit_text(original_response, config.max_response_chars)}\n\n"
+                "Required corrections:\n"
+                f"{format_corrections_for_model(corrections)}\n\n"
+                "Verifier-corrected answer:\n"
+                f"{_limit_text(corrected_response, config.max_response_chars)}"
+            ),
+        },
+    ]
+    response = call_llm(
+        provider=runtime.get("provider"),
+        model=runtime.get("model"),
+        base_url=runtime.get("base_url"),
+        api_key=runtime.get("api_key"),
+        main_runtime=runtime,
+        messages=messages,
+        temperature=config.temperature,
+        max_tokens=config.max_repair_tokens,
+    )
+    return _extract_text(response).strip()
+
+
+def _compact_evidence(
+    *,
+    messages: List[Dict[str, Any]],
+    original_user_message: Any,
+    final_response: str,
+    max_context_chars: int,
+    max_response_chars: int,
+) -> str:
+    parts = []
+    if isinstance(original_user_message, str) and original_user_message.strip():
+        parts.append("Current user request:\n" + _limit_text(original_user_message, 4000))
+
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        role = str(msg.get("role") or "")
+        if role not in {"user", "assistant", "tool"}:
+            continue
+        if msg.get("_truth_refiner_synthetic"):
+            continue
+        content = _message_content_text(msg.get("content"))
+        if not content.strip() and not msg.get("tool_calls"):
+            continue
+        label = role
+        if role == "tool":
+            label = f"tool:{msg.get('name') or msg.get('tool_call_id') or 'result'}"
+        if role == "assistant" and msg.get("tool_calls"):
+            calls = []
+            for call in msg.get("tool_calls") or []:
+                if isinstance(call, dict):
+                    calls.append(call.get("function", {}).get("name") or call.get("name") or "tool")
+            if calls:
+                content = (content + "\n" if content else "") + "Tool calls: " + ", ".join(calls)
+        parts.append(f"{label}:\n{_limit_text(content, 3000)}")
+
+    parts.append("Draft final answer under review:\n" + _limit_text(final_response, max_response_chars))
+    evidence = "\n\n---\n\n".join(parts)
+    return _limit_text(evidence, max_context_chars)
+
+
+def _message_content_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        pieces = []
+        for item in content:
+            if isinstance(item, dict):
+                if isinstance(item.get("text"), str):
+                    pieces.append(item["text"])
+                elif item.get("type"):
+                    pieces.append(f"[{item.get('type')}]")
+            elif isinstance(item, str):
+                pieces.append(item)
+        return "\n".join(pieces)
+    if content is None:
+        return ""
+    return str(content)
+
+
+def _extract_text(response: Any) -> str:
+    if isinstance(response, str):
+        return response
+    try:
+        return str(response.choices[0].message.content or "")
+    except Exception:
+        return str(response or "")
+
+
+def _loads_jsonish(text: str) -> Any:
+    cleaned = text.strip()
+    fence = re.search(r"```(?:json)?\s*(.*?)```", cleaned, flags=re.DOTALL | re.IGNORECASE)
+    if fence:
+        cleaned = fence.group(1).strip()
+    try:
+        return json.loads(cleaned)
+    except json.JSONDecodeError:
+        pass
+    start = cleaned.find("{")
+    end = cleaned.rfind("}")
+    if start != -1 and end != -1 and end > start:
+        try:
+            return json.loads(cleaned[start:end + 1])
+        except json.JSONDecodeError:
+            return None
+    return None
+
+
+def _limit_text(text: str, limit: int) -> str:
+    if limit <= 0 or len(text) <= limit:
+        return text
+    if limit <= 120:
+        return text[:limit].rstrip()
+    return text[: limit - 80].rstrip() + f"\n...[truncated {len(text) - limit + 80} chars]"
+
+
+def _positive_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+__all__ = [
+    "TruthCorrection",
+    "TruthRefinerConfig",
+    "TruthRefinementResult",
+    "format_corrections_for_model",
+    "load_truth_refiner_config",
+    "parse_truth_refiner_output",
+    "refine_final_response",
+]

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -458,6 +458,28 @@ prompt_caching:
 #                           # reasoning controls:
 #                           # extra_body:
 #                           #   enable_thinking: false
+#
+#   # Truth refiner: corrective final-output verification
+#   truth_refiner:
+#     provider: "auto"
+#     model: ""
+#     timeout: 60
+
+# =============================================================================
+# Truth Refiner
+# =============================================================================
+# Corrective final-output verification. When enabled, Hermes asks an auxiliary
+# model to identify false or unsupported parts of the final answer, produce
+# concrete corrections, then feed those corrections back to the main model for
+# one repair pass. This is not a yes/no validator; the output is a corrected
+# answer.
+truth_refiner:
+  enabled: false
+  max_context_chars: 16000
+  max_response_chars: 12000
+  repair_with_main_model: true
+  max_repair_tokens: 2400
+  temperature: 0.0
 
 # =============================================================================
 # Persistent Memory

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -951,6 +951,14 @@ DEFAULT_CONFIG = {
             "timeout": 30,
             "extra_body": {},
         },
+        "truth_refiner": {
+            "provider": "auto",
+            "model": "",
+            "base_url": "",
+            "api_key": "",
+            "timeout": 60,
+            "extra_body": {},
+        },
         # Triage specifier — flesh out a rough one-liner in the Kanban
         # Triage column into a concrete spec, then promote it to ``todo``.
         # Invoked by ``hermes kanban specify`` (single id or --all). Set a
@@ -1198,6 +1206,19 @@ DEFAULT_CONFIG = {
     # a plugin in plugins/context_engine/<name>/ or ~/.hermes/plugins/.
     "context": {
         "engine": "compressor",
+    },
+
+    # Truth refiner -- corrective final-output verification.
+    # When enabled, Hermes asks an auxiliary model to identify false or
+    # unsupported parts of the final answer, produce concrete corrections,
+    # and feed those corrections back to the main model for one repair pass.
+    "truth_refiner": {
+        "enabled": False,
+        "max_context_chars": 16000,
+        "max_response_chars": 12000,
+        "repair_with_main_model": True,
+        "max_repair_tokens": 2400,
+        "temperature": 0.0,
     },
 
     # Persistent memory -- bounded curated memory injected into system prompt

--- a/run_agent.py
+++ b/run_agent.py
@@ -2088,6 +2088,23 @@ class AIAgent:
         except Exception:
             pass
 
+    def _refine_final_response_truth(
+        self,
+        *,
+        messages: List[Dict],
+        original_user_message: Any,
+        final_response: str,
+    ):
+        """Run corrective truth refinement for a final response."""
+        from agent.truth_refiner import refine_final_response
+        return refine_final_response(
+            agent=self,
+            messages=messages,
+            original_user_message=original_user_message,
+            final_response=final_response,
+            config=self._truth_refiner_config,
+        )
+
     def release_clients(self) -> None:
         """Release LLM client resources WITHOUT tearing down session tool state.
 

--- a/tests/agent/test_truth_refiner.py
+++ b/tests/agent/test_truth_refiner.py
@@ -1,0 +1,245 @@
+"""Tests for corrective truth refinement."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from agent.truth_refiner import (
+    TruthRefinerConfig,
+    format_corrections_for_model,
+    load_truth_refiner_config,
+    parse_truth_refiner_output,
+    refine_final_response,
+)
+
+
+class _AgentStub:
+    model = "test-model"
+    provider = "test-provider"
+    base_url = "https://example.invalid/v1"
+    api_key = "test-key"
+    api_mode = "chat_completions"
+
+    def _current_main_runtime(self):
+        return {
+            "model": self.model,
+            "provider": self.provider,
+            "base_url": self.base_url,
+            "api_key": self.api_key,
+            "api_mode": self.api_mode,
+        }
+
+
+def _response(text: str):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=text))]
+    )
+
+
+def test_parse_truth_refiner_output_accepts_fenced_json():
+    raw = """```json
+{
+  "corrected_response": "I changed app.py. I could not change cli.py.",
+  "corrections": [
+    {
+      "claim": "I changed both files.",
+      "problem": "cli.py patch failed.",
+      "replacement": "I changed app.py only.",
+      "evidence": "tool result reported failure for cli.py"
+    }
+  ]
+}
+```"""
+
+    corrected, corrections = parse_truth_refiner_output(raw)
+
+    assert corrected.startswith("I changed app.py")
+    assert len(corrections) == 1
+    assert corrections[0].claim == "I changed both files."
+    assert corrections[0].replacement == "I changed app.py only."
+
+
+def test_parse_truth_refiner_output_rejects_malformed_text():
+    corrected, corrections = parse_truth_refiner_output("not json")
+
+    assert corrected == ""
+    assert corrections == []
+
+
+def test_format_corrections_for_model_is_not_yes_no():
+    corrected, corrections = parse_truth_refiner_output(
+        json.dumps({
+            "corrected_response": "Corrected answer",
+            "corrections": [{
+                "claim": "Claim",
+                "problem": "Unsupported",
+                "replacement": "Replacement",
+                "evidence": "Tool output",
+            }],
+        })
+    )
+
+    rendered = format_corrections_for_model(corrections)
+
+    assert corrected == "Corrected answer"
+    assert "Claim: Claim" in rendered
+    assert "Problem: Unsupported" in rendered
+    assert "Replacement: Replacement" in rendered
+    assert "yes" not in rendered.lower()
+    assert "no" not in rendered.lower()
+
+
+def test_refine_final_response_returns_original_when_disabled(monkeypatch):
+    calls = []
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        return _response("{}")
+
+    monkeypatch.setattr("agent.auxiliary_client.call_llm", fake_call_llm)
+
+    result = refine_final_response(
+        agent=_AgentStub(),
+        messages=[],
+        original_user_message="Do it",
+        final_response="Done.",
+        config=TruthRefinerConfig(enabled=False),
+    )
+
+    assert result.final_response == "Done."
+    assert result.changed is False
+    assert calls == []
+
+
+def test_refine_final_response_noops_when_no_corrections(monkeypatch):
+    def fake_call_llm(**kwargs):
+        return _response(json.dumps({
+            "corrected_response": "Done.",
+            "corrections": [],
+        }))
+
+    monkeypatch.setattr("agent.auxiliary_client.call_llm", fake_call_llm)
+
+    result = refine_final_response(
+        agent=_AgentStub(),
+        messages=[{"role": "tool", "content": "success"}],
+        original_user_message="Do it",
+        final_response="Done.",
+        config=TruthRefinerConfig(enabled=True),
+    )
+
+    assert result.final_response == "Done."
+    assert result.changed is False
+    assert result.corrections == []
+
+
+def test_refine_final_response_feeds_corrections_back_to_main_model(monkeypatch):
+    calls = []
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            return _response(json.dumps({
+                "corrected_response": "I changed app.py. cli.py was not changed.",
+                "corrections": [{
+                    "claim": "I changed app.py and cli.py.",
+                    "problem": "cli.py patch failed.",
+                    "replacement": "cli.py was not changed.",
+                    "evidence": "tool result: patch failed",
+                }],
+            }))
+        return _response("I changed app.py. cli.py was not changed.")
+
+    monkeypatch.setattr("agent.auxiliary_client.call_llm", fake_call_llm)
+
+    result = refine_final_response(
+        agent=_AgentStub(),
+        messages=[
+            {"role": "user", "content": "change both files"},
+            {"role": "tool", "name": "patch", "content": "app.py ok; cli.py failed"},
+        ],
+        original_user_message="change both files",
+        final_response="I changed app.py and cli.py.",
+        config=TruthRefinerConfig(enabled=True, repair_with_main_model=True),
+    )
+
+    assert result.final_response == "I changed app.py. cli.py was not changed."
+    assert result.used_main_repair is True
+    assert result.changed is True
+    assert len(calls) == 2
+    assert calls[0]["task"] == "truth_refiner"
+    assert calls[1]["provider"] == "test-provider"
+    assert "Required corrections" in calls[1]["messages"][1]["content"]
+    assert "cli.py patch failed" in calls[1]["messages"][1]["content"]
+
+
+def test_refine_final_response_uses_corrected_answer_if_main_repair_fails(monkeypatch):
+    calls = []
+
+    def fake_call_llm(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            return _response(json.dumps({
+                "corrected_response": "The command failed.",
+                "corrections": [{
+                    "claim": "The command succeeded.",
+                    "problem": "Tool output says exit code 1.",
+                    "replacement": "The command failed.",
+                }],
+            }))
+        raise RuntimeError("main repair unavailable")
+
+    monkeypatch.setattr("agent.auxiliary_client.call_llm", fake_call_llm)
+
+    result = refine_final_response(
+        agent=_AgentStub(),
+        messages=[{"role": "tool", "content": "exit code 1"}],
+        original_user_message="run command",
+        final_response="The command succeeded.",
+        config=TruthRefinerConfig(enabled=True, repair_with_main_model=True),
+    )
+
+    assert result.final_response == "The command failed."
+    assert result.changed is True
+    assert result.error == ""
+
+
+def test_refine_final_response_can_skip_main_repair(monkeypatch):
+    def fake_call_llm(**kwargs):
+        return _response(json.dumps({
+            "corrected_response": "The command failed.",
+            "corrections": [{
+                "claim": "The command succeeded.",
+                "problem": "Tool output says exit code 1.",
+                "replacement": "The command failed.",
+            }],
+        }))
+
+    monkeypatch.setattr("agent.auxiliary_client.call_llm", fake_call_llm)
+
+    result = refine_final_response(
+        agent=_AgentStub(),
+        messages=[{"role": "tool", "content": "exit code 1"}],
+        original_user_message="run command",
+        final_response="The command succeeded.",
+        config=TruthRefinerConfig(enabled=True, repair_with_main_model=False),
+    )
+
+    assert result.final_response == "The command failed."
+    assert result.used_main_repair is False
+    assert result.changed is True
+
+
+def test_load_truth_refiner_config_tolerates_bad_numbers():
+    cfg = load_truth_refiner_config({
+        "enabled": True,
+        "max_context_chars": "bad",
+        "max_response_chars": 0,
+        "max_repair_tokens": "44",
+    })
+
+    assert cfg.enabled is True
+    assert cfg.max_context_chars == 16000
+    assert cfg.max_response_chars == 12000
+    assert cfg.max_repair_tokens == 44


### PR DESCRIPTION
## Summary
- add an opt-in truth_refiner final-output pass that returns concrete corrections and a corrected response instead of a yes/no verdict
- feed verifier corrections back to the main model for one repair pass, falling back to the verifier-corrected answer if repair fails
- update the stored final assistant message with the refined answer so hooks, memory, and session history see corrected output
- force corrected final output to display when streaming already previewed the draft

## Config
- adds truth_refiner.enabled and tuning limits
- adds auxiliary.truth_refiner provider/model/timeout routing
- disabled by default to avoid surprise extra model calls

## Tests
- uv run ruff check agent/truth_refiner.py tests/agent/test_truth_refiner.py agent/agent_init.py agent/conversation_loop.py run_agent.py hermes_cli/config.py
- uv run python -m py_compile agent/truth_refiner.py agent/agent_init.py agent/conversation_loop.py run_agent.py
- uv run python - <<'PY'
import yaml
with open('cli-config.yaml.example', encoding='utf-8') as f:
    yaml.safe_load(f)
print('yaml ok')
PY
- scripts/run_tests.sh tests/agent/test_truth_refiner.py tests/run_agent/test_run_agent.py -- -q