### PR TITLE
Fail fast when Hermes home is unwritable

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -354,7 +354,7 @@ def get_container_exec_info() -> Optional[dict]:
 # =============================================================================
 
 # Re-export from hermes_constants — canonical definition lives there.
-from hermes_constants import get_hermes_home  # noqa: F811,E402
+from hermes_constants import get_hermes_home, is_termux  # noqa: F811,E402
 from utils import atomic_replace
 
 def get_config_path() -> Path:
@@ -447,6 +447,31 @@ def _ensure_default_soul_md(home: Path) -> None:
     _secure_file(soul_path)
 
 
+def _probe_hermes_home_writable(home: Path) -> None:
+    """Fail fast when HERMES_HOME exists but cannot actually accept writes."""
+    fd, probe_path = tempfile.mkstemp(prefix=".hermes-write-test-", dir=home)
+    os.close(fd)
+    try:
+        os.unlink(probe_path)
+    except FileNotFoundError:
+        pass
+
+
+def _raise_hermes_home_access_error(home: Path, exc: OSError) -> None:
+    """Raise a user-facing HERMES_HOME access error with platform-specific help."""
+    msg = (
+        f"Cannot initialize HERMES_HOME at {home}: {exc}. "
+        "Hermes needs read/write access to this directory before startup can continue."
+    )
+    if is_termux():
+        msg += (
+            " In Termux on Android, this often means another Hermes installation "
+            "(for example the Android app) is using a different sandboxed ~/.hermes. "
+            "Set HERMES_HOME to a Termux-only directory or remove the conflicting install."
+        )
+    raise RuntimeError(msg) from exc
+
+
 def ensure_hermes_home():
     """Ensure ~/.hermes directory structure exists with secure permissions.
 
@@ -462,16 +487,20 @@ def ensure_hermes_home():
         finally:
             os.umask(old_umask)
     else:
-        home.mkdir(parents=True, exist_ok=True)
-        _secure_dir(home)
-        for subdir in (
-            "cron", "sessions", "logs", "logs/curator", "memories",
-            "pairing", "hooks", "image_cache", "audio_cache", "skills",
-        ):
-            d = home / subdir
-            d.mkdir(parents=True, exist_ok=True)
-            _secure_dir(d)
-        _ensure_default_soul_md(home)
+        try:
+            home.mkdir(parents=True, exist_ok=True)
+            _secure_dir(home)
+            for subdir in (
+                "cron", "sessions", "logs", "logs/curator", "memories",
+                "pairing", "hooks", "image_cache", "audio_cache", "skills",
+            ):
+                d = home / subdir
+                d.mkdir(parents=True, exist_ok=True)
+                _secure_dir(d)
+            _probe_hermes_home_writable(home)
+            _ensure_default_soul_md(home)
+        except OSError as exc:
+            _raise_hermes_home_access_error(home, exc)
 
 
 def _ensure_hermes_home_managed(home: Path):

--- a/tests/hermes_cli/test_hermes_home_preflight.py
+++ b/tests/hermes_cli/test_hermes_home_preflight.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+import pytest
+
+
+def test_ensure_hermes_home_surfaces_writable_probe_failures(tmp_path):
+    from hermes_cli import config as config_mod
+
+    home = tmp_path / ".hermes"
+
+    with (
+        pytest.MonkeyPatch.context() as mp,
+        pytest.raises(RuntimeError, match="Cannot initialize HERMES_HOME"),
+    ):
+        mp.setattr(config_mod, "get_hermes_home", lambda: home)
+        mp.setattr(
+            config_mod,
+            "_probe_hermes_home_writable",
+            lambda _home: (_ for _ in ()).throw(PermissionError("Write denied")),
+        )
+        config_mod.ensure_hermes_home()
+
+
+def test_ensure_hermes_home_mentions_termux_android_conflicts(tmp_path):
+    from hermes_cli import config as config_mod
+
+    home = tmp_path / ".hermes"
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(config_mod, "get_hermes_home", lambda: home)
+        mp.setattr(config_mod, "is_termux", lambda: True)
+        mp.setattr(
+            config_mod,
+            "_probe_hermes_home_writable",
+            lambda _home: (_ for _ in ()).throw(PermissionError("Write denied")),
+        )
+        with pytest.raises(RuntimeError) as excinfo:
+            config_mod.ensure_hermes_home()
+
+    msg = str(excinfo.value)
+    assert "Termux" in msg
+    assert "Android app" in msg
+    assert "HERMES_HOME" in msg


### PR DESCRIPTION
Fixes #31803.

## Summary
- fail fast when Hermes can create `HERMES_HOME` but cannot actually write inside it
- surface a clearer startup error, with Termux-specific guidance about Android app sandbox conflicts
- add a regression test for generic write denial and the Termux-specific message

## Proof
- `PYTHONPATH=. python3 -m pytest -c /dev/null tests/hermes_cli/test_hermes_home_preflight.py`
- `uv run --frozen ruff check hermes_cli/config.py tests/hermes_cli/test_hermes_home_preflight.py`
- `uv run --frozen python -m py_compile hermes_cli/config.py tests/hermes_cli/test_hermes_home_preflight.py`
- `git diff --check`