### PR TITLE
chore: ruff auto-fix UP012 — unnecessary-encode-utf8

### DIFF
--- a/optional-skills/productivity/telephony/scripts/telephony.py
+++ b/optional-skills/productivity/telephony/scripts/telephony.py
@@ -293,7 +293,7 @@ def _twilio_creds() -> tuple[str, str]:
 
 def _twilio_basic_headers() -> dict[str, str]:
     sid, token = _twilio_creds()
-    auth = base64.b64encode(f"{sid}:{token}".encode("utf-8")).decode("ascii")
+    auth = base64.b64encode(f"{sid}:{token}".encode()).decode("ascii")
     return {"Authorization": f"Basic {auth}"}
 
 

--- a/plugins/platforms/irc/adapter.py
+++ b/plugins/platforms/irc/adapter.py
@@ -298,7 +298,7 @@ class IRCAdapter(BasePlatformAdapter):
         # Strip markdown formatting that doesn't render in IRC
         content = self._strip_markdown(content)
 
-        overhead = len(f"PRIVMSG {target} :".encode("utf-8")) + 2  # +2 for \r\n
+        overhead = len(f"PRIVMSG {target} :".encode()) + 2  # +2 for \r\n
         max_bytes = 510 - overhead
         user_limit = self.max_message_length
 
@@ -869,7 +869,7 @@ async def _standalone_send(
         # exceeds the IRC 510-byte protocol limit.  Reuses the same
         # algorithm as IRCAdapter._split_message, with control-character
         # stripping per line to block CRLF injection from message content.
-        overhead = len(f"PRIVMSG {target} :".encode("utf-8")) + 2
+        overhead = len(f"PRIVMSG {target} :".encode()) + 2
         max_bytes = 510 - overhead
         sent_any = False
         for paragraph in plain.split("\n"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,7 +257,7 @@ preview = true  # required for PLW1514 (unspecified-encoding) — preview rule
 # which silently corrupts any non-ASCII file content.  We had three
 # separate Windows sandbox regressions in one debug session before
 # adding the explicit encoding.  This rule keeps new code honest.
-select = ["PLW1514"]
+select = ["UP012", "PLW1514"]
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can intentionally exercise locale-encoding edge cases.

--- a/tests/gateway/test_irc_adapter.py
+++ b/tests/gateway/test_irc_adapter.py
@@ -395,7 +395,7 @@ class TestIRCAdapterSplitting:
         adapter._current_nick = "bot"
         lines = adapter._split_message(text, "#test")
         for line in lines:
-            overhead = len(f"PRIVMSG #test :{line}\r\n".encode("utf-8"))
+            overhead = len(f"PRIVMSG #test :{line}\r\n".encode())
             assert overhead <= 512, f"line over 512 bytes: {overhead}"
 
     def test_split_prefers_word_boundary(self):

--- a/tests/gateway/test_ntfy_plugin.py
+++ b/tests/gateway/test_ntfy_plugin.py
@@ -940,4 +940,4 @@ class TestTruncateHelper:
 
     def test_unicode_message_encoded(self):
         result = _ntfy._truncate_body("héllo 🔔", context="test")
-        assert result == "héllo 🔔".encode("utf-8")
+        assert result == "héllo 🔔".encode()


### PR DESCRIPTION
## What does this PR do?

Adds the `UP012` rule to pyproject.toml and applies auto-fix across 5 files.

Replaces `s.encode('utf-8')` and `s.encode('utf8')` with the simpler `s.encode()`.

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- Standardizes the PR description to the same review format used in #29640.
- Preserves the original detailed description below so no context is lost.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- `ruff check` passa com zero erros (regra já ativa na config)
- Nenhuma mudança de comportamento em runtime — apenas transformações sintáticas
- `pytest` mantém o comportamento esperado

---

_Generated by Hermes Turbo_

## Related PRs / issues

- Original body preserved below for full context.

<details>
<summary>Original body</summary>

## Summary

Adds the `UP012` rule to pyproject.toml and applies auto-fix across 5 files.

Replaces `s.encode('utf-8')` and `s.encode('utf8')` with the simpler `s.encode()`.

## What Changed

- `pyproject.toml`: added `UP012` to `[tool.ruff.lint] select`
- **5 files** changed: **+6/-6** lines

## Fluxo

O ruff percorre a árvore do projeto aplicando a regra `UP012` onde encontra violações. As transformações foram feitas por auto-fix e mantêm o comportamento do código.

## Visão

Com a regra habilitada no lint, o projeto passa a bloquear regressões futuras no mesmo padrão e fica mais consistente para novos commits.

## Test Plan

- `ruff check` passa com zero erros (regra já ativa na config)
- Nenhuma mudança de comportamento em runtime — apenas transformações sintáticas
- `pytest` mantém o comportamento esperado

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_