### PR TITLE
fix(kanban-db): retry integrity probe before flagging DB as corrupt

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1112,21 +1112,37 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
         return
     if str(resolved) in _INITIALIZED_PATHS:
         return
+    # Probe with retries. Under WAL with concurrent writers, a probe can
+    # transiently see a torn page and SQLite returns DatabaseError
+    # ("database disk image is malformed") or a non-"ok" integrity row
+    # — even though the file is fine and the next probe succeeds. We
+    # retry a few times with a short backoff before declaring corruption
+    # to avoid disabling the dispatcher on a brief contention blip.
     reason: Optional[str] = None
-    try:
-        probe = sqlite3.connect(str(resolved), timeout=5, isolation_level=None)
+    attempts = 3
+    backoff = 0.25
+    for attempt in range(1, attempts + 1):
+        reason = None
         try:
-            row = probe.execute("PRAGMA integrity_check").fetchone()
-        finally:
-            probe.close()
-        if not row or (row[0] or "").lower() != "ok":
-            reason = f"integrity_check returned {row[0] if row else '<no row>'!r}"
-    except sqlite3.OperationalError:
-        # Lock contention, busy, transient IO — not corruption. Let it propagate.
-        raise
-    except sqlite3.DatabaseError as exc:
-        reason = f"sqlite refused to open file: {exc}"
+            probe = sqlite3.connect(str(resolved), timeout=5, isolation_level=None)
+            try:
+                row = probe.execute("PRAGMA integrity_check").fetchone()
+            finally:
+                probe.close()
+            if not row or (row[0] or "").lower() != "ok":
+                reason = f"integrity_check returned {row[0] if row else '<no row>'!r}"
+        except sqlite3.OperationalError:
+            # Lock contention, busy, transient IO — not corruption. Let it propagate.
+            raise
+        except sqlite3.DatabaseError as exc:
+            reason = f"sqlite refused to open file: {exc}"
+        if reason is None:
+            return
+        if attempt < attempts:
+            time.sleep(backoff * attempt)
     if reason is None:
+        # All attempts produced a "no error" outcome — defensive guard;
+        # in practice we'd have returned above on the first clean probe.
         return
     backup = _backup_corrupt_db(resolved)
     raise KanbanDbCorruptError(resolved, backup, reason)

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3069,6 +3069,40 @@ def test_locked_healthy_db_does_not_classify_as_corrupt(tmp_path, monkeypatch):
     assert "still here" in titles
 
 
+def test_transient_malformed_probe_does_not_classify_as_corrupt(tmp_path, monkeypatch):
+    """A transient ``DatabaseError`` (e.g. WAL torn-page seen mid-write)
+    must NOT permanently flag the file as corrupt. The guard should retry
+    the integrity probe and accept the file when a subsequent attempt
+    succeeds. Regression test for the kanban dispatcher disabling itself
+    on a healthy DB after a worker write blip."""
+    db_path = tmp_path / "kanban.db"
+    kb.init_db(db_path=db_path)
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+    real_connect = sqlite3.connect
+    calls = {"n": 0}
+
+    def flaky_then_healthy_connect(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            # Simulate a single transient torn-page read.
+            raise sqlite3.DatabaseError("database disk image is malformed")
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr(kb.sqlite3, "connect", flaky_then_healthy_connect)
+
+    # Should succeed without raising — the retry sees a healthy DB on attempt 2.
+    with kb.connect(db_path=db_path) as conn:
+        kb.create_task(conn, title="survived")
+        titles = [t.title for t in kb.list_tasks(conn)]
+    assert "survived" in titles
+
+    # And critically: no .corrupt backup may be produced for a transient blip.
+    backups = list(tmp_path.glob("*.corrupt.*"))
+    assert backups == [], f"unexpected corrupt backups: {backups}"
+    assert calls["n"] >= 2, "retry path was not exercised"
+
+
 def test_init_db_allows_missing_then_healthy(tmp_path):
     db_path = tmp_path / "fresh.db"
     assert not db_path.exists()


### PR DESCRIPTION
The kanban gateway dispatcher opens a fresh sqlite connection per tick, each of which runs PRAGMA integrity_check via _guard_existing_db_is_healthy. Under WAL with concurrent worker writes, the probe can transiently observe a torn page and either return a non-'ok' integrity row or raise sqlite3.DatabaseError('database disk image is malformed') -- even though the file is fine and the very next probe succeeds.

The previous guard treated the first such hit as terminal corruption: it copied the file to a timestamped .corrupt.*.bak and raised KanbanDbCorruptError, which the gateway dispatcher then used to disable dispatch on that board until the file mtime changed or the gateway restarted. In practice this caused the dispatcher to silently stop processing tasks on a perfectly healthy DB, and left dozens of spurious .corrupt backup files on disk.

Retry the integrity probe up to 3 times with a short backoff (250ms, 500ms) before declaring corruption. A genuinely corrupt file still gets flagged after 3 consistent failures; a transient WAL blip from a concurrent worker write now self-heals.

Adds a regression test that injects a single transient DatabaseError on the first probe attempt and asserts:
  - connect() succeeds (retry sees a healthy DB on attempt 2)
  - no .corrupt backup is produced
  - the retry path was actually exercised

Existing tests for genuine corruption and locked-but-healthy DBs continue to pass unchanged.