### PR TITLE
Add claude-cli provider: route Hermes through Claude Code subscription

### DIFF
--- a/plugins/model-providers/claude-cli/__init__.py
+++ b/plugins/model-providers/claude-cli/__init__.py
@@ -1,0 +1,70 @@
+"""Claude CLI provider profile.
+
+Routes inference through a local OpenAI-compatible HTTP shim (default
+``http://localhost:9180/v1``) that subprocesses Anthropic's official
+``claude`` CLI. Each request uses the user's existing Claude Code OAuth
+session (``~/.claude/.credentials.json``), so billing flows against the
+**Claude Code subscription's base Max allowance** instead of pay-per-token
+API credits or separately-purchased extra-usage credits.
+
+This is the same auth path users see when running ``claude`` interactively
+in a terminal. It does **not** call ``api.anthropic.com`` directly — the
+shim is what makes it look like an OpenAI server to Hermes.
+
+Why this is its own provider (rather than just using ``provider: custom``):
+
+  - Picker visibility: ``hermes model`` lists named providers so users
+    discover the Claude-via-subscription path without reading docs.
+  - Curated model list: aliases (``sonnet``, ``opus``, ``haiku``) plus
+    full IDs that the ``claude`` CLI accepts.
+  - Default aux model: routes auxiliary tasks (compression, vision
+    routing, title generation) to ``haiku`` so they don't burn the
+    main-model allowance.
+
+Setup requires an external shim daemon — Hermes intentionally does **not**
+spawn or manage the ``claude`` subprocess itself, both to keep the core
+free of Go/Node dependencies and to let the same shim serve non-Hermes
+tools (Open WebUI, Cursor, etc.).
+
+Reference shim: https://github.com/niski84/claude-bridge
+
+Override the shim URL with ``CLAUDE_BRIDGE_URL`` if running on a
+non-default host/port or behind a reverse proxy.
+"""
+
+from __future__ import annotations
+
+import os
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+claude_cli = ProviderProfile(
+    name="claude-cli",
+    aliases=("claude", "claude-code", "claude-max", "claude-subscription"),
+    env_vars=("CLAUDE_BRIDGE_URL",),
+    display_name="Claude CLI (Max subscription)",
+    description=(
+        "Claude via the local claude CLI subscription — uses Max base "
+        "allowance instead of API credits. Requires the claude-bridge "
+        "shim running on localhost (github.com/niski84/claude-bridge)."
+    ),
+    signup_url="https://claude.ai/code",
+    base_url=os.getenv("CLAUDE_BRIDGE_URL", "http://localhost:9180/v1"),
+    fallback_models=(
+        "sonnet",
+        "opus",
+        "haiku",
+        "claude-sonnet-4-6",
+        "claude-opus-4-7",
+        "claude-haiku-4-5",
+    ),
+    default_aux_model="haiku",
+    default_headers={
+        "X-Title": "Hermes Agent (via Claude CLI bridge)",
+    },
+)
+
+
+register_provider(claude_cli)

--- a/plugins/model-providers/claude-cli/plugin.yaml
+++ b/plugins/model-providers/claude-cli/plugin.yaml
@@ -1,0 +1,5 @@
+name: claude-cli-provider
+kind: model-provider
+version: 1.0.0
+description: Claude via the local claude CLI subscription (Max base allowance, not API credits)
+author: Nous Research


### PR DESCRIPTION
## Summary

Adds a `claude-cli` provider profile so users with a **Claude Code subscription (Max plan)** can use their base allowance with Hermes Agent — instead of needing separately-purchased extra-usage credits to call `api.anthropic.com` as a third-party app.

## The problem this solves

The bundled `anthropic` provider calls `api.anthropic.com` directly via API key or OAuth. With a Claude Max subscription, that path returns:

> `Third-party apps now draw from your extra usage, not your plan limits.`

…because Max's base allowance only applies to **first-party** Claude Code, not third-party API consumers. Users with an active Max subscription but no extra-usage credits cannot currently use Hermes against Claude without paying twice.

## How it works

The new provider points at a local OpenAI-compatible HTTP shim (default `http://localhost:9180/v1`) that subprocesses the official `claude` CLI for every request. The CLI uses the user's existing `~/.claude/.credentials.json` (the same OAuth session they get from `claude login`), so billing flows through the first-party path — base Max allowance, then extra usage, then API as configured by the user in their Anthropic settings.

Hermes never calls Anthropic directly through this provider. It just speaks OpenAI Chat Completions to the shim.

## Why a new provider rather than just `provider: custom`

1. **Picker visibility** — `hermes model` surfaces it so users discover the Claude-via-subscription path without reading docs or knowing about the shim.
2. **Curated model list** — aliases (`sonnet` / `opus` / `haiku`) plus full IDs that the `claude` CLI accepts, matching how users think about Claude.
3. **`default_aux_model="haiku"`** so auxiliary tasks (compression, vision routing, title gen) don't burn the main allowance.

## Setup (downstream)

The shim is a separate ~350-LOC Go binary that I open-sourced under MIT:
👉 https://github.com/niski84/claude-bridge

Hermes intentionally does **not** spawn or manage the `claude` subprocess itself, for two reasons:
- Keeps the core free of Go/Node deps.
- The same shim is useful for non-Hermes tools — Open WebUI, Cursor, LibreChat all work too.

Once the shim is running locally, users just pick `claude-cli` in `hermes model` (or set `provider: claude-cli` in `config.yaml`) and Hermes routes through it like any other provider.

I also have a standalone Hermes plugin that mirrors this provider for users on older Hermes versions:
👉 https://github.com/niski84/hermes-claude-cli

The plugin's `install.sh` bootstraps the whole stack (clone bridge → `go build` → systemd user service → symlink plugin → write `CLAUDE_BRIDGE_URL` to `~/.hermes/.env`).

## Files changed

- `plugins/model-providers/claude-cli/__init__.py` (66 lines) — `ProviderProfile` registration
- `plugins/model-providers/claude-cli/plugin.yaml` (5 lines) — manifest

Discovery via the existing `_discover_providers()` scaffold — no core code changes.

## Test plan

- [ ] CI green (the provider just declares a `ProviderProfile`; no behavioral overrides → no new tests required beyond what the existing model-provider discovery tests cover)
- [ ] Local: install [claude-bridge](https://github.com/niski84/claude-bridge), restart Hermes, verify `hermes model` shows "Claude CLI (Max subscription)"
- [ ] Local: pick `claude-cli` as provider, run a chat, confirm response routes through the bridge subprocess (visible in bridge logs)
- [ ] Local: confirm `~/.claude/.credentials.json` is the auth source (no `ANTHROPIC_API_KEY` consumed)

## Notes

- I'm happy to iterate on naming (`claude-cli` vs `claude-code-cli` vs `claude-subscription` etc.) — picked `claude-cli` to match the binary name and stay short for picker UX.
- If the maintainers prefer to bundle a reference shim rather than point at an external repo, happy to discuss — but my reading of the codebase is that keeping HTTP shims out of the core matches the existing `copilot-acp` / `openai-codex` pattern (they assume external auth/process infrastructure already exists).
- The `env_vars=("CLAUDE_BRIDGE_URL",)` declaration is what makes the provider visible in the picker (the picker filters by "has at least one env var set"). The shim's install.sh writes a localhost default. Could also be a sentinel like `HERMES_CLAUDE_CLI_ENABLED=true` if maintainers prefer.

Happy to address any feedback. Thanks for the great agent framework!