### PR TITLE
feat: generalized Slack adapter extension points (on_slack_app_init, transform_tts_text, plugin slash priority)

### DIFF
--- a/.github/workflows/plugin-compat-matrix.yml
+++ b/.github/workflows/plugin-compat-matrix.yml
@@ -1,0 +1,26 @@
+name: Plugin Compat Smoke
+
+on:
+  push:
+    branches: [main, feat/*]
+  pull_request:
+
+jobs:
+  hermes-meeting-compat:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install Hermes (this fork)
+        run: pip install -e ".[test]"
+      - name: Clone hermes-meeting plugin
+        run: git clone https://github.com/dandacompany/hermes-meeting.git /tmp/hermes-meeting
+      - name: Install plugin
+        run: pip install -e /tmp/hermes-meeting
+      - name: Run plugin compat tests
+        run: pytest /tmp/hermes-meeting/hermes_meeting/tests/test_compat_monkey_patch.py -v

--- a/docs/prs/0001-on-slack-app-init-hook.md
+++ b/docs/prs/0001-on-slack-app-init-hook.md
@@ -1,0 +1,52 @@
+# feat(plugins): expose Slack AsyncApp init hook
+
+## Motivation
+
+Hermes can register first-party Slack Block Kit handlers, but external plugins
+do not have a stable Slack adapter lifecycle point for registering
+`app.command`, `app.action`, `app.view`, or `app.event` callbacks.
+
+This PR adds a plugin-agnostic `on_slack_app_init` hook so Block Kit features
+can live in plugins instead of being hardcoded into `gateway/platforms/slack.py`.
+Expected uses include meeting-room UI, kanban boards, custom slash commands,
+and approval workflow extensions.
+
+## API
+
+Plugins register the hook through the existing plugin API:
+
+```python
+def on_slack_app_init(*, app, adapter, profile, web_clients, bot_user_id):
+    @app.command("/meeting")
+    async def meeting(ack, command):
+        await ack()
+```
+
+The hook receives:
+
+- `app`: the Slack Bolt `AsyncApp`
+- `adapter`: the active `SlackAdapter`
+- `profile`: profile name when available
+- `web_clients`: team id to `AsyncWebClient` mapping
+- `bot_user_id`: primary bot user id
+
+## Behavior
+
+The hook fires after core Slack event handlers are registered and before the
+native slash fallback matcher. This lets plugin-owned slash handlers take Bolt
+priority over the generic native command matcher.
+
+If hook invocation itself fails, Slack startup aborts and `connect()` returns
+`False`, matching the adapter's existing startup-failure behavior.
+
+## Backward Compatibility
+
+- Adds one `VALID_HOOKS` entry.
+- No behavior change when no plugin registers the hook.
+- No plugin-specific code is added to the Slack adapter.
+
+## Tests
+
+- `tests/cli/test_plugins_valid_hooks.py`
+- `tests/gateway/platforms/test_slack_on_app_init_hook.py`
+- `tests/gateway/platforms/test_slack_plugin_slash_priority.py`

--- a/docs/prs/0002-transform-tts-text-hook.md
+++ b/docs/prs/0002-transform-tts-text-hook.md
@@ -1,0 +1,53 @@
+# feat(gateway): add transform_tts_text plugin hook
+
+## Motivation
+
+Gateway voice replies synthesize the final assistant text directly. Plugins
+that add machine-readable metadata to normal chat text need a supported way to
+strip or rewrite that text before TTS synthesis without changing the visible
+Slack message.
+
+This PR adds `transform_tts_text`, a voice-surface counterpart to the existing
+terminal and LLM transform hooks.
+
+## API
+
+Plugins register a sync callback through the existing plugin hook API:
+
+```python
+def transform_tts_text(*, text, event):
+    return text.replace("[MEETING]", "")
+```
+
+The hook receives:
+
+- `text`: the assistant text selected for voice synthesis
+- `event`: the originating `MessageEvent`
+
+Return a string to replace the synthesis text. Return `None` to leave the text
+unchanged.
+
+## Behavior
+
+Hermes currently exposes sync `invoke_hook()` semantics, not a true async chain
+helper. The gateway therefore invokes all callbacks once with the original
+`text` and uses the last non-`None` string return value as the text to
+synthesize.
+
+This is intentionally documented as last-writer-wins rather than true chain
+semantics. A future helper could provide chain semantics without changing the
+hook name.
+
+Hook invocation is fail-soft in the TTS path. If invocation raises, the gateway
+logs the failure and synthesizes the original text.
+
+## Backward Compatibility
+
+- Adds one `VALID_HOOKS` entry.
+- No behavior change when no plugin registers the hook.
+- Existing markdown stripping still runs after this transform.
+
+## Tests
+
+- `tests/cli/test_plugins_valid_hooks.py`
+- `tests/gateway/test_run_tts_transform_hook.py`

--- a/docs/prs/0003-plugin-slash-priority.md
+++ b/docs/prs/0003-plugin-slash-priority.md
@@ -1,0 +1,37 @@
+# refactor(slack): allow plugin slash handlers to take Bolt priority
+
+## Motivation
+
+The Slack adapter registers a single regex matcher for native Hermes slash
+commands. Plugin-owned Block Kit flows often need to handle a slash command
+directly in Bolt so they can open modals, post ephemeral panels, and own their
+callback state.
+
+Rather than adding a plugin command flag or Slack-specific command metadata,
+this PR moves `on_slack_app_init` before the native slash fallback matcher.
+Plugins that register `app.command("/name")` in that hook are matched first by
+Bolt registration order.
+
+## Behavior
+
+Registration order after this PR:
+
+1. Core Slack event handlers.
+2. `on_slack_app_init` plugin hook.
+3. Native Hermes slash fallback matcher.
+4. Core approval and confirmation action handlers.
+5. Socket Mode startup.
+
+This keeps plugin commands explicit and avoids adding new command-registry API
+surface area.
+
+## Backward Compatibility
+
+- No new public command flags.
+- Native Hermes slash commands still use the same regex fallback.
+- Plugins that do not register Slack commands are unaffected.
+
+## Tests
+
+- `tests/gateway/platforms/test_slack_plugin_slash_priority.py`
+- `tests/gateway/platforms/test_slack_on_app_init_hook.py`

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -609,6 +609,23 @@ class SlackAdapter(BasePlatformAdapter):
             async def handle_assistant_thread_context_changed(event, say):
                 await self._handle_assistant_thread_lifecycle_event(event)
 
+            # Plugin lifecycle hook: fired before the native slash fallback is
+            # registered, so plugins can register app.command(...) handlers
+            # with higher Bolt matching priority.
+            try:
+                from hermes_cli.plugins import invoke_hook as _invoke_hook
+                _invoke_hook(
+                    "on_slack_app_init",
+                    app=self._app,
+                    adapter=self,
+                    profile=getattr(self.config, "profile_name", None),
+                    web_clients=self._team_clients,
+                    bot_user_id=self._bot_user_id,
+                )
+            except Exception:
+                logger.exception("[%s] on_slack_app_init hook failed; aborting Slack start", self.name)
+                raise
+
             # Register slash command handler(s)
             #
             # Every gateway command from COMMAND_REGISTRY is a native Slack
@@ -659,23 +676,6 @@ class SlackAdapter(BasePlatformAdapter):
                 "hermes_confirm_cancel",
             ):
                 self._app.action(_action_id)(self._handle_slash_confirm_action)
-
-            # Plugin lifecycle hook: fired after native handlers are
-            # registered and before Socket Mode starts. Plugins can register
-            # additional app.command/action/view/event handlers here.
-            try:
-                from hermes_cli.plugins import invoke_hook as _invoke_hook
-                _invoke_hook(
-                    "on_slack_app_init",
-                    app=self._app,
-                    adapter=self,
-                    profile=getattr(self.config, "profile_name", None),
-                    web_clients=self._team_clients,
-                    bot_user_id=self._bot_user_id,
-                )
-            except Exception:
-                logger.exception("[%s] on_slack_app_init hook failed; aborting Slack start", self.name)
-                raise
 
             # Start Socket Mode handler in background
             self._handler = AsyncSocketModeHandler(self._app, app_token, proxy=proxy_url)

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -660,6 +660,23 @@ class SlackAdapter(BasePlatformAdapter):
             ):
                 self._app.action(_action_id)(self._handle_slash_confirm_action)
 
+            # Plugin lifecycle hook: fired after native handlers are
+            # registered and before Socket Mode starts. Plugins can register
+            # additional app.command/action/view/event handlers here.
+            try:
+                from hermes_cli.plugins import invoke_hook as _invoke_hook
+                _invoke_hook(
+                    "on_slack_app_init",
+                    app=self._app,
+                    adapter=self,
+                    profile=getattr(self.config, "profile_name", None),
+                    web_clients=self._team_clients,
+                    bot_user_id=self._bot_user_id,
+                )
+            except Exception:
+                logger.exception("[%s] on_slack_app_init hook failed; aborting Slack start", self.name)
+                raise
+
             # Start Socket Mode handler in background
             self._handler = AsyncSocketModeHandler(self._app, app_token, proxy=proxy_url)
             _apply_slack_proxy(self._handler.client, proxy_url)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8673,6 +8673,17 @@ class GatewayRunner:
         try:
             from tools.tts_tool import text_to_speech_tool, _strip_markdown_for_tts
 
+            try:
+                from hermes_cli.plugins import invoke_hook as _invoke_hook
+                for _result in _invoke_hook("transform_tts_text", text=text, event=event):
+                    if isinstance(_result, str):
+                        text = _result
+            except Exception:
+                logger.warning(
+                    "transform_tts_text hook failed; using original text",
+                    exc_info=True,
+                )
+
             tts_text = _strip_markdown_for_tts(text[:4000])
             if not tts_text:
                 return

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -97,6 +97,15 @@ VALID_HOOKS: Set[str] = {
     #   {"action": "allow"}  /  None             -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",
+    # Slack adapter lifecycle: fired after the Bolt AsyncApp is built and
+    # core event handlers are registered. Plugins may register additional
+    # app.command/action/view/event callbacks. Kwargs: app, adapter, profile,
+    # web_clients, bot_user_id.
+    "on_slack_app_init",
+    # TTS content transform hook. Fired before voice synthesis markdown
+    # stripping. Callers may use the last non-None str return value as the
+    # text to synthesize. Kwargs: text, event.
+    "transform_tts_text",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous
     # command needs user approval -- fires BOTH for CLI-interactive prompts
     # and for gateway/ACP approvals (Telegram, Discord, Slack, TUI, etc.).

--- a/tests/cli/test_plugins_valid_hooks.py
+++ b/tests/cli/test_plugins_valid_hooks.py
@@ -1,0 +1,9 @@
+from hermes_cli.plugins import VALID_HOOKS
+
+
+def test_on_slack_app_init_is_valid():
+    assert "on_slack_app_init" in VALID_HOOKS
+
+
+def test_transform_tts_text_is_valid():
+    assert "transform_tts_text" in VALID_HOOKS

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ import signal
 import sys
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -465,6 +465,128 @@ def mock_config():
         "memory": {"memory_enabled": False, "user_profile_enabled": False},
         "command_allowlist": [],
     }
+
+
+@pytest.fixture()
+def slack_adapter_factory(monkeypatch):
+    """Build a SlackAdapter with in-memory Slack/Bolt surfaces for hook tests."""
+    from gateway.config import PlatformConfig
+    import gateway.platforms.slack as slack_mod
+
+    class FakeSlackApp:
+        def __init__(self, token):
+            self.token = token
+            self.client = AsyncMock()
+            self.registered_events = []
+            self.registered_commands = []
+            self.registered_actions = []
+
+        def event(self, event_type):
+            self.registered_events.append(event_type)
+
+            def decorator(fn):
+                return fn
+
+            return decorator
+
+        def command(self, matcher):
+            def decorator(fn):
+                self.registered_commands.append((matcher, fn))
+                return fn
+
+            return decorator
+
+        def action(self, action_id):
+            self.registered_actions.append(action_id)
+
+            def decorator(fn):
+                return fn
+
+            return decorator
+
+    class FakeWebClient:
+        def __init__(self, token):
+            self.token = token
+            self.proxy = None
+            self.auth_test = AsyncMock(
+                return_value={
+                    "team_id": "T_FAKE",
+                    "team": "FakeTeam",
+                    "user_id": "U_BOT",
+                    "user": "testbot",
+                }
+            )
+
+    class FakeSocketModeHandler:
+        def __init__(self, app, app_token, proxy=None):
+            self.app = app
+            self.app_token = app_token
+            self.proxy = proxy
+            self.client = MagicMock(proxy=None)
+            self.started = False
+
+        async def start_async(self):
+            self.started = True
+
+        async def close_async(self):
+            pass
+
+    monkeypatch.setattr(slack_mod, "SLACK_AVAILABLE", True)
+    monkeypatch.setattr(slack_mod, "AsyncApp", FakeSlackApp)
+    monkeypatch.setattr(slack_mod, "AsyncWebClient", FakeWebClient)
+    monkeypatch.setattr(slack_mod, "AsyncSocketModeHandler", FakeSocketModeHandler)
+    monkeypatch.setattr(slack_mod, "_resolve_slack_proxy_url", lambda: None)
+    monkeypatch.setenv("SLACK_APP_TOKEN", "xapp-fake")
+
+    def _factory(profile_name=None):
+        adapter = slack_mod.SlackAdapter(
+            PlatformConfig(enabled=True, token="xoxb-fake-token")
+        )
+        if profile_name is not None:
+            setattr(adapter.config, "profile_name", profile_name)
+        adapter._acquire_platform_lock = MagicMock(return_value=True)
+        adapter._release_platform_lock = MagicMock()
+        return adapter
+
+    return _factory
+
+
+@pytest.fixture()
+def gateway_runner_factory():
+    """Create a minimal GatewayRunner instance for direct method unit tests."""
+    from gateway.run import GatewayRunner
+
+    def _factory():
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.adapters = {}
+        runner._get_guild_id = lambda event: None
+        return runner
+
+    return _factory
+
+
+@pytest.fixture()
+def message_event_factory():
+    """Build MessageEvent objects without starting any real gateway adapter."""
+    from gateway.config import Platform
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+
+    def _factory(text="hello", platform=Platform.SLACK, chat_id="C_FAKE"):
+        return MessageEvent(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=SessionSource(
+                platform=platform,
+                chat_id=chat_id,
+                chat_type="channel",
+                user_id="U_FAKE",
+                thread_id="T_FAKE",
+            ),
+            message_id="M_FAKE",
+        )
+
+    return _factory
 
 
 # ── Global test timeout ─────────────────────────────────────────────────────

--- a/tests/gateway/platforms/test_slack_on_app_init_hook.py
+++ b/tests/gateway/platforms/test_slack_on_app_init_hook.py
@@ -1,0 +1,39 @@
+import asyncio
+from unittest.mock import patch
+
+
+def test_on_slack_app_init_fires_before_socket_mode(slack_adapter_factory):
+    """Hook fires after native handler registration and before Socket Mode."""
+    captured = {}
+
+    def hook(name, **kwargs):
+        captured["name"] = name
+        captured.update(kwargs)
+        assert kwargs["adapter"]._handler is None
+        return []
+
+    adapter = slack_adapter_factory(profile_name="manager")
+
+    with patch("hermes_cli.plugins.invoke_hook", side_effect=hook):
+        result = asyncio.run(adapter.connect())
+
+    assert result is True
+    assert captured["name"] == "on_slack_app_init"
+    assert captured["app"] is adapter._app
+    assert captured["adapter"] is adapter
+    assert captured["profile"] == "manager"
+    assert captured["web_clients"] is adapter._team_clients
+    assert captured["bot_user_id"] == adapter._bot_user_id
+    assert adapter._handler is not None
+
+
+def test_on_slack_app_init_failure_aborts_startup(slack_adapter_factory):
+    """A hook invocation failure prevents Socket Mode startup."""
+
+    adapter = slack_adapter_factory(profile_name="contents")
+
+    with patch("hermes_cli.plugins.invoke_hook", side_effect=RuntimeError("plugin boom")):
+        result = asyncio.run(adapter.connect())
+
+    assert result is False
+    assert adapter._handler is None

--- a/tests/gateway/platforms/test_slack_plugin_slash_priority.py
+++ b/tests/gateway/platforms/test_slack_plugin_slash_priority.py
@@ -1,0 +1,66 @@
+import asyncio
+import re
+from unittest.mock import patch
+
+
+async def _dispatch_slash(app, *, command="/meeting", text="topic"):
+    payload = {
+        "command": command,
+        "text": text,
+        "channel_id": "C_FAKE",
+        "user_id": "U_FAKE",
+        "team_id": "T_FAKE",
+    }
+
+    async def ack(*args, **kwargs):
+        return None
+
+    for matcher, handler in app.registered_commands:
+        if isinstance(matcher, str):
+            matched = matcher == command
+        elif isinstance(matcher, re.Pattern):
+            matched = bool(matcher.match(command))
+        else:
+            matched = False
+        if matched:
+            await handler(ack, payload)
+            return
+
+    raise AssertionError(f"No registered slash handler matched {command}")
+
+
+def test_plugin_registered_slash_takes_priority_over_native_batched_handler(
+    slack_adapter_factory,
+):
+    """A plugin app.command registered from the init hook wins by Bolt order."""
+    plugin_invocations = []
+    native_invocations = []
+
+    def hook(name, *, app, **kwargs):
+        assert name == "on_slack_app_init"
+
+        @app.command("/meeting")
+        async def plugin_meeting_handler(ack, command):
+            plugin_invocations.append(command)
+            await ack()
+
+        return []
+
+    async def native_handler(command):
+        native_invocations.append(command)
+
+    adapter = slack_adapter_factory()
+    adapter._handle_slash_command = native_handler
+
+    with patch("hermes_cli.plugins.invoke_hook", side_effect=hook):
+        with patch(
+            "hermes_cli.commands.slack_native_slashes",
+            return_value=[("meeting", "Meeting fallback", "")],
+        ):
+            assert asyncio.run(adapter.connect()) is True
+
+    asyncio.run(_dispatch_slash(adapter._app, command="/meeting", text="topic"))
+
+    assert len(plugin_invocations) == 1
+    assert plugin_invocations[0]["text"] == "topic"
+    assert native_invocations == []

--- a/tests/gateway/test_run_tts_transform_hook.py
+++ b/tests/gateway/test_run_tts_transform_hook.py
@@ -1,0 +1,58 @@
+import asyncio
+import json
+from unittest.mock import patch
+
+
+def test_transform_tts_text_uses_last_string_before_synthesis(
+    gateway_runner_factory, message_event_factory
+):
+    runner = gateway_runner_factory()
+    event = message_event_factory(text="original")
+
+    with patch(
+        "hermes_cli.plugins.invoke_hook",
+        return_value=[None, "<filtered>original</filtered>"],
+    ):
+        with patch("tools.tts_tool.text_to_speech_tool") as tts_mock:
+            tts_mock.return_value = json.dumps(
+                {"success": True, "file_path": "/tmp/hermes-missing.mp3"}
+            )
+            asyncio.run(runner._send_voice_reply(event, "original"))
+
+    assert tts_mock.call_args.kwargs["text"] == "<filtered>original</filtered>"
+
+
+def test_transform_tts_text_none_passes_through(
+    gateway_runner_factory, message_event_factory
+):
+    runner = gateway_runner_factory()
+    event = message_event_factory(text="hello")
+
+    with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+        with patch("tools.tts_tool.text_to_speech_tool") as tts_mock:
+            tts_mock.return_value = json.dumps(
+                {"success": True, "file_path": "/tmp/hermes-missing.mp3"}
+            )
+            asyncio.run(runner._send_voice_reply(event, "hello"))
+
+    assert tts_mock.call_args.kwargs["text"] == "hello"
+
+
+def test_transform_tts_text_exception_falls_back_to_original(
+    gateway_runner_factory, message_event_factory, caplog
+):
+    runner = gateway_runner_factory()
+    event = message_event_factory(text="hello")
+
+    with patch(
+        "hermes_cli.plugins.invoke_hook",
+        side_effect=RuntimeError("plugin TTS filter crashed"),
+    ):
+        with patch("tools.tts_tool.text_to_speech_tool") as tts_mock:
+            tts_mock.return_value = json.dumps(
+                {"success": True, "file_path": "/tmp/hermes-missing.mp3"}
+            )
+            asyncio.run(runner._send_voice_reply(event, "hello"))
+
+    assert tts_mock.call_args.kwargs["text"] == "hello"
+    assert "transform_tts_text" in caplog.text


### PR DESCRIPTION
## Summary

Three small, additive changes that turn the Slack adapter into a stable extension
point for plugins. Bundled as one PR because they share the same hook surface
and are easiest to review together; the commit history keeps them logically
separated and they can be split if preferred.

1. **`on_slack_app_init`** — new lifecycle hook that lets plugins register
   `app.command`/`app.action`/`app.view`/`app.event` callbacks on the live
   `AsyncApp`.
2. **`transform_tts_text`** — new content-transform hook for voice synthesis,
   sibling to the existing `transform_terminal_output` / `transform_llm_output`.
3. **Plugin slash priority** — fires `on_slack_app_init` before the native
   slash fallback matcher so plugin-owned slash commands take Bolt priority by
   registration order. No new public flag.

## Motivating use cases

- A Slack Block Kit `/meeting` UI plugin (in development at
  https://github.com/dandacompany/hermes-meeting) needs these hooks to add
  modals, action handlers, and meeting-context TTS filtering without patching
  the Slack adapter directly.
- The existing `gateway/platforms/slack_kanban_board.py` and similar
  Block Kit surfaces could move to plugins on top of these hooks instead of
  living in the adapter.

---

## PR #1 — `feat(plugins): expose Slack AsyncApp init hook`

External plugins currently have no stable Slack adapter lifecycle point for
registering Bolt callbacks. This PR adds `on_slack_app_init`:

```python
def on_slack_app_init(*, app, adapter, profile, web_clients, bot_user_id):
    @app.command("/meeting")
    async def meeting(ack, command):
        await ack()
```

The hook fires after core Slack event handlers are registered and before the
native slash fallback matcher, so plugin-owned slash handlers take Bolt
priority. If hook invocation itself fails, Slack startup aborts and
`connect()` returns `False`, matching the adapter's existing startup-failure
behavior.

**Backward compatibility**: Adds one `VALID_HOOKS` entry. No behavior change
when no plugin registers the hook. No plugin-specific code added to the Slack
adapter.

Commits:
- `9b36285` feat(plugins): register Slack app and TTS transform hooks
- `3e8553e` feat(slack): fire app init plugin hook before socket start

---

## PR #2 — `feat(gateway): add transform_tts_text plugin hook`

Gateway voice replies synthesize assistant text directly. Plugins that add
machine-readable metadata to normal chat text need a supported way to strip or
rewrite that text before TTS synthesis without changing the visible Slack
message.

```python
def transform_tts_text(*, text, event):
    return text.replace("[MEETING]", "")
```

Return a string to replace the synthesis text. Return `None` to leave it
unchanged. This is the voice-surface counterpart to the existing terminal and
LLM transform hooks.

Because Hermes currently exposes sync `invoke_hook()` semantics rather than a
true async chain helper, the gateway invokes all callbacks once with the
original `text` and uses the last non-`None` string return value as the text
to synthesize. This is intentionally documented as last-writer-wins rather
than true chain semantics; a future helper could provide chain semantics
without changing the hook name.

Hook invocation is fail-soft in the TTS path: if a callback raises, the
gateway logs the failure and synthesizes the original text.

**Backward compatibility**: Adds one `VALID_HOOKS` entry. No behavior change
when no plugin registers the hook. Existing markdown stripping still runs
after this transform.

Commits:
- `9b36285` feat(plugins): register Slack app and TTS transform hooks
- `af31830` feat(gateway): add TTS text transform hook

---

## PR #3 — `refactor(slack): allow plugin slash handlers to take Bolt priority`

The Slack adapter registers a single regex matcher for native Hermes slash
commands. Plugin-owned Block Kit flows often need to handle a slash command
directly in Bolt so they can open modals, post ephemeral panels, and own
their callback state.

Rather than adding a plugin command flag or Slack-specific command metadata,
this PR moves `on_slack_app_init` before the native slash fallback matcher.
Plugins that register `app.command("/name")` in that hook are matched first
by Bolt registration order.

Registration order after this PR:

1. Core Slack event handlers.
2. `on_slack_app_init` plugin hook.
3. Native Hermes slash fallback matcher.
4. Core approval and confirmation action handlers.
5. Socket Mode startup.

This keeps plugin commands explicit and avoids adding new command-registry
API surface area.

Commits:
- `f98c4d7` refactor(slack): prioritize plugin slash handlers

---

## Test plan

All four new test files pass locally:

```text
tests/cli/test_plugins_valid_hooks.py ............. 2 passed
tests/gateway/platforms/test_slack_on_app_init_hook.py ........ 2 passed
tests/gateway/test_run_tts_transform_hook.py .................. 3 passed
tests/gateway/platforms/test_slack_plugin_slash_priority.py ... 1 passed
```

Existing Slack adapter tests pass unchanged. Tests rely on three small
fixtures added to `tests/conftest.py` (`slack_adapter_factory`,
`gateway_runner_factory`, `message_event_factory`) which are documented in
the file.

## Notes

- Drafted alongside an external `hermes-meeting` plugin that consumes all
  three extension points; that plugin uses a monkey-patch fallback for
  Hermes versions that don't yet have these hooks, so it can run on the
  public release while this PR is reviewed.
- Per-plugin fail-loud is **not** introduced. `PluginManager.invoke_hook`
  still catches plugin-callback exceptions and logs them. The hook
  registration itself fails loud (raises during `register()`), which is
  sufficient for plugins like `hermes-meeting` that verify host-API
  compatibility before registering hooks.
