### PR TITLE
fix(weixin): replace aiohttp ClientTimeout with asyncio.wait_for in _api_post/_api_get

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -378,12 +378,16 @@ async def _api_post(
 ) -> Dict[str, Any]:
     body = _json_dumps({**payload, "base_info": _base_info()})
     url = f"{base_url.rstrip('/')}/{endpoint}"
-    timeout = aiohttp.ClientTimeout(total=timeout_ms / 1000)
-    async with session.post(url, data=body, headers=_headers(token, body), timeout=timeout) as response:
-        raw = await response.text()
-        if not response.ok:
-            raise RuntimeError(f"iLink POST {endpoint} HTTP {response.status}: {raw[:200]}")
-        return json.loads(raw)
+    # Use asyncio.wait_for() instead of aiohttp ClientTimeout to avoid
+    # "Timeout context manager should be used inside a task" errors when
+    # invoked via asyncio.run_coroutine_threadsafe() from cron jobs.
+    async def _do() -> Dict[str, Any]:
+        async with session.post(url, data=body, headers=_headers(token, body)) as response:
+            raw = await response.text()
+            if not response.ok:
+                raise RuntimeError(f"iLink POST {endpoint} HTTP {response.status}: {raw[:200]}")
+            return json.loads(raw)
+    return await asyncio.wait_for(_do(), timeout=timeout_ms / 1000)
 
 
 async def _api_get(
@@ -398,12 +402,16 @@ async def _api_get(
         "iLink-App-Id": ILINK_APP_ID,
         "iLink-App-ClientVersion": str(ILINK_APP_CLIENT_VERSION),
     }
-    timeout = aiohttp.ClientTimeout(total=timeout_ms / 1000)
-    async with session.get(url, headers=headers, timeout=timeout) as response:
-        raw = await response.text()
-        if not response.ok:
-            raise RuntimeError(f"iLink GET {endpoint} HTTP {response.status}: {raw[:200]}")
-        return json.loads(raw)
+    # Use asyncio.wait_for() instead of aiohttp ClientTimeout to avoid
+    # "Timeout context manager should be used inside a task" errors when
+    # invoked via asyncio.run_coroutine_threadsafe() from cron jobs.
+    async def _do() -> Dict[str, Any]:
+        async with session.get(url, headers=headers) as response:
+            raw = await response.text()
+            if not response.ok:
+                raise RuntimeError(f"iLink GET {endpoint} HTTP {response.status}: {raw[:200]}")
+            return json.loads(raw)
+    return await asyncio.wait_for(_do(), timeout=timeout_ms / 1000)
 
 
 async def _get_updates(


### PR DESCRIPTION
## Problem

Cron delivery to WeChat fails with:

```
delivery error: Weixin send failed: Timeout context manager should be used inside a task
```

This happens because `_api_post` and `_api_get` use aiohttp's `ClientTimeout` directly. When the cron scheduler calls `send()` via `asyncio.run_coroutine_threadsafe()`, aiohttp cannot find a running task and raises `RuntimeError`.

## Fix

Replace `aiohttp.ClientTimeout` with `asyncio.wait_for()` in `_api_post` and `_api_get`, following the same pattern already applied to `_upload_media`, `_download_bytes`, and `_download_remote_media`.

The three helper functions above were already fixed to avoid this error (with comments explaining why). `_api_post` and `_api_get` were the remaining two iLink API helpers still using the raw `ClientTimeout` approach.

## Notes

- The `_send_session` already disables aiohttp timeouts entirely (`total=None`) to let `asyncio.wait_for()` manage timeouts externally — this is correct and unchanged.
- Tested: verified no remaining problematic `ClientTimeout` usage in weixin.py. Only the intentionally-disabled one on `_send_session` remains.