### PR TITLE
fix: close PIL Image file descriptors to prevent resource leaks

### DIFF
--- a/hermes_cli/clipboard.py
+++ b/hermes_cli/clipboard.py
@@ -403,7 +403,10 @@ def _convert_to_png(path: Path) -> bool:
     try:
         from PIL import Image
         img = Image.open(path)
-        img.save(path, "PNG")
+        try:
+            img.save(path, "PNG")
+        finally:
+            img.close()
         return True
     except ImportError:
         pass

--- a/skills/creative/pixel-art/scripts/pixel_art.py
+++ b/skills/creative/pixel-art/scripts/pixel_art.py
@@ -105,7 +105,11 @@ def pixel_art(input_path, output_path, preset="arcade", **overrides):
         )
     cfg = {**PRESETS[preset], **overrides}
 
-    img = Image.open(input_path).convert("RGB")
+    original = Image.open(input_path)
+    try:
+        img = original.convert("RGB")
+    finally:
+        original.close()
 
     img = ImageEnhance.Contrast(img).enhance(cfg["contrast"])
     img = ImageEnhance.Color(img).enhance(cfg["color"])

--- a/skills/creative/pixel-art/scripts/pixel_art_video.py
+++ b/skills/creative/pixel-art/scripts/pixel_art_video.py
@@ -273,7 +273,11 @@ def pixel_art_video(
         )
     _ensure_ffmpeg()
 
