### PR TITLE
fix(email): support SMTP port 465 with implicit SSL (SMTP_SSL)

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -316,8 +316,11 @@ class EmailAdapter(BasePlatformAdapter):
 
         try:
             # Test SMTP connection
-            smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
-            smtp.starttls(context=ssl.create_default_context())
+            if self._smtp_port == 465:
+                smtp = smtplib.SMTP_SSL(self._smtp_host, self._smtp_port, timeout=30)
+            else:
+                smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
+                smtp.starttls(context=ssl.create_default_context())
             smtp.login(self._address, self._password)
             smtp.quit()
             logger.info("[Email] SMTP connection test passed.")
@@ -548,9 +551,12 @@ class EmailAdapter(BasePlatformAdapter):
 
         msg.attach(MIMEText(body, "plain", "utf-8"))
 
-        smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
-        try:
+        if self._smtp_port == 465:
+            smtp = smtplib.SMTP_SSL(self._smtp_host, self._smtp_port, timeout=30)
+        else:
+            smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
             smtp.starttls(context=ssl.create_default_context())
+        try:
             smtp.login(self._address, self._password)
             smtp.send_message(msg)
         finally:
@@ -670,9 +676,12 @@ class EmailAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("[Email] Failed to attach %s: %s", file_path, e)
 
-        smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
-        try:
+        if self._smtp_port == 465:
+            smtp = smtplib.SMTP_SSL(self._smtp_host, self._smtp_port, timeout=30)
+        else:
+            smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
             smtp.starttls(context=ssl.create_default_context())
+        try:
             smtp.login(self._address, self._password)
             smtp.send_message(msg)
         finally:
@@ -749,9 +758,12 @@ class EmailAdapter(BasePlatformAdapter):
             part.add_header("Content-Disposition", f"attachment; filename={fname}")
             msg.attach(part)
 
-        smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
-        try:
+        if self._smtp_port == 465:
+            smtp = smtplib.SMTP_SSL(self._smtp_host, self._smtp_port, timeout=30)
+        else:
+            smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
             smtp.starttls(context=ssl.create_default_context())
+        try:
             smtp.login(self._address, self._password)
             smtp.send_message(msg)
         finally:


### PR DESCRIPTION
## Problem

The email gateway adapter (`gateway/platforms/email.py`) only uses `smtplib.SMTP()` + `starttls()` for all SMTP connections, which works for ports 25 and 587 but **not port 465** (implicit SSL).

Many cloud VPS providers (AWS, Alibaba Cloud, Tencent Cloud, etc.) block outbound ports 25 and 587 by default, leaving port 465 as the only available SMTP submission option. When `EMAIL_SMTP_PORT=465` is configured, the adapter fails with a timeout because it tries to establish a plain-text TCP connection before STARTTLS on a port that expects immediate SSL negotiation.

## Fix

Added a port check in all 4 SMTP call sites in `gateway/platforms/email.py`:
- **Port 465** → `smtplib.SMTP_SSL()` (implicit SSL, no `starttls()` needed)
- **Other ports** → existing `smtplib.SMTP()` + `starttls()` behavior preserved (backward compatible)

### Affected methods:
1. `connect()` — SMTP connection test during adapter initialization
2. `_send_email()` — sending replies
3. `_send_email_with_attachments()` — sending multi-attachment messages
4. `_send_email_with_attachment()` — sending single-attachment messages

## Testing

Verified on Tencent Cloud VPS with `claw.163.com` (Coremail):
- Port 25: blocked by cloud provider (timeout) ❌
- Port 587: blocked by cloud provider (timeout) ❌  
- Port 465 with SMTP_SSL: login + send successful ✅

Gateway logs after fix:
```
[Email] IMAP connection test passed. 5 existing messages skipped.
[Email] SMTP connection test passed.   ← first time ever passing
[Email] Connected as kooriagent@claw.163.com
```

## Risk

Low. The change is gated on `self._smtp_port == 465`. All other port values use the original code path unchanged.