### PR TITLE
chore: ruff auto-fix UP015 — redundant-open-modes

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -650,7 +650,7 @@ class BatchRunner:
             raise FileNotFoundError(f"Dataset file not found: {self.dataset_file}")
         
         dataset = []
-        with open(self.dataset_file, 'r', encoding='utf-8') as f:
+        with open(self.dataset_file, encoding='utf-8') as f:
             for line_num, line in enumerate(f, 1):
                 line = line.strip()
                 if not line:
@@ -701,7 +701,7 @@ class BatchRunner:
             }
         
         try:
-            with open(self.checkpoint_file, 'r', encoding='utf-8') as f:
+            with open(self.checkpoint_file, encoding='utf-8') as f:
                 return json.load(f)
         except Exception as e:
             print(f"⚠️  Warning: Failed to load checkpoint: {e}")
@@ -749,7 +749,7 @@ class BatchRunner:
         
         for batch_file in batch_files:
             try:
-                with open(batch_file, 'r', encoding='utf-8') as f:
+                with open(batch_file, encoding='utf-8') as f:
                     for line in f:
                         try:
                             entry = json.loads(line.strip())
@@ -1044,7 +1044,7 @@ class BatchRunner:
                 batch_files_found += 1
                 batch_num = batch_file.stem.split("_")[1]  # Extract batch number for logging
                 
-                with open(batch_file, 'r', encoding='utf-8') as infile:
+                with open(batch_file, encoding='utf-8') as infile:
                     for line in infile:
                         total_entries += 1
                         try:
