### PR TITLE
fix(gateway): keep idle cached agents alive until session expires

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15161,6 +15161,27 @@ class GatewayRunner:
                 if last_activity is None:
                     continue
                 if (now - last_activity) > _AGENT_CACHE_IDLE_TTL_SECS:
+                    # Check whether the session has actually expired in the
+                    # session store.  If it hasn't (e.g. daily-reset mode
+                    # where the reset fires hours after the user's last
+                    # message), keep the agent in cache so the session-store
+                    # expiry watcher can still find it and call
+                    # on_session_end() with the live transcript.  Skipping
+                    # eviction here means the agent stays alive until the
+                    # session genuinely expires, at which point the watcher
+                    # (gateway/run.py _session_expiry_watcher) tears it down
+                    # properly.  (#11205 follow-up)
+                    session_entry = None
+                    try:
+                        _store = getattr(self, "session_store", None)
+                        if _store is not None:
+                            _store._ensure_loaded()
+                            session_entry = _store._entries.get(key)
+                    except Exception:
+                        pass
+                    if session_entry is not None:
+                        if not _store._is_session_expired(session_entry):
+                            continue  # keep agent — session hasn't expired
                     to_evict.append((key, agent))
             for key, _ in to_evict:
                 _cache.pop(key, None)

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -604,6 +604,58 @@ class TestAgentCacheBoundedGrowth:
         assert runner._sweep_idle_cached_agents() == 0
         assert "s" in runner._agent_cache
 
+    def test_idle_sweep_keeps_agent_when_session_not_expired(self, monkeypatch):
+        """Agents past idle TTL are kept if the session hasn't expired yet.
+
+        In daily-reset mode the reset can fire hours after the last
+        user message — evicting the agent early means the
+        session-expiry watcher has nothing to call on_session_end()
+        with, and memory providers miss the live transcript.
+        """
+        from gateway import run as gw_run
+
+        monkeypatch.setattr(gw_run, "_AGENT_CACHE_IDLE_TTL_SECS", 0.01)
+        runner = self._bounded_runner()
+        runner._cleanup_agent_resources = MagicMock()
+
+        import time as _t
+        stale = self._fake_agent(last_activity=_t.time() - 10.0)
+
+        # Session store says the session is still alive.
+        session_entry = MagicMock()
+        runner.session_store = MagicMock()
+        runner.session_store._entries = {"stale-session": session_entry}
+        runner.session_store._is_session_expired.return_value = False
+
+        runner._agent_cache["stale-session"] = (stale, "sig")
+
+        evicted = runner._sweep_idle_cached_agents()
+        assert evicted == 0
+        assert "stale-session" in runner._agent_cache
+
+    def test_idle_sweep_evicts_when_session_is_expired(self, monkeypatch):
+        """Agent IS evicted when past idle TTL AND session store says expired."""
+        from gateway import run as gw_run
+
+        monkeypatch.setattr(gw_run, "_AGENT_CACHE_IDLE_TTL_SECS", 0.01)
+        runner = self._bounded_runner()
+        runner._cleanup_agent_resources = MagicMock()
+
+        import time as _t
+        stale = self._fake_agent(last_activity=_t.time() - 10.0)
+
+        # Session store says the session has expired.
+        session_entry = MagicMock()
+        runner.session_store = MagicMock()
+        runner.session_store._entries = {"stale-session": session_entry}
+        runner.session_store._is_session_expired.return_value = True
+
+        runner._agent_cache["stale-session"] = (stale, "sig")
+
+        evicted = runner._sweep_idle_cached_agents()
+        assert evicted == 1
+        assert "stale-session" not in runner._agent_cache
+
     def test_plain_dict_cache_is_tolerated(self):
         """Test fixtures using plain {} don't crash _enforce_agent_cache_cap."""
         from gateway.run import GatewayRunner


### PR DESCRIPTION
## What does this PR do?

The idle-TTL sweep (_sweep_idle_cached_agents) was evicting agents as soon as they passed _AGENT_CACHE_IDLE_TTL_SECS, even when the session hadn't expired yet. In daily-reset mode the reset can fire hours after the last user message — evicting the agent early means the session-expiry watcher has no agent in cache to call on_session_end() with, so memory providers miss the live transcript.

Now the sweep checks the session store before evicting: if the session still exists and hasn't expired, the agent stays in cache so the expiry watcher can tear it down properly later. When the session store is unavailable or throws, falls back to the original eviction behavior (safe default).

## Related Issue

Fixes #11205

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`gateway/run.py`** — `_sweep_idle_cached_agents()` now checks the session store before evicting an agent past idle TTL. If the session hasn't actually expired (e.g., daily-reset mode where the reset fires hours after the last user message), the agent stays in cache so `_session_expiry_watcher` can find it later and call `on_session_end()` with the live transcript. Falls back to original eviction behavior when the session store is unavailable or throws.

- **`tests/gateway/test_agent_cache.py`** — Two new tests in `TestAgentCacheBoundedGrowth`:
  - `test_idle_sweep_keeps_agent_when_session_not_expired` — agent past idle TTL is *kept* when session store says session is alive
  - `test_idle_sweep_evicts_when_session_is_expired` — agent past idle TTL is *evicted* when session store confirms session expired

## How to Test

1. Run the gateway in daily-reset mode with an active memory provider
2. Send a message, then stop interacting for longer than `_AGENT_CACHE_IDLE_TTL_SECS` but before the daily reset time
3. Without the fix: the agent is evicted from cache before the session expires; when the session-expiry watcher fires, it finds no agent and memory providers miss `on_session_end()`
4. With the fix: the agent stays in cache until the session actually expires in the session store, then `_session_expiry_watcher` tears it down properly — memory providers receive the live transcript

Unit test verification: `python -m pytest tests/gateway/test_agent_cache.py::TestAgentCacheBoundedGrowth -v -o 'addopts='`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Fedora 44 (Linux 6.19)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure Python session-store logic, no OS surface)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ python -m pytest tests/gateway/test_agent_cache.py::TestAgentCacheBoundedGrowth -v -o 'addopts='
...
test_cap_evicts_lru_when_exceeded PASSED
test_cap_respects_move_to_end PASSED
test_cap_triggers_cleanup_thread PASSED
test_idle_ttl_sweep_evicts_stale_agents PASSED
test_idle_sweep_skips_agents_without_activity_ts PASSED
test_idle_sweep_keeps_agent_when_session_not_expired PASSED  ← new
test_idle_sweep_evicts_when_session_is_expired PASSED         ← new
test_plain_dict_cache_is_tolerated PASSED
test_main_lookup_updates_lru_order PASSED
9 passed in 0.40s

$ python -m pytest tests/gateway/test_shutdown_cache_cleanup.py tests/gateway/test_shutdown_memory_provider_messages.py -o 'addopts='
15 passed in 0.95s
```