### PR TITLE
fix(gateway): keep parallel Telegram DM topic sessions from collapsing

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2187,6 +2187,32 @@ class GatewayRunner:
             session_id=session_entry.session_id,
         )
 
+    def _source_has_existing_session(self, source: SessionSource) -> bool:
+        """True when the source's own topic already has a session.
+
+        "Has a session" means either a running agent or a persisted session in
+        the session store for this exact source. Used by topic recovery to
+        avoid hijacking a topic the user is deliberately writing to.
+        """
+        try:
+            session_key = self._session_key_for_source(source)
+        except Exception:
+            return False
+        if not session_key:
+            return False
+        running = getattr(self, "_running_agents", None)
+        if running and session_key in running:
+            return True
+        store = getattr(self, "session_store", None)
+        if store is not None:
+            try:
+                store._ensure_loaded()
+                if session_key in store._entries:
+                    return True
+            except Exception:
+                logger.debug("topic-recover: session-store probe failed", exc_info=True)
+        return False
+
     def _recover_telegram_topic_thread_id(
         self,
         source: SessionSource,
@@ -2224,7 +2250,14 @@ class GatewayRunner:
         inbound = str(source.thread_id or "")
         is_lobby = not inbound or inbound in self._TELEGRAM_GENERAL_TOPIC_IDS
         known = {str(b.get("thread_id") or "") for b in bindings}
-        if not is_lobby and inbound in known:
+        # Leave a concrete (non-General) inbound topic alone if it is a known
+        # binding OR already has its own session. Telegram assigns DM "lobby"
+        # topics a dynamic thread_id that is neither in
+        # _TELEGRAM_GENERAL_TOPIC_IDS nor in the bindings table; without the
+        # session check such a topic falls through to the redirect below and
+        # gets collapsed into the user's newest named lane, breaking parallel
+        # multi-topic sessions (#30538).
+        if not is_lobby and (inbound in known or self._source_has_existing_session(source)):
             return None
         user_id = str(source.user_id)
         for b in bindings:  # newest-first

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1278,6 +1278,7 @@ AUTHOR_MAP = {
     "erik.engervall@gmail.com": "erikengervall",  # PR #28774 (firecrawl integration tag)
     "egilewski@egilewski.com": "egilewski",  # PR #30432 (MEDIA path traversal fix, GHSA-jmf9-9729-7pp8)
     "edison@mcclean.codes": "McClean-Edison",  # PR #29817 (register_auxiliary_task plugin API)
+    "officialasishkumar@gmail.com": "officialasishkumar",  # Telegram DM topic parallel-session recovery (#30538)
 }
 
 

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -1193,6 +1193,46 @@ def test_recover_rewrites_lobby_thread_id_to_most_recent(tmp_path):
     assert runner._recover_telegram_topic_thread_id(_make_source(thread_id=None)) == "222"
 
 
+def test_recover_returns_none_when_inbound_topic_has_running_agent(tmp_path):
+    # Regression for #30538: a DM "lobby" topic whose thread_id is dynamically
+    # assigned by Telegram (not in _TELEGRAM_GENERAL_TOPIC_IDS and not a tracked
+    # binding) but which already has its own running agent must NOT be collapsed
+    # into the user's newest named lane.
+    db = SessionDB(db_path=tmp_path / "state.db")
+    _seed_two_topic_bindings(db)
+    runner = _make_runner(session_db=db)
+
+    lobby = _make_source(thread_id="494403")
+    runner._running_agents = {runner._session_key_for_source(lobby): object()}
+
+    # Without the guard this would redirect to the most-recent binding ("222").
+    assert runner._recover_telegram_topic_thread_id(lobby) is None
+
+
+def test_recover_returns_none_when_inbound_topic_has_persisted_session(tmp_path):
+    # Same as above but the topic only has a persisted (not running) session.
+    db = SessionDB(db_path=tmp_path / "state.db")
+    _seed_two_topic_bindings(db)
+    runner = _make_runner(session_db=db)
+
+    lobby = _make_source(thread_id="494403")
+    key = runner._session_key_for_source(lobby)
+    runner.session_store._ensure_loaded = MagicMock()
+    runner.session_store._entries = {key: object()}
+
+    assert runner._recover_telegram_topic_thread_id(lobby) is None
+
+
+def test_recover_still_rewrites_unknown_topic_without_session(tmp_path):
+    # The guard is scoped: an unknown inbound topic with NO session of its own
+    # is still recovered to the most-recent binding (cross-topic Reply leak).
+    db = SessionDB(db_path=tmp_path / "state.db")
+    _seed_two_topic_bindings(db)
+    runner = _make_runner(session_db=db)
+
+    assert runner._recover_telegram_topic_thread_id(_make_source(thread_id="9999")) == "222"
+
+
 def test_recover_returns_none_when_topic_mode_disabled(tmp_path):
     # Non-topic-mode DMs keep the existing strip-to-lobby behavior.
     db = SessionDB(db_path=tmp_path / "state.db")


### PR DESCRIPTION
## What does this PR do?

Fixes a silent collapse of parallel Telegram DM topic sessions.

`_recover_telegram_topic_thread_id` (`gateway/run.py`) pins DM-topic routing to the user's most-recent topic binding whenever the inbound `thread_id` is missing/General **or not a known named-lane binding**. The intent (from #3206) is to recover stripped plain-reply messages back to the user's active lane.

The problem: Telegram assigns the DM **lobby / General-System** topic a *dynamically allocated* `thread_id` (e.g. `494403`). That id is neither in `_TELEGRAM_GENERAL_TOPIC_IDS` (`{"", "1"}`) nor in the `telegram_dm_topic_bindings` table (bindings only track named lanes created via `/topic`). So when a user has both a lobby session and a named lane (e.g. "English") active, a message sent to the lobby falls through to the redirect and is answered **in the named lane's session** — collapsing two parallel topic sessions into one. Log evidence: `telegram topic recovery: chat=... user=... '494403' -> 494621`.

The fix guards the redirect: a concrete (non-General) inbound topic that **already has its own session** — a running agent, or a persisted session in the session store — is left alone, because the user is deliberately writing to that topic. The General / stripped-reply lobby path (`is_lobby`) is intentionally unchanged, so the #3206 recovery still works.

## Related Issue

Fixes #30538

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` — add `_source_has_existing_session(source)` (checks `_running_agents` then the persisted session store) and extend the early-return in `_recover_telegram_topic_thread_id` so a non-lobby inbound topic with an existing session is not redirected.
- `tests/gateway/test_telegram_topic_mode.py` — regression tests: running-agent case, persisted-session case, and a control confirming an unknown topic with *no* session of its own is still recovered to the most-recent binding.
- `scripts/release.py` — add contributor to `AUTHOR_MAP` (required by the `contributor-check` workflow).

## How to Test

1. Enable DM topic mode (`/topic`), create a named lane (e.g. "English").
2. Send a message in the General/System lobby, then in the named lane, then again in the lobby.
3. Before: the second lobby message is answered in the named lane's session. After: it stays in the lobby session.
4. Run the tests:
   ```bash
   python -m pytest tests/gateway/test_telegram_topic_mode.py -k recover -q
   ```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(gateway): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests and they pass (`6 passed` — 3 new + 3 existing recover tests)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 (Python 3.12)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal routing behavior; no user-facing docs/config keys)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (no OS-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
