### PR TITLE
feat(cli): add configurable session sort order (started_at | last_active)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6146,10 +6146,12 @@ class HermesCLI:
         if not self._session_db:
             return []
         try:
+            from hermes_cli.config import get_session_sort_order
             sessions = self._session_db.list_sessions_rich(
                 source="cli",
                 exclude_sources=["tool"],
                 limit=limit,
+                order_by_last_active=get_session_sort_order() == "last_active",
             )
         except Exception:
             return []

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1021,6 +1021,10 @@ DEFAULT_CONFIG = {
         # when an exchange was tool-heavy. Set False to restore the legacy
         # behavior of showing tool-call summaries inline.
         "resume_skip_tool_only": True,
+        # Sort session list by most recent activity instead of creation time.
+        # "started_at" (default) sorts by when the session began.
+        # "last_active" sorts by the most recent message timestamp.
+        "session_sort_order": "started_at",
         "busy_input_mode": "interrupt",  # interrupt | queue | steer
         # When true, `hermes --tui` auto-resumes the most recent human-
         # facing session on launch instead of forging a fresh one.
@@ -1802,6 +1806,25 @@ DEFAULT_CONFIG = {
     # Config schema version - bump this when adding new required fields
     "_config_version": 23,
 }
+
+
+def get_session_sort_order() -> str:
+    """Return the configured session sort order from config.yaml.
+
+    Returns ``\"started_at\"`` (default) for creation-time ordering, or
+    ``\"last_active\"`` for most-recent-message ordering.  Falls back to
+    ``\"started_at\"`` on any config read failure.
+    """
+    try:
+        cfg = load_config()
+        display = cfg.get("display", {})
+        if not isinstance(display, dict):
+            return "started_at"
+        val = display.get("session_sort_order", "started_at")
+        return val if val in ("started_at", "last_active") else "started_at"
+    except Exception:
+        return "started_at"
+
 
 # =============================================================================
 # Config Migration System

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12964,7 +12964,7 @@ Examples:
     # =========================================================================
     sessions_parser = subparsers.add_parser(
         "sessions",
-        help="Manage session history (list, rename, export, prune, delete)",
+        help="Manage session history (list, rename, sort, export, prune, delete)",
         description="View and manage the SQLite session store",
     )
     sessions_subparsers = sessions_parser.add_subparsers(dest="sessions_action")
@@ -12975,6 +12975,16 @@ Examples:
     )
     sessions_list.add_argument(
         "--limit", type=int, default=20, help="Max sessions to show"
+    )
+
+    sessions_sort = sessions_subparsers.add_parser(
+        "sort", help="Get or set session sort order (started_at | last_active)"
+    )
+    sessions_sort.add_argument(
+        "order",
+        nargs="?",
+        choices=["started_at", "last_active"],
+        help="Sort by session creation time (started_at) or most recent activity (last_active). Omit to show current value.",
     )
 
     sessions_export = sessions_subparsers.add_parser(
@@ -13050,8 +13060,10 @@ Examples:
         _exclude = None if _source else ["tool"]
 
         if action == "list":
+            from hermes_cli.config import get_session_sort_order
             sessions = db.list_sessions_rich(
-                source=args.source, exclude_sources=_exclude, limit=args.limit
+                source=args.source, exclude_sources=_exclude, limit=args.limit,
+                order_by_last_active=get_session_sort_order() == "last_active",
             )
             if not sessions:
                 print("No sessions found.")
@@ -13077,6 +13089,17 @@ Examples:
                 else:
                     sid = s["id"]
                     print(f"{preview:<50} {last_active:<13} {s['source']:<6} {sid}")
+
+        elif action == "sort":
+            if args.order is None:
+                from hermes_cli.config import get_session_sort_order
+                current = get_session_sort_order()
+                print(f"Current sort order: {current}")
+                return
+            from hermes_cli.config import set_config_value
+            set_config_value("display.session_sort_order", args.order)
+            print(f"✓ Session sort order set to '{args.order}'.")
+            print(f"  Open /resume to see the updated session list.")
 
         elif action == "export":
             if args.session_id:
@@ -13158,8 +13181,10 @@ Examples:
             limit = getattr(args, "limit", 500) or 500
             source = getattr(args, "source", None)
             _browse_exclude = None if source else ["tool"]
+            from hermes_cli.config import get_session_sort_order
             sessions = db.list_sessions_rich(
-                source=source, exclude_sources=_browse_exclude, limit=limit
+                source=source, exclude_sources=_browse_exclude, limit=limit,
+                order_by_last_active=get_session_sort_order() == "last_active",
             )
             db.close()
             if not sessions:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -610,7 +610,8 @@ async def get_status():
         from hermes_state import SessionDB
         db = SessionDB()
         try:
-            sessions = db.list_sessions_rich(limit=50)
+            from hermes_cli.config import get_session_sort_order
+            sessions = db.list_sessions_rich(limit=50, order_by_last_active=get_session_sort_order() == "last_active")
             now = time.time()
             active_sessions = sum(
                 1 for s in sessions
@@ -779,7 +780,8 @@ async def get_sessions(limit: int = 20, offset: int = 0):
         from hermes_state import SessionDB
         db = SessionDB()
         try:
-            sessions = db.list_sessions_rich(limit=limit, offset=offset)
+            from hermes_cli.config import get_session_sort_order
+            sessions = db.list_sessions_rich(limit=limit, offset=offset, order_by_last_active=get_session_sort_order() == "last_active")
             total = db.session_count()
             now = time.time()
             for s in sessions:
@@ -2422,7 +2424,8 @@ def _session_latest_descendant(session_id: str):
                     "started_at": row_get(row, "started_at", 2),
                 })
         else:
