### PR TITLE
fix(profile): ignore stray profiles/default in profile list

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -609,6 +609,10 @@ def list_profiles() -> List[ProfileInfo]:
             name = entry.name
             if not _PROFILE_ID_RE.match(name):
                 continue
+            if name == "default":
+                # The built-in default profile is the root HERMES_HOME itself.
+                # Ignore stray profiles/default directories so it never appears twice.
+                continue
             model, provider = _read_config_model(entry)
             alias_path = wrapper_dir / name
             dist_name, dist_version, dist_source = _read_distribution_meta(entry)

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -478,6 +478,18 @@ class TestListProfiles:
         assert profiles[0].name == "default"
         assert profiles[0].is_default is True
 
+    def test_ignores_stray_named_default_directory(self, profile_env):
+        tmp_path = profile_env
+        stray_default = tmp_path / ".hermes" / "profiles" / "default"
+        stray_default.mkdir(parents=True)
+        (stray_default / "config.yaml").write_text("model: stray\n")
+
+        profiles = list_profiles()
+
+        defaults = [p for p in profiles if p.name == "default"]
+        assert len(defaults) == 1
+        assert defaults[0].path == tmp_path / ".hermes"
+
 
 # ===================================================================
 # TestActiveProfile


### PR DESCRIPTION
## Summary
- skip stray `profiles/default` directories when listing profiles
- keep the built-in root profile as the only `default` entry
- add a regression test for a stray named default directory

Fixes #30326

## Testing
- uv run --frozen pytest -o addopts= tests/hermes_cli/test_profiles.py -q\n- uv run --frozen ruff check hermes_cli/profiles.py tests/hermes_cli/test_profiles.py\n- uv run --frozen python -m py_compile hermes_cli/profiles.py tests/hermes_cli/test_profiles.py\n- git diff --check