### PR TITLE
chore: ruff auto-fix UP041 — timeout-error-alias

### DIFF
--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -400,7 +400,7 @@ class LSPClient:
             if self.is_running:
                 try:
                     await asyncio.wait_for(self._send_request("shutdown", None), timeout=2.0)
-                except (asyncio.TimeoutError, LSPRequestError, LSPProtocolError):
+                except (TimeoutError, LSPRequestError, LSPProtocolError):
                     pass
                 try:
                     await self._send_notification("exit", None)
@@ -432,7 +432,7 @@ class LSPClient:
                 proc.terminate()
                 try:
                     await asyncio.wait_for(proc.wait(), timeout=SHUTDOWN_GRACE)
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     try:
                         proc.kill()
                         await proc.wait()
@@ -760,7 +760,7 @@ class LSPClient:
                 params,
                 timeout=DIAGNOSTICS_REQUEST_TIMEOUT,
             )
-        except (LSPRequestError, LSPProtocolError, asyncio.TimeoutError) as e:
+        except (TimeoutError, LSPRequestError, LSPProtocolError) as e:
             logger.debug("[%s] document diagnostic pull failed: %s", self.server_id, e)
             return
         if not isinstance(result, dict):
@@ -850,7 +850,7 @@ class LSPClient:
                     self._push_event.clear()
                     try:
                         await asyncio.wait_for(self._push_event.wait(), timeout=remaining)
-                    except asyncio.TimeoutError:
+                    except TimeoutError:
                         break
                 return
             remaining = deadline - asyncio.get_event_loop().time()
@@ -864,7 +864,7 @@ class LSPClient:
             self._push_event.clear()
             try:
                 await asyncio.wait_for(self._push_event.wait(), timeout=min(remaining, 0.5))
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 continue
 
     def diagnostics_for(self, path: str) -> List[Dict[str, Any]]:

--- a/agent/lsp/manager.py
+++ b/agent/lsp/manager.py
@@ -347,7 +347,7 @@ class LSPService:
         try:
             t = timeout if timeout is not None else self._wait_timeout + 2.0
             diags = self._loop.run(self._open_and_wait_async(file_path), timeout=t) or []
-        except asyncio.TimeoutError as e:
+        except TimeoutError as e:
             eventlog.log_timeout(server_id, file_path)
             logger.debug("LSP diagnostics timeout for %s: %s", file_path, e)
             self._mark_broken_for_file(file_path, e)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3230,7 +3230,7 @@ class APIServerAdapter(BasePlatformAdapter):
             while True:
                 try:
                     event = await asyncio.wait_for(q.get(), timeout=30.0)
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     await response.write(b": keepalive\n\n")
                     continue
                 if event is None:
@@ -3365,7 +3365,7 @@ class APIServerAdapter(BasePlatformAdapter):
             # slow/unresponsive interrupt can't hang this handler.
             try:
                 await asyncio.wait_for(asyncio.shield(task), timeout=5.0)
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 logger.warning(
                     "[api_server] stop for run %s timed out after 5s; "
                     "agent may still be finishing the current step",

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2446,7 +2446,7 @@ class BasePlatformAdapter(ABC):
                             self.send_typing(chat_id, metadata=metadata),
                             timeout=_send_typing_timeout,
                         )
-                    except asyncio.TimeoutError:
+                    except TimeoutError:
                         # Slow network — abandon this tick, keep the loop
                         # on schedule so the next send_typing fires fresh.
                         pass