-            rows = db.list_sessions_rich(limit=10000, offset=0)
+            from hermes_cli.config import get_session_sort_order
+            rows = db.list_sessions_rich(limit=10000, offset=0, order_by_last_active=get_session_sort_order() == "last_active")
 
         children = {}
         for row in rows:

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3850,7 +3850,7 @@ def test_session_most_recent_returns_first_non_denied(monkeypatch):
     """Drops `tool` rows like session.list does, returns the first hit."""
 
     class _DB:
-        def list_sessions_rich(self, *, source=None, limit=200):
+        def list_sessions_rich(self, *, source=None, limit=200, **kwargs):
             return [
                 {"id": "tool-1", "source": "tool", "title": "noise", "started_at": 100},
                 {"id": "tui-1", "source": "tui", "title": "real", "started_at": 99},
@@ -3869,7 +3869,7 @@ def test_session_most_recent_returns_first_non_denied(monkeypatch):
 
 def test_session_most_recent_returns_null_when_only_tool_rows(monkeypatch):
     class _DB:
-        def list_sessions_rich(self, *, source=None, limit=200):
+        def list_sessions_rich(self, *, source=None, limit=200, **kwargs):
             return [{"id": "tool-1", "source": "tool", "started_at": 1}]
 
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
@@ -3887,7 +3887,7 @@ def test_session_most_recent_folds_db_exception_into_null_result(monkeypatch):
     'no answer' (Copilot review on #17130)."""
 
     class _BrokenDB:
-        def list_sessions_rich(self, *, source=None, limit=200):
+        def list_sessions_rich(self, *, source=None, limit=200, **kwargs):
             raise RuntimeError("db locked")
 
     monkeypatch.setattr(server, "_get_db", lambda: _BrokenDB())

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2293,6 +2293,15 @@ def _(rid, params: dict) -> dict:
     )
 
 
+def _order_by_last_active() -> bool:
+    """Check if config says sessions should be sorted by last activity time."""
+    try:
+        from hermes_cli.config import get_session_sort_order
+        return get_session_sort_order() == "last_active"
+    except Exception:
+        return False
+
+
 @method("session.list")
 def _(rid, params: dict) -> dict:
     db = _get_db()
@@ -2316,7 +2325,7 @@ def _(rid, params: dict) -> dict:
         fetch_limit = max(limit * 2, 200)
         rows = [
             s
-            for s in db.list_sessions_rich(source=None, limit=fetch_limit)
+            for s in db.list_sessions_rich(source=None, limit=fetch_limit, order_by_last_active=_order_by_last_active())
             if (s.get("source") or "").strip().lower() not in deny
         ][:limit]
         return _ok(
@@ -2363,7 +2372,7 @@ def _(rid, params: dict) -> dict:
         # users (lots of recent ``tool`` rows) don't get a false
         # "no eligible session" answer.  ``session.list`` uses a
         # similar over-fetch strategy.
-        rows = db.list_sessions_rich(source=None, limit=200)
+        rows = db.list_sessions_rich(source=None, limit=200, order_by_last_active=_order_by_last_active())
         for row in rows:
             src = (row.get("source") or "").strip().lower()
             if src in deny:
@@ -6020,7 +6029,7 @@ def _(rid, params: dict) -> dict:
         cutoff = time.time() - days * 86400
         rows = [
             s
-            for s in db.list_sessions_rich(limit=500)
+            for s in db.list_sessions_rich(limit=500, order_by_last_active=_order_by_last_active())
             if (s.get("started_at") or 0) >= cutoff
         ]
         return _ok(


### PR DESCRIPTION
## What does this PR do?

`list_sessions_rich()` has had an `order_by_last_active` parameter with a complete SQL implementation (including recursive CTE for compression chains) since the beginning, but **every** caller passed the default `False` — meaning the session list was always sorted by creation time.

This PR wires that parameter through to all callers, and adds a config option so users can choose the sort order without editing code.

Changes:
1. New config key `display.session_sort_order` in `DEFAULT_CONFIG` (`"started_at"` = creation time, default; `"last_active"` = most recent message timestamp).
2. Public helper `get_session_sort_order()` in `hermes_cli/config.py`.
3. New CLI subcommand `hermes sessions sort <started_at|last_active>` to get/set the sort order.
4. All session-list UIs updated to pass the configured value:
   - TUI `/resume` picker (`tui_gateway/server.py`, 3 call sites)
   - CLI `_list_recent_sessions()` (`cli.py`)
   - `sessions list` / `sessions browse` (`hermes_cli/main.py`)
   - Web dashboard (`hermes_cli/web_server.py`, 3 call sites)

## Related Issue

No existing issue — raised by a user experiencing exactly this pain point.

Fixes # N/A

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/config.py` — add `session_sort_order` default + `get_session_sort_order()` helper
- `tui_gateway/server.py` — add `_order_by_last_active()` helper + pass to 3 call sites
- `cli.py` — pass `order_by_last_active` in `_list_recent_sessions()`
- `hermes_cli/main.py` — register `sessions sort` subcommand + pass param in list/browse
- `hermes_cli/web_server.py` — pass param in 3 call sites
- `tests/test_tui_gateway_server.py` — update 3 mock classes to accept `**kwargs`

## How to Test

1. Run `hermes sessions sort` to check current sort order (default: `started_at`)
2. Run `hermes sessions sort last_active` to switch to most-recent-activity sorting
3. Run `hermes sessions sort started_at` to switch back
4. Run `hermes sessions sort invalid` to confirm invalid values are rejected
5. In TUI, open `/resume` to see the updated list order

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(cli): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — N/A (no docs change needed for this config option)
- [ ] I've updated `cli-config.yaml.example` — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact: pure config + import change, no platform-specific code
- [ ] I've updated tool descriptions/schemas — N/A