@@ -1272,7 +1272,7 @@ def main(
     prefill_messages = None
     if prefill_messages_file:
         try:
-            with open(prefill_messages_file, 'r', encoding='utf-8') as f:
+            with open(prefill_messages_file, encoding='utf-8') as f:
                 prefill_messages = json.load(f)
             if not isinstance(prefill_messages, list):
                 print("❌ Error: prefill_messages_file must contain a JSON array of messages")

--- a/cli.py
+++ b/cli.py
@@ -297,7 +297,7 @@ def _load_prefill_messages(file_path: str) -> List[Dict[str, Any]]:
         logger.warning("Prefill messages file not found: %s", path)
         return []
     try:
-        with open(path, "r", encoding="utf-8") as f:
+        with open(path, encoding="utf-8") as f:
             data = json.load(f)
         if not isinstance(data, list):
             logger.warning("Prefill messages file must contain a JSON array: %s", path)
@@ -473,7 +473,7 @@ def load_cli_config() -> Dict[str, Any]:
     # Load from file if exists
     if config_path.exists():
         try:
-            with open(config_path, "r", encoding="utf-8") as f:
+            with open(config_path, encoding="utf-8") as f:
                 from hermes_cli.config import _normalize_root_model_keys
 
                 file_config = _normalize_root_model_keys(yaml.safe_load(f) or {})
@@ -2413,7 +2413,7 @@ def _preserve_ctrl_enter_newline() -> bool:
     # WSL detection — env vars can be scrubbed under sudo, also peek /proc.
     for p in ("/proc/version", "/proc/sys/kernel/osrelease"):
         try:
-            with open(p, "r", encoding="utf-8", errors="ignore") as f:
+            with open(p, encoding="utf-8", errors="ignore") as f:
                 if "microsoft" in f.read().lower():
                     return True
         except OSError:

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -408,13 +408,13 @@ def load_jobs() -> List[Dict[str, Any]]:
         return []
     
     try:
-        with open(JOBS_FILE, 'r', encoding='utf-8') as f:
+        with open(JOBS_FILE, encoding='utf-8') as f:
             data = json.load(f)
             return data.get("jobs", [])
     except json.JSONDecodeError:
         # Retry with strict=False to handle bare control chars in string values
         try:
-            with open(JOBS_FILE, 'r', encoding='utf-8') as f:
+            with open(JOBS_FILE, encoding='utf-8') as f:
                 data = json.loads(f.read(), strict=False)
                 jobs = data.get("jobs", [])
                 if jobs:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1459,7 +1459,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 pfpath = _get_hermes_home() / pfpath
             if pfpath.exists():
                 try:
-                    with open(pfpath, "r", encoding="utf-8") as _pf:
+                    with open(pfpath, encoding="utf-8") as _pf:
                         prefill_messages = json.load(_pf)
                     if not isinstance(prefill_messages, list):
                         prefill_messages = None

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -699,7 +699,7 @@ def load_gateway_config() -> GatewayConfig:
     gateway_json_path = _home / "gateway.json"
     if gateway_json_path.exists():
         try:
-            with open(gateway_json_path, "r", encoding="utf-8") as f:
+            with open(gateway_json_path, encoding="utf-8") as f:
                 gw_data = json.load(f) or {}
             logger.info(
                 "Loaded legacy %s — consider moving settings to config.yaml",

--- a/gateway/platforms/feishu_comment_rules.py
+++ b/gateway/platforms/feishu_comment_rules.py
@@ -90,7 +90,7 @@ class _MtimeCache:
             return self._data
 
         try:
-            with open(self._path, "r", encoding="utf-8") as f:
+            with open(self._path, encoding="utf-8") as f:
                 data = json.load(f)
             if not isinstance(data, dict):
                 data = {}

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1195,7 +1195,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 return
 
             import yaml as _yaml
-            with open(config_path, "r", encoding="utf-8") as f:
+            with open(config_path, encoding="utf-8") as f:
                 config = _yaml.safe_load(f) or {}
 
             # Navigate to platforms.telegram.extra.dm_topics
@@ -5396,7 +5396,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 return
 
             import yaml as _yaml
-            with open(config_path, "r", encoding="utf-8") as f:
+            with open(config_path, encoding="utf-8") as f:
                 config = _yaml.safe_load(f) or {}
 
             dm_topics = (

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1395,7 +1395,7 @@ def _load_gateway_config() -> dict:
     try:
         if config_path.exists():
             import yaml
-            with open(config_path, 'r', encoding='utf-8') as f:
+            with open(config_path, encoding='utf-8') as f:
                 return yaml.safe_load(f) or {}
     except Exception:
         logger.debug("Could not load gateway config from %s", config_path)
@@ -2773,7 +2773,7 @@ class GatewayRunner:
             logger.warning("Prefill messages file not found: %s", path)
             return []
         try:
-            with open(path, "r", encoding="utf-8") as f:
+            with open(path, encoding="utf-8") as f:
                 data = json.load(f)
             if not isinstance(data, list):
                 logger.warning("Prefill messages file must contain a JSON array: %s", path)

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -705,7 +705,7 @@ class SessionStore:
 
         if sessions_file.exists():
             try:
-                with open(sessions_file, "r", encoding="utf-8") as f:
+                with open(sessions_file, encoding="utf-8") as f:
                     data = json.load(f)
                     for key, entry_data in data.items():
                         try:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -326,7 +326,7 @@ def get_container_exec_info() -> Optional[dict]:
 
     try:
         info = {}
-        with open(container_mode_file, "r", encoding="utf-8") as f:
+        with open(container_mode_file, encoding="utf-8") as f:
             for line in f:
                 line = line.strip()
                 if "=" in line and not line.startswith("#"):
@@ -411,7 +411,7 @@ def _is_container() -> bool:
         return True
     # LXC / cgroup-based detection
     try:
-        with open("/proc/1/cgroup", "r", encoding="utf-8") as f:
+        with open("/proc/1/cgroup", encoding="utf-8") as f:
             cgroup_content = f.read()
         if "docker" in cgroup_content or "lxc" in cgroup_content or "kubepods" in cgroup_content:
             return True
@@ -5566,7 +5566,7 @@ def _inject_platform_plugin_env_vars() -> None:
             if not manifest_path.exists():
                 continue
             try:
-                with open(manifest_path, "r", encoding="utf-8") as f:
+                with open(manifest_path, encoding="utf-8") as f:
                     manifest = yaml.safe_load(f) or {}
             except Exception:
                 continue

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -298,7 +298,7 @@ def _load_secrets_config(home_path: Path) -> dict:
     except ImportError:
         return {}
     try:
-        with open(config_path, "r", encoding="utf-8") as f:
+        with open(config_path, encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
     except Exception:  # noqa: BLE001
         return {}

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4201,7 +4201,7 @@ def _pid_alive(pid: Optional[int]) -> bool:
     # where we have a cheap, deterministic process-state probe.
     if sys.platform == "linux":
         try:
-            with open(f"/proc/{int(pid)}/status", "r", encoding="utf-8") as f:
+            with open(f"/proc/{int(pid)}/status", encoding="utf-8") as f:
                 for line in f:
                     if line.startswith("State:"):
                         # "State:\tZ (zombie)" → dead

--- a/hermes_cli/logs.py
+++ b/hermes_cli/logs.py
@@ -288,7 +288,7 @@ def _read_last_n_lines(path: Path, n: int) -> list:
 
         # For files up to 1MB, just read the whole thing — simple and correct.
         if size <= 1_048_576:
-            with open(path, "r", encoding="utf-8", errors="replace") as f:
+            with open(path, encoding="utf-8", errors="replace") as f:
                 all_lines = f.readlines()
             return all_lines[-n:]
 
@@ -326,7 +326,7 @@ def _read_last_n_lines(path: Path, n: int) -> list:
 
     except Exception:
         # Fallback: read entire file
-        with open(path, "r", encoding="utf-8", errors="replace") as f:
+        with open(path, encoding="utf-8", errors="replace") as f:
             all_lines = f.readlines()
         return all_lines[-n:]
 
@@ -340,7 +340,7 @@ def _follow_log(
     component_prefixes: Optional[Sequence[str]] = None,
 ) -> None:
     """Poll a log file for new content and print matching lines."""
-    with open(path, "r", encoding="utf-8", errors="replace") as f:
+    with open(path, encoding="utf-8", errors="replace") as f:
         # Seek to end
         f.seek(0, 2)
         while True:

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -439,7 +439,7 @@ def _read_distribution_meta(profile_dir: Path) -> tuple:
         return None, None, None
     try:
         import yaml
-        with open(mf_path, "r", encoding="utf-8") as f:
+        with open(mf_path, encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
         if not isinstance(data, dict):
             return None, None, None
@@ -459,7 +459,7 @@ def _read_config_model(profile_dir: Path) -> tuple:
         return None, None
     try:
         import yaml
-        with open(config_path, "r", encoding="utf-8") as f:
+        with open(config_path, encoding="utf-8") as f:
             cfg = yaml.safe_load(f) or {}
         model_cfg = cfg.get("model", {})
         if isinstance(model_cfg, str):
@@ -524,7 +524,7 @@ def read_profile_meta(profile_dir: Path) -> dict:
         return {"description": "", "description_auto": False}
     try:
         import yaml
-        with open(path, "r", encoding="utf-8") as f:
+        with open(path, encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
     except Exception:
         return {"description": "", "description_auto": False}
@@ -555,7 +555,7 @@ def write_profile_meta(
     existing: dict = {}
     if path.is_file():
         try:
-            with open(path, "r", encoding="utf-8") as f:
+            with open(path, encoding="utf-8") as f:
                 loaded = yaml.safe_load(f) or {}
             if isinstance(loaded, dict):
                 existing = loaded

--- a/hermes_cli/send_cmd.py
+++ b/hermes_cli/send_cmd.py
@@ -252,7 +252,7 @@ def _load_hermes_env() -> None:
         return
 
     try:
-        with open(config_path, "r", encoding="utf-8") as fh:
+        with open(config_path, encoding="utf-8") as fh:
             raw = yaml.safe_load(fh) or {}
     except Exception:
         return

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -662,7 +662,7 @@ def _load_skin_from_yaml(path: Path) -> Optional[Dict[str, Any]]:
     """Load a skin definition from a YAML file."""
     try:
         import yaml
-        with open(path, "r", encoding="utf-8") as f:
+        with open(path, encoding="utf-8") as f:
             data = yaml.safe_load(f)
         if isinstance(data, dict) and "name" in data:
             return data

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -326,7 +326,7 @@ def is_wsl() -> bool:
     if _wsl_detected is not None:
         return _wsl_detected
     try:
-        with open("/proc/version", "r", encoding="utf-8") as f:
+        with open("/proc/version", encoding="utf-8") as f:
             _wsl_detected = "microsoft" in f.read().lower()
     except Exception:
         _wsl_detected = False
@@ -353,7 +353,7 @@ def is_container() -> bool:
         _container_detected = True
         return True
     try:
-        with open("/proc/1/cgroup", "r", encoding="utf-8") as f:
+        with open("/proc/1/cgroup", encoding="utf-8") as f:
             cgroup = f.read()
             if "docker" in cgroup or "podman" in cgroup or "/lxc/" in cgroup:
                 _container_detected = True

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -375,7 +375,7 @@ def _read_logging_config():
         import yaml
         config_path = get_config_path()
         if config_path.exists():
-            with open(config_path, "r", encoding="utf-8") as f:
+            with open(config_path, encoding="utf-8") as f:
                 cfg = yaml.safe_load(f) or {}
             log_cfg = cfg.get("logging", {})
             if isinstance(log_cfg, dict):

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -88,7 +88,7 @@ def _load_sessions_index() -> dict:
     if not sessions_file.exists():
         return {}
     try:
-        with open(sessions_file, "r", encoding="utf-8") as f:
+        with open(sessions_file, encoding="utf-8") as f:
             return json.load(f)
     except Exception as e:
         logger.debug("Failed to load sessions.json: %s", e)
@@ -108,7 +108,7 @@ def _load_channel_directory() -> dict:
     if not directory_file.exists():
         return {}
     try:
-        with open(directory_file, "r", encoding="utf-8") as f:
+        with open(directory_file, encoding="utf-8") as f:
             return json.load(f)
     except Exception as e:
         logger.debug("Failed to load channel_directory.json: %s", e)

--- a/mini_swe_runner.py
+++ b/mini_swe_runner.py
@@ -710,7 +710,7 @@ def main(
     elif prompts_file:
         # Batch mode
         prompts = []
-        with open(prompts_file, 'r', encoding='utf-8') as f:
+        with open(prompts_file, encoding='utf-8') as f:
             for line in f:
                 line = line.strip()
                 if line:

--- a/optional-skills/productivity/memento-flashcards/scripts/memento_cards.py
+++ b/optional-skills/productivity/memento-flashcards/scripts/memento_cards.py
@@ -42,7 +42,7 @@ def _load() -> dict:
     if not CARDS_FILE.exists():
         return _empty_store()
     try:
-        with open(CARDS_FILE, "r", encoding="utf-8") as f:
+        with open(CARDS_FILE, encoding="utf-8") as f:
             data = json.load(f)
         if not isinstance(data, dict) or "cards" not in data:
             return _empty_store()
@@ -240,7 +240,7 @@ def cmd_import(args: argparse.Namespace) -> None:
         sys.exit(1)
 
     created = 0
-    with open(file_path, "r", encoding="utf-8") as f:
+    with open(file_path, encoding="utf-8") as f:
         reader = csv.reader(f)
         for row in reader:
             if len(row) < 2:

--- a/optional-skills/security/oss-forensics/scripts/evidence-store.py
+++ b/optional-skills/security/oss-forensics/scripts/evidence-store.py
@@ -72,7 +72,7 @@ class EvidenceStore:
         }
         if os.path.exists(filepath):
             try:
-                with open(filepath, "r", encoding="utf-8") as f:
+                with open(filepath, encoding="utf-8") as f:
                     self.data = json.load(f)
             except (json.JSONDecodeError, IOError) as e:
                 print(f"Error loading evidence store '{filepath}': {e}", file=sys.stderr)

--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -581,7 +581,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
                 )
             # Validate file parses before handing to google-auth for nicer error.
             try:
-                with open(sa_path, "r", encoding="utf-8") as fh:
+                with open(sa_path, encoding="utf-8") as fh:
                     info = json.load(fh)
             except json.JSONDecodeError as exc:
                 raise ValueError(
@@ -3192,7 +3192,7 @@ async def _standalone_send(
                 if not os.path.exists(sa_value):
                     return {"error": f"Google Chat standalone send: SA JSON file not found at {sa_value}"}
                 try:
-                    with open(sa_value, "r", encoding="utf-8") as fh:
+                    with open(sa_value, encoding="utf-8") as fh:
                         info = json.load(fh)
                 except json.JSONDecodeError as exc:
                     return {"error": f"Google Chat standalone send: SA JSON file is invalid: {exc}"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,7 +257,7 @@ preview = true  # required for PLW1514 (unspecified-encoding) — preview rule
 # which silently corrupts any non-ASCII file content.  We had three
 # separate Windows sandbox regressions in one debug session before
 # adding the explicit encoding.  This rule keeps new code honest.
-select = ["PLW1514"]
+select = ["UP015", "PLW1514"]
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can intentionally exercise locale-encoding edge cases.

--- a/scripts/sample_and_compress.py
+++ b/scripts/sample_and_compress.py
@@ -298,7 +298,7 @@ def merge_output_to_single_jsonl(input_dir: Path, output_file: Path):
     for jsonl_file in sorted(input_dir.glob("*.jsonl")):
         if jsonl_file.name == output_file.name:
             continue
-        with open(jsonl_file, 'r', encoding='utf-8') as f:
+        with open(jsonl_file, encoding='utf-8') as f:
             for line in f:
                 line = line.strip()
                 if line:

--- a/skills/creative/comfyui/scripts/hardware_check.py
+++ b/skills/creative/comfyui/scripts/hardware_check.py
@@ -68,7 +68,7 @@ def is_wsl() -> bool:
     if "microsoft" in platform.release().lower() or "wsl" in platform.release().lower():
         return True
     try:
-        with open("/proc/version", "r") as fh:
+        with open("/proc/version") as fh:
             return "microsoft" in fh.read().lower()
     except OSError:
         return False
@@ -227,7 +227,7 @@ def total_system_ram_gb() -> float:
             return 0.0
     if sysname == "Linux":
         try:
-            with open("/proc/meminfo", "r") as fh:
+            with open("/proc/meminfo") as fh:
                 for line in fh:
                     if line.startswith("MemTotal:"):
                         kb = int(line.split()[1])

--- a/skills/creative/excalidraw/scripts/upload.py
+++ b/skills/creative/excalidraw/scripts/upload.py
@@ -112,7 +112,7 @@ def main():
         print(f"Error: File not found: {file_path}")
         sys.exit(1)
 
-    with open(file_path, "r", encoding="utf-8") as f:
+    with open(file_path, encoding="utf-8") as f:
         content = f.read()
 
     # Basic validation: should be valid JSON with an "elements" key

--- a/tests/integration/test_checkpoint_resumption.py
+++ b/tests/integration/test_checkpoint_resumption.py
@@ -81,7 +81,7 @@ def monitor_checkpoint_during_run(checkpoint_file: Path, duration: int = 30) -> 
                 elapsed = time.time() - start_time
                 
                 try:
-                    with open(checkpoint_file, 'r') as f:
+                    with open(checkpoint_file) as f:
                         checkpoint_data = json.load(f)
                     
                     snapshot = {
@@ -238,7 +238,7 @@ def test_interruption_and_resume():
     temp_dataset = Path("tests/test_data/checkpoint_test_resume_partial.jsonl")
     try:
         # Create a modified dataset with only first 5 prompts for initial run
-        with open(dataset_file, 'r') as f:
+        with open(dataset_file) as f:
             lines = f.readlines()[:5]
         with open(temp_dataset, 'w') as f:
             f.writelines(lines)
@@ -261,7 +261,7 @@ def test_interruption_and_resume():
             print("❌ ERROR: Checkpoint file not created after first run")
             return False
         
-        with open(checkpoint_file, 'r') as f:
+        with open(checkpoint_file) as f:
             checkpoint_data = json.load(f)
         
         initial_completed = len(checkpoint_data.get("completed_prompts", []))
@@ -284,7 +284,7 @@ def test_interruption_and_resume():
         runner2.run(resume=True)
         
         # Check final checkpoint
-        with open(checkpoint_file, 'r') as f:
+        with open(checkpoint_file) as f:
             final_checkpoint = json.load(f)
         
         final_completed = len(final_checkpoint.get("completed_prompts", []))

--- a/tests/skills/test_memento_cards.py
+++ b/tests/skills/test_memento_cards.py
@@ -230,7 +230,7 @@ class TestCSV:
         assert result["exported"] == 2
 
         # Verify CSV content
-        with open(csv_path, "r") as f:
+        with open(csv_path) as f:
             reader = csv.reader(f)
             rows = list(reader)
         assert len(rows) == 2

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -444,7 +444,7 @@ class TestVprintForceParameter:
     def test_error_messages_use_force_in_run_agent(self):
         """Verify that critical error _vprint calls in run_agent.py
         include force=True."""
-        with open("run_agent.py", "r") as f:
+        with open("run_agent.py") as f:
             source = f.read()
 
         tree = ast.parse(source)

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -923,7 +923,7 @@ def _run_chrome_fallback_command(
             proc.wait()
             return {"success": False, "error": f"Chrome fallback '{cmd}' timed out"}
         try:
-            with open(stdout_path, "r", encoding="utf-8") as f:
+            with open(stdout_path, encoding="utf-8") as f:
                 stdout = f.read().strip()
             if stdout:
                 return json.loads(stdout.split("\n")[-1])
@@ -2091,9 +2091,9 @@ def _run_browser_command(
             result = {"success": False, "error": f"Command timed out after {timeout} seconds"}
             # Fall through to fallback check below
         else:
-            with open(stdout_path, "r", encoding="utf-8") as f:
+            with open(stdout_path, encoding="utf-8") as f:
                 stdout = f.read()
-            with open(stderr_path, "r", encoding="utf-8") as f:
+            with open(stderr_path, encoding="utf-8") as f:
                 stderr = f.read()
             returncode = proc.returncode
 
@@ -3588,7 +3588,7 @@ def _running_in_docker() -> bool:
     if os.path.exists("/.dockerenv"):
         return True
     try:
-        with open("/proc/1/cgroup", "rt", encoding="utf-8") as fp:
+        with open("/proc/1/cgroup", encoding="utf-8") as fp:
             return "docker" in fp.read()
     except OSError:
         return False

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -154,7 +154,7 @@ def _read_failure_reason() -> str | None:
         mtime = os.path.getmtime(p)
         if (time.time() - mtime) >= _MARKER_TTL:
             return None
-        with open(p, "r", encoding="utf-8") as f:
+        with open(p, encoding="utf-8") as f:
             return f.read().strip()
     except OSError:
         return None

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -110,7 +110,7 @@ def detect_audio_environment() -> dict:
     # WSL detection — PulseAudio bridge makes audio work in WSL.
     # Only block if PULSE_SERVER is not configured.
     try:
-        with open('/proc/version', 'r', encoding="utf-8") as f:
+        with open('/proc/version', encoding="utf-8") as f:
             if 'microsoft' in f.read().lower():
                 if os.environ.get('PULSE_SERVER'):
                     notices.append("Running in WSL with PulseAudio bridge")

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -125,7 +125,7 @@ class CompressionConfig:
     @classmethod
     def from_yaml(cls, yaml_path: str) -> "CompressionConfig":
         """Load configuration from YAML file."""
-        with open(yaml_path, 'r', encoding="utf-8") as f:
+        with open(yaml_path, encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
 
         config = cls()
@@ -1005,7 +1005,7 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
         all_entries = []  # List of (file_path, entry_idx, entry)
         
         for file_path in jsonl_files:
-            with open(file_path, 'r', encoding='utf-8') as f:
+            with open(file_path, encoding='utf-8') as f:
                 for line_num, line in enumerate(f):
                     line = line.strip()
                     if line:
@@ -1375,7 +1375,7 @@ def main(
         
         # Load entries from the single file
         entries = []
-        with open(input_path, 'r', encoding='utf-8') as f:
+        with open(input_path, encoding='utf-8') as f:
             for line_num, line in enumerate(f, 1):
                 line = line.strip()
                 if line:
@@ -1420,7 +1420,7 @@ def main(
             output_path.parent.mkdir(parents=True, exist_ok=True)
             with open(output_path, 'w', encoding='utf-8') as out_f:
                 for jsonl_file in sorted(temp_output_dir.glob("*.jsonl")):
-                    with open(jsonl_file, 'r', encoding='utf-8') as in_f:
+                    with open(jsonl_file, encoding='utf-8') as in_f:
                         for line in in_f:
                             out_f.write(line)
             
@@ -1459,7 +1459,7 @@ def main(
                 # Sample from each JSONL file
                 for jsonl_file in sorted(input_path.glob("*.jsonl")):
                     entries = []
-                    with open(jsonl_file, 'r', encoding='utf-8') as f:
+                    with open(jsonl_file, encoding='utf-8') as f:
                         for line in f:
                             line = line.strip()
                             if line:


### PR DESCRIPTION
## What does this PR do?

Adds the `UP015` rule to pyproject.toml and applies auto-fix across 34 files.

Replaces redundant `open(mode='r')` with the default `open()` call.

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- Standardizes the PR description to the same review format used in #29640.
- Preserves the original detailed description below so no context is lost.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- `ruff check` passa com zero erros (regra já ativa na config)
- Nenhuma mudança de comportamento em runtime — apenas transformações sintáticas
- `pytest` mantém o comportamento esperado

---

_Generated by Hermes Turbo_

## Related PRs / issues

- Original body preserved below for full context.

<details>
<summary>Original body</summary>

## Summary

Adds the `UP015` rule to pyproject.toml and applies auto-fix across 34 files.

Replaces redundant `open(mode='r')` with the default `open()` call.

## What Changed

- `pyproject.toml`: added `UP015` to `[tool.ruff.lint] select`
- **34 files** changed: **+65/-65** lines

## Fluxo

O ruff percorre a árvore do projeto aplicando a regra `UP015` onde encontra violações. As transformações foram feitas por auto-fix e mantêm o comportamento do código.

## Visão

Com a regra habilitada no lint, o projeto passa a bloquear regressões futuras no mesmo padrão e fica mais consistente para novos commits.

## Test Plan

- `ruff check` passa com zero erros (regra já ativa na config)
- Nenhuma mudança de comportamento em runtime — apenas transformações sintáticas
- `pytest` mantém o comportamento esperado

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_