@@ -3046,7 +3046,7 @@ class BasePlatformAdapter(ABC):
                 await asyncio.wait_for(asyncio.shield(task), timeout=5.0)
             except asyncio.CancelledError:
                 pass
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 logger.warning(
                     "[%s] Cancelled task for %s did not exit within 5s; "
                     "unblocking dispatch and letting the task unwind in the background",
@@ -3414,7 +3414,7 @@ class BasePlatformAdapter(ABC):
             typing_task.cancel()
             try:
                 await asyncio.wait_for(asyncio.shield(typing_task), timeout=0.5)
-            except (asyncio.CancelledError, asyncio.TimeoutError):
+            except (TimeoutError, asyncio.CancelledError):
                 # Cancellation cleanup must not block adapter shutdown.  The
                 # typing task is already cancelled; if the parent task is also
                 # cancelling, let this message-processing task unwind now.
@@ -3907,7 +3907,7 @@ class BasePlatformAdapter(ABC):
                     ),
                     timeout=5.0,
                 )
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 logger.warning(
                     "[%s] %d background task(s) did not exit within 5s; "
                     "releasing tracking and letting them unwind in the background",

--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -347,7 +347,7 @@ class DingTalkAdapter(BasePlatformAdapter):
             self._stream_task.cancel()
             try:
                 await asyncio.wait_for(self._stream_task, timeout=5.0)
-            except (asyncio.CancelledError, asyncio.TimeoutError):
+            except (TimeoutError, asyncio.CancelledError):
                 logger.debug("[%s] stream task did not exit cleanly during disconnect", self.name)
             self._stream_task = None
 

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1708,7 +1708,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 logger.debug("[Feishu] Waiting for websocket thread to exit (timeout=10s)")
                 await asyncio.wait_for(asyncio.shield(ws_future), timeout=10.0)
                 logger.debug("[Feishu] Websocket thread exited cleanly")
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 logger.warning("[Feishu] Websocket thread did not exit within 10s - may be stuck")
             except asyncio.CancelledError:
                 logger.debug("[Feishu] Websocket thread cancelled during disconnect")
@@ -3270,7 +3270,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 request.read(),
                 timeout=_FEISHU_WEBHOOK_BODY_TIMEOUT_SECONDS,
             )
-        except asyncio.TimeoutError:
+        except TimeoutError:
             logger.warning("[Feishu] Webhook body read timed out after %ds from %s", _FEISHU_WEBHOOK_BODY_TIMEOUT_SECONDS, remote_ip)
             self._record_webhook_anomaly(remote_ip, "408")
             return web.Response(status=408, text="Request Timeout")

--- a/gateway/platforms/homeassistant.py
+++ b/gateway/platforms/homeassistant.py
@@ -432,7 +432,7 @@ class HomeAssistantAdapter(BasePlatformAdapter):
                             body = await resp.text()
                             return SendResult(success=False, error=f"HTTP {resp.status}: {body}")
 
-        except asyncio.TimeoutError:
+        except TimeoutError:
             return SendResult(success=False, error="Timeout sending notification to HA")
         except Exception as e:
             return SendResult(success=False, error=str(e))

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -2117,7 +2117,7 @@ class QQAdapter(BasePlatformAdapter):
                     stderr[:200].decode(errors="replace"),
                 )
                 return None
-        except (asyncio.TimeoutError, FileNotFoundError) as exc:
+        except (TimeoutError, FileNotFoundError) as exc:
             logger.warning("[%s] ffmpeg conversion error: %s", self._log_tag, exc)
             return None
 

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3378,7 +3378,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     "[%s] gmail-triage callback failed: verb=%s arg=%s rc=%s stderr=%s",
                     self.name, verb, arg, proc.returncode, stderr_text,
                 )
-        except asyncio.TimeoutError:
+        except TimeoutError:
             label = f"❌ {verb} timed out"
             logger.error("[%s] gmail-triage callback timed out: verb=%s arg=%s", self.name, verb, arg)
         except Exception as exc:

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -1311,7 +1311,7 @@ class WeComAdapter(BasePlatformAdapter):
                     prepared["final_type"],
                     upload_result["media_id"],
                 )
-        except asyncio.TimeoutError:
+        except TimeoutError:
             return SendResult(success=False, error="Timeout sending media to WeCom")
         except Exception as exc:
             logger.error("[%s] Failed to send media %s: %s", self.name, media_source, exc)
@@ -1375,7 +1375,7 @@ class WeComAdapter(BasePlatformAdapter):
                         "markdown": {"content": content[:self.MAX_MESSAGE_LENGTH]},
                     },
                 )
