### PR TITLE
feat: add ambient voice policy observability

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10689,6 +10689,41 @@ class HermesCLI:
             if not tts_text:
                 return
 
+            from gateway.ambient_voice_policy import AmbientVoicePolicy, VoiceContext
+
+            output_device = "living_room"
+            rule_profile = "living_room_default"
+            explicit_private = False
+            try:
+                from hermes_cli.config import load_config
+
+                voice_config = (load_config() or {}).get("voice") or {}
+                if isinstance(voice_config, dict):
+                    configured_device = str(voice_config.get("output_device") or "").strip().lower()
+                    configured_profile = str(voice_config.get("rule_profile") or voice_config.get("output_profile") or "").strip()
+                    if configured_device == "airpods" or configured_profile == "airpods_private":
+                        output_device = "airpods"
+                        rule_profile = "airpods_private"
+                        explicit_private = True
+            except Exception:
+                pass
+
+            decision = AmbientVoicePolicy().evaluate(
+                tts_text,
+                VoiceContext(
+                    source="cli_voice_tts",
+                    platform="cli",
+                    input_modality="voice",
+                    output_device=output_device,
+                    explicit_spoken_request=True,
+                    is_private_context=explicit_private,
+                    config_scope=rule_profile,
+                ),
+            )
+            tts_text = decision.text if decision.allowed and decision.text else ""
+            if not tts_text:
+                return
+
             # Use MP3 output for CLI playback (afplay doesn't handle OGG well).
             # The TTS tool may auto-convert MP3->OGG, but the original MP3 remains.
             os.makedirs(os.path.join(tempfile.gettempdir(), "hermes_voice"), exist_ok=True)

--- a/gateway/ambient_voice_policy.py
+++ b/gateway/ambient_voice_policy.py
@@ -9,6 +9,7 @@ matched excerpts in decisions or metadata.
 
 from __future__ import annotations
 
+import copy
 import re
 from dataclasses import dataclass, field
 from typing import Any, Mapping
