### PR TITLE
fix(update): suppress unicode-animations postinstall demo

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6482,6 +6482,7 @@ def _run_npm_install_deterministic(
     *,
     extra_args: tuple[str, ...] = (),
     capture_output: bool = True,
+    env_overrides: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess:
     """Run a deterministic npm install that does not mutate ``package-lock.json``.
 
@@ -6493,6 +6494,10 @@ def _run_npm_install_deterministic(
     lockfile — repeatedly.
     """
     lockfile = cwd / "package-lock.json"
+    env = None
+    if env_overrides:
+        env = os.environ.copy()
+        env.update(env_overrides)
     if lockfile.exists():
         ci_cmd = [npm, "ci", *extra_args]
         ci_result = subprocess.run(
@@ -6503,6 +6508,7 @@ def _run_npm_install_deterministic(
             encoding="utf-8",
             errors="replace",
             check=False,
+            env=env,
         )
         if ci_result.returncode == 0:
             return ci_result
@@ -6517,6 +6523,7 @@ def _run_npm_install_deterministic(
         encoding="utf-8",
         errors="replace",
         check=False,
+        env=env,
     )
 
 
@@ -8173,6 +8180,7 @@ def _update_node_dependencies() -> None:
             path,
             extra_args=("--no-fund", "--no-audit", "--progress=false"),
             capture_output=False,
+            env_overrides={"CI": "1"},
         )
         if result.returncode == 0:
             print(f"  ✓ {label}")

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -170,6 +170,10 @@ class TestCmdUpdateBranchFallback:
                 "repo-root / ui-tui npm install must stream output "
                 "(no capture_output) so postinstall progress is visible"
             )
+            assert call.kwargs.get("env", {}).get("CI") == "1", (
+                "update-mode npm installs must set CI=1 so noisy dependency "
+                "postinstall demos stay out of automation logs"
+            )
 
     def test_update_non_interactive_runs_safe_config_migrations(self, mock_args, capsys):
         """Dashboard/web updates apply non-interactive migrations before restart."""

--- a/tests/hermes_cli/test_web_ui_build.py
+++ b/tests/hermes_cli/test_web_ui_build.py
@@ -134,6 +134,22 @@ class TestBuildWebUISkipsWhenFresh:
         assert kwargs["encoding"] == "utf-8"
         assert kwargs["errors"] == "replace"
 
+    def test_npm_install_accepts_env_overrides(self, tmp_path):
+        web_dir, _ = _make_web_dir(tmp_path)
+        (web_dir / "package-lock.json").write_text("{}", encoding="utf-8")
+
+        mock_cp = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
+        with patch("hermes_cli.main.subprocess.run", return_value=mock_cp) as mock_run:
+            result = _run_npm_install_deterministic(
+                "/usr/bin/npm",
+                web_dir,
+                env_overrides={"CI": "1"},
+            )
+
+        assert result.returncode == 0
+        _, kwargs = mock_run.call_args
+        assert kwargs["env"]["CI"] == "1"
+
     def test_web_build_uses_utf8_replace_output_decoding(self, tmp_path):
         web_dir, _ = _make_web_dir(tmp_path)
 


### PR DESCRIPTION
## Summary
- set `CI=1` for the repo-root and `ui-tui` npm refreshes that run during `hermes update`
- keep deterministic npm install behavior and streamed output intact while silencing `unicode-animations`' noisy `postinstall` demo
- add regression coverage for the update path and helper env override plumbing

## Testing
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/hermes-fix-28500-auth-retry/.venv/bin/pytest -o addopts='' tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_web_ui_build.py`
- `python3 -m ruff check hermes_cli/main.py tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_web_ui_build.py`
- `python3 -m py_compile hermes_cli/main.py tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_web_ui_build.py`
- `git diff --check`

Closes #31816.