-        except asyncio.TimeoutError:
+        except TimeoutError:
             return SendResult(success=False, error="Timeout sending message to WeCom")
         except Exception as exc:
             logger.error("[%s] Send failed: %s", self.name, exc)

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -423,7 +423,7 @@ async def _get_updates(
             token=token,
             timeout_ms=timeout_ms,
         )
-    except asyncio.TimeoutError:
+    except TimeoutError:
         return {"ret": 0, "msgs": [], "get_updates_buf": sync_buf}
 
 
@@ -1099,7 +1099,7 @@ async def qr_login(
                     endpoint=f"{EP_GET_QR_STATUS}?qrcode={qrcode_value}",
                     timeout_ms=QR_TIMEOUT_MS,
                 )
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 await asyncio.sleep(1)
                 continue
             except Exception as exc:

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -2681,7 +2681,7 @@ class DispatchMiddleware(InboundMiddleware):
             while True:
                 try:
                     dispatch_fn = await asyncio.wait_for(queue.get(), timeout=_IDLE_TIMEOUT)
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     break
                 logger.debug(
                     "[%s] Group queue: dispatching for %s (remaining=%d)",
@@ -2877,7 +2877,7 @@ class ConnectionManager:
 
             return True
 
-        except asyncio.TimeoutError:
+        except TimeoutError:
             logger.error("[%s] Connection timed out", adapter.name)
             await self._cleanup_ws()
             adapter._release_platform_lock()
@@ -2983,7 +2983,7 @@ class ConnectionManager:
                         logger.error("[%s] BIND_ACK missing connectId", adapter.name)
                         return False
 
-        except asyncio.TimeoutError:
+        except TimeoutError:
             logger.error("[%s] AUTH_BIND timeout", adapter.name)
             return False
         except Exception as exc:
@@ -3033,7 +3033,7 @@ class ConnectionManager:
                     try:
                         await asyncio.wait_for(pong_future, timeout=10.0)
                         self._consecutive_hb_timeouts = 0
-                    except asyncio.TimeoutError:
+                    except TimeoutError:
                         self._pending_acks.pop(msg_id, None)
                         self._consecutive_hb_timeouts += 1
                         logger.warning(
@@ -3282,7 +3282,7 @@ class ConnectionManager:
             await self._ws.send(encoded_conn_msg)
             result = await asyncio.wait_for(asyncio.shield(future), timeout=timeout)
             return result
-        except asyncio.TimeoutError:
+        except TimeoutError:
             raise
         except Exception:
             raise
@@ -3369,7 +3369,7 @@ class ConnectionManager:
                 )
                 return True
 
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 logger.warning("[%s] Reconnect attempt %d timed out", adapter.name, attempt + 1)
             except Exception as exc:
                 logger.warning(
@@ -3695,7 +3695,7 @@ class GroupQueryService:
             if biz_data and isinstance(biz_data, bytes):
                 return decode_query_group_info_rsp(biz_data)
             return {"group_code": group_code}
-        except asyncio.TimeoutError:
+        except TimeoutError:
             logger.warning("[%s] query_group_info timeout: group=%s", adapter.name, group_code)
             return None
         except Exception as exc:
@@ -3732,7 +3732,7 @@ class GroupQueryService:
             if result and result.get("members"):
                 adapter._member_cache[group_code] = (time.time(), result["members"])
             return result
-        except asyncio.TimeoutError:
+        except TimeoutError:
             logger.warning("[%s] get_group_member_list timeout: group=%s", adapter.name, group_code)
             return None
         except Exception as exc:
@@ -4318,7 +4318,7 @@ class MessageSender:
         try:
             response = await adapter._connection.send_biz_request(encoded, req_id=req_id)
             return {"success": True, "msg_key": response.get("msg_id", "")}
-        except asyncio.TimeoutError:
+        except TimeoutError:
             return {"success": False, "error": f"Request timeout after {DEFAULT_SEND_TIMEOUT}s"}
         except Exception as exc:
             return {"success": False, "error": str(exc)}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2067,7 +2067,7 @@ class GatewayRunner:
                 await adapter.disconnect()
             else:
                 await asyncio.wait_for(adapter.disconnect(), timeout=timeout)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             logger.warning(
                 "Timed out after %.1fs while disconnecting %s adapter; continuing shutdown",
                 timeout,
@@ -2117,7 +2117,7 @@ class GatewayRunner:
             return await adapter.connect()
         try:
             return await asyncio.wait_for(adapter.connect(), timeout=timeout)
-        except asyncio.TimeoutError as exc:
+        except TimeoutError as exc:
             raise TimeoutError(
                 f"{platform.value} connect timed out after {timeout:g}s"
             ) from exc
@@ -7528,7 +7528,7 @@ class GatewayRunner:
                                 from agent.redact import redact_sensitive_text
                                 output = redact_sensitive_text(output)
                             return output if output else "Command returned no output."
-                        except asyncio.TimeoutError:
+                        except TimeoutError:
                             return "Quick command timed out (30s)."
                         except Exception as e:
                             return f"Quick command error: {e}"
@@ -15554,7 +15554,7 @@ class GatewayRunner:
             if stream_task:
                 try:
                     await asyncio.wait_for(stream_task, timeout=5.0)
-                except (asyncio.TimeoutError, asyncio.CancelledError):
+                except (TimeoutError, asyncio.CancelledError):
                     stream_task.cancel()
 
         _elapsed = time.time() - _start
@@ -17575,7 +17575,7 @@ class GatewayRunner:
                     if _sc and stream_task:
                         try:
                             await asyncio.wait_for(stream_task, timeout=5.0)
-                        except (asyncio.TimeoutError, asyncio.CancelledError):
+                        except (TimeoutError, asyncio.CancelledError):
                             stream_task.cancel()
                             try:
                                 await stream_task
@@ -17714,7 +17714,7 @@ class GatewayRunner:
                 else:
                     try:
                         await asyncio.wait_for(stream_task, timeout=5.0)
-                    except (asyncio.TimeoutError, asyncio.CancelledError):
+                    except (TimeoutError, asyncio.CancelledError):
                         stream_task.cancel()
                         try:
                             await stream_task

--- a/hermes_cli/proxy/server.py
+++ b/hermes_cli/proxy/server.py
@@ -191,7 +191,7 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
                     ),
                     None,
                 )
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 return (
                     _json_error(
                         504,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -724,7 +724,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 if not adapter_self._ready_event.is_set():
                     try:
                         await asyncio.wait_for(adapter_self._ready_event.wait(), timeout=30.0)
-                    except asyncio.TimeoutError:
+                    except TimeoutError:
                         pass
 
                 # Dedup: Discord RESUME replays events after reconnects (#4777)
@@ -859,7 +859,7 @@ class DiscordAdapter(BasePlatformAdapter):
             self._running = True
             return True
 
-        except asyncio.TimeoutError:
+        except TimeoutError:
             logger.error("[%s] Timeout waiting for connection to Discord", self.name, exc_info=True)
             self._release_platform_lock()
             return False
@@ -1125,7 +1125,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 summary["created"],
                 summary["deleted"],
             )
-        except asyncio.TimeoutError:
+        except TimeoutError:
             logger.warning(
                 "[%s] Slash command sync timed out — Discord rate-limit bucket "
                 "may be saturated; will retry on next reconnect",
@@ -1982,7 +1982,7 @@ class DiscordAdapter(BasePlatformAdapter):
             vc.play(source, after=_after)
             try:
                 await asyncio.wait_for(done.wait(), timeout=self.PLAYBACK_TIMEOUT)
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 logger.warning("Voice playback timed out after %ds", self.PLAYBACK_TIMEOUT)
                 vc.stop()
             self._reset_voice_timeout(guild_id)

--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -920,7 +920,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
             self._supervisor_task.cancel()
             try:
                 await asyncio.wait_for(self._supervisor_task, timeout=5.0)
-            except (asyncio.CancelledError, asyncio.TimeoutError):
+            except (TimeoutError, asyncio.CancelledError):
                 pass
         if self._streaming_pull_future is not None:
             try:
@@ -2283,7 +2283,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
                     self._typing_card_inflight[chat_id].wait(),
                     timeout=5.0,
                 )
-            except (asyncio.TimeoutError, KeyError):
+            except (TimeoutError, KeyError):
                 pass
             return
 
@@ -3224,7 +3224,7 @@ async def _standalone_send(
             asyncio.to_thread(creds.refresh, _GoogleAuthRequest()),
             timeout=10.0,
         )
-    except asyncio.TimeoutError:
+    except TimeoutError:
         return {"error": "Google Chat standalone send: token refresh timed out"}
     except asyncio.CancelledError:
         raise

--- a/plugins/platforms/irc/adapter.py
+++ b/plugins/platforms/irc/adapter.py
@@ -199,7 +199,7 @@ class IRCAdapter(BasePlatformAdapter):
         # Wait for registration (001 RPL_WELCOME) with timeout
         try:
             await asyncio.wait_for(self._registration_event.wait(), timeout=30.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             logger.error("IRC: registration timed out")
             await self.disconnect()
             self._set_fatal_error("registration_timeout", "IRC server did not send RPL_WELCOME", retryable=True)
@@ -809,7 +809,7 @@ async def _standalone_send(
                 return {"error": "IRC standalone send: registration timeout (no RPL_WELCOME)"}
             try:
                 raw_line = await asyncio.wait_for(reader.readuntil(b"\r\n"), timeout=remaining)
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 return {"error": "IRC standalone send: registration timeout (no RPL_WELCOME)"}
             except asyncio.IncompleteReadError:
                 return {"error": "IRC standalone send: server closed connection during registration"}
@@ -852,7 +852,7 @@ async def _standalone_send(
                     break
                 try:
                     raw_line = await asyncio.wait_for(reader.readuntil(b"\r\n"), timeout=remaining)
-                except (asyncio.TimeoutError, asyncio.IncompleteReadError):
+                except (TimeoutError, asyncio.IncompleteReadError):
                     break
                 decoded = raw_line.decode("utf-8", errors="replace").rstrip("\r\n")
                 jmsg = _parse_irc_message(decoded)
@@ -907,7 +907,7 @@ async def _standalone_send(
         await _raw("QUIT :delivered")
         try:
             await asyncio.wait_for(reader.read(1024), timeout=2.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pass
 
         return {"success": True, "message_id": str(int(time.time() * 1000))}
@@ -920,7 +920,7 @@ async def _standalone_send(
         try:
             writer.close()
             await asyncio.wait_for(writer.wait_closed(), timeout=5.0)
-        except (asyncio.TimeoutError, Exception):
+        except (TimeoutError, Exception):
             pass
 
 

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -450,7 +450,7 @@ class MattermostAdapter(BasePlatformAdapter):
                     file_data = await resp.read()
                     ct = resp.content_type or "application/octet-stream"
                     break
-            except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+            except (TimeoutError, aiohttp.ClientError) as exc:
                 if attempt < 2:
                     await asyncio.sleep(1.5 * (attempt + 1))
                     continue

--- a/plugins/web/firecrawl/provider.py
+++ b/plugins/web/firecrawl/provider.py
@@ -490,7 +490,7 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
                         ),
                         timeout=60,
                     )
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     logger.warning("Firecrawl scrape timed out for %s", url)
                     results.append(
                         {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,7 +257,7 @@ preview = true  # required for PLW1514 (unspecified-encoding) — preview rule
 # which silently corrupts any non-ASCII file content.  We had three
 # separate Windows sandbox regressions in one debug session before
 # adding the explicit encoding.  This rule keeps new code honest.
-select = ["PLW1514"]
+select = ["UP041", "PLW1514"]
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can intentionally exercise locale-encoding edge cases.

--- a/tests/acp/test_ping_suppression.py
+++ b/tests/acp/test_ping_suppression.py
@@ -199,7 +199,7 @@ async def test_bare_ping_request_produces_proper_response_and_no_stderr_noise(
         in_write_file.close()
         try:
             await asyncio.wait_for(agent_task, timeout=2.0)
-        except (asyncio.TimeoutError, Exception):
+        except (TimeoutError, Exception):
             agent_task.cancel()
             try:
                 await agent_task

--- a/tests/fakes/fake_ha_server.py
+++ b/tests/fakes/fake_ha_server.py
@@ -224,7 +224,7 @@ class FakeHAServer:
                         "type": "event",
                         "event": event_data,
                     })
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     continue
         except (ConnectionResetError, asyncio.CancelledError):
             pass

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -268,7 +268,7 @@ async def test_connect_releases_token_lock_on_timeout(monkeypatch):
 
     async def fake_wait_for(awaitable, timeout):
         awaitable.close()
-        raise asyncio.TimeoutError()
+        raise TimeoutError()
 
     monkeypatch.setattr(discord_platform.asyncio, "wait_for", fake_wait_for)
 

--- a/tests/gateway/test_irc_adapter.py
+++ b/tests/gateway/test_irc_adapter.py
@@ -625,7 +625,7 @@ class TestIRCStandaloneSend:
             try:
                 return await coro
             except asyncio.IncompleteReadError:
-                raise asyncio.TimeoutError()
+                raise TimeoutError()
 
         monkeypatch.setattr(_irc_mod.asyncio, "wait_for", _fast_timeout)
 

--- a/tests/gateway/test_keep_typing_timeout.py
+++ b/tests/gateway/test_keep_typing_timeout.py
@@ -85,7 +85,7 @@ class TestKeepTypingTimeoutPerTick:
         stop_event.set()
         try:
             await asyncio.wait_for(task, timeout=2.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             task.cancel()
             pytest.fail(
                 "_keep_typing did not exit within 2s of stop_event.set() — "

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -376,7 +376,7 @@ async def test_heartbeat_probe_reenters_ladder_when_get_me_times_out():
     async def fast_wait_for(coro, timeout):
         if asyncio.iscoroutine(coro):
             coro.close()
-        raise asyncio.TimeoutError()
+        raise TimeoutError()
 
     with patch("asyncio.sleep", new_callable=AsyncMock):
         with patch("gateway.platforms.telegram.asyncio.wait_for", new=fast_wait_for):

--- a/tests/tools/test_mcp_cancelled_error_propagation.py
+++ b/tests/tools/test_mcp_cancelled_error_propagation.py
@@ -50,7 +50,7 @@ class TestCancelledErrorPropagation:
                     await asyncio.wait_for(task, timeout=2.0)
                 except asyncio.CancelledError:
                     return "cancelled_cleanly"
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     # If we hit this, the reconnect loop swallowed the cancel
                     # and stayed wedged — the exact #9930 bug.
                     task.cancel()
@@ -84,7 +84,7 @@ class TestCancelledErrorPropagation:
                 server._task.cancel()
                 try:
                     await asyncio.wait_for(server._task, timeout=2.0)
-                except (asyncio.CancelledError, asyncio.TimeoutError):
+                except (TimeoutError, asyncio.CancelledError):
                     pass
                 return server._task.done()
 

--- a/tests/tools/test_mcp_sse_transport.py
+++ b/tests/tools/test_mcp_sse_transport.py
@@ -101,7 +101,7 @@ class TestSSEReadTimeout:
                         }),
                         timeout=2.0,
                     )
-                except (asyncio.TimeoutError, StopAsyncIteration, Exception):
+                except (TimeoutError, StopAsyncIteration, Exception):
                     pass
 
         asyncio.run(drive())
@@ -132,7 +132,7 @@ class TestSSEReadTimeout:
                         }),
                         timeout=2.0,
                     )
-                except (asyncio.TimeoutError, StopAsyncIteration, Exception):
+                except (TimeoutError, StopAsyncIteration, Exception):
                     pass
 
         asyncio.run(drive())
@@ -167,7 +167,7 @@ class TestSSEOAuthForwarding:
                         }),
                         timeout=2.0,
                     )
