### PR TITLE
fix: guard json.loads() against non-JSON HTTP responses in security_audit

### DIFF
--- a/hermes_cli/security_audit.py
+++ b/hermes_cli/security_audit.py
@@ -288,13 +288,25 @@ def _http_post_json(url: str, payload: dict) -> dict:
         url, data=data, headers={"Content-Type": "application/json"}, method="POST"
     )
     with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
-        return json.loads(resp.read().decode("utf-8"))
+        body = resp.read()
+    try:
+        return json.loads(body.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise RuntimeError(
+            f"OSV API returned non-JSON response ({resp.status}): {body[:200]!r}"
+        ) from exc
 
 
 def _http_get_json(url: str) -> dict:
     req = urllib.request.Request(url, method="GET")
     with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
-        return json.loads(resp.read().decode("utf-8"))
+        body = resp.read()
+    try:
+        return json.loads(body.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise RuntimeError(
+            f"OSV API returned non-JSON response ({resp.status}): {body[:200]!r}"
+        ) from exc
 
 
 def _osv_query_batch(components: list[Component]) -> dict[Component, list[str]]:
@@ -318,7 +330,7 @@ def _osv_query_batch(components: list[Component]) -> dict[Component, list[str]]:
         }
         try:
             resp = _http_post_json(OSV_BATCH_URL, payload)
-        except (urllib.error.URLError, TimeoutError, ConnectionError) as exc:
+        except (urllib.error.URLError, TimeoutError, ConnectionError, RuntimeError) as exc:
             raise RuntimeError(f"OSV batch query failed: {exc}") from exc
         results = resp.get("results") or []
         for comp, result in zip(chunk, results):
@@ -393,7 +405,7 @@ def _osv_fetch_details(vuln_ids: Iterable[str]) -> dict[str, Vulnerability]:
     def _fetch_one(vid: str) -> Vulnerability:
         try:
             rec = _http_get_json(OSV_VULN_URL.format(vid=vid))
-        except (urllib.error.URLError, TimeoutError, ConnectionError):
+        except (urllib.error.URLError, TimeoutError, ConnectionError, RuntimeError):
             return Vulnerability(osv_id=vid)
         return Vulnerability(
             osv_id=vid,


### PR DESCRIPTION
## Problem

When the OSV API returns non-JSON (HTML error pages, 502/503 gateway errors), `json.loads()` crashes with `JSONDecodeError`. The callers only catch network errors (`URLError`, `TimeoutError`, `ConnectionError`), so the JSON parse error propagates as an unhandled exception.

## Fix

Wrap `json.loads()` in `_http_post_json()` and `_http_get_json()` with `try/except` that converts `JSONDecodeError`/`UnicodeDecodeError` into a `RuntimeError` with context (status code + response preview).

Update callers to also catch `RuntimeError`:
- `_osv_query_batch()` line 330
- `_fetch_one()` line 405

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| OSV returns HTML 502 | `JSONDecodeError` crash | `RuntimeError("OSV API returned non-JSON response (502): ...")` |
| OSV returns empty body | `JSONDecodeError` crash | `RuntimeError("OSV API returned non-JSON response (200): b''")` |

## Tests

- File passes `py_compile` validation
- Error messages include status code and response preview for debugging