### PR TITLE
chore: ruff auto-fix C4 series

### DIFF
--- a/optional-skills/devops/watchers/scripts/_watermark.py
+++ b/optional-skills/devops/watchers/scripts/_watermark.py
@@ -80,7 +80,7 @@ class Watermark:
         batch (so save() persists the full new watermark).  On first run,
         records every id but returns an empty list (baseline, no replay).
         """
-        existing = set(str(x) for x in self._data.get("seen_ids", []))
+        existing = {str(x) for x in self._data.get("seen_ids", [])}
         was_first_run = self.is_first_run
 
         new_items: List[Dict[str, Any]] = []

--- a/optional-skills/research/drug-discovery/scripts/ro5_screen.py
+++ b/optional-skills/research/drug-discovery/scripts/ro5_screen.py
@@ -21,7 +21,7 @@ def fetch(name):
 def check(p):
     mw,logp,hbd,hba,rot,tpsa = float(p.get("MolecularWeight",0)),float(p.get("XLogP",0)),int(p.get("HBondDonorCount",0)),int(p.get("HBondAcceptorCount",0)),int(p.get("RotatableBondCount",0)),float(p.get("TPSA",0))
     v = sum([mw>500,logp>5,hbd>5,hba>10])
-    return dict(mw=mw,logp=logp,hbd=hbd,hba=hba,rot=rot,tpsa=tpsa,violations=v,ro5=v<=1,veber=tpsa<=140 and rot<=10,ok=v<=1 and tpsa<=140 and rot<=10)
+    return {"mw": mw,"logp": logp,"hbd": hbd,"hba": hba,"rot": rot,"tpsa": tpsa,"violations": v,"ro5": v<=1,"veber": tpsa<=140 and rot<=10,"ok": v<=1 and tpsa<=140 and rot<=10}
 
 def report(name, r):
     if not r: print(f"✗ {name:30s} — not found"); return

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -892,12 +892,12 @@ class HindsightMemoryProvider(MemoryProvider):
                     llm_provider = "openai"
                 logger.debug("Creating HindsightEmbedded client (profile=%s, provider=%s)",
                              self._config.get("profile", "hermes"), llm_provider)
-                kwargs = dict(
-                    profile=self._config.get("profile", "hermes"),
-                    llm_provider=llm_provider,
-                    llm_api_key=self._config.get("llmApiKey") or self._config.get("llm_api_key") or os.environ.get("HINDSIGHT_LLM_API_KEY", ""),
-                    llm_model=self._config.get("llm_model", ""),
-                )
+                kwargs = {
+                    "profile": self._config.get("profile", "hermes"),
+                    "llm_provider": llm_provider,
+                    "llm_api_key": self._config.get("llmApiKey") or self._config.get("llm_api_key") or os.environ.get("HINDSIGHT_LLM_API_KEY", ""),
+                    "llm_model": self._config.get("llm_model", ""),
+                }
                 if self._llm_base_url:
                     kwargs["llm_base_url"] = self._llm_base_url
                 idle_timeout = _parse_int_setting(

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -1192,7 +1192,7 @@ def cmd_migrate(args) -> None:
                     session_key = hcfg.resolve_session_name()
                     mgr.get_or_create(session_key)
                     # Upload from each directory that had user files
-                    dirs_with_files = set(str(f.parent) for f in user_files)
+                    dirs_with_files = {str(f.parent) for f in user_files}
                     any_uploaded = False
                     for d in dirs_with_files:
                         if mgr.migrate_memory_files(session_key, d):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,7 +257,7 @@ preview = true  # required for PLW1514 (unspecified-encoding) — preview rule
 # which silently corrupts any non-ASCII file content.  We had three
 # separate Windows sandbox regressions in one debug session before
 # adding the explicit encoding.  This rule keeps new code honest.
-select = ["PLW1514"]
+select = ["C4", "PLW1514"]
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can intentionally exercise locale-encoding edge cases.

--- a/skills/creative/comfyui/scripts/_common.py
+++ b/skills/creative/comfyui/scripts/_common.py
@@ -557,7 +557,7 @@ def _http_once(
                     body = r.content
                 return HTTPResponse(
                     status=r.status_code,
-                    headers={k: v for k, v in r.headers.items()},
+                    headers=dict(r.headers.items()),
                     body=body,
                     url=r.url,
                 )

--- a/tests/agent/test_curator_reports.py
+++ b/tests/agent/test_curator_reports.py
@@ -201,16 +201,16 @@ def test_same_second_reruns_get_unique_dirs(curator_env):
     curator = curator_env["curator"]
     start = datetime(2026, 4, 29, 5, 33, 34, tzinfo=timezone.utc)
 
-    kwargs = dict(
-        started_at=start,
-        elapsed_seconds=1.0,
-        auto_counts={"checked": 0, "marked_stale": 0, "archived": 0, "reactivated": 0},
-        auto_summary="no changes",
-        before_report=[],
-        before_names=set(),
-        after_report=[],
-        llm_meta=_make_llm_meta(),
-    )
+    kwargs = {
+        "started_at": start,
+        "elapsed_seconds": 1.0,
+        "auto_counts": {"checked": 0, "marked_stale": 0, "archived": 0, "reactivated": 0},
+        "auto_summary": "no changes",
+        "before_report": [],
+        "before_names": set(),
+        "after_report": [],
+        "llm_meta": _make_llm_meta(),
+    }
     a = curator._write_run_report(**kwargs)
     b = curator._write_run_report(**kwargs)
     assert a != b

--- a/tests/agent/test_plugin_llm.py
+++ b/tests/agent/test_plugin_llm.py
@@ -57,16 +57,16 @@ def _fake_response(text: str, *, prompt: int = 4, completion: int = 6) -> Simple
 
 
 def _trusted_policy(plugin_id: str = "trusted-plugin", **overrides: Any) -> _TrustPolicy:
-    defaults = dict(
-        allow_provider_override=True,
-        allowed_providers=None,
-        allow_any_provider=True,
-        allow_model_override=True,
-        allowed_models=None,
-        allow_any_model=True,
-        allow_agent_id_override=True,
-        allow_profile_override=True,
-    )
+    defaults = {
+        "allow_provider_override": True,
+        "allowed_providers": None,
+        "allow_any_provider": True,
+        "allow_model_override": True,
+        "allowed_models": None,
+        "allow_any_model": True,
+        "allow_agent_id_override": True,
+        "allow_profile_override": True,
+    }
     defaults.update(overrides)
     return _TrustPolicy(plugin_id=plugin_id, **defaults)
 

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -42,35 +42,8 @@ def _fake_dingtalk_optional_sdks(monkeypatch):
     """Keep DingTalk adapter tests hermetic when optional SDKs are absent."""
     from gateway.platforms import dingtalk as dt
 
-    card_models = SimpleNamespace(**{
-        name: _FakeDingTalkModel
-        for name in (
-            "CreateCardRequest",
-            "CreateCardRequestCardData",
-            "CreateCardRequestImGroupOpenSpaceModel",
-            "CreateCardRequestImRobotOpenSpaceModel",
-            "CreateCardHeaders",
-            "DeliverCardRequest",
-            "DeliverCardRequestImGroupOpenDeliverModel",
-            "DeliverCardRequestImRobotOpenDeliverModel",
-            "DeliverCardHeaders",
-            "StreamingUpdateRequest",
-            "StreamingUpdateHeaders",
-        )
-    })
-    robot_models = SimpleNamespace(**{
-        name: _FakeDingTalkModel
-        for name in (
-            "RobotReplyEmotionRequestTextEmotion",
-            "RobotReplyEmotionRequest",
-            "RobotReplyEmotionHeaders",
-            "RobotRecallEmotionRequestTextEmotion",
-            "RobotRecallEmotionRequest",
-            "RobotRecallEmotionHeaders",
-            "RobotMessageFileDownloadRequest",
-            "RobotMessageFileDownloadHeaders",
-        )
-    })
+    card_models = SimpleNamespace(**dict.fromkeys(("CreateCardRequest", "CreateCardRequestCardData", "CreateCardRequestImGroupOpenSpaceModel", "CreateCardRequestImRobotOpenSpaceModel", "CreateCardHeaders", "DeliverCardRequest", "DeliverCardRequestImGroupOpenDeliverModel", "DeliverCardRequestImRobotOpenDeliverModel", "DeliverCardHeaders", "StreamingUpdateRequest", "StreamingUpdateHeaders"), _FakeDingTalkModel))
+    robot_models = SimpleNamespace(**dict.fromkeys(("RobotReplyEmotionRequestTextEmotion", "RobotReplyEmotionRequest", "RobotReplyEmotionHeaders", "RobotRecallEmotionRequestTextEmotion", "RobotRecallEmotionRequest", "RobotRecallEmotionHeaders", "RobotMessageFileDownloadRequest", "RobotMessageFileDownloadHeaders"), _FakeDingTalkModel))
 
     monkeypatch.setattr(dt, "ChatbotMessage", _FakeChatbotMessage, raising=False)
     monkeypatch.setattr(

--- a/tests/hermes_cli/test_dashboard_lifecycle_flags.py
+++ b/tests/hermes_cli/test_dashboard_lifecycle_flags.py
@@ -20,10 +20,10 @@ from hermes_cli.main import cmd_dashboard, _report_dashboard_status
 
 def _ns(**kw):
     """Build an argparse.Namespace with dashboard defaults plus overrides."""
-    defaults = dict(
-        port=9119, host="127.0.0.1", no_open=False, insecure=False,
-        tui=False, stop=False, status=False,
-    )
+    defaults = {
+        "port": 9119, "host": "127.0.0.1", "no_open": False, "insecure": False,
+        "tui": False, "stop": False, "status": False,
+    }
     defaults.update(kw)
     return argparse.Namespace(**defaults)
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2472,23 +2472,23 @@ def test_resolve_hermes_argv_module_actually_runs():
 
 def _make_task(**overrides) -> "kb.Task":
     """Minimal Task with all required fields filled in. Override anything."""
-    defaults = dict(
-        id="t_age",
-        title="x",
-        body=None,
-        assignee=None,
-        status="ready",
-        priority=0,
-        created_by=None,
-        created_at=0,
-        started_at=None,
-        completed_at=None,
-        workspace_kind="scratch",
-        workspace_path=None,
-        claim_lock=None,
-        claim_expires=None,
-        tenant=None,
-    )
+    defaults = {
+        "id": "t_age",
+        "title": "x",
+        "body": None,
+        "assignee": None,
+        "status": "ready",
+        "priority": 0,
+        "created_by": None,
+        "created_at": 0,
+        "started_at": None,
+        "completed_at": None,
+        "workspace_kind": "scratch",
+        "workspace_path": None,
+        "claim_lock": None,
+        "claim_expires": None,
+        "tenant": None,
+    }
     defaults.update(overrides)
     return kb.Task(**defaults)
 

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -371,7 +371,7 @@ class TestPartitionNousModelsByTier:
     def test_all_free_models(self):
         """When all models are free, free-tier users can select all."""
         models = ["xiaomi/mimo-v2-pro", "xiaomi/mimo-v2-omni"]
-        pricing = {m: self._FREE for m in models}
+        pricing = dict.fromkeys(models, self._FREE)
         sel, unav = partition_nous_models_by_tier(models, pricing, free_tier=True)
         assert sel == models
         assert unav == []
@@ -379,7 +379,7 @@ class TestPartitionNousModelsByTier:
     def test_all_paid_models(self):
         """When all models are paid, free-tier users have none selectable."""
         models = ["anthropic/claude-opus-4.6", "openai/gpt-5.4"]
-        pricing = {m: self._PAID for m in models}
+        pricing = dict.fromkeys(models, self._PAID)
         sel, unav = partition_nous_models_by_tier(models, pricing, free_tier=True)
         assert sel == []
         assert unav == models

--- a/tests/hermes_cli/test_opencode_go_flat_namespace.py
+++ b/tests/hermes_cli/test_opencode_go_flat_namespace.py
@@ -111,13 +111,13 @@ def test_openrouter_still_prepends_vendor():
 def _run_switch(raw_input: str, **extra):
     """Call switch_model with opencode-go as current provider, mocking the
     live catalog so the test doesn't hit the network."""
