### PR TITLE
fix(mattermost): keep metadata-routed sends in threads

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -286,11 +286,16 @@ class MattermostAdapter(BasePlatformAdapter):
                 "channel_id": chat_id,
                 "message": chunk,
             }
-            # Thread support: reply_to is the root post ID.
-            if reply_to and self._reply_mode == "thread":
+            # Thread support: reply_to is the root post ID. Gateway status,
+            # progress, and other synthetic sends often carry thread routing in
+            # metadata instead of reply_to, so honor metadata.thread_id too.
+            effective_reply_to = reply_to
+            if not effective_reply_to and metadata:
+                effective_reply_to = metadata.get("thread_id") or metadata.get("root_id")
+            if effective_reply_to and self._reply_mode == "thread":
                 # Ensure root_id points to the thread root, not a reply.
                 # Mattermost rejects non-root post IDs as root_id.
-                resolved_root = await self._resolve_root_id(reply_to)
+                resolved_root = await self._resolve_root_id(effective_reply_to)
                 payload["root_id"] = resolved_root
 
             data = await self._api_post("posts", payload)

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -218,6 +218,38 @@ class TestMattermostSend:
         assert payload["root_id"] == "root_post"
 
     @pytest.mark.asyncio
+    async def test_send_uses_metadata_thread_id_as_root_id(self):
+        """Status/progress sends carry thread context in metadata, not reply_to."""
+        self.adapter._reply_mode = "thread"
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": "status_post"})
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_get_resp = AsyncMock()
+        mock_get_resp.status = 200
+        mock_get_resp.json = AsyncMock(return_value={"id": "root_post", "root_id": ""})
+        mock_get_resp.text = AsyncMock(return_value="")
+        mock_get_resp.__aenter__ = AsyncMock(return_value=mock_get_resp)
+        mock_get_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+        self.adapter._session.get = MagicMock(return_value=mock_get_resp)
+
+        result = await self.adapter.send(
+            "channel_1",
+            "⏳ Still working...",
+            metadata={"thread_id": "root_post"},
+        )
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert payload["root_id"] == "root_post"
+
+    @pytest.mark.asyncio
     async def test_send_without_thread_no_root_id(self):
         """When reply_mode is 'off', reply_to should NOT set root_id."""
         self.adapter._reply_mode = "off"


### PR DESCRIPTION
## Summary
- Keep Mattermost synthetic/status sends in the active thread when routing is carried via `metadata.thread_id` / `metadata.root_id`.
- Preserve existing explicit `reply_to` behavior and only set Mattermost `root_id` when `reply_mode == "thread"`.
- Add regression coverage for a `⏳ Still working...`-style send that has metadata thread context but no `reply_to`.

## Why
Gateway status/progress paths pass thread routing in send metadata. `MattermostAdapter.send()` accepted metadata but ignored it when constructing the Mattermost post payload, so long-running notices such as `⏳ Still working...` could be posted at channel level instead of inside the thread.

This is complementary to #30385: that PR ensures CRT root posts populate `source.thread_id`; this PR ensures metadata-routed sends actually use that thread id as Mattermost `root_id`.

## Test plan
- GitHub CI requested per downstream maintainer preference.
- Downstream hotpatch was validated in the PD One Mattermost gateway before upstreaming; no local CI was run on this upstream branch.