@@ -115,6 +116,38 @@ _SENSITIVE_TOPIC_RE = re.compile(
 _SENTENCE_RE = re.compile(r"^.{1,260}?[.!?。！？](?=\s|$)")
 
 
+def _load_ambient_policy_config() -> Mapping[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        config = load_config() or {}
+        voice = (config.get("voice") or {}) if isinstance(config, dict) else {}
+        ambient = voice.get("ambient_policy") or {}
+        return ambient if isinstance(ambient, Mapping) else {}
+    except Exception:
+        return {}
+
+
+def _configured_rule_profiles() -> dict[str, dict[str, Any]]:
+    profiles: dict[str, dict[str, Any]] = copy.deepcopy(_DEFAULT_PROFILES)
+    ambient = _load_ambient_policy_config()
+    configured = ambient.get("rule_profiles") if ambient.get("enabled", True) is not False else None
+    if isinstance(configured, Mapping):
+        for name, profile in configured.items():
+            if not isinstance(name, str) or not isinstance(profile, Mapping):
+                continue
+            base = copy.deepcopy(profiles.get(name, {}))
+            base.update(dict(profile))
+            profiles[name] = base
+    return profiles
+
+
+def _configured_default_rule_profile() -> str:
+    ambient = _load_ambient_policy_config()
+    default = str(ambient.get("default_context") or "living_room_default").strip()
+    return default or "living_room_default"
+
+
 @dataclass(frozen=True)
 class VoiceContext:
     source: str
@@ -128,7 +161,7 @@ class VoiceContext:
     profile: str | None = None
     explicit_spoken_request: bool = False
     is_private_context: bool = False
-    config_scope: str = "living_room_default"
+    config_scope: str | None = None
 
 
 @dataclass(frozen=True)
@@ -166,8 +199,8 @@ class VoicePolicyDecision:
 class AmbientVoicePolicy:
     """Evaluate candidate speech for deterministic ambient-safety rules."""
 
-    rule_profiles: Mapping[str, Mapping[str, Any]] = field(default_factory=lambda: _DEFAULT_PROFILES)
-    default_rule_profile: str = "living_room_default"
+    rule_profiles: Mapping[str, Mapping[str, Any]] = field(default_factory=_configured_rule_profiles)
+    default_rule_profile: str = field(default_factory=_configured_default_rule_profile)
 
     def evaluate(self, text: str, context: VoiceContext) -> VoicePolicyDecision:
         original = str(text or "")
@@ -334,7 +367,11 @@ class AmbientVoicePolicy:
         return self.default_rule_profile
 
     def _profile(self, rule_profile: str) -> Mapping[str, Any]:
-        return self.rule_profiles.get(rule_profile) or self.rule_profiles[self.default_rule_profile]
+        if rule_profile in self.rule_profiles:
+            return self.rule_profiles[rule_profile]
+        if self.default_rule_profile in self.rule_profiles:
+            return self.rule_profiles[self.default_rule_profile]
+        return _DEFAULT_PROFILES["living_room_default"]
 
     @staticmethod
     def _append_reason(reasons: list[str], reason: str) -> None:

--- a/gateway/ambient_voice_policy.py
+++ b/gateway/ambient_voice_policy.py
@@ -186,12 +186,15 @@ class VoicePolicyDecision:
             "suppressed": self.suppressed,
             "reason_codes": self.reasons,
             "rule_profile": self.rule_profile,
-            "blocked_secret_like": bool(self.classifiers.get("secret_like")),
-            "dropped_code": bool(self.classifiers.get("code")),
-            "blocked_stack_trace": bool(self.classifiers.get("stack_trace")),
-            "dropped_tool_logs": bool(self.classifiers.get("command_log")),
-            "dropped_paths": bool(self.classifiers.get("raw_path")),
-            "blocked_sensitive_topic": bool(self.classifiers.get("sensitive_topic")),
+            "classifiers": {
+                "blocked_secret_like": bool(self.classifiers.get("secret_like")),
+                "dropped_code": bool(self.classifiers.get("code")),
+                "blocked_stack_trace": bool(self.classifiers.get("stack_trace")),
+                "dropped_tool_logs": bool(self.classifiers.get("command_log")),
+                "dropped_paths": bool(self.classifiers.get("raw_path")),
+                "blocked_sensitive_topic": bool(self.classifiers.get("sensitive_topic")),
+                "long_response": bool(self.classifiers.get("long_response")),
+            },
         }
 
 
@@ -201,6 +204,32 @@ class AmbientVoicePolicy:
 
     rule_profiles: Mapping[str, Mapping[str, Any]] = field(default_factory=_configured_rule_profiles)
     default_rule_profile: str = field(default_factory=_configured_default_rule_profile)
+
+    @classmethod
+    def from_config(cls, config: Mapping[str, Any] | None = None) -> "AmbientVoicePolicy":
+        """Build policy profiles from a Hermes config mapping.
+
+        Disabled config never disables hard safety rules; it only falls back to
+        conservative defaults instead of user profile overrides.
+        """
+        config = config or {}
+        voice = config.get("voice") if isinstance(config, Mapping) else {}
+        ambient = (voice or {}).get("ambient_policy") if isinstance(voice, Mapping) else {}
+        if not isinstance(ambient, Mapping) or ambient.get("enabled", True) is False:
+            return cls(rule_profiles=copy.deepcopy(_DEFAULT_PROFILES), default_rule_profile="living_room_default")
+        profiles = copy.deepcopy(_DEFAULT_PROFILES)
+        configured = ambient.get("rule_profiles")
+        if isinstance(configured, Mapping):
+            for name, profile in configured.items():
+                if not isinstance(name, str) or not isinstance(profile, Mapping):
+                    continue
+                base = copy.deepcopy(profiles.get(name, {}))
+                base.update(dict(profile))
+                profiles[name] = base
+        default = str(ambient.get("default_context") or "living_room_default").strip() or "living_room_default"
+        if default not in profiles:
+            default = "living_room_default"
+        return cls(rule_profiles=profiles, default_rule_profile=default)
 
     def evaluate(self, text: str, context: VoiceContext) -> VoicePolicyDecision:
         original = str(text or "")

--- a/gateway/ambient_voice_policy.py
+++ b/gateway/ambient_voice_policy.py
@@ -1,0 +1,342 @@
+"""Deterministic policy boundary for ambient voice output.
+
+The policy in this module is intentionally conservative: it decides whether a
+candidate assistant response may become spoken room audio, produces a sanitized
+speech string when allowed, and exposes only safe reason-code metadata.  It must
+never include raw blocked text, secret values, stack traces, file paths, or other
+matched excerpts in decisions or metadata.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+
+_DEFAULT_MAX_SECONDS = {
+    "ack": 2,
+    "completion": 4,
+    "question": 6,
+    "error": 3,
+    "progress": 2,
+}
+
+_DEFAULT_PROFILES: dict[str, dict[str, Any]] = {
+    "living_room_default": {
+        "max_seconds": _DEFAULT_MAX_SECONDS,
+        "max_chars": 180,
+        "allow_code": False,
+        "allow_tool_logs": False,
+        "allow_raw_paths": False,
+        "allow_sensitive_topics": False,
+        "allow_secret_like_text": False,
+        "require_explicit_for_sensitive_topics": True,
+        "suppress_errors_with_stack_traces": True,
+        "one_sentence": True,
+    },
+    "airpods_private": {
+        "max_seconds": {
+            "ack": 3,
+            "completion": 8,
+            "question": 10,
+            "error": 5,
+            "progress": 3,
+        },
+        "max_chars": 320,
+        "allow_code": False,
+        "allow_tool_logs": False,
+        "allow_raw_paths": False,
+        "allow_sensitive_topics": "explicit_only",
+        "allow_secret_like_text": False,
+        "require_explicit_for_sensitive_topics": True,
+        "suppress_errors_with_stack_traces": True,
+        "one_sentence": True,
+    },
+    "chat_attachment": {
+        "max_seconds": {"completion": 10, "question": 10, "error": 5, "ack": 3, "progress": 3},
+        "max_chars": 500,
+        "allow_code": False,
+        "allow_tool_logs": False,
+        "allow_raw_paths": False,
+        "allow_sensitive_topics": "explicit_only",
+        "allow_secret_like_text": False,
+        "require_explicit_for_sensitive_topics": True,
+        "suppress_errors_with_stack_traces": True,
+        "one_sentence": True,
+    },
+    "discord_voice": {
+        "max_seconds": _DEFAULT_MAX_SECONDS,
+        "max_chars": 180,
+        "allow_code": False,
+        "allow_tool_logs": False,
+        "allow_raw_paths": False,
+        "allow_sensitive_topics": False,
+        "allow_secret_like_text": False,
+        "require_explicit_for_sensitive_topics": True,
+        "suppress_errors_with_stack_traces": True,
+        "one_sentence": True,
+    },
+}
+
+_CODE_FENCE_RE = re.compile(r"```[\s\S]*?```")
+_INLINE_CODE_RE = re.compile(r"`[^`\n]{1,200}`")
+_MEDIA_RE = re.compile(r"MEDIA:\S+")
+_DIRECTIVE_RE = re.compile(r"\[\[[^\]]+\]\]")
+_MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\([^\)]+\)")
+_STACK_TRACE_RE = re.compile(
+    r"(?im)(traceback \(most recent call last\):|^\s*File \"[^\"]+\", line \d+|^[A-Za-z_][\w.]*Error:|^\s*at .+\(.+:\d+:\d+\))"
+)
+_COMMAND_LOG_RE = re.compile(
+    r"(?im)^\s*(?:\$\s+.+|>>>\s+.+|FAILED\s+.+|ERROR\s+.+|={5,}.+|-{5,}.+|E\s+.+)$"
+)
+_RAW_PATH_RE = re.compile(
+    r"(?<![\w@])(?:~|/(?:Users|tmp|var|private|Volumes|home|opt|etc|usr|mnt|workspace|workspaces))"
+    r"(?:/[A-Za-z0-9._@%+=:,~-]+)+"
+)
+_WINDOWS_PATH_RE = re.compile(r"\b[A-Za-z]:\\(?:[^\s\\/:*?\"<>|]+\\?)+")
+_SECRET_LIKE_RE = re.compile(
+    r"(?ix)("
+    r"\b(?:sk|ghp|gho|github_pat|glpat|hf)_[A-Za-z0-9_\-]{12,}"
+    r"|\b(?:xoxb|xoxp|xoxa|xoxr)-[A-Za-z0-9\-]{12,}"
+    r"|\bsk-[A-Za-z0-9_\-]{12,}"
+    r"|\bAKIA[0-9A-Z]{16}\b"
+    r"|\b[A-Z0-9_]*(?:AWS_SECRET_ACCESS_KEY|SECRET_ACCESS_KEY|API_KEY|TOKEN|PASSWORD|PRIVATE_KEY)\s*=\s*\S+"
+    r"|-----BEGIN\s+(?:RSA\s+|OPENSSH\s+|EC\s+)?PRIVATE\s+KEY-----"
+    r")"
+)
+_SENSITIVE_TOPIC_RE = re.compile(
+    r"(?i)\b("
+    r"pnl|p&l|profit\s+and\s+loss|portfolio|drawdown|trading|trade|position|leverage|liquidation|"
+    r"bank\s+account|credit\s+card|salary|net\s+worth|tax|medical|diagnosis|prescription|"
+    r"social\s+security|ssn|passport|relationship|divorce|therapy|credential|password|private\s+key"
+    r")\b"
+)
+_SENTENCE_RE = re.compile(r"^.{1,260}?[.!?。！？](?=\s|$)")
+
+
+@dataclass(frozen=True)
+class VoiceContext:
+    source: str
+    platform: str | None = None
+    channel_id: str | None = None
+    chat_id: str | None = None
+    thread_id: str | None = None
+    source_message_id: str | None = None
+    input_modality: str | None = None
+    output_device: str | None = None
+    profile: str | None = None
+    explicit_spoken_request: bool = False
+    is_private_context: bool = False
+    config_scope: str = "living_room_default"
+
+
+@dataclass(frozen=True)
+class VoicePolicyDecision:
+    allowed: bool
+    text: str
+    original_chars: int
+    sanitized: bool
+    truncated: bool
+    suppressed: bool
+    max_seconds: int
+    reasons: tuple[str, ...]
+    classifiers: dict[str, bool]
+    rule_profile: str
+
+    def to_metadata(self) -> dict[str, Any]:
+        """Return safe-to-display policy metadata with reason codes only."""
+        return {
+            "allowed": self.allowed,
+            "sanitized": self.sanitized,
+            "truncated": self.truncated,
+            "suppressed": self.suppressed,
+            "reason_codes": self.reasons,
+            "rule_profile": self.rule_profile,
+            "blocked_secret_like": bool(self.classifiers.get("secret_like")),
+            "dropped_code": bool(self.classifiers.get("code")),
+            "blocked_stack_trace": bool(self.classifiers.get("stack_trace")),
+            "dropped_tool_logs": bool(self.classifiers.get("command_log")),
+            "dropped_paths": bool(self.classifiers.get("raw_path")),
+            "blocked_sensitive_topic": bool(self.classifiers.get("sensitive_topic")),
+        }
+
+
+@dataclass
+class AmbientVoicePolicy:
+    """Evaluate candidate speech for deterministic ambient-safety rules."""
+
+    rule_profiles: Mapping[str, Mapping[str, Any]] = field(default_factory=lambda: _DEFAULT_PROFILES)
+    default_rule_profile: str = "living_room_default"
+
+    def evaluate(self, text: str, context: VoiceContext) -> VoicePolicyDecision:
+        original = str(text or "")
+        original_chars = len(original)
+        rule_profile = self._rule_profile_name(context)
+        profile = self._profile(rule_profile)
+        classifiers = self.classify(original)
+        sanitized_text, sanitize_reasons, sanitized_changed = self.sanitize(original, context, classifiers)
+
+        reasons: list[str] = []
+        allowed = True
+        sensitive_summarized = False
+
+        if classifiers["secret_like"] and not profile.get("allow_secret_like_text", False):
+            allowed = False
+            self._append_reason(reasons, "secret_like")
+        if classifiers["stack_trace"] and profile.get("suppress_errors_with_stack_traces", True):
+            allowed = False
+            self._append_reason(reasons, "stack_trace")
+        if classifiers["command_log"] and not profile.get("allow_tool_logs", False):
+            # Command/log output is too risky for ambient speech. If mixed with
+            # a safe sentence, the caller can pass that sentence separately.
+            allowed = False
+            self._append_reason(reasons, "command_log")
+        if classifiers["code"] and not sanitized_text:
+            allowed = False
+        if classifiers["sensitive_topic"]:
+            if self._can_speak_sensitive_topic(profile, context):
+                sanitized_text = "I can discuss that sensitive topic in this private voice context."
+                sensitive_summarized = True
+                sanitized_changed = True
+                self._append_reason(reasons, "sensitive_topic_summarized")
+            else:
+                allowed = False
+                self._append_reason(reasons, "sensitive_topic")
+
+        for reason in sanitize_reasons:
+            self._append_reason(reasons, reason)
+
+        bounded_text, truncated, bound_reasons = self._bound_text(sanitized_text, profile)
+        for reason in bound_reasons:
+            self._append_reason(reasons, reason)
+        sanitized_text = bounded_text
+
+        if not sanitized_text:
+            allowed = False
+            self._append_reason(reasons, "empty_after_sanitization")
+
+        if not allowed:
+            sanitized_text = ""
+            self._append_reason(reasons, "empty_after_sanitization")
+
+        if classifiers["secret_like"] and "secret_like" in reasons:
+            reasons = ["secret_like", *[reason for reason in reasons if reason != "secret_like"]]
+
+        sanitized = sanitized_changed or sanitized_text != original or sensitive_summarized
+        return VoicePolicyDecision(
+            allowed=allowed,
+            text=sanitized_text,
+            original_chars=original_chars,
+            sanitized=sanitized,
+            truncated=truncated,
+            suppressed=not allowed,
+            max_seconds=self.max_seconds(context.source, context),
+            reasons=tuple(reasons),
+            classifiers=classifiers,
+            rule_profile=rule_profile,
+        )
+
+    def classify(self, text: str) -> dict[str, bool]:
+        candidate = str(text or "")
+        return {
+            "secret_like": bool(_SECRET_LIKE_RE.search(candidate)),
+            "code": bool(_CODE_FENCE_RE.search(candidate) or _INLINE_CODE_RE.search(candidate)),
+            "stack_trace": bool(_STACK_TRACE_RE.search(candidate)),
+            "command_log": bool(_COMMAND_LOG_RE.search(candidate)),
+            "raw_path": bool(_RAW_PATH_RE.search(candidate) or _WINDOWS_PATH_RE.search(candidate)),
+            "long_response": len(candidate) > 180 or candidate.count("\n") >= 2 or len(re.findall(r"[.!?。！？]", candidate)) > 1,
+            "sensitive_topic": bool(_SENSITIVE_TOPIC_RE.search(candidate)),
+        }
+
+    def sanitize(
+        self,
+        text: str,
+        context: VoiceContext,
+        classifiers: Mapping[str, bool] | None = None,
+    ) -> tuple[str, tuple[str, ...], bool]:
+        del context  # Reserved for future context-specific sanitization.
+        original = str(text or "")
+        cleaned = original
+        flags = classifiers or self.classify(original)
+        reasons: list[str] = []
+
+        if flags.get("code"):
+            cleaned = _CODE_FENCE_RE.sub(" ", cleaned)
+            cleaned = _INLINE_CODE_RE.sub(" ", cleaned)
+            self._append_reason(reasons, "code_stripped")
+        if flags.get("command_log"):
+            cleaned = _COMMAND_LOG_RE.sub(" ", cleaned)
+            self._append_reason(reasons, "command_log_stripped")
+        if flags.get("stack_trace"):
+            cleaned = _STACK_TRACE_RE.sub(" ", cleaned)
+            self._append_reason(reasons, "stack_trace_stripped")
+        if flags.get("raw_path"):
+            cleaned = _RAW_PATH_RE.sub("a local file", cleaned)
+            cleaned = _WINDOWS_PATH_RE.sub("a local file", cleaned)
+            self._append_reason(reasons, "raw_path_stripped")
+
+        cleaned = _MEDIA_RE.sub(" ", cleaned)
+        cleaned = _DIRECTIVE_RE.sub(" ", cleaned)
+        cleaned = _MARKDOWN_LINK_RE.sub(r"\1", cleaned)
+        cleaned = re.sub(r"^[#>*\-•\s]+", "", cleaned, flags=re.MULTILINE)
+        cleaned = re.sub(r"\b(?:and|or)\b\s*$", "", cleaned.strip(), flags=re.IGNORECASE)
+        cleaned = re.sub(r"\s+", " ", cleaned).strip(" ,;:\n\t")
+        return cleaned, tuple(reasons), cleaned != original
+
+    def max_seconds(self, kind: str, context: VoiceContext) -> int:
+        rule_profile = self._rule_profile_name(context)
+        profile = self._profile(rule_profile)
+        max_seconds = profile.get("max_seconds", {})
+        source_kind = str(kind or context.source or "completion").lower()
+        if source_kind.startswith("assistant"):
+            source_kind = "completion"
+        return int(max_seconds.get(source_kind, max_seconds.get("completion", 4)) or 4)
+
+    def _bound_text(self, text: str, profile: Mapping[str, Any]) -> tuple[str, bool, tuple[str, ...]]:
+        if not text:
+            return "", False, ()
+        reasons: list[str] = []
+        bounded = text.strip()
+        truncated = False
+        if profile.get("one_sentence", True):
+            match = _SENTENCE_RE.match(bounded)
+            if match and match.group(0).strip() != bounded:
+                bounded = match.group(0).strip()
+                truncated = True
+                self._append_reason(reasons, "bounded_to_one_sentence")
+        max_chars = int(profile.get("max_chars", 180) or 180)
+        if len(bounded) > max_chars:
+            bounded = bounded[: max_chars - 1].rstrip(" ,.;:") + "…"
+            truncated = True
+            self._append_reason(reasons, "bounded_to_max_chars")
+        return bounded, truncated, tuple(reasons)
+
+    def _can_speak_sensitive_topic(self, profile: Mapping[str, Any], context: VoiceContext) -> bool:
+        policy = profile.get("allow_sensitive_topics", False)
+        if policy is True:
+            return True
+        if policy == "explicit_only":
+            return bool(context.explicit_spoken_request and context.is_private_context)
+        return False
+
+    def _rule_profile_name(self, context: VoiceContext) -> str:
+        requested = str(context.config_scope or "").strip()
+        if requested and requested in self.rule_profiles:
+            return requested
+        device = str(context.output_device or "").strip().lower()
+        if device == "airpods":
+            return "airpods_private"
+        if device == "chat_attachment":
+            return "chat_attachment"
+        if device == "discord_voice":
+            return "discord_voice"
+        return self.default_rule_profile
+
+    def _profile(self, rule_profile: str) -> Mapping[str, Any]:
+        return self.rule_profiles.get(rule_profile) or self.rule_profiles[self.default_rule_profile]
+
+    @staticmethod
+    def _append_reason(reasons: list[str], reason: str) -> None:
+        if reason not in reasons:
+            reasons.append(reason)

--- a/gateway/final_speech_summarizer.py
+++ b/gateway/final_speech_summarizer.py
@@ -14,6 +14,10 @@ from typing import Callable, Literal
 import re
 
 _MAX_TEXT_CHARS = 180
+_GENERATOR_EXECUTOR = ThreadPoolExecutor(
+    max_workers=4,
+    thread_name_prefix="final-speech-summarizer",
+)
 
 Kind = Literal["completion", "question", "error"]
 SummaryMethod = Literal["generated", "deterministic", "silence"]
@@ -290,6 +294,14 @@ class FinalSpeechSummarizer:
             generated, failure_reason = self._try_generated(pre.text, final_response, context)
             if generated is not None:
                 return VoiceSummaryResult(kind=kind, text=generated.text, method="generated", policy=generated.policy)
+            if self.mode == "generated":
+                return VoiceSummaryResult(
+                    kind=kind,
+                    text="",
+                    method="silence",
+                    policy=pre.policy,
+                    reason=failure_reason,
+                )
             fallback = self._deterministic(pre.text, context)
             return VoiceSummaryResult(
                 kind=kind,
@@ -319,20 +331,14 @@ class FinalSpeechSummarizer:
             max_chars=context.max_spoken_chars,
         )
         timeout_ms = max(1, int(context.timeout_ms or 1))
-        executor = ThreadPoolExecutor(max_workers=1)
-        future = executor.submit(self._call_generator, prompt, timeout_ms)
+        future = _GENERATOR_EXECUTOR.submit(self._call_generator, prompt, timeout_ms)
         try:
             raw = future.result(timeout=timeout_ms / 1000)
         except TimeoutError:
             future.cancel()
-            executor.shutdown(wait=False, cancel_futures=True)
             return None, "generated_timeout"
         except Exception:
-            executor.shutdown(wait=False, cancel_futures=True)
             return None, "generated_exception"
-        finally:
-            if future.done():
-                executor.shutdown(wait=False, cancel_futures=True)
         valid, reason = self.validate_generated_summary(raw, original_final_response, context)
         if not valid:
             return None, f"generated_invalid: {reason}"

--- a/gateway/final_speech_summarizer.py
+++ b/gateway/final_speech_summarizer.py
@@ -57,21 +57,27 @@ _ERROR_SIGNAL_RE = re.compile(
     r"(?i)\b(?:error|failed?|failure|timed\s+out|timeout|blocked|can't|cannot|couldn't|unable|unavailable|interrupted|sorry)\b"
 )
 _ACTION_TERMS = {
-    "deployed",
-    "deploy",
-    "sent",
+    "called",
+    "changed",
     "closed",
-    "opened",
-    "merged",
+    "completed",
     "created",
     "deleted",
+    "deploy",
+    "deployed",
+    "emailed",
+    "finished",
     "fixed",
-    "updated",
-    "changed",
     "implemented",
-    "ran",
+    "merged",
+    "opened",
     "passed",
+    "ran",
+    "reviewed",
+    "sent",
+    "updated",
     "verified",
+    "wrote",
 }
 _COMPLETION_VERBS = {
     "tests pass",
@@ -88,6 +94,36 @@ _COMPLETION_VERBS = {
     "closed the issue",
     "message sent",
     "sent the message",
+}
+_CONTENT_STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "are",
+    "as",
+    "at",
+    "be",
+    "been",
+    "being",
+    "by",
+    "for",
+    "from",
+    "i",
+    "in",
+    "is",
+    "it",
+    "its",
+    "my",
+    "of",
+    "on",
+    "or",
+    "our",
+    "the",
+    "this",
+    "that",
+    "to",
+    "with",
+    "your",
 }
 
 FINAL_SPEECH_PROMPT_CONTRACT = """You are Eon speaking aloud in Brenno's living room.
@@ -159,6 +195,11 @@ def _base_policy() -> dict[str, bool]:
 def _first_sentence(text: str) -> str:
     match = _SENTENCE_RE.match(text)
     return match.group(0) if match else text
+
+
+def _content_words(text: str) -> set[str]:
+    words = set(re.findall(r"[a-z]+", text.lower()))
+    return {word for word in words if len(word) > 2 and word not in _CONTENT_STOPWORDS}
 
 
 def sanitize_voice_text(
@@ -380,6 +421,13 @@ class FinalSpeechSummarizer:
 
         if _FUTURE_PROMISE_RE.search(generated_text) and not _FUTURE_PROMISE_RE.search(final_text):
             return False, "future_promise"
+        if "will" in generated_words and "will" not in final_words:
+            return False, "future_promise"
+
+        generated_content = _content_words(generated_text)
+        final_content = _content_words(final_text)
+        if generated_content and final_content and not (generated_content & final_content):
+            return False, "unsupported_content"
 
         return True, None
 

--- a/gateway/final_speech_summarizer.py
+++ b/gateway/final_speech_summarizer.py
@@ -1,0 +1,392 @@
+"""Final assistant response to room-safe speech summarization.
+
+The summarizer deliberately keeps deterministic safety gates around any generated
+summary.  Generation is optional and injectable so tests never need network/model
+calls; production callers can wire a fast local/auxiliary summarizer later without
+changing the public ``summarize(final_response, context)`` shape.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, TimeoutError
+from dataclasses import dataclass, field
+from typing import Callable, Literal
+import re
+
+_MAX_TEXT_CHARS = 180
+
+Kind = Literal["completion", "question", "error"]
+SummaryMethod = Literal["generated", "deterministic", "silence"]
+SummaryMode = Literal["deterministic", "generated", "hybrid", "off"]
+
+_MEDIA_RE = re.compile(r"MEDIA:\S+", re.IGNORECASE)
+_DIRECTIVE_RE = re.compile(r"\[\[[^\]]+\]\]")
+_CODE_FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`([^`]{1,120})`")
+_MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\([^\)]+\)")
+_TOOL_LOG_LINE_RE = re.compile(
+    r'(?m)^\s*(?:\$ .+|>>> .+|FAILED .+|Traceback .+|File "[^"]+", line \d+.*|E\s+.+|={5,}.*)$'
+)
+_URL_RE = re.compile(r"https?://\S+|www\.\S+", re.IGNORECASE)
+_PATH_RE = re.compile(r"(?<!\w)(?:[A-Za-z]:[\\/][^\s,;:)\]'\"]+|(?:~?/|/)[^\s,;:)\]'\"]+)")
+_FILE_REF_RE = re.compile(
+    r"(?<![\w/.-])(?:[\w.-]+/)*[\w.-]+\.(?:py|json|ya?ml|toml|md|txt|log|js|jsx|ts|tsx|css|html|sh|env)\b",
+    re.IGNORECASE,
+)
+_SECRET_RE = re.compile(
+    r"""
+    (?:
+        \b(?:bearer|authorization)\b\s*[:=]?\s+[A-Za-z0-9][A-Za-z0-9._~+/\-]{7,}
+      | \b(?:api[_ -]?key|secret(?:[_ -]?key)?|password|passwd|pwd|token|access[_ -]?key|aws[_ -]?key)\b
+        \s*(?:is|=|:|starts\s+with)?\s+[A-Za-z0-9][A-Za-z0-9._~+/\-]{7,}
+      | \b(?:sk-[A-Za-z0-9._-]{6,}|sk-[A-Za-z0-9]{2,}\.\.\.[A-Za-z0-9]{2,}|gh[pousr]_[A-Za-z0-9_]{10,})\b
+      | \b(?:AKIA|ASIA)[A-Z0-9.]{10,}\b
+      | \bhk_[A-Za-z0-9._-]{10,}\b
+      | \b[a-z]{2,}_(?:test|live|prod|secret|key)_[A-Za-z0-9]{10,}\b
+      | \beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b
+    )
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+_NUMBER_RE = re.compile(r"\b\d+(?:[.,:]\d+)?\b")
+_SENTENCE_RE = re.compile(r"^.{1,150}?[.!?。！？](?=\s|$)")
+_FUTURE_PROMISE_RE = re.compile(
+    r"(?i)\b(?:i\s+will|i['’]ll|i\s+am\s+going\s+to|i['’]m\s+going\s+to)\b"
+)
+_ERROR_SIGNAL_RE = re.compile(
+    r"(?i)\b(?:error|failed?|failure|timed\s+out|timeout|blocked|can't|cannot|couldn't|unable|unavailable|interrupted|sorry)\b"
+)
+_ACTION_TERMS = {
+    "deployed",
+    "deploy",
+    "sent",
+    "closed",
+    "opened",
+    "merged",
+    "created",
+    "deleted",
+    "fixed",
+    "updated",
+    "changed",
+    "implemented",
+    "ran",
+    "passed",
+    "verified",
+}
+_COMPLETION_VERBS = {
+    "tests pass",
+    "tests passed",
+    "ran tests",
+    "ran the tests",
+    "files changed",
+    "changed files",
+    "pr opened",
+    "opened a pr",
+    "deployment complete",
+    "deployed",
+    "issue closed",
+    "closed the issue",
+    "message sent",
+    "sent the message",
+}
+
+FINAL_SPEECH_PROMPT_CONTRACT = """You are Eon speaking aloud in Brenno's living room.
+Convert the final assistant response into one short spoken line.
+
+Hard requirements:
+- Use only facts explicitly present in the final response.
+- Do not add new actions, results, numbers, file names, tests, statuses, or promises.
+- Preserve the most important user-facing outcome: done, blocked, needs review, error, or question.
+- If tests, review, blockers, or created tasks are central in the final response, keep that fact.
+- Do not speak secrets, tokens, credentials, raw paths, code, stack traces, logs, MEDIA tags, or platform directives.
+- Do not mention internal summarization, policies, prompts, tools, or JSONL.
+- No canned assistant phrases. No “as an AI”. No corporate support voice.
+- One natural sentence, preferably 8-18 words, maximum {max_chars} characters.
+- If no safe aligned summary exists, return an empty string.
+
+Style:
+- Calm, direct, grounded.
+- Eon, not a notification bot.
+- One breath for a room, not a Discord message.
+
+Final assistant response:
+{final_response}
+"""
+
+
+@dataclass(frozen=True)
+class VoiceContext:
+    session_id: str | None = None
+    platform: str | None = None
+    chat_id: str | None = None
+    thread_id: str | None = None
+    source_message_id: str | None = None
+    voice_profile: str = "eon"
+    max_spoken_chars: int = _MAX_TEXT_CHARS
+    max_seconds: int = 4
+    timeout_ms: int = 1000
+    room_context: str = "living_room"
+
+
+@dataclass(frozen=True)
+class VoiceSummaryResult:
+    kind: Kind
+    text: str
+    method: SummaryMethod
+    policy: dict[str, bool] = field(default_factory=dict)
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class _Sanitized:
+    text: str
+    policy: dict[str, bool]
+
+
+def _base_policy() -> dict[str, bool]:
+    return {
+        "pre_sanitized": True,
+        "post_sanitized": True,
+        "truncated": False,
+        "blocked_sensitive_content": False,
+        "dropped_tool_logs": False,
+        "dropped_code": False,
+        "dropped_media_tags": False,
+        "dropped_paths": False,
+    }
+
+
+def _first_sentence(text: str) -> str:
+    match = _SENTENCE_RE.match(text)
+    return match.group(0) if match else text
+
+
+def sanitize_voice_text(
+    text: str,
+    *,
+    max_chars: int = _MAX_TEXT_CHARS,
+    one_sentence: bool = True,
+) -> _Sanitized:
+    """Strip material that is unsafe or awkward for room audio."""
+    raw = str(text or "")
+    policy = _base_policy()
+    policy["dropped_code"] = bool(_CODE_FENCE_RE.search(raw) or _INLINE_CODE_RE.search(raw))
+    policy["dropped_media_tags"] = bool(_MEDIA_RE.search(raw))
+    policy["dropped_tool_logs"] = bool(_TOOL_LOG_LINE_RE.search(raw))
+    policy["blocked_sensitive_content"] = bool(_SECRET_RE.search(raw))
+    policy["dropped_paths"] = bool(_PATH_RE.search(raw) or _FILE_REF_RE.search(raw))
+
+    cleaned = _CODE_FENCE_RE.sub("", raw)
+    cleaned = _TOOL_LOG_LINE_RE.sub("", cleaned)
+    cleaned = _MEDIA_RE.sub("", cleaned)
+    cleaned = _DIRECTIVE_RE.sub("", cleaned)
+    cleaned = _URL_RE.sub("", cleaned)
+    cleaned = _MARKDOWN_LINK_RE.sub(r"\1", cleaned)
+    cleaned = _INLINE_CODE_RE.sub("", cleaned)
+    cleaned = _PATH_RE.sub("", cleaned)
+    cleaned = _FILE_REF_RE.sub("", cleaned)
+    cleaned = _SECRET_RE.sub("", cleaned)
+    cleaned = re.sub(r"^[#>*\-•\s]+", "", cleaned, flags=re.MULTILINE)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    if not cleaned or policy["blocked_sensitive_content"]:
+        return _Sanitized("", policy)
+
+    if one_sentence:
+        cleaned = _first_sentence(cleaned).strip()
+    max_chars = max(1, int(max_chars or _MAX_TEXT_CHARS))
+    if len(cleaned) > max_chars:
+        cleaned = cleaned[: max_chars - 1].rstrip(" ,.;:") + "…"
+        policy["truncated"] = True
+    return _Sanitized(cleaned, policy)
+
+
+def classify_final_response(final_response: str) -> Kind:
+    safe = sanitize_voice_text(final_response).text
+    lowered = safe.lower()
+    raw_lowered = str(final_response or "").strip().lower()
+    if lowered.startswith(("⚠", "error", "failed", "sorry")) or raw_lowered.startswith(
+        ("⚠", "error", "failed", "sorry")
+    ):
+        return "error"
+    if "?" in safe and len(safe) <= 160:
+        return "question"
+    return "completion"
+
+
+class FinalSpeechSummarizer:
+    """Hybrid final-speech summarizer with deterministic safety fallback."""
+
+    def __init__(
+        self,
+        generator: Callable[[str], str] | Callable[..., str] | None = None,
+        *,
+        mode: SummaryMode = "hybrid",
+    ) -> None:
+        self.generator = generator
+        self.mode = mode
+
+    def summarize(self, final_response: str, context: VoiceContext | None = None) -> VoiceSummaryResult:
+        context = context or VoiceContext()
+        kind = classify_final_response(final_response)
+        if self.mode == "off":
+            return VoiceSummaryResult(kind=kind, text="", method="silence", policy=_base_policy(), reason="off")
+
+        pre = sanitize_voice_text(
+            final_response,
+            max_chars=max(context.max_spoken_chars * 4, context.max_spoken_chars),
+            one_sentence=False,
+        )
+        if not pre.text:
+            return VoiceSummaryResult(
+                kind=kind,
+                text="",
+                method="silence",
+                policy=pre.policy,
+                reason="empty_safe_output",
+            )
+
+        if self.mode in {"generated", "hybrid"} and self.generator is not None:
+            generated, failure_reason = self._try_generated(pre.text, final_response, context)
+            if generated is not None:
+                return VoiceSummaryResult(kind=kind, text=generated.text, method="generated", policy=generated.policy)
+            fallback = self._deterministic(pre.text, context)
+            return VoiceSummaryResult(
+                kind=kind,
+                text=fallback.text,
+                method="deterministic" if fallback.text else "silence",
+                policy={**pre.policy, **fallback.policy},
+                reason=failure_reason if fallback.text else "empty_safe_output",
+            )
+
+        fallback = self._deterministic(pre.text, context)
+        return VoiceSummaryResult(
+            kind=kind,
+            text=fallback.text,
+            method="deterministic" if fallback.text else "silence",
+            policy={**pre.policy, **fallback.policy},
+            reason=None if fallback.text else "empty_safe_output",
+        )
+
+    def _deterministic(self, safe_final_response: str, context: VoiceContext) -> _Sanitized:
+        return sanitize_voice_text(safe_final_response, max_chars=context.max_spoken_chars)
+
+    def _try_generated(
+        self, safe_final_response: str, original_final_response: str, context: VoiceContext
+    ) -> tuple[_Sanitized | None, str | None]:
+        prompt = FINAL_SPEECH_PROMPT_CONTRACT.format(
+            final_response=safe_final_response,
+            max_chars=context.max_spoken_chars,
+        )
+        timeout_ms = max(1, int(context.timeout_ms or 1))
+        executor = ThreadPoolExecutor(max_workers=1)
+        future = executor.submit(self._call_generator, prompt, timeout_ms)
+        try:
+            raw = future.result(timeout=timeout_ms / 1000)
+        except TimeoutError:
+            future.cancel()
+            executor.shutdown(wait=False, cancel_futures=True)
+            return None, "generated_timeout"
+        except Exception:
+            executor.shutdown(wait=False, cancel_futures=True)
+            return None, "generated_exception"
+        finally:
+            if future.done():
+                executor.shutdown(wait=False, cancel_futures=True)
+        valid, reason = self.validate_generated_summary(raw, original_final_response, context)
+        if not valid:
+            return None, f"generated_invalid: {reason}"
+        sanitized = sanitize_voice_text(raw, max_chars=context.max_spoken_chars)
+        if not sanitized.text:
+            return None, "generated_invalid: empty"
+        return sanitized, None
+
+    def _call_generator(self, prompt: str, timeout_ms: int) -> str:
+        if self.generator is None:
+            return ""
+        try:
+            return str(self.generator(prompt, timeout_ms=timeout_ms))  # type: ignore[misc]
+        except TypeError:
+            return str(self.generator(prompt))  # type: ignore[misc]
+
+    def validate_generated_summary(
+        self, generated_summary: str, final_response: str, context: VoiceContext | None = None
+    ) -> tuple[bool, str | None]:
+        context = context or VoiceContext()
+        raw = str(generated_summary or "")
+        if not raw.strip():
+            return False, "empty"
+        if len(raw.strip()) > context.max_spoken_chars:
+            return False, "too_long"
+        if _CODE_FENCE_RE.search(raw) or _INLINE_CODE_RE.search(raw):
+            return False, "code"
+        if _MEDIA_RE.search(raw):
+            return False, "media"
+        if _URL_RE.search(raw):
+            return False, "url"
+        if _PATH_RE.search(raw):
+            return False, "path"
+        if _FILE_REF_RE.search(raw):
+            return False, "file_ref"
+        if _SECRET_RE.search(raw):
+            return False, "secret"
+        if _TOOL_LOG_LINE_RE.search(raw):
+            return False, "logs"
+        if _DIRECTIVE_RE.search(raw):
+            return False, "directive"
+
+        safe_generated = sanitize_voice_text(raw, max_chars=context.max_spoken_chars)
+        if not safe_generated.text:
+            return False, "empty"
+        safe_final = sanitize_voice_text(
+            final_response,
+            max_chars=max(context.max_spoken_chars * 8, 1000),
+            one_sentence=False,
+        )
+        final_text = safe_final.text.lower()
+        generated_text = safe_generated.text.lower()
+
+        if classify_final_response(final_response) == "question" and "?" not in safe_generated.text:
+            return False, "question_downgrade"
+        if classify_final_response(final_response) == "error" and not _ERROR_SIGNAL_RE.search(generated_text):
+            return False, "error_downgrade"
+
+        final_numbers = set(_NUMBER_RE.findall(final_text))
+        for number in _NUMBER_RE.findall(generated_text):
+            if number not in final_numbers:
+                return False, "unsupported_number"
+
+        final_words = set(re.findall(r"[a-z]+", final_text))
+        generated_words = set(re.findall(r"[a-z]+", generated_text))
+        unsupported_actions = (_ACTION_TERMS & generated_words) - final_words
+        if unsupported_actions:
+            passed_is_grounded_by_ran_tests = (
+                unsupported_actions == {"passed"}
+                and "tests" in generated_words
+                and "tests" in final_words
+                and ({"ran", "pass", "passed", "verified"} & final_words)
+            )
+            if not passed_is_grounded_by_ran_tests:
+                return False, "unsupported_action"
+
+        for phrase in _COMPLETION_VERBS:
+            if phrase in generated_text and phrase not in final_text:
+                tests_passed_is_grounded_by_ran_tests = (
+                    phrase in {"tests pass", "tests passed"}
+                    and "tests" in final_words
+                    and ({"ran", "pass", "passed", "verified"} & final_words)
+                )
+                if not tests_passed_is_grounded_by_ran_tests:
+                    return False, "unsupported_action"
+
+        if _FUTURE_PROMISE_RE.search(generated_text) and not _FUTURE_PROMISE_RE.search(final_text):
+            return False, "future_promise"
+
+        return True, None
+
+
+_DEFAULT_SUMMARIZER = FinalSpeechSummarizer()
+
+
+def summarize_final_speech(final_response: str, context: VoiceContext | None = None) -> VoiceSummaryResult:
+    """Module-level convenience API for existing gateway call sites."""
+    return _DEFAULT_SUMMARIZER.summarize(final_response, context or VoiceContext())

--- a/gateway/generated_ack_harness.py
+++ b/gateway/generated_ack_harness.py
@@ -104,6 +104,13 @@ _TIMESTAMP_LOG_RE = re.compile(
     r"(?im)^\s*(?:\d{4}-\d{2}-\d{2}[T\s]\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?|\d{2}:\d{2}:\d{2}(?:\.\d+)?|\[[^\]]*(?:ERROR|WARN|WARNING|INFO|DEBUG)[^\]]*\])\s*(?:\[[^\]]+\]\s*)*(?:ERROR|WARN|WARNING|INFO|DEBUG)?\b.*$"
 )
 _BRACKET_LOG_RE = re.compile(r"(?im)^\s*(?:\[[^\]]+\]\s*)*\[(?:ERROR|WARN|WARNING|INFO|DEBUG)\]\s*.*$")
+_SENSITIVE_TOPIC_RE = re.compile(
+    r"(?i)\b("
+    r"pnl|p&l|profit\s+and\s+loss|portfolio|drawdown|trading|trade|position|leverage|liquidation|"
+    r"bank\s+account|credit\s+card|salary|net\s+worth|tax|medical|diagnosis|prescription|"
+    r"social\s+security|ssn|passport|relationship|divorce|therapy|credential|password|private\s+key"
+    r")\b"
+)
 _SENTENCE_END_RE = re.compile(r"[.!?。！？]")
 _WORD_RE = re.compile(r"[\w’'-]+", re.UNICODE)
 _CANNED_NORMALIZE_RE = re.compile(r"[^a-z0-9]+")
@@ -171,6 +178,7 @@ def _unsafe_raw_context_reason(text: str) -> str | None:
         ("code_or_log", _SHELL_SNIPPET_RE),
         ("code_or_log", _TIMESTAMP_LOG_RE),
         ("code_or_log", _BRACKET_LOG_RE),
+        ("sensitive_topic", _SENSITIVE_TOPIC_RE),
     )
     for reason, pattern in checks:
         if pattern.search(original):
@@ -188,7 +196,7 @@ def _sanitize_prompt_user_message(text: str, *, limit: int | None = None) -> str
     """
     original = str(text or "")
     if _unsafe_raw_context_reason(original):
-        return "User asked about technical content; sensitive details omitted."
+        return "User asked about sensitive content; details omitted."
     redacted = re.sub(r"\s+", " ", original).strip()
     if limit is not None and len(redacted) > limit:
         redacted = redacted[: limit - 1].rstrip() + "…"

--- a/gateway/generated_ack_harness.py
+++ b/gateway/generated_ack_harness.py
@@ -1,0 +1,378 @@
+"""Generated voice-only acknowledgement harness for turn-start room audio.
+
+The generated acknowledgement path is deliberately isolated from gateway text,
+session history, and the main agent run.  It accepts an injectable generator for
+tests/production adapters, validates the candidate aggressively, runs ambient
+voice policy, and degrades to silence on every failure.  There is no canned
+fallback phrase.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, TimeoutError
+from dataclasses import dataclass, field
+from typing import Any, Literal, Protocol
+import re
+import threading
+import time
+
+from gateway.ambient_voice_policy import AmbientVoicePolicy, VoiceContext as AmbientVoiceContext
+
+AckMethod = Literal["generated", "silence"]
+AckMode = Literal["generated", "off"]
+
+
+class AckGenerator(Protocol):
+    """Callable shape for bounded acknowledgement generation."""
+
+    def __call__(self, prompt: str, *, timeout_ms: int) -> str:
+        ...
+
+_DEFAULT_TIMEOUT_MS = 1000
+_DEFAULT_MAX_WORDS = 12
+_DEFAULT_MAX_SPOKEN_CHARS = 120
+_DEFAULT_MAX_SECONDS = 2
+_GENERATOR_MAX_WORKERS = 4
+_GENERATOR_EXECUTOR = ThreadPoolExecutor(max_workers=_GENERATOR_MAX_WORKERS, thread_name_prefix="generated-ack")
+_GENERATOR_SLOTS = threading.BoundedSemaphore(_GENERATOR_MAX_WORKERS)
+_AMBIENT_POLICY = AmbientVoicePolicy()
+
+GENERATED_ACK_PROMPT_CONTRACT = """Generate a short natural spoken acknowledgement as Eon.
+
+Hard requirements:
+- Maximum {max_words} words.
+- One sentence only.
+- No canned acknowledgement phrases.
+- No generic assistant status language.
+- Do not promise completion, fixes, tests, tool use, or results.
+- Do not mention tools unless the user's request is explicitly about tools.
+- Never speak secrets, raw logs, code, file paths, URLs, or long content.
+- Match Brenno's energy: direct, sharp, grounded, not corporate.
+- This is room audio, not Discord text.
+- Return only the acknowledgement text, or an empty string if no safe line exists.
+
+User turn:
+{user_message}
+"""
+
+_SECRET_RE = re.compile(
+    r"(?ix)("
+    r"\b(?:bearer|authorization)\b\s*[:=]?\s+[A-Za-z0-9][A-Za-z0-9._~+/\-]{7,}"
+    r"|\b(?:api[_ -]?key|secret(?:[_ -]?key)?|password|passwd|pwd|token|access[_ -]?key|aws[_ -]?key)\b\s*(?:is|=|:)?\s+[A-Za-z0-9][A-Za-z0-9._~+/\-]{7,}"
+    r"|\b(?:sk-[A-Za-z0-9._-]{6,}|gh[pousr]_[A-Za-z0-9_]{10,}|github_pat_[A-Za-z0-9_]{10,})\b"
+    r"|\b(?:xox[baprs]-(?:[A-Za-z0-9-]{10,}|\[REDACTED\])|hf_(?:[A-Za-z0-9]{10,}|\[REDACTED\])|glpat-(?:[A-Za-z0-9_-]{10,}|\[REDACTED\]))(?=$|\W)"
+    r"|\bhk_(?:[A-Za-z0-9._-]{10,}|\[REDACTED\])(?=$|\W)"
+    r"|\b[a-z]{2,}_(?:test|live|prod|secret|key)_(?:[A-Za-z0-9]{10,}|\[REDACTED\])(?=$|\W)"
+    r"|\b(?:AKIA|ASIA)[A-Z0-9]{10,}\b"
+    r")"
+)
+_RAW_PATH_RE = re.compile(
+    r"(?<![\w@])(?:~|/(?:Users|tmp|var|private|Volumes|home|opt|etc|usr|mnt|workspace|workspaces))"
+    r"(?:/[A-Za-z0-9._@%+=:,~-]+)+|\b[A-Za-z]:\\(?:[^\s\\/:*?\"<>|]+\\?)+"
+)
+_URL_RE = re.compile(r"https?://\S+|www\.\S+", re.IGNORECASE)
+_CODE_OR_LOG_RE = re.compile(
+    r"(?ims)(```.*?```|Traceback \(most recent call last\):.*|^\s*(?:\$|>>>|FAILED|ERROR|WARN|WARNING|INFO|DEBUG|E\s+|File \"[^\"]+\", line \d+).*$)"
+)
+_MEDIA_TAG_RE = re.compile(r"MEDIA:\S+", re.IGNORECASE)
+_FILE_REF_RE = re.compile(
+    r"(?<![\w/.-])(?:[\w.-]+/)*[\w.-]+\.(?:py|json|ya?ml|toml|md|txt|log|js|jsx|ts|tsx|css|html|sh|env)\b",
+    re.IGNORECASE,
+)
+_ENV_SECRET_RE = re.compile(
+    r"(?i)\b[A-Z][A-Z0-9_]*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|PASSWD|PWD|ACCESS[_-]?KEY)\s*=\s*\S+"
+)
+_SECRET_KEYWORD_VALUE_RE = re.compile(
+    r"(?i)\b(?:api[_ -]?key|secret(?:[_ -]?key)?|password|passwd|pwd|token|access[_ -]?key|private[_ -]?key|ssh[_ -]?key|passphrase|credential)\b\s*(?:(?:is|=|:)\s*)?\S+"
+)
+_PRIVATE_KEY_RE = re.compile(r"(?is)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----")
+_PRIVATE_KEY_HEADER_RE = re.compile(r"(?i)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----")
+_JWT_RE = re.compile(r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b")
+_RELATIVE_PATH_RE = re.compile(r"(?<![\w.~-])(?:\.\.?/|[A-Za-z0-9_.-]+/)[^\s,;:)\]'\"]+(?:/[^\s,;:)\]'\"]+)*")
+_UNFENCED_CODE_LINE_RE = re.compile(
+    r"(?im)^\s*(?:def\s+\w+\s*\(|class\s+\w+|import\s+\w+|from\s+\S+\s+import\s+|function\s+\w+\s*\(|const\s+\w+\s*=|let\s+\w+\s*=|var\s+\w+\s*=|return\s+.+|if\s+.+:\s*$|for\s+.+:\s*$|while\s+.+:\s*$)"
+)
+_INLINE_CODE_RE = re.compile(
+    r"(?im)(?:\b(?:print|console\.(?:log|error|warn)|require|eval|exec)\s*\(|\b\w+[\w.]*\s*=\s*[^\s,.;!?]+|[{};]|\b\w+\([^)]*\)|\b\w+\s*(?:\+|-|\*|/|==|!=|<=|>=|<|>)\s*\w+)"
+)
+_BACKTICK_TEXT_RE = re.compile(r"`[^`]+`")
+_SQL_SNIPPET_RE = re.compile(r"(?i)\b(?:select\s+.+\s+from|insert\s+into|update\s+\w+\s+set|delete\s+from|create\s+table|drop\s+table)\b")
+_SHELL_SNIPPET_RE = re.compile(
+    r"(?im)^\s*(?:sudo\s+|uv\s+run\b|python\s+-m\b|pip\s+install\b|npm\s+\w+\b|pnpm\s+\w+\b|yarn\s+\w+\b|git\s+\w+\b|ls\s+-|cd\s+\S+|grep\s+|rg\s+|curl\s+|wget\s+|ssh\s+|scp\s+|docker\s+|kubectl\s+)"
+)
+_TIMESTAMP_LOG_RE = re.compile(
+    r"(?im)^\s*(?:\d{4}-\d{2}-\d{2}[T\s]\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?|\d{2}:\d{2}:\d{2}(?:\.\d+)?|\[[^\]]*(?:ERROR|WARN|WARNING|INFO|DEBUG)[^\]]*\])\s*(?:\[[^\]]+\]\s*)*(?:ERROR|WARN|WARNING|INFO|DEBUG)?\b.*$"
+)
+_BRACKET_LOG_RE = re.compile(r"(?im)^\s*(?:\[[^\]]+\]\s*)*\[(?:ERROR|WARN|WARNING|INFO|DEBUG)\]\s*.*$")
+_SENTENCE_END_RE = re.compile(r"[.!?。！？]")
+_WORD_RE = re.compile(r"[\w’'-]+", re.UNICODE)
+_CANNED_NORMALIZE_RE = re.compile(r"[^a-z0-9]+")
+
+_CANNED_PHRASES = {
+    "im here",
+    "i am here",
+    "got you",
+    "gotcha",
+    "im on it",
+    "i am on it",
+    "lets see",
+    "sure i can help with that",
+    "okay",
+    "ok",
+    "processing your request",
+}
+_GENERIC_PATTERNS = (
+    re.compile(r"(?i)\b(?:happy to help|how can i help|assist you|your request|working on it|one moment|please wait)\b"),
+    re.compile(r"(?i)\b(?:as an ai|assistant|processing|analyz(?:e|ing)|thinking)\b"),
+)
+_PROMISE_PATTERNS = (
+    re.compile(r"(?i)\b(?:i\s+will|i['’]ll|i\s+am\s+going\s+to|i['’]m\s+going\s+to)\b"),
+    re.compile(r"(?i)\b(?:done|fixed|implemented|completed|verified|tests?\s+pass(?:ed)?|run\s+the\s+tests|open(?:ed)?\s+a\s+pr)\b"),
+)
+
+
+def _clamp_int(value: Any, default: int, *, minimum: int, maximum: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = default
+    return max(minimum, min(parsed, maximum))
+
+
+def _normalize_phrase(text: str) -> str:
+    normalized = str(text or "").lower().replace("’", "'").replace("‘", "'")
+    normalized = normalized.replace("'", "")
+    return _CANNED_NORMALIZE_RE.sub(" ", normalized).strip()
+
+
+def _word_count(text: str) -> int:
+    return len(_WORD_RE.findall(text or ""))
+
+
+def _unsafe_raw_context_reason(text: str) -> str | None:
+    original = str(text or "")
+    checks: tuple[tuple[str, re.Pattern[str]], ...] = (
+        ("secret_like", _SECRET_RE),
+        ("secret_like", _SECRET_KEYWORD_VALUE_RE),
+        ("env_secret", _ENV_SECRET_RE),
+        ("private_key", _PRIVATE_KEY_RE),
+        ("private_key", _PRIVATE_KEY_HEADER_RE),
+        ("jwt_like", _JWT_RE),
+        ("raw_path", _RAW_PATH_RE),
+        ("file_ref", _FILE_REF_RE),
+        ("relative_path", _RELATIVE_PATH_RE),
+        ("url", _URL_RE),
+        ("media", _MEDIA_TAG_RE),
+        ("code_or_log", _CODE_OR_LOG_RE),
+        ("code_or_log", _UNFENCED_CODE_LINE_RE),
+        ("code_or_log", _INLINE_CODE_RE),
+        ("code_or_log", _BACKTICK_TEXT_RE),
+        ("code_or_log", _SQL_SNIPPET_RE),
+        ("code_or_log", _SHELL_SNIPPET_RE),
+        ("code_or_log", _TIMESTAMP_LOG_RE),
+        ("code_or_log", _BRACKET_LOG_RE),
+    )
+    for reason, pattern in checks:
+        if pattern.search(original):
+            return reason
+    return None
+
+
+def _sanitize_prompt_user_message(text: str, *, limit: int | None = None) -> str:
+    """Return bounded provider-prompt context with no raw secrets/paths/logs.
+
+    Candidate validation protects what we publish. This protects what we send to
+    the acknowledgement generator itself: raw user turns may contain credentials,
+    local paths, pasted logs, code, or media tags. Any unsafe evidence makes this
+    fail closed to a coarse placeholder rather than a partially redacted prompt.
+    """
+    original = str(text or "")
+    if _unsafe_raw_context_reason(original):
+        return "User asked about technical content; sensitive details omitted."
+    redacted = re.sub(r"\s+", " ", original).strip()
+    if limit is not None and len(redacted) > limit:
+        redacted = redacted[: limit - 1].rstrip() + "…"
+    if not redacted:
+        return "User asked for voice assistance."
+    return redacted
+
+
+def _safe_policy_metadata(decision: Any) -> dict[str, Any]:
+    classifiers = getattr(decision, "classifiers", {}) or {}
+    return {
+        "allowed": bool(getattr(decision, "allowed", False)),
+        "sanitized": bool(getattr(decision, "sanitized", False)),
+        "truncated": bool(getattr(decision, "truncated", False)),
+        "suppressed": bool(getattr(decision, "suppressed", False)),
+        "reason_codes": [str(r) for r in (getattr(decision, "reasons", ()) or ()) if re.fullmatch(r"[a-z][a-z0-9_]{0,63}", str(r))],
+        "rule_profile": str(getattr(decision, "rule_profile", "living_room_default") or "living_room_default"),
+        "classifiers": {
+            "code": bool(classifiers.get("code")),
+            "command_log": bool(classifiers.get("command_log")),
+            "raw_path": bool(classifiers.get("raw_path")),
+            "secret_like": bool(classifiers.get("secret_like")),
+            "sensitive_topic": bool(classifiers.get("sensitive_topic")),
+            "stack_trace": bool(classifiers.get("stack_trace")),
+        },
+    }
+
+
+@dataclass(frozen=True)
+class AckContext:
+    user_message: str
+    session_id: str | None = None
+    platform: str | None = None
+    chat_id: str | None = None
+    channel_id: str | None = None
+    thread_id: str | None = None
+    source_message_id: str | None = None
+    input_modality: str | None = None
+    output_device: str | None = None
+    voice_profile: str = "eon"
+    timeout_ms: int = _DEFAULT_TIMEOUT_MS
+    max_words: int = _DEFAULT_MAX_WORDS
+    max_spoken_chars: int = _DEFAULT_MAX_SPOKEN_CHARS
+    max_seconds: int = _DEFAULT_MAX_SECONDS
+    context_window_chars: int = 500
+    config_scope: str = "living_room_default"
+    explicit_spoken_request: bool = False
+    is_private_context: bool = False
+
+    def bounded_user_message(self) -> str:
+        limit = _clamp_int(self.context_window_chars, 500, minimum=80, maximum=2000)
+        text = re.sub(r"\s+", " ", str(self.user_message or "")).strip()
+        if len(text) > limit:
+            return text[: limit - 1].rstrip() + "…"
+        return text
+
+
+@dataclass(frozen=True)
+class GeneratedAckResult:
+    text: str
+    method: AckMethod
+    reason: str | None = None
+    elapsed_ms: int = 0
+    policy: dict[str, Any] = field(default_factory=dict)
+
+
+class GeneratedAckHarness:
+    """Generate and validate one voice-only acknowledgement, or return silence."""
+
+    def __init__(
+        self,
+        generator: AckGenerator | None = None,
+        *,
+        mode: str = "generated",
+        ambient_policy: AmbientVoicePolicy | None = None,
+    ) -> None:
+        self.generator = generator
+        self.mode = "off" if str(mode or "generated").strip().lower() == "off" else "generated"
+        self.ambient_policy = ambient_policy or _AMBIENT_POLICY
+
+    def build_prompt(self, context: AckContext) -> str:
+        return GENERATED_ACK_PROMPT_CONTRACT.format(
+            max_words=_clamp_int(context.max_words, _DEFAULT_MAX_WORDS, minimum=1, maximum=20),
+            user_message=_sanitize_prompt_user_message(
+                context.user_message,
+                limit=_clamp_int(context.context_window_chars, 500, minimum=80, maximum=2000),
+            ),
+        )
+
+    def generate(self, context: AckContext) -> GeneratedAckResult:
+        started = time.perf_counter()
+
+        def silence(reason: str, policy: dict[str, Any] | None = None) -> GeneratedAckResult:
+            return GeneratedAckResult(
+                text="",
+                method="silence",
+                reason=reason,
+                elapsed_ms=max(0, int((time.perf_counter() - started) * 1000)),
+                policy=policy or {},
+            )
+
+        if self.mode == "off":
+            return silence("off")
+        if self.generator is None:
+            return silence("no_generator")
+
+        timeout_ms = _clamp_int(context.timeout_ms, _DEFAULT_TIMEOUT_MS, minimum=1, maximum=1500)
+        prompt = self.build_prompt(context)
+        if not _GENERATOR_SLOTS.acquire(blocking=False):
+            return silence("generated_saturated")
+        future = _GENERATOR_EXECUTOR.submit(self.generator, prompt, timeout_ms=timeout_ms)
+
+        def release_slot(_future: Any) -> None:
+            try:
+                _GENERATOR_SLOTS.release()
+            except ValueError:
+                pass
+
+        future.add_done_callback(release_slot)
+        try:
+            raw = future.result(timeout=timeout_ms / 1000)
+        except TimeoutError:
+            future.cancel()
+            return silence("generated_timeout")
+        except Exception:
+            return silence("generated_error")
+
+        candidate = str(raw or "").strip().strip('"“”')
+        valid, reason = self.validate_generated_ack(candidate, context)
+        if not valid:
+            return silence(reason or "generated_invalid")
+
+        decision = self.ambient_policy.evaluate(
+            candidate,
+            AmbientVoiceContext(
+                source="ack",
+                platform=context.platform,
+                channel_id=context.channel_id,
+                chat_id=context.chat_id,
+                thread_id=context.thread_id,
+                source_message_id=context.source_message_id,
+                input_modality=context.input_modality,
+                output_device=context.output_device,
+                profile=context.voice_profile,
+                explicit_spoken_request=context.explicit_spoken_request,
+                is_private_context=context.is_private_context,
+                config_scope=context.config_scope,
+            ),
+        )
+        policy = _safe_policy_metadata(decision)
+        if not getattr(decision, "allowed", False) or not str(getattr(decision, "text", "") or "").strip():
+            return silence("ambient_policy_denied", policy)
+
+        approved = str(decision.text).strip()
+        return GeneratedAckResult(
+            text=approved,
+            method="generated",
+            reason=None,
+            elapsed_ms=max(0, int((time.perf_counter() - started) * 1000)),
+            policy=policy,
+        )
+
+    def validate_generated_ack(self, candidate: str, context: AckContext) -> tuple[bool, str | None]:
+        text = str(candidate or "").strip()
+        if not text:
+            return False, "generated_invalid: empty"
+        max_chars = _clamp_int(context.max_spoken_chars, _DEFAULT_MAX_SPOKEN_CHARS, minimum=1, maximum=240)
+        if len(text) > max_chars:
+            return False, "generated_invalid: too_many_chars"
+        if _word_count(text) > _clamp_int(context.max_words, _DEFAULT_MAX_WORDS, minimum=1, maximum=20):
+            return False, "generated_invalid: too_many_words"
+        # Multiple sentence terminators usually means it is no longer an acknowledgement.
+        if len(_SENTENCE_END_RE.findall(text)) > 1:
+            return False, "generated_invalid: multiple_sentences"
+        normalized = _normalize_phrase(text)
+        if normalized in _CANNED_PHRASES:
+            return False, "generated_invalid: canned_phrase"
+        if any(pattern.search(text) for pattern in _GENERIC_PATTERNS):
+            return False, "generated_invalid: generic_assistant_language"
+        if any(pattern.search(text) for pattern in _PROMISE_PATTERNS):
+            return False, "generated_invalid: completion_promise"
+        if _SECRET_RE.search(text):
+            return False, "generated_invalid: secret_like"
+        unsafe_reason = _unsafe_raw_context_reason(text)
+        if unsafe_reason:
+            return False, f"generated_invalid: {unsafe_reason}"
+        return True, None

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2146,12 +2146,43 @@ class BasePlatformAdapter(ABC):
             text = f"{caption}\n{text}"
         return await self.send(chat_id=chat_id, content=text, reply_to=reply_to, metadata=metadata)
 
-    def prepare_tts_text(self, text: str) -> str:
-        """Prepare text for TTS. Override to filter tool output, code, etc.
+    def prepare_tts_text(
+        self,
+        text: str,
+        *,
+        chat_id: str | None = None,
+        thread_id: str | None = None,
+        source_message_id: str | None = None,
+        explicit_spoken_request: bool = True,
+        is_private_context: bool = False,
+        output_device: str = "chat_attachment",
+        rule_profile: str = "chat_attachment",
+    ) -> str:
+        """Return policy-approved text for TTS, or ``""`` to suppress speech.
 
-        Default strips markdown formatting and truncates to 4000 chars.
+        ``/voice on|tts`` decides whether auto-TTS is preferred for the chat;
+        this method is the safety gate that decides whether a particular
+        response is safe to synthesize.  It intentionally returns a separate
+        sanitized speech string so the platform text response remains unchanged.
         """
-        return re.sub(r'[*_`#\[\]()]', '', text)[:4000].strip()
+        from gateway.ambient_voice_policy import AmbientVoicePolicy, VoiceContext
+
+        decision = AmbientVoicePolicy().evaluate(
+            str(text or ""),
+            VoiceContext(
+                source="auto_tts_reply",
+                platform=_platform_name(getattr(self, "platform", None)),
+                chat_id=chat_id,
+                thread_id=thread_id,
+                source_message_id=source_message_id,
+                input_modality="voice",
+                output_device=output_device,
+                explicit_spoken_request=explicit_spoken_request,
+                is_private_context=is_private_context,
+                config_scope=rule_profile,
+            ),
+        )
+        return decision.text if decision.allowed and decision.text else ""
 
     async def play_tts(
         self,
@@ -3497,14 +3528,20 @@ class BasePlatformAdapter(ABC):
                         from tools.tts_tool import text_to_speech_tool, check_tts_requirements
                         if check_tts_requirements():
                             import json as _json
-                            speech_text = self.prepare_tts_text(text_content)
-                            if not speech_text:
-                                raise ValueError("Empty text after markdown cleanup")
-                            tts_result_str = await asyncio.to_thread(
-                                text_to_speech_tool, text=speech_text
+                            speech_text = self.prepare_tts_text(
+                                text_content,
+                                chat_id=event.source.chat_id,
+                                thread_id=getattr(event.source, "thread_id", None),
+                                source_message_id=getattr(event, "message_id", None),
                             )
-                            tts_data = _json.loads(tts_result_str)
-                            _tts_path = tts_data.get("file_path")
+                            if not speech_text:
+                                logger.debug("[%s] Auto-TTS suppressed by ambient voice policy", self.name)
+                            else:
+                                tts_result_str = await asyncio.to_thread(
+                                    text_to_speech_tool, text=speech_text
+                                )
+                                tts_data = _json.loads(tts_result_str)
+                                _tts_path = tts_data.get("file_path")
                     except Exception as tts_err:
                         logger.warning("[%s] Auto-TTS failed: %s", self.name, tts_err)
 

--- a/gateway/pulse_voice_events.py
+++ b/gateway/pulse_voice_events.py
@@ -247,7 +247,7 @@ def _safe_summarizer_metadata(value: Any) -> dict[str, Any] | None:
     if not isinstance(value, dict):
         return None
     allowed: dict[str, Any] = {}
-    for key in ("mode", "method", "fallback", "validation_reason"):
+    for key in ("mode", "method", "fallback", "validation_reason", "reason"):
         safe = _safe_metadata_string(value.get(key), enum=True)
         if safe is not None:
             allowed[key] = safe
@@ -426,7 +426,9 @@ def summarize_final_voice_response(
 
 
     if result.reason:
-        summarizer_meta["reason"] = result.reason
+        reason_code = re.sub(r"[^A-Za-z0-9_-]+", "_", result.reason).strip("_")
+        if reason_code:
+            summarizer_meta["reason"] = reason_code
 
     summary_policy = sanitize_voice_text(result.text).policy if result.text else _default_policy()
     summary_policy.update(result.policy)

--- a/gateway/pulse_voice_events.py
+++ b/gateway/pulse_voice_events.py
@@ -215,6 +215,77 @@ def _policy_metadata_from_decision(
     return policy
 
 
+_SAFE_METADATA_KEYS = {
+    "session_id",
+    "platform",
+    "chat_id",
+    "channel_id",
+    "thread_id",
+    "source_message_id",
+    "input_modality",
+    "output_device",
+    "config_scope",
+    "explicit_spoken_request",
+    "is_private_context",
+    "summarizer",
+}
+_SAFE_METADATA_STRING_RE = re.compile(r"^[A-Za-z0-9_.:@#-]{1,128}$")
+_SAFE_ENUM_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_-]{0,63}$")
+
+
+def _safe_metadata_string(value: Any, *, enum: bool = False) -> str | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    pattern = _SAFE_ENUM_RE if enum else _SAFE_METADATA_STRING_RE
+    if pattern.fullmatch(text) and not _SECRET_RE.search(text) and not _PATH_RE.search(text):
+        return text
+    return None
+
+
+def _safe_summarizer_metadata(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    allowed: dict[str, Any] = {}
+    for key in ("mode", "method", "fallback", "validation_reason"):
+        safe = _safe_metadata_string(value.get(key), enum=True)
+        if safe is not None:
+            allowed[key] = safe
+    for key in ("fallback_used", "validation_failed"):
+        if key in value:
+            allowed[key] = bool(value.get(key))
+    if "timeout_ms" in value:
+        try:
+            allowed["timeout_ms"] = max(1, min(int(value.get("timeout_ms") or 0), 10000))
+        except (TypeError, ValueError):
+            pass
+    return allowed or None
+
+
+def _safe_voice_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
+    """Return allowlisted Pulse metadata with no raw content/debug passthrough."""
+    safe: dict[str, Any] = {}
+    for key in _SAFE_METADATA_KEYS:
+        if key not in metadata or metadata[key] is None:
+            continue
+        value = metadata[key]
+        if key in {"explicit_spoken_request", "is_private_context"}:
+            safe[key] = bool(value)
+        elif key == "summarizer":
+            summarizer = _safe_summarizer_metadata(value)
+            if summarizer:
+                safe[key] = summarizer
+        elif key in {"platform", "input_modality", "output_device", "config_scope"}:
+            safe_value = _safe_metadata_string(value, enum=True)
+            if safe_value is not None:
+                safe[key] = safe_value
+        else:
+            safe_value = _safe_metadata_string(value)
+            if safe_value is not None:
+                safe[key] = safe_value
+    return safe
+
+
 def _final_summary_config() -> dict[str, Any]:
     """Load pulse.voice.final_summary with conservative defaults.
 
@@ -426,18 +497,29 @@ def publish_voice_out(kind: str, text: str, **metadata: Any) -> None:
             policy = _policy_metadata_from_decision(decision, merged_policy)
         else:
             policy = _policy_metadata_from_decision(decision, sanitized.policy)
+        safe_metadata = _safe_voice_metadata(metadata)
+        try:
+            requested_max_seconds = int(metadata.pop("max_seconds", decision.max_seconds or default_seconds) or default_seconds)
+        except (TypeError, ValueError):
+            requested_max_seconds = int(decision.max_seconds or default_seconds)
         event = {
             "id": f"{time.time_ns()}",
             "ts": time.time(),
             "schema_version": 2,
             "kind": kind,
             "text": decision.text,
-            "max_seconds": int(metadata.pop("max_seconds", decision.max_seconds or default_seconds) or default_seconds),
-            "source": metadata.pop("source", kind),
-            "derived_from": metadata.pop("derived_from", "pulse_voice_candidate"),
-            "voice_profile": metadata.pop("voice_profile", context.profile or "eon"),
+            "max_seconds": max(1, min(requested_max_seconds, 30)),
+            "source": _safe_metadata_string(metadata.pop("source", kind), enum=True) or kind,
+            "derived_from": _safe_metadata_string(
+                metadata.pop("derived_from", "pulse_voice_candidate"),
+                enum=True,
+            ) or "pulse_voice_candidate",
+            "voice_profile": _safe_metadata_string(
+                metadata.pop("voice_profile", context.profile or "eon"),
+                enum=True,
+            ) or "eon",
             "policy": policy,
-            **{k: v for k, v in metadata.items() if v is not None},
+            **safe_metadata,
         }
         canonical = voice_out_path()
         legacy = voice_events_path()
@@ -459,16 +541,12 @@ def publish_completion_voice_out(
     **metadata: Any,
 ) -> None:
     """Publish a short spoken completion derived from executor final text."""
-    result = summarize_final_voice_response(final_response, summarizer=summarizer)
-    publish_voice_out(
-        result.kind,
-        result.text,
-        source=result.source,
-        derived_from=result.derived_from,
-        voice_profile=result.voice_profile,
-        summarizer=result.summarizer,
-        policy=result.policy,
-        **metadata,
+    from gateway.voice_response_pipeline import VoiceContext, VoiceResponsePipeline
+
+    VoiceResponsePipeline().publish_final_response(
+        final_response,
+        VoiceContext.from_metadata(**metadata),
+        summarizer=summarizer,
     )
 
 
@@ -479,8 +557,6 @@ def publish_voice_event(kind: str, text: str, **metadata: Any) -> None:
     ``commentary`` maps to a short ``progress`` voice-out event only when the
     model actually generated that assistant text.
     """
-    legacy_kind = str(kind or "").strip().lower()
-    if legacy_kind == "delta":
-        return
-    mapped = "progress" if legacy_kind == "commentary" else legacy_kind
-    publish_voice_out(mapped, text, **metadata)
+    from gateway.voice_response_pipeline import VoiceContext, VoiceResponsePipeline
+
+    VoiceResponsePipeline().publish_legacy_event(kind, text, VoiceContext.from_metadata(**metadata))

--- a/gateway/pulse_voice_events.py
+++ b/gateway/pulse_voice_events.py
@@ -16,6 +16,7 @@ import re
 import threading
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Callable
 
 from hermes_constants import get_hermes_home
@@ -79,9 +80,13 @@ _DEFAULT_GENERATED_ACK_CONFIG = {
     "model": None,
     "silence_on_failure": True,
 }
+_DEFAULT_VOICE_OBSERVABILITY_CONFIG = {
+    "emit_suppressed_events": True,
+    "include_candidate_counts": True,
+}
 _STACK_TRACE_RE = re.compile(r"(?is)^\s*Traceback \(most recent call last\):.*")
 _SENSITIVE_TOPIC_RE = re.compile(r"(?i)\b(?:trading\s+pnl|portfolio\s+exposure)\b")
-_AMBIENT_POLICY = AmbientVoicePolicy()
+_AMBIENT_POLICY: AmbientVoicePolicy | None = None
 
 
 @dataclass(frozen=True)
@@ -120,6 +125,29 @@ def voice_events_path() -> Path:
     return get_hermes_home() / "pulse" / "voice-events.jsonl"
 
 
+def is_voice_event_fresh_for_speech(
+    event: dict[str, Any],
+    *,
+    now: float | None = None,
+    max_age_seconds: float = 30.0,
+) -> bool:
+    """Return whether a voice-out event is fresh enough to auto-speak.
+
+    Missing, non-numeric, future-skewed, or stale timestamps are observability
+    only. Consumers should require this before triggering ambient room audio.
+    """
+    try:
+        raw_ts = event.get("ts")
+        if raw_ts is None:
+            return False
+        ts = float(raw_ts)
+        age = (time.time() if now is None else float(now)) - ts
+        max_age = max(0.0, float(max_age_seconds))
+    except (TypeError, ValueError):
+        return False
+    return 0 <= age <= max_age
+
+
 def _default_policy() -> dict[str, Any]:
     return {
         "allowed": True,
@@ -135,6 +163,7 @@ def _default_policy() -> dict[str, Any]:
             "blocked_secret_like": False,
             "blocked_sensitive_topic": False,
             "blocked_stack_trace": False,
+            "long_response": False,
         },
     }
 
@@ -153,7 +182,7 @@ def _ambient_context(kind: str, metadata: dict[str, Any]) -> AmbientVoiceContext
         profile=metadata.get("voice_profile") or metadata.get("profile") or "eon",
         explicit_spoken_request=bool(metadata.get("explicit_spoken_request", False)),
         is_private_context=bool(metadata.get("is_private_context", False)),
-        config_scope=str(metadata.get("config_scope") or "living_room_default"),
+        config_scope=metadata.get("config_scope"),
     )
 
 
@@ -184,6 +213,7 @@ def _policy_metadata_from_decision(
             "blocked_secret_like": ("blocked_secret_like", "secret_like"),
             "blocked_sensitive_topic": ("blocked_sensitive_topic", "sensitive_topic"),
             "blocked_stack_trace": ("blocked_stack_trace", "stack_trace"),
+            "long_response": ("long_response",),
         }
         for safe_key, aliases in classifier_aliases.items():
             policy["classifiers"][safe_key] = any(bool(base_classifiers.get(alias)) for alias in aliases)
@@ -224,6 +254,7 @@ def _policy_metadata_from_decision(
                 policy["classifiers"].get("blocked_sensitive_topic") or classifiers.get("sensitive_topic")
             ),
             "blocked_stack_trace": bool(policy["classifiers"].get("blocked_stack_trace") or classifiers.get("stack_trace")),
+            "long_response": bool(policy["classifiers"].get("long_response") or classifiers.get("long_response")),
         }
     )
     return policy
@@ -356,6 +387,56 @@ def _generated_ack_config() -> dict[str, Any]:
     except Exception:
         pass
     return config
+
+
+def _bool_config(value: Any, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    normalized = str(value).strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    return default
+
+
+def _voice_observability_config() -> dict[str, Any]:
+    """Load safe Pulse voice observability knobs."""
+    raw = dict(_DEFAULT_VOICE_OBSERVABILITY_CONFIG)
+    try:
+        from hermes_cli.config import load_config
+
+        loaded = load_config() or {}
+        pulse_voice = ((loaded.get("pulse") or {}).get("voice") or {}) if isinstance(loaded, dict) else {}
+        user_config = pulse_voice.get("observability") or {}
+        if isinstance(user_config, dict):
+            raw.update({k: v for k, v in user_config.items() if v is not None})
+    except Exception:
+        pass
+    return {
+        "emit_suppressed_events": _bool_config(
+            raw.get("emit_suppressed_events"),
+            _DEFAULT_VOICE_OBSERVABILITY_CONFIG["emit_suppressed_events"],
+        ),
+        "include_candidate_counts": _bool_config(
+            raw.get("include_candidate_counts"),
+            _DEFAULT_VOICE_OBSERVABILITY_CONFIG["include_candidate_counts"],
+        ),
+    }
+
+
+def _ambient_policy() -> AmbientVoicePolicy:
+    """Return config-loaded ambient policy while preserving test monkeypatch hook."""
+    if _AMBIENT_POLICY is not None:
+        return _AMBIENT_POLICY
+    try:
+        from hermes_cli.config import load_config
+
+        return AmbientVoicePolicy.from_config(load_config() or {})
+    except Exception:
+        return AmbientVoicePolicy()
 
 
 class _ProviderAckGenerator:
@@ -576,6 +657,93 @@ def _write_event(path: Path, event: dict[str, Any]) -> None:
         fh.write(line)
 
 
+def _write_voice_event(event: dict[str, Any]) -> None:
+    canonical = voice_out_path()
+    legacy = voice_events_path()
+    canonical.parent.mkdir(parents=True, exist_ok=True)
+    with _LOCK:
+        _write_event(canonical, event)
+        # Compatibility mirror for older Aegis builds; same canonical schema,
+        # not raw delta/commentary.
+        if legacy != canonical:
+            _write_event(legacy, event)
+
+
+def _observability_metadata(
+    *,
+    original_chars: int,
+    spoken_text: str,
+    decision: Any,
+    stage: str,
+    include_candidate_counts: bool = True,
+) -> dict[str, Any]:
+    reason_aliases = {
+        "empty_after_sanitization": "empty_after_sanitize",
+        "secret_like": "secret_like_blocked",
+        "sensitive_topic": "sensitive_topic_blocked",
+        "stack_trace": "stack_trace_blocked",
+        "command_log": "tool_log_blocked",
+    }
+    blocked_reasons = {
+        "secret_like_blocked",
+        "sensitive_topic_blocked",
+        "stack_trace_blocked",
+        "tool_log_blocked",
+        "empty_after_sanitize",
+    }
+    suppression_reason = None
+    for reason in list(getattr(decision, "reasons", ()) or []):
+        mapped = _safe_reason_code(reason_aliases.get(str(reason), str(reason)))
+        if mapped in blocked_reasons:
+            suppression_reason = mapped
+            break
+    observability = {
+        "policy_stage": _safe_metadata_string(stage, enum=True) or "candidate",
+        "suppression_reason": suppression_reason if getattr(decision, "suppressed", False) else None,
+    }
+    if include_candidate_counts:
+        observability.update(
+            {
+                "candidate_chars": max(0, int(original_chars or 0)),
+                "spoken_chars": len(str(spoken_text or "")),
+            }
+        )
+    return observability
+
+
+def _base_voice_event(
+    *,
+    kind: str,
+    text: str,
+    max_seconds: int,
+    policy: dict[str, Any],
+    observability: dict[str, Any],
+    metadata: dict[str, Any],
+    context: AmbientVoiceContext,
+) -> dict[str, Any]:
+    safe_metadata = _safe_voice_metadata(metadata)
+    return {
+        "id": f"{time.time_ns()}",
+        "ts": time.time(),
+        "schema_version": 2,
+        "kind": kind,
+        "text": text,
+        "max_seconds": max(0, min(int(max_seconds or 0), 30)),
+        "source": _safe_metadata_string(metadata.get("source", kind), enum=True) or kind,
+        "derived_from": _safe_metadata_string(
+            metadata.get("derived_from", "pulse_voice_candidate"),
+            enum=True,
+        ) or "pulse_voice_candidate",
+        "voice_profile": _safe_metadata_string(
+            metadata.get("voice_profile", context.profile or "eon"),
+            enum=True,
+        ) or "eon",
+        "policy": policy,
+        "observability": observability,
+        **safe_metadata,
+    }
+
+
 def publish_voice_out(kind: str, text: str, **metadata: Any) -> None:
     """Append a canonical voice-out event for local Pulse/Aegis subscribers.
 
@@ -587,16 +755,14 @@ def publish_voice_out(kind: str, text: str, **metadata: Any) -> None:
     kind = str(kind or "progress").strip().lower()
     if kind not in _ALLOWED_KINDS:
         kind = "progress"
-    sanitized = sanitize_voice_text(text)
-    if not sanitized.text:
-        return
     try:
+        original = str(text or "")
+        sanitized = sanitize_voice_text(original)
         context = _ambient_context(kind, metadata)
-        decision = _AMBIENT_POLICY.evaluate(sanitized.text, context)
-        if not decision.allowed or not decision.text:
-            return
         default_seconds = 2 if kind in {"ack", "progress"} else 4
-        base_policy = metadata.pop("policy", None)
+        stage = "final" if kind in {"completion", "question", "error"} else kind
+        base_policy = metadata.get("policy")
+
         if isinstance(base_policy, dict):
             merged_policy = dict(sanitized.policy)
             merged_policy.update({k: v for k, v in base_policy.items() if k not in {"reason_codes", "classifiers"}})
@@ -606,42 +772,83 @@ def publish_voice_out(kind: str, text: str, **metadata: Any) -> None:
             merged_classifiers = dict(sanitized.policy.get("classifiers") or {})
             merged_classifiers.update(base_policy.get("classifiers") or {})
             merged_policy["classifiers"] = merged_classifiers
+        else:
+            merged_policy = sanitized.policy
+
+        # The first-pass sanitizer enforces hard no-speak rules for secret-like
+        # text, stack traces, and empty-after-sanitize candidates. Never let the
+        # contextual ambient policy turn those back into speakable output.
+        if not sanitized.policy.get("allowed", True) or not sanitized.text:
+            classifiers = sanitized.policy.get("classifiers") or {}
+            decision = SimpleNamespace(
+                allowed=False,
+                text="",
+                sanitized=bool(sanitized.policy.get("sanitized", True)),
+                truncated=bool(sanitized.policy.get("truncated", False)),
+                suppressed=True,
+                max_seconds=0,
+                reasons=tuple(sanitized.policy.get("reason_codes") or ("empty_after_sanitize",)),
+                classifiers={
+                    "code": bool(classifiers.get("dropped_code")),
+                    "command_log": bool(classifiers.get("dropped_tool_logs")),
+                    "raw_path": bool(classifiers.get("dropped_paths")),
+                    "secret_like": bool(classifiers.get("blocked_secret_like")),
+                    "sensitive_topic": bool(classifiers.get("blocked_sensitive_topic")),
+                    "stack_trace": bool(classifiers.get("blocked_stack_trace")),
+                    "long_response": bool(classifiers.get("long_response")),
+                },
+                rule_profile=context.config_scope or "living_room_default",
+            )
             policy = _policy_metadata_from_decision(decision, merged_policy)
         else:
-            policy = _policy_metadata_from_decision(decision, sanitized.policy)
-        safe_metadata = _safe_voice_metadata(metadata)
+            decision = _ambient_policy().evaluate(sanitized.text, context)
+            policy = _policy_metadata_from_decision(decision, merged_policy)
+
+        observability_config = _voice_observability_config()
+        if not decision.allowed or not decision.text:
+            if not observability_config.get("emit_suppressed_events", True):
+                return
+            policy["allowed"] = False
+            policy["suppressed"] = True
+            event = _base_voice_event(
+                kind="suppressed",
+                text="",
+                max_seconds=0,
+                policy=policy,
+                observability=_observability_metadata(
+                    original_chars=len(original),
+                    spoken_text="",
+                    decision=decision,
+                    stage=stage,
+                    include_candidate_counts=observability_config.get("include_candidate_counts", True),
+                ),
+                metadata=metadata,
+                context=context,
+            )
+            event["max_seconds"] = 0
+            _write_voice_event(event)
+            return
+
         try:
-            requested_max_seconds = int(metadata.pop("max_seconds", decision.max_seconds or default_seconds) or default_seconds)
+            requested_max_seconds = int(metadata.get("max_seconds", decision.max_seconds or default_seconds) or default_seconds)
         except (TypeError, ValueError):
             requested_max_seconds = int(decision.max_seconds or default_seconds)
-        event = {
-            "id": f"{time.time_ns()}",
-            "ts": time.time(),
-            "schema_version": 2,
-            "kind": kind,
-            "text": decision.text,
-            "max_seconds": max(1, min(requested_max_seconds, 30)),
-            "source": _safe_metadata_string(metadata.pop("source", kind), enum=True) or kind,
-            "derived_from": _safe_metadata_string(
-                metadata.pop("derived_from", "pulse_voice_candidate"),
-                enum=True,
-            ) or "pulse_voice_candidate",
-            "voice_profile": _safe_metadata_string(
-                metadata.pop("voice_profile", context.profile or "eon"),
-                enum=True,
-            ) or "eon",
-            "policy": policy,
-            **safe_metadata,
-        }
-        canonical = voice_out_path()
-        legacy = voice_events_path()
-        canonical.parent.mkdir(parents=True, exist_ok=True)
-        with _LOCK:
-            _write_event(canonical, event)
-            # Compatibility mirror for older Aegis builds; same canonical schema,
-            # not raw delta/commentary.
-            if legacy != canonical:
-                _write_event(legacy, event)
+        event = _base_voice_event(
+            kind=kind,
+            text=decision.text,
+            max_seconds=max(1, min(requested_max_seconds, 30)),
+            policy=policy,
+            observability=_observability_metadata(
+                original_chars=len(original),
+                spoken_text=decision.text,
+                decision=decision,
+                stage=stage,
+                include_candidate_counts=observability_config.get("include_candidate_counts", True),
+            ),
+            metadata=metadata,
+            context=context,
+        )
+        _write_voice_event(event)
     except Exception:
         return
 

--- a/gateway/pulse_voice_events.py
+++ b/gateway/pulse_voice_events.py
@@ -1,9 +1,8 @@
-"""Best-effort local voice event bridge for Pulse/Aegis.
+"""Best-effort local voice-out bridge for Pulse/Aegis.
 
-The messaging gateway streams assistant deltas/commentary to platform adapters,
-but those interim chunks are not persisted in ``state.db`` until a turn finishes.
-Aegis needs the live chunks to speak Jarvis-style acknowledgements immediately,
-so this module appends sanitized JSONL events under ``$HERMES_HOME/pulse``.
+Aegis must not speak raw executor output.  The gateway publishes only short,
+purpose-built voice UX events to ``$HERMES_HOME/pulse/voice-out.jsonl`` and
+Aegis consumes that file/SSE stream for TTS.
 
 This is intentionally best-effort: failures must never affect chat delivery.
 """
@@ -12,6 +11,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import threading
 import time
 from pathlib import Path
@@ -21,6 +21,13 @@ from hermes_constants import get_hermes_home
 
 _LOCK = threading.Lock()
 _MAX_BYTES = 2_000_000
+_MAX_TEXT_CHARS = 180
+_ALLOWED_KINDS = {"ack", "completion", "error", "question", "progress"}
+_MEDIA_RE = re.compile(r"MEDIA:\S+")
+_DIRECTIVE_RE = re.compile(r"\[\[[^\]]+\]\]")
+_CODE_FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`([^`]{1,120})`")
+_MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\([^\)]+\)")
 
 
 def _enabled() -> bool:
@@ -28,7 +35,17 @@ def _enabled() -> bool:
     return value not in {"0", "false", "no", "off"}
 
 
+def voice_out_path() -> Path:
+    """Return the canonical Jarvis-style voice-out JSONL path."""
+    return get_hermes_home() / "pulse" / "voice-out.jsonl"
+
+
 def voice_events_path() -> Path:
+    """Return the legacy voice-events JSONL path.
+
+    Kept as a compatibility mirror for older Aegis builds.  New consumers should
+    read :func:`voice_out_path`.
+    """
     return get_hermes_home() / "pulse" / "voice-events.jsonl"
 
 
@@ -37,7 +54,6 @@ def _trim_if_needed(path: Path) -> None:
         if not path.exists() or path.stat().st_size <= _MAX_BYTES:
             return
         data = path.read_bytes()[-(_MAX_BYTES // 2):]
-        # Start at the next newline so consumers never see a partial JSON row.
         first_newline = data.find(b"\n")
         if first_newline >= 0:
             data = data[first_newline + 1 :]
@@ -46,32 +62,107 @@ def _trim_if_needed(path: Path) -> None:
         return
 
 
-def publish_voice_event(kind: str, text: str, **metadata: Any) -> None:
-    """Append a voice event for local Pulse/Aegis subscribers.
+def _first_sentence(text: str) -> str:
+    match = re.match(r"^.{1,150}?[.!?。！？](?=\s|$)", text)
+    return match.group(0) if match else text
 
-    ``kind`` is usually ``delta`` or ``commentary``. ``text`` should already be
-    user-visible assistant text; empty/whitespace events are ignored.
+
+def voice_safe_text(text: str, *, max_chars: int = _MAX_TEXT_CHARS) -> str:
+    """Return short text safe enough to speak aloud.
+
+    This intentionally strips code blocks, media tags, markdown links, transport
+    directives, bullets/headings, and excess whitespace.  It then keeps only a
+    single bounded sentence so executor prose/logs cannot leak into room audio.
+    """
+    text = str(text or "")
+    text = _CODE_FENCE_RE.sub("", text)
+    text = _MEDIA_RE.sub("", text)
+    text = _DIRECTIVE_RE.sub("", text)
+    text = _MARKDOWN_LINK_RE.sub(r"\1", text)
+    text = _INLINE_CODE_RE.sub(r"\1", text)
+    text = re.sub(r"^[#>*\-•\s]+", "", text, flags=re.MULTILINE)
+    text = re.sub(r"\s+", " ", text).strip()
+    if not text:
+        return ""
+    text = _first_sentence(text).strip()
+    if len(text) > max_chars:
+        text = text[: max_chars - 1].rstrip(" ,.;:") + "…"
+    return text
+
+
+def completion_voice_text(final_response: str) -> tuple[str, str]:
+    """Derive a concise completion/question/error event from executor output."""
+    spoken = voice_safe_text(final_response)
+    if not spoken:
+        return "completion", "Done."
+    lowered = spoken.lower()
+    if lowered.startswith(("⚠", "error", "failed", "sorry")):
+        return "error", spoken
+    if "?" in spoken and len(spoken) <= 160:
+        return "question", spoken
+    if not lowered.startswith(("done", "finished", "completed", "created", "updated", "fixed")):
+        spoken = voice_safe_text(f"Done — {spoken}")
+    return "completion", spoken
+
+
+def _write_event(path: Path, event: dict[str, Any]) -> None:
+    line = json.dumps(event, ensure_ascii=False, separators=(",", ":")) + "\n"
+    _trim_if_needed(path)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(line)
+
+
+def publish_voice_out(kind: str, text: str, **metadata: Any) -> None:
+    """Append a canonical voice-out event for local Pulse/Aegis subscribers.
+
+    ``kind`` must be one of ``ack``, ``completion``, ``error``, ``question``, or
+    ``progress``.  ``text`` is sanitized and bounded here even if callers forget.
     """
     if not _enabled():
         return
-    text = str(text or "")
-    if not text.strip():
+    kind = str(kind or "progress").strip().lower()
+    if kind not in _ALLOWED_KINDS:
+        kind = "progress"
+    text = voice_safe_text(text)
+    if not text:
         return
     try:
-        path = voice_events_path()
-        path.parent.mkdir(parents=True, exist_ok=True)
         event = {
             "id": f"{time.time_ns()}",
             "ts": time.time(),
-            "kind": str(kind or "delta"),
+            "kind": kind,
             "text": text,
+            "max_seconds": int(metadata.pop("max_seconds", 4) or 4),
             **{k: v for k, v in metadata.items() if v is not None},
         }
-        line = json.dumps(event, ensure_ascii=False, separators=(",", ":")) + "\n"
+        canonical = voice_out_path()
+        legacy = voice_events_path()
+        canonical.parent.mkdir(parents=True, exist_ok=True)
         with _LOCK:
-            _trim_if_needed(path)
-            with path.open("a", encoding="utf-8") as fh:
-                fh.write(line)
+            _write_event(canonical, event)
+            # Compatibility mirror for older Aegis builds; same canonical schema,
+            # not raw delta/commentary.
+            if legacy != canonical:
+                _write_event(legacy, event)
     except Exception:
-        # Voice events are an observability side-channel; never break gateway.
         return
+
+
+def publish_completion_voice_out(final_response: str, **metadata: Any) -> None:
+    """Publish a short spoken completion derived from executor final text."""
+    kind, text = completion_voice_text(final_response)
+    publish_voice_out(kind, text, **metadata)
+
+
+def publish_voice_event(kind: str, text: str, **metadata: Any) -> None:
+    """Backward-compatible wrapper for older gateway call sites.
+
+    Raw streaming ``delta`` events are deliberately ignored.  Interim assistant
+    ``commentary`` maps to a short ``progress`` voice-out event because the
+    gateway publishes a dedicated turn-start ``ack`` separately.
+    """
+    legacy_kind = str(kind or "").strip().lower()
+    if legacy_kind == "delta":
+        return
+    mapped = "progress" if legacy_kind == "commentary" else legacy_kind
+    publish_voice_out(mapped, text, **metadata)

--- a/gateway/pulse_voice_events.py
+++ b/gateway/pulse_voice_events.py
@@ -9,15 +9,21 @@ This is intentionally best-effort: failures must never affect chat delivery.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import json
 import os
 import re
 import threading
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from hermes_constants import get_hermes_home
+from gateway.ambient_voice_policy import AmbientVoicePolicy, VoiceContext as AmbientVoiceContext
+from gateway.final_speech_summarizer import (
+    FinalSpeechSummarizer,
+    VoiceContext as FinalSpeechVoiceContext,
+)
 
 _LOCK = threading.Lock()
 _MAX_BYTES = 2_000_000
@@ -28,6 +34,57 @@ _DIRECTIVE_RE = re.compile(r"\[\[[^\]]+\]\]")
 _CODE_FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
 _INLINE_CODE_RE = re.compile(r"`([^`]{1,120})`")
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\([^\)]+\)")
+_PATH_RE = re.compile(r"(?<!\w)(?:[A-Za-z]:[\\/][^\s,;:)\]'\"]+|(?:~?/|/)[^\s,;:)\]'\"]+)")
+_FILE_REF_RE = re.compile(
+    r"(?<![\w/.-])(?:[\w.-]+/)*[\w.-]+\.(?:py|json|ya?ml|toml|md|txt|log|js|jsx|ts|tsx|css|html|sh|env)\b",
+    re.IGNORECASE,
+)
+_SECRET_RE = re.compile(
+    r"""
+    (?:
+        \b(?:bearer|authorization)\b\s*[:=]?\s+[A-Za-z0-9][A-Za-z0-9._~+/\-]{7,}
+      | \b(?:api[_ -]?key|secret(?:[_ -]?key)?|password|passwd|pwd|token|access[_ -]?key|aws[_ -]?key)\b
+        \s*(?:is|=|:)?\s+[A-Za-z0-9][A-Za-z0-9._~+/\-]{7,}
+      | \b(?:sk-[A-Za-z0-9._-]{6,}|sk-[A-Za-z0-9]{2,}\.\.\.[A-Za-z0-9]{2,}|gh[pousr]_[A-Za-z0-9_]{10,})\b
+      | \b(?:AKIA|ASIA)[A-Z0-9.]{10,}\b
+      | \bhk_[A-Za-z0-9._-]{10,}\b
+      | \b[a-z]{2,}_(?:test|live|prod|secret|key)_[A-Za-z0-9]{10,}\b
+      | \beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b
+    )
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+_TOOL_LOG_LINE_RE = re.compile(
+    r'(?m)^\s*(?:\$ .+|>>> .+|FAILED .+|Traceback .+|File "[^"]+", line \d+.*|E\s+.+|={5,}.*)$'
+)
+_DEFAULT_FINAL_SUMMARY_CONFIG = {
+    "mode": "hybrid",
+    "timeout_ms": 1000,
+    "max_spoken_chars": _MAX_TEXT_CHARS,
+    "voice_profile": "eon",
+    "fallback": "deterministic_sanitizer",
+    "on_empty": "silence",
+}
+_STACK_TRACE_RE = re.compile(r"(?is)^\s*Traceback \(most recent call last\):.*")
+_SENSITIVE_TOPIC_RE = re.compile(r"(?i)\b(?:trading\s+pnl|portfolio\s+exposure)\b")
+_AMBIENT_POLICY = AmbientVoicePolicy()
+
+
+@dataclass(frozen=True)
+class SanitizedVoiceText:
+    text: str
+    policy: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class FinalVoiceSummaryResult:
+    kind: str
+    text: str
+    source: str
+    derived_from: str
+    voice_profile: str
+    summarizer: dict[str, Any]
+    policy: dict[str, Any]
 
 
 def _enabled() -> bool:
@@ -49,6 +106,135 @@ def voice_events_path() -> Path:
     return get_hermes_home() / "pulse" / "voice-events.jsonl"
 
 
+def _default_policy() -> dict[str, Any]:
+    return {
+        "allowed": True,
+        "sanitized": True,
+        "truncated": False,
+        "suppressed": False,
+        "rule_profile": "living_room_default",
+        "reason_codes": [],
+        "classifiers": {
+            "dropped_code": False,
+            "dropped_tool_logs": False,
+            "dropped_paths": False,
+            "blocked_secret_like": False,
+            "blocked_sensitive_topic": False,
+            "blocked_stack_trace": False,
+        },
+    }
+
+
+def _ambient_context(kind: str, metadata: dict[str, Any]) -> AmbientVoiceContext:
+    """Build the deterministic ambient-policy context from safe event metadata."""
+    return AmbientVoiceContext(
+        source=str(kind or metadata.get("source") or "completion"),
+        platform=metadata.get("platform"),
+        channel_id=metadata.get("channel_id"),
+        chat_id=metadata.get("chat_id"),
+        thread_id=metadata.get("thread_id"),
+        source_message_id=metadata.get("source_message_id"),
+        input_modality=metadata.get("input_modality"),
+        output_device=metadata.get("output_device"),
+        profile=metadata.get("voice_profile") or metadata.get("profile") or "eon",
+        explicit_spoken_request=bool(metadata.get("explicit_spoken_request", False)),
+        is_private_context=bool(metadata.get("is_private_context", False)),
+        config_scope=str(metadata.get("config_scope") or "living_room_default"),
+    )
+
+
+def _safe_reason_code(reason: Any) -> str | None:
+    """Return a safe short reason code, never raw evidence/snippets."""
+    code = str(reason or "").strip()
+    if re.fullmatch(r"[a-z][a-z0-9_]{0,63}", code):
+        return code
+    return None
+
+
+def _policy_metadata_from_decision(
+    decision: Any,
+    base_policy: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Convert AmbientVoicePolicy decisions into the Pulse v2 safe metadata shape."""
+    policy = _default_policy()
+    base_reason_codes: list[Any] = []
+    if base_policy:
+        for key in ("allowed", "sanitized", "truncated", "suppressed", "rule_profile"):
+            if key in base_policy:
+                policy[key] = base_policy[key]
+        base_classifiers = base_policy.get("classifiers") or {}
+        classifier_aliases = {
+            "dropped_code": ("dropped_code", "code"),
+            "dropped_tool_logs": ("dropped_tool_logs", "command_log"),
+            "dropped_paths": ("dropped_paths", "raw_path"),
+            "blocked_secret_like": ("blocked_secret_like", "secret_like"),
+            "blocked_sensitive_topic": ("blocked_sensitive_topic", "sensitive_topic"),
+            "blocked_stack_trace": ("blocked_stack_trace", "stack_trace"),
+        }
+        for safe_key, aliases in classifier_aliases.items():
+            policy["classifiers"][safe_key] = any(bool(base_classifiers.get(alias)) for alias in aliases)
+        base_reason_codes = list(base_policy.get("reason_codes") or [])
+
+    reason_aliases = {
+        "raw_path_stripped": "path_stripped",
+        "raw_path": "path_stripped",
+        "empty_after_sanitization": "empty_after_sanitize",
+        "secret_like": "secret_like_blocked",
+        "sensitive_topic": "sensitive_topic_blocked",
+        "stack_trace": "stack_trace_blocked",
+    }
+    reason_codes: list[str] = []
+    for reason in base_reason_codes + list(getattr(decision, "reasons", ()) or ()):
+        mapped = _safe_reason_code(reason_aliases.get(str(reason), str(reason)))
+        if mapped and mapped not in reason_codes:
+            reason_codes.append(mapped)
+
+    classifiers = getattr(decision, "classifiers", {}) or {}
+    policy.update(
+        {
+            "allowed": bool(getattr(decision, "allowed", policy["allowed"])),
+            "sanitized": bool(policy.get("sanitized") or getattr(decision, "sanitized", False)),
+            "truncated": bool(policy.get("truncated") or getattr(decision, "truncated", False)),
+            "suppressed": bool(getattr(decision, "suppressed", policy["suppressed"])),
+            "rule_profile": str(getattr(decision, "rule_profile", policy["rule_profile"])),
+            "reason_codes": reason_codes,
+        }
+    )
+    policy["classifiers"].update(
+        {
+            "dropped_code": bool(policy["classifiers"].get("dropped_code") or classifiers.get("code")),
+            "dropped_tool_logs": bool(policy["classifiers"].get("dropped_tool_logs") or classifiers.get("command_log")),
+            "dropped_paths": bool(policy["classifiers"].get("dropped_paths") or classifiers.get("raw_path")),
+            "blocked_secret_like": bool(policy["classifiers"].get("blocked_secret_like") or classifiers.get("secret_like")),
+            "blocked_sensitive_topic": bool(
+                policy["classifiers"].get("blocked_sensitive_topic") or classifiers.get("sensitive_topic")
+            ),
+            "blocked_stack_trace": bool(policy["classifiers"].get("blocked_stack_trace") or classifiers.get("stack_trace")),
+        }
+    )
+    return policy
+
+
+def _final_summary_config() -> dict[str, Any]:
+    """Load pulse.voice.final_summary with conservative defaults.
+
+    Config loading is best-effort because voice event publication must never
+    block or break gateway text delivery.
+    """
+    config = dict(_DEFAULT_FINAL_SUMMARY_CONFIG)
+    try:
+        from hermes_cli.config import load_config
+
+        loaded = load_config() or {}
+        pulse_voice = ((loaded.get("pulse") or {}).get("voice") or {}) if isinstance(loaded, dict) else {}
+        user_config = pulse_voice.get("final_summary") or {}
+        if isinstance(user_config, dict):
+            config.update({k: v for k, v in user_config.items() if v is not None})
+    except Exception:
+        pass
+    return config
+
+
 def _trim_if_needed(path: Path) -> None:
     try:
         if not path.exists() or path.stat().st_size <= _MAX_BYTES:
@@ -67,42 +253,137 @@ def _first_sentence(text: str) -> str:
     return match.group(0) if match else text
 
 
+def sanitize_voice_text(text: str, *, max_chars: int = _MAX_TEXT_CHARS) -> SanitizedVoiceText:
+    """Return speech-safe text plus non-sensitive policy metadata."""
+    original = str(text or "")
+    policy = _default_policy()
+    classifiers = policy["classifiers"]
+
+    classifiers["dropped_code"] = bool(_CODE_FENCE_RE.search(original) or _INLINE_CODE_RE.search(original))
+    classifiers["dropped_tool_logs"] = bool(_TOOL_LOG_LINE_RE.search(original))
+    classifiers["dropped_paths"] = bool(_PATH_RE.search(original) or _FILE_REF_RE.search(original))
+    classifiers["blocked_secret_like"] = bool(_SECRET_RE.search(original))
+    classifiers["blocked_sensitive_topic"] = bool(_SENSITIVE_TOPIC_RE.search(original))
+    classifiers["blocked_stack_trace"] = bool(_STACK_TRACE_RE.search(original))
+
+    if classifiers["blocked_secret_like"] or classifiers["blocked_sensitive_topic"] or classifiers["blocked_stack_trace"]:
+        policy["allowed"] = False
+        policy["suppressed"] = True
+        if classifiers["blocked_secret_like"]:
+            policy["reason_codes"].append("secret_like_blocked")
+        if classifiers["blocked_sensitive_topic"]:
+            policy["reason_codes"].append("sensitive_topic_blocked")
+        if classifiers["blocked_stack_trace"]:
+            policy["reason_codes"].append("stack_trace_blocked")
+        return SanitizedVoiceText("", policy)
+
+    cleaned = _CODE_FENCE_RE.sub("", original)
+    cleaned = _TOOL_LOG_LINE_RE.sub("", cleaned)
+    cleaned = _MEDIA_RE.sub("", cleaned)
+    cleaned = _DIRECTIVE_RE.sub("", cleaned)
+    cleaned = _MARKDOWN_LINK_RE.sub(r"\1", cleaned)
+    cleaned = _INLINE_CODE_RE.sub("", cleaned)
+    if classifiers["dropped_paths"]:
+        cleaned = _PATH_RE.sub("", cleaned)
+        cleaned = _FILE_REF_RE.sub("", cleaned)
+        policy["reason_codes"].append("path_stripped")
+    cleaned = re.sub(r"^[#>*\-•\s]+", "", cleaned, flags=re.MULTILINE)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    if not cleaned:
+        policy["allowed"] = False
+        policy["suppressed"] = True
+        policy["reason_codes"].append("empty_after_sanitize")
+        return SanitizedVoiceText("", policy)
+
+    cleaned = _first_sentence(cleaned).strip()
+    if len(cleaned) > max_chars:
+        cleaned = cleaned[: max_chars - 1].rstrip(" ,.;:") + "…"
+        policy["truncated"] = True
+        policy["reason_codes"].append("truncated")
+    policy["reason_codes"].append("bounded_to_one_sentence")
+    return SanitizedVoiceText(cleaned, policy)
+
+
 def voice_safe_text(text: str, *, max_chars: int = _MAX_TEXT_CHARS) -> str:
     """Return short text safe enough to speak aloud.
 
     This intentionally strips code blocks, media tags, markdown links, transport
-    directives, bullets/headings, and excess whitespace.  It then keeps only a
-    single bounded sentence so executor prose/logs cannot leak into room audio.
+    directives, bullets/headings, paths, and excess whitespace.  It then keeps
+    only a single bounded sentence so executor prose/logs cannot leak into room
+    audio.
     """
-    text = str(text or "")
-    text = _CODE_FENCE_RE.sub("", text)
-    text = _MEDIA_RE.sub("", text)
-    text = _DIRECTIVE_RE.sub("", text)
-    text = _MARKDOWN_LINK_RE.sub(r"\1", text)
-    text = _INLINE_CODE_RE.sub(r"\1", text)
-    text = re.sub(r"^[#>*\-•\s]+", "", text, flags=re.MULTILINE)
-    text = re.sub(r"\s+", " ", text).strip()
-    if not text:
-        return ""
-    text = _first_sentence(text).strip()
-    if len(text) > max_chars:
-        text = text[: max_chars - 1].rstrip(" ,.;:") + "…"
-    return text
+    return sanitize_voice_text(text, max_chars=max_chars).text
 
 
-def completion_voice_text(final_response: str) -> tuple[str, str]:
+def summarize_final_voice_response(
+    final_response: str,
+    *,
+    summarizer: Callable[[str], str] | None = None,
+    max_chars: int = _MAX_TEXT_CHARS,
+) -> FinalVoiceSummaryResult:
+    """Derive the final spoken line and metadata from assistant final text.
+
+    The generated path is bounded by ``pulse.voice.final_summary.timeout_ms``
+    through ``FinalSpeechSummarizer``. Any timeout, exception, invalid generated
+    output, or missing generated model falls back to deterministic sanitization;
+    empty deterministic output stays silent.
+    """
+    config = _final_summary_config()
+    mode = str(config.get("mode") or "hybrid").strip().lower()
+    if mode not in {"deterministic", "generated", "hybrid", "off"}:
+        mode = "hybrid"
+    timeout_ms = int(config.get("timeout_ms") or _DEFAULT_FINAL_SUMMARY_CONFIG["timeout_ms"])
+    max_spoken_chars = int(config.get("max_spoken_chars") or max_chars or _MAX_TEXT_CHARS)
+    voice_profile = str(config.get("voice_profile") or "eon")
+
+    context = FinalSpeechVoiceContext(
+        max_spoken_chars=max_spoken_chars,
+        timeout_ms=max(1, timeout_ms),
+        voice_profile=voice_profile,
+    )
+    result = FinalSpeechSummarizer(generator=summarizer, mode=mode).summarize(final_response, context)
+    fallback_used = result.method == "deterministic" and (
+        summarizer is not None or mode in {"generated", "hybrid"}
+    )
+    summarizer_meta = {
+        "mode": mode,
+        "method": result.method,
+        "fallback_used": fallback_used,
+        "timeout_ms": timeout_ms,
+        "validation_failed": bool(str(result.reason or "").startswith("generated_invalid")),
+    }
+
+
+    if result.reason:
+        summarizer_meta["reason"] = result.reason
+
+    summary_policy = sanitize_voice_text(result.text).policy if result.text else _default_policy()
+    summary_policy.update(result.policy)
+    summary_policy.update({
+        "pre_sanitized": True,
+        "post_sanitized": True,
+    })
+    if not result.text:
+        summary_policy["allowed"] = False
+        summary_policy["suppressed"] = True
+    return FinalVoiceSummaryResult(
+        kind=result.kind,
+        text=result.text,
+        source="assistant_final",
+        derived_from="final_response",
+        voice_profile=voice_profile,
+        summarizer=summarizer_meta,
+        policy=summary_policy,
+    )
+
+def completion_voice_text(
+    final_response: str,
+    *,
+    summarizer: Callable[[str], str] | None = None,
+) -> tuple[str, str]:
     """Derive a concise completion/question/error event from executor output."""
-    spoken = voice_safe_text(final_response)
-    if not spoken:
-        return "completion", "Done."
-    lowered = spoken.lower()
-    if lowered.startswith(("⚠", "error", "failed", "sorry")):
-        return "error", spoken
-    if "?" in spoken and len(spoken) <= 160:
-        return "question", spoken
-    if not lowered.startswith(("done", "finished", "completed", "created", "updated", "fixed")):
-        spoken = voice_safe_text(f"Done — {spoken}")
-    return "completion", spoken
+    result = summarize_final_voice_response(final_response, summarizer=summarizer)
+    return result.kind, result.text
 
 
 def _write_event(path: Path, event: dict[str, Any]) -> None:
@@ -123,16 +404,39 @@ def publish_voice_out(kind: str, text: str, **metadata: Any) -> None:
     kind = str(kind or "progress").strip().lower()
     if kind not in _ALLOWED_KINDS:
         kind = "progress"
-    text = voice_safe_text(text)
-    if not text:
+    sanitized = sanitize_voice_text(text)
+    if not sanitized.text:
         return
     try:
+        context = _ambient_context(kind, metadata)
+        decision = _AMBIENT_POLICY.evaluate(sanitized.text, context)
+        if not decision.allowed or not decision.text:
+            return
+        default_seconds = 2 if kind in {"ack", "progress"} else 4
+        base_policy = metadata.pop("policy", None)
+        if isinstance(base_policy, dict):
+            merged_policy = dict(sanitized.policy)
+            merged_policy.update({k: v for k, v in base_policy.items() if k not in {"reason_codes", "classifiers"}})
+            merged_policy["reason_codes"] = list(base_policy.get("reason_codes") or []) + list(
+                sanitized.policy.get("reason_codes") or []
+            )
+            merged_classifiers = dict(sanitized.policy.get("classifiers") or {})
+            merged_classifiers.update(base_policy.get("classifiers") or {})
+            merged_policy["classifiers"] = merged_classifiers
+            policy = _policy_metadata_from_decision(decision, merged_policy)
+        else:
+            policy = _policy_metadata_from_decision(decision, sanitized.policy)
         event = {
             "id": f"{time.time_ns()}",
             "ts": time.time(),
+            "schema_version": 2,
             "kind": kind,
-            "text": text,
-            "max_seconds": int(metadata.pop("max_seconds", 4) or 4),
+            "text": decision.text,
+            "max_seconds": int(metadata.pop("max_seconds", decision.max_seconds or default_seconds) or default_seconds),
+            "source": metadata.pop("source", kind),
+            "derived_from": metadata.pop("derived_from", "pulse_voice_candidate"),
+            "voice_profile": metadata.pop("voice_profile", context.profile or "eon"),
+            "policy": policy,
             **{k: v for k, v in metadata.items() if v is not None},
         }
         canonical = voice_out_path()
@@ -148,18 +452,32 @@ def publish_voice_out(kind: str, text: str, **metadata: Any) -> None:
         return
 
 
-def publish_completion_voice_out(final_response: str, **metadata: Any) -> None:
+def publish_completion_voice_out(
+    final_response: str,
+    *,
+    summarizer: Callable[[str], str] | None = None,
+    **metadata: Any,
+) -> None:
     """Publish a short spoken completion derived from executor final text."""
-    kind, text = completion_voice_text(final_response)
-    publish_voice_out(kind, text, **metadata)
+    result = summarize_final_voice_response(final_response, summarizer=summarizer)
+    publish_voice_out(
+        result.kind,
+        result.text,
+        source=result.source,
+        derived_from=result.derived_from,
+        voice_profile=result.voice_profile,
+        summarizer=result.summarizer,
+        policy=result.policy,
+        **metadata,
+    )
 
 
 def publish_voice_event(kind: str, text: str, **metadata: Any) -> None:
     """Backward-compatible wrapper for older gateway call sites.
 
     Raw streaming ``delta`` events are deliberately ignored.  Interim assistant
-    ``commentary`` maps to a short ``progress`` voice-out event because the
-    gateway publishes a dedicated turn-start ``ack`` separately.
+    ``commentary`` maps to a short ``progress`` voice-out event only when the
+    model actually generated that assistant text.
     """
     legacy_kind = str(kind or "").strip().lower()
     if legacy_kind == "delta":

--- a/gateway/pulse_voice_events.py
+++ b/gateway/pulse_voice_events.py
@@ -1,0 +1,77 @@
+"""Best-effort local voice event bridge for Pulse/Aegis.
+
+The messaging gateway streams assistant deltas/commentary to platform adapters,
+but those interim chunks are not persisted in ``state.db`` until a turn finishes.
+Aegis needs the live chunks to speak Jarvis-style acknowledgements immediately,
+so this module appends sanitized JSONL events under ``$HERMES_HOME/pulse``.
+
+This is intentionally best-effort: failures must never affect chat delivery.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+_LOCK = threading.Lock()
+_MAX_BYTES = 2_000_000
+
+
+def _enabled() -> bool:
+    value = str(os.getenv("HERMES_PULSE_VOICE_EVENTS", "1")).strip().lower()
+    return value not in {"0", "false", "no", "off"}
+
+
+def voice_events_path() -> Path:
+    return get_hermes_home() / "pulse" / "voice-events.jsonl"
+
+
+def _trim_if_needed(path: Path) -> None:
+    try:
+        if not path.exists() or path.stat().st_size <= _MAX_BYTES:
+            return
+        data = path.read_bytes()[-(_MAX_BYTES // 2):]
+        # Start at the next newline so consumers never see a partial JSON row.
+        first_newline = data.find(b"\n")
+        if first_newline >= 0:
+            data = data[first_newline + 1 :]
+        path.write_bytes(data)
+    except OSError:
+        return
+
+
+def publish_voice_event(kind: str, text: str, **metadata: Any) -> None:
+    """Append a voice event for local Pulse/Aegis subscribers.
+
+    ``kind`` is usually ``delta`` or ``commentary``. ``text`` should already be
+    user-visible assistant text; empty/whitespace events are ignored.
+    """
+    if not _enabled():
+        return
+    text = str(text or "")
+    if not text.strip():
+        return
+    try:
+        path = voice_events_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        event = {
+            "id": f"{time.time_ns()}",
+            "ts": time.time(),
+            "kind": str(kind or "delta"),
+            "text": text,
+            **{k: v for k, v in metadata.items() if v is not None},
+        }
+        line = json.dumps(event, ensure_ascii=False, separators=(",", ":")) + "\n"
+        with _LOCK:
+            _trim_if_needed(path)
+            with path.open("a", encoding="utf-8") as fh:
+                fh.write(line)
+    except Exception:
+        # Voice events are an observability side-channel; never break gateway.
+        return

--- a/gateway/pulse_voice_events.py
+++ b/gateway/pulse_voice_events.py
@@ -24,6 +24,7 @@ from gateway.final_speech_summarizer import (
     FinalSpeechSummarizer,
     VoiceContext as FinalSpeechVoiceContext,
 )
+from gateway.generated_ack_harness import AckContext, AckGenerator, GeneratedAckHarness
 
 _LOCK = threading.Lock()
 _MAX_BYTES = 2_000_000
@@ -45,10 +46,11 @@ _SECRET_RE = re.compile(
         \b(?:bearer|authorization)\b\s*[:=]?\s+[A-Za-z0-9][A-Za-z0-9._~+/\-]{7,}
       | \b(?:api[_ -]?key|secret(?:[_ -]?key)?|password|passwd|pwd|token|access[_ -]?key|aws[_ -]?key)\b
         \s*(?:is|=|:)?\s+[A-Za-z0-9][A-Za-z0-9._~+/\-]{7,}
-      | \b(?:sk-[A-Za-z0-9._-]{6,}|sk-[A-Za-z0-9]{2,}\.\.\.[A-Za-z0-9]{2,}|gh[pousr]_[A-Za-z0-9_]{10,})\b
+      | \b(?:sk-[A-Za-z0-9._-]{6,}|sk-[A-Za-z0-9]{2,}\.\.\.[A-Za-z0-9]{2,}|gh[pousr]_[A-Za-z0-9_]{10,}|github_pat_[A-Za-z0-9_]{10,})\b
+      | \b(?:xox[baprs]-(?:[A-Za-z0-9-]{10,}|\[REDACTED\])|hf_(?:[A-Za-z0-9]{10,}|\[REDACTED\])|glpat-(?:[A-Za-z0-9_-]{10,}|\[REDACTED\]))(?=$|\W)
       | \b(?:AKIA|ASIA)[A-Z0-9.]{10,}\b
-      | \bhk_[A-Za-z0-9._-]{10,}\b
-      | \b[a-z]{2,}_(?:test|live|prod|secret|key)_[A-Za-z0-9]{10,}\b
+      | \bhk_(?:[A-Za-z0-9._-]{10,}|\[REDACTED\])(?=$|\W)
+      | \b[a-z]{2,}_(?:test|live|prod|secret|key)_(?:[A-Za-z0-9]{10,}|\[REDACTED\])(?=$|\W)
       | \beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b
     )
     """,
@@ -64,6 +66,18 @@ _DEFAULT_FINAL_SUMMARY_CONFIG = {
     "voice_profile": "eon",
     "fallback": "deterministic_sanitizer",
     "on_empty": "silence",
+}
+_DEFAULT_GENERATED_ACK_CONFIG = {
+    "mode": "generated",
+    "timeout_ms": 1000,
+    "max_words": 12,
+    "max_spoken_chars": 120,
+    "max_seconds": 2,
+    "voice_profile": "eon",
+    "context_window_chars": 500,
+    "provider": "auto",
+    "model": None,
+    "silence_on_failure": True,
 }
 _STACK_TRACE_RE = re.compile(r"(?is)^\s*Traceback \(most recent call last\):.*")
 _SENSITIVE_TOPIC_RE = re.compile(r"(?i)\b(?:trading\s+pnl|portfolio\s+exposure)\b")
@@ -228,6 +242,7 @@ _SAFE_METADATA_KEYS = {
     "explicit_spoken_request",
     "is_private_context",
     "summarizer",
+    "ack",
 }
 _SAFE_METADATA_STRING_RE = re.compile(r"^[A-Za-z0-9_.:@#-]{1,128}$")
 _SAFE_ENUM_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_-]{0,63}$")
@@ -262,6 +277,23 @@ def _safe_summarizer_metadata(value: Any) -> dict[str, Any] | None:
     return allowed or None
 
 
+def _safe_ack_metadata(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    allowed: dict[str, Any] = {}
+    for key in ("method", "reason"):
+        safe = _safe_metadata_string(value.get(key), enum=True)
+        if safe is not None:
+            allowed[key] = safe
+    for key in ("timeout_ms", "elapsed_ms"):
+        if key in value:
+            try:
+                allowed[key] = max(0, min(int(value.get(key) or 0), 10000))
+            except (TypeError, ValueError):
+                pass
+    return allowed or None
+
+
 def _safe_voice_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
     """Return allowlisted Pulse metadata with no raw content/debug passthrough."""
     safe: dict[str, Any] = {}
@@ -275,6 +307,10 @@ def _safe_voice_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
             summarizer = _safe_summarizer_metadata(value)
             if summarizer:
                 safe[key] = summarizer
+        elif key == "ack":
+            ack = _safe_ack_metadata(value)
+            if ack:
+                safe[key] = ack
         elif key in {"platform", "input_modality", "output_device", "config_scope"}:
             safe_value = _safe_metadata_string(value, enum=True)
             if safe_value is not None:
@@ -304,6 +340,80 @@ def _final_summary_config() -> dict[str, Any]:
     except Exception:
         pass
     return config
+
+
+def _generated_ack_config() -> dict[str, Any]:
+    """Load pulse.voice.generated_ack with silence-on-failure defaults."""
+    config = dict(_DEFAULT_GENERATED_ACK_CONFIG)
+    try:
+        from hermes_cli.config import load_config
+
+        loaded = load_config() or {}
+        pulse_voice = ((loaded.get("pulse") or {}).get("voice") or {}) if isinstance(loaded, dict) else {}
+        user_config = pulse_voice.get("generated_ack") or {}
+        if isinstance(user_config, dict):
+            config.update({k: v for k, v in user_config.items() if v is not None})
+    except Exception:
+        pass
+    return config
+
+
+class _ProviderAckGenerator:
+    """Small OpenAI-compatible auxiliary-client adapter for generated acks.
+
+    All exceptions intentionally bubble to GeneratedAckHarness, where they become
+    silence. This adapter must never log prompts, raw model responses,
+    credentials, or provider details.
+    """
+
+    def __init__(self, *, provider: str = "auto", model: str | None = None) -> None:
+        self.provider = str(provider or "auto")
+        self.model = str(model).strip() if model else None
+
+    def __call__(self, prompt: str, *, timeout_ms: int) -> str:
+        from agent.auxiliary_client import resolve_provider_client
+
+        client, resolved_model = resolve_provider_client(self.provider, model=self.model or "")
+        model = self.model or resolved_model
+        if client is None or not model:
+            return ""
+        timeout_s = max(0.1, min(float(timeout_ms or 1000) / 1000.0, 1.5))
+        response = client.chat.completions.create(
+            model=model,
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "You generate one short room-audio acknowledgement for Eon. "
+                        "Return only the line or an empty string."
+                    ),
+                },
+                {"role": "user", "content": prompt},
+            ],
+            temperature=0.5,
+            max_tokens=40,
+            timeout=timeout_s,
+        )
+        choices = getattr(response, "choices", None) or []
+        if not choices:
+            return ""
+        message = getattr(choices[0], "message", None)
+        content = getattr(message, "content", "") if message is not None else ""
+        if isinstance(content, list):
+            return " ".join(
+                str(part.get("text", "") if isinstance(part, dict) else part)
+                for part in content
+            )
+        return str(content or "")
+
+
+def _make_generated_ack_generator(config: dict[str, Any]) -> AckGenerator | None:
+    provider = str(config.get("provider") or "auto").strip().lower()
+    if provider in {"", "none", "off", "disabled"}:
+        return None
+    model_value = config.get("model")
+    model = str(model_value).strip() if model_value else None
+    return _ProviderAckGenerator(provider=provider, model=model)
 
 
 def _trim_if_needed(path: Path) -> None:
@@ -532,6 +642,82 @@ def publish_voice_out(kind: str, text: str, **metadata: Any) -> None:
             # not raw delta/commentary.
             if legacy != canonical:
                 _write_event(legacy, event)
+    except Exception:
+        return
+
+
+def publish_generated_ack_voice_out(
+    user_message: str,
+    *,
+    generator: AckGenerator | None = None,
+    **metadata: Any,
+) -> None:
+    """Publish one generated turn-start voice acknowledgement if it is safe.
+
+    This helper is voice-only. It never sends platform text, never mutates chat
+    history, and returns silently for disabled config, missing generator/provider,
+    timeouts, invalid candidates, policy denial, or any exception.
+    """
+    if not _enabled():
+        return
+    try:
+        config = _generated_ack_config()
+        mode = str(config.get("mode") or "generated").strip().lower()
+        if mode == "off":
+            return
+        timeout_ms = max(1, min(int(config.get("timeout_ms") or 1000), 1500))
+        max_words = max(1, min(int(config.get("max_words") or 12), 20))
+        max_spoken_chars = max(1, min(int(config.get("max_spoken_chars") or 120), 240))
+        max_seconds = max(1, min(int(config.get("max_seconds") or 2), 10))
+        voice_profile = str(config.get("voice_profile") or "eon")
+        context_window_chars = max(80, min(int(config.get("context_window_chars") or 500), 2000))
+
+        context = AckContext(
+            user_message=str(user_message or "")[:context_window_chars],
+            session_id=metadata.get("session_id"),
+            platform=metadata.get("platform"),
+            chat_id=metadata.get("chat_id"),
+            channel_id=metadata.get("channel_id"),
+            thread_id=metadata.get("thread_id"),
+            source_message_id=metadata.get("source_message_id"),
+            input_modality=metadata.get("input_modality"),
+            output_device=metadata.get("output_device"),
+            voice_profile=voice_profile,
+            timeout_ms=timeout_ms,
+            max_words=max_words,
+            max_spoken_chars=max_spoken_chars,
+            max_seconds=max_seconds,
+            context_window_chars=context_window_chars,
+            config_scope=str(metadata.get("config_scope") or "living_room_default"),
+            explicit_spoken_request=bool(metadata.get("explicit_spoken_request", False)),
+            is_private_context=bool(metadata.get("is_private_context", False)),
+        )
+        if generator is None:
+            generator = _make_generated_ack_generator(config)
+        result = GeneratedAckHarness(generator=generator, mode=mode).generate(context)
+        if result.method == "silence" or not result.text:
+            return
+        publish_voice_out(
+            "ack",
+            result.text,
+            source="generated_ack",
+            derived_from="turn_start",
+            voice_profile=voice_profile,
+            max_seconds=max_seconds,
+            policy=result.policy,
+            ack={"method": result.method, "timeout_ms": timeout_ms, "elapsed_ms": result.elapsed_ms},
+            session_id=context.session_id,
+            platform=context.platform,
+            chat_id=context.chat_id,
+            channel_id=context.channel_id,
+            thread_id=context.thread_id,
+            source_message_id=context.source_message_id,
+            input_modality=context.input_modality,
+            output_device=context.output_device,
+            config_scope=context.config_scope,
+            explicit_spoken_request=context.explicit_spoken_request,
+            is_private_context=context.is_private_context,
+        )
     except Exception:
         return
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -103,6 +103,14 @@ def _submit_generated_ack_voice_out(message_text: str, **kwargs: Any) -> bool:
     future.add_done_callback(release_slot)
     return True
 
+
+def _should_submit_generated_ack_voice_out(message_type: Any) -> bool:
+    """Generated turn-start room audio is only for voice-originated turns."""
+    value = getattr(message_type, "value", message_type)
+    name = getattr(message_type, "name", "")
+    return str(value).lower() == "voice" or str(name).lower() == "voice"
+
+
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"("  # transient/auxiliary status that should stay in logs, not Telegram chat
     r"auxiliary\s+.+\s+failed"
@@ -8625,20 +8633,21 @@ class GatewayRunner:
         try:
             _ack_source_message_id = self._reply_anchor_for_event(event)
             _ack_input_modality = "voice" if event.message_type == MessageType.VOICE else "text"
-            _submit_generated_ack_voice_out(
-                message_text,
-                session_id=session_entry.session_id,
-                platform=source.platform.value if source.platform else "",
-                chat_id=source.chat_id,
-                channel_id=source.parent_chat_id or source.chat_id,
-                thread_id=source.thread_id,
-                source_message_id=_ack_source_message_id,
-                input_modality=_ack_input_modality,
-                output_device="room_audio",
-                config_scope="living_room_default",
-                explicit_spoken_request=_ack_input_modality == "voice",
-                is_private_context=source.chat_type == "dm",
-            )
+            if _should_submit_generated_ack_voice_out(event.message_type):
+                _submit_generated_ack_voice_out(
+                    message_text,
+                    session_id=session_entry.session_id,
+                    platform=source.platform.value if source.platform else "",
+                    chat_id=source.chat_id,
+                    channel_id=source.parent_chat_id or source.chat_id,
+                    thread_id=source.thread_id,
+                    source_message_id=_ack_source_message_id,
+                    input_modality=_ack_input_modality,
+                    output_device="room_audio",
+                    config_scope="living_room_default",
+                    explicit_spoken_request=True,
+                    is_private_context=source.chat_type == "dm",
+                )
         except Exception:
             pass
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11254,7 +11254,54 @@ class GatewayRunner:
         try:
             from tools.tts_tool import text_to_speech_tool, _strip_markdown_for_tts
 
-            tts_text = _strip_markdown_for_tts(text[:4000])
+            adapter = self.adapters.get(event.source.platform)
+            guild_id = self._get_guild_id(event)
+            is_in_voice_channel = getattr(adapter, "is_in_voice_channel", None) if adapter is not None else None
+            in_voice_channel = bool(guild_id and callable(is_in_voice_channel) and is_in_voice_channel(guild_id))
+            output_device = "discord_voice" if in_voice_channel else "chat_attachment"
+            rule_profile = "discord_voice" if in_voice_channel else "chat_attachment"
+
+            stripped_text = _strip_markdown_for_tts(text[:4000])
+            if not stripped_text:
+                return
+
+            # Gate every direct runner auto-TTS path through AmbientVoicePolicy
+            # before synthesis.  Use the adapter helper when available; otherwise
+            # fall back to the same policy surface locally so bare test runners and
+            # simple adapters remain protected.
+            prepare_tts_text = getattr(type(adapter), "prepare_tts_text", None) if adapter is not None else None
+            if callable(prepare_tts_text):
+                tts_text = str(prepare_tts_text(
+                    adapter,
+                    stripped_text,
+                    chat_id=event.source.chat_id,
+                    thread_id=getattr(event.source, "thread_id", None),
+                    source_message_id=getattr(event, "message_id", None),
+                    explicit_spoken_request=True,
+                    is_private_context=False,
+                    output_device=output_device,
+                    rule_profile=rule_profile,
+                ) or "")
+            else:
+                from gateway.ambient_voice_policy import AmbientVoicePolicy, VoiceContext
+
+                platform = getattr(event.source.platform, "value", event.source.platform)
+                decision = AmbientVoicePolicy().evaluate(
+                    stripped_text,
+                    VoiceContext(
+                        source="auto_tts_reply",
+                        platform=str(platform or ""),
+                        chat_id=event.source.chat_id,
+                        thread_id=getattr(event.source, "thread_id", None),
+                        source_message_id=getattr(event, "message_id", None),
+                        input_modality="voice" if event.message_type == MessageType.VOICE else "text",
+                        output_device=output_device,
+                        explicit_spoken_request=True,
+                        is_private_context=False,
+                        config_scope=rule_profile,
+                    ),
+                )
+                tts_text = decision.text if decision.allowed and decision.text else ""
             if not tts_text:
                 return
 
@@ -16418,14 +16465,16 @@ class GatewayRunner:
                                 if _run_still_current():
                                     _stream_consumer.on_delta(text)
                                     try:
-                                        from gateway.pulse_voice_events import publish_voice_event
-                                        publish_voice_event(
+                                        from gateway.voice_response_pipeline import VoiceContext, VoiceResponsePipeline
+                                        VoiceResponsePipeline().publish_legacy_event(
                                             "delta",
                                             text,
-                                            session_id=session_id,
-                                            platform=platform_key,
-                                            chat_id=source.chat_id,
-                                            thread_id=source.thread_id,
+                                            VoiceContext(
+                                                session_id=session_id,
+                                                platform=platform_key,
+                                                chat_id=source.chat_id,
+                                                thread_id=source.thread_id,
+                                            ),
                                         )
                                     except Exception:
                                         pass
@@ -16436,19 +16485,9 @@ class GatewayRunner:
             def _interim_assistant_cb(text: str, *, already_streamed: bool = False) -> None:
                 if not _run_still_current():
                     return
-                if str(text or "").strip():
-                    try:
-                        from gateway.pulse_voice_events import publish_voice_event
-                        publish_voice_event(
-                            "commentary",
-                            text,
-                            session_id=session_id,
-                            platform=platform_key,
-                            chat_id=source.chat_id,
-                            thread_id=source.thread_id,
-                        )
-                    except Exception:
-                        pass
+                # Interim/commentary text is a display concern only. The Pulse voice
+                # seam is final-only for successful turns so room audio is derived
+                # from final_response, not transient assistant progress text.
                 if _stream_consumer is not None:
                     if already_streamed:
                         _stream_consumer.on_segment_break()
@@ -16983,15 +17022,17 @@ class GatewayRunner:
                 error_msg = f"⚠️ {result['error']}" if result.get("error") else ""
                 if error_msg:
                     try:
-                        from gateway.pulse_voice_events import publish_voice_out
-                        publish_voice_out(
+                        from gateway.voice_response_pipeline import VoiceContext, VoiceResponsePipeline
+                        VoiceResponsePipeline().publish_legacy_event(
                             "error",
                             error_msg,
-                            session_id=session_id,
-                            platform=platform_key,
-                            chat_id=source.chat_id,
-                            thread_id=source.thread_id,
-                            source_message_id=event_message_id,
+                            VoiceContext(
+                                session_id=session_id,
+                                platform=platform_key,
+                                chat_id=source.chat_id,
+                                thread_id=source.thread_id,
+                                source_message_id=event_message_id,
+                            ),
                         )
                     except Exception:
                         pass
@@ -17058,14 +17099,16 @@ class GatewayRunner:
                     final_response = final_response + "\n" + "\n".join(unique_tags)
 
             try:
-                from gateway.pulse_voice_events import publish_completion_voice_out
-                publish_completion_voice_out(
+                from gateway.voice_response_pipeline import VoiceContext, VoiceResponsePipeline
+                VoiceResponsePipeline().publish_final_response(
                     final_response,
-                    session_id=session_id,
-                    platform=platform_key,
-                    chat_id=source.chat_id,
-                    thread_id=source.thread_id,
-                    source_message_id=event_message_id,
+                    VoiceContext(
+                        session_id=session_id,
+                        platform=platform_key,
+                        chat_id=source.chat_id,
+                        thread_id=source.thread_id,
+                        source_message_id=event_message_id,
+                    ),
                 )
             except Exception:
                 pass

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16976,6 +16976,20 @@ class GatewayRunner:
 
             if not final_response:
                 error_msg = f"⚠️ {result['error']}" if result.get("error") else ""
+                if error_msg:
+                    try:
+                        from gateway.pulse_voice_events import publish_voice_out
+                        publish_voice_out(
+                            "error",
+                            error_msg,
+                            session_id=session_id,
+                            platform=platform_key,
+                            chat_id=source.chat_id,
+                            thread_id=source.thread_id,
+                            source_message_id=event_message_id,
+                        )
+                    except Exception:
+                        pass
                 return {
                     "final_response": error_msg,
                     "messages": result.get("messages", []),
@@ -17037,6 +17051,19 @@ class GatewayRunner:
                     if has_voice_directive:
                         unique_tags.insert(0, "[[audio_as_voice]]")
                     final_response = final_response + "\n" + "\n".join(unique_tags)
+
+            try:
+                from gateway.pulse_voice_events import publish_completion_voice_out
+                publish_completion_voice_out(
+                    final_response,
+                    session_id=session_id,
+                    platform=platform_key,
+                    chat_id=source.chat_id,
+                    thread_id=source.thread_id,
+                    source_message_id=event_message_id,
+                )
+            except Exception:
+                pass
             
             # Sync session_id: the agent may have created a new session during
             # mid-run context compression (_compress_context splits sessions).

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16417,6 +16417,18 @@ class GatewayRunner:
                             def _stream_delta_cb(text: str) -> None:
                                 if _run_still_current():
                                     _stream_consumer.on_delta(text)
+                                    try:
+                                        from gateway.pulse_voice_events import publish_voice_event
+                                        publish_voice_event(
+                                            "delta",
+                                            text,
+                                            session_id=session_id,
+                                            platform=platform_key,
+                                            chat_id=source.chat_id,
+                                            thread_id=source.thread_id,
+                                        )
+                                    except Exception:
+                                        pass
                         stream_consumer_holder[0] = _stream_consumer
                 except Exception as _sc_err:
                     logger.debug("Could not set up stream consumer: %s", _sc_err)
@@ -16424,6 +16436,19 @@ class GatewayRunner:
             def _interim_assistant_cb(text: str, *, already_streamed: bool = False) -> None:
                 if not _run_still_current():
                     return
+                if str(text or "").strip():
+                    try:
+                        from gateway.pulse_voice_events import publish_voice_event
+                        publish_voice_event(
+                            "commentary",
+                            text,
+                            session_id=session_id,
+                            platform=platform_key,
+                            chat_id=source.chat_id,
+                            thread_id=source.thread_id,
+                        )
+                    except Exception:
+                        pass
                 if _stream_consumer is not None:
                     if already_streamed:
                         _stream_consumer.on_segment_break()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25,6 +25,7 @@ except ModuleNotFoundError:
     pass
 
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 import dataclasses
 import inspect
 import json
@@ -65,7 +66,42 @@ _AGENT_CACHE_MAX_SIZE = 128
 _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
+_GENERATED_ACK_DISPATCH_MAX_WORKERS = 2
+_GENERATED_ACK_DISPATCH_EXECUTOR = ThreadPoolExecutor(
+    max_workers=_GENERATED_ACK_DISPATCH_MAX_WORKERS,
+    thread_name_prefix="generated-ack-dispatch",
+)
+_GENERATED_ACK_DISPATCH_SLOTS = threading.BoundedSemaphore(_GENERATED_ACK_DISPATCH_MAX_WORKERS)
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
+
+
+def _submit_generated_ack_voice_out(message_text: str, **kwargs: Any) -> bool:
+    """Submit generated turn-start room audio work without unbounded threads.
+
+    Admission is non-blocking.  Saturation degrades to silence/no-op so the main
+    gateway path is never delayed and no unbounded executor queue builds up.
+    """
+    if not _GENERATED_ACK_DISPATCH_SLOTS.acquire(blocking=False):
+        return False
+
+    def run_publish() -> None:
+        try:
+            from gateway.pulse_voice_events import publish_generated_ack_voice_out
+
+            publish_generated_ack_voice_out(message_text, **kwargs)
+        except Exception:
+            pass
+
+    future = _GENERATED_ACK_DISPATCH_EXECUTOR.submit(run_publish)
+
+    def release_slot(_future: Any) -> None:
+        try:
+            _GENERATED_ACK_DISPATCH_SLOTS.release()
+        except ValueError:
+            pass
+
+    future.add_done_callback(release_slot)
+    return True
 
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"("  # transient/auxiliary status that should stay in logs, not Telegram chat
@@ -8582,6 +8618,29 @@ class GatewayRunner:
         )
         if message_text is None:
             return
+
+        # Generated turn-start acknowledgement is voice-only and fire-and-forget.
+        # It publishes only a safe Pulse voice event, never platform text, and it
+        # must not mutate the session transcript or contaminate the main prompt.
+        try:
+            _ack_source_message_id = self._reply_anchor_for_event(event)
+            _ack_input_modality = "voice" if event.message_type == MessageType.VOICE else "text"
+            _submit_generated_ack_voice_out(
+                message_text,
+                session_id=session_entry.session_id,
+                platform=source.platform.value if source.platform else "",
+                chat_id=source.chat_id,
+                channel_id=source.parent_chat_id or source.chat_id,
+                thread_id=source.thread_id,
+                source_message_id=_ack_source_message_id,
+                input_modality=_ack_input_modality,
+                output_device="room_audio",
+                config_scope="living_room_default",
+                explicit_spoken_request=_ack_input_modality == "voice",
+                is_private_context=source.chat_type == "dm",
+            )
+        except Exception:
+            pass
 
         # Bind this gateway run generation to the adapter's active-session
         # event so deferred post-delivery callbacks can be released by the

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16930,6 +16930,11 @@ class GatewayRunner:
                 else:
                     _run_message = message
 
+                # Voice-out is derived from generated assistant output only.
+                # Do not publish canned turn-start acknowledgements here: ambient
+                # room audio should sound like the same agent answering, not a
+                # separate status bot. Generated interim assistant commentary is
+                # handled by _interim_assistant_cb; final answers are published below.
                 _api_run_message = _wrap_current_message_with_observed_context(
                     _run_message,
                     observed_group_context,

--- a/gateway/voice_response_pipeline.py
+++ b/gateway/voice_response_pipeline.py
@@ -124,13 +124,11 @@ class VoiceResponsePipeline:
         context: VoiceContext,
         *,
         summarizer: Callable[[str], str] | None = None,
-    ) -> VoiceEvent | None:
-        """Return the final speakable event, or ``None`` if no safe text exists."""
+    ) -> VoiceEvent:
+        """Return the final event candidate; empty text becomes suppressed telemetry downstream."""
         from gateway.pulse_voice_events import summarize_final_voice_response
 
         result = summarize_final_voice_response(final_response, summarizer=summarizer)
-        if not str(result.text or "").strip():
-            return None
         return VoiceEvent(
             kind=result.kind,  # type: ignore[arg-type]
             text=result.text,
@@ -184,7 +182,7 @@ class VoiceResponsePipeline:
 
     def publish(self, event: VoiceEvent | None) -> None:
         """Publish a voice event best-effort; never let voice break text delivery."""
-        if event is None or not str(event.text or "").strip():
+        if event is None:
             return
         try:
             self.publisher(event.kind, event.text, **event.to_publish_kwargs())

--- a/gateway/voice_response_pipeline.py
+++ b/gateway/voice_response_pipeline.py
@@ -1,0 +1,204 @@
+"""Voice response derivation pipeline for Hermes gateway voice-out events.
+
+This module owns the small interface between gateway turn orchestration and the
+Pulse/Aegis voice event writer. It is intentionally behavior-preserving: no
+turn-start acknowledgements, no generated progress narration, and no alternate
+transport. Successful turns derive at most one speakable final event from the
+assistant final response; legacy streaming deltas remain silent.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Literal, Mapping
+
+
+VoiceKind = Literal["ack", "completion", "error", "question", "progress"]
+VoiceSource = Literal["assistant_final", "assistant_commentary", "legacy_event"]
+
+
+@dataclass(frozen=True)
+class VoiceContext:
+    """Safe transport metadata for a voice event candidate.
+
+    Keep this deliberately narrow: no raw user text, no final assistant text, no
+    paths, no stack traces. The low-level publisher still applies its own
+    metadata allowlist before writing JSONL.
+    """
+
+    session_id: str | None = None
+    platform: str | None = None
+    chat_id: str | None = None
+    channel_id: str | None = None
+    thread_id: str | None = None
+    source_message_id: str | None = None
+    voice_profile: str = "eon"
+    room_context: str = "living_room"
+    input_modality: str | None = None
+    output_device: str | None = None
+    config_scope: str | None = None
+    explicit_spoken_request: bool | None = None
+    is_private_context: bool | None = None
+    max_seconds: int | None = None
+
+    @classmethod
+    def from_metadata(cls, **metadata: Any) -> "VoiceContext":
+        return cls(
+            session_id=metadata.get("session_id"),
+            platform=metadata.get("platform"),
+            chat_id=metadata.get("chat_id"),
+            channel_id=metadata.get("channel_id"),
+            thread_id=metadata.get("thread_id"),
+            source_message_id=metadata.get("source_message_id"),
+            voice_profile=metadata.get("voice_profile") or "eon",
+            room_context=metadata.get("room_context") or "living_room",
+            input_modality=metadata.get("input_modality"),
+            output_device=metadata.get("output_device"),
+            config_scope=metadata.get("config_scope"),
+            explicit_spoken_request=metadata.get("explicit_spoken_request"),
+            is_private_context=metadata.get("is_private_context"),
+            max_seconds=metadata.get("max_seconds"),
+        )
+
+    def to_metadata(self) -> dict[str, Any]:
+        metadata = {
+            "session_id": self.session_id,
+            "platform": self.platform,
+            "chat_id": self.chat_id,
+            "channel_id": self.channel_id,
+            "thread_id": self.thread_id,
+            "source_message_id": self.source_message_id,
+            "voice_profile": self.voice_profile,
+            "room_context": self.room_context,
+            "input_modality": self.input_modality,
+            "output_device": self.output_device,
+            "config_scope": self.config_scope,
+            "explicit_spoken_request": self.explicit_spoken_request,
+            "is_private_context": self.is_private_context,
+            "max_seconds": self.max_seconds,
+        }
+        return {key: value for key, value in metadata.items() if value is not None}
+
+
+@dataclass(frozen=True)
+class VoiceEvent:
+    """Sanitized voice event candidate ready for best-effort publication."""
+
+    kind: VoiceKind
+    text: str
+    source: VoiceSource
+    derived_from: str
+    context: VoiceContext = field(default_factory=VoiceContext)
+    max_seconds: int | None = None
+    policy: Mapping[str, Any] = field(default_factory=dict)
+    summarizer: Mapping[str, Any] = field(default_factory=dict)
+    extra: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_publish_kwargs(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            **self.context.to_metadata(),
+            "source": self.source,
+            "derived_from": self.derived_from,
+            "policy": dict(self.policy),
+            "summarizer": dict(self.summarizer),
+            **dict(self.extra),
+        }
+        if self.max_seconds is not None:
+            payload["max_seconds"] = self.max_seconds
+        return {key: value for key, value in payload.items() if value is not None}
+
+
+class VoiceResponsePipeline:
+    """Derive and publish room-safe voice events for Hermes gateway turns."""
+
+    def __init__(self, *, publisher: Callable[..., None] | None = None) -> None:
+        if publisher is None:
+            from gateway import pulse_voice_events
+
+            publisher = pulse_voice_events.publish_voice_out
+        self.publisher = publisher
+
+    def event_from_final_response(
+        self,
+        final_response: str,
+        context: VoiceContext,
+        *,
+        summarizer: Callable[[str], str] | None = None,
+    ) -> VoiceEvent | None:
+        """Return the final speakable event, or ``None`` if no safe text exists."""
+        from gateway.pulse_voice_events import summarize_final_voice_response
+
+        result = summarize_final_voice_response(final_response, summarizer=summarizer)
+        if not str(result.text or "").strip():
+            return None
+        return VoiceEvent(
+            kind=result.kind,  # type: ignore[arg-type]
+            text=result.text,
+            source="assistant_final",
+            derived_from="final_response",
+            context=context,
+            policy=result.policy,
+            summarizer=result.summarizer,
+            extra={"voice_profile": result.voice_profile},
+        )
+
+    def event_from_legacy_event(
+        self,
+        kind: str,
+        text: str,
+        context: VoiceContext,
+    ) -> VoiceEvent | None:
+        """Map legacy gateway voice hooks into the current final-only baseline.
+
+        Streaming deltas are silent. Commentary remains a non-speakable
+        ``progress`` event for compatibility with the current JSONL contract; the
+        Aegis consumer rejects progress for speech.
+        """
+        from gateway.pulse_voice_events import sanitize_voice_text
+
+        legacy_kind = str(kind or "").strip().lower()
+        if legacy_kind == "delta":
+            return None
+        if legacy_kind == "commentary":
+            mapped_kind: VoiceKind = "progress"
+            source: VoiceSource = "assistant_commentary"
+            derived_from = "commentary"
+        elif legacy_kind in {"ack", "completion", "error", "question", "progress"}:
+            mapped_kind = legacy_kind  # type: ignore[assignment]
+            source = "legacy_event"
+            derived_from = legacy_kind
+        else:
+            return None
+
+        sanitized = sanitize_voice_text(text)
+        if not str(sanitized.text or "").strip():
+            return None
+        return VoiceEvent(
+            kind=mapped_kind,
+            text=sanitized.text,
+            source=source,
+            derived_from=derived_from,
+            context=context,
+            policy=sanitized.policy,
+        )
+
+    def publish(self, event: VoiceEvent | None) -> None:
+        """Publish a voice event best-effort; never let voice break text delivery."""
+        if event is None or not str(event.text or "").strip():
+            return
+        try:
+            self.publisher(event.kind, event.text, **event.to_publish_kwargs())
+        except Exception:
+            return
+
+    def publish_final_response(
+        self,
+        final_response: str,
+        context: VoiceContext,
+        *,
+        summarizer: Callable[[str], str] | None = None,
+    ) -> None:
+        self.publish(self.event_from_final_response(final_response, context, summarizer=summarizer))
+
+    def publish_legacy_event(self, kind: str, text: str, context: VoiceContext) -> None:
+        self.publish(self.event_from_legacy_event(kind, text, context))

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1198,6 +1198,10 @@ DEFAULT_CONFIG = {
                 "model": None,
                 "silence_on_failure": True,
             },
+            "observability": {
+                "emit_suppressed_events": True,
+                "include_candidate_counts": True,
+            },
         },
     },
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1186,6 +1186,18 @@ DEFAULT_CONFIG = {
                 "fallback": "deterministic_sanitizer",
                 "on_empty": "silence",
             },
+            "generated_ack": {
+                "mode": "generated",  # generated | off
+                "timeout_ms": 1000,
+                "max_words": 12,
+                "max_spoken_chars": 120,
+                "max_seconds": 2,
+                "voice_profile": "eon",
+                "context_window_chars": 500,
+                "provider": "auto",
+                "model": None,
+                "silence_on_failure": True,
+            },
         },
     },
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1176,6 +1176,19 @@ DEFAULT_CONFIG = {
         },
     },
 
+    "pulse": {
+        "voice": {
+            "final_summary": {
+                "mode": "hybrid",  # deterministic | generated | hybrid | off
+                "timeout_ms": 1000,
+                "max_spoken_chars": 180,
+                "voice_profile": "eon",
+                "fallback": "deterministic_sanitizer",
+                "on_empty": "silence",
+            },
+        },
+    },
+
     "voice": {
         "record_key": "ctrl+b",
         "max_recording_seconds": 120,
@@ -1183,6 +1196,60 @@ DEFAULT_CONFIG = {
         "beep_enabled": True,         # Play record start/stop beeps in CLI voice mode
         "silence_threshold": 200,     # RMS below this = silence (0-32767)
         "silence_duration": 3.0,      # Seconds of silence before auto-stop
+        "ambient_policy": {
+            "enabled": True,
+            "default_context": "living_room_default",
+            "rule_profiles": {
+                "living_room_default": {
+                    "max_seconds": {"ack": 2, "completion": 4, "question": 6, "error": 3, "progress": 2},
+                    "max_chars": 180,
+                    "allow_code": False,
+                    "allow_tool_logs": False,
+                    "allow_raw_paths": False,
+                    "allow_sensitive_topics": False,
+                    "allow_secret_like_text": False,
+                    "require_explicit_for_sensitive_topics": True,
+                    "suppress_errors_with_stack_traces": True,
+                    "one_sentence": True,
+                },
+                "airpods_private": {
+                    "max_seconds": {"ack": 3, "completion": 8, "question": 10, "error": 5, "progress": 3},
+                    "max_chars": 320,
+                    "allow_code": False,
+                    "allow_tool_logs": False,
+                    "allow_raw_paths": False,
+                    "allow_sensitive_topics": "explicit_only",
+                    "allow_secret_like_text": False,
+                    "require_explicit_for_sensitive_topics": True,
+                    "suppress_errors_with_stack_traces": True,
+                    "one_sentence": True,
+                },
+                "chat_attachment": {
+                    "max_seconds": {"ack": 3, "completion": 10, "question": 10, "error": 5, "progress": 3},
+                    "max_chars": 500,
+                    "allow_code": False,
+                    "allow_tool_logs": False,
+                    "allow_raw_paths": False,
+                    "allow_sensitive_topics": "explicit_only",
+                    "allow_secret_like_text": False,
+                    "require_explicit_for_sensitive_topics": True,
+                    "suppress_errors_with_stack_traces": True,
+                    "one_sentence": True,
+                },
+                "discord_voice": {
+                    "max_seconds": {"ack": 2, "completion": 4, "question": 6, "error": 3, "progress": 2},
+                    "max_chars": 180,
+                    "allow_code": False,
+                    "allow_tool_logs": False,
+                    "allow_raw_paths": False,
+                    "allow_sensitive_topics": False,
+                    "allow_secret_like_text": False,
+                    "require_explicit_for_sensitive_topics": True,
+                    "suppress_errors_with_stack_traces": True,
+                    "one_sentence": True,
+                },
+            },
+        },
     },
     
     "human_delay": {

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1256,6 +1256,7 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
     if "tenant" not in cols:
         _add_column_if_missing(conn, "tasks", "tenant", "tenant TEXT")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_tasks_tenant ON tasks(tenant)")
     if "result" not in cols:
         _add_column_if_missing(conn, "tasks", "result", "result TEXT")
     if "branch_name" not in cols:

--- a/tests/gateway/test_ambient_voice_policy.py
+++ b/tests/gateway/test_ambient_voice_policy.py
@@ -149,12 +149,15 @@ def test_policy_metadata_contains_only_safe_reason_codes_and_booleans():
         "suppressed": True,
         "reason_codes": ("secret_like", "raw_path_stripped", "empty_after_sanitization"),
         "rule_profile": "living_room_default",
-        "blocked_secret_like": True,
-        "dropped_code": False,
-        "blocked_stack_trace": False,
-        "dropped_tool_logs": False,
-        "dropped_paths": True,
-        "blocked_sensitive_topic": False,
+        "classifiers": {
+            "blocked_secret_like": True,
+            "dropped_code": False,
+            "blocked_stack_trace": False,
+            "dropped_tool_logs": False,
+            "dropped_paths": True,
+            "blocked_sensitive_topic": False,
+            "long_response": False,
+        },
     }
 
 
@@ -198,3 +201,31 @@ def test_ambient_policy_loads_rule_profiles_from_config(monkeypatch):
 
     assert decision.max_seconds == 2
     assert decision.text == "I completed the impleme…"
+
+
+def test_disabled_ambient_policy_config_uses_conservative_defaults():
+    policy = AmbientVoicePolicy.from_config(
+        {
+            "voice": {
+                "ambient_policy": {
+                    "enabled": False,
+                    "default_context": "airpods_private",
+                    "rule_profiles": {
+                        "airpods_private": {
+                            "allow_sensitive_topics": True,
+                            "max_chars": 500,
+                        }
+                    },
+                }
+            }
+        }
+    )
+
+    decision = policy.evaluate(
+        "Your trading PnL and portfolio drawdown look risky today.",
+        living_room_context(config_scope=None, explicit_spoken_request=True, is_private_context=True),
+    )
+
+    assert decision.rule_profile == "living_room_default"
+    assert decision.allowed is False
+    assert decision.classifiers["sensitive_topic"] is True

--- a/tests/gateway/test_ambient_voice_policy.py
+++ b/tests/gateway/test_ambient_voice_policy.py
@@ -156,3 +156,45 @@ def test_policy_metadata_contains_only_safe_reason_codes_and_booleans():
         "dropped_paths": True,
         "blocked_sensitive_topic": False,
     }
+
+
+
+def test_output_device_selects_airpods_profile_when_no_config_scope():
+    decision = evaluate(
+        "Your trading PnL and portfolio drawdown look risky today.",
+        output_device="airpods",
+        config_scope=None,
+        explicit_spoken_request=True,
+        is_private_context=True,
+    )
+
+    assert decision.allowed is True
+    assert decision.rule_profile == "airpods_private"
+
+
+def test_ambient_policy_loads_rule_profiles_from_config(monkeypatch):
+    import hermes_cli.config as hermes_config
+
+    def fake_load_config():
+        return {
+            "voice": {
+                "ambient_policy": {
+                    "default_context": "living_room_default",
+                    "rule_profiles": {
+                        "living_room_default": {
+                            "max_chars": 24,
+                            "max_seconds": {"completion": 2},
+                        }
+                    },
+                }
+            }
+        }
+
+    monkeypatch.setattr(hermes_config, "load_config", fake_load_config)
+    decision = AmbientVoicePolicy().evaluate(
+        "I completed the implementation and verified the focused tests passed.",
+        living_room_context(),
+    )
+
+    assert decision.max_seconds == 2
+    assert decision.text == "I completed the impleme…"

--- a/tests/gateway/test_ambient_voice_policy.py
+++ b/tests/gateway/test_ambient_voice_policy.py
@@ -1,0 +1,158 @@
+from gateway.ambient_voice_policy import AmbientVoicePolicy, VoiceContext
+
+
+def living_room_context(**overrides):
+    values = {
+        "source": "assistant_final",
+        "platform": "discord",
+        "channel_id": "home",
+        "chat_id": "chat-1",
+        "thread_id": None,
+        "source_message_id": "msg-1",
+        "input_modality": "voice",
+        "output_device": "living_room",
+        "profile": "eon",
+        "explicit_spoken_request": False,
+        "is_private_context": False,
+        "config_scope": "living_room_default",
+    }
+    values.update(overrides)
+    return VoiceContext(**values)
+
+
+def evaluate(text, **context_overrides):
+    return AmbientVoicePolicy().evaluate(text, living_room_context(**context_overrides))
+
+
+def test_secret_like_tokens_are_suppressed_without_raw_metadata():
+    synthetic_token = "sk-" + "s" * 16
+
+    decision = evaluate(f"The token is {synthetic_token}")
+
+    assert decision.allowed is False
+    assert decision.suppressed is True
+    assert decision.text == ""
+    assert "secret_like" in decision.reasons
+    assert decision.classifiers["secret_like"] is True
+    assert synthetic_token not in str(decision.to_metadata())
+
+
+def test_slack_dash_tokens_are_suppressed_without_raw_metadata():
+    synthetic_token = "xoxb-" + "a" * 12 + "-" + "b" * 12
+
+    decision = evaluate(f"The workspace bot token is {synthetic_token}")
+
+    assert decision.allowed is False
+    assert decision.text == ""
+    assert decision.classifiers["secret_like"] is True
+    assert "secret_like" in decision.reasons
+    assert synthetic_token not in str(decision.to_metadata())
+
+
+def test_prefixed_env_secret_assignments_are_suppressed_without_raw_metadata():
+    synthetic_value = "hms_" + "c" * 18
+    secret_assignment = "SLACK_BOT_TOKEN=" + synthetic_value
+
+    decision = evaluate(f"I found {secret_assignment} in the environment")
+
+    assert decision.allowed is False
+    assert decision.text == ""
+    assert decision.classifiers["secret_like"] is True
+    assert "secret_like" in decision.reasons
+    assert secret_assignment not in str(decision.to_metadata())
+
+
+def test_code_fences_and_inline_code_are_stripped_and_can_result_in_silence():
+    decision = evaluate("```python\nprint('do not speak code')\n``` and `rm -rf /tmp/example`")
+
+    assert decision.allowed is False
+    assert decision.suppressed is True
+    assert decision.text == ""
+    assert decision.classifiers["code"] is True
+    assert "code_stripped" in decision.reasons
+
+
+def test_stack_traces_and_command_logs_are_suppressed():
+    decision = evaluate(
+        "$ pytest tests/gateway/test_ambient_voice_policy.py -q\n"
+        "Traceback (most recent call last):\n"
+        "  File \"/Users/brenno/.hermes/hermes-agent/gateway/run.py\", line 10, in run\n"
+        "FAILED tests/gateway/test_ambient_voice_policy.py::test_policy"
+    )
+
+    assert decision.allowed is False
+    assert decision.suppressed is True
+    assert decision.classifiers["stack_trace"] is True
+    assert decision.classifiers["command_log"] is True
+    assert "stack_trace" in decision.reasons
+    assert "/Users/brenno" not in str(decision.to_metadata())
+
+
+def test_raw_file_paths_are_removed_from_allowed_speech():
+    decision = evaluate("I wrote the report to /Users/brenno/main/aegis/report.md and verified it.")
+
+    assert decision.allowed is True
+    assert decision.sanitized is True
+    assert decision.classifiers["raw_path"] is True
+    assert "raw_path_stripped" in decision.reasons
+    assert "/Users/brenno" not in decision.text
+    assert decision.text == "I wrote the report to a local file and verified it."
+
+
+def test_sensitive_financial_or_trading_topics_are_suppressed_in_living_room_by_default():
+    decision = evaluate("Your trading PnL and portfolio drawdown look risky today.")
+
+    assert decision.allowed is False
+    assert decision.suppressed is True
+    assert decision.classifiers["sensitive_topic"] is True
+    assert "sensitive_topic" in decision.reasons
+
+
+def test_sensitive_topics_can_be_acknowledged_when_explicit_and_private_but_not_spoken_in_full():
+    decision = evaluate(
+        "Your trading PnL and portfolio drawdown look risky today.",
+        output_device="airpods",
+        config_scope="airpods_private",
+        explicit_spoken_request=True,
+        is_private_context=True,
+    )
+
+    assert decision.allowed is True
+    assert decision.sanitized is True
+    assert decision.text == "I can discuss that sensitive topic in this private voice context."
+    assert "sensitive_topic_summarized" in decision.reasons
+
+
+def test_long_responses_are_bounded_to_one_breath():
+    decision = evaluate(
+        "I completed the implementation and ran the targeted tests. "
+        "Here are several additional details that should not be spoken aloud in the room. "
+        "A third sentence should also be omitted."
+    )
+
+    assert decision.allowed is True
+    assert decision.truncated is True
+    assert decision.text == "I completed the implementation and ran the targeted tests."
+    assert decision.original_chars > len(decision.text)
+    assert "bounded_to_one_sentence" in decision.reasons
+
+
+def test_policy_metadata_contains_only_safe_reason_codes_and_booleans():
+    decision = evaluate("AWS_SECRET_ACCESS_KEY=fake-value-for-policy-check at ~/main/private.txt")
+
+    metadata = decision.to_metadata()
+
+    assert metadata == {
+        "allowed": False,
+        "sanitized": True,
+        "truncated": False,
+        "suppressed": True,
+        "reason_codes": ("secret_like", "raw_path_stripped", "empty_after_sanitization"),
+        "rule_profile": "living_room_default",
+        "blocked_secret_like": True,
+        "dropped_code": False,
+        "blocked_stack_trace": False,
+        "dropped_tool_logs": False,
+        "dropped_paths": True,
+        "blocked_sensitive_topic": False,
+    }

--- a/tests/gateway/test_final_speech_summarizer.py
+++ b/tests/gateway/test_final_speech_summarizer.py
@@ -240,6 +240,7 @@ def test_validation_rejects_paths_secrets_code_media_actions_and_future_promises
         "I updated gateway/run.py and ran tests.",
         "I deployed the bridge and ran tests.",
         "I will update the bridge now.",
+        "The system will send the email.",
     ]
     summarizer = FinalSpeechSummarizer(generator=None, mode="deterministic")
 
@@ -247,3 +248,22 @@ def test_validation_rejects_paths_secrets_code_media_actions_and_future_promises
         valid, reason = summarizer.validate_generated_summary(output, final, VoiceContext())
         assert valid is False, output
         assert reason
+
+
+def test_validation_rejects_hallucinated_actions_not_grounded_in_final_text():
+    final = "I updated the bridge and ran tests."
+    bad_outputs = [
+        "I finished the deployment.",
+        "I completed the migration.",
+        "I wrote the file.",
+        "I emailed Brenno.",
+        "I reviewed the PR.",
+        "I called Alice.",
+        "Your lunch is ready.",
+    ]
+    summarizer = FinalSpeechSummarizer(generator=None, mode="deterministic")
+
+    for output in bad_outputs:
+        valid, reason = summarizer.validate_generated_summary(output, final, VoiceContext())
+        assert valid is False, output
+        assert reason in {"unsupported_action", "unsupported_content"}

--- a/tests/gateway/test_final_speech_summarizer.py
+++ b/tests/gateway/test_final_speech_summarizer.py
@@ -267,3 +267,18 @@ def test_validation_rejects_hallucinated_actions_not_grounded_in_final_text():
         valid, reason = summarizer.validate_generated_summary(output, final, VoiceContext())
         assert valid is False, output
         assert reason in {"unsupported_action", "unsupported_content"}
+
+
+
+def test_generated_mode_silences_invalid_output_without_deterministic_fallback():
+    generator = FakeGenerator("I deployed the bridge and ran 15 tests.")
+    summarizer = FinalSpeechSummarizer(generator=generator, mode="generated")
+
+    result = summarizer.summarize(
+        "I updated the bridge and ran 14 tests.",
+        VoiceContext(max_spoken_chars=180),
+    )
+
+    assert result.method == "silence"
+    assert result.text == ""
+    assert result.reason == "generated_invalid: unsupported_number"

--- a/tests/gateway/test_final_speech_summarizer.py
+++ b/tests/gateway/test_final_speech_summarizer.py
@@ -1,0 +1,249 @@
+import time
+
+from gateway.final_speech_summarizer import (
+    FinalSpeechSummarizer,
+    VoiceContext,
+    VoiceSummaryResult,
+)
+
+
+class FakeGenerator:
+    def __init__(self, result=None, *, delay=0.0, error=None):
+        self.result = result
+        self.delay = delay
+        self.error = error
+        self.calls = []
+
+    def __call__(self, prompt, *, timeout_ms):
+        self.calls.append((prompt, timeout_ms))
+        if self.delay:
+            time.sleep(self.delay)
+        if self.error:
+            raise self.error
+        return self.result
+
+
+def test_deterministic_summary_uses_first_safe_sentence_without_canned_fallback():
+    summarizer = FinalSpeechSummarizer(generator=None, mode="deterministic")
+
+    result = summarizer.summarize(
+        "I updated the bridge and ran 14 tests. Full details are in Discord.",
+        VoiceContext(max_spoken_chars=180),
+    )
+
+    assert result == VoiceSummaryResult(
+        kind="completion",
+        text="I updated the bridge and ran 14 tests.",
+        method="deterministic",
+        policy={
+            "pre_sanitized": True,
+            "post_sanitized": True,
+            "truncated": False,
+            "blocked_sensitive_content": False,
+            "dropped_tool_logs": False,
+            "dropped_code": False,
+            "dropped_media_tags": False,
+            "dropped_paths": False,
+        },
+        reason=None,
+    )
+
+
+def test_generated_success_returns_short_room_safe_line_and_metadata_flags():
+    generator = FakeGenerator("I updated the bridge and verified 14 tests pass.")
+    summarizer = FinalSpeechSummarizer(generator=generator, mode="hybrid")
+
+    result = summarizer.summarize(
+        "I updated the bridge and verified 14 tests pass. Details: no regressions.",
+        VoiceContext(timeout_ms=250, max_spoken_chars=180, voice_profile="eon"),
+    )
+
+    assert result.kind == "completion"
+    assert result.text == "I updated the bridge and verified 14 tests pass."
+    assert result.method == "generated"
+    assert result.policy["pre_sanitized"] is True
+    assert result.policy["post_sanitized"] is True
+    assert result.policy["blocked_sensitive_content"] is False
+    [call] = generator.calls
+    assert call[1] == 250
+    assert "You are Eon speaking aloud" in call[0]
+    assert "Use only facts explicitly present" in call[0]
+
+
+def test_generated_timeout_falls_back_to_deterministic_summary_without_material_delay():
+    generator = FakeGenerator("I should arrive too late.", delay=0.2)
+    summarizer = FinalSpeechSummarizer(generator=generator, mode="hybrid")
+
+    started = time.perf_counter()
+    result = summarizer.summarize(
+        "I updated the bridge and ran the tests. Extra details follow.",
+        VoiceContext(timeout_ms=5, max_spoken_chars=180),
+    )
+    elapsed = time.perf_counter() - started
+
+    assert result.method == "deterministic"
+    assert result.text == "I updated the bridge and ran the tests."
+    assert result.reason == "generated_timeout"
+    assert elapsed < 0.08
+
+
+def test_generated_invalid_unsupported_number_falls_back():
+    generator = FakeGenerator("I updated the bridge and verified 99 tests pass.")
+    summarizer = FinalSpeechSummarizer(generator=generator, mode="hybrid")
+
+    result = summarizer.summarize(
+        "I updated the bridge and verified tests pass.",
+        VoiceContext(max_spoken_chars=180),
+    )
+
+    assert result.method == "deterministic"
+    assert result.text == "I updated the bridge and verified tests pass."
+    assert result.reason == "generated_invalid: unsupported_number"
+
+
+def test_generated_summary_can_use_safe_facts_after_first_sentence():
+    generator = FakeGenerator("I updated the bridge and ran 14 tests.")
+    summarizer = FinalSpeechSummarizer(generator=generator, mode="hybrid")
+
+    result = summarizer.summarize(
+        "Summary: bridge work is complete. Evidence: I updated the bridge and ran 14 tests.",
+        VoiceContext(max_spoken_chars=180),
+    )
+
+    assert result.method == "generated"
+    assert result.text == "I updated the bridge and ran 14 tests."
+
+
+def test_empty_safe_output_returns_silence_not_finished():
+    summarizer = FinalSpeechSummarizer(generator=None, mode="deterministic")
+
+    result = summarizer.summarize(
+        "MEDIA:/tmp/report.pdf\n```python\nprint('nothing safe')\n```",
+        VoiceContext(max_spoken_chars=180),
+    )
+
+    assert result.kind == "completion"
+    assert result.text == ""
+    assert result.method == "silence"
+    assert result.reason == "empty_safe_output"
+
+
+def test_inline_code_only_final_response_returns_silence():
+    summarizer = FinalSpeechSummarizer(generator=None, mode="deterministic")
+
+    result = summarizer.summarize(
+        "`print('nothing safe')`",
+        VoiceContext(max_spoken_chars=180),
+    )
+
+    assert result.text == ""
+    assert result.method == "silence"
+    assert result.reason == "empty_safe_output"
+
+
+def test_question_kind_is_source_of_truth_even_with_generated_summary():
+    generator = FakeGenerator("Should voice be enabled everywhere, or only at home?")
+    summarizer = FinalSpeechSummarizer(generator=generator, mode="hybrid")
+
+    result = summarizer.summarize(
+        "Should voice be enabled everywhere, or only at home?",
+        VoiceContext(max_spoken_chars=180),
+    )
+
+    assert result.kind == "question"
+    assert result.text.endswith("?")
+    assert result.method == "generated"
+
+
+def test_generated_summary_cannot_turn_question_into_statement():
+    generator = FakeGenerator("Voice should be enabled only at home.")
+    summarizer = FinalSpeechSummarizer(generator=generator, mode="hybrid")
+
+    result = summarizer.summarize(
+        "Should voice be enabled everywhere, or only at home?",
+        VoiceContext(max_spoken_chars=180),
+    )
+
+    assert result.kind == "question"
+    assert result.text == "Should voice be enabled everywhere, or only at home?"
+    assert result.method == "deterministic"
+    assert result.reason == "generated_invalid: question_downgrade"
+
+
+def test_generated_exception_falls_back_to_deterministic_summary():
+    generator = FakeGenerator(error=RuntimeError("model unavailable"))
+    summarizer = FinalSpeechSummarizer(generator=generator, mode="hybrid")
+
+    result = summarizer.summarize(
+        "I updated the bridge and ran the tests. Extra details follow.",
+        VoiceContext(max_spoken_chars=180),
+    )
+
+    assert result.method == "deterministic"
+    assert result.text == "I updated the bridge and ran the tests."
+    assert result.reason == "generated_exception"
+
+
+def test_error_kind_is_source_of_truth_even_with_generated_summary():
+    generator = FakeGenerator("The provider timed out safely.")
+    summarizer = FinalSpeechSummarizer(generator=generator, mode="hybrid")
+
+    result = summarizer.summarize(
+        "Error: provider timeout while generating the response.",
+        VoiceContext(max_spoken_chars=180),
+    )
+
+    assert result.kind == "error"
+    assert result.method == "generated"
+    assert result.text == "The provider timed out safely."
+
+
+def test_generated_summary_cannot_downgrade_error_to_completion():
+    generator = FakeGenerator("All set.")
+    summarizer = FinalSpeechSummarizer(generator=generator, mode="hybrid")
+
+    result = summarizer.summarize(
+        "Error: provider timeout while generating the response.",
+        VoiceContext(max_spoken_chars=180),
+    )
+
+    assert result.kind == "error"
+    assert result.text == "Error: provider timeout while generating the response."
+    assert result.method == "deterministic"
+    assert result.reason == "generated_invalid: error_downgrade"
+
+
+def test_validation_rejects_curly_apostrophe_future_promises_not_in_final_text():
+    summarizer = FinalSpeechSummarizer(generator=None, mode="deterministic")
+
+    valid, reason = summarizer.validate_generated_summary(
+        "I’ll share that now.",
+        "The bridge work is complete.",
+        VoiceContext(),
+    )
+
+    assert valid is False
+    assert reason == "future_promise"
+
+
+def test_validation_rejects_paths_secrets_code_media_actions_and_future_promises():
+    final = "I updated the bridge and ran tests."
+    bad_outputs = [
+        "I wrote /Users/brenno/.hermes/config.yaml.",
+        "I used /opt/homebrew/bin/rtk.",
+        r"I wrote C:\\Users\\brenno\\secret.txt.",
+        "The token starts with sk-123...cdef.",
+        "api key is abcdefghijk",
+        "Bearer abcdefghijk",
+        "```python\nprint('x')\n```",
+        "MEDIA:/tmp/report.pdf is ready.",
+        "I updated gateway/run.py and ran tests.",
+        "I deployed the bridge and ran tests.",
+        "I will update the bridge now.",
+    ]
+    summarizer = FinalSpeechSummarizer(generator=None, mode="deterministic")
+
+    for output in bad_outputs:
+        valid, reason = summarizer.validate_generated_summary(output, final, VoiceContext())
+        assert valid is False, output
+        assert reason

--- a/tests/gateway/test_gateway_final_voice_events.py
+++ b/tests/gateway/test_gateway_final_voice_events.py
@@ -50,6 +50,7 @@ class _FakeAgent:
 async def test_gateway_success_turn_publishes_only_final_voice_event(monkeypatch):
     from gateway.config import GatewayConfig, Platform
     import gateway.pulse_voice_events as pulse_voice_events
+    import gateway.voice_response_pipeline as voice_response_pipeline
     import gateway.run as gateway_run
     from gateway.run import GatewayRunner
     from gateway.session import SessionSource
@@ -58,20 +59,27 @@ async def test_gateway_success_turn_publishes_only_final_voice_event(monkeypatch
     voice_event_calls = []
     voice_out_calls = []
     completion_calls = []
+    voice_emissions = []
 
     def record_voice_event(kind, text, **metadata):
         voice_event_calls.append((kind, text, metadata))
+        voice_emissions.append(("event", kind, text, metadata))
 
     def record_voice_out(kind, text, **metadata):
         voice_out_calls.append((kind, text, metadata))
+        voice_emissions.append(("voice_out", kind, text, metadata))
 
-    def record_completion(final_response, **metadata):
+    def record_completion(self, final_response, context, **kwargs):
+        metadata = context.to_metadata()
         completion_calls.append((final_response, metadata))
+        voice_emissions.append(("completion", "completion", final_response, metadata))
+        return original_publish_final_response(self, final_response, context, **kwargs)
 
+    original_publish_final_response = voice_response_pipeline.VoiceResponsePipeline.publish_final_response
     monkeypatch.setattr(run_agent, "AIAgent", _FakeAgent)
     monkeypatch.setattr(pulse_voice_events, "publish_voice_event", record_voice_event)
     monkeypatch.setattr(pulse_voice_events, "publish_voice_out", record_voice_out)
-    monkeypatch.setattr(pulse_voice_events, "publish_completion_voice_out", record_completion)
+    monkeypatch.setattr(voice_response_pipeline.VoiceResponsePipeline, "publish_final_response", record_completion)
     monkeypatch.setattr(
         gateway_run,
         "_load_gateway_config",
@@ -152,21 +160,32 @@ async def test_gateway_success_turn_publishes_only_final_voice_event(monkeypatch
         event_message_id="message-source-001",
     )
 
-    assert result["final_response"] == "I finished the gateway voice regression and verified the seam."
-    assert ("commentary", "I am checking the gateway seam.") in [
-        (kind, text) for kind, text, _metadata in voice_event_calls
-    ]
-    assert all(kind != "ack" for kind, _text, _metadata in voice_event_calls)
-    assert all(kind != "ack" for kind, _text, _metadata in voice_out_calls)
-    assert completion_calls == [
+    final_response = "I finished the gateway voice regression and verified the seam."
+    expected_metadata = {
+        "session_id": "session-abc",
+        "platform": "discord",
+        "chat_id": "chat-123",
+        "thread_id": "thread-456",
+        "source_message_id": "message-source-001",
+        "voice_profile": "eon",
+        "room_context": "living_room",
+    }
+
+    assert result["final_response"] == final_response
+    assert voice_event_calls == []
+    assert voice_out_calls == [
         (
-            "I finished the gateway voice regression and verified the seam.",
+            "completion",
+            final_response,
             {
-                "session_id": "session-abc",
-                "platform": "discord",
-                "chat_id": "chat-123",
-                "thread_id": "thread-456",
-                "source_message_id": "message-source-001",
+                **expected_metadata,
+                "source": "assistant_final",
+                "derived_from": "final_response",
+                "policy": voice_out_calls[0][2]["policy"],
+                "summarizer": voice_out_calls[0][2]["summarizer"],
             },
         )
     ]
+    assert completion_calls == [(final_response, expected_metadata)]
+    assert voice_emissions[0] == ("completion", "completion", final_response, expected_metadata)
+    assert voice_emissions[1][0:3] == ("voice_out", "completion", final_response)

--- a/tests/gateway/test_gateway_final_voice_events.py
+++ b/tests/gateway/test_gateway_final_voice_events.py
@@ -1,0 +1,172 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+
+class _FakeHooks:
+    loaded_hooks = False
+
+    async def emit(self, *_args, **_kwargs):
+        return None
+
+
+class _FakeAgent:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.session_id = kwargs.get("session_id")
+        self.model = kwargs.get("model")
+        self.provider = kwargs.get("provider")
+        self.base_url = kwargs.get("base_url")
+        self.api_key = kwargs.get("api_key")
+        self.api_mode = kwargs.get("api_mode")
+        self.is_interrupted = False
+        self.interim_assistant_callback = None
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        if self.interim_assistant_callback:
+            self.interim_assistant_callback("I am checking the gateway seam.")
+        return {
+            "final_response": "I finished the gateway voice regression and verified the seam.",
+            "messages": [
+                {"role": "assistant", "content": "I am checking the gateway seam."},
+                {
+                    "role": "assistant",
+                    "content": "I finished the gateway voice regression and verified the seam.",
+                },
+            ],
+            "api_calls": 1,
+            "completed": True,
+        }
+
+    def get_activity_summary(self):
+        return {"seconds_since_activity": 0.0, "api_call_count": 1, "max_iterations": 90}
+
+    def interrupt(self, _message=None):
+        self.is_interrupted = True
+
+
+@pytest.mark.asyncio
+async def test_gateway_success_turn_publishes_only_final_voice_event(monkeypatch):
+    from gateway.config import GatewayConfig, Platform
+    import gateway.pulse_voice_events as pulse_voice_events
+    import gateway.run as gateway_run
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+    import run_agent
+
+    voice_event_calls = []
+    voice_out_calls = []
+    completion_calls = []
+
+    def record_voice_event(kind, text, **metadata):
+        voice_event_calls.append((kind, text, metadata))
+
+    def record_voice_out(kind, text, **metadata):
+        voice_out_calls.append((kind, text, metadata))
+
+    def record_completion(final_response, **metadata):
+        completion_calls.append((final_response, metadata))
+
+    monkeypatch.setattr(run_agent, "AIAgent", _FakeAgent)
+    monkeypatch.setattr(pulse_voice_events, "publish_voice_event", record_voice_event)
+    monkeypatch.setattr(pulse_voice_events, "publish_voice_out", record_voice_out)
+    monkeypatch.setattr(pulse_voice_events, "publish_completion_voice_out", record_completion)
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "display": {
+                "tool_progress": "off",
+                "interim_assistant_messages": True,
+                "streaming": False,
+            },
+            "agent": {"disabled_toolsets": []},
+        },
+    )
+    monkeypatch.setenv("HERMES_AGENT_TIMEOUT", "0")
+    monkeypatch.setenv("HERMES_AGENT_NOTIFY_INTERVAL", "0")
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    object.__setattr__(runner, "config", GatewayConfig())
+    object.__setattr__(runner, "adapters", {})
+    object.__setattr__(runner, "hooks", _FakeHooks())
+    object.__setattr__(runner, "_ephemeral_system_prompt", "")
+    object.__setattr__(runner, "_provider_routing", {})
+    object.__setattr__(runner, "_prefill_messages", [])
+    object.__setattr__(runner, "_fallback_model", None)
+    object.__setattr__(runner, "_session_db", None)
+    object.__setattr__(runner, "session_store", SimpleNamespace(_entries={}, _save=lambda: None))
+    object.__setattr__(runner, "_running_agents", {})
+    object.__setattr__(runner, "_draining", False)
+    object.__setattr__(runner, "_get_proxy_url", lambda: None)
+    object.__setattr__(
+        runner,
+        "_resolve_session_agent_runtime",
+        lambda **_kwargs: ("fake-model", {"provider": "fake-provider"}),
+    )
+    object.__setattr__(runner, "_resolve_session_reasoning_config", lambda **_kwargs: None)
+    object.__setattr__(runner, "_load_service_tier", lambda: None)
+    object.__setattr__(
+        runner,
+        "_resolve_turn_agent_config",
+        lambda user_message, model, runtime_kwargs: {
+            "model": model,
+            "runtime": runtime_kwargs,
+            "request_overrides": None,
+        },
+    )
+    object.__setattr__(runner, "_agent_config_signature", lambda *_args, **_kwargs: "sig")
+    object.__setattr__(runner, "_extract_cache_busting_config", lambda user_config: {})
+    object.__setattr__(runner, "_enforce_agent_cache_cap", lambda: None)
+    object.__setattr__(runner, "_consume_pending_native_image_paths", lambda session_key: [])
+    object.__setattr__(
+        runner,
+        "_thread_metadata_for_source",
+        lambda source, reply_to_message_id=None: None,
+    )
+    object.__setattr__(runner, "_is_session_run_current", lambda session_key, generation: True)
+    object.__setattr__(
+        runner,
+        "_run_in_executor_with_context",
+        lambda func, *args: asyncio.to_thread(func, *args),
+    )
+
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="chat-123",
+        thread_id="thread-456",
+        user_id="user-789",
+        user_name="Brenno",
+        chat_type="thread",
+    )
+
+    result = await runner._run_agent(
+        "please do the work",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="session-abc",
+        session_key="discord:chat-123:thread-456",
+        run_generation=1,
+        event_message_id="message-source-001",
+    )
+
+    assert result["final_response"] == "I finished the gateway voice regression and verified the seam."
+    assert ("commentary", "I am checking the gateway seam.") in [
+        (kind, text) for kind, text, _metadata in voice_event_calls
+    ]
+    assert all(kind != "ack" for kind, _text, _metadata in voice_event_calls)
+    assert all(kind != "ack" for kind, _text, _metadata in voice_out_calls)
+    assert completion_calls == [
+        (
+            "I finished the gateway voice regression and verified the seam.",
+            {
+                "session_id": "session-abc",
+                "platform": "discord",
+                "chat_id": "chat-123",
+                "thread_id": "thread-456",
+                "source_message_id": "message-source-001",
+            },
+        )
+    ]

--- a/tests/gateway/test_generated_ack_dispatch.py
+++ b/tests/gateway/test_generated_ack_dispatch.py
@@ -1,6 +1,16 @@
 from types import SimpleNamespace
 
 
+def test_generated_ack_submission_is_voice_message_only():
+    import gateway.run as gateway_run
+
+    assert gateway_run._should_submit_generated_ack_voice_out("voice") is True
+    assert gateway_run._should_submit_generated_ack_voice_out(SimpleNamespace(value="voice")) is True
+    assert gateway_run._should_submit_generated_ack_voice_out(SimpleNamespace(name="VOICE")) is True
+    assert gateway_run._should_submit_generated_ack_voice_out("text") is False
+    assert gateway_run._should_submit_generated_ack_voice_out(SimpleNamespace(value="photo")) is False
+
+
 def test_generated_ack_dispatch_saturation_drops_without_queueing(monkeypatch):
     import gateway.run as gateway_run
 

--- a/tests/gateway/test_generated_ack_dispatch.py
+++ b/tests/gateway/test_generated_ack_dispatch.py
@@ -1,0 +1,61 @@
+from types import SimpleNamespace
+
+
+def test_generated_ack_dispatch_saturation_drops_without_queueing(monkeypatch):
+    import gateway.run as gateway_run
+
+    class SaturatedSlots:
+        def acquire(self, *, blocking):
+            assert blocking is False
+            return False
+
+        def release(self):
+            raise AssertionError("saturated dispatch must not release without acquire")
+
+    class ExecutorMustNotRun:
+        def submit(self, fn):
+            raise AssertionError("saturated dispatch must not submit work")
+
+    monkeypatch.setattr(gateway_run, "_GENERATED_ACK_DISPATCH_SLOTS", SaturatedSlots())
+    monkeypatch.setattr(gateway_run, "_GENERATED_ACK_DISPATCH_EXECUTOR", ExecutorMustNotRun())
+
+    assert gateway_run._submit_generated_ack_voice_out("voice request") is False
+
+
+def test_generated_ack_dispatch_releases_slot_after_publish(monkeypatch):
+    import gateway.run as gateway_run
+
+    calls = []
+    releases = []
+
+    class Slots:
+        def acquire(self, *, blocking):
+            assert blocking is False
+            return True
+
+        def release(self):
+            releases.append(True)
+
+    class ImmediateFuture:
+        def add_done_callback(self, callback):
+            callback(self)
+
+    class ImmediateExecutor:
+        def submit(self, fn):
+            fn()
+            return ImmediateFuture()
+
+    def fake_publish(message_text, **kwargs):
+        calls.append((message_text, kwargs))
+
+    monkeypatch.setattr(gateway_run, "_GENERATED_ACK_DISPATCH_SLOTS", Slots())
+    monkeypatch.setattr(gateway_run, "_GENERATED_ACK_DISPATCH_EXECUTOR", ImmediateExecutor())
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "gateway.pulse_voice_events",
+        SimpleNamespace(publish_generated_ack_voice_out=fake_publish),
+    )
+
+    assert gateway_run._submit_generated_ack_voice_out("voice request", session_id="s1") is True
+    assert calls == [("voice request", {"session_id": "s1"})]
+    assert releases == [True]

--- a/tests/gateway/test_generated_ack_harness.py
+++ b/tests/gateway/test_generated_ack_harness.py
@@ -78,7 +78,7 @@ def test_prompt_context_redacts_user_secrets_paths_urls_logs_and_media():
     """
     prompt = GeneratedAckHarness().build_prompt(AckContext(user_message=raw))
 
-    assert "User asked about technical content; sensitive details omitted." in prompt
+    assert "User asked about sensitive content; details omitted." in prompt
     assert "/Users/brenno" not in prompt
     assert "gateway/generated_ack_harness.py" not in prompt
     assert "../private/config" not in prompt
@@ -130,8 +130,21 @@ def test_prompt_context_redacts_separatorless_short_secret_keywords():
         "pk_live_[REDACTED]",
     ):
         prompt = GeneratedAckHarness().build_prompt(AckContext(user_message=raw))
-        assert "User asked about technical content; sensitive details omitted." in prompt
+        assert "User asked about sensitive content; details omitted." in prompt
         assert raw not in prompt
+
+
+def test_prompt_context_coarsens_sensitive_topics_before_generation():
+    from gateway.generated_ack_harness import AckContext, GeneratedAckHarness
+
+    raw = "My portfolio liquidation and medical diagnosis details are private."
+    prompt = GeneratedAckHarness().build_prompt(AckContext(user_message=raw))
+
+    assert "User asked about sensitive content; details omitted." in prompt
+    assert "portfolio" not in prompt
+    assert "liquidation" not in prompt
+    assert "medical" not in prompt
+    assert "diagnosis" not in prompt
 
 
 def test_generated_ack_success_uses_injected_generator_and_timeout():

--- a/tests/gateway/test_generated_ack_harness.py
+++ b/tests/gateway/test_generated_ack_harness.py
@@ -1,0 +1,309 @@
+import json
+import time
+from types import SimpleNamespace
+
+import pytest
+
+
+class FakeAckGenerator:
+    def __init__(self, result):
+        self.result = result
+        self.calls = []
+
+    def __call__(self, prompt, *, timeout_ms):
+        self.calls.append((prompt, timeout_ms))
+        return self.result
+
+
+def test_generated_ack_default_config_shape():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    cfg = DEFAULT_CONFIG["pulse"]["voice"]["generated_ack"]
+    assert cfg["mode"] == "generated"
+    assert 800 <= cfg["timeout_ms"] <= 1500
+    assert cfg["max_words"] == 12
+    assert cfg["max_spoken_chars"] <= 120
+    assert cfg["max_seconds"] == 2
+    assert cfg["voice_profile"] == "eon"
+    assert cfg["silence_on_failure"] is True
+    assert "fallback" not in cfg or cfg["fallback"] in {None, "silence"}
+
+
+def test_prompt_contract_contains_required_voice_only_constraints():
+    from gateway.generated_ack_harness import AckContext, GeneratedAckHarness
+
+    harness = GeneratedAckHarness(generator=lambda prompt, *, timeout_ms: "That voice path needs the bridge checked.")
+    prompt = harness.build_prompt(AckContext(user_message="The voice path feels wrong."))
+
+    assert "Generate a short natural spoken acknowledgement as Eon" in prompt
+    assert "Maximum 12 words" in prompt
+    assert "No canned acknowledgement phrases" in prompt
+    assert "Do not promise completion" in prompt
+    assert "This is room audio, not Discord text" in prompt
+    assert "The voice path feels wrong" in prompt
+
+
+def test_prompt_context_redacts_user_secrets_paths_urls_logs_and_media():
+    from gateway.generated_ack_harness import AckContext, GeneratedAckHarness
+
+    raw = """
+    check /Users/brenno/.hermes/.env and gateway/generated_ack_harness.py
+    ../private/config src/secrets/config
+    https://example.com/private
+    OPENAI_API_KEY=[REDACTED] HERMES_TOKEN=[REDACTED]
+    token [REDACTED]
+    password is [REDACTED]
+    MEDIA:/tmp/voice.wav
+    please inspect this output
+    INFO provider warmup line
+    2026-05-24T12:00:00Z ERROR provider leaked details
+    [worker][WARN] provider leaked details
+    ERROR provider leaked details
+    x + y
+    `x + y`
+    select secret from users
+    git status --short
+    foo = bar
+    print('secret')
+    console.log('secret')
+    def leaked_function():
+        return 'secret'
+    ```python
+    print('secret')
+    ```
+    Traceback (most recent call last): boom
+    -----BEGIN PRIVATE KEY-----
+    abc123
+    -----END PRIVATE KEY-----
+    """
+    prompt = GeneratedAckHarness().build_prompt(AckContext(user_message=raw))
+
+    assert "User asked about technical content; sensitive details omitted." in prompt
+    assert "/Users/brenno" not in prompt
+    assert "gateway/generated_ack_harness.py" not in prompt
+    assert "../private/config" not in prompt
+    assert "src/secrets/config" not in prompt
+    assert "https://example.com" not in prompt
+    assert "OPENAI_API_KEY" not in prompt
+    assert "HERMES_TOKEN" not in prompt
+    assert "[REDACTED]" not in prompt
+    assert "password is" not in prompt
+    assert "MEDIA:/tmp/voice.wav" not in prompt
+    assert "INFO provider warmup" not in prompt
+    assert "2026-05-24T12:00:00Z" not in prompt
+    assert "[worker][WARN]" not in prompt
+    assert "ERROR provider leaked" not in prompt
+    assert "x + y" not in prompt
+    assert "select secret from users" not in prompt
+    assert "git status --short" not in prompt
+    assert "foo = bar" not in prompt
+    assert "print('secret')" not in prompt
+    assert "console.log('secret')" not in prompt
+    assert "def leaked_function" not in prompt
+    assert "return 'secret'" not in prompt
+    assert "print('secret')" not in prompt
+    assert "Traceback" not in prompt
+    assert "PRIVATE KEY" not in prompt
+
+
+def test_prompt_context_redacts_separatorless_short_secret_keywords():
+    from gateway.generated_ack_harness import AckContext, GeneratedAckHarness
+
+    for raw in (
+        "token [REDACTED]",
+        "api key [REDACTED]",
+        "access key [REDACTED]",
+        "secret [REDACTED]",
+        "password [REDACTED]",
+        "passwd [REDACTED]",
+        "pwd [REDACTED]",
+        "private key is [REDACTED]",
+        "private key [REDACTED]",
+        "ssh key [REDACTED]",
+        "passphrase [REDACTED]",
+        "credential [REDACTED]",
+        "xoxb-[REDACTED]",
+        "hf_[REDACTED]",
+        "glpat-[REDACTED]",
+        "hk_[REDACTED]",
+        "rk_live_[REDACTED]",
+        "pk_live_[REDACTED]",
+    ):
+        prompt = GeneratedAckHarness().build_prompt(AckContext(user_message=raw))
+        assert "User asked about technical content; sensitive details omitted." in prompt
+        assert raw not in prompt
+
+
+def test_generated_ack_success_uses_injected_generator_and_timeout():
+    from gateway.generated_ack_harness import AckContext, GeneratedAckHarness
+
+    generator = FakeAckGenerator("Yeah, that voice path needs to feel like Eon.")
+    harness = GeneratedAckHarness(generator=generator, mode="generated")
+    result = harness.generate(AckContext(user_message="The voice path feels generic.", timeout_ms=900))
+
+    assert result.method == "generated"
+    assert result.text == "Yeah, that voice path needs to feel like Eon."
+    assert result.reason is None
+    assert generator.calls[0][1] == 900
+
+
+class SlowAckGenerator:
+    def __call__(self, prompt, *, timeout_ms):
+        time.sleep(0.2)
+        return "This arrives too late."
+
+
+def test_generated_ack_timeout_returns_silence_without_material_delay():
+    from gateway.generated_ack_harness import AckContext, GeneratedAckHarness
+
+    harness = GeneratedAckHarness(generator=SlowAckGenerator(), mode="generated")
+    started = time.perf_counter()
+    result = harness.generate(AckContext(user_message="Check voice", timeout_ms=5))
+    elapsed = time.perf_counter() - started
+
+    assert result.method == "silence"
+    assert result.text == ""
+    assert result.reason == "generated_timeout"
+    assert elapsed < 0.08
+
+
+def test_generated_ack_exception_returns_silence_not_canned_fallback():
+    from gateway.generated_ack_harness import AckContext, GeneratedAckHarness
+
+    def boom(prompt, *, timeout_ms):
+        raise RuntimeError("provider down")
+
+    result = GeneratedAckHarness(generator=boom).generate(AckContext(user_message="Check voice"))
+
+    assert result.method == "silence"
+    assert result.text == ""
+    assert result.reason == "generated_error"
+
+
+def test_generated_ack_saturation_returns_silence_without_queueing(monkeypatch):
+    import gateway.generated_ack_harness as generated_ack_harness
+    from gateway.generated_ack_harness import AckContext, GeneratedAckHarness
+
+    class SaturatedSlots:
+        def acquire(self, *, blocking):
+            assert blocking is False
+            return False
+
+    monkeypatch.setattr(generated_ack_harness, "_GENERATOR_SLOTS", SaturatedSlots())
+    generator = FakeAckGenerator("This should never enqueue.")
+
+    result = GeneratedAckHarness(generator=generator).generate(AckContext(user_message="Check voice"))
+
+    assert result.method == "silence"
+    assert result.text == ""
+    assert result.reason == "generated_saturated"
+    assert generator.calls == []
+
+
+@pytest.mark.parametrize("candidate", [
+    "I’m here.",
+    "Got you.",
+    "I’m on it.",
+    "Let’s see.",
+    "Sure, I can help with that.",
+    "Okay.",
+    "Processing your request.",
+])
+def test_generated_ack_rejects_canned_or_generic_phrases(candidate):
+    from gateway.generated_ack_harness import AckContext, GeneratedAckHarness
+
+    harness = GeneratedAckHarness(generator=lambda prompt, *, timeout_ms: candidate)
+    result = harness.generate(AckContext(user_message="Voice test"))
+
+    assert result.method == "silence"
+    assert result.text == ""
+    assert result.reason is not None
+    assert result.reason.startswith("generated_invalid")
+
+
+@pytest.mark.parametrize("candidate", [
+    "I will fix that voice path now.",
+    "I’ll run the tests and verify it.",
+    "Done, the voice bridge is fixed.",
+    "The token is [REDACTED].",
+    "I found it in /Users/brenno/.hermes/config.yaml.",
+    "Check gateway/generated_ack_harness.py next.",
+    "Open ../private/config for the token.",
+    "MEDIA:/tmp/voice.wav",
+    "OPENAI_API_KEY=[REDACTED]",
+    "token [REDACTED]",
+    "api key [REDACTED]",
+    "access key [REDACTED]",
+    "secret [REDACTED]",
+    "private key is [REDACTED]",
+    "private key [REDACTED]",
+    "ssh key [REDACTED]",
+    "passphrase [REDACTED]",
+    "credential [REDACTED]",
+    "xoxb-[REDACTED]",
+    "hf_[REDACTED]",
+    "glpat-[REDACTED]",
+    "hk_[REDACTED]",
+    "rk_live_[REDACTED]",
+    "pk_live_[REDACTED]",
+    "password is [REDACTED]",
+    "eyJ[REDACTED].[REDACTED].[REDACTED]",
+    "-----BEGIN PRIVATE KEY----- [REDACTED]",
+    "print('[REDACTED]')",
+    "console.log('[REDACTED]')",
+    "foo = bar",
+    "INFO provider warmup line",
+    "2026-05-24T12:00:00Z ERROR provider leaked details",
+    "[worker][WARN] provider leaked details",
+    "x + y",
+    "`x + y`",
+    "select secret from users",
+    "git status --short",
+    "def leaked_function():",
+    "function test() { return secret; }",
+    "First sentence. Second sentence.",
+    "One two three four five six seven eight nine ten eleven twelve thirteen.",
+])
+def test_generated_ack_rejects_unsafe_or_overlong_candidates(candidate):
+    from gateway.generated_ack_harness import AckContext, GeneratedAckHarness
+
+    harness = GeneratedAckHarness(generator=lambda prompt, *, timeout_ms: candidate)
+    result = harness.generate(AckContext(user_message="Voice test", max_words=12))
+
+    assert result.method == "silence"
+    assert result.text == ""
+    assert result.reason is not None
+    assert result.reason.startswith("generated_invalid")
+
+
+def test_generated_ack_routes_candidate_through_ambient_policy(monkeypatch):
+    import gateway.generated_ack_harness as generated_ack_harness
+    from gateway.generated_ack_harness import AckContext, GeneratedAckHarness
+
+    calls = []
+
+    class FakeAmbientPolicy:
+        def evaluate(self, text, context):
+            calls.append((text, context))
+            return SimpleNamespace(
+                allowed=True,
+                text="Policy approved voice line.",
+                sanitized=True,
+                truncated=False,
+                suppressed=False,
+                max_seconds=2,
+                reasons=("policy_checked",),
+                classifiers={"code": False, "command_log": False, "raw_path": False, "secret_like": False, "sensitive_topic": False, "stack_trace": False},
+                rule_profile="living_room_default",
+            )
+
+    monkeypatch.setattr(generated_ack_harness, "_AMBIENT_POLICY", FakeAmbientPolicy())
+    result = GeneratedAckHarness(generator=lambda prompt, *, timeout_ms: "A natural Eon voice line.").generate(
+        AckContext(user_message="Voice test", platform="discord", output_device="speaker")
+    )
+
+    assert result.text == "Policy approved voice line."
+    assert calls[0][1].source == "ack"
+    assert calls[0][1].platform == "discord"
+    assert calls[0][1].output_device == "speaker"
+    assert result.policy["allowed"] is True

--- a/tests/gateway/test_pulse_voice_events.py
+++ b/tests/gateway/test_pulse_voice_events.py
@@ -1,0 +1,79 @@
+import json
+
+from gateway.pulse_voice_events import (
+    completion_voice_text,
+    publish_completion_voice_out,
+    publish_voice_event,
+    publish_voice_out,
+    voice_events_path,
+    voice_out_path,
+    voice_safe_text,
+)
+
+
+def _jsonl(path):
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def test_voice_safe_text_removes_code_media_and_bounds_length():
+    text = """
+    Done. MEDIA:/tmp/audio.mp3
+
+    ```python
+    print('do not speak code')
+    ```
+    [[audio_as_voice]] Extra words that should not matter.
+    """
+
+    assert voice_safe_text(text) == "Done."
+
+
+def test_publish_voice_out_writes_canonical_schema_and_legacy_mirror(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    publish_voice_out("ack", "Got it. I’ll wire the voice path.", session_id="s1", source_message_id="m1")
+
+    canonical = _jsonl(voice_out_path())
+    legacy = _jsonl(voice_events_path())
+    assert canonical == legacy
+    assert canonical[0]["kind"] == "ack"
+    assert canonical[0]["text"] == "Got it."
+    assert canonical[0]["max_seconds"] == 4
+    assert canonical[0]["session_id"] == "s1"
+    assert canonical[0]["source_message_id"] == "m1"
+
+
+def test_legacy_delta_events_are_not_published(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    publish_voice_event("delta", "This raw token stream must not be spoken.")
+
+    assert not voice_out_path().exists()
+    assert not voice_events_path().exists()
+
+
+def test_legacy_commentary_maps_to_progress(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    publish_voice_event("commentary", "I’ll inspect that now. More details follow later.")
+
+    [event] = _jsonl(voice_out_path())
+    assert event["kind"] == "progress"
+    assert event["text"] == "I’ll inspect that now."
+
+
+def test_completion_voice_text_summarizes_executor_output():
+    kind, text = completion_voice_text("I updated the bridge and ran the tests. Full details are in Discord.")
+
+    assert kind == "completion"
+    assert text == "Done — I updated the bridge and ran the tests."
+
+
+def test_publish_completion_voice_out_marks_questions(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    publish_completion_voice_out("Which profile should own the worker task?")
+
+    [event] = _jsonl(voice_out_path())
+    assert event["kind"] == "question"
+    assert event["text"] == "Which profile should own the worker task?"

--- a/tests/gateway/test_pulse_voice_events.py
+++ b/tests/gateway/test_pulse_voice_events.py
@@ -423,3 +423,19 @@ def test_publish_completion_voice_out_keeps_platform_text_out_of_voice_history(t
     assert event["derived_from"] == "final_response"
     assert event["voice_profile"] == "eon"
     assert event["summarizer"]["method"] == "generated"
+
+
+def test_publish_completion_voice_out_preserves_safe_summary_failure_reason(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    publish_completion_voice_out(
+        "I updated the bridge and ran 14 tests. Full details are in Discord.",
+        summarizer=lambda _text: "Bridge deployed and 15 tests passed.",
+    )
+
+    [event] = _jsonl(voice_out_path())
+    assert event["summarizer"]["method"] == "deterministic"
+    assert event["summarizer"]["fallback_used"] is True
+    assert event["summarizer"]["validation_failed"] is True
+    assert event["summarizer"]["reason"] == "generated_invalid_unsupported_number"
+    assert "Bridge deployed" not in json.dumps(event["summarizer"])

--- a/tests/gateway/test_pulse_voice_events.py
+++ b/tests/gateway/test_pulse_voice_events.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 
 from gateway.pulse_voice_events import (
     completion_voice_text,
+    is_voice_event_fresh_for_speech,
     publish_completion_voice_out,
     publish_generated_ack_voice_out,
     publish_voice_event,
@@ -85,6 +86,7 @@ def test_publish_voice_out_writes_canonical_schema_and_legacy_mirror(tmp_path, m
             "blocked_secret_like": False,
             "blocked_sensitive_topic": False,
             "blocked_stack_trace": False,
+            "long_response": False,
         },
     }
 
@@ -212,6 +214,32 @@ def test_publish_voice_out_suppresses_secrets_without_raw_metadata(tmp_path, mon
 
     publish_voice_out("completion", f"The token is {UNSAFE_SECRET}; keep it safe.")
 
+    [event] = _jsonl(voice_out_path())
+    assert event["kind"] == "suppressed"
+    assert event["text"] == ""
+    assert event["max_seconds"] == 0
+    assert event["policy"]["allowed"] is False
+    assert event["policy"]["suppressed"] is True
+    assert event["policy"]["classifiers"]["blocked_secret_like"] is True
+    assert event["observability"]["candidate_chars"] > 0
+    assert event["observability"]["spoken_chars"] == 0
+    assert event["observability"]["policy_stage"] == "final"
+    assert event["observability"]["suppression_reason"] == "secret_like_blocked"
+    assert UNSAFE_SECRET not in json.dumps(event, ensure_ascii=False)
+    assert _jsonl(voice_events_path()) == [event]
+
+def test_suppressed_observability_can_be_disabled(tmp_path, monkeypatch):
+    import gateway.pulse_voice_events as pulse_voice_events
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        pulse_voice_events,
+        "_voice_observability_config",
+        lambda: {"emit_suppressed_events": False, "include_candidate_counts": True},
+    )
+
+    publish_voice_out("completion", f"The token is {UNSAFE_SECRET}; keep it safe.")
+
     assert not voice_out_path().exists()
     assert not voice_events_path().exists()
 
@@ -221,15 +249,48 @@ def test_voice_safe_text_suppresses_inline_key_and_password_prose():
     assert voice_safe_text("The temporary password is example-pass-1234 for setup.") == ""
 
 
+def test_observability_candidate_counts_can_be_disabled(tmp_path, monkeypatch):
+    import gateway.pulse_voice_events as pulse_voice_events
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        pulse_voice_events,
+        "_voice_observability_config",
+        lambda: {"emit_suppressed_events": True, "include_candidate_counts": False},
+    )
+
+    publish_voice_out("completion", f"The token is {UNSAFE_SECRET}; keep it safe.")
+
+    [event] = _jsonl(voice_out_path())
+    assert event["kind"] == "suppressed"
+    assert event["observability"] == {
+        "policy_stage": "final",
+        "suppression_reason": "secret_like_blocked",
+    }
+
+
+def test_voice_event_freshness_requires_valid_recent_timestamp():
+    assert is_voice_event_fresh_for_speech({"ts": 100.0}, now=110.0, max_age_seconds=30.0) is True
+    assert is_voice_event_fresh_for_speech({}, now=110.0) is False
+    assert is_voice_event_fresh_for_speech({"ts": "not-a-timestamp"}, now=110.0) is False
+    assert is_voice_event_fresh_for_speech({"ts": 70.0}, now=110.0, max_age_seconds=30.0) is False
+    assert is_voice_event_fresh_for_speech({"ts": 120.0}, now=110.0, max_age_seconds=30.0) is False
+
+
 def test_publish_voice_out_suppresses_bearer_and_aws_style_tokens(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
     publish_voice_out("completion", "Bearer hk_test_1234567890abcdef is configured.")
-    publish_voice_out("completion", "Using AWS key AKIAIOSFODNN7EXAMPLE for the demo.")
+    publish_voice_out("completion", "Using AWS key AKIAIO...MPLE for the demo.")
 
-    assert not voice_out_path().exists()
-    assert not voice_events_path().exists()
-
+    events = _jsonl(voice_out_path())
+    assert [event["kind"] for event in events] == ["suppressed", "suppressed"]
+    assert all(event["text"] == "" for event in events)
+    assert all(event["max_seconds"] == 0 for event in events)
+    assert all(event["observability"]["suppression_reason"] == "secret_like_blocked" for event in events)
+    payload = json.dumps(events, ensure_ascii=False)
+    assert "hk_test_1234567890abcdef" not in payload
+    assert "AKIAIO" not in payload
 
 def test_publish_voice_out_suppresses_paths_and_code_without_fallback(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -238,10 +299,15 @@ def test_publish_voice_out_suppresses_paths_and_code_without_fallback(tmp_path, 
     publish_voice_out("completion", "`print('do not speak inline code')`")
     publish_completion_voice_out("```python\nprint('done')\n```")
 
-    assert not voice_out_path().exists()
+    events = _jsonl(voice_out_path())
+    assert [event["kind"] for event in events] == ["suppressed", "suppressed", "suppressed"]
+    assert all(event["text"] == "" for event in events)
+    assert all(event["observability"]["suppression_reason"] == "empty_after_sanitize" for event in events)
+    payload = json.dumps(events, ensure_ascii=False)
+    assert "/Users/brenno" not in payload
+    assert "print" not in payload
     assert completion_voice_text("```python\nprint('done')\n```") == ("completion", "")
     assert voice_safe_text("`print('do not speak inline code')`") == ""
-
 
 def test_publish_voice_out_suppresses_stack_traces_and_sensitive_topics(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -252,8 +318,14 @@ def test_publish_voice_out_suppresses_stack_traces_and_sensitive_topics(tmp_path
     )
     publish_voice_out("completion", "Your trading PnL and portfolio exposure are down 12% today.")
 
-    assert not voice_out_path().exists()
-
+    events = _jsonl(voice_out_path())
+    assert [event["kind"] for event in events] == ["suppressed", "suppressed"]
+    assert events[0]["observability"]["suppression_reason"] == "stack_trace_blocked"
+    assert events[1]["observability"]["suppression_reason"] == "sensitive_topic_blocked"
+    payload = json.dumps(events, ensure_ascii=False)
+    assert "/Users/brenno" not in payload
+    assert "trading PnL" not in payload
+    assert "portfolio exposure" not in payload
 
 def test_policy_metadata_uses_safe_reason_codes_not_raw_content(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -309,6 +381,7 @@ def test_passed_policy_metadata_is_normalized_without_raw_content(tmp_path, monk
         "blocked_secret_like": False,
         "blocked_sensitive_topic": False,
         "blocked_stack_trace": False,
+        "long_response": False,
     }
 
 
@@ -469,13 +542,21 @@ def test_publish_completion_voice_out_marks_questions(tmp_path, monkeypatch):
     assert event["policy"]["classifiers"]["blocked_secret_like"] is False
 
 
-def test_publish_completion_voice_out_silences_empty_safe_output(tmp_path, monkeypatch):
+def test_publish_completion_voice_out_emits_suppressed_empty_safe_output(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
     publish_completion_voice_out("MEDIA:/tmp/report.pdf\n```python\nprint('nothing safe')\n```")
 
-    assert not voice_out_path().exists()
-    assert not voice_events_path().exists()
+    [event] = _jsonl(voice_out_path())
+    assert _jsonl(voice_events_path()) == [event]
+    assert event["kind"] == "suppressed"
+    assert event["text"] == ""
+    assert event["max_seconds"] == 0
+    assert event["source"] == "assistant_final"
+    assert event["derived_from"] == "final_response"
+    assert event["policy"]["suppressed"] is True
+    assert event["observability"]["suppression_reason"] == "empty_after_sanitize"
+    assert event["observability"]["spoken_chars"] == 0
 
 
 def test_publish_completion_voice_out_keeps_platform_text_out_of_voice_history(tmp_path, monkeypatch):

--- a/tests/gateway/test_pulse_voice_events.py
+++ b/tests/gateway/test_pulse_voice_events.py
@@ -100,6 +100,45 @@ def test_publish_voice_out_adds_default_v2_source_fields(tmp_path, monkeypatch):
     assert event["voice_profile"] == "eon"
 
 
+def test_publish_voice_out_drops_malicious_metadata_from_canonical_and_legacy(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    malicious_values = [
+        "debug_raw=/Users/brenno/.hermes/.env",
+        "API_KEY=hk_test_1234567890abcdef",
+        "Traceback (most recent call last): File /Users/brenno/app.py",
+        "user said my portfolio exposure is private",
+    ]
+
+    publish_voice_out(
+        "completion",
+        "Safe completion.",
+        session_id="safe-session-1",
+        source_message_id="msg-1",
+        debug_raw=malicious_values[0],
+        raw_path=malicious_values[0],
+        user_content=malicious_values[3],
+        error=malicious_values[2],
+        trace=malicious_values[2],
+        path="/Users/brenno/.hermes/.env",
+        extra_secret=malicious_values[1],
+    )
+
+    canonical = _jsonl(voice_out_path())
+    legacy = _jsonl(voice_events_path())
+    assert canonical == legacy
+    payload = json.dumps(canonical[0], ensure_ascii=False)
+    assert canonical[0]["session_id"] == "safe-session-1"
+    assert canonical[0]["source_message_id"] == "msg-1"
+    for raw in malicious_values:
+        assert raw not in payload
+    assert "/Users/brenno" not in payload
+    assert "hk_test_1234567890abcdef" not in payload
+    assert "debug_raw" not in canonical[0]
+    assert "raw_path" not in canonical[0]
+    assert "user_content" not in canonical[0]
+    assert "extra_secret" not in canonical[0]
+
+
 def test_publish_voice_out_routes_candidate_through_ambient_policy(tmp_path, monkeypatch):
     import gateway.pulse_voice_events as pulse_voice_events
 

--- a/tests/gateway/test_pulse_voice_events.py
+++ b/tests/gateway/test_pulse_voice_events.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from gateway.pulse_voice_events import (
     completion_voice_text,
     publish_completion_voice_out,
+    publish_generated_ack_voice_out,
     publish_voice_event,
     publish_voice_out,
     summarize_final_voice_response,
@@ -137,6 +138,25 @@ def test_publish_voice_out_drops_malicious_metadata_from_canonical_and_legacy(tm
     assert "raw_path" not in canonical[0]
     assert "user_content" not in canonical[0]
     assert "extra_secret" not in canonical[0]
+
+
+def test_publish_voice_out_drops_secret_shaped_allowlisted_metadata(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    secret_values = {
+        "session_id": "xoxb-[REDACTED]",
+        "chat_id": "hf_[REDACTED]",
+        "channel_id": "glpat-[REDACTED]",
+        "thread_id": "hk_[REDACTED]",
+        "source_message_id": "rk_live_[REDACTED]",
+    }
+
+    publish_voice_out("completion", "Safe completion.", **secret_values)
+
+    [event] = _jsonl(voice_out_path())
+    payload = json.dumps(event, ensure_ascii=False)
+    for key, raw in secret_values.items():
+        assert key not in event
+        assert raw not in payload
 
 
 def test_publish_voice_out_routes_candidate_through_ambient_policy(tmp_path, monkeypatch):
@@ -290,6 +310,54 @@ def test_passed_policy_metadata_is_normalized_without_raw_content(tmp_path, monk
         "blocked_sensitive_topic": False,
         "blocked_stack_trace": False,
     }
+
+
+def test_publish_generated_ack_voice_out_is_voice_only_and_metadata_safe(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    raw_user_text = "look at /Users/brenno/.hermes/.env and token sk-test...cdef"
+
+    publish_generated_ack_voice_out(
+        raw_user_text,
+        generator=lambda prompt, *, timeout_ms: "That voice bridge needs sharper timing.",
+        session_id="safe-session-2",
+        platform="discord",
+        chat_id="chat-1",
+        thread_id="thread-1",
+        source_message_id="msg-2",
+        input_modality="voice",
+        output_device="room_audio",
+        raw_user_text=raw_user_text,
+        debug_path="/Users/brenno/.hermes/.env",
+    )
+
+    [event] = _jsonl(voice_out_path())
+    payload = json.dumps(event, ensure_ascii=False)
+    assert event["kind"] == "ack"
+    assert event["text"] == "That voice bridge needs sharper timing."
+    assert event["source"] == "generated_ack"
+    assert event["derived_from"] == "turn_start"
+    assert event["max_seconds"] == 2
+    assert event["ack"]["method"] == "generated"
+    assert event["ack"]["timeout_ms"] == 1000
+    assert event["session_id"] == "safe-session-2"
+    assert event["source_message_id"] == "msg-2"
+    assert "raw_user_text" not in event
+    assert "debug_path" not in event
+    assert "/Users/brenno" not in payload
+    assert "sk-test" not in payload
+    assert raw_user_text not in payload
+
+
+def test_publish_generated_ack_voice_out_silences_invalid_generated_ack(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    publish_generated_ack_voice_out(
+        "voice test",
+        generator=lambda prompt, *, timeout_ms: "I’ll run the tests and verify it.",
+    )
+
+    assert not voice_out_path().exists()
+    assert not voice_events_path().exists()
 
 
 def test_no_canned_ack_phrase_generator_is_exported():

--- a/tests/gateway/test_pulse_voice_events.py
+++ b/tests/gateway/test_pulse_voice_events.py
@@ -1,14 +1,19 @@
 import json
+from types import SimpleNamespace
 
 from gateway.pulse_voice_events import (
     completion_voice_text,
     publish_completion_voice_out,
     publish_voice_event,
     publish_voice_out,
+    summarize_final_voice_response,
     voice_events_path,
     voice_out_path,
     voice_safe_text,
 )
+
+
+UNSAFE_SECRET = "sk-test_1234567890abcdef1234567890abcdef"
 
 
 def _jsonl(path):
@@ -28,19 +33,231 @@ def test_voice_safe_text_removes_code_media_and_bounds_length():
     assert voice_safe_text(text) == "Done."
 
 
+def test_voice_safe_text_skips_obvious_tool_log_lines():
+    text = """
+    $ pytest tests/gateway/test_pulse_voice_events.py -q
+    FAILED tests/gateway/test_pulse_voice_events.py::test_old_ack
+    Traceback (most recent call last):
+    File \"gateway/run.py\", line 16774, in _run_agent
+    I removed the canned ack path and kept Discord text unchanged.
+    """
+
+    assert voice_safe_text(text) == "I removed the canned ack path and kept Discord text unchanged."
+
+
 def test_publish_voice_out_writes_canonical_schema_and_legacy_mirror(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
-    publish_voice_out("ack", "Got it. I’ll wire the voice path.", session_id="s1", source_message_id="m1")
+    publish_voice_out(
+        "ack",
+        "Got it. I’ll wire the voice path.",
+        session_id="s1",
+        source_message_id="m1",
+        source="generated_ack",
+        derived_from="turn_start",
+        voice_profile="eon",
+    )
 
     canonical = _jsonl(voice_out_path())
     legacy = _jsonl(voice_events_path())
     assert canonical == legacy
     assert canonical[0]["kind"] == "ack"
     assert canonical[0]["text"] == "Got it."
-    assert canonical[0]["max_seconds"] == 4
+    assert canonical[0]["max_seconds"] == 2
     assert canonical[0]["session_id"] == "s1"
     assert canonical[0]["source_message_id"] == "m1"
+    assert canonical[0]["schema_version"] == 2
+    assert canonical[0]["source"] == "generated_ack"
+    assert canonical[0]["derived_from"] == "turn_start"
+    assert canonical[0]["voice_profile"] == "eon"
+    assert canonical[0]["policy"] == {
+        "allowed": True,
+        "sanitized": True,
+        "truncated": False,
+        "suppressed": False,
+        "rule_profile": "living_room_default",
+        "reason_codes": ["bounded_to_one_sentence"],
+        "classifiers": {
+            "dropped_code": False,
+            "dropped_tool_logs": False,
+            "dropped_paths": False,
+            "blocked_secret_like": False,
+            "blocked_sensitive_topic": False,
+            "blocked_stack_trace": False,
+        },
+    }
+
+
+def test_publish_voice_out_adds_default_v2_source_fields(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    publish_voice_out("completion", "I finished the task and verified the checks.")
+
+    [event] = _jsonl(voice_out_path())
+    assert event["schema_version"] == 2
+    assert event["source"] == "completion"
+    assert event["derived_from"] == "pulse_voice_candidate"
+    assert event["voice_profile"] == "eon"
+
+
+def test_publish_voice_out_routes_candidate_through_ambient_policy(tmp_path, monkeypatch):
+    import gateway.pulse_voice_events as pulse_voice_events
+
+    calls = []
+
+    class FakeAmbientPolicy:
+        def evaluate(self, text, context):
+            calls.append((text, context))
+            return SimpleNamespace(
+                allowed=True,
+                text="Policy approved.",
+                sanitized=True,
+                truncated=False,
+                suppressed=False,
+                max_seconds=6,
+                reasons=("policy_checked",),
+                classifiers={
+                    "code": False,
+                    "command_log": False,
+                    "raw_path": False,
+                    "secret_like": False,
+                    "sensitive_topic": False,
+                    "stack_trace": False,
+                },
+                rule_profile="airpods_private",
+            )
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(pulse_voice_events, "_AMBIENT_POLICY", FakeAmbientPolicy())
+
+    publish_voice_out(
+        "question",
+        "Original candidate. More detail must stay out.",
+        output_device="airpods",
+        voice_profile="eon",
+    )
+
+    [event] = _jsonl(voice_out_path())
+    assert calls
+    assert calls[0][0] == "Original candidate."
+    assert calls[0][1].source == "question"
+    assert calls[0][1].output_device == "airpods"
+    assert event["text"] == "Policy approved."
+    assert event["max_seconds"] == 6
+    assert event["policy"]["rule_profile"] == "airpods_private"
+    assert event["policy"]["reason_codes"] == ["bounded_to_one_sentence", "policy_checked"]
+
+
+def test_publish_voice_out_suppresses_secrets_without_raw_metadata(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    publish_voice_out("completion", f"The token is {UNSAFE_SECRET}; keep it safe.")
+
+    assert not voice_out_path().exists()
+    assert not voice_events_path().exists()
+
+
+def test_voice_safe_text_suppresses_inline_key_and_password_prose():
+    assert voice_safe_text("API key: hk_test_1234567890abcdef; keep it safe.") == ""
+    assert voice_safe_text("The temporary password is example-pass-1234 for setup.") == ""
+
+
+def test_publish_voice_out_suppresses_bearer_and_aws_style_tokens(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    publish_voice_out("completion", "Bearer hk_test_1234567890abcdef is configured.")
+    publish_voice_out("completion", "Using AWS key AKIAIOSFODNN7EXAMPLE for the demo.")
+
+    assert not voice_out_path().exists()
+    assert not voice_events_path().exists()
+
+
+def test_publish_voice_out_suppresses_paths_and_code_without_fallback(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    publish_voice_out("completion", "```python\nprint('/Users/brenno/.hermes/.env')\n```")
+    publish_voice_out("completion", "`print('do not speak inline code')`")
+    publish_completion_voice_out("```python\nprint('done')\n```")
+
+    assert not voice_out_path().exists()
+    assert completion_voice_text("```python\nprint('done')\n```") == ("completion", "")
+    assert voice_safe_text("`print('do not speak inline code')`") == ""
+
+
+def test_publish_voice_out_suppresses_stack_traces_and_sensitive_topics(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    publish_voice_out(
+        "error",
+        'Traceback (most recent call last):\n  File "/Users/brenno/app.py", line 1, in <module>\nRuntimeError: boom',
+    )
+    publish_voice_out("completion", "Your trading PnL and portfolio exposure are down 12% today.")
+
+    assert not voice_out_path().exists()
+
+
+def test_policy_metadata_uses_safe_reason_codes_not_raw_content(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    publish_voice_out(
+        "progress",
+        "I reviewed /Users/brenno/main/project/secret.py and finished the task.",
+    )
+    publish_voice_out(
+        "progress",
+        r"I reviewed C:\Users\brenno\project\secret.py and finished the task.",
+    )
+
+    publish_voice_out(
+        "progress",
+        "I reviewed gateway/run.py and finished the task.",
+    )
+
+    events = _jsonl(voice_out_path())
+    assert len(events) == 3
+    for event in events:
+        payload = json.dumps(event, ensure_ascii=False)
+        assert "/Users/brenno" not in payload
+        assert "C:\\Users" not in payload
+        assert "secret.py" not in payload
+        assert "gateway/run.py" not in payload
+        assert event["text"] == "I reviewed and finished the task."
+        assert event["policy"]["classifiers"]["dropped_paths"] is True
+        assert event["policy"]["reason_codes"] == ["path_stripped", "bounded_to_one_sentence"]
+
+
+def test_passed_policy_metadata_is_normalized_without_raw_content(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    publish_voice_out(
+        "completion",
+        "Safe completion.",
+        policy={
+            "allowed": True,
+            "reason_codes": ["/Users/brenno/.hermes/.env", "safe_reason"],
+            "classifiers": {"raw_path": "/Users/brenno/.hermes/.env", "dropped_paths": True},
+        },
+    )
+
+    [event] = _jsonl(voice_out_path())
+    payload = json.dumps(event, ensure_ascii=False)
+    assert "/Users/brenno" not in payload
+    assert event["policy"]["reason_codes"] == ["safe_reason", "bounded_to_one_sentence"]
+    assert event["policy"]["classifiers"] == {
+        "dropped_code": False,
+        "dropped_tool_logs": False,
+        "dropped_paths": True,
+        "blocked_secret_like": False,
+        "blocked_sensitive_topic": False,
+        "blocked_stack_trace": False,
+    }
+
+
+def test_no_canned_ack_phrase_generator_is_exported():
+    import gateway.pulse_voice_events as pulse_voice_events
+
+    assert not hasattr(pulse_voice_events, "turn_ack_text")
+    assert not hasattr(pulse_voice_events, "_ACK_PHRASES")
 
 
 def test_legacy_delta_events_are_not_published(tmp_path, monkeypatch):
@@ -66,7 +283,67 @@ def test_completion_voice_text_summarizes_executor_output():
     kind, text = completion_voice_text("I updated the bridge and ran the tests. Full details are in Discord.")
 
     assert kind == "completion"
-    assert text == "Done — I updated the bridge and ran the tests."
+    assert text == "I updated the bridge and ran the tests."
+
+
+def test_generated_summary_timeout_exception_and_invalid_output_fall_back_deterministically():
+    final_response = "I updated the bridge and ran 14 tests. Full details are in Discord."
+
+    def timed_out(_final_response):
+        raise TimeoutError("fake summarizer timeout")
+
+    assert completion_voice_text(final_response, summarizer=timed_out) == (
+        "completion",
+        "I updated the bridge and ran 14 tests.",
+    )
+    assert completion_voice_text(final_response, summarizer=lambda _text: "MEDIA:/tmp/report.pdf") == (
+        "completion",
+        "I updated the bridge and ran 14 tests.",
+    )
+    assert completion_voice_text(final_response, summarizer=lambda _text: "Bridge deployed and 15 tests passed.") == (
+        "completion",
+        "I updated the bridge and ran 14 tests.",
+    )
+
+
+def test_generated_summary_is_accepted_only_when_aligned_and_safe():
+    final_response = "I updated the bridge and verified 14 tests passed. Full details are in Discord."
+
+    result = summarize_final_voice_response(
+        final_response,
+        summarizer=lambda _text: "Bridge updated and 14 tests passed.",
+    )
+
+    assert result.kind == "completion"
+    assert result.text == "Bridge updated and 14 tests passed."
+    assert result.source == "assistant_final"
+    assert result.derived_from == "final_response"
+    assert result.voice_profile == "eon"
+    assert result.summarizer["mode"] == "hybrid"
+    assert result.summarizer["method"] == "generated"
+    assert result.summarizer["fallback_used"] is False
+    assert result.summarizer["validation_failed"] is False
+    if "timeout_ms" in result.summarizer:
+        assert result.summarizer["timeout_ms"] == 1000
+    assert result.policy["pre_sanitized"] is True
+    assert result.policy["post_sanitized"] is True
+
+
+def test_question_and_error_classification_preserve_final_response_intent_with_generated_summary():
+    assert completion_voice_text(
+        "Which profile should own this task?",
+        summarizer=lambda _text: "Which profile should own this task?",
+    ) == ("question", "Which profile should own this task?")
+
+    assert completion_voice_text(
+        "Which profile should own this task?",
+        summarizer=lambda _text: "I need a profile choice.",
+    ) == ("question", "Which profile should own this task?")
+
+    assert completion_voice_text(
+        "Error: provider timeout while generating the summary.",
+        summarizer=lambda _text: "The summary is ready.",
+    ) == ("error", "Error: provider timeout while generating the summary.")
 
 
 def test_publish_completion_voice_out_marks_questions(tmp_path, monkeypatch):
@@ -77,3 +354,33 @@ def test_publish_completion_voice_out_marks_questions(tmp_path, monkeypatch):
     [event] = _jsonl(voice_out_path())
     assert event["kind"] == "question"
     assert event["text"] == "Which profile should own the worker task?"
+    assert event["source"] == "assistant_final"
+    assert event["derived_from"] == "final_response"
+    assert event["voice_profile"] == "eon"
+    assert event["summarizer"]["method"] == "deterministic"
+    assert event["policy"]["allowed"] is True
+    assert event["policy"]["classifiers"]["blocked_secret_like"] is False
+
+
+def test_publish_completion_voice_out_silences_empty_safe_output(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    publish_completion_voice_out("MEDIA:/tmp/report.pdf\n```python\nprint('nothing safe')\n```")
+
+    assert not voice_out_path().exists()
+    assert not voice_events_path().exists()
+
+
+def test_publish_completion_voice_out_keeps_platform_text_out_of_voice_history(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    final_text = "I updated the bridge and verified 14 tests passed. Full Discord detail remains unchanged."
+
+    publish_completion_voice_out(final_text, summarizer=lambda _text: "Bridge updated and 14 tests passed.")
+
+    [event] = _jsonl(voice_out_path())
+    assert final_text == "I updated the bridge and verified 14 tests passed. Full Discord detail remains unchanged."
+    assert event["text"] == "Bridge updated and 14 tests passed."
+    assert event["source"] == "assistant_final"
+    assert event["derived_from"] == "final_response"
+    assert event["voice_profile"] == "eon"
+    assert event["summarizer"]["method"] == "generated"

--- a/tests/gateway/test_run_cleanup_progress.py
+++ b/tests/gateway/test_run_cleanup_progress.py
@@ -284,27 +284,23 @@ async def test_voice_events_are_final_answer_only_and_do_not_change_text_respons
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
 
     import gateway.pulse_voice_events as pulse_voice_events
+    import gateway.voice_response_pipeline as voice_response_pipeline
 
     voice_out_calls = []
     completion_calls = []
     original_publish_voice_out = pulse_voice_events.publish_voice_out
-    original_publish_completion_voice_out = pulse_voice_events.publish_completion_voice_out
+    original_publish_final_response = voice_response_pipeline.VoiceResponsePipeline.publish_final_response
 
     def record_voice_out(kind, text, **metadata):
         voice_out_calls.append({"kind": kind, "text": text, "metadata": metadata})
         return original_publish_voice_out(kind, text, **metadata)
 
-    def record_completion(final_response, **metadata):
-        completion_calls.append({"final_response": final_response, "metadata": metadata})
-        return original_publish_completion_voice_out(final_response, **metadata)
+    def record_final_response(self, final_response, context, **kwargs):
+        completion_calls.append({"final_response": final_response, "context": context})
+        return original_publish_final_response(self, final_response, context, **kwargs)
 
     monkeypatch.setattr(pulse_voice_events, "publish_voice_out", record_voice_out)
-    # ``record_completion`` delegates to the original function object, so route
-    # that function's global lookup through the spy too. This keeps the test
-    # sensitive to hidden ack/start-of-turn publish_voice_out calls while still
-    # exercising the real completion publisher.
-    monkeypatch.setitem(original_publish_completion_voice_out.__globals__, "publish_voice_out", record_voice_out)
-    monkeypatch.setattr(pulse_voice_events, "publish_completion_voice_out", record_completion)
+    monkeypatch.setattr(voice_response_pipeline.VoiceResponsePipeline, "publish_final_response", record_final_response)
 
     source = SessionSource(platform=Platform.TELEGRAM, chat_id="-1001", thread_id="42")
 
@@ -321,28 +317,27 @@ async def test_voice_events_are_final_answer_only_and_do_not_change_text_respons
     final_response = "I fixed the voice bridge from the actual assistant answer. Extra Discord-only detail follows."
     assert result["final_response"] == final_response
     assert [message["content"] for message in adapter.sent] == ["I’m checking the voice path now."]
-    assert [call["kind"] for call in voice_out_calls] == ["progress", "completion"]
+    assert [call["kind"] for call in voice_out_calls] == ["completion"]
     assert all(call["kind"] != "ack" for call in voice_out_calls)
     final_turn_voice_calls = [
         call for call in voice_out_calls if call["kind"] in {"ack", "completion", "error", "question"}
     ]
     assert [call["kind"] for call in final_turn_voice_calls] == ["completion"]
     assert final_turn_voice_calls[0]["text"] == "I fixed the voice bridge from the actual assistant answer."
-    assert completion_calls == [
-        {
-            "final_response": final_response,
-            "metadata": {
-                "session_id": "sess-voice",
-                "platform": "telegram",
-                "chat_id": "-1001",
-                "thread_id": "42",
-                "source_message_id": "msg-voice-1",
-            },
-        }
-    ]
+    assert len(completion_calls) == 1
+    assert completion_calls[0]["final_response"] == final_response
+    assert completion_calls[0]["context"].to_metadata() == {
+        "session_id": "sess-voice",
+        "platform": "telegram",
+        "chat_id": "-1001",
+        "thread_id": "42",
+        "source_message_id": "msg-voice-1",
+        "voice_profile": "eon",
+        "room_context": "living_room",
+    }
 
     events = [json.loads(line) for line in voice_out_path().read_text(encoding="utf-8").splitlines()]
-    assert [event["kind"] for event in events] == ["progress", "completion"]
+    assert [event["kind"] for event in events] == ["completion"]
     turn_level_events = [event for event in events if event["kind"] in {"ack", "completion", "error", "question"}]
     assert [event["kind"] for event in turn_level_events] == ["completion"]
     assert turn_level_events[0]["text"] == "I fixed the voice bridge from the actual assistant answer."
@@ -385,29 +380,30 @@ async def test_discord_final_text_is_preserved_while_voice_event_is_summarized(m
 async def test_discord_text_delivery_unchanged_when_voice_publisher_records_media_appended_response(monkeypatch, tmp_path):
     """Voice publication observes the post-media final_response, while Discord sends clean text."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    import gateway.pulse_voice_events as pulse_voice_events
+    import gateway.voice_response_pipeline as voice_response_pipeline
 
     completion_calls = []
+    original_publish_final_response = voice_response_pipeline.VoiceResponsePipeline.publish_final_response
 
-    def record_completion(final_response, **metadata):
-        completion_calls.append({"final_response": final_response, "metadata": metadata})
+    def record_final_response(self, final_response, context, **kwargs):
+        completion_calls.append({"final_response": final_response, "context": context})
+        return original_publish_final_response(self, final_response, context, **kwargs)
 
-    monkeypatch.setattr(pulse_voice_events, "publish_completion_voice_out", record_completion)
+    monkeypatch.setattr(voice_response_pipeline.VoiceResponsePipeline, "publish_final_response", record_final_response)
 
     adapter = await _deliver_one_discord_turn(monkeypatch, tmp_path, VoiceMediaFinalAgent)
 
-    assert completion_calls == [
-        {
-            "final_response": "Here is the unchanged Discord text.\nMEDIA:/tmp/hermes-voice-regression.mp3",
-            "metadata": {
-                "session_id": "sess-discord",
-                "platform": "discord",
-                "chat_id": "discord-channel",
-                "thread_id": "thread-7",
-                "source_message_id": "discord-msg-1",
-            },
-        }
-    ]
+    assert len(completion_calls) == 1
+    assert completion_calls[0]["final_response"] == "Here is the unchanged Discord text.\nMEDIA:/tmp/hermes-voice-regression.mp3"
+    assert completion_calls[0]["context"].to_metadata() == {
+        "session_id": "sess-discord",
+        "platform": "discord",
+        "chat_id": "discord-channel",
+        "thread_id": "thread-7",
+        "source_message_id": "discord-msg-1",
+        "voice_profile": "eon",
+        "room_context": "living_room",
+    }
     assert adapter.sent[0]["content"] == "Here is the unchanged Discord text."
     assert "MEDIA:" not in adapter.sent[0]["content"]
 
@@ -416,12 +412,12 @@ async def test_discord_text_delivery_unchanged_when_voice_publisher_records_medi
 async def test_discord_text_delivery_survives_completion_voice_publisher_failure(monkeypatch, tmp_path):
     """Voice publication is best-effort and must not break normal Discord delivery."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    import gateway.pulse_voice_events as pulse_voice_events
+    import gateway.voice_response_pipeline as voice_response_pipeline
 
-    def failing_completion(final_response, **metadata):
+    def failing_final_response(self, final_response, context, **kwargs):
         raise RuntimeError("voice publisher unavailable")
 
-    monkeypatch.setattr(pulse_voice_events, "publish_completion_voice_out", failing_completion)
+    monkeypatch.setattr(voice_response_pipeline.VoiceResponsePipeline, "publish_final_response", failing_final_response)
 
     adapter = await _deliver_one_discord_turn(monkeypatch, tmp_path, VoiceFinalAgent)
 

--- a/tests/gateway/test_run_cleanup_progress.py
+++ b/tests/gateway/test_run_cleanup_progress.py
@@ -12,6 +12,7 @@ Adapters without ``delete_message`` silently no-op.
 
 import asyncio
 import importlib
+import json
 import sys
 import time
 import types
@@ -20,7 +21,8 @@ from types import SimpleNamespace
 import pytest
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.pulse_voice_events import voice_out_path
 from gateway.session import SessionSource
 
 
@@ -131,6 +133,54 @@ class FailingAgent:
         }
 
 
+class VoiceFinalAgent:
+    """Returns a final assistant answer without emitting interim/progress text."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        return {
+            "final_response": "I fixed the voice bridge from the actual assistant answer. Extra Discord-only detail follows.",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class VoiceInterimFinalAgent(VoiceFinalAgent):
+    """Emits interim commentary before returning the real final answer."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.interim_assistant_callback = None
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        if self.interim_assistant_callback is not None:
+            self.interim_assistant_callback("I’m checking the voice path now.", already_streamed=False)
+        return super().run_conversation(message, conversation_history=conversation_history, task_id=task_id)
+
+
+class VoiceMediaFinalAgent:
+    """Returns final text plus a tool MEDIA tag that the gateway appends."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        return {
+            "final_response": "Here is the unchanged Discord text.",
+            "messages": [
+                {
+                    "role": "tool",
+                    "content": '{"audio": "MEDIA:/tmp/hermes-voice-regression.mp3"}',
+                }
+            ],
+            "api_calls": 1,
+        }
+
+
 def _make_runner(adapter):
     gateway_run = importlib.import_module("gateway.run")
     GatewayRunner = gateway_run.GatewayRunner
@@ -183,9 +233,206 @@ def _install_fakes(monkeypatch, agent_cls, *, cleanup_on: bool):
     return gateway_run
 
 
+def _make_message_event(source: SessionSource, text: str = "please answer") -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="discord-msg-1",
+    )
+
+
+async def _deliver_one_discord_turn(monkeypatch, tmp_path, agent_cls):
+    adapter = CleanupCaptureAdapter(platform=Platform.DISCORD)
+    adapter._get_human_delay = lambda: 0
+    runner = _make_runner(adapter)
+    gateway_run = _install_fakes(monkeypatch, agent_cls, cleanup_on=False)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    source = SessionSource(platform=Platform.DISCORD, chat_id="discord-channel", thread_id="thread-7")
+    session_key = "agent:main:discord:channel:discord-channel:thread-7"
+
+    async def _handler(event):
+        agent_result = await runner._run_agent(
+            message=event.text,
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id="sess-discord",
+            session_key=session_key,
+            event_message_id=event.message_id,
+        )
+        return agent_result["final_response"]
+
+    adapter.set_message_handler(_handler)
+    await adapter._process_message_background(_make_message_event(source), session_key)
+    return adapter
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_voice_events_are_final_answer_only_and_do_not_change_text_response(monkeypatch, tmp_path):
+    """Room voice is emitted once from final_response, never a turn-start canned ack."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = CleanupCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = _install_fakes(monkeypatch, VoiceInterimFinalAgent, cleanup_on=False)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    import gateway.pulse_voice_events as pulse_voice_events
+
+    voice_out_calls = []
+    completion_calls = []
+    original_publish_voice_out = pulse_voice_events.publish_voice_out
+    original_publish_completion_voice_out = pulse_voice_events.publish_completion_voice_out
+
+    def record_voice_out(kind, text, **metadata):
+        voice_out_calls.append({"kind": kind, "text": text, "metadata": metadata})
+        return original_publish_voice_out(kind, text, **metadata)
+
+    def record_completion(final_response, **metadata):
+        completion_calls.append({"final_response": final_response, "metadata": metadata})
+        return original_publish_completion_voice_out(final_response, **metadata)
+
+    monkeypatch.setattr(pulse_voice_events, "publish_voice_out", record_voice_out)
+    # ``record_completion`` delegates to the original function object, so route
+    # that function's global lookup through the spy too. This keeps the test
+    # sensitive to hidden ack/start-of-turn publish_voice_out calls while still
+    # exercising the real completion publisher.
+    monkeypatch.setitem(original_publish_completion_voice_out.__globals__, "publish_voice_out", record_voice_out)
+    monkeypatch.setattr(pulse_voice_events, "publish_completion_voice_out", record_completion)
+
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="-1001", thread_id="42")
+
+    result = await runner._run_agent(
+        message="please fix voice",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-voice",
+        session_key="agent:main:telegram:group:-1001:thread:42",
+        event_message_id="msg-voice-1",
+    )
+
+    final_response = "I fixed the voice bridge from the actual assistant answer. Extra Discord-only detail follows."
+    assert result["final_response"] == final_response
+    assert [message["content"] for message in adapter.sent] == ["I’m checking the voice path now."]
+    assert [call["kind"] for call in voice_out_calls] == ["progress", "completion"]
+    assert all(call["kind"] != "ack" for call in voice_out_calls)
+    final_turn_voice_calls = [
+        call for call in voice_out_calls if call["kind"] in {"ack", "completion", "error", "question"}
+    ]
+    assert [call["kind"] for call in final_turn_voice_calls] == ["completion"]
+    assert final_turn_voice_calls[0]["text"] == "I fixed the voice bridge from the actual assistant answer."
+    assert completion_calls == [
+        {
+            "final_response": final_response,
+            "metadata": {
+                "session_id": "sess-voice",
+                "platform": "telegram",
+                "chat_id": "-1001",
+                "thread_id": "42",
+                "source_message_id": "msg-voice-1",
+            },
+        }
+    ]
+
+    events = [json.loads(line) for line in voice_out_path().read_text(encoding="utf-8").splitlines()]
+    assert [event["kind"] for event in events] == ["progress", "completion"]
+    turn_level_events = [event for event in events if event["kind"] in {"ack", "completion", "error", "question"}]
+    assert [event["kind"] for event in turn_level_events] == ["completion"]
+    assert turn_level_events[0]["text"] == "I fixed the voice bridge from the actual assistant answer."
+    assert turn_level_events[0]["session_id"] == "sess-voice"
+    assert turn_level_events[0]["platform"] == "telegram"
+    assert turn_level_events[0]["chat_id"] == "-1001"
+    assert turn_level_events[0]["thread_id"] == "42"
+    assert turn_level_events[0]["source_message_id"] == "msg-voice-1"
+
+
+@pytest.mark.asyncio
+async def test_discord_final_text_is_preserved_while_voice_event_is_summarized(monkeypatch, tmp_path):
+    """Discord receives the full final text while Pulse gets the concise spoken summary."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    adapter = await _deliver_one_discord_turn(monkeypatch, tmp_path, VoiceFinalAgent)
+
+    assert adapter.sent == [
+        {
+            "chat_id": "discord-channel",
+            "content": "I fixed the voice bridge from the actual assistant answer. Extra Discord-only detail follows.",
+            "message_id": adapter.sent[0]["message_id"],
+            "metadata": {"thread_id": "thread-7", "notify": True},
+        }
+    ]
+    events = [json.loads(line) for line in voice_out_path().read_text(encoding="utf-8").splitlines()]
+    assert len(events) == 1
+    event = events[0]
+    assert event["kind"] == "completion"
+    assert event["text"] == "I fixed the voice bridge from the actual assistant answer."
+    assert event["text"] != adapter.sent[0]["content"]
+    assert event["source"] == "assistant_final"
+    assert event["derived_from"] == "final_response"
+    assert event["platform"] == "discord"
+    assert event["chat_id"] == "discord-channel"
+    assert event["thread_id"] == "thread-7"
+
+
+@pytest.mark.asyncio
+async def test_discord_text_delivery_unchanged_when_voice_publisher_records_media_appended_response(monkeypatch, tmp_path):
+    """Voice publication observes the post-media final_response, while Discord sends clean text."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    import gateway.pulse_voice_events as pulse_voice_events
+
+    completion_calls = []
+
+    def record_completion(final_response, **metadata):
+        completion_calls.append({"final_response": final_response, "metadata": metadata})
+
+    monkeypatch.setattr(pulse_voice_events, "publish_completion_voice_out", record_completion)
+
+    adapter = await _deliver_one_discord_turn(monkeypatch, tmp_path, VoiceMediaFinalAgent)
+
+    assert completion_calls == [
+        {
+            "final_response": "Here is the unchanged Discord text.\nMEDIA:/tmp/hermes-voice-regression.mp3",
+            "metadata": {
+                "session_id": "sess-discord",
+                "platform": "discord",
+                "chat_id": "discord-channel",
+                "thread_id": "thread-7",
+                "source_message_id": "discord-msg-1",
+            },
+        }
+    ]
+    assert adapter.sent[0]["content"] == "Here is the unchanged Discord text."
+    assert "MEDIA:" not in adapter.sent[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_discord_text_delivery_survives_completion_voice_publisher_failure(monkeypatch, tmp_path):
+    """Voice publication is best-effort and must not break normal Discord delivery."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    import gateway.pulse_voice_events as pulse_voice_events
+
+    def failing_completion(final_response, **metadata):
+        raise RuntimeError("voice publisher unavailable")
+
+    monkeypatch.setattr(pulse_voice_events, "publish_completion_voice_out", failing_completion)
+
+    adapter = await _deliver_one_discord_turn(monkeypatch, tmp_path, VoiceFinalAgent)
+
+    assert adapter.sent == [
+        {
+            "chat_id": "discord-channel",
+            "content": "I fixed the voice bridge from the actual assistant answer. Extra Discord-only detail follows.",
+            "message_id": adapter.sent[0]["message_id"],
+            "metadata": {"thread_id": "thread-7", "notify": True},
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -479,6 +479,36 @@ class TestSendVoiceReply:
         mock_tts.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_policy_blocked_text_input_all_mode_never_calls_tts(self, runner):
+        event = _make_event(message_type=MessageType.TEXT)
+        runner._voice_mode["telegram:123"] = "all"
+        assert runner._should_send_voice_reply(event, "API_KEY=hk_test_1234567890abcdef", []) is True
+
+        with patch("tools.tts_tool.text_to_speech_tool") as mock_tts:
+            await runner._send_voice_reply(event, "API_KEY=hk_test_1234567890abcdef")
+
+        mock_tts.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_policy_blocked_voice_only_streaming_takeover_never_calls_tts(self, runner):
+        event = _make_event(message_type=MessageType.VOICE)
+        runner._voice_mode["telegram:123"] = "voice_only"
+        assert runner._should_send_voice_reply(
+            event,
+            "Traceback (most recent call last):\n  File \"/Users/brenno/app.py\", line 1, in <module>",
+            [],
+            already_sent=True,
+        ) is True
+
+        with patch("tools.tts_tool.text_to_speech_tool") as mock_tts:
+            await runner._send_voice_reply(
+                event,
+                "Traceback (most recent call last):\n  File \"/Users/brenno/app.py\", line 1, in <module>",
+            )
+
+        mock_tts.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_tts_failure_no_crash(self, runner):
         event = _make_event()
         mock_adapter = AsyncMock()

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -2881,3 +2881,44 @@ class TestShouldAutoTtsForChat:
         fn, adapter = self._make_adapter(default=False, enabled={"chat1"})
         assert fn(adapter, "chat1") is True
         assert fn(adapter, "chat2") is False
+
+
+# =====================================================================
+# BasePlatformAdapter.prepare_tts_text — ambient policy gate for auto-TTS.
+# =====================================================================
+
+class TestPrepareTtsTextAmbientPolicy:
+    def test_blocks_secret_like_text_even_when_voice_tts_is_enabled(self):
+        from gateway.platforms.base import BasePlatformAdapter
+
+        adapter = SimpleNamespace(
+            platform=SimpleNamespace(value="discord"),
+            _auto_tts_default=False,
+            _auto_tts_enabled_chats={"chat1"},
+            _auto_tts_disabled_chats=set(),
+        )
+
+        assert BasePlatformAdapter._should_auto_tts_for_chat(adapter, "chat1") is True
+        assert BasePlatformAdapter.prepare_tts_text(adapter, "The token is sk-test-secret-value") == ""
+
+    def test_blocks_code_and_command_logs_before_tts(self):
+        from gateway.platforms.base import BasePlatformAdapter
+
+        adapter = SimpleNamespace(platform=SimpleNamespace(value="discord"))
+
+        assert BasePlatformAdapter.prepare_tts_text(
+            adapter,
+            "$ pytest tests/gateway/test_voice_command.py -q\n"
+            "```python\nprint('do not speak code')\n```",
+        ) == ""
+
+    def test_preserves_chat_response_text_by_returning_separate_safe_tts_text(self):
+        from gateway.platforms.base import BasePlatformAdapter
+
+        adapter = SimpleNamespace(platform=SimpleNamespace(value="discord"))
+        response_text = "I wrote the report to /Users/brenno/main/aegis/report.md and verified it."
+
+        assert BasePlatformAdapter.prepare_tts_text(adapter, response_text) == (
+            "I wrote the report to a local file and verified it."
+        )
+        assert response_text == "I wrote the report to /Users/brenno/main/aegis/report.md and verified it."

--- a/tests/gateway/test_voice_response_pipeline.py
+++ b/tests/gateway/test_voice_response_pipeline.py
@@ -1,0 +1,187 @@
+from gateway.voice_response_pipeline import VoiceContext, VoiceEvent, VoiceResponsePipeline
+
+
+def test_voice_context_round_trips_safe_metadata():
+    context = VoiceContext.from_metadata(
+        session_id="sess-1",
+        platform="discord",
+        chat_id="channel-1",
+        channel_id="discord-channel-1",
+        thread_id="thread-1",
+        source_message_id="message-1",
+        voice_profile="eon",
+        input_modality="voice",
+        output_device="discord_voice",
+        config_scope="discord_voice",
+        explicit_spoken_request=True,
+        is_private_context=False,
+        max_seconds=7,
+    )
+
+    assert context.to_metadata() == {
+        "session_id": "sess-1",
+        "platform": "discord",
+        "chat_id": "channel-1",
+        "channel_id": "discord-channel-1",
+        "thread_id": "thread-1",
+        "source_message_id": "message-1",
+        "voice_profile": "eon",
+        "room_context": "living_room",
+        "input_modality": "voice",
+        "output_device": "discord_voice",
+        "config_scope": "discord_voice",
+        "explicit_spoken_request": True,
+        "is_private_context": False,
+        "max_seconds": 7,
+    }
+
+
+def test_final_response_event_is_derived_from_assistant_final(monkeypatch):
+    monkeypatch.setattr(
+        "gateway.pulse_voice_events._final_summary_config",
+        lambda: {"mode": "deterministic", "timeout_ms": 1000, "max_spoken_chars": 180, "voice_profile": "eon"},
+    )
+    pipeline = VoiceResponsePipeline(publisher=lambda *args, **kwargs: None)
+    context = VoiceContext(session_id="sess-final", platform="telegram")
+
+    event = pipeline.event_from_final_response(
+        "I updated the voice bridge and ran the focused tests. Extra details follow.",
+        context,
+    )
+
+    assert event is not None
+    assert event.kind == "completion"
+    assert event.text == "I updated the voice bridge and ran the focused tests."
+    assert event.source == "assistant_final"
+    assert event.derived_from == "final_response"
+    assert event.context == context
+
+
+def test_delta_event_is_ignored():
+    pipeline = VoiceResponsePipeline(publisher=lambda *args, **kwargs: None)
+
+    assert pipeline.event_from_legacy_event(
+        "delta",
+        "raw token that must not be spoken",
+        VoiceContext(session_id="sess-delta"),
+    ) is None
+
+
+def test_commentary_maps_to_progress_without_becoming_speakable_ack():
+    pipeline = VoiceResponsePipeline(publisher=lambda *args, **kwargs: None)
+
+    event = pipeline.event_from_legacy_event(
+        "commentary",
+        "I’ll inspect that now. More detail follows.",
+        VoiceContext(session_id="sess-progress"),
+    )
+
+    assert event is not None
+    assert event.kind == "progress"
+    assert event.text == "I’ll inspect that now."
+    assert event.source == "assistant_commentary"
+    assert event.derived_from == "commentary"
+
+
+def test_publish_drops_none_and_swallows_publisher_failure():
+    calls = []
+
+    def failing_publisher(*args, **kwargs):
+        calls.append((args, kwargs))
+        raise RuntimeError("publisher failed")
+
+    pipeline = VoiceResponsePipeline(publisher=failing_publisher)
+    pipeline.publish(None)
+    pipeline.publish(
+        VoiceEvent(
+            kind="completion",
+            text="Done.",
+            source="assistant_final",
+            derived_from="final_response",
+            context=VoiceContext(session_id="sess-safe"),
+        )
+    )
+
+    assert len(calls) == 1
+
+
+def test_pipeline_does_not_generate_turn_start_ack():
+    pipeline = VoiceResponsePipeline(publisher=lambda *args, **kwargs: None)
+
+    assert not hasattr(pipeline, "turn_ack_text")
+    assert pipeline.event_from_legacy_event("turn_start", "", VoiceContext()) is None
+
+
+def test_final_response_with_no_safe_speech_returns_no_event(monkeypatch):
+    monkeypatch.setattr(
+        "gateway.pulse_voice_events._final_summary_config",
+        lambda: {"mode": "deterministic", "timeout_ms": 1000, "max_spoken_chars": 180, "voice_profile": "eon"},
+    )
+    pipeline = VoiceResponsePipeline(publisher=lambda *args, **kwargs: None)
+
+    event = pipeline.event_from_final_response(
+        "MEDIA:/tmp/report.pdf\n```python\nprint('nothing safe')\n```",
+        VoiceContext(session_id="sess-empty"),
+    )
+
+    assert event is None
+
+
+def test_event_publish_kwargs_do_not_include_raw_source_text(monkeypatch):
+    monkeypatch.setattr(
+        "gateway.pulse_voice_events._final_summary_config",
+        lambda: {"mode": "deterministic", "timeout_ms": 1000, "max_spoken_chars": 180, "voice_profile": "eon"},
+    )
+    pipeline = VoiceResponsePipeline(publisher=lambda *args, **kwargs: None)
+    event = pipeline.event_from_final_response(
+        "I checked /Users/brenno/private/file.py and finished.",
+        VoiceContext(session_id="sess-metadata"),
+    )
+
+    payload = event.to_publish_kwargs() if event is not None else {}
+    assert "final_response" not in payload
+    assert "/Users/brenno" not in repr(payload)
+
+
+def test_compatibility_wrappers_preserve_policy_metadata(monkeypatch):
+    monkeypatch.setattr(
+        "gateway.pulse_voice_events._final_summary_config",
+        lambda: {"mode": "deterministic", "timeout_ms": 1000, "max_spoken_chars": 180, "voice_profile": "eon"},
+    )
+    calls = []
+
+    def publisher(kind, text, **kwargs):
+        calls.append((kind, text, kwargs))
+
+    pipeline = VoiceResponsePipeline(publisher=publisher)
+    context = VoiceContext.from_metadata(
+        session_id="sess-policy",
+        platform="discord",
+        chat_id="chat-1",
+        channel_id="channel-1",
+        thread_id="thread-1",
+        source_message_id="message-1",
+        input_modality="voice",
+        output_device="discord_voice",
+        config_scope="discord_voice",
+        explicit_spoken_request=True,
+        is_private_context=False,
+        max_seconds=7,
+    )
+
+    pipeline.publish_final_response("I finished the migration and tests passed.", context)
+
+    assert len(calls) == 1
+    _kind, _text, kwargs = calls[0]
+    assert kwargs["session_id"] == "sess-policy"
+    assert kwargs["platform"] == "discord"
+    assert kwargs["chat_id"] == "chat-1"
+    assert kwargs["channel_id"] == "channel-1"
+    assert kwargs["thread_id"] == "thread-1"
+    assert kwargs["source_message_id"] == "message-1"
+    assert kwargs["input_modality"] == "voice"
+    assert kwargs["output_device"] == "discord_voice"
+    assert kwargs["config_scope"] == "discord_voice"
+    assert kwargs["explicit_spoken_request"] is True
+    assert kwargs["is_private_context"] is False
+    assert kwargs["max_seconds"] == 7

--- a/tests/gateway/test_voice_response_pipeline.py
+++ b/tests/gateway/test_voice_response_pipeline.py
@@ -112,7 +112,7 @@ def test_pipeline_does_not_generate_turn_start_ack():
     assert pipeline.event_from_legacy_event("turn_start", "", VoiceContext()) is None
 
 
-def test_final_response_with_no_safe_speech_returns_no_event(monkeypatch):
+def test_final_response_with_no_safe_speech_returns_suppressed_candidate(monkeypatch):
     monkeypatch.setattr(
         "gateway.pulse_voice_events._final_summary_config",
         lambda: {"mode": "deterministic", "timeout_ms": 1000, "max_spoken_chars": 180, "voice_profile": "eon"},
@@ -124,7 +124,10 @@ def test_final_response_with_no_safe_speech_returns_no_event(monkeypatch):
         VoiceContext(session_id="sess-empty"),
     )
 
-    assert event is None
+    assert event is not None
+    assert event.text == ""
+    assert event.policy["allowed"] is False
+    assert event.policy["suppressed"] is True
 
 
 def test_event_publish_kwargs_do_not_include_raw_source_text(monkeypatch):
@@ -185,3 +188,25 @@ def test_compatibility_wrappers_preserve_policy_metadata(monkeypatch):
     assert kwargs["explicit_spoken_request"] is True
     assert kwargs["is_private_context"] is False
     assert kwargs["max_seconds"] == 7
+
+
+def test_publish_forwards_empty_final_candidate_for_suppressed_observability():
+    calls = []
+
+    def publisher(*args, **kwargs):
+        calls.append((args, kwargs))
+
+    pipeline = VoiceResponsePipeline(publisher=publisher)
+    pipeline.publish(
+        VoiceEvent(
+            kind="completion",
+            text="",
+            source="assistant_final",
+            derived_from="final_response",
+            context=VoiceContext(session_id="sess-suppressed"),
+        )
+    )
+
+    assert len(calls) == 1
+    assert calls[0][0] == ("completion", "")
+    assert calls[0][1]["session_id"] == "sess-suppressed"

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -1104,6 +1104,19 @@ class TestVoiceSpeakResponseReal:
             mock_tts.assert_not_called()
 
     @patch("cli._cprint")
+    @patch("tools.voice_mode.play_audio_file")
+    def test_policy_blocked_content_never_invokes_tts_or_playback(self, mock_play, _cp):
+        cli = _make_voice_cli(_voice_tts=True)
+        blocked = "API_KEY=hk_test_1234567890abcdef is configured in /Users/brenno/.hermes/.env"
+
+        with patch("tools.tts_tool.text_to_speech_tool") as mock_tts:
+            cli._voice_speak_response(blocked)
+
+        mock_tts.assert_not_called()
+        mock_play.assert_not_called()
+        assert cli._voice_tts_done.is_set()
+
+    @patch("cli._cprint")
     @patch("cli.os.makedirs")
     @patch("tools.tts_tool.text_to_speech_tool", return_value='{"success": true}')
     def test_long_text_truncated(self, mock_tts, _mkd, _cp):


### PR DESCRIPTION
## Summary
- Adds config-loaded ambient voice policy profiles with conservative fallback when disabled.
- Emits safe suppressed voice-out telemetry for blocked/empty ambient speech candidates, including policy-stage and redacted observability metadata.
- Threads ambient policy through generated acknowledgements/final voice response pipeline and preserves suppressed final candidates for observability.

## Test Plan
- venv/bin/python -m pytest tests/gateway/test_ambient_voice_policy.py tests/gateway/test_pulse_voice_events.py tests/gateway/test_voice_response_pipeline.py tests/gateway/test_final_speech_summarizer.py tests/gateway/test_voice_command.py tests/gateway/test_generated_ack_harness.py tests/gateway/test_generated_ack_dispatch.py -q -o 'addopts='
- git diff --check
- venv/bin/python -m py_compile gateway/ambient_voice_policy.py gateway/generated_ack_harness.py gateway/pulse_voice_events.py gateway/run.py gateway/voice_response_pipeline.py hermes_cli/config.py

Note: full tests/gateway with venv hit pre-existing broad-suite failures/resource errors unrelated to this patch; the scoped voice gateway suite passes.