### PR TITLE
fix(file_tools): validate read_file path before dispatch (#31791)

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -67,6 +67,37 @@ class TestReadFileHandler:
         assert "error" in result
         assert "terminal not available" in result["error"]
 
+    def test_missing_path_key_returns_error(self):
+        """#31791 — handler must reject calls where 'path' key is absent rather than
+        defaulting to "" and producing a confusing 'File not found: ' error with
+        unrelated similar_files suggestions."""
+        from tools.file_tools import _handle_read_file
+
+        result = json.loads(_handle_read_file({}))
+        assert "error" in result
+        assert "path" in result["error"].lower()
+
+    def test_empty_path_returns_error(self):
+        """#31791 — explicit empty string path is rejected before resolution."""
+        from tools.file_tools import _handle_read_file
+
+        result = json.loads(_handle_read_file({"path": ""}))
+        assert "error" in result
+        assert "path" in result["error"].lower()
+
+    def test_non_string_path_returns_error(self):
+        """#31791 — non-string path (e.g. None, list) is rejected."""
+        from tools.file_tools import _handle_read_file
+
+        result = json.loads(_handle_read_file({"path": None}))
+        assert "error" in result
+        assert "path" in result["error"].lower()
+
+    def test_read_file_schema_requires_non_empty_path(self):
+        """#31791 — schema declares minLength: 1 so providers that honor JSON Schema
+        can reject empty paths before the call reaches the handler."""
+        assert READ_FILE_SCHEMA["parameters"]["properties"]["path"].get("minLength") == 1
+
 
 class TestWriteFileHandler:
     @patch("tools.file_tools._get_file_ops")

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1089,7 +1089,7 @@ READ_FILE_SCHEMA = {
     "parameters": {
         "type": "object",
         "properties": {
-            "path": {"type": "string", "description": "Path to the file to read (absolute, relative, or ~/path)"},
+            "path": {"type": "string", "minLength": 1, "description": "Path to the file to read (absolute, relative, or ~/path)"},
             "offset": {"type": "integer", "description": "Line number to start reading from (1-indexed, default: 1)", "default": 1, "minimum": 1},
             "limit": {"type": "integer", "description": "Maximum number of lines to read (default: 500, max: 2000)", "default": 500, "maximum": 2000}
         },
@@ -1188,7 +1188,12 @@ SEARCH_FILES_SCHEMA = {
 
 def _handle_read_file(args, **kw):
     tid = kw.get("task_id") or "default"
-    return read_file_tool(path=args.get("path", ""), offset=args.get("offset", 1), limit=args.get("limit", 500), task_id=tid)
+    if not args.get("path") or not isinstance(args.get("path"), str):
+        return tool_error(
+            "read_file: missing required field 'path'. Re-emit the tool call with "
+            "a valid file path (absolute, relative, or ~/path)."
+        )
+    return read_file_tool(path=args["path"], offset=args.get("offset", 1), limit=args.get("limit", 500), task_id=tid)
 
 
 def _handle_write_file(args, **kw):


### PR DESCRIPTION
## Summary

Fixes #31791.

When the model calls `read_file` with a missing or empty `path` argument, `_handle_read_file` defaulted to `""`. The empty path resolved to CWD and propagated through `_suggest_similar_files`, producing a confusing error like `"File not found: ", "similar_files": ["./backups", "./fix_sql.py", ...]`. The unrelated suggestions burned API calls as the model tried to self-correct.

## Changes

- `tools/file_tools.py`: add a presence/type guard in `_handle_read_file` mirroring the existing `_handle_write_file` validation, returning a clear `tool_error` instead.
- `tools/file_tools.py`: declare `minLength: 1` on the `READ_FILE_SCHEMA` `path` property so providers honoring JSON Schema reject the call before it reaches the handler.
- `tests/tools/test_file_tools.py`: add four tests for missing key, empty string, non-string, and schema `minLength`.

## Test plan

- [x] `pytest tests/tools/test_file_tools.py::TestReadFileHandler` — 8/8 pass (4 existing + 4 new)
- [ ] Manual: trigger an empty-path `read_file` call from a model and confirm the new `tool_error` surfaces instead of the misleading `"File not found: "` message.
