### PR TITLE
fix(cli): hermes doctor --fix now auto-converts custom_providers dict to list

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -765,6 +765,7 @@ def run_doctor(args):
             config_issues = validate_config_structure()
             if config_issues:
                 _section("Config Structure")
+                needs_cp_fix = False
                 for ci in config_issues:
                     if ci.severity == "error":
                         check_fail(ci.message)
@@ -774,6 +775,27 @@ def run_doctor(args):
                     for hint_line in ci.hint.splitlines():
                         check_info(hint_line)
                     issues.append(ci.message)
+                    # Track if we need to fix custom_providers dict→list
+                    if ci.message.startswith("custom_providers is a dict"):
+                        needs_cp_fix = True
+                
+                # Auto-fix custom_providers dict→list if requested
+                if should_fix and needs_cp_fix and config_path:
+                    import yaml as _yaml
+                    try:
+                        cfg = _yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+                        cp = cfg.get("custom_providers")
+                        if isinstance(cp, dict):
+                            # Convert dict to list format
+                            cfg["custom_providers"] = [
+                                {"name": k, **v} for k, v in cp.items()
+                            ]
+                            from utils import atomic_yaml_write
+                            atomic_yaml_write(config_path, cfg)
+                            check_ok("Converted custom_providers from dict to list format")
+                            fixed_count += 1
+                    except Exception as e:
+                        check_fail(f"Failed to fix custom_providers structure: {e}")
         except Exception:
             pass
 


### PR DESCRIPTION
## Problem
`hermes doctor` correctly detects when `custom_providers` is a dict instead of a list, but running `hermes doctor --fix` does not actually rewrite the config.

## Root Cause
In `hermes_cli/doctor.py` (lines 762-778), the `validate_config_structure` check reports config structure issues but has **no `should_fix` branch**. Unlike the stale root-level keys check (lines 746-756) which correctly handles `should_fix` by rewriting the config with `atomic_yaml_write`, the custom_providers issue only appends to the issues list without applying any fix.

## Fix
Adds the missing `should_fix` logic for `custom_providers` migration:
- Adds `needs_cp_fix` flag to track when custom_providers needs dict→list conversion
- When `--fix` is passed and custom_providers is dict-formatted:
  - Converts dict keys to list entries with `"name"` field
  - Uses existing `atomic_yaml_write` for safe config update
  - Shows success message after conversion

## Code Intelligence
- Analyzed: `run_doctor` in `hermes_cli/doctor.py` (4 callers in test suite)
- Blast radius: LOW — change is isolated to the config structure validation section
- Related patterns: Stale root-level keys fix (line 746) uses the same `atomic_yaml_write` pattern

## Checklist
- [x] Only changes `hermes_cli/doctor.py`
- [x] Uses existing `atomic_yaml_write` helper for safe config writes
- [x] Follows the same pattern as stale root-level keys fix
- [x] Fixes #31780