### PR TITLE
fix: dedupe corrupt kanban db backups

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -71,6 +71,7 @@ new locking.
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import json
 import os
 import re
@@ -1042,6 +1043,24 @@ def _backup_corrupt_db(path: Path) -> Optional[Path]:
     resolved = path.resolve()
     parent = resolved.parent
     base_name = resolved.name  # basename only
+    try:
+        original_stat = resolved.stat()
+        original_hash = hashlib.sha256(resolved.read_bytes()).hexdigest()
+    except OSError:
+        return None
+    # A gateway dispatcher ticks every minute. If a corrupt DB is left in
+    # place until an operator recovers it, every tick re-runs this guard.
+    # Preserve the first copy, but do not clone the same damaged bytes over
+    # and over into an accidental backup landfill.
+    for existing in sorted(parent.glob(f"{base_name}.corrupt.*.bak")):
+        try:
+            if existing.stat().st_size != original_stat.st_size:
+                continue
+            if hashlib.sha256(existing.read_bytes()).hexdigest() == original_hash:
+                return existing
+        except OSError:
+            continue
+
     stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     candidate = parent / f"{base_name}.corrupt.{stamp}.bak"
     # Defensive: candidate must still be inside parent after construction.

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3038,6 +3038,21 @@ def test_connect_refuses_corrupt_existing_file(tmp_path):
         kb.connect(db_path=db_path)
 
 
+def test_repeated_corrupt_db_probe_reuses_existing_backup(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    _write_corrupt_db(db_path)
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+    with pytest.raises(kb.KanbanDbCorruptError) as first:
+        kb.connect(db_path=db_path)
+    with pytest.raises(kb.KanbanDbCorruptError) as second:
+        kb.connect(db_path=db_path)
+
+    assert first.value.backup_path == second.value.backup_path
+    backups = list(tmp_path.glob("kanban.db.corrupt.*.bak"))
+    assert backups == [first.value.backup_path]
+
+
 def test_locked_healthy_db_does_not_classify_as_corrupt(tmp_path, monkeypatch):
     """A transient lock during the probe must not produce a .corrupt backup
     and must not be reported as :class:`KanbanDbCorruptError`. Raw sqlite


### PR DESCRIPTION
## Summary
- Reuse an existing corrupt Kanban DB backup when the bytes match
- Avoid creating backup landfill on repeated dispatcher probes
- Add regression coverage for repeated corrupt DB probes

## Test Plan
- python -m pytest tests/hermes_cli/test_kanban_db.py::test_init_db_refuses_corrupt_existing_file tests/hermes_cli/test_kanban_db.py::test_connect_refuses_corrupt_existing_file tests/hermes_cli/test_kanban_db.py::test_repeated_corrupt_db_probe_reuses_existing_backup tests/hermes_cli/test_kanban_db.py::test_locked_healthy_db_does_not_classify_as_corrupt -q -o 'addopts='