### PR TITLE
fix: add md, html, and htm to MEDIA: extractor and make extension matching case-insensitive

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2298,7 +2298,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|md|html?|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?''', re.IGNORECASE
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/tests/gateway/test_send_image_file.py
+++ b/tests/gateway/test_send_image_file.py
@@ -49,6 +49,28 @@ class TestExtractMediaImages:
         media, _ = BasePlatformAdapter.extract_media(content)
         assert len(media) == 1
 
+    def test_markdown_doc_extracted(self):
+        """MEDIA: tags with .md extension should be extracted as documents."""
+        content = "Here is the report:\nMEDIA:/tmp/report.md"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert len(media) == 1
+        assert media[0][0] == "/tmp/report.md"
+        assert "MEDIA:" not in cleaned
+
+    def test_html_doc_extracted(self):
+        """MEDIA: tags with .html/.htm extension should be extracted as documents."""
+        for ext in (".html", ".htm"):
+            content = f"MEDIA:/tmp/page{ext}"
+            media, _ = BasePlatformAdapter.extract_media(content)
+            assert len(media) == 1, f"failed for {ext}"
+
+    def test_markdown_case_insensitive(self):
+        """.MD and .Md variants should also be recognized."""
+        for ext in (".MD", ".Md", ".mD"):
+            content = f"MEDIA:/tmp/doc{ext}"
+            media, _ = BasePlatformAdapter.extract_media(content)
+            assert len(media) == 1, f"failed for {ext}"
+
     def test_mixed_audio_and_image(self):
         content = "MEDIA:/audio.ogg\nMEDIA:/screenshot.png"
         media, _ = BasePlatformAdapter.extract_media(content)


### PR DESCRIPTION
fix: add md, html, and htm to MEDIA: extractor and make extension matching case-insensitive

Closes #31560

The BasePlatformAdapter.extract_media() regex did not recognize .md, .html, or .htm files in MEDIA: tags, causing generated markdown reports and HTML artifacts to be silently dropped instead of delivered as attachments. The extractor was also case-sensitive for all extensions.

Changes:
- Add md, html? (matching .html and .htm) to the MEDIA: tag extension list
- Make the regex case-insensitive so .MD, .HTML, .PNG, .JPG etc. are all recognized
- Add tests covering .md, .html, .htm extraction and case-insensitive matching