### PR TITLE
fix(feishu): use interactive card messages for Markdown rendering

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -162,7 +162,20 @@ _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
 _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
 _MENTION_RE = re.compile(r"@_user_\d+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
-_POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect", re.IGNORECASE)
+_POST_CONTENT_INVALID_RE = re.compile(r"(content format of the post type is incorrect|field validation failed)", re.IGNORECASE)
+_INTERACTIVE_SEND_ERROR_CODES = frozenset({99992402, 99992403, 99992404})
+
+
+def _should_fallback_from_interactive(error_str: str) -> bool:
+    """Check if an interactive (card) message send error should trigger plain text fallback."""
+    if _POST_CONTENT_INVALID_RE.search(error_str):
+        return True
+    # Extract error code from format like "[99992402] field validation failed"
+    import re as _re
+    code_match = _re.search(r"\[(\d+)\]", error_str)
+    if code_match and int(code_match.group(1)) in _INTERACTIVE_SEND_ERROR_CODES:
+        return True
+    return False
 # ---------------------------------------------------------------------------
 # Media type sets and upload constants
 # ---------------------------------------------------------------------------
@@ -558,6 +571,22 @@ def _build_markdown_post_payload(content: str) -> str:
         },
         ensure_ascii=False,
     )
+
+
+def _build_markdown_card_payload(content: str) -> str:
+    """Build an Feishu interactive card payload with a markdown element.
+
+    Feishu's post-type does NOT support the 'md' tag — only interactive cards
+    have a proper markdown element that renders formatting. This builder wraps
+    the markdown content in a minimal card structure.
+    """
+    card = {
+        "config": {"wide_screen_mode": True},
+        "elements": [
+            {"tag": "markdown", "content": content},
+        ],
+    }
+    return json.dumps(card, ensure_ascii=False)
 
 
 def _build_markdown_post_rows(content: str) -> List[List[Dict[str, str]]]:
@@ -1792,9 +1821,9 @@ class FeishuAdapter(BasePlatformAdapter):
                         metadata=metadata,
                     )
                 except Exception as exc:
-                    if msg_type != "post" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
+                    if msg_type != "interactive" or not _should_fallback_from_interactive(str(exc)):
                         raise
-                    logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
+                    logger.warning("[Feishu] Invalid interactive payload rejected by API; falling back to plain text")
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
                         msg_type="text",
@@ -1803,11 +1832,11 @@ class FeishuAdapter(BasePlatformAdapter):
                         metadata=metadata,
                     )
                 if (
-                    msg_type == "post"
+                    msg_type == "interactive"
                     and not self._response_succeeded(response)
-                    and _POST_CONTENT_INVALID_RE.search(str(getattr(response, "msg", "") or ""))
+                    and _should_fallback_from_interactive(str(getattr(response, "msg", "") or ""))
                 ):
-                    logger.warning("[Feishu] Post payload rejected by API response; falling back to plain text")
+                    logger.warning("[Feishu] Interactive payload rejected by API response; falling back to plain text")
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
                         msg_type="text",
@@ -1841,8 +1870,8 @@ class FeishuAdapter(BasePlatformAdapter):
             request = self._build_update_message_request(message_id=message_id, request_body=body)
             response = await asyncio.to_thread(self._client.im.v1.message.update, request)
             result = self._finalize_send_result(response, "update failed")
-            if not result.success and msg_type == "post" and _POST_CONTENT_INVALID_RE.search(result.error or ""):
-                logger.warning("[Feishu] Invalid post update payload rejected by API; falling back to plain text")
+            if not result.success and msg_type == "interactive" and _should_fallback_from_interactive(result.error or ""):
+                logger.warning("[Feishu] Invalid interactive update payload rejected by API; falling back to plain text")
                 fallback_body = self._build_update_message_body(
                     msg_type="text",
                     content=json.dumps({"text": _strip_markdown_to_plain_text(content)}, ensure_ascii=False),
@@ -2137,7 +2166,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 )
                 message_response = await self._feishu_send_with_retry(
                     chat_id=chat_id,
-                    msg_type="post",
+                    msg_type="interactive",
                     payload=post_payload,
                     reply_to=reply_to,
                     metadata=metadata,
@@ -4315,7 +4344,10 @@ class FeishuAdapter(BasePlatformAdapter):
             text_payload = {"text": content}
             return "text", json.dumps(text_payload, ensure_ascii=False)
         if _MARKDOWN_HINT_RE.search(content):
-            return "post", _build_markdown_post_payload(content)
+            # Use interactive (card) message for Markdown content — Feishu's
+            # post-type does NOT support the 'md' tag; only interactive cards
+            # have a proper markdown element that renders formatting.
+            return "interactive", _build_markdown_card_payload(content)
         text_payload = {"text": content}
         return "text", json.dumps(text_payload, ensure_ascii=False)
 
@@ -4365,7 +4397,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 }
                 message_response = await self._feishu_send_with_retry(
                     chat_id=chat_id,
-                    msg_type="post",
+                    msg_type="interactive",
                     payload=self._build_media_post_payload(caption=caption, media_tag=media_tag),
                     reply_to=reply_to,
                     metadata=metadata,
@@ -4599,7 +4631,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 return response
             except Exception as exc:
                 last_error = exc
-                if msg_type == "post" and _POST_CONTENT_INVALID_RE.search(str(exc)):
+                if msg_type == "interactive" and _should_fallback_from_interactive(str(exc)):
                     raise
                 if attempt >= _FEISHU_SEND_ATTEMPTS - 1:
                     raise
@@ -4780,13 +4812,12 @@ class FeishuAdapter(BasePlatformAdapter):
         return SimpleNamespace(request_body=request_body)
 
     def _build_post_payload(self, content: str) -> str:
-        return _build_markdown_post_payload(content)
+        return _build_markdown_card_payload(content)
 
     def _build_media_post_payload(self, *, caption: str, media_tag: Dict[str, str]) -> str:
-        payload = json.loads(self._build_post_payload(caption))
-        content = payload.setdefault("zh_cn", {}).setdefault("content", [])
-        content.append([media_tag])
-        return json.dumps(payload, ensure_ascii=False)
+        card = json.loads(self._build_post_payload(caption))
+        card["elements"].append(media_tag)
+        return json.dumps(card, ensure_ascii=False)
 
     @staticmethod
     def _resolve_outbound_file_routing(


### PR DESCRIPTION
## Problem

Feishu (Lark) `post` message type does **not** support the `md` (Markdown) tag. When Hermes sends Markdown-formatted messages as `post` type, formatting like **bold**, *italic*, lists, and code blocks renders as plain text — users see raw Markdown syntax instead of formatted output.

## Solution

Switch to Feishu `interactive` (card) message type, which has a proper markdown element (`{"tag": "markdown"}`) that correctly renders all Markdown formatting.

## Changes

- **`_build_markdown_card_payload()`** — New function that builds a minimal interactive card structure wrapping Markdown content in a proper `markdown` element
- **`_should_fallback_from_interactive()`** — New fallback handler for card send failures (error codes 99992402/03/04, field validation errors) with graceful degradation to plain text
- **`_resolve_message_type_and_payload()`** — Return `msg_type="interactive"` instead of `"post"` for Markdown content
- **`_build_media_post_payload()`** — Adapt media caption payloads to use the card format
- **`_build_post_payload()`** — Delegate to `_build_markdown_card_payload()`
- All send/update paths updated from `"post"` → `"interactive"` with expanded error detection

## Testing

Before: Markdown messages rendered as raw text with `**bold**`, `- lists`, etc. visible.
After: Messages render with proper formatting through Feishu card markdown element.