-                except (asyncio.TimeoutError, StopAsyncIteration, Exception):
+                except (TimeoutError, StopAsyncIteration, Exception):
                     pass
 
         asyncio.run(drive())
@@ -198,7 +198,7 @@ class TestSSEOAuthForwarding:
                         }),
                         timeout=2.0,
                     )
-                except (asyncio.TimeoutError, StopAsyncIteration, Exception):
+                except (TimeoutError, StopAsyncIteration, Exception):
                     pass
 
         asyncio.run(drive())

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -388,7 +388,7 @@ def browser_cdp(
         result = _run_async(
             _cdp_call(endpoint, method, call_params, target_id, safe_timeout)
         )
-    except asyncio.TimeoutError as exc:
+    except TimeoutError as exc:
         return tool_error(
             f"CDP call timed out after {safe_timeout}s: {exc}",
             method=method,

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -460,7 +460,7 @@ def _rpc_server_loop(
         while True:
             try:
                 chunk = conn.recv(65536)
-            except socket.timeout:
+            except TimeoutError:
                 break
             if not chunk:
                 break
@@ -544,7 +544,7 @@ def _rpc_server_loop(
 
                 conn.sendall((result + "\n").encode())
 
-    except socket.timeout:
+    except TimeoutError:
         logger.debug("RPC listener socket timeout")
     except OSError as e:
         logger.debug("RPC listener socket error: %s", e, exc_info=True)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -967,7 +967,7 @@ class SamplingHandler:
             response = await asyncio.wait_for(
                 asyncio.to_thread(_sync_call), timeout=self.timeout,
             )
-        except asyncio.TimeoutError:
+        except TimeoutError:
             self.metrics["errors"] += 1
             return self._error(
                 f"Sampling LLM call timed out after {self.timeout}s "
@@ -1689,7 +1689,7 @@ class MCPServerTask:
         if self._task and not self._task.done():
             try:
                 await asyncio.wait_for(self._task, timeout=10)
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 logger.warning(
                     "MCP server '%s' shutdown timed out, cancelling task",
                     self.name,

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -1081,7 +1081,7 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
                             description=f"[dim]✅ {compressed_count} compressed | ⏭️ {skipped_count} skipped | ⏱️ {timeout_count} timeout | 🔄 {api_calls} API calls | ⚡ {in_flight} in-flight[/dim]"
                         )
                 
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     self.logger.warning(f"Timeout processing entry from {file_path}:{entry_idx} (>{self.config.per_trajectory_timeout}s)")
                     
                     async with progress_lock:


### PR DESCRIPTION
## What does this PR do?

Adds the `UP041` rule to pyproject.toml and applies auto-fix across 32 files.

Replaces `socket.timeout` with the standard `TimeoutError`.

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- Standardizes the PR description to the same review format used in #29640.
- Preserves the original detailed description below so no context is lost.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- `ruff check` passa com zero erros (regra já ativa na config)
- Nenhuma mudança de comportamento em runtime — apenas transformações sintáticas
- `pytest` mantém o comportamento esperado

---

_Generated by Hermes Turbo_

## Related PRs / issues

- Original body preserved below for full context.

<details>
<summary>Original body</summary>

## Summary

Adds the `UP041` rule to pyproject.toml and applies auto-fix across 32 files.

Replaces `socket.timeout` with the standard `TimeoutError`.

## What Changed

- `pyproject.toml`: added `UP041` to `[tool.ruff.lint] select`
- **32 files** changed: **+71/-71** lines

## Fluxo

O ruff percorre a árvore do projeto aplicando a regra `UP041` onde encontra violações. As transformações foram feitas por auto-fix e mantêm o comportamento do código.

## Visão

Com a regra habilitada no lint, o projeto passa a bloquear regressões futuras no mesmo padrão e fica mais consistente para novos commits.

## Test Plan

- `ruff check` passa com zero erros (regra já ativa na config)
- Nenhuma mudança de comportamento em runtime — apenas transformações sintáticas
- `pytest` mantém o comportamento esperado

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_