### PR TITLE
chore: ruff auto-fix UP024 — os-error-alias

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -886,7 +886,7 @@ def read_claude_code_credentials() -> Optional[Dict[str, Any]]:
                         "expiresAt": oauth_data.get("expiresAt", 0),
                         "source": "claude_code_credentials_file",
                     }
-        except (json.JSONDecodeError, OSError, IOError) as e:
+        except (json.JSONDecodeError, OSError) as e:
             logger.debug("Failed to read ~/.claude/.credentials.json: %s", e)
 
     return None
@@ -901,7 +901,7 @@ def read_claude_managed_key() -> Optional[str]:
             primary_key = data.get("primaryApiKey", "")
             if isinstance(primary_key, str) and primary_key.strip():
                 return primary_key.strip()
-        except (json.JSONDecodeError, OSError, IOError) as e:
+        except (json.JSONDecodeError, OSError) as e:
             logger.debug("Failed to read ~/.claude.json: %s", e)
     return None
 
@@ -1070,7 +1070,7 @@ def _write_claude_code_credentials(
             except OSError:
                 pass
             raise
-    except (OSError, IOError) as e:
+    except OSError as e:
         logger.debug("Failed to write refreshed credentials: %s", e)
 
 
@@ -1331,7 +1331,7 @@ def read_hermes_oauth_credentials() -> Optional[Dict[str, Any]]:
             data = json.loads(_HERMES_OAUTH_FILE.read_text(encoding="utf-8"))
             if data.get("accessToken"):
                 return data
-        except (json.JSONDecodeError, OSError, IOError) as e:
+        except (json.JSONDecodeError, OSError) as e:
             logger.debug("Failed to read Hermes OAuth credentials: %s", e)
     return None
 

--- a/agent/google_oauth.py
+++ b/agent/google_oauth.py
@@ -474,7 +474,7 @@ def load_credentials() -> Optional[GoogleCredentials]:
         with _credentials_lock():
             raw = path.read_text(encoding="utf-8")
         data = json.loads(raw)
-    except (json.JSONDecodeError, OSError, IOError) as exc:
+    except (json.JSONDecodeError, OSError) as exc:
         logger.warning("Failed to read Google OAuth credentials at %s: %s", path, exc)
         return None
     if not isinstance(data, dict):

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -634,7 +634,7 @@ def _locked_update_approvals() -> Iterator[Dict[str, Any]]:
         finally:
             try:
                 fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
-            except (OSError, IOError):
+            except OSError:
                 pass
 
 

--- a/cli.py
+++ b/cli.py
@@ -4054,7 +4054,7 @@ class HermesCLI:
             # the input to be silently dropped (#17666).
             try:
                 return path.read_text(encoding="utf-8")
-            except (OSError, IOError):
+            except OSError:
                 logger.warning("Paste file gone or unreadable, returning placeholder: %s", path)
                 return match.group(0)
 

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -425,7 +425,7 @@ def load_jobs() -> List[Dict[str, Any]]:
         except Exception as e:
             logger.error("Failed to auto-repair jobs.json: %s", e)
             raise RuntimeError(f"Cron database corrupted and unrepairable: {e}") from e
-    except IOError as e:
+    except OSError as e:
         logger.error("IOError reading jobs.json: %s", e)
         raise RuntimeError(f"Failed to read cron database: {e}") from e
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1813,7 +1813,7 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
             fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         elif msvcrt:
             msvcrt.locking(lock_fd.fileno(), msvcrt.LK_NBLCK, 1)
-    except (OSError, IOError):
+    except OSError:
         logger.debug("Tick skipped — another instance holds the lock")
         if lock_fd is not None:
             lock_fd.close()
@@ -1958,12 +1958,12 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
         if fcntl:
             try:
                 fcntl.flock(lock_fd, fcntl.LOCK_UN)
-            except (OSError, IOError):
+            except OSError:
                 pass
         elif msvcrt:
             try:
                 msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
-            except (OSError, IOError):
+            except OSError:
                 pass
         lock_fd.close()
 

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1934,7 +1934,7 @@ class QQAdapter(BasePlatformAdapter):
             else:
                 logger.warning("[%s] STT: ASR returned empty transcript", self._log_tag)
             return transcript
-        except (httpx.HTTPStatusError, httpx.TransportError, IOError) as exc:
+        except (OSError, httpx.HTTPStatusError, httpx.TransportError) as exc:
             logger.warning(
                 "[%s] STT failed for voice attachment: %s: %s",
                 self._log_tag,
@@ -2233,7 +2233,7 @@ class QQAdapter(BasePlatformAdapter):
             if text.strip():
                 return text.strip()
             return None
-        except (httpx.HTTPStatusError, IOError) as exc:
+        except (OSError, httpx.HTTPStatusError) as exc:
             logger.warning(
                 "[%s] STT API call failed (model=%s, base=%s): %s",
                 self._log_tag,

--- a/gateway/platforms/qqbot/chunked_upload.py
+++ b/gateway/platforms/qqbot/chunked_upload.py
@@ -549,7 +549,7 @@ def _read_file_chunk(file_path: str, offset: int, length: int) -> bytes:
         fh.seek(offset)
         data = fh.read(length)
         if len(data) != length:
-            raise IOError(
+            raise OSError(
                 f"Short read from {file_path}: expected {length} bytes at "
                 f"offset {offset}, got {len(data)} (file may be truncated)"
             )

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -957,13 +957,13 @@ def _file_lock(
             if fcntl:
                 try:
                     fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
-                except (OSError, IOError):
+                except OSError:
                     pass
             elif msvcrt:
                 try:
                     lock_file.seek(0)
                     msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
-                except (OSError, IOError):
+                except OSError:
                     pass
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -415,7 +415,7 @@ def _is_container() -> bool:
             cgroup_content = f.read()
         if "docker" in cgroup_content or "lxc" in cgroup_content or "kubepods" in cgroup_content:
             return True
-    except (OSError, IOError):
+    except OSError:
         pass
     return False
 

--- a/optional-skills/creative/meme-generation/scripts/generate_meme.py
+++ b/optional-skills/creative/meme-generation/scripts/generate_meme.py
@@ -186,12 +186,12 @@ def find_font(size: int) -> ImageFont.FreeTypeFont:
         if os.path.exists(path):
             try:
                 return ImageFont.truetype(path, size)
-            except (OSError, IOError):
+            except OSError:
                 continue
     # Last resort: Pillow default
     try:
         return ImageFont.truetype("DejaVuSans-Bold", size)
-    except (OSError, IOError):
+    except OSError:
         return ImageFont.load_default()
 
 

--- a/optional-skills/security/oss-forensics/scripts/evidence-store.py
+++ b/optional-skills/security/oss-forensics/scripts/evidence-store.py
@@ -74,7 +74,7 @@ class EvidenceStore:
             try:
                 with open(filepath, "r", encoding="utf-8") as f:
                     self.data = json.load(f)
-            except (json.JSONDecodeError, IOError) as e:
+            except (OSError, json.JSONDecodeError) as e:
                 print(f"Error loading evidence store '{filepath}': {e}", file=sys.stderr)
                 print("Hint: The file might be corrupted. Check for manual edits or syntax errors.", file=sys.stderr)
                 sys.exit(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,7 +257,7 @@ preview = true  # required for PLW1514 (unspecified-encoding) — preview rule
 # which silently corrupts any non-ASCII file content.  We had three
 # separate Windows sandbox regressions in one debug session before
 # adding the explicit encoding.  This rule keeps new code honest.
-select = ["PLW1514"]
+select = ["UP024", "PLW1514"]
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can intentionally exercise locale-encoding edge cases.

--- a/tests/hermes_cli/test_codex_runtime_switch.py
+++ b/tests/hermes_cli/test_codex_runtime_switch.py
@@ -146,7 +146,7 @@ class TestApply:
         cfg = {}
 
         def persist_boom(c):
-            raise IOError("disk full")
+            raise OSError("disk full")
 
         with patch.object(crs, "check_codex_binary_ok",
                           return_value=(True, "0.130.0")):

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -291,7 +291,7 @@ class FileSyncManager:
         finally:
             try:
                 fcntl.flock(lock_fd, fcntl.LOCK_UN)
-            except (OSError, IOError):
+            except OSError:
                 pass
             lock_fd.close()
 

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -199,13 +199,13 @@ class MemoryStore:
             if fcntl:
                 try:
                     fcntl.flock(fd, fcntl.LOCK_UN)
-                except (OSError, IOError):
+                except OSError:
                     pass
             elif msvcrt:
                 try:
                     fd.seek(0)
                     msvcrt.locking(fd.fileno(), msvcrt.LK_UNLCK, 1)
-                except (OSError, IOError):
+                except OSError:
                     pass
             fd.close()
 
@@ -468,7 +468,7 @@ class MemoryStore:
             return []
         try:
             raw = path.read_text(encoding="utf-8")
-        except (OSError, IOError):
+        except OSError:
             return []
 
         if not raw.strip():
@@ -508,7 +508,7 @@ class MemoryStore:
             return None
         try:
             raw = path.read_text(encoding="utf-8")
-        except (OSError, IOError):
+        except OSError:
             return None
         if not raw.strip():
             return None
@@ -530,7 +530,7 @@ class MemoryStore:
         bak_path = path.with_suffix(path.suffix + f".bak.{ts}")
         try:
             bak_path.write_text(raw, encoding="utf-8")
-        except (OSError, IOError):
+        except OSError:
             return str(bak_path) + " (BACKUP FAILED — file unchanged on disk)"
         return str(bak_path)
 
@@ -562,7 +562,7 @@ class MemoryStore:
                 except OSError:
                     pass
                 raise
-        except (OSError, IOError) as e:
+        except OSError as e:
             raise RuntimeError(f"Failed to write memory file {path}: {e}")
 
 

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -89,13 +89,13 @@ def _usage_file_lock():
         if fcntl:
             try:
                 fcntl.flock(fd, fcntl.LOCK_UN)
-            except (OSError, IOError):
+            except OSError:
                 pass
         elif msvcrt:
             try:
                 fd.seek(0)
                 msvcrt.locking(fd.fileno(), msvcrt.LK_UNLCK, 1)
-            except (OSError, IOError):
+            except OSError:
                 pass
         fd.close()
 

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -72,7 +72,7 @@ def _read_manifest() -> Dict[str, str]:
                 # v1 format: plain name — empty hash triggers migration
                 result[line] = ""
         return result
-    except (OSError, IOError):
+    except OSError:
         return {}
 
 
@@ -167,7 +167,7 @@ def _dir_hash(directory: Path) -> str:
                 rel = fpath.relative_to(directory)
                 hasher.update(str(rel).encode("utf-8"))
                 hasher.update(fpath.read_bytes())
-    except (OSError, IOError):
+    except OSError:
         pass
     return hasher.hexdigest()
 
@@ -231,7 +231,7 @@ def sync_skills(quiet: bool = False) -> dict:
                     manifest[skill_name] = bundled_hash
                     if not quiet:
                         print(f"  + {skill_name}")
-            except (OSError, IOError) as e:
+            except OSError as e:
                 if not quiet:
                     print(f"  ! Failed to copy {skill_name}: {e}")
                 # Do NOT add to manifest — next sync should retry
@@ -273,12 +273,12 @@ def sync_skills(quiet: bool = False) -> dict:
                             print(f"  ↑ {skill_name} (updated)")
                         # Remove backup after successful copy
                         shutil.rmtree(backup, ignore_errors=True)
-                    except (OSError, IOError):
+                    except OSError:
                         # Restore from backup
                         if backup.exists() and not dest.exists():
                             shutil.move(str(backup), str(dest))
                         raise
-                except (OSError, IOError) as e:
+                except OSError as e:
                     if not quiet:
                         print(f"  ! Failed to update {skill_name}: {e}")
             else:
@@ -301,7 +301,7 @@ def sync_skills(quiet: bool = False) -> dict:
             try:
                 dest_desc.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy2(desc_md, dest_desc)
-            except (OSError, IOError) as e:
+            except OSError as e:
                 logger.debug("Could not copy %s: %s", desc_md, e)
 
     _write_manifest(manifest)
@@ -383,7 +383,7 @@ def reset_bundled_skill(name: str, restore: bool = False) -> dict:
             try:
                 shutil.rmtree(dest)
                 deleted_user_copy = True
-            except (OSError, IOError) as e:
+            except OSError as e:
                 return {
                     "ok": False,
                     "action": "manifest_cleared",


### PR DESCRIPTION
## What does this PR do?

Adds the `UP024` rule to pyproject.toml and applies auto-fix across 18 files.

Replaces `EnvironmentError`, `IOError`, `socket.error` with the canonical `OSError`.

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- Standardizes the PR description to the same review format used in #29640.
- Preserves the original detailed description below so no context is lost.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- `ruff check` passa com zero erros (regra já ativa na config)
- Nenhuma mudança de comportamento em runtime — apenas transformações sintáticas
- `pytest` mantém o comportamento esperado

---

_Generated by Hermes Turbo_

## Related PRs / issues

- Original body preserved below for full context.

<details>
<summary>Original body</summary>

## Summary

Adds the `UP024` rule to pyproject.toml and applies auto-fix across 18 files.

Replaces `EnvironmentError`, `IOError`, `socket.error` with the canonical `OSError`.

## What Changed

- `pyproject.toml`: added `UP024` to `[tool.ruff.lint] select`
- **18 files** changed: **+38/-38** lines

## Fluxo

O ruff percorre a árvore do projeto aplicando a regra `UP024` onde encontra violações. As transformações foram feitas por auto-fix e mantêm o comportamento do código.

## Visão

Com a regra habilitada no lint, o projeto passa a bloquear regressões futuras no mesmo padrão e fica mais consistente para novos commits.

## Test Plan

- `ruff check` passa com zero erros (regra já ativa na config)
- Nenhuma mudança de comportamento em runtime — apenas transformações sintáticas
- `pytest` mantém o comportamento esperado

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_