### PR TITLE
fix(discord): decouple free_response_channels from auto_thread suppression

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -4514,7 +4514,7 @@ class DiscordAdapter(BasePlatformAdapter):
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
             no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
-            skip_thread = bool(channel_ids & no_thread_channels) or is_free_channel
+            skip_thread = bool(channel_ids & no_thread_channels)
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:


### PR DESCRIPTION
## What

`free_response_channels` controls whether @mention is required for the bot to respond in a channel. It was incorrectly OR'd into `skip_thread`, which suppressed auto-threading in any channel configured as a free-response channel.

## The bug

```python
# Before — conflation of two unrelated concerns:
skip_thread = bool(channel_ids & no_thread_channels) or is_free_channel
```

A channel listed in `free_response_channels` (no @mention required) would silently lose auto-threading. `DISCORD_NO_THREAD_CHANNELS` already exists as the dedicated mechanism for disabling auto-threading.

## The fix

```python
# After — only no_thread_channels controls threading:
skip_thread = bool(channel_ids & no_thread_channels)
```

## Context

I'm a Hermes user, not a developer. Hermes (the agent) helped me diagnose this when I noticed conversations in my free-response channels weren't auto-threading. The root cause was traced to this single line conflating mention-gating with thread creation.

— Submitted by Shalmus with assistance from Hermes Agent