-    defaults = dict(
-        current_provider="opencode-go",
-        current_model="kimi-k2.6",
-        current_base_url="https://opencode.ai/zen/go/v1",
-        current_api_key="sk-test-opencode-go",
-        is_global=False,
-    )
+    defaults = {
+        "current_provider": "opencode-go",
+        "current_model": "kimi-k2.6",
+        "current_base_url": "https://opencode.ai/zen/go/v1",
+        "current_api_key": "sk-test-opencode-go",
+        "is_global": False,
+    }
     defaults.update(extra)
 
     def fake_list_provider_models(provider: str):

--- a/tests/hermes_cli/test_setup_irc.py
+++ b/tests/hermes_cli/test_setup_irc.py
@@ -17,25 +17,25 @@ def _register_irc_platform(**overrides):
     Tests run outside the normal plugin-discovery path, so we inject the entry
     directly into the singleton registry and yield its dict shape.
     """
-    defaults = dict(
-        name="irc",
-        label="IRC",
-        adapter_factory=lambda cfg: None,
-        check_fn=lambda: bool(os.getenv("IRC_SERVER", "") and os.getenv("IRC_CHANNEL", "")),
-        validate_config=None,
-        required_env=["IRC_SERVER", "IRC_CHANNEL", "IRC_NICKNAME"],
-        install_hint="No extra packages needed (stdlib only)",
-        setup_fn=lambda: None,
-        source="plugin",
-        plugin_name="irc_platform",
-        allowed_users_env="IRC_ALLOWED_USERS",
-        allow_all_env="IRC_ALLOW_ALL_USERS",
-        max_message_length=450,
-        pii_safe=False,
-        emoji="💬",
-        allow_update_command=True,
-        platform_hint="You are chatting via IRC.",
-    )
+    defaults = {
+        "name": "irc",
+        "label": "IRC",
+        "adapter_factory": lambda cfg: None,
+        "check_fn": lambda: bool(os.getenv("IRC_SERVER", "") and os.getenv("IRC_CHANNEL", "")),
+        "validate_config": None,
+        "required_env": ["IRC_SERVER", "IRC_CHANNEL", "IRC_NICKNAME"],
+        "install_hint": "No extra packages needed (stdlib only)",
+        "setup_fn": lambda: None,
+        "source": "plugin",
+        "plugin_name": "irc_platform",
+        "allowed_users_env": "IRC_ALLOWED_USERS",
+        "allow_all_env": "IRC_ALLOW_ALL_USERS",
+        "max_message_length": 450,
+        "pii_safe": False,
+        "emoji": "💬",
+        "allow_update_command": True,
+        "platform_hint": "You are chatting via IRC.",
+    }
     defaults.update(overrides)
     entry = PlatformEntry(**defaults)
     platform_registry.register(entry)

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -879,7 +879,7 @@ class TestDialecticCadenceDefaults:
         from unittest.mock import patch, MagicMock
         from plugins.memory.honcho.client import HonchoClientConfig
 
-        defaults = dict(api_key="test-key", enabled=True, recall_mode="hybrid")
+        defaults = {"api_key": "test-key", "enabled": True, "recall_mode": "hybrid"}
         if cfg_extra:
             defaults.update(cfg_extra)
         cfg = HonchoClientConfig(**defaults)
@@ -950,7 +950,7 @@ class TestDialecticDepth:
         from unittest.mock import patch, MagicMock
         from plugins.memory.honcho.client import HonchoClientConfig
 
-        defaults = dict(api_key="test-key", enabled=True, recall_mode="hybrid")
+        defaults = {"api_key": "test-key", "enabled": True, "recall_mode": "hybrid"}
         if cfg_extra:
             defaults.update(cfg_extra)
         cfg = HonchoClientConfig(**defaults)
@@ -1258,7 +1258,7 @@ class TestSessionStartDialecticPrewarm:
         from unittest.mock import patch, MagicMock
         from plugins.memory.honcho.client import HonchoClientConfig
 
-        defaults = dict(api_key="test-key", enabled=True, recall_mode="hybrid")
+        defaults = {"api_key": "test-key", "enabled": True, "recall_mode": "hybrid"}
         if cfg_extra:
             defaults.update(cfg_extra)
         cfg = HonchoClientConfig(**defaults)
@@ -1330,7 +1330,7 @@ class TestDialecticLiveness:
         from unittest.mock import patch, MagicMock
         from plugins.memory.honcho.client import HonchoClientConfig
 
-        defaults = dict(api_key="test-key", enabled=True, recall_mode="hybrid", timeout=2.0)
+        defaults = {"api_key": "test-key", "enabled": True, "recall_mode": "hybrid", "timeout": 2.0}
         if cfg_extra:
             defaults.update(cfg_extra)
         cfg = HonchoClientConfig(**defaults)
@@ -1472,11 +1472,11 @@ class TestDialecticLifecycleSmoke:
         from unittest.mock import patch, MagicMock
         from plugins.memory.honcho.client import HonchoClientConfig
 
-        defaults = dict(
-            api_key="test-key", enabled=True, recall_mode="hybrid",
-            dialectic_reasoning_level="low", reasoning_heuristic=True,
-            reasoning_level_cap="high", dialectic_depth=1,
-        )
+        defaults = {
+            "api_key": "test-key", "enabled": True, "recall_mode": "hybrid",
+            "dialectic_reasoning_level": "low", "reasoning_heuristic": True,
+            "reasoning_level_cap": "high", "dialectic_depth": 1,
+        }
         if cfg_extra:
             defaults.update(cfg_extra)
         cfg = HonchoClientConfig(**defaults)
@@ -1611,11 +1611,11 @@ class TestReasoningHeuristic:
         from unittest.mock import patch, MagicMock
         from plugins.memory.honcho.client import HonchoClientConfig
 
-        defaults = dict(
-            api_key="test-key", enabled=True, recall_mode="hybrid",
-            dialectic_reasoning_level="low", reasoning_heuristic=True,
-            reasoning_level_cap="high",
-        )
+        defaults = {
+            "api_key": "test-key", "enabled": True, "recall_mode": "hybrid",
+            "dialectic_reasoning_level": "low", "reasoning_heuristic": True,
+            "reasoning_level_cap": "high",
+        }
         if cfg_extra:
             defaults.update(cfg_extra)
         cfg = HonchoClientConfig(**defaults)

--- a/tests/run_agent/test_compression_boundary.py
+++ b/tests/run_agent/test_compression_boundary.py
@@ -30,13 +30,13 @@ def _assistant_with_tools(*call_ids: str) -> dict:
 
 
 def _make_compressor(**kwargs) -> ContextCompressor:
-    defaults = dict(
-        model="test-model",
-        threshold_percent=0.75,
-        protect_first_n=3,
-        protect_last_n=4,
-        quiet_mode=True,
-    )
+    defaults = {
+        "model": "test-model",
+        "threshold_percent": 0.75,
+        "protect_first_n": 3,
+        "protect_last_n": 4,
+        "quiet_mode": True,
+    }
     defaults.update(kwargs)
     with patch("agent.context_compressor.get_model_context_length", return_value=8000):
         return ContextCompressor(**defaults)

--- a/tests/run_agent/test_compression_boundary_hook.py
+++ b/tests/run_agent/test_compression_boundary_hook.py
@@ -71,9 +71,7 @@ class TestCompressionBoundaryHook:
                 "compression should rotate session_id when session_db is set"
 
             # Hook fired with boundary_reason="compression" and old_session_id
-            calls = [
-                c for c in compressor.on_session_start.call_args_list
-            ]
+            calls = list(compressor.on_session_start.call_args_list)
             assert calls, "on_session_start was never called on the context engine"
             # Find the compression boundary call (there may be others from init)
             comp_calls = [

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -49,16 +49,16 @@ def _make_agent(monkeypatch, provider, api_mode="chat_completions", base_url="ht
     monkeypatch.setattr("run_agent.get_tool_definitions", lambda **kw: _tool_defs("web_search", "terminal"))
     monkeypatch.setattr("run_agent.check_toolset_requirements", lambda: {})
     monkeypatch.setattr("run_agent.OpenAI", _FakeOpenAI)
-    kwargs = dict(
-        api_key="test-key",
-        base_url=base_url,
-        provider=provider,
-        api_mode=api_mode,
-        max_iterations=4,
-        quiet_mode=True,
-        skip_context_files=True,
-        skip_memory=True,
-    )
+    kwargs = {
+        "api_key": "test-key",
+        "base_url": base_url,
+        "provider": provider,
+        "api_mode": api_mode,
+        "max_iterations": 4,
+        "quiet_mode": True,
+        "skip_context_files": True,
+        "skip_memory": True,
+    }
     if model:
         kwargs["model"] = model
     elif provider == "nous":

--- a/tests/run_agent/test_stream_interrupt_retry.py
+++ b/tests/run_agent/test_stream_interrupt_retry.py
@@ -20,14 +20,14 @@ def _make_agent(**kwargs):
     """Create a minimal AIAgent for streaming tests."""
     from run_agent import AIAgent
 
-    defaults = dict(
-        api_key="test-key",
-        base_url="https://example.com/v1",
-        model="test/model",
-        quiet_mode=True,
-        skip_context_files=True,
-        skip_memory=True,
-    )
+    defaults = {
+        "api_key": "test-key",
+        "base_url": "https://example.com/v1",
+        "model": "test/model",
+        "quiet_mode": True,
+        "skip_context_files": True,
+        "skip_memory": True,
+    }
     defaults.update(kwargs)
     agent = AIAgent(**defaults)
     agent.api_mode = "chat_completions"

--- a/tests/skills/test_openclaw_migration_hardening.py
+++ b/tests/skills/test_openclaw_migration_hardening.py
@@ -158,16 +158,16 @@ def _make_minimal_migrator(mod, tmp_path, **overrides):
     (source / "openclaw.json").write_text("{}", encoding="utf-8")
     target = tmp_path / "hermes"
     target.mkdir()
-    defaults = dict(
-        source_root=source,
-        target_root=target,
-        execute=False,
-        workspace_target=None,
-        overwrite=False,
-        migrate_secrets=False,
-        output_dir=None,
-        selected_options=set(),
-    )
+    defaults = {
+        "source_root": source,
+        "target_root": target,
+        "execute": False,
+        "workspace_target": None,
+        "overwrite": False,
+        "migrate_secrets": False,
+        "output_dir": None,
+        "selected_options": set(),
+    }
     defaults.update(overrides)
     return mod.Migrator(**defaults)
 

--- a/tests/tools/test_accretion_caps.py
+++ b/tests/tools/test_accretion_caps.py
@@ -37,7 +37,7 @@ class TestReadTrackerCaps:
         task_data = {
             "last_key": None,
             "consecutive": 0,
-            "read_history": set((f"/p{i}", 0, 500) for i in range(50)),
+            "read_history": {(f"/p{i}", 0, 500) for i in range(50)},
             "dedup": {},
             "read_timestamps": {},
         }


### PR DESCRIPTION
## What does this PR do?

Adds the `C4` lint rule group to pyproject.toml and applies `ruff check --fix --unsafe-fixes` across 21 files.

Rules: C401 (unnecessary-generator-set: `set(x for x in y)` → `{x for x in y}`), C408 (unnecessary-collection-call: `dict()` → `{}`, `list()` → `[]`), C416 (unnecessary-comprehension: `[x for x in y]` → `list(y)`)

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- Standardizes the PR description to the same review format used in #29640.
- Preserves the original detailed description below so no context is lost.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- `ruff check` passa com zero erros (regra já ativa na config)
- Nenhuma mudança de comportamento em runtime — apenas transformações sintáticas
- `pytest` mantém o comportamento esperado

---

_Generated by Hermes Turbo_

## Related PRs / issues

- Original body preserved below for full context.

<details>
<summary>Original body</summary>

## Summary

Adds the `C4` lint rule group to pyproject.toml and applies `ruff check --fix --unsafe-fixes` across 21 files.

Rules: C401 (unnecessary-generator-set: `set(x for x in y)` → `{x for x in y}`), C408 (unnecessary-collection-call: `dict()` → `{}`, `list()` → `[]`), C416 (unnecessary-comprehension: `[x for x in y]` → `list(y)`)

## What Changed

- `pyproject.toml`: added `C4` to `[tool.ruff.lint] select`
- **21 files** changed: **+133/-162** lines

## Fluxo

O ruff percorre a árvore do projeto aplicando a regra `C4` onde encontra violações. As transformações foram feitas por auto-fix e mantêm o comportamento do código.

## Visão

Com a regra habilitada no lint, o projeto passa a bloquear regressões futuras no mesmo padrão e fica mais consistente para novos commits.

## Test Plan

- `ruff check` passa com zero erros (regra já ativa na config)
- Nenhuma mudança de comportamento em runtime — apenas transformações sintáticas
- `pytest` mantém o comportamento esperado

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_