### PR TITLE
fix(discord): clarify thread handoff follow-up

### DIFF
--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -455,6 +455,8 @@ class TestCreateThread:
         result = json.loads(discord_core(action="create_thread", channel_id="11", name="New Thread"))
         assert result["success"] is True
         assert result["thread_id"] == "800"
+        assert result["delivery_target"] == "discord:11:800"
+        assert "does not switch the active Hermes conversation" in result["note"]
         # Verify the API call
         mock_req.assert_called_once_with(
             "POST", "/channels/11/threads", "test-token",
@@ -469,6 +471,8 @@ class TestCreateThread:
             action="create_thread", channel_id="11", name="Discussion", message_id="1001",
         ))
         assert result["success"] is True
+        assert result["delivery_target"] == "discord:11:801"
+        assert "send_message(target='discord:11:801'" in result["note"]
         mock_req.assert_called_once_with(
             "POST", "/channels/11/messages/1001/threads", "test-token",
             body={"name": "Discussion", "auto_archive_duration": 1440},
@@ -591,6 +595,7 @@ class TestRegistration:
         assert "fetch_messages(channel_id)" in desc
         assert "search_members(guild_id, query)" in desc
         assert "create_thread(channel_id, name)" in desc
+        assert "does not rebind the active conversation" in desc
         # Admin actions should NOT be in core description
         assert "list_guilds()" not in desc
         assert "add_role(" not in desc

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -447,10 +447,18 @@ def _create_thread(
             "type": 11,  # PUBLIC_THREAD
         }
     thread = _discord_request("POST", path, token, body=body)
+    thread_target = f"discord:{channel_id}:{thread['id']}"
     return json.dumps({
         "success": True,
         "thread_id": thread["id"],
         "name": thread.get("name"),
+        "delivery_target": thread_target,
+        "note": (
+            "create_thread only creates the Discord thread resource; it does not "
+            "switch the active Hermes conversation into that thread. Use "
+            f"send_message(target='{thread_target}', ...) for follow-up delivery, "
+            "or use the Discord /thread command when you want Hermes to continue there."
+        ),
     })
 
 
@@ -510,7 +518,11 @@ _ACTION_MANIFEST: List[Tuple[str, str, str]] = [
     ("pin_message", "(channel_id, message_id)", "pin a message"),
     ("unpin_message", "(channel_id, message_id)", "unpin a message"),
     ("delete_message", "(channel_id, message_id)", "delete a message"),
-    ("create_thread", "(channel_id, name)", "create a public thread; optional message_id anchor"),
+    (
+        "create_thread",
+        "(channel_id, name)",
+        "create a public thread; optional message_id anchor; does not switch conversation context",
+    ),
     ("add_role", "(guild_id, user_id, role_id)", "assign a role"),
     ("remove_role", "(guild_id, user_id, role_id)", "remove a role"),
 ]
@@ -656,7 +668,10 @@ def _build_schema(
             "Available actions:\n"
             f"{manifest_block}\n\n"
             "Use the channel_id from the current conversation context. "
-            "Use search_members to look up user IDs by name prefix."
+            "Use search_members to look up user IDs by name prefix. "
+            "create_thread only creates the thread resource; it does not rebind the "
+            "active conversation. Use the returned delivery_target with send_message "
+            "for follow-up delivery into that thread."
             f"{content_note}"
         )
 
@@ -691,7 +706,10 @@ def _build_schema(
         },
         "name": {
             "type": "string",
-            "description": "New thread name (create_thread).",
+            "description": (
+                "New thread name (create_thread). This action creates the thread "
+                "resource only; it does not switch the active conversation there."
+            ),
         },
         "limit": {
             "type": "integer",


### PR DESCRIPTION
## Summary
- make `discord` tool `create_thread` return a ready-to-use Discord thread delivery target
- clarify in the tool output and schema that `create_thread` does not rebind the active Hermes conversation
- add regression coverage for the new handoff guidance fields

## Testing
- `uv run --frozen --extra dev pytest tests/tools/test_discord_tool.py`
- `uv run --frozen --extra dev ruff check tools/discord_tool.py tests/tools/test_discord_tool.py`
- `uv run --frozen --extra dev python -m py_compile tools/discord_tool.py tests/tools/test_discord_tool.py`
- `git diff --check`

Fixes #31550