### PR TITLE
chore: ruff auto-fix UP032 — f-string

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -2795,10 +2795,7 @@ class MatrixAdapter(BasePlatformAdapter):
         result = re.sub(
             r"\[([^\]]+)\]\(([^)]+)\)",
             lambda m: _protect_html(
-                '<a href="{}">{}</a>'.format(
-                    MatrixAdapter._sanitize_link_url(m.group(2)),
-                    _html_escape(m.group(1)),
-                )
+                f'<a href="{MatrixAdapter._sanitize_link_url(m.group(2))}">{_html_escape(m.group(1))}</a>'
             ),
             result,
         )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14016,7 +14016,7 @@ class GatewayRunner:
                     else:
                         await adapter.send(
                             chat_id,
-                            "❌ Hermes update failed (exit code {}).".format(exit_code),
+                            f"❌ Hermes update failed (exit code {exit_code}).",
                             metadata=metadata,
                         )
                     logger.info("Update finished (exit=%s), notified %s", exit_code, session_key)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10076,9 +10076,7 @@ def cmd_profile(args):
                     print(f"{copied} bundled skills synced.")
                 else:
                     print(
-                        "⚠ Skills could not be seeded. Run `{} update` to retry.".format(
-                            name
-                        )
+                        f"⚠ Skills could not be seeded. Run `{name} update` to retry."
                     )
 
             # Create wrapper alias

--- a/hermes_cli/pairing.py
+++ b/hermes_cli/pairing.py
@@ -88,8 +88,8 @@ def _cmd_approve(store, platform: str, code: str):
         )
         print(f"  Lockout clears in ~{mins} minute(s).")
         print(
-            "  To reset sooner, delete the '_lockout:{0}' entry from "
-            "~/.hermes/platforms/pairing/_rate_limits.json\n".format(platform)
+            f"  To reset sooner, delete the '_lockout:{platform}' entry from "
+            "~/.hermes/platforms/pairing/_rate_limits.json\n"
         )
     else:
         print(f"\n  Code '{code}' not found or expired for platform '{platform}'.")

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1092,8 +1092,8 @@ class PluginManager:
             if not is_enabled:
                 loaded = LoadedPlugin(manifest=manifest, enabled=False)
                 loaded.error = (
-                    "not enabled in config (run `hermes plugins enable {}` to activate)"
-                    .format(lookup_key)
+                    f"not enabled in config (run `hermes plugins enable {lookup_key}` to activate)"
+                    
                 )
                 self._plugins[lookup_key] = loaded
                 logger.debug(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,7 +257,7 @@ preview = true  # required for PLW1514 (unspecified-encoding) — preview rule
 # which silently corrupts any non-ASCII file content.  We had three
 # separate Windows sandbox regressions in one debug session before
 # adding the explicit encoding.  This rule keeps new code honest.
-select = ["PLW1514"]
+select = ["UP032", "PLW1514"]
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can intentionally exercise locale-encoding edge cases.

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -525,7 +525,7 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
         result["category"] = category
     result["hint"] = (
         "To add reference files, templates, or scripts, use "
-        "skill_manage(action='write_file', name='{}', file_path='references/example.md', file_content='...')".format(name)
+        f"skill_manage(action='write_file', name='{name}', file_path='references/example.md', file_content='...')"
     )
     return result
 


### PR DESCRIPTION
## What does this PR do?

Adds the `UP032` rule to pyproject.toml and applies auto-fix across 7 files.

Converts `str.format()` calls to f-strings where the conversion is safe and straightforward.

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- Standardizes the PR description to the same review format used in #29640.
- Preserves the original detailed description below so no context is lost.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- `ruff check` passa com zero erros (regra já ativa na config)
- Nenhuma mudança de comportamento em runtime — apenas transformações sintáticas
- `pytest` mantém o comportamento esperado

---

_Generated by Hermes Turbo_

## Related PRs / issues

- Original body preserved below for full context.

<details>
<summary>Original body</summary>

## Summary

Adds the `UP032` rule to pyproject.toml and applies auto-fix across 7 files.

Converts `str.format()` calls to f-strings where the conversion is safe and straightforward.

## What Changed

- `pyproject.toml`: added `UP032` to `[tool.ruff.lint] select`
- **7 files** changed: **+9/-14** lines

## Fluxo

O ruff percorre a árvore do projeto aplicando a regra `UP032` onde encontra violações. As transformações foram feitas por auto-fix e mantêm o comportamento do código.

## Visão

Com a regra habilitada no lint, o projeto passa a bloquear regressões futuras no mesmo padrão e fica mais consistente para novos commits.

## Test Plan

- `ruff check` passa com zero erros (regra já ativa na config)
- Nenhuma mudança de comportamento em runtime — apenas transformações sintáticas
- `pytest` mantém o comportamento esperado

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_