-    base = Image.open(base_image).convert("RGB")
+    original = Image.open(base_image)
+    try:
+        base = original.convert("RGB")
+    finally:
+        original.close()
     W, H = base.size
 
     rng = random.Random(seed if seed is not None else 42)

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -346,62 +346,65 @@ def _resize_image_for_vision(image_path: Path, mime_type: Optional[str] = None,
         if data_url is None:
             data_url = _image_to_base64_data_url(image_path, mime_type=mime_type)
         return data_url  # fall through to size-check in caller
-    # Convert RGBA to RGB for JPEG output
-    if pil_format == "JPEG" and img.mode in {"RGBA", "P"}:
-        img = img.convert("RGB")
+    try:
+        # Convert RGBA to RGB for JPEG output
+        if pil_format == "JPEG" and img.mode in {"RGBA", "P"}:
+            img = img.convert("RGB")
 
-    # Strategy: halve dimensions until base64 fits, up to 4 rounds.
-    # For JPEG, also try reducing quality at each size step.
-    # For PNG, quality is irrelevant — only dimension reduction helps.
-    quality_steps = (85, 70, 50) if pil_format == "JPEG" else (None,)
-    prev_dims = (img.width, img.height)
-    candidate = None  # will be set on first loop iteration
+        # Strategy: halve dimensions until base64 fits, up to 4 rounds.
+        # For JPEG, also try reducing quality at each size step.
+        # For PNG, quality is irrelevant — only dimension reduction helps.
+        quality_steps = (85, 70, 50) if pil_format == "JPEG" else (None,)
+        prev_dims = (img.width, img.height)
+        candidate = None  # will be set on first loop iteration
 
-    for attempt in range(5):
-        if attempt > 0:
-            # Proportional scaling: halve the longer side and scale the
-            # shorter side to preserve aspect ratio (min dimension 64).
-            scale = 0.5
-            new_w = max(int(img.width * scale), 64)
-            new_h = max(int(img.height * scale), 64)
-            # Re-derive the scale from whichever dimension hit the floor
-            # so both axes shrink by the same factor.
-            if new_w == 64 and img.width > 0:
-                effective_scale = 64 / img.width
-                new_h = max(int(img.height * effective_scale), 64)
-            elif new_h == 64 and img.height > 0:
-                effective_scale = 64 / img.height
-                new_w = max(int(img.width * effective_scale), 64)
-            # Stop if dimensions can't shrink further
-            if (new_w, new_h) == prev_dims:
-                break
-            img = img.resize((new_w, new_h), Image.LANCZOS)
-            prev_dims = (new_w, new_h)
-            logger.info("Resized to %dx%d (attempt %d)", new_w, new_h, attempt)
+        for attempt in range(5):
+            if attempt > 0:
+                # Proportional scaling: halve the longer side and scale the
+                # shorter side to preserve aspect ratio (min dimension 64).
+                scale = 0.5
+                new_w = max(int(img.width * scale), 64)
+                new_h = max(int(img.height * scale), 64)
+                # Re-derive the scale from whichever dimension hit the floor
+                # so both axes shrink by the same factor.
+                if new_w == 64 and img.width > 0:
+                    effective_scale = 64 / img.width
+                    new_h = max(int(img.height * effective_scale), 64)
+                elif new_h == 64 and img.height > 0:
+                    effective_scale = 64 / img.height
+                    new_w = max(int(img.width * effective_scale), 64)
+                # Stop if dimensions can't shrink further
+                if (new_w, new_h) == prev_dims:
+                    break
+                img = img.resize((new_w, new_h), Image.LANCZOS)
+                prev_dims = (new_w, new_h)
+                logger.info("Resized to %dx%d (attempt %d)", new_w, new_h, attempt)
 
-        for q in quality_steps:
-            buf = _io.BytesIO()
-            save_kwargs = {"format": pil_format}
-            if q is not None:
-                save_kwargs["quality"] = q
-            img.save(buf, **save_kwargs)
-            encoded = base64.b64encode(buf.getvalue()).decode("ascii")
-            candidate = f"data:{out_mime};base64,{encoded}"
-            if len(candidate) <= max_base64_bytes:
-                logger.info("Auto-resized image fits: %.1f MB (quality=%s, %dx%d)",
-                            len(candidate) / (1024 * 1024), q,
-                            img.width, img.height)
-                return candidate
+            for q in quality_steps:
+                buf = _io.BytesIO()
+                save_kwargs = {"format": pil_format}
+                if q is not None:
+                    save_kwargs["quality"] = q
+                img.save(buf, **save_kwargs)
+                encoded = base64.b64encode(buf.getvalue()).decode("ascii")
+                candidate = f"data:{out_mime};base64,{encoded}"
+                if len(candidate) <= max_base64_bytes:
+                    logger.info("Auto-resized image fits: %.1f MB (quality=%s, %dx%d)",
+                                len(candidate) / (1024 * 1024), q,
+                                img.width, img.height)
+                    return candidate
 
-    # If we still can't get it small enough, return the best attempt
-    # and let the caller decide
-    if candidate is not None:
-        logger.warning("Auto-resize could not fit image under %.1f MB (best: %.1f MB)",
-                       max_base64_bytes / (1024 * 1024), len(candidate) / (1024 * 1024))
-        return candidate
+        # If we still can't get it small enough, return the best attempt
+        # and let the caller decide
+        if candidate is not None:
+            logger.warning("Auto-resize could not fit image under %.1f MB (best: %.1f MB)",
+                           max_base64_bytes / (1024 * 1024), len(candidate) / (1024 * 1024))
+            return candidate
 
-    # Shouldn't reach here, but fall back to full encode
-    return data_url or _image_to_base64_data_url(image_path, mime_type=mime_type)
+        # Shouldn't reach here, but fall back to full encode
+        return data_url or _image_to_base64_data_url(image_path, mime_type=mime_type)
+    finally:
+        img.close()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`Image.open()` holds the file descriptor open until the Image object is garbage-collected. When called in loops or without explicit `.close()`, this leaks fds and can hit OS limits under sustained load.

## Fix

4 files patched to properly close PIL Image file descriptors:

| File | Issue | Fix |
|------|-------|-----|
| `tools/vision_tools.py` | `Image.open()` in resize loop, never closed | Wrap loop in `try/finally` with `img.close()` |
| `hermes_cli/clipboard.py` | `Image.open()` + `.save()` without close | Add `try/finally` around save + close |
| `pixel_art.py` | `Image.open().convert()` leaks original fd | Split into two statements, close original |
| `pixel_art_video.py` | Same `.convert()` pattern | Same fix |

## Key Insight

`.convert()` creates a **new** Image object but the **original** still holds the file descriptor. The common pattern `img = Image.open(path).convert("RGB")` leaks the original fd. Splitting into two statements and closing the original fixes the leak without changing behavior.

## Tests

- All 4 files pass `py_compile` validation
- No behavioral changes — same image processing, just proper resource